### PR TITLE
feat: tool invocation tracking

### DIFF
--- a/components/agent/deps.edn
+++ b/components/agent/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {}
+ :deps {ai.miniforge/tool {:local/root "../tool"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -7,7 +7,8 @@
    Agents are pure functions: (context, task) -> (artifacts, decisions, signals)"
   (:require
    [ai.miniforge.agent.protocol :as protocol]
-   [ai.miniforge.agent.memory :as memory]))
+   [ai.miniforge.agent.memory :as memory]
+   [ai.miniforge.tool.interface :as tool]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Role configurations and defaults
@@ -355,10 +356,11 @@ Output execution logs and status reports."})
                   (memory/create-memory {:scope :task :scope-id task-id}))
 
           ;; Add context to execution
-          exec-context (assoc context
-                              :memory mem
-                              :agent-id agent-id
-                              :task-id task-id)
+          exec-context (-> context
+                           (assoc :memory mem
+                                  :agent-id agent-id
+                                  :task-id task-id)
+                           (tool/attach-invocation-tracking))
 
           ;; Initialize agent
           initialized-agent (protocol/init agent (:config agent))
@@ -390,7 +392,8 @@ Output execution logs and status reports."})
 
           ;; Update metrics with total duration
           final-metrics (-> (or (:metrics final-result) (make-metrics))
-                            (assoc :total-duration-ms duration))]
+                            (assoc :total-duration-ms duration))
+          tool-invocations (tool/tool-invocations exec-context)]
 
       ;; Save memory if store available
       (when memory-store
@@ -399,6 +402,7 @@ Output execution logs and status reports."})
       ;; Return result
       (assoc final-result
              :metrics final-metrics
+             :tool/invocations tool-invocations
              :agent-id agent-id
              :task-id task-id
              :executed-at (java.util.Date.)))))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -63,6 +63,11 @@
      {}
      phases)))
 
+(defn collect-tool-invocations
+  "Collect tool invocation records from workflow state."
+  [workflow-state]
+  (vec (or (:workflow/tool-invocations workflow-state) [])))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Policy Check Evidence
 
@@ -119,6 +124,7 @@
         phase-evidence (collect-all-phases workflow-state)
         policy-checks (collect-policy-checks workflow-state)
         outcome (build-outcome-evidence workflow-state)
+        tool-invocations (collect-tool-invocations workflow-state)
 
         ;; Get artifacts for semantic validation
         artifacts (when artifact-store
@@ -144,6 +150,8 @@
       :evidence/policy-checks policy-checks
       :evidence/outcome outcome}
      phase-evidence
+     (when (seq tool-invocations)
+       {:evidence/tool-invocations tool-invocations})
      (when semantic-validation
        {:evidence/semantic-validation semantic-validation}))))
 

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/protocols/impl/evidence_bundle.clj
@@ -57,6 +57,9 @@
         policy-checks (or (:policy-checks opts)
                          (let [collect-fn (requiring-resolve 'ai.miniforge.evidence-bundle.collector/collect-policy-checks)]
                            (collect-fn workflow-state)))
+        tool-invocations (let [collect-fn (requiring-resolve
+                                           'ai.miniforge.evidence-bundle.collector/collect-tool-invocations)]
+                           (collect-fn workflow-state))
         semantic-validation (or (:semantic-validation opts) {})
         collect-all-fn (requiring-resolve 'ai.miniforge.evidence-bundle.collector/collect-all-phases)
         phase-evidence (collect-all-fn workflow-state)
@@ -72,6 +75,9 @@
                  :evidence/policy-checks policy-checks
                  :evidence/outcome outcome}
                 phase-evidence)
+        bundle (cond-> bundle
+                 (seq tool-invocations)
+                 (assoc :evidence/tool-invocations tool-invocations))
 
         new-bundles (assoc @bundles bundle-id bundle)]
 

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/schema.clj
@@ -149,6 +149,7 @@
    ;; Validation
    :evidence/semantic-validation map?
    :evidence/policy-checks vector?
+   (optional-key :evidence/tool-invocations) vector?
 
    ;; Outcome
    :evidence/outcome map?
@@ -185,6 +186,16 @@
    (optional-key :tool/exit-code) int?
    (optional-key :tool/output-summary) string?})
 
