### PR TITLE
docs: add git worktrees rule for parallel workflows

### DIFF
--- a/.cursor/rules/000-index.mdc
+++ b/.cursor/rules/000-index.mdc
@@ -37,8 +37,9 @@ Uses Dewey Decimal principles: hierarchical, numeric, extensible.
 │   └── 320-kubernetes.mdc
 ├── 700-workflows/
 │   ├── 710-git-branch-management.mdc
-│   ├── 720-pr-layering.mdc
-│   └── 721-pr-documentation.mdc
+│   ├── 720-git-worktrees.mdc
+│   ├── 721-pr-documentation.mdc
+│   └── 730-datever.mdc
 └── 900-meta/
     └── 900-rule-format.mdc
 ```
@@ -66,8 +67,9 @@ Uses Dewey Decimal principles: hierarchical, numeric, extensible.
 | ID | File | Description |
 |----|------|-------------|
 | 710 | `710-git-branch-management` | Branch from main, single-purpose PRs |
-| 720 | `720-pr-layering` | Stratified PR decomposition |
+| 720 | `720-git-worktrees` | Parallel workflows with worktrees, operator multi-loop |
 | 721 | `721-pr-documentation` | Living PR docs in `docs/pull-requests/` |
+| 730 | `730-datever` | Date-based versioning strategy |
 
 ### 900-meta/
 | ID | File | Description |

--- a/.cursor/rules/700-workflows/720-git-worktrees.mdc
+++ b/.cursor/rules/700-workflows/720-git-worktrees.mdc
@@ -1,0 +1,330 @@
+---
+title: Git Worktrees for Parallel Workflows
+category: workflows
+tags: [git, worktrees, parallel, isolation, miniforge-architecture]
+confidence: high
+impact: high
+---
+
+# Git Worktrees for Parallel Workflows
+
+## Context
+
+Git worktrees enable multiple branches to be checked out simultaneously in separate directories from a single repository. This is critical for:
+
+1. **Development workflow**: Working on multiple features without branch switching overhead
+2. **miniforge architecture**: The Operator agent managing multiple concurrent workflows with isolated contexts
+3. **IDE integration**: Dedicated worktrees for different editors (e.g., Cursor on `main` for stable reference)
+
+## Development Usage
+
+### Creating Worktrees
+
+**For feature work:**
+```bash
+# Create new worktree with new branch
+git worktree add -b feat/new-feature /path/to/worktree origin/main
+
+# Example: artifact component
+git worktree add -b feat/artifact-component \
+  /Users/chris/Local/miniforge.ai/miniforge-artifact \
+  origin/main
+```
+
+**For IDE isolation:**
+```bash
+# Permanent worktree for Cursor IDE (stays on main)
+git worktree add /Users/chris/Local/miniforge.ai/miniforge-cursor main
+```
+
+### Standard Worktree Layout
+
+```
+miniforge.ai/
+├── miniforge/              # Main worktree (for active feature work)
+├── miniforge-cursor/       # Permanent: Cursor IDE on main branch
+├── miniforge-{feature}/    # Temporary: One per active feature PR
+└── miniforge-{context}/    # Optional: For operator spawned workflows
+```
+
+### Worktree Lifecycle
+
+**1. Create** (when starting feature):
+```bash
+git worktree add -b feat/component-name /path/to/miniforge-component origin/main
+```
+
+**2. Work** (develop in isolation):
+```bash
+cd /path/to/miniforge-component
+# All git operations work normally
+git add, commit, push, etc.
+```
+
+**3. Cleanup** (after PR merge):
+```bash
+# Remove the worktree directory
+git worktree remove /path/to/miniforge-component
+
+# Delete remote branch (if not auto-deleted)
+git push origin --delete feat/component-name
+
+# Prune stale references
+git worktree prune
+git fetch --prune
+```
+
+### Cleanup Checklist
+
+After **every PR merge**, clean up:
+
+- [ ] `git worktree remove /path/to/feature-worktree`
+- [ ] `git push origin --delete feat/branch-name` (if needed)
+- [ ] `git fetch --prune` (update local refs)
+- [ ] Verify: `git worktree list` shows only active worktrees
+
+### Permanent vs Temporary Worktrees
+
+**Permanent** (keep indefinitely):
+- `miniforge-cursor` - Dedicated IDE worktree on `main`
+- `miniforge` - Main development worktree (reuse by switching branches)
+
+**Temporary** (delete after merge):
+- `miniforge-{feature}` - Created per feature, removed after PR merge
+- `miniforge-{fix}` - Created for urgent fixes, removed after merge
+
+## miniforge Operator Usage
+
+### Architectural Significance
+
+Git worktrees are a **native feature** for miniforge's multi-loop architecture:
+
+```
+Operator Agent
+    ├── Main Workflow     → miniforge/           (feat/user-feature)
+    ├── Fix Workflow      → miniforge-fix-123/   (fix/workflow-error)
+    ├── Test Workflow     → miniforge-test-456/  (test/new-strategy)
+    └── Review Context    → miniforge-cursor/    (main, read-only)
+```
+
+**Benefits for Operator:**
+
+1. **Isolation**: Each workflow has its own working directory
+   - No branch switching conflicts
+   - Independent git state per workflow
+   - Clean context separation
+
+2. **Concurrency**: Multiple workflows run in parallel
+   - Main feature continues while fix is being developed
+   - Test strategies can run without blocking main work
+   - No mutex on repository access
+
+3. **Provenance**: Each worktree maps to a workflow instance
+   - Clear artifact → worktree → branch mapping
+   - Easy debugging (inspect worktree state)
+   - Audit trail via git history per worktree
+
+4. **Recovery**: Pause/resume workflows naturally
+   - Worktree persists if workflow paused
+   - Resume by switching to worktree directory
+   - Crash recovery: worktree state is on disk
+
+### Operator Workflow Pattern
+
+```clojure
+;; Operator spawns fix workflow
+(defn spawn-fix-workflow [operator problem]
+  (let [worktree-path (str "/tmp/miniforge-fix-" (uuid))
+        branch-name (str "fix/" (kebab-case (:description problem)))]
+
+    ;; Create isolated worktree
+    (shell "git" "worktree" "add" "-b" branch-name worktree-path "origin/main")
+
+    ;; Start workflow in worktree context
+    (start-workflow {:type :fix
+                     :context {:cwd worktree-path
+                               :branch branch-name}
+                     :problem problem})
+
+    ;; Cleanup after merge
+    (on-workflow-complete
+      (fn [result]
+        (shell "git" "worktree" "remove" worktree-path)
+        (shell "git" "push" "origin" "--delete" branch-name)))))
+```
+
+### Worktree Metadata for Workflows
+
+Track worktrees in operator state:
+
+```clojure
+{:workflows
+ [{:id #uuid "..."
+   :type :main
+   :worktree "/Users/chris/Local/miniforge.ai/miniforge"
+   :branch "feat/user-feature"
+   :status :running}
+
+  {:id #uuid "..."
+   :type :fix
+   :worktree "/tmp/miniforge-fix-abc123"
+   :branch "fix/validation-error"
+   :status :running
+   :spawned-by #uuid "..."}  ; parent workflow
+
+  {:id #uuid "..."
+   :type :review
+   :worktree "/Users/chris/Local/miniforge.ai/miniforge-cursor"
+   :branch "main"
+   :status :read-only}]}
+```
+
+## Common Patterns
+
+### Pattern: Feature Development
+```bash
+# Start feature
+git worktree add -b feat/new-thing miniforge-new-thing origin/main
+cd miniforge-new-thing
+# ... develop ...
+git push -u origin feat/new-thing
+gh pr create
+
+# After merge
+git worktree remove miniforge-new-thing
+git push origin --delete feat/new-thing
+```
+
+### Pattern: Urgent Fix While Feature in Progress
+```bash
+# Main feature work in progress at miniforge/
+# Spawn fix without disrupting main work
+git worktree add -b fix/urgent-bug miniforge-urgent-fix origin/main
+cd miniforge-urgent-fix
+# ... fix bug ...
+git push -u origin fix/urgent-bug
+gh pr create --base main
+
+# After merge, cleanup
+git worktree remove miniforge-urgent-fix
+
+# Main feature work continues uninterrupted at miniforge/
+```
+
+### Pattern: Operator Self-Improvement
+```bash
+# Operator detects problem in its own workflow
+# Spawns fix workflow in isolated worktree
+git worktree add -b fix/workflow-123 /tmp/miniforge-self-fix origin/main
+# Fix workflow runs independently
+# Main workflow continues or pauses
+# After fix merged, resume main workflow
+git worktree remove /tmp/miniforge-self-fix
+```
+
+## Anti-Patterns
+
+❌ **Don't**: Check out `main` in multiple worktrees
+```bash
+# BAD: Will fail
+git worktree add miniforge-feature main  # Error: main already checked out
+```
+
+✅ **Do**: Create feature branches
+```bash
+# GOOD: Each worktree has unique branch
+git worktree add -b feat/feature miniforge-feature origin/main
+```
+
+❌ **Don't**: Leave worktrees after merge
+```bash
+# BAD: Accumulates stale worktrees
+git worktree list
+# /path/to/merged-feature-1  (merged 3 months ago)
+# /path/to/merged-feature-2  (merged 2 months ago)
+```
+
+✅ **Do**: Clean up immediately after merge
+```bash
+# GOOD: Clean up as part of merge process
+git worktree remove /path/to/feature
+git push origin --delete feat/branch
+```
+
+❌ **Don't**: Use worktrees for long-lived branches
+```bash
+# BAD: Creates confusion
+git worktree add miniforge-staging staging
+git worktree add miniforge-production production
+```
+
+✅ **Do**: Use worktrees for isolated, temporary work
+```bash
+# GOOD: Short-lived feature branches
+git worktree add -b feat/component miniforge-component origin/main
+```
+
+## Troubleshooting
+
+### Worktree already exists
+```bash
+# Error: 'feat/branch' is already checked out at '/path/to/worktree'
+# Fix: Remove old worktree first
+git worktree remove /path/to/worktree
+# Or: Prune if directory was manually deleted
+git worktree prune
+```
+
+### Can't delete worktree
+```bash
+# Error: working tree already exists
+# Fix: Make sure no processes are using the directory
+lsof +D /path/to/worktree  # Check open files
+git worktree remove --force /path/to/worktree  # Force removal
+```
+
+### Branch deleted but worktree remains
+```bash
+# Clean up stale worktrees
+git worktree prune
+git fetch --prune
+```
+
+## Integration with miniforge
+
+### Phase 3: Control Plane Implementation
+
+When implementing the Operator agent:
+
+1. **Worktree Manager** component
+   - Create/remove worktrees per workflow
+   - Track worktree → workflow mapping
+   - Cleanup on workflow completion
+
+2. **Workflow Isolation**
+   - Each workflow runs in dedicated worktree
+   - File system isolation prevents conflicts
+   - Git state isolation prevents race conditions
+
+3. **Monitoring**
+   - `git worktree list` shows active workflows
+   - Disk usage monitoring per worktree
+   - Automatic cleanup of abandoned worktrees
+
+### Future: Distributed miniforge
+
+Worktrees enable **local multi-loop** execution. For distributed:
+- Each node creates local worktrees
+- Shared git remote coordinates state
+- Worktree per workflow instance per node
+
+## References
+
+- Git worktree docs: `git help worktree`
+- See also: [710-git-branch-management.mdc](./710-git-branch-management.mdc)
+- See also: [721-pr-documentation.mdc](./721-pr-documentation.mdc)
+- Architecture: `docs/specs/operational-modes.spec` (Operator agent)
+
+---
+
+**Rule**: Use git worktrees for parallel development and operator multi-loop execution. Create per feature, cleanup after merge. Leverage for miniforge's concurrent workflow architecture.


### PR DESCRIPTION
Adds comprehensive rule covering git worktrees for:

## Development Workflow
- Creating/managing worktrees per feature
- Cleanup after PR merge
- Permanent vs temporary worktrees

## miniforge Architecture
- **Critical feature**: Worktrees enable Operator to manage multiple concurrent loops
- Isolated contexts per workflow (main, fix, test, review)
- Natural pause/resume for workflows
- Clean provenance: worktree → workflow → branch → artifacts

## Key Benefits
- No branch switching overhead
- Parallel development without conflicts
- File system + git state isolation
- Perfect for operator spawning fix workflows while main work continues

Related to operational-modes.spec and future control plane implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)