### PR TITLE
Create Formula directory in homebrew-tap before writing formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -209,6 +209,9 @@ jobs:
           MACOS_ARM64_SHA=$(cat artifacts/macos-arm64/miniforge-macos-arm64.sha256 | awk '{print $1}')
           LINUX_X86_SHA=$(cat artifacts/linux-x86_64/miniforge-linux-x86_64.sha256 | awk '{print $1}')
 
+          # Create Formula directory if it doesn't exist
+          mkdir -p homebrew-tap/Formula
+
           cat > homebrew-tap/Formula/miniforge.rb << EOF
           class Miniforge < Formula
             desc "Autonomous SDLC platform - convert intent to production software"


### PR DESCRIPTION
## Problem

The homebrew-tap repository doesn't have a `Formula` directory yet, causing the formula generation step to fail with:

```
homebrew-tap/Formula/miniforge.rb: No such file or directory
```

## Solution

Add `mkdir -p homebrew-tap/Formula` before writing the formula file to ensure the directory exists.

## Testing

Once merged, we can re-run the Homebrew update job from the v2026.01.20.1 release workflow to verify the formula is created successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)