+(def tool-invocation-schema
+  "Schema for tool invocation record."
+  {:tool/id keyword?
+   :tool/invoked-at inst?
+   :tool/duration-ms nat-int?
+   :tool/args map?
+   (optional-key :tool/result) (fn [_] true)
+   (optional-key :tool/exit-code) int?
+   (optional-key :tool/error) map?})
+
 ;------------------------------------------------------------------------------ Layer 8
 ;; Helper Functions
 
@@ -214,4 +225,5 @@
    :evidence/intent {}
    :evidence/semantic-validation {}
    :evidence/policy-checks []
-   :evidence/outcome {}})
+   :evidence/outcome {}
+   :evidence/tool-invocations []})

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/interface_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/interface_test.clj
@@ -122,11 +122,11 @@
           workflow-id (random-uuid)
           state (create-test-workflow-state workflow-id :completed)
           bundle (evidence/create-bundle manager workflow-id {:workflow-state state})
-          bundle-id (:evidence-bundle/id bundle)]
+          bundle-id (:evidence-bundle/id bundle)
+          retrieved (evidence/get-bundle manager bundle-id)]
 
-      (let [retrieved (evidence/get-bundle manager bundle-id)]
-        (is (= bundle-id (:evidence-bundle/id retrieved)))
-        (is (= workflow-id (:evidence-bundle/workflow-id retrieved))))))
+      (is (= bundle-id (:evidence-bundle/id retrieved)))
+      (is (= workflow-id (:evidence-bundle/workflow-id retrieved)))))
 
   (testing "Returns nil for non-existent bundle"
     (let [store (create-test-artifact-store)
@@ -139,11 +139,11 @@
           manager (evidence/create-evidence-manager {:artifact-store store})
           workflow-id (random-uuid)
           state (create-test-workflow-state workflow-id :completed)
-          bundle (evidence/create-bundle manager workflow-id {:workflow-state state})]
+          bundle (evidence/create-bundle manager workflow-id {:workflow-state state})
+          retrieved (evidence/get-bundle-by-workflow manager workflow-id)]
 
-      (let [retrieved (evidence/get-bundle-by-workflow manager workflow-id)]
-        (is (= workflow-id (:evidence-bundle/workflow-id retrieved)))
-        (is (= (:evidence-bundle/id bundle) (:evidence-bundle/id retrieved)))))))
+      (is (= workflow-id (:evidence-bundle/workflow-id retrieved)))
+      (is (= (:evidence-bundle/id bundle) (:evidence-bundle/id retrieved))))))
 
 ;------------------------------------------------------------------------------ Layer 4: Bundle Querying
 

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/interface_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/interface_test.clj
@@ -14,7 +14,7 @@
 
 (defn create-test-workflow-state
   "Create a test workflow state."
-  [workflow-id status]
+  [workflow-id status & {:keys [tool-invocations] :or {tool-invocations []}}]
   {:workflow/id workflow-id
    :workflow/status status
    :workflow/spec {:intent/type :import
@@ -34,6 +34,7 @@
                                 :output {:implementation "Test impl"}
                                 :artifacts []}}
    :workflow/gate-results []
+   :workflow/tool-invocations tool-invocations
    :workflow/pr-info {:number 123
                       :url "https://github.com/test/repo/pull/123"
                       :status :merged
@@ -83,6 +84,20 @@
       ;; Check outcome
       (is (true? (get-in bundle [:evidence/outcome :outcome/success])))
       (is (= 123 (get-in bundle [:evidence/outcome :outcome/pr-number])))))
