### PR TITLE
feat(fsm): add FSM component with clj-statecharts wrapper

### DIFF
--- a/components/fsm/deps.edn
+++ b/components/fsm/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src" "resources"]
+ :deps {clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {}}}}

--- a/components/fsm/src/ai/miniforge/fsm/core.clj
+++ b/components/fsm/src/ai/miniforge/fsm/core.clj
@@ -1,0 +1,301 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.fsm.core
+  "Core FSM implementation wrapping clj-statecharts.
+
+   Provides a thin wrapper around clj-statecharts with miniforge conventions:
+   - Data-driven machine definitions
+   - Integration with response chains for action results
+   - Guards that can inspect execution context
+
+   Machine definition format:
+   {:fsm/id       :workflow
+    :fsm/initial  :idle
+    :fsm/context  {}
+    :fsm/states
+    {:idle     {:on {:start :running}}
+     :running  {:on {:complete :completed
+                     :fail     :failed}}
+     :completed {:type :final}
+     :failed    {:type :final}}}"
+  (:require
+   [statecharts.core :as sc]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Internal helpers
+
+(defn- compile-transitions
+  "Compile transition definitions.
+
+   Supports shorthand and full forms:
+   - :event :target           -> simple transition
+   - :event {:target :state}  -> full form
+   - :event {:target :state :guard fn :actions [...]} -> with guard/actions"
+  [transitions]
+  (reduce-kv
+   (fn [acc event target-or-config]
+     (assoc acc event
+            (if (keyword? target-or-config)
+              {:target target-or-config}
+              target-or-config)))
+   {}
+   transitions))
+
+(defn- compile-state
+  "Compile a state definition to clj-statecharts format.
+
+   Supports:
+   - :on - Event/transition map
+   - :entry - Entry actions
+   - :exit - Exit actions
+   - :type - :final for terminal states (tracked separately, not passed to clj-statecharts)"
+  [state-def]
+  (let [{:keys [on entry exit]} state-def]
+    ;; Note: :type :final is handled separately - clj-statecharts doesn't support it
+    (cond-> {}
+      on    (assoc :on (compile-transitions on))
+      entry (assoc :entry entry)
+      exit  (assoc :exit exit))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Machine definition
+
+(defn- extract-final-states
+  "Extract the set of states marked as :type :final."
+  [states]
+  (into #{}
+        (comp (filter (fn [[_ v]] (= :final (:type v))))
+              (map first))
+        states))
+
+(defn define-machine
+  "Create a state machine definition from miniforge config.
+
+   Arguments:
+     config - Machine configuration map with:
+       :fsm/id       - Machine identifier
+       :fsm/initial  - Initial state keyword
+       :fsm/context  - Initial context data
+       :fsm/states   - State definitions map
+
+   Returns:
+     Compiled state machine definition with :miniforge/final-states metadata."
+  [{:fsm/keys [id initial context states]}]
+  (let [final-states (extract-final-states states)
+        machine (sc/machine
+                 {:id      id
+                  :initial initial
+                  :context (or context {})
+                  :states  (reduce-kv
+                            (fn [acc state-id state-def]
+                              (assoc acc state-id (compile-state state-def)))
+                            {}
+                            states)})]
+    ;; Attach final states as metadata
+    (assoc machine :miniforge/final-states final-states)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; State operations
+
+(defn initialize
+  "Initialize a state machine, returning the initial state.
+
+   Arguments:
+     machine - Compiled machine definition
+
+   Returns:
+     Initial state map with :_state and context."
+  [machine]
+  (sc/initialize machine))
+
+(defn transition
+  "Transition the machine given an event.
+
+   Arguments:
+     machine - Compiled machine definition
+     state   - Current state
+     event   - Event keyword or {:type :event-type :data ...}
+
+   Returns:
+     New state after transition (or same state if no valid transition)."
+  [machine state event]
+  (let [event-map (if (keyword? event)
+                    {:type event}
+                    event)]
+    (try
+      (sc/transition machine state event-map)
+      (catch clojure.lang.ExceptionInfo e
+        ;; If it's an unknown event error, return current state unchanged
+        (if (re-find #"got unknown event" (ex-message e))
+          state
+          (throw e))))))
+
+(defn current-state
+  "Get the current state value from a state map.
+
+   Arguments:
+     state - State map from initialize or transition
+
+   Returns:
+     Current state keyword."
+  [state]
+  (:_state state))
+
+(defn context
+  "Get the context from a state map.
+
+   Arguments:
+     state - State map
+
+   Returns:
+     Context map (everything except internal state keys)."
+  [state]
+  (dissoc state :_state))
+
+(defn in-state?
+  "Check if the machine is in a specific state.
+
+   Arguments:
+     state    - State map
+     state-id - State keyword to check
+
+   Returns:
+     Boolean."
+  [state state-id]
+  (= state-id (current-state state)))
+
+(defn final?
+  "Check if the current state is a final state.
+
+   Arguments:
+     machine - Compiled machine definition
+     state   - Current state map
+
+   Returns:
+     Boolean."
+  [machine state]
+  (let [current (current-state state)
+        final-states (:miniforge/final-states machine #{})]
+    (contains? final-states current)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Context manipulation
+
+(defn assign
+  "Create an action that assigns values to context.
+
+   Arguments:
+     assignments - Map of context keys to values or functions
+                   Functions receive (context, event) and return new value
+
+   Returns:
+     Action function for use in :entry/:exit/:actions."
+  [assignments]
+  (fn [state event]
+    (reduce-kv
+     (fn [s k v]
+       (assoc s k (if (fn? v)
+                    (v (context s) event)
+                    v)))
+     state
+     assignments)))
+
+(defn update-context
+  "Update context in a state map.
+
+   Arguments:
+     state - Current state map
+     f     - Function to apply to context
+     args  - Additional args to f
+
+   Returns:
+     Updated state map."
+  [state f & args]
+  (let [ctx (context state)
+        new-ctx (apply f ctx args)]
+    (merge state new-ctx)))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Guard helpers
+
+(defn guard
+  "Create a guard function from a predicate.
+
+   Arguments:
+     pred - Predicate fn (context, event) -> boolean
+
+   Returns:
+     Guard function for use in transitions."
+  [pred]
+  (fn [state event]
+    (pred (context state) event)))
+
+(defn all-guards
+  "Combine multiple guards with AND logic.
+
+   Arguments:
+     guards - Sequence of guard functions
+
+   Returns:
+     Combined guard that passes only if all pass."
+  [& guards]
+  (fn [state event]
+    (every? #(% state event) guards)))
+
+(defn any-guard
+  "Combine multiple guards with OR logic.
+
+   Arguments:
+     guards - Sequence of guard functions
+
+   Returns:
+     Combined guard that passes if any pass."
+  [& guards]
+  (fn [state event]
+    (some #(% state event) guards)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Define a simple workflow machine
+  (def workflow-machine
+    (define-machine
+     {:fsm/id :workflow
+      :fsm/initial :idle
+      :fsm/context {:phase-index 0}
+      :fsm/states
+      {:idle      {:on {:start :running}}
+       :running   {:on {:phase-complete {:target :running
+                                         :actions [(assign {:phase-index inc})]}
+                        :complete :completed
+                        :fail :failed}}
+       :completed {:type :final}
+       :failed    {:type :final}}}))
+
+  ;; Use the machine
+  (def s0 (initialize workflow-machine))
+  (current-state s0) ;; => :idle
+
+  (def s1 (transition workflow-machine s0 :start))
+  (current-state s1) ;; => :running
+
+  (def s2 (transition workflow-machine s1 :phase-complete))
+  (current-state s2) ;; => :running
+  (context s2)       ;; => {:phase-index 1}
+
+  (def s3 (transition workflow-machine s2 :complete))
+  (current-state s3)                    ;; => :completed
+  (final? workflow-machine s3)          ;; => true
+
+  :leave-this-here)

--- a/components/fsm/src/ai/miniforge/fsm/interface.clj
+++ b/components/fsm/src/ai/miniforge/fsm/interface.clj
@@ -1,0 +1,165 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.fsm.interface
+  "Finite State Machine public interface.
+
+   Provides declarative state machine definitions for workflows, phases,
+   and other stateful processes in miniforge.
+
+   Example usage:
+     (def machine (define-machine workflow-config))
+     (def state (initialize machine))
+     (def state' (transition machine state :event))
+     (current-state state') ;; => :new-state"
+  (:require
+   [ai.miniforge.fsm.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Machine definition
+
+(def define-machine
+  "Create a state machine definition from config.
+
+   Config format:
+   {:fsm/id       :machine-name
+    :fsm/initial  :initial-state
+    :fsm/context  {:key value}  ; optional initial context
+    :fsm/states
+    {:state-a {:on {:event-1 :state-b
+                    :event-2 {:target :state-c
+                              :guard guard-fn
+                              :actions [action-fn]}}}
+     :state-b {:entry entry-action
+               :exit exit-action
+               :on {...}}
+     :state-c {:type :final}}}
+
+   Returns compiled machine definition."
+  core/define-machine)
+
+;------------------------------------------------------------------------------ Layer 1
+;; State operations
+
+(def initialize
+  "Initialize a machine, returning the initial state.
+
+   Example:
+     (def state (initialize machine))"
+  core/initialize)
+
+(def transition
+  "Transition given an event.
+
+   Arguments:
+     machine - Compiled machine
+     state   - Current state
+     event   - Event keyword or {:type :event :data ...}
+
+   Example:
+     (transition machine state :complete)
+     (transition machine state {:type :fail :data {:error \"timeout\"}})"
+  core/transition)
+
+(def current-state
+  "Get current state keyword from state map.
+
+   Example:
+     (current-state state) ;; => :running"
+  core/current-state)
+
+(def context
+  "Get context data from state map.
+
+   Example:
+     (context state) ;; => {:phase-index 2}"
+  core/context)
+
+(def in-state?
+  "Check if machine is in a specific state.
+
+   Example:
+     (in-state? state :running) ;; => true"
+  core/in-state?)
+
+(def final?
+  "Check if current state is a final state.
+
+   Example:
+     (final? machine state) ;; => false"
+  core/final?)
+
+;------------------------------------------------------------------------------ Layer 2
+;; Context manipulation
+
+(def assign
+  "Create action that assigns values to context.
+
+   Values can be constants or functions (context, event) -> value.
+
+   Example:
+     (assign {:count inc
+              :last-event (fn [ctx event] (:type event))})"
+  core/assign)
+
+(def update-context
+  "Update context with a function.
+
+   Example:
+     (update-context state assoc :key value)"
+  core/update-context)
+
+;------------------------------------------------------------------------------ Layer 3
+;; Guard helpers
+
+(def guard
+  "Create a guard from predicate (context, event) -> boolean.
+
+   Example:
+     (guard (fn [ctx event] (< (:attempts ctx) 3)))"
+  core/guard)
+
+(def all-guards
+  "Combine guards with AND logic.
+
+   Example:
+     (all-guards has-budget? has-permission?)"
+  core/all-guards)
+
+(def any-guard
+  "Combine guards with OR logic.
+
+   Example:
+     (any-guard is-admin? is-owner?)"
+  core/any-guard)
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Simple traffic light example
+  (def traffic-light
+    (define-machine
+     {:fsm/id :traffic-light
+      :fsm/initial :red
+      :fsm/states
+      {:red    {:on {:timer :green}}
+       :green  {:on {:timer :yellow}}
+       :yellow {:on {:timer :red}}}}))
+
+  (def s (initialize traffic-light))
+  (current-state s) ;; => :red
+
+  (def s' (transition traffic-light s :timer))
+  (current-state s') ;; => :green
+
+  :leave-this-here)

--- a/components/fsm/test/ai/miniforge/fsm/interface_test.clj
+++ b/components/fsm/test/ai/miniforge/fsm/interface_test.clj
@@ -1,0 +1,202 @@
+(ns ai.miniforge.fsm.interface-test
+  "Tests for the FSM component."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.fsm.interface :as fsm]))
+
+;; ============================================================================
+;; Machine definition tests
+;; ============================================================================
+
+(deftest define-machine-basic-test
+  (testing "define-machine creates a machine from config"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :idle
+                    :fsm/states
+                    {:idle {:on {:start :running}}
+                     :running {:on {:stop :idle}}}})]
+      (is (some? machine))
+      (is (= :test (:id machine))))))
+
+(deftest define-machine-with-context-test
+  (testing "define-machine includes initial context"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :idle
+                    :fsm/context {:counter 0}
+                    :fsm/states
+                    {:idle {:on {:start :running}}
+                     :running {:type :final}}})]
+      (is (= {:counter 0} (:context machine))))))
+
+;; ============================================================================
+;; Initialize tests
+;; ============================================================================
+
+(deftest initialize-test
+  (testing "initialize returns initial state"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :idle
+                    :fsm/context {:x 1}
+                    :fsm/states {:idle {:on {:go :done}}
+                                 :done {:type :final}}})
+          state (fsm/initialize machine)]
+      (is (= :idle (fsm/current-state state)))
+      (is (= 1 (:x (fsm/context state)))))))
+
+;; ============================================================================
+;; Transition tests
+;; ============================================================================
+
+(deftest transition-basic-test
+  (testing "transition moves to target state"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :a
+                    :fsm/states {:a {:on {:next :b}}
+                                 :b {:on {:next :c}}
+                                 :c {:type :final}}})
+          s0 (fsm/initialize machine)
+          s1 (fsm/transition machine s0 :next)
+          s2 (fsm/transition machine s1 :next)]
+      (is (= :a (fsm/current-state s0)))
+      (is (= :b (fsm/current-state s1)))
+      (is (= :c (fsm/current-state s2))))))
+
+(deftest transition-no-match-test
+  (testing "transition stays in state when no matching event"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :idle
+                    :fsm/states {:idle {:on {:start :running}}
+                                 :running {:type :final}}})
+          s0 (fsm/initialize machine)
+          s1 (fsm/transition machine s0 :unknown-event)]
+      (is (= :idle (fsm/current-state s1))))))
+
+(deftest transition-with-event-data-test
+  (testing "transition accepts event with data"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :idle
+                    :fsm/states {:idle {:on {:go :done}}
+                                 :done {:type :final}}})
+          s0 (fsm/initialize machine)
+          s1 (fsm/transition machine s0 {:type :go :data {:reason "test"}})]
+      (is (= :done (fsm/current-state s1))))))
+
+;; ============================================================================
+;; State query tests
+;; ============================================================================
+
+(deftest in-state?-test
+  (testing "in-state? checks current state"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :idle
+                    :fsm/states {:idle {:on {:start :running}}
+                                 :running {:type :final}}})
+          state (fsm/initialize machine)]
+      (is (fsm/in-state? state :idle))
+      (is (not (fsm/in-state? state :running))))))
+
+(deftest final?-test
+  (testing "final? detects final states"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :working
+                    :fsm/states {:working {:on {:done :finished}}
+                                 :finished {:type :final}}})
+          s0 (fsm/initialize machine)
+          s1 (fsm/transition machine s0 :done)]
+      (is (not (fsm/final? machine s0)))
+      (is (fsm/final? machine s1)))))
+
+;; ============================================================================
+;; Context tests
+;; ============================================================================
+
+(deftest context-test
+  (testing "context returns context without internal state"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :idle
+                    :fsm/context {:a 1 :b 2}
+                    :fsm/states {:idle {:type :final}}})
+          state (fsm/initialize machine)
+          ctx (fsm/context state)]
+      (is (= 1 (:a ctx)))
+      (is (= 2 (:b ctx)))
+      (is (not (contains? ctx :_state))))))
+
+(deftest update-context-test
+  (testing "update-context applies function to context"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :test
+                    :fsm/initial :idle
+                    :fsm/context {:count 0}
+                    :fsm/states {:idle {:type :final}}})
+          s0 (fsm/initialize machine)
+          s1 (fsm/update-context s0 update :count inc)]
+      (is (= 0 (:count (fsm/context s0))))
+      (is (= 1 (:count (fsm/context s1)))))))
+
+;; ============================================================================
+;; Guard tests
+;; ============================================================================
+
+(deftest guard-test
+  (testing "guard creates predicate function"
+    (let [g (fsm/guard (fn [ctx _event] (< (:attempts ctx) 3)))]
+      (is (g {:attempts 0 :_state :x} {}))
+      (is (g {:attempts 2 :_state :x} {}))
+      (is (not (g {:attempts 3 :_state :x} {}))))))
+
+(deftest all-guards-test
+  (testing "all-guards combines with AND"
+    (let [g1 (fsm/guard (fn [ctx _] (:a ctx)))
+          g2 (fsm/guard (fn [ctx _] (:b ctx)))
+          combined (fsm/all-guards g1 g2)]
+      (is (combined {:a true :b true :_state :x} {}))
+      (is (not (combined {:a true :b false :_state :x} {})))
+      (is (not (combined {:a false :b true :_state :x} {}))))))
+
+(deftest any-guard-test
+  (testing "any-guard combines with OR"
+    (let [g1 (fsm/guard (fn [ctx _] (:a ctx)))
+          g2 (fsm/guard (fn [ctx _] (:b ctx)))
+          combined (fsm/any-guard g1 g2)]
+      (is (combined {:a true :b true :_state :x} {}))
+      (is (combined {:a true :b false :_state :x} {}))
+      (is (combined {:a false :b true :_state :x} {}))
+      (is (not (combined {:a false :b false :_state :x} {}))))))
+
+;; ============================================================================
+;; Workflow FSM example test
+;; ============================================================================
+
+(deftest workflow-fsm-test
+  (testing "workflow FSM handles typical workflow transitions"
+    (let [machine (fsm/define-machine
+                   {:fsm/id :workflow
+                    :fsm/initial :idle
+                    :fsm/context {:phase-index 0
+                                  :phases [:plan :implement :verify]}
+                    :fsm/states
+                    {:idle      {:on {:start :running}}
+                     :running   {:on {:phase-complete :running
+                                      :workflow-complete :completed
+                                      :fail :failed}}
+                     :completed {:type :final}
+                     :failed    {:type :final}}})
+          s0 (fsm/initialize machine)
+          s1 (fsm/transition machine s0 :start)
+          s2 (fsm/transition machine s1 :phase-complete)
+          s3 (fsm/transition machine s2 :workflow-complete)]
+      (is (= :idle (fsm/current-state s0)))
+      (is (= :running (fsm/current-state s1)))
+      (is (= :running (fsm/current-state s2)))
+      (is (= :completed (fsm/current-state s3)))
+      (is (fsm/final? machine s3)))))

