### PR TITLE
Rename installed binary from 'miniforge' to 'mf'

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,7 +160,7 @@ jobs:
             ### Verification
             Verify the installation:
             ```bash
-            miniforge version
+            mf version
             ```
 
             ### Changes
@@ -233,12 +233,12 @@ jobs:
             depends_on "gum"
 
             def install
-              bin.install "miniforge-macos-arm64" => "miniforge" if OS.mac?
-              bin.install "miniforge-linux-x86_64" => "miniforge" if OS.linux?
+              bin.install "miniforge-macos-arm64" => "mf" if OS.mac?
+              bin.install "miniforge-linux-x86_64" => "mf" if OS.linux?
             end
 
             test do
-              assert_match "miniforge", shell_output("#{bin}/miniforge version")
+              assert_match "miniforge", shell_output("#{bin}/mf version")
             end
           end
           EOF

--- a/Formula/miniforge.rb.template
+++ b/Formula/miniforge.rb.template
@@ -30,11 +30,11 @@ class Miniforge < Formula
   depends_on "gum"
 
   def install
-    bin.install "miniforge-macos-arm64" => "miniforge" if OS.mac?
-    bin.install "miniforge-linux-x86_64" => "miniforge" if OS.linux?
+    bin.install "miniforge-macos-arm64" => "mf" if OS.mac?
+    bin.install "miniforge-linux-x86_64" => "mf" if OS.linux?
   end
 
   test do
-    assert_match "miniforge", shell_output("#{bin}/miniforge version")
+    assert_match "miniforge", shell_output("#{bin}/mf version")
   end
 end


### PR DESCRIPTION
## Problem

The `miniforge` command name conflicts with the conda/mamba Miniforge distribution, preventing clean installation via Homebrew.

## Solution

Rename the installed binary to `mf` while keeping the package name as `miniforge`.

**Installation:**
```bash
brew install miniforge-ai/tap/miniforge
```

**Usage:**
```bash
mf version
mf help
mf status
```

## Changes

- ✅ Updated formula template to install as `mf`
- ✅ Updated release workflow formula generation
- ✅ Updated release notes verification example

## Benefits

- ✅ Short, memorable command: `mf`
- ✅ No naming conflicts with existing tools
- ✅ Cleaner user experience
- ✅ Consistent with other CLI tools (e.g., `gh`, `jq`, `bb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)