+
+  (testing "Includes tool invocations when present"
+    (let [store (create-test-artifact-store)
+          manager (evidence/create-evidence-manager {:artifact-store store})
+          workflow-id (random-uuid)
+          invocations [{:tool/id :tools/demo
+                        :tool/invoked-at (java.time.Instant/now)
+                        :tool/duration-ms 12
+                        :tool/args {:x 1}
+                        :tool/result {:ok true}}]
+          state (create-test-workflow-state workflow-id :completed
+                                            :tool-invocations invocations)
+          bundle (evidence/create-bundle manager workflow-id {:workflow-state state})]
+      (is (= invocations (:evidence/tool-invocations bundle)))))
 
   (testing "Creates bundle for failed workflow"
     (let [store (create-test-artifact-store)

--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -5,7 +5,8 @@
   (:require
    [clojure.set :as set]
    [clojure.string :as str]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.tool.tracking :as tracking]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Tool schema and validation
@@ -97,18 +98,23 @@
      :parameters parameters
      :metadata metadata})
   (execute [_this params context]
-    (let [validation (validate-params parameters params)]
-      (if (:valid? validation)
-        (try
-          {:success true
-           :result (handler params context)}
-          (catch Exception e
-            {:success false
-             :error {:type "execution_error"
-                     :message (.getMessage e)}}))
-        {:success false
-         :error {:type "validation_error"
-                 :errors (:errors validation)}})))
+    (let [start-ms (System/currentTimeMillis)
+          validation (validate-params parameters params)
+          result (if (:valid? validation)
+                   (try
+                     {:success true
+                      :result (handler params context)}
+                     (catch Exception e
+                       {:success false
+                        :error {:type "execution_error"
+                                :message (.getMessage e)}}))
+                   {:success false
+                    :error {:type "validation_error"
+                            :errors (:errors validation)}})
+          end-ms (System/currentTimeMillis)
+          invocation (tracking/build-invocation id params start-ms end-ms result)]
+      (tracking/record-invocation context invocation)
+      result))
   (validate-args [_this args]
     (validate-params parameters args))
   (get-schema [_this]

--- a/components/tool/src/ai/miniforge/tool/interface.clj
+++ b/components/tool/src/ai/miniforge/tool/interface.clj
@@ -7,7 +7,8 @@
 
    See docs/specs/extensibility.spec for MCP integration details."
   (:require
-   [ai.miniforge.tool.core :as core]))
+   [ai.miniforge.tool.core :as core]
+   [ai.miniforge.tool.tracking :as tracking]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Re-export protocols for extension
@@ -164,6 +165,19 @@
   "Extract error details from a failed execution."
   [result]
   (:error result))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Invocation tracking
+
+(defn attach-invocation-tracking
+  "Attach tool invocation tracking to a context map."
+  [context]
+  (tracking/attach-invocation-tracking context))
+
+(defn tool-invocations
+  "Get tool invocation records from a context map."
+  [context]
+  (tracking/tool-invocations context))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tool/src/ai/miniforge/tool/tracking.clj
+++ b/components/tool/src/ai/miniforge/tool/tracking.clj
@@ -1,0 +1,83 @@
+(ns ai.miniforge.tool.tracking
+  "Tool invocation tracking helpers.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Invocation records
+
+(defn- instant-from-ms
+  "Create an Instant from epoch millis."
+  [millis]
+  (java.time.Instant/ofEpochMilli millis))
+
+(defn build-invocation
+  "Build a tool invocation record from execution inputs and result."
+  [tool-id params start-ms end-ms result]
+  (let [duration (- end-ms start-ms)]
+    (cond-> {:tool/id tool-id
+             :tool/invoked-at (instant-from-ms start-ms)
+             :tool/duration-ms (max 0 duration)
+             :tool/args (or params {})}
+      (contains? result :result)
+      (assoc :tool/result (:result result))
+
+      (contains? result :exit-code)
+      (assoc :tool/exit-code (:exit-code result))
+
+      (contains? result :error)
+      (assoc :tool/error (:error result)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Context helpers
+
+(defn attach-invocation-tracking
+  "Attach invocation tracking to a context map.
+   Adds :tool/invocations (atom) and :tool/record-invocation when missing."
+  [context]
+  (let [existing (:tool/invocations context)]
+    (if (and existing (:tool/record-invocation context))
+      context
+      (let [store (if (instance? clojure.lang.IAtom existing)
+                    existing
+                    (atom (vec (or existing []))))
+            record-fn (fn [invocation]
+                        (swap! store conj invocation))]
+        (assoc context
+               :tool/invocations store
+               :tool/record-invocation record-fn)))))
+
+(defn tool-invocations
+  "Return tool invocations from a context map."
+  [context]
+  (let [store (:tool/invocations context)]
+    (cond
+      (instance? clojure.lang.IAtom store) @store
+      (sequential? store) (vec store)
+      :else [])))
+
+(defn record-invocation
+  "Record a tool invocation using context if tracking is configured."
+  [context invocation]
+  (let [record-fn (:tool/record-invocation context)
+        store (:tool/invocations context)]
+    (cond
+      (fn? record-fn)
+      (record-fn invocation)
+
+      (instance? clojure.lang.IAtom store)
+      (swap! store conj invocation)
+
+      :else nil))
+  invocation)
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def ctx (attach-invocation-tracking {}))
+  (record-invocation ctx
+                     {:tool/id :tools/demo
+                      :tool/invoked-at (java.time.Instant/now)
+                      :tool/duration-ms 10
+                      :tool/args {:x 1}
+                      :tool/result :ok})
+  (tool-invocations ctx)
+
+  :leave-this-here)

--- a/components/tool/test/ai/miniforge/tool/interface_test.clj
+++ b/components/tool/test/ai/miniforge/tool/interface_test.clj
@@ -180,6 +180,37 @@
       (is (not (tool/success? result)))
       (is (= "not_found" (get-in (tool/get-error result) [:type]))))))
 