--- a/components/response/src/ai/miniforge/response/chain.clj
+++ b/components/response/src/ai/miniforge/response/chain.clj
@@ -168,6 +168,28 @@
   [chain]
   (filterv (complement :succeeded?) (:response-chain chain)))
 
+(defn errors
+  "Get errors from the chain in a flat format.
+
+   Returns a vector of error maps with:
+   - :type - The operation name as a keyword prefixed with 'error-'
+   - :operation - The original operation name
+   - :anomaly - The anomaly code
+   - :message - Error message from response
+   - :data - Additional error data from response
+
+   This provides a migration path from :execution/errors to response chains."
+  [chain]
+  (->> (all-failures chain)
+       (mapv (fn [{:keys [operation anomaly response]}]
+               {:type (keyword (str "error-" (name operation)))
+                :operation operation
+                :anomaly anomaly
+                :message (or (:error response)
+                             (:message response)
+                             (str "Operation " operation " failed"))
+                :data (dissoc response :error :message)}))))
+
 (defn operations
   "Get the sequence of operation names in order."
   [chain]

--- a/components/response/src/ai/miniforge/response/interface.clj
+++ b/components/response/src/ai/miniforge/response/interface.clj
@@ -142,6 +142,27 @@
   "Get all failed entries in the chain."
   chain/all-failures)
 
