### PR TITLE
feat(pr-train): implement linked PR choreography component

### DIFF
--- a/components/pr-train/deps.edn
+++ b/components/pr-train/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/schema {:local/root "../schema"}
+        metosin/malli {:mvn/version "0.16.4"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/pr-train/src/ai/miniforge/pr_train/core.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/core.clj
@@ -1,0 +1,417 @@
+(ns ai.miniforge.pr-train.core
+  "Core implementation of PR Train management.
+   Provides PRTrainManager protocol and in-memory implementation."
+  (:require
+   [ai.miniforge.pr-train.schema :as schema]
+   [ai.miniforge.pr-train.state :as state]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Protocol definition
+
+(defprotocol PRTrainManager
+  "Protocol for managing PR trains.
+
+   PR trains are coordinated sets of related PRs that must merge
+   in topological order based on repository dependencies."
+
+  ;; Lifecycle
+  (create-train [this name dag-id description]
+    "Create a new PR train linked to a repo DAG.
+     Returns train-id.")
+
+  (add-pr [this train-id repo pr-number url branch title]
+    "Add a PR to the train. Assigns next merge-order.
+     Returns updated train or nil if train not found.")
+
+  (remove-pr [this train-id pr-number]
+    "Remove a PR from the train. Reorders remaining PRs.
+     Returns updated train or nil if train/PR not found.")
+
+  (link-prs [this train-id]
+    "Auto-compute depends-on/blocks relationships from merge order.
+     Returns updated train.")
+
+  ;; State management
+  (sync-pr-status [this train-id status-map]
+    "Update status for all PRs from external source.
+     status-map: {pr-number {:status :ci-status :gate-results}}
+     Returns updated train.")
+
+  (update-pr-status [this train-id pr-number new-status]
+    "Update status for a single PR.
+     Returns updated train or nil if invalid transition.")
+
+  (update-pr-ci-status [this train-id pr-number ci-status]
+    "Update CI status for a single PR.
+     Returns updated train.")
+
+  ;; Queries
+  (get-train [this train-id]
+    "Retrieve a train by ID.
+     Returns train or nil if not found.")
+
+  (get-blocking [this train-id]
+    "Return PRs that are blocking train progress.
+     Returns vector of PR numbers.")
+
+  (get-ready-to-merge [this train-id]
+    "Return PRs that can merge now.
+     Returns vector of PR numbers in merge order.")
+
+  (get-progress [this train-id]
+    "Return progress summary.
+     Returns {:total :merged :approved :pending :failed}.")
+
+  ;; Actions
+  (merge-next [this train-id]
+    "Mark the next ready PR as merging.
+     Returns {:pr-number :train} or nil if none ready.
+     NOTE: Actual merge is performed by adapter.")
+
+  (complete-merge [this train-id pr-number]
+    "Mark a PR merge as complete (transition to merged).
+     Returns updated train.")
+
+  (fail-merge [this train-id pr-number reason]
+    "Mark a PR merge as failed.
+     Returns updated train.")
+
+  (pause-train [this train-id reason]
+    "Pause all train activity. Sets status to blocked state.
+     Returns updated train.")
+
+  (resume-train [this train-id]
+    "Resume paused train.
+     Returns updated train.")
+
+  (rollback [this train-id trigger reason]
+    "Plan rollback: compute which PRs to revert.
+     Returns updated train with rollback plan.")
+
+  (execute-rollback-step [this train-id pr-number]
+    "Mark a PR as reverted during rollback.
+     Returns updated train.")
+
+  (complete-rollback [this train-id]
+    "Mark rollback as complete.
+     Returns updated train.")
+
+  (abandon-train [this train-id reason]
+    "Mark train as abandoned.
+     Returns updated train.")
+
+  ;; Evidence
+  (generate-evidence-bundle [this train-id]
+    "Create evidence bundle from train state.
+     Returns EvidenceBundle.")
+
+  (get-evidence-bundle [this bundle-id]
+    "Retrieve evidence bundle by ID.
+     Returns bundle or nil if not found."))
+
+;------------------------------------------------------------------------------ Layer 1
+;; In-memory implementation
+
+(defrecord InMemoryPRTrainManager [trains evidence-bundles]
+  PRTrainManager
+
+  ;; Lifecycle
+  (create-train [_this name dag-id description]
+    (let [train-id (random-uuid)
+          train (state/create-train-state train-id name dag-id
+                                          :description description)]
+      (swap! trains assoc train-id train)
+      train-id))
+
+  (add-pr [_this train-id repo pr-number url branch title]
+    (when-let [train (get @trains train-id)]
+      (let [merge-order (inc (count (:train/prs train)))
+            pr (state/create-pr-state repo pr-number url branch title merge-order)
+            updated (-> train
+                        (update :train/prs conj pr)
+                        state/recompute-train-state)]
+        (swap! trains assoc train-id updated)
+        updated)))
+
+  (remove-pr [_this train-id pr-number]
+    (when-let [train (get @trains train-id)]
+      (let [prs (:train/prs train)
+            filtered (remove #(= pr-number (:pr/number %)) prs)
+            ;; Reorder remaining PRs
+            reordered (vec (map-indexed
+                           (fn [idx pr]
+                             (assoc pr :pr/merge-order (inc idx)))
+                           (sort-by :pr/merge-order filtered)))
+            updated (-> train
+                        (assoc :train/prs reordered)
+                        state/link-pr-dependencies)]
+        (swap! trains assoc train-id updated)
+        updated)))
+
+  (link-prs [_this train-id]
+    (when-let [train (get @trains train-id)]
+      (let [updated (state/link-pr-dependencies train)]
+        (swap! trains assoc train-id updated)
+        updated)))
+
+  ;; State management
+  (sync-pr-status [_this train-id status-map]
+    (when-let [train (get @trains train-id)]
+      (let [updated (reduce
+                     (fn [t [pr-num updates]]
+                       (state/update-pr t pr-num
+                                        (fn [pr]
+                                          (merge pr
+                                                 (select-keys updates
+                                                              [:pr/status :pr/ci-status
+                                                               :pr/gate-results])))))
+                     train
+                     status-map)
+            final (-> updated
+                      state/recompute-train-state
+                      state/auto-transition-train)]
+        (swap! trains assoc train-id final)
+        final)))
+
+  (update-pr-status [_this train-id pr-number new-status]
+    (when-let [train (get @trains train-id)]
+      (when-let [updated (state/transition-pr-status train pr-number new-status)]
+        (let [final (-> updated
+                        state/recompute-train-state
+                        state/auto-transition-train)]
+          (swap! trains assoc train-id final)
+          final))))
+
+  (update-pr-ci-status [_this train-id pr-number ci-status]
+    (when-let [train (get @trains train-id)]
+      (let [updated (-> train
+                        (state/update-pr pr-number #(assoc % :pr/ci-status ci-status))
+                        state/recompute-train-state)]
+        (swap! trains assoc train-id updated)
+        updated)))
+
+  ;; Queries
+  (get-train [_this train-id]
+    (get @trains train-id))
+
+  (get-blocking [_this train-id]
+    (when-let [train (get @trains train-id)]
+      (:train/blocking-prs train)))
+
+  (get-ready-to-merge [_this train-id]
+    (when-let [train (get @trains train-id)]
+      (:train/ready-to-merge train)))
+
+  (get-progress [_this train-id]
+    (when-let [train (get @trains train-id)]
+      (:train/progress train)))
+
+  ;; Actions
+  (merge-next [_this train-id]
+    (when-let [train (get @trains train-id)]
+      (when-let [pr-number (first (:train/ready-to-merge train))]
+        (when-let [updated (state/transition-pr-status train pr-number :merging)]
+          (let [final (-> updated
+                          state/recompute-train-state
+                          state/auto-transition-train)]
+            (swap! trains assoc train-id final)
+            {:pr-number pr-number :train final})))))
+
+  (complete-merge [_this train-id pr-number]
+    (when-let [train (get @trains train-id)]
+      (when-let [updated (state/transition-pr-status train pr-number :merged)]
+        (let [final (-> updated
+                        state/recompute-train-state
+                        state/auto-transition-train)]
+          (swap! trains assoc train-id final)
+          final))))
+
+  (fail-merge [_this train-id pr-number reason]
+    (when-let [train (get @trains train-id)]
+      (let [updated (-> train
+                        (state/update-pr pr-number
+                                         #(assoc % :pr/status :failed))
+                        (state/compute-rollback-plan :ci-failure :pause)
+                        state/recompute-train-state
+                        state/auto-transition-train)]
+        (swap! trains assoc train-id updated)
+        updated)))
+
+  (pause-train [_this train-id reason]
+    (when-let [train (get @trains train-id)]
+      (let [updated (-> train
+                        (assoc :train/paused? true)
+                        (assoc :train/pause-reason reason)
+                        state/update-timestamp)]
+        (swap! trains assoc train-id updated)
+        updated)))
+
+  (resume-train [_this train-id]
+    (when-let [train (get @trains train-id)]
+      (let [updated (-> train
+                        (dissoc :train/paused? :train/pause-reason)
+                        state/recompute-train-state)]
+        (swap! trains assoc train-id updated)
+        updated)))
+
+  (rollback [_this train-id trigger reason]
+    (when-let [train (get @trains train-id)]
+      (let [updated (-> train
+                        (state/compute-rollback-plan trigger :revert-all)
+                        (assoc :train/rollback-reason reason))]
+        (swap! trains assoc train-id updated)
+        updated)))
+
+  (execute-rollback-step [_this train-id pr-number]
+    (when-let [train (get @trains train-id)]
+      (let [updated (state/update-pr train pr-number
+                                     #(assoc % :pr/rolled-back? true))]
+        (swap! trains assoc train-id updated)
+        updated)))
+
+  (complete-rollback [_this train-id]
+    (when-let [train (get @trains train-id)]
+      (when-let [updated (state/transition-train-status train :rolled-back)]
+        (swap! trains assoc train-id updated)
+        updated)))
+
+  (abandon-train [_this train-id reason]
+    (when-let [train (get @trains train-id)]
+      (when-let [updated (state/transition-train-status train :abandoned)]
+        (let [final (assoc updated :train/abandon-reason reason)]
+          (swap! trains assoc train-id final)
+          final))))
+
+  ;; Evidence
+  (generate-evidence-bundle [_this train-id]
+    (when-let [train (get @trains train-id)]
+      (let [bundle-id (random-uuid)
+            now (java.util.Date.)
+            prs (:train/prs train)
+            pr-evidence (mapv (fn [pr]
+                                {:pr/repo (:pr/repo pr)
+                                 :pr/number (:pr/number pr)
+                                 :evidence/artifacts
+                                 (vec
+                                  (concat
+                                   (when-let [gates (:pr/gate-results pr)]
+                                     (mapv (fn [g]
+                                             {:type :gate-results
+                                              :content (pr-str g)
+                                              :hash (str (hash g))
+                                              :timestamp (or (:gate/timestamp g) now)})
+                                           gates))
+                                   (when-let [intent (:pr/intent pr)]
+                                     [{:type :intent-validation
+                                       :content (pr-str intent)
+                                       :hash (str (hash intent))
+                                       :timestamp now}])
+                                   (when (#{:approved :merged} (:pr/status pr))
+                                     [{:type :approval-record
+                                       :content (str "PR " (:pr/number pr) " approved")
+                                       :hash (str (hash pr))
+                                       :timestamp now}])))})
+                              prs)
+            all-gates (mapcat :pr/gate-results prs)
+            gates-passed (count (filter :gate/passed? all-gates))
+            gates-failed (count (remove :gate/passed? all-gates))
+            approvals (count (filter #(#{:approved :merged} (:pr/status %)) prs))
+            semantic-violations 0
+            bundle {:evidence/id bundle-id
+                    :evidence/train-id train-id
+                    :evidence/created-at now
+                    :evidence/prs pr-evidence
+                    :evidence/summary {:total-prs (count prs)
+                                       :gates-passed gates-passed
+                                       :gates-failed gates-failed
+                                       :human-approvals approvals
+                                       :semantic-violations semantic-violations}
+                    :evidence/miniforge-version "0.1.0"}]
+        (swap! evidence-bundles assoc bundle-id bundle)
+        (swap! trains assoc-in [train-id :train/evidence-bundle-id] bundle-id)
+        bundle)))
+
+  (get-evidence-bundle [_this bundle-id]
+    (get @evidence-bundles bundle-id)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Factory function
+
+(defn create-manager
+  "Create a new in-memory PR train manager.
+
+   Returns an InMemoryPRTrainManager instance."
+  []
+  (->InMemoryPRTrainManager (atom {}) (atom {})))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Utility functions for working with trains
+
+(defn list-trains
+  "List all trains in a manager.
+
+   Returns vector of train summaries: [{:train/id :train/name :train/status}]"
+  [manager]
+  (->> @(:trains manager)
+       vals
+       (mapv #(select-keys % [:train/id :train/name :train/status
+                              :train/progress :train/created-at]))))
+
+(defn find-trains-by-status
+  "Find trains with a given status.
+
+   Returns vector of train-ids."
+  [manager status]
+  (->> @(:trains manager)
+       (filter (fn [[_id train]] (= status (:train/status train))))
+       (map first)
+       vec))
+
+(defn find-trains-by-dag
+  "Find trains using a specific DAG.
+
+   Returns vector of train-ids."
+  [manager dag-id]
+  (->> @(:trains manager)
+       (filter (fn [[_id train]] (= dag-id (:train/dag-id train))))
+       (map first)
+       vec))
+
+(defn train-contains-pr?
+  "Check if a train contains a specific PR."
+  [manager train-id repo pr-number]
+  (when-let [train (get-train manager train-id)]
+    (some #(and (= repo (:pr/repo %))
+                (= pr-number (:pr/number %)))
+          (:train/prs train))))
+
+(defn get-pr-from-train
+  "Get a PR from a train.
+
+   Returns TrainPR or nil if not found."
+  [manager train-id pr-number]
+  (when-let [train (get-train manager train-id)]
+    (state/find-pr train pr-number)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def mgr (create-manager))
+  (def train-id (create-train mgr "Add Auth" (random-uuid) "Authentication feature"))
+  (add-pr mgr train-id "acme/modules" 100
+          "https://github.com/acme/modules/pull/100"
+          "feat/auth" "Add auth module")
+  (add-pr mgr train-id "acme/live" 200
+          "https://github.com/acme/live/pull/200"
+          "feat/auth" "Deploy auth")
+  (link-prs mgr train-id)
+  (get-train mgr train-id)
+  (update-pr-status mgr train-id 100 :open)
+  (update-pr-status mgr train-id 100 :reviewing)
+  (update-pr-status mgr train-id 100 :approved)
+  (update-pr-ci-status mgr train-id 100 :passed)
+  (get-ready-to-merge mgr train-id)
+  (merge-next mgr train-id)
+  (complete-merge mgr train-id 100)
+  (generate-evidence-bundle mgr train-id)
+  (list-trains mgr)
+  :end)

--- a/components/pr-train/src/ai/miniforge/pr_train/interface.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/interface.clj
@@ -1,0 +1,270 @@
+(ns ai.miniforge.pr-train.interface
+  "Public API for the pr-train component.
+   Manages linked PR trains with coordinated state and merge ordering."
+  (:require
+   [ai.miniforge.pr-train.core :as core]
+   [ai.miniforge.pr-train.schema :as schema]
+   [ai.miniforge.pr-train.state :as state]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Protocol and schema re-exports
+
+(def PRTrainManager core/PRTrainManager)
+
+;; Schema re-exports
+(def TrainPR schema/TrainPR)
+(def PRTrain schema/PRTrain)
+(def EvidenceBundle schema/EvidenceBundle)
+(def GateResult schema/GateResult)
+(def TaskIntent schema/TaskIntent)
+(def Progress schema/Progress)
+(def RollbackPlan schema/RollbackPlan)
+
+;; Enum value sets
+(def pr-statuses schema/pr-statuses)
+(def train-statuses schema/train-statuses)
+(def ci-statuses schema/ci-statuses)
+(def rollback-triggers schema/rollback-triggers)
+(def evidence-types schema/evidence-types)
+
+;; State machine re-exports
+(def train-transitions state/train-transitions)
+(def pr-transitions state/pr-transitions)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Manager creation
+
+(def create-manager
+  "Create a new PR train manager.
+
+   Returns an InMemoryPRTrainManager instance."
+  core/create-manager)
+
+;------------------------------------------------------------------------------ Layer 2
+;; Train lifecycle
+
+(defn create-train
+  "Create a new PR train linked to a repo DAG.
+
+   Returns train-id (UUID)."
+  [manager name dag-id description]
+  (core/create-train manager name dag-id description))
+
+(defn add-pr
+  "Add a PR to the train.
+
+   Returns updated train or nil if train not found."
+  [manager train-id repo pr-number url branch title]
+  (core/add-pr manager train-id repo pr-number url branch title))
+
+(defn remove-pr
+  "Remove a PR from the train.
+
+   Returns updated train or nil if train/PR not found."
+  [manager train-id pr-number]
+  (core/remove-pr manager train-id pr-number))
+
+(defn link-prs
+  "Auto-compute depends-on/blocks relationships.
+
+   Returns updated train."
+  [manager train-id]
+  (core/link-prs manager train-id))
+
+;------------------------------------------------------------------------------ Layer 3
+;; State management
+
+(defn sync-pr-status
+  "Update status for all PRs from external source.
+
+   Returns updated train."
+  [manager train-id status-map]
+  (core/sync-pr-status manager train-id status-map))
+
+(defn update-pr-status
+  "Update status for a single PR.
+
+   Returns updated train or nil if invalid transition."
+  [manager train-id pr-number new-status]
+  (core/update-pr-status manager train-id pr-number new-status))
+
+(defn update-pr-ci-status
+  "Update CI status for a single PR.
+
+   Returns updated train."
+  [manager train-id pr-number ci-status]
+  (core/update-pr-ci-status manager train-id pr-number ci-status))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Queries
+
+(defn get-train
+  "Retrieve a train by ID.
+
+   Returns full PRTrain map or nil if not found."
+  [manager train-id]
+  (core/get-train manager train-id))
+
+(defn get-blocking
+  "Return PRs that are blocking train progress.
+
+   Returns vector of PR numbers sorted by merge order."
+  [manager train-id]
+  (core/get-blocking manager train-id))
+
+(defn get-ready-to-merge
+  "Return PRs that can merge now.
+
+   Returns vector of PR numbers sorted by merge order."
+  [manager train-id]
+  (core/get-ready-to-merge manager train-id))
+
+(defn get-progress
+  "Return progress summary.
+
+   Returns {:total :merged :approved :pending :failed}."
+  [manager train-id]
+  (core/get-progress manager train-id))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Merge actions
+
+(defn merge-next
+  "Mark the next ready PR as merging.
+
+   Returns {:pr-number :train} or nil if none ready."
+  [manager train-id]
+  (core/merge-next manager train-id))
+
+(defn complete-merge
+  "Mark a PR merge as complete.
+
+   Returns updated train."
+  [manager train-id pr-number]
+  (core/complete-merge manager train-id pr-number))
+
+(defn fail-merge
+  "Mark a PR merge as failed.
+
+   Returns updated train."
+  [manager train-id pr-number reason]
+  (core/fail-merge manager train-id pr-number reason))
+
+(defn merge-all-ready
+  "Get all PRs ready to merge in order.
+
+   Returns vector of PR numbers."
+  [manager train-id]
+  (get-ready-to-merge manager train-id))
+
+;------------------------------------------------------------------------------ Layer 6
+;; Train control
+
+(defn pause-train
+  "Pause all train activity.
+
+   Returns updated train."
+  [manager train-id reason]
+  (core/pause-train manager train-id reason))
+
+(defn resume-train
+  "Resume paused train.
+
+   Returns updated train."
+  [manager train-id]
+  (core/resume-train manager train-id))
+
+(defn rollback
+  "Plan rollback: compute which PRs to revert.
+
+   Returns updated train with :train/rollback-plan set."
+  [manager train-id trigger reason]
+  (core/rollback manager train-id trigger reason))
+
+(defn abandon-train
+  "Mark train as abandoned.
+
+   Returns updated train."
+  [manager train-id reason]
+  (core/abandon-train manager train-id reason))
+
+;------------------------------------------------------------------------------ Layer 7
+;; Evidence
+
+(defn generate-evidence-bundle
+  "Collect and bundle all evidence artifacts.
+
+   Returns EvidenceBundle."
+  [manager train-id]
+  (core/generate-evidence-bundle manager train-id))
+
+(defn get-evidence-bundle
+  "Retrieve evidence bundle by ID.
+
+   Returns EvidenceBundle or nil if not found."
+  [manager bundle-id]
+  (core/get-evidence-bundle manager bundle-id))
+
+;------------------------------------------------------------------------------ Layer 8
+;; Utility functions
+
+(def list-trains
+  "List all trains in a manager."
+  core/list-trains)
+
+(def find-trains-by-status
+  "Find trains with a given status."
+  core/find-trains-by-status)
+
+(def find-trains-by-dag
+  "Find trains using a specific DAG."
+  core/find-trains-by-dag)
+
+(def train-contains-pr?
+  "Check if a train contains a specific PR."
+  core/train-contains-pr?)
+
+(def get-pr-from-train
+  "Get a PR from a train."
+  core/get-pr-from-train)
+
+;------------------------------------------------------------------------------ Layer 9
+;; State machine queries
+
+(defn valid-train-transition?
+  "Check if a train status transition is valid."
+  [from-status to-status]
+  (state/valid-train-transition? from-status to-status))
+
+(defn valid-pr-transition?
+  "Check if a PR status transition is valid."
+  [from-status to-status]
+  (state/valid-pr-transition? from-status to-status))
+
+(defn ready-to-merge?
+  "Check if a PR is ready to merge within a train context."
+  [train pr]
+  (state/ready-to-merge? train pr))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def mgr (create-manager))
+  (def dag-id (random-uuid))
+  (def train-id (create-train mgr "Add Authentication" dag-id "Auth feature"))
+  (add-pr mgr train-id "acme/terraform-modules" 100
+          "https://github.com/acme/terraform-modules/pull/100"
+          "feat/auth" "Add Cognito module")
+  (add-pr mgr train-id "acme/terraform-live" 200
+          "https://github.com/acme/terraform-live/pull/200"
+          "feat/auth" "Deploy Cognito")
+  (link-prs mgr train-id)
+  (update-pr-status mgr train-id 100 :open)
+  (update-pr-status mgr train-id 100 :reviewing)
+  (update-pr-status mgr train-id 100 :approved)
+  (update-pr-ci-status mgr train-id 100 :passed)
+  (get-ready-to-merge mgr train-id)
+  (merge-next mgr train-id)
+  (complete-merge mgr train-id 100)
+  (get-progress mgr train-id)
+  (generate-evidence-bundle mgr train-id)
+  :end)

--- a/components/pr-train/src/ai/miniforge/pr_train/schema.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/schema.clj
@@ -1,0 +1,260 @@
+(ns ai.miniforge.pr-train.schema
+  "Malli schemas for PR Train component.
+   Defines TrainPR, PRTrain, EvidenceBundle, and related types."
+  (:require
+   [malli.core :as m]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Enums and base types
+
+(def pr-statuses
+  "Possible states for a PR in a train."
+  [:draft :open :reviewing :changes-requested
+   :approved :merging :merged :closed :failed])
+
+(def train-statuses
+  "Possible states for a PR train."
+  [:drafting :open :reviewing :merging
+   :merged :failed :rolled-back :abandoned])
+
+(def ci-statuses
+  "CI status values."
+  [:pending :running :passed :failed :skipped])
+
+(def rollback-triggers
+  "What can trigger a rollback."
+  [:ci-failure :gate-failure :manual :timeout])
+
+(def rollback-actions
+  "Actions to take on rollback."
+  [:revert-all :revert-to-checkpoint :pause])
+
+(def evidence-types
+  "Types of evidence artifacts."
+  [:terraform-plan :atlantis-log :ci-log
+   :gate-results :intent-validation :approval-record])
+
+(def intent-types
+  "Types of semantic intent."
+  [:create :import :modify :delete :migrate])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registry
+
+(def registry
+  "Malli registry for PR train types."
+  {;; Identifiers
+   :id/uuid uuid?
+   :id/string [:string {:min 1}]
+
+   ;; PR identifiers
+   :pr/repo [:string {:min 1}]
+   :pr/number pos-int?
+   :pr/url [:string {:min 1}]
+   :pr/branch [:string {:min 1}]
+   :pr/title [:string {:min 1}]
+   :pr/status (into [:enum] pr-statuses)
+   :pr/merge-order pos-int?
+   :pr/ci-status (into [:enum] ci-statuses)
+
+   ;; Train identifiers
+   :train/id :id/uuid
+   :train/name [:string {:min 1}]
+   :train/status (into [:enum] train-statuses)
+   :train/dag-id :id/uuid
+
+   ;; Evidence identifiers
+   :evidence/id :id/uuid
+   :evidence/type (into [:enum] evidence-types)
+
+   ;; Common types
+   :common/timestamp inst?
+   :common/non-neg-int [:int {:min 0}]
+   :common/pos-number [:double {:min 0.0}]})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Gate result schema
+
+(def GateResult
+  "Schema for a gate check result."
+  [:map {:registry registry}
+   [:gate/id keyword?]
+   [:gate/type keyword?]
+   [:gate/passed? boolean?]
+   [:gate/message {:optional true} :id/string]
+   [:gate/details {:optional true} [:map-of keyword? any?]]
+   [:gate/timestamp {:optional true} :common/timestamp]])
+
+;------------------------------------------------------------------------------ Layer 3
+;; Task intent schema (for semantic validation)
+
+(def Invariant
+  "Schema for an intent invariant."
+  [:map {:registry registry}
+   [:invariant/id keyword?]
+   [:invariant/description :id/string]
+   [:invariant/check
+    [:map
+     [:type [:enum :plan-output :diff-analysis :state-comparison]]
+     [:condition any?]]]])
+
+(def TaskIntent
+  "Schema for semantic intent attached to a PR."
+  [:map {:registry registry}
+   [:intent/type (into [:enum] intent-types)]
+   [:intent/invariants {:optional true} [:vector Invariant]]
+   [:intent/forbidden-actions {:optional true} [:vector keyword?]]
+   [:intent/required-evidence {:optional true} [:vector keyword?]]])
+
+;------------------------------------------------------------------------------ Layer 4
+;; TrainPR schema
+
+(def TrainPR
+  "Schema for an individual PR in a train."
+  [:map {:registry registry}
+   [:pr/repo :pr/repo]
+   [:pr/number :pr/number]
+   [:pr/url :pr/url]
+   [:pr/branch :pr/branch]
+   [:pr/title :pr/title]
+   [:pr/status :pr/status]
+   [:pr/merge-order :pr/merge-order]
+   [:pr/depends-on [:vector :pr/number]]
+   [:pr/blocks [:vector :pr/number]]
+   [:pr/ci-status :pr/ci-status]
+   [:pr/gate-results {:optional true} [:vector GateResult]]
+   [:pr/intent {:optional true} TaskIntent]])
+
+;------------------------------------------------------------------------------ Layer 5
+;; Progress schema
+
+(def Progress
+  "Schema for train progress summary."
+  [:map {:registry registry}
+   [:total pos-int?]
+   [:merged :common/non-neg-int]
+   [:approved :common/non-neg-int]
+   [:pending :common/non-neg-int]
+   [:failed :common/non-neg-int]])
+
+;------------------------------------------------------------------------------ Layer 6
+;; Rollback plan schema
+
+(def RollbackPlan
+  "Schema for train rollback configuration."
+  [:map {:registry registry}
+   [:trigger (into [:enum] rollback-triggers)]
+   [:action (into [:enum] rollback-actions)]
+   [:checkpoint {:optional true} :pr/number]
+   [:prs-to-revert [:vector :pr/number]]])
+
+;------------------------------------------------------------------------------ Layer 7
+;; PRTrain schema
+
+(def PRTrain
+  "Schema for a complete PR train."
+  [:map {:registry registry}
+   [:train/id :train/id]
+   [:train/name :train/name]
+   [:train/description {:optional true} :id/string]
+   [:train/dag-id :train/dag-id]
+   [:train/status :train/status]
+   [:train/prs [:vector TrainPR]]
+
+   ;; Computed aggregate state
+   [:train/blocking-prs [:vector :pr/number]]
+   [:train/ready-to-merge [:vector :pr/number]]
+   [:train/progress {:optional true} Progress]
+
+   ;; Rollback configuration
+   [:train/rollback-plan {:optional true} RollbackPlan]
+
+   ;; Evidence reference
+   [:train/evidence-bundle-id {:optional true} :id/uuid]
+
+   ;; Timing
+   [:train/created-at :common/timestamp]
+   [:train/updated-at :common/timestamp]
+   [:train/merged-at {:optional true} :common/timestamp]])
+
+;------------------------------------------------------------------------------ Layer 8
+;; Evidence artifact schema
+
+(def EvidenceArtifact
+  "Schema for an individual evidence artifact."
+  [:map {:registry registry}
+   [:type :evidence/type]
+   [:content :id/string]
+   [:hash :id/string]
+   [:timestamp :common/timestamp]])
+
+(def PREvidence
+  "Schema for evidence associated with a single PR."
+  [:map {:registry registry}
+   [:pr/repo :pr/repo]
+   [:pr/number :pr/number]
+   [:evidence/artifacts [:vector EvidenceArtifact]]])
+
+(def EvidenceSummary
+  "Schema for evidence bundle summary."
+  [:map {:registry registry}
+   [:total-prs pos-int?]
+   [:gates-passed :common/non-neg-int]
+   [:gates-failed :common/non-neg-int]
+   [:human-approvals :common/non-neg-int]
+   [:semantic-violations :common/non-neg-int]])
+
+(def EvidenceBundle
+  "Schema for the complete evidence bundle of a train."
+  [:map {:registry registry}
+   [:evidence/id :evidence/id]
+   [:evidence/train-id :train/id]
+   [:evidence/created-at :common/timestamp]
+   [:evidence/prs [:vector PREvidence]]
+   [:evidence/summary EvidenceSummary]
+   [:evidence/miniforge-version :id/string]])
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Validate TrainPR
+  (m/validate TrainPR
+              {:pr/repo "acme/terraform"
+               :pr/number 123
+               :pr/url "https://github.com/acme/terraform/pull/123"
+               :pr/branch "feature/auth"
+               :pr/title "Add auth module"
+               :pr/status :open
+               :pr/merge-order 1
+               :pr/depends-on []
+               :pr/blocks [124]
+               :pr/ci-status :pending})
+  ;; => true
+
+  ;; Validate PRTrain
+  (m/validate PRTrain
+              {:train/id (random-uuid)
+               :train/name "Add User Auth"
+               :train/dag-id (random-uuid)
+               :train/status :drafting
+               :train/prs []
+               :train/blocking-prs []
+               :train/ready-to-merge []
+               :train/created-at (java.util.Date.)
+               :train/updated-at (java.util.Date.)})
+  ;; => true
+
+  ;; Validate EvidenceBundle
+  (m/validate EvidenceBundle
+              {:evidence/id (random-uuid)
+               :evidence/train-id (random-uuid)
+               :evidence/created-at (java.util.Date.)
+               :evidence/prs []
+               :evidence/summary {:total-prs 3
+                                  :gates-passed 5
+                                  :gates-failed 0
+                                  :human-approvals 3
+                                  :semantic-violations 0}
+               :evidence/miniforge-version "0.1.0"})
+  ;; => true
+
+  :end)

--- a/components/pr-train/src/ai/miniforge/pr_train/state.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/state.clj
@@ -1,0 +1,437 @@
+(ns ai.miniforge.pr-train.state
+  "State machine for PR trains and individual PRs.
+   Manages valid transitions and state computations."
+  (:require
+   [ai.miniforge.pr-train.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; State machine definitions
+
+(def train-transitions
+  "Valid train status transitions.
+   DRAFTING -> OPEN -> REVIEWING -> MERGING -> MERGED
+                                          |
+                                    FAILED -> ROLLED-BACK
+                                          |
+                                    ABANDONED"
+  {:drafting    #{:open :abandoned}
+   :open        #{:reviewing :abandoned}
+   :reviewing   #{:merging :abandoned}
+   :merging     #{:merged :failed :abandoned}
+   :merged      #{}
+   :failed      #{:rolled-back :abandoned}
+   :rolled-back #{}
+   :abandoned   #{}})
+
+(def pr-transitions
+  "Valid PR status transitions."
+  {:draft             #{:open :closed}
+   :open              #{:reviewing :closed}
+   :reviewing         #{:changes-requested :approved :closed}
+   :changes-requested #{:reviewing :closed}
+   :approved          #{:merging :closed}
+   :merging           #{:merged :failed}
+   :merged            #{}
+   :closed            #{:open}  ; Can reopen
+   :failed            #{:open}}) ; Can retry
+
+;------------------------------------------------------------------------------ Layer 1
+;; Transition validation
+
+(defn valid-train-transition?
+  "Check if a train status transition is valid."
+  [from-status to-status]
+  (contains? (get train-transitions from-status #{}) to-status))
+
+(defn valid-pr-transition?
+  "Check if a PR status transition is valid."
+  [from-status to-status]
+  (contains? (get pr-transitions from-status #{}) to-status))
+
+(defn terminal-train-status?
+  "Check if a train status is terminal (no further transitions)."
+  [status]
+  (empty? (get train-transitions status #{})))
+
+(defn terminal-pr-status?
+  "Check if a PR status is terminal."
+  [status]
+  (empty? (get pr-transitions status #{})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Train state creation and updates
+
+(defn update-timestamp
+  "Update the updated-at timestamp."
+  [train]
+  (assoc train :train/updated-at (java.util.Date.)))
+
+(defn create-train-state
+  "Create initial train state.
+
+   Arguments:
+   - train-id: UUID for the train
+   - name: Name of the train
+   - dag-id: UUID of the repo DAG this train uses
+
+   Returns a new PRTrain map in :drafting status."
+  [train-id name dag-id & {:keys [description]}]
+  (let [now (java.util.Date.)]
+    {:train/id train-id
+     :train/name name
+     :train/description description
+     :train/dag-id dag-id
+     :train/status :drafting
+     :train/prs []
+     :train/blocking-prs []
+     :train/ready-to-merge []
+     :train/progress nil
+     :train/rollback-plan nil
+     :train/evidence-bundle-id nil
+     :train/created-at now
+     :train/updated-at now
+     :train/merged-at nil}))
+
+(defn transition-train-status
+  "Transition train to a new status if valid.
+
+   Returns updated train or nil if transition is invalid."
+  [train new-status]
+  (let [current-status (:train/status train)]
+    (when (valid-train-transition? current-status new-status)
+      (-> train
+          (assoc :train/status new-status)
+          (cond-> (= new-status :merged)
+            (assoc :train/merged-at (java.util.Date.)))
+          update-timestamp))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; PR state management within train
+
+(defn create-pr-state
+  "Create a new PR state for addition to a train.
+
+   Arguments:
+   - repo: Repository name (e.g., 'acme/terraform')
+   - pr-number: PR number
+   - url: Full URL to the PR
+   - branch: Branch name
+   - title: PR title
+   - merge-order: Position in train merge order (1-indexed)
+
+   Returns a TrainPR map."
+  [repo pr-number url branch title merge-order]
+  {:pr/repo repo
+   :pr/number pr-number
+   :pr/url url
+   :pr/branch branch
+   :pr/title title
+   :pr/status :draft
+   :pr/merge-order merge-order
+   :pr/depends-on []
+   :pr/blocks []
+   :pr/ci-status :pending
+   :pr/gate-results nil
+   :pr/intent nil})
+
+(defn find-pr
+  "Find a PR in the train by number."
+  [train pr-number]
+  (first (filter #(= pr-number (:pr/number %)) (:train/prs train))))
+
+(defn update-pr
+  "Update a PR in the train by number.
+
+   Arguments:
+   - train: The PRTrain
+   - pr-number: PR number to update
+   - update-fn: Function to apply to the PR
+
+   Returns updated train."
+  [train pr-number update-fn]
+  (-> train
+      (update :train/prs
+              (fn [prs]
+                (mapv (fn [pr]
+                        (if (= pr-number (:pr/number pr))
+                          (update-fn pr)
+                          pr))
+                      prs)))
+      update-timestamp))
+
+(defn transition-pr-status
+  "Transition a PR to a new status if valid.
+
+   Returns updated train or nil if transition is invalid."
+  [train pr-number new-status]
+  (when-let [pr (find-pr train pr-number)]
+    (let [current-status (:pr/status pr)]
+      (when (valid-pr-transition? current-status new-status)
+        (update-pr train pr-number #(assoc % :pr/status new-status))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Ready-to-merge computation
+
+(defn pr-merged?
+  "Check if a PR is merged."
+  [train pr-number]
+  (when-let [pr (find-pr train pr-number)]
+    (= :merged (:pr/status pr))))
+
+(defn deps-merged?
+  "Check if all dependencies of a PR are merged."
+  [train pr]
+  (every? #(pr-merged? train %) (:pr/depends-on pr)))
+
+(defn gates-passed?
+  "Check if all gates have passed for a PR."
+  [pr]
+  (let [gate-results (:pr/gate-results pr)]
+    (or (nil? gate-results)
+        (empty? gate-results)
+        (every? :gate/passed? gate-results))))
+
+(defn ready-to-merge?
+  "Check if a PR is ready to merge.
+
+   A PR is ready when:
+   1. All dependencies are merged
+   2. PR is approved
+   3. CI has passed
+   4. All gates have passed"
+  [train pr]
+  (and (deps-merged? train pr)
+       (= :approved (:pr/status pr))
+       (= :passed (:pr/ci-status pr))
+       (gates-passed? pr)))
+
+(defn compute-ready-to-merge
+  "Compute list of PR numbers ready to merge.
+
+   Returns vector of PR numbers sorted by merge order."
+  [train]
+  (->> (:train/prs train)
+       (filter #(ready-to-merge? train %))
+       (sort-by :pr/merge-order)
+       (mapv :pr/number)))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Blocking PR computation
+
+(defn pr-blocking?
+  "Check if a PR is blocking train progress.
+
+   A PR is blocking when:
+   1. Its dependencies are merged (it could proceed)
+   2. But it's not approved, CI hasn't passed, or gates haven't passed"
+  [train pr]
+  (let [deps-ok? (deps-merged? train pr)
+        not-merged? (not= :merged (:pr/status pr))
+        not-ready? (not (ready-to-merge? train pr))]
+    (and deps-ok? not-merged? not-ready?)))
+
+(defn compute-blocking-prs
+  "Compute list of PR numbers that are blocking progress.
+
+   Returns vector of PR numbers sorted by merge order."
+  [train]
+  (->> (:train/prs train)
+       (filter #(pr-blocking? train %))
+       (sort-by :pr/merge-order)
+       (mapv :pr/number)))
+
+;------------------------------------------------------------------------------ Layer 6
+;; Progress computation
+
+(defn compute-progress
+  "Compute progress summary for a train.
+
+   Returns a Progress map with counts of PRs in each state."
+  [train]
+  (let [prs (:train/prs train)
+        total (count prs)]
+    (when (pos? total)
+      (let [merged (count (filter #(= :merged (:pr/status %)) prs))
+            approved (count (filter #(= :approved (:pr/status %)) prs))
+            failed (count (filter #(= :failed (:pr/status %)) prs))
+            pending (- total merged approved failed)]
+        {:total total
+         :merged merged
+         :approved approved
+         :pending pending
+         :failed failed}))))
+
+;------------------------------------------------------------------------------ Layer 7
+;; Aggregate state recomputation
+
+(defn recompute-train-state
+  "Recompute all derived state for a train.
+
+   Updates:
+   - :train/blocking-prs
+   - :train/ready-to-merge
+   - :train/progress
+
+   Returns updated train."
+  [train]
+  (-> train
+      (assoc :train/blocking-prs (compute-blocking-prs train))
+      (assoc :train/ready-to-merge (compute-ready-to-merge train))
+      (assoc :train/progress (compute-progress train))
+      update-timestamp))
+
+;------------------------------------------------------------------------------ Layer 8
+;; Dependency linking
+
+(defn link-pr-dependencies
+  "Link PR dependencies based on merge order.
+
+   PRs depend on all PRs with lower merge order.
+   This is a simple linear dependency chain.
+
+   For more complex DAG-based dependencies, use link-prs-from-dag.
+
+   Returns updated train."
+  [train]
+  (let [prs (:train/prs train)
+        pr-numbers (set (map :pr/number prs))
+        linked-prs (mapv (fn [pr]
+                           (let [order (:pr/merge-order pr)
+                                 deps (->> prs
+                                           (filter #(< (:pr/merge-order %) order))
+                                           (mapv :pr/number))
+                                 blocks (->> prs
+                                             (filter #(> (:pr/merge-order %) order))
+                                             (mapv :pr/number))]
+                             (-> pr
+                                 (assoc :pr/depends-on (vec deps))
+                                 (assoc :pr/blocks (vec blocks)))))
+                         prs)]
+    (-> train
+        (assoc :train/prs linked-prs)
+        recompute-train-state)))
+
+;------------------------------------------------------------------------------ Layer 9
+;; Rollback planning
+
+(defn compute-rollback-plan
+  "Compute a rollback plan for the train.
+
+   Arguments:
+   - train: The PRTrain
+   - trigger: What triggered the rollback
+   - action: What action to take
+
+   Returns updated train with rollback plan."
+  [train trigger action]
+  (let [merged-prs (->> (:train/prs train)
+                        (filter #(= :merged (:pr/status %)))
+                        (sort-by :pr/merge-order >)  ; Reverse order
+                        (mapv :pr/number))
+        checkpoint (when (seq merged-prs)
+                     (first (sort merged-prs)))]  ; First merged PR
+    (-> train
+        (assoc :train/rollback-plan
+               {:trigger trigger
+                :action action
+                :checkpoint checkpoint
+                :prs-to-revert merged-prs})
+        update-timestamp)))
+
+;------------------------------------------------------------------------------ Layer 10
+;; Auto-transition based on PR states
+
+(defn infer-train-status
+  "Infer what the train status should be based on PR states.
+
+   Returns suggested new status or nil if no change needed."
+  [train]
+  (let [prs (:train/prs train)
+        current-status (:train/status train)]
+    (cond
+      ;; All PRs merged -> train is merged
+      (and (seq prs)
+           (every? #(= :merged (:pr/status %)) prs)
+           (not= :merged current-status))
+      :merged
+
+      ;; Any PR failed -> train failed
+      (and (some #(= :failed (:pr/status %)) prs)
+           (not= :failed current-status)
+           (not (terminal-train-status? current-status)))
+      :failed
+
+      ;; Any PR merging -> train is merging
+      (and (some #(= :merging (:pr/status %)) prs)
+           (= :reviewing current-status))
+      :merging
+
+      ;; Any PR reviewing/approved -> train is reviewing
+      (and (some #(#{:reviewing :approved} (:pr/status %)) prs)
+           (= :open current-status))
+      :reviewing
+
+      ;; Any PR open -> train is open
+      (and (some #(= :open (:pr/status %)) prs)
+           (= :drafting current-status))
+      :open
+
+      :else nil)))
+
+(defn auto-transition-train
+  "Automatically transition train status based on PR states.
+
+   Returns updated train or original if no transition needed."
+  [train]
+  (if-let [new-status (infer-train-status train)]
+    (or (transition-train-status train new-status) train)
+    train))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create a train
+  (def my-train
+    (create-train-state (random-uuid) "Auth Feature" (random-uuid)))
+
+  ;; Add some PRs
+  (def pr1 (create-pr-state "acme/modules" 100
+                            "https://github.com/acme/modules/pull/100"
+                            "feat/auth" "Add auth module" 1))
+
+  (def pr2 (create-pr-state "acme/live" 200
+                            "https://github.com/acme/live/pull/200"
+                            "feat/auth" "Deploy auth" 2))
+
+  (def train-with-prs
+    (-> my-train
+        (update :train/prs conj pr1)
+        (update :train/prs conj pr2)
+        link-pr-dependencies))
+
+  ;; Check dependencies
+  (:pr/depends-on (find-pr train-with-prs 200))
+  ;; => [100]
+
+  ;; Simulate approvals and CI
+  (def ready-train
+    (-> train-with-prs
+        (update-pr 100 #(assoc % :pr/status :approved :pr/ci-status :passed))
+        recompute-train-state))
+
+  ;; Check ready-to-merge
+  (:train/ready-to-merge ready-train)
+  ;; => [100]
+
+  ;; Simulate merging PR 100
+  (def merged-train
+    (-> ready-train
+        (transition-pr-status 100 :merging)
+        (transition-pr-status 100 :merged)
+        (update-pr 200 #(assoc % :pr/status :approved :pr/ci-status :passed))
+        recompute-train-state))
+
+  ;; Now PR 200 should be ready
+  (:train/ready-to-merge merged-train)
+  ;; => [200]
+
+  :end)

--- a/components/pr-train/test/ai/miniforge/pr_train/interface_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/interface_test.clj
@@ -1,0 +1,424 @@
+(ns ai.miniforge.pr-train.interface-test
+  "Tests for the pr-train component interface."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.pr-train.interface :as train]))
+
+;; ============================================================================
+;; Manager creation tests
+;; ============================================================================
+
+(deftest create-manager-test
+  (testing "create-manager returns a manager"
+    (let [mgr (train/create-manager)]
+      (is (some? mgr))
+      (is (satisfies? train/PRTrainManager mgr)))))
+
+;; ============================================================================
+;; Train lifecycle tests
+;; ============================================================================
+
+(deftest create-train-test
+  (testing "create-train returns a train-id"
+    (let [mgr (train/create-manager)
+          dag-id (random-uuid)
+          train-id (train/create-train mgr "Test Train" dag-id "A test train")]
+      (is (uuid? train-id))
+
+      (testing "get-train returns the created train"
+        (let [t (train/get-train mgr train-id)]
+          (is (some? t))
+          (is (= train-id (:train/id t)))
+          (is (= "Test Train" (:train/name t)))
+          (is (= dag-id (:train/dag-id t)))
+          (is (= :drafting (:train/status t)))
+          (is (empty? (:train/prs t))))))))
+
+(deftest add-pr-test
+  (testing "add-pr adds a PR to the train"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)
+          updated (train/add-pr mgr train-id "acme/repo" 123
+                                "https://github.com/acme/repo/pull/123"
+                                "feat/test" "Test PR")]
+      (is (some? updated))
+      (is (= 1 (count (:train/prs updated))))
+
+      (let [pr (first (:train/prs updated))]
+        (is (= "acme/repo" (:pr/repo pr)))
+        (is (= 123 (:pr/number pr)))
+        (is (= 1 (:pr/merge-order pr)))
+        (is (= :draft (:pr/status pr)))
+        (is (= :pending (:pr/ci-status pr))))))
+
+  (testing "add-pr assigns sequential merge-order"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 1 "url1" "branch" "PR 1")
+      (train/add-pr mgr train-id "acme/b" 2 "url2" "branch" "PR 2")
+      (train/add-pr mgr train-id "acme/c" 3 "url3" "branch" "PR 3")
+
+      (let [t (train/get-train mgr train-id)
+            orders (map :pr/merge-order (:train/prs t))]
+        (is (= [1 2 3] orders))))))
+
+(deftest remove-pr-test
+  (testing "remove-pr removes a PR and reorders"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 1 "url1" "branch" "PR 1")
+      (train/add-pr mgr train-id "acme/b" 2 "url2" "branch" "PR 2")
+      (train/add-pr mgr train-id "acme/c" 3 "url3" "branch" "PR 3")
+
+      (let [updated (train/remove-pr mgr train-id 2)
+            remaining (map :pr/number (:train/prs updated))
+            orders (map :pr/merge-order (:train/prs updated))]
+        (is (= [1 3] remaining))
+        (is (= [1 2] orders))))))
+
+(deftest link-prs-test
+  (testing "link-prs computes dependencies"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 100 "url1" "branch" "PR 1")
+      (train/add-pr mgr train-id "acme/b" 200 "url2" "branch" "PR 2")
+      (train/add-pr mgr train-id "acme/c" 300 "url3" "branch" "PR 3")
+      (train/link-prs mgr train-id)
+
+      (let [pr1 (train/get-pr-from-train mgr train-id 100)
+            pr2 (train/get-pr-from-train mgr train-id 200)
+            pr3 (train/get-pr-from-train mgr train-id 300)]
+        (is (= [] (:pr/depends-on pr1)))
+        (is (= [200 300] (:pr/blocks pr1)))
+        (is (= [100] (:pr/depends-on pr2)))
+        (is (= [300] (:pr/blocks pr2)))
+        (is (= [100 200] (:pr/depends-on pr3)))
+        (is (= [] (:pr/blocks pr3)))))))
+
+;; ============================================================================
+;; State management tests
+;; ============================================================================
+
+(deftest update-pr-status-test
+  (testing "update-pr-status transitions PR state"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/repo" 123 "url" "branch" "PR")
+
+      (let [t1 (train/update-pr-status mgr train-id 123 :open)]
+        (is (some? t1))
+        (is (= :open (:pr/status (train/get-pr-from-train mgr train-id 123)))))
+
+      (let [t2 (train/update-pr-status mgr train-id 123 :reviewing)]
+        (is (some? t2))
+        (is (= :reviewing (:pr/status (train/get-pr-from-train mgr train-id 123)))))
+
+      (let [t3 (train/update-pr-status mgr train-id 123 :approved)]
+        (is (some? t3))
+        (is (= :approved (:pr/status (train/get-pr-from-train mgr train-id 123)))))))
+
+  (testing "invalid transitions return nil"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/repo" 123 "url" "branch" "PR")
+      (is (nil? (train/update-pr-status mgr train-id 123 :approved)))
+      (is (= :draft (:pr/status (train/get-pr-from-train mgr train-id 123)))))))
+
+(deftest update-pr-ci-status-test
+  (testing "update-pr-ci-status updates CI status"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/repo" 123 "url" "branch" "PR")
+
+      (train/update-pr-ci-status mgr train-id 123 :running)
+      (is (= :running (:pr/ci-status (train/get-pr-from-train mgr train-id 123))))
+
+      (train/update-pr-ci-status mgr train-id 123 :passed)
+      (is (= :passed (:pr/ci-status (train/get-pr-from-train mgr train-id 123)))))))
+
+;; ============================================================================
+;; Ready-to-merge tests
+;; ============================================================================
+
+(deftest ready-to-merge-test
+  (testing "PR is ready when deps merged, approved, CI passed, gates passed"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 100 "url1" "branch" "PR 1")
+      (train/add-pr mgr train-id "acme/b" 200 "url2" "branch" "PR 2")
+      (train/link-prs mgr train-id)
+
+      (is (empty? (train/get-ready-to-merge mgr train-id)))
+
+      (train/update-pr-status mgr train-id 100 :open)
+      (train/update-pr-status mgr train-id 100 :reviewing)
+      (train/update-pr-status mgr train-id 100 :approved)
+      (train/update-pr-ci-status mgr train-id 100 :passed)
+
+      (is (= [100] (train/get-ready-to-merge mgr train-id)))
+
+      (train/update-pr-status mgr train-id 200 :open)
+      (train/update-pr-status mgr train-id 200 :reviewing)
+      (train/update-pr-status mgr train-id 200 :approved)
+      (train/update-pr-ci-status mgr train-id 200 :passed)
+
+      (is (= [100] (train/get-ready-to-merge mgr train-id)))))
+
+  (testing "PR becomes ready after deps merge"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 100 "url1" "branch" "PR 1")
+      (train/add-pr mgr train-id "acme/b" 200 "url2" "branch" "PR 2")
+      (train/link-prs mgr train-id)
+
+      (train/update-pr-status mgr train-id 100 :open)
+      (train/update-pr-status mgr train-id 100 :reviewing)
+      (train/update-pr-status mgr train-id 100 :approved)
+      (train/update-pr-ci-status mgr train-id 100 :passed)
+
+      (train/update-pr-status mgr train-id 200 :open)
+      (train/update-pr-status mgr train-id 200 :reviewing)
+      (train/update-pr-status mgr train-id 200 :approved)
+      (train/update-pr-ci-status mgr train-id 200 :passed)
+
+      (train/merge-next mgr train-id)
+      (train/complete-merge mgr train-id 100)
+
+      (is (= [200] (train/get-ready-to-merge mgr train-id))))))
+
+;; ============================================================================
+;; Blocking PR tests
+;; ============================================================================
+
+(deftest get-blocking-test
+  (testing "blocking PRs are those that could proceed but aren't ready"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 100 "url1" "branch" "PR 1")
+      (train/add-pr mgr train-id "acme/b" 200 "url2" "branch" "PR 2")
+      (train/link-prs mgr train-id)
+
+      (train/update-pr-status mgr train-id 100 :open)
+      (train/update-pr-ci-status mgr train-id 100 :passed)
+
+      (is (= [100] (train/get-blocking mgr train-id)))
+
+      (train/update-pr-status mgr train-id 200 :open)
+
+      (is (= [100] (train/get-blocking mgr train-id))))))
+
+;; ============================================================================
+;; Progress tests
+;; ============================================================================
+
+(deftest get-progress-test
+  (testing "progress tracks PR states"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 100 "url1" "branch" "PR 1")
+      (train/add-pr mgr train-id "acme/b" 200 "url2" "branch" "PR 2")
+      (train/add-pr mgr train-id "acme/c" 300 "url3" "branch" "PR 3")
+      (train/link-prs mgr train-id)
+
+      (let [p (train/get-progress mgr train-id)]
+        (is (= 3 (:total p)))
+        (is (= 0 (:merged p)))
+        (is (= 0 (:approved p)))
+        (is (= 3 (:pending p)))
+        (is (= 0 (:failed p))))
+
+      (train/update-pr-status mgr train-id 100 :open)
+      (train/update-pr-status mgr train-id 100 :reviewing)
+      (train/update-pr-status mgr train-id 100 :approved)
+      (train/update-pr-ci-status mgr train-id 100 :passed)
+
+      (let [p (train/get-progress mgr train-id)]
+        (is (= 1 (:approved p)))
+        (is (= 2 (:pending p))))
+
+      (train/merge-next mgr train-id)
+      (train/complete-merge mgr train-id 100)
+
+      (let [p (train/get-progress mgr train-id)]
+        (is (= 1 (:merged p)))
+        (is (= 0 (:approved p)))
+        (is (= 2 (:pending p)))))))
+
+;; ============================================================================
+;; Merge action tests
+;; ============================================================================
+
+(deftest merge-next-test
+  (testing "merge-next marks the next ready PR as merging"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 100 "url1" "branch" "PR 1")
+      (train/link-prs mgr train-id)
+
+      (is (nil? (train/merge-next mgr train-id)))
+
+      (train/update-pr-status mgr train-id 100 :open)
+      (train/update-pr-status mgr train-id 100 :reviewing)
+      (train/update-pr-status mgr train-id 100 :approved)
+      (train/update-pr-ci-status mgr train-id 100 :passed)
+
+      (let [result (train/merge-next mgr train-id)]
+        (is (= 100 (:pr-number result)))
+        (is (some? (:train result)))
+        (is (= :merging (:pr/status (train/get-pr-from-train mgr train-id 100))))))))
+
+(deftest complete-merge-test
+  (testing "complete-merge marks PR as merged"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 100 "url1" "branch" "PR 1")
+      (train/link-prs mgr train-id)
+
+      (train/update-pr-status mgr train-id 100 :open)
+      (train/update-pr-status mgr train-id 100 :reviewing)
+      (train/update-pr-status mgr train-id 100 :approved)
+      (train/update-pr-ci-status mgr train-id 100 :passed)
+      (train/merge-next mgr train-id)
+
+      (train/complete-merge mgr train-id 100)
+      (is (= :merged (:pr/status (train/get-pr-from-train mgr train-id 100)))))))
+
+(deftest fail-merge-test
+  (testing "fail-merge marks PR as failed and creates rollback plan"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 100 "url1" "branch" "PR 1")
+      (train/link-prs mgr train-id)
+
+      (train/update-pr-status mgr train-id 100 :open)
+      (train/update-pr-status mgr train-id 100 :reviewing)
+      (train/update-pr-status mgr train-id 100 :approved)
+      (train/update-pr-ci-status mgr train-id 100 :passed)
+      (train/merge-next mgr train-id)
+
+      (let [updated (train/fail-merge mgr train-id 100 "Merge conflict")]
+        (is (= :failed (:pr/status (train/get-pr-from-train mgr train-id 100))))
+        (is (some? (:train/rollback-plan updated)))))))
+
+;; ============================================================================
+;; Train control tests
+;; ============================================================================
+
+(deftest pause-resume-test
+  (testing "pause-train and resume-train work"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+
+      (let [paused (train/pause-train mgr train-id "Security review")]
+        (is (:train/paused? paused))
+        (is (= "Security review" (:train/pause-reason paused))))
+
+      (let [resumed (train/resume-train mgr train-id)]
+        (is (not (:train/paused? resumed)))
+        (is (nil? (:train/pause-reason resumed)))))))
+
+(deftest abandon-train-test
+  (testing "abandon-train marks train as abandoned"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+
+      (let [abandoned (train/abandon-train mgr train-id "Project cancelled")]
+        (is (= :abandoned (:train/status abandoned)))
+        (is (= "Project cancelled" (:train/abandon-reason abandoned)))))))
+
+;; ============================================================================
+;; Evidence tests
+;; ============================================================================
+
+(deftest generate-evidence-bundle-test
+  (testing "generate-evidence-bundle creates an evidence bundle"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 100 "url1" "branch" "PR 1")
+      (train/add-pr mgr train-id "acme/b" 200 "url2" "branch" "PR 2")
+      (train/link-prs mgr train-id)
+
+      (train/update-pr-status mgr train-id 100 :open)
+      (train/update-pr-status mgr train-id 100 :reviewing)
+      (train/update-pr-status mgr train-id 100 :approved)
+      (train/update-pr-ci-status mgr train-id 100 :passed)
+      (train/merge-next mgr train-id)
+      (train/complete-merge mgr train-id 100)
+
+      (let [bundle (train/generate-evidence-bundle mgr train-id)]
+        (is (uuid? (:evidence/id bundle)))
+        (is (= train-id (:evidence/train-id bundle)))
+        (is (= 2 (count (:evidence/prs bundle))))
+        (is (= "0.1.0" (:evidence/miniforge-version bundle)))
+
+        (let [summary (:evidence/summary bundle)]
+          (is (= 2 (:total-prs summary)))
+          (is (= 1 (:human-approvals summary))))))))
+
+(deftest get-evidence-bundle-test
+  (testing "get-evidence-bundle retrieves stored bundle"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/a" 100 "url1" "branch" "PR 1")
+
+      (let [bundle (train/generate-evidence-bundle mgr train-id)
+            bundle-id (:evidence/id bundle)
+            retrieved (train/get-evidence-bundle mgr bundle-id)]
+        (is (= bundle retrieved))))))
+
+;; ============================================================================
+;; Utility function tests
+;; ============================================================================
+
+(deftest list-trains-test
+  (testing "list-trains returns all trains"
+    (let [mgr (train/create-manager)]
+      (train/create-train mgr "Train 1" (random-uuid) nil)
+      (train/create-train mgr "Train 2" (random-uuid) nil)
+
+      (let [trains (train/list-trains mgr)]
+        (is (= 2 (count trains)))
+        (is (every? :train/id trains))
+        (is (every? :train/name trains))))))
+
+(deftest find-trains-by-status-test
+  (testing "find-trains-by-status filters by status"
+    (let [mgr (train/create-manager)
+          t1 (train/create-train mgr "Train 1" (random-uuid) nil)
+          t2 (train/create-train mgr "Train 2" (random-uuid) nil)]
+
+      (is (= 2 (count (train/find-trains-by-status mgr :drafting))))
+
+      (train/abandon-train mgr t1 "Cancelled")
+      (is (= 1 (count (train/find-trains-by-status mgr :drafting))))
+      (is (= 1 (count (train/find-trains-by-status mgr :abandoned)))))))
+
+(deftest train-contains-pr?-test
+  (testing "train-contains-pr? checks PR membership"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "Test" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/repo" 123 "url" "branch" "PR")
+
+      (is (train/train-contains-pr? mgr train-id "acme/repo" 123))
+      (is (not (train/train-contains-pr? mgr train-id "acme/repo" 456)))
+      (is (not (train/train-contains-pr? mgr train-id "other/repo" 123))))))
+
+;; ============================================================================
+;; State machine validation tests
+;; ============================================================================
+
+(deftest valid-train-transition?-test
+  (testing "valid-train-transition? validates transitions"
+    (is (train/valid-train-transition? :drafting :open))
+    (is (train/valid-train-transition? :open :reviewing))
+    (is (train/valid-train-transition? :failed :rolled-back))
+    (is (not (train/valid-train-transition? :merged :drafting)))
+    (is (not (train/valid-train-transition? :abandoned :open)))))
+
+(deftest valid-pr-transition?-test
+  (testing "valid-pr-transition? validates transitions"
+    (is (train/valid-pr-transition? :draft :open))
+    (is (train/valid-pr-transition? :reviewing :approved))
+    (is (train/valid-pr-transition? :merging :merged))
+    (is (not (train/valid-pr-transition? :merged :draft)))
+    (is (not (train/valid-pr-transition? :draft :merged)))))

--- a/components/pr-train/test/ai/miniforge/pr_train/state_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/state_test.clj
@@ -1,0 +1,443 @@
+(ns ai.miniforge.pr-train.state-test
+  "Tests for pr-train state machine logic."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.pr-train.state :as state]))
+
+;; ============================================================================
+;; State transition validation tests
+;; ============================================================================
+
+(deftest train-transitions-test
+  (testing "train-transitions map is complete"
+    (is (map? state/train-transitions))
+    (is (contains? state/train-transitions :drafting))
+    (is (contains? state/train-transitions :merged))
+    (is (contains? state/train-transitions :abandoned))))
+
+(deftest valid-train-transition?-test
+  (testing "valid forward transitions"
+    (is (state/valid-train-transition? :drafting :open))
+    (is (state/valid-train-transition? :drafting :abandoned))
+    (is (state/valid-train-transition? :open :reviewing))
+    (is (state/valid-train-transition? :reviewing :merging))
+    (is (state/valid-train-transition? :merging :merged))
+    (is (state/valid-train-transition? :merging :failed))
+    (is (state/valid-train-transition? :failed :rolled-back))
+    (is (state/valid-train-transition? :failed :abandoned)))
+
+  (testing "invalid transitions"
+    (is (not (state/valid-train-transition? :merged :drafting)))
+    (is (not (state/valid-train-transition? :abandoned :drafting)))
+    (is (not (state/valid-train-transition? :rolled-back :open)))
+    (is (not (state/valid-train-transition? :drafting :merged)))))
+
+(deftest valid-pr-transition?-test
+  (testing "valid PR transitions"
+    (is (state/valid-pr-transition? :draft :open))
+    (is (state/valid-pr-transition? :draft :closed))
+    (is (state/valid-pr-transition? :open :reviewing))
+    (is (state/valid-pr-transition? :reviewing :changes-requested))
+    (is (state/valid-pr-transition? :reviewing :approved))
+    (is (state/valid-pr-transition? :changes-requested :reviewing))
+    (is (state/valid-pr-transition? :approved :merging))
+    (is (state/valid-pr-transition? :merging :merged))
+    (is (state/valid-pr-transition? :merging :failed))
+    (is (state/valid-pr-transition? :closed :open)))
+
+  (testing "invalid PR transitions"
+    (is (not (state/valid-pr-transition? :draft :merged)))
+    (is (not (state/valid-pr-transition? :merged :draft)))
+    (is (not (state/valid-pr-transition? :open :merged)))
+    (is (not (state/valid-pr-transition? :reviewing :merged)))))
+
+(deftest terminal-status-tests
+  (testing "terminal train statuses"
+    (is (state/terminal-train-status? :merged))
+    (is (state/terminal-train-status? :rolled-back))
+    (is (state/terminal-train-status? :abandoned))
+    (is (not (state/terminal-train-status? :drafting)))
+    (is (not (state/terminal-train-status? :failed))))
+
+  (testing "terminal PR statuses"
+    (is (state/terminal-pr-status? :merged))
+    (is (not (state/terminal-pr-status? :draft)))
+    (is (not (state/terminal-pr-status? :failed)))))
+
+;; ============================================================================
+;; Train state creation tests
+;; ============================================================================
+
+(deftest create-train-state-test
+  (testing "creates valid initial state"
+    (let [train-id (random-uuid)
+          dag-id (random-uuid)
+          train (state/create-train-state train-id "My Train" dag-id)]
+      (is (= train-id (:train/id train)))
+      (is (= "My Train" (:train/name train)))
+      (is (= dag-id (:train/dag-id train)))
+      (is (= :drafting (:train/status train)))
+      (is (empty? (:train/prs train)))
+      (is (empty? (:train/blocking-prs train)))
+      (is (empty? (:train/ready-to-merge train)))
+      (is (nil? (:train/progress train)))
+      (is (inst? (:train/created-at train)))
+      (is (inst? (:train/updated-at train)))))
+
+  (testing "accepts optional description"
+    (let [train (state/create-train-state (random-uuid) "Test" (random-uuid)
+                                          :description "A description")]
+      (is (= "A description" (:train/description train))))))
+
+(deftest transition-train-status-test
+  (testing "valid transition updates status"
+    (let [train (state/create-train-state (random-uuid) "Test" (random-uuid))
+          updated (state/transition-train-status train :open)]
+      (is (some? updated))
+      (is (= :open (:train/status updated)))))
+
+  (testing "invalid transition returns nil"
+    (let [train (state/create-train-state (random-uuid) "Test" (random-uuid))
+          updated (state/transition-train-status train :merged)]
+      (is (nil? updated))))
+
+  (testing "transition to merged sets merged-at timestamp"
+    (let [train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/status :merging))
+          updated (state/transition-train-status train :merged)]
+      (is (inst? (:train/merged-at updated))))))
+
+;; ============================================================================
+;; PR state creation tests
+;; ============================================================================
+
+(deftest create-pr-state-test
+  (testing "creates valid PR state"
+    (let [pr (state/create-pr-state "acme/repo" 123
+                                    "https://github.com/acme/repo/pull/123"
+                                    "feat/test" "Test PR" 1)]
+      (is (= "acme/repo" (:pr/repo pr)))
+      (is (= 123 (:pr/number pr)))
+      (is (= "https://github.com/acme/repo/pull/123" (:pr/url pr)))
+      (is (= "feat/test" (:pr/branch pr)))
+      (is (= "Test PR" (:pr/title pr)))
+      (is (= 1 (:pr/merge-order pr)))
+      (is (= :draft (:pr/status pr)))
+      (is (= :pending (:pr/ci-status pr)))
+      (is (empty? (:pr/depends-on pr)))
+      (is (empty? (:pr/blocks pr))))))
+
+(deftest find-pr-test
+  (testing "finds PR by number"
+    (let [pr1 (state/create-pr-state "acme/a" 100 "url1" "branch" "PR 1" 1)
+          pr2 (state/create-pr-state "acme/b" 200 "url2" "branch" "PR 2" 2)
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1 pr2]))]
+      (is (= pr1 (state/find-pr train 100)))
+      (is (= pr2 (state/find-pr train 200)))
+      (is (nil? (state/find-pr train 300))))))
+
+(deftest update-pr-test
+  (testing "updates PR in train"
+    (let [pr1 (state/create-pr-state "acme/a" 100 "url1" "branch" "PR 1" 1)
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1]))
+          updated (state/update-pr train 100 #(assoc % :pr/status :open))]
+      (is (= :open (:pr/status (state/find-pr updated 100)))))))
+
+(deftest transition-pr-status-test
+  (testing "valid PR transition updates status"
+    (let [pr (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr]))
+          updated (state/transition-pr-status train 100 :open)]
+      (is (some? updated))
+      (is (= :open (:pr/status (state/find-pr updated 100))))))
+
+  (testing "invalid PR transition returns nil"
+    (let [pr (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr]))
+          updated (state/transition-pr-status train 100 :merged)]
+      (is (nil? updated)))))
+
+;; ============================================================================
+;; Ready-to-merge computation tests
+;; ============================================================================
+
+(deftest deps-merged?-test
+  (testing "PR with no deps is always deps-merged"
+    (let [pr (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr]))]
+      (is (state/deps-merged? train pr))))
+
+  (testing "PR with unmerged deps is not deps-merged"
+    (let [pr1 (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+          pr2 (-> (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+                  (assoc :pr/depends-on [100]))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1 pr2]))]
+      (is (not (state/deps-merged? train pr2)))))
+
+  (testing "PR with merged deps is deps-merged"
+    (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+                  (assoc :pr/status :merged))
+          pr2 (-> (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+                  (assoc :pr/depends-on [100]))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1 pr2]))]
+      (is (state/deps-merged? train pr2)))))
+
+(deftest gates-passed?-test
+  (testing "PR with no gates passes"
+    (let [pr (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)]
+      (is (state/gates-passed? pr))))
+
+  (testing "PR with all gates passed passes"
+    (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+                 (assoc :pr/gate-results
+                        [{:gate/id :security :gate/type :security :gate/passed? true}
+                         {:gate/id :lint :gate/type :lint :gate/passed? true}]))]
+      (is (state/gates-passed? pr))))
+
+  (testing "PR with failed gate does not pass"
+    (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+                 (assoc :pr/gate-results
+                        [{:gate/id :security :gate/type :security :gate/passed? true}
+                         {:gate/id :lint :gate/type :lint :gate/passed? false}]))]
+      (is (not (state/gates-passed? pr))))))
+
+(deftest ready-to-merge?-test
+  (testing "PR is ready when all conditions met"
+    (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+                 (assoc :pr/status :approved)
+                 (assoc :pr/ci-status :passed))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr]))]
+      (is (state/ready-to-merge? train pr))))
+
+  (testing "PR not ready if not approved"
+    (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+                 (assoc :pr/status :reviewing)
+                 (assoc :pr/ci-status :passed))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr]))]
+      (is (not (state/ready-to-merge? train pr)))))
+
+  (testing "PR not ready if CI not passed"
+    (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+                 (assoc :pr/status :approved)
+                 (assoc :pr/ci-status :running))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr]))]
+      (is (not (state/ready-to-merge? train pr)))))
+
+  (testing "PR not ready if deps not merged"
+    (let [pr1 (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+          pr2 (-> (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+                  (assoc :pr/depends-on [100])
+                  (assoc :pr/status :approved)
+                  (assoc :pr/ci-status :passed))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1 pr2]))]
+      (is (not (state/ready-to-merge? train pr2))))))
+
+(deftest compute-ready-to-merge-test
+  (testing "returns ready PRs in merge order"
+    (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+                  (assoc :pr/status :approved)
+                  (assoc :pr/ci-status :passed))
+          pr2 (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1 pr2]))]
+      (is (= [100] (state/compute-ready-to-merge train))))))
+
+;; ============================================================================
+;; Blocking PR computation tests
+;; ============================================================================
+
+(deftest pr-blocking?-test
+  (testing "PR is blocking when deps merged but not ready"
+    (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+                 (assoc :pr/status :open)
+                 (assoc :pr/ci-status :passed))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr]))]
+      (is (state/pr-blocking? train pr))))
+
+  (testing "Merged PR is not blocking"
+    (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+                 (assoc :pr/status :merged))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr]))]
+      (is (not (state/pr-blocking? train pr)))))
+
+  (testing "Ready PR is not blocking"
+    (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR" 1)
+                 (assoc :pr/status :approved)
+                 (assoc :pr/ci-status :passed))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr]))]
+      (is (not (state/pr-blocking? train pr))))))
+
+(deftest compute-blocking-prs-test
+  (testing "returns blocking PRs"
+    (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+                  (assoc :pr/status :open))
+          pr2 (-> (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+                  (assoc :pr/depends-on [100])
+                  (assoc :pr/status :approved)
+                  (assoc :pr/ci-status :passed))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1 pr2]))]
+      (is (= [100] (state/compute-blocking-prs train))))))
+
+;; ============================================================================
+;; Progress computation tests
+;; ============================================================================
+
+(deftest compute-progress-test
+  (testing "computes correct progress"
+    (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+                  (assoc :pr/status :merged))
+          pr2 (-> (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+                  (assoc :pr/status :approved))
+          pr3 (state/create-pr-state "acme/c" 300 "url" "branch" "PR 3" 3)
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1 pr2 pr3]))
+          progress (state/compute-progress train)]
+      (is (= 3 (:total progress)))
+      (is (= 1 (:merged progress)))
+      (is (= 1 (:approved progress)))
+      (is (= 1 (:pending progress)))
+      (is (= 0 (:failed progress)))))
+
+  (testing "returns nil for empty train"
+    (let [train (state/create-train-state (random-uuid) "Test" (random-uuid))]
+      (is (nil? (state/compute-progress train))))))
+
+;; ============================================================================
+;; Dependency linking tests
+;; ============================================================================
+
+(deftest link-pr-dependencies-test
+  (testing "links PRs in linear chain"
+    (let [pr1 (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+          pr2 (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+          pr3 (state/create-pr-state "acme/c" 300 "url" "branch" "PR 3" 3)
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1 pr2 pr3]))
+          linked (state/link-pr-dependencies train)]
+
+      (let [p1 (state/find-pr linked 100)
+            p2 (state/find-pr linked 200)
+            p3 (state/find-pr linked 300)]
+        (is (= [] (:pr/depends-on p1)))
+        (is (= [200 300] (:pr/blocks p1)))
+        (is (= [100] (:pr/depends-on p2)))
+        (is (= [300] (:pr/blocks p2)))
+        (is (= [100 200] (:pr/depends-on p3)))
+        (is (= [] (:pr/blocks p3)))))))
+
+;; ============================================================================
+;; Rollback planning tests
+;; ============================================================================
+
+(deftest compute-rollback-plan-test
+  (testing "computes rollback plan with merged PRs"
+    (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+                  (assoc :pr/status :merged))
+          pr2 (-> (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+                  (assoc :pr/status :merged))
+          pr3 (-> (state/create-pr-state "acme/c" 300 "url" "branch" "PR 3" 3)
+                  (assoc :pr/status :failed))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1 pr2 pr3]))
+          planned (state/compute-rollback-plan train :ci-failure :revert-all)]
+
+      (let [plan (:train/rollback-plan planned)]
+        (is (= :ci-failure (:trigger plan)))
+        (is (= :revert-all (:action plan)))
+        (is (= 100 (:checkpoint plan)))
+        (is (= [200 100] (:prs-to-revert plan)))))))
+
+;; ============================================================================
+;; Auto-transition tests
+;; ============================================================================
+
+(deftest infer-train-status-test
+  (testing "infers :merged when all PRs merged"
+    (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+                  (assoc :pr/status :merged))
+          pr2 (-> (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+                  (assoc :pr/status :merged))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/status :merging)
+                    (assoc :train/prs [pr1 pr2]))]
+      (is (= :merged (state/infer-train-status train)))))
+
+  (testing "infers :failed when any PR failed"
+    (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+                  (assoc :pr/status :merged))
+          pr2 (-> (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+                  (assoc :pr/status :failed))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/status :merging)
+                    (assoc :train/prs [pr1 pr2]))]
+      (is (= :failed (state/infer-train-status train)))))
+
+  (testing "infers :reviewing when any PR reviewing/approved"
+    (let [pr (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+                 (assoc :pr/status :reviewing))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/status :open)
+                    (assoc :train/prs [pr]))]
+      (is (= :reviewing (state/infer-train-status train)))))
+
+  (testing "returns nil when no change needed"
+    (let [pr (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr]))]
+      (is (nil? (state/infer-train-status train))))))
+
+(deftest auto-transition-train-test
+  (testing "auto-transitions train based on PR states"
+    (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+                  (assoc :pr/status :merged))
+          pr2 (-> (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+                  (assoc :pr/status :merged))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/status :merging)
+                    (assoc :train/prs [pr1 pr2]))
+          transitioned (state/auto-transition-train train)]
+      (is (= :merged (:train/status transitioned)))))
+
+  (testing "does not transition if not valid"
+    (let [train (state/create-train-state (random-uuid) "Test" (random-uuid))
+          result (state/auto-transition-train train)]
+      (is (= :drafting (:train/status result))))))
+
+;; ============================================================================
+;; Recompute train state tests
+;; ============================================================================
+
+(deftest recompute-train-state-test
+  (testing "recomputes all derived state"
+    (let [pr1 (-> (state/create-pr-state "acme/a" 100 "url" "branch" "PR 1" 1)
+                  (assoc :pr/status :approved)
+                  (assoc :pr/ci-status :passed))
+          pr2 (-> (state/create-pr-state "acme/b" 200 "url" "branch" "PR 2" 2)
+                  (assoc :pr/depends-on [100])
+                  (assoc :pr/status :open))
+          train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
+                    (assoc :train/prs [pr1 pr2]))
+          recomputed (state/recompute-train-state train)]
+
+      (is (= [100] (:train/ready-to-merge recomputed)))
+      (is (empty? (:train/blocking-prs recomputed)))
+      (let [progress (:train/progress recomputed)]
+        (is (= 2 (:total progress)))
+        (is (= 0 (:merged progress)))
+        (is (= 1 (:approved progress)))
+        (is (= 1 (:pending progress)))))))