+;; Invocation tracking tests
+
+(deftest invocation-tracking-test
+  (testing "records successful invocation"
+    (let [context (tool/attach-invocation-tracking {})
+          my-tool (tool/create-tool
+                   {:id :test/track
+                    :parameters {:message {:type :string :required true}}
+                    :handler echo-handler})
+          result (tool/execute my-tool {:message "Hello"} context)
+          invocations (tool/tool-invocations context)
+          invocation (first invocations)]
+      (is (tool/success? result))
+      (is (= 1 (count invocations)))
+      (is (= :test/track (:tool/id invocation)))
+      (is (= {:message "Hello"} (:tool/args invocation)))
+      (is (inst? (:tool/invoked-at invocation)))
+      (is (>= (:tool/duration-ms invocation) 0))
+      (is (= "Hello" (:tool/result invocation)))))
+
+  (testing "records validation errors"
+    (let [context (tool/attach-invocation-tracking {})
+          my-tool (tool/create-tool
+                   {:id :test/track-error
+                    :parameters {:required-param {:required true}}
+                    :handler (constantly nil)})
+          _result (tool/execute my-tool {} context)
+          [invocation] (tool/tool-invocations context)]
+      (is (= :test/track-error (:tool/id invocation)))
+      (is (= "validation_error" (get-in invocation [:tool/error :type]))))))
+
 ;; Protocol method tests (N1 conformance)
 
 (deftest validate-args-test

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -7,6 +7,7 @@
         ai.miniforge/task {:local/root "../task"}
         ai.miniforge/loop {:local/root "../loop"}
         ai.miniforge/artifact {:local/root "../artifact"}
+        ai.miniforge/tool {:local/root "../tool"}
         ai.miniforge/policy {:local/root "../policy"}      ; Gate evaluation
         ai.miniforge/heuristic {:local/root "../heuristic"} ; Workflow storage
         ai.miniforge/phase {:local/root "../phase"}        ; Phase interceptors

--- a/components/workflow/src/ai/miniforge/workflow/protocols/impl/phase_executor.clj
+++ b/components/workflow/src/ai/miniforge/workflow/protocols/impl/phase_executor.clj
@@ -5,7 +5,8 @@
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.task.interface :as task]
    [ai.miniforge.loop.interface :as loop]
-   [ai.miniforge.artifact.interface :as artifact]))
+   [ai.miniforge.artifact.interface :as artifact]
+   [ai.miniforge.tool.interface :as tool]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Helper functions
@@ -67,13 +68,18 @@
    Pure function that orchestrates agent execution."
   [agent-constructor task context max-iterations]
   (let [agent-instance (agent-constructor)
-        invoke-args (or (:invoke-args context) task)
+        tracking-context (tool/attach-invocation-tracking context)
+        invoke-args (or (:invoke-args tracking-context) task)
         generate-fn (fn [_task _ctx]
-                      (let [result (agent/invoke agent-instance invoke-args context)]
+                      (let [result (agent/invoke agent-instance invoke-args tracking-context)]
                         {:artifact (:artifact result)
-                         :tokens (or (:tokens result) 0)}))]
-    (loop/run-simple task generate-fn
-                     (merge context {:max-iterations max-iterations}))))
+                         :tokens (or (:tokens result) 0)}))
+        result (loop/run-simple task
+                                generate-fn
+                                (merge tracking-context
+                                       {:max-iterations max-iterations}))
+        tool-invocations (tool/tool-invocations tracking-context)]
+    (assoc result :tool/invocations tool-invocations)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Plan phase implementation