+(def errors
+  "Get errors from the chain in a flat format.
+
+   Returns a vector of error maps with:
+   - :type - The operation name as a keyword prefixed with 'error-'
+   - :operation - The original operation name
+   - :anomaly - The anomaly code
+   - :message - Error message from response
+   - :data - Additional error data from response
+
+   This provides a migration path from :execution/errors to response chains.
+
+   Example:
+     (errors chain)
+     ;; => [{:type :error-verify
+     ;;      :operation :verify
+     ;;      :anomaly :anomalies.gate/validation-failed
+     ;;      :message \"test failed\"
+     ;;      :data {:errors [...]}}]"
+  chain/errors)
+
 (def operations
   "Get the sequence of operation names in order.
 

--- a/components/response/test/ai/miniforge/response/interface_test.clj
+++ b/components/response/test/ai/miniforge/response/interface_test.clj
@@ -230,3 +230,32 @@
 
   (testing "returns nil for unknown"
     (is (nil? (r/anomaly-category :not-an-anomaly)))))
+
+;; ============================================================================
+;; Errors extraction tests
+;; ============================================================================
+
+(deftest errors-test
+  (testing "extracts errors in flat format"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :plan {})
+                    (r/add-failure :verify :anomalies.gate/validation-failed
+                                   {:error "test failed" :errors ["error1" "error2"]})
+                    (r/add-failure :impl :anomalies.phase/agent-failed
+                                   {:message "timeout occurred"}))
+          errors (r/errors chain)]
+      (is (= 2 (count errors)))
+      ;; First error
+      (is (= :error-verify (:type (first errors))))
+      (is (= :verify (:operation (first errors))))
+      (is (= :anomalies.gate/validation-failed (:anomaly (first errors))))
+      (is (= "test failed" (:message (first errors))))
+      (is (= {:errors ["error1" "error2"]} (:data (first errors))))
+      ;; Second error
+      (is (= :error-impl (:type (second errors))))
+      (is (= "timeout occurred" (:message (second errors))))))
+
+  (testing "returns empty vector when no failures"
+    (let [chain (-> (r/create :test)
+                    (r/add-success :step-1 {}))]
+      (is (= [] (r/errors chain))))))

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -2,6 +2,7 @@
  :deps {ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/response {:local/root "../response"}  ; Response chains
+        ai.miniforge/fsm {:local/root "../fsm"}            ; State machines
         ai.miniforge/agent {:local/root "../agent"}
         ai.miniforge/task {:local/root "../task"}
         ai.miniforge/loop {:local/root "../loop"}

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -15,20 +15,59 @@
 (ns ai.miniforge.workflow.fsm
   "Finite State Machine for workflow execution.
 
-   Defines explicit states, valid transitions, and guards for workflow execution.")
+   Uses the fsm component (clj-statecharts wrapper) for state machine implementation.
+   Defines explicit states, valid transitions, and guards for workflow execution.
+
+   States:
+   - :pending   - Initial state, workflow not started
+   - :running   - Workflow is executing
+   - :completed - Workflow completed successfully
+   - :failed    - Workflow failed
+   - :paused    - Workflow execution paused
+   - :cancelled - Workflow cancelled by user
+
+   Events:
+   - :start   - Begin workflow execution
+   - :complete - Mark workflow as completed
+   - :fail    - Mark workflow as failed
+   - :pause   - Pause execution
+   - :resume  - Resume paused execution
+   - :cancel  - Cancel workflow"
+  (:require
+   [ai.miniforge.fsm.interface :as fsm]))
 
 ;; ============================================================================
-;; FSM Definition
+;; FSM Definition using clj-statecharts
+;; ============================================================================
+
+(def workflow-machine-config
+  "Workflow execution state machine configuration."
+  {:fsm/id :workflow-execution
+   :fsm/initial :pending
+   :fsm/context {}
+   :fsm/states
+   {:pending   {:on {:start :running}}
+    :running   {:on {:complete :completed
+                     :fail :failed
+                     :pause :paused
+                     :cancel :cancelled}}
+    :paused    {:on {:resume :running
+                     :cancel :cancelled}}
+    :completed {:type :final}
+    :failed    {:type :final}
+    :cancelled {:type :final}}})
+
+(def ^:private workflow-machine
+  "Compiled workflow state machine."
+  (fsm/define-machine workflow-machine-config))
+
+;; ============================================================================
+;; Legacy API - for backward compatibility with state.clj
 ;; ============================================================================
 
 (def workflow-states
   "Valid states for workflow execution."
-  #{:pending     ; Initial state, workflow not started
-    :running     ; Workflow is executing
-    :completed   ; Workflow completed successfully
-    :failed      ; Workflow failed
-    :paused      ; Workflow execution paused
-    :cancelled}) ; Workflow cancelled by user
+  #{:pending :running :completed :failed :paused :cancelled})
 
 (def workflow-transitions
   "Valid state transitions. Map of [from-state event] -> to-state."
@@ -45,7 +84,7 @@
   #{:completed :failed :cancelled})
 
 ;; ============================================================================
-;; FSM Operations
+;; FSM Operations (legacy API backed by clj-statecharts)
 ;; ============================================================================
 
 (defn valid-transition?
@@ -82,6 +121,8 @@
 
 (defn transition
   "Attempt state transition with guard checking.
+
+   Uses clj-statecharts internally for proper FSM semantics.
 
    Arguments:
    - current-state: Current FSM state keyword
@@ -120,10 +161,14 @@
       :error :invalid-transition
       :message (str "No transition defined for [" current-state " " event "]")}
 
-     ;; Valid transition
+     ;; Valid transition - use clj-statecharts for actual transition
      :else
-     {:success? true
-      :state (next-state current-state event)})))
+     (let [;; Create a temporary state with the current state value
+           state-map {:_state current-state}
+           new-state-map (fsm/transition workflow-machine state-map event)
+           new-state (fsm/current-state new-state-map)]
+       {:success? true
+        :state new-state}))))
 
 (defn valid-state?
   "Check if a state keyword is valid.
@@ -162,3 +207,80 @@
                            {:from from :event event :to to})
                          workflow-transitions))
    :terminal-states terminal-states})
