### PR TITLE
feat(workflow): add interceptor-based pipeline architecture

### DIFF
--- a/components/gate/deps.edn
+++ b/components/gate/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src" "resources"]
+ :deps {}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {}}}}

--- a/components/gate/deps.edn
+++ b/components/gate/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {}
+ :deps {ai.miniforge/response {:local/root "../response"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {}}}}

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -1,0 +1,140 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.interface
+  "Gate registry interface.
+
+   Gates are validation checkpoints with check and repair functions.
+   Each gate type registers via defmethod, providing:
+   - :check - (fn [artifact ctx] -> {:passed? bool :errors [...]}
+   - :repair - (fn [artifact errors ctx] -> {:success? bool :artifact ...})
+
+   Usage:
+     (get-gate :syntax)
+     (check-gate :lint artifact ctx)
+     (repair-gate :lint artifact errors ctx)"
+  (:require
+   ;; Require implementations for side effects
+   [ai.miniforge.gate.syntax]
+   [ai.miniforge.gate.lint]
+   [ai.miniforge.gate.test]
+   [ai.miniforge.gate.policy]
+   [ai.miniforge.gate.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Re-export registry functions
+
+(def get-gate
+  "Get gate implementation for a keyword.
+
+   Arguments:
+     gate-kw - Gate keyword like :syntax, :lint, :tests-pass
+
+   Returns:
+     Gate map with :name, :check, :repair"
+  registry/get-gate)
+
+(def list-gates
+  "List all registered gate types.
+
+   Returns:
+     Set of gate keywords"
+  registry/list-gates)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Gate operations
+
+(defn check-gate
+  "Run gate check on an artifact.
+
+   Arguments:
+     gate-kw  - Gate keyword
+     artifact - Artifact to validate
+     ctx      - Execution context
+
+   Returns:
+     {:passed? bool :errors [...] :gate gate-kw}"
+  [gate-kw artifact ctx]
+  (let [{:keys [check]} (get-gate gate-kw)]
+    (try
+      (let [result (check artifact ctx)]
+        (assoc result :gate gate-kw))
+      (catch Exception ex
+        {:passed? false
+         :gate gate-kw
+         :errors [{:type :check-error
+                   :message (ex-message ex)
+                   :data (ex-data ex)}]}))))
+
+(defn repair-gate
+  "Attempt to repair gate failures.
+
+   Arguments:
+     gate-kw  - Gate keyword
+     artifact - Artifact to repair
+     errors   - Errors from check
+     ctx      - Execution context
+
+   Returns:
+     {:success? bool :artifact ... :gate gate-kw}"
+  [gate-kw artifact errors ctx]
+  (let [{:keys [repair]} (get-gate gate-kw)]
+    (if repair
+      (try
+        (let [result (repair artifact errors ctx)]
+          (assoc result :gate gate-kw))
+        (catch Exception ex
+          {:success? false
+           :gate gate-kw
+           :artifact artifact
+           :error {:message (ex-message ex)
+                   :data (ex-data ex)}}))
+      {:success? false
+       :gate gate-kw
+       :artifact artifact
+       :error {:message "No repair function for gate"}})))
+
+(defn check-gates
+  "Run multiple gates on an artifact.
+
+   Arguments:
+     gate-kws - Vector of gate keywords
+     artifact - Artifact to validate
+     ctx      - Execution context
+
+   Returns:
+     {:all-passed? bool :results [...]}"
+  [gate-kws artifact ctx]
+  (let [results (mapv #(check-gate % artifact ctx) gate-kws)
+        all-passed? (every? :passed? results)]
+    {:all-passed? all-passed?
+     :results results
+     :failed-gates (filterv (complement :passed?) results)}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; List available gates
+  (list-gates)
+  ;; => #{:syntax :lint :tests-pass :coverage :no-secrets ...}
+
+  ;; Get a gate
+  (get-gate :syntax)
+
+  ;; Check a gate
+  (check-gate :syntax {:content "(defn foo [])"} {})
+
+  ;; Check multiple gates
+  (check-gates [:syntax :lint] {:content "(defn foo [])"} {})
+
+  :leave-this-here)

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -30,7 +30,8 @@
    [ai.miniforge.gate.lint]
    [ai.miniforge.gate.test]
    [ai.miniforge.gate.policy]
-   [ai.miniforge.gate.registry :as registry]))
+   [ai.miniforge.gate.registry :as registry]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Re-export registry functions
@@ -122,6 +123,47 @@
      :results results
      :failed-gates (filterv (complement :passed?) results)}))
 
+;------------------------------------------------------------------------------ Layer 2
+;; Response chain support
+
+(defn check-gates-chain
+  "Run multiple gates on an artifact, returning a response chain.
+
+   Arguments:
+     gate-kws - Vector of gate keywords
+     artifact - Artifact to validate
+     ctx      - Execution context
+
+   Returns:
+     Response chain with each gate as an operation.
+
+   Example:
+     (check-gates-chain [:syntax :lint] artifact ctx)
+     ;; => {:operation :gates
+     ;;     :succeeded? true
+     ;;     :response-chain [{:operation :syntax :succeeded? true ...}
+     ;;                      {:operation :lint :succeeded? true ...}]}"
+  [gate-kws artifact ctx]
+  (reduce
+   (fn [chain gate-kw]
+     (let [{:keys [check]} (get-gate gate-kw)]
+       (response/execute-with-handling
+        chain
+        gate-kw
+        (fn [ex]
+          ;; Extract anomaly from exception data, or default to check-failed
+          (or (:anomaly (ex-data ex))
+              :anomalies.gate/check-failed))
+        (fn []
+          (let [result (check artifact ctx)]
+            (if (:passed? result)
+              result
+              (throw (ex-info "Gate validation failed"
+                              {:anomaly :anomalies.gate/validation-failed
+                               :errors (:errors result)}))))))))
+   (response/create :gates)
+   gate-kws))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; List available gates
@@ -136,5 +178,11 @@
 
   ;; Check multiple gates
   (check-gates [:syntax :lint] {:content "(defn foo [])"} {})
+
+  ;; Check gates with response chain
+  (def chain (check-gates-chain [:syntax :lint] {:content "(defn foo [])"} {}))
+  (response/succeeded? chain)
+  (response/operations chain)
+  (response/first-failure chain)
 
   :leave-this-here)

