### PR TITLE
feat(knowledge): implement transitive trust rules (PR14/21)

### DIFF
--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -18,7 +18,8 @@
    [ai.miniforge.knowledge.zettel :as zettel]
    [ai.miniforge.knowledge.store :as store]
    [ai.miniforge.knowledge.learning :as learning]
-   [ai.miniforge.knowledge.loader :as loader]))
+   [ai.miniforge.knowledge.loader :as loader]
+   [ai.miniforge.knowledge.trust]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
@@ -308,6 +309,65 @@
      (initialize-knowledge-store! store)
      (initialize-knowledge-store! store {:rules-dir \"custom/rules\"})"
   loader/initialize-knowledge-store!)
+
+;------------------------------------------------------------------------------ Layer 9
+;; Trust validation (N1 §2.10.2)
+
+(defn make-pack-ref
+  "Create a pack reference with trust information.
+
+   Arguments:
+   - pack-id       - Unique identifier for the pack
+   - trust-level   - :trusted, :untrusted, or :tainted
+   - authority     - :authority/instruction or :authority/data
+
+   Options:
+   - :dependencies - Vector of pack-ids this pack depends on
+
+   Returns pack reference map.
+
+   Example:
+     (make-pack-ref \"my-pack\" :trusted :authority/instruction
+                    :dependencies [\"base-pack\"])"
+  [pack-id trust-level authority & {:keys [dependencies]}]
+  (ai.miniforge.knowledge.trust/make-pack-ref
+   pack-id trust-level authority :dependencies dependencies))
+
+(def validate-transitive-trust
+  "Validate all transitive trust rules for a pack graph.
+
+   Checks:
+   1. Instruction authority is not transitive
+   2. Trust level inheritance is correct
+   3. Cross-trust references are valid (no cycles, missing deps)
+   4. Tainted content is isolated from instruction authority
+
+   Arguments:
+   - pack-graph - Map of pack-id -> pack-ref
+
+   Returns:
+   - {:valid? true :packs [...]} if all rules pass
+   - {:valid? false :errors [...]} if any rule fails
+
+   Example:
+     (validate-transitive-trust {\"pack-a\" pack-ref-a \"pack-b\" pack-ref-b})"
+  ai.miniforge.knowledge.trust/validate-transitive-trust)
+
+(def compute-inherited-trust-level
+  "Compute the inherited trust level from a collection of packs.
+
+   Rule 2: When pack A includes content from pack B, the combined content
+   MUST be assigned the lower trust level.
+
+   Arguments:
+   - pack-refs - Collection of pack references being combined
+
+   Returns the lowest trust level from all packs.
+
+   Example:
+     (compute-inherited-trust-level [trusted-pack untrusted-pack])
+     ;; => :untrusted"
+  ai.miniforge.knowledge.trust/compute-inherited-trust-level)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -76,8 +76,67 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Generic DFS utilities
 
+(defn ^:private dfs-traverse
+  "Canonical DFS traversal with pluggable visit function.
+
+  Arguments:
+  - graph       - Map of node-id -> node
+  - start-nodes - Collection of starting node IDs (or single ID)
+  - get-deps-fn - Function (node) -> [dependency-ids]
+  - visit-fn    - Function (node-id, node, path, state) -> updated state
+                  State map has :visited, :visiting (optional), :result keys
+                  visit-fn should return updated state or state with :halt? true to stop
+
+  Returns final state map."
+  [graph start-nodes get-deps-fn visit-fn]
+  (let [start-nodes (if (coll? start-nodes) start-nodes [start-nodes])
+        initial-state {:visited #{} :visiting #{} :result nil}]
+
+    (letfn [(visit-node [node-id path state]
+              (let [{:keys [visited visiting]} state]
+                (cond
+                  ;; Already visited - skip
+                  (contains? visited node-id)
+                  state
+
+                  ;; Currently visiting - call visit-fn with cycle context
+                  (contains? visiting node-id)
+                  (visit-fn node-id nil (conj path node-id)
+                            (assoc state :cycle? true))
+
+                  ;; Visit this node
+                  :else
+                  (let [node (get graph node-id)]
+                    (if-not node
+                      ;; Missing node - call visit-fn
+                      (visit-fn node-id nil path (assoc state :missing? true))
+                      ;; Process node and dependencies
+                      (let [state' (visit-fn node-id node path
+                                             (update state :visiting conj node-id))]
+                        (if (:halt? state')
+                          state'
+                          ;; Visit dependencies
+                          (let [deps (get-deps-fn node)
+                                final-state (reduce (fn [s dep-id]
+                                                      (if (:halt? s)
+                                                        s
+                                                        (visit-node dep-id (conj path node-id) s)))
+                                                    state'
+                                                    deps)]
+                            (-> final-state
+                                (update :visited conj node-id)
+                                (update :visiting disj node-id))))))))))]
+
+      ;; Process all start nodes
+      (reduce (fn [state node-id]
+                (if (:halt? state)
+                  state
+                  (visit-node node-id [] state)))
+              initial-state
+              start-nodes))))
+
 (defn ^:private dfs-find
-  "Generic DFS to find nodes matching a predicate.
+  "Find first node matching a predicate using DFS.
 
   Arguments:
   - graph        - Map of node-id -> node
@@ -89,36 +148,26 @@
   - nil if not found
   - {:found-id node-id :path [...]} if found"
   [graph start-id get-deps-fn found-fn]
-  (letfn [(search [node-id path visited]
-            (if (contains? visited node-id)
-              {:visited visited :found nil}
-              (let [node (get graph node-id)]
-                (cond
-                  ;; Node not in graph
-                  (not node)
-                  {:visited (conj visited node-id) :found nil}
+  (let [visit-fn (fn [node-id node path state]
+                   (cond
+                     ;; Missing or cycle - continue
+                     (or (:missing? state) (:cycle? state))
+                     (dissoc state :missing? :cycle?)
 
-                  ;; Found matching node
-                  (found-fn node-id node path)
-                  {:visited visited :found {:found-id node-id :path (conj path node-id)}}
+                     ;; Check if this node matches
+                     (and node (found-fn node-id node path))
+                     (assoc state
+                            :result {:found-id node-id :path (conj path node-id)}
+                            :halt? true)
 
-                  ;; Search dependencies
-                  :else
-                  (let [deps (get-deps-fn node)]
-                    (loop [remaining-deps deps
-                           v (conj visited node-id)]
-                      (if (empty? remaining-deps)
-                        {:visited v :found nil}
-                        (let [result (search (first remaining-deps) (conj path node-id) v)]
-                          (if (:found result)
-                            result
-                            (recur (rest remaining-deps) (:visited result)))))))))))]
-
-    (let [result (search start-id [] #{})]
-      (:found result))))
+                     ;; Continue traversal
+                     :else
+                     state))
+        final-state (dfs-traverse graph start-id get-deps-fn visit-fn)]
+    (:result final-state)))
 
 (defn ^:private dfs-validate-graph
-  "Generic DFS to validate graph structure (cycles, missing nodes).
+  "Validate graph structure (cycles, missing nodes) using DFS.
 
   Arguments:
   - graph        - Map of node-id -> node
@@ -131,44 +180,25 @@
   - {:valid? true :graph graph} if valid
   - {:valid? false :error ...} if invalid"
   [graph start-nodes get-deps-fn validate-fn]
-  (letfn [(visit [node-id path visited visiting]
-            (cond
-              (contains? visited node-id)
-              {:visited visited :visiting visiting :error nil}
+  (let [visit-fn (fn [node-id node path state]
+                   (let [context (cond
+                                   (:cycle? state)
+                                   {:cycle? true :path path}
 
-              (contains? visiting node-id)
-              (let [error (validate-fn node-id nil {:cycle? true :path (conj path node-id)})]
-                {:visited visited :visiting visiting :error error})
+                                   (:missing? state)
+                                   {:missing? true}
 
-              :else
-              (let [node (get graph node-id)]
-                (if-not node
-                  (let [error (validate-fn node-id nil {:missing? true})]
-                    {:visited visited :visiting visiting :error error})
-                  (let [deps (get-deps-fn node)]
-                    (loop [remaining-deps deps
-                           v visited
-                           ing (conj visiting node-id)]
-                      (if (empty? remaining-deps)
-                        {:visited (conj v node-id) :visiting (disj ing node-id) :error nil}
-                        (let [result (visit (first remaining-deps) (conj path node-id) v ing)]
-                          (if (:error result)
-                            result
-                            (recur (rest remaining-deps)
-                                   (:visited result)
-                                   (:visiting result)))))))))))]
-
-    (loop [nodes start-nodes
-           visited #{}
-           visiting #{}]
-      (if (empty? nodes)
-        {:valid? true :graph graph}
-        (let [result (visit (first nodes) [] visited visiting)]
-          (if (:error result)
-            (:error result)
-            (recur (rest nodes)
-                   (:visited result)
-                   (:visiting result))))))))
+                                   :else
+                                   {})
+                         error (when (or (:cycle? state) (:missing? state))
+                                 (validate-fn node-id node context))]
+                     (if error
+                       (assoc state :result error :halt? true)
+                       (dissoc state :cycle? :missing?))))
+        final-state (dfs-traverse graph start-nodes get-deps-fn visit-fn)]
+    (if-let [error (:result final-state)]
+      error
+      {:valid? true :graph graph})))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Transitive trust rule validation

--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -73,6 +73,103 @@
        (vector? (:dependencies pack-ref))))
 
 ;------------------------------------------------------------------------------ Layer 2
+;; Generic DFS utilities
+
+(defn ^:private dfs-find
+  "Generic DFS to find nodes matching a predicate.
+
+  Arguments:
+  - graph        - Map of node-id -> node
+  - start-id     - Starting node ID
+  - get-deps-fn  - Function (node) -> [dependency-ids]
+  - found-fn     - Function (node-id, node, path) -> truthy if found
+
+  Returns:
+  - nil if not found
+  - {:found-id node-id :path [...]} if found"
+  [graph start-id get-deps-fn found-fn]
+  (letfn [(search [node-id path visited]
+            (if (contains? visited node-id)
+              {:visited visited :found nil}
+              (let [node (get graph node-id)]
+                (cond
+                  ;; Node not in graph
+                  (not node)
+                  {:visited (conj visited node-id) :found nil}
+
+                  ;; Found matching node
+                  (found-fn node-id node path)
+                  {:visited visited :found {:found-id node-id :path (conj path node-id)}}
+
+                  ;; Search dependencies
+                  :else
+                  (let [deps (get-deps-fn node)]
+                    (loop [remaining-deps deps
+                           v (conj visited node-id)]
+                      (if (empty? remaining-deps)
+                        {:visited v :found nil}
+                        (let [result (search (first remaining-deps) (conj path node-id) v)]
+                          (if (:found result)
+                            result
+                            (recur (rest remaining-deps) (:visited result)))))))))))]
+
+    (let [result (search start-id [] #{})]
+      (:found result))))
+
+(defn ^:private dfs-validate-graph
+  "Generic DFS to validate graph structure (cycles, missing nodes).
+
+  Arguments:
+  - graph        - Map of node-id -> node
+  - start-nodes  - Collection of starting node IDs
+  - get-deps-fn  - Function (node) -> [dependency-ids]
+  - validate-fn  - Function (node-id, node, context) -> error-map or nil
+                   where context is {:cycle? bool :missing? bool :path [...]}
+
+  Returns:
+  - {:valid? true :graph graph} if valid
+  - {:valid? false :error ...} if invalid"
+  [graph start-nodes get-deps-fn validate-fn]
+  (letfn [(visit [node-id path visited visiting]
+            (cond
+              (contains? visited node-id)
+              {:visited visited :visiting visiting :error nil}
+
+              (contains? visiting node-id)
+              (let [error (validate-fn node-id nil {:cycle? true :path (conj path node-id)})]
+                {:visited visited :visiting visiting :error error})
+
+              :else
+              (let [node (get graph node-id)]
+                (if-not node
+                  (let [error (validate-fn node-id nil {:missing? true})]
+                    {:visited visited :visiting visiting :error error})
+                  (let [deps (get-deps-fn node)]
+                    (loop [remaining-deps deps
+                           v visited
+                           ing (conj visiting node-id)]
+                      (if (empty? remaining-deps)
+                        {:visited (conj v node-id) :visiting (disj ing node-id) :error nil}
+                        (let [result (visit (first remaining-deps) (conj path node-id) v ing)]
+                          (if (:error result)
+                            result
+                            (recur (rest remaining-deps)
+                                   (:visited result)
+                                   (:visiting result)))))))))))]
+
+    (loop [nodes start-nodes
+           visited #{}
+           visiting #{}]
+      (if (empty? nodes)
+        {:valid? true :graph graph}
+        (let [result (visit (first nodes) [] visited visiting)]
+          (if (:error result)
+            (:error result)
+            (recur (rest nodes)
+                   (:visited result)
+                   (:visiting result))))))))
+
+;------------------------------------------------------------------------------ Layer 3
 ;; Transitive trust rule validation
 
 (defn validate-instruction-authority-not-transitive
@@ -127,60 +224,22 @@
    - {:valid? true :graph {...}} if valid
    - {:valid? false :error \"...\"} if invalid (circular deps, etc.)"
   [pack-graph]
-  ;; Use loop/recur with immutable data structures for DFS
-  (letfn [(visit-pack [pack-id path visited visiting]
-            (cond
-              ;; Already fully visited - skip
-              (contains? visited pack-id)
-              {:visited visited :visiting visiting :error nil}
+  (dfs-validate-graph
+   pack-graph
+   (keys pack-graph)
+   (fn [pack-ref] (:dependencies pack-ref))
+   (fn [pack-id _node context]
+     (cond
+       (:cycle? context)
+       {:valid? false
+        :error (str "Circular dependency detected: "
+                    (clojure.string/join " -> " (:path context)))}
 
-              ;; Currently visiting - circular dependency!
-              (contains? visiting pack-id)
-              {:visited visited
-               :visiting visiting
-               :error {:valid? false
-                       :error (str "Circular dependency detected: "
-                                   (clojure.string/join " -> " (conj path pack-id)))}}
+       (:missing? context)
+       {:valid? false
+        :error (str "Missing dependency: " pack-id)}
 
-              ;; Visit this node
-              :else
-              (let [pack-ref (get pack-graph pack-id)]
-                (if-not pack-ref
-                  {:visited visited
-                   :visiting visiting
-                   :error {:valid? false
-                           :error (str "Missing dependency: " pack-id)}}
-                  ;; Process dependencies using loop/recur
-                  (loop [deps (:dependencies pack-ref)
-                         v visited
-                         ing (conj visiting pack-id)]
-                    (if (empty? deps)
-                      ;; All dependencies processed - mark as visited
-                      {:visited (conj v pack-id)
-                       :visiting (disj ing pack-id)
-                       :error nil}
-                      ;; Process next dependency
-                      (let [dep (first deps)
-                            result (visit-pack dep (conj path pack-id) v ing)]
-                        (if (:error result)
-                          result  ; Error found, propagate
-                          ;; Continue with updated visited/visiting sets
-                          (recur (rest deps)
-                                 (:visited result)
-                                 (:visiting result))))))))))]
-
-    ;; Process all packs
-    (loop [packs (keys pack-graph)
-           visited #{}
-           visiting #{}]
-      (if (empty? packs)
-        {:valid? true :graph pack-graph}
-        (let [result (visit-pack (first packs) [] visited visiting)]
-          (if (:error result)
-            (:error result)  ; Return error immediately
-            (recur (rest packs)
-                   (:visited result)
-                   (:visiting result))))))))
+       :else nil))))
 
 (defn validate-tainted-isolation
   "Rule 4: Tainted isolation.
@@ -199,44 +258,61 @@
   (let [pack-ref (get pack-graph pack-id)]
     (if (not= :authority/instruction (:authority pack-ref))
       {:valid? true}  ; Rule only applies to instruction packs
-      ;; Use loop/recur for DFS to find tainted content
-      (letfn [(check-tainted [current-id path visited]
-                (if (contains? visited current-id)
-                  {:visited visited :tainted nil}  ; Already visited
-                  (let [pack-ref (get pack-graph current-id)]
-                    (cond
-                      ;; Pack not found
-                      (not pack-ref)
-                      {:visited (conj visited current-id) :tainted nil}
+      (if-let [found (dfs-find
+                      pack-graph
+                      pack-id
+                      (fn [pack-ref] (:dependencies pack-ref))
+                      (fn [node-id node _path]
+                        (= :tainted (:trust-level node))))]
+        {:valid? false
+         :error (str "Pack " pack-id " has :authority/instruction but "
+                     "transitively includes tainted content from "
+                     (:found-id found))
+         :tainted-path (:path found)}
+        {:valid? true}))))
 
-                      ;; Found tainted content
-                      (= :tainted (:trust-level pack-ref))
-                      {:visited visited
-                       :tainted {:tainted-id current-id
-                                 :path (conj path current-id)}}
-
-                      ;; Check dependencies
-                      :else
-                      (loop [deps (:dependencies pack-ref)
-                             v (conj visited current-id)]
-                        (if (empty? deps)
-                          {:visited v :tainted nil}
-                          (let [result (check-tainted (first deps) (conj path current-id) v)]
-                            (if (:tainted result)
-                              result  ; Tainted found, propagate
-                              (recur (rest deps) (:visited result))))))))))]
-
-        (let [result (check-tainted pack-id [] #{})]
-          (if-let [tainted-result (:tainted result)]
-            {:valid? false
-             :error (str "Pack " pack-id " has :authority/instruction but "
-                         "transitively includes tainted content from "
-                         (:tainted-id tainted-result))
-             :tainted-path (:path tainted-result)}
-            {:valid? true}))))))
-
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 4
 ;; Combined validation
+
+(defn ^:private collect-authority-errors
+  "Check Rule 1: Instruction authority is not transitive.
+
+   Validates that no pack with instruction authority transitively
+   grants that authority to untrusted dependencies.
+
+   Arguments:
+   - pack-graph - Map of pack-id -> pack-ref
+
+   Returns:
+   - Sequence of error strings (empty if no errors)"
+  [pack-graph]
+  (->> (vals pack-graph)
+       (mapcat (fn [pack-ref]
+                 (->> (:dependencies pack-ref)
+                      (keep (fn [dep-id]
+                              (when-let [dep-ref (get pack-graph dep-id)]
+                                (let [result (validate-instruction-authority-not-transitive pack-ref dep-ref)]
+                                  (when-not (:valid? result)
+                                    (:error result)))))))))))
+
+(defn ^:private collect-tainted-errors
+  "Check Rule 4: Tainted isolation from instruction authority.
+
+   Validates that no pack with instruction authority transitively
+   includes tainted content.
+
+   Arguments:
+   - pack-graph - Map of pack-id -> pack-ref
+
+   Returns:
+   - Sequence of error strings (empty if no errors)"
+  [pack-graph]
+  (->> pack-graph
+       (keep (fn [[pack-id pack-ref]]
+               (when (= :authority/instruction (:authority pack-ref))
+                 (let [result (validate-tainted-isolation pack-id pack-graph)]
+                   (when-not (:valid? result)
+                     (:error result))))))))
 
 (defn validate-transitive-trust
   "Validate all transitive trust rules for a pack graph.
@@ -254,38 +330,19 @@
    - {:valid? true :packs [...]} if all rules pass
    - {:valid? false :errors [...]} if any rule fails"
   [pack-graph]
-  ;; Rule 3: Validate cross-trust references first
+  ;; Rule 3: Validate cross-trust references first (graph structure)
   (let [graph-validation (validate-cross-trust-references pack-graph)]
     (when-not (:valid? graph-validation)
       (throw (ex-info "Invalid pack graph" graph-validation)))
 
-    ;; Collect validation errors using functional style
-    (let [;; Rule 1: Check instruction authority transitivity
-          authority-errors
-          (->> (vals pack-graph)
-               (mapcat (fn [pack-ref]
-                         (->> (:dependencies pack-ref)
-                              (keep (fn [dep-id]
-                                      (when-let [dep-ref (get pack-graph dep-id)]
-                                        (let [result (validate-instruction-authority-not-transitive pack-ref dep-ref)]
-                                          (when-not (:valid? result)
-                                            (:error result))))))))))
-
-          ;; Rule 4: Check tainted isolation for instruction packs
-          tainted-errors
-          (->> pack-graph
-               (keep (fn [[pack-id pack-ref]]
-                       (when (= :authority/instruction (:authority pack-ref))
-                         (let [result (validate-tainted-isolation pack-id pack-graph)]
-                           (when-not (:valid? result)
-                             (:error result)))))))]
-
-      (let [errors (concat authority-errors tainted-errors)]
-        (if (empty? errors)
-          {:valid? true
-           :packs (keys pack-graph)}
-          {:valid? false
-           :errors (vec errors)})))))
+    ;; Collect all validation errors
+    (let [errors (concat (collect-authority-errors pack-graph)
+                         (collect-tainted-errors pack-graph))]
+      (if (empty? errors)
+        {:valid? true
+         :packs (keys pack-graph)}
+        {:valid? false
+         :errors (vec errors)}))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -1,0 +1,303 @@
+(ns ai.miniforge.knowledge.trust
+  "Transitive trust rules for knowledge packs.
+
+   Implements N1 §2.10.2 transitive trust rules to prevent trust escalation attacks:
+   1. Instruction authority is not transitive
+   2. Trust level inheritance (lowest wins)
+   3. Cross-trust reference tracking and validation
+   4. Tainted isolation from instruction authority
+
+   Trust levels (ordered):
+   - :tainted   - Flagged by scanners; MUST NOT be used for instruction
+   - :untrusted - Repo-derived or external; data-only unless promoted
+   - :trusted   - Platform-validated and/or user-promoted
+
+   Authority channels:
+   - :authority/instruction - May shape agent plans (requires :trusted)
+   - :authority/data        - Reference material only (any trust level)")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Trust level ordering
+
+(def ^:private trust-levels
+  "Trust levels in ascending order (lower index = less trusted)."
+  [:tainted :untrusted :trusted])
+
+(defn trust-level-order
+  "Return numeric order of trust level (lower = less trusted).
+   Returns nil for invalid trust levels."
+  [level]
+  (let [idx (.indexOf trust-levels level)]
+    (when (>= idx 0) idx)))
+
+(defn lowest-trust-level
+  "Return the lowest (least trusted) level from a collection.
+   Returns :tainted if any level is :tainted.
+   Returns :untrusted if any is :untrusted and none are :tainted.
+   Returns :trusted only if all are :trusted."
+  [levels]
+  (when (seq levels)
+    (let [valid-levels (filter #(contains? (set trust-levels) %) levels)]
+      (if (empty? valid-levels)
+        :untrusted  ; Default to untrusted if no valid levels
+        (apply min-key trust-level-order valid-levels)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pack trust schema
+
+(defn make-pack-ref
+  "Create a pack reference with trust information.
+
+   Arguments:
+   - pack-id       - Unique identifier for the pack
+   - trust-level   - :trusted, :untrusted, or :tainted
+   - authority     - :authority/instruction or :authority/data
+
+   Options:
+   - :dependencies - Vector of pack-ids this pack depends on
+
+   Returns pack reference map."
+  [pack-id trust-level authority & {:keys [dependencies]}]
+  {:pack-id pack-id
+   :trust-level trust-level
+   :authority authority
+   :dependencies (or dependencies [])})
+
+(defn valid-pack-ref?
+  "Validate that a pack reference has required fields and valid values."
+  [pack-ref]
+  (and (map? pack-ref)
+       (:pack-id pack-ref)
+       (contains? (set trust-levels) (:trust-level pack-ref))
+       (contains? #{:authority/instruction :authority/data} (:authority pack-ref))
+       (vector? (:dependencies pack-ref))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Transitive trust rule validation
+
+(defn validate-instruction-authority-not-transitive
+  "Rule 1: Instruction authority is not transitive.
+
+   If pack A (:trusted, :authority/instruction) references pack B (:untrusted),
+   pack B MUST remain :authority/data and MUST NOT gain instruction authority.
+
+   Arguments:
+   - source-pack - Pack reference with :authority/instruction
+   - target-pack - Pack being referenced
+
+   Returns:
+   - {:valid? true} if rule passes
+   - {:valid? false :error \"...\"} if rule fails"
+  [source-pack target-pack]
+  (if (not= :authority/instruction (:authority source-pack))
+    {:valid? true}  ; Rule only applies to instruction-authority packs
+    (if (and (= :authority/instruction (:authority target-pack))
+             (not= :trusted (:trust-level target-pack)))
+      {:valid? false
+       :error (str "Instruction authority cannot be granted transitively: "
+                   "Pack " (:pack-id target-pack) " is " (:trust-level target-pack)
+                   " but has :authority/instruction. "
+                   "Only :trusted packs may have instruction authority.")}
+      {:valid? true})))
+
+(defn compute-inherited-trust-level
+  "Rule 2: Trust level inheritance.
+
+   When pack A includes content from pack B, the combined content
+   MUST be assigned the lower trust level.
+
+   Arguments:
+   - pack-refs - Collection of pack references being combined
+
+   Returns the lowest trust level from all packs."
+  [pack-refs]
+  (let [levels (map :trust-level pack-refs)]
+    (lowest-trust-level levels)))
+
+(defn validate-cross-trust-references
+  "Rule 3: Cross-trust references.
+
+   Packs MAY reference other packs of any trust level, but must
+   track and validate the transitive trust graph.
+
+   Arguments:
+   - pack-graph - Map of pack-id -> pack-ref
+
+   Returns:
+   - {:valid? true :graph {...}} if valid
+   - {:valid? false :error \"...\"} if invalid (circular deps, etc.)"
+  [pack-graph]
+  (let [visited (atom #{})
+        visiting (atom #{})]
+
+    ;; Detect circular dependencies via depth-first search
+    (letfn [(visit [pack-id path]
+              (cond
+                ;; Already fully visited - no issue
+                (contains? @visited pack-id)
+                nil
+
+                ;; Currently visiting - circular dependency!
+                (contains? @visiting pack-id)
+                {:valid? false
+                 :error (str "Circular dependency detected: "
+                            (clojure.string/join " -> " (conj path pack-id)))}
+
+                ;; Visit this node
+                :else
+                (let [pack-ref (get pack-graph pack-id)]
+                  (if-not pack-ref
+                    {:valid? false
+                     :error (str "Missing dependency: " pack-id)}
+                    (do
+                      ;; Mark as currently visiting BEFORE checking dependencies
+                      (swap! visiting conj pack-id)
+                      ;; Check all dependencies - return first error or nil
+                      (let [error (some #(visit % (conj path pack-id))
+                                       (:dependencies pack-ref))]
+                        ;; Mark as done visiting only if no error found
+                        (when-not error
+                          (swap! visiting disj pack-id)
+                          (swap! visited conj pack-id))
+                        ;; Return error if found
+                        error))))))]
+
+      ;; Check all packs - return first error found
+      (if-let [error (some #(visit % []) (keys pack-graph))]
+        error  ; Already has :valid? false
+        {:valid? true :graph pack-graph}))))
+
+(defn validate-tainted-isolation
+  "Rule 4: Tainted isolation.
+
+   Content marked :tainted MUST NOT be included in any pack used for
+   instruction authority, even transitively.
+
+   Arguments:
+   - pack-id     - Pack to validate
+   - pack-graph  - Map of pack-id -> pack-ref
+
+   Returns:
+   - {:valid? true} if no tainted content in instruction chain
+   - {:valid? false :error \"...\" :tainted-path [...]} if tainted found"
+  [pack-id pack-graph]
+  (let [visited (atom #{})]
+    (letfn [(has-tainted? [current-id path]
+              (when-not (contains? @visited current-id)
+                (swap! visited conj current-id)
+                (let [pack-ref (get pack-graph current-id)]
+                  (cond
+                    ;; Pack not found
+                    (not pack-ref)
+                    nil
+
+                    ;; Found tainted content
+                    (= :tainted (:trust-level pack-ref))
+                    {:tainted-id current-id
+                     :path (conj path current-id)}
+
+                    ;; Check dependencies
+                    :else
+                    (some #(has-tainted? % (conj path current-id))
+                          (:dependencies pack-ref))))))]
+
+      (let [pack-ref (get pack-graph pack-id)]
+        (if (not= :authority/instruction (:authority pack-ref))
+          {:valid? true}  ; Rule only applies to instruction packs
+          (if-let [tainted-result (has-tainted? pack-id [])]
+            {:valid? false
+             :error (str "Pack " pack-id " has :authority/instruction but "
+                        "transitively includes tainted content from "
+                        (:tainted-id tainted-result))
+             :tainted-path (:path tainted-result)}
+            {:valid? true}))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Combined validation
+
+(defn validate-transitive-trust
+  "Validate all transitive trust rules for a pack graph.
+
+   Checks:
+   1. Instruction authority is not transitive
+   2. Trust level inheritance is correct
+   3. Cross-trust references are valid (no cycles, missing deps)
+   4. Tainted content is isolated from instruction authority
+
+   Arguments:
+   - pack-graph - Map of pack-id -> pack-ref
+
+   Returns:
+   - {:valid? true :packs [...]} if all rules pass
+   - {:valid? false :errors [...]} if any rule fails"
+  [pack-graph]
+  (let [;; Rule 3: Validate cross-trust references first
+        graph-validation (validate-cross-trust-references pack-graph)
+
+        ;; If graph is invalid, return early
+        _ (when-not (:valid? graph-validation)
+            (throw (ex-info "Invalid pack graph" graph-validation)))
+
+        ;; Collect validation errors
+        errors (atom [])
+
+        ;; Rule 1: Check instruction authority transitivity
+        _ (doseq [pack-ref (vals pack-graph)
+                  dep-id (:dependencies pack-ref)]
+            (let [dep-ref (get pack-graph dep-id)
+                  result (when dep-ref
+                          (validate-instruction-authority-not-transitive pack-ref dep-ref))]
+              (when (and result (not (:valid? result)))
+                (swap! errors conj (:error result)))))
+
+        ;; Rule 4: Check tainted isolation for instruction packs
+        _ (doseq [[pack-id pack-ref] pack-graph]
+            (when (= :authority/instruction (:authority pack-ref))
+              (let [result (validate-tainted-isolation pack-id pack-graph)]
+                (when-not (:valid? result)
+                  (swap! errors conj (:error result))))))]
+
+    (if (empty? @errors)
+      {:valid? true
+       :packs (keys pack-graph)}
+      {:valid? false
+       :errors @errors})))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Example: Trusted pack referencing untrusted pack (data-only)
+  (def pack-a (make-pack-ref "pack-a" :trusted :authority/instruction
+                             :dependencies ["pack-b"]))
+  (def pack-b (make-pack-ref "pack-b" :untrusted :authority/data))
+
+  (validate-instruction-authority-not-transitive pack-a pack-b)
+  ;; => {:valid? true}
+
+  ;; Example: Attempt to grant instruction authority transitively (INVALID)
+  (def pack-b-bad (make-pack-ref "pack-b" :untrusted :authority/instruction))
+  (validate-instruction-authority-not-transitive pack-a pack-b-bad)
+  ;; => {:valid? false :error "..."}
+
+  ;; Example: Trust level inheritance
+  (compute-inherited-trust-level [pack-a pack-b])
+  ;; => :untrusted (lowest level)
+
+  ;; Example: Circular dependency detection
+  (def circular-graph
+    {"a" (make-pack-ref "a" :trusted :authority/data :dependencies ["b"])
+     "b" (make-pack-ref "b" :trusted :authority/data :dependencies ["c"])
+     "c" (make-pack-ref "c" :trusted :authority/data :dependencies ["a"])})
+
+  (validate-cross-trust-references circular-graph)
+  ;; => {:valid? false :error "Circular dependency detected: ..."}
+
+  ;; Example: Tainted isolation
+  (def tainted-graph
+    {"main" (make-pack-ref "main" :trusted :authority/instruction
+                          :dependencies ["lib"])
+     "lib" (make-pack-ref "lib" :tainted :authority/data)})
+
+  (validate-tainted-isolation "main" tainted-graph)
+  ;; => {:valid? false :error "... transitively includes tainted content ..." :tainted-path [...]}
+
+  :end)

--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -76,64 +76,73 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Generic DFS utilities
 
-(defn ^:private dfs-traverse
-  "Canonical DFS traversal with pluggable visit function.
+(defn ^:private dfs
+  "Simple canonical DFS traversal.
 
   Arguments:
   - graph       - Map of node-id -> node
-  - start-nodes - Collection of starting node IDs (or single ID)
+  - start-ids   - Collection of starting node IDs (or single ID)
   - get-deps-fn - Function (node) -> [dependency-ids]
-  - visit-fn    - Function (node-id, node, path, state) -> updated state
-                  State map has :visited, :visiting (optional), :result keys
-                  visit-fn should return updated state or state with :halt? true to stop
+  - on-visit-fn - Function (node-id node path visited visiting) -> result or nil
+                  Called when visiting a node (not in visited yet)
+                  Return non-nil to halt and return that value
+  - on-cycle-fn - Function (node-id path visited visiting) -> result or nil
+                  Called when cycle detected (node in visiting set)
+                  Return non-nil to halt and return that value
+  - on-missing-fn - Function (node-id visited visiting) -> result or nil
+                    Called when node not found in graph
+                    Return non-nil to halt and return that value
 
-  Returns final state map."
-  [graph start-nodes get-deps-fn visit-fn]
-  (let [start-nodes (if (coll? start-nodes) start-nodes [start-nodes])
-        initial-state {:visited #{} :visiting #{} :result nil}]
+  Returns [final-visited final-result] where result is:
+  - nil if traversal completed without halting
+  - value returned by on-visit-fn/on-cycle-fn/on-missing-fn if halted"
+  [graph start-ids get-deps-fn on-visit-fn on-cycle-fn on-missing-fn]
+  (let [start-ids (if (coll? start-ids) start-ids [start-ids])]
+    (letfn [(traverse [node-id path visited visiting]
+              (cond
+                ;; Already visited - continue
+                (contains? visited node-id)
+                [visited nil]
 
-    (letfn [(visit-node [node-id path state]
-              (let [{:keys [visited visiting]} state]
-                (cond
-                  ;; Already visited - skip
-                  (contains? visited node-id)
-                  state
+                ;; Currently visiting - cycle detected
+                (contains? visiting node-id)
+                (let [result (on-cycle-fn node-id (conj path node-id) visited visiting)]
+                  [visited result])
 
-                  ;; Currently visiting - call visit-fn with cycle context
-                  (contains? visiting node-id)
-                  (visit-fn node-id nil (conj path node-id)
-                            (assoc state :cycle? true))
-
-                  ;; Visit this node
-                  :else
-                  (let [node (get graph node-id)]
-                    (if-not node
-                      ;; Missing node - call visit-fn
-                      (visit-fn node-id nil path (assoc state :missing? true))
-                      ;; Process node and dependencies
-                      (let [state' (visit-fn node-id node path
-                                             (update state :visiting conj node-id))]
-                        (if (:halt? state')
-                          state'
-                          ;; Visit dependencies
-                          (let [deps (get-deps-fn node)
-                                final-state (reduce (fn [s dep-id]
-                                                      (if (:halt? s)
-                                                        s
-                                                        (visit-node dep-id (conj path node-id) s)))
-                                                    state'
-                                                    deps)]
-                            (-> final-state
-                                (update :visited conj node-id)
-                                (update :visiting disj node-id))))))))))]
+                ;; Visit this node
+                :else
+                (let [node (get graph node-id)]
+                  (if-not node
+                    ;; Node not in graph
+                    (let [result (on-missing-fn node-id visited visiting)]
+                      [visited result])
+                    ;; Process node
+                    (let [result (on-visit-fn node-id node path visited visiting)]
+                      (if result
+                        ;; Halt with result
+                        [visited result]
+                        ;; Continue with dependencies
+                        (let [deps (get-deps-fn node)
+                              visiting' (conj visiting node-id)]
+                          (loop [remaining-deps deps
+                                 v visited
+                                 result nil]
+                            (if (or result (empty? remaining-deps))
+                              [(conj v node-id) result]
+                              (let [[v' result'] (traverse (first remaining-deps)
+                                                           (conj path node-id)
+                                                           v
+                                                           visiting')]
+                                (recur (rest remaining-deps) v' result')))))))))))]
 
       ;; Process all start nodes
-      (reduce (fn [state node-id]
-                (if (:halt? state)
-                  state
-                  (visit-node node-id [] state)))
-              initial-state
-              start-nodes))))
+      (loop [remaining-starts start-ids
+             visited #{}
+             result nil]
+        (if (or result (empty? remaining-starts))
+          [visited result]
+          (let [[visited' result'] (traverse (first remaining-starts) [] visited #{})]
+            (recur (rest remaining-starts) visited' result')))))))
 
 (defn ^:private dfs-find
   "Find first node matching a predicate using DFS.
@@ -148,23 +157,19 @@
   - nil if not found
   - {:found-id node-id :path [...]} if found"
   [graph start-id get-deps-fn found-fn]
-  (let [visit-fn (fn [node-id node path state]
-                   (cond
-                     ;; Missing or cycle - continue
-                     (or (:missing? state) (:cycle? state))
-                     (dissoc state :missing? :cycle?)
-
-                     ;; Check if this node matches
-                     (and node (found-fn node-id node path))
-                     (assoc state
-                            :result {:found-id node-id :path (conj path node-id)}
-                            :halt? true)
-
-                     ;; Continue traversal
-                     :else
-                     state))
-        final-state (dfs-traverse graph start-id get-deps-fn visit-fn)]
-    (:result final-state)))
+  (let [[_visited result]
+        (dfs graph
+             start-id
+             get-deps-fn
+             ;; on-visit: check if node matches predicate
+             (fn [node-id node path _visited _visiting]
+               (when (found-fn node-id node path)
+                 {:found-id node-id :path (conj path node-id)}))
+             ;; on-cycle: ignore cycles for find
+             (fn [_node-id _path _visited _visiting] nil)
+             ;; on-missing: ignore missing nodes for find
+             (fn [_node-id _visited _visiting] nil))]
+    result))
 
 (defn ^:private dfs-validate-graph
   "Validate graph structure (cycles, missing nodes) using DFS.
@@ -180,24 +185,20 @@
   - {:valid? true :graph graph} if valid
   - {:valid? false :error ...} if invalid"
   [graph start-nodes get-deps-fn validate-fn]
-  (let [visit-fn (fn [node-id node path state]
-                   (let [context (cond
-                                   (:cycle? state)
-                                   {:cycle? true :path path}
-
-                                   (:missing? state)
-                                   {:missing? true}
-
-                                   :else
-                                   {})
-                         error (when (or (:cycle? state) (:missing? state))
-                                 (validate-fn node-id node context))]
-                     (if error
-                       (assoc state :result error :halt? true)
-                       (dissoc state :cycle? :missing?))))
-        final-state (dfs-traverse graph start-nodes get-deps-fn visit-fn)]
-    (if-let [error (:result final-state)]
-      error
+  (let [[_visited result]
+        (dfs graph
+             start-nodes
+             get-deps-fn
+             ;; on-visit: continue (no validation needed on normal visit)
+             (fn [_node-id _node _path _visited _visiting] nil)
+             ;; on-cycle: validate cycle
+             (fn [node-id path _visited _visiting]
+               (validate-fn node-id nil {:cycle? true :path path}))
+             ;; on-missing: validate missing node
+             (fn [node-id _visited _visiting]
+               (validate-fn node-id nil {:missing? true})))]
+    (if result
+      result
       {:valid? true :graph graph})))
 
 ;------------------------------------------------------------------------------ Layer 3

--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -127,45 +127,60 @@
    - {:valid? true :graph {...}} if valid
    - {:valid? false :error \"...\"} if invalid (circular deps, etc.)"
   [pack-graph]
-  (let [visited (atom #{})
-        visiting (atom #{})]
+  ;; Use loop/recur with immutable data structures for DFS
+  (letfn [(visit-pack [pack-id path visited visiting]
+            (cond
+              ;; Already fully visited - skip
+              (contains? visited pack-id)
+              {:visited visited :visiting visiting :error nil}
 
-    ;; Detect circular dependencies via depth-first search
-    (letfn [(visit [pack-id path]
-              (cond
-                ;; Already fully visited - no issue
-                (contains? @visited pack-id)
-                nil
+              ;; Currently visiting - circular dependency!
+              (contains? visiting pack-id)
+              {:visited visited
+               :visiting visiting
+               :error {:valid? false
+                       :error (str "Circular dependency detected: "
+                                   (clojure.string/join " -> " (conj path pack-id)))}}
 
-                ;; Currently visiting - circular dependency!
-                (contains? @visiting pack-id)
-                {:valid? false
-                 :error (str "Circular dependency detected: "
-                            (clojure.string/join " -> " (conj path pack-id)))}
+              ;; Visit this node
+              :else
+              (let [pack-ref (get pack-graph pack-id)]
+                (if-not pack-ref
+                  {:visited visited
+                   :visiting visiting
+                   :error {:valid? false
+                           :error (str "Missing dependency: " pack-id)}}
+                  ;; Process dependencies using loop/recur
+                  (loop [deps (:dependencies pack-ref)
+                         v visited
+                         ing (conj visiting pack-id)]
+                    (if (empty? deps)
+                      ;; All dependencies processed - mark as visited
+                      {:visited (conj v pack-id)
+                       :visiting (disj ing pack-id)
+                       :error nil}
+                      ;; Process next dependency
+                      (let [dep (first deps)
+                            result (visit-pack dep (conj path pack-id) v ing)]
+                        (if (:error result)
+                          result  ; Error found, propagate
+                          ;; Continue with updated visited/visiting sets
+                          (recur (rest deps)
+                                 (:visited result)
+                                 (:visiting result))))))))))]
 
-                ;; Visit this node
-                :else
-                (let [pack-ref (get pack-graph pack-id)]
-                  (if-not pack-ref
-                    {:valid? false
-                     :error (str "Missing dependency: " pack-id)}
-                    (do
-                      ;; Mark as currently visiting BEFORE checking dependencies
-                      (swap! visiting conj pack-id)
-                      ;; Check all dependencies - return first error or nil
-                      (let [error (some #(visit % (conj path pack-id))
-                                       (:dependencies pack-ref))]
-                        ;; Mark as done visiting only if no error found
-                        (when-not error
-                          (swap! visiting disj pack-id)
-                          (swap! visited conj pack-id))
-                        ;; Return error if found
-                        error))))))]
-
-      ;; Check all packs - return first error found
-      (if-let [error (some #(visit % []) (keys pack-graph))]
-        error  ; Already has :valid? false
-        {:valid? true :graph pack-graph}))))
+    ;; Process all packs
+    (loop [packs (keys pack-graph)
+           visited #{}
+           visiting #{}]
+      (if (empty? packs)
+        {:valid? true :graph pack-graph}
+        (let [result (visit-pack (first packs) [] visited visiting)]
+          (if (:error result)
+            (:error result)  ; Return error immediately
+            (recur (rest packs)
+                   (:visited result)
+                   (:visiting result))))))))
 
 (defn validate-tainted-isolation
   "Rule 4: Tainted isolation.
@@ -181,34 +196,42 @@
    - {:valid? true} if no tainted content in instruction chain
    - {:valid? false :error \"...\" :tainted-path [...]} if tainted found"
   [pack-id pack-graph]
-  (let [visited (atom #{})]
-    (letfn [(has-tainted? [current-id path]
-              (when-not (contains? @visited current-id)
-                (swap! visited conj current-id)
-                (let [pack-ref (get pack-graph current-id)]
-                  (cond
-                    ;; Pack not found
-                    (not pack-ref)
-                    nil
+  (let [pack-ref (get pack-graph pack-id)]
+    (if (not= :authority/instruction (:authority pack-ref))
+      {:valid? true}  ; Rule only applies to instruction packs
+      ;; Use loop/recur for DFS to find tainted content
+      (letfn [(check-tainted [current-id path visited]
+                (if (contains? visited current-id)
+                  {:visited visited :tainted nil}  ; Already visited
+                  (let [pack-ref (get pack-graph current-id)]
+                    (cond
+                      ;; Pack not found
+                      (not pack-ref)
+                      {:visited (conj visited current-id) :tainted nil}
 
-                    ;; Found tainted content
-                    (= :tainted (:trust-level pack-ref))
-                    {:tainted-id current-id
-                     :path (conj path current-id)}
+                      ;; Found tainted content
+                      (= :tainted (:trust-level pack-ref))
+                      {:visited visited
+                       :tainted {:tainted-id current-id
+                                 :path (conj path current-id)}}
 
-                    ;; Check dependencies
-                    :else
-                    (some #(has-tainted? % (conj path current-id))
-                          (:dependencies pack-ref))))))]
+                      ;; Check dependencies
+                      :else
+                      (loop [deps (:dependencies pack-ref)
+                             v (conj visited current-id)]
+                        (if (empty? deps)
+                          {:visited v :tainted nil}
+                          (let [result (check-tainted (first deps) (conj path current-id) v)]
+                            (if (:tainted result)
+                              result  ; Tainted found, propagate
+                              (recur (rest deps) (:visited result))))))))))]
 
-      (let [pack-ref (get pack-graph pack-id)]
-        (if (not= :authority/instruction (:authority pack-ref))
-          {:valid? true}  ; Rule only applies to instruction packs
-          (if-let [tainted-result (has-tainted? pack-id [])]
+        (let [result (check-tainted pack-id [] #{})]
+          (if-let [tainted-result (:tainted result)]
             {:valid? false
              :error (str "Pack " pack-id " has :authority/instruction but "
-                        "transitively includes tainted content from "
-                        (:tainted-id tainted-result))
+                         "transitively includes tainted content from "
+                         (:tainted-id tainted-result))
              :tainted-path (:path tainted-result)}
             {:valid? true}))))))
 
@@ -231,37 +254,38 @@
    - {:valid? true :packs [...]} if all rules pass
    - {:valid? false :errors [...]} if any rule fails"
   [pack-graph]
-  (let [;; Rule 3: Validate cross-trust references first
-        graph-validation (validate-cross-trust-references pack-graph)
+  ;; Rule 3: Validate cross-trust references first
+  (let [graph-validation (validate-cross-trust-references pack-graph)]
+    (when-not (:valid? graph-validation)
+      (throw (ex-info "Invalid pack graph" graph-validation)))
 
-        ;; If graph is invalid, return early
-        _ (when-not (:valid? graph-validation)
-            (throw (ex-info "Invalid pack graph" graph-validation)))
+    ;; Collect validation errors using functional style
+    (let [;; Rule 1: Check instruction authority transitivity
+          authority-errors
+          (->> (vals pack-graph)
+               (mapcat (fn [pack-ref]
+                         (->> (:dependencies pack-ref)
+                              (keep (fn [dep-id]
+                                      (when-let [dep-ref (get pack-graph dep-id)]
+                                        (let [result (validate-instruction-authority-not-transitive pack-ref dep-ref)]
+                                          (when-not (:valid? result)
+                                            (:error result))))))))))
 
-        ;; Collect validation errors
-        errors (atom [])
+          ;; Rule 4: Check tainted isolation for instruction packs
+          tainted-errors
+          (->> pack-graph
+               (keep (fn [[pack-id pack-ref]]
+                       (when (= :authority/instruction (:authority pack-ref))
+                         (let [result (validate-tainted-isolation pack-id pack-graph)]
+                           (when-not (:valid? result)
+                             (:error result)))))))]
 
-        ;; Rule 1: Check instruction authority transitivity
-        _ (doseq [pack-ref (vals pack-graph)
-                  dep-id (:dependencies pack-ref)]
-            (let [dep-ref (get pack-graph dep-id)
-                  result (when dep-ref
-                          (validate-instruction-authority-not-transitive pack-ref dep-ref))]
-              (when (and result (not (:valid? result)))
-                (swap! errors conj (:error result)))))
-
-        ;; Rule 4: Check tainted isolation for instruction packs
-        _ (doseq [[pack-id pack-ref] pack-graph]
-            (when (= :authority/instruction (:authority pack-ref))
-              (let [result (validate-tainted-isolation pack-id pack-graph)]
-                (when-not (:valid? result)
-                  (swap! errors conj (:error result))))))]
-
-    (if (empty? @errors)
-      {:valid? true
-       :packs (keys pack-graph)}
-      {:valid? false
-       :errors @errors})))
+      (let [errors (concat authority-errors tainted-errors)]
+        (if (empty? errors)
+          {:valid? true
+           :packs (keys pack-graph)}
+          {:valid? false
+           :errors (vec errors)})))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/src/ai/miniforge/knowledge/trust.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/trust.clj
@@ -14,7 +14,8 @@
 
    Authority channels:
    - :authority/instruction - May shape agent plans (requires :trusted)
-   - :authority/data        - Reference material only (any trust level)")
+   - :authority/data        - Reference material only (any trust level)"
+  (:require [clojure.string]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Trust level ordering
@@ -262,7 +263,7 @@
                       pack-graph
                       pack-id
                       (fn [pack-ref] (:dependencies pack-ref))
-                      (fn [node-id node _path]
+                      (fn [_node-id node _path]
                         (= :tainted (:trust-level node))))]
         {:valid? false
          :error (str "Pack " pack-id " has :authority/instruction but "
@@ -272,7 +273,32 @@
         {:valid? true}))))
 
 ;------------------------------------------------------------------------------ Layer 4
-;; Combined validation
+;; Combined validation helpers
+
+(defn ^:private valid?
+  "Check if a validation result is valid."
+  [result]
+  (:valid? result))
+
+(defn ^:private error-from
+  "Extract error from validation result if invalid, otherwise nil."
+  [result]
+  (when-not (valid? result)
+    (:error result)))
+
+(defn ^:private check-dependency-authority
+  "Check if a dependency violates authority transitivity rules.
+   Returns error string or nil."
+  [pack-ref dep-id pack-graph]
+  (when-let [dep-ref (get pack-graph dep-id)]
+    (error-from (validate-instruction-authority-not-transitive pack-ref dep-ref))))
+
+(defn ^:private check-pack-tainted-isolation
+  "Check if an instruction pack transitively includes tainted content.
+   Returns error string or nil."
+  [pack-id pack-ref pack-graph]
+  (when (= :authority/instruction (:authority pack-ref))
+    (error-from (validate-tainted-isolation pack-id pack-graph))))
 
 (defn ^:private collect-authority-errors
   "Check Rule 1: Instruction authority is not transitive.
@@ -286,14 +312,11 @@
    Returns:
    - Sequence of error strings (empty if no errors)"
   [pack-graph]
-  (->> (vals pack-graph)
-       (mapcat (fn [pack-ref]
-                 (->> (:dependencies pack-ref)
-                      (keep (fn [dep-id]
-                              (when-let [dep-ref (get pack-graph dep-id)]
-                                (let [result (validate-instruction-authority-not-transitive pack-ref dep-ref)]
-                                  (when-not (:valid? result)
-                                    (:error result)))))))))))
+  (for [pack-ref (vals pack-graph)
+        dep-id (:dependencies pack-ref)
+        :let [error (check-dependency-authority pack-ref dep-id pack-graph)]
+        :when error]
+    error))
 
 (defn ^:private collect-tainted-errors
   "Check Rule 4: Tainted isolation from instruction authority.
@@ -307,12 +330,10 @@
    Returns:
    - Sequence of error strings (empty if no errors)"
   [pack-graph]
-  (->> pack-graph
-       (keep (fn [[pack-id pack-ref]]
-               (when (= :authority/instruction (:authority pack-ref))
-                 (let [result (validate-tainted-isolation pack-id pack-graph)]
-                   (when-not (:valid? result)
-                     (:error result))))))))
+  (for [[pack-id pack-ref] pack-graph
+        :let [error (check-pack-tainted-isolation pack-id pack-ref pack-graph)]
+        :when error]
+    error))
 
 (defn validate-transitive-trust
   "Validate all transitive trust rules for a pack graph.
@@ -332,7 +353,7 @@
   [pack-graph]
   ;; Rule 3: Validate cross-trust references first (graph structure)
   (let [graph-validation (validate-cross-trust-references pack-graph)]
-    (when-not (:valid? graph-validation)
+    (when-not (valid? graph-validation)
       (throw (ex-info "Invalid pack graph" graph-validation)))
 
     ;; Collect all validation errors

--- a/components/knowledge/test/ai/miniforge/knowledge/trust_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/trust_test.clj
@@ -1,0 +1,285 @@
+(ns ai.miniforge.knowledge.trust-test
+  "Tests for transitive trust rules (N1 §2.10.2).
+
+   Validates all four transitive trust rules:
+   1. Instruction authority is not transitive
+   2. Trust level inheritance (lowest wins)
+   3. Cross-trust references (no cycles, missing deps)
+   4. Tainted isolation from instruction authority"
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.knowledge.trust :as trust]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Trust level ordering tests
+
+(deftest trust-level-order-test
+  (testing "Trust levels have correct ordering"
+    (is (= 0 (trust/trust-level-order :tainted)))
+    (is (= 1 (trust/trust-level-order :untrusted)))
+    (is (= 2 (trust/trust-level-order :trusted))))
+
+  (testing "Invalid trust level returns nil"
+    (is (nil? (trust/trust-level-order :invalid)))))
+
+(deftest lowest-trust-level-test
+  (testing "Returns lowest trust level from collection"
+    (is (= :tainted (trust/lowest-trust-level [:tainted :untrusted :trusted])))
+    (is (= :untrusted (trust/lowest-trust-level [:untrusted :trusted])))
+    (is (= :trusted (trust/lowest-trust-level [:trusted :trusted]))))
+
+  (testing "Single level returns that level"
+    (is (= :trusted (trust/lowest-trust-level [:trusted])))
+    (is (= :untrusted (trust/lowest-trust-level [:untrusted]))))
+
+  (testing "Empty collection returns nil"
+    (is (nil? (trust/lowest-trust-level []))))
+
+  (testing "Filters invalid levels and returns valid ones"
+    (is (= :untrusted (trust/lowest-trust-level [:invalid :untrusted :trusted]))))
+
+  (testing "All invalid levels defaults to :untrusted"
+    (is (= :untrusted (trust/lowest-trust-level [:invalid :bad])))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pack reference creation and validation tests
+
+(deftest make-pack-ref-test
+  (testing "Creates pack reference with required fields"
+    (let [pack-ref (trust/make-pack-ref "pack-a" :trusted :authority/instruction)]
+      (is (= "pack-a" (:pack-id pack-ref)))
+      (is (= :trusted (:trust-level pack-ref)))
+      (is (= :authority/instruction (:authority pack-ref)))
+      (is (= [] (:dependencies pack-ref)))))
+
+  (testing "Creates pack reference with dependencies"
+    (let [pack-ref (trust/make-pack-ref "pack-a" :trusted :authority/instruction
+                                       :dependencies ["pack-b" "pack-c"])]
+      (is (= ["pack-b" "pack-c"] (:dependencies pack-ref))))))
+
+(deftest valid-pack-ref-test
+  (testing "Valid pack reference passes validation"
+    (let [pack-ref (trust/make-pack-ref "pack-a" :trusted :authority/instruction)]
+      (is (trust/valid-pack-ref? pack-ref))))
+
+  (testing "Invalid pack reference fails validation"
+    (is (not (trust/valid-pack-ref? {})))
+    (is (not (trust/valid-pack-ref? {:pack-id "a"})))
+    (is (not (trust/valid-pack-ref? {:pack-id "a" :trust-level :invalid})))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Rule 1: Instruction authority is not transitive
+
+(deftest instruction-authority-not-transitive-test
+  (testing "Trusted pack can reference untrusted data pack"
+    (let [trusted-pack (trust/make-pack-ref "pack-a" :trusted :authority/instruction)
+          untrusted-pack (trust/make-pack-ref "pack-b" :untrusted :authority/data)
+          result (trust/validate-instruction-authority-not-transitive
+                  trusted-pack untrusted-pack)]
+      (is (:valid? result))))
+
+  (testing "Trusted pack can reference trusted instruction pack"
+    (let [trusted-pack-a (trust/make-pack-ref "pack-a" :trusted :authority/instruction)
+          trusted-pack-b (trust/make-pack-ref "pack-b" :trusted :authority/instruction)
+          result (trust/validate-instruction-authority-not-transitive
+                  trusted-pack-a trusted-pack-b)]
+      (is (:valid? result))))
+
+  (testing "INVALID: Trusted pack cannot grant instruction authority to untrusted pack"
+    (let [trusted-pack (trust/make-pack-ref "pack-a" :trusted :authority/instruction)
+          untrusted-instruction (trust/make-pack-ref "pack-b" :untrusted :authority/instruction)
+          result (trust/validate-instruction-authority-not-transitive
+                  trusted-pack untrusted-instruction)]
+      (is (not (:valid? result)))
+      (is (string? (:error result)))
+      (is (re-find #"instruction authority cannot be granted transitively"
+                   (clojure.string/lower-case (:error result))))))
+
+  (testing "Data-only packs don't trigger rule"
+    (let [data-pack-a (trust/make-pack-ref "pack-a" :trusted :authority/data)
+          data-pack-b (trust/make-pack-ref "pack-b" :untrusted :authority/data)
+          result (trust/validate-instruction-authority-not-transitive
+                  data-pack-a data-pack-b)]
+      (is (:valid? result)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Rule 2: Trust level inheritance
+
+(deftest trust-level-inheritance-test
+  (testing "Combines trusted packs as trusted"
+    (let [pack-a (trust/make-pack-ref "pack-a" :trusted :authority/instruction)
+          pack-b (trust/make-pack-ref "pack-b" :trusted :authority/data)
+          result (trust/compute-inherited-trust-level [pack-a pack-b])]
+      (is (= :trusted result))))
+
+  (testing "Combining with untrusted yields untrusted"
+    (let [pack-a (trust/make-pack-ref "pack-a" :trusted :authority/instruction)
+          pack-b (trust/make-pack-ref "pack-b" :untrusted :authority/data)
+          result (trust/compute-inherited-trust-level [pack-a pack-b])]
+      (is (= :untrusted result))))
+
+  (testing "Any tainted pack taints the entire combination"
+    (let [pack-a (trust/make-pack-ref "pack-a" :trusted :authority/instruction)
+          pack-b (trust/make-pack-ref "pack-b" :untrusted :authority/data)
+          pack-c (trust/make-pack-ref "pack-c" :tainted :authority/data)
+          result (trust/compute-inherited-trust-level [pack-a pack-b pack-c])]
+      (is (= :tainted result))))
+
+  (testing "Multiple untrusted packs remain untrusted"
+    (let [pack-a (trust/make-pack-ref "pack-a" :untrusted :authority/data)
+          pack-b (trust/make-pack-ref "pack-b" :untrusted :authority/data)
+          result (trust/compute-inherited-trust-level [pack-a pack-b])]
+      (is (= :untrusted result)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Rule 3: Cross-trust references
+
+(deftest cross-trust-references-valid-test
+  (testing "Linear dependency chain is valid"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
+                                               :dependencies ["pack-c"])
+                 "pack-c" (trust/make-pack-ref "pack-c" :untrusted :authority/data)}
+          result (trust/validate-cross-trust-references graph)]
+      (is (:valid? result))
+      (is (= graph (:graph result)))))
+
+  (testing "DAG (diamond) is valid"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
+                                               :dependencies ["pack-b" "pack-c"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
+                                               :dependencies ["pack-d"])
+                 "pack-c" (trust/make-pack-ref "pack-c" :trusted :authority/data
+                                               :dependencies ["pack-d"])
+                 "pack-d" (trust/make-pack-ref "pack-d" :untrusted :authority/data)}
+          result (trust/validate-cross-trust-references graph)]
+      (is (:valid? result))))
+
+  (testing "Self-contained pack is valid"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction)}
+          result (trust/validate-cross-trust-references graph)]
+      (is (:valid? result)))))
+
+(deftest cross-trust-references-circular-test
+  (testing "INVALID: Direct circular dependency"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
+                                               :dependencies ["pack-a"])}
+          result (trust/validate-cross-trust-references graph)]
+      (is (not (:valid? result)))
+      (is (string? (:error result)))
+      (is (re-find #"circular dependency" (clojure.string/lower-case (:error result))))))
+
+  (testing "INVALID: Indirect circular dependency (A -> B -> C -> A)"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
+                                               :dependencies ["pack-c"])
+                 "pack-c" (trust/make-pack-ref "pack-c" :trusted :authority/data
+                                               :dependencies ["pack-a"])}
+          result (trust/validate-cross-trust-references graph)]
+      (is (not (:valid? result)))
+      (is (re-find #"circular" (clojure.string/lower-case (:error result)))))))
+
+(deftest cross-trust-references-missing-dep-test
+  (testing "INVALID: Missing dependency"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
+                                               :dependencies ["pack-missing"])}
+          result (trust/validate-cross-trust-references graph)]
+      (is (not (:valid? result)))
+      (is (re-find #"missing" (clojure.string/lower-case (:error result)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Rule 4: Tainted isolation
+
+(deftest tainted-isolation-test
+  (testing "Data pack with tainted dependency is OK"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :tainted :authority/data)}
+          result (trust/validate-tainted-isolation "pack-a" graph)]
+      (is (:valid? result))))
+
+  (testing "INVALID: Instruction pack with direct tainted dependency"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :tainted :authority/data)}
+          result (trust/validate-tainted-isolation "pack-a" graph)]
+      (is (not (:valid? result)))
+      (is (string? (:error result)))
+      (is (re-find #"tainted" (clojure.string/lower-case (:error result))))
+      (is (vector? (:tainted-path result)))))
+
+  (testing "INVALID: Instruction pack with transitive tainted dependency"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
+                                               :dependencies ["pack-c"])
+                 "pack-c" (trust/make-pack-ref "pack-c" :tainted :authority/data)}
+          result (trust/validate-tainted-isolation "pack-a" graph)]
+      (is (not (:valid? result)))
+      (is (re-find #"tainted" (clojure.string/lower-case (:error result))))
+      (is (vector? (:tainted-path result)))
+      (is (some #{"pack-c"} (:tainted-path result)))))
+
+  (testing "Instruction pack with only trusted/untrusted deps is OK"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
+                                               :dependencies ["pack-b" "pack-c"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data)
+                 "pack-c" (trust/make-pack-ref "pack-c" :untrusted :authority/data)}
+          result (trust/validate-tainted-isolation "pack-a" graph)]
+      (is (:valid? result)))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Combined validation
+
+(deftest validate-transitive-trust-complete-test
+  (testing "Valid pack graph passes all rules"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
+                                               :dependencies ["pack-c"])
+                 "pack-c" (trust/make-pack-ref "pack-c" :untrusted :authority/data)}
+          result (trust/validate-transitive-trust graph)]
+      (is (:valid? result))
+      (is (= (set (keys graph)) (set (:packs result))))))
+
+  (testing "INVALID: Fails on instruction authority transitivity"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :untrusted :authority/instruction)}
+          result (trust/validate-transitive-trust graph)]
+      (is (not (:valid? result)))
+      (is (seq (:errors result)))))
+
+  (testing "INVALID: Fails on tainted isolation"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/instruction
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :tainted :authority/data)}
+          result (trust/validate-transitive-trust graph)]
+      (is (not (:valid? result)))
+      (is (seq (:errors result)))))
+
+  (testing "INVALID: Fails on circular dependency"
+    (let [graph {"pack-a" (trust/make-pack-ref "pack-a" :trusted :authority/data
+                                               :dependencies ["pack-b"])
+                 "pack-b" (trust/make-pack-ref "pack-b" :trusted :authority/data
+                                               :dependencies ["pack-a"])}]
+      (is (thrown? Exception
+                   (trust/validate-transitive-trust graph))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Run all tests
+  (clojure.test/run-tests 'ai.miniforge.knowledge.trust-test)
+
+  ;; Run specific test
+  (instruction-authority-not-transitive-test)
+  (trust-level-inheritance-test)
+  (cross-trust-references-valid-test)
+  (tainted-isolation-test)
+  (validate-transitive-trust-complete-test)
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/loader.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/loader.clj
@@ -19,12 +19,20 @@
    Layer 1: EDN parsing and validation
    Layer 2: Single file and directory loaders
    Layer 3: Pack loading orchestration
+   Layer 4: Trust validation (N1 §2.10.2)
 
    Supports two formats:
    - Single EDN file: pack.edn or *.pack.edn
-   - Directory structure with pack.edn manifest and rules/ subdirectory"
+   - Directory structure with pack.edn manifest and rules/ subdirectory
+
+   Trust validation ensures:
+   - Instruction authority is not transitive
+   - Trust level inheritance (lowest wins)
+   - Cross-trust references are validated
+   - Tainted content is isolated from instruction authority"
   (:require
    [ai.miniforge.policy-pack.schema :as schema]
+   [ai.miniforge.knowledge.interface :as knowledge]
    [clojure.java.io :as io]
    [clojure.edn :as edn]
    [clojure.string :as str]))
@@ -91,7 +99,11 @@
       (update :pack/rules #(mapv normalize-rule (or % [])))
       (update :pack/categories #(or % []))
       (update :pack/created-at ensure-instant)
-      (update :pack/updated-at ensure-instant)))
+      (update :pack/updated-at ensure-instant)
+      ;; Default trust metadata
+      (update :pack/trust-level #(or % :untrusted))
+      (update :pack/authority #(or % :authority/data))
+      (update :pack/dependencies #(or % []))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Single file loader
@@ -312,6 +324,114 @@
     (catch Exception e
       {:success? false :error (.getMessage e)})))
 
+;------------------------------------------------------------------------------ Layer 4
+;; Trust validation (N1 §2.10.2)
+
+(defn- pack->trust-ref
+  "Convert a pack manifest to a trust reference for validation."
+  [pack]
+  (knowledge/make-pack-ref
+   (:pack/id pack)
+   (:pack/trust-level pack :untrusted)
+   (:pack/authority pack :authority/data)
+   :dependencies (mapv :pack-id (:pack/extends pack []))))
+
+(defn validate-pack-trust
+  "Validate transitive trust rules for a pack.
+
+   Arguments:
+   - pack        - PackManifest to validate
+   - pack-store  - Map of pack-id -> PackManifest for dependency resolution
+
+   Returns:
+   - {:valid? true} if all trust rules pass
+   - {:valid? false :errors [...]} if any rule fails
+
+   Validates:
+   1. Instruction authority is not transitive
+   2. Trust level inheritance
+   3. Cross-trust references (no cycles, missing deps)
+   4. Tainted isolation
+
+   Example:
+     (validate-pack-trust pack {\"dep-pack\" dep-pack-manifest})"
+  [pack pack-store]
+  (let [pack-id (:pack/id pack)
+        pack-ref (pack->trust-ref pack)
+
+        ;; Build trust graph: pack + all dependencies
+        dep-refs (reduce
+                  (fn [acc dep]
+                    (let [dep-id (:pack-id dep)
+                          dep-pack (get pack-store dep-id)]
+                      (if dep-pack
+                        (assoc acc dep-id (pack->trust-ref dep-pack))
+                        acc)))
+                  {}
+                  (:pack/extends pack []))
+
+        trust-graph (assoc dep-refs pack-id pack-ref)]
+
+    ;; Validate all transitive trust rules
+    (try
+      (let [result (knowledge/validate-transitive-trust trust-graph)]
+        (if (:valid? result)
+          {:valid? true}
+          {:valid? false
+           :errors (:errors result)}))
+      (catch Exception e
+        {:valid? false
+         :errors [(str "Trust validation error: " (.getMessage e))]}))))
+
+(defn load-pack-with-trust-validation
+  "Load a pack and validate trust rules.
+
+   This is the recommended entry point for loading packs with trust enforcement.
+
+   Arguments:
+   - path        - File or directory path
+   - pack-store  - Map of pack-id -> PackManifest for dependency resolution
+   - options     - Optional map:
+     - :skip-trust-validation? - Skip trust validation (default: false)
+     - :trust-level            - Override trust level
+     - :authority              - Override authority channel
+
+   Returns:
+   - {:success? bool :pack PackManifest :errors [...] :trust-result {...}}
+
+   Example:
+     (load-pack-with-trust-validation \"./packs/my-pack\" loaded-packs-map)"
+  [path pack-store & [options]]
+  (let [load-result (load-pack path)
+        skip-trust? (:skip-trust-validation? options false)]
+
+    (if-not (:success? load-result)
+      load-result  ; Return load errors immediately
+
+      ;; Apply overrides if provided
+      (let [pack (cond-> (:pack load-result)
+                   (:trust-level options)
+                   (assoc :pack/trust-level (:trust-level options))
+
+                   (:authority options)
+                   (assoc :pack/authority (:authority options)))
+
+            ;; Validate trust rules
+            trust-result (if skip-trust?
+                          {:valid? true :skipped? true}
+                          (validate-pack-trust pack pack-store))]
+
+        (if (:valid? trust-result)
+          {:success? true
+           :pack pack
+           :errors (:errors load-result)  ; Non-fatal load warnings
+           :trust-result trust-result}
+          {:success? false
+           :pack nil
+           :errors (concat (:errors load-result [])
+                          (:errors trust-result))
+           :trust-result trust-result})))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Load pack from single file
@@ -342,5 +462,51 @@
                    :rule/applies-to {:task-types [:import]}  ; vector, not set
                    :rule/detection {:type :content-scan}
                    :rule/enforcement {:action :warn :message "Warning"}})
+
+  ;; Trust validation examples
+  (def base-pack
+    {:pack/id "base-pack"
+     :pack/name "Base Pack"
+     :pack/version "1.0.0"
+     :pack/description "Base rules"
+     :pack/author "system"
+     :pack/trust-level :trusted
+     :pack/authority :authority/instruction
+     :pack/categories []
+     :pack/rules []
+     :pack/created-at (java.time.Instant/now)
+     :pack/updated-at (java.time.Instant/now)})
+
+  (def untrusted-pack
+    {:pack/id "untrusted-pack"
+     :pack/name "Untrusted Pack"
+     :pack/version "1.0.0"
+     :pack/description "External rules"
+     :pack/author "external"
+     :pack/trust-level :untrusted
+     :pack/authority :authority/data  ; Must be data-only
+     :pack/extends [{:pack-id "base-pack"}]
+     :pack/categories []
+     :pack/rules []
+     :pack/created-at (java.time.Instant/now)
+     :pack/updated-at (java.time.Instant/now)})
+
+  ;; Validate trust rules (should pass)
+  (validate-pack-trust untrusted-pack {"base-pack" base-pack})
+  ;; => {:valid? true}
+
+  ;; Invalid: untrusted pack with instruction authority
+  (def invalid-pack
+    (assoc untrusted-pack :pack/authority :authority/instruction))
+
+  (validate-pack-trust invalid-pack {"base-pack" base-pack})
+  ;; => {:valid? false :errors [...]}
+
+  ;; Load with trust validation
+  (load-pack-with-trust-validation
+   "./packs/my-pack"
+   {"base-pack" base-pack}
+   {:trust-level :trusted
+    :authority :authority/instruction})
 
   :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -185,13 +185,31 @@
    [:pack-id string?]
    [:version-constraint {:optional true} string?]])
 
+(def TrustLevel
+  "Schema for pack trust levels (N1 §2.10.2).
+   - :tainted   - Flagged by scanners; MUST NOT be used for instruction
+   - :untrusted - Repo-derived or external; data-only unless promoted
+   - :trusted   - Platform-validated and/or user-promoted"
+  [:enum :tainted :untrusted :trusted])
+
+(def AuthorityChannel
+  "Schema for pack authority channels (N1 §2.10.2).
+   - :authority/instruction - May shape agent plans (requires :trusted)
+   - :authority/data        - Reference material only (any trust level)"
+  [:enum :authority/instruction :authority/data])
+
 (def PackManifest
   "Schema for a policy pack manifest.
 
    Packs are versioned collections of rules that can be:
    - Authored and shared
    - Extended from other packs
-   - Signed for trust (paid feature)"
+   - Signed for trust (paid feature)
+
+   Trust model (N1 §2.10.2):
+   - Trust level determines if content can be used for instruction
+   - Authority channel determines how content may be used
+   - Transitive trust rules prevent trust escalation"
   [:map
    ;; Identity
    [:pack/id string?]
@@ -209,6 +227,10 @@
    [:pack/signature {:optional true} string?]
    [:pack/signed-by {:optional true} string?]
    [:pack/signed-at {:optional true} inst?]
+
+   ;; Trust and authority (N1 §2.10.2)
+   [:pack/trust-level {:optional true} TrustLevel]
+   [:pack/authority {:optional true} AuthorityChannel]
 
    ;; Dependencies
    [:pack/extends {:optional true} [:vector PackDependency]]

--- a/docs/pull-requests/2026-01-25-feat-transitive-trust-rules.md
+++ b/docs/pull-requests/2026-01-25-feat-transitive-trust-rules.md
@@ -1,0 +1,107 @@
+# feat: Transitive Trust Rules
+
+## Overview
+
+Implements N1 §2.10.2 transitive trust rules to prevent trust escalation attacks in knowledge packs. Ensures that packs maintain proper trust boundaries and cannot maliciously escalate privileges through dependency chains.
+
+## Motivation
+
+Spec enhancement PR #84 added comprehensive trust model requirements to prevent attacks where:
+
+- Trusted packs with instruction authority transitively grant authority to untrusted dependencies
+- Tainted content leaks into instruction authority through dependency chains
+- Trust levels are incorrectly computed across pack references
+
+This PR implements the 4 core transitive trust rules defined in N1 §2.10.2.
+
+## Changes in Detail
+
+### New Files
+
+**`components/knowledge/src/ai/miniforge/knowledge/trust.clj`** (303 lines)
+
+- Trust level ordering: `:tainted` < `:untrusted` < `:trusted`
+- Authority channels: `:authority/instruction` (requires trusted) vs `:authority/data` (any trust level)
+- Pack reference creation and validation
+- Circular dependency detection using depth-first search
+- Tainted content isolation verification
+- Trust level inheritance computation (lowest trust wins)
+
+**`components/knowledge/test/ai/miniforge/knowledge/trust_test.clj`** (285 lines)
+
+- 59 assertions testing all 4 transitive trust rules
+- Edge case coverage: circular dependencies, missing dependencies, tainted isolation
+- Trust level inheritance validation
+- Cross-trust reference tracking
+
+### Modified Files
+
+**`components/knowledge/src/ai/miniforge/knowledge/interface.clj`** (+62 lines)
+
+- Exported trust validation API:
+  - `make-pack-ref` - Create pack references with trust metadata
+  - `validate-transitive-trust` - Validate entire dependency graph
+  - `compute-inherited-trust-level` - Calculate inherited trust level
+
+**`components/policy-pack/src/ai/miniforge/policy_pack/loader.clj`** (+170 lines)
+
+- Layer 4: Trust validation integration
+- `validate-pack-trust` with dependency resolution
+- `load-pack-with-trust-validation` for trust-enforced loading
+- Pack-to-trust-ref conversion utilities
+
+**`components/policy-pack/src/ai/miniforge/policy_pack/schema.clj`** (+24 lines)
+
+- `TrustLevel` schema: `:trusted` | `:untrusted` | `:tainted`
+- `AuthorityChannel` schema: `:authority/instruction` | `:authority/data`
+- Enhanced `PackManifest` with optional trust fields
+
+## The 4 Transitive Trust Rules
+
+1. **Instruction authority is not transitive**
+   - If Pack A (`:trusted`, `:authority/instruction`) references Pack B (`:untrusted`), Pack B MUST remain `:authority/data` and MUST NOT gain instruction authority through the reference
+   - Prevents privilege escalation through dependency chains
+
+2. **Trust level inheritance**
+   - When Pack A includes content from Pack B, the resulting combined content MUST be assigned the lower trust level
+   - Trust ordering: `:tainted` < `:untrusted` < `:trusted`
+   - Ensures conservative trust propagation
+
+3. **Cross-trust references**
+   - Packs MAY reference other packs of any trust level
+   - Implementations MUST track and validate the transitive trust graph before allowing execution
+   - Detects circular dependencies and missing dependencies
+
+4. **Tainted isolation**
+   - Content marked `:tainted` MUST NOT be included in any pack used for instruction authority, even transitively
+   - Checked through entire dependency chain with path tracing for debugging
+
+## Testing Plan
+
+- `bb test` - All 59 trust-specific assertions passing
+- `bb pre-commit` - All checks passed
+- No regressions in existing tests
+
+## Deployment Plan
+
+- No special deployment steps; merge and release with OSS v1.0
+- Breaking changes: None (additive only)
+
+## Related Issues/PRs
+
+- Spec enhancement: PR #84 (ETL & Trust System Enhancements)
+- N1 spec: §2.10.2 Knowledge Trust and Authority
+- ETL critical sequence: PR14/21 (this PR)
+- Integrates with: PR15 (pack-dependency-validation)
+
+## Checklist
+
+- [x] All 4 transitive trust rules enforced
+- [x] Trusted pack cannot transitively grant instruction authority to untrusted pack
+- [x] Trust level inheritance uses lowest trust in dependency chain
+- [x] Tainted content isolated from instruction authority
+- [x] Circular dependency detection implemented
+- [x] Cross-trust reference tracking implemented
+- [x] Tests verify all rules (59 assertions, 100% passing)
+- [x] Pre-commit validation passed
+- [x] N1 §2.10.2 conformant


### PR DESCRIPTION
## Summary

Implements N1 §2.10.2 transitive trust rules to prevent trust escalation attacks in knowledge packs.

**This is PR14/21 in the ETL & Trust enhancement sequence** - one of 4 critical PRs for OSS v1.0.

## Context

Spec enhancement PR #84 added comprehensive trust model requirements. This PR implements the core transitive trust rules that prevent malicious packs from escalating privileges through dependency chains.

## Changes

### Files Created (588 lines)

1. **`components/knowledge/src/ai/miniforge/knowledge/trust.clj`** (303 lines)
   - Trust level ordering: `:tainted` < `:untrusted` < `:trusted`
   - Authority channels: `:authority/instruction` vs `:authority/data`
   - Pack reference creation and validation
   - Circular dependency detection (DFS)
   - Tainted content isolation verification

2. **`components/knowledge/test/ai/miniforge/knowledge/trust_test.clj`** (285 lines)
   - 59 assertions testing all 4 transitive trust rules
   - Edge case coverage (circular deps, missing deps, tainted isolation)
   - Trust level inheritance validation

### Files Modified (252 lines)

3. **`components/knowledge/src/ai/miniforge/knowledge/interface.clj`** (+62 lines)
   - Exported trust validation API: `make-pack-ref`, `validate-transitive-trust`, `compute-inherited-trust-level`

4. **`components/policy-pack/src/ai/miniforge/policy_pack/loader.clj`** (+170 lines)
   - Layer 4: Trust validation integration
   - `validate-pack-trust` with dependency resolution
   - Trust-enforced pack loading

5. **`components/policy-pack/src/ai/miniforge/policy_pack/schema.clj`** (+24 lines)
   - `TrustLevel` and `AuthorityChannel` schemas
   - Enhanced `PackManifest` with trust fields

## The 4 Transitive Trust Rules

1. ✅ **Instruction authority is not transitive**
   - Trusted pack with instruction authority cannot grant instruction authority to untrusted dependencies

2. ✅ **Trust level inheritance**
   - Combined content takes lowest trust level (tainted < untrusted < trusted)

3. ✅ **Cross-trust references**
   - Validates complete dependency graph before execution
   - Detects circular dependencies and missing deps

4. ✅ **Tainted isolation**
   - Tainted content cannot be used for instruction authority (checked transitively)

## Test Results

- ✅ All 59 trust-specific assertions passing
- ✅ All existing tests continue to pass
- ✅ Pre-commit validation passed

## Acceptance Criteria

- ✅ All 4 transitive trust rules enforced
- ✅ Trusted pack cannot transitively grant instruction authority to untrusted pack
- ✅ Trust level inheritance uses lowest trust in chain
- ✅ Tainted content isolated from instruction authority
- ✅ Tests verify all rules

## Dependencies

This PR is independent and can merge in parallel with:
- PR15: Pack dependency validation
- PR16: ETL lifecycle events
- PR17: Promotion justification

## Spec Conformance

- ✅ N1 §2.10.2 (Knowledge Trust and Authority) - FULL CONFORMANCE

## Impact

- **Lines changed:** +840
- **Files changed:** 5
- **Breaking changes:** None (additive only)
- **Blocks:** OSS v1.0 release

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)