+
+;; ============================================================================
+;; New clj-statecharts API
+;; ============================================================================
+
+(defn get-machine
+  "Get the compiled workflow state machine for direct clj-statecharts usage.
+
+   Returns: Compiled state machine definition"
+  []
+  workflow-machine)
+
+(defn initialize
+  "Initialize workflow FSM state.
+
+   Returns: Initial FSM state map with :_state = :pending"
+  []
+  (fsm/initialize workflow-machine))
+
+(defn transition-fsm
+  "Transition the workflow FSM using full statecharts semantics.
+
+   Arguments:
+   - state: Current FSM state map (from initialize or previous transition)
+   - event: Event keyword or map {:type :event-type :data ...}
+
+   Returns: New FSM state map"
+  [state event]
+  (fsm/transition workflow-machine state event))
+
+(defn current-state
+  "Get the current state keyword from FSM state map.
+
+   Arguments:
+   - state: FSM state map
+
+   Returns: State keyword"
+  [state]
+  (fsm/current-state state))
+
+(defn is-final?
+  "Check if the FSM is in a final (terminal) state.
+
+   Arguments:
+   - state: FSM state map
+
+   Returns: boolean"
+  [state]
+  (fsm/final? workflow-machine state))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Using the legacy API (for backward compatibility)
+  (valid-transition? :pending :start)  ;; => true
+  (valid-transition? :pending :fail)   ;; => false
+
+  (transition :pending :start)
+  ;; => {:success? true :state :running}
+
+  (transition :completed :start)
+  ;; => {:success? false :error :terminal-state ...}
+
+  (get-available-events :running)
+  ;; => [:complete :fail :pause :cancel]
+
+  ;; Using the new clj-statecharts API
+  (def s0 (initialize))
+  (current-state s0)  ;; => :pending
+
+  (def s1 (transition-fsm s0 :start))
+  (current-state s1)  ;; => :running
+
+  (def s2 (transition-fsm s1 :complete))
+  (current-state s2)  ;; => :completed
+  (is-final? s2)      ;; => true
+
+  :leave-this-here)

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -20,10 +20,17 @@
 
    - :enter - Execute the phase
    - :leave - Post-processing and metrics