--- a/components/gate/src/ai/miniforge/gate/lint.clj
+++ b/components/gate/src/ai/miniforge/gate/lint.clj
@@ -1,0 +1,81 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.lint
+  "Lint validation gate.
+
+   Checks that code passes linting rules."
+  (:require [ai.miniforge.gate.registry :as registry]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Lint checking (simplified - real impl would call clj-kondo)
+
+(defn- check-unused-vars
+  "Check for obvious unused variable patterns."
+  [code-str]
+  (let [let-bindings (re-seq #"\[([a-z_][a-z0-9_-]*)\s+" code-str)]
+    ;; Simplified: just check if binding is used after definition
+    []))
+
+(defn- check-lint
+  "Check lint rules on artifact content.
+
+   Arguments:
+     artifact - Artifact with :content
+     ctx      - Execution context (may contain :lint-config)
+
+   Returns:
+     {:passed? bool :errors [] :warnings []}"
+  [artifact ctx]
+  (let [content (or (:content artifact)
+                    (get-in artifact [:artifact/content])
+                    "")
+        content-str (if (string? content) content (pr-str content))
+        ;; In real impl, this would invoke clj-kondo
+        errors []
+        warnings (check-unused-vars content-str)]
+    (if (empty? errors)
+      {:passed? true
+       :warnings warnings}
+      {:passed? false
+       :errors errors
+       :warnings warnings})))
+
+(defn- repair-lint
+  "Attempt to repair lint errors.
+
+   Currently returns failure - lint repair requires LLM."
+  [artifact errors _ctx]
+  {:success? false
+   :artifact artifact
+   :errors errors
+   :message "Lint repair requires LLM agent"})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registry
+
+(registry/register-gate! :lint)
+
+(defmethod registry/get-gate :lint
+  [_]
+  {:name :lint
+   :description "Validates code passes linting rules (clj-kondo)"
+   :check check-lint
+   :repair repair-lint})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (check-lint {:content "(defn foo [] 42)"} {})
+  :leave-this-here)

--- a/components/gate/src/ai/miniforge/gate/policy.clj
+++ b/components/gate/src/ai/miniforge/gate/policy.clj
@@ -1,0 +1,158 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.policy
+  "Policy validation gates.
+
+   - :no-secrets - Check for hardcoded secrets
+   - :quality-check - General quality validation
+   - :review-approved - Review approval check
+   - :release-ready - Release readiness check
+   - :plan-complete - Plan completeness check"
+  (:require [ai.miniforge.gate.registry :as registry]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Policy checks
+
+(def ^:private secret-patterns
+  "Patterns that might indicate hardcoded secrets."
+  [#"(?i)(password|secret|api[_-]?key|token)\s*=\s*[\"'][^\"']{8,}"
+   #"(?i)aws[_-]?(access|secret)[_-]?key[_-]?id?\s*=\s*[\"'][A-Z0-9]{16,}"
+   #"sk-[a-zA-Z0-9]{32,}"  ; OpenAI keys
+   #"ghp_[a-zA-Z0-9]{36}"]) ; GitHub tokens
+
+(defn- check-no-secrets
+  "Check for hardcoded secrets in content."
+  [artifact _ctx]
+  (let [content (or (:content artifact)
+                    (get-in artifact [:artifact/content])
+                    "")
+        content-str (if (string? content) content (pr-str content))
+        matches (for [pattern secret-patterns
+                      :let [matches (re-seq pattern content-str)]
+                      :when (seq matches)]
+                  {:pattern (str pattern)
+                   :count (count matches)})]
+    (if (empty? matches)
+      {:passed? true}
+      {:passed? false
+       :errors [{:type :secrets-detected
+                 :message "Potential hardcoded secrets detected"
+                 :matches matches}]})))
+
+(defn- check-plan-complete
+  "Check if plan artifact is complete."
+  [artifact _ctx]
+  (let [plan (or (:plan artifact)
+                 (get-in artifact [:artifact/content :plan])
+                 artifact)]
+    (cond
+      (nil? plan)
+      {:passed? false
+       :errors [{:type :no-plan
+                 :message "No plan found in artifact"}]}
+
+      (empty? (:steps plan))
+      {:passed? false
+       :errors [{:type :empty-plan
+                 :message "Plan has no steps"}]}
+
+      :else
+      {:passed? true
+       :step-count (count (:steps plan))})))
+
+(defn- check-review-approved
+  "Check if review is approved."
+  [artifact _ctx]
+  (let [approved? (or (get-in artifact [:metadata :approved])
+                      (get-in artifact [:artifact/metadata :approved])
+                      (get-in artifact [:review :approved]))]
+    (if approved?
+      {:passed? true}
+      {:passed? false
+       :errors [{:type :not-approved
+                 :message "Review not approved"}]})))
+
+(defn- check-quality
+  "Generic quality check - passes if no explicit failures."
+  [artifact _ctx]
+  (let [quality-issues (get-in artifact [:metadata :quality-issues] [])]
+    (if (empty? quality-issues)
+      {:passed? true}
+      {:passed? false
+       :errors quality-issues})))
+
+(defn- check-release-ready
+  "Check release readiness."
+  [artifact _ctx]
+  (let [ready? (or (get-in artifact [:metadata :release-ready])
+                   (get-in artifact [:release :ready])
+                   true)]  ; Default to ready
+    (if ready?
+      {:passed? true}
+      {:passed? false
+       :errors [{:type :not-release-ready
+                 :message "Artifact not ready for release"}]})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registry
+
+(registry/register-gate! :no-secrets)
+(registry/register-gate! :plan-complete)
+(registry/register-gate! :review-approved)
+(registry/register-gate! :quality-check)
+(registry/register-gate! :release-ready)
+
+(defmethod registry/get-gate :no-secrets
+  [_]
+  {:name :no-secrets
+   :description "Validates no hardcoded secrets in content"
+   :check check-no-secrets
+   :repair nil})
+
+(defmethod registry/get-gate :plan-complete
+  [_]
+  {:name :plan-complete
+   :description "Validates plan artifact is complete"
+   :check check-plan-complete
+   :repair nil})
+
+(defmethod registry/get-gate :review-approved
+  [_]
+  {:name :review-approved
+   :description "Validates review is approved"
+   :check check-review-approved
+   :repair nil})
+
+(defmethod registry/get-gate :quality-check
+  [_]
+  {:name :quality-check
+   :description "General quality validation"
+   :check check-quality
+   :repair nil})
+
+(defmethod registry/get-gate :release-ready
+  [_]
+  {:name :release-ready
+   :description "Validates artifact is ready for release"
+   :check check-release-ready
+   :repair nil})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (check-no-secrets {:content "(def password \"secret123\")"} {})
+  (check-no-secrets {:content "(def x 42)"} {})
+  (check-plan-complete {:plan {:steps [{:name "step1"}]}} {})
+  :leave-this-here)

--- a/components/gate/src/ai/miniforge/gate/registry.clj
+++ b/components/gate/src/ai/miniforge/gate/registry.clj
@@ -1,0 +1,74 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.registry
+  "Gate registry using multimethods.
+
+   Gates register via defmethod, providing:
+   - :check  (fn [artifact ctx] -> {:passed? bool :errors [...]})
+   - :repair (fn [artifact errors ctx] -> {:success? bool :artifact ...})
+
+   Pattern borrowed from Ixi's interceptor registry.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Registry tracking
+
+(defonce ^:private registered-gates (atom #{}))
+
+(defn register-gate!
+  "Track a gate as registered."
+  [gate-kw]
+  (swap! registered-gates conj gate-kw))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Multimethod registry
+
+(defmulti get-gate
+  "Get gate implementation for a keyword.
+
+   Dispatches on gate keyword.
+
+   Returns:
+     {:name keyword?
+      :check (fn [artifact ctx] -> {:passed? bool :errors [...]})
+      :repair (fn [artifact errors ctx] -> {:success? bool :artifact ...})}"
+  identity)
+
+;; Default: unknown gates pass through with warning
+(defmethod get-gate :default
+  [gate-kw]
+  {:name gate-kw
+   :description "Unknown gate (pass-through)"
+   :check (fn [_artifact _ctx]
+            {:passed? true
+             :warnings [{:type :unknown-gate
+                         :message (str "Unknown gate: " gate-kw ", passing through")}]})
+   :repair nil})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry query
+
+(defn list-gates
+  "List all registered gate types.
+
+   Returns:
+     Set of gate keywords"
+  []
+  @registered-gates)
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (list-gates)
+  (get-gate :unknown-gate)
+  :leave-this-here)

--- a/components/gate/src/ai/miniforge/gate/syntax.clj
+++ b/components/gate/src/ai/miniforge/gate/syntax.clj
@@ -1,0 +1,92 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.syntax
+  "Syntax validation gate.
+
+   Checks that code artifacts parse without errors."
+  (:require [ai.miniforge.gate.registry :as registry]
+            [clojure.edn :as edn]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Syntax checking
+
+(defn- parse-clojure
+  "Attempt to parse Clojure code.
+
+   Returns:
+     {:valid? bool :error string?}"
+  [code-str]
+  (try
+    (read-string code-str)
+    {:valid? true}
+    (catch Exception ex
+      {:valid? false
+       :error (ex-message ex)})))
+
+(defn- check-syntax
+  "Check syntax of artifact content.
+
+   Arguments:
+     artifact - Artifact with :content
+     ctx      - Execution context
+
+   Returns:
+     {:passed? bool :errors [...]}"
+  [artifact _ctx]
+  (let [content (or (:content artifact)
+                    (get-in artifact [:artifact/content])
+                    "")
+        content-str (if (string? content) content (pr-str content))
+        result (parse-clojure content-str)]
+    (if (:valid? result)
+      {:passed? true}
+      {:passed? false
+       :errors [{:type :syntax-error
+                 :message (:error result)
+                 :location nil}]})))
+
+(defn- repair-syntax
+  "Attempt to repair syntax errors.
+
+   Currently returns failure - syntax repair requires LLM."
+  [artifact errors _ctx]
+  {:success? false
+   :artifact artifact
+   :errors errors
+   :message "Syntax repair requires LLM agent"})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registry
+
+(registry/register-gate! :syntax)
+
+(defmethod registry/get-gate :syntax
+  [_]
+  {:name :syntax
+   :description "Validates code parses without syntax errors"
+   :check check-syntax
+   :repair repair-syntax})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Valid syntax
+  (check-syntax {:content "(defn foo [] 42)"} {})
+  ;; => {:passed? true}
+
+  ;; Invalid syntax
+  (check-syntax {:content "(defn foo [] 42"} {})
+  ;; => {:passed? false :errors [...]}
+
+  :leave-this-here)

--- a/components/gate/src/ai/miniforge/gate/test.clj
+++ b/components/gate/src/ai/miniforge/gate/test.clj
@@ -1,0 +1,105 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.test
+  "Test validation gates.
+
+   - :tests-pass - All tests pass
+   - :coverage - Coverage meets threshold"
+  (:require [ai.miniforge.gate.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test checking
+
+(defn- check-tests-pass
+  "Check if tests pass.
+
+   In real impl, this would run tests and check results.
+   Here we check for test results in artifact metadata."
+  [artifact _ctx]
+  (let [test-results (or (get-in artifact [:metadata :test-results])
+                         (get-in artifact [:artifact/metadata :test-results]))]
+    (cond
+      (nil? test-results)
+      {:passed? true
+       :warnings [{:type :no-tests
+                   :message "No test results found"}]}
+
+      (:all-passed? test-results)
+      {:passed? true
+       :test-count (:test-count test-results)
+       :pass-count (:pass-count test-results)}
+
+      :else
+      {:passed? false
+       :errors [{:type :tests-failed
+                 :message (str (:fail-count test-results) " tests failed")
+                 :failures (:failures test-results)}]})))
+
+(defn- check-coverage
+  "Check if coverage meets threshold.
+
+   Default threshold: 80%"
+  [artifact ctx]
+  (let [threshold (or (get-in ctx [:coverage-threshold]) 80)
+        coverage (or (get-in artifact [:metadata :coverage])
+                     (get-in artifact [:artifact/metadata :coverage]))]
+    (cond
+      (nil? coverage)
+      {:passed? true
+       :warnings [{:type :no-coverage
+                   :message "No coverage data found"}]}
+
+      (>= coverage threshold)
+      {:passed? true
+       :coverage coverage
+       :threshold threshold}
+
+      :else
+      {:passed? false
+       :errors [{:type :coverage-below-threshold
+                 :message (str "Coverage " coverage "% below threshold " threshold "%")
+                 :coverage coverage
+                 :threshold threshold}]})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registry
+
+(registry/register-gate! :tests-pass)
+(registry/register-gate! :coverage)
+
+(defmethod registry/get-gate :tests-pass
+  [_]
+  {:name :tests-pass
+   :description "Validates all tests pass"
+   :check check-tests-pass
+   :repair nil})
+
+(defmethod registry/get-gate :coverage
+  [_]
+  {:name :coverage
+   :description "Validates test coverage meets threshold (default 80%)"
+   :check check-coverage
+   :repair nil})
+
+;; Aliases for common gate names
+(registry/register-gate! :test)
+(defmethod registry/get-gate :test [_] (registry/get-gate :tests-pass))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (check-tests-pass {:metadata {:test-results {:all-passed? true :test-count 10}}} {})
+  (check-coverage {:metadata {:coverage 85}} {})
+  (check-coverage {:metadata {:coverage 70}} {})
+  :leave-this-here)

--- a/components/gate/test/ai/miniforge/gate/interface_test.clj
+++ b/components/gate/test/ai/miniforge/gate/interface_test.clj
@@ -3,6 +3,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.gate.interface :as gate]
+   [ai.miniforge.response.interface :as response]
    ;; Require implementations to register methods
    [ai.miniforge.gate.syntax]
    [ai.miniforge.gate.lint]
@@ -143,3 +144,32 @@
     (let [result (gate/repair-gate :no-secrets {:content "bad"} [] {})]
       (is (not (:success? result)))
       (is (= :no-secrets (:gate result))))))
+
+;; ============================================================================
+;; Response chain tests
+;; ============================================================================
+
+(deftest check-gates-chain-all-pass-test
+  (testing "check-gates-chain succeeds when all gates pass"
+    (let [chain (gate/check-gates-chain [:syntax]
+                                         {:content "(+ 1 2)"}
+                                         {})]
+      (is (response/succeeded? chain))
+      (is (= [:syntax] (response/operations chain))))))
+
+(deftest check-gates-chain-one-fails-test
+  (testing "check-gates-chain fails when any gate fails"
+    (let [chain (gate/check-gates-chain [:syntax :no-secrets]
+                                         {:content "password = \"secretpassword123\""}
+                                         {})]
+      ;; Syntax passes but secrets fails
+      (is (response/failed? chain))
+      (is (= :no-secrets (:operation (response/first-failure chain))))
+      (is (= :anomalies.gate/validation-failed
+             (:anomaly (response/first-failure chain)))))))
+
+(deftest check-gates-chain-empty-test
+  (testing "check-gates-chain succeeds for empty gate list"
+    (let [chain (gate/check-gates-chain [] {} {})]
+      (is (response/succeeded? chain))
+      (is (empty? (response/operations chain))))))

--- a/components/gate/test/ai/miniforge/gate/interface_test.clj
+++ b/components/gate/test/ai/miniforge/gate/interface_test.clj
@@ -1,0 +1,145 @@
+(ns ai.miniforge.gate.interface-test
+  "Tests for the gate component."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.gate.interface :as gate]
+   ;; Require implementations to register methods
+   [ai.miniforge.gate.syntax]
+   [ai.miniforge.gate.lint]
+   [ai.miniforge.gate.test]
+   [ai.miniforge.gate.policy]))
+
+;; ============================================================================
+;; Registry tests
+;; ============================================================================
+
+(deftest get-gate-syntax-test
+  (testing "get-gate returns gate for :syntax"
+    (let [g (gate/get-gate :syntax)]
+      (is (map? g))
+      (is (= :syntax (:name g)))
+      (is (fn? (:check g))))))
+
+(deftest get-gate-lint-test
+  (testing "get-gate returns gate for :lint"
+    (let [g (gate/get-gate :lint)]
+      (is (map? g))
+      (is (= :lint (:name g)))
+      (is (fn? (:check g))))))
+
+(deftest get-gate-tests-pass-test
+  (testing "get-gate returns gate for :tests-pass"
+    (let [g (gate/get-gate :tests-pass)]
+      (is (map? g))
+      (is (= :tests-pass (:name g)))
+      (is (fn? (:check g))))))
+
+(deftest get-gate-coverage-test
+  (testing "get-gate returns gate for :coverage"
+    (let [g (gate/get-gate :coverage)]
+      (is (map? g))
+      (is (= :coverage (:name g)))
+      (is (fn? (:check g))))))
+
+(deftest get-gate-no-secrets-test
+  (testing "get-gate returns gate for :no-secrets"
+    (let [g (gate/get-gate :no-secrets)]
+      (is (map? g))
+      (is (= :no-secrets (:name g)))
+      (is (fn? (:check g))))))
+
+(deftest get-gate-plan-complete-test
+  (testing "get-gate returns gate for :plan-complete"
+    (let [g (gate/get-gate :plan-complete)]
+      (is (map? g))
+      (is (= :plan-complete (:name g)))
+      (is (fn? (:check g))))))
+
+(deftest get-gate-unknown-test
+  (testing "get-gate returns default for unknown gate"
+    (let [g (gate/get-gate :unknown-gate)]
+      (is (map? g))
+      (is (= :unknown-gate (:name g)))
+      (is (fn? (:check g)))
+      ;; Default gate should pass
+      (let [result ((:check g) {} {})]
+        (is (:passed? result))))))
+
+;; ============================================================================
+;; Gate check tests
+;; ============================================================================
+
+(deftest check-gate-syntax-valid-test
+  (testing "syntax gate passes for valid Clojure"
+    (let [result (gate/check-gate :syntax {:content "(+ 1 2)"} {})]
+      (is (:passed? result)))))
+
+(deftest check-gate-syntax-invalid-test
+  (testing "syntax gate fails for invalid Clojure"
+    (let [result (gate/check-gate :syntax {:content "(+ 1 2"} {})]
+      (is (not (:passed? result)))
+      (is (seq (:errors result))))))
+
+(deftest check-gate-no-secrets-clean-test
+  (testing "no-secrets gate passes for clean content"
+    (let [result (gate/check-gate :no-secrets {:content "(def x 42)"} {})]
+      (is (:passed? result)))))
+
+(deftest check-gate-no-secrets-detected-test
+  (testing "no-secrets gate fails when secrets detected"
+    ;; Pattern expects: password = "value" format
+    (let [result (gate/check-gate :no-secrets
+                                   {:content "password = \"mysecretpassword123\""}
+                                   {})]
+      (is (not (:passed? result))))))
+
+(deftest check-gate-plan-complete-valid-test
+  (testing "plan-complete gate passes for complete plan"
+    (let [result (gate/check-gate :plan-complete
+                                   {:plan {:steps [{:name "step1"}]}}
+                                   {})]
+      (is (:passed? result)))))
+
+(deftest check-gate-plan-complete-empty-test
+  (testing "plan-complete gate fails for empty plan"
+    (let [result (gate/check-gate :plan-complete
+                                   {:plan {:steps []}}
+                                   {})]
+      (is (not (:passed? result))))))
+
+;; ============================================================================
+;; Check gates (multiple) tests
+;; ============================================================================
+
+(deftest check-gates-all-pass-test
+  (testing "check-gates returns passed when all gates pass"
+    (let [result (gate/check-gates [:syntax]
+                                    {:content "(+ 1 2)"}
+                                    {})]
+      (is (:all-passed? result))
+      (is (empty? (:failed-gates result))))))
+
+(deftest check-gates-one-fails-test
+  (testing "check-gates returns failed when any gate fails"
+    ;; Pattern expects: password = "value" format
+    (let [result (gate/check-gates [:syntax :no-secrets]
+                                    {:content "password = \"secretpassword123\""}
+                                    {})]
+      ;; Syntax passes but secrets fails
+      (is (not (:all-passed? result)))
+      (is (seq (:failed-gates result))))))
+
+(deftest check-gates-empty-test
+  (testing "check-gates passes for empty gate list"
+    (let [result (gate/check-gates [] {} {})]
+      (is (:all-passed? result)))))
+
+;; ============================================================================
+;; Repair gate tests
+;; ============================================================================
+
+(deftest repair-gate-no-repair-test
+  (testing "repair-gate returns failure when gate has no repair function"
+    (let [result (gate/repair-gate :no-secrets {:content "bad"} [] {})]
+      (is (not (:success? result)))
+      (is (= :no-secrets (:gate result))))))

--- a/components/phase/deps.edn
+++ b/components/phase/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src" "resources"]
+ :deps {}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {}}}}

--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -1,0 +1,130 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.implement
+  "Implementation phase interceptor.
+
+   Generates code artifacts from plans.
+   Agent: :implementer
+   Default gates: [:syntax :lint]"
+  (:require [ai.miniforge.phase.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+
+(def default-config
+  {:agent :implementer
+   :gates [:syntax :lint]
+   :budget {:tokens 30000
+            :iterations 5
+            :time-seconds 600}})
+
+;; Register defaults on load
+(registry/register-phase-defaults! :implement default-config)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Interceptor implementation
+
+(defn- enter-implement
+  "Execute implementation phase.
+
+   Reads plan from context, invokes implementer agent,
+   runs through inner loop with syntax/lint gates."
+  [ctx]
+  (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
+        {:keys [agent gates budget]} config
+        start-time (System/currentTimeMillis)]
+    (-> ctx
+        (assoc-in [:phase :name] :implement)
+        (assoc-in [:phase :agent] agent)
+        (assoc-in [:phase :gates] gates)
+        (assoc-in [:phase :budget] budget)
+        (assoc-in [:phase :started-at] start-time)
+        (assoc-in [:phase :status] :running))))
+
+(defn- leave-implement
+  "Post-processing for implementation phase.
+
+   Records metrics, captures code artifacts."
+  [ctx]
+  (let [start-time (get-in ctx [:phase :started-at])
+        end-time (System/currentTimeMillis)
+        duration-ms (- end-time start-time)
+        iterations (get-in ctx [:phase :iterations] 1)]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (assoc-in [:metrics :implementation :duration-ms] duration-ms)
+        (assoc-in [:metrics :implementation :repair-cycles] (dec iterations))
+        (update-in [:execution :phases-completed] (fnil conj []) :implement))))
+
+(defn- error-implement
+  "Handle implementation phase errors.
+
+   Attempts repair via inner loop if within budget."
+  [ctx ex]
+  (let [iterations (get-in ctx [:phase :iterations] 0)
+        max-iterations (get-in ctx [:phase :budget :iterations] 5)
+        on-fail (get-in ctx [:phase-config :on-fail])]
+    (cond
+      ;; Within budget - retry
+      (< iterations max-iterations)
+      (-> ctx
+          (update-in [:phase :iterations] (fnil inc 0))
+          (assoc-in [:phase :last-error] (ex-message ex))
+          (assoc-in [:phase :status] :retrying))
+
+      ;; Has on-fail transition - redirect
+      on-fail
+      (-> ctx
+          (assoc-in [:phase :status] :failed)
+          (assoc-in [:phase :redirect-to] on-fail)
+          (assoc-in [:phase :error] {:message (ex-message ex)
+                                     :data (ex-data ex)}))
+
+      ;; No recovery - propagate
+      :else
+      (-> ctx
+          (assoc-in [:phase :status] :failed)
+          (assoc-in [:phase :error] {:message (ex-message ex)
+                                     :data (ex-data ex)})))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry method
+
+(defmethod registry/get-phase-interceptor :implement
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name ::implement
+     :config merged
+     :enter (fn [ctx]
+              (enter-implement (assoc ctx :phase-config merged)))
+     :leave leave-implement
+     :error error-implement}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Get implement interceptor with defaults
+  (registry/get-phase-interceptor {:phase :implement})
+
+  ;; Get with overrides
+  (registry/get-phase-interceptor {:phase :implement
+                                   :budget {:tokens 50000}
+                                   :gates [:syntax :lint :no-secrets]})
+
+  ;; Check defaults
+  (registry/phase-defaults :implement)
+
+  :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/interface.clj
+++ b/components/phase/src/ai/miniforge/phase/interface.clj
@@ -1,0 +1,150 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.interface
+  "Phase interceptor registry interface.
+
+   Phases are interceptors with :enter, :leave, and :error functions.
+   Each phase type registers via defmethod, providing defaults and behavior.
+
+   Usage:
+     (get-phase-interceptor {:phase :implement})
+     (get-phase-interceptor {:phase :implement :budget {:tokens 50000}})
+
+   Interceptor structure (Pedestal-style):
+     {:name    keyword?
+      :enter   (fn [ctx] -> ctx)    ; Execute phase
+      :leave   (fn [ctx] -> ctx)    ; Post-processing
+      :error   (fn [ctx ex] -> ctx) ; Error handling/repair}"
+  (:require
+   ;; Require implementation namespaces for side effects (method registration)
+   [ai.miniforge.phase.plan]
+   [ai.miniforge.phase.implement]
+   [ai.miniforge.phase.verify]
+   [ai.miniforge.phase.review]
+   [ai.miniforge.phase.release]
+   [ai.miniforge.phase.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Re-export registry functions
+
+(def get-phase-interceptor
+  "Get interceptor for a phase configuration.
+
+   Arguments:
+     config - Map with :phase keyword and optional overrides
+              {:phase :implement :budget {:tokens 50000}}
+
+   Returns:
+     Interceptor map with :name, :enter, :leave, :error"
+  registry/get-phase-interceptor)
+
+(def list-phases
+  "List all registered phase types.
+
+   Returns:
+     Set of phase keywords"
+  registry/list-phases)
+
+(def phase-defaults
+  "Get default configuration for a phase type.
+
+   Arguments:
+     phase-kw - Phase keyword like :plan, :implement
+
+   Returns:
+     Default config map or nil if unknown"
+  registry/phase-defaults)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pipeline construction
+
+(defn build-pipeline
+  "Build interceptor pipeline from workflow config.
+
+   Arguments:
+     workflow - Workflow map with :workflow/pipeline vector
+
+   Returns:
+     Vector of interceptor maps"
+  [workflow]
+  (mapv get-phase-interceptor (:workflow/pipeline workflow)))
+
+(defn validate-pipeline
+  "Validate a workflow pipeline configuration.
+
+   Arguments:
+     workflow - Workflow map
+
+   Returns:
+     {:valid? bool :errors [...] :warnings [...]}"
+  [workflow]
+  (let [pipeline (:workflow/pipeline workflow)
+        known-phases (list-phases)
+        errors (atom [])
+        warnings (atom [])]
+
+    (when (empty? pipeline)
+      (swap! errors conj {:error :empty-pipeline
+                          :message "Workflow pipeline is empty"}))
+
+    (doseq [{:keys [phase on-fail on-success] :as config} pipeline]
+      (when-not (contains? known-phases phase)
+        (swap! errors conj {:error :unknown-phase
+                            :phase phase
+                            :message (str "Unknown phase: " phase)}))
+
+      (when (and on-fail (not (contains? known-phases on-fail)))
+        (swap! warnings conj {:warning :unknown-on-fail-target
+                              :phase phase
+                              :target on-fail}))
+
+      (when (and on-success (not (contains? known-phases on-success)))
+        (swap! warnings conj {:warning :unknown-on-success-target
+                              :phase phase
+                              :target on-success})))
+
+    {:valid? (empty? @errors)
+     :errors @errors
+     :warnings @warnings}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; List available phases
+  (list-phases)
+  ;; => #{:plan :implement :verify :review :release :done}
+
+  ;; Get defaults for a phase
+  (phase-defaults :implement)
+  ;; => {:agent :implementer :gates [:syntax :lint] :budget {...}}
+
+  ;; Get interceptor with defaults
+  (get-phase-interceptor {:phase :plan})
+
+  ;; Get interceptor with overrides
+  (get-phase-interceptor {:phase :implement
+                          :budget {:tokens 50000}
+                          :gates [:syntax :lint :no-secrets]})
+
+  ;; Build pipeline from workflow
+  (def workflow {:workflow/id :test
+                 :workflow/pipeline [{:phase :plan}
+                                     {:phase :implement}
+                                     {:phase :done}]})
+  (build-pipeline workflow)
+
+  ;; Validate pipeline
+  (validate-pipeline workflow)
+
+  :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/plan.clj
+++ b/components/phase/src/ai/miniforge/phase/plan.clj
@@ -1,0 +1,112 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.plan
+  "Planning phase interceptor.
+
+   Creates implementation plans from specifications.
+   Agent: :planner
+   Default gates: [:plan-complete]"
+  (:require [ai.miniforge.phase.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+
+(def default-config
+  {:agent :planner
+   :gates [:plan-complete]
+   :budget {:tokens 10000
+            :iterations 3
+            :time-seconds 300}})
+
+;; Register defaults on load
+(registry/register-phase-defaults! :plan default-config)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Interceptor implementation
+
+(defn- enter-plan
+  "Execute planning phase.
+
+   Reads specification from context, invokes planner agent,
+   runs through inner loop with gates."
+  [ctx]
+  (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
+        {:keys [agent gates budget]} config
+        start-time (System/currentTimeMillis)]
+    (-> ctx
+        (assoc-in [:phase :name] :plan)
+        (assoc-in [:phase :agent] agent)
+        (assoc-in [:phase :gates] gates)
+        (assoc-in [:phase :budget] budget)
+        (assoc-in [:phase :started-at] start-time)
+        (assoc-in [:phase :status] :running))))
+
+(defn- leave-plan
+  "Post-processing for planning phase.
+
+   Records metrics and updates execution state."
+  [ctx]
+  (let [start-time (get-in ctx [:phase :started-at])
+        end-time (System/currentTimeMillis)
+        duration-ms (- end-time start-time)]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (update-in [:execution :phases-completed] (fnil conj []) :plan))))
+
+(defn- error-plan
+  "Handle planning phase errors.
+
+   Attempts repair if within budget, otherwise propagates error."
+  [ctx ex]
+  (let [iterations (get-in ctx [:phase :iterations] 0)
+        max-iterations (get-in ctx [:phase :budget :iterations] 3)]
+    (if (< iterations max-iterations)
+      (-> ctx
+          (update-in [:phase :iterations] (fnil inc 0))
+          (assoc-in [:phase :last-error] (ex-message ex))
+          (assoc-in [:phase :status] :retrying))
+      (-> ctx
+          (assoc-in [:phase :status] :failed)
+          (assoc-in [:phase :error] {:message (ex-message ex)
+                                     :data (ex-data ex)})))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry method
+
+(defmethod registry/get-phase-interceptor :plan
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name ::plan
+     :config merged
+     :enter (fn [ctx]
+              (enter-plan (assoc ctx :phase-config merged)))
+     :leave leave-plan
+     :error error-plan}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Get plan interceptor with defaults
+  (registry/get-phase-interceptor {:phase :plan})
+
+  ;; Get with overrides
+  (registry/get-phase-interceptor {:phase :plan
+                                   :budget {:tokens 20000}})
+
+  ;; Check defaults
+  (registry/phase-defaults :plan)
+
+  :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/registry.clj
+++ b/components/phase/src/ai/miniforge/phase/registry.clj
@@ -1,0 +1,149 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.registry
+  "Phase interceptor registry using multimethods.
+
+   Phases register via defmethod, providing:
+   - Default configuration (agent, gates, budget)
+   - Interceptor factory function
+
+   Pattern borrowed from Ixi's interceptors-pedestal component."
+  (:require [malli.core :as m]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schemas
+
+(def Budget
+  "Budget configuration schema"
+  [:map
+   [:tokens {:optional true} pos-int?]
+   [:iterations {:optional true} pos-int?]
+   [:time-seconds {:optional true} pos-int?]])
+
+(def PhaseConfig
+  "Phase configuration schema"
+  [:map
+   [:phase keyword?]
+   [:agent {:optional true} keyword?]
+   [:gates {:optional true} [:vector keyword?]]
+   [:budget {:optional true} Budget]
+   [:on-fail {:optional true} keyword?]
+   [:on-success {:optional true} keyword?]
+   [:metadata {:optional true} map?]])
+
+(def Interceptor
+  "Interceptor schema (Pedestal-style)"
+  [:map
+   [:name keyword?]
+   [:enter {:optional true} fn?]
+   [:leave {:optional true} fn?]
+   [:error {:optional true} fn?]])
+
+;; Defaults registry (atom for extensibility)
+(defonce ^:private defaults-registry (atom {}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Multimethod registry
+
+(defmulti get-phase-interceptor
+  "Get interceptor for a phase configuration.
+
+   Dispatches on :phase keyword.
+
+   Arguments:
+     config - Map with :phase and optional overrides
+
+   Returns:
+     Interceptor map with :name, :enter, :leave, :error"
+  :phase)
+
+(defmethod get-phase-interceptor :default
+  [{:keys [phase]}]
+  (throw (ex-info (str "Unknown phase type: " phase
+                       ". Available: " (keys @defaults-registry))
+                  {:phase phase
+                   :available (keys @defaults-registry)})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry management
+
+(defn register-phase-defaults!
+  "Register default configuration for a phase type.
+
+   Arguments:
+     phase-kw - Phase keyword like :plan, :implement
+     defaults - Default config map {:agent :gates :budget}"
+  [phase-kw defaults]
+  (swap! defaults-registry assoc phase-kw defaults))
+
+(defn phase-defaults
+  "Get default configuration for a phase type.
+
+   Arguments:
+     phase-kw - Phase keyword
+
+   Returns:
+     Default config map or nil"
+  [phase-kw]
+  (get @defaults-registry phase-kw))
+
+(defn list-phases
+  "List all registered phase types.
+
+   Returns:
+     Set of phase keywords"
+  []
+  (set (keys @defaults-registry)))
+
+(defn merge-with-defaults
+  "Merge user config with phase defaults.
+
+   Arguments:
+     config - User-provided phase config
+
+   Returns:
+     Merged config with defaults"
+  [{:keys [phase] :as config}]
+  (let [defaults (phase-defaults phase)]
+    (merge defaults config)))
+
+(defn valid-config?
+  "Check if phase config is valid against schema."
+  [config]
+  (m/validate PhaseConfig config))
+
+(defn valid-interceptor?
+  "Check if interceptor is valid against schema."
+  [interceptor]
+  (m/validate Interceptor interceptor))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Register a phase
+  (register-phase-defaults! :test
+                            {:agent :tester
+                             :gates [:tests-pass]
+                             :budget {:tokens 5000}})
+
+  ;; Check defaults
+  (phase-defaults :test)
+
+  ;; List phases
+  (list-phases)
+
+  ;; Merge with defaults
+  (merge-with-defaults {:phase :test :budget {:tokens 10000}})
+
+  :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/release.clj
+++ b/components/phase/src/ai/miniforge/phase/release.clj
@@ -1,0 +1,123 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.release
+  "Release phase interceptor.
+
+   Prepares release artifacts and creates PRs.
+   Agent: :releaser
+   Default gates: [:release-ready]"
+  (:require [ai.miniforge.phase.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+
+(def default-config
+  {:agent :releaser
+   :gates [:release-ready]
+   :budget {:tokens 5000
+            :iterations 2
+            :time-seconds 180}})
+
+;; Register defaults on load
+(registry/register-phase-defaults! :release default-config)
+
+;; Also register :done as a terminal phase
+(registry/register-phase-defaults! :done
+                                   {:agent nil
+                                    :gates []
+                                    :budget {:tokens 0 :iterations 1 :time-seconds 1}})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Interceptor implementation
+
+(defn- enter-release
+  "Execute release phase.
+
+   Prepares release artifacts, creates PR if configured."
+  [ctx]
+  (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
+        {:keys [agent gates budget]} config
+        start-time (System/currentTimeMillis)]
+    (-> ctx
+        (assoc-in [:phase :name] :release)
+        (assoc-in [:phase :agent] agent)
+        (assoc-in [:phase :gates] gates)
+        (assoc-in [:phase :budget] budget)
+        (assoc-in [:phase :started-at] start-time)
+        (assoc-in [:phase :status] :running))))
+
+(defn- leave-release
+  "Post-processing for release phase.
+
+   Records release metrics."
+  [ctx]
+  (let [start-time (get-in ctx [:phase :started-at])
+        end-time (System/currentTimeMillis)
+        duration-ms (- end-time start-time)]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (update-in [:execution :phases-completed] (fnil conj []) :release))))
+
+(defn- error-release
+  "Handle release phase errors."
+  [ctx ex]
+  (let [iterations (get-in ctx [:phase :iterations] 0)
+        max-iterations (get-in ctx [:phase :budget :iterations] 2)]
+    (if (< iterations max-iterations)
+      (-> ctx
+          (update-in [:phase :iterations] (fnil inc 0))
+          (assoc-in [:phase :last-error] (ex-message ex))
+          (assoc-in [:phase :status] :retrying))
+      (-> ctx
+          (assoc-in [:phase :status] :failed)
+          (assoc-in [:phase :error] {:message (ex-message ex)
+                                     :data (ex-data ex)})))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry methods
+
+(defmethod registry/get-phase-interceptor :release
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name ::release
+     :config merged
+     :enter (fn [ctx]
+              (enter-release (assoc ctx :phase-config merged)))
+     :leave leave-release
+     :error error-release}))
+
+(defmethod registry/get-phase-interceptor :done
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name ::done
+     :config merged
+     :enter (fn [ctx]
+              (-> ctx
+                  (assoc-in [:phase :name] :done)
+                  (assoc-in [:phase :status] :completed)
+                  (assoc-in [:execution :status] :completed)))
+     :leave identity
+     :error (fn [ctx _ex] ctx)}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (registry/get-phase-interceptor {:phase :release})
+  (registry/get-phase-interceptor {:phase :done})
+  (registry/phase-defaults :release)
+  (registry/phase-defaults :done)
+  (registry/list-phases)
+  :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/review.clj
+++ b/components/phase/src/ai/miniforge/phase/review.clj
@@ -1,0 +1,115 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.review
+  "Review phase interceptor.
+
+   Performs code review and quality checks.
+   Agent: :reviewer
+   Default gates: [:review-approved :quality-check]"
+  (:require [ai.miniforge.phase.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+
+(def default-config
+  {:agent :reviewer
+   :gates [:review-approved :quality-check]
+   :budget {:tokens 10000
+            :iterations 2
+            :time-seconds 180}})
+
+;; Register defaults on load
+(registry/register-phase-defaults! :review default-config)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Interceptor implementation
+
+(defn- enter-review
+  "Execute review phase.
+
+   Runs code review, quality checks, and policy validation."
+  [ctx]
+  (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
+        {:keys [agent gates budget]} config
+        start-time (System/currentTimeMillis)]
+    (-> ctx
+        (assoc-in [:phase :name] :review)
+        (assoc-in [:phase :agent] agent)
+        (assoc-in [:phase :gates] gates)
+        (assoc-in [:phase :budget] budget)
+        (assoc-in [:phase :started-at] start-time)
+        (assoc-in [:phase :status] :running))))
+
+(defn- leave-review
+  "Post-processing for review phase.
+
+   Records review metrics: issues found, approval status."
+  [ctx]
+  (let [start-time (get-in ctx [:phase :started-at])
+        end-time (System/currentTimeMillis)
+        duration-ms (- end-time start-time)]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (update-in [:execution :phases-completed] (fnil conj []) :review))))
+
+(defn- error-review
+  "Handle review phase errors.
+
+   On rejection, can redirect to :implement if on-fail specified."
+  [ctx ex]
+  (let [iterations (get-in ctx [:phase :iterations] 0)
+        max-iterations (get-in ctx [:phase :budget :iterations] 2)
+        on-fail (get-in ctx [:phase-config :on-fail])]
+    (cond
+      (< iterations max-iterations)
+      (-> ctx
+          (update-in [:phase :iterations] (fnil inc 0))
+          (assoc-in [:phase :last-error] (ex-message ex))
+          (assoc-in [:phase :status] :retrying))
+
+      on-fail
+      (-> ctx
+          (assoc-in [:phase :status] :failed)
+          (assoc-in [:phase :redirect-to] on-fail)
+          (assoc-in [:phase :error] {:message (ex-message ex)
+                                     :data (ex-data ex)}))
+
+      :else
+      (-> ctx
+          (assoc-in [:phase :status] :failed)
+          (assoc-in [:phase :error] {:message (ex-message ex)
+                                     :data (ex-data ex)})))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry method
+
+(defmethod registry/get-phase-interceptor :review
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name ::review
+     :config merged
+     :enter (fn [ctx]
+              (enter-review (assoc ctx :phase-config merged)))
+     :leave leave-review
+     :error error-review}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (registry/get-phase-interceptor {:phase :review})
+  (registry/get-phase-interceptor {:phase :review :on-fail :implement})
+  (registry/phase-defaults :review)
+  :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/verify.clj
+++ b/components/phase/src/ai/miniforge/phase/verify.clj
@@ -1,0 +1,116 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.verify
+  "Verification phase interceptor.
+
+   Generates and runs tests for code artifacts.
+   Agent: :tester
+   Default gates: [:tests-pass :coverage]"
+  (:require [ai.miniforge.phase.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+
+(def default-config
+  {:agent :tester
+   :gates [:tests-pass :coverage]
+   :budget {:tokens 15000
+            :iterations 3
+            :time-seconds 300}})
+
+;; Register defaults on load
+(registry/register-phase-defaults! :verify default-config)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Interceptor implementation
+
+(defn- enter-verify
+  "Execute verification phase.
+
+   Generates tests for code artifacts, runs them,
+   checks coverage thresholds."
+  [ctx]
+  (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
+        {:keys [agent gates budget]} config
+        start-time (System/currentTimeMillis)]
+    (-> ctx
+        (assoc-in [:phase :name] :verify)
+        (assoc-in [:phase :agent] agent)
+        (assoc-in [:phase :gates] gates)
+        (assoc-in [:phase :budget] budget)
+        (assoc-in [:phase :started-at] start-time)
+        (assoc-in [:phase :status] :running))))
+
+(defn- leave-verify
+  "Post-processing for verification phase.
+
+   Records test metrics: count, pass rate, coverage."
+  [ctx]
+  (let [start-time (get-in ctx [:phase :started-at])
+        end-time (System/currentTimeMillis)
+        duration-ms (- end-time start-time)]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (update-in [:execution :phases-completed] (fnil conj []) :verify))))
+
+(defn- error-verify
+  "Handle verification phase errors.
+
+   On test failure, can redirect to :implement if on-fail specified."
+  [ctx ex]
+  (let [iterations (get-in ctx [:phase :iterations] 0)
+        max-iterations (get-in ctx [:phase :budget :iterations] 3)
+        on-fail (get-in ctx [:phase-config :on-fail])]
+    (cond
+      (< iterations max-iterations)
+      (-> ctx
+          (update-in [:phase :iterations] (fnil inc 0))
+          (assoc-in [:phase :last-error] (ex-message ex))
+          (assoc-in [:phase :status] :retrying))
+
+      on-fail
+      (-> ctx
+          (assoc-in [:phase :status] :failed)
+          (assoc-in [:phase :redirect-to] on-fail)
+          (assoc-in [:phase :error] {:message (ex-message ex)
+                                     :data (ex-data ex)}))
+
+      :else
+      (-> ctx
+          (assoc-in [:phase :status] :failed)
+          (assoc-in [:phase :error] {:message (ex-message ex)
+                                     :data (ex-data ex)})))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry method
+
+(defmethod registry/get-phase-interceptor :verify
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name ::verify
+     :config merged
+     :enter (fn [ctx]
+              (enter-verify (assoc ctx :phase-config merged)))
+     :leave leave-verify
+     :error error-verify}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (registry/get-phase-interceptor {:phase :verify})
+  (registry/get-phase-interceptor {:phase :verify :on-fail :implement})
+  (registry/phase-defaults :verify)
+  :leave-this-here)

--- a/components/phase/test/ai/miniforge/phase/interface_test.clj
+++ b/components/phase/test/ai/miniforge/phase/interface_test.clj
@@ -1,0 +1,126 @@
+(ns ai.miniforge.phase.interface-test
+  "Tests for the phase component."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.phase.interface :as phase]
+   ;; Require implementations to register methods
+   [ai.miniforge.phase.plan :as plan]
+   [ai.miniforge.phase.implement :as impl]
+   [ai.miniforge.phase.verify :as verify]
+   [ai.miniforge.phase.review :as review]
+   [ai.miniforge.phase.release :as release]))
+
+;; ============================================================================
+;; Registry tests
+;; ============================================================================
+
+(deftest get-phase-interceptor-plan-test
+  (testing "get-phase-interceptor returns interceptor for :plan"
+    (let [interceptor (phase/get-phase-interceptor {:phase :plan})]
+      (is (map? interceptor))
+      (is (= ::plan/plan (:name interceptor)))
+      (is (fn? (:enter interceptor)))
+      (is (fn? (:leave interceptor)))
+      (is (fn? (:error interceptor))))))
+
+(deftest get-phase-interceptor-implement-test
+  (testing "get-phase-interceptor returns interceptor for :implement"
+    (let [interceptor (phase/get-phase-interceptor {:phase :implement})]
+      (is (map? interceptor))
+      (is (= ::impl/implement (:name interceptor)))
+      (is (fn? (:enter interceptor))))))
+
+(deftest get-phase-interceptor-verify-test
+  (testing "get-phase-interceptor returns interceptor for :verify"
+    (let [interceptor (phase/get-phase-interceptor {:phase :verify})]
+      (is (map? interceptor))
+      (is (= ::verify/verify (:name interceptor))))))
+
+(deftest get-phase-interceptor-review-test
+  (testing "get-phase-interceptor returns interceptor for :review"
+    (let [interceptor (phase/get-phase-interceptor {:phase :review})]
+      (is (map? interceptor))
+      (is (= ::review/review (:name interceptor))))))
+
+(deftest get-phase-interceptor-release-test
+  (testing "get-phase-interceptor returns interceptor for :release"
+    (let [interceptor (phase/get-phase-interceptor {:phase :release})]
+      (is (map? interceptor))
+      (is (= ::release/release (:name interceptor))))))
+
+(deftest get-phase-interceptor-done-test
+  (testing "get-phase-interceptor returns interceptor for :done"
+    (let [interceptor (phase/get-phase-interceptor {:phase :done})]
+      (is (map? interceptor))
+      (is (= ::release/done (:name interceptor))))))
+
+(deftest get-phase-interceptor-unknown-test
+  (testing "get-phase-interceptor throws for unknown phase"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Unknown phase type"
+         (phase/get-phase-interceptor {:phase :unknown-phase})))))
+
+;; ============================================================================
+;; Config merge tests
+;; ============================================================================
+
+(deftest config-merge-test
+  (testing "custom config merges with defaults"
+    (let [interceptor (phase/get-phase-interceptor
+                       {:phase :implement
+                        :budget {:tokens 50000}})]
+      ;; Should have merged config
+      (is (= 50000 (get-in interceptor [:config :budget :tokens])))
+      ;; Should have default gates
+      (is (= [:syntax :lint] (get-in interceptor [:config :gates]))))))
+
+(deftest custom-gates-test
+  (testing "custom gates override defaults"
+    (let [interceptor (phase/get-phase-interceptor
+                       {:phase :implement
+                        :gates [:syntax :lint :no-secrets]})]
+      (is (= [:syntax :lint :no-secrets] (get-in interceptor [:config :gates]))))))
+
+;; ============================================================================
+;; Pipeline building tests
+;; ============================================================================
+
+(deftest build-pipeline-test
+  (testing "build-pipeline creates interceptor vector"
+    (let [workflow {:workflow/pipeline
+                    [{:phase :plan}
+                     {:phase :implement}
+                     {:phase :done}]}
+          pipeline (phase/build-pipeline workflow)]
+      (is (vector? pipeline))
+      (is (= 3 (count pipeline)))
+      (is (= ::plan/plan (:name (first pipeline))))
+      (is (= ::impl/implement (:name (second pipeline))))
+      (is (= ::release/done (:name (last pipeline)))))))
+
+;; ============================================================================
+;; Validation tests
+;; ============================================================================
+
+(deftest validate-pipeline-empty-test
+  (testing "validate-pipeline rejects empty pipeline"
+    (let [result (phase/validate-pipeline {:workflow/pipeline []})]
+      (is (not (:valid? result)))
+      (is (seq (:errors result))))))
+
+(deftest validate-pipeline-valid-test
+  (testing "validate-pipeline accepts valid pipeline"
+    (let [result (phase/validate-pipeline
+                  {:workflow/pipeline
+                   [{:phase :plan}
+                    {:phase :implement}
+                    {:phase :done}]})]
+      (is (:valid? result))
+      (is (empty? (:errors result))))))
+
+(deftest validate-pipeline-missing-phase-test
+  (testing "validate-pipeline rejects config without :phase"
+    (let [result (phase/validate-pipeline
+                  {:workflow/pipeline [{:not-phase :plan}]})]
+      (is (not (:valid? result))))))

--- a/components/response/deps.edn
+++ b/components/response/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src"]
+ :deps {}
+ :aliases {:test {:extra-paths ["test"]}}}

--- a/components/response/src/ai/miniforge/response/anomaly.clj
+++ b/components/response/src/ai/miniforge/response/anomaly.clj
@@ -1,0 +1,138 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response.anomaly
+  "Anomaly taxonomy for miniforge operations.
+
+   Anomalies are keywords that categorize failures. They provide:
+   - Consistent error classification across components
+   - Mapping to appropriate responses (HTTP status, retry behavior, etc.)
+   - Clear semantics for error handling
+
+   Categories:
+   - :anomalies/... - General errors
+   - :anomalies.phase/... - Phase execution errors
+   - :anomalies.gate/... - Gate validation errors
+   - :anomalies.agent/... - Agent errors
+   - :anomalies.workflow/... - Workflow orchestration errors")
+
+;------------------------------------------------------------------------------ Layer 0
+;; General anomalies (compatible with cognitect.anomalies)
+
+(def general-anomalies
+  "General anomaly categories."
+  #{:anomalies/unavailable      ; Temporarily unavailable, retry may succeed
+    :anomalies/interrupted      ; Operation was interrupted
+    :anomalies/incorrect        ; Bad input or configuration
+    :anomalies/forbidden        ; Not authorized
+    :anomalies/not-found        ; Resource not found
+    :anomalies/conflict         ; Conflicting state
+    :anomalies/fault            ; Internal error
+    :anomalies/unsupported      ; Operation not supported
+    :anomalies/busy             ; Rate limited or overloaded
+    :anomalies/timeout})        ; Operation timed out
+
+;------------------------------------------------------------------------------ Layer 1
+;; Domain-specific anomalies
+
+(def phase-anomalies
+  "Phase execution anomalies."
+  #{:anomalies.phase/unknown-phase     ; Phase type not registered
+    :anomalies.phase/enter-failed      ; Phase :enter function failed
+    :anomalies.phase/leave-failed      ; Phase :leave function failed
+    :anomalies.phase/budget-exceeded   ; Token/time/iteration budget exceeded
+    :anomalies.phase/no-agent          ; No agent configured for phase
+    :anomalies.phase/agent-failed})    ; Agent invocation failed
+
+(def gate-anomalies
+  "Gate validation anomalies."
+  #{:anomalies.gate/unknown-gate       ; Gate type not registered
+    :anomalies.gate/check-failed       ; Gate check threw exception
+    :anomalies.gate/validation-failed  ; Gate validation returned false
+    :anomalies.gate/repair-failed      ; Gate repair failed
+    :anomalies.gate/no-repair})        ; Gate has no repair function
+
+(def agent-anomalies
+  "Agent execution anomalies."
+  #{:anomalies.agent/unknown-agent     ; Agent type not registered
+    :anomalies.agent/invoke-failed     ; Agent invocation failed
+    :anomalies.agent/parse-failed      ; Failed to parse agent output
+    :anomalies.agent/llm-error})       ; LLM backend error
+
+(def workflow-anomalies
+  "Workflow orchestration anomalies."
+  #{:anomalies.workflow/empty-pipeline   ; No phases in pipeline
+    :anomalies.workflow/invalid-config   ; Invalid workflow configuration
+    :anomalies.workflow/max-phases       ; Exceeded max phase iterations
+    :anomalies.workflow/invalid-transition  ; Invalid phase transition
+    :anomalies.workflow/rollback-limit}) ; Exceeded max rollbacks
+
+;------------------------------------------------------------------------------ Layer 2
+;; Anomaly utilities
+
+(def all-anomalies
+  "Set of all known anomaly keywords."
+  (into #{}
+        (concat general-anomalies
+                phase-anomalies
+                gate-anomalies
+                agent-anomalies
+                workflow-anomalies)))
+
+(defn anomaly?
+  "Check if a keyword is a known anomaly."
+  [kw]
+  (contains? all-anomalies kw))
+
+(defn retryable?
+  "Check if an anomaly indicates the operation may succeed on retry."
+  [anomaly]
+  (contains? #{:anomalies/unavailable
+               :anomalies/interrupted
+               :anomalies/busy
+               :anomalies/timeout
+               :anomalies.agent/llm-error}
+             anomaly))
+
+(defn anomaly-category
+  "Get the category of an anomaly.
+
+   Returns :general, :phase, :gate, :agent, :workflow, or nil."
+  [anomaly]
+  (cond
+    (contains? general-anomalies anomaly) :general
+    (contains? phase-anomalies anomaly) :phase
+    (contains? gate-anomalies anomaly) :gate
+    (contains? agent-anomalies anomaly) :agent
+    (contains? workflow-anomalies anomaly) :workflow
+    :else nil))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (anomaly? :anomalies/fault)
+  ;; => true
+
+  (anomaly? :not-an-anomaly)
+  ;; => false
+
+  (retryable? :anomalies/unavailable)
+  ;; => true
+
+  (retryable? :anomalies/forbidden)
+  ;; => false
+
+  (anomaly-category :anomalies.phase/enter-failed)
+  ;; => :phase
+
+  :leave-this-here)

--- a/components/response/src/ai/miniforge/response/chain.clj
+++ b/components/response/src/ai/miniforge/response/chain.clj
@@ -1,0 +1,314 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response.chain
+  "Response chain for tracking operation sequences.
+
+   A response chain is an immutable data structure that accumulates
+   the results of sequential operations. Each operation adds an entry
+   to the chain with its result, and the overall success status is
+   calculated as all-operations-succeeded.
+
+   Response chain structure:
+   {:operation keyword        ; Root operation name
+    :succeeded? boolean       ; True if ALL operations succeeded
+    :response-chain vector}   ; Vector of wrapped responses
+
+   Each chain entry structure:
+   {:operation keyword        ; Operation name
+    :anomaly keyword|nil      ; Anomaly code if failed, nil if succeeded
+    :succeeded? boolean       ; True if this operation succeeded
+    :response any}            ; Operation result data
+
+   Usage:
+     (-> (create :my-workflow)
+         (add-response :step-1 nil {:result \"ok\"})
+         (add-response :step-2 nil {:result \"done\"})
+         (succeeded?))
+     ;; => true"
+  (:require [ai.miniforge.response.anomaly :as anomaly]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Chain creation
+
+(defn create
+  "Create a new response chain.
+
+   Arguments:
+     operation - Keyword identifying the root operation
+
+   Returns:
+     {:operation operation
+      :succeeded? true        ; Starts as true, becomes false on first failure
+      :response-chain []}"
+  [operation]
+  {:operation operation
+   :succeeded? true
+   :response-chain []})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Wrapping responses
+
+(defn wrap-response
+  "Wrap an operation result with metadata.
+
+   Arguments:
+     operation - Keyword identifying the operation
+     anomaly   - Anomaly keyword if failed, nil if succeeded
+     response  - Operation result data
+
+   Returns:
+     {:operation operation
+      :anomaly anomaly
+      :succeeded? (nil? anomaly)
+      :response response}"
+  [operation anomaly response]
+  {:operation operation
+   :anomaly anomaly
+   :succeeded? (nil? anomaly)
+   :response response})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Chain operations
+
+(defn add-response
+  "Add an operation result to the response chain.
+
+   Arguments:
+     chain     - Response chain
+     operation - Keyword identifying the operation
+     anomaly   - Anomaly keyword if failed, nil if succeeded
+     response  - Operation result data
+
+   Returns:
+     Updated chain with new entry and recalculated succeeded? status"
+  [chain operation anomaly response]
+  (let [entry (wrap-response operation anomaly response)
+        chain' (update chain :response-chain conj entry)
+        all-succeeded? (every? :succeeded? (:response-chain chain'))]
+    (assoc chain' :succeeded? all-succeeded?)))
+
+(defn add-success
+  "Add a successful operation result to the chain.
+
+   Shorthand for (add-response chain op nil response)"
+  [chain operation response]
+  (add-response chain operation nil response))
+
+(defn add-failure
+  "Add a failed operation result to the chain.
+
+   Arguments:
+     chain     - Response chain
+     operation - Keyword identifying the operation
+     anomaly   - Anomaly keyword (required)
+     response  - Error details or partial result"
+  [chain operation anomaly response]
+  {:pre [(some? anomaly)]}
+  (add-response chain operation anomaly response))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Chain queries
+
+(defn succeeded?
+  "Check if all operations in the chain succeeded."
+  [chain]
+  (:succeeded? chain))
+
+(defn failed?
+  "Check if any operation in the chain failed."
+  [chain]
+  (not (:succeeded? chain)))
+
+(defn last-entry
+  "Get the most recent entry in the chain."
+  [chain]
+  (peek (:response-chain chain)))
+
+(defn last-response
+  "Get the response from the most recent entry."
+  [chain]
+  (:response (last-entry chain)))
+
+(defn last-anomaly
+  "Get the anomaly from the most recent entry (nil if succeeded)."
+  [chain]
+  (:anomaly (last-entry chain)))
+
+(defn last-operation
+  "Get the operation name from the most recent entry."
+  [chain]
+  (:operation (last-entry chain)))
+
+(defn last-response-or-default
+  "Get the last response if succeeded, otherwise return default."
+  [chain default]
+  (if (succeeded? chain)
+    (last-response chain)
+    default))
+
+(defn first-failure
+  "Get the first failed entry in the chain, or nil if all succeeded."
+  [chain]
+  (first (filter (complement :succeeded?) (:response-chain chain))))
+
+(defn all-failures
+  "Get all failed entries in the chain."
+  [chain]
+  (filterv (complement :succeeded?) (:response-chain chain)))
+
+(defn operations
+  "Get the sequence of operation names in order."
+  [chain]
+  (mapv :operation (:response-chain chain)))
+
+(defn responses
+  "Get all responses in order."
+  [chain]
+  (mapv :response (:response-chain chain)))
+
+(defn entry-count
+  "Get the number of entries in the chain."
+  [chain]
+  (count (:response-chain chain)))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Chain transformations
+
+(defn merge-metrics
+  "Merge metrics from all responses in the chain.
+
+   Assumes each response has a :metrics map with numeric values."
+  [chain]
+  (reduce (fn [acc entry]
+            (if-let [metrics (get-in entry [:response :metrics])]
+              (merge-with + acc metrics)
+              acc))
+          {:tokens 0 :cost-usd 0.0 :duration-ms 0}
+          (:response-chain chain)))
+
+(defn collect-artifacts
+  "Collect all artifacts from responses in the chain.
+
+   Assumes each response may have an :artifacts vector."
+  [chain]
+  (into []
+        (comp (map :response)
+              (mapcat :artifacts)
+              (filter some?))
+        (:response-chain chain)))
+
+(defn summarize
+  "Create a summary of the chain execution.
+
+   Returns:
+     {:operation root-operation
+      :succeeded? boolean
+      :entry-count number
+      :operations [keywords]
+      :first-failure entry|nil
+      :metrics merged-metrics
+      :artifacts collected-artifacts}"
+  [chain]
+  {:operation (:operation chain)
+   :succeeded? (succeeded? chain)
+   :entry-count (entry-count chain)
+   :operations (operations chain)
+   :first-failure (first-failure chain)
+   :metrics (merge-metrics chain)
+   :artifacts (collect-artifacts chain)})
+
+;------------------------------------------------------------------------------ Layer 5
+;; Exception handling helper
+
+(defn execute-with-handling
+  "Execute a function and add its result to the chain.
+
+   On success: adds (operation, nil, result) to chain
+   On exception: adds (operation, anomaly, {:error message :data ex-data})
+
+   Arguments:
+     chain      - Response chain
+     operation  - Keyword identifying the operation
+     anomaly-fn - Function (Exception -> anomaly-keyword) to classify errors
+     f          - Function to execute (no args)
+
+   Returns:
+     Updated chain"
+  [chain operation anomaly-fn f]
+  (try
+    (let [result (f)]
+      (add-success chain operation result))
+    (catch Exception ex
+      (let [anomaly (or (anomaly-fn ex) :anomalies/fault)]
+        (add-failure chain operation anomaly
+                     {:error (ex-message ex)
+                      :data (ex-data ex)})))))
+
+(defn default-anomaly-classifier
+  "Default function to classify exceptions into anomalies."
+  [ex]
+  (let [data (ex-data ex)]
+    (cond
+      ;; If ex-data contains an anomaly, use it
+      (:anomaly data) (:anomaly data)
+
+      ;; Classify by exception type
+      (instance? java.util.concurrent.TimeoutException ex)
+      :anomalies/timeout
+
+      (instance? InterruptedException ex)
+      :anomalies/interrupted
+
+      ;; Default to fault
+      :else :anomalies/fault)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create a chain and add operations
+  (def chain
+    (-> (create :my-workflow)
+        (add-success :plan {:artifacts [{:type :plan}]
+                           :metrics {:tokens 100}})
+        (add-success :implement {:artifacts [{:type :code}]
+                                :metrics {:tokens 500}})
+        (add-failure :verify :anomalies.gate/validation-failed
+                     {:errors ["test failed"]})))
+
+  (succeeded? chain)
+  ;; => false
+
+  (first-failure chain)
+  ;; => {:operation :verify, :anomaly :anomalies.gate/validation-failed, ...}
+
+  (merge-metrics chain)
+  ;; => {:tokens 600, :cost-usd 0.0, :duration-ms 0}
+
+  (collect-artifacts chain)
+  ;; => [{:type :plan} {:type :code}]
+
+  (operations chain)
+  ;; => [:plan :implement :verify]
+
+  (summarize chain)
+
+  ;; With exception handling
+  (-> (create :safe-operation)
+      (execute-with-handling :step-1 default-anomaly-classifier
+                             #(do "success"))
+      (execute-with-handling :step-2 default-anomaly-classifier
+                             #(throw (ex-info "oops" {:code 123})))
+      summarize)
+
+  :leave-this-here)

--- a/components/response/src/ai/miniforge/response/interface.clj
+++ b/components/response/src/ai/miniforge/response/interface.clj
@@ -1,0 +1,258 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response.interface
+  "Response chain public interface.
+
+   Response chains track sequences of operations with their results,
+   providing consistent error handling and operation history.
+
+   Core workflow:
+   1. Create a chain: (create :my-workflow)
+   2. Add results:    (add-success chain :step-1 result)
+                      (add-failure chain :step-2 :anomalies/fault error)
+   3. Query status:   (succeeded? chain)
+   4. Get summary:    (summarize chain)"
+  (:require
+   [ai.miniforge.response.chain :as chain]
+   [ai.miniforge.response.anomaly :as anomaly]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Chain creation
+
+(def create
+  "Create a new response chain.
+
+   Arguments:
+     operation - Keyword identifying the root operation
+
+   Returns:
+     {:operation operation
+      :succeeded? true
+      :response-chain []}
+
+   Example:
+     (create :workflow-execution)"
+  chain/create)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Adding responses
+
+(def add-response
+  "Add an operation result to the response chain.
+
+   Arguments:
+     chain     - Response chain
+     operation - Keyword identifying the operation
+     anomaly   - Anomaly keyword if failed, nil if succeeded
+     response  - Operation result data
+
+   Returns:
+     Updated chain with new entry and recalculated succeeded? status
+
+   Example:
+     (add-response chain :plan nil {:artifacts [...]})
+     (add-response chain :verify :anomalies.gate/validation-failed {:errors [...]})"
+  chain/add-response)
+
+(def add-success
+  "Add a successful operation result to the chain.
+
+   Shorthand for (add-response chain op nil response)
+
+   Example:
+     (add-success chain :implement {:code \"...\"})"
+  chain/add-success)
+
+(def add-failure
+  "Add a failed operation result to the chain.
+
+   Arguments:
+     chain     - Response chain
+     operation - Keyword identifying the operation
+     anomaly   - Anomaly keyword (required)
+     response  - Error details or partial result
+
+   Example:
+     (add-failure chain :verify :anomalies.gate/validation-failed
+                  {:errors [\"test failed\"]})"
+  chain/add-failure)
+
+;------------------------------------------------------------------------------ Layer 2
+;; Chain queries
+
+(def succeeded?
+  "Check if all operations in the chain succeeded.
+
+   Example:
+     (if (succeeded? chain)
+       (last-response chain)
+       (first-failure chain))"
+  chain/succeeded?)
+
+(def failed?
+  "Check if any operation in the chain failed."
+  chain/failed?)
+
+(def last-entry
+  "Get the most recent entry in the chain.
+
+   Returns:
+     {:operation :step-name
+      :anomaly nil|keyword
+      :succeeded? boolean
+      :response result-data}"
+  chain/last-entry)
+
+(def last-response
+  "Get the response from the most recent entry."
+  chain/last-response)
+
+(def last-anomaly
+  "Get the anomaly from the most recent entry (nil if succeeded)."
+  chain/last-anomaly)
+
+(def last-operation
+  "Get the operation name from the most recent entry."
+  chain/last-operation)
+
+(def last-response-or-default
+  "Get the last response if succeeded, otherwise return default.
+
+   Example:
+     (last-response-or-default chain {:status :unknown})"
+  chain/last-response-or-default)
+
+(def first-failure
+  "Get the first failed entry in the chain, or nil if all succeeded."
+  chain/first-failure)
+
+(def all-failures
+  "Get all failed entries in the chain."
+  chain/all-failures)
+
+(def operations
+  "Get the sequence of operation names in order.
+
+   Example:
+     (operations chain)
+     ;; => [:plan :implement :verify]"
+  chain/operations)
+
+(def responses
+  "Get all responses in order."
+  chain/responses)
+
+(def entry-count
+  "Get the number of entries in the chain."
+  chain/entry-count)
+
+;------------------------------------------------------------------------------ Layer 3
+;; Chain transformations
+
+(def merge-metrics
+  "Merge metrics from all responses in the chain.
+
+   Assumes each response has a :metrics map with numeric values.
+   Returns merged {:tokens :cost-usd :duration-ms} map."
+  chain/merge-metrics)
+
+(def collect-artifacts
+  "Collect all artifacts from responses in the chain.
+
+   Assumes each response may have an :artifacts vector."
+  chain/collect-artifacts)
+
+(def summarize
+  "Create a summary of the chain execution.
+
+   Returns:
+     {:operation root-operation
+      :succeeded? boolean
+      :entry-count number
+      :operations [keywords]
+      :first-failure entry|nil
+      :metrics merged-metrics
+      :artifacts collected-artifacts}"
+  chain/summarize)
+
+;------------------------------------------------------------------------------ Layer 4
+;; Exception handling
+
+(def execute-with-handling
+  "Execute a function and add its result to the chain.
+
+   On success: adds (operation, nil, result) to chain
+   On exception: adds (operation, anomaly, {:error message :data ex-data})
+
+   Arguments:
+     chain      - Response chain
+     operation  - Keyword identifying the operation
+     anomaly-fn - Function (Exception -> anomaly-keyword) to classify errors
+     f          - Function to execute (no args)
+
+   Returns:
+     Updated chain
+
+   Example:
+     (execute-with-handling chain :step-1 default-anomaly-classifier
+                            #(risky-operation))"
+  chain/execute-with-handling)
+
+(def default-anomaly-classifier
+  "Default function to classify exceptions into anomalies."
+  chain/default-anomaly-classifier)
+
+;------------------------------------------------------------------------------ Layer 5
+;; Anomaly utilities
+
+(def anomaly?
+  "Check if a keyword is a known anomaly."
+  anomaly/anomaly?)
+
+(def retryable?
+  "Check if an anomaly indicates the operation may succeed on retry."
+  anomaly/retryable?)
+
+(def anomaly-category
+  "Get the category of an anomaly.
+
+   Returns :general, :phase, :gate, :agent, :workflow, or nil."
+  anomaly/anomaly-category)
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create and build a chain
+  (def chain
+    (-> (create :my-workflow)
+        (add-success :plan {:artifacts [{:type :plan}]
+                           :metrics {:tokens 100}})
+        (add-success :implement {:artifacts [{:type :code}]
+                                :metrics {:tokens 500}})
+        (add-failure :verify :anomalies.gate/validation-failed
+                     {:errors ["test failed"]})))
+
+  (succeeded? chain)        ;; => false
+  (operations chain)        ;; => [:plan :implement :verify]
+  (first-failure chain)     ;; => {:operation :verify, :anomaly ..., ...}
+  (merge-metrics chain)     ;; => {:tokens 600, ...}
+  (collect-artifacts chain) ;; => [{:type :plan} {:type :code}]
+  (summarize chain)
+
+  ;; Check anomalies
+  (anomaly? :anomalies.gate/validation-failed) ;; => true
+  (retryable? :anomalies/unavailable)          ;; => true
+  (anomaly-category :anomalies.phase/enter-failed) ;; => :phase
+
+  :leave-this-here)

--- a/components/response/test/ai/miniforge/response/interface_test.clj
+++ b/components/response/test/ai/miniforge/response/interface_test.clj
@@ -1,0 +1,232 @@
+(ns ai.miniforge.response.interface-test
+  "Tests for the response component."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.response.interface :as r]))
+
+;; ============================================================================
+;; Chain creation tests
+;; ============================================================================
+
+(deftest create-test
+  (testing "create initializes empty chain"
+    (let [chain (r/create :my-workflow)]
+      (is (= :my-workflow (:operation chain)))
+      (is (true? (:succeeded? chain)))
+      (is (empty? (:response-chain chain))))))
+
+;; ============================================================================
+;; Add response tests
+;; ============================================================================
+
+(deftest add-success-test
+  (testing "add-success adds entry with nil anomaly"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {:result "ok"}))]
+      (is (= 1 (r/entry-count chain)))
+      (is (r/succeeded? chain))
+      (is (= :step-1 (r/last-operation chain)))
+      (is (nil? (r/last-anomaly chain)))
+      (is (= {:result "ok"} (r/last-response chain))))))
+
+(deftest add-failure-test
+  (testing "add-failure adds entry with anomaly"
+    (let [chain (-> (r/create :test)
+                    (r/add-failure :step-1 :anomalies/fault {:error "boom"}))]
+      (is (= 1 (r/entry-count chain)))
+      (is (r/failed? chain))
+      (is (= :anomalies/fault (r/last-anomaly chain)))
+      (is (= {:error "boom"} (r/last-response chain))))))
+
+(deftest add-response-test
+  (testing "add-response with nil anomaly succeeds"
+    (let [chain (-> (r/create :test)
+                    (r/add-response :step-1 nil {:ok true}))]
+      (is (r/succeeded? chain))))
+
+  (testing "add-response with anomaly fails"
+    (let [chain (-> (r/create :test)
+                    (r/add-response :step-1 :anomalies/fault {:ok false}))]
+      (is (r/failed? chain)))))
+
+(deftest succeeded-aggregation-test
+  (testing "succeeded? is true only when all operations succeed"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {})
+                    (r/add-success :step-2 {}))]
+      (is (r/succeeded? chain))))
+
+  (testing "succeeded? is false when any operation fails"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {})
+                    (r/add-failure :step-2 :anomalies/fault {})
+                    (r/add-success :step-3 {}))]
+      (is (r/failed? chain)))))
+
+;; ============================================================================
+;; Query tests
+;; ============================================================================
+
+(deftest last-entry-test
+  (testing "last-entry returns most recent"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {:n 1})
+                    (r/add-success :step-2 {:n 2}))]
+      (is (= :step-2 (:operation (r/last-entry chain))))
+      (is (= {:n 2} (:response (r/last-entry chain)))))))
+
+(deftest last-response-or-default-test
+  (testing "returns response when succeeded"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {:result "ok"}))]
+      (is (= {:result "ok"} (r/last-response-or-default chain :default)))))
+
+  (testing "returns default when failed"
+    (let [chain (-> (r/create :test)
+                    (r/add-failure :step-1 :anomalies/fault {}))]
+      (is (= :default (r/last-response-or-default chain :default))))))
+
+(deftest first-failure-test
+  (testing "returns first failed entry"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {})
+                    (r/add-failure :step-2 :anomalies/fault {:n 2})
+                    (r/add-failure :step-3 :anomalies/timeout {:n 3}))]
+      (is (= :step-2 (:operation (r/first-failure chain))))
+      (is (= :anomalies/fault (:anomaly (r/first-failure chain))))))
+
+  (testing "returns nil when all succeeded"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {}))]
+      (is (nil? (r/first-failure chain))))))
+
+(deftest all-failures-test
+  (testing "returns all failed entries"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {})
+                    (r/add-failure :step-2 :anomalies/fault {})
+                    (r/add-failure :step-3 :anomalies/timeout {}))]
+      (is (= 2 (count (r/all-failures chain))))
+      (is (= [:step-2 :step-3] (mapv :operation (r/all-failures chain)))))))
+
+(deftest operations-test
+  (testing "returns operation names in order"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :plan {})
+                    (r/add-success :implement {})
+                    (r/add-success :verify {}))]
+      (is (= [:plan :implement :verify] (r/operations chain))))))
+
+;; ============================================================================
+;; Transformation tests
+;; ============================================================================
+
+(deftest merge-metrics-test
+  (testing "merges metrics from all responses"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :plan {:metrics {:tokens 100 :cost-usd 0.01}})
+                    (r/add-success :impl {:metrics {:tokens 500 :cost-usd 0.05}}))
+          merged (r/merge-metrics chain)]
+      (is (= 600 (:tokens merged)))
+      (is (< (Math/abs (- 0.06 (:cost-usd merged))) 0.0001))
+      (is (= 0 (:duration-ms merged)))))
+
+  (testing "handles missing metrics gracefully"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {:no-metrics true}))]
+      (is (= {:tokens 0 :cost-usd 0.0 :duration-ms 0}
+             (r/merge-metrics chain))))))
+
+(deftest collect-artifacts-test
+  (testing "collects artifacts from all responses"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :plan {:artifacts [{:type :plan}]})
+                    (r/add-success :impl {:artifacts [{:type :code} {:type :test}]}))]
+      (is (= [{:type :plan} {:type :code} {:type :test}]
+             (r/collect-artifacts chain)))))
+
+  (testing "handles missing artifacts gracefully"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {:no-artifacts true}))]
+      (is (= [] (r/collect-artifacts chain))))))
+
+(deftest summarize-test
+  (testing "creates summary of chain"
+    (let [chain (-> (r/create :workflow)
+                    (r/add-success :plan {:artifacts [{:type :plan}]
+                                         :metrics {:tokens 100}})
+                    (r/add-failure :impl :anomalies.phase/agent-failed
+                                  {:error "timeout"}))
+          summary (r/summarize chain)]
+      (is (= :workflow (:operation summary)))
+      (is (false? (:succeeded? summary)))
+      (is (= 2 (:entry-count summary)))
+      (is (= [:plan :impl] (:operations summary)))
+      (is (= :impl (:operation (:first-failure summary))))
+      (is (= {:tokens 100 :cost-usd 0.0 :duration-ms 0} (:metrics summary)))
+      (is (= [{:type :plan}] (:artifacts summary))))))
+
+;; ============================================================================
+;; Exception handling tests
+;; ============================================================================
+
+(deftest execute-with-handling-success-test
+  (testing "successful execution adds success entry"
+    (let [chain (-> (r/create :test)
+                    (r/execute-with-handling :step-1 r/default-anomaly-classifier
+                                             #(do {:result "ok"})))]
+      (is (r/succeeded? chain))
+      (is (= {:result "ok"} (r/last-response chain))))))
+
+(deftest execute-with-handling-failure-test
+  (testing "exception adds failure entry"
+    (let [chain (-> (r/create :test)
+                    (r/execute-with-handling :step-1 r/default-anomaly-classifier
+                                             #(throw (ex-info "boom" {:code 123}))))]
+      (is (r/failed? chain))
+      (is (= :anomalies/fault (r/last-anomaly chain)))
+      (is (= "boom" (:error (r/last-response chain))))
+      (is (= {:code 123} (:data (r/last-response chain)))))))
+
+(deftest execute-with-handling-custom-classifier-test
+  (testing "custom classifier maps exceptions"
+    (let [classifier (fn [_ex] :anomalies.phase/budget-exceeded)
+          chain (-> (r/create :test)
+                    (r/execute-with-handling :step-1 classifier
+                                             #(throw (Exception. "too slow"))))]
+      (is (= :anomalies.phase/budget-exceeded (r/last-anomaly chain))))))
+
+;; ============================================================================
+;; Anomaly tests
+;; ============================================================================
+
+(deftest anomaly?-test
+  (testing "recognizes known anomalies"
+    (is (r/anomaly? :anomalies/fault))
+    (is (r/anomaly? :anomalies.phase/enter-failed))
+    (is (r/anomaly? :anomalies.gate/validation-failed)))
+
+  (testing "rejects unknown keywords"
+    (is (not (r/anomaly? :not-an-anomaly)))
+    (is (not (r/anomaly? :random/keyword)))))
+
+(deftest retryable?-test
+  (testing "identifies retryable anomalies"
+    (is (r/retryable? :anomalies/unavailable))
+    (is (r/retryable? :anomalies/busy))
+    (is (r/retryable? :anomalies/timeout)))
+
+  (testing "identifies non-retryable anomalies"
+    (is (not (r/retryable? :anomalies/forbidden)))
+    (is (not (r/retryable? :anomalies/incorrect)))))
+
+(deftest anomaly-category-test
+  (testing "categorizes anomalies"
+    (is (= :general (r/anomaly-category :anomalies/fault)))
+    (is (= :phase (r/anomaly-category :anomalies.phase/enter-failed)))
+    (is (= :gate (r/anomaly-category :anomalies.gate/validation-failed)))
+    (is (= :agent (r/anomaly-category :anomalies.agent/llm-error)))
+    (is (= :workflow (r/anomaly-category :anomalies.workflow/max-phases))))
+
+  (testing "returns nil for unknown"
+    (is (nil? (r/anomaly-category :not-an-anomaly)))))

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
+        ai.miniforge/response {:local/root "../response"}  ; Response chains
         ai.miniforge/agent {:local/root "../agent"}
         ai.miniforge/task {:local/root "../task"}
         ai.miniforge/loop {:local/root "../loop"}

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -7,6 +7,8 @@
         ai.miniforge/artifact {:local/root "../artifact"}
         ai.miniforge/policy {:local/root "../policy"}      ; Gate evaluation
         ai.miniforge/heuristic {:local/root "../heuristic"} ; Workflow storage
+        ai.miniforge/phase {:local/root "../phase"}        ; Phase interceptors
+        ai.miniforge/gate {:local/root "../gate"}          ; Gate interceptors
         babashka/fs {:mvn/version "0.5.22"}
         babashka/process {:mvn/version "0.5.22"}
         metosin/malli {:mvn/version "0.16.1"}}             ; Schema validation

--- a/components/workflow/resources/workflows/quick-fix-v2.0.0.edn
+++ b/components/workflow/resources/workflows/quick-fix-v2.0.0.edn
@@ -1,0 +1,26 @@
+;; Quick Fix Workflow v2.0.0 (Interceptor-based)
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Minimal workflow for quick bug fixes.
+;; Skips planning, goes straight to implementation with basic verification.
+
+{:workflow/id :quick-fix
+ :workflow/version "2.0.0"
+ :workflow/name "Quick Fix Workflow"
+ :workflow/description "Fast path for small fixes: implement -> verify -> done"
+
+ :workflow/pipeline
+ [;; Jump straight to implementation
+  {:phase :implement
+   :budget {:tokens 20000 :iterations 3}}
+
+  ;; Basic verification
+  {:phase :verify
+   :gates [:tests-pass]
+   :on-fail :implement}
+
+  {:phase :done}]
+
+ :workflow/config
+ {:max-tokens 50000
+  :max-iterations 15}}

--- a/components/workflow/resources/workflows/simple-v2.0.0.edn
+++ b/components/workflow/resources/workflows/simple-v2.0.0.edn
@@ -1,0 +1,24 @@
+;; Simple Workflow v2.0.0 (Interceptor-based)
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Minimal workflow using the new interceptor-based pipeline.
+;; Phase behavior is defined by registry, not configuration.
+;;
+;; Compare to simple-test-v1.0.0.edn (76 lines) - this is ~20 lines.
+
+{:workflow/id :simple
+ :workflow/version "2.0.0"
+ :workflow/name "Simple Workflow"
+ :workflow/description "Minimal plan -> implement -> done workflow using interceptors."
+
+ ;; Pipeline: vector of phase configurations
+ ;; Each phase resolves behavior from the phase registry
+ :workflow/pipeline
+ [{:phase :plan}       ; Uses registry defaults: planner agent, 3 iterations
+  {:phase :implement}  ; Uses registry defaults: implementer agent, [:syntax :lint] gates
+  {:phase :done}]      ; Terminal phase
+
+ ;; Optional: global config overrides
+ :workflow/config
+ {:max-tokens 30000
+  :max-iterations 20}}

--- a/components/workflow/resources/workflows/standard-sdlc-v2.0.0.edn
+++ b/components/workflow/resources/workflows/standard-sdlc-v2.0.0.edn
@@ -1,0 +1,40 @@
+;; Standard SDLC Workflow v2.0.0 (Interceptor-based)
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Full SDLC workflow using the new interceptor-based pipeline.
+;; Replaces canonical-sdlc-v1.0.0.edn (145+ lines) with ~30 lines.
+;;
+;; Phase behavior is defined by registry defaults. Override only what differs.
+
+{:workflow/id :standard-sdlc
+ :workflow/version "2.0.0"
+ :workflow/name "Standard SDLC Workflow"
+ :workflow/description "Full SDLC: plan -> implement -> verify -> review -> release"
+
+ :workflow/pipeline
+ [;; Planning phase - uses :planner agent
+  {:phase :plan}
+
+  ;; Implementation phase - override to add policy gate
+  {:phase :implement
+   :gates [:syntax :lint :no-secrets]
+   :budget {:tokens 50000}}
+
+  ;; Verification phase - runs tests, retries implementation on failure
+  {:phase :verify
+   :on-fail :implement}
+
+  ;; Review phase - quality and approval checks
+  {:phase :review
+   :on-fail :implement}
+
+  ;; Release phase - creates PR
+  {:phase :release}
+
+  ;; Terminal phase
+  {:phase :done}]
+
+ :workflow/config
+ {:max-tokens 150000
+  :max-iterations 50
+  :failure-strategy :retry}}

--- a/components/workflow/src/ai/miniforge/workflow/interface.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface.clj
@@ -165,7 +165,68 @@
   core/run-workflow)
 
 ;------------------------------------------------------------------------------ Layer 5
-;; Configurable workflow API (Layer 2)
+;; Interceptor-based workflow API (Simplified)
+
+(defn run-pipeline
+  "Execute a workflow using interceptor pipeline.
+
+   This is the new simplified API using phase and gate interceptors.
+   Workflows are defined as vectors of phase configurations.
+
+   Arguments:
+   - workflow: Workflow configuration with :workflow/pipeline
+   - input: Input data for the workflow
+   - opts: Execution options
+     - :max-phases - Max phases to execute (default 50)
+     - :on-phase-start - Callback fn [ctx interceptor]
+     - :on-phase-complete - Callback fn [ctx interceptor result]
+
+   Returns execution context with:
+   - :execution/status - :completed or :failed
+   - :execution/phase-results - Results per phase
+   - :execution/artifacts - All artifacts produced
+   - :execution/metrics - Accumulated metrics
+
+   Example:
+     (def workflow
+       {:workflow/id :simple
+        :workflow/version \"2.0.0\"
+        :workflow/pipeline
+        [{:phase :plan}
+         {:phase :implement}
+         {:phase :done}]})
+     (run-pipeline workflow {:task \"Build feature\"} {})"
+  ([workflow input]
+   (run-pipeline workflow input {}))
+  ([workflow input opts]
+   ((requiring-resolve 'ai.miniforge.workflow.runner/run-pipeline)
+    workflow input opts)))
+
+(defn build-pipeline
+  "Build interceptor pipeline from workflow config.
+
+   Arguments:
+   - workflow: Workflow configuration with :workflow/pipeline
+
+   Returns vector of interceptor maps.
+
+   Example:
+     (build-pipeline {:workflow/pipeline [{:phase :plan} {:phase :implement}]})"
+  [workflow]
+  ((requiring-resolve 'ai.miniforge.workflow.runner/build-pipeline) workflow))
+
+(defn validate-pipeline
+  "Validate a workflow pipeline configuration.
+
+   Arguments:
+   - workflow: Workflow configuration with :workflow/pipeline
+
+   Returns {:valid? bool :errors []}"
+  [workflow]
+  ((requiring-resolve 'ai.miniforge.workflow.runner/validate-pipeline) workflow))
+
+;------------------------------------------------------------------------------ Layer 6
+;; Configurable workflow API (Legacy)
 
 (defn load-workflow
   "Load a workflow configuration by ID and version.

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -1,0 +1,365 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.runner
+  "Interceptor-based workflow pipeline execution.
+
+   Executes workflows as chains of phase interceptors.
+   Each phase interceptor has :enter, :leave, and :error functions.
+
+   - :enter - Execute the phase
+   - :leave - Post-processing and metrics
+   - :error - Handle failures and transitions"
+  (:require [ai.miniforge.phase.interface :as phase]
+            [ai.miniforge.gate.interface :as gate]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Execution context
+
+(defn create-context
+  "Create initial execution context.
+
+   Arguments:
+   - workflow: Workflow configuration
+   - input: Input data for the workflow
+   - opts: Execution options
+
+   Returns execution context map."
+  [workflow input opts]
+  {:execution/id (random-uuid)
+   :execution/workflow-id (:workflow/id workflow)
+   :execution/workflow-version (:workflow/version workflow)
+   :execution/status :running
+   :execution/input input
+   :execution/artifacts []
+   :execution/errors []
+   :execution/phase-results {}
+   :execution/current-phase nil
+   :execution/phase-index 0
+   :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
+   :execution/started-at (System/currentTimeMillis)
+   :execution/opts opts})
+
+(defn- merge-metrics
+  "Merge phase metrics into execution metrics."
+  [exec-metrics phase-metrics]
+  (merge-with + exec-metrics
+              (select-keys phase-metrics [:tokens :cost-usd :duration-ms])))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Phase transition logic
+
+(defn- determine-next-index
+  "Determine next phase index based on result and config.
+
+   Arguments:
+   - pipeline: Vector of phase interceptors
+   - current-index: Current phase index
+   - phase-config: Current phase configuration
+   - phase-result: Result from phase execution
+
+   Returns next index or :done."
+  [pipeline current-index phase-config phase-result]
+  (let [status (:phase/status phase-result)
+        on-fail (:on-fail phase-config)
+        on-success (:on-success phase-config)]
+    (cond
+      ;; Phase completed successfully
+      (= :completed status)
+      (if on-success
+        ;; Find target phase by name
+        (let [target-index (->> pipeline
+                                (map-indexed vector)
+                                (filter #(= on-success (get-in (second %) [:config :phase])))
+                                (first))]
+          (if target-index (first target-index) (inc current-index)))
+        ;; Default: next phase
+        (let [next-idx (inc current-index)]
+          (if (< next-idx (count pipeline))
+            next-idx
+            :done)))
+
+      ;; Phase failed
+      (= :failed status)
+      (if on-fail
+        ;; Find target phase by name
+        (let [target-index (->> pipeline
+                                (map-indexed vector)
+                                (filter #(= on-fail (get-in (second %) [:config :phase])))
+                                (first))]
+          (if target-index
+            (first target-index)
+            ;; Target not found, fail the workflow
+            :error))
+        ;; No retry target, fail the workflow
+        :error)
+
+      ;; Default: move to next
+      :else (inc current-index))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Interceptor execution
+
+(defn- execute-enter
+  "Execute the :enter function of an interceptor.
+
+   Returns updated context."
+  [interceptor ctx]
+  (if-let [enter-fn (:enter interceptor)]
+    (try
+      (enter-fn ctx)
+      (catch Exception ex
+        (if-let [error-fn (:error interceptor)]
+          (error-fn ctx ex)
+          (-> ctx
+              (assoc :execution/status :failed)
+              (update :execution/errors conj
+                      {:type :phase-error
+                       :phase (get-in interceptor [:config :phase])
+                       :message (ex-message ex)
+                       :data (ex-data ex)})))))
+    ctx))
+
+(defn- execute-leave
+  "Execute the :leave function of an interceptor.
+
+   Returns updated context."
+  [interceptor ctx]
+  (if-let [leave-fn (:leave interceptor)]
+    (try
+      (leave-fn ctx)
+      (catch Exception ex
+        (-> ctx
+            (update :execution/errors conj
+                    {:type :leave-error
+                     :phase (get-in interceptor [:config :phase])
+                     :message (ex-message ex)}))))
+    ctx))
+
+(defn- run-gates
+  "Run gates for a phase and return result.
+
+   Returns {:passed? bool :errors []}."
+  [gate-keywords artifact ctx]
+  (gate/check-gates gate-keywords artifact ctx))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Pipeline execution
+
+(defn build-pipeline
+  "Build interceptor pipeline from workflow config.
+
+   Arguments:
+   - workflow: Workflow configuration with :workflow/pipeline
+
+   Returns vector of interceptor maps."
+  [workflow]
+  (let [pipeline-config (:workflow/pipeline workflow)]
+    (if (seq pipeline-config)
+      ;; New simplified format
+      (mapv phase/get-phase-interceptor pipeline-config)
+      ;; Fall back to legacy format
+      (let [phases (:workflow/phases workflow)]
+        (mapv (fn [phase-def]
+                (phase/get-phase-interceptor
+                 {:phase (:phase/id phase-def)
+                  :config phase-def}))
+              phases)))))
+
+(defn validate-pipeline
+  "Validate a workflow pipeline.
+
+   Returns {:valid? bool :errors []}."
+  [workflow]
+  (phase/validate-pipeline workflow))
+
+(defn- execute-phase-step
+  "Execute a single phase step and return updated context.
+
+   Arguments:
+   - pipeline: Vector of interceptors
+   - ctx: Current execution context
+   - callbacks: Map with :on-phase-start, :on-phase-complete
+
+   Returns updated context or nil if done."
+  [pipeline ctx callbacks]
+  (let [phase-index (:execution/phase-index ctx)
+        interceptor (get pipeline phase-index)
+        phase-name (get-in interceptor [:config :phase])
+        {:keys [on-phase-start on-phase-complete]} callbacks]
+
+    ;; Update current phase
+    (let [ctx' (assoc ctx :execution/current-phase phase-name)]
+
+      ;; Callback: phase start
+      (when on-phase-start
+        (on-phase-start ctx' interceptor))
+
+      ;; Execute :enter
+      (let [ctx-entered (execute-enter interceptor ctx')
+            phase-result (get-in ctx-entered [:phase])
+
+            ;; Run gates if phase has them
+            gate-keywords (get-in interceptor [:config :gates] [])
+            artifact (:artifact phase-result)
+            gate-result (when (and (seq gate-keywords) artifact)
+                          (run-gates gate-keywords artifact ctx-entered))
+
+            ;; Update phase result with gate status
+            phase-result' (if gate-result
+                            (if (:passed? gate-result)
+                              phase-result
+                              (assoc phase-result
+                                     :phase/status :failed
+                                     :phase/gate-errors (:errors gate-result)))
+                            phase-result)
+
+            ;; Execute :leave
+            ctx-left (execute-leave interceptor
+                                    (assoc ctx-entered :phase phase-result'))
+
+            ;; Record phase result
+            ctx-recorded (-> ctx-left
+                             (assoc-in [:execution/phase-results phase-name] phase-result')
+                             (update :execution/metrics merge-metrics
+                                     (or (:metrics phase-result') {}))
+                             (update :execution/artifacts into
+                                     (or (:artifacts phase-result') [])))]
+
+        ;; Callback: phase complete
+        (when on-phase-complete
+          (on-phase-complete ctx-recorded interceptor phase-result'))
+
+        ;; Determine next phase
+        (let [next-index (determine-next-index
+                          pipeline phase-index
+                          (:config interceptor)
+                          phase-result')]
+          (cond
+            ;; Workflow complete
+            (= :done next-index)
+            (-> ctx-recorded
+                (assoc :execution/status :completed)
+                (assoc :execution/ended-at (System/currentTimeMillis)))
+
+            ;; Error - workflow failed
+            (= :error next-index)
+            (-> ctx-recorded
+                (assoc :execution/status :failed)
+                (assoc :execution/ended-at (System/currentTimeMillis)))
+
+            ;; Continue to next phase
+            (number? next-index)
+            (if (< next-index (count pipeline))
+              (assoc ctx-recorded :execution/phase-index next-index)
+              (-> ctx-recorded
+                  (assoc :execution/status :completed)
+                  (assoc :execution/ended-at (System/currentTimeMillis))))
+
+            ;; Unknown - shouldn't happen
+            :else
+            (-> ctx-recorded
+                (assoc :execution/status :failed)
+                (update :execution/errors conj
+                        {:type :invalid-transition
+                         :message (str "Invalid next index: " next-index)}))))))))
+
+(defn run-pipeline
+  "Execute a workflow pipeline.
+
+   Arguments:
+   - workflow: Workflow configuration
+   - input: Input data
+   - opts: Execution options
+     - :max-phases - Max phases to execute (default 50)
+     - :on-phase-start - Callback fn [ctx interceptor]
+     - :on-phase-complete - Callback fn [ctx interceptor result]
+
+   Returns final execution context."
+  ([workflow input]
+   (run-pipeline workflow input {}))
+  ([workflow input opts]
+   (let [pipeline (build-pipeline workflow)
+         max-phases (or (:max-phases opts) 50)
+         callbacks {:on-phase-start (:on-phase-start opts)
+                    :on-phase-complete (:on-phase-complete opts)}
+         initial-ctx (create-context workflow input opts)]
+
+     (if (empty? pipeline)
+       (-> initial-ctx
+           (assoc :execution/status :failed)
+           (update :execution/errors conj
+                   {:type :empty-pipeline
+                    :message "Workflow has no phases"}))
+
+       ;; Execute pipeline loop
+       (loop [ctx initial-ctx
+              iteration 0]
+         (cond
+           ;; Terminal state
+           (#{:completed :failed} (:execution/status ctx))
+           ctx
+
+           ;; Max phases exceeded
+           (>= iteration max-phases)
+           (-> ctx
+               (assoc :execution/status :failed)
+               (update :execution/errors conj
+                       {:type :max-phases-exceeded
+                        :message (str "Exceeded maximum phase count: " max-phases)})
+               (assoc :execution/ended-at (System/currentTimeMillis)))
+
+           ;; Execute next phase
+           :else
+           (recur (execute-phase-step pipeline ctx callbacks)
+                  (inc iteration))))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (require '[ai.miniforge.phase.plan])
+  (require '[ai.miniforge.phase.implement])
+  (require '[ai.miniforge.phase.verify])
+  (require '[ai.miniforge.phase.review])
+  (require '[ai.miniforge.phase.release])
+
+  ;; Simple workflow config
+  (def simple-workflow
+    {:workflow/id :simple-test
+     :workflow/version "2.0.0"
+     :workflow/pipeline
+     [{:phase :plan}
+      {:phase :implement}
+      {:phase :done}]})
+
+  ;; Build pipeline
+  (build-pipeline simple-workflow)
+
+  ;; Validate pipeline
+  (validate-pipeline simple-workflow)
+
+  ;; Run pipeline
+  (def result
+    (run-pipeline simple-workflow
+                  {:task "Test task"}
+                  {:on-phase-start (fn [ctx ic]
+                                     (println "Starting:" (get-in ic [:config :phase])))
+                   :on-phase-complete (fn [ctx ic result]
+                                        (println "Completed:" (get-in ic [:config :phase])
+                                                 "Status:" (:phase/status result)))}))
+
+  (:execution/status result)
+  (:execution/phase-results result)
+  (:execution/metrics result)
+
+  :leave-this-here)

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -22,7 +22,8 @@
    - :leave - Post-processing and metrics
    - :error - Handle failures and transitions"
   (:require [ai.miniforge.phase.interface :as phase]
-            [ai.miniforge.gate.interface :as gate]))
+            [ai.miniforge.gate.interface :as gate]
+            [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Execution context
@@ -43,7 +44,8 @@
    :execution/status :running
    :execution/input input
    :execution/artifacts []
-   :execution/errors []
+   :execution/errors []  ; Kept for backward compatibility
+   :execution/response-chain (response/create (:workflow/id workflow))
    :execution/phase-results {}
    :execution/current-phase nil
    :execution/phase-index 0
@@ -71,7 +73,8 @@
 
    Returns next index or :done."
   [pipeline current-index phase-config phase-result]
-  (let [status (:phase/status phase-result)
+  ;; Check both :status and :phase/status for compatibility
+  (let [status (or (:status phase-result) (:phase/status phase-result))
         on-fail (:on-fail phase-config)
         on-success (:on-success phase-config)]
     (cond
@@ -116,36 +119,47 @@
 
    Returns updated context."
   [interceptor ctx]
-  (if-let [enter-fn (:enter interceptor)]
-    (try
-      (enter-fn ctx)
-      (catch Exception ex
-        (if-let [error-fn (:error interceptor)]
-          (error-fn ctx ex)
-          (-> ctx
-              (assoc :execution/status :failed)
-              (update :execution/errors conj
-                      {:type :phase-error
-                       :phase (get-in interceptor [:config :phase])
-                       :message (ex-message ex)
-                       :data (ex-data ex)})))))
-    ctx))
+  (let [phase-name (get-in interceptor [:config :phase])]
+    (if-let [enter-fn (:enter interceptor)]
+      (try
+        (enter-fn ctx)
+        (catch Exception ex
+          (if-let [error-fn (:error interceptor)]
+            (error-fn ctx ex)
+            (-> ctx
+                (assoc :execution/status :failed)
+                (update :execution/errors conj
+                        {:type :phase-error
+                         :phase phase-name
+                         :message (ex-message ex)
+                         :data (ex-data ex)})
+                (update :execution/response-chain
+                        response/add-failure phase-name
+                        :anomalies.phase/enter-failed
+                        {:error (ex-message ex)
+                         :data (ex-data ex)})))))
+      ctx)))
 
 (defn- execute-leave
   "Execute the :leave function of an interceptor.
 
    Returns updated context."
   [interceptor ctx]
-  (if-let [leave-fn (:leave interceptor)]
-    (try
-      (leave-fn ctx)
-      (catch Exception ex
-        (-> ctx
-            (update :execution/errors conj
-                    {:type :leave-error
-                     :phase (get-in interceptor [:config :phase])
-                     :message (ex-message ex)}))))
-    ctx))
+  (let [phase-name (get-in interceptor [:config :phase])]
+    (if-let [leave-fn (:leave interceptor)]
+      (try
+        (leave-fn ctx)
+        (catch Exception ex
+          (-> ctx
+              (update :execution/errors conj
+                      {:type :leave-error
+                       :phase phase-name
+                       :message (ex-message ex)})
+              (update :execution/response-chain
+                      response/add-failure phase-name
+                      :anomalies.phase/leave-failed
+                      {:error (ex-message ex)}))))
+      ctx)))
 
 (defn- run-gates
   "Run gates for a phase and return result.
@@ -229,23 +243,40 @@
             ctx-left (execute-leave interceptor
                                     (assoc ctx-entered :phase phase-result'))
 
-            ;; Record phase result
-            ctx-recorded (-> ctx-left
-                             (assoc-in [:execution/phase-results phase-name] phase-result')
+            ;; Get final phase result after :leave (may have updated status)
+            final-phase-result (get-in ctx-left [:phase])
+
+            ;; Record phase result in response chain
+            ;; Check both :status and :phase/status for compatibility
+            phase-succeeded? (or (= :completed (:status final-phase-result))
+                                 (= :completed (:phase/status final-phase-result)))
+            ctx-with-response (if phase-succeeded?
+                                (update ctx-left :execution/response-chain
+                                        response/add-success phase-name final-phase-result)
+                                (update ctx-left :execution/response-chain
+                                        response/add-failure phase-name
+                                        (if (:phase/gate-errors final-phase-result)
+                                          :anomalies.gate/validation-failed
+                                          :anomalies.phase/agent-failed)
+                                        final-phase-result))
+
+            ;; Record phase result (legacy format)
+            ctx-recorded (-> ctx-with-response
+                             (assoc-in [:execution/phase-results phase-name] final-phase-result)
                              (update :execution/metrics merge-metrics
-                                     (or (:metrics phase-result') {}))
+                                     (or (:metrics final-phase-result) {}))
                              (update :execution/artifacts into
-                                     (or (:artifacts phase-result') [])))]
+                                     (or (:artifacts final-phase-result) [])))]
 
         ;; Callback: phase complete
         (when on-phase-complete
-          (on-phase-complete ctx-recorded interceptor phase-result'))
+          (on-phase-complete ctx-recorded interceptor final-phase-result))
 
         ;; Determine next phase
         (let [next-index (determine-next-index
                           pipeline phase-index
                           (:config interceptor)
-                          phase-result')]
+                          final-phase-result)]
           (cond
             ;; Workflow complete
             (= :done next-index)
@@ -273,7 +304,12 @@
                 (assoc :execution/status :failed)
                 (update :execution/errors conj
                         {:type :invalid-transition
-                         :message (str "Invalid next index: " next-index)}))))))))
+                         :message (str "Invalid next index: " next-index)})
+                (update :execution/response-chain
+                        response/add-failure :pipeline
+                        :anomalies.workflow/invalid-transition
+                        {:error (str "Invalid next index: " next-index)
+                         :next-index next-index}))))))))
 
 (defn run-pipeline
   "Execute a workflow pipeline.
@@ -301,7 +337,11 @@
            (assoc :execution/status :failed)
            (update :execution/errors conj
                    {:type :empty-pipeline
-                    :message "Workflow has no phases"}))
+                    :message "Workflow has no phases"})
+           (update :execution/response-chain
+                   response/add-failure :pipeline
+                   :anomalies.workflow/empty-pipeline
+                   {:error "Workflow has no phases"}))
 
        ;; Execute pipeline loop
        (loop [ctx initial-ctx
@@ -318,6 +358,11 @@
                (update :execution/errors conj
                        {:type :max-phases-exceeded
                         :message (str "Exceeded maximum phase count: " max-phases)})
+               (update :execution/response-chain
+                       response/add-failure :pipeline
+                       :anomalies.workflow/max-phases
+                       {:error (str "Exceeded maximum phase count: " max-phases)
+                        :max-phases max-phases})
                (assoc :execution/ended-at (System/currentTimeMillis)))
 
            ;; Execute next phase

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -161,3 +161,28 @@
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (map? (:execution/metrics result)))
       (is (contains? (:execution/metrics result) :tokens)))))
+
+;; ============================================================================
+;; Response chain tests
+;; ============================================================================
+
+(deftest response-chain-created-test
+  (testing "response chain is initialized in context"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"}
+          ctx (runner/create-context workflow {:task "Test"} {})]
+      (is (contains? ctx :execution/response-chain))
+      (is (= :test (:operation (:execution/response-chain ctx))))
+      (is (true? (:succeeded? (:execution/response-chain ctx)))))))
+
+(deftest response-chain-records-phases-test
+  (testing "response chain records phase results"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :plan}
+                                        {:phase :done}]}
+          result (runner/run-pipeline workflow {:task "Test"} {})
+          chain (:execution/response-chain result)]
+      (is (= :completed (:execution/status result)))
+      (is (>= (count (:response-chain chain)) 2))
+      (is (true? (:succeeded? chain))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -1,0 +1,163 @@
+(ns ai.miniforge.workflow.runner-test
+  "Tests for the interceptor-based workflow runner."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.workflow.runner :as runner]
+   ;; Require phase implementations
+   [ai.miniforge.phase.plan]
+   [ai.miniforge.phase.implement]
+   [ai.miniforge.phase.verify]
+   [ai.miniforge.phase.review]
+   [ai.miniforge.phase.release]
+   ;; Require gate implementations
+   [ai.miniforge.gate.syntax]
+   [ai.miniforge.gate.lint]
+   [ai.miniforge.gate.test]
+   [ai.miniforge.gate.policy]))
+
+;; ============================================================================
+;; Context creation tests
+;; ============================================================================
+
+(deftest create-context-test
+  (testing "create-context initializes execution state"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"}
+          ctx (runner/create-context workflow {:task "Test"} {})]
+      (is (uuid? (:execution/id ctx)))
+      (is (= :test (:execution/workflow-id ctx)))
+      (is (= :running (:execution/status ctx)))
+      (is (= {:task "Test"} (:execution/input ctx)))
+      (is (vector? (:execution/artifacts ctx)))
+      (is (number? (:execution/started-at ctx))))))
+
+;; ============================================================================
+;; Pipeline building tests
+;; ============================================================================
+
+(deftest build-pipeline-simple-test
+  (testing "build-pipeline creates interceptors from config"
+    (let [workflow {:workflow/pipeline
+                    [{:phase :plan}
+                     {:phase :implement}
+                     {:phase :done}]}
+          pipeline (runner/build-pipeline workflow)]
+      (is (vector? pipeline))
+      (is (= 3 (count pipeline)))
+      (is (every? #(contains? % :enter) pipeline)))))
+
+(deftest build-pipeline-empty-test
+  (testing "build-pipeline handles empty pipeline"
+    (let [workflow {:workflow/pipeline []}
+          pipeline (runner/build-pipeline workflow)]
+      (is (empty? pipeline)))))
+
+(deftest build-pipeline-legacy-format-test
+  (testing "build-pipeline handles legacy phase format"
+    (let [workflow {:workflow/phases
+                    [{:phase/id :plan}
+                     {:phase/id :implement}
+                     {:phase/id :done}]}
+          pipeline (runner/build-pipeline workflow)]
+      (is (= 3 (count pipeline))))))
+
+;; ============================================================================
+;; Validation tests
+;; ============================================================================
+
+(deftest validate-pipeline-valid-test
+  (testing "validate-pipeline accepts valid workflow"
+    (let [workflow {:workflow/pipeline
+                    [{:phase :plan}
+                     {:phase :done}]}
+          result (runner/validate-pipeline workflow)]
+      (is (:valid? result)))))
+
+(deftest validate-pipeline-nil-test
+  (testing "validate-pipeline handles nil pipeline"
+    (let [workflow {}
+          result (runner/validate-pipeline workflow)]
+      (is (not (:valid? result))))))
+
+;; ============================================================================
+;; Pipeline execution tests
+;; ============================================================================
+
+(deftest run-pipeline-empty-test
+  (testing "run-pipeline fails for empty workflow"
+    (let [workflow {:workflow/pipeline []}
+          result (runner/run-pipeline workflow {} {})]
+      (is (= :failed (:execution/status result)))
+      (is (some #(= :empty-pipeline (:type %)) (:execution/errors result))))))
+
+(deftest run-pipeline-done-only-test
+  (testing "run-pipeline completes with just :done phase"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :done}]}
+          result (runner/run-pipeline workflow {:task "Test"} {})]
+      (is (= :completed (:execution/status result)))
+      (is (number? (:execution/ended-at result))))))
+
+(deftest run-pipeline-callbacks-test
+  (testing "run-pipeline invokes callbacks"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :done}]}
+          started (atom [])
+          completed (atom [])
+          result (runner/run-pipeline workflow {:task "Test"}
+                                       {:on-phase-start
+                                        (fn [ctx ic]
+                                          (swap! started conj
+                                                 (get-in ic [:config :phase])))
+                                        :on-phase-complete
+                                        (fn [ctx ic res]
+                                          (swap! completed conj
+                                                 (get-in ic [:config :phase])))})]
+      (is (= :completed (:execution/status result)))
+      (is (= [:done] @started))
+      (is (= [:done] @completed)))))
+
+(deftest run-pipeline-max-phases-test
+  (testing "run-pipeline respects max phases option"
+    ;; Since phase stubs succeed, they don't trigger :on-fail loops
+    ;; Just test that max-phases option is respected with a simple workflow
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline
+                    [{:phase :plan}
+                     {:phase :implement}
+                     {:phase :verify}
+                     {:phase :review}
+                     {:phase :release}
+                     {:phase :done}]}
+          ;; This should complete before max-phases=50
+          result (runner/run-pipeline workflow {:task "Test"} {:max-phases 50})]
+      ;; Should complete successfully (6 phases < 50)
+      (is (= :completed (:execution/status result))))))
+
+;; ============================================================================
+;; Phase result recording tests
+;; ============================================================================
+
+(deftest phase-results-recorded-test
+  (testing "phase results are recorded in execution context"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :done}]}
+          result (runner/run-pipeline workflow {:task "Test"} {})]
+      (is (contains? (:execution/phase-results result) :done)))))
+
+;; ============================================================================
+;; Metrics accumulation tests
+;; ============================================================================
+
+(deftest metrics-accumulated-test
+  (testing "metrics are accumulated across phases"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :done}]}
+          result (runner/run-pipeline workflow {:task "Test"} {})]
+      (is (map? (:execution/metrics result)))
+      (is (contains? (:execution/metrics result) :tokens)))))

--- a/deps.edn
+++ b/deps.edn
@@ -26,6 +26,7 @@
                        "components/policy/resources"
                        "components/heuristic/src"
                        "components/heuristic/resources"
+                       "components/response/src"
                        "components/phase/src"
                        "components/phase/resources"
                        "components/gate/src"
@@ -51,6 +52,7 @@
                       ai.miniforge/knowledge {:local/root "components/knowledge"}
                       ai.miniforge/policy {:local/root "components/policy"}
                       ai.miniforge/heuristic {:local/root "components/heuristic"}
+                      ai.miniforge/response {:local/root "components/response"}
                       ai.miniforge/phase {:local/root "components/phase"}
                       ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}
@@ -61,6 +63,7 @@
 
   :test {:extra-paths ["development/test"
                        "components/schema/test"
+                       "components/response/test"
                        "components/logging/test"
                        "components/llm/test"
                        "components/tool/test"
@@ -89,6 +92,7 @@
                       ai.miniforge/knowledge {:local/root "components/knowledge"}
                       ai.miniforge/policy {:local/root "components/policy"}
                       ai.miniforge/heuristic {:local/root "components/heuristic"}
+                      ai.miniforge/response {:local/root "components/response"}
                       ai.miniforge/phase {:local/root "components/phase"}
                       ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}

--- a/deps.edn
+++ b/deps.edn
@@ -26,6 +26,10 @@
                        "components/policy/resources"
                        "components/heuristic/src"
                        "components/heuristic/resources"
+                       "components/phase/src"
+                       "components/phase/resources"
+                       "components/gate/src"
+                       "components/gate/resources"
                        "components/workflow/src"
                        "components/workflow/resources"
                        "components/operator/src"
@@ -47,6 +51,8 @@
                       ai.miniforge/knowledge {:local/root "components/knowledge"}
                       ai.miniforge/policy {:local/root "components/policy"}
                       ai.miniforge/heuristic {:local/root "components/heuristic"}
+                      ai.miniforge/phase {:local/root "components/phase"}
+                      ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}
                       ai.miniforge/operator {:local/root "components/operator"}
                       ai.miniforge/observer {:local/root "components/observer"}
@@ -65,6 +71,8 @@
                        "components/knowledge/test"
                        "components/policy/test"
                        "components/heuristic/test"
+                       "components/phase/test"
+                       "components/gate/test"
                        "components/workflow/test"
                        "components/operator/test"
                        "components/observer/test"
@@ -81,6 +89,8 @@
                       ai.miniforge/knowledge {:local/root "components/knowledge"}
                       ai.miniforge/policy {:local/root "components/policy"}
                       ai.miniforge/heuristic {:local/root "components/heuristic"}
+                      ai.miniforge/phase {:local/root "components/phase"}
+                      ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}
                       ai.miniforge/operator {:local/root "components/operator"}
                       ai.miniforge/observer {:local/root "components/observer"}

--- a/docs/specs/workflow-interceptors.spec
+++ b/docs/specs/workflow-interceptors.spec
@@ -1,0 +1,420 @@
+# Workflow Interceptor Architecture — Specification
+
+**Version:** 0.1.0
+**Status:** Draft
+**Author:** Christopher Lester
+**Date:** 2026-01-22
+
+---
+
+## 1. Problem Statement
+
+### Current Complexity
+
+The miniforge workflow configuration suffers from:
+
+1. **Per-phase verbosity** — Each phase requires ~20 lines with deeply nested maps
+2. **Dual architecture** — Hard-coded phase executors (core.clj) vs flexible EDN configs (configurable.clj)
+3. **Switch statement factories** — 70+ lines of `case` statements for agent/gate creation
+4. **Unused fields** — `:phase/actions`, `:phase/metrics`, redundant `:phase/validation-steps`
+5. **Magic keywords** — `:repair-strategy :fix-errors` has no implementation mapping
+
+### Ixi Patterns to Adopt
+
+From the Ixi codebase:
+
+1. **Multimethod registry** — Interceptors registered via `defmethod`, not case switches
+2. **Composition via vectors** — Routes compose interceptors as `[auth validate handler]`
+3. **Integrant/EDN config** — Configuration declares what, code provides how
+4. **Separation of bricks** — `interceptors-*` component separate from `routes-*` component
+5. **Layered structure** — Strata 0 (primitives) → Strata 1 (interceptor defs)
+
+---
+
+## 2. Core Principles
+
+### 2.1 Workflows Are Interceptor Chains
+
+A workflow is a vector of interceptors. Each phase is an interceptor with `:enter` and `:leave` functions.
+
+```clojure
+;; Pedestal-style interceptor
+{:name ::implement
+ :enter (fn [ctx] (run-implementation ctx))
+ :leave (fn [ctx] (collect-metrics ctx))
+ :error (fn [ctx ex] (handle-repair ctx ex))}
+```
+
+### 2.2 Registry Over Switch
+
+Register phase handlers via multimethod, not case statements:
+
+```clojure
+;; Define once in each domain module
+(defmethod get-phase-interceptor :plan [opts]
+  (create-interceptor {:agent :planner ...}))
+
+(defmethod get-phase-interceptor :implement [opts]
+  (create-interceptor {:agent :implementer ...}))
+```
+
+### 2.3 Configuration Is Data, Behavior Is Code
+
+Configuration says **what** runs. Code in registries defines **how**.
+
+```clojure
+;; BAD: Config defines behavior
+{:phase/repair-strategy :fix-errors}  ; Magic keyword
+
+;; GOOD: Config declares intent, registry provides behavior
+{:phase :implement :gates [:syntax :lint]}
+;; Registry knows: :syntax → syntax-gate implementation
+```
+
+### 2.4 Composition Over Configuration
+
+Instead of configuring every detail, compose from defaults:
+
+```clojure
+;; BAD: 20 lines per phase
+{:phase/id :implement
+ :phase/name "Implementation"
+ :phase/agent :implementer
+ :phase/inner-loop {:max-iterations 3 ...}
+ :phase/gates [...]
+ :phase/budget {...}
+ ...}
+
+;; GOOD: Compose from registry defaults
+{:phase :implement}  ; Registry provides defaults
+;; Or override specific things:
+{:phase :implement :budget {:tokens 50000}}
+```
+
+---
+
+## 3. Architecture
+
+### 3.1 Component Structure (Polylith)
+
+```
+components/
+├── workflow/           ; Orchestration
+│   ├── interface.clj   ; Public API
+│   ├── runner.clj      ; Pipeline executor
+│   └── state.clj       ; Execution state
+│
+├── phase/              ; Phase definitions (NEW)
+│   ├── interface.clj   ; Registry multimethod
+│   ├── plan.clj        ; :plan phase
+│   ├── implement.clj   ; :implement phase
+│   ├── verify.clj      ; :verify phase
+│   ├── review.clj      ; :review phase
+│   └── release.clj     ; :release phase
+│
+├── gate/               ; Gate definitions (NEW)
+│   ├── interface.clj   ; Registry multimethod
+│   ├── syntax.clj      ; :syntax gate
+│   ├── lint.clj        ; :lint gate
+│   ├── test.clj        ; :tests gate
+│   └── policy.clj      ; Policy gates
+│
+└── loop/               ; Inner loop (existing)
+    ├── interface.clj
+    └── inner.clj
+```
+
+### 3.2 Registry Pattern
+
+**Phase Registry** (`phase/interface.clj`):
+
+```clojure
+(ns ai.miniforge.phase.interface)
+
+;; Multimethod dispatches on :phase keyword
+(defmulti get-phase-interceptor
+  "Get interceptor for a phase configuration."
+  :phase)
+
+;; Default implementation throws
+(defmethod get-phase-interceptor :default [{:keys [phase]}]
+  (throw (ex-info (str "Unknown phase: " phase) {:phase phase})))
+```
+
+**Phase Implementation** (`phase/implement.clj`):
+
+```clojure
+(ns ai.miniforge.phase.implement
+  (:require [ai.miniforge.phase.interface :refer [get-phase-interceptor]]
+            [ai.miniforge.agent.interface :as agent]
+            [ai.miniforge.loop.interface :as loop]))
+
+;; Layer 0: Pure defaults
+(def default-config
+  {:agent :implementer
+   :gates [:syntax :lint]
+   :budget {:tokens 30000 :iterations 5}})
+
+;; Layer 1: Interceptor factory
+(defmethod get-phase-interceptor :implement
+  [config]
+  (let [merged (merge default-config config)]
+    {:name ::implement
+     :enter (fn [ctx] (run-phase ctx merged))
+     :leave (fn [ctx] (record-metrics ctx))
+     :error (fn [ctx ex] (attempt-repair ctx ex merged))}))
+```
+
+**Gate Registry** (`gate/interface.clj`):
+
+```clojure
+(ns ai.miniforge.gate.interface)
+
+(defmulti get-gate
+  "Get gate implementation for keyword."
+  identity)
+
+(defmethod get-gate :default [k]
+  ;; Unknown gates pass through (warn in dev)
+  {:name k
+   :check (constantly true)
+   :repair nil})
+```
+
+**Gate Implementation** (`gate/syntax.clj`):
+
+```clojure
+(ns ai.miniforge.gate.syntax
+  (:require [ai.miniforge.gate.interface :refer [get-gate]]))
+
+(defmethod get-gate :syntax [_]
+  {:name :syntax
+   :check (fn [artifact ctx]
+            (syntax/valid? (:content artifact)))
+   :repair (fn [artifact errors ctx]
+             (syntax/fix (:content artifact) errors))})
+```
+
+### 3.3 Workflow Configuration (Simplified EDN)
+
+**Before** (80 lines for simple workflow):
+
+```clojure
+{:workflow/id :simple-test-v1
+ :workflow/version "1.0.0"
+ :workflow/phases
+ [{:phase/id :plan
+   :phase/name "Planning"
+   :phase/agent :planner
+   :phase/actions [:create-plan]
+   :phase/inner-loop
+   {:max-iterations 2
+    :validation-steps [:plan-complete]
+    :repair-strategy :adjust-plan}
+   :phase/gates [:plan-complete]
+   :phase/budget {:tokens 3000 :time-seconds 60 :iterations 2}
+   :phase/next [{:target :implement}]
+   :phase/metrics [:planning-time]}
+  ;; ... 40 more lines
+  ]}
+```
+
+**After** (15 lines):
+
+```clojure
+{:workflow/id :simple-test
+ :workflow/version "1.0.0"
+
+ ;; Pipeline: vector of phase configs
+ :workflow/pipeline
+ [{:phase :plan}                           ; Uses registry defaults
+  {:phase :implement :budget {:tokens 50000}}  ; Override budget
+  {:phase :verify :on-fail :implement}     ; Explicit retry transition
+  {:phase :done}]}
+```
+
+### 3.4 Pipeline Runner
+
+```clojure
+(ns ai.miniforge.workflow.runner
+  (:require [ai.miniforge.phase.interface :as phase]
+            [ai.miniforge.gate.interface :as gate]))
+
+;; Layer 0: Build interceptor chain from config
+(defn build-pipeline [workflow-config]
+  (->> (:workflow/pipeline workflow-config)
+       (mapv phase/get-phase-interceptor)))
+
+;; Layer 1: Execute pipeline (Pedestal-style)
+(defn execute [pipeline initial-ctx]
+  (reduce
+    (fn [ctx interceptor]
+      (try
+        ((:enter interceptor) ctx)
+        (catch Exception ex
+          (if-let [error-fn (:error interceptor)]
+            (error-fn ctx ex)
+            (throw ex)))))
+    initial-ctx
+    pipeline))
+```
+
+---
+
+## 4. Configuration Schema
+
+### 4.1 Workflow Schema (Minimal)
+
+```clojure
+(def Workflow
+  [:map
+   [:workflow/id keyword?]
+   [:workflow/version string?]
+   [:workflow/pipeline [:vector PhaseConfig]]])
+
+(def PhaseConfig
+  [:map
+   [:phase keyword?]                        ; Required: phase type
+   [:budget {:optional true} Budget]        ; Optional override
+   [:gates {:optional true} [:vector keyword?]]  ; Optional override
+   [:on-fail {:optional true} keyword?]     ; Transition on failure
+   [:on-success {:optional true} keyword?]]) ; Transition on success (default: next)
+
+(def Budget
+  [:map
+   [:tokens {:optional true} pos-int?]
+   [:iterations {:optional true} pos-int?]
+   [:time-seconds {:optional true} pos-int?]])
+```
+
+### 4.2 Interceptor Schema
+
+```clojure
+(def Interceptor
+  [:map
+   [:name keyword?]
+   [:enter {:optional true} fn?]
+   [:leave {:optional true} fn?]
+   [:error {:optional true} fn?]])
+
+(def Gate
+  [:map
+   [:name keyword?]
+   [:check fn?]                ; (fn [artifact ctx] -> bool)
+   [:repair {:optional true} fn?]])  ; (fn [artifact errors ctx] -> artifact)
+```
+
+---
+
+## 5. Execution Flow
+
+### 5.1 Phase Execution
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                     PHASE INTERCEPTOR                           │
+├─────────────────────────────────────────────────────────────────┤
+│  :enter                                                         │
+│  ├── 1. Resolve agent from registry                            │
+│  ├── 2. Resolve gates from registry                            │
+│  ├── 3. Run inner loop (generate → validate → repair)          │
+│  └── 4. Return ctx with :artifact                              │
+│                                                                 │
+│  :leave                                                         │
+│  └── Record metrics, update execution state                    │
+│                                                                 │
+│  :error                                                         │
+│  ├── If retryable: attempt repair via inner loop               │
+│  ├── If :on-fail specified: transition to that phase           │
+│  └── Else: propagate error                                      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### 5.2 Inner Loop (Unchanged)
+
+The existing inner loop remains: `generate → validate → repair`
+
+But gates are now resolved from registry, not created via switch statement.
+
+---
+
+## 6. Migration Path
+
+### Phase 1: Create Registries
+
+1. Create `phase/` component with multimethod registry
+2. Create `gate/` component with multimethod registry
+3. Move existing agent/gate creation to registry methods
+
+### Phase 2: Simplify Configuration
+
+1. Define minimal workflow schema
+2. Add defaults to phase registry entries
+3. Update loader to handle simplified config
+
+### Phase 3: Remove Legacy
+
+1. Remove `agent_factory.clj` switch statements
+2. Remove unused fields from schema
+3. Update existing workflow EDN files
+
+---
+
+## 7. Benefits
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Config lines per phase | ~20 | ~1-3 |
+| Adding new phase type | Modify agent_factory.clj | Add new file, register method |
+| Adding new gate type | Modify agent_factory.clj | Add new file, register method |
+| Understanding phase behavior | Read factory + agent + config | Read single phase module |
+| Defaults | Scattered/duplicated | Centralized in registry |
+| Validation | Optional, incomplete | Schema enforced |
+
+---
+
+## 8. Example: Full Workflow
+
+```clojure
+;; resources/workflows/standard-sdlc.edn
+{:workflow/id :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :workflow/pipeline
+ [{:phase :spec}
+  {:phase :plan}
+  {:phase :implement
+   :budget {:tokens 50000}
+   :gates [:syntax :lint :no-secrets]}
+  {:phase :verify
+   :on-fail :implement}
+  {:phase :review
+   :on-fail :implement}
+  {:phase :release}
+  {:phase :done}]
+
+ ;; Optional: global config
+ :workflow/config
+ {:max-tokens 100000
+  :max-iterations 50}}
+```
+
+Compare to current 145-line canonical-sdlc-v1.edn — this is **~20 lines** with equivalent power.
+
+---
+
+## 9. Open Questions
+
+1. **Integrant for lifecycle?** — Ixi uses Integrant for DI. Worth adopting for miniforge?
+2. **Parallel phases?** — Current config supports `:parallel-phases`. Keep or simplify?
+3. **Metrics collection** — Currently per-phase. Move to interceptor `:leave`?
+4. **Response chain pattern** — Ixi tracks operation history. Useful for debugging?
+
+---
+
+## 10. References
+
+- [Pedestal Interceptors](http://pedestal.io/reference/interceptors)
+- [Ixi interceptors-spicybrain](../../../ixi/components/interceptors-spicybrain/)
+- [Current workflow config](../../../components/workflow/resources/workflows/)
+- [miniforge.spec](./miniforge.spec) — Main product specification


### PR DESCRIPTION
## Summary

- Implements Pedestal-style interceptor pattern for workflow configuration
- Replaces verbose per-phase configuration with registry-driven defaults
- New `phase` component with multimethod registry for phase interceptors
- New `gate` component with multimethod registry for validation gates
- New pipeline runner with :enter/:leave/:error interceptor execution

## Key Features

**Registry over switch:** Replace case statements with multimethods
```clojure
(defmethod get-phase-interceptor :plan [cfg]
  {:name ::plan :enter ... :leave ... :error ...})
```

**Simplified workflow config:** ~20 lines vs ~145 lines
```clojure
{:workflow/pipeline
 [{:phase :plan}
  {:phase :implement :budget {:tokens 50000}}
  {:phase :verify :on-fail :implement}
  {:phase :done}]}
```

**Composable defaults:** Override only what differs from registry defaults

## Components Added

| Component | Purpose |
|-----------|---------|
| `phase/` | Phase interceptor registry (:plan, :implement, :verify, :review, :release, :done) |
| `gate/` | Gate validation registry (:syntax, :lint, :tests-pass, :coverage, :no-secrets, etc.) |
| `workflow/runner.clj` | Pipeline execution engine |

## Test plan

- [x] 42 tests, 90 assertions passing
- [x] clj-kondo linting (warnings only, no errors)
- [x] Full project compilation successful
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)