### PR TITLE
Add local installation tasks for testing

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -142,6 +142,45 @@
    :task (run! "clojure" "-T:build" "compile-all")}
 
   ;; ──────────────────────────────────────────────────────────────────────────
+  ;; Local Installation (for testing)
+  ;; ──────────────────────────────────────────────────────────────────────────
+
+  install:local
+  {:doc  "Install built CLI to ~/.local/bin/mf"
+   :task (let [source "dist/miniforge"
+               bin-dir (str (System/getProperty "user.home") "/.local/bin")
+               target (str bin-dir "/mf")]
+           (if (fs/exists? source)
+             (do
+               (println "📦 Installing miniforge CLI to" target)
+               (fs/create-dirs bin-dir)
+               (fs/copy source target {:replace-existing true})
+               (p/shell "chmod" "+x" target)
+               (println "✅ Installed successfully")
+               (println "   Ensure ~/.local/bin is in your PATH")
+               (println "   Run 'mf version' to verify"))
+             (println "❌ dist/miniforge not found. Run 'bb build:cli' first")))}
+
+  uninstall:local
+  {:doc  "Remove local installation from ~/.local/bin/mf"
+   :task (let [target (str (System/getProperty "user.home") "/.local/bin/mf")]
+           (if (fs/exists? target)
+             (do
+               (println "🗑️  Removing" target)
+               (fs/delete target)
+               (println "✅ Uninstalled successfully"))
+             (println "✓ Not installed at" target)))}
+
+  test:local
+  {:doc     "Build CLI, install locally, and test"
+   :depends [build:cli install:local]
+   :task    (do
+              (println "\n🧪 Testing local installation...\n")
+              (p/shell "mf" "version")
+              (p/shell "mf" "help")
+              (println "\n✅ Local installation test complete\n"))}
+
+  ;; ──────────────────────────────────────────────────────────────────────────
   ;; Installers (via Homebrew)
   ;; ──────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Purpose

Adds bb tasks for local installation and testing while the repository is private and Homebrew installation is not yet available.

## New Tasks

- **`bb install:local`** - Install built CLI to `~/.local/bin/mf`
- **`bb uninstall:local`** - Remove local installation  
- **`bb test:local`** - Build, install, and test CLI locally

## Usage

```bash
# Build and install
bb build:cli
bb install:local

# Test (ensure ~/.local/bin is in PATH)
export PATH="$HOME/.local/bin:$PATH"
mf version
mf help
mf status

# Clean up
bb uninstall:local
```

## Benefits

- ✅ Test complete installation flow without making repo public
- ✅ No sudo required (installs to user directory)
- ✅ Simple workflow for development and testing
- ✅ Bridge solution until Homebrew distribution is ready

## Verification

Tested locally:
```bash
$ bb install:local
📦 Installing miniforge CLI to /Users/chris/.local/bin/mf
✅ Installed successfully

$ mf version
miniforge dev
Build: development
Date: 2026-01-20

$ mf help
miniforge - Autonomous SDLC Platform
...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)