-   - :error - Handle failures and transitions"
+   - :error - Handle failures and transitions
+
+   Uses the workflow FSM for explicit state transitions:
+   - pending -> running (on start)
+   - running -> completed (all phases done)
+   - running -> failed (phase failure with no recovery)
+   - running -> paused (human intervention needed)"
   (:require [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.gate.interface :as gate]
-            [ai.miniforge.response.interface :as response]))
+            [ai.miniforge.response.interface :as response]
+            [ai.miniforge.workflow.fsm :as fsm]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Execution context
@@ -36,28 +43,52 @@
    - input: Input data for the workflow
    - opts: Execution options
 
-   Returns execution context map."
+   Returns execution context map with FSM state initialized."
   [workflow input opts]
-  {:execution/id (random-uuid)
-   :execution/workflow-id (:workflow/id workflow)
-   :execution/workflow-version (:workflow/version workflow)
-   :execution/status :running
-   :execution/input input
-   :execution/artifacts []
-   :execution/errors []  ; Kept for backward compatibility
-   :execution/response-chain (response/create (:workflow/id workflow))
-   :execution/phase-results {}
-   :execution/current-phase nil
-   :execution/phase-index 0
-   :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
-   :execution/started-at (System/currentTimeMillis)
-   :execution/opts opts})
+  (let [;; Initialize FSM and transition to running state
+        fsm-state (-> (fsm/initialize)
+                      (fsm/transition-fsm :start))]
+    {:execution/id (random-uuid)
+     :execution/workflow-id (:workflow/id workflow)
+     :execution/workflow-version (:workflow/version workflow)
+     :execution/status (fsm/current-state fsm-state)  ; Use FSM state
+     :execution/fsm-state fsm-state                   ; Track FSM state
+     :execution/input input
+     :execution/artifacts []
+     :execution/errors []  ; DEPRECATED: Use :execution/response-chain instead
+     :execution/response-chain (response/create (:workflow/id workflow))
+     :execution/phase-results {}
+     :execution/current-phase nil
+     :execution/phase-index 0
+     :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
+     :execution/started-at (System/currentTimeMillis)
+     :execution/opts opts}))
 
 (defn- merge-metrics
   "Merge phase metrics into execution metrics."
   [exec-metrics phase-metrics]
   (merge-with + exec-metrics
               (select-keys phase-metrics [:tokens :cost-usd :duration-ms])))
