### PR TITLE
fix(agent): reduce agent/core.clj from 6 to 3 layers

### DIFF
--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -1,17 +1,13 @@
 (ns ai.miniforge.agent.core
   "Agent execution logic and factory.
-   Layer 0: Role configurations and defaults
-   Layer 1: Agent record implementation
-   Layer 2: Agent factory
-   Layer 3: Agent executor implementation
-   Layer 4: Specialized agent support (create-base-agent, cycle-agent)
+   Layer 0: Role configurations, defaults, and utility functions
+   Layer 1: Agent record implementation and metrics
+   Layer 2: Agent factory and executor
 
    Agents are pure functions: (context, task) -> (artifacts, decisions, signals)"
   (:require
    [ai.miniforge.agent.protocol :as protocol]
-   [ai.miniforge.agent.memory :as memory]
-   [ai.miniforge.schema.interface :as schema]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.agent.memory :as memory]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Role configurations and defaults
@@ -145,9 +141,6 @@ Your role is to execute commands and coordinate system operations.
 Schedule tasks, run scripts, and report on execution status.
 Output execution logs and status reports."})
 
-;------------------------------------------------------------------------------ Layer 1
-;; Metrics tracking
-
 (defn make-metrics
   "Create initial metrics map for agent execution."
   []
@@ -194,7 +187,7 @@ Output execution logs and status reports."})
     :deploy :manifest
     :code))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 1
 ;; Agent implementation
 
 (defrecord BaseAgent [id role capabilities config memory-id state]
@@ -281,8 +274,8 @@ Output execution logs and status reports."})
     (assoc this :state {:status :shutdown
                         :shutdown-at (java.util.Date.)})))
 
-;------------------------------------------------------------------------------ Layer 3
-;; Agent factory
+;------------------------------------------------------------------------------ Layer 2
+;; Agent factory and executor
 
 (defn create-agent
   "Create an agent by role with optional config overrides.
@@ -330,9 +323,6 @@ Output execution logs and status reports."})
       :agent/capabilities (:capabilities agent)
       :agent/memory (:memory-id agent)
       :agent/config (:config agent)})))
-
-;------------------------------------------------------------------------------ Layer 4
-;; Agent executor
 
 (defrecord DefaultExecutor [logger memory-store]
   protocol/AgentExecutor
@@ -408,9 +398,6 @@ Output execution logs and status reports."})
   ([{:keys [logger memory-store]}]
    (->DefaultExecutor logger (or memory-store (memory/create-memory-store)))))
 
-;------------------------------------------------------------------------------ Layer 5
-;; Mock LLM Backend for testing
-
 (defrecord MockLLMBackend [responses]
   protocol/LLMBackend
   (complete [_this _messages _opts]
@@ -439,133 +426,6 @@ Output execution logs and status reports."})
                                {:content "Mock response"
                                 :usage {:input-tokens 100 :output-tokens 50}
                                 :model "mock"})))))
