### PR TITLE
fix(loop): reduce nesting in inner.clj and repair.clj

### DIFF
--- a/components/loop/src/ai/miniforge/loop/inner.clj
+++ b/components/loop/src/ai/miniforge/loop/inner.clj
@@ -338,7 +338,64 @@
               (transition loop-state :generating))))))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Loop runner
+;; Loop runner helpers
+
+(defn- handle-terminal-state
+  "Handle terminal states (complete, failed, escalated).
+   Returns the final result map."
+  [state logger]
+  (let [current-state (:loop/state state)
+        success? (= current-state :complete)]
+    (when logger
+      (if success?
+        (log/info logger :loop :inner/validation-passed
+                  {:message "Inner loop completed successfully"
+                   :data {:iterations (:loop/iteration state)}})
+        (log/warn logger :loop :inner/escalated
+                  {:message "Inner loop terminated"
+                   :data {:state current-state
+                          :reason (get-in state [:loop/termination :reason])}})))
+    {:success success?
+     :artifact (when success? (:loop/artifact state))
+     :iterations (:loop/iteration state)
+     :metrics (:loop/metrics state)
+     :termination (:loop/termination state)
+     :final-state state}))
+
+(defn- handle-pre-termination
+  "Handle pre-termination conditions (budget exhausted, max iterations).
+   Returns updated state transitioned to appropriate terminal state."
+  [state termination-result]
+  (let [{:keys [reason]} termination-result]
+    (-> state
+        (set-termination reason)
+        (transition (if (= reason :gates-passed)
+                      :complete
+                      :escalated)))))
+
+(defn- handle-pending-state
+  "Handle pending state - initiate generation.
+   Returns updated state."
+  [state generate-fn context]
+  (generate-step state generate-fn context))
+
+(defn- handle-generating-state
+  "Handle generating state - continue generation.
+   Returns updated state."
+  [state generate-fn context]
+  (generate-step state generate-fn context))
+
+(defn- handle-validating-state
+  "Handle validating state - run validation.
+   Returns updated state."
+  [state gates context]
+  (validate-step state gates context))
+
+(defn- handle-repairing-state
+  "Handle repairing state - attempt repair.
+   Returns updated state."
+  [state strategies context]
+  (repair-step state strategies context))
 
 (defn run-inner-loop
   "Run the inner loop to completion.
@@ -365,52 +422,29 @@
                         :max-iterations (get-in loop-state [:loop/config :max-iterations])}}))
 
     (loop [state loop-state]
-      (let [current-state (:loop/state state)]
+      (let [current-state (:loop/state state)
+            termination-check (should-terminate? state)]
         (cond
-          ;; Terminal states
+          ;; Terminal states - return result
           (terminal-state? current-state)
-          (let [success? (= current-state :complete)]
-            (when logger
-              (if success?
-                (log/info logger :loop :inner/validation-passed
-                          {:message "Inner loop completed successfully"
-                           :data {:iterations (:loop/iteration state)}})
-                (log/warn logger :loop :inner/escalated
-                          {:message "Inner loop terminated"
-                           :data {:state current-state
-                                  :reason (get-in state [:loop/termination :reason])}})))
-            {:success success?
-             :artifact (when success? (:loop/artifact state))
-             :iterations (:loop/iteration state)
-             :metrics (:loop/metrics state)
-             :termination (:loop/termination state)
-             :final-state state})
+          (handle-terminal-state state logger)
 
-          ;; Pre-termination check
-          (should-terminate? state)
-          (let [{:keys [reason]} (should-terminate? state)]
-            (recur (-> state
-                       (set-termination reason)
-                       (transition (if (= reason :gates-passed)
-                                     :complete
-                                     :escalated)))))
+          ;; Pre-termination check - cache result to avoid calling twice
+          termination-check
+          (recur (handle-pre-termination state termination-check))
 
-          ;; Pending -> Generate
+          ;; State-based dispatch
           (= current-state :pending)
-          (recur (generate-step state generate-fn context))
+          (recur (handle-pending-state state generate-fn context))
 
-          ;; Generating -> already handled in generate-step
-          ;; This state is transient, shouldn't be observed here
           (= current-state :generating)
-          (recur (generate-step state generate-fn context))
+          (recur (handle-generating-state state generate-fn context))
 
-          ;; Validating
           (= current-state :validating)
-          (recur (validate-step state gates context))
+          (recur (handle-validating-state state gates context))
 
-          ;; Repairing
           (= current-state :repairing)
-          (recur (repair-step state strategies context))
+          (recur (handle-repairing-state state strategies context))
 
           ;; Unknown state (shouldn't happen)
           :else

--- a/components/loop/src/ai/miniforge/loop/repair.clj
+++ b/components/loop/src/ai/miniforge/loop/repair.clj
@@ -173,6 +173,67 @@
   [strategies errors context]
   (first (filter #(can-repair? % errors context) strategies)))
 
+(defn- make-max-attempts-result
+  "Create a result map for max attempts exceeded."
+  [attempt results errors]
+  {:success? false
+   :attempts attempt
+   :results results
+   :errors errors
+   :message "Maximum repair attempts exceeded"})
+
+(defn- make-exhausted-strategies-result
+  "Create a result map for exhausted strategies."
+  [attempt results errors]
+  {:success? false
+   :attempts attempt
+   :results results
+   :errors errors
+   :message "All repair strategies exhausted"})
+
+(defn- make-success-result
+  "Create a result map for successful repair."
+  [result attempt results]
+  {:success? true
+   :artifact (:artifact result)
+   :attempts (inc attempt)
+   :results (conj results result)
+   :strategy (:strategy result)})
+
+(defn- make-escalation-result
+  "Create a result map for escalation."
+  [result attempt results errors]
+  {:success? false
+   :escalate? true
+   :attempts (inc attempt)
+   :results (conj results result)
+   :errors errors
+   :message "Repair escalated to outer loop"})
+
+(defn- try-repair-with-strategy
+  "Try to repair using a single strategy.
+   Returns result map or nil if strategy can't handle errors."
+  [strategy artifact errors context]
+  (when (can-repair? strategy errors context)
+    (repair strategy artifact errors context)))
+
+(defn- process-repair-result
+  "Process the result of a repair attempt.
+   Returns a map with :action (:success, :escalate, or :continue) and :result."
+  [result attempt results errors]
+  (cond
+    (:success? result)
+    {:action :success
+     :result (make-success-result result attempt results)}
+
+    (:escalate? result)
+    {:action :escalate
+     :result (make-escalation-result result attempt results errors)}
+
+    :else
+    {:action :continue
+     :result result}))
+
 (defn attempt-repair
   "Attempt to repair an artifact using available strategies.
    Tries strategies in order until one succeeds or all fail.
@@ -195,46 +256,25 @@
       (cond
         ;; Max attempts reached
         (>= attempt max-attempts)
-        {:success? false
-         :attempts attempt
-         :results results
-         :errors errors
-         :message "Maximum repair attempts exceeded"}
+        (make-max-attempts-result attempt results errors)
 
         ;; No more strategies
         (empty? remaining-strategies)
-        {:success? false
-         :attempts attempt
-         :results results
-         :errors errors
-         :message "All repair strategies exhausted"}
+        (make-exhausted-strategies-result attempt results errors)
 
         :else
-        (let [strategy (first remaining-strategies)]
-          (if (can-repair? strategy errors context)
-            ;; Try this strategy
-            (let [result (repair strategy artifact errors context)]
-              (if (:success? result)
-                ;; Success!
-                {:success? true
-                 :artifact (:artifact result)
-                 :attempts (inc attempt)
-                 :results (conj results result)
-                 :strategy (:strategy result)}
-                ;; Failed or escalating
-                (if (:escalate? result)
-                  ;; Explicit escalation
-                  {:success? false
-                   :escalate? true
-                   :attempts (inc attempt)
-                   :results (conj results result)
-                   :errors errors
-                   :message "Repair escalated to outer loop"}
-                  ;; Try next strategy
-                  (recur (rest remaining-strategies)
-                         (inc attempt)
-                         (conj results result)))))
-            ;; Strategy can't handle these errors, try next
+        (let [strategy (first remaining-strategies)
+              repair-result (try-repair-with-strategy strategy artifact errors context)]
+          (if repair-result
+            ;; Strategy attempted repair
+            (let [processed (process-repair-result repair-result attempt results errors)]
+              (case (:action processed)
+                :success (:result processed)
+                :escalate (:result processed)
+                :continue (recur (rest remaining-strategies)
+                                (inc attempt)
+                                (conj results repair-result))))
+            ;; Strategy can't handle these errors, skip to next
             (recur (rest remaining-strategies)
                    attempt
                    results)))))))


### PR DESCRIPTION
## Summary

Reduced nesting in loop/inner.clj and loop/repair.clj.

Cherry-picked from original PR #46 which had merge conflicts.

---
Generated with [Claude Code](https://claude.ai/claude-code)