+
+(defn- transition-to-completed
+  "Transition workflow to completed state using FSM."
+  [ctx]
+  (let [fsm-state (:execution/fsm-state ctx)
+        new-fsm-state (fsm/transition-fsm fsm-state :complete)]
+    (-> ctx
+        (assoc :execution/fsm-state new-fsm-state)
+        (assoc :execution/status (fsm/current-state new-fsm-state))
+        (assoc :execution/ended-at (System/currentTimeMillis)))))
+
+(defn- transition-to-failed
+  "Transition workflow to failed state using FSM."
+  [ctx]
+  (let [fsm-state (:execution/fsm-state ctx)
+        new-fsm-state (fsm/transition-fsm fsm-state :fail)]
+    (-> ctx
+        (assoc :execution/fsm-state new-fsm-state)
+        (assoc :execution/status (fsm/current-state new-fsm-state))
+        (assoc :execution/ended-at (System/currentTimeMillis)))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Phase transition logic
@@ -278,30 +309,24 @@
                           (:config interceptor)
                           final-phase-result)]
           (cond
-            ;; Workflow complete
+            ;; Workflow complete - use FSM transition
             (= :done next-index)
-            (-> ctx-recorded
-                (assoc :execution/status :completed)
-                (assoc :execution/ended-at (System/currentTimeMillis)))
+            (transition-to-completed ctx-recorded)
 
-            ;; Error - workflow failed
+            ;; Error - workflow failed - use FSM transition
             (= :error next-index)
-            (-> ctx-recorded
-                (assoc :execution/status :failed)
-                (assoc :execution/ended-at (System/currentTimeMillis)))
+            (transition-to-failed ctx-recorded)
 
             ;; Continue to next phase
             (number? next-index)
             (if (< next-index (count pipeline))
               (assoc ctx-recorded :execution/phase-index next-index)
-              (-> ctx-recorded
-                  (assoc :execution/status :completed)
-                  (assoc :execution/ended-at (System/currentTimeMillis))))
+              ;; Past end of pipeline - complete via FSM
+              (transition-to-completed ctx-recorded))
 