--- a/components/workflow/src/ai/miniforge/workflow/protocols/impl/workflow.clj
+++ b/components/workflow/src/ai/miniforge/workflow/protocols/impl/workflow.clj
@@ -35,6 +35,7 @@
    :workflow/phase :spec
    :workflow/status :pending
    :workflow/artifacts []
+   :workflow/tool-invocations []
    :workflow/errors []
    :workflow/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
    :workflow/history []
@@ -104,6 +105,8 @@
           new-phase (next-phase current-phase success?)
           new-artifacts (into (:workflow/artifacts state)
                               (:artifacts phase-result []))
+          tool-invocations (into (:workflow/tool-invocations state)
+                                 (:tool/invocations phase-result []))
           new-errors (into (:workflow/errors state)
                            (:errors phase-result []))
           new-metrics (merge-with + (:workflow/metrics state)
@@ -112,6 +115,7 @@
                         (assoc :workflow/phase new-phase)
                         (assoc :workflow/status (if (= new-phase :done) :completed :running))
                         (assoc :workflow/artifacts new-artifacts)
+                        (assoc :workflow/tool-invocations tool-invocations)
                         (assoc :workflow/errors new-errors)
                         (assoc :workflow/metrics new-metrics)
                         (record-phase-transition current-phase new-phase

--- a/docs/pull-requests/2026-01-24-feat-tool-invocation-tracking.md
+++ b/docs/pull-requests/2026-01-24-feat-tool-invocation-tracking.md
@@ -1,0 +1,37 @@
+# feat: Tool Invocation Tracking
+
+## Overview
+
+Add tool invocation tracking to capture per-call metadata and include it in evidence bundles.
+
+## Motivation
+
+N1 spec requires tool usage to be recorded for evidence and auditability.
+We need a consistent mechanism to capture tool inputs/outputs, timing,
+and errors and surface them in evidence bundles.
+
+## Changes in Detail
+
+- Add tool invocation tracking helpers and record invocations during tool execution.
+- Attach tracking to agent execution and workflow phase execution contexts.
+- Persist tool invocations into workflow state and include them in evidence bundle assembly.
+- Extend evidence bundle schema/template and tests to cover tool invocations.
+
+## Testing Plan
+
+- `bb pre-commit`
+
+## Deployment Plan
+
+- No special deployment steps; merge and release with standard workflow.
+
+## Related Issues/PRs
+
+- N1 spec PR DAG: PR5 (tool invocation tracking).
+
+## Checklist
+
+- [x] Tool invocations recorded with id, timestamp, duration, args, result, exit-code, error
+- [x] Evidence bundle includes tool invocations when present
+- [x] Tests updated or added for tracking and evidence bundle inclusion
+- [x] Docs updated if required


### PR DESCRIPTION
# feat: Tool Invocation Tracking

## Overview

Add tool invocation tracking to capture per-call metadata and include it in evidence bundles.

## Motivation

N1 spec requires tool usage to be recorded for evidence and auditability.
We need a consistent mechanism to capture tool inputs/outputs, timing,
and errors and surface them in evidence bundles.

## Changes in Detail

- Add tool invocation tracking helpers and record invocations during tool execution.
- Attach tracking to agent execution and workflow phase execution contexts.
- Persist tool invocations into workflow state and include them in evidence bundle assembly.
- Extend evidence bundle schema/template and tests to cover tool invocations.

## Testing Plan

- `bb pre-commit`

## Deployment Plan

- No special deployment steps; merge and release with standard workflow.

## Related Issues/PRs

- N1 spec PR DAG: PR5 (tool invocation tracking).

## Checklist

- [x] Tool invocations recorded with id, timestamp, duration, args, result, exit-code, error
- [x] Evidence bundle includes tool invocations when present
- [x] Tests updated or added for tracking and evidence bundle inclusion
- [x] Docs updated if required