-
-;------------------------------------------------------------------------------ Layer 6
-;; Specialized Agent Support
-;; These functions support the specialized agents (planner, implementer, tester)
-;; that use a functional approach rather than the protocol-based BaseAgent.
-
-(defprotocol SpecializedAgent
-  "Protocol for specialized AI agents with functional invoke/validate/repair.
-   This allows specialized agents to define their behavior via functions."
-
-  (invoke [this context input]
-    "Execute the agent's primary function on the input.
-     Returns {:status :success/:error, :output <result>, :metrics {...}}")
-
-  (validate [this output]
-    "Validate the agent's output against its schema.
-     Returns {:valid? bool, :errors [...] or nil}")
-
-  (repair [this output errors context]
-    "Attempt to repair invalid output based on validation errors.
-     Returns {:status :success/:error, :output <repaired-result>}"))
-
-(defrecord FunctionalAgent [role config system-prompt invoke-fn validate-fn repair-fn logger]
-  ;; Implement the main Agent protocol for compatibility with workflow/core.clj
-  ;; The Agent protocol signature is: (invoke [this task context])
-  ;; The invoke-fn expects: (invoke-fn context input)
-  ;; So we adapt by swapping the order
-  protocol/Agent
-  (invoke [_this task context]
-    (let [start-time (System/currentTimeMillis)]
-      (try
-        (log/debug logger :agent :agent/invoke-started
-                   {:data {:role role :task-type (:task/type task)}})
-        (let [result (invoke-fn context task)]
-          (log/info logger :agent :agent/invoke-completed
-                    {:data {:role role
-                            :duration-ms (- (System/currentTimeMillis) start-time)
-                            :status (:status result)}})
-          result)
-        (catch Exception e
-          (log/error logger :agent :agent/invoke-failed
-                     {:message (.getMessage e)
-                      :data {:role role
-                             :duration-ms (- (System/currentTimeMillis) start-time)}})
-          {:status :error
-           :error (.getMessage e)
-           :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}}))))
-
-  (validate [_this output _context]
-    (validate-fn output))
-
-  (repair [_this output errors context]
-    (log/debug logger :agent :agent/repair-started
-               {:data {:role role :error-count (count (if (map? errors) (vals errors) errors))}})
-    (let [result (repair-fn output errors context)]
-      (log/info logger :agent :agent/repair-completed
-                {:data {:role role :status (:status result)}})
-      result)))
-
-(defn create-base-agent
-  "Create a base agent with the given configuration.
-   Used by specialized agents (planner, implementer, tester).
-
-   Required options:
-   - :role          - Agent role keyword (:planner, :implementer, :tester, etc.)
-   - :system-prompt - System prompt for the agent
-   - :invoke-fn     - Function (fn [context input] -> result)
-   - :validate-fn   - Function (fn [output] -> {:valid? bool, :errors [...]})
-   - :repair-fn     - Function (fn [output errors context] -> repaired-result)
-
-   Optional:
-   - :config - Agent configuration map (model, temperature, etc.)
-   - :logger - Logger instance (defaults to silent logger)"
-  [{:keys [role system-prompt invoke-fn validate-fn repair-fn config logger]
-    :or {config {}
-         logger (log/create-logger {:min-level :info :output (fn [_])})}}]
-  {:pre [(keyword? role)
-         (string? system-prompt)
-         (fn? invoke-fn)
-         (fn? validate-fn)
-         (fn? repair-fn)]}
-  (->FunctionalAgent role config system-prompt invoke-fn validate-fn repair-fn logger))
-
-(defn make-validator
-  "Create a validation function from a Malli schema."
-  [malli-schema]
-  (fn [output]
-    (if (schema/valid? malli-schema output)
-      {:valid? true :errors nil}
-      {:valid? false :errors (schema/explain malli-schema output)})))
-
-(defn cycle-agent
-  "Execute a full invoke-validate-repair cycle on a specialized agent.
-   Returns the final result after up to max-iterations of repair attempts.
-
-   Options:
-   - :max-iterations - Maximum repair attempts (default 3)"
-  [agent context input & {:keys [max-iterations] :or {max-iterations 3}}]
-  (loop [iteration 0
-         current-output nil]
-    (if (zero? iteration)
-      ;; First iteration: invoke the agent
-      (let [result (invoke agent context input)]
-        (if (= :error (:status result))
-          result
-          (let [validation (validate agent (:output result))]
-            (if (:valid? validation)
-              result
-              (if (>= iteration max-iterations)
-                {:status :error
-                 :output (:output result)
-                 :errors (:errors validation)
-                 :message "Max repair iterations reached"}
-                (recur (inc iteration) (:output result)))))))
-      ;; Subsequent iterations: repair and validate
-      (let [validation (validate agent current-output)]
-        (if (:valid? validation)
-          {:status :success :output current-output}
-          (if (>= iteration max-iterations)
-            {:status :error
-             :output current-output
-             :errors (:errors validation)
-             :message "Max repair iterations reached"}
-            (let [repair-result (repair agent current-output (:errors validation) context)]
-              (if (= :error (:status repair-result))
-                repair-result
-                (recur (inc iteration) (:output repair-result))))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -2,7 +2,7 @@
   "Implementer agent implementation.
    Generates code from plans and task descriptions."
   (:require
-   [ai.miniforge.agent.core :as core]
+   [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
@@ -301,7 +301,7 @@ Write code that is easy to understand, test, and maintain.")
   [& [opts]]
   (let [logger (or (:logger opts)
                    (log/create-logger {:min-level :info :output (fn [_])}))]
-    (core/create-base-agent
+    (specialized/create-base-agent
      {:role :implementer
       :system-prompt implementer-system-prompt
       :config (merge {:model "claude-sonnet-4"
@@ -405,7 +405,7 @@ Write code that is easy to understand, test, and maintain.")
   (def impl (create-implementer))
 
   ;; Invoke with a task
-  (core/invoke impl
+  (specialized/invoke impl
                {:language "clojure"
                 :suggested-path "src/ai/miniforge/auth/login.clj"}
                {:task/description "Implement user login with email verification"

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -7,6 +7,7 @@
    [ai.miniforge.agent.core :as core]
    [ai.miniforge.agent.memory :as mem]
    [ai.miniforge.agent.protocol :as proto]
+   [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.agent.planner :as planner]
    [ai.miniforge.agent.implementer :as implementer]
    [ai.miniforge.agent.tester :as tester]
@@ -271,6 +272,40 @@
   ([responses] (core/create-mock-llm responses)))
 
 ;------------------------------------------------------------------------------ Layer 7
+;; Specialized agent support
+
+(defn create-base-agent
+  "Create a base agent with the given configuration.
+   Used by specialized agents (planner, implementer, tester).
+
+   Required options:
+   - :role          - Agent role keyword (:planner, :implementer, :tester, etc.)
+   - :system-prompt - System prompt for the agent
+   - :invoke-fn     - Function (fn [context input] -> result)
+   - :validate-fn   - Function (fn [output] -> {:valid? bool, :errors [...]})
+   - :repair-fn     - Function (fn [output errors context] -> repaired-result)
+
+   Optional:
+   - :config - Agent configuration map (model, temperature, etc.)
+   - :logger - Logger instance (defaults to silent logger)"
+  [opts]
+  (specialized/create-base-agent opts))
+
+(defn make-validator
+  "Create a validation function from a Malli schema."
+  [malli-schema]
+  (specialized/make-validator malli-schema))
+
+(defn cycle-agent
+  "Execute a full invoke-validate-repair cycle on a specialized agent.
+   Returns the final result after up to max-iterations of repair attempts.
+
+   Options:
+   - :max-iterations - Maximum repair attempts (default 3)"
+  [agent context input & {:keys [max-iterations] :or {max-iterations 3}}]
+  (specialized/cycle-agent agent context input :max-iterations max-iterations))
+
+;------------------------------------------------------------------------------ Layer 8
 ;; Specialized agent creation
 
 (def create-planner

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -2,7 +2,7 @@
   "Planner agent implementation.
    Analyzes specifications and creates detailed implementation plans."
   (:require
-   [ai.miniforge.agent.core :as core]
+   [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
@@ -322,7 +322,7 @@ necessary dependencies. Optimize for clarity and testability.")
   [& [opts]]
   (let [logger (or (:logger opts)
                    (log/create-logger {:min-level :info :output (fn [_])}))]
-    (core/create-base-agent
+    (specialized/create-base-agent
      {:role :planner
       :system-prompt planner-system-prompt
       :config (merge {:model "claude-sonnet-4"
@@ -425,7 +425,7 @@ necessary dependencies. Optimize for clarity and testability.")
   (def planner (create-planner))
 
   ;; Invoke with a specification
-  (core/invoke planner
+  (specialized/invoke planner
                {:codebase {:has-tests? true}}
                "As a user, I want to log in with my email so that I can access my account.")
   ;; => {:status :success, :output {:plan/id ..., :plan/tasks [...], ...}}

--- a/components/agent/src/ai/miniforge/agent/specialized.clj
+++ b/components/agent/src/ai/miniforge/agent/specialized.clj
@@ -1,0 +1,179 @@
+(ns ai.miniforge.agent.specialized
+  "Specialized agent support for functional-style agents.
+   Layer 0: Protocol definitions
+   Layer 1: FunctionalAgent implementation
+   Layer 2: Orchestration functions (create-base-agent, cycle-agent)
+
+   These functions support specialized agents (planner, implementer, tester)
+   that use a functional approach rather than the protocol-based BaseAgent."
+  (:require
+   [ai.miniforge.agent.protocol :as protocol]
+   [ai.miniforge.schema.interface :as schema]
+   [ai.miniforge.logging.interface :as log]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Protocol definitions
+
+(defprotocol SpecializedAgent
+  "Protocol for specialized AI agents with functional invoke/validate/repair.
+   This allows specialized agents to define their behavior via functions."
+
+  (invoke [this context input]
+    "Execute the agent's primary function on the input.
+     Returns {:status :success/:error, :output <result>, :metrics {...}}")
+
+  (validate [this output]
+    "Validate the agent's output against its schema.
+     Returns {:valid? bool, :errors [...] or nil}")
+
+  (repair [this output errors context]
+    "Attempt to repair invalid output based on validation errors.
+     Returns {:status :success/:error, :output <repaired-result>}"))
+
+;------------------------------------------------------------------------------ Layer 1
+;; FunctionalAgent implementation
+
+(defrecord FunctionalAgent [role config system-prompt invoke-fn validate-fn repair-fn logger]
+  ;; Implement the main Agent protocol for compatibility with workflow/core.clj
+  ;; The Agent protocol signature is: (invoke [this task context])
+  ;; The invoke-fn expects: (invoke-fn context input)
+  ;; So we adapt by swapping the order
+  protocol/Agent
+  (invoke [_this task context]
+    (let [start-time (System/currentTimeMillis)]
+      (try
+        (log/debug logger :agent :agent/invoke-started
+                   {:data {:role role :task-type (:task/type task)}})
+        (let [result (invoke-fn context task)]
+          (log/info logger :agent :agent/invoke-completed
+                    {:data {:role role
+                            :duration-ms (- (System/currentTimeMillis) start-time)
+                            :status (:status result)}})
+          result)
+        (catch Exception e
+          (log/error logger :agent :agent/invoke-failed
+                     {:message (.getMessage e)
+                      :data {:role role
+                             :duration-ms (- (System/currentTimeMillis) start-time)}})
+          {:status :error
+           :error (.getMessage e)
+           :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}}))))
+
+  (validate [_this output _context]
+    (validate-fn output))
+
+  (repair [_this output errors context]
+    (log/debug logger :agent :agent/repair-started
+               {:data {:role role :error-count (count (if (map? errors) (vals errors) errors))}})
+    (let [result (repair-fn output errors context)]
+      (log/info logger :agent :agent/repair-completed
+                {:data {:role role :status (:status result)}})
+      result)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Helper functions for cycle-agent
+
+(defn- handle-first-iteration
+  "Handle the first iteration: invoke the agent and validate output.
+   Returns either the successful result or continues to repair loop."
+  [agent context input max-iterations]
+  (let [result (invoke agent context input)]
+    (if (= :error (:status result))
+      result
+      (let [validation (validate agent (:output result))]
+        (if (:valid? validation)
+          result
+          (if (>= 0 max-iterations)
+            {:status :error
+             :output (:output result)
+             :errors (:errors validation)
+             :message "Max repair iterations reached"}
+            {:continue-repair true
+             :iteration 1
+             :output (:output result)}))))))
+
+(defn- handle-repair-iteration
+  "Handle a repair iteration: validate output and attempt repair if needed.
+   Returns either success, error, or continuation signal."
+  [agent current-output iteration max-iterations context]
+  (let [validation (validate agent current-output)]
+    (if (:valid? validation)
+      {:status :success :output current-output}
+      (if (>= iteration max-iterations)
+        {:status :error
+         :output current-output
+         :errors (:errors validation)
+         :message "Max repair iterations reached"}
+        (let [repair-result (repair agent current-output (:errors validation) context)]
+          (if (= :error (:status repair-result))
+            repair-result
+            {:continue-repair true
+             :iteration (inc iteration)
+             :output (:output repair-result)}))))))
+
+;; Orchestration functions
+
+(defn create-base-agent
+  "Create a base agent with the given configuration.
+   Used by specialized agents (planner, implementer, tester).
+
+   Required options:
+   - :role          - Agent role keyword (:planner, :implementer, :tester, etc.)
+   - :system-prompt - System prompt for the agent
+   - :invoke-fn     - Function (fn [context input] -> result)
+   - :validate-fn   - Function (fn [output] -> {:valid? bool, :errors [...]})
+   - :repair-fn     - Function (fn [output errors context] -> repaired-result)
+
+   Optional:
+   - :config - Agent configuration map (model, temperature, etc.)
+   - :logger - Logger instance (defaults to silent logger)"
+  [{:keys [role system-prompt invoke-fn validate-fn repair-fn config logger]
+    :or {config {}
+         logger (log/create-logger {:min-level :info :output (fn [_])})}}]
+  {:pre [(keyword? role)
+         (string? system-prompt)
+         (fn? invoke-fn)
+         (fn? validate-fn)
+         (fn? repair-fn)]}
+  (->FunctionalAgent role config system-prompt invoke-fn validate-fn repair-fn logger))
+
+(defn make-validator
+  "Create a validation function from a Malli schema."
+  [malli-schema]
+  (fn [output]
+    (if (schema/valid? malli-schema output)
+      {:valid? true :errors nil}
+      {:valid? false :errors (schema/explain malli-schema output)})))
+
+(defn cycle-agent
+  "Execute a full invoke-validate-repair cycle on a specialized agent.
+   Returns the final result after up to max-iterations of repair attempts.
+
+   Options:
+   - :max-iterations - Maximum repair attempts (default 3)"
+  [agent context input & {:keys [max-iterations] :or {max-iterations 3}}]
+  (loop [iteration 0
+         current-output nil]
+    (let [result (if (zero? iteration)
+                   (handle-first-iteration agent context input max-iterations)
+                   (handle-repair-iteration agent current-output iteration max-iterations context))]
+      (if (:continue-repair result)
+        (recur (:iteration result) (:output result))
+        result))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create a specialized agent
+  (def test-agent
+    (create-base-agent
+     {:role :test-agent
+      :system-prompt "Test agent system prompt"
+      :invoke-fn (fn [_ctx input] {:status :success :output input})
+      :validate-fn (fn [output] {:valid? (map? output) :errors nil})
+      :repair-fn (fn [output _errors _ctx] {:status :success :output output})}))
+
+  ;; Use the cycle-agent function
+  (cycle-agent test-agent {} {:test "input"})
+  ;; => {:status :success, :output {:test "input"}}
+
+  :leave-this-here)

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -2,7 +2,7 @@
   "Tester agent implementation.
    Generates tests for code artifacts and validates coverage."
   (:require
-   [ai.miniforge.agent.core :as core]
+   [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
@@ -367,7 +367,7 @@ and what behavior is expected. Make tests readable and maintainable.")
   [& [opts]]
   (let [logger (or (:logger opts)
                    (log/create-logger {:min-level :info :output (fn [_])}))]
-    (core/create-base-agent
+    (specialized/create-base-agent
      {:role :tester
       :system-prompt tester-system-prompt
       :config (merge {:model "claude-sonnet-4"
@@ -494,7 +494,7 @@ and what behavior is expected. Make tests readable and maintainable.")
   (def tester (create-tester))
 
   ;; Invoke with a code artifact
-  (core/invoke tester
+  (specialized/invoke tester
                {:test-framework "clojure.test"}
                {:code {:code/id (random-uuid)
                        :code/files [{:path "src/auth/login.clj"


### PR DESCRIPTION
## Summary

Refactored agent/core.clj to reduce from 6 to 3 layers.

Cherry-picked from original PR #45 which had merge conflicts.

- Extracted specialized agents into separate specialized.clj module
- Consolidated layers

---
Generated with [Claude Code](https://claude.ai/claude-code)