-            ;; Unknown - shouldn't happen
+            ;; Unknown - shouldn't happen - fail via FSM
             :else
             (-> ctx-recorded
-                (assoc :execution/status :failed)
                 (update :execution/errors conj
                         {:type :invalid-transition
                          :message (str "Invalid next index: " next-index)})
@@ -309,7 +334,8 @@
                         response/add-failure :pipeline
                         :anomalies.workflow/invalid-transition
                         {:error (str "Invalid next index: " next-index)
-                         :next-index next-index}))))))))
+                         :next-index next-index})
+                (transition-to-failed))))))))
 
 (defn run-pipeline
   "Execute a workflow pipeline.
@@ -334,14 +360,14 @@
 
      (if (empty? pipeline)
        (-> initial-ctx
-           (assoc :execution/status :failed)
            (update :execution/errors conj
                    {:type :empty-pipeline
                     :message "Workflow has no phases"})
            (update :execution/response-chain
                    response/add-failure :pipeline
                    :anomalies.workflow/empty-pipeline
-                   {:error "Workflow has no phases"}))
+                   {:error "Workflow has no phases"})
+           (transition-to-failed))
 
        ;; Execute pipeline loop
        (loop [ctx initial-ctx
@@ -351,10 +377,9 @@
            (#{:completed :failed} (:execution/status ctx))
            ctx
 
-           ;; Max phases exceeded
+           ;; Max phases exceeded - use FSM transition
            (>= iteration max-phases)
            (-> ctx
-               (assoc :execution/status :failed)
                (update :execution/errors conj
                        {:type :max-phases-exceeded
                         :message (str "Exceeded maximum phase count: " max-phases)})
@@ -363,7 +388,7 @@
                        :anomalies.workflow/max-phases
                        {:error (str "Exceeded maximum phase count: " max-phases)
                         :max-phases max-phases})
-               (assoc :execution/ended-at (System/currentTimeMillis)))
+               (transition-to-failed))
 
            ;; Execute next phase
            :else

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -186,3 +186,30 @@
       (is (= :completed (:execution/status result)))
       (is (>= (count (:response-chain chain)) 2))
       (is (true? (:succeeded? chain))))))
+
+;; ============================================================================
+;; FSM state tracking tests
+;; ============================================================================
+
+(deftest fsm-state-tracked-test
+  (testing "FSM state is tracked in context"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"}
+          ctx (runner/create-context workflow {:task "Test"} {})]
+      (is (contains? ctx :execution/fsm-state))
+      (is (map? (:execution/fsm-state ctx)))
+      (is (= :running (:_state (:execution/fsm-state ctx))))))
+
+  (testing "FSM state transitions on completion"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :done}]}
+          result (runner/run-pipeline workflow {:task "Test"} {})]
+      (is (= :completed (:execution/status result)))
+      (is (= :completed (:_state (:execution/fsm-state result))))))
+
+  (testing "FSM state transitions on failure"
+    (let [workflow {:workflow/pipeline []}
+          result (runner/run-pipeline workflow {} {})]
+      (is (= :failed (:execution/status result)))
+      (is (= :failed (:_state (:execution/fsm-state result)))))))

--- a/components/workflow/test/ai/miniforge/workflow/state_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/state_test.clj
@@ -22,7 +22,10 @@
    :workflow/version "1.0.0"
    :workflow/type :test
    :workflow/entry-phase :plan
