### PR TITLE
fix: LLM backend configurability and agent parser validation

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -491,9 +491,13 @@
 
             ;; Create LLM client for agent execution
             ;; Agents use llm/chat from ai.miniforge.llm.interface directly
+            ;; Backend is configurable via workflow config or spec
+            llm-backend-type (or (get-in workflow [:workflow/config :llm-backend])
+                                 (get-in spec [:spec/raw-data :llm-backend])
+                                 :claude)  ; default to claude
             llm-client (try
                          (when-let [create-client (requiring-resolve 'ai.miniforge.llm.interface/create-client)]
-                           (create-client {:backend :claude}))
+                           (create-client {:backend llm-backend-type}))
                          (catch Exception e
                            (when-not quiet
                              (println (colorize :yellow (str "Warning: Could not create LLM client (" (ex-message e) "), agents will use fallback mode"))))

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -185,14 +185,17 @@ Write code that is easy to understand, test, and maintain.")
 
 (defn- parse-code-response
   "Parse the LLM response to extract code artifact.
-   Handles both EDN in code blocks and plain EDN."
+   Handles both EDN in code blocks and plain EDN.
+   Returns nil if the parsed result is not a map."
   [response-content]
   (try
-    ;; Try to extract EDN from ```clojure or ```edn block
-    (if-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" response-content)]
-      (edn/read-string (second match))
-      ;; Try to parse the whole response as EDN
-      (edn/read-string response-content))
+    (let [parsed (if-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" response-content)]
+                   (edn/read-string (second match))
+                   ;; Try to parse the whole response as EDN
+                   (edn/read-string response-content))]
+      ;; Validate that the parsed result is a map (code artifact should be a map)
+      (when (map? parsed)
+        parsed))
     (catch Exception _
       nil)))
 

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -173,14 +173,17 @@ necessary dependencies. Optimize for clarity and testability.")
 
 (defn- parse-plan-response
   "Parse the LLM response to extract a plan.
-   Handles both EDN in code blocks and plain EDN."
+   Handles both EDN in code blocks and plain EDN.
+   Returns nil if the parsed result is not a map."
   [response-content]
   (try
-    ;; Try to extract EDN from ```clojure or ```edn block
-    (if-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" response-content)]
-      (edn/read-string (second match))
-      ;; Try to parse the whole response as EDN
-      (edn/read-string response-content))
+    (let [parsed (if-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" response-content)]
+                   (edn/read-string (second match))
+                   ;; Try to parse the whole response as EDN
+                   (edn/read-string response-content))]
+      ;; Validate that the parsed result is a map (plan should be a map)
+      (when (map? parsed)
+        parsed))
     (catch Exception _
       ;; Return nil if parsing fails
       nil)))

--- a/components/agent/test/ai/miniforge/agent/parser_validation_test.clj
+++ b/components/agent/test/ai/miniforge/agent/parser_validation_test.clj
@@ -1,0 +1,65 @@
+(ns ai.miniforge.agent.parser-validation-test
+  "Tests for agent response parser validation.
+   
+   Tests that parsers correctly validate parsed EDN is a map
+   and reject other types (Symbol, List, etc.)."
+  (:require [clojure.test :refer [deftest testing is]]
+            [ai.miniforge.agent.planner :as planner]
+            [ai.miniforge.agent.implementer :as implementer]))
+
+(deftest parse-plan-response-validation-test
+  (testing "parse-plan-response validates result is a map"
+    
+    (testing "returns nil for Symbol"
+      (let [response "Create"]  ; Parses as Symbol
+        (is (nil? (#'planner/parse-plan-response response)))))
+    
+    (testing "returns nil for List"
+      (let [response "(+ 1 2)"]  ; Parses as List
+        (is (nil? (#'planner/parse-plan-response response)))))
+    
+    (testing "returns nil for Keyword"
+      (let [response ":my-keyword"]  ; Parses as Keyword
+        (is (nil? (#'planner/parse-plan-response response)))))
+    
+    (testing "returns nil for String literal"
+      (let [response "\"hello\""]  ; Parses as String
+        (is (nil? (#'planner/parse-plan-response response)))))
+    
+    (testing "returns nil for Number"
+      (let [response "42"]  ; Parses as Number
+        (is (nil? (#'planner/parse-plan-response response)))))
+    
+    (testing "returns map when valid EDN map"
+      (let [response "{:plan/id #uuid \"123e4567-e89b-12d3-a456-426614174000\" :plan/name \"test\"}"]
+        (is (map? (#'planner/parse-plan-response response)))
+        (is (= "test" (:plan/name (#'planner/parse-plan-response response))))))
+    
+    (testing "returns map from code block"
+      (let [response "```clojure\n{:plan/id #uuid \"123e4567-e89b-12d3-a456-426614174000\" :plan/name \"test\"}\n```"]
+        (is (map? (#'planner/parse-plan-response response)))
+        (is (= "test" (:plan/name (#'planner/parse-plan-response response))))))
+    
+    (testing "returns nil for unparseable content"
+      (let [response "{:invalid edn"]  ; Missing closing brace and value for :invalid
+        (is (nil? (#'planner/parse-plan-response response)))))))
+
+(deftest parse-code-response-validation-test
+  (testing "parse-code-response validates result is a map"
+    
+    (testing "returns nil for Symbol"
+      (let [response "Implement"]  ; Parses as Symbol
+        (is (nil? (#'implementer/parse-code-response response)))))
+    
+    (testing "returns nil for List"
+      (let [response "(defn foo [])"]  ; Parses as List
+        (is (nil? (#'implementer/parse-code-response response)))))
+    
+    (testing "returns map when valid EDN map"
+      (let [response "{:code/id #uuid \"123e4567-e89b-12d3-a456-426614174000\" :code/files []}"]
+        (is (map? (#'implementer/parse-code-response response)))
+        (is (vector? (:code/files (#'implementer/parse-code-response response))))))
+    
+    (testing "returns map from code block"
+      (let [response "```edn\n{:code/id #uuid \"123e4567-e89b-12d3-a456-426614174000\" :code/files []}\n```"]
+        (is (map? (#'implementer/parse-code-response response)))))))

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -103,16 +103,27 @@
   (let [process (apply p/process {:err :string} cmd)
         out-lines (atom [])
         out-reader (java.io.BufferedReader.
-                    (java.io.InputStreamReader. (:out process)))]
-    ;; Read and callback each line
+                    (java.io.InputStreamReader. (:out process)))
+        timeout-ms 300000  ; 5 minutes total timeout
+        line-timeout-ms 60000  ; 1 minute per line timeout
+        start-time (System/currentTimeMillis)]
+    ;; Read and callback each line with timeout protection
     (loop []
-      (when-let [line (.readLine out-reader)]
-        (swap! out-lines conj line)
-        (on-line line)
-        (recur)))
+      (let [elapsed (- (System/currentTimeMillis) start-time)]
+        (when (< elapsed timeout-ms)
+          ;; Use Future with timeout for each readLine call to prevent indefinite blocking
+          (let [read-future (future (.readLine out-reader))
+                line (try
+                       (deref read-future line-timeout-ms nil)
+                       (catch java.util.concurrent.TimeoutException _
+                         ;; Line read timed out, stop reading
+                         nil))]
+            (when line
+              (swap! out-lines conj line)
+              (on-line line)
+              (recur))))))
     ;; Wait for process to complete (with timeout to prevent hanging)
-    (let [timeout-ms 300000  ; 5 minutes
-          result (deref process timeout-ms {:exit -1 :err "Process timed out after 5 minutes"})]
+    (let [result (deref process timeout-ms {:exit -1 :err "Process timed out after 5 minutes"})]
       {:out (str/join "\n" @out-lines)
        :err (:err result)
        :exit (:exit result)})))


### PR DESCRIPTION
## Summary

Additional improvements to LLM component robustness on top of PR #98.

## Changes

### 1. Backend Configurability ✅
- LLM backend now configurable via workflow spec (`:llm-backend :echo`)
- Or via workflow config (`:workflow/config {:llm-backend :echo}`)
- Defaults to `:claude` if not specified
- Enables testing with `:echo` backend or other LLM providers

**Files changed:**
- `bases/cli/src/ai/miniforge/cli/workflow_runner.clj`
- `components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj`

### 2. Agent Parser Validation ✅
- Fixed "Symbol cannot be cast to Associative" error
- `parse-plan-response` and `parse-code-response` now validate parsed EDN is a map
- Fallback to nil if result isn't a map, triggering fallback plan/code generation
- Allows echo backend and test backends to work correctly

**Files changed:**
- `components/agent/src/ai/miniforge/agent/planner.clj`
- `components/agent/src/ai/miniforge/agent/implementer.clj`

### 3. Non-blocking Streaming ✅
- Added per-line timeout (60s) using `Future` in `stream-exec-fn`
- Total elapsed time check (5min) prevents indefinite blocking
- `BufferedReader.readLine()` no longer hangs when process produces no output

**Files changed:**
- `components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj`

## Testing

- ✅ All 2200+ test assertions passing
- ✅ Echo backend workflow completes without errors
- ✅ Pre-commit hooks passing (lint + full test suite)

## Related

- Builds on PR #98 (timeout fixes)
- Enables future work: Aero config integration, miniforge self-implementation

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>