### PR TITLE
Remove Linux ARM64 build due to unavailable runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,9 +28,6 @@ jobs:
           - os: linux
             arch: x86_64
             runner: ubuntu-latest
-          - os: linux
-            arch: arm64
-            runner: ubuntu-latest-arm64
 
     steps:
       - name: Checkout code
@@ -160,13 +157,6 @@ jobs:
             sudo mv miniforge /usr/local/bin/
             ```
 
-            **Linux ARM64**
-            ```bash
-            curl -L https://github.com/${{ github.repository }}/releases/download/v${{ steps.version.outputs.version }}/miniforge-linux-arm64 -o miniforge
-            chmod +x miniforge
-            sudo mv miniforge /usr/local/bin/
-            ```
-
             ### Verification
             Verify the installation:
             ```bash
@@ -211,12 +201,6 @@ jobs:
           name: miniforge-linux-x86_64
           path: artifacts/linux-x86_64
 
-      - name: Download Linux ARM64 artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: miniforge-linux-arm64
-          path: artifacts/linux-arm64
-
       - name: Generate formula
         run: |
           VERSION="${{ needs.release.outputs.version }}"
@@ -224,7 +208,6 @@ jobs:
           # Read SHA256 checksums
           MACOS_ARM64_SHA=$(cat artifacts/macos-arm64/miniforge-macos-arm64.sha256 | awk '{print $1}')
           LINUX_X86_SHA=$(cat artifacts/linux-x86_64/miniforge-linux-x86_64.sha256 | awk '{print $1}')
-          LINUX_ARM64_SHA=$(cat artifacts/linux-arm64/miniforge-linux-arm64.sha256 | awk '{print $1}')
 
           cat > homebrew-tap/Formula/miniforge.rb << EOF
           class Miniforge < Formula
@@ -239,13 +222,8 @@ jobs:
             end
 
             on_linux do
-              if Hardware::CPU.arm?
-                url "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/miniforge-linux-arm64"
-                sha256 "${LINUX_ARM64_SHA}"
-              else
-                url "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/miniforge-linux-x86_64"
-                sha256 "${LINUX_X86_SHA}"
-              end
+              url "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/miniforge-linux-x86_64"
+              sha256 "${LINUX_X86_SHA}"
             end
 
             depends_on "babashka"
@@ -253,8 +231,7 @@ jobs:
 
             def install
               bin.install "miniforge-macos-arm64" => "miniforge" if OS.mac?
-              bin.install "miniforge-linux-arm64" => "miniforge" if OS.linux? && Hardware::CPU.arm?
-              bin.install "miniforge-linux-x86_64" => "miniforge" if OS.linux? && Hardware::CPU.intel?
+              bin.install "miniforge-linux-x86_64" => "miniforge" if OS.linux?
             end
 
             test do

--- a/Formula/miniforge.rb.template
+++ b/Formula/miniforge.rb.template
@@ -22,13 +22,8 @@ class Miniforge < Formula
   end
 
   on_linux do
-    if Hardware::CPU.arm?
-      url "https://github.com/miniforge-ai/miniforge/releases/download/vVERSION/miniforge-linux-arm64"
-      sha256 "LINUX_ARM64_SHA256"
-    else
-      url "https://github.com/miniforge-ai/miniforge/releases/download/vVERSION/miniforge-linux-x86_64"
-      sha256 "LINUX_X86_SHA256"
-    end
+    url "https://github.com/miniforge-ai/miniforge/releases/download/vVERSION/miniforge-linux-x86_64"
+    sha256 "LINUX_X86_SHA256"
   end
 
   depends_on "babashka"
@@ -36,8 +31,7 @@ class Miniforge < Formula
 
   def install
     bin.install "miniforge-macos-arm64" => "miniforge" if OS.mac?
-    bin.install "miniforge-linux-arm64" => "miniforge" if OS.linux? && Hardware::CPU.arm?
-    bin.install "miniforge-linux-x86_64" => "miniforge" if OS.linux? && Hardware::CPU.intel?
+    bin.install "miniforge-linux-x86_64" => "miniforge" if OS.linux?
   end
 
   test do


### PR DESCRIPTION
## Problem

The `ubuntu-latest-arm64` runner is not available on standard GitHub Actions and requires paid/enterprise plans. The v2026.01.20.1 release workflow was stuck with the Linux ARM64 build queued for 8+ hours without starting.

This is the same issue we encountered with `macos-15-large` for macOS Intel builds.

## Changes

- ✅ Removed Linux ARM64 from build matrix in release workflow
- ✅ Updated Homebrew formula to only support Linux x86_64 (not ARM64)
- ✅ Removed Linux ARM64 download step from Homebrew formula generation
- ✅ Updated release notes to remove Linux ARM64 installation instructions

## Supported Platforms

After this change, miniforge will build for:
- ✅ **macOS ARM64** (Apple Silicon) - via `macos-latest`
- ✅ **Linux x86_64** (Intel/AMD 64-bit) - via `ubuntu-latest`
- ❌ ~~Linux ARM64~~ (requires paid runner)

## Testing

Pre-commit checks passed locally. Once merged, we can create a new tag to trigger a successful release with just these two platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)