-   :workflow/exit-phases [:done]})
+   :workflow/exit-phases [:done]
+   :workflow/phases [{:phase/id :plan}
+                     {:phase/id :implement}
+                     {:phase/id :done}]})
 
 (deftest create-execution-state-test
   (testing "Create initial execution state"
@@ -64,16 +67,18 @@
           "Should update current phase")
       (is (= :running (:execution/status exec-state2))
           "Should update status to running")
-      (is (= 1 (count (:execution/history exec-state2)))
-          "Should add transition to history")
-      (let [transition (first (:execution/history exec-state2))]
-        (is (= :plan (:from transition))
+      ;; History now includes both FSM transition (pending->running) and phase transition
+      (is (= 2 (count (:execution/history exec-state2)))
+          "Should have FSM and phase transitions in history")
+      ;; Phase transition is the second entry (after FSM transition)
+      (let [phase-transition (second (:execution/history exec-state2))]
+        (is (= :plan (:from-phase phase-transition))
             "Transition should record from phase")
-        (is (= :implement (:to transition))
+        (is (= :implement (:to-phase phase-transition))
             "Transition should record to phase")
-        (is (= :advance (:reason transition))
+        (is (= :advance (:reason phase-transition))
             "Transition should record reason")
-        (is (number? (:timestamp transition))
+        (is (number? (:timestamp phase-transition))
             "Transition should have timestamp"))))
 
   (testing "Transition with custom reason"
@@ -81,8 +86,9 @@
           exec-state2 (state/transition-to-phase exec-state :implement :rollback)]
       (is (= :implement (:execution/current-phase exec-state2))
           "Should update current phase")
-      (let [transition (first (:execution/history exec-state2))]
-        (is (= :rollback (:reason transition))
+      ;; Phase transition is the second entry
+      (let [phase-transition (second (:execution/history exec-state2))]
+        (is (= :rollback (:reason phase-transition))
             "Should record custom reason")))))
 
 (deftest record-phase-result-test
@@ -141,8 +147,10 @@
 
 (deftest mark-completed-test
   (testing "Mark execution as completed"
+    ;; Must first transition to running before completing
     (let [exec-state (state/create-execution-state sample-workflow {})
-          exec-state2 (state/mark-completed exec-state)]
+          exec-state-running (state/transition-status exec-state :start)
+          exec-state2 (state/mark-completed exec-state-running)]
       (is (= :completed (:execution/status exec-state2))
           "Should set status to completed")
       (is (number? (:execution/completed-at exec-state2))
@@ -156,9 +164,11 @@
 
 (deftest mark-failed-test
   (testing "Mark execution as failed with error map"
+    ;; Must first transition to running before failing
     (let [exec-state (state/create-execution-state sample-workflow {})
+          exec-state-running (state/transition-status exec-state :start)
           error {:type :execution-failed :message "Something went wrong"}
-          exec-state2 (state/mark-failed exec-state error)]
+          exec-state2 (state/mark-failed exec-state-running error)]
       (is (= :failed (:execution/status exec-state2))
           "Should set status to failed")
       (is (= 1 (count (:execution/errors exec-state2)))
@@ -173,8 +183,10 @@
           "completed? predicate should return false")))
 
   (testing "Mark execution as failed with error string"
+    ;; Must first transition to running before failing
     (let [exec-state (state/create-execution-state sample-workflow {})
-          exec-state2 (state/mark-failed exec-state "Error message")]
+          exec-state-running (state/transition-status exec-state :start)
+          exec-state2 (state/mark-failed exec-state-running "Error message")]
       (is (= :failed (:execution/status exec-state2))
           "Should set status to failed")
       (is (= 1 (count (:execution/errors exec-state2)))
@@ -213,9 +225,11 @@
           "Should return accumulated metrics")))
 
   (testing "get-duration-ms"
-    (let [exec-state (state/create-execution-state sample-workflow {})]
+    ;; Must first transition to running before completing
+    (let [exec-state (state/create-execution-state sample-workflow {})
+          exec-state-running (state/transition-status exec-state :start)]
       (Thread/sleep 10)  ; Wait a bit
-      (let [exec-state2 (state/mark-completed exec-state)
+      (let [exec-state2 (state/mark-completed exec-state-running)
             duration (state/get-duration-ms exec-state2)]
         (is (pos? duration)
             "Duration should be positive")
@@ -226,7 +240,7 @@
   (testing "Complete workflow execution flow"
     (let [input {:task "Build feature"}
           exec-state (state/create-execution-state sample-workflow input)
-          ;; Execute plan phase
+          ;; Execute plan phase (this will auto-start the workflow)
           exec-state2 (-> exec-state
                           (state/transition-to-phase :plan)
                           (state/record-phase-result :plan
@@ -258,5 +272,7 @@
       (is (= {:tokens 300 :cost-usd 0.0 :duration-ms 0}
              (:execution/metrics exec-state4))
           "Should have accumulated metrics")
-      (is (= 3 (count (:execution/history exec-state4)))
-          "Should have transition history for plan->plan, plan->implement, implement->done"))))
+      ;; History now includes: FSM (pending->running), phase (plan->plan),
+      ;; phase (plan->implement), phase (implement->done), FSM (running->completed)
+      (is (= 5 (count (:execution/history exec-state4)))
+          "Should have FSM and phase transitions in history"))))

--- a/deps.edn
+++ b/deps.edn
@@ -27,6 +27,8 @@
                        "components/heuristic/src"
                        "components/heuristic/resources"
                        "components/response/src"
+                       "components/fsm/src"
+                       "components/fsm/resources"
                        "components/phase/src"
                        "components/phase/resources"
                        "components/gate/src"
@@ -53,6 +55,7 @@
                       ai.miniforge/policy {:local/root "components/policy"}
                       ai.miniforge/heuristic {:local/root "components/heuristic"}
                       ai.miniforge/response {:local/root "components/response"}
+                      ai.miniforge/fsm {:local/root "components/fsm"}
                       ai.miniforge/phase {:local/root "components/phase"}
                       ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}
@@ -64,6 +67,7 @@
   :test {:extra-paths ["development/test"
                        "components/schema/test"
                        "components/response/test"
+                       "components/fsm/test"
                        "components/logging/test"
                        "components/llm/test"
                        "components/tool/test"
@@ -93,6 +97,7 @@
                       ai.miniforge/policy {:local/root "components/policy"}
                       ai.miniforge/heuristic {:local/root "components/heuristic"}
                       ai.miniforge/response {:local/root "components/response"}
+                      ai.miniforge/fsm {:local/root "components/fsm"}
                       ai.miniforge/phase {:local/root "components/phase"}
                       ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}


### PR DESCRIPTION
## Summary

- Add new `fsm` component wrapping clj-statecharts for declarative state machine support
- Refactor workflow FSM to use clj-statecharts with backward-compatible API
- Update runner to track FSM state in context and use explicit transitions
- Add response chain `errors` function for migration from legacy error tracking
- Mark `:execution/errors` as deprecated in favor of response chains

## Key Changes

### New FSM Component (`components/fsm/`)
- Thin wrapper around clj-statecharts with miniforge conventions
- `define-machine` - Create state machine from declarative config
- `initialize`, `transition` - State operations
- `guard`, `all-guards`, `any-guard` - Guard combinators
- `assign`, `update-context` - Context manipulation
- Handles clj-statecharts limitations (`:type :final`, unknown events)

### Workflow FSM Updates
- Now uses clj-statecharts internally while maintaining backward-compatible API
- Declarative configuration: `{:fsm/id :workflow, :fsm/initial :pending, ...}`
- New clj-statecharts API: `initialize`, `transition-fsm`, `current-state`, `is-final?`

### Runner FSM Integration
- Tracks FSM state in `:execution/fsm-state`
- Uses FSM for status transitions (completed, failed)
- `:execution/status` derived from FSM state

### Response Chain Enhancement
- New `errors` function extracts errors in flat format for migration
- Provides path from `:execution/errors` to response chains

## Test Plan

- [x] FSM component tests (14 tests, 34 assertions)
- [x] Workflow FSM tests (9 tests, 76 assertions)
- [x] Workflow state tests (7 tests, 59 assertions)
- [x] Workflow runner tests (15 tests, 37 assertions)
- [x] Response chain tests (20 tests, 71 assertions)
- [x] Gate interface tests (20 tests, 43 assertions)
- [x] All 85 tests passing with 320 assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)