### PR TITLE
fix: Export check-gate from loop.interface for proper component boundaries

### DIFF
--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -7,7 +7,6 @@
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.loop.interface :as loop]
-   [ai.miniforge.loop.gates :as gates]  ; TODO: Should be exported by loop.interface
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -76,7 +75,7 @@
     (log/debug logger :reviewer :reviewer/gate-start
                {:data {:gate-idx idx :gate-id gate-id}})
     (try
-      (let [result (gates/check gate artifact context)
+      (let [result (loop/check-gate gate artifact context)
             duration (- (System/currentTimeMillis) gate-start)
             feedback (gate-result->feedback gate result)]
         (log/info logger :reviewer :reviewer/gate-complete

--- a/components/loop/src/ai/miniforge/loop/interface.clj
+++ b/components/loop/src/ai/miniforge/loop/interface.clj
@@ -228,6 +228,12 @@
   []
   (gates/strict-gates))
 
+(defn check-gate
+  "Run a single gate check on an artifact.
+   Returns gate result map with :gate/id, :gate/type, :gate/passed?, etc."
+  [gate artifact context]
+  (gates/check gate artifact context))
+
 (defn run-gates
   "Run multiple gates against an artifact.
    Options:


### PR DESCRIPTION
Fixes the component boundary violation that required `--no-verify` in PR #38.

## Problem
PR #38 (refactoring reviewer.clj) had to bypass pre-commit hooks because it imported `loop.gates` directly:
```
Error 101: Illegal dependency on namespace loop.gates in agent.reviewer
```

This violated Polylith component boundaries and required using `--no-verify` to commit.

## Solution
- **Added `loop/check-gate` function** to `loop.interface` that properly exports the gate checking capability
- **Updated `reviewer.clj`** to use `loop/check-gate` instead of `gates/check`
- **Removed `loop.gates` import** from reviewer.clj

## Benefits
✅ Respects Polylith component boundaries  
✅ No `--no-verify` needed going forward  
✅ Passes all pre-commit validation  
✅ Proper architecture with interface-only dependencies

## Testing
```bash
# Compiles without errors
clojure -M:test -e "(require 'ai.miniforge.agent.reviewer)"

# Passes all pre-commit checks
git commit
# ✅ No bypass needed!
```

This ensures the refactored composable functions in reviewer.clj work within proper Polylith architectural boundaries.