### PR TITLE
feat(repo-dag): implement multi-repo dependency graph

### DIFF
--- a/components/repo-dag/deps.edn
+++ b/components/repo-dag/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src" "resources"]
+ :deps {metosin/malli {:mvn/version "0.16.4"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/core.clj
@@ -1,0 +1,488 @@
+(ns ai.miniforge.repo-dag.core
+  "Implementation of the repo-dag component.
+   Layer 0: Pure functions for DAG operations
+   Layer 1: Protocol definition
+   Layer 2: In-memory implementation"
+  (:require
+   [clojure.set :as set]
+   [clojure.string :as str]
+   [malli.core :as m]
+   [malli.error :as me]
+   [ai.miniforge.repo-dag.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pure functions for DAG operations
+
+(defn- validate-schema
+  "Validate a value against a schema, returning the value or throwing."
+  [schema-def value]
+  (if (m/validate schema-def value)
+    value
+    (throw (ex-info "Schema validation failed"
+                    {:schema schema-def
+                     :value value
+                     :errors (me/humanize (m/explain schema-def value))}))))
+
+(defn make-repo-node
+  "Create a repo node with layer inference if not specified."
+  [{:keys [repo/url repo/name repo/org repo/type repo/layer repo/default-branch repo/watch-config]
+    :or {default-branch "main"}}]
+  (let [inferred-layer (or layer (schema/infer-layer type))
+        node (cond-> {:repo/url url
+                      :repo/name name
+                      :repo/type type
+                      :repo/layer inferred-layer
+                      :repo/default-branch default-branch}
+               org (assoc :repo/org org)
+               watch-config (assoc :repo/watch-config watch-config))]
+    (validate-schema schema/RepoNode node)))
+
+(defn make-repo-edge
+  "Create a repo edge with default merge ordering."
+  [{:keys [edge/from edge/to edge/constraint edge/merge-ordering edge/validation]
+    :or {merge-ordering :sequential}}]
+  (let [edge (cond-> {:edge/from from
+                      :edge/to to
+                      :edge/constraint constraint
+                      :edge/merge-ordering merge-ordering}
+               validation (assoc :edge/validation validation))]
+    (validate-schema schema/RepoEdge edge)))
+
+(defn make-dag
+  "Create a new empty DAG."
+  [id dag-name description]
+  (let [dag (cond-> {:dag/id id
+                     :dag/name dag-name
+                     :dag/repos []
+                     :dag/edges []}
+              description (assoc :dag/description description))]
+    (validate-schema schema/RepoDag dag)))
+
+(defn- find-repo-by-name
+  "Find a repo node by name in the DAG."
+  [dag repo-name]
+  (some #(when (= repo-name (:repo/name %)) %) (:dag/repos dag)))
+
+(defn- find-edge
+  "Find an edge by from/to pair."
+  [dag from-repo to-repo]
+  (some #(when (and (= from-repo (:edge/from %))
+                    (= to-repo (:edge/to %)))
+           %)
+        (:dag/edges dag)))
+
+(defn- repo-names
+  "Get set of all repo names in the DAG."
+  [dag]
+  (set (map :repo/name (:dag/repos dag))))
+
+;------------------------------------------------------------------------------ Layer 0.5
+;; Kahn's algorithm for topological sort
+
+(defn topo-sort
+  "Perform topological sort using Kahn's algorithm.
+   Returns {:success true :order [...]} or {:success false :error :cycle-detected :cycle-nodes #{...}}"
+  [dag]
+  (let [nodes (repo-names dag)
+        edges (:dag/edges dag)
+        ;; Build in-degree map: count of incoming edges per node
+        in-degree (reduce (fn [acc edge]
+                            (update acc (:edge/to edge) (fnil inc 0)))
+                          (zipmap nodes (repeat 0))
+                          edges)
+        ;; Build adjacency list: map from node to list of nodes it points to
+        adj (reduce (fn [acc edge]
+                      (update acc (:edge/from edge) (fnil conj []) (:edge/to edge)))
+                    {}
+                    edges)
+        ;; Find initial set of nodes with no incoming edges
+        initial-queue (filterv #(zero? (get in-degree %)) nodes)]
+    ;; Kahn's algorithm loop
+    (loop [queue (into clojure.lang.PersistentQueue/EMPTY initial-queue)
+           in-deg in-degree
+           result []]
+      (if (empty? queue)
+        ;; Check if all nodes were processed
+        (if (= (count result) (count nodes))
+          {:success true :order result}
+          ;; Cycle detected - find nodes not in result
+          (let [remaining (set/difference nodes (set result))]
+            {:success false
+             :error :cycle-detected
+             :cycle-nodes remaining}))
+        ;; Process next node
+        (let [node (peek queue)
+              neighbors (get adj node [])
+              ;; Update in-degrees for neighbors
+              new-in-deg (reduce #(update %1 %2 dec) in-deg neighbors)
+              ;; Find newly ready neighbors (in-degree becomes 0)
+              ready-neighbors (filterv #(zero? (get new-in-deg %)) neighbors)]
+          (recur (into (pop queue) ready-neighbors)
+                 new-in-deg
+                 (conj result node)))))))
+
+(defn find-cycle-nodes
+  "Find nodes involved in a cycle. Returns nil if no cycle."
+  [dag]
+  (let [result (topo-sort dag)]
+    (when-not (:success result)
+      (:cycle-nodes result))))
+
+;------------------------------------------------------------------------------ Layer 0.6
+;; Graph traversal functions
+
+(defn- build-adjacency
+  "Build adjacency list from DAG edges."
+  [dag]
+  (reduce (fn [acc edge]
+            (update acc (:edge/from edge) (fnil conj #{}) (:edge/to edge)))
+          {}
+          (:dag/edges dag)))
+
+(defn- build-reverse-adjacency
+  "Build reverse adjacency list (for finding upstream repos)."
+  [dag]
+  (reduce (fn [acc edge]
+            (update acc (:edge/to edge) (fnil conj #{}) (:edge/from edge)))
+          {}
+          (:dag/edges dag)))
+
+(defn downstream-repos
+  "Get all repos that depend on the given repo (transitive closure)."
+  [dag repo-name]
+  (let [adj (build-adjacency dag)]
+    (loop [to-visit #{repo-name}
+           visited #{}]
+      (if (empty? to-visit)
+        (disj visited repo-name) ; Don't include the starting repo
+        (let [current (first to-visit)
+              neighbors (get adj current #{})]
+          (recur (into (disj to-visit current)
+                       (set/difference neighbors visited))
+                 (conj visited current)))))))
+
+(defn upstream-repos-impl
+  "Get all repos that this repo depends on (transitive closure)."
+  [dag repo-name]
+  (let [rev-adj (build-reverse-adjacency dag)]
+    (loop [to-visit #{repo-name}
+           visited #{}]
+      (if (empty? to-visit)
+        (disj visited repo-name) ; Don't include the starting repo
+        (let [current (first to-visit)
+              neighbors (get rev-adj current #{})]
+          (recur (into (disj to-visit current)
+                       (set/difference neighbors visited))
+                 (conj visited current)))))))
+
+(defn compute-merge-order
+  "Given a set of repo names, compute valid merge order based on DAG topology.
+   Only considers repos in the pr-set."
+  [dag pr-set]
+  (let [pr-names (set pr-set)
+        ;; Filter edges to only those between repos in pr-set
+        relevant-edges (filterv (fn [edge]
+                                  (and (contains? pr-names (:edge/from edge))
+                                       (contains? pr-names (:edge/to edge))))
+                                (:dag/edges dag))
+        ;; Create sub-DAG
+        sub-dag (assoc dag
+                       :dag/repos (filterv #(contains? pr-names (:repo/name %))
+                                           (:dag/repos dag))
+                       :dag/edges relevant-edges)]
+    (topo-sort sub-dag)))
+
+(defn compute-layers
+  "Group repos by their layer."
+  [dag]
+  (reduce (fn [acc repo]
+            (let [rname (:repo/name repo)
+                  rlayer (:repo/layer repo)]
+              (update acc rlayer (fnil conj []) rname)))
+          {}
+          (:dag/repos dag)))
+
+;------------------------------------------------------------------------------ Layer 0.7
+;; Validation functions
+
+(defn validate-dag-impl
+  "Validate DAG structure. Returns {:valid? bool :errors [...]}"
+  [dag]
+  (let [repo-name-set (repo-names dag)
+        errors (atom [])]
+    ;; Check for duplicate repo names
+    (let [names (map :repo/name (:dag/repos dag))
+          freqs (frequencies names)
+          dups (filterv #(> (val %) 1) freqs)]
+      (doseq [[dup-name dup-count] dups]
+        (swap! errors conj {:type :duplicate-repo
+                            :message (str "Duplicate repo name: " dup-name " (appears " dup-count " times)")
+                            :data {:repo-name dup-name :count dup-count}})))
+
+    ;; Check for edges referencing missing repos
+    (doseq [edge (:dag/edges dag)]
+      (let [from-repo (:edge/from edge)
+            to-repo (:edge/to edge)]
+        (when-not (contains? repo-name-set from-repo)
+          (swap! errors conj {:type :missing-repo
+                              :message (str "Edge references missing repo: " from-repo)
+                              :data {:edge-from from-repo :edge-to to-repo}}))
+        (when-not (contains? repo-name-set to-repo)
+          (swap! errors conj {:type :missing-repo
+                              :message (str "Edge references missing repo: " to-repo)
+                              :data {:edge-from from-repo :edge-to to-repo}}))))
+
+    ;; Check for self-loops
+    (doseq [edge (:dag/edges dag)]
+      (let [from-repo (:edge/from edge)
+            to-repo (:edge/to edge)]
+        (when (= from-repo to-repo)
+          (swap! errors conj {:type :self-loop
+                              :message (str "Self-loop detected: " from-repo " -> " to-repo)
+                              :data {:repo from-repo}}))))
+
+    ;; Check for cycles
+    (let [result (topo-sort dag)]
+      (when-not (:success result)
+        (swap! errors conj {:type :cycle
+                            :message (str "Cycle detected involving repos: "
+                                          (str/join ", " (:cycle-nodes result)))
+                            :data {:cycle-nodes (:cycle-nodes result)}})))
+
+    {:valid? (empty? @errors)
+     :errors @errors}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Protocol definition
+
+(defprotocol RepoDagManager
+  "Protocol for managing repository dependency graphs."
+
+  ;; CRUD operations
+  (create-dag [this dag-name description]
+    "Create a new empty DAG. Returns the created DAG.")
+
+  (add-repo [this dag-id repo-config]
+    "Add a repository node to the DAG. Returns updated DAG.")
+
+  (remove-repo [this dag-id repo-name]
+    "Remove a repository from the DAG (and its edges). Returns updated DAG.")
+
+  (add-edge [this dag-id from-repo to-repo constraint merge-ordering]
+    "Add a dependency edge between repos. Returns updated DAG or error if invalid.")
+
+  (remove-edge [this dag-id from-repo to-repo]
+    "Remove a dependency edge. Returns updated DAG.")
+
+  ;; Queries
+  (get-dag [this dag-id]
+    "Retrieve a DAG by ID. Returns nil if not found.")
+
+  (compute-topo-order [this dag-id]
+    "Compute topological sort of repos. Returns {:success true :order [...]} or error.")
+
+  (affected-repos [this dag-id changed-repo]
+    "Given a changed repo, return all downstream repos that may be affected.")
+
+  (upstream-repos [this dag-id repo-name]
+    "Return all repos that this repo depends on.")
+
+  (merge-order [this dag-id pr-set]
+    "Given a set of PRs across repos, return valid merge order.")
+
+  ;; Validation
+  (validate-dag [this dag-id]
+    "Check for cycles, orphans, invalid references. Returns {:valid? bool :errors [...]}."))
+
+;------------------------------------------------------------------------------ Layer 2
+;; In-memory implementation
+
+(defrecord InMemoryDagManager [store]
+  RepoDagManager
+
+  (create-dag [_this dag-name description]
+    (let [id (random-uuid)
+          dag (make-dag id dag-name description)]
+      (swap! store assoc id dag)
+      dag))
+
+  (add-repo [_this dag-id repo-config]
+    (if-let [dag (get @store dag-id)]
+      (let [node (make-repo-node repo-config)
+            rname (:repo/name node)]
+        ;; Check for duplicate
+        (when (find-repo-by-name dag rname)
+          (throw (ex-info "Repo already exists"
+                          {:dag-id dag-id :repo-name rname})))
+        (let [updated (update dag :dag/repos conj node)]
+          (swap! store assoc dag-id updated)
+          updated))
+      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+
+  (remove-repo [_this dag-id repo-name]
+    (if-let [dag (get @store dag-id)]
+      (let [;; Remove the repo
+            updated-repos (filterv #(not= repo-name (:repo/name %)) (:dag/repos dag))
+            ;; Remove edges referencing this repo
+            updated-edges (filterv #(and (not= repo-name (:edge/from %))
+                                         (not= repo-name (:edge/to %)))
+                                   (:dag/edges dag))
+            updated (assoc dag
+                           :dag/repos updated-repos
+                           :dag/edges updated-edges)]
+        (swap! store assoc dag-id updated)
+        updated)
+      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+
+  (add-edge [_this dag-id from-repo to-repo constraint merge-ordering]
+    (if-let [dag (get @store dag-id)]
+      (let [repo-name-set (repo-names dag)]
+        ;; Validate repos exist
+        (when-not (contains? repo-name-set from-repo)
+          (throw (ex-info "From repo not found in DAG"
+                          {:dag-id dag-id :repo-name from-repo})))
+        (when-not (contains? repo-name-set to-repo)
+          (throw (ex-info "To repo not found in DAG"
+                          {:dag-id dag-id :repo-name to-repo})))
+        ;; Check for self-loop
+        (when (= from-repo to-repo)
+          (throw (ex-info "Self-loop not allowed"
+                          {:dag-id dag-id :repo-name from-repo})))
+        ;; Check for existing edge
+        (when (find-edge dag from-repo to-repo)
+          (throw (ex-info "Edge already exists"
+                          {:dag-id dag-id :from from-repo :to to-repo})))
+        ;; Create edge
+        (let [edge (make-repo-edge {:edge/from from-repo
+                                    :edge/to to-repo
+                                    :edge/constraint constraint
+                                    :edge/merge-ordering merge-ordering})
+              updated (update dag :dag/edges conj edge)
+              ;; Check for cycles
+              result (topo-sort updated)]
+          (if (:success result)
+            (do
+              (swap! store assoc dag-id updated)
+              updated)
+            (throw (ex-info "Adding edge would create cycle"
+                            {:dag-id dag-id
+                             :from from-repo
+                             :to to-repo
+                             :cycle-nodes (:cycle-nodes result)})))))
+      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+
+  (remove-edge [_this dag-id from-repo to-repo]
+    (if-let [dag (get @store dag-id)]
+      (let [updated-edges (filterv #(not (and (= from-repo (:edge/from %))
+                                              (= to-repo (:edge/to %))))
+                                   (:dag/edges dag))
+            updated (assoc dag :dag/edges updated-edges)]
+        (swap! store assoc dag-id updated)
+        updated)
+      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+
+  (get-dag [_this dag-id]
+    (get @store dag-id))
+
+  (compute-topo-order [_this dag-id]
+    (if-let [dag (get @store dag-id)]
+      (topo-sort dag)
+      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+
+  (affected-repos [_this dag-id changed-repo]
+    (if-let [dag (get @store dag-id)]
+      (downstream-repos dag changed-repo)
+      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+
+  (upstream-repos [_this dag-id repo-name]
+    (if-let [dag (get @store dag-id)]
+      (upstream-repos-impl dag repo-name)
+      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+
+  (merge-order [_this dag-id pr-set]
+    (if-let [dag (get @store dag-id)]
+      (compute-merge-order dag pr-set)
+      (throw (ex-info "DAG not found" {:dag-id dag-id}))))
+
+  (validate-dag [_this dag-id]
+    (if-let [dag (get @store dag-id)]
+      (validate-dag-impl dag)
+      (throw (ex-info "DAG not found" {:dag-id dag-id})))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Factory functions
+
+(defn create-manager
+  "Create a new in-memory DAG manager."
+  []
+  (->InMemoryDagManager (atom {})))
+
+(defn get-all-dags
+  "Get all DAGs from the manager's store."
+  [manager]
+  (vals @(:store manager)))
+
+(defn reset-manager!
+  "Reset the manager's store. Useful for testing."
+  [manager]
+  (reset! (:store manager) {}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create a manager
+  (def mgr (create-manager))
+
+  ;; Create a DAG
+  (def dag (create-dag mgr "kiddom-infra" "Kiddom infrastructure repos"))
+
+  ;; Add repos
+  (add-repo mgr (:dag/id dag)
+            {:repo/url "https://github.com/kiddom/terraform-modules"
+             :repo/name "terraform-modules"
+             :repo/type :terraform-module})
+
+  (add-repo mgr (:dag/id dag)
+            {:repo/url "https://github.com/kiddom/terraform"
+             :repo/name "terraform-live"
+             :repo/type :terraform-live})
+
+  (add-repo mgr (:dag/id dag)
+            {:repo/url "https://github.com/kiddom/k8s-manifests"
+             :repo/name "k8s-manifests"
+             :repo/type :kubernetes})
+
+  ;; Add edges
+  (add-edge mgr (:dag/id dag)
+            "terraform-modules" "terraform-live"
+            :module-before-live :sequential)
+
+  (add-edge mgr (:dag/id dag)
+            "terraform-live" "k8s-manifests"
+            :infra-before-k8s :sequential)
+
+  ;; Compute topo order
+  (compute-topo-order mgr (:dag/id dag))
+  ;; => {:success true, :order ["terraform-modules" "terraform-live" "k8s-manifests"]}
+
+  ;; Get affected repos
+  (affected-repos mgr (:dag/id dag) "terraform-modules")
+  ;; => #{"terraform-live" "k8s-manifests"}
+
+  ;; Get upstream repos
+  (upstream-repos mgr (:dag/id dag) "k8s-manifests")
+  ;; => #{"terraform-modules" "terraform-live"}
+
+  ;; Validate
+  (validate-dag mgr (:dag/id dag))
+  ;; => {:valid? true, :errors []}
+
+  ;; Try to create a cycle
+  (try
+    (add-edge mgr (:dag/id dag)
+              "k8s-manifests" "terraform-modules"
+              :library-before-consumer :sequential)
+    (catch Exception e
+      (ex-data e)))
+  ;; => {:dag-id ..., :from "k8s-manifests", :to "terraform-modules", :cycle-nodes #{"terraform-modules" "terraform-live" "k8s-manifests"}}
+
+  :leave-this-here)

--- a/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/interface.clj
@@ -1,0 +1,366 @@
+(ns ai.miniforge.repo-dag.interface
+  "Public API for the repo-dag component.
+   Provides DAG CRUD, topological sorting, and dependency graph queries."
+  (:require
+   [ai.miniforge.repo-dag.core :as core]
+   [ai.miniforge.repo-dag.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema re-exports
+
+(def RepoNode schema/RepoNode)
+(def RepoEdge schema/RepoEdge)
+(def RepoDag schema/RepoDag)
+(def WatchConfig schema/WatchConfig)
+(def EdgeValidation schema/EdgeValidation)
+
+;; Enum value sets for programmatic access
+(def repo-types schema/repo-types)
+(def repo-layers schema/repo-layers)
+(def edge-constraints schema/edge-constraints)
+(def merge-orderings schema/merge-orderings)
+(def type->layer schema/type->layer)
+
+;; Validation helpers
+(def valid-repo-node? schema/valid-repo-node?)
+(def valid-repo-edge? schema/valid-repo-edge?)
+(def valid-repo-dag? schema/valid-repo-dag?)
+(def infer-layer schema/infer-layer)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Manager lifecycle
+
+(defn create-manager
+  "Create a new in-memory DAG manager.
+
+   Returns a manager instance that can be used with all other functions.
+
+   Example:
+     (def mgr (create-manager))"
+  []
+  (core/create-manager))
+
+(defn reset-manager!
+  "Reset the manager's store to empty. Useful for testing.
+
+   Arguments:
+   - manager: The DAG manager instance"
+  [manager]
+  (core/reset-manager! manager))
+
+(defn get-all-dags
+  "Get all DAGs from the manager's store.
+
+   Arguments:
+   - manager: The DAG manager instance
+
+   Returns a sequence of all DAGs."
+  [manager]
+  (core/get-all-dags manager))
+
+;------------------------------------------------------------------------------ Layer 2
+;; DAG CRUD operations
+
+(defn create-dag
+  "Create a new empty DAG.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-name: Name for the DAG
+   - description: Optional description
+
+   Returns the created DAG.
+
+   Example:
+     (create-dag mgr \"kiddom-infra\" \"Kiddom infrastructure repos\")"
+  ([manager dag-name] (core/create-dag manager dag-name nil))
+  ([manager dag-name description] (core/create-dag manager dag-name description)))
+
+(defn get-dag
+  "Retrieve a DAG by ID.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-id: UUID of the DAG
+
+   Returns the DAG or nil if not found."
+  [manager dag-id]
+  (core/get-dag manager dag-id))
+
+(defn add-repo
+  "Add a repository node to the DAG.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-id: UUID of the DAG
+   - repo-config: Map with repo fields (:repo/url, :repo/name, :repo/type required)
+
+   Returns the updated DAG.
+
+   Throws if:
+   - DAG not found
+   - Repo with same name already exists
+
+   Example:
+     (add-repo mgr dag-id
+               {:repo/url \"https://github.com/acme/terraform-modules\"
+                :repo/name \"terraform-modules\"
+                :repo/type :terraform-module})"
+  [manager dag-id repo-config]
+  (core/add-repo manager dag-id repo-config))
+
+(defn remove-repo
+  "Remove a repository from the DAG.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-id: UUID of the DAG
+   - repo-name: Name of the repo to remove
+
+   Returns the updated DAG.
+   Also removes all edges referencing this repo.
+
+   Throws if DAG not found."
+  [manager dag-id repo-name]
+  (core/remove-repo manager dag-id repo-name))
+
+(defn add-edge
+  "Add a dependency edge between repos.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-id: UUID of the DAG
+   - from-repo: Name of the upstream repo (dependency)
+   - to-repo: Name of the downstream repo (dependent)
+   - constraint: Edge constraint type (see edge-constraints)
+   - merge-ordering: How PRs should merge (see merge-orderings)
+
+   Returns the updated DAG.
+
+   Throws if:
+   - DAG not found
+   - Either repo not in DAG
+   - Edge would create a cycle
+   - Edge already exists
+   - Self-loop attempted
+
+   Example:
+     (add-edge mgr dag-id
+               \"terraform-modules\" \"terraform-live\"
+               :module-before-live :sequential)"
+  [manager dag-id from-repo to-repo constraint merge-ordering]
+  (core/add-edge manager dag-id from-repo to-repo constraint merge-ordering))
+
+(defn remove-edge
+  "Remove a dependency edge.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-id: UUID of the DAG
+   - from-repo: Name of the upstream repo
+   - to-repo: Name of the downstream repo
+
+   Returns the updated DAG.
+
+   Throws if DAG not found."
+  [manager dag-id from-repo to-repo]
+  (core/remove-edge manager dag-id from-repo to-repo))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Query operations
+
+(defn compute-topo-order
+  "Compute topological sort of repos in the DAG.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-id: UUID of the DAG
+
+   Returns:
+   - On success: {:success true :order [repo-names...]}
+   - On failure: {:success false :error :cycle-detected :cycle-nodes #{...}}
+
+   Example:
+     (compute-topo-order mgr dag-id)
+     ;; => {:success true :order [\"terraform-modules\" \"terraform-live\" \"k8s\"]}"
+  [manager dag-id]
+  (core/compute-topo-order manager dag-id))
+
+(defn affected-repos
+  "Given a changed repo, return all downstream repos that may be affected.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-id: UUID of the DAG
+   - changed-repo: Name of the repo that changed
+
+   Returns a set of repo names that are downstream (depend on) the changed repo.
+
+   Example:
+     (affected-repos mgr dag-id \"terraform-modules\")
+     ;; => #{\"terraform-live\" \"k8s-manifests\"}"
+  [manager dag-id changed-repo]
+  (core/affected-repos manager dag-id changed-repo))
+
+(defn upstream-repos
+  "Return all repos that the given repo depends on.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-id: UUID of the DAG
+   - repo-name: Name of the repo to query
+
+   Returns a set of repo names that are upstream (dependencies of) the given repo.
+
+   Example:
+     (upstream-repos mgr dag-id \"k8s-manifests\")
+     ;; => #{\"terraform-modules\" \"terraform-live\"}"
+  [manager dag-id repo-name]
+  (core/upstream-repos manager dag-id repo-name))
+
+(defn merge-order
+  "Given a set of repos with PRs, compute valid merge order.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-id: UUID of the DAG
+   - pr-set: Set of repo names that have PRs to merge
+
+   Returns:
+   - On success: {:success true :order [repo-names...]}
+   - On failure: {:success false :error :cycle-detected :cycle-nodes #{...}}
+
+   Only considers dependencies between repos in the pr-set.
+
+   Example:
+     (merge-order mgr dag-id #{\"terraform-modules\" \"terraform-live\"})
+     ;; => {:success true :order [\"terraform-modules\" \"terraform-live\"]}"
+  [manager dag-id pr-set]
+  (core/merge-order manager dag-id pr-set))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Validation
+
+(defn validate-dag
+  "Check DAG for structural validity.
+
+   Arguments:
+   - manager: The DAG manager instance
+   - dag-id: UUID of the DAG
+
+   Returns:
+   {:valid? boolean
+    :errors [{:type keyword :message string :data any}...]}
+
+   Checks for:
+   - Cycles
+   - Duplicate repo names
+   - Edges referencing missing repos
+   - Self-loops
+
+   Example:
+     (validate-dag mgr dag-id)
+     ;; => {:valid? true :errors []}"
+  [manager dag-id]
+  (core/validate-dag manager dag-id))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Pure functions (no manager required)
+
+(defn topo-sort
+  "Perform topological sort on a DAG directly.
+
+   Arguments:
+   - dag: A RepoDag map
+
+   Returns:
+   - On success: {:success true :order [repo-names...]}
+   - On failure: {:success false :error :cycle-detected :cycle-nodes #{...}}
+
+   This is a pure function that operates on the DAG data directly."
+  [dag]
+  (core/topo-sort dag))
+
+(defn find-cycle-nodes
+  "Find nodes involved in a cycle.
+
+   Arguments:
+   - dag: A RepoDag map
+
+   Returns a set of repo names in the cycle, or nil if no cycle."
+  [dag]
+  (core/find-cycle-nodes dag))
+
+(defn compute-layers
+  "Group repos by their layer.
+
+   Arguments:
+   - dag: A RepoDag map
+
+   Returns a map of layer keyword to vector of repo names.
+
+   Example:
+     (compute-layers dag)
+     ;; => {:foundations [\"terraform-modules\"]
+     ;;     :infrastructure [\"terraform-live\"]
+     ;;     :platform [\"k8s-manifests\"]}"
+  [dag]
+  (core/compute-layers dag))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; --- Manager Lifecycle ---
+  (def mgr (create-manager))
+  (reset-manager! mgr)
+
+  ;; --- DAG Creation ---
+  (def dag (create-dag mgr "kiddom-infra" "Kiddom infrastructure repos"))
+
+  ;; --- Add Repos ---
+  (add-repo mgr (:dag/id dag)
+            {:repo/url "https://github.com/kiddom/terraform-modules"
+             :repo/name "terraform-modules"
+             :repo/type :terraform-module})
+
+  (add-repo mgr (:dag/id dag)
+            {:repo/url "https://github.com/kiddom/terraform"
+             :repo/name "terraform-live"
+             :repo/type :terraform-live})
+
+  (add-repo mgr (:dag/id dag)
+            {:repo/url "https://github.com/kiddom/k8s-manifests"
+             :repo/name "k8s-manifests"
+             :repo/type :kubernetes})
+
+  ;; --- Add Edges ---
+  (add-edge mgr (:dag/id dag)
+            "terraform-modules" "terraform-live"
+            :module-before-live :sequential)
+
+  (add-edge mgr (:dag/id dag)
+            "terraform-live" "k8s-manifests"
+            :infra-before-k8s :sequential)
+
+  ;; --- Queries ---
+  (compute-topo-order mgr (:dag/id dag))
+  ;; => {:success true, :order ["terraform-modules" "terraform-live" "k8s-manifests"]}
+
+  (affected-repos mgr (:dag/id dag) "terraform-modules")
+  ;; => #{"terraform-live" "k8s-manifests"}
+
+  (upstream-repos mgr (:dag/id dag) "k8s-manifests")
+  ;; => #{"terraform-modules" "terraform-live"}
+
+  (merge-order mgr (:dag/id dag) #{"terraform-live" "k8s-manifests"})
+  ;; => {:success true, :order ["terraform-live" "k8s-manifests"]}
+
+  ;; --- Validation ---
+  (validate-dag mgr (:dag/id dag))
+  ;; => {:valid? true, :errors []}
+
+  ;; --- Pure Functions ---
+  (def current-dag (get-dag mgr (:dag/id dag)))
+  (topo-sort current-dag)
+  (compute-layers current-dag)
+
+  :leave-this-here)

--- a/components/repo-dag/src/ai/miniforge/repo_dag/schema.clj
+++ b/components/repo-dag/src/ai/miniforge/repo_dag/schema.clj
@@ -1,0 +1,192 @@
+(ns ai.miniforge.repo-dag.schema
+  "Malli schemas for the repo-dag component.
+   Layer 0: Enums and base types
+   Layer 1: RepoNode and RepoEdge schemas
+   Layer 2: RepoDag composite schema"
+  (:require
+   [malli.core :as m]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Enums and base types
+
+(def repo-types
+  "Types of repositories that can be modeled in the DAG."
+  [:terraform-module :terraform-live :kubernetes
+   :argocd :application :library :documentation])
+
+(def repo-layers
+  "Logical layers for repository categorization."
+  [:foundations :infrastructure :platform :application :adapters])
+
+(def edge-constraints
+  "Constraint types for dependency edges."
+  [:module-before-live      ; TF modules before live infra
+   :infra-before-k8s        ; Infrastructure before K8s manifests
+   :k8s-before-argocd       ; Manifests before ArgoCD apps
+   :library-before-consumer ; Libraries before consumers
+   :schema-before-impl])    ; Schema changes before implementations
+
+(def merge-orderings
+  "Merge ordering strategies for edges."
+  [:sequential    ; Must merge in order
+   :parallel-ok   ; Can merge in parallel if both ready
+   :same-pr-train]) ; Must be in same PR train
+
+(def type->layer
+  "Default layer inference from repository type."
+  {:terraform-module :foundations
+   :terraform-live   :infrastructure
+   :kubernetes       :platform
+   :argocd           :platform
+   :application      :application
+   :library          :foundations
+   :documentation    :adapters})
+
+(def registry
+  "Malli registry for repo-dag schema types."
+  {;; Identifiers
+   :dag/id          uuid?
+   :repo/url        [:string {:min 1}]
+   :repo/name       [:string {:min 1}]
+
+   ;; Repo enums
+   :repo/type       (into [:enum] repo-types)
+   :repo/layer      (into [:enum] repo-layers)
+
+   ;; Edge enums
+   :edge/constraint (into [:enum] edge-constraints)
+   :edge/merge-ordering (into [:enum] merge-orderings)})
+
+;------------------------------------------------------------------------------ Layer 1
+;; RepoNode and RepoEdge schemas
+
+(def WatchConfig
+  "Configuration for watching repository changes."
+  [:map
+   [:labels-include {:optional true} [:vector string?]]
+   [:labels-exclude {:optional true} [:vector string?]]
+   [:paths-include {:optional true} [:vector string?]]
+   [:paths-exclude {:optional true} [:vector string?]]])
+
+(def RepoNode
+  "Repository node in the DAG.
+   Represents a single repository with its metadata and configuration."
+  [:map {:registry registry}
+   [:repo/url :repo/url]
+   [:repo/name :repo/name]
+   [:repo/org {:optional true} string?]
+   [:repo/type :repo/type]
+   [:repo/layer :repo/layer]
+   [:repo/default-branch {:default "main"} string?]
+   [:repo/watch-config {:optional true} WatchConfig]])
+
+(def EdgeValidation
+  "Validation configuration for an edge."
+  [:map
+   [:require-ci-pass? {:default true} boolean?]
+   [:require-plan-clean? {:default false} boolean?]
+   [:custom-gate {:optional true} keyword?]])
+
+(def RepoEdge
+  "Dependency edge between repositories.
+   Represents a directed relationship from one repo to another."
+  [:map {:registry registry}
+   [:edge/from :repo/name]
+   [:edge/to :repo/name]
+   [:edge/constraint :edge/constraint]
+   [:edge/merge-ordering :edge/merge-ordering]
+   [:edge/validation {:optional true} EdgeValidation]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; RepoDag composite schema
+
+(def RepoDag
+  "Complete repository dependency graph.
+   Contains all nodes, edges, and computed ordering information."
+  [:map {:registry registry}
+   [:dag/id :dag/id]
+   [:dag/name [:string {:min 1}]]
+   [:dag/description {:optional true} string?]
+   [:dag/repos [:vector RepoNode]]
+   [:dag/edges [:vector RepoEdge]]
+   ;; Computed at runtime
+   [:dag/topo-order {:optional true} [:vector :repo/name]]
+   [:dag/layers {:optional true} [:map-of keyword? [:vector :repo/name]]]])
+
+(def TopoSortResult
+  "Result of a topological sort operation."
+  [:map
+   [:success boolean?]
+   [:order {:optional true} [:vector string?]]
+   [:error {:optional true} [:enum :cycle-detected :invalid-dag]]
+   [:cycle-nodes {:optional true} [:set string?]]])
+
+(def ValidationResult
+  "Result of DAG validation."
+  [:map
+   [:valid? boolean?]
+   [:errors [:vector
+             [:map
+              [:type [:enum :cycle :orphan-edge :missing-repo :duplicate-repo :self-loop]]
+              [:message string?]
+              [:data {:optional true} any?]]]]])
+
+;------------------------------------------------------------------------------ Layer 3
+;; Validation helpers
+
+(defn valid-repo-node?
+  "Check if a value is a valid RepoNode."
+  [value]
+  (m/validate RepoNode value))
+
+(defn valid-repo-edge?
+  "Check if a value is a valid RepoEdge."
+  [value]
+  (m/validate RepoEdge value))
+
+(defn valid-repo-dag?
+  "Check if a value is a valid RepoDag."
+  [value]
+  (m/validate RepoDag value))
+
+(defn infer-layer
+  "Infer the layer from repository type if not explicitly specified."
+  [repo-type]
+  (get type->layer repo-type :application))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Validate RepoNode
+  (m/validate RepoNode
+              {:repo/url "https://github.com/acme/terraform-modules"
+               :repo/name "terraform-modules"
+               :repo/org "acme"
+               :repo/type :terraform-module
+               :repo/layer :foundations
+               :repo/default-branch "main"})
+  ;; => true
+
+  ;; Validate RepoEdge
+  (m/validate RepoEdge
+              {:edge/from "terraform-modules"
+               :edge/to "terraform-live"
+               :edge/constraint :module-before-live
+               :edge/merge-ordering :sequential})
+  ;; => true
+
+  ;; Validate RepoDag
+  (m/validate RepoDag
+              {:dag/id (random-uuid)
+               :dag/name "acme-infra"
+               :dag/repos []
+               :dag/edges []})
+  ;; => true
+
+  ;; Infer layer
+  (infer-layer :terraform-module)
+  ;; => :foundations
+
+  (infer-layer :kubernetes)
+  ;; => :platform
+
+  :leave-this-here)

--- a/components/repo-dag/test/ai/miniforge/repo_dag/interface_test.clj
+++ b/components/repo-dag/test/ai/miniforge/repo_dag/interface_test.clj
@@ -1,0 +1,474 @@
+(ns ai.miniforge.repo-dag.interface-test
+  (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
+            [ai.miniforge.repo-dag.interface :as dag]))
+
+;------------------------------------------------------------------------------ Fixtures
+
+(def ^:dynamic *manager* nil)
+
+(defn manager-fixture [f]
+  (binding [*manager* (dag/create-manager)]
+    (f)))
+
+(use-fixtures :each manager-fixture)
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema validation tests
+
+(deftest schema-validation-test
+  (testing "valid-repo-node? validates correctly"
+    (is (dag/valid-repo-node?
+         {:repo/url "https://github.com/acme/tf-modules"
+          :repo/name "tf-modules"
+          :repo/type :terraform-module
+          :repo/layer :foundations
+          :repo/default-branch "main"}))
+    (is (not (dag/valid-repo-node?
+              {:repo/name "missing-required-fields"}))))
+
+  (testing "valid-repo-edge? validates correctly"
+    (is (dag/valid-repo-edge?
+         {:edge/from "repo-a"
+          :edge/to "repo-b"
+          :edge/constraint :module-before-live
+          :edge/merge-ordering :sequential}))
+    (is (not (dag/valid-repo-edge?
+              {:edge/from "repo-a"}))))
+
+  (testing "infer-layer derives layer from type"
+    (is (= :foundations (dag/infer-layer :terraform-module)))
+    (is (= :infrastructure (dag/infer-layer :terraform-live)))
+    (is (= :platform (dag/infer-layer :kubernetes)))
+    (is (= :platform (dag/infer-layer :argocd)))
+    (is (= :application (dag/infer-layer :application)))
+    (is (= :foundations (dag/infer-layer :library)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; DAG CRUD tests
+
+(deftest create-dag-test
+  (testing "creates DAG with required fields"
+    (let [d (dag/create-dag *manager* "test-dag")]
+      (is (uuid? (:dag/id d)))
+      (is (= "test-dag" (:dag/name d)))
+      (is (= [] (:dag/repos d)))
+      (is (= [] (:dag/edges d)))))
+
+  (testing "creates DAG with description"
+    (let [d (dag/create-dag *manager* "test-dag" "A test DAG")]
+      (is (= "A test DAG" (:dag/description d)))))
+
+  (testing "DAG is retrievable after creation"
+    (let [d (dag/create-dag *manager* "test-dag")]
+      (is (= d (dag/get-dag *manager* (:dag/id d)))))))
+
+(deftest add-repo-test
+  (testing "adds repo with explicit layer"
+    (let [d (dag/create-dag *manager* "test-dag")
+          updated (dag/add-repo *manager* (:dag/id d)
+                                {:repo/url "https://github.com/acme/tf-modules"
+                                 :repo/name "tf-modules"
+                                 :repo/type :terraform-module
+                                 :repo/layer :foundations})]
+      (is (= 1 (count (:dag/repos updated))))
+      (is (= "tf-modules" (-> updated :dag/repos first :repo/name)))))
+
+  (testing "adds repo with inferred layer"
+    (let [d (dag/create-dag *manager* "test-dag")
+          updated (dag/add-repo *manager* (:dag/id d)
+                                {:repo/url "https://github.com/acme/tf-modules"
+                                 :repo/name "tf-modules"
+                                 :repo/type :terraform-module})]
+      ;; Layer should be inferred as :foundations
+      (is (= :foundations (-> updated :dag/repos first :repo/layer)))))
+
+  (testing "throws on duplicate repo name"
+    (let [d (dag/create-dag *manager* "test-dag")]
+      (dag/add-repo *manager* (:dag/id d)
+                    {:repo/url "https://github.com/acme/tf-modules"
+                     :repo/name "tf-modules"
+                     :repo/type :terraform-module})
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Repo already exists"
+            (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/other/tf-modules"
+                           :repo/name "tf-modules"
+                           :repo/type :terraform-module}))))))
+
+(deftest remove-repo-test
+  (testing "removes repo from DAG"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/tf-modules"
+                           :repo/name "tf-modules"
+                           :repo/type :terraform-module})
+          updated (dag/remove-repo *manager* (:dag/id d) "tf-modules")]
+      (is (= 0 (count (:dag/repos updated))))))
+
+  (testing "removes edges when repo is removed"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/a"
+                           :repo/name "repo-a"
+                           :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/b"
+                           :repo/name "repo-b"
+                           :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
+                          :library-before-consumer :sequential)
+          updated (dag/remove-repo *manager* (:dag/id d) "repo-a")]
+      (is (= 1 (count (:dag/repos updated))))
+      (is (= 0 (count (:dag/edges updated)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Edge operations tests
+
+(deftest add-edge-test
+  (testing "adds edge between repos"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/a"
+                           :repo/name "repo-a"
+                           :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/b"
+                           :repo/name "repo-b"
+                           :repo/type :application})
+          updated (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
+                                :library-before-consumer :sequential)]
+      (is (= 1 (count (:dag/edges updated))))
+      (let [edge (first (:dag/edges updated))]
+        (is (= "repo-a" (:edge/from edge)))
+        (is (= "repo-b" (:edge/to edge)))
+        (is (= :library-before-consumer (:edge/constraint edge)))
+        (is (= :sequential (:edge/merge-ordering edge))))))
+
+  (testing "throws on missing from-repo"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/b"
+                           :repo/name "repo-b"
+                           :repo/type :application})]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"From repo not found"
+            (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
+                          :library-before-consumer :sequential)))))
+
+  (testing "throws on self-loop"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/a"
+                           :repo/name "repo-a"
+                           :repo/type :library})]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Self-loop not allowed"
+            (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-a"
+                          :library-before-consumer :sequential)))))
+
+  (testing "throws on duplicate edge"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/a"
+                           :repo/name "repo-a"
+                           :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/b"
+                           :repo/name "repo-b"
+                           :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
+                          :library-before-consumer :sequential)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Edge already exists"
+            (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
+                          :library-before-consumer :sequential))))))
+
+(deftest remove-edge-test
+  (testing "removes edge from DAG"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/a"
+                           :repo/name "repo-a"
+                           :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/acme/b"
+                           :repo/name "repo-b"
+                           :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "repo-a" "repo-b"
+                          :library-before-consumer :sequential)
+          updated (dag/remove-edge *manager* (:dag/id d) "repo-a" "repo-b")]
+      (is (= 0 (count (:dag/edges updated)))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Topological sort tests
+
+(deftest topo-sort-test
+  (testing "returns correct order for linear chain"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :application})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/c" :repo/name "c" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          _ (dag/add-edge *manager* (:dag/id d) "b" "c" :library-before-consumer :sequential)
+          result (dag/compute-topo-order *manager* (:dag/id d))]
+      (is (:success result))
+      (is (= ["a" "b" "c"] (:order result)))))
+
+  (testing "handles diamond dependency"
+    (let [d (dag/create-dag *manager* "test-dag")
+          ;; Diamond: a -> b, a -> c, b -> d, c -> d
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/c" :repo/name "c" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/d" :repo/name "d" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          _ (dag/add-edge *manager* (:dag/id d) "a" "c" :library-before-consumer :sequential)
+          _ (dag/add-edge *manager* (:dag/id d) "b" "d" :library-before-consumer :sequential)
+          _ (dag/add-edge *manager* (:dag/id d) "c" "d" :library-before-consumer :sequential)
+          result (dag/compute-topo-order *manager* (:dag/id d))]
+      (is (:success result))
+      ;; a must come first, d must come last
+      (is (= "a" (first (:order result))))
+      (is (= "d" (last (:order result))))
+      ;; b and c must come before d
+      (is (< (.indexOf (:order result) "b") (.indexOf (:order result) "d")))
+      (is (< (.indexOf (:order result) "c") (.indexOf (:order result) "d")))))
+
+  (testing "handles isolated nodes"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :application})
+          result (dag/compute-topo-order *manager* (:dag/id d))]
+      (is (:success result))
+      (is (= 2 (count (:order result))))
+      (is (= #{"a" "b"} (set (:order result)))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Cycle detection tests
+
+(deftest cycle-detection-test
+  (testing "detects simple cycle on add-edge"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Adding edge would create cycle"
+            (dag/add-edge *manager* (:dag/id d) "b" "a"
+                          :library-before-consumer :sequential)))))
+
+  (testing "detects longer cycle on add-edge"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/c" :repo/name "c" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          _ (dag/add-edge *manager* (:dag/id d) "b" "c" :library-before-consumer :sequential)]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Adding edge would create cycle"
+            (dag/add-edge *manager* (:dag/id d) "c" "a"
+                          :library-before-consumer :sequential)))))
+
+  (testing "find-cycle-nodes identifies cycle members"
+    ;; We can test the pure function directly by creating a dag with a cycle
+    ;; (bypassing the add-edge check)
+    (let [dag-with-cycle {:dag/id (random-uuid)
+                          :dag/name "cyclic"
+                          :dag/repos [{:repo/url "a" :repo/name "a" :repo/type :library :repo/layer :foundations :repo/default-branch "main"}
+                                      {:repo/url "b" :repo/name "b" :repo/type :library :repo/layer :foundations :repo/default-branch "main"}
+                                      {:repo/url "c" :repo/name "c" :repo/type :library :repo/layer :foundations :repo/default-branch "main"}]
+                          :dag/edges [{:edge/from "a" :edge/to "b" :edge/constraint :library-before-consumer :edge/merge-ordering :sequential}
+                                      {:edge/from "b" :edge/to "c" :edge/constraint :library-before-consumer :edge/merge-ordering :sequential}
+                                      {:edge/from "c" :edge/to "a" :edge/constraint :library-before-consumer :edge/merge-ordering :sequential}]}
+          cycle-nodes (dag/find-cycle-nodes dag-with-cycle)]
+      (is (= #{"a" "b" "c"} cycle-nodes)))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Affected repos and upstream repos tests
+
+(deftest affected-repos-test
+  (testing "returns direct downstream repos"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          affected (dag/affected-repos *manager* (:dag/id d) "a")]
+      (is (= #{"b"} affected))))
+
+  (testing "returns transitive downstream repos"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/c" :repo/name "c" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          _ (dag/add-edge *manager* (:dag/id d) "b" "c" :library-before-consumer :sequential)
+          affected (dag/affected-repos *manager* (:dag/id d) "a")]
+      (is (= #{"b" "c"} affected))))
+
+  (testing "returns empty set for leaf node"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          affected (dag/affected-repos *manager* (:dag/id d) "b")]
+      (is (= #{} affected)))))
+
+(deftest upstream-repos-test
+  (testing "returns direct upstream repos"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          upstream (dag/upstream-repos *manager* (:dag/id d) "b")]
+      (is (= #{"a"} upstream))))
+
+  (testing "returns transitive upstream repos"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/c" :repo/name "c" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          _ (dag/add-edge *manager* (:dag/id d) "b" "c" :library-before-consumer :sequential)
+          upstream (dag/upstream-repos *manager* (:dag/id d) "c")]
+      (is (= #{"a" "b"} upstream))))
+
+  (testing "returns empty set for root node"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          upstream (dag/upstream-repos *manager* (:dag/id d) "a")]
+      (is (= #{} upstream)))))
+
+;------------------------------------------------------------------------------ Layer 6
+;; Merge order tests
+
+(deftest merge-order-test
+  (testing "computes merge order for subset of repos"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/c" :repo/name "c" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          _ (dag/add-edge *manager* (:dag/id d) "b" "c" :library-before-consumer :sequential)
+          ;; Only merge b and c (not a)
+          result (dag/merge-order *manager* (:dag/id d) #{"b" "c"})]
+      (is (:success result))
+      (is (= ["b" "c"] (:order result)))))
+
+  (testing "handles disconnected repos in pr-set"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/c" :repo/name "c" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "c" :library-before-consumer :sequential)
+          ;; a and b are disconnected, but both in PR set
+          result (dag/merge-order *manager* (:dag/id d) #{"a" "b"})]
+      (is (:success result))
+      (is (= 2 (count (:order result))))
+      (is (= #{"a" "b"} (set (:order result)))))))
+
+;------------------------------------------------------------------------------ Layer 7
+;; DAG validation tests
+
+(deftest validate-dag-test
+  (testing "valid DAG passes validation"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/a" :repo/name "a" :repo/type :library})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/b" :repo/name "b" :repo/type :application})
+          _ (dag/add-edge *manager* (:dag/id d) "a" "b" :library-before-consumer :sequential)
+          result (dag/validate-dag *manager* (:dag/id d))]
+      (is (:valid? result))
+      (is (empty? (:errors result)))))
+
+  (testing "empty DAG is valid"
+    (let [d (dag/create-dag *manager* "test-dag")
+          result (dag/validate-dag *manager* (:dag/id d))]
+      (is (:valid? result))
+      (is (empty? (:errors result))))))
+
+;------------------------------------------------------------------------------ Layer 8
+;; Compute layers tests
+
+(deftest compute-layers-test
+  (testing "groups repos by layer"
+    (let [d (dag/create-dag *manager* "test-dag")
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/tf-mod" :repo/name "tf-modules"
+                           :repo/type :terraform-module})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/tf-live" :repo/name "tf-live"
+                           :repo/type :terraform-live})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/k8s" :repo/name "k8s"
+                           :repo/type :kubernetes})
+          _ (dag/add-repo *manager* (:dag/id d)
+                          {:repo/url "https://github.com/app" :repo/name "app"
+                           :repo/type :application})
+          current-dag (dag/get-dag *manager* (:dag/id d))
+          layers (dag/compute-layers current-dag)]
+      (is (= ["tf-modules"] (:foundations layers)))
+      (is (= ["tf-live"] (:infrastructure layers)))
+      (is (= ["k8s"] (:platform layers)))
+      (is (= ["app"] (:application layers))))))
+
+;------------------------------------------------------------------------------ Layer 9
+;; Edge cases and error handling tests
+
+(deftest edge-cases-test
+  (testing "operations on nonexistent DAG"
+    (let [fake-id (random-uuid)]
+      (is (nil? (dag/get-dag *manager* fake-id)))
+      (is (thrown? clojure.lang.ExceptionInfo
+            (dag/add-repo *manager* fake-id
+                          {:repo/url "https://github.com/a" :repo/name "a"
+                           :repo/type :library})))
+      (is (thrown? clojure.lang.ExceptionInfo
+            (dag/compute-topo-order *manager* fake-id)))))
+
+  (testing "get-all-dags returns all dags"
+    (dag/create-dag *manager* "dag-1")
+    (dag/create-dag *manager* "dag-2")
+    (dag/create-dag *manager* "dag-3")
+    (is (= 3 (count (dag/get-all-dags *manager*)))))
+
+  (testing "reset-manager clears all dags"
+    (dag/create-dag *manager* "dag-1")
+    (dag/reset-manager! *manager*)
+    (is (= 0 (count (dag/get-all-dags *manager*))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (test/run-tests 'ai.miniforge.repo-dag.interface-test)
+
+  :leave-this-here)


### PR DESCRIPTION
## Summary

Add the `repo-dag` component for modeling multi-repository dependencies.

Cherry-picked from original PR #47.

### Features
- Kahn's algorithm for topological sort
- Cycle detection in dependency graphs
- Layer inference for merge ordering
- Malli schemas for RepoNode, RepoEdge, RepoDag

---
Generated with [Claude Code](https://claude.ai/claude-code)