--- a/docs/specs/change-train.spec
+++ b/docs/specs/change-train.spec
@@ -1,0 +1,616 @@
+# miniforge.ai — Change Train Specification
+
+**Version:** 0.1.0
+**Status:** Draft
+**Date:** 2026-01-22
+
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Change Train is miniforge's high-value wedge product: **multi-repo change trains with policy-as-code gates and semantic intent enforcement for infrastructure/platform work**.
+
+This spec defines two new components:
+- **repo-dag**: Multi-repo dependency graph with topological ordering
+- **pr-train**: Linked PR choreography with coordinated state management
+
+### 1.2 Design Principles
+
+1. **Explicit dependencies**: Repo relationships are modeled as a DAG, not implicit
+2. **Topological correctness**: PRs merge in dependency order, never out of sequence
+3. **Train-as-unit**: A set of related PRs is managed as a single coherent change
+4. **Fail-safe rollback**: Partial merges can be reverted cleanly
+5. **Evidence-driven**: Every train produces an auditable evidence bundle
+
+### 1.3 Key Differentiators
+
+| Capability | Claude Code | Fleet Mode MVP | Change Train |
+|------------|-------------|----------------|--------------|
+| Watch PRs across repos | No | Yes | Yes |
+| Dependency ordering | No | No | Yes |
+| Linked PR sets | No | No | Yes |
+| Semantic intent validation | No | No | Yes |
+| Evidence bundles | No | Partial | Yes |
+
+---
+
+## 2. Repo DAG Component
+
+### 2.1 Responsibility
+
+Model explicit dependencies between repositories for topologically-sorted merge ordering.
+
+### 2.2 Schema
+
+```clojure
+;; Repository node in the DAG
+(def RepoNode
+  [:map
+   [:repo/url string?]
+   [:repo/name string?]
+   [:repo/org {:optional true} string?]
+   [:repo/type [:enum :terraform-module :terraform-live :kubernetes
+                :argocd :application :library :documentation]]
+   [:repo/layer [:enum :foundations :infrastructure :platform :application :adapters]]
+   [:repo/default-branch {:default "main"} string?]
+   [:repo/watch-config {:optional true}
+    [:map
+     [:labels-include {:optional true} [:vector string?]]
+     [:labels-exclude {:optional true} [:vector string?]]
+     [:paths-include {:optional true} [:vector string?]]
+     [:paths-exclude {:optional true} [:vector string?]]]]])
+
+;; Edge representing a dependency relationship
+(def RepoEdge
+  [:map
+   [:edge/from string?]                    ; repo name
+   [:edge/to string?]                      ; repo name
+   [:edge/constraint
+    [:enum :module-before-live             ; TF modules before live infra
+           :infra-before-k8s               ; Infrastructure before K8s manifests
+           :k8s-before-argocd              ; Manifests before ArgoCD apps
+           :library-before-consumer        ; Libraries before consumers
+           :schema-before-impl]]           ; Schema changes before implementations
+   [:edge/merge-ordering
+    [:enum :sequential                     ; Must merge in order
+           :parallel-ok                    ; Can merge in parallel if both ready
+           :same-pr-train]]                ; Must be in same PR train
+   [:edge/validation {:optional true}
+    [:map
+     [:require-ci-pass? {:default true} boolean?]
+     [:require-plan-clean? {:default false} boolean?]
+     [:custom-gate {:optional true} keyword?]]]])
+
+;; The complete DAG
+(def RepoDag
+  [:map
+   [:dag/id uuid?]
+   [:dag/name string?]
+   [:dag/description {:optional true} string?]
+   [:dag/repos [:vector RepoNode]]
+   [:dag/edges [:vector RepoEdge]]
+   ;; Computed at runtime
+   [:dag/topo-order {:optional true} [:vector string?]]
+   [:dag/layers {:optional true} [:map-of keyword? [:vector string?]]]])
+```
+
+### 2.3 Protocol
+
+```clojure
+(defprotocol RepoDagManager
+  ;; CRUD
+  (create-dag [this name description]
+    "Create a new empty DAG")
+
+  (add-repo [this dag-id repo-config]
+    "Add a repository node to the DAG")
+
+  (remove-repo [this dag-id repo-name]
+    "Remove a repository from the DAG (and its edges)")
+
+  (add-edge [this dag-id from-repo to-repo constraint merge-ordering]
+    "Add a dependency edge between repos")
+
+  (remove-edge [this dag-id from-repo to-repo]
+    "Remove a dependency edge")
+
+  ;; Queries
+  (get-dag [this dag-id]
+    "Retrieve a DAG by ID")
+
+  (compute-topo-order [this dag-id]
+    "Compute topological sort of repos. Returns ordered vector or error if cyclic.")
+
+  (affected-repos [this dag-id changed-repo]
+    "Given a changed repo, return all downstream repos that may be affected")
+
+  (upstream-repos [this dag-id repo-name]
+    "Return all repos that this repo depends on")
+
+  (merge-order [this dag-id pr-set]
+    "Given a set of PRs across repos, return valid merge order")
+
+  ;; Validation
+  (validate-dag [this dag-id]
+    "Check for cycles, orphans, invalid references. Returns {:valid? bool :errors [...]}"))
+```
+
+### 2.4 Implementation Notes
+
+#### Topological Sort Algorithm
+
+Use Kahn's algorithm for deterministic ordering:
+
+```clojure
+(defn topo-sort [dag]
+  (let [nodes (set (map :repo/name (:dag/repos dag)))
+        edges (:dag/edges dag)
+        in-degree (reduce (fn [acc {:edge/to to}]
+                           (update acc to (fnil inc 0)))
+                         (zipmap nodes (repeat 0))
+                         edges)
+        adj (reduce (fn [acc {:edge/from from :edge/to to}]
+                     (update acc from (fnil conj []) to))
+                   {}
+                   edges)]
+    ;; Kahn's algorithm
+    (loop [queue (into clojure.lang.PersistentQueue/EMPTY
+                       (filter #(zero? (in-degree %)) nodes))
+           in-deg in-degree
+           result []]
+      (if (empty? queue)
+        (if (= (count result) (count nodes))
+          {:success true :order result}
+          {:success false :error :cycle-detected})
+        (let [node (peek queue)
+              neighbors (get adj node [])]
+          (recur (into (pop queue)
+                       (filter #(zero? (dec (in-deg %)))
+                               neighbors))
+                 (reduce #(update %1 %2 dec) in-deg neighbors)
+                 (conj result node)))))))
+```
+
+#### Cycle Detection
+
+Cycles MUST be rejected. When detected:
+1. Return specific nodes involved in cycle
+2. Suggest which edge to remove
+3. Never allow DAG creation with cycles
+
+#### Layer Inference
+
+If repo layer not specified, infer from type:
+- `:terraform-module` → `:foundations`
+- `:terraform-live` → `:infrastructure`
+- `:kubernetes` → `:platform`
+- `:argocd` → `:platform`
+- `:application` → `:application`
+- `:library` → `:foundations`
+
+---
+
+## 3. PR Train Component
+
+### 3.1 Responsibility
+
+Manage a set of related PRs as a single unit with coordinated state and merge ordering.
+
+### 3.2 Schema
+
+```clojure
+;; Individual PR in a train
+(def TrainPR
+  [:map
+   [:pr/repo string?]
+   [:pr/number pos-int?]
+   [:pr/url string?]
+   [:pr/branch string?]
+   [:pr/title string?]
+   [:pr/status [:enum :draft :open :reviewing :changes-requested
+                :approved :merging :merged :closed :failed]]
+   [:pr/merge-order pos-int?]             ; Position in train (1-indexed)
+   [:pr/depends-on [:vector pos-int?]]    ; PR numbers that must merge first
+   [:pr/blocks [:vector pos-int?]]        ; PR numbers waiting on this
+   [:pr/ci-status [:enum :pending :running :passed :failed :skipped]]
+   [:pr/gate-results {:optional true} [:vector GateResult]]
+   [:pr/intent {:optional true} TaskIntent]])
+
+;; The complete PR train
+(def PRTrain
+  [:map
+   [:train/id uuid?]
+   [:train/name string?]
+   [:train/description {:optional true} string?]
+   [:train/dag-id uuid?]                  ; Reference to repo DAG
+   [:train/status [:enum :drafting :open :reviewing :merging
+                   :merged :failed :rolled-back :abandoned]]
+   [:train/prs [:vector TrainPR]]
+
+   ;; Aggregate state (computed)
+   [:train/blocking-prs [:vector pos-int?]]
+   [:train/ready-to-merge [:vector pos-int?]]
+   [:train/progress {:optional true}
+    [:map
+     [:total pos-int?]
+     [:merged nat-int?]
+     [:approved nat-int?]
+     [:pending nat-int?]
+     [:failed nat-int?]]]
+
+   ;; Rollback configuration
+   [:train/rollback-plan {:optional true}
+    [:map
+     [:trigger [:enum :ci-failure :gate-failure :manual :timeout]]
+     [:action [:enum :revert-all :revert-to-checkpoint :pause]]
+     [:checkpoint {:optional true} pos-int?]  ; Last known good PR number
+     [:prs-to-revert [:vector pos-int?]]]]
+
+   ;; Evidence
+   [:train/evidence-bundle-id {:optional true} uuid?]
+
+   ;; Timing
+   [:train/created-at inst?]
+   [:train/updated-at inst?]
+   [:train/merged-at {:optional true} inst?]])
+
+;; Evidence bundle for audit trail
+(def EvidenceBundle
+  [:map
+   [:evidence/id uuid?]
+   [:evidence/train-id uuid?]
+   [:evidence/created-at inst?]
+   [:evidence/prs
+    [:vector
+     [:map
+      [:pr/repo string?]
+      [:pr/number pos-int?]
+      [:evidence/artifacts
+       [:vector
+        [:map
+         [:type [:enum :terraform-plan :atlantis-log :ci-log
+                 :gate-results :intent-validation :approval-record]]
+         [:content string?]
+         [:hash string?]
+         [:timestamp inst?]]]]]]]
+   [:evidence/summary
+    [:map
+     [:total-prs pos-int?]
+     [:gates-passed nat-int?]
+     [:gates-failed nat-int?]
+     [:human-approvals nat-int?]
+     [:semantic-violations nat-int?]]]
+   [:evidence/miniforge-version string?]])
+```
+
+### 3.3 Protocol
+
+```clojure
+(defprotocol PRTrainManager
+  ;; Lifecycle
+  (create-train [this name dag-id description]
+    "Create a new PR train linked to a repo DAG")
+
+  (add-pr [this train-id repo pr-number]
+    "Add a PR to the train")
+
+  (remove-pr [this train-id pr-number]
+    "Remove a PR from the train")
+
+  (link-prs [this train-id]
+    "Auto-compute depends-on/blocks from DAG topology")
+
+  ;; State management
+  (sync-pr-status [this train-id]
+    "Fetch latest status for all PRs from GitHub")
+
+  (update-pr-status [this train-id pr-number new-status]
+    "Update status for a single PR")
+
+  ;; Queries
+  (get-train [this train-id]
+    "Retrieve a train by ID")
+
+  (get-blocking [this train-id]
+    "Return PRs that are blocking train progress")
+
+  (get-ready-to-merge [this train-id]
+    "Return PRs that can merge now (all deps merged, approved, CI passed)")
+
+  (get-progress [this train-id]
+    "Return progress summary: total, merged, approved, pending, failed")
+
+  ;; Actions
+  (merge-next [this train-id]
+    "Merge the next ready PR in topological order")
+
+  (merge-all-ready [this train-id]
+    "Merge all currently ready PRs (respecting order)")
+
+  (pause-train [this train-id reason]
+    "Pause all train activity")
+
+  (resume-train [this train-id]
+    "Resume paused train")
+
+  (rollback [this train-id reason]
+    "Execute rollback plan: revert merged PRs")
+
+  (abandon-train [this train-id reason]
+    "Mark train as abandoned, optionally close PRs")
+
+  ;; Evidence
+  (generate-evidence-bundle [this train-id]
+    "Collect and bundle all evidence artifacts")
+
+  (get-evidence-bundle [this bundle-id]
+    "Retrieve evidence bundle"))
+```
+
+### 3.4 State Machine
+
+```
+                                    ┌─────────────┐
+                          ┌─────────│  DRAFTING   │─────────┐
+                          │         └──────┬──────┘         │
+                          │                │ open           │ abandon
+                          │                ▼                │
+                          │         ┌─────────────┐         │
+                          │    ┌────│    OPEN     │────┐    │
+                          │    │    └──────┬──────┘    │    │
+                          │    │           │ review    │    │
+                          │    │           ▼           │    │
+                          │    │    ┌─────────────┐    │    │
+                          │    │    │  REVIEWING  │────┼────┤
+                          │    │    └──────┬──────┘    │    │
+                          │    │           │ all       │    │
+                          │    │           │ approved  │    │
+                          │    │           ▼           │    │
+                          │    │    ┌─────────────┐    │    │
+                          │    │    │   MERGING   │────┼────┤
+                          │    │    └──────┬──────┘    │    │
+                          │    │           │           │    │
+                    ┌─────┴────┴───────────┼───────────┴────┴─────┐
+                    │                      │                       │
+                    ▼                      ▼                       ▼
+             ┌─────────────┐        ┌─────────────┐         ┌─────────────┐
+             │   FAILED    │        │   MERGED    │         │  ABANDONED  │
+             └──────┬──────┘        └─────────────┘         └─────────────┘
+                    │
+                    │ rollback
+                    ▼
+             ┌─────────────┐
+             │ ROLLED-BACK │
+             └─────────────┘
+```
+
+### 3.5 Merge Ordering Rules
+
+1. **Topological constraint**: A PR can only merge after all its `depends-on` PRs have merged
+2. **Status constraint**: PR must be in `approved` status with `ci-status: :passed`
+3. **Gate constraint**: All gates must pass (configurable per-DAG)
+4. **Intent constraint**: Semantic intent validation must pass (if configured)
+
+Ready-to-merge calculation:
+
+```clojure
+(defn ready-to-merge? [train pr]
+  (let [deps-merged? (every? #(= :merged (:pr/status (get-pr train %)))
+                             (:pr/depends-on pr))
+        approved? (= :approved (:pr/status pr))
+        ci-passed? (= :passed (:pr/ci-status pr))
+        gates-passed? (every? :gate/passed? (:pr/gate-results pr))]
+    (and deps-merged? approved? ci-passed? gates-passed?)))
+```
+
+### 3.6 Rollback Strategy
+
+When a train fails mid-merge:
+
+1. **Identify checkpoint**: Last successfully merged PR
+2. **Collect revert targets**: All PRs merged after checkpoint
+3. **Create revert PRs**: In reverse topological order
+4. **Execute reverts**: Merge revert PRs (also in order)
+5. **Update evidence**: Record rollback in evidence bundle
+
+```clojure
+(defn execute-rollback [train reason]
+  (let [merged-prs (->> (:train/prs train)
+                        (filter #(= :merged (:pr/status %)))
+                        (sort-by :pr/merge-order >))  ; Reverse order
+        revert-prs (map create-revert-pr merged-prs)]
+    ;; Merge reverts in reverse order
+    (doseq [revert revert-prs]
+      (merge-pr revert))
+    {:status :rolled-back
+     :reverted-prs (map :pr/number merged-prs)
+     :reason reason}))
+```
+
+---
+
+## 4. Integration Points
+
+### 4.1 With Existing Components
+
+| Component | Integration |
+|-----------|-------------|
+| `workflow` | New workflow type `:change-train` that uses PR train |
+| `loop/gates` | Gates run per-PR in train |
+| `policy` | Policy packs apply to train as a whole |
+| `task` | Tasks can reference semantic intent for validation |
+| `reporting` | Dashboard views for train status |
+| `orchestrator` | Coordinates multi-repo work across train |
+
+### 4.2 With Fleet Mode
+
+PR Train extends Fleet Mode:
+- Fleet watches repos and PRs independently
+- PR Train groups related PRs into coherent changes
+- Dashboard shows both individual PRs and trains
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│ MINIFORGE FLEET - 4 repos │ 23 PRs │ 2 trains │ 3 active               │
+├─────────────────────────────────────────────────────────────────────────┤
+│                                                                         │
+│ ▶ ACTIVE TRAINS (2)                                                     │
+│   ├─ [TRAIN] Add User Auth (#123 → #124 → #125)                        │
+│   │   └─ Status: REVIEWING │ 1/3 merged │ Blocked: #124 needs review   │
+│   └─ [TRAIN] Migrate DB Schema (#200 → #201)                           │
+│       └─ Status: MERGING │ 1/2 merged │ Ready: #201                    │
+│                                                                         │
+│ ○ STANDALONE PRs (18)                                                   │
+│   ├─ acme/frontend#456 [APPROVED] "Fix nav bug"                        │
+│   └─ ... 17 more                                                        │
+│                                                                         │
+├─────────────────────────────────────────────────────────────────────────┤
+│ [T] New Train  [M] Merge Ready  [V] View Train  [↑↓] Navigate  [Q] Quit │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+### 4.3 CLI Commands
+
+```bash
+# DAG management
+miniforge dag create "kiddom-infra" --description "Kiddom infrastructure repos"
+miniforge dag add-repo kiddom-infra github.com/kiddom/terraform-modules --type terraform-module
+miniforge dag add-repo kiddom-infra github.com/kiddom/terraform --type terraform-live
+miniforge dag add-edge kiddom-infra terraform-modules terraform --constraint module-before-live
+miniforge dag show kiddom-infra
+miniforge dag validate kiddom-infra
+
+# Train management
+miniforge train create "Add user auth" --dag kiddom-infra
+miniforge train add-pr user-auth terraform-modules#123
+miniforge train add-pr user-auth terraform#124
+miniforge train add-pr user-auth k8s-manifests#125
+miniforge train link user-auth  # Auto-compute dependencies
+miniforge train status user-auth
+miniforge train merge-next user-auth
+miniforge train merge-all user-auth
+miniforge train rollback user-auth --reason "CI failure in production"
+
+# Evidence
+miniforge train evidence user-auth --output evidence-bundle.edn
+```
+
+---
+
+## 5. Semantic Intent Integration
+
+### 5.1 Task Intent Schema
+
+```clojure
+(def TaskIntent
+  [:map
+   [:intent/type [:enum :create :import :modify :delete :migrate]]
+
+   ;; Invariants that MUST hold
+   [:intent/invariants
+    [:vector
+     [:map
+      [:invariant/id keyword?]
+      [:invariant/description string?]
+      [:invariant/check
+       [:map
+        [:type [:enum :plan-output :diff-analysis :state-comparison]]
+        [:condition any?]]]]]]
+
+   ;; Actions forbidden for this intent type
+   [:intent/forbidden-actions [:vector keyword?]]
+
+   ;; Required evidence artifacts
+   [:intent/required-evidence [:vector keyword?]]])
+
+;; Example: IMPORT intent
+{:intent/type :import
+ :intent/invariants
+ [{:invariant/id :no-creates
+   :invariant/description "Import must not create new resources"
+   :invariant/check {:type :plan-output
+                     :condition {:creates 0}}}
+  {:invariant/id :no-destroys
+   :invariant/description "Import must not destroy resources"
+   :invariant/check {:type :plan-output
+                     :condition {:destroys 0}}}
+  {:invariant/id :preserve-import-blocks
+   :invariant/description "Import blocks must not be removed"
+   :invariant/check {:type :diff-analysis
+                     :condition {:removed-patterns [#"import\s*\{"]
+                                 :count 0}}}]
+ :intent/forbidden-actions
+ [:remove-import-block :create-new-resource :destroy-existing-resource]
+ :intent/required-evidence
+ [:terraform-plan-output :atlantis-apply-log :state-list-before-after]}
+```
+
+### 5.2 Intent Validation Gate
+
+```clojure
+(defrecord SemanticIntentGate [id config]
+  Gate
+  (check [_this artifact context]
+    (let [task (:task context)
+          intent (:task/intent task)]
+      (if-not intent
+        (pass-result id :semantic-intent)  ; No intent = pass
+        (let [violations (validate-invariants artifact intent)]
+          (if (empty? violations)
+            (pass-result id :semantic-intent)
+            (fail-result id :semantic-intent
+                         (map invariant->error violations)))))))
+  (gate-id [_this] id)
+  (gate-type [_this] :semantic-intent))
+```
+
+---
+
+## 6. Deliverables
+
+### Phase 1: Core Components
+
+- [ ] `components/repo-dag/` - Schema, protocol, in-memory implementation
+- [ ] `components/pr-train/` - Schema, protocol, state machine
+- [ ] Tests for both components
+- [ ] Integration with existing `schema` component
+
+### Phase 2: GitHub Integration
+
+- [ ] GitHub API adapter for PR status sync
+- [ ] Merge operation implementation
+- [ ] Revert PR creation
+- [ ] Webhook handlers for PR events
+
+### Phase 3: CLI & Dashboard
+
+- [ ] CLI commands for dag and train management
+- [ ] Fleet Mode dashboard extension
+- [ ] Train visualization (dependency graph)
+
+### Phase 4: Intent & Evidence
+
+- [ ] Semantic intent schema in `task` component
+- [ ] `SemanticIntentGate` in `loop/gates`
+- [ ] Evidence bundle generation
+- [ ] Evidence serialization (EDN + optional JSON)
+
+---
+
+## 7. Open Questions
+
+1. **Partial train progress**: Can a train be "done" if some PRs are abandoned?
+2. **Cross-org trains**: Should trains span GitHub organizations?
+3. **Concurrent trains**: Can PRs be in multiple trains simultaneously?
+4. **Auto-train detection**: Should we auto-detect related PRs and suggest trains?
+5. **Train templates**: Pre-defined train structures for common change types?
+
+---
+
+## 8. References
+
+- [operational-modes.spec](./operational-modes.spec) — Fleet Mode foundation
+- [miniforge.spec](./miniforge.spec) — Core product spec
+- [architecture.spec](./architecture.spec) — Component architecture

--- a/docs/specs/default-packs.spec
+++ b/docs/specs/default-packs.spec
@@ -1,0 +1,876 @@
+# miniforge.ai — Default Policy Packs Specification
+
+**Version:** 0.1.0
+**Status:** Draft
+**Date:** 2026-01-22
+
+---
+
+## 1. Overview
+
+This spec defines the initial set of official policy packs that ship with miniforge. These packs establish baseline safety and quality standards while demonstrating the pack authoring patterns.
+
+### 1.1 Official Packs
+
+| Pack ID | Category | Description |
+|---------|----------|-------------|
+| `foundations` | 000 | Architectural principles (Stratified Design, Simple Made Easy) |
+| `clojure` | 200 | Clojure/Polylith conventions |
+| `terraform-safety` | 300 | Terraform infrastructure safety |
+| `kubernetes-safety` | 400 | Kubernetes deployment safety |
+| `security-baseline` | 500 | Security best practices |
+
+---
+
+## 2. Foundations Pack
+
+### 2.1 Manifest
+
+```clojure
+{:pack/id "foundations"
+ :pack/name "Foundations Pack"
+ :pack/version "2026.01.22"
+ :pack/description "Core architectural principles: Stratified Design and Simple Made Easy"
+ :pack/author "miniforge-official"
+ :pack/license "Apache-2.0"
+
+ :pack/categories
+ [{:category/id "001"
+   :category/name "Stratified Design"
+   :category/rules [:001-no-upward-imports
+                    :001-no-cycles
+                    :001-pure-domain
+                    :001-ports-and-adapters]}
+  {:category/id "002"
+   :category/name "Simple Made Easy"
+   :category/rules [:002-values-over-state
+                    :002-data-over-syntax
+                    :002-functions-over-methods]}]
+
+ :pack/rules [...]}
+```
+
+### 2.2 Rules
+
+#### 001-no-upward-imports
+
+```clojure
+{:rule/id :001-no-upward-imports
+ :rule/title "No upward imports in stratified design"
+ :rule/description "Modules may only import from same stratum or below. Never import 'up' the stack."
+ :rule/severity :major
+ :rule/category "001"
+
+ :rule/applies-to
+ {:file-globs ["**/*.clj" "**/*.cljc" "**/*.ts" "**/*.py"]}
+
+ :rule/detection
+ {:type :custom
+  :custom-fn 'miniforge.packs.foundations/detect-upward-import}
+
+ :rule/agent-behavior
+ "Before writing code for a feature, output:
+  - A short stratified plan (modules, their stratum, and allowed dependencies)
+  - The ports/interfaces to be introduced or reused
+
+  When editing existing code:
+  - Detect and call out any 'upward' import or cross-strata leakage
+  - If violation found, propose minimal refactor (move interface down, split module, add adapter)"
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "Upward import detected: %s imports from %s (stratum %d → %d)"
+  :remediation "Move the interface to a lower stratum, or inject via port/adapter pattern"}}
+```
+
+#### 001-no-cycles
+
+```clojure
+{:rule/id :001-no-cycles
+ :rule/title "No import cycles"
+ :rule/description "Reject any change that introduces an import/namespace cycle"
+ :rule/severity :critical
+ :rule/category "001"
+
+ :rule/applies-to
+ {:file-globs ["**/*.clj" "**/*.cljc" "**/*.ts" "**/*.py"]}
+
+ :rule/detection
+ {:type :custom
+  :custom-fn 'miniforge.packs.foundations/detect-import-cycle}
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "Import cycle detected: %s"
+  :remediation "Break the cycle by extracting shared interface to lower stratum"}}
+```
+
+#### 001-pure-domain
+
+```clojure
+{:rule/id :001-pure-domain
+ :rule/title "Domain layer must be pure"
+ :rule/description "Domain modules must be free of I/O, frameworks, and runtime state"
+ :rule/severity :major
+ :rule/category "001"
+
+ :rule/applies-to
+ {:file-globs ["**/domain/**/*.clj" "**/domain/**/*.ts" "**/domain/**/*.py"]}
+
+ :rule/detection
+ {:type :content-scan
+  :patterns [;; Clojure I/O
+             #"slurp\s*\(" #"spit\s*\(" #"clojure\.java\.io"
+             #"http/get" #"http/post" #"jdbc/"
+             ;; TypeScript I/O
+             #"fetch\s*\(" #"fs\." #"axios\." #"prisma\."
+             ;; Python I/O
+             #"open\s*\(" #"requests\." #"urllib" #"sqlalchemy"]}
+
+ :rule/agent-behavior
+ "Domain layer must contain only:
+  - Pure functions (no side effects)
+  - Business rules and invariants
+  - Data transformations
+
+  If I/O is needed, define a port (interface) in Application layer and inject adapter."
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "I/O detected in Domain layer: %s"
+  :remediation "Move I/O to Infrastructure adapter, inject via port"}}
+```
+
+#### 002-values-over-state
+
+```clojure
+{:rule/id :002-values-over-state
+ :rule/title "Prefer values over mutable state"
+ :rule/description "Minimize mutable state; make it explicit, local, and small when necessary"
+ :rule/severity :minor
+ :rule/category "002"
+
+ :rule/applies-to
+ {:file-globs ["**/*.clj" "**/*.cljc"]}
+
+ :rule/detection
+ {:type :content-scan
+  :patterns [#"def\s+\S+\s+\(atom" #"def\s+\S+\s+\(ref\s"
+             #"volatile!" #"set!"]}
+
+ :rule/agent-behavior
+ "When proposing a design, include:
+  1) A short 'simple vs easy' comparison (2-3 bullets)
+  2) The minimal set of pure functions and data structures
+  3) Where any state is confined and why it's necessary"
+
+ :rule/enforcement
+ {:action :warn
+  :message "Mutable state detected: %s. Is this necessary?"
+  :remediation "Consider if immutable value + pure function would suffice"}}
+```
+
+---
+
+## 3. Clojure Pack
+
+### 3.1 Manifest
+
+```clojure
+{:pack/id "clojure"
+ :pack/name "Clojure Conventions Pack"
+ :pack/version "2026.01.22"
+ :pack/description "Clojure and Polylith coding conventions"
+ :pack/author "miniforge-official"
+ :pack/license "Apache-2.0"
+
+ :pack/extends
+ [{:pack-id "foundations" :version-constraint ">=2026.01.01"}]
+
+ :pack/categories
+ [{:category/id "210"
+   :category/name "Polylith Architecture"
+   :category/rules [:210-interface-only-deps
+                    :210-no-project-deps
+                    :210-component-layout]}
+  {:category/id "211"
+   :category/name "Per-File Stratification"
+   :category/rules [:211-layer-headings
+                    :211-max-three-layers
+                    :211-comment-block-last]}]
+
+ :pack/rules [...]}
+```
+
+### 3.2 Rules
+
+#### 210-interface-only-deps
+
+```clojure
+{:rule/id :210-interface-only-deps
+ :rule/title "Cross-component deps must target interface"
+ :rule/description "Components may only depend on other components via their .interface namespace"
+ :rule/severity :major
+ :rule/category "210"
+
+ :rule/applies-to
+ {:file-globs ["components/**/src/**/*.clj" "components/**/src/**/*.cljc"]}
+
+ :rule/detection
+ {:type :content-scan
+  :patterns [#"\[ai\.miniforge\.\w+\.core\s" #"\[ai\.miniforge\.\w+\.impl\s"
+             #"require.*\.core\]" #"require.*\.impl\]"]}
+
+ :rule/agent-behavior
+ "For cross-component calls, target ...<other>.interface — surface a fix if .core is used.
+
+  WRONG: [ai.miniforge.agent.core :as agent-core]
+  RIGHT: [ai.miniforge.agent.interface :as agent]"
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "Direct dependency on component implementation: %s"
+  :remediation "Change to .interface namespace"}}
+```
+
+#### 211-layer-headings
+
+```clojure
+{:rule/id :211-layer-headings
+ :rule/title "Use layer headings in namespaces"
+ :rule/description "Structure each ns with labeled strata as headings"
+ :rule/severity :minor
+ :rule/category "211"
+
+ :rule/applies-to
+ {:file-globs ["components/**/src/**/*.clj" "bases/**/src/**/*.clj"]}
+
+ :rule/detection
+ {:type :content-scan
+  :patterns [#"defn\s.*\n.*defn"]} ; Multiple defns without layer separator
+
+ :rule/agent-behavior
+ "When creating/editing a namespace:
+  1) Insert/maintain Layer 0/1/2 headings: ;-------------- Layer N
+  2) Keep them monotonic increasing (0 → 1 → 2)
+  3) Keep pure helpers in Layer 0
+  4) Put orchestration in higher layers"
+
+ :rule/enforcement
+ {:action :warn
+  :message "Namespace lacks layer headings"
+  :remediation "Add layer heading comments to organize code by abstraction level"}}
+```
+
+#### 211-max-three-layers
+
+```clojure
+{:rule/id :211-max-three-layers
+ :rule/title "Maximum 3 layers per file"
+ :rule/description "If you need more than 3 strata, split the namespace"
+ :rule/severity :minor
+ :rule/category "211"
+
+ :rule/applies-to
+ {:file-globs ["components/**/src/**/*.clj"]}
+
+ :rule/detection
+ {:type :content-scan
+  :pattern #"Layer\s+[4-9]"}
+
+ :rule/agent-behavior
+ "If you cross 3 layers, propose a split into another namespace."
+
+ :rule/enforcement
+ {:action :warn
+  :message "More than 3 layers detected"
+  :remediation "Split into separate namespaces to maintain clarity"}}
+```
+
+#### 211-comment-block-last
+
+```clojure
+{:rule/id :211-comment-block-last
+ :rule/title "Rich comment block must be last"
+ :rule/description "Reserve the very bottom of file for (comment ...) section. No def/defn after it."
+ :rule/severity :minor
+ :rule/category "211"
+
+ :rule/applies-to
+ {:file-globs ["**/*.clj" "**/*.cljc"]}
+
+ :rule/detection
+ {:type :content-scan
+  :pattern #"\(comment[\s\S]*?\)\s*\n\s*\(def"}
+
+ :rule/agent-behavior
+ "Ensure the last top-level form is a single (comment ...) block with quick REPL samples."
+
+ :rule/enforcement
+ {:action :warn
+  :message "Code appears after (comment ...) block"
+  :remediation "Move all def/defn above the comment block"}}
+```
+
+---
+
+## 4. Terraform Safety Pack
+
+### 4.1 Manifest
+
+```clojure
+{:pack/id "terraform-safety"
+ :pack/name "Terraform Safety Pack"
+ :pack/version "2026.01.22"
+ :pack/description "Essential safety rules for Terraform infrastructure changes"
+ :pack/author "miniforge-official"
+ :pack/license "Apache-2.0"
+
+ :pack/categories
+ [{:category/id "310"
+   :category/name "Import Safety"
+   :category/rules [:310-import-block-preservation
+                    :311-import-no-creates
+                    :312-import-state-verification]}
+  {:category/id "320"
+   :category/name "Network Safety"
+   :category/rules [:320-network-recreation-block
+                    :321-security-group-blast-radius]}
+  {:category/id "330"
+   :category/name "State Safety"
+   :category/rules [:330-state-drift-detection
+                    :331-module-version-pinning]}
+  {:category/id "340"
+   :category/name "Data Safety"
+   :category/rules [:340-s3-lifecycle-data-loss
+                    :341-database-deletion-protection]}]
+
+ :pack/rules [...]}
+```
+
+### 4.2 Rules
+
+#### 310-import-block-preservation
+
+```clojure
+{:rule/id :310-import-block-preservation
+ :rule/title "Preserve import blocks during IMPORT tasks"
+ :rule/description "When task type is IMPORT, never remove import blocks"
+ :rule/severity :critical
+ :rule/category "310"
+
+ :rule/applies-to
+ {:task-types #{:import}
+  :file-globs ["**/*.tf" "**/terragrunt.hcl"]}
+
+ :rule/detection
+ {:type :diff-analysis
+  :pattern #"^-\s*import\s*\{"
+  :context-lines 5}
+
+ :rule/agent-behavior
+ "When Atlantis reports 'resource already exists':
+  - WRONG interpretation: Remove import block (agent thinks import is done)
+  - RIGHT interpretation: Keep import block (resource exists in AWS, import is working)
+
+  Only remove import block when Atlantis reports 'already managed by Terraform'.
+
+  Error interpretation guide:
+  | Error Message | Meaning | Action |
+  |---------------|---------|--------|
+  | 'resource already exists' | Resource in AWS, import working | KEEP import block |
+  | 'already managed by Terraform' | Import complete | OK to remove import block |
+  | 'resource not found' | Resource doesn't exist | Check AWS, maybe create instead |"
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "Cannot remove import blocks during IMPORT task"
+  :remediation "Restore the import block and re-run the plan"}
+
+ :rule/examples
+ [{:description "Agent removes import block thinking import is done"
+   :input "- import {\n-   to = aws_s3_bucket.logs\n-   id = \"my-bucket\"\n- }"
+   :expected :fail
+   :explanation "Import block removal forbidden during IMPORT task"}
+  {:description "Import block unchanged"
+   :input "  import {\n    to = aws_s3_bucket.logs\n    id = \"my-bucket\"\n  }"
+   :expected :pass}]}
+```
+
+#### 311-import-no-creates
+
+```clojure
+{:rule/id :311-import-no-creates
+ :rule/title "IMPORT tasks must not create resources"
+ :rule/description "When task type is IMPORT, plan should show 0 resources to create"
+ :rule/severity :critical
+ :rule/category "310"
+
+ :rule/applies-to
+ {:task-types #{:import}}
+
+ :rule/detection
+ {:type :plan-output
+  :pattern #"Plan:.*(\d+) to add"
+  :condition (fn [match] (> (parse-long (second match)) 0))}
+
+ :rule/agent-behavior
+ "For IMPORT tasks, the terraform plan should show:
+  - 0 to add (no creates)
+  - 0 to destroy (no destroys)
+  - N to change (importing existing resources)
+
+  If 'to add' > 0, the import block is wrong or the resource doesn't exist."
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "IMPORT task would create %d new resources - this violates import semantics"
+  :remediation "Verify resource exists in AWS and import block references correct ID"}}
+```
+
+#### 320-network-recreation-block
+
+```clojure
+{:rule/id :320-network-recreation-block
+ :rule/title "Block recreation of network resources"
+ :rule/description "Prevent destroy-then-create operations on critical network infrastructure"
+ :rule/severity :critical
+ :rule/category "320"
+
+ :rule/applies-to
+ {:file-globs ["**/*.tf"]}
+
+ :rule/detection
+ {:type :plan-output
+  :patterns [#"-/\+\s+aws_route\b"
+             #"-/\+\s+aws_route_table\b"
+             #"-/\+\s+aws_subnet\b"
+             #"-/\+\s+aws_nat_gateway\b"
+             #"-/\+\s+aws_vpc\b"
+             #"-/\+\s+aws_security_group\b"
+             #"-/\+\s+aws_internet_gateway\b"
+             #"-/\+\s+aws_vpc_peering_connection\b"]}
+
+ :rule/agent-behavior
+ "HIGHEST PRIORITY - Network resources affect all services:
+  - aws_route, aws_route_table
+  - aws_subnet, aws_nat_gateway
+  - aws_vpc, aws_internet_gateway
+  - aws_security_group (if attached to instances)
+  - aws_vpc_peering_connection
+
+  Recreation (-/+) of these resources causes:
+  - Service outage during recreation window
+  - IP address changes breaking DNS/routing
+  - Security group detachment from running instances
+
+  If recreation is truly required, document blast radius and get explicit approval."
+
+ :rule/enforcement
+ {:action :require-approval
+  :approvers [:human :senior-engineer]
+  :message "Network resource recreation detected: %s"
+  :remediation "Review plan carefully. Consider lifecycle { prevent_destroy = true }. Document blast radius."}}
+```
+
+#### 340-s3-lifecycle-data-loss
+
+```clojure
+{:rule/id :340-s3-lifecycle-data-loss
+ :rule/title "S3 lifecycle rules that delete data require approval"
+ :rule/description "Flag lifecycle expiration rules that permanently delete objects"
+ :rule/severity :major
+ :rule/category "340"
+
+ :rule/applies-to
+ {:file-globs ["**/*.tf"]}
+
+ :rule/detection
+ {:type :content-scan
+  :patterns [#"expiration\s*\{[^}]*days\s*=\s*\d+"
+             #"noncurrent_version_expiration"
+             #"abort_incomplete_multipart_upload"]}
+
+ :rule/agent-behavior
+ "S3 lifecycle rules that expire objects result in PERMANENT DATA LOSS.
+
+  Before adding expiration rules, verify:
+  1. Data is not needed for compliance/audit
+  2. Retention period meets business requirements
+  3. Cross-region replication provides backup (if needed)
+
+  Safe patterns:
+  - Transition to GLACIER/DEEP_ARCHIVE (not delete)
+  - Expire only noncurrent versions after backup period
+  - Expire multipart uploads (usually safe)"
+
+ :rule/enforcement
+ {:action :require-approval
+  :approvers [:human]
+  :message "S3 lifecycle rule may cause data loss: %s"
+  :remediation "Confirm data retention requirements. Consider transition instead of expiration."}}
+```
+
+---
+
+## 5. Kubernetes Safety Pack
+
+### 5.1 Manifest
+
+```clojure
+{:pack/id "kubernetes-safety"
+ :pack/name "Kubernetes Safety Pack"
+ :pack/version "2026.01.22"
+ :pack/description "Safety rules for Kubernetes deployments"
+ :pack/author "miniforge-official"
+ :pack/license "Apache-2.0"
+
+ :pack/categories
+ [{:category/id "410"
+   :category/name "Container Safety"
+   :category/rules [:410-no-latest-tag
+                    :411-no-privileged
+                    :412-resource-limits-required]}
+  {:category/id "420"
+   :category/name "Deployment Safety"
+   :category/rules [:420-replica-minimum
+                    :421-rolling-update-strategy
+                    :422-pod-disruption-budget]}
+  {:category/id "430"
+   :category/name "Security Context"
+   :category/rules [:430-run-as-non-root
+                    :431-read-only-root-filesystem]}]
+
+ :pack/rules [...]}
+```
+
+### 5.2 Rules
+
+#### 410-no-latest-tag
+
+```clojure
+{:rule/id :410-no-latest-tag
+ :rule/title "No 'latest' image tags"
+ :rule/description "Container images must use explicit version tags, not 'latest'"
+ :rule/severity :major
+ :rule/category "410"
+
+ :rule/applies-to
+ {:file-globs ["**/*.yaml" "**/*.yml"]
+  :repo-types #{:kubernetes :argocd}}
+
+ :rule/detection
+ {:type :content-scan
+  :patterns [#"image:\s*\S+:latest\b"
+             #"image:\s*[^:]+\s*$"]}  ; No tag at all defaults to latest
+
+ :rule/agent-behavior
+ "Always use explicit image tags for reproducibility and rollback capability.
+
+  WRONG: image: nginx:latest
+  WRONG: image: nginx  (defaults to latest)
+  RIGHT: image: nginx:1.25.3
+  RIGHT: image: nginx@sha256:abc123..."
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "Image uses 'latest' tag or no tag: %s"
+  :remediation "Specify explicit version tag or SHA256 digest"}}
+```
+
+#### 411-no-privileged
+
+```clojure
+{:rule/id :411-no-privileged
+ :rule/title "No privileged containers"
+ :rule/description "Containers must not run in privileged mode"
+ :rule/severity :critical
+ :rule/category "410"
+
+ :rule/applies-to
+ {:file-globs ["**/*.yaml" "**/*.yml"]
+  :repo-types #{:kubernetes}}
+
+ :rule/detection
+ {:type :content-scan
+  :pattern #"privileged:\s*true"}
+
+ :rule/agent-behavior
+ "Privileged containers have full host access and bypass security controls.
+  Only allowed for specific infrastructure components (CNI, storage drivers)
+  with explicit approval."
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "Privileged container detected"
+  :remediation "Remove privileged: true. Use specific capabilities instead if needed."}}
+```
+
+#### 412-resource-limits-required
+
+```clojure
+{:rule/id :412-resource-limits-required
+ :rule/title "Resource limits required"
+ :rule/description "All containers must specify CPU and memory limits"
+ :rule/severity :major
+ :rule/category "410"
+
+ :rule/applies-to
+ {:file-globs ["**/*.yaml" "**/*.yml"]
+  :repo-types #{:kubernetes}}
+
+ :rule/detection
+ {:type :custom
+  :custom-fn 'miniforge.packs.kubernetes/detect-missing-limits}
+
+ :rule/agent-behavior
+ "Every container must have:
+  resources:
+    requests:
+      memory: '128Mi'
+      cpu: '100m'
+    limits:
+      memory: '512Mi'
+      cpu: '500m'
+
+  Without limits, a single pod can consume all node resources."
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "Container missing resource limits: %s"
+  :remediation "Add resources.limits.cpu and resources.limits.memory"}}
+```
+
+#### 430-run-as-non-root
+
+```clojure
+{:rule/id :430-run-as-non-root
+ :rule/title "Run as non-root user"
+ :rule/description "Containers should not run as root"
+ :rule/severity :major
+ :rule/category "430"
+
+ :rule/applies-to
+ {:file-globs ["**/*.yaml" "**/*.yml"]
+  :repo-types #{:kubernetes}}
+
+ :rule/detection
+ {:type :custom
+  :custom-fn 'miniforge.packs.kubernetes/detect-root-user}
+
+ :rule/agent-behavior
+ "Set securityContext at pod or container level:
+  securityContext:
+    runAsNonRoot: true
+    runAsUser: 1000
+
+  If image requires root, consider using a different image or init container."
+
+ :rule/enforcement
+ {:action :warn
+  :message "Container may run as root"
+  :remediation "Add securityContext.runAsNonRoot: true"}}
+```
+
+---
+
+## 6. Security Baseline Pack
+
+### 6.1 Manifest
+
+```clojure
+{:pack/id "security-baseline"
+ :pack/name "Security Baseline Pack"
+ :pack/version "2026.01.22"
+ :pack/description "Security best practices for all code"
+ :pack/author "miniforge-official"
+ :pack/license "Apache-2.0"
+
+ :pack/categories
+ [{:category/id "510"
+   :category/name "Secrets Management"
+   :category/rules [:510-no-hardcoded-secrets
+                    :511-no-secrets-in-logs]}
+  {:category/id "520"
+   :category/name "IAM Best Practices"
+   :category/rules [:520-no-wildcard-actions
+                    :521-least-privilege]}]
+
+ :pack/rules [...]}
+```
+
+### 6.2 Rules
+
+#### 510-no-hardcoded-secrets
+
+```clojure
+{:rule/id :510-no-hardcoded-secrets
+ :rule/title "No hardcoded secrets"
+ :rule/description "Secrets must not be hardcoded in source files"
+ :rule/severity :critical
+ :rule/category "510"
+
+ :rule/applies-to
+ {:file-globs ["**/*.clj" "**/*.ts" "**/*.py" "**/*.tf" "**/*.yaml"]}
+
+ :rule/detection
+ {:type :content-scan
+  :patterns [;; API keys and tokens
+             #"(?i)(api[_-]?key|secret|password|token)\s*[:=]\s*['\"][a-zA-Z0-9]{16,}['\"]"
+             ;; AWS credentials
+             #"AKIA[0-9A-Z]{16}"
+             #"(?i)aws[_-]?secret[_-]?access[_-]?key\s*[:=]\s*['\"][^'\"]{40}['\"]"
+             ;; Private keys
+             #"-----BEGIN (RSA |EC |DSA |OPENSSH )?PRIVATE KEY-----"
+             ;; Bearer tokens
+             #"(?i)bearer\s+[a-zA-Z0-9_-]{20,}"]}
+
+ :rule/agent-behavior
+ "Never hardcode secrets. Use:
+  - Environment variables: (System/getenv \"API_KEY\")
+  - Secrets manager: AWS Secrets Manager, HashiCorp Vault
+  - K8s secrets: Mounted as files or env vars
+
+  If you see what looks like a secret in code, flag it immediately."
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "Possible hardcoded secret detected"
+  :remediation "Remove secret from code. Use environment variable or secrets manager."}}
+```
+
+#### 520-no-wildcard-actions
+
+```clojure
+{:rule/id :520-no-wildcard-actions
+ :rule/title "No wildcard IAM actions"
+ :rule/description "IAM policies must not use Action: '*'"
+ :rule/severity :critical
+ :rule/category "520"
+
+ :rule/applies-to
+ {:file-globs ["**/*.tf" "**/*.json"]
+  :resource-patterns [#"aws_iam_policy" #"aws_iam_role_policy"]}
+
+ :rule/detection
+ {:type :content-scan
+  :patterns [#"\"Action\"\s*:\s*\"\*\""
+             #"\"Action\"\s*:\s*\[\s*\"\*\"\s*\]"
+             #"Action\s*=\s*\[\s*\"\*\"\s*\]"]}
+
+ :rule/agent-behavior
+ "IAM policies must follow least privilege:
+  - Specify exact actions needed (s3:GetObject, s3:PutObject)
+  - Never use Action: '*' (admin access)
+  - Scope resources to specific ARNs, not '*'
+
+  If broad access is truly needed, document justification and get security review."
+
+ :rule/enforcement
+ {:action :hard-halt
+  :message "IAM policy uses wildcard action"
+  :remediation "Replace '*' with specific actions needed. Document if broad access required."}}
+```
+
+---
+
+## 7. Pack Composition Example
+
+### 7.1 Combining Packs
+
+```clojure
+;; .miniforge/config.edn
+{:packs
+ [;; Official packs
+  {:id "foundations" :version "2026.01.22"}
+  {:id "clojure" :version "2026.01.22"}
+  {:id "terraform-safety" :version "2026.01.22"}
+  {:id "kubernetes-safety" :version "2026.01.22"}
+  {:id "security-baseline" :version "2026.01.22"}
+
+  ;; Company-specific overrides
+  {:id "acme-policies"
+   :source {:type :local :path ".miniforge/packs/acme-policies"}}]
+
+ ;; Override specific rules
+ :pack-overrides
+ {;; Downgrade to warning for development repos
+  :320-network-recreation-block
+  {:rule/enforcement {:action :warn}}
+
+  ;; Stricter for production
+  :410-no-latest-tag
+  {:rule/enforcement {:action :hard-halt
+                      :approvers [:senior-engineer :security]}}}}
+```
+
+### 7.2 Custom Pack Extending Official
+
+```clojure
+;; acme-policies/pack.edn
+{:pack/id "acme-policies"
+ :pack/name "Acme Corp Policies"
+ :pack/version "2026.01.22"
+ :pack/author "acme-platform-team"
+
+ :pack/extends
+ [{:pack-id "security-baseline" :version-constraint ">=2026.01.01"}]
+
+ :pack/rules
+ [;; Company-specific: require specific naming convention
+  {:rule/id :800-acme-naming
+   :rule/title "Acme resource naming convention"
+   :rule/description "All resources must follow {env}-{service}-{resource} naming"
+   :rule/severity :minor
+   :rule/category "800"
+
+   :rule/applies-to
+   {:file-globs ["**/*.tf"]}
+
+   :rule/detection
+   {:type :content-scan
+    :pattern #"name\s*=\s*\"(?!(?:dev|staging|prod)-)"} ; Must start with env
+
+   :rule/enforcement
+   {:action :warn
+    :message "Resource name doesn't follow Acme naming convention"
+    :remediation "Use format: {env}-{service}-{resource}"}}]}
+```
+
+---
+
+## 8. Deliverables
+
+### Phase 1: Foundation Packs
+
+- [ ] `foundations` pack with Stratified Design rules
+- [ ] `clojure` pack with Polylith conventions
+- [ ] Pack loader that reads EDN format
+- [ ] Integration tests for all rules
+
+### Phase 2: Infrastructure Packs
+
+- [ ] `terraform-safety` pack
+- [ ] `kubernetes-safety` pack
+- [ ] Plan output parser for Terraform
+- [ ] YAML manifest parser for Kubernetes
+
+### Phase 3: Security Pack
+
+- [ ] `security-baseline` pack
+- [ ] Secret detection patterns
+- [ ] IAM policy analyzer
+
+### Phase 4: Distribution
+
+- [ ] Pack bundled with miniforge distribution
+- [ ] Pack update mechanism
+- [ ] Documentation for each pack
+
+---
+
+## 9. References
+
+- [policy-pack.spec](./policy-pack.spec) — Pack schema and registry
+- [change-train.spec](./change-train.spec) — Integration with PR trains
+- Kiddom cursor-rules — Rule patterns and organization

--- a/docs/specs/policy-pack.spec
+++ b/docs/specs/policy-pack.spec
@@ -1,0 +1,679 @@
+# miniforge.ai — Policy Pack Specification
+
+**Version:** 0.1.0
+**Status:** Draft
+**Date:** 2026-01-22
+
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+Policy Packs are extensible, versioned collections of validation rules that can be authored, shared, and imported. They enable "policy-as-code" enforcement across the miniforge ecosystem.
+
+This spec defines:
+- **policy-pack**: Schema, registry, and lifecycle for rule collections
+- **Marketplace patterns**: Distribution, versioning, and discovery
+- **Integration**: How packs plug into the existing gate system
+
+### 1.2 Design Principles
+
+1. **Data over code**: Rules are EDN data, not compiled code
+2. **Dewey organization**: Rules follow Dewey-style hierarchical categories
+3. **Composable**: Packs can extend and override other packs
+4. **Versioned**: DateVer versioning for clear chronological ordering
+5. **Signable**: Paid feature for organizational trust chains
+
+### 1.3 Inspiration
+
+This design draws from:
+- Kiddom cursor-rules Dewey organization (000-900 categories)
+- `.mdc` file format (YAML frontmatter + Markdown body)
+- Git submodule distribution pattern
+- DateVer versioning (`YYYY.MM.DD`)
+
+---
+
+## 2. Rule Schema
+
+### 2.1 Individual Rule
+
+```clojure
+(def RuleSeverity
+  [:enum :critical :major :minor :info])
+
+(def RuleEnforcement
+  [:enum :hard-halt        ; Blocks all progress
+         :require-approval ; Requires human sign-off
+         :warn             ; Warning only, doesn't block
+         :audit])          ; Log only, for compliance
+
+(def RuleApplicability
+  [:map
+   ;; When does this rule apply?
+   [:task-types {:optional true} [:set [:enum :create :import :modify :delete :migrate]]]
+   [:file-globs {:optional true} [:vector string?]]
+   [:resource-patterns {:optional true} [:vector [:or string? :re]]]
+   [:repo-types {:optional true} [:set [:enum :terraform-module :terraform-live
+                                        :kubernetes :argocd :application]]]
+   [:phases {:optional true} [:set keyword?]]])
+
+(def RuleDetection
+  [:map
+   [:type [:enum :plan-output      ; Parse terraform plan
+                 :diff-analysis    ; Analyze git diff
+                 :state-comparison ; Compare before/after state
+                 :content-scan     ; Regex scan of content
+                 :ast-analysis     ; Parse code AST
+                 :custom]]         ; Custom detection function
+   [:pattern {:optional true} [:or string? :re]]
+   [:patterns {:optional true} [:vector [:or string? :re]]]
+   [:context-lines {:optional true} pos-int?]
+   [:custom-fn {:optional true} symbol?]])  ; For custom detection
+
+(def Rule
+  [:map
+   [:rule/id keyword?]                      ; e.g., :310-tf-import-preservation
+   [:rule/title string?]
+   [:rule/description string?]
+   [:rule/severity RuleSeverity]
+   [:rule/category string?]                 ; Dewey category e.g., "300"
+
+   ;; When does this rule apply?
+   [:rule/applies-to RuleApplicability]
+
+   ;; How to detect violations
+   [:rule/detection RuleDetection]
+
+   ;; Agent guidance (critical for correct interpretation)
+   [:rule/agent-behavior {:optional true} string?]
+
+   ;; What happens when violated
+   [:rule/enforcement
+    [:map
+     [:action RuleEnforcement]
+     [:message string?]
+     [:remediation {:optional true} string?]
+     [:approvers {:optional true} [:vector [:enum :human :senior-engineer :security]]]]]
+
+   ;; Examples (for documentation and testing)
+   [:rule/examples {:optional true}
+    [:vector
+     [:map
+      [:description string?]
+      [:input string?]
+      [:expected [:enum :pass :fail]]
+      [:explanation {:optional true} string?]]]]
+
+   ;; Metadata
+   [:rule/version {:optional true} string?]
+   [:rule/author {:optional true} string?]
+   [:rule/references {:optional true} [:vector string?]]])
+```
+
+### 2.2 Rule Categories (Dewey-Style)
+
+| Range | Category | Description |
+|-------|----------|-------------|
+| 000-099 | Foundations | Architectural principles (Stratified Design, Simple Made Easy) |
+| 100-199 | Version Control | Git workflows, branching, PR patterns |
+| 200-299 | Languages | Language-specific conventions (Clojure, Python, TypeScript) |
+| 300-399 | Infrastructure | Terraform, Terragrunt, AWS, IaC safety |
+| 400-499 | Orchestration | Kubernetes, ArgoCD, container management |
+| 500-599 | Security | Secrets, IAM, access control, compliance |
+| 600-699 | Documentation | PR docs, ADRs, API documentation |
+| 700-799 | Workflows | CI/CD, release processes, operational procedures |
+| 800-899 | Project-Specific | Team/org-specific rules (reserved for customization) |
+| 900-999 | Meta | Rule format, pack creation, tooling |
+
+---
+
+## 3. Policy Pack Schema
+
+### 3.1 Pack Manifest
+
+```clojure
+(def PackManifest
+  [:map
+   [:pack/id string?]                       ; e.g., "terraform-safety"
+   [:pack/name string?]                     ; Human-readable name
+   [:pack/version string?]                  ; DateVer: "2026.01.22"
+   [:pack/description string?]
+   [:pack/author string?]
+   [:pack/license {:optional true} string?] ; e.g., "Apache-2.0"
+   [:pack/homepage {:optional true} string?]
+   [:pack/repository {:optional true} string?]
+
+   ;; For signed packs (paid feature)
+   [:pack/signature {:optional true} string?]
+   [:pack/signed-by {:optional true} string?]
+   [:pack/signed-at {:optional true} inst?]
+
+   ;; Dependencies on other packs
+   [:pack/extends {:optional true}
+    [:vector
+     [:map
+      [:pack-id string?]
+      [:version-constraint {:optional true} string?]]]]  ; e.g., ">=2026.01.01"
+
+   ;; Categories included in this pack
+   [:pack/categories
+    [:vector
+     [:map
+      [:category/id string?]                ; e.g., "300"
+      [:category/name string?]
+      [:category/rules [:vector keyword?]]]]]  ; Rule IDs in this category
+
+   ;; The actual rules
+   [:pack/rules [:vector Rule]]
+
+   ;; Metadata
+   [:pack/created-at inst?]
+   [:pack/updated-at inst?]
+   [:pack/changelog {:optional true} string?]])
+```
+
+### 3.2 Example Pack
+
+```clojure
+{:pack/id "terraform-safety"
+ :pack/name "Terraform Safety Pack"
+ :pack/version "2026.01.22"
+ :pack/description "Essential safety rules for Terraform infrastructure changes"
+ :pack/author "miniforge-official"
+ :pack/license "Apache-2.0"
+
+ :pack/categories
+ [{:category/id "310"
+   :category/name "Import Safety"
+   :category/rules [:310-import-block-preservation
+                    :311-import-no-creates
+                    :312-import-state-verification]}
+  {:category/id "320"
+   :category/name "Network Safety"
+   :category/rules [:320-network-recreation-block
+                    :321-security-group-blast-radius
+                    :322-vpc-modification-approval]}
+  {:category/id "330"
+   :category/name "State Safety"
+   :category/rules [:330-state-drift-detection
+                    :331-state-backup-required
+                    :332-state-lock-verification]}]
+
+ :pack/rules
+ [{:rule/id :310-import-block-preservation
+   :rule/title "Preserve import blocks during IMPORT tasks"
+   :rule/description "When task type is IMPORT, never remove import blocks"
+   :rule/severity :critical
+   :rule/category "310"
+
+   :rule/applies-to
+   {:task-types #{:import}
+    :file-globs ["**/*.tf" "**/terragrunt.hcl"]
+    :resource-patterns [#"import\s*\{" #"terraform\s+import"]}
+
+   :rule/detection
+   {:type :diff-analysis
+    :pattern #"^-\s*import\s*\{"
+    :context-lines 5}
+
+   :rule/agent-behavior
+   "When Atlantis reports 'resource already exists':
+    - WRONG interpretation: Remove import block (agent thinks import is done)
+    - RIGHT interpretation: Keep import block (resource exists in AWS, import is working)
+
+    Only remove import block when Atlantis reports 'already managed by Terraform'."
+
+   :rule/enforcement
+   {:action :hard-halt
+    :message "Cannot remove import blocks during IMPORT task"
+    :remediation "Restore the import block and re-run the plan"}
+
+   :rule/examples
+   [{:description "Removing import block during import task"
+     :input "diff showing -import { to = aws_s3_bucket.example ..."
+     :expected :fail
+     :explanation "Import block removal forbidden during IMPORT task"}
+    {:description "Keeping import block after successful import"
+     :input "no changes to import blocks"
+     :expected :pass}]}
+
+  {:rule/id :320-network-recreation-block
+   :rule/title "Block recreation of network resources"
+   :rule/description "Prevent destroy-then-create operations on critical network infrastructure"
+   :rule/severity :critical
+   :rule/category "320"
+
+   :rule/applies-to
+   {:file-globs ["**/*.tf"]
+    :resource-patterns [#"aws_route" #"aws_subnet" #"aws_nat_gateway"
+                        #"aws_vpc" #"aws_security_group" #"aws_internet_gateway"]}
+
+   :rule/detection
+   {:type :plan-output
+    :patterns [#"-/\+.*aws_route"
+               #"-/\+.*aws_subnet"
+               #"-/\+.*aws_nat_gateway"
+               #"-/\+.*aws_vpc"
+               #"-/\+.*aws_security_group"
+               #"-/\+.*aws_internet_gateway"]}
+
+   :rule/enforcement
+   {:action :require-approval
+    :approvers [:human :senior-engineer]
+    :message "Network resource recreation detected - requires human approval"
+    :remediation "Review the plan carefully. Consider using lifecycle { prevent_destroy = true }"}}]}
+```
+
+---
+
+## 4. Pack Registry
+
+### 4.1 Protocol
+
+```clojure
+(defprotocol PolicyPackRegistry
+  ;; CRUD
+  (register-pack [this pack]
+    "Register a new pack or new version of existing pack")
+
+  (get-pack [this pack-id]
+    "Get latest version of pack")
+
+  (get-pack-version [this pack-id version]
+    "Get specific version of pack")
+
+  (list-packs [this criteria]
+    "List packs matching criteria {:category :author :search}")
+
+  (delete-pack [this pack-id version]
+    "Remove a pack version (admin only)")
+
+  ;; Import/Export
+  (import-pack [this source]
+    "Import pack from URL, file path, or git repo")
+
+  (export-pack [this pack-id version format]
+    "Export pack to EDN, JSON, or directory structure")
+
+  ;; Validation
+  (validate-pack [this pack]
+    "Validate pack schema and rule consistency")
+
+  (verify-signature [this pack]
+    "Verify pack signature (paid feature)")
+
+  ;; Composition
+  (resolve-pack [this pack-id]
+    "Resolve pack with all extended packs merged")
+
+  (get-rules-for-context [this pack-ids context]
+    "Get applicable rules given task context"))
+```
+
+### 4.2 Rule Resolution
+
+When multiple packs are active, rules are resolved by:
+
+1. **Merge by category**: Rules from all packs are collected
+2. **Override by ID**: Later packs override earlier packs for same rule ID
+3. **Severity escalation**: Higher severity wins when rules conflict
+4. **Enforcement escalation**: Stricter enforcement wins
+
+```clojure
+(defn resolve-rules [packs]
+  (let [all-rules (mapcat :pack/rules packs)
+        by-id (group-by :rule/id all-rules)]
+    (map (fn [[id rules]]
+           (reduce merge-rules rules))
+         by-id)))
+
+(defn merge-rules [base override]
+  (-> base
+      (merge override)
+      (update :rule/severity max-severity)
+      (update-in [:rule/enforcement :action] stricter-enforcement)))
+```
+
+---
+
+## 5. File Format
+
+### 5.1 Directory Structure
+
+Packs can be distributed as directories:
+
+```
+terraform-safety/
+├── pack.edn                    # Pack manifest
+├── CHANGELOG.md                # Version history
+├── README.md                   # Documentation
+├── rules/
+│   ├── 310-import-safety/
+│   │   ├── 310-import-block-preservation.edn
+│   │   ├── 311-import-no-creates.edn
+│   │   └── 312-import-state-verification.edn
+│   ├── 320-network-safety/
+│   │   ├── 320-network-recreation-block.edn
+│   │   └── ...
+│   └── ...
+└── examples/                   # Test cases
+    ├── 310-examples.edn
+    └── 320-examples.edn
+```
+
+### 5.2 Single-File Format
+
+For simple packs, a single EDN file:
+
+```clojure
+;; terraform-safety.pack.edn
+{:pack/id "terraform-safety"
+ :pack/version "2026.01.22"
+ ...
+ :pack/rules [...]}
+```
+
+### 5.3 MDC Format (Human-Friendly)
+
+Rules can also be authored as `.mdc` files (Markdown Concise):
+
+```markdown
+---
+rule-id: 310-import-block-preservation
+title: Preserve import blocks during IMPORT tasks
+severity: critical
+category: "310"
+applies-to:
+  task-types: [import]
+  file-globs: ["**/*.tf", "**/terragrunt.hcl"]
+enforcement:
+  action: hard-halt
+  message: Cannot remove import blocks during IMPORT task
+---
+
+# Import Block Preservation (CRITICAL)
+
+When task type is IMPORT, never remove import blocks.
+
+## Agent Behavior
+
+When Atlantis reports 'resource already exists':
+- **WRONG**: Remove import block (agent thinks import is done)
+- **RIGHT**: Keep import block (resource exists in AWS, import is working)
+
+Only remove import block when Atlantis reports 'already managed by Terraform'.
+
+## Detection
+
+```regex
+^-\s*import\s*\{
+```
+
+Look for removed lines starting with `import {`.
+
+## Examples
+
+<example type="fail">
+Diff showing `-import { to = aws_s3_bucket.example ...`
+This is forbidden during an IMPORT task.
+</example>
+
+<example type="pass">
+No changes to import blocks - plan proceeds normally.
+</example>
+```
+
+---
+
+## 6. Integration with Gates
+
+### 6.1 PolicyPackGate
+
+```clojure
+(defrecord PolicyPackGate [id registry pack-ids]
+  Gate
+  (check [_this artifact context]
+    (let [applicable-rules (get-rules-for-context registry pack-ids context)
+          violations (check-rules applicable-rules artifact context)]
+      (if (empty? violations)
+        (pass-result id :policy-pack)
+        (let [blocking (filter #(= :hard-halt (get-in % [:rule/enforcement :action])) violations)
+              warnings (remove #(= :hard-halt (get-in % [:rule/enforcement :action])) violations)]
+          (if (seq blocking)
+            (fail-result id :policy-pack
+                         (map violation->error blocking)
+                         :warnings (map violation->warning warnings))
+            (pass-result id :policy-pack
+                         :warnings (map violation->warning violations)))))))
+
+  (gate-id [_this] id)
+  (gate-type [_this] :policy-pack))
+```
+
+### 6.2 Check Rules Implementation
+
+```clojure
+(defn check-rules [rules artifact context]
+  (keep (fn [rule]
+          (when (rule-applies? rule artifact context)
+            (when-let [violation (detect-violation rule artifact context)]
+              {:rule rule
+               :violation violation
+               :timestamp (java.time.Instant/now)})))
+        rules))
+
+(defn rule-applies? [rule artifact context]
+  (let [{:keys [task-types file-globs resource-patterns repo-types phases]}
+        (:rule/applies-to rule)]
+    (and (or (nil? task-types)
+             (contains? task-types (get-in context [:task :task/intent :intent/type])))
+         (or (nil? file-globs)
+             (some #(glob-matches? % (:artifact/path artifact)) file-globs))
+         (or (nil? repo-types)
+             (contains? repo-types (get-in context [:repo :repo/type])))
+         (or (nil? phases)
+             (contains? phases (:phase context))))))
+
+(defn detect-violation [rule artifact context]
+  (let [{:keys [type pattern patterns]} (:rule/detection rule)]
+    (case type
+      :content-scan
+      (when (or (and pattern (re-find (re-pattern pattern) (:artifact/content artifact)))
+                (and patterns (some #(re-find (re-pattern %) (:artifact/content artifact)) patterns)))
+        {:type :content-match
+         :matched (extract-match pattern (:artifact/content artifact))})
+
+      :diff-analysis
+      (when-let [diff (:artifact/diff artifact)]
+        (when (or (and pattern (re-find (re-pattern pattern) diff))
+                  (and patterns (some #(re-find (re-pattern %) diff) patterns)))
+          {:type :diff-match
+           :matched (extract-match pattern diff)}))
+
+      :plan-output
+      (when-let [plan (:terraform-plan context)]
+        (analyze-plan-violations rule plan))
+
+      :custom
+      (when-let [custom-fn (resolve (:custom-fn (:rule/detection rule)))]
+        (custom-fn artifact context))
+
+      nil)))
+```
+
+---
+
+## 7. Distribution
+
+### 7.1 Git Submodule (Recommended)
+
+```bash
+# Add pack as submodule
+git submodule add https://github.com/miniforge-packs/terraform-safety.git \
+    .miniforge/packs/terraform-safety
+
+# Pin to specific version
+cd .miniforge/packs/terraform-safety
+git checkout 2026.01.22
+
+# Update to latest
+git submodule update --remote .miniforge/packs/terraform-safety
+```
+
+### 7.2 Direct Import
+
+```bash
+# Import from URL
+miniforge pack import https://github.com/miniforge-packs/terraform-safety.git
+
+# Import from local path
+miniforge pack import ./my-custom-pack/
+
+# Import specific version
+miniforge pack import terraform-safety@2026.01.22
+```
+
+### 7.3 Pack Configuration
+
+```clojure
+;; .miniforge/config.edn
+{:packs
+ [{:id "terraform-safety"
+   :source {:type :git
+            :url "https://github.com/miniforge-packs/terraform-safety.git"
+            :version "2026.01.22"}}
+  {:id "kubernetes-safety"
+   :source {:type :git
+            :url "https://github.com/miniforge-packs/kubernetes-safety.git"
+            :version "2026.01.15"}}
+  {:id "company-policies"
+   :source {:type :local
+            :path ".miniforge/packs/company-policies"}}]
+
+ :pack-overrides
+ {:320-network-recreation-block
+  {:rule/enforcement {:action :warn}}}}  ; Downgrade to warning for this project
+```
+
+---
+
+## 8. CLI Commands
+
+```bash
+# Pack management
+miniforge pack list                          # List installed packs
+miniforge pack search "terraform"            # Search marketplace
+miniforge pack install terraform-safety      # Install latest
+miniforge pack install terraform-safety@2026.01.22  # Install specific version
+miniforge pack update terraform-safety       # Update to latest
+miniforge pack remove terraform-safety       # Uninstall
+
+# Pack inspection
+miniforge pack show terraform-safety         # Show pack details
+miniforge pack rules terraform-safety        # List all rules in pack
+miniforge pack rule 310-import-preservation  # Show specific rule
+
+# Pack authoring
+miniforge pack init my-pack                  # Create new pack scaffold
+miniforge pack validate ./my-pack            # Validate pack structure
+miniforge pack test ./my-pack                # Run rule examples as tests
+miniforge pack build ./my-pack               # Build distributable pack
+miniforge pack publish ./my-pack             # Publish to marketplace (paid)
+
+# Pack execution
+miniforge check --packs terraform-safety,kubernetes-safety ./changes
+miniforge check --all-packs ./changes        # Run all installed packs
+```
+
+---
+
+## 9. Marketplace (Paid Feature)
+
+### 9.1 Official Packs
+
+Maintained by miniforge team:
+- `miniforge-official/foundations` - Stratified Design, Simple Made Easy
+- `miniforge-official/terraform-safety` - Terraform safety rules
+- `miniforge-official/kubernetes-safety` - Kubernetes safety rules
+- `miniforge-official/security-baseline` - Security best practices
+
+### 9.2 Community Packs
+
+Published by community:
+- Discovery via search
+- Rating and reviews
+- Usage statistics
+- Verified author badges
+
+### 9.3 Enterprise Packs (Paid)
+
+- **Signed packs**: Cryptographic verification of pack integrity
+- **Private packs**: Org-only distribution
+- **Compliance packs**: SOC2, HIPAA, PCI-DSS mappings
+- **Pack analytics**: Usage and violation statistics
+
+---
+
+## 10. Deliverables
+
+### Phase 1: Core Schema
+
+- [ ] Rule schema in `components/schema/`
+- [ ] Pack manifest schema
+- [ ] Pack registry protocol
+- [ ] In-memory registry implementation
+
+### Phase 2: Gate Integration
+
+- [ ] `PolicyPackGate` in `components/loop/`
+- [ ] Rule detection implementations (content-scan, diff-analysis)
+- [ ] Integration with existing gate runner
+
+### Phase 3: File Format
+
+- [ ] EDN pack loader
+- [ ] Directory pack loader
+- [ ] MDC rule parser
+
+### Phase 4: CLI
+
+- [ ] Pack management commands
+- [ ] Pack authoring commands
+- [ ] Pack execution commands
+
+### Phase 5: Distribution
+
+- [ ] Git submodule support
+- [ ] Direct URL import
+- [ ] Version constraint resolution
+
+---
+
+## 11. Default Packs
+
+See [default-packs.spec](./default-packs.spec) for the initial set of official packs including:
+- Foundations (Stratified Design, Simple Made Easy)
+- Clojure conventions
+- Terraform safety
+- Kubernetes safety
+- Security baseline
+
+---
+
+## 12. Open Questions
+
+1. **Custom detection functions**: How to safely execute user-defined detection code?
+2. **Pack signing**: Which signing mechanism (GPG, Sigstore, custom)?
+3. **Conflict resolution**: What happens when two packs have conflicting rules?
+4. **Performance**: How to efficiently check many rules against large diffs?
+5. **Offline mode**: Should packs be fully cached for air-gapped environments?
+
+---
+
+## 13. References
+
+- [change-train.spec](./change-train.spec) — PR Train integration
+- [loop/gates.clj](../../components/loop/src/ai/miniforge/loop/gates.clj) — Existing gate system
+- Kiddom cursor-rules — Dewey organization pattern


### PR DESCRIPTION
## Summary

Add the `pr-train` component for managing coordinated sets of related PRs.

Cherry-picked from original PR #48.

### Features
- State machine: DRAFTING→OPEN→REVIEWING→MERGING→MERGED
- Ready-to-merge computation (deps merged + approved + CI passed + gates passed)
- Blocking PR detection
- Evidence bundle generation for audit trails
- 44 tests, 203 assertions

### Includes
- docs/specs/change-train.spec
- docs/specs/policy-pack.spec
- docs/specs/default-packs.spec

---
Generated with [Claude Code](https://claude.ai/claude-code)