### PR TITLE
feat(policy-pack): implement extensible policy-as-code system

### DIFF
--- a/components/policy-pack/deps.edn
+++ b/components/policy-pack/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src" "resources"]
+ :deps {metosin/malli {:mvn/version "0.16.4"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/policy-pack/src/ai/miniforge/policy_pack/core.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/core.clj
@@ -1,0 +1,500 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.core
+  "Core policy pack operations.
+
+   Layer 0: Severity and enforcement comparison
+   Layer 1: Rule merging and resolution
+   Layer 2: Pack composition and orchestration
+
+   Handles multi-pack rule resolution with:
+   - Merge by category
+   - Override by ID (later pack wins)
+   - Severity escalation (higher wins)
+   - Enforcement escalation (stricter wins)"
+  (:require
+   [ai.miniforge.policy-pack.detection :as detection]
+   [ai.miniforge.policy-pack.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Severity and enforcement comparison
+
+(def severity-order
+  "Severity levels from most to least severe."
+  {:critical 0
+   :major 1
+   :minor 2
+   :info 3})
+
+(def enforcement-order
+  "Enforcement actions from strictest to most lenient."
+  {:hard-halt 0
+   :require-approval 1
+   :warn 2
+   :audit 3})
+
+(defn compare-severity
+  "Compare two severity levels.
+   Returns negative if a is more severe, positive if b is more severe, 0 if equal."
+  [a b]
+  (- (get severity-order a 99)
+     (get severity-order b 99)))
+
+(defn more-severe
+  "Return the more severe of two severity levels."
+  [a b]
+  (if (neg? (compare-severity a b)) a b))
+
+(defn compare-enforcement
+  "Compare two enforcement actions.
+   Returns negative if a is stricter, positive if b is stricter, 0 if equal."
+  [a b]
+  (- (get enforcement-order a 99)
+     (get enforcement-order b 99)))
+
+(defn stricter-enforcement
+  "Return the stricter of two enforcement actions."
+  [a b]
+  (if (neg? (compare-enforcement a b)) a b))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rule merging
+
+(defn merge-rules
+  "Merge two rules with the same ID.
+
+   Resolution strategy:
+   - Later rule overrides base rule for most fields
+   - Severity: higher severity wins
+   - Enforcement action: stricter action wins
+   - Description: concatenate with separator if different
+
+   Arguments:
+   - base - Original rule
+   - override - Rule that overrides base
+
+   Returns:
+   - Merged rule"
+  [base override]
+  (let [base-severity (:rule/severity base)
+        override-severity (:rule/severity override)
+        base-enforcement (get-in base [:rule/enforcement :action])
+        override-enforcement (get-in override [:rule/enforcement :action])]
+    (-> (merge base override)
+        ;; Escalate severity
+        (assoc :rule/severity (more-severe base-severity override-severity))
+        ;; Escalate enforcement
+        (assoc-in [:rule/enforcement :action]
+                  (stricter-enforcement base-enforcement override-enforcement)))))
+
+(defn resolve-rules
+  "Resolve a collection of rules from multiple packs.
+
+   Resolution:
+   1. Group rules by ID
+   2. For each ID, merge all rules using merge-rules
+   3. Return deduplicated rules
+
+   Arguments:
+   - rules - Sequence of rules from multiple packs (in order of precedence)
+
+   Returns:
+   - Vector of resolved rules"
+  [rules]
+  (let [by-id (group-by :rule/id rules)]
+    (->> by-id
+         (map (fn [[_id group]]
+                (reduce merge-rules group)))
+         vec)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rule applicability
+
+(defn rule-applies-to-artifact?
+  "Check if a rule applies to an artifact based on file globs.
+
+   Arguments:
+   - rule - Rule with :rule/applies-to
+   - artifact - Artifact with :artifact/path
+
+   Returns:
+   - true if rule applies, false otherwise"
+  [rule artifact]
+  (let [file-globs (get-in rule [:rule/applies-to :file-globs])
+        path (:artifact/path artifact "")]
+    (or (nil? file-globs)
+        (empty? file-globs)
+        (some #(registry/glob-matches? % path) file-globs))))
+
+(defn rule-applies-to-task?
+  "Check if a rule applies to a task type.
+
+   Arguments:
+   - rule - Rule with :rule/applies-to
+   - task-type - Task type keyword
+
+   Returns:
+   - true if rule applies, false otherwise"
+  [rule task-type]
+  (let [task-types (get-in rule [:rule/applies-to :task-types])]
+    (or (nil? task-types)
+        (empty? task-types)
+        (contains? task-types task-type))))
+
+(defn rule-applies-to-phase?
+  "Check if a rule applies to a workflow phase.
+
+   Arguments:
+   - rule - Rule with :rule/applies-to
+   - phase - Phase keyword
+
+   Returns:
+   - true if rule applies, false otherwise"
+  [rule phase]
+  (let [phases (get-in rule [:rule/applies-to :phases])]
+    (or (nil? phases)
+        (empty? phases)
+        (contains? phases phase))))
+
+(defn filter-applicable-rules
+  "Filter rules to those applicable to the given context.
+
+   Arguments:
+   - rules - Vector of rules
+   - context - Context map with :artifact, :task, :phase
+
+   Returns:
+   - Vector of applicable rules"
+  [rules context]
+  (let [artifact (:artifact context)
+        task-type (get-in context [:task :task/intent :intent/type])
+        phase (:phase context)]
+    (filterv (fn [rule]
+               (and (rule-applies-to-artifact? rule artifact)
+                    (rule-applies-to-task? rule task-type)
+                    (rule-applies-to-phase? rule phase)))
+             rules)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Pack operations
+
+(defn create-pack
+  "Create a new policy pack with default values.
+
+   Arguments:
+   - id - Pack ID string
+   - name - Human-readable name
+   - description - Pack description
+   - author - Author string
+
+   Options:
+   - :version - DateVer string (default: today's date)
+   - :license - License string
+   - :rules - Vector of rules
+
+   Returns:
+   - PackManifest"
+  [id name description author & {:keys [version license rules]
+                                  :or {rules []}}]
+  (let [now (java.time.Instant/now)
+        version (or version
+                    (let [date (java.time.LocalDate/now)]
+                      (format "%d.%02d.%02d"
+                              (.getYear date)
+                              (.getMonthValue date)
+                              (.getDayOfMonth date))))]
+    {:pack/id id
+     :pack/name name
+     :pack/version version
+     :pack/description description
+     :pack/author author
+     :pack/license license
+     :pack/categories []
+     :pack/rules (vec rules)
+     :pack/created-at now
+     :pack/updated-at now}))
+
+(defn add-rule-to-pack
+  "Add a rule to a pack.
+
+   Arguments:
+   - pack - PackManifest
+   - rule - Rule to add
+
+   Returns:
+   - Updated pack"
+  [pack rule]
+  (-> pack
+      (update :pack/rules conj rule)
+      (assoc :pack/updated-at (java.time.Instant/now))))
+
+(defn remove-rule-from-pack
+  "Remove a rule from a pack by ID.
+
+   Arguments:
+   - pack - PackManifest
+   - rule-id - Rule ID keyword
+
+   Returns:
+   - Updated pack"
+  [pack rule-id]
+  (-> pack
+      (update :pack/rules (fn [rules]
+                            (vec (remove #(= rule-id (:rule/id %)) rules))))
+      (assoc :pack/updated-at (java.time.Instant/now))))
+
+(defn update-pack-categories
+  "Update pack categories based on rules.
+
+   Automatically generates categories from rule category codes.
+
+   Arguments:
+   - pack - PackManifest
+
+   Returns:
+   - Updated pack with regenerated categories"
+  [pack]
+  (let [rules (:pack/rules pack)
+        by-category (group-by :rule/category rules)
+        categories (->> by-category
+                        (map (fn [[cat-id rules]]
+                               {:category/id cat-id
+                                :category/name (str "Category " cat-id)
+                                :category/rules (mapv :rule/id rules)}))
+                        (sort-by :category/id)
+                        vec)]
+    (assoc pack :pack/categories categories)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Rule checking orchestration
+
+(defn check-artifact
+  "Check an artifact against all applicable rules from a pack.
+
+   Arguments:
+   - pack - PackManifest (or vector of packs)
+   - artifact - Artifact to check
+   - context - Execution context
+
+   Returns:
+   - {:passed? bool
+      :violations [...]
+      :warnings [...]
+      :errors [...]}
+
+   Example:
+     (check-artifact pack
+                     {:artifact/content \"...\" :artifact/path \"main.tf\"}
+                     {:phase :implement})"
+  [pack artifact context]
+  (let [;; Handle single pack or vector of packs
+        packs (if (vector? pack) pack [pack])
+        all-rules (mapcat :pack/rules packs)
+        resolved (resolve-rules all-rules)
+        ctx (assoc context :artifact artifact)
+        applicable (filter-applicable-rules resolved ctx)
+        violations (detection/check-rules applicable artifact context)
+
+        ;; Classify violations
+        blocking (detection/blocking-violations violations)
+        approvals (detection/approval-required-violations violations)
+        warnings (detection/warning-violations violations)
+        audits (detection/audit-violations violations)]
+
+    {:passed? (empty? blocking)
+     :violations violations
+     :blocking (mapv detection/violation->error blocking)
+     :require-approval (mapv detection/violation->error approvals)
+     :warnings (mapv detection/violation->warning warnings)
+     :audits (mapv detection/violation->warning audits)}))
+
+(defn check-artifacts
+  "Check multiple artifacts against pack rules.
+
+   Arguments:
+   - pack - PackManifest (or vector of packs)
+   - artifacts - Vector of artifacts
+   - context - Execution context
+
+   Returns:
+   - Vector of check results, one per artifact"
+  [pack artifacts context]
+  (mapv #(check-artifact pack % context) artifacts))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Rule creation helpers
+
+(defn create-rule
+  "Create a new rule with required fields.
+
+   Arguments:
+   - id - Rule ID keyword (e.g., :310-import-preservation)
+   - title - Short title
+   - description - Full description
+   - severity - :critical, :major, :minor, or :info
+   - category - Dewey category string (e.g., \"310\")
+   - detection - Detection config map
+   - enforcement - Enforcement config map
+
+   Options:
+   - :applies-to - Applicability config
+   - :agent-behavior - Agent guidance string
+   - :examples - Vector of example maps
+
+   Returns:
+   - Rule map"
+  [id title description severity category detection enforcement
+   & {:keys [applies-to agent-behavior examples]}]
+  {:rule/id id
+   :rule/title title
+   :rule/description description
+   :rule/severity severity
+   :rule/category category
+   :rule/applies-to (or applies-to {})
+   :rule/detection detection
+   :rule/enforcement enforcement
+   :rule/agent-behavior agent-behavior
+   :rule/examples examples})
+
+(defn content-scan-detection
+  "Create a content-scan detection config.
+
+   Arguments:
+   - pattern - Regex pattern string or compiled pattern
+   - opts - Optional map with :context-lines
+
+   Returns:
+   - Detection config map"
+  ([pattern]
+   (content-scan-detection pattern {}))
+  ([pattern {:keys [context-lines] :or {context-lines 2}}]
+   {:type :content-scan
+    :pattern pattern
+    :context-lines context-lines}))
+
+(defn diff-analysis-detection
+  "Create a diff-analysis detection config.
+
+   Arguments:
+   - pattern - Regex pattern string or compiled pattern
+   - opts - Optional map with :context-lines
+
+   Returns:
+   - Detection config map"
+  ([pattern]
+   (diff-analysis-detection pattern {}))
+  ([pattern {:keys [context-lines] :or {context-lines 3}}]
+   {:type :diff-analysis
+    :pattern pattern
+    :context-lines context-lines}))
+
+(defn plan-output-detection
+  "Create a plan-output detection config.
+
+   Arguments:
+   - patterns - Vector of regex patterns
+
+   Returns:
+   - Detection config map"
+  [patterns]
+  {:type :plan-output
+   :patterns patterns})
+
+(defn warn-enforcement
+  "Create a warn-only enforcement config.
+
+   Arguments:
+   - message - Violation message
+
+   Returns:
+   - Enforcement config map"
+  [message]
+  {:action :warn
+   :message message})
+
+(defn halt-enforcement
+  "Create a hard-halt enforcement config.
+
+   Arguments:
+   - message - Violation message
+   - opts - Optional map with :remediation
+
+   Returns:
+   - Enforcement config map"
+  ([message]
+   (halt-enforcement message {}))
+  ([message {:keys [remediation]}]
+   (cond-> {:action :hard-halt
+            :message message}
+     remediation (assoc :remediation remediation))))
+
+(defn approval-enforcement
+  "Create a require-approval enforcement config.
+
+   Arguments:
+   - message - Violation message
+   - approvers - Vector of approver types
+
+   Returns:
+   - Enforcement config map"
+  [message approvers]
+  {:action :require-approval
+   :message message
+   :approvers approvers})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Test severity comparison
+  (compare-severity :critical :major)  ;; => -1 (critical more severe)
+  (more-severe :minor :major)          ;; => :major
+
+  ;; Test enforcement comparison
+  (compare-enforcement :hard-halt :warn)  ;; => -2 (hard-halt stricter)
+  (stricter-enforcement :warn :require-approval)  ;; => :require-approval
+
+  ;; Test rule merging
+  (merge-rules
+   {:rule/id :test
+    :rule/severity :major
+    :rule/enforcement {:action :warn :message "Warning"}}
+   {:rule/id :test
+    :rule/severity :minor  ; Less severe, but original keeps major
+    :rule/enforcement {:action :hard-halt :message "Halt"}})
+  ;; => severity stays :major, enforcement escalates to :hard-halt
+
+  ;; Create a pack
+  (def test-pack
+    (create-pack "test" "Test Pack" "A test" "author"
+                 :rules
+                 [(create-rule :no-todos
+                               "No TODOs"
+                               "Don't leave TODOs in code"
+                               :minor "800"
+                               (content-scan-detection "TODO")
+                               (warn-enforcement "Found TODO comment"))]))
+
+  ;; Check artifact
+  (check-artifact test-pack
+                  {:artifact/content "# TODO: fix this"
+                   :artifact/path "main.py"}
+                  {})
+
+  ;; Resolve rules from multiple packs
+  (resolve-rules
+   [{:rule/id :test :rule/severity :minor :rule/enforcement {:action :warn}}
+    {:rule/id :test :rule/severity :major :rule/enforcement {:action :hard-halt}}
+    {:rule/id :other :rule/severity :info :rule/enforcement {:action :audit}}])
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -1,0 +1,420 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.detection
+  "Rule violation detection implementations.
+
+   Layer 0: Pattern matching utilities
+   Layer 1: Detection type implementations
+   Layer 2: Unified detection dispatcher
+
+   Supports detection types:
+   - :content-scan - Regex against artifact content
+   - :diff-analysis - Regex against git diff
+   - :plan-output - Parse terraform plan output
+   - :custom - Custom detection function"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pattern matching utilities
+
+(defn- ensure-pattern
+  "Convert string or regex to compiled pattern."
+  [p]
+  (cond
+    (instance? java.util.regex.Pattern p) p
+    (string? p) (re-pattern p)
+    :else nil))
+
+(defn- find-matches
+  "Find all matches of a pattern in content.
+   Returns vector of {:match string :line int :column int :context string}."
+  [pattern content context-lines]
+  (when-let [pat (ensure-pattern pattern)]
+    (let [lines (str/split-lines content)
+          context-lines (or context-lines 2)]
+      (->> lines
+           (map-indexed vector)
+           (keep (fn [[idx line]]
+                   (when-let [match (re-find pat line)]
+                     (let [match-str (if (string? match) match (first match))
+                           start (max 0 (- idx context-lines))
+                           end (min (count lines) (+ idx context-lines 1))
+                           context-vec (subvec (vec lines) start end)]
+                       {:match match-str
+                        :line (inc idx)  ; 1-indexed
+                        :column (when-let [idx (str/index-of line match-str)]
+                                  (inc idx))
+                        :context (str/join "\n" context-vec)}))))
+           vec))))
+
+(defn- any-pattern-matches?
+  "Check if any of the patterns match the content.
+   Returns the first matching pattern's matches, or nil."
+  [patterns content context-lines]
+  (when (seq patterns)
+    (some (fn [p]
+            (let [matches (find-matches p content context-lines)]
+              (when (seq matches)
+                matches)))
+          patterns)))
+
+(defn- extract-patterns
+  "Extract pattern(s) from detection config.
+   Returns vector of patterns."
+  [detection]
+  (let [{:keys [pattern patterns]} detection]
+    (cond
+      (seq patterns) patterns
+      pattern [pattern]
+      :else [])))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Content scan detection
+
+(defn detect-content-scan
+  "Detect violations by scanning artifact content.
+
+   Looks for pattern matches in the artifact's content field.
+
+   Arguments:
+   - rule - Rule with :rule/detection config
+   - artifact - Artifact with :artifact/content
+   - context - Execution context (unused for content-scan)
+
+   Returns:
+   - Violation map if detected, nil otherwise"
+  [rule artifact _context]
+  (let [detection (:rule/detection rule)
+        content (:artifact/content artifact)
+        patterns (extract-patterns detection)
+        context-lines (:context-lines detection 2)]
+    (when (and content (seq patterns))
+      (when-let [matches (any-pattern-matches? patterns content context-lines)]
+        {:type :content-scan
+         :rule-id (:rule/id rule)
+         :matches matches
+         :artifact-path (:artifact/path artifact)
+         :message (get-in rule [:rule/enforcement :message])}))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Diff analysis detection
+
+(defn detect-diff-analysis
+  "Detect violations by analyzing git diff.
+
+   Looks for pattern matches in:
+   - The artifact's diff field (if present)
+   - The context's diff field
+
+   Useful for detecting removed lines, changed patterns, etc.
+
+   Arguments:
+   - rule - Rule with :rule/detection config
+   - artifact - Artifact with optional :artifact/diff
+   - context - Context with optional :diff
+
+   Returns:
+   - Violation map if detected, nil otherwise"
+  [rule artifact context]
+  (let [detection (:rule/detection rule)
+        ;; Diff can be on artifact or in context
+        diff (or (:artifact/diff artifact)
+                 (:diff context))
+        patterns (extract-patterns detection)
+        context-lines (:context-lines detection 3)]
+    (when (and diff (seq patterns))
+      (when-let [matches (any-pattern-matches? patterns diff context-lines)]
+        {:type :diff-analysis
+         :rule-id (:rule/id rule)
+         :matches matches
+         :artifact-path (:artifact/path artifact)
+         :message (get-in rule [:rule/enforcement :message])}))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Plan output detection
+
+(defn- parse-plan-resources
+  "Parse terraform plan output to extract resource changes.
+   Returns vector of {:action :resource :details}."
+  [plan-output]
+  (when plan-output
+    (let [;; Match lines like:
+          ;; "# aws_route.main will be destroyed"
+          ;; "# aws_subnet.private[0] must be replaced"
+          ;; "# aws_vpc.main will be created"
+          ;; "  -/+ aws_route.main (tainted)"
+          action-patterns
+          [{:pattern #"#\s+(\S+)\s+will be (created|destroyed|updated)"
+            :extractor (fn [[_ resource action]]
+                         {:resource resource
+                          :action (keyword action)})}
+           {:pattern #"#\s+(\S+)\s+must be (replaced)"
+            :extractor (fn [[_ resource action]]
+                         {:resource resource
+                          :action (keyword action)})}
+           {:pattern #"^\s*(-/\+|~|\+|-)\s+(\S+)"
+            :extractor (fn [[_ symbol resource]]
+                         {:resource resource
+                          :action (case symbol
+                                    "-/+" :replace
+                                    "~" :update
+                                    "+" :create
+                                    "-" :destroy
+                                    :unknown)})}]]
+      (->> (str/split-lines plan-output)
+           (mapcat (fn [line]
+                     (keep (fn [{:keys [pattern extractor]}]
+                             (when-let [match (re-find pattern line)]
+                               (assoc (extractor match)
+                                      :line line)))
+                           action-patterns)))
+           (distinct)
+           vec))))
+
+(defn detect-plan-output
+  "Detect violations by analyzing terraform plan output.
+
+   Parses plan output and checks for:
+   - Resource patterns matching replace/destroy actions
+   - Specific patterns in plan text
+
+   Arguments:
+   - rule - Rule with :rule/detection config
+   - artifact - Artifact (may contain plan output)
+   - context - Context with :terraform-plan
+
+   Returns:
+   - Violation map if detected, nil otherwise"
+  [rule artifact context]
+  (let [detection (:rule/detection rule)
+        plan-output (or (:terraform-plan context)
+                        (:artifact/content artifact))
+        patterns (extract-patterns detection)
+        resource-patterns (get-in rule [:rule/applies-to :resource-patterns])]
+    (when plan-output
+      ;; Two detection modes:
+      ;; 1. Pattern match against raw plan text
+      ;; 2. Parse plan and check resource changes
+      (let [pattern-matches (when (seq patterns)
+                              (any-pattern-matches? patterns plan-output 2))
+            ;; Parse resources and check for concerning actions
+            parsed (parse-plan-resources plan-output)
+            resource-violations
+            (when (and (seq resource-patterns) (seq parsed))
+              (->> parsed
+                   (filter (fn [{:keys [resource action]}]
+                             (and (#{:replace :destroy} action)
+                                  (some (fn [rp]
+                                          (re-find (ensure-pattern rp) resource))
+                                        resource-patterns))))
+                   seq))]
+        (when (or pattern-matches resource-violations)
+          {:type :plan-output
+           :rule-id (:rule/id rule)
+           :matches (or pattern-matches [])
+           :resource-violations (vec resource-violations)
+           :message (get-in rule [:rule/enforcement :message])})))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Custom detection
+
+(defn detect-custom
+  "Detect violations using a custom function.
+
+   The custom function is specified by symbol in :custom-fn and must:
+   - Accept [artifact context]
+   - Return violation map or nil
+
+   Arguments:
+   - rule - Rule with :rule/detection containing :custom-fn
+   - artifact - Artifact being checked
+   - context - Execution context
+
+   Returns:
+   - Violation map if detected, nil otherwise"
+  [rule artifact context]
+  (let [detection (:rule/detection rule)
+        custom-fn-sym (:custom-fn detection)]
+    (when custom-fn-sym
+      (try
+        ;; Attempt to resolve the function
+        (when-let [f (resolve custom-fn-sym)]
+          (when-let [result (f artifact context)]
+            (assoc result
+                   :type :custom
+                   :rule-id (:rule/id rule))))
+        (catch Exception e
+          ;; Return error as violation
+          {:type :custom-error
+           :rule-id (:rule/id rule)
+           :error (.getMessage e)
+           :message (str "Custom detection failed: " (.getMessage e))})))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Unified detection dispatcher
+
+(defn detect-violation
+  "Detect violations for a rule against an artifact.
+
+   Dispatches to the appropriate detection implementation based on
+   the rule's :rule/detection :type.
+
+   Arguments:
+   - rule - Rule with :rule/detection
+   - artifact - Artifact being validated
+   - context - Execution context map
+
+   Returns:
+   - Violation map if detected, nil otherwise.
+   - Violation map contains:
+     - :type - Detection type used
+     - :rule-id - Rule that was violated
+     - :matches - Pattern matches found
+     - :message - Enforcement message"
+  [rule artifact context]
+  (let [detection-type (get-in rule [:rule/detection :type])]
+    (case detection-type
+      :content-scan (detect-content-scan rule artifact context)
+      :diff-analysis (detect-diff-analysis rule artifact context)
+      :plan-output (detect-plan-output rule artifact context)
+      :custom (detect-custom rule artifact context)
+      ;; Unsupported types
+      :state-comparison nil  ; Not implemented
+      :ast-analysis nil       ; Not implemented
+      nil)))
+
+(defn check-rules
+  "Check multiple rules against an artifact.
+
+   Returns vector of violations found.
+
+   Arguments:
+   - rules - Vector of rules to check
+   - artifact - Artifact being validated
+   - context - Execution context
+
+   Returns:
+   - Vector of violation maps, each with :rule and :violation keys"
+  [rules artifact context]
+  (->> rules
+       (keep (fn [rule]
+               (when-let [violation (detect-violation rule artifact context)]
+                 {:rule rule
+                  :violation violation
+                  :timestamp (java.time.Instant/now)})))
+       vec))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Violation classification helpers
+
+(defn blocking-violations
+  "Filter violations that should block progress (:hard-halt enforcement)."
+  [violations]
+  (filter #(= :hard-halt (get-in % [:rule :rule/enforcement :action]))
+          violations))
+
+(defn approval-required-violations
+  "Filter violations that require approval."
+  [violations]
+  (filter #(= :require-approval (get-in % [:rule :rule/enforcement :action]))
+          violations))
+
+(defn warning-violations
+  "Filter violations that are warnings only."
+  [violations]
+  (filter #(= :warn (get-in % [:rule :rule/enforcement :action]))
+          violations))
+
+(defn audit-violations
+  "Filter violations that are audit-only."
+  [violations]
+  (filter #(= :audit (get-in % [:rule :rule/enforcement :action]))
+          violations))
+
+(defn violation->error
+  "Convert a violation to a gate error map."
+  [{:keys [rule violation]}]
+  {:code (:rule/id rule)
+   :message (:message violation)
+   :severity (:rule/severity rule)
+   :location {:matches (:matches violation)
+              :path (:artifact-path violation)}
+   :remediation (get-in rule [:rule/enforcement :remediation])})
+
+(defn violation->warning
+  "Convert a violation to a gate warning map."
+  [{:keys [rule violation]}]
+  {:code (:rule/id rule)
+   :message (:message violation)
+   :severity (:rule/severity rule)})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Test content scan detection
+  (detect-content-scan
+   {:rule/id :no-todos
+    :rule/detection {:type :content-scan
+                     :pattern "TODO"
+                     :context-lines 1}
+    :rule/enforcement {:action :warn
+                       :message "Found TODO"}}
+   {:artifact/content "def foo():\n    # TODO: implement\n    pass"
+    :artifact/path "main.py"}
+   {})
+  ;; => {:type :content-scan, :rule-id :no-todos, :matches [...], ...}
+
+  ;; Test diff analysis
+  (detect-diff-analysis
+   {:rule/id :310-import-block-preservation
+    :rule/detection {:type :diff-analysis
+                     :pattern "^-\\s*import\\s*\\{"
+                     :context-lines 3}
+    :rule/enforcement {:action :hard-halt
+                       :message "Cannot remove import blocks"}}
+   {:artifact/diff "- import {\n-   to = aws_s3_bucket.example\n- }"
+    :artifact/path "main.tf"}
+   {})
+
+  ;; Test plan output detection
+  (detect-plan-output
+   {:rule/id :320-network-recreation-block
+    :rule/detection {:type :plan-output
+                     :patterns ["-/\\+.*aws_route"]}
+    :rule/applies-to {:resource-patterns ["aws_route" "aws_subnet"]}
+    :rule/enforcement {:action :require-approval
+                       :message "Network resource recreation detected"}}
+   {}
+   {:terraform-plan "# aws_route.main will be replaced\n  -/+ aws_route.main"})
+
+  ;; Parse plan resources
+  (parse-plan-resources
+   "# aws_vpc.main will be created
+    # aws_subnet.private[0] will be destroyed
+    # aws_route.public must be replaced
+      -/+ aws_route.main (tainted)")
+
+  ;; Check multiple rules
+  (check-rules
+   [{:rule/id :no-todos
+     :rule/detection {:type :content-scan :pattern "TODO"}
+     :rule/enforcement {:action :warn :message "Found TODO"}}
+    {:rule/id :no-fixmes
+     :rule/detection {:type :content-scan :pattern "FIXME"}
+     :rule/enforcement {:action :warn :message "Found FIXME"}}]
+   {:artifact/content "# TODO: fix this\n# FIXME: broken"}
+   {})
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -1,0 +1,579 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.interface
+  "Public API for the policy-pack component.
+
+   Provides policy-as-code functionality:
+   - Pack and rule schemas
+   - Pack registry for CRUD and composition
+   - Pack loading from EDN files and directories
+   - Rule violation detection
+   - Artifact checking against packs
+
+   Layer 0: Schema re-exports
+   Layer 1: Registry operations
+   Layer 2: Loading operations
+   Layer 3: Detection and checking
+   Layer 4: Rule and pack builders"
+  (:require
+   [ai.miniforge.policy-pack.schema :as schema]
+   [ai.miniforge.policy-pack.registry :as registry]
+   [ai.miniforge.policy-pack.loader :as loader]
+   [ai.miniforge.policy-pack.detection :as detection]
+   [ai.miniforge.policy-pack.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema re-exports
+
+(def Rule
+  "Malli schema for a policy rule."
+  schema/Rule)
+
+(def PackManifest
+  "Malli schema for a policy pack manifest."
+  schema/PackManifest)
+
+(def RuleSeverity
+  "Malli schema for rule severity enum."
+  schema/RuleSeverity)
+
+(def RuleEnforcement
+  "Malli schema for enforcement action enum."
+  schema/RuleEnforcement)
+
+(def RuleApplicability
+  "Malli schema for rule applicability config."
+  schema/RuleApplicability)
+
+(def RuleDetection
+  "Malli schema for rule detection config."
+  schema/RuleDetection)
+
+;; Enum values for programmatic access
+(def rule-severities
+  "Rule severity levels: [:critical :major :minor :info]"
+  schema/rule-severities)
+
+(def enforcement-actions
+  "Enforcement actions: [:hard-halt :require-approval :warn :audit]"
+  schema/enforcement-actions)
+
+(def detection-types
+  "Detection types: [:plan-output :diff-analysis :state-comparison :content-scan :ast-analysis :custom]"
+  schema/detection-types)
+
+;------------------------------------------------------------------------------ Layer 0
+;; Validation functions
+
+(def valid-rule?
+  "Check if value is a valid Rule.
+   Returns boolean."
+  schema/valid-rule?)
+
+(def validate-rule
+  "Validate a rule against the schema.
+   Returns {:valid? bool :errors map-or-nil}."
+  schema/validate-rule)
+
+(def valid-pack?
+  "Check if value is a valid PackManifest.
+   Returns boolean."
+  schema/valid-pack?)
+
+(def validate-pack
+  "Validate a pack manifest against the schema.
+   Returns {:valid? bool :errors map-or-nil}."
+  schema/validate-pack)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registry protocol re-export
+
+(def PolicyPackRegistry
+  "Protocol for managing policy packs.
+
+   Methods:
+   - register-pack [this pack]
+   - get-pack [this pack-id]
+   - get-pack-version [this pack-id version]
+   - list-packs [this criteria]
+   - delete-pack [this pack-id version]
+   - import-pack [this source]
+   - export-pack [this pack-id version format]
+   - validate-pack [this pack]
+   - verify-signature [this pack]
+   - resolve-pack [this pack-id]
+   - get-rules-for-context [this pack-ids context]"
+  registry/PolicyPackRegistry)
+
+(def create-registry
+  "Create an in-memory policy pack registry.
+
+   Options:
+   - :logger - Logger instance for structured logging
+
+   Example:
+     (create-registry)
+     (create-registry {:logger my-logger})"
+  registry/create-registry)
+
+;; Registry operations delegated
+(defn register-pack
+  "Register a pack in the registry.
+   Returns the registered pack."
+  [registry pack]
+  (registry/register-pack registry pack))
+
+(defn get-pack
+  "Get latest version of a pack by ID.
+   Returns pack or nil."
+  [registry pack-id]
+  (registry/get-pack registry pack-id))
+
+(defn get-pack-version
+  "Get specific version of a pack.
+   Returns pack or nil."
+  [registry pack-id version]
+  (registry/get-pack-version registry pack-id version))
+
+(defn list-packs
+  "List packs matching criteria.
+   Criteria: {:category :author :search}"
+  [registry criteria]
+  (registry/list-packs registry criteria))
+
+(defn delete-pack
+  "Delete a pack version from registry.
+   Returns true if deleted."
+  [registry pack-id version]
+  (registry/delete-pack registry pack-id version))
+
+(defn resolve-pack
+  "Resolve a pack with all extensions merged.
+   Returns fully resolved pack."
+  [registry pack-id]
+  (registry/resolve-pack registry pack-id))
+
+(defn get-rules-for-context
+  "Get applicable rules for pack IDs and context.
+   Returns vector of applicable rules."
+  [registry pack-ids context]
+  (registry/get-rules-for-context registry pack-ids context))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Loading operations
+
+(def load-pack
+  "Load a policy pack, auto-detecting format.
+
+   Supports:
+   - Single EDN file (pack.edn or *.pack.edn)
+   - Directory with pack.edn manifest
+
+   Arguments:
+   - path - File or directory path
+
+   Returns:
+   - {:success? bool :pack PackManifest :errors [...]}
+
+   Example:
+     (load-pack \"terraform-safety.pack.edn\")
+     (load-pack \"./packs/terraform-safety/\")"
+  loader/load-pack)
+
+(def load-pack-from-file
+  "Load a policy pack from a single EDN file.
+
+   Arguments:
+   - file-path - Path to the .pack.edn file
+
+   Returns:
+   - {:success? bool :pack PackManifest :errors [...]}
+
+   Example:
+     (load-pack-from-file \"terraform-safety.pack.edn\")"
+  loader/load-pack-from-file)
+
+(def load-pack-from-directory
+  "Load a policy pack from a directory structure.
+
+   Expected structure:
+   ```
+   my-pack/
+   ├── pack.edn           # Pack manifest
+   └── rules/             # Optional separate rule files
+       └── ...
+   ```
+
+   Arguments:
+   - dir-path - Path to the pack directory
+
+   Returns:
+   - {:success? bool :pack PackManifest :errors [...]}
+
+   Example:
+     (load-pack-from-directory \"./packs/terraform-safety\")"
+  loader/load-pack-from-directory)
+
+(def discover-packs
+  "Discover all packs in a directory.
+
+   Arguments:
+   - packs-dir - Directory containing packs
+
+   Returns:
+   - Vector of {:path string :type :file|:directory}"
+  loader/discover-packs)
+
+(def load-all-packs
+  "Load all packs from a packs directory.
+
+   Arguments:
+   - packs-dir - Directory containing packs
+
+   Returns:
+   - {:loaded [PackManifest...] :failed [{:path :errors}...]}
+
+   Example:
+     (load-all-packs \".miniforge/packs\")"
+  loader/load-all-packs)
+
+(def write-pack-to-file
+  "Write a pack manifest to a single EDN file.
+
+   Arguments:
+   - pack - PackManifest
+   - file-path - Output file path
+
+   Returns:
+   - {:success? bool :error string}"
+  loader/write-pack-to-file)
+
+;------------------------------------------------------------------------------ Layer 3
+;; Detection and checking
+
+(def detect-violation
+  "Detect violations for a rule against an artifact.
+
+   Dispatches to the appropriate detection implementation based on
+   the rule's :rule/detection :type.
+
+   Arguments:
+   - rule - Rule with :rule/detection
+   - artifact - Artifact being validated
+   - context - Execution context map
+
+   Returns:
+   - Violation map if detected, nil otherwise."
+  detection/detect-violation)
+
+(def check-rules
+  "Check multiple rules against an artifact.
+
+   Arguments:
+   - rules - Vector of rules to check
+   - artifact - Artifact being validated
+   - context - Execution context
+
+   Returns:
+   - Vector of violation maps"
+  detection/check-rules)
+
+(def check-artifact
+  "Check an artifact against all applicable rules from pack(s).
+
+   Arguments:
+   - pack - PackManifest (or vector of packs)
+   - artifact - Artifact to check
+   - context - Execution context
+
+   Returns:
+   - {:passed? bool
+      :violations [...]
+      :blocking [...]
+      :require-approval [...]
+      :warnings [...]
+      :audits [...]}
+
+   Example:
+     (check-artifact pack
+                     {:artifact/content \"...\" :artifact/path \"main.tf\"}
+                     {:phase :implement})"
+  core/check-artifact)
+
+(def check-artifacts
+  "Check multiple artifacts against pack rules.
+
+   Arguments:
+   - pack - PackManifest (or vector of packs)
+   - artifacts - Vector of artifacts
+   - context - Execution context
+
+   Returns:
+   - Vector of check results, one per artifact"
+  core/check-artifacts)
+
+;; Violation classification helpers
+(def blocking-violations
+  "Filter violations that block progress (:hard-halt)."
+  detection/blocking-violations)
+
+(def approval-required-violations
+  "Filter violations requiring approval."
+  detection/approval-required-violations)
+
+(def warning-violations
+  "Filter warning-only violations."
+  detection/warning-violations)
+
+(def violation->error
+  "Convert violation to gate error map."
+  detection/violation->error)
+
+(def violation->warning
+  "Convert violation to gate warning map."
+  detection/violation->warning)
+
+;------------------------------------------------------------------------------ Layer 4
+;; Rule and pack builders
+
+(def create-pack
+  "Create a new policy pack with default values.
+
+   Arguments:
+   - id - Pack ID string
+   - name - Human-readable name
+   - description - Pack description
+   - author - Author string
+
+   Options:
+   - :version - DateVer string (default: today's date)
+   - :license - License string
+   - :rules - Vector of rules
+
+   Returns:
+   - PackManifest
+
+   Example:
+     (create-pack \"my-pack\" \"My Pack\" \"Description\" \"author\"
+                  :license \"Apache-2.0\"
+                  :rules [rule1 rule2])"
+  core/create-pack)
+
+(def create-rule
+  "Create a new rule with required fields.
+
+   Arguments:
+   - id - Rule ID keyword
+   - title - Short title
+   - description - Full description
+   - severity - :critical, :major, :minor, or :info
+   - category - Dewey category string
+   - detection - Detection config map
+   - enforcement - Enforcement config map
+
+   Options:
+   - :applies-to - Applicability config
+   - :agent-behavior - Agent guidance string
+   - :examples - Vector of example maps
+
+   Returns:
+   - Rule map
+
+   Example:
+     (create-rule :no-todos
+                  \"No TODOs\"
+                  \"Forbid TODO comments in production code\"
+                  :minor \"800\"
+                  (content-scan-detection \"TODO\")
+                  (warn-enforcement \"Found TODO comment\"))"
+  core/create-rule)
+
+(def add-rule-to-pack
+  "Add a rule to a pack. Returns updated pack."
+  core/add-rule-to-pack)
+
+(def remove-rule-from-pack
+  "Remove a rule from a pack by ID. Returns updated pack."
+  core/remove-rule-from-pack)
+
+(def update-pack-categories
+  "Regenerate pack categories from rules."
+  core/update-pack-categories)
+
+;; Detection config builders
+(def content-scan-detection
+  "Create a content-scan detection config.
+
+   Arguments:
+   - pattern - Regex pattern
+   - opts - Optional {:context-lines n}
+
+   Example:
+     (content-scan-detection \"TODO\")
+     (content-scan-detection \"FIXME\" {:context-lines 5})"
+  core/content-scan-detection)
+
+(def diff-analysis-detection
+  "Create a diff-analysis detection config.
+
+   Arguments:
+   - pattern - Regex pattern for diff content
+   - opts - Optional {:context-lines n}
+
+   Example:
+     (diff-analysis-detection \"^-\\\\s*import\\\\s*\\\\{\")"
+  core/diff-analysis-detection)
+
+(def plan-output-detection
+  "Create a plan-output detection config.
+
+   Arguments:
+   - patterns - Vector of regex patterns
+
+   Example:
+     (plan-output-detection [\"-/\\\\+.*aws_route\"])"
+  core/plan-output-detection)
+
+;; Enforcement config builders
+(def warn-enforcement
+  "Create a warn-only enforcement config.
+
+   Arguments:
+   - message - Violation message
+
+   Example:
+     (warn-enforcement \"Found TODO comment\")"
+  core/warn-enforcement)
+
+(def halt-enforcement
+  "Create a hard-halt enforcement config.
+
+   Arguments:
+   - message - Violation message
+   - opts - Optional {:remediation string}
+
+   Example:
+     (halt-enforcement \"Critical violation\"
+                       {:remediation \"Revert the change\"})"
+  core/halt-enforcement)
+
+(def approval-enforcement
+  "Create a require-approval enforcement config.
+
+   Arguments:
+   - message - Violation message
+   - approvers - Vector of approver types [:human :senior-engineer :security]
+
+   Example:
+     (approval-enforcement \"Network change detected\"
+                           [:human :senior-engineer])"
+  core/approval-enforcement)
+
+;------------------------------------------------------------------------------ Layer 4
+;; Rule resolution
+
+(def resolve-rules
+  "Resolve rules from multiple packs.
+
+   Resolution:
+   - Group by ID
+   - Merge with severity/enforcement escalation
+
+   Arguments:
+   - rules - Sequence of rules
+
+   Returns:
+   - Vector of resolved rules"
+  core/resolve-rules)
+
+(def merge-rules
+  "Merge two rules with the same ID.
+
+   Resolution:
+   - Override with escalation for severity and enforcement
+
+   Arguments:
+   - base - Original rule
+   - override - Overriding rule
+
+   Returns:
+   - Merged rule"
+  core/merge-rules)
+
+;------------------------------------------------------------------------------ Layer 4
+;; Utility functions
+
+(def glob-matches?
+  "Check if a glob pattern matches a path.
+
+   Arguments:
+   - pattern - Glob pattern (supports * and **)
+   - path - File path to match
+
+   Returns:
+   - boolean
+
+   Example:
+     (glob-matches? \"**/*.tf\" \"modules/vpc/main.tf\") ;; => true"
+  registry/glob-matches?)
+
+(def compare-versions
+  "Compare two DateVer version strings.
+
+   Returns negative if a < b, 0 if equal, positive if a > b.
+
+   Example:
+     (compare-versions \"2026.01.22\" \"2026.01.15\") ;; => 7"
+  registry/compare-versions)
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create a registry and add packs
+  (def reg (create-registry))
+
+  ;; Create a simple pack
+  (def my-pack
+    (create-pack "my-rules" "My Rules" "Custom rules" "me"
+                 :rules
+                 [(create-rule :no-todos
+                               "No TODOs"
+                               "Forbid TODO comments"
+                               :minor "800"
+                               (content-scan-detection "TODO")
+                               (warn-enforcement "Found TODO"))
+                  (create-rule :no-fixmes
+                               "No FIXMEs"
+                               "Forbid FIXME comments"
+                               :minor "800"
+                               (content-scan-detection "FIXME")
+                               (warn-enforcement "Found FIXME"))]))
+
+  ;; Register it
+  (register-pack reg my-pack)
+
+  ;; Check an artifact
+  (check-artifact my-pack
+                  {:artifact/content "# TODO: implement this\ndef foo(): pass"
+                   :artifact/path "main.py"}
+                  {:phase :implement})
+
+  ;; Load packs from disk
+  (load-pack "terraform-safety.pack.edn")
+  (load-all-packs ".miniforge/packs")
+
+  ;; Validate a pack
+  (validate-pack my-pack)
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/loader.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/loader.clj
@@ -1,0 +1,346 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.loader
+  "Load policy packs from EDN files and directory structures.
+
+   Layer 0: File discovery and path utilities
+   Layer 1: EDN parsing and validation
+   Layer 2: Single file and directory loaders
+   Layer 3: Pack loading orchestration
+
+   Supports two formats:
+   - Single EDN file: pack.edn or *.pack.edn
+   - Directory structure with pack.edn manifest and rules/ subdirectory"
+  (:require
+   [ai.miniforge.policy-pack.schema :as schema]
+   [clojure.java.io :as io]
+   [clojure.edn :as edn]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; File discovery and path utilities
+
+(defn- find-rule-files
+  "Find all rule .edn files in a rules/ directory, recursive."
+  [rules-dir]
+  (when (.exists (io/file rules-dir))
+    (->> (file-seq (io/file rules-dir))
+         (filter #(.isFile %))
+         (filter #(str/ends-with? (.getName %) ".edn")))))
+
+(defn- pack-file?
+  "Check if a file is a pack file (pack.edn or *.pack.edn)."
+  [file]
+  (let [name (.getName file)]
+    (or (= name "pack.edn")
+        (str/ends-with? name ".pack.edn"))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; EDN parsing and validation
+
+(defn- safe-read-edn
+  "Safely read EDN from a file.
+   Returns {:success? bool :data any :error string}."
+  [file]
+  (try
+    (let [content (slurp file)
+          data (edn/read-string content)]
+      {:success? true :data data :error nil})
+    (catch Exception e
+      {:success? false :data nil :error (.getMessage e)})))
+
+(defn- ensure-instant
+  "Convert various timestamp representations to Instant."
+  [value]
+  (cond
+    (inst? value) value
+    (string? value) (try
+                      (java.time.Instant/parse value)
+                      (catch Exception _
+                        (java.time.Instant/now)))
+    :else (java.time.Instant/now)))
+
+(defn- normalize-rule
+  "Normalize a rule, ensuring required fields and types."
+  [rule]
+  (-> rule
+      (update :rule/applies-to #(or % {}))
+      (update-in [:rule/applies-to :task-types]
+                 #(when % (if (set? %) % (set %))))
+      (update-in [:rule/applies-to :repo-types]
+                 #(when % (if (set? %) % (set %))))
+      (update-in [:rule/applies-to :phases]
+                 #(when % (if (set? %) % (set %))))))
+
+(defn- normalize-pack
+  "Normalize a pack, ensuring required fields and types."
+  [pack]
+  (-> pack
+      (update :pack/rules #(mapv normalize-rule (or % [])))
+      (update :pack/categories #(or % []))
+      (update :pack/created-at ensure-instant)
+      (update :pack/updated-at ensure-instant)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Single file loader
+
+(defn load-pack-from-file
+  "Load a policy pack from a single EDN file.
+
+   The file should contain a complete pack manifest with all rules inline.
+
+   Arguments:
+   - file-path - Path to the .pack.edn or pack.edn file
+
+   Returns:
+   - {:success? bool :pack PackManifest :errors [...]}
+
+   Example:
+     (load-pack-from-file \"terraform-safety.pack.edn\")"
+  [file-path]
+  (let [file (io/file file-path)]
+    (if (.exists file)
+      (let [{:keys [success? data error]} (safe-read-edn file)]
+        (if success?
+          (let [pack (normalize-pack data)
+                {:keys [valid? errors]} (schema/validate-pack pack)]
+            (if valid?
+              {:success? true :pack pack :errors nil}
+              {:success? false :pack nil :errors errors}))
+          {:success? false :pack nil :errors [{:file file-path :error error}]}))
+      {:success? false :pack nil :errors [{:file file-path :error "File not found"}]})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Directory structure loader
+
+(defn- load-rule-file
+  "Load a single rule from an EDN file."
+  [file]
+  (let [{:keys [success? data error]} (safe-read-edn file)]
+    (if success?
+      {:success? true :rule (normalize-rule data) :error nil}
+      {:success? false :rule nil :error error})))
+
+(defn load-pack-from-directory
+  "Load a policy pack from a directory structure.
+
+   Expected structure:
+   ```
+   my-pack/
+   ├── pack.edn           # Pack manifest (rules can be inline or in rules/)
+   ├── rules/             # Optional separate rule files
+   │   ├── 310-import-safety/
+   │   │   ├── 310-import-block-preservation.edn
+   │   │   └── 311-import-no-creates.edn
+   │   └── 320-network-safety/
+   │       └── 320-network-recreation-block.edn
+   └── examples/          # Optional test examples
+       └── ...
+   ```
+
+   Arguments:
+   - dir-path - Path to the pack directory
+
+   Returns:
+   - {:success? bool :pack PackManifest :errors [...]}
+
+   Example:
+     (load-pack-from-directory \"./packs/terraform-safety\")"
+  [dir-path]
+  (let [dir (io/file dir-path)
+        manifest-file (io/file dir "pack.edn")
+        rules-dir (io/file dir "rules")]
+
+    (cond
+      (not (.exists dir))
+      {:success? false :pack nil :errors [{:dir dir-path :error "Directory not found"}]}
+
+      (not (.exists manifest-file))
+      {:success? false :pack nil :errors [{:file "pack.edn" :error "Manifest not found in directory"}]}
+
+      :else
+      (let [{:keys [success? data error]} (safe-read-edn manifest-file)]
+        (if-not success?
+          {:success? false :pack nil :errors [{:file "pack.edn" :error error}]}
+
+          ;; Load rules from rules/ directory if it exists
+          (let [rule-files (when (.exists rules-dir)
+                             (find-rule-files rules-dir))
+                rule-results (mapv load-rule-file rule-files)
+                successful-rules (keep :rule (filter :success? rule-results))
+                rule-errors (keep (fn [r]
+                                    (when-not (:success? r)
+                                      {:error (:error r)}))
+                                  rule-results)
+
+                ;; Merge rules: inline rules + directory rules
+                ;; Directory rules override inline rules with same ID
+                inline-rules (:pack/rules data [])
+                inline-by-id (zipmap (map :rule/id inline-rules) inline-rules)
+                dir-by-id (zipmap (map :rule/id successful-rules) successful-rules)
+                merged-rules (vals (merge inline-by-id dir-by-id))
+
+                pack (-> data
+                         (assoc :pack/rules (vec merged-rules))
+                         normalize-pack)
+
+                {:keys [valid? errors]} (schema/validate-pack pack)]
+
+            (if valid?
+              {:success? true
+               :pack pack
+               :errors (when (seq rule-errors) rule-errors)}
+              {:success? false
+               :pack nil
+               :errors (concat errors rule-errors)})))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Auto-detect and load
+
+(defn load-pack
+  "Load a policy pack, auto-detecting format.
+
+   Supports:
+   - Single EDN file (pack.edn or *.pack.edn)
+   - Directory with pack.edn manifest
+
+   Arguments:
+   - path - File or directory path
+
+   Returns:
+   - {:success? bool :pack PackManifest :errors [...]}
+
+   Example:
+     (load-pack \"terraform-safety.pack.edn\")
+     (load-pack \"./packs/terraform-safety/\")"
+  [path]
+  (let [file (io/file path)]
+    (cond
+      (not (.exists file))
+      {:success? false :pack nil :errors [{:path path :error "Path not found"}]}
+
+      (.isFile file)
+      (load-pack-from-file path)
+
+      (.isDirectory file)
+      (load-pack-from-directory path)
+
+      :else
+      {:success? false :pack nil :errors [{:path path :error "Unknown path type"}]})))
+
+(defn discover-packs
+  "Discover all packs in a directory.
+
+   Looks for:
+   - *.pack.edn files
+   - Subdirectories containing pack.edn
+
+   Arguments:
+   - packs-dir - Directory containing packs
+
+   Returns:
+   - Vector of {:path string :type :file|:directory}"
+  [packs-dir]
+  (let [dir (io/file packs-dir)]
+    (when (.exists dir)
+      (let [;; Find *.pack.edn files
+            pack-files (->> (.listFiles dir)
+                            (filter #(.isFile %))
+                            (filter pack-file?)
+                            (map (fn [f]
+                                   {:path (.getPath f)
+                                    :type :file})))
+            ;; Find subdirectories with pack.edn
+            pack-dirs (->> (.listFiles dir)
+                           (filter #(.isDirectory %))
+                           (filter #(.exists (io/file % "pack.edn")))
+                           (map (fn [d]
+                                  {:path (.getPath d)
+                                   :type :directory})))]
+        (vec (concat pack-files pack-dirs))))))
+
+(defn load-all-packs
+  "Load all packs from a packs directory.
+
+   Arguments:
+   - packs-dir - Directory containing packs
+
+   Returns:
+   - {:loaded [PackManifest...] :failed [{:path :errors}...]}
+
+   Example:
+     (load-all-packs \".miniforge/packs\")"
+  [packs-dir]
+  (let [discovered (discover-packs packs-dir)
+        results (map (fn [{:keys [path]}]
+                       (assoc (load-pack path) :path path))
+                     discovered)]
+    {:loaded (vec (keep :pack (filter :success? results)))
+     :failed (vec (map #(select-keys % [:path :errors])
+                       (remove :success? results)))}))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Pack writing
+
+(defn write-pack-to-file
+  "Write a pack manifest to a single EDN file.
+
+   Arguments:
+   - pack - PackManifest
+   - file-path - Output file path
+
+   Returns:
+   - {:success? bool :error string}"
+  [pack file-path]
+  (try
+    (let [content (with-out-str
+                    (clojure.pprint/pprint pack))]
+      (spit file-path content)
+      {:success? true :error nil})
+    (catch Exception e
+      {:success? false :error (.getMessage e)})))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Load pack from single file
+  (load-pack-from-file "terraform-safety.pack.edn")
+
+  ;; Load pack from directory
+  (load-pack-from-directory "./packs/terraform-safety")
+
+  ;; Auto-detect and load
+  (load-pack "./packs/terraform-safety.pack.edn")
+  (load-pack "./packs/terraform-safety/")
+
+  ;; Discover all packs
+  (discover-packs ".miniforge/packs")
+  ;; => [{:path ".miniforge/packs/terraform-safety.pack.edn" :type :file}
+  ;;     {:path ".miniforge/packs/kubernetes/" :type :directory}]
+
+  ;; Load all packs
+  (load-all-packs ".miniforge/packs")
+  ;; => {:loaded [...] :failed [...]}
+
+  ;; Test normalization
+  (normalize-rule {:rule/id :test
+                   :rule/title "Test"
+                   :rule/description "Desc"
+                   :rule/severity :major
+                   :rule/category "300"
+                   :rule/applies-to {:task-types [:import]}  ; vector, not set
+                   :rule/detection {:type :content-scan}
+                   :rule/enforcement {:action :warn :message "Warning"}})
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
@@ -1,0 +1,379 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.registry
+  "Policy pack registry protocol and in-memory implementation.
+
+   Layer 0: Protocol definition
+   Layer 1: In-memory registry implementation
+   Layer 2: Registry constructors"
+  (:require
+   [ai.miniforge.policy-pack.schema :as schema]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Protocol definition
+
+(defprotocol PolicyPackRegistry
+  "Protocol for managing policy packs.
+
+   Provides CRUD operations, import/export, validation,
+   and composition capabilities for policy packs."
+
+  ;; CRUD
+  (register-pack [this pack]
+    "Register a new pack or new version of existing pack.
+     Returns the registered pack.")
+
+  (get-pack [this pack-id]
+    "Get latest version of pack.
+     Returns pack or nil if not found.")
+
+  (get-pack-version [this pack-id version]
+    "Get specific version of pack.
+     Returns pack or nil if not found.")
+
+  (list-packs [this criteria]
+    "List packs matching criteria.
+     Criteria map:
+     - :category - Filter by category prefix
+     - :author - Filter by author
+     - :search - Text search in name/description
+     Returns vector of pack summaries.")
+
+  (delete-pack [this pack-id version]
+    "Remove a pack version.
+     Returns true if deleted, false if not found.")
+
+  ;; Import/Export
+  (import-pack [this source]
+    "Import pack from URL, file path, or git repo.
+     Source can be:
+     - String file path
+     - Map with :type (:file, :url, :git)
+     Returns imported pack or throws.")
+
+  (export-pack [this pack-id version format]
+    "Export pack to specified format.
+     Format: :edn, :json, or :directory
+     Returns exported data as string or map.")
+
+  ;; Validation
+  (validate-pack [this pack]
+    "Validate pack schema and rule consistency.
+     Returns {:valid? bool :errors [...]}.")
+
+  (verify-signature [this pack]
+    "Verify pack signature (paid feature).
+     Returns {:verified? bool :signer string :timestamp inst}.")
+
+  ;; Composition
+  (resolve-pack [this pack-id]
+    "Resolve pack with all extended packs merged.
+     Returns fully resolved pack with inherited rules.")
+
+  (get-rules-for-context [this pack-ids context]
+    "Get applicable rules given task context.
+     Context map should contain:
+     - :task - Task map with :task/intent
+     - :artifact - Artifact being checked
+     - :repo - Repository metadata
+     - :phase - Current workflow phase
+     Returns vector of applicable rules."))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Version comparison helpers
+
+(defn parse-datever
+  "Parse DateVer string (YYYY.MM.DD) into comparable vector."
+  [version-str]
+  (when version-str
+    (try
+      (mapv parse-long (str/split version-str #"\."))
+      (catch Exception _
+        nil))))
+
+(defn compare-versions
+  "Compare two DateVer version strings.
+   Returns negative if a < b, 0 if equal, positive if a > b."
+  [a b]
+  (let [va (or (parse-datever a) [0 0 0])
+        vb (or (parse-datever b) [0 0 0])]
+    (compare va vb)))
+
+(defn latest-version
+  "Get the latest version from a collection of version strings."
+  [versions]
+  (when (seq versions)
+    (first (sort-by identity (comparator #(pos? (compare-versions %1 %2))) versions))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Rule applicability checking
+
+(defn glob-matches?
+  "Simple glob pattern matching.
+   Supports * (any within segment) and ** (any path segments)."
+  [pattern path]
+  (let [regex-pattern (-> pattern
+                          (str/replace "." "\\.")
+                          (str/replace "**" "<<<GLOBSTAR>>>")
+                          (str/replace "*" "[^/]*")
+                          (str/replace "<<<GLOBSTAR>>>" ".*")
+                          (str "^" "$"))]
+    (try
+      (boolean (re-matches (re-pattern regex-pattern) path))
+      (catch Exception _
+        false))))
+
+(defn rule-applies?
+  "Check if a rule applies to the given context.
+
+   Context map:
+   - :task - Task with :task/intent containing :intent/type
+   - :artifact - Artifact with :artifact/path, :artifact/type
+   - :repo - Repository with :repo/type
+   - :phase - Current workflow phase keyword"
+  [rule context]
+  (let [{:keys [task-types file-globs resource-patterns repo-types phases]}
+        (:rule/applies-to rule)]
+    (and
+     ;; Task type filter
+     (or (nil? task-types)
+         (empty? task-types)
+         (contains? task-types (get-in context [:task :task/intent :intent/type])))
+
+     ;; File glob filter
+     (or (nil? file-globs)
+         (empty? file-globs)
+         (let [path (get-in context [:artifact :artifact/path] "")]
+           (some #(glob-matches? % path) file-globs)))
+
+     ;; Repo type filter
+     (or (nil? repo-types)
+         (empty? repo-types)
+         (contains? repo-types (get-in context [:repo :repo/type])))
+
+     ;; Phase filter
+     (or (nil? phases)
+         (empty? phases)
+         (contains? phases (:phase context))))))
+
+(defn dedupe-by-id
+  "Remove duplicate rules, keeping the last occurrence (later pack wins)."
+  [rules]
+  (vals (reduce (fn [acc rule]
+                  (assoc acc (:rule/id rule) rule))
+                {}
+                rules)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; In-memory registry implementation
+
+(defrecord InMemoryPackRegistry [state]
+  PolicyPackRegistry
+
+  (register-pack [_this pack]
+    (let [{:keys [valid? errors]} (schema/validate-pack pack)]
+      (if valid?
+        (let [pack-id (:pack/id pack)
+              version (:pack/version pack)]
+          (swap! state assoc-in [:packs pack-id version] pack)
+          pack)
+        (throw (ex-info "Invalid pack schema"
+                        {:errors errors
+                         :pack-id (:pack/id pack)})))))
+
+  (get-pack [this pack-id]
+    (let [versions (get-in @state [:packs pack-id])]
+      (when (seq versions)
+        (let [latest (latest-version (keys versions))]
+          (get-pack-version this pack-id latest)))))
+
+  (get-pack-version [_this pack-id version]
+    (get-in @state [:packs pack-id version]))
+
+  (list-packs [_this criteria]
+    (let [{:keys [category author search]} criteria
+          all-packs (for [[_pack-id versions] (:packs @state)
+                          [_version pack] versions]
+                      pack)]
+      (->> all-packs
+           (filter (fn [pack]
+                     (and (or (nil? category)
+                              (some #(str/starts-with? (:category/id %) category)
+                                    (:pack/categories pack)))
+                          (or (nil? author)
+                              (= author (:pack/author pack)))
+                          (or (nil? search)
+                              (str/includes? (str/lower-case (:pack/name pack ""))
+                                             (str/lower-case search))
+                              (str/includes? (str/lower-case (:pack/description pack ""))
+                                             (str/lower-case search))))))
+           ;; Return summaries
+           (map (fn [pack]
+                  {:pack/id (:pack/id pack)
+                   :pack/name (:pack/name pack)
+                   :pack/version (:pack/version pack)
+                   :pack/author (:pack/author pack)
+                   :pack/description (:pack/description pack)
+                   :rule-count (count (:pack/rules pack))}))
+           (distinct)
+           vec)))
+
+  (delete-pack [_this pack-id version]
+    (if (get-in @state [:packs pack-id version])
+      (do
+        (swap! state update-in [:packs pack-id] dissoc version)
+        ;; Clean up empty pack-id entry
+        (when (empty? (get-in @state [:packs pack-id]))
+          (swap! state update :packs dissoc pack-id))
+        true)
+      false))
+
+  (import-pack [this source]
+    ;; Delegate to loader - this is a placeholder
+    ;; Real implementation would handle :file, :url, :git sources
+    (if (map? source)
+      ;; Assume source is already a pack map
+      (register-pack this source)
+      ;; String path - would need loader integration
+      (throw (ex-info "File/URL import not implemented in registry"
+                      {:source source
+                       :hint "Use loader/load-pack-from-file instead"}))))
+
+  (export-pack [_this pack-id version format]
+    (if-let [pack (get-in @state [:packs pack-id version])]
+      (case format
+        :edn (pr-str pack)
+        :json (throw (ex-info "JSON export not implemented" {:format format}))
+        :directory (throw (ex-info "Directory export not implemented" {:format format}))
+        (throw (ex-info "Unknown export format" {:format format})))
+      (throw (ex-info "Pack not found"
+                      {:pack-id pack-id
+                       :version version}))))
+
+  (validate-pack [_this pack]
+    (schema/validate-pack pack))
+
+  (verify-signature [_this pack]
+    ;; Signature verification is a paid feature - stub implementation
+    (if (:pack/signature pack)
+      {:verified? false
+       :reason "Signature verification not implemented (paid feature)"
+       :signer (:pack/signed-by pack)
+       :timestamp (:pack/signed-at pack)}
+      {:verified? false
+       :reason "Pack is not signed"}))
+
+  (resolve-pack [this pack-id]
+    (when-let [pack (get-pack this pack-id)]
+      (if-let [extends (:pack/extends pack)]
+        ;; Recursively resolve parent packs and merge
+        (let [parent-rules (mapcat (fn [{:keys [pack-id]}]
+                                     (when-let [parent (resolve-pack this pack-id)]
+                                       (:pack/rules parent)))
+                                   extends)
+              ;; Child rules override parent rules by ID
+              child-rules (:pack/rules pack)
+              child-ids (set (map :rule/id child-rules))
+              merged-rules (concat
+                            (remove #(child-ids (:rule/id %)) parent-rules)
+                            child-rules)]
+          (assoc pack :pack/rules (vec merged-rules)))
+        ;; No extensions, return as-is
+        pack)))
+
+  (get-rules-for-context [this pack-ids context]
+    (let [resolved-packs (keep #(resolve-pack this %) pack-ids)
+          all-rules (mapcat :pack/rules resolved-packs)]
+      (->> all-rules
+           (filter #(rule-applies? % context))
+           (dedupe-by-id)
+           vec))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry constructors
+
+(defn create-registry
+  "Create an in-memory policy pack registry.
+
+   Options:
+   - :logger - Logger instance for structured logging
+
+   Example:
+     (create-registry)
+     (create-registry {:logger my-logger})"
+  ([]
+   (create-registry {}))
+  ([_opts]
+   (->InMemoryPackRegistry (atom {:packs {}}))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create registry
+  (def reg (create-registry))
+
+  ;; Register a pack
+  (register-pack reg
+                 {:pack/id "test-pack"
+                  :pack/name "Test Pack"
+                  :pack/version "2026.01.22"
+                  :pack/description "A test policy pack"
+                  :pack/author "test-author"
+                  :pack/categories [{:category/id "300"
+                                     :category/name "Infrastructure"
+                                     :category/rules [:test-rule]}]
+                  :pack/rules [{:rule/id :test-rule
+                                :rule/title "Test Rule"
+                                :rule/description "A test rule"
+                                :rule/severity :major
+                                :rule/category "300"
+                                :rule/applies-to {}
+                                :rule/detection {:type :content-scan
+                                                 :pattern "TODO"}
+                                :rule/enforcement {:action :warn
+                                                   :message "Found TODO"}}]
+                  :pack/created-at (java.time.Instant/now)
+                  :pack/updated-at (java.time.Instant/now)})
+
+  ;; Get pack
+  (get-pack reg "test-pack")
+
+  ;; List packs
+  (list-packs reg {:author "test-author"})
+
+  ;; Get applicable rules
+  (get-rules-for-context reg
+                         ["test-pack"]
+                         {:artifact {:artifact/path "main.tf"}
+                          :phase :implement})
+
+  ;; Version comparison
+  (compare-versions "2026.01.22" "2026.01.15")
+  ;; => 7 (positive, first is later)
+
+  (latest-version ["2025.12.01" "2026.01.22" "2026.01.15"])
+  ;; => "2026.01.22"
+
+  ;; Glob matching
+  (glob-matches? "**/*.tf" "modules/vpc/main.tf")
+  ;; => true
+
+  (glob-matches? "*.tf" "main.tf")
+  ;; => true
+
+  (glob-matches? "*.tf" "modules/main.tf")
+  ;; => false
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -1,0 +1,302 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.schema
+  "Malli schemas for policy packs and rules.
+
+   Layer 0: Enums and base types
+   Layer 1: Rule component schemas (applicability, detection, enforcement)
+   Layer 2: Rule and PackManifest schemas
+
+   Based on policy-pack.spec"
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Enums and base types
+
+(def rule-severities
+  "Rule severity levels, ordered from most to least severe."
+  [:critical :major :minor :info])
+
+(def RuleSeverity
+  "Schema for rule severity enum."
+  (into [:enum] rule-severities))
+
+(def enforcement-actions
+  "Enforcement actions, ordered from strictest to most lenient."
+  [:hard-halt :require-approval :warn :audit])
+
+(def RuleEnforcement
+  "Schema for enforcement action enum."
+  (into [:enum] enforcement-actions))
+
+(def detection-types
+  "Types of violation detection."
+  [:plan-output :diff-analysis :state-comparison :content-scan :ast-analysis :custom])
+
+(def DetectionType
+  "Schema for detection type enum."
+  (into [:enum] detection-types))
+
+(def task-types
+  "Task types that rules can apply to."
+  [:create :import :modify :delete :migrate])
+
+(def TaskType
+  "Schema for task type enum."
+  (into [:enum] task-types))
+
+(def repo-types
+  "Repository types for rule applicability."
+  [:terraform-module :terraform-live :kubernetes :argocd :application])
+
+(def RepoType
+  "Schema for repository type enum."
+  (into [:enum] repo-types))
+
+(def approver-types
+  "Types of approvers for require-approval enforcement."
+  [:human :senior-engineer :security])
+
+(def ApproverType
+  "Schema for approver type enum."
+  (into [:enum] approver-types))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rule component schemas
+
+(def RuleApplicability
+  "Schema for when a rule applies.
+
+   All fields are optional - if omitted, rule applies to all matching contexts."
+  [:map
+   [:task-types {:optional true} [:set TaskType]]
+   [:file-globs {:optional true} [:vector string?]]
+   [:resource-patterns {:optional true} [:vector [:or string? [:re {:error/message "should be a regex pattern"}]]]]
+   [:repo-types {:optional true} [:set RepoType]]
+   [:phases {:optional true} [:set keyword?]]])
+
+(def RuleDetection
+  "Schema for how to detect violations.
+
+   Required:
+   - :type - Detection mechanism
+
+   Optional:
+   - :pattern - Single regex pattern
+   - :patterns - Multiple regex patterns
+   - :context-lines - Lines of context to include
+   - :custom-fn - Symbol for custom detection function"
+  [:map
+   [:type DetectionType]
+   [:pattern {:optional true} [:or string? [:re {:error/message "should be a regex pattern"}]]]
+   [:patterns {:optional true} [:vector [:or string? [:re {:error/message "should be a regex pattern"}]]]]
+   [:context-lines {:optional true} pos-int?]
+   [:custom-fn {:optional true} symbol?]])
+
+(def RuleEnforcementConfig
+  "Schema for what happens when a rule is violated.
+
+   Required:
+   - :action - The enforcement action to take
+   - :message - Human-readable violation message
+
+   Optional:
+   - :remediation - Suggested fix
+   - :approvers - Required approvers for :require-approval action"
+  [:map
+   [:action RuleEnforcement]
+   [:message string?]
+   [:remediation {:optional true} string?]
+   [:approvers {:optional true} [:vector ApproverType]]])
+
+(def RuleExample
+  "Schema for rule test examples.
+
+   Examples serve as both documentation and test cases."
+  [:map
+   [:description string?]
+   [:input string?]
+   [:expected [:enum :pass :fail]]
+   [:explanation {:optional true} string?]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; Rule and Pack schemas
+
+(def Rule
+  "Schema for an individual policy rule.
+
+   Rules define:
+   - What to check (applicability)
+   - How to detect violations (detection)
+   - What to do when violated (enforcement)
+   - Examples for testing and documentation"
+  [:map
+   ;; Identity
+   [:rule/id keyword?]
+   [:rule/title string?]
+   [:rule/description string?]
+   [:rule/severity RuleSeverity]
+   [:rule/category string?]
+
+   ;; When does this rule apply?
+   [:rule/applies-to RuleApplicability]
+
+   ;; How to detect violations
+   [:rule/detection RuleDetection]
+
+   ;; Agent guidance (critical for correct interpretation)
+   [:rule/agent-behavior {:optional true} string?]
+
+   ;; What happens when violated
+   [:rule/enforcement RuleEnforcementConfig]
+
+   ;; Examples (for documentation and testing)
+   [:rule/examples {:optional true} [:vector RuleExample]]
+
+   ;; Metadata
+   [:rule/version {:optional true} string?]
+   [:rule/author {:optional true} string?]
+   [:rule/references {:optional true} [:vector string?]]])
+
+(def PackCategory
+  "Schema for a category within a pack."
+  [:map
+   [:category/id string?]
+   [:category/name string?]
+   [:category/rules [:vector keyword?]]])
+
+(def PackDependency
+  "Schema for pack extension/dependency."
+  [:map
+   [:pack-id string?]
+   [:version-constraint {:optional true} string?]])
+
+(def PackManifest
+  "Schema for a policy pack manifest.
+
+   Packs are versioned collections of rules that can be:
+   - Authored and shared
+   - Extended from other packs
+   - Signed for trust (paid feature)"
+  [:map
+   ;; Identity
+   [:pack/id string?]
+   [:pack/name string?]
+   [:pack/version string?]
+   [:pack/description string?]
+   [:pack/author string?]
+
+   ;; Optional metadata
+   [:pack/license {:optional true} string?]
+   [:pack/homepage {:optional true} string?]
+   [:pack/repository {:optional true} string?]
+
+   ;; Signing (paid feature)
+   [:pack/signature {:optional true} string?]
+   [:pack/signed-by {:optional true} string?]
+   [:pack/signed-at {:optional true} inst?]
+
+   ;; Dependencies
+   [:pack/extends {:optional true} [:vector PackDependency]]
+
+   ;; Organization
+   [:pack/categories [:vector PackCategory]]
+
+   ;; The actual rules
+   [:pack/rules [:vector Rule]]
+
+   ;; Timestamps
+   [:pack/created-at inst?]
+   [:pack/updated-at inst?]
+   [:pack/changelog {:optional true} string?]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; Validation helpers
+
+(defn valid?
+  "Check if value validates against schema."
+  [schema value]
+  (m/validate schema value))
+
+(defn validate
+  "Validate value against schema.
+   Returns {:valid? bool :errors map-or-nil}."
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn explain
+  "Return human-readable explanation of validation errors, or nil if valid."
+  [schema value]
+  (when-let [explanation (m/explain schema value)]
+    (me/humanize explanation)))
+
+(defn valid-rule?
+  "Check if value is a valid Rule."
+  [value]
+  (valid? Rule value))
+
+(defn validate-rule
+  "Validate a rule. Returns {:valid? bool :errors ...}."
+  [value]
+  (validate Rule value))
+
+(defn valid-pack?
+  "Check if value is a valid PackManifest."
+  [value]
+  (valid? PackManifest value))
+
+(defn validate-pack
+  "Validate a pack manifest. Returns {:valid? bool :errors ...}."
+  [value]
+  (validate PackManifest value))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Validate a rule
+  (valid-rule?
+   {:rule/id :310-import-block-preservation
+    :rule/title "Preserve import blocks"
+    :rule/description "Never remove import blocks during IMPORT tasks"
+    :rule/severity :critical
+    :rule/category "310"
+    :rule/applies-to {:task-types #{:import}
+                      :file-globs ["**/*.tf"]}
+    :rule/detection {:type :diff-analysis
+                     :pattern "^-\\s*import\\s*\\{"}
+    :rule/enforcement {:action :hard-halt
+                       :message "Cannot remove import blocks"}})
+  ;; => true
+
+  ;; Validate a pack
+  (validate-pack
+   {:pack/id "test-pack"
+    :pack/name "Test Pack"
+    :pack/version "2026.01.22"
+    :pack/description "A test pack"
+    :pack/author "test"
+    :pack/categories []
+    :pack/rules []
+    :pack/created-at (java.time.Instant/now)
+    :pack/updated-at (java.time.Instant/now)})
+
+  ;; Get validation errors
+  (explain Rule {:rule/id "not-a-keyword"})
+
+  :leave-this-here)

--- a/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
@@ -1,0 +1,229 @@
+(ns ai.miniforge.policy-pack.detection-test
+  "Tests for the policy-pack detection logic."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.policy-pack.detection :as detection]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Content scan detection tests
+
+(deftest content-scan-test
+  (testing "Detects pattern in content"
+    (let [rule {:rule/id :no-todos
+                :rule/detection {:type :content-scan
+                                 :pattern "TODO"
+                                 :context-lines 1}
+                :rule/enforcement {:action :warn
+                                   :message "Found TODO"}}
+          artifact {:artifact/content "# TODO: implement this\ndef foo(): pass"
+                    :artifact/path "main.py"}
+          result (detection/detect-content-scan rule artifact {})]
+      (is (some? result))
+      (is (= :content-scan (:type result)))
+      (is (= :no-todos (:rule-id result)))
+      (is (= 1 (count (:matches result))))))
+
+  (testing "No match returns nil"
+    (let [rule {:rule/id :no-todos
+                :rule/detection {:type :content-scan
+                                 :pattern "TODO"}}
+          artifact {:artifact/content "# Clean code here"
+                    :artifact/path "main.py"}]
+      (is (nil? (detection/detect-content-scan rule artifact {})))))
+
+  (testing "Multiple patterns - any match triggers"
+    (let [rule {:rule/id :no-debug
+                :rule/detection {:type :content-scan
+                                 :patterns ["console.log" "debugger"]}
+                :rule/enforcement {:action :warn :message "Debug code found"}}
+          artifact {:artifact/content "debugger;\nlet x = 1;"}]
+      (is (some? (detection/detect-content-scan rule artifact {})))))
+
+  (testing "Match includes context lines"
+    (let [rule {:rule/id :test
+                :rule/detection {:type :content-scan
+                                 :pattern "ERROR"
+                                 :context-lines 2}
+                :rule/enforcement {:action :warn :message "Error"}}
+          artifact {:artifact/content "line1\nline2\nERROR here\nline4\nline5"}]
+      (let [result (detection/detect-content-scan rule artifact {})
+            match (first (:matches result))]
+        (is (= 3 (:line match)))
+        (is (clojure.string/includes? (:context match) "line2"))
+        (is (clojure.string/includes? (:context match) "line4"))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Diff analysis detection tests
+
+(deftest diff-analysis-test
+  (testing "Detects pattern in diff"
+    (let [rule {:rule/id :import-removal
+                :rule/detection {:type :diff-analysis
+                                 :pattern "^-\\s*import\\s*\\{"
+                                 :context-lines 3}
+                :rule/enforcement {:action :hard-halt
+                                   :message "Cannot remove import blocks"}}
+          artifact {:artifact/diff "- import {\n-   to = aws_s3_bucket.example\n- }"
+                    :artifact/path "main.tf"}]
+      (let [result (detection/detect-diff-analysis rule artifact {})]
+        (is (some? result))
+        (is (= :diff-analysis (:type result)))
+        (is (= :import-removal (:rule-id result))))))
+
+  (testing "Uses context diff if artifact diff absent"
+    (let [rule {:rule/id :test
+                :rule/detection {:type :diff-analysis
+                                 :pattern "^-"}}]
+      (let [result (detection/detect-diff-analysis
+                    rule
+                    {:artifact/path "test.tf"}
+                    {:diff "- removed line\n+ added line"})]
+        (is (some? result)))))
+
+  (testing "No match in diff"
+    (let [rule {:rule/id :test
+                :rule/detection {:type :diff-analysis
+                                 :pattern "SECRET"}}
+          artifact {:artifact/diff "+ added line\n+ another line"}]
+      (is (nil? (detection/detect-diff-analysis rule artifact {}))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Plan output detection tests
+
+(deftest plan-output-test
+  (testing "Detects terraform plan patterns"
+    (let [rule {:rule/id :network-recreation
+                :rule/detection {:type :plan-output
+                                 :patterns ["-/\\+.*aws_route"]}
+                :rule/applies-to {:resource-patterns ["aws_route"]}
+                :rule/enforcement {:action :require-approval
+                                   :message "Network resource recreation"}}
+          context {:terraform-plan "# aws_route.main will be replaced\n  -/+ aws_route.main (tainted)"}]
+      (let [result (detection/detect-plan-output rule {} context)]
+        (is (some? result))
+        (is (= :plan-output (:type result)))
+        (is (seq (:resource-violations result))))))
+
+  (testing "Parses resource changes from plan"
+    (let [rule {:rule/id :destruction
+                :rule/detection {:type :plan-output}
+                :rule/applies-to {:resource-patterns ["aws_vpc" "aws_subnet"]}
+                :rule/enforcement {:action :require-approval :message "Destruction"}}
+          context {:terraform-plan "# aws_vpc.main will be destroyed\n# aws_subnet.private[0] must be replaced"}]
+      (let [result (detection/detect-plan-output rule {} context)]
+        (is (some? result))
+        (is (= 2 (count (:resource-violations result)))))))
+
+  (testing "No violations when no matching resources"
+    (let [rule {:rule/id :test
+                :rule/detection {:type :plan-output}
+                :rule/applies-to {:resource-patterns ["aws_vpc"]}}
+          context {:terraform-plan "# aws_s3_bucket.example will be created"}]
+      (is (nil? (detection/detect-plan-output rule {} context))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Unified detection tests
+
+(deftest detect-violation-test
+  (testing "Dispatches to correct detection type"
+    (let [content-rule {:rule/id :content
+                        :rule/detection {:type :content-scan :pattern "TODO"}
+                        :rule/enforcement {:action :warn :message "TODO"}}
+          diff-rule {:rule/id :diff
+                     :rule/detection {:type :diff-analysis :pattern "^-"}
+                     :rule/enforcement {:action :warn :message "Removal"}}]
+      ;; Content scan
+      (is (some? (detection/detect-violation
+                  content-rule
+                  {:artifact/content "# TODO"}
+                  {})))
+
+      ;; Diff analysis
+      (is (some? (detection/detect-violation
+                  diff-rule
+                  {:artifact/diff "- removed"}
+                  {})))))
+
+  (testing "Returns nil for unsupported types"
+    (let [rule {:rule/id :test
+                :rule/detection {:type :state-comparison}}]
+      (is (nil? (detection/detect-violation rule {} {}))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Check rules tests
+
+(deftest check-rules-test
+  (testing "Checks multiple rules and returns violations"
+    (let [rules [{:rule/id :no-todos
+                  :rule/detection {:type :content-scan :pattern "TODO"}
+                  :rule/enforcement {:action :warn :message "TODO found"}}
+                 {:rule/id :no-fixmes
+                  :rule/detection {:type :content-scan :pattern "FIXME"}
+                  :rule/enforcement {:action :warn :message "FIXME found"}}]
+          artifact {:artifact/content "# TODO: fix\n# FIXME: broken"}
+          violations (detection/check-rules rules artifact {})]
+      (is (= 2 (count violations)))
+      (is (every? :rule violations))
+      (is (every? :violation violations))
+      (is (every? :timestamp violations))))
+
+  (testing "Returns empty when no violations"
+    (let [rules [{:rule/id :test
+                  :rule/detection {:type :content-scan :pattern "SECRET"}}]
+          artifact {:artifact/content "# Clean code"}]
+      (is (empty? (detection/check-rules rules artifact {}))))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Violation classification tests
+
+(deftest violation-classification-test
+  (testing "Filters blocking violations"
+    (let [violations [{:rule {:rule/enforcement {:action :hard-halt}}}
+                      {:rule {:rule/enforcement {:action :warn}}}]]
+      (is (= 1 (count (detection/blocking-violations violations))))))
+
+  (testing "Filters approval-required violations"
+    (let [violations [{:rule {:rule/enforcement {:action :require-approval}}}
+                      {:rule {:rule/enforcement {:action :warn}}}]]
+      (is (= 1 (count (detection/approval-required-violations violations))))))
+
+  (testing "Filters warning violations"
+    (let [violations [{:rule {:rule/enforcement {:action :warn}}}
+                      {:rule {:rule/enforcement {:action :hard-halt}}}]]
+      (is (= 1 (count (detection/warning-violations violations))))))
+
+  (testing "Filters audit violations"
+    (let [violations [{:rule {:rule/enforcement {:action :audit}}}
+                      {:rule {:rule/enforcement {:action :warn}}}]]
+      (is (= 1 (count (detection/audit-violations violations)))))))
+
+(deftest violation-conversion-test
+  (testing "Converts violation to error"
+    (let [violation {:rule {:rule/id :test-rule
+                            :rule/severity :major
+                            :rule/enforcement {:action :hard-halt
+                                               :message "Error!"
+                                               :remediation "Fix it"}}
+                     :violation {:matches [{:match "TODO" :line 1}]
+                                 :artifact-path "main.py"
+                                 :message "Error!"}}
+          error (detection/violation->error violation)]
+      (is (= :test-rule (:code error)))
+      (is (= "Error!" (:message error)))
+      (is (= :major (:severity error)))
+      (is (= "Fix it" (:remediation error)))))
+
+  (testing "Converts violation to warning"
+    (let [violation {:rule {:rule/id :test-rule
+                            :rule/severity :minor}
+                     :violation {:message "Warning"}}
+          warning (detection/violation->warning violation)]
+      (is (= :test-rule (:code warning)))
+      (is (= :minor (:severity warning))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Run tests
+  (clojure.test/run-tests 'ai.miniforge.policy-pack.detection-test)
+
+  :leave-this-here)

--- a/components/policy-pack/test/ai/miniforge/policy_pack/interface_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/interface_test.clj
@@ -1,0 +1,359 @@
+(ns ai.miniforge.policy-pack.interface-test
+  "Tests for the policy-pack component public interface."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.policy-pack.interface :as pp]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema validation tests
+
+(deftest valid-rule-test
+  (testing "Valid rule passes validation"
+    (let [rule {:rule/id :test-rule
+                :rule/title "Test Rule"
+                :rule/description "A test rule"
+                :rule/severity :major
+                :rule/category "800"
+                :rule/applies-to {}
+                :rule/detection {:type :content-scan
+                                 :pattern "TODO"}
+                :rule/enforcement {:action :warn
+                                   :message "Found violation"}}]
+      (is (pp/valid-rule? rule))))
+
+  (testing "Invalid rule fails validation"
+    (is (not (pp/valid-rule? {:rule/id "not-a-keyword"})))
+    (is (not (pp/valid-rule? {:rule/id :test :rule/severity :invalid})))))
+
+(deftest validate-rule-test
+  (testing "Returns valid result for valid rule"
+    (let [rule {:rule/id :test
+                :rule/title "Test"
+                :rule/description "Desc"
+                :rule/severity :minor
+                :rule/category "800"
+                :rule/applies-to {}
+                :rule/detection {:type :content-scan}
+                :rule/enforcement {:action :warn :message "Warning"}}
+          result (pp/validate-rule rule)]
+      (is (:valid? result))
+      (is (nil? (:errors result)))))
+
+  (testing "Returns errors for invalid rule"
+    (let [result (pp/validate-rule {:rule/id "not-keyword"})]
+      (is (not (:valid? result)))
+      (is (some? (:errors result))))))
+
+(deftest valid-pack-test
+  (testing "Valid pack passes validation"
+    (let [now (java.time.Instant/now)
+          pack {:pack/id "test-pack"
+                :pack/name "Test Pack"
+                :pack/version "2026.01.22"
+                :pack/description "A test pack"
+                :pack/author "test-author"
+                :pack/categories []
+                :pack/rules []
+                :pack/created-at now
+                :pack/updated-at now}]
+      (is (pp/valid-pack? pack))))
+
+  (testing "Invalid pack fails validation"
+    (is (not (pp/valid-pack? {:pack/id 123})))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registry tests
+
+(deftest registry-crud-test
+  (testing "Register and retrieve pack"
+    (let [reg (pp/create-registry)
+          now (java.time.Instant/now)
+          pack {:pack/id "test"
+                :pack/name "Test Pack"
+                :pack/version "2026.01.22"
+                :pack/description "Test"
+                :pack/author "author"
+                :pack/categories []
+                :pack/rules []
+                :pack/created-at now
+                :pack/updated-at now}]
+      ;; Register
+      (pp/register-pack reg pack)
+
+      ;; Retrieve
+      (let [retrieved (pp/get-pack reg "test")]
+        (is (= "test" (:pack/id retrieved)))
+        (is (= "Test Pack" (:pack/name retrieved))))
+
+      ;; Retrieve specific version
+      (let [retrieved (pp/get-pack-version reg "test" "2026.01.22")]
+        (is (some? retrieved)))))
+
+  (testing "Delete pack"
+    (let [reg (pp/create-registry)
+          now (java.time.Instant/now)
+          pack {:pack/id "to-delete"
+                :pack/name "Delete Me"
+                :pack/version "2026.01.01"
+                :pack/description "Test"
+                :pack/author "author"
+                :pack/categories []
+                :pack/rules []
+                :pack/created-at now
+                :pack/updated-at now}]
+      (pp/register-pack reg pack)
+      (is (some? (pp/get-pack reg "to-delete")))
+      (is (true? (pp/delete-pack reg "to-delete" "2026.01.01")))
+      (is (nil? (pp/get-pack reg "to-delete"))))))
+
+(deftest registry-list-test
+  (testing "List packs with criteria"
+    (let [reg (pp/create-registry)
+          now (java.time.Instant/now)
+          pack1 {:pack/id "pack-a"
+                 :pack/name "Pack Alpha"
+                 :pack/version "2026.01.01"
+                 :pack/description "First pack"
+                 :pack/author "alice"
+                 :pack/categories [{:category/id "300" :category/name "Infra" :category/rules []}]
+                 :pack/rules []
+                 :pack/created-at now
+                 :pack/updated-at now}
+          pack2 {:pack/id "pack-b"
+                 :pack/name "Pack Beta"
+                 :pack/version "2026.01.02"
+                 :pack/description "Second pack"
+                 :pack/author "bob"
+                 :pack/categories []
+                 :pack/rules []
+                 :pack/created-at now
+                 :pack/updated-at now}]
+      (pp/register-pack reg pack1)
+      (pp/register-pack reg pack2)
+
+      ;; List all
+      (let [all (pp/list-packs reg {})]
+        (is (= 2 (count all))))
+
+      ;; Filter by author
+      (let [alice-packs (pp/list-packs reg {:author "alice"})]
+        (is (= 1 (count alice-packs)))
+        (is (= "pack-a" (:pack/id (first alice-packs)))))
+
+      ;; Search by name
+      (let [beta-packs (pp/list-packs reg {:search "beta"})]
+        (is (= 1 (count beta-packs)))
+        (is (= "pack-b" (:pack/id (first beta-packs))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Pack and rule builders test
+
+(deftest create-pack-test
+  (testing "Creates pack with required fields"
+    (let [pack (pp/create-pack "my-pack" "My Pack" "Description" "me")]
+      (is (= "my-pack" (:pack/id pack)))
+      (is (= "My Pack" (:pack/name pack)))
+      (is (= "me" (:pack/author pack)))
+      (is (string? (:pack/version pack)))
+      (is (inst? (:pack/created-at pack)))))
+
+  (testing "Creates pack with options"
+    (let [rule {:rule/id :test
+                :rule/title "Test"
+                :rule/description "Desc"
+                :rule/severity :minor
+                :rule/category "800"
+                :rule/applies-to {}
+                :rule/detection {:type :content-scan}
+                :rule/enforcement {:action :warn :message "Warning"}}
+          pack (pp/create-pack "my-pack" "My Pack" "Desc" "me"
+                               :version "2026.01.15"
+                               :license "Apache-2.0"
+                               :rules [rule])]
+      (is (= "2026.01.15" (:pack/version pack)))
+      (is (= "Apache-2.0" (:pack/license pack)))
+      (is (= 1 (count (:pack/rules pack)))))))
+
+(deftest create-rule-test
+  (testing "Creates rule with builder"
+    (let [rule (pp/create-rule
+                :no-todos
+                "No TODOs"
+                "Forbid TODO comments"
+                :minor
+                "800"
+                (pp/content-scan-detection "TODO")
+                (pp/warn-enforcement "Found TODO"))]
+      (is (= :no-todos (:rule/id rule)))
+      (is (= :minor (:rule/severity rule)))
+      (is (= :content-scan (get-in rule [:rule/detection :type])))
+      (is (= :warn (get-in rule [:rule/enforcement :action])))))
+
+  (testing "Creates rule with options"
+    (let [rule (pp/create-rule
+                :test
+                "Test"
+                "Test rule"
+                :major
+                "300"
+                (pp/diff-analysis-detection "^-")
+                (pp/halt-enforcement "Violation!" {:remediation "Fix it"})
+                :applies-to {:task-types #{:import}}
+                :agent-behavior "Don't do that")]
+      (is (= #{:import} (get-in rule [:rule/applies-to :task-types])))
+      (is (= "Don't do that" (:rule/agent-behavior rule)))
+      (is (= "Fix it" (get-in rule [:rule/enforcement :remediation]))))))
+
+(deftest detection-builders-test
+  (testing "Content scan detection"
+    (let [det (pp/content-scan-detection "pattern")]
+      (is (= :content-scan (:type det)))
+      (is (= "pattern" (:pattern det))))
+
+    (let [det (pp/content-scan-detection "pattern" {:context-lines 5})]
+      (is (= 5 (:context-lines det)))))
+
+  (testing "Diff analysis detection"
+    (let [det (pp/diff-analysis-detection "^-")]
+      (is (= :diff-analysis (:type det)))
+      (is (= "^-" (:pattern det)))))
+
+  (testing "Plan output detection"
+    (let [det (pp/plan-output-detection ["pattern1" "pattern2"])]
+      (is (= :plan-output (:type det)))
+      (is (= ["pattern1" "pattern2"] (:patterns det))))))
+
+(deftest enforcement-builders-test
+  (testing "Warn enforcement"
+    (let [enf (pp/warn-enforcement "Warning message")]
+      (is (= :warn (:action enf)))
+      (is (= "Warning message" (:message enf)))))
+
+  (testing "Halt enforcement"
+    (let [enf (pp/halt-enforcement "Halt!")]
+      (is (= :hard-halt (:action enf))))
+
+    (let [enf (pp/halt-enforcement "Halt!" {:remediation "Fix it"})]
+      (is (= "Fix it" (:remediation enf)))))
+
+  (testing "Approval enforcement"
+    (let [enf (pp/approval-enforcement "Needs approval" [:human :security])]
+      (is (= :require-approval (:action enf)))
+      (is (= [:human :security] (:approvers enf))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Detection and checking tests
+
+(deftest check-artifact-test
+  (testing "Detects content violations"
+    (let [pack (pp/create-pack "test" "Test" "Test pack" "author"
+                               :rules
+                               [(pp/create-rule :no-todos "No TODOs" "Desc"
+                                                :minor "800"
+                                                (pp/content-scan-detection "TODO")
+                                                (pp/warn-enforcement "Found TODO"))])
+          result (pp/check-artifact pack
+                                    {:artifact/content "# TODO: fix this"
+                                     :artifact/path "main.py"}
+                                    {})]
+      (is (:passed? result))  ; Warnings don't block
+      (is (= 1 (count (:violations result))))
+      (is (= 1 (count (:warnings result))))))
+
+  (testing "Blocking violations fail"
+    (let [pack (pp/create-pack "test" "Test" "Test pack" "author"
+                               :rules
+                               [(pp/create-rule :no-secrets "No Secrets" "Desc"
+                                                :critical "500"
+                                                (pp/content-scan-detection "SECRET_KEY")
+                                                (pp/halt-enforcement "Found secret!"))])
+          result (pp/check-artifact pack
+                                    {:artifact/content "SECRET_KEY=abc123"
+                                     :artifact/path "config.py"}
+                                    {})]
+      (is (not (:passed? result)))
+      (is (= 1 (count (:blocking result))))))
+
+  (testing "No violations pass"
+    (let [pack (pp/create-pack "test" "Test" "Test pack" "author"
+                               :rules
+                               [(pp/create-rule :no-todos "No TODOs" "Desc"
+                                                :minor "800"
+                                                (pp/content-scan-detection "TODO")
+                                                (pp/warn-enforcement "Found TODO"))])
+          result (pp/check-artifact pack
+                                    {:artifact/content "# Clean code"
+                                     :artifact/path "main.py"}
+                                    {})]
+      (is (:passed? result))
+      (is (empty? (:violations result))))))
+
+(deftest check-multiple-packs-test
+  (testing "Rules from multiple packs are checked"
+    (let [pack1 (pp/create-pack "pack1" "Pack 1" "First" "author"
+                                :rules
+                                [(pp/create-rule :no-todos "No TODOs" "Desc"
+                                                 :minor "800"
+                                                 (pp/content-scan-detection "TODO")
+                                                 (pp/warn-enforcement "Found TODO"))])
+          pack2 (pp/create-pack "pack2" "Pack 2" "Second" "author"
+                                :rules
+                                [(pp/create-rule :no-fixmes "No FIXMEs" "Desc"
+                                                 :minor "800"
+                                                 (pp/content-scan-detection "FIXME")
+                                                 (pp/warn-enforcement "Found FIXME"))])
+          result (pp/check-artifact [pack1 pack2]
+                                    {:artifact/content "# TODO: and FIXME:"}
+                                    {})]
+      (is (= 2 (count (:violations result)))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Rule resolution tests
+
+(deftest resolve-rules-test
+  (testing "Later rules override earlier ones"
+    (let [rule1 {:rule/id :test
+                 :rule/severity :minor
+                 :rule/enforcement {:action :warn :message "Warn"}}
+          rule2 {:rule/id :test
+                 :rule/severity :major
+                 :rule/enforcement {:action :hard-halt :message "Halt"}}
+          resolved (pp/resolve-rules [rule1 rule2])]
+      (is (= 1 (count resolved)))
+      ;; Severity escalates to higher
+      (is (= :major (:rule/severity (first resolved))))
+      ;; Enforcement escalates to stricter
+      (is (= :hard-halt (get-in (first resolved) [:rule/enforcement :action])))))
+
+  (testing "Different rule IDs are preserved"
+    (let [rule1 {:rule/id :rule-a :rule/severity :minor}
+          rule2 {:rule/id :rule-b :rule/severity :major}
+          resolved (pp/resolve-rules [rule1 rule2])]
+      (is (= 2 (count resolved))))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Utility function tests
+
+(deftest glob-matches-test
+  (testing "Simple glob matching"
+    (is (pp/glob-matches? "*.tf" "main.tf"))
+    (is (not (pp/glob-matches? "*.tf" "main.py")))
+    (is (not (pp/glob-matches? "*.tf" "dir/main.tf"))))
+
+  (testing "Double star glob matching"
+    (is (pp/glob-matches? "**/*.tf" "main.tf"))
+    (is (pp/glob-matches? "**/*.tf" "modules/vpc/main.tf"))
+    (is (not (pp/glob-matches? "**/*.tf" "main.py")))))
+
+(deftest compare-versions-test
+  (testing "Version comparison"
+    (is (pos? (pp/compare-versions "2026.01.22" "2026.01.15")))
+    (is (neg? (pp/compare-versions "2025.12.01" "2026.01.01")))
+    (is (zero? (pp/compare-versions "2026.01.22" "2026.01.22")))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Run all tests
+  (clojure.test/run-tests 'ai.miniforge.policy-pack.interface-test)
+
+  :leave-this-here)

--- a/components/policy-pack/test/ai/miniforge/policy_pack/loader_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/loader_test.clj
@@ -1,0 +1,287 @@
+(ns ai.miniforge.policy-pack.loader-test
+  "Tests for the policy-pack loader."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [ai.miniforge.policy-pack.loader :as loader]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures
+
+(def ^:dynamic *test-dir* nil)
+
+(defn create-test-dir
+  "Create a temporary directory for test files."
+  []
+  (let [dir (io/file (System/getProperty "java.io.tmpdir")
+                     (str "policy-pack-test-" (System/currentTimeMillis)))]
+    (.mkdirs dir)
+    dir))
+
+(defn delete-dir
+  "Recursively delete a directory."
+  [dir]
+  (when (.exists dir)
+    (doseq [f (reverse (file-seq dir))]
+      (.delete f))))
+
+(defn test-fixture
+  "Create and cleanup test directory."
+  [f]
+  (let [dir (create-test-dir)]
+    (try
+      (binding [*test-dir* dir]
+        (f))
+      (finally
+        (delete-dir dir)))))
+
+(use-fixtures :each test-fixture)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Single file loader tests
+
+(deftest load-pack-from-file-test
+  (testing "Loads valid pack from EDN file"
+    (let [pack-file (io/file *test-dir* "test.pack.edn")
+          pack-content "{:pack/id \"test-pack\"
+                        :pack/name \"Test Pack\"
+                        :pack/version \"2026.01.22\"
+                        :pack/description \"A test pack\"
+                        :pack/author \"test\"
+                        :pack/categories []
+                        :pack/rules []
+                        :pack/created-at #inst \"2026-01-22T00:00:00Z\"
+                        :pack/updated-at #inst \"2026-01-22T00:00:00Z\"}"]
+      (spit pack-file pack-content)
+
+      (let [result (loader/load-pack-from-file (.getPath pack-file))]
+        (is (:success? result))
+        (is (= "test-pack" (get-in result [:pack :pack/id])))
+        (is (= "Test Pack" (get-in result [:pack :pack/name]))))))
+
+  (testing "Returns error for missing file"
+    (let [result (loader/load-pack-from-file "/nonexistent/path.pack.edn")]
+      (is (not (:success? result)))
+      (is (seq (:errors result)))))
+
+  (testing "Returns error for invalid EDN"
+    (let [pack-file (io/file *test-dir* "invalid.pack.edn")]
+      (spit pack-file "{:pack/id \"test\" :invalid")
+      (let [result (loader/load-pack-from-file (.getPath pack-file))]
+        (is (not (:success? result)))))))
+
+(deftest load-pack-with-rules-test
+  (testing "Loads pack with inline rules"
+    (let [pack-file (io/file *test-dir* "with-rules.pack.edn")
+          pack-content "{:pack/id \"rules-pack\"
+                        :pack/name \"Rules Pack\"
+                        :pack/version \"2026.01.22\"
+                        :pack/description \"Pack with rules\"
+                        :pack/author \"test\"
+                        :pack/categories []
+                        :pack/rules [{:rule/id :test-rule
+                                     :rule/title \"Test Rule\"
+                                     :rule/description \"A test rule\"
+                                     :rule/severity :major
+                                     :rule/category \"800\"
+                                     :rule/applies-to {}
+                                     :rule/detection {:type :content-scan
+                                                     :pattern \"TODO\"}
+                                     :rule/enforcement {:action :warn
+                                                       :message \"Found TODO\"}}]
+                        :pack/created-at #inst \"2026-01-22T00:00:00Z\"
+                        :pack/updated-at #inst \"2026-01-22T00:00:00Z\"}"]
+      (spit pack-file pack-content)
+
+      (let [result (loader/load-pack-from-file (.getPath pack-file))]
+        (is (:success? result))
+        (is (= 1 (count (get-in result [:pack :pack/rules]))))
+        (is (= :test-rule (get-in result [:pack :pack/rules 0 :rule/id])))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Directory loader tests
+
+(deftest load-pack-from-directory-test
+  (testing "Loads pack from directory with manifest"
+    (let [pack-dir (io/file *test-dir* "my-pack")]
+      (.mkdirs pack-dir)
+      (spit (io/file pack-dir "pack.edn")
+            "{:pack/id \"dir-pack\"
+              :pack/name \"Directory Pack\"
+              :pack/version \"2026.01.22\"
+              :pack/description \"Pack from directory\"
+              :pack/author \"test\"
+              :pack/categories []
+              :pack/rules []
+              :pack/created-at #inst \"2026-01-22T00:00:00Z\"
+              :pack/updated-at #inst \"2026-01-22T00:00:00Z\"}")
+
+      (let [result (loader/load-pack-from-directory (.getPath pack-dir))]
+        (is (:success? result))
+        (is (= "dir-pack" (get-in result [:pack :pack/id]))))))
+
+  (testing "Loads rules from rules/ subdirectory"
+    (let [pack-dir (io/file *test-dir* "pack-with-rules-dir")
+          rules-dir (io/file pack-dir "rules")]
+      (.mkdirs rules-dir)
+
+      ;; Write manifest
+      (spit (io/file pack-dir "pack.edn")
+            "{:pack/id \"rules-dir-pack\"
+              :pack/name \"Pack with Rules Dir\"
+              :pack/version \"2026.01.22\"
+              :pack/description \"Test\"
+              :pack/author \"test\"
+              :pack/categories []
+              :pack/rules []
+              :pack/created-at #inst \"2026-01-22T00:00:00Z\"
+              :pack/updated-at #inst \"2026-01-22T00:00:00Z\"}")
+
+      ;; Write rule file
+      (spit (io/file rules-dir "test-rule.edn")
+            "{:rule/id :test-rule
+              :rule/title \"Test Rule\"
+              :rule/description \"Loaded from directory\"
+              :rule/severity :minor
+              :rule/category \"800\"
+              :rule/applies-to {}
+              :rule/detection {:type :content-scan :pattern \"test\"}
+              :rule/enforcement {:action :warn :message \"Found test\"}}")
+
+      (let [result (loader/load-pack-from-directory (.getPath pack-dir))]
+        (is (:success? result))
+        (is (= 1 (count (get-in result [:pack :pack/rules]))))
+        (is (= :test-rule (get-in result [:pack :pack/rules 0 :rule/id]))))))
+
+  (testing "Directory rules override inline rules"
+    (let [pack-dir (io/file *test-dir* "override-pack")
+          rules-dir (io/file pack-dir "rules")]
+      (.mkdirs rules-dir)
+
+      ;; Manifest with inline rule
+      (spit (io/file pack-dir "pack.edn")
+            "{:pack/id \"override-pack\"
+              :pack/name \"Override Pack\"
+              :pack/version \"2026.01.22\"
+              :pack/description \"Test\"
+              :pack/author \"test\"
+              :pack/categories []
+              :pack/rules [{:rule/id :same-id
+                           :rule/title \"Inline Version\"
+                           :rule/description \"From inline\"
+                           :rule/severity :minor
+                           :rule/category \"800\"
+                           :rule/applies-to {}
+                           :rule/detection {:type :content-scan :pattern \"inline\"}
+                           :rule/enforcement {:action :warn :message \"Inline\"}}]
+              :pack/created-at #inst \"2026-01-22T00:00:00Z\"
+              :pack/updated-at #inst \"2026-01-22T00:00:00Z\"}")
+
+      ;; Directory rule with same ID
+      (spit (io/file rules-dir "same-id.edn")
+            "{:rule/id :same-id
+              :rule/title \"Directory Version\"
+              :rule/description \"From directory\"
+              :rule/severity :major
+              :rule/category \"800\"
+              :rule/applies-to {}
+              :rule/detection {:type :content-scan :pattern \"directory\"}
+              :rule/enforcement {:action :hard-halt :message \"Directory\"}}")
+
+      (let [result (loader/load-pack-from-directory (.getPath pack-dir))
+            rules (get-in result [:pack :pack/rules])
+            rule (first rules)]
+        (is (:success? result))
+        (is (= 1 (count rules)))
+        ;; Directory version should win
+        (is (= "Directory Version" (:rule/title rule)))
+        (is (= :major (:rule/severity rule)))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Auto-detect and discovery tests
+
+(deftest load-pack-auto-detect-test
+  (testing "Auto-detects file format"
+    (let [pack-file (io/file *test-dir* "auto.pack.edn")]
+      (spit pack-file "{:pack/id \"auto-pack\"
+                        :pack/name \"Auto Pack\"
+                        :pack/version \"2026.01.22\"
+                        :pack/description \"Auto detected\"
+                        :pack/author \"test\"
+                        :pack/categories []
+                        :pack/rules []
+                        :pack/created-at #inst \"2026-01-22T00:00:00Z\"
+                        :pack/updated-at #inst \"2026-01-22T00:00:00Z\"}")
+
+      (let [result (loader/load-pack (.getPath pack-file))]
+        (is (:success? result))
+        (is (= "auto-pack" (get-in result [:pack :pack/id]))))))
+
+  (testing "Auto-detects directory format"
+    (let [pack-dir (io/file *test-dir* "auto-dir")]
+      (.mkdirs pack-dir)
+      (spit (io/file pack-dir "pack.edn")
+            "{:pack/id \"auto-dir-pack\"
+              :pack/name \"Auto Dir Pack\"
+              :pack/version \"2026.01.22\"
+              :pack/description \"Auto detected directory\"
+              :pack/author \"test\"
+              :pack/categories []
+              :pack/rules []
+              :pack/created-at #inst \"2026-01-22T00:00:00Z\"
+              :pack/updated-at #inst \"2026-01-22T00:00:00Z\"}")
+
+      (let [result (loader/load-pack (.getPath pack-dir))]
+        (is (:success? result))
+        (is (= "auto-dir-pack" (get-in result [:pack :pack/id])))))))
+
+(deftest discover-packs-test
+  (testing "Discovers packs in directory"
+    (let [packs-dir (io/file *test-dir* "packs")]
+      (.mkdirs packs-dir)
+
+      ;; Create a .pack.edn file
+      (spit (io/file packs-dir "file-pack.pack.edn")
+            "{:pack/id \"file\" :pack/name \"File\" :pack/version \"1\"
+              :pack/description \"\" :pack/author \"\" :pack/categories []
+              :pack/rules [] :pack/created-at #inst \"2026-01-01\" :pack/updated-at #inst \"2026-01-01\"}")
+
+      ;; Create a pack directory
+      (let [dir-pack (io/file packs-dir "dir-pack")]
+        (.mkdirs dir-pack)
+        (spit (io/file dir-pack "pack.edn")
+              "{:pack/id \"dir\" :pack/name \"Dir\" :pack/version \"1\"
+                :pack/description \"\" :pack/author \"\" :pack/categories []
+                :pack/rules [] :pack/created-at #inst \"2026-01-01\" :pack/updated-at #inst \"2026-01-01\"}"))
+
+      (let [discovered (loader/discover-packs (.getPath packs-dir))]
+        (is (= 2 (count discovered)))
+        (is (some #(= :file (:type %)) discovered))
+        (is (some #(= :directory (:type %)) discovered))))))
+
+(deftest load-all-packs-test
+  (testing "Loads all packs from directory"
+    (let [packs-dir (io/file *test-dir* "all-packs")]
+      (.mkdirs packs-dir)
+
+      ;; Create two packs
+      (spit (io/file packs-dir "pack1.pack.edn")
+            "{:pack/id \"pack1\" :pack/name \"Pack 1\" :pack/version \"2026.01.01\"
+              :pack/description \"First\" :pack/author \"test\" :pack/categories []
+              :pack/rules [] :pack/created-at #inst \"2026-01-01\" :pack/updated-at #inst \"2026-01-01\"}")
+
+      (spit (io/file packs-dir "pack2.pack.edn")
+            "{:pack/id \"pack2\" :pack/name \"Pack 2\" :pack/version \"2026.01.02\"
+              :pack/description \"Second\" :pack/author \"test\" :pack/categories []
+              :pack/rules [] :pack/created-at #inst \"2026-01-01\" :pack/updated-at #inst \"2026-01-01\"}")
+
+      (let [result (loader/load-all-packs (.getPath packs-dir))]
+        (is (= 2 (count (:loaded result))))
+        (is (empty? (:failed result)))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Run tests
+  (clojure.test/run-tests 'ai.miniforge.policy-pack.loader-test)
+
+  :leave-this-here)


### PR DESCRIPTION
## Summary

- Add `policy-pack` component implementing extensible policy-as-code enforcement
- Malli schemas for rules, packs, detection, and enforcement configurations
- `PolicyPackRegistry` protocol with in-memory implementation
- Pack loaders supporting single EDN files and directory structures
- Detection implementations for content-scan, diff-analysis, and plan-output
- Rule resolution with severity/enforcement escalation across multiple packs

## Details

### Schemas (`schema.clj`)
- `Rule` - Individual rule with id, severity, detection, enforcement
- `PackManifest` - Versioned collection of rules
- `RuleSeverity` - `:critical`, `:major`, `:minor`, `:info`
- `RuleEnforcement` - `:hard-halt`, `:require-approval`, `:warn`, `:audit`

### Registry (`registry.clj`)
- CRUD operations: `register-pack`, `get-pack`, `list-packs`, `delete-pack`
- Composition: `resolve-pack` (merges inherited rules), `get-rules-for-context`
- Version comparison using DateVer (YYYY.MM.DD)

### Loader (`loader.clj`)
- `load-pack` - Auto-detects file vs directory format
- `load-pack-from-file` - Single `.pack.edn` files
- `load-pack-from-directory` - `pack.edn` manifest with `rules/` subdirectory
- `discover-packs`, `load-all-packs` for bulk loading

### Detection (`detection.clj`)
- `:content-scan` - Regex against artifact content
- `:diff-analysis` - Regex against git diff
- `:plan-output` - Parse terraform plan for resource changes
- Violation classification helpers

### Core (`core.clj`)
- Rule resolution: severity escalation, enforcement escalation
- Pack composition with later-wins override semantics
- Builder helpers: `create-pack`, `create-rule`, `content-scan-detection`, etc.

## Test Plan

- [x] Schema validation tests
- [x] Registry CRUD tests
- [x] Pack/rule builder tests
- [x] Content scan detection tests
- [x] Diff analysis detection tests
- [x] Plan output detection tests
- [x] Loader tests with temp directories
- [x] Rule resolution tests

Based on `docs/specs/policy-pack.spec`

---

Generated with [Claude Code](https://claude.ai/code)