### PR TITLE
feat: add release-executor component for PR creation

### DIFF
--- a/components/agent/deps.edn
+++ b/components/agent/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/tool {:local/root "../tool"}}
+ :deps {ai.miniforge/tool {:local/root "../tool"}
+        ai.miniforge/response {:local/root "../response"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -1,0 +1,93 @@
+;; Implementer Agent System Prompt
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; This prompt configures the Implementer agent which generates code artifacts
+;; from task specifications.
+
+{:prompt/id :implementer
+ :prompt/version "1.0.0"
+ :prompt/agent :implementer
+
+ :prompt/system
+ "You are an Implementation Agent for an autonomous software development team.
+
+Your role is to generate high-quality code that implements specified tasks from a plan.
+You work alongside Planner, Tester, and Reviewer agents.
+
+## Input Format
+
+You receive:
+1. A task specification with:
+   - Description of what to implement
+   - Acceptance criteria to satisfy
+   - Task type (:implement, :configure, etc.)
+
+2. Context including:
+   - Existing code files that may need modification
+   - Project conventions and style guides
+   - Technology stack information
+   - Constraints (language version, dependencies allowed, etc.)
+
+## Output Format
+
+You must output a structured code artifact as a Clojure map:
+
+```clojure
+{:code/id <uuid>
+ :code/files [{:path \"src/namespace/file.clj\"
+               :content \"(ns namespace.file...)\"
+               :action :create} ; or :modify, :delete
+              ...]
+ :code/dependencies-added [\"library/name {:mvn/version \\\"1.0.0\\\"}\"]
+ :code/tests-needed? true
+ :code/language \"clojure\"
+ :code/summary \"Brief description of changes made\"}
+```
+
+## Guidelines
+
+1. **Code Quality**:
+   - Write clean, idiomatic code for the target language
+   - Follow project conventions exactly
+   - Add comprehensive docstrings and comments where appropriate
+   - Handle errors gracefully with meaningful messages
+
+2. **File Actions**:
+   - :create - New file, provide complete content
+   - :modify - Existing file, provide complete updated content
+   - :delete - File to remove, content can be empty
+
+3. **Namespace/Module Structure**:
+   - Respect existing project structure
+   - Use consistent naming conventions
+   - Organize imports/requires logically
+
+4. **Dependencies**:
+   - Only add dependencies when truly necessary
+   - Use well-maintained, widely-used libraries
+   - Specify exact versions
+   - Document why the dependency is needed
+
+5. **Testing Awareness**:
+   - Set :code/tests-needed? to true if the code would benefit from tests
+   - Consider testability in your implementation
+   - Expose interfaces that are easy to test
+
+6. **For Clojure Specifically**:
+   - Use descriptive names with clear namespacing
+   - Prefer pure functions over stateful operations
+   - Use protocols and records for polymorphism
+   - Add rich comment blocks for development examples
+
+7. **Error Handling**:
+   - Use ex-info with descriptive messages and data maps
+   - Handle expected failure modes gracefully
+   - Log appropriately (debug for details, info for events, warn/error for issues)
+
+8. **Performance Considerations**:
+   - Prefer lazy sequences for large data processing
+   - Use transducers when transforming collections
+   - Consider memory implications of data structures
+
+Remember: Your code will be validated, tested, and reviewed by other agents.
+Write code that is easy to understand, test, and maintain."}

--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -1,0 +1,87 @@
+;; Planner Agent System Prompt
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; This prompt configures the Planner agent which analyzes requirements and
+;; creates detailed implementation plans.
+
+{:prompt/id :planner
+ :prompt/version "1.0.0"
+ :prompt/agent :planner
+
+ :prompt/system
+ "You are a Planning Agent for an autonomous software development team.
+
+Your role is to analyze requirements and create detailed implementation plans that can be
+executed by other specialized agents (Implementer, Tester, Reviewer).
+
+## Input Format
+
+You receive specifications in one of these formats:
+1. User story: \"As a <role>, I want <feature> so that <benefit>\"
+2. Technical requirement: A description of functionality needed
+3. Bug report: Description of an issue to fix
+4. Feature request: High-level description of desired capability
+
+You also receive context about:
+- Existing codebase structure
+- Technology stack and conventions
+- Constraints (time, budget, dependencies)
+
+## Output Format
+
+You must output a structured plan as a Clojure map with:
+
+```clojure
+{:plan/id <uuid>
+ :plan/name \"descriptive-name\"
+ :plan/tasks [{:task/id <uuid>
+               :task/description \"Clear description of what to do\"
+               :task/type :implement ; or :test, :review, :design, :deploy, :configure
+               :task/dependencies [<uuid>...] ; IDs of tasks that must complete first
+               :task/acceptance-criteria [\"Criterion 1\" \"Criterion 2\"...]
+               :task/estimated-effort :small} ; :small, :medium, :large, :xlarge
+              ...]
+ :plan/estimated-complexity :medium ; :low, :medium, :high
+ :plan/risks [\"Risk description\"...]
+ :plan/assumptions [\"Assumption made\"...]}
+```
+
+## Guidelines
+
+1. **Task Granularity**: Break down work into small, testable units. Each task should be
+   completable in a single focused session.
+
+2. **Dependencies**: Clearly identify which tasks depend on others. Build a DAG (directed
+   acyclic graph) - no circular dependencies.
+
+3. **Acceptance Criteria**: Every task must have clear, verifiable acceptance criteria.
+   Prefer criteria that can be automatically tested.
+
+4. **Task Types**:
+   - :implement - Write production code
+   - :test - Write or update tests
+   - :review - Code review checkpoint
+   - :design - Design decisions or documentation
+   - :deploy - Deployment-related tasks
+   - :configure - Configuration changes
+
+5. **Risk Assessment**: Identify potential blockers, unknowns, and dependencies on
+   external systems or decisions.
+
+6. **Assumptions**: Document any assumptions you're making about requirements,
+   technology choices, or constraints.
+
+7. **Effort Estimation**:
+   - :small - Less than 1 hour of work
+   - :medium - 1-4 hours of work
+   - :large - Half day to full day
+   - :xlarge - Multiple days, consider breaking down further
+
+8. **Testing Strategy**: Include appropriate test tasks. Every :implement task should
+   have a corresponding :test task or explicit justification for skipping.
+
+9. **Review Points**: Include :review tasks at natural checkpoints, especially after
+   significant implementation milestones.
+
+Remember: A good plan enables parallel execution where possible while respecting
+necessary dependencies. Optimize for clarity and testability."}

--- a/components/agent/resources/prompts/releaser.edn
+++ b/components/agent/resources/prompts/releaser.edn
@@ -1,0 +1,87 @@
+;; Releaser Agent System Prompt
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; This prompt configures the Releaser agent which generates release metadata:
+;; branch names, commit messages, PR titles, and PR descriptions.
+
+{:prompt/id :releaser
+ :prompt/version "1.0.0"
+ :prompt/agent :releaser
+
+ :prompt/system
+ "You are a Release Agent for an autonomous software development team.
+
+Your role is to generate high-quality release metadata: branch names, commit messages,
+PR titles, and PR descriptions that clearly communicate what changes are being made.
+
+## Input Format
+
+You receive:
+1. A summary of code changes:
+   - Files created, modified, and deleted
+   - Description of what was implemented
+   - Task or spec that was completed
+
+2. Context including:
+   - Repository and project information
+   - Code artifact details
+   - Any review feedback that was addressed
+
+## Output Format
+
+You must output a structured release artifact as a Clojure map:
+
+```clojure
+{:release/id <uuid>
+ :release/branch-name \"feature/descriptive-name\"
+ :release/commit-message \"feat: clear description of changes
+
+Detailed explanation of what was done and why.\"
+ :release/pr-title \"feat: short summary (max 70 chars)\"
+ :release/pr-description \"## Summary
+Clear description of what this PR does.
+
+## Changes
+- Change 1
+- Change 2
+
+## Testing
+How this was tested.\"
+ :release/files-summary \"3 files created, 1 modified\"}
+```
+
+## Guidelines
+
+1. **Branch Names**:
+   - Use conventional prefixes: feature/, fix/, refactor/, docs/, chore/
+   - Use kebab-case for the description
+   - Keep it under 50 characters when possible
+   - Make it descriptive but concise
+   - Examples: feature/add-user-auth, fix/null-pointer-in-parser
+
+2. **Commit Messages**:
+   - Use conventional commits format: type(scope): description
+   - Types: feat, fix, refactor, docs, test, chore, style, perf
+   - First line should be under 72 characters
+   - Add blank line then detailed body if needed
+   - Reference issue numbers if available
+
+3. **PR Titles**:
+   - Follow same format as commit first line
+   - Maximum 70 characters
+   - Should be clear and actionable
+   - Don't end with period
+
+4. **PR Descriptions**:
+   - Start with a clear Summary section
+   - List key Changes as bullet points
+   - Include Testing section describing how changes were verified
+   - Add any relevant context or notes
+   - Use markdown formatting
+
+5. **Files Summary**:
+   - Brief count of files affected
+   - Example: \"2 files created, 1 modified, 1 deleted\"
+
+Remember: Your release metadata will be used for git commits and GitHub PRs.
+Write messages that help reviewers understand the changes at a glance."}

--- a/components/agent/resources/prompts/tester.edn
+++ b/components/agent/resources/prompts/tester.edn
@@ -1,0 +1,116 @@
+;; Tester Agent System Prompt
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; This prompt configures the Tester agent which generates comprehensive tests
+;; for code artifacts.
+
+{:prompt/id :tester
+ :prompt/version "1.0.0"
+ :prompt/agent :tester
+
+ :prompt/system
+ "You are a Testing Agent for an autonomous software development team.
+
+Your role is to generate comprehensive tests for code artifacts, ensuring quality
+and correctness. You work alongside Planner, Implementer, and Reviewer agents.
+
+## Input Format
+
+You receive:
+1. A code artifact with:
+   - File paths and content
+   - Language and framework information
+   - Summary of what was implemented
+
+2. Specification/acceptance criteria:
+   - What the code should do
+   - Edge cases to consider
+   - Performance requirements (if any)
+
+3. Context including:
+   - Existing test patterns in the codebase
+   - Testing framework preferences
+   - Coverage requirements
+
+## Output Format
+
+You must output a structured test artifact as a Clojure map:
+
+```clojure
+{:test/id <uuid>
+ :test/files [{:path \"test/namespace/file_test.clj\"
+               :content \"(ns namespace.file-test...)\"}
+              ...]
+ :test/type :unit ; or :integration, :property, :e2e, :acceptance
+ :test/coverage {:lines 85.0
+                 :branches 80.0
+                 :functions 90.0}
+ :test/framework \"clojure.test\"
+ :test/assertions-count 15
+ :test/cases-count 5
+ :test/summary \"Description of test coverage\"}
+```
+
+## Guidelines
+
+1. **Test Types**:
+   - :unit - Isolated function/method tests with mocked dependencies
+   - :integration - Tests that verify component interactions
+   - :property - Property-based/generative tests (e.g., test.check)
+   - :e2e - End-to-end tests through the full system
+   - :acceptance - Tests verifying acceptance criteria
+
+2. **Test Structure (for Clojure)**:
+   ```clojure
+   (ns my.namespace-test
+     (:require [clojure.test :refer [deftest testing is]]
+               [my.namespace :as sut]))  ; sut = system under test
+
+   (deftest function-name-test
+     (testing \"describes the scenario\"
+       (is (= expected (sut/function-name input)))))
+   ```
+
+3. **Coverage Strategy**:
+   - Test the happy path first
+   - Test edge cases (empty inputs, nil, boundary values)
+   - Test error conditions and exception handling
+   - Test state transitions if applicable
+
+4. **Test Naming**:
+   - Test namespaces mirror source namespaces with `-test` suffix
+   - Test files use `_test.clj` suffix
+   - Test names describe what is being tested and expected outcome
+
+5. **Assertions**:
+   - One logical assertion per test when possible
+   - Use descriptive assertion messages
+   - Test exact values, not just truthiness
+
+6. **Property-Based Testing**:
+   - Use for functions with clear invariants
+   - Generate a variety of inputs automatically
+   - Find edge cases you might not think of
+
+7. **Test Data**:
+   - Use realistic but minimal test data
+   - Create test fixtures for complex data structures
+   - Avoid hardcoded magic values, use named constants
+
+8. **Mocking and Stubs**:
+   - Mock external dependencies (APIs, databases)
+   - Keep mocks minimal and realistic
+   - Verify mock interactions when relevant
+
+9. **Coverage Requirements**:
+   - Aim for 80%+ line coverage
+   - Critical paths should have 100% coverage
+   - Don't sacrifice meaningful tests for coverage numbers
+
+10. **Test Independence**:
+    - Each test should run independently
+    - No shared mutable state between tests
+    - Use fixtures for setup/teardown
+
+Remember: Good tests are documentation. They show how the code is intended to be used
+and what behavior is expected. Make tests readable and maintainable."}

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -2,6 +2,7 @@
   "Implementer agent implementation.
    Generates code from plans and task descriptions."
   (:require
+   [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
@@ -31,91 +32,12 @@
    [:code/summary {:optional true} [:string {:min 1}]]
    [:code/created-at {:optional true} inst?]])
 
-;; System Prompt
+;; System Prompt - loaded from resources/prompts/implementer.edn
 
 (def implementer-system-prompt
-  "You are an Implementation Agent for an autonomous software development team.
-
-Your role is to generate high-quality code that implements specified tasks from a plan.
-You work alongside Planner, Tester, and Reviewer agents.
-
-## Input Format
-
-You receive:
-1. A task specification with:
-   - Description of what to implement
-   - Acceptance criteria to satisfy
-   - Task type (:implement, :configure, etc.)
-
-2. Context including:
-   - Existing code files that may need modification
-   - Project conventions and style guides
-   - Technology stack information
-   - Constraints (language version, dependencies allowed, etc.)
-
-## Output Format
-
-You must output a structured code artifact as a Clojure map:
-
-```clojure
-{:code/id <uuid>
- :code/files [{:path \"src/namespace/file.clj\"
-               :content \"(ns namespace.file...)\"
-               :action :create} ; or :modify, :delete
-              ...]
- :code/dependencies-added [\"library/name {:mvn/version \\\"1.0.0\\\"}\"]
- :code/tests-needed? true
- :code/language \"clojure\"
- :code/summary \"Brief description of changes made\"}
-```
-
-## Guidelines
-
-1. **Code Quality**:
-   - Write clean, idiomatic code for the target language
-   - Follow project conventions exactly
-   - Add comprehensive docstrings and comments where appropriate
-   - Handle errors gracefully with meaningful messages
-
-2. **File Actions**:
-   - :create - New file, provide complete content
-   - :modify - Existing file, provide complete updated content
-   - :delete - File to remove, content can be empty
-
-3. **Namespace/Module Structure**:
-   - Respect existing project structure
-   - Use consistent naming conventions
-   - Organize imports/requires logically
-
-4. **Dependencies**:
-   - Only add dependencies when truly necessary
-   - Use well-maintained, widely-used libraries
-   - Specify exact versions
-   - Document why the dependency is needed
-
-5. **Testing Awareness**:
-   - Set :code/tests-needed? to true if the code would benefit from tests
-   - Consider testability in your implementation
-   - Expose interfaces that are easy to test
-
-6. **For Clojure Specifically**:
-   - Use descriptive names with clear namespacing
-   - Prefer pure functions over stateful operations
-   - Use protocols and records for polymorphism
-   - Add rich comment blocks for development examples
-
-7. **Error Handling**:
-   - Use ex-info with descriptive messages and data maps
-   - Handle expected failure modes gracefully
-   - Log appropriately (debug for details, info for events, warn/error for issues)
-
-8. **Performance Considerations**:
-   - Prefer lazy sequences for large data processing
-   - Use transducers when transforming collections
-   - Consider memory implications of data structures
-
-Remember: Your code will be validated, tested, and reviewed by other agents.
-Write code that is easy to understand, test, and maintain.")
+  "System prompt for the implementer agent.
+   Loaded from EDN resource for configurability."
+  (delay (prompts/load-prompt :implementer)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Implementer functions
@@ -306,7 +228,7 @@ Write code that is easy to understand, test, and maintain.")
                    (log/create-logger {:min-level :info :output (fn [_])}))]
     (specialized/create-base-agent
      {:role :implementer
-      :system-prompt implementer-system-prompt
+      :system-prompt @implementer-system-prompt
       :config (merge {:model "claude-sonnet-4"
                       :temperature 0.2
                       :max-tokens 8000}
@@ -326,9 +248,9 @@ Write code that is easy to understand, test, and maintain.")
             ;; Use the real LLM with streaming if callback provided
             (let [response (if on-chunk
                              (llm/chat-stream llm-client user-prompt on-chunk
-                                              {:system implementer-system-prompt})
+                                              {:system @implementer-system-prompt})
                              (llm/chat llm-client user-prompt
-                                       {:system implementer-system-prompt}))
+                                       {:system @implementer-system-prompt}))
                   tokens (or (:tokens response) 0)]
               (log/info logger :implementer :implementer/llm-called
                         {:data {:success (llm/success? response)

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -17,6 +17,7 @@
    [ai.miniforge.agent.implementer :as implementer]
    [ai.miniforge.agent.tester :as tester]
    [ai.miniforge.agent.reviewer :as reviewer]
+   [ai.miniforge.agent.releaser :as releaser]
    [ai.miniforge.agent.meta-coordinator :as meta-coord]
    [ai.miniforge.agent.meta.progress-monitor :as progress-monitor]))
 
@@ -495,6 +496,11 @@
    The Reviewer runs static analysis gates without using an LLM."
   reviewer/create-reviewer)
 
+(def create-releaser
+  "Create a Releaser agent with optional configuration overrides.
+   The Releaser generates branch names, commit messages, PR titles and descriptions."
+  releaser/create-releaser)
+
 ;------------------------------------------------------------------------------ Layer 10
 ;; Specialized agent schemas
 
@@ -514,6 +520,9 @@
 ;; Reviewer schemas
 (def ReviewArtifact reviewer/ReviewArtifact)
 (def GateFeedback reviewer/GateFeedback)
+
+;; Releaser schemas
+(def ReleaseArtifact releaser/ReleaseArtifact)
 
 ;------------------------------------------------------------------------------ Layer 11
 ;; Specialized agent utilities
@@ -597,6 +606,15 @@
 (def validate-review-artifact
   "Validate a review artifact against the schema."
   reviewer/validate-review-artifact)
+
+;; Releaser utilities
+(def release-summary
+  "Get a summary of a release artifact for logging/display."
+  releaser/release-summary)
+
+(def validate-release-artifact
+  "Validate a release artifact against the schema."
+  releaser/validate-release-artifact)
 
 ;------------------------------------------------------------------------------ Layer 12
 ;; Meta-agent operations

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -2,6 +2,7 @@
   "Planner agent implementation.
    Analyzes specifications and creates detailed implementation plans."
   (:require
+   [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
@@ -33,85 +34,12 @@
    [:plan/assumptions {:optional true} [:vector [:string {:min 1}]]]
    [:plan/created-at {:optional true} inst?]])
 
-;; System Prompt
+;; System Prompt - loaded from resources/prompts/planner.edn
 
 (def planner-system-prompt
-  "You are a Planning Agent for an autonomous software development team.
-
-Your role is to analyze requirements and create detailed implementation plans that can be
-executed by other specialized agents (Implementer, Tester, Reviewer).
-
-## Input Format
-
-You receive specifications in one of these formats:
-1. User story: \"As a <role>, I want <feature> so that <benefit>\"
-2. Technical requirement: A description of functionality needed
-3. Bug report: Description of an issue to fix
-4. Feature request: High-level description of desired capability
-
-You also receive context about:
-- Existing codebase structure
-- Technology stack and conventions
-- Constraints (time, budget, dependencies)
-
-## Output Format
-
-You must output a structured plan as a Clojure map with:
-
-```clojure
-{:plan/id <uuid>
- :plan/name \"descriptive-name\"
- :plan/tasks [{:task/id <uuid>
-               :task/description \"Clear description of what to do\"
-               :task/type :implement ; or :test, :review, :design, :deploy, :configure
-               :task/dependencies [<uuid>...] ; IDs of tasks that must complete first
-               :task/acceptance-criteria [\"Criterion 1\" \"Criterion 2\"...]
-               :task/estimated-effort :small} ; :small, :medium, :large, :xlarge
-              ...]
- :plan/estimated-complexity :medium ; :low, :medium, :high
- :plan/risks [\"Risk description\"...]
- :plan/assumptions [\"Assumption made\"...]}
-```
-
-## Guidelines
-
-1. **Task Granularity**: Break down work into small, testable units. Each task should be
-   completable in a single focused session.
-
-2. **Dependencies**: Clearly identify which tasks depend on others. Build a DAG (directed
-   acyclic graph) - no circular dependencies.
-
-3. **Acceptance Criteria**: Every task must have clear, verifiable acceptance criteria.
-   Prefer criteria that can be automatically tested.
-
-4. **Task Types**:
-   - :implement - Write production code
-   - :test - Write or update tests
-   - :review - Code review checkpoint
-   - :design - Design decisions or documentation
-   - :deploy - Deployment-related tasks
-   - :configure - Configuration changes
-
-5. **Risk Assessment**: Identify potential blockers, unknowns, and dependencies on
-   external systems or decisions.
-
-6. **Assumptions**: Document any assumptions you're making about requirements,
-   technology choices, or constraints.
-
-7. **Effort Estimation**:
-   - :small - Less than 1 hour of work
-   - :medium - 1-4 hours of work
-   - :large - Half day to full day
-   - :xlarge - Multiple days, consider breaking down further
-
-8. **Testing Strategy**: Include appropriate test tasks. Every :implement task should
-   have a corresponding :test task or explicit justification for skipping.
-
-9. **Review Points**: Include :review tasks at natural checkpoints, especially after
-   significant implementation milestones.
-
-Remember: A good plan enables parallel execution where possible while respecting
-necessary dependencies. Optimize for clarity and testability.")
+  "System prompt for the planner agent.
+   Loaded from EDN resource for configurability."
+  (delay (prompts/load-prompt :planner)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Planner functions
@@ -327,7 +255,7 @@ necessary dependencies. Optimize for clarity and testability.")
                    (log/create-logger {:min-level :info :output (fn [_])}))]
     (specialized/create-base-agent
      {:role :planner
-      :system-prompt planner-system-prompt
+      :system-prompt @planner-system-prompt
       :config (merge {:model "claude-sonnet-4"
                       :temperature 0.3
                       :max-tokens 4000}
@@ -347,9 +275,9 @@ necessary dependencies. Optimize for clarity and testability.")
             ;; Use the real LLM with streaming if callback provided
             (let [response (if on-chunk
                              (llm/chat-stream llm-client user-prompt on-chunk
-                                              {:system planner-system-prompt})
+                                              {:system @planner-system-prompt})
                              (llm/chat llm-client user-prompt
-                                       {:system planner-system-prompt}))
+                                       {:system @planner-system-prompt}))
                   tokens (or (:tokens response) 0)]
               (log/info logger :planner :planner/llm-called
                         {:data {:success (llm/success? response)

--- a/components/agent/src/ai/miniforge/agent/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/prompts.clj
@@ -1,0 +1,60 @@
+(ns ai.miniforge.agent.prompts
+  "Agent prompt loading utilities.
+   Loads system prompts from EDN resources for configurability."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Prompt loading
+
+(defn load-prompt
+  "Load an agent prompt from the resources directory.
+
+   Arguments:
+   - agent-type: Keyword identifying the agent (e.g., :implementer, :planner)
+
+   Returns:
+   - The system prompt string
+
+   Throws:
+   - ExceptionInfo if prompt cannot be loaded"
+  [agent-type]
+  (let [resource-path (str "prompts/" (name agent-type) ".edn")]
+    (if-let [resource (io/resource resource-path)]
+      (let [prompt-data (with-open [rdr (io/reader resource)]
+                          (edn/read (java.io.PushbackReader. rdr)))]
+        (or (:prompt/system prompt-data)
+            (throw (ex-info "Prompt data missing :prompt/system key"
+                            {:agent-type agent-type
+                             :resource-path resource-path
+                             :keys (keys prompt-data)}))))
+      (throw (ex-info "Could not find prompt resource"
+                      {:agent-type agent-type
+                       :resource-path resource-path})))))
+
+(defn load-prompt-data
+  "Load full prompt data map from resources.
+
+   Arguments:
+   - agent-type: Keyword identifying the agent
+
+   Returns:
+   - The full prompt data map including :prompt/id, :prompt/version, etc."
+  [agent-type]
+  (let [resource-path (str "prompts/" (name agent-type) ".edn")]
+    (if-let [resource (io/resource resource-path)]
+      (with-open [rdr (io/reader resource)]
+        (edn/read (java.io.PushbackReader. rdr)))
+      (throw (ex-info "Could not find prompt resource"
+                      {:agent-type agent-type
+                       :resource-path resource-path})))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (load-prompt :implementer)
+  (load-prompt :tester)
+  (load-prompt :planner)
+  (load-prompt :releaser)
+  (load-prompt-data :implementer)
+  :leave-this-here)

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -3,10 +3,12 @@
    Generates branch names, commit messages, PR titles and descriptions
    for the release phase."
   (:require
+   [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
+   [ai.miniforge.response.interface :as response]
    [clojure.string :as str]
    [clojure.edn :as edn]
    [malli.core :as m]))
@@ -25,85 +27,12 @@
    [:release/files-summary {:optional true} [:string {:min 1}]]
    [:release/created-at {:optional true} inst?]])
 
-;; System Prompt
+;; System Prompt - loaded from resources/prompts/releaser.edn
 
 (def releaser-system-prompt
-  "You are a Release Agent for an autonomous software development team.
-
-Your role is to generate high-quality release metadata: branch names, commit messages,
-PR titles, and PR descriptions that clearly communicate what changes are being made.
-
-## Input Format
-
-You receive:
-1. A summary of code changes:
-   - Files created, modified, and deleted
-   - Description of what was implemented
-   - Task or spec that was completed
-
-2. Context including:
-   - Repository and project information
-   - Code artifact details
-   - Any review feedback that was addressed
-
-## Output Format
-
-You must output a structured release artifact as a Clojure map:
-
-```clojure
-{:release/id <uuid>
- :release/branch-name \"feature/descriptive-name\"
- :release/commit-message \"feat: clear description of changes
-
-Detailed explanation of what was done and why.\"
- :release/pr-title \"feat: short summary (max 70 chars)\"
- :release/pr-description \"## Summary
-Clear description of what this PR does.
-
-## Changes
-- Change 1
-- Change 2
-
-## Testing
-How this was tested.\"
- :release/files-summary \"3 files created, 1 modified\"}
-```
-
-## Guidelines
-
-1. **Branch Names**:
-   - Use conventional prefixes: feature/, fix/, refactor/, docs/, chore/
-   - Use kebab-case for the description
-   - Keep it under 50 characters when possible
-   - Make it descriptive but concise
-   - Examples: feature/add-user-auth, fix/null-pointer-in-parser
-
-2. **Commit Messages**:
-   - Use conventional commits format: type(scope): description
-   - Types: feat, fix, refactor, docs, test, chore, style, perf
-   - First line should be under 72 characters
-   - Add blank line then detailed body if needed
-   - Reference issue numbers if available
-
-3. **PR Titles**:
-   - Follow same format as commit first line
-   - Maximum 70 characters
-   - Should be clear and actionable
-   - Don't end with period
-
-4. **PR Descriptions**:
-   - Start with a clear Summary section
-   - List key Changes as bullet points
-   - Include Testing section describing how changes were verified
-   - Add any relevant context or notes
-   - Use markdown formatting
-
-5. **Files Summary**:
-   - Brief count of files affected
-   - Example: \"2 files created, 1 modified, 1 deleted\"
-
-Remember: Your release metadata will be used for git commits and GitHub PRs.
-Write messages that help reviewers understand the changes at a glance.")
+  "System prompt for the releaser agent.
+   Loaded from EDN resource for configurability."
+  (delay (prompts/load-prompt :releaser)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Releaser functions
@@ -187,14 +116,27 @@ Write messages that help reviewers understand the changes at a glance.")
       nil)))
 
 (defn- slugify
-  "Convert a string to a URL-safe slug."
+  "Convert a string to a URL-safe slug.
+   Handles basic ASCII transliteration and normalizes spacing."
   [s]
-  (-> (or s "change")
-      str/lower-case
-      (str/replace #"[^a-z0-9\s-]" "")
-      (str/replace #"\s+" "-")
-      (str/replace #"-+" "-")
-      (subs 0 (min 40 (count s)))))
+  (let [input (or s "change")
+        ;; Basic ASCII transliteration for common characters
+        transliterated (-> input
+                           (str/replace #"[àáâãäå]" "a")
+                           (str/replace #"[èéêë]" "e")
+                           (str/replace #"[ìíîï]" "i")
+                           (str/replace #"[òóôõö]" "o")
+                           (str/replace #"[ùúûü]" "u")
+                           (str/replace #"[ñ]" "n")
+                           (str/replace #"[ç]" "c")
+                           (str/replace #"[ß]" "ss"))
+        slug (-> transliterated
+                 str/lower-case
+                 (str/replace #"[^a-z0-9\s-]" "")
+                 (str/replace #"\s+" "-")
+                 (str/replace #"-+" "-")
+                 (str/replace #"^-|-$" ""))]
+    (subs slug 0 (min 40 (count slug)))))
 
 (defn- make-fallback-artifact
   "Create a fallback release artifact when LLM response cannot be parsed."
@@ -270,7 +212,7 @@ Write messages that help reviewers understand the changes at a glance.")
                    (log/create-logger {:min-level :info :output (fn [_])}))]
     (specialized/create-base-agent
      {:role :releaser
-      :system-prompt releaser-system-prompt
+      :system-prompt @releaser-system-prompt
       :config (merge {:model "claude-sonnet-4"
                       :temperature 0.3
                       :max-tokens 2000}
@@ -284,45 +226,35 @@ Write messages that help reviewers understand the changes at a glance.")
               user-prompt (input->text input context)]
           (if llm-client
             ;; Use the real LLM with streaming if callback provided
-            (let [response (if on-chunk
-                             (llm/chat-stream llm-client user-prompt on-chunk
-                                              {:system releaser-system-prompt})
-                             (llm/chat llm-client user-prompt
-                                       {:system releaser-system-prompt}))
-                  tokens (or (:tokens response) 0)]
+            (let [llm-response (if on-chunk
+                                 (llm/chat-stream llm-client user-prompt on-chunk
+                                                  {:system @releaser-system-prompt})
+                                 (llm/chat llm-client user-prompt
+                                           {:system @releaser-system-prompt}))
+                  tokens (or (:tokens llm-response) 0)]
               (log/info logger :releaser :releaser/llm-called
-                        {:data {:success (llm/success? response)
+                        {:data {:success (llm/success? llm-response)
                                 :tokens tokens
                                 :streaming? (boolean on-chunk)}})
-              (if (llm/success? response)
-                (let [content (llm/get-content response)
+              (if (llm/success? llm-response)
+                (let [content (llm/get-content llm-response)
                       parsed (parse-release-response content)
                       release (or parsed (make-fallback-artifact input))
                       ;; Ensure proper ID and timestamp
                       release-with-meta (-> release
                                             (update :release/id #(or % (random-uuid)))
                                             (assoc :release/created-at (java.util.Date.)))]
-                  {:status :success
-                   :output release-with-meta
-                   :artifact release-with-meta
-                   :tokens tokens
-                   :metrics {:tokens tokens}})
+                  (response/success release-with-meta {:tokens tokens}))
                 ;; LLM call failed
-                (let [fallback (make-fallback-artifact input)]
-                  {:status :error
-                   :error (llm/get-error response)
-                   :output fallback
-                   :artifact fallback
-                   :metrics {:tokens 0}})))
+                (let [fallback (make-fallback-artifact input)
+                      error-msg (or (:message (llm/get-error llm-response))
+                                    "LLM call failed")]
+                  (response/error error-msg {:output fallback}))))
             ;; No LLM client - use fallback (for testing)
             (do
               (log/warn logger :releaser :releaser/no-llm-backend
                         {:message "No LLM backend provided, using fallback release metadata"})
-              (let [release (make-fallback-artifact input)]
-                {:status :success
-                 :output release
-                 :artifact release
-                 :metrics {:tokens 0}})))))
+              (response/success (make-fallback-artifact input))))))
 
       :validate-fn validate-release-artifact
 

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -1,0 +1,366 @@
+(ns ai.miniforge.agent.releaser
+  "Releaser agent implementation.
+   Generates branch names, commit messages, PR titles and descriptions
+   for the release phase."
+  (:require
+   [ai.miniforge.agent.specialized :as specialized]
+   [ai.miniforge.schema.interface :as schema]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.llm.interface :as llm]
+   [clojure.string :as str]
+   [clojure.edn :as edn]
+   [malli.core :as m]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Releaser-specific schemas
+
+(def ReleaseArtifact
+  "Schema for the releaser's output."
+  [:map
+   [:release/id uuid?]
+   [:release/branch-name [:string {:min 1 :max 100}]]
+   [:release/commit-message [:string {:min 1}]]
+   [:release/pr-title [:string {:min 1 :max 70}]]
+   [:release/pr-description [:string {:min 1}]]
+   [:release/files-summary {:optional true} [:string {:min 1}]]
+   [:release/created-at {:optional true} inst?]])
+
+;; System Prompt
+
+(def releaser-system-prompt
+  "You are a Release Agent for an autonomous software development team.
+
+Your role is to generate high-quality release metadata: branch names, commit messages,
+PR titles, and PR descriptions that clearly communicate what changes are being made.
+
+## Input Format
+
+You receive:
+1. A summary of code changes:
+   - Files created, modified, and deleted
+   - Description of what was implemented
+   - Task or spec that was completed
+
+2. Context including:
+   - Repository and project information
+   - Code artifact details
+   - Any review feedback that was addressed
+
+## Output Format
+
+You must output a structured release artifact as a Clojure map:
+
+```clojure
+{:release/id <uuid>
+ :release/branch-name \"feature/descriptive-name\"
+ :release/commit-message \"feat: clear description of changes
+
+Detailed explanation of what was done and why.\"
+ :release/pr-title \"feat: short summary (max 70 chars)\"
+ :release/pr-description \"## Summary
+Clear description of what this PR does.
+
+## Changes
+- Change 1
+- Change 2
+
+## Testing
+How this was tested.\"
+ :release/files-summary \"3 files created, 1 modified\"}
+```
+
+## Guidelines
+
+1. **Branch Names**:
+   - Use conventional prefixes: feature/, fix/, refactor/, docs/, chore/
+   - Use kebab-case for the description
+   - Keep it under 50 characters when possible
+   - Make it descriptive but concise
+   - Examples: feature/add-user-auth, fix/null-pointer-in-parser
+
+2. **Commit Messages**:
+   - Use conventional commits format: type(scope): description
+   - Types: feat, fix, refactor, docs, test, chore, style, perf
+   - First line should be under 72 characters
+   - Add blank line then detailed body if needed
+   - Reference issue numbers if available
+
+3. **PR Titles**:
+   - Follow same format as commit first line
+   - Maximum 70 characters
+   - Should be clear and actionable
+   - Don't end with period
+
+4. **PR Descriptions**:
+   - Start with a clear Summary section
+   - List key Changes as bullet points
+   - Include Testing section describing how changes were verified
+   - Add any relevant context or notes
+   - Use markdown formatting
+
+5. **Files Summary**:
+   - Brief count of files affected
+   - Example: \"2 files created, 1 modified, 1 deleted\"
+
+Remember: Your release metadata will be used for git commits and GitHub PRs.
+Write messages that help reviewers understand the changes at a glance.")
+
+;------------------------------------------------------------------------------ Layer 1
+;; Releaser functions
+
+(defn validate-release-artifact
+  "Validate a release artifact against the schema and check for issues."
+  [artifact]
+  (let [schema-valid? (m/validate ReleaseArtifact artifact)]
+    (if-not schema-valid?
+      {:valid? false
+       :errors (schema/explain ReleaseArtifact artifact)}
+      ;; Additional validations
+      (cond
+        ;; Branch name shouldn't have spaces
+        (str/includes? (:release/branch-name artifact "") " ")
+        {:valid? false
+         :errors {:branch-name "Branch name cannot contain spaces"}}
+
+        ;; PR title too long
+        (> (count (:release/pr-title artifact "")) 70)
+        {:valid? false
+         :errors {:pr-title "PR title exceeds 70 characters"}}
+
+        ;; Commit message empty first line
+        (str/blank? (first (str/split-lines (:release/commit-message artifact ""))))
+        {:valid? false
+         :errors {:commit-message "Commit message first line cannot be empty"}}
+
+        :else
+        {:valid? true :errors nil}))))
+
+(defn- summarize-files
+  "Create a summary of file operations."
+  [files]
+  (let [by-action (group-by :action files)
+        created (count (:create by-action))
+        modified (count (:modify by-action))
+        deleted (count (:delete by-action))
+        parts (cond-> []
+                (pos? created) (conj (str created " file" (when (> created 1) "s") " created"))
+                (pos? modified) (conj (str modified " file" (when (> modified 1) "s") " modified"))
+                (pos? deleted) (conj (str deleted " file" (when (> deleted 1) "s") " deleted")))]
+    (if (seq parts)
+      (str/join ", " parts)
+      "no file changes")))
+
+(defn- input->text
+  "Convert input to text for the LLM."
+  [input context]
+  (let [code-artifact (:code-artifact input)
+        task-description (:task-description input)
+        files (:code/files code-artifact)
+        file-summary (when files (summarize-files files))]
+    (str "Generate release metadata for the following changes:\n\n"
+         (when task-description
+           (str "## Task Description\n" task-description "\n\n"))
+         (when (:code/summary code-artifact)
+           (str "## Implementation Summary\n" (:code/summary code-artifact) "\n\n"))
+         (when file-summary
+           (str "## Files Changed\n" file-summary "\n\n"))
+         (when files
+           (str "## File Details\n"
+                (str/join "\n" (map #(str "- " (name (:action %)) ": " (:path %)) files))
+                "\n\n"))
+         (when-let [repo (:repository context)]
+           (str "## Repository\n" repo "\n\n")))))
+
+(defn- parse-release-response
+  "Parse the LLM response to extract release artifact.
+   Handles both EDN in code blocks and plain EDN.
+   Returns nil if the parsed result is not a map."
+  [response-content]
+  (try
+    (let [parsed (if-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" response-content)]
+                   (edn/read-string (second match))
+                   ;; Try to parse the whole response as EDN
+                   (edn/read-string response-content))]
+      (when (map? parsed)
+        parsed))
+    (catch Exception _
+      nil)))
+
+(defn- slugify
+  "Convert a string to a URL-safe slug."
+  [s]
+  (-> (or s "change")
+      str/lower-case
+      (str/replace #"[^a-z0-9\s-]" "")
+      (str/replace #"\s+" "-")
+      (str/replace #"-+" "-")
+      (subs 0 (min 40 (count s)))))
+
+(defn- make-fallback-artifact
+  "Create a fallback release artifact when LLM response cannot be parsed."
+  [input]
+  (let [code-artifact (:code-artifact input)
+        task-description (or (:task-description input) "implement changes")
+        files (:code/files code-artifact)
+        slug (slugify task-description)
+        file-summary (when files (summarize-files files))]
+    {:release/id (random-uuid)
+     :release/branch-name (str "feature/" slug)
+     :release/commit-message (str "feat: " task-description "\n\n"
+                                  (when file-summary (str file-summary "\n")))
+     :release/pr-title (str "feat: " (subs task-description 0 (min 60 (count task-description))))
+     :release/pr-description (str "## Summary\n"
+                                  task-description "\n\n"
+                                  "## Changes\n"
+                                  (if files
+                                    (str/join "\n" (map #(str "- " (name (:action %)) " `" (:path %) "`") files))
+                                    "- See commits for details")
+                                  "\n\n## Testing\n"
+                                  "- [ ] Manual verification")
+     :release/files-summary (or file-summary "no file changes")
+     :release/created-at (java.util.Date.)}))
+
+(defn- repair-release-artifact
+  "Attempt to repair a release artifact based on validation errors."
+  [artifact errors _context]
+  (let [repaired (atom artifact)]
+    ;; Fix missing ID
+    (when-not (:release/id @repaired)
+      (swap! repaired assoc :release/id (random-uuid)))
+
+    ;; Fix branch name with spaces
+    (when (str/includes? (:release/branch-name @repaired "") " ")
+      (swap! repaired update :release/branch-name
+             #(str/replace % " " "-")))
+
+    ;; Truncate PR title if too long
+    (when (> (count (:release/pr-title @repaired "")) 70)
+      (swap! repaired update :release/pr-title
+             #(str (subs % 0 67) "...")))
+
+    ;; Ensure commit message has content
+    (when (str/blank? (:release/commit-message @repaired))
+      (swap! repaired assoc :release/commit-message "chore: update"))
+
+    ;; Ensure PR description has content
+    (when (str/blank? (:release/pr-description @repaired))
+      (swap! repaired assoc :release/pr-description "## Summary\nUpdates as described in the commit."))
+
+    {:status :success
+     :output @repaired
+     :repairs-made (when (not= artifact @repaired)
+                     {:original-errors errors})}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Public API
+
+(defn create-releaser
+  "Create a Releaser agent with optional configuration overrides.
+
+   Options:
+   - :config - Agent configuration (model, temperature, etc.)
+   - :logger - Logger instance
+   - :llm-backend - LLM client (if not provided, uses :llm-backend from context)
+
+   Example:
+     (create-releaser)
+     (create-releaser {:config {:model \"claude-sonnet-4\" :temperature 0.3}})"
+  [& [opts]]
+  (let [logger (or (:logger opts)
+                   (log/create-logger {:min-level :info :output (fn [_])}))]
+    (specialized/create-base-agent
+     {:role :releaser
+      :system-prompt releaser-system-prompt
+      :config (merge {:model "claude-sonnet-4"
+                      :temperature 0.3
+                      :max-tokens 2000}
+                     (:config opts))
+      :logger logger
+
+      :invoke-fn
+      (fn [context input]
+        (let [llm-client (or (:llm-backend opts) (:llm-backend context))
+              on-chunk (:on-chunk context)
+              user-prompt (input->text input context)]
+          (if llm-client
+            ;; Use the real LLM with streaming if callback provided
+            (let [response (if on-chunk
+                             (llm/chat-stream llm-client user-prompt on-chunk
+                                              {:system releaser-system-prompt})
+                             (llm/chat llm-client user-prompt
+                                       {:system releaser-system-prompt}))
+                  tokens (or (:tokens response) 0)]
+              (log/info logger :releaser :releaser/llm-called
+                        {:data {:success (llm/success? response)
+                                :tokens tokens
+                                :streaming? (boolean on-chunk)}})
+              (if (llm/success? response)
+                (let [content (llm/get-content response)
+                      parsed (parse-release-response content)
+                      release (or parsed (make-fallback-artifact input))
+                      ;; Ensure proper ID and timestamp
+                      release-with-meta (-> release
+                                            (update :release/id #(or % (random-uuid)))
+                                            (assoc :release/created-at (java.util.Date.)))]
+                  {:status :success
+                   :output release-with-meta
+                   :artifact release-with-meta
+                   :tokens tokens
+                   :metrics {:tokens tokens}})
+                ;; LLM call failed
+                (let [fallback (make-fallback-artifact input)]
+                  {:status :error
+                   :error (llm/get-error response)
+                   :output fallback
+                   :artifact fallback
+                   :metrics {:tokens 0}})))
+            ;; No LLM client - use fallback (for testing)
+            (do
+              (log/warn logger :releaser :releaser/no-llm-backend
+                        {:message "No LLM backend provided, using fallback release metadata"})
+              (let [release (make-fallback-artifact input)]
+                {:status :success
+                 :output release
+                 :artifact release
+                 :metrics {:tokens 0}})))))
+
+      :validate-fn validate-release-artifact
+
+      :repair-fn repair-release-artifact})))
+
+(defn release-summary
+  "Get a summary of a release artifact for logging/display."
+  [artifact]
+  {:id (:release/id artifact)
+   :branch (:release/branch-name artifact)
+   :pr-title (:release/pr-title artifact)
+   :files-summary (:release/files-summary artifact)})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create a releaser
+  (def rel (create-releaser))
+
+  ;; Invoke with code artifact
+  (specialized/invoke rel
+                      {:repository "miniforge-ai/miniforge"}
+                      {:code-artifact {:code/files [{:path "src/auth.clj" :action :create}]
+                                       :code/summary "Added authentication"}
+                       :task-description "Implement user authentication"})
+
+  ;; Validate a release artifact
+  (validate-release-artifact
+   {:release/id (random-uuid)
+    :release/branch-name "feature/add-auth"
+    :release/commit-message "feat: add user authentication"
+    :release/pr-title "feat: add user authentication"
+    :release/pr-description "## Summary\nAdds auth."})
+  ;; => {:valid? true, :errors nil}
+
+  ;; Get summary
+  (release-summary {:release/id (random-uuid)
+                    :release/branch-name "feature/add-auth"
+                    :release/pr-title "feat: add user auth"
+                    :release/files-summary "1 file created"})
+
+  :leave-this-here)

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -2,6 +2,7 @@
   "Tester agent implementation.
    Generates tests for code artifacts and validates coverage."
   (:require
+   [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
@@ -39,114 +40,12 @@
    [:test/summary {:optional true} [:string {:min 1}]]
    [:test/created-at {:optional true} inst?]])
 
-;; System Prompt
+;; System Prompt - loaded from resources/prompts/tester.edn
 
 (def tester-system-prompt
-  "You are a Testing Agent for an autonomous software development team.
-
-Your role is to generate comprehensive tests for code artifacts, ensuring quality
-and correctness. You work alongside Planner, Implementer, and Reviewer agents.
-
-## Input Format
-
-You receive:
-1. A code artifact with:
-   - File paths and content
-   - Language and framework information
-   - Summary of what was implemented
-
-2. Specification/acceptance criteria:
-   - What the code should do
-   - Edge cases to consider
-   - Performance requirements (if any)
-
-3. Context including:
-   - Existing test patterns in the codebase
-   - Testing framework preferences
-   - Coverage requirements
-
-## Output Format
-
-You must output a structured test artifact as a Clojure map:
-
-```clojure
-{:test/id <uuid>
- :test/files [{:path \"test/namespace/file_test.clj\"
-               :content \"(ns namespace.file-test...)\"}
-              ...]
- :test/type :unit ; or :integration, :property, :e2e, :acceptance
- :test/coverage {:lines 85.0
-                 :branches 80.0
-                 :functions 90.0}
- :test/framework \"clojure.test\"
- :test/assertions-count 15
- :test/cases-count 5
- :test/summary \"Description of test coverage\"}
-```
-
-## Guidelines
-
-1. **Test Types**:
-   - :unit - Isolated function/method tests with mocked dependencies
-   - :integration - Tests that verify component interactions
-   - :property - Property-based/generative tests (e.g., test.check)
-   - :e2e - End-to-end tests through the full system
-   - :acceptance - Tests verifying acceptance criteria
-
-2. **Test Structure (for Clojure)**:
-   ```clojure
-   (ns my.namespace-test
-     (:require [clojure.test :refer [deftest testing is]]
-               [my.namespace :as sut]))  ; sut = system under test
-
-   (deftest function-name-test
-     (testing \"describes the scenario\"
-       (is (= expected (sut/function-name input)))))
-   ```
-
-3. **Coverage Strategy**:
-   - Test the happy path first
-   - Test edge cases (empty inputs, nil, boundary values)
-   - Test error conditions and exception handling
-   - Test state transitions if applicable
-
-4. **Test Naming**:
-   - Test namespaces mirror source namespaces with `-test` suffix
-   - Test files use `_test.clj` suffix
-   - Test names describe what is being tested and expected outcome
-
-5. **Assertions**:
-   - One logical assertion per test when possible
-   - Use descriptive assertion messages
-   - Test exact values, not just truthiness
-
-6. **Property-Based Testing**:
-   - Use for functions with clear invariants
-   - Generate a variety of inputs automatically
-   - Find edge cases you might not think of
-
-7. **Test Data**:
-   - Use realistic but minimal test data
-   - Create test fixtures for complex data structures
-   - Avoid hardcoded magic values, use named constants
-
-8. **Mocking and Stubs**:
-   - Mock external dependencies (APIs, databases)
-   - Keep mocks minimal and realistic
-   - Verify mock interactions when relevant
-
-9. **Coverage Requirements**:
-   - Aim for 80%+ line coverage
-   - Critical paths should have 100% coverage
-   - Don't sacrifice meaningful tests for coverage numbers
-
-10. **Test Independence**:
-    - Each test should run independently
-    - No shared mutable state between tests
-    - Use fixtures for setup/teardown
-
-Remember: Good tests are documentation. They show how the code is intended to be used
-and what behavior is expected. Make tests readable and maintainable.")
+  "System prompt for the tester agent.
+   Loaded from EDN resource for configurability."
+  (delay (prompts/load-prompt :tester)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Tester functions
@@ -369,7 +268,7 @@ and what behavior is expected. Make tests readable and maintainable.")
                    (log/create-logger {:min-level :info :output (fn [_])}))]
     (specialized/create-base-agent
      {:role :tester
-      :system-prompt tester-system-prompt
+      :system-prompt @tester-system-prompt
       :config (merge {:model "claude-sonnet-4"
                       :temperature 0.2
                       :max-tokens 6000}
@@ -398,9 +297,9 @@ and what behavior is expected. Make tests readable and maintainable.")
             ;; Use the real LLM with streaming if callback provided
             (let [response (if on-chunk
                              (llm/chat-stream llm-client user-prompt on-chunk
-                                              {:system tester-system-prompt})
+                                              {:system @tester-system-prompt})
                              (llm/chat llm-client user-prompt
-                                       {:system tester-system-prompt}))
+                                       {:system @tester-system-prompt}))
                   tokens (or (:tokens response) 0)]
               (log/info logger :tester :tester/llm-called
                         {:data {:success (llm/success? response)

--- a/components/agent/test/ai/miniforge/agent/releaser_test.clj
+++ b/components/agent/test/ai/miniforge/agent/releaser_test.clj
@@ -1,0 +1,167 @@
+(ns ai.miniforge.agent.releaser-test
+  "Tests for the Releaser agent."
+  (:require
+   [clojure.test :as test :refer [deftest testing is]]
+   [ai.miniforge.agent.core :as core]
+   [ai.miniforge.agent.releaser :as releaser]
+   [ai.miniforge.logging.interface :as log]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures
+
+(def valid-release-artifact
+  {:release/id (random-uuid)
+   :release/branch-name "feature/add-user-auth"
+   :release/commit-message "feat: add user authentication\n\nImplements login flow."
+   :release/pr-title "feat: add user authentication"
+   :release/pr-description "## Summary\nAdds auth.\n\n## Changes\n- Added login"
+   :release/files-summary "1 file created"})
+
+(def minimal-release-artifact
+  {:release/id (random-uuid)
+   :release/branch-name "feature/update"
+   :release/commit-message "chore: update"
+   :release/pr-title "chore: update"
+   :release/pr-description "## Summary\nUpdates."})
+
+(def code-artifact-input
+  {:code-artifact {:code/id (random-uuid)
+                   :code/files [{:path "src/auth/login.clj"
+                                 :content "(ns auth.login)"
+                                 :action :create}
+                                {:path "src/auth/session.clj"
+                                 :content "(ns auth.session)"
+                                 :action :create}]
+                   :code/summary "Added authentication module"}
+   :task-description "Implement user authentication"})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Agent creation tests
+
+(deftest create-releaser-test
+  (testing "creates releaser with default config"
+    (let [agent (releaser/create-releaser)]
+      (is (some? agent))
+      (is (= :releaser (:role agent)))
+      (is (string? (:system-prompt agent)))))
+
+  (testing "creates releaser with custom config"
+    (let [agent (releaser/create-releaser {:config {:temperature 0.1}})]
+      (is (= 0.1 (get-in agent [:config :temperature])))))
+
+  (testing "creates releaser with logger"
+    (let [[logger _] (log/collecting-logger)
+          agent (releaser/create-releaser {:logger logger})]
+      (is (some? (:logger agent))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Invoke tests
+
+(deftest releaser-invoke-test
+  (testing "generates release metadata from code artifact"
+    (let [agent (releaser/create-releaser)
+          result (core/invoke agent {} code-artifact-input)]
+      (is (= :success (:status result)))
+      (is (uuid? (get-in result [:output :release/id])))
+      (is (string? (get-in result [:output :release/branch-name])))
+      (is (string? (get-in result [:output :release/commit-message])))
+      (is (string? (get-in result [:output :release/pr-title])))
+      (is (string? (get-in result [:output :release/pr-description])))))
+
+  (testing "generates branch name with proper prefix"
+    (let [agent (releaser/create-releaser)
+          result (core/invoke agent {} code-artifact-input)
+          branch-name (get-in result [:output :release/branch-name])]
+      (is (re-matches #"(feature|fix|refactor|docs|chore)/.*" branch-name))))
+
+  (testing "handles minimal input"
+    (let [agent (releaser/create-releaser)
+          result (core/invoke agent {} {:task-description "simple change"})]
+      (is (= :success (:status result)))
+      (is (string? (get-in result [:output :release/branch-name]))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Validation tests
+
+(deftest validate-release-artifact-test
+  (testing "valid artifact passes validation"
+    (let [result (releaser/validate-release-artifact valid-release-artifact)]
+      (is (:valid? result))
+      (is (nil? (:errors result)))))
+
+  (testing "minimal artifact passes validation"
+    (let [result (releaser/validate-release-artifact minimal-release-artifact)]
+      (is (:valid? result))))
+
+  (testing "missing required fields fails validation"
+    (let [result (releaser/validate-release-artifact {:release/id (random-uuid)})]
+      (is (not (:valid? result)))))
+
+  (testing "branch name with spaces fails validation"
+    (let [bad-artifact (assoc valid-release-artifact
+                              :release/branch-name "feature/bad branch name")
+          result (releaser/validate-release-artifact bad-artifact)]
+      (is (not (:valid? result)))
+      (is (= "Branch name cannot contain spaces" (:branch-name (:errors result))))))
+
+  (testing "PR title exceeding 70 chars fails validation"
+    (let [long-title (apply str (repeat 80 "x"))
+          bad-artifact (assoc valid-release-artifact :release/pr-title long-title)
+          result (releaser/validate-release-artifact bad-artifact)]
+      ;; Schema validation catches this at the :max 70 constraint
+      (is (not (:valid? result))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Utility tests
+
+(deftest release-summary-test
+  (testing "returns release summary"
+    (let [summary (releaser/release-summary valid-release-artifact)]
+      (is (uuid? (:id summary)))
+      (is (string? (:branch summary)))
+      (is (string? (:pr-title summary)))
+      (is (string? (:files-summary summary))))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Repair tests
+
+(deftest releaser-repair-test
+  (testing "repairs branch name with spaces"
+    (let [agent (releaser/create-releaser)
+          bad-artifact (assoc valid-release-artifact
+                              :release/branch-name "feature/bad branch")
+          result (core/repair agent bad-artifact {:branch-name ["spaces"]} {})]
+      (is (= :success (:status result)))
+      (is (not (re-find #" " (get-in result [:output :release/branch-name]))))))
+
+  (testing "truncates long PR title"
+    (let [agent (releaser/create-releaser)
+          long-title (apply str (repeat 80 "x"))
+          bad-artifact (assoc valid-release-artifact :release/pr-title long-title)
+          result (core/repair agent bad-artifact {:pr-title ["too long"]} {})]
+      (is (= :success (:status result)))
+      (is (<= (count (get-in result [:output :release/pr-title])) 70))))
+
+  (testing "adds missing ID"
+    (let [agent (releaser/create-releaser)
+          bad-artifact (dissoc valid-release-artifact :release/id)
+          result (core/repair agent bad-artifact {:release/id ["required"]} {})]
+      (is (= :success (:status result)))
+      (is (uuid? (get-in result [:output :release/id]))))))
+
+;------------------------------------------------------------------------------ Layer 6
+;; Full cycle tests
+
+(deftest releaser-cycle-test
+  (testing "full invoke-validate cycle succeeds"
+    (let [agent (releaser/create-releaser)
+          result (core/cycle-agent agent {} code-artifact-input)]
+      (is (= :success (:status result)))
+      (is (uuid? (get-in result [:output :release/id])))
+      (is (string? (get-in result [:output :release/branch-name]))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (test/run-tests 'ai.miniforge.agent.releaser-test)
+
+  :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/release.clj
+++ b/components/phase/src/ai/miniforge/phase/release.clj
@@ -15,10 +15,11 @@
 (ns ai.miniforge.phase.release
   "Release phase interceptor.
 
-   Prepares release artifacts and creates PRs.
-   Agent: :releaser (simplified - no LLM agent yet)
+   Prepares release artifacts and creates PRs using the release-executor component.
+   Agent: :releaser
    Default gates: [:release-ready]"
   (:require [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.release-executor.interface :as release-executor]
             [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -43,41 +44,82 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
 
-(defn- create-release-artifact
-  "Create a simple release artifact from previous phase outputs.
-   This is a simplified implementation until a full releaser agent is created."
+(defn- build-workflow-state
+  "Build workflow state from phase context for the release executor."
   [ctx]
   (let [implement-result (get-in ctx [:phases :implement :result])
-        verify-result (get-in ctx [:phases :verify :result])
-        review-result (get-in ctx [:phases :review :result])
+        code-artifacts (if-let [artifacts (:artifacts implement-result)]
+                         (map (fn [a] {:artifact/type :code
+                                       :artifact/content a})
+                              artifacts)
+                         ;; Fallback: wrap result directly
+                         [{:artifact/type :code
+                           :artifact/content implement-result}])
         input (get-in ctx [:execution/input])]
-    {:release/id (random-uuid)
-     :release/status :ready
-     :release/artifacts {:code implement-result
-                         :tests verify-result
-                         :review review-result}
-     :release/title (or (:title input) "Release")
-     :release/description (or (:description input) "")
-     :release/created-at (java.util.Date.)}))
+    {:workflow/id (or (get-in ctx [:execution/id]) (random-uuid))
+     :workflow/phase :release
+     :workflow/spec {:spec/description (or (:description input)
+                                           (:title input)
+                                           "implement changes")}
+     :workflow/artifacts code-artifacts}))
+
+(defn- build-executor-context
+  "Build context for the release executor from phase context."
+  [ctx config]
+  {:worktree-path (or (get-in ctx [:execution/worktree-path])
+                      (get-in ctx [:worktree-path])
+                      (get-in config [:worktree-path]))
+   :logger (get-in ctx [:execution/logger])
+   :llm-backend (get-in ctx [:execution/llm-backend])
+   :artifact-store (get-in ctx [:execution/artifact-store])
+   ;; Allow disabling PR creation via config
+   :create-pr? (get config :create-pr? true)})
 
 (defn- enter-release
   "Execute release phase.
 
-   Prepares release artifacts, creates PR if configured."
+   Uses the workflow release executor to:
+   - Generate release metadata (branch name, commit message, PR title/body)
+   - Create git branch
+   - Write files and stage them
+   - Commit changes
+   - Push branch and create PR (if enabled)"
   [ctx]
   (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
         {:keys [gates budget]} config
         start-time (System/currentTimeMillis)
 
-        ;; Create release artifact (simplified - no agent yet)
-        ;; In the future, this would invoke a releaser agent that:
-        ;; - Generates changelog
-        ;; - Creates git commits
-        ;; - Prepares PR description
-        ;; - Handles versioning
+        ;; Build workflow state and context
+        workflow-state (build-workflow-state ctx)
+        exec-context (build-executor-context ctx config)
+        releaser-agent (get config :releaser-agent)
+
+        ;; Execute the release phase
         result (try
-                 (let [artifact (create-release-artifact ctx)]
-                   (response/success artifact))
+                 (let [exec-result (release-executor/execute-release-phase
+                                    workflow-state
+                                    exec-context
+                                    {:releaser releaser-agent})]
+                   (if (:success? exec-result)
+                     (let [release-artifact (first (:artifacts exec-result))
+                           content (:artifact/content release-artifact)]
+                       (response/success
+                        (merge
+                         {:release/id (or (:artifact/id release-artifact) (random-uuid))
+                          :release/status :completed
+                          :release/artifacts (:artifacts exec-result)}
+                         ;; Include PR info for evidence bundle
+                         (when (:pr-url content)
+                           {:workflow/pr-info {:pr-number (:pr-number content)
+                                               :pr-url (:pr-url content)
+                                               :branch (:branch content)
+                                               :commit-sha (:commit-sha content)}})
+                         {:release/metrics (:metrics exec-result)})))
+                     ;; Execution failed
+                     (response/failure
+                      (ex-info "Release phase failed"
+                               {:errors (:errors exec-result)
+                                :metrics (:metrics exec-result)}))))
                  (catch Exception e
                    (response/failure e)))]
 
@@ -88,19 +130,25 @@
         (assoc-in [:phase :budget] budget)
         (assoc-in [:phase :started-at] start-time)
         (assoc-in [:phase :status] :running)
-        (assoc-in [:phase :result] result))))
+        (assoc-in [:phase :result] result)
+        ;; Store PR info at top level for easy access
+        (cond-> (= :success (:status result))
+          (assoc-in [:workflow/pr-info] (get-in (:output result) [:workflow/pr-info]))))))
 
 (defn- leave-release
   "Post-processing for release phase.
 
-   Records release metrics."
+   Records release metrics and PR info."
   [ctx]
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
         duration-ms (- end-time start-time)
         result (get-in ctx [:phase :result])
-        metrics (get result :metrics {:tokens 0 :duration-ms duration-ms})
-        iterations (get-in ctx [:phase :iterations] 1)]
+        release-data (when (= :success (:status result)) (:output result))
+        release-metrics (or (:release/metrics release-data) {})
+        metrics (merge {:tokens 0 :duration-ms duration-ms} release-metrics)
+        iterations (get-in ctx [:phase :iterations] 1)
+        pr-info (get-in ctx [:workflow/pr-info])]
     (-> ctx
         (assoc-in [:phase :ended-at] end-time)
         (assoc-in [:phase :duration-ms] duration-ms)
@@ -108,6 +156,9 @@
         (assoc-in [:phase :metrics] metrics)
         (assoc-in [:metrics :release :duration-ms] duration-ms)
         (assoc-in [:metrics :release :repair-cycles] (dec iterations))
+        ;; Include PR info in metrics for evidence bundle
+        (cond-> pr-info
+          (assoc-in [:metrics :release :pr-info] pr-info))
         (update-in [:execution :phases-completed] (fnil conj []) :release)
         ;; Merge agent metrics into execution metrics
         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))

--- a/components/release-executor/deps.edn
+++ b/components/release-executor/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/workflow {:local/root "../workflow"}
+        ai.miniforge/artifact {:local/root "../artifact"}
+        ai.miniforge/logging {:local/root "../logging"}
+        babashka/fs {:mvn/version "0.5.22"}
+        babashka/process {:mvn/version "0.5.22"}}}

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -1,425 +1,22 @@
 (ns ai.miniforge.release-executor.core
-  "Release phase executor for creating PRs from code artifacts.
+  "Release phase executor - orchestrates the release pipeline.
 
-   This component provides the full release flow:
-   - Check GitHub CLI authentication
-   - Generate release metadata (branch name, commit message, PR title/body)
-   - Create git branch
-   - Write files and stage them
-   - Commit changes
-   - Push branch and create PR
+   This is the main entry point that coordinates:
+   - Git operations (branch, commit, push, PR)
+   - File operations (write, delete, stage)
+   - Metadata generation (releaser agent or fallback)
 
-   Extracted to a separate component to avoid circular dependencies
-   between workflow and phase components."
+   The pipeline pattern ensures clean sequential execution with early exit on failure."
   (:require
    [ai.miniforge.artifact.interface :as artifact]
    [ai.miniforge.logging.interface :as log]
-   [babashka.fs :as fs]
-   [babashka.process :as process]
-   [clojure.string :as str]))
+   [ai.miniforge.release-executor.files :as files]
+   [ai.miniforge.release-executor.git :as git]
+   [ai.miniforge.release-executor.metadata :as metadata]
+   [ai.miniforge.release-executor.result :as result]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; File operation helpers
-
-(defn- ensure-parent-dir!
-  "Create parent directories for a file path if they don't exist."
-  [file-path]
-  (let [parent (fs/parent file-path)]
-    (when parent
-      (fs/create-dirs parent))
-    parent))
-
-(defn- write-file!
-  "Write content to a file, creating parent directories as needed."
-  [file-path content]
-  (ensure-parent-dir! file-path)
-  (spit (str file-path) content)
-  file-path)
-
-(defn- delete-file!
-  "Delete a file if it exists. Returns true if deleted, false if file didn't exist."
-  [file-path]
-  (if (fs/exists? file-path)
-    (do
-      (fs/delete file-path)
-      true)
-    false))
-
-;------------------------------------------------------------------------------ Layer 0.5
-;; Result helpers
-
-(defn- shell-success
-  "Create a shell operation success result."
-  [data]
-  (merge {:success? true} data))
-
-(defn- shell-failure
-  "Create a shell operation failure result."
-  ([error-msg]
-   (shell-failure error-msg {}))
-  ([error-msg data]
-   (merge {:success? false :error error-msg} data)))
-
-(defn- phase-success
-  "Create a release phase success result."
-  [artifacts metrics]
-  {:success? true
-   :artifacts artifacts
-   :errors []
-   :metrics metrics})
-
-(defn- phase-failure
-  "Create a release phase failure result."
-  ([error-type error-msg]
-   (phase-failure error-type error-msg {}))
-  ([error-type error-msg opts]
-   {:success? false
-    :artifacts []
-    :errors [(merge {:type error-type :message error-msg}
-                    (select-keys opts [:hint :data]))]
-    :metrics (or (:metrics opts) {})}))
-
-;------------------------------------------------------------------------------ Layer 0.6
-;; String utilities
-
-(defn- slugify
-  "Convert a string to a URL-safe slug.
-   Handles basic ASCII transliteration and normalizes spacing."
-  [s]
-  (let [input (or s "change")
-        ;; Basic ASCII transliteration for common characters
-        transliterated (-> input
-                           (str/replace #"[àáâãäå]" "a")
-                           (str/replace #"[èéêë]" "e")
-                           (str/replace #"[ìíîï]" "i")
-                           (str/replace #"[òóôõö]" "o")
-                           (str/replace #"[ùúûü]" "u")
-                           (str/replace #"[ñ]" "n")
-                           (str/replace #"[ç]" "c")
-                           (str/replace #"[ß]" "ss"))
-        slug (-> transliterated
-                 str/lower-case
-                 (str/replace #"[^a-z0-9\s-]" "")
-                 (str/replace #"\s+" "-")
-                 (str/replace #"-+" "-")
-                 (str/replace #"^-|-$" ""))]
-    (subs slug 0 (min 40 (count slug)))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Git operations
-
-(defn- stage-files!
-  "Stage files in git worktree using git add."
-  [worktree-path file-paths]
-  (try
-    (let [git-args (if (= file-paths :all)
-                     ["git" "add" "."]
-                     (into ["git" "add"] (map str file-paths)))
-          result (apply process/shell
-                        {:dir (str worktree-path)
-                         :out :string
-                         :err :string
-                         :continue true}
-                        git-args)]
-      (if (zero? (:exit result))
-        (shell-success {:output (:out result "")})
-        (shell-failure (:err result "") {:output (:out result "")})))
-    (catch Exception e
-      (shell-failure (.getMessage e)))))
-
-(defn- gh-unavailable
-  "Create result for gh CLI not available."
-  [error-msg]
-  {:available? false :authenticated? false :error error-msg})
-
-(defn- gh-available-unauthenticated
-  "Create result for gh CLI available but not authenticated."
-  [error-msg]
-  {:available? true :authenticated? false :error error-msg})
-
-(defn- gh-authenticated
-  "Create result for gh CLI available and authenticated."
-  [user]
-  {:available? true :authenticated? true :user user})
-
-(defn check-gh-auth!
-  "Check if gh CLI is available and authenticated.
-
-   Returns {:available? bool :authenticated? bool :user string :error string}"
-  []
-  (try
-    (let [which-result (process/shell
-                        {:out :string :err :string :continue true}
-                        "which" "gh")]
-      (if-not (zero? (:exit which-result))
-        (gh-unavailable "gh CLI not found. Install with: brew install gh")
-        (let [auth-result (process/shell
-                           {:out :string :err :string :continue true}
-                           "gh" "auth" "status")]
-          (if (zero? (:exit auth-result))
-            (let [output (:out auth-result "")
-                  user-match (re-find #"Logged in to [^\s]+ account (\S+)" output)]
-              (gh-authenticated (or (second user-match) "unknown")))
-            (gh-available-unauthenticated
-             (str "gh not authenticated. Run: gh auth login\n" (:err auth-result)))))))
-    (catch Exception e
-      (gh-unavailable (.getMessage e)))))
-
-(defn create-branch!
-  "Create a new git branch from main/master.
-
-   Arguments:
-   - worktree-path - Path to git worktree root
-   - branch-name   - Name for the new branch
-
-   Returns {:success? bool :branch string :base-branch string :error string}"
-  [worktree-path branch-name]
-  (try
-    (let [dir-opts {:dir (str worktree-path) :out :string :err :string :continue true}
-          default-branch-result (process/shell dir-opts
-                                               "git" "symbolic-ref" "refs/remotes/origin/HEAD")
-          default-branch (if (zero? (:exit default-branch-result))
-                           (-> (:out default-branch-result)
-                               str/trim
-                               (str/replace #"refs/remotes/origin/" ""))
-                           "main")
-          fetch-result (process/shell dir-opts "git" "fetch" "origin" default-branch)]
-
-      (if-not (zero? (:exit fetch-result))
-        (shell-failure (str "Failed to fetch: " (:err fetch-result)) {:branch nil})
-        (let [checkout-result (process/shell dir-opts
-                                             "git" "checkout" "-b" branch-name
-                                             (str "origin/" default-branch))]
-          (if (zero? (:exit checkout-result))
-            (shell-success {:branch branch-name :base-branch default-branch})
-            (let [timestamped-name (str branch-name "-" (System/currentTimeMillis))
-                  retry-result (process/shell dir-opts
-                                              "git" "checkout" "-b" timestamped-name
-                                              (str "origin/" default-branch))]
-              (if (zero? (:exit retry-result))
-                (shell-success {:branch timestamped-name :base-branch default-branch})
-                (shell-failure (str "Failed to create branch: " (:err retry-result))
-                               {:branch nil})))))))
-    (catch Exception e
-      (shell-failure (.getMessage e) {:branch nil}))))
-
-(defn commit-changes!
-  "Commit staged changes with the given message.
-
-   Returns {:success? bool :commit-sha string :error string}"
-  [worktree-path commit-message]
-  (try
-    (let [result (process/shell
-                  {:dir (str worktree-path) :out :string :err :string :continue true}
-                  "git" "commit" "-m" commit-message)]
-      (if (zero? (:exit result))
-        (let [sha-result (process/shell
-                          {:dir (str worktree-path) :out :string :err :string :continue true}
-                          "git" "rev-parse" "HEAD")]
-          (shell-success {:commit-sha (str/trim (:out sha-result ""))
-                          :output (:out result)}))
-        (shell-failure (:err result) {:commit-sha nil})))
-    (catch Exception e
-      (shell-failure (.getMessage e) {:commit-sha nil}))))
-
-(defn push-branch!
-  "Push the current branch to origin.
-
-   Returns {:success? bool :error string}"
-  [worktree-path branch-name]
-  (try
-    (let [result (process/shell
-                  {:dir (str worktree-path) :out :string :err :string :continue true}
-                  "git" "push" "-u" "origin" branch-name)]
-      (if (zero? (:exit result))
-        (shell-success {:output (:out result)})
-        (shell-failure (:err result))))
-    (catch Exception e
-      (shell-failure (.getMessage e)))))
-
-(defn create-pr!
-  "Create a pull request using gh CLI.
-
-   Returns {:success? bool :pr-number int :pr-url string :error string}"
-  [worktree-path {:keys [title body base-branch]}]
-  (try
-    (let [base (or base-branch "main")
-          args ["gh" "pr" "create"
-                "--title" title
-                "--body" body
-                "--base" base]
-          result (apply process/shell
-                        {:dir (str worktree-path) :out :string :err :string :continue true}
-                        args)]
-      (if (zero? (:exit result))
-        (let [pr-url (str/trim (:out result ""))
-              pr-num (when-let [match (re-find #"/pull/(\d+)" pr-url)]
-                       (parse-long (second match)))]
-          (shell-success {:pr-url pr-url :pr-number pr-num}))
-        (shell-failure (:err result) {:pr-url nil :pr-number nil})))
-    (catch Exception e
-      (shell-failure (.getMessage e) {:pr-url nil :pr-number nil}))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; File action processing
-
-(defmulti ^:private process-file-action
-  "Process a file action based on its :action keyword."
-  (fn [_worktree-path file-spec _logger] (:action file-spec)))
-
-(defmethod process-file-action :create
-  [worktree-path {:keys [path content]} logger]
-  (try
-    (let [full-path (fs/path worktree-path path)]
-      (write-file! full-path content)
-      (when logger
-        (log/debug logger :release-executor :file-created {:data {:path path}}))
-      {:success? true :action :create :path path})
-    (catch Exception e
-      (when logger
-        (log/error logger :release-executor :file-create-failed
-                  {:message (.getMessage e) :data {:path path}}))
-      {:success? false :action :create :path path :error (.getMessage e)})))
-
-(defmethod process-file-action :modify
-  [worktree-path {:keys [path content]} logger]
-  (try
-    (let [full-path (fs/path worktree-path path)]
-      (write-file! full-path content)
-      (when logger
-        (log/debug logger :release-executor :file-modified {:data {:path path}}))
-      {:success? true :action :modify :path path})
-    (catch Exception e
-      (when logger
-        (log/error logger :release-executor :file-modify-failed
-                  {:message (.getMessage e) :data {:path path}}))
-      {:success? false :action :modify :path path :error (.getMessage e)})))
-
-(defmethod process-file-action :delete
-  [worktree-path {:keys [path]} logger]
-  (try
-    (let [full-path (fs/path worktree-path path)
-          deleted? (delete-file! full-path)]
-      (when logger
-        (log/debug logger :release-executor :file-deleted {:data {:path path :existed? deleted?}}))
-      {:success? true :action :delete :path path :deleted? deleted?})
-    (catch Exception e
-      (when logger
-        (log/error logger :release-executor :file-delete-failed
-                  {:message (.getMessage e) :data {:path path}}))
-      {:success? false :action :delete :path path :error (.getMessage e)})))
-
-(defmethod process-file-action :default
-  [_worktree-path {:keys [path action]} logger]
-  (when logger
-    (log/warn logger :release-executor :unknown-action {:data {:path path :action action}}))
-  {:success? false :action action :path path :error (str "Unknown action: " action)})
-
-;------------------------------------------------------------------------------ Layer 3
-;; Code artifact extraction
-
-(defn- extract-code-artifacts
-  "Extract code artifacts from workflow artifacts."
-  [workflow-artifacts]
-  (->> workflow-artifacts
-       (filter #(or (= :code (:type %))
-                    (= :code (:artifact/type %))))
-       (map (fn [artifact]
-              (or (:artifact/content artifact)
-                  (:content artifact))))))
-
-(defn- write-and-stage-files!
-  "Write files to worktree and stage them. Returns result map."
-  [worktree-path code-artifacts logger]
-  (let [results (atom {:created 0 :modified 0 :deleted 0 :errors []})
-        all-files (mapcat :code/files code-artifacts)]
-
-    (doseq [file-spec all-files]
-      (let [result (process-file-action worktree-path file-spec logger)]
-        (if (:success? result)
-          (case (:action result)
-            :create (swap! results update :created inc)
-            :modify (swap! results update :modified inc)
-            :delete (swap! results update :deleted inc)
-            nil)
-          (swap! results update :errors conj
-                 {:type :file-operation-failed
-                  :message (:error result)
-                  :file (:path result)
-                  :action (:action result)}))))
-
-    (let [{:keys [created modified deleted errors]} @results
-          total-operations (+ created modified deleted)]
-      (if (seq errors)
-        {:success? false
-         :errors errors
-         :metrics {:files-written created :files-modified modified :files-deleted deleted}}
-        (let [stage-result (stage-files! worktree-path :all)]
-          (if (:success? stage-result)
-            {:success? true
-             :metrics {:files-written created :files-modified modified :files-deleted deleted
-                       :total-operations total-operations}}
-            {:success? false
-             :errors [{:type :git-stage-failed :message (:error stage-result)}]
-             :metrics {:files-written created :files-modified modified :files-deleted deleted}}))))))
-
-;------------------------------------------------------------------------------ Layer 4
-;; Releaser agent integration
-
-(defn- invoke-releaser
-  "Invoke the releaser agent to generate release metadata.
-   Falls back to nil if agent fails (caller should use fallback)."
-  [releaser code-artifacts task-description context logger]
-  (let [llm-backend (:llm-backend context)
-        first-artifact (first code-artifacts)
-        input {:code-artifact first-artifact
-               :task-description (or task-description
-                                     (:code/summary first-artifact)
-                                     "implement changes")}]
-    (if (and releaser llm-backend)
-      (try
-        (let [result ((:invoke-fn releaser)
-                      (assoc context :llm-backend llm-backend)
-                      input)]
-          (when logger
-            (log/debug logger :release-executor :releaser-invoked
-                       {:data {:status (:status result)}}))
-          (if (= :success (:status result))
-            (:output result)
-            (do
-              (when logger
-                (log/warn logger :release-executor :releaser-failed-fallback
-                          {:message "Releaser agent failed, using fallback"}))
-              nil)))
-        (catch Exception e
-          (when logger
-            (log/warn logger :release-executor :releaser-exception
-                      {:message (.getMessage e)}))
-          nil))
-      nil)))
-
-(defn- make-fallback-release-metadata
-  "Generate fallback release metadata when releaser agent is unavailable."
-  [code-artifacts task-description]
-  (let [first-artifact (first code-artifacts)
-        files (:code/files first-artifact)
-        summary (or (:code/summary first-artifact) "code changes")
-        task-desc (or task-description summary)
-        slug (slugify task-desc)]
-    {:release/id (random-uuid)
-     :release/branch-name (str "feature/" slug)
-     :release/commit-message (str "feat: " task-desc)
-     :release/pr-title (str "feat: " (subs task-desc 0 (min 60 (count task-desc))))
-     :release/pr-description (str "## Summary\n" task-desc "\n\n"
-                                  "## Changes\n"
-                                  (if files
-                                    (str/join "\n" (map #(str "- " (name (:action %)) " `" (:path %) "`") files))
-                                    "See commits for details"))
-     :release/created-at (java.util.Date.)}))
-
-;------------------------------------------------------------------------------ Layer 5
-;; Pipeline step functions
-;; Each step takes pipeline state, returns updated state or adds :failure
+;; Pipeline helpers
 
 (defn- failed?
   "Check if pipeline has failed."
@@ -436,9 +33,20 @@
            (cond-> {:type error-type :message error-msg}
              hint (assoc :hint hint)))))
 
-(defn- step-validate-inputs
-  "Validate required inputs are present."
-  [state]
+(defn- extract-code-artifacts
+  "Extract code artifacts from workflow artifacts."
+  [workflow-artifacts]
+  (->> workflow-artifacts
+       (filter #(or (= :code (:type %))
+                    (= :code (:artifact/type %))))
+       (map (fn [artifact]
+              (or (:artifact/content artifact)
+                  (:content artifact))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pipeline steps
+
+(defn- step-validate-inputs [state]
   (cond
     (failed? state) state
     (not (:worktree-path state))
@@ -451,14 +59,12 @@
       (fail state :no-code-artifacts "No code artifacts found in workflow state"))
     :else state))
 
-(defn- step-check-gh-auth
-  "Check GitHub CLI authentication if creating PR."
-  [state]
+(defn- step-check-gh-auth [state]
   (cond
     (failed? state) state
     (not (:create-pr? state)) state
     :else
-    (let [gh-auth (check-gh-auth!)]
+    (let [gh-auth (git/check-gh-auth!)]
       (if (:authenticated? gh-auth)
         state
         (fail state :gh-auth-failed (:error gh-auth)
@@ -466,37 +72,31 @@
                       "Run: gh auth login"
                       "Install: brew install gh"))))))
 
-(defn- step-generate-metadata
-  "Generate release metadata using releaser agent or fallback."
-  [state]
+(defn- step-generate-metadata [state]
   (if (failed? state)
     state
     (let [{:keys [releaser code-artifacts task-description context logger]} state
-          release-meta (or (invoke-releaser releaser code-artifacts task-description context logger)
-                           (make-fallback-release-metadata code-artifacts task-description))]
+          release-meta (metadata/generate-release-metadata
+                        releaser code-artifacts task-description context logger)]
       (assoc state :release-meta release-meta))))
 
-(defn- step-create-branch
-  "Create git branch for the release."
-  [state]
+(defn- step-create-branch [state]
   (if (failed? state)
     state
     (let [{:keys [worktree-path release-meta]} state
           branch-name (:release/branch-name release-meta)
-          result (create-branch! worktree-path branch-name)]
+          result (git/create-branch! worktree-path branch-name)]
       (if (:success? result)
         (assoc state
                :branch (:branch result)
                :base-branch (:base-branch result))
         (fail state :branch-create-failed (:error result))))))
 
-(defn- step-write-and-stage
-  "Write files to worktree and stage them."
-  [state]
+(defn- step-write-and-stage [state]
   (if (failed? state)
     state
     (let [{:keys [worktree-path code-artifacts logger]} state
-          result (write-and-stage-files! worktree-path code-artifacts logger)]
+          result (files/write-and-stage-files! worktree-path code-artifacts logger)]
       (if (:success? result)
         (assoc state :write-metrics (:metrics result))
         (do
@@ -507,51 +107,43 @@
                  :failure {:type :write-stage-failed :errors (:errors result)}
                  :write-metrics (:metrics result)))))))
 
-(defn- step-commit
-  "Commit the staged changes."
-  [state]
+(defn- step-commit [state]
   (if (failed? state)
     state
     (let [{:keys [worktree-path release-meta]} state
-          result (commit-changes! worktree-path (:release/commit-message release-meta))]
+          result (git/commit-changes! worktree-path (:release/commit-message release-meta))]
       (if (:success? result)
         (assoc state :commit-sha (:commit-sha result))
         (fail state :commit-failed (:error result))))))
 
-(defn- step-push
-  "Push branch to origin if creating PR."
-  [state]
+(defn- step-push [state]
   (cond
     (failed? state) state
     (not (:create-pr? state)) state
     :else
     (let [{:keys [worktree-path branch]} state
-          result (push-branch! worktree-path branch)]
+          result (git/push-branch! worktree-path branch)]
       (if (:success? result)
         state
         (fail state :push-failed (:error result))))))
 
-(defn- step-create-pr
-  "Create pull request if enabled."
-  [state]
+(defn- step-create-pr [state]
   (cond
     (failed? state) state
     (not (:create-pr? state)) state
     :else
     (let [{:keys [worktree-path release-meta base-branch]} state
-          result (create-pr! worktree-path
-                             {:title (:release/pr-title release-meta)
-                              :body (:release/pr-description release-meta)
-                              :base-branch base-branch})]
+          result (git/create-pr! worktree-path
+                                 {:title (:release/pr-title release-meta)
+                                  :body (:release/pr-description release-meta)
+                                  :base-branch base-branch})]
       (if (:success? result)
         (assoc state
                :pr-number (:pr-number result)
                :pr-url (:pr-url result))
         (fail state :pr-create-failed (:error result))))))
 
-(defn- step-build-artifact
-  "Build the release artifact."
-  [state]
+(defn- step-build-artifact [state]
   (if (failed? state)
     state
     (let [{:keys [worktree-path branch base-branch commit-sha create-pr?
@@ -575,9 +167,7 @@
                                         :code-artifacts-count (count code-artifacts)}})]
       (assoc state :release-artifact release-artifact))))
 
-(defn- step-save-artifact
-  "Save artifact to store if available."
-  [state]
+(defn- step-save-artifact [state]
   (if (failed? state)
     state
     (do
@@ -593,9 +183,9 @@
   (let [{:keys [logger failure release-artifact write-metrics
                 branch commit-sha pr-number pr-url]} state]
     (if failure
-      (phase-failure (:type failure) (:message failure)
-                     {:hint (:hint failure)
-                      :metrics (or write-metrics {})})
+      (result/phase-failure (:type failure) (:message failure)
+                            {:hint (:hint failure)
+                             :metrics (or write-metrics {})})
       (do
         (when logger
           (log/info logger :release-executor :phase-completed
@@ -603,7 +193,7 @@
                             :commit commit-sha
                             :pr-url pr-url
                             :files-written (:files-written write-metrics)}}))
-        (phase-success
+        (result/phase-success
          [release-artifact]
          (merge write-metrics
                 {:pr-number pr-number
@@ -611,7 +201,7 @@
                  :commit-sha commit-sha
                  :branch branch}))))))
 
-;------------------------------------------------------------------------------ Layer 6
+;------------------------------------------------------------------------------ Layer 2
 ;; Main execute function
 
 (defn execute-release-phase

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -45,6 +45,32 @@
       true)
     false))
 
+;------------------------------------------------------------------------------ Layer 0.5
+;; String utilities
+
+(defn- slugify
+  "Convert a string to a URL-safe slug.
+   Handles basic ASCII transliteration and normalizes spacing."
+  [s]
+  (let [input (or s "change")
+        ;; Basic ASCII transliteration for common characters
+        transliterated (-> input
+                           (str/replace #"[àáâãäå]" "a")
+                           (str/replace #"[èéêë]" "e")
+                           (str/replace #"[ìíîï]" "i")
+                           (str/replace #"[òóôõö]" "o")
+                           (str/replace #"[ùúûü]" "u")
+                           (str/replace #"[ñ]" "n")
+                           (str/replace #"[ç]" "c")
+                           (str/replace #"[ß]" "ss"))
+        slug (-> transliterated
+                 str/lower-case
+                 (str/replace #"[^a-z0-9\s-]" "")
+                 (str/replace #"\s+" "-")
+                 (str/replace #"-+" "-")
+                 (str/replace #"^-|-$" ""))]
+    (subs slug 0 (min 40 (count slug)))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Git operations
 
@@ -366,11 +392,7 @@
         files (:code/files first-artifact)
         summary (or (:code/summary first-artifact) "code changes")
         task-desc (or task-description summary)
-        slug-raw (-> task-desc
-                     str/lower-case
-                     (str/replace #"[^a-z0-9\s-]" "")
-                     (str/replace #"\s+" "-"))
-        slug (subs slug-raw 0 (min 40 (count slug-raw)))]
+        slug (slugify task-desc)]
     {:release/id (random-uuid)
      :release/branch-name (str "feature/" slug)
      :release/commit-message (str "feat: " task-desc)

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -1,0 +1,563 @@
+(ns ai.miniforge.release-executor.core
+  "Release phase executor for creating PRs from code artifacts.
+
+   This component provides the full release flow:
+   - Check GitHub CLI authentication
+   - Generate release metadata (branch name, commit message, PR title/body)
+   - Create git branch
+   - Write files and stage them
+   - Commit changes
+   - Push branch and create PR
+
+   Extracted to a separate component to avoid circular dependencies
+   between workflow and phase components."
+  (:require
+   [ai.miniforge.artifact.interface :as artifact]
+   [ai.miniforge.logging.interface :as log]
+   [babashka.fs :as fs]
+   [babashka.process :as process]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; File operation helpers
+
+(defn- ensure-parent-dir!
+  "Create parent directories for a file path if they don't exist."
+  [file-path]
+  (let [parent (fs/parent file-path)]
+    (when parent
+      (fs/create-dirs parent))
+    parent))
+
+(defn- write-file!
+  "Write content to a file, creating parent directories as needed."
+  [file-path content]
+  (ensure-parent-dir! file-path)
+  (spit (str file-path) content)
+  file-path)
+
+(defn- delete-file!
+  "Delete a file if it exists. Returns true if deleted, false if file didn't exist."
+  [file-path]
+  (if (fs/exists? file-path)
+    (do
+      (fs/delete file-path)
+      true)
+    false))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Git operations
+
+(defn- stage-files!
+  "Stage files in git worktree using git add."
+  [worktree-path file-paths]
+  (try
+    (let [git-args (if (= file-paths :all)
+                     ["git" "add" "."]
+                     (into ["git" "add"] (map str file-paths)))
+          result (apply process/shell
+                        {:dir (str worktree-path)
+                         :out :string
+                         :err :string
+                         :continue true}
+                        git-args)]
+      {:success? (zero? (:exit result))
+       :output (:out result "")
+       :error (:err result "")})
+    (catch Exception e
+      {:success? false
+       :output ""
+       :error (.getMessage e)})))
+
+(defn check-gh-auth!
+  "Check if gh CLI is available and authenticated.
+
+   Returns {:available? bool :authenticated? bool :user string :error string}"
+  []
+  (try
+    (let [which-result (process/shell
+                        {:out :string :err :string :continue true}
+                        "which" "gh")]
+      (if-not (zero? (:exit which-result))
+        {:available? false
+         :authenticated? false
+         :error "gh CLI not found. Install with: brew install gh"}
+
+        (let [auth-result (process/shell
+                          {:out :string :err :string :continue true}
+                          "gh" "auth" "status")]
+          (if (zero? (:exit auth-result))
+            (let [output (:out auth-result "")
+                  user-match (re-find #"Logged in to [^\s]+ account (\S+)" output)]
+              {:available? true
+               :authenticated? true
+               :user (or (second user-match) "unknown")})
+            {:available? true
+             :authenticated? false
+             :error (str "gh not authenticated. Run: gh auth login\n" (:err auth-result))}))))
+    (catch Exception e
+      {:available? false
+       :authenticated? false
+       :error (.getMessage e)})))
+
+(defn create-branch!
+  "Create a new git branch from main/master.
+
+   Arguments:
+   - worktree-path - Path to git worktree root
+   - branch-name   - Name for the new branch
+
+   Returns {:success? bool :branch string :base-branch string :error string}"
+  [worktree-path branch-name]
+  (try
+    (let [dir-opts {:dir (str worktree-path) :out :string :err :string :continue true}
+          default-branch-result (process/shell dir-opts
+                                               "git" "symbolic-ref" "refs/remotes/origin/HEAD")
+          default-branch (if (zero? (:exit default-branch-result))
+                           (-> (:out default-branch-result)
+                               str/trim
+                               (str/replace #"refs/remotes/origin/" ""))
+                           "main")
+          fetch-result (process/shell dir-opts "git" "fetch" "origin" default-branch)]
+
+      (if-not (zero? (:exit fetch-result))
+        {:success? false
+         :branch nil
+         :error (str "Failed to fetch: " (:err fetch-result))}
+
+        (let [checkout-result (process/shell dir-opts
+                                             "git" "checkout" "-b" branch-name
+                                             (str "origin/" default-branch))]
+          (if (zero? (:exit checkout-result))
+            {:success? true
+             :branch branch-name
+             :base-branch default-branch}
+            (let [timestamped-name (str branch-name "-" (System/currentTimeMillis))
+                  retry-result (process/shell dir-opts
+                                              "git" "checkout" "-b" timestamped-name
+                                              (str "origin/" default-branch))]
+              (if (zero? (:exit retry-result))
+                {:success? true
+                 :branch timestamped-name
+                 :base-branch default-branch}
+                {:success? false
+                 :branch nil
+                 :error (str "Failed to create branch: " (:err retry-result))}))))))
+    (catch Exception e
+      {:success? false
+       :branch nil
+       :error (.getMessage e)})))
+
+(defn commit-changes!
+  "Commit staged changes with the given message.
+
+   Returns {:success? bool :commit-sha string :error string}"
+  [worktree-path commit-message]
+  (try
+    (let [result (process/shell
+                  {:dir (str worktree-path) :out :string :err :string :continue true}
+                  "git" "commit" "-m" commit-message)]
+      (if (zero? (:exit result))
+        (let [sha-result (process/shell
+                          {:dir (str worktree-path) :out :string :err :string :continue true}
+                          "git" "rev-parse" "HEAD")]
+          {:success? true
+           :commit-sha (str/trim (:out sha-result ""))
+           :output (:out result)})
+        {:success? false
+         :commit-sha nil
+         :error (:err result)}))
+    (catch Exception e
+      {:success? false
+       :commit-sha nil
+       :error (.getMessage e)})))
+
+(defn push-branch!
+  "Push the current branch to origin.
+
+   Returns {:success? bool :error string}"
+  [worktree-path branch-name]
+  (try
+    (let [result (process/shell
+                  {:dir (str worktree-path) :out :string :err :string :continue true}
+                  "git" "push" "-u" "origin" branch-name)]
+      (if (zero? (:exit result))
+        {:success? true
+         :output (:out result)}
+        {:success? false
+         :error (:err result)}))
+    (catch Exception e
+      {:success? false
+       :error (.getMessage e)})))
+
+(defn create-pr!
+  "Create a pull request using gh CLI.
+
+   Returns {:success? bool :pr-number int :pr-url string :error string}"
+  [worktree-path {:keys [title body base-branch]}]
+  (try
+    (let [base (or base-branch "main")
+          args ["gh" "pr" "create"
+                "--title" title
+                "--body" body
+                "--base" base]
+          result (apply process/shell
+                        {:dir (str worktree-path) :out :string :err :string :continue true}
+                        args)]
+      (if (zero? (:exit result))
+        (let [pr-url (str/trim (:out result ""))
+              pr-num (when-let [match (re-find #"/pull/(\d+)" pr-url)]
+                       (parse-long (second match)))]
+          {:success? true
+           :pr-url pr-url
+           :pr-number pr-num})
+        {:success? false
+         :pr-url nil
+         :pr-number nil
+         :error (:err result)}))
+    (catch Exception e
+      {:success? false
+       :pr-url nil
+       :pr-number nil
+       :error (.getMessage e)})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; File action processing
+
+(defmulti ^:private process-file-action
+  "Process a file action based on its :action keyword."
+  (fn [_worktree-path file-spec _logger] (:action file-spec)))
+
+(defmethod process-file-action :create
+  [worktree-path {:keys [path content]} logger]
+  (try
+    (let [full-path (fs/path worktree-path path)]
+      (write-file! full-path content)
+      (when logger
+        (log/debug logger :release-executor :file-created {:data {:path path}}))
+      {:success? true :action :create :path path})
+    (catch Exception e
+      (when logger
+        (log/error logger :release-executor :file-create-failed
+                  {:message (.getMessage e) :data {:path path}}))
+      {:success? false :action :create :path path :error (.getMessage e)})))
+
+(defmethod process-file-action :modify
+  [worktree-path {:keys [path content]} logger]
+  (try
+    (let [full-path (fs/path worktree-path path)]
+      (write-file! full-path content)
+      (when logger
+        (log/debug logger :release-executor :file-modified {:data {:path path}}))
+      {:success? true :action :modify :path path})
+    (catch Exception e
+      (when logger
+        (log/error logger :release-executor :file-modify-failed
+                  {:message (.getMessage e) :data {:path path}}))
+      {:success? false :action :modify :path path :error (.getMessage e)})))
+
+(defmethod process-file-action :delete
+  [worktree-path {:keys [path]} logger]
+  (try
+    (let [full-path (fs/path worktree-path path)
+          deleted? (delete-file! full-path)]
+      (when logger
+        (log/debug logger :release-executor :file-deleted {:data {:path path :existed? deleted?}}))
+      {:success? true :action :delete :path path :deleted? deleted?})
+    (catch Exception e
+      (when logger
+        (log/error logger :release-executor :file-delete-failed
+                  {:message (.getMessage e) :data {:path path}}))
+      {:success? false :action :delete :path path :error (.getMessage e)})))
+
+(defmethod process-file-action :default
+  [_worktree-path {:keys [path action]} logger]
+  (when logger
+    (log/warn logger :release-executor :unknown-action {:data {:path path :action action}}))
+  {:success? false :action action :path path :error (str "Unknown action: " action)})
+
+;------------------------------------------------------------------------------ Layer 3
+;; Code artifact extraction
+
+(defn- extract-code-artifacts
+  "Extract code artifacts from workflow artifacts."
+  [workflow-artifacts]
+  (->> workflow-artifacts
+       (filter #(or (= :code (:type %))
+                    (= :code (:artifact/type %))))
+       (map (fn [artifact]
+              (or (:artifact/content artifact)
+                  (:content artifact))))))
+
+(defn- write-and-stage-files!
+  "Write files to worktree and stage them. Returns result map."
+  [worktree-path code-artifacts logger]
+  (let [results (atom {:created 0 :modified 0 :deleted 0 :errors []})
+        all-files (mapcat :code/files code-artifacts)]
+
+    (doseq [file-spec all-files]
+      (let [result (process-file-action worktree-path file-spec logger)]
+        (if (:success? result)
+          (case (:action result)
+            :create (swap! results update :created inc)
+            :modify (swap! results update :modified inc)
+            :delete (swap! results update :deleted inc)
+            nil)
+          (swap! results update :errors conj
+                 {:type :file-operation-failed
+                  :message (:error result)
+                  :file (:path result)
+                  :action (:action result)}))))
+
+    (let [{:keys [created modified deleted errors]} @results
+          total-operations (+ created modified deleted)]
+      (if (seq errors)
+        {:success? false
+         :errors errors
+         :metrics {:files-written created :files-modified modified :files-deleted deleted}}
+        (let [stage-result (stage-files! worktree-path :all)]
+          (if (:success? stage-result)
+            {:success? true
+             :metrics {:files-written created :files-modified modified :files-deleted deleted
+                       :total-operations total-operations}}
+            {:success? false
+             :errors [{:type :git-stage-failed :message (:error stage-result)}]
+             :metrics {:files-written created :files-modified modified :files-deleted deleted}}))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Releaser agent integration
+
+(defn- invoke-releaser
+  "Invoke the releaser agent to generate release metadata.
+   Falls back to nil if agent fails (caller should use fallback)."
+  [releaser code-artifacts task-description context logger]
+  (let [llm-backend (:llm-backend context)
+        first-artifact (first code-artifacts)
+        input {:code-artifact first-artifact
+               :task-description (or task-description
+                                     (:code/summary first-artifact)
+                                     "implement changes")}]
+    (if (and releaser llm-backend)
+      (try
+        (let [result ((:invoke-fn releaser)
+                      (assoc context :llm-backend llm-backend)
+                      input)]
+          (when logger
+            (log/debug logger :release-executor :releaser-invoked
+                       {:data {:status (:status result)}}))
+          (if (= :success (:status result))
+            (:output result)
+            (do
+              (when logger
+                (log/warn logger :release-executor :releaser-failed-fallback
+                          {:message "Releaser agent failed, using fallback"}))
+              nil)))
+        (catch Exception e
+          (when logger
+            (log/warn logger :release-executor :releaser-exception
+                      {:message (.getMessage e)}))
+          nil))
+      nil)))
+
+(defn- make-fallback-release-metadata
+  "Generate fallback release metadata when releaser agent is unavailable."
+  [code-artifacts task-description]
+  (let [first-artifact (first code-artifacts)
+        files (:code/files first-artifact)
+        summary (or (:code/summary first-artifact) "code changes")
+        task-desc (or task-description summary)
+        slug-raw (-> task-desc
+                     str/lower-case
+                     (str/replace #"[^a-z0-9\s-]" "")
+                     (str/replace #"\s+" "-"))
+        slug (subs slug-raw 0 (min 40 (count slug-raw)))]
+    {:release/id (random-uuid)
+     :release/branch-name (str "feature/" slug)
+     :release/commit-message (str "feat: " task-desc)
+     :release/pr-title (str "feat: " (subs task-desc 0 (min 60 (count task-desc))))
+     :release/pr-description (str "## Summary\n" task-desc "\n\n"
+                                  "## Changes\n"
+                                  (if files
+                                    (str/join "\n" (map #(str "- " (name (:action %)) " `" (:path %) "`") files))
+                                    "See commits for details"))
+     :release/created-at (java.util.Date.)}))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Main execute function
+
+(defn execute-release-phase
+  "Execute the release phase.
+
+   Arguments:
+   - workflow-state - Workflow state with :workflow/artifacts
+   - context        - Execution context with :worktree-path, :logger, etc.
+   - opts           - Options with :releaser (optional)
+
+   Returns:
+   {:success? bool
+    :artifacts [release-artifact]
+    :errors []
+    :metrics {...}}"
+  [workflow-state context opts]
+  (let [logger (:logger context)
+        worktree-path (:worktree-path context)
+        artifact-store (:artifact-store context)
+        task-description (get-in workflow-state [:workflow/spec :spec/description])
+        create-pr? (get context :create-pr? true)
+        releaser (:releaser opts)]
+
+    (when logger
+      (log/info logger :release-executor :phase-started
+                {:data {:worktree-path worktree-path :create-pr? create-pr?}}))
+
+    (if-not worktree-path
+      (do
+        (when logger
+          (log/error logger :release-executor :missing-worktree-path
+                     {:message "Context must include :worktree-path"}))
+        {:success? false
+         :artifacts []
+         :errors [{:type :missing-worktree-path
+                   :message "Context must include :worktree-path for release phase"}]
+         :metrics {}})
+
+      (let [code-artifacts (extract-code-artifacts (:workflow/artifacts workflow-state))]
+
+        (if (empty? code-artifacts)
+          (do
+            (when logger
+              (log/warn logger :release-executor :no-code-artifacts
+                        {:message "No code artifacts found to release"}))
+            {:success? false
+             :artifacts []
+             :errors [{:type :no-code-artifacts
+                       :message "No code artifacts found in workflow state"}]
+             :metrics {}})
+
+          (let [gh-auth (when create-pr? (check-gh-auth!))
+                gh-ok? (or (not create-pr?) (:authenticated? gh-auth))]
+
+            (if (and create-pr? (not gh-ok?))
+              (do
+                (when logger
+                  (log/error logger :release-executor :gh-auth-failed
+                             {:message (:error gh-auth)}))
+                {:success? false
+                 :artifacts []
+                 :errors [{:type :gh-auth-failed
+                           :message (:error gh-auth)
+                           :hint (if (:available? gh-auth)
+                                   "Run: gh auth login"
+                                   "Install: brew install gh")}]
+                 :metrics {}})
+
+              (let [release-meta (or (invoke-releaser releaser code-artifacts task-description context logger)
+                                     (make-fallback-release-metadata code-artifacts task-description))
+                    branch-name (:release/branch-name release-meta)
+                    branch-result (create-branch! worktree-path branch-name)]
+                (if-not (:success? branch-result)
+                  (do
+                    (when logger
+                      (log/error logger :release-executor :branch-failed
+                                 {:message (:error branch-result)}))
+                    {:success? false
+                     :artifacts []
+                     :errors [{:type :branch-create-failed
+                               :message (:error branch-result)}]
+                     :metrics {}})
+
+                  (let [actual-branch (:branch branch-result)
+                        base-branch (:base-branch branch-result)
+                        write-result (write-and-stage-files! worktree-path code-artifacts logger)]
+
+                    (if-not (:success? write-result)
+                      (do
+                        (when logger
+                          (log/error logger :release-executor :write-stage-failed
+                                     {:data {:errors (:errors write-result)}}))
+                        {:success? false
+                         :artifacts []
+                         :errors (:errors write-result)
+                         :metrics (:metrics write-result)})
+
+                      (let [commit-result (commit-changes! worktree-path (:release/commit-message release-meta))]
+                        (if-not (:success? commit-result)
+                          (do
+                            (when logger
+                              (log/error logger :release-executor :commit-failed
+                                         {:message (:error commit-result)}))
+                            {:success? false
+                             :artifacts []
+                             :errors [{:type :commit-failed
+                                       :message (:error commit-result)}]
+                             :metrics (:metrics write-result)})
+
+                          (let [push-result (when create-pr?
+                                              (push-branch! worktree-path actual-branch))]
+                            (if (and create-pr? (not (:success? push-result)))
+                              (do
+                                (when logger
+                                  (log/error logger :release-executor :push-failed
+                                             {:message (:error push-result)}))
+                                {:success? false
+                                 :artifacts []
+                                 :errors [{:type :push-failed
+                                           :message (:error push-result)}]
+                                 :metrics (:metrics write-result)})
+
+                              (let [pr-result (when create-pr?
+                                                (create-pr! worktree-path
+                                                            {:title (:release/pr-title release-meta)
+                                                             :body (:release/pr-description release-meta)
+                                                             :base-branch base-branch}))]
+
+                                (if (and create-pr? (not (:success? pr-result)))
+                                  (do
+                                    (when logger
+                                      (log/error logger :release-executor :pr-failed
+                                                 {:message (:error pr-result)}))
+                                    {:success? false
+                                     :artifacts []
+                                     :errors [{:type :pr-create-failed
+                                               :message (:error pr-result)}]
+                                     :metrics (:metrics write-result)})
+
+                                  (let [release-content (merge
+                                                         (:metrics write-result)
+                                                         {:git-staged? true
+                                                          :worktree-path (str worktree-path)
+                                                          :branch actual-branch
+                                                          :base-branch base-branch
+                                                          :commit-sha (:commit-sha commit-result)
+                                                          :pr-created? (boolean create-pr?)
+                                                          :pr-number (:pr-number pr-result)
+                                                          :pr-url (:pr-url pr-result)
+                                                          :release-metadata release-meta})
+                                        release-artifact (artifact/build-artifact
+                                                          {:id (random-uuid)
+                                                           :type :release
+                                                           :version "1.0.0"
+                                                           :content release-content
+                                                           :metadata {:phase :release
+                                                                      :code-artifacts-count (count code-artifacts)}})]
+
+                                    (when artifact-store
+                                      (try
+                                        (artifact/save! artifact-store release-artifact)
+                                        (catch Exception _e nil)))
+
+                                    (when logger
+                                      (log/info logger :release-executor :phase-completed
+                                                {:data {:branch actual-branch
+                                                        :commit (:commit-sha commit-result)
+                                                        :pr-url (:pr-url pr-result)
+                                                        :files-written (get-in write-result [:metrics :files-written])}}))
+
+                                    {:success? true
+                                     :artifacts [release-artifact]
+                                     :errors []
+                                     :metrics (merge (:metrics write-result)
+                                                     {:pr-number (:pr-number pr-result)
+                                                      :pr-url (:pr-url pr-result)
+                                                      :commit-sha (:commit-sha commit-result)
+                                                      :branch actual-branch})}))))))))))))))))))

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -418,6 +418,200 @@
      :release/created-at (java.util.Date.)}))
 
 ;------------------------------------------------------------------------------ Layer 5
+;; Pipeline step functions
+;; Each step takes pipeline state, returns updated state or adds :failure
+
+(defn- failed?
+  "Check if pipeline has failed."
+  [state]
+  (contains? state :failure))
+
+(defn- fail
+  "Mark pipeline as failed with error info."
+  [state error-type error-msg & {:keys [hint]}]
+  (let [logger (:logger state)]
+    (when logger
+      (log/error logger :release-executor error-type {:message error-msg}))
+    (assoc state :failure
+           (cond-> {:type error-type :message error-msg}
+             hint (assoc :hint hint)))))
+
+(defn- step-validate-inputs
+  "Validate required inputs are present."
+  [state]
+  (cond
+    (failed? state) state
+    (not (:worktree-path state))
+    (fail state :missing-worktree-path "Context must include :worktree-path for release phase")
+    (empty? (:code-artifacts state))
+    (do
+      (when-let [logger (:logger state)]
+        (log/warn logger :release-executor :no-code-artifacts
+                  {:message "No code artifacts found to release"}))
+      (fail state :no-code-artifacts "No code artifacts found in workflow state"))
+    :else state))
+
+(defn- step-check-gh-auth
+  "Check GitHub CLI authentication if creating PR."
+  [state]
+  (cond
+    (failed? state) state
+    (not (:create-pr? state)) state
+    :else
+    (let [gh-auth (check-gh-auth!)]
+      (if (:authenticated? gh-auth)
+        state
+        (fail state :gh-auth-failed (:error gh-auth)
+              :hint (if (:available? gh-auth)
+                      "Run: gh auth login"
+                      "Install: brew install gh"))))))
+
+(defn- step-generate-metadata
+  "Generate release metadata using releaser agent or fallback."
+  [state]
+  (if (failed? state)
+    state
+    (let [{:keys [releaser code-artifacts task-description context logger]} state
+          release-meta (or (invoke-releaser releaser code-artifacts task-description context logger)
+                           (make-fallback-release-metadata code-artifacts task-description))]
+      (assoc state :release-meta release-meta))))
+
+(defn- step-create-branch
+  "Create git branch for the release."
+  [state]
+  (if (failed? state)
+    state
+    (let [{:keys [worktree-path release-meta]} state
+          branch-name (:release/branch-name release-meta)
+          result (create-branch! worktree-path branch-name)]
+      (if (:success? result)
+        (assoc state
+               :branch (:branch result)
+               :base-branch (:base-branch result))
+        (fail state :branch-create-failed (:error result))))))
+
+(defn- step-write-and-stage
+  "Write files to worktree and stage them."
+  [state]
+  (if (failed? state)
+    state
+    (let [{:keys [worktree-path code-artifacts logger]} state
+          result (write-and-stage-files! worktree-path code-artifacts logger)]
+      (if (:success? result)
+        (assoc state :write-metrics (:metrics result))
+        (do
+          (when logger
+            (log/error logger :release-executor :write-stage-failed
+                       {:data {:errors (:errors result)}}))
+          (assoc state
+                 :failure {:type :write-stage-failed :errors (:errors result)}
+                 :write-metrics (:metrics result)))))))
+
+(defn- step-commit
+  "Commit the staged changes."
+  [state]
+  (if (failed? state)
+    state
+    (let [{:keys [worktree-path release-meta]} state
+          result (commit-changes! worktree-path (:release/commit-message release-meta))]
+      (if (:success? result)
+        (assoc state :commit-sha (:commit-sha result))
+        (fail state :commit-failed (:error result))))))
+
+(defn- step-push
+  "Push branch to origin if creating PR."
+  [state]
+  (cond
+    (failed? state) state
+    (not (:create-pr? state)) state
+    :else
+    (let [{:keys [worktree-path branch]} state
+          result (push-branch! worktree-path branch)]
+      (if (:success? result)
+        state
+        (fail state :push-failed (:error result))))))
+
+(defn- step-create-pr
+  "Create pull request if enabled."
+  [state]
+  (cond
+    (failed? state) state
+    (not (:create-pr? state)) state
+    :else
+    (let [{:keys [worktree-path release-meta base-branch]} state
+          result (create-pr! worktree-path
+                             {:title (:release/pr-title release-meta)
+                              :body (:release/pr-description release-meta)
+                              :base-branch base-branch})]
+      (if (:success? result)
+        (assoc state
+               :pr-number (:pr-number result)
+               :pr-url (:pr-url result))
+        (fail state :pr-create-failed (:error result))))))
+
+(defn- step-build-artifact
+  "Build the release artifact."
+  [state]
+  (if (failed? state)
+    state
+    (let [{:keys [worktree-path branch base-branch commit-sha create-pr?
+                  pr-number pr-url release-meta write-metrics code-artifacts]} state
+          release-content (merge write-metrics
+                                 {:git-staged? true
+                                  :worktree-path (str worktree-path)
+                                  :branch branch
+                                  :base-branch base-branch
+                                  :commit-sha commit-sha
+                                  :pr-created? (boolean create-pr?)
+                                  :pr-number pr-number
+                                  :pr-url pr-url
+                                  :release-metadata release-meta})
+          release-artifact (artifact/build-artifact
+                            {:id (random-uuid)
+                             :type :release
+                             :version "1.0.0"
+                             :content release-content
+                             :metadata {:phase :release
+                                        :code-artifacts-count (count code-artifacts)}})]
+      (assoc state :release-artifact release-artifact))))
+
+(defn- step-save-artifact
+  "Save artifact to store if available."
+  [state]
+  (if (failed? state)
+    state
+    (do
+      (when-let [artifact-store (:artifact-store state)]
+        (try
+          (artifact/save! artifact-store (:release-artifact state))
+          (catch Exception _e nil)))
+      state)))
+
+(defn- pipeline->result
+  "Convert pipeline state to phase result."
+  [state]
+  (let [{:keys [logger failure release-artifact write-metrics
+                branch commit-sha pr-number pr-url]} state]
+    (if failure
+      (phase-failure (:type failure) (:message failure)
+                     {:hint (:hint failure)
+                      :metrics (or write-metrics {})})
+      (do
+        (when logger
+          (log/info logger :release-executor :phase-completed
+                    {:data {:branch branch
+                            :commit commit-sha
+                            :pr-url pr-url
+                            :files-written (:files-written write-metrics)}}))
+        (phase-success
+         [release-artifact]
+         (merge write-metrics
+                {:pr-number pr-number
+                 :pr-url pr-url
+                 :commit-sha commit-sha
+                 :branch branch}))))))
+
+;------------------------------------------------------------------------------ Layer 6
 ;; Main execute function
 
 (defn execute-release-phase
@@ -435,140 +629,29 @@
     :metrics {...}}"
   [workflow-state context opts]
   (let [logger (:logger context)
-        worktree-path (:worktree-path context)
-        artifact-store (:artifact-store context)
-        task-description (get-in workflow-state [:workflow/spec :spec/description])
-        create-pr? (get context :create-pr? true)
-        releaser (:releaser opts)]
+        initial-state {:logger logger
+                       :worktree-path (:worktree-path context)
+                       :artifact-store (:artifact-store context)
+                       :context context
+                       :create-pr? (get context :create-pr? true)
+                       :releaser (:releaser opts)
+                       :task-description (get-in workflow-state [:workflow/spec :spec/description])
+                       :code-artifacts (extract-code-artifacts (:workflow/artifacts workflow-state))}]
 
     (when logger
       (log/info logger :release-executor :phase-started
-                {:data {:worktree-path worktree-path :create-pr? create-pr?}}))
+                {:data {:worktree-path (:worktree-path initial-state)
+                        :create-pr? (:create-pr? initial-state)}}))
 
-    (if-not worktree-path
-      (do
-        (when logger
-          (log/error logger :release-executor :missing-worktree-path
-                     {:message "Context must include :worktree-path"}))
-        (phase-failure :missing-worktree-path
-                       "Context must include :worktree-path for release phase"))
-
-      (let [code-artifacts (extract-code-artifacts (:workflow/artifacts workflow-state))]
-
-        (if (empty? code-artifacts)
-          (do
-            (when logger
-              (log/warn logger :release-executor :no-code-artifacts
-                        {:message "No code artifacts found to release"}))
-            (phase-failure :no-code-artifacts
-                           "No code artifacts found in workflow state"))
-
-          (let [gh-auth (when create-pr? (check-gh-auth!))
-                gh-ok? (or (not create-pr?) (:authenticated? gh-auth))]
-
-            (if (and create-pr? (not gh-ok?))
-              (do
-                (when logger
-                  (log/error logger :release-executor :gh-auth-failed
-                             {:message (:error gh-auth)}))
-                (phase-failure :gh-auth-failed (:error gh-auth)
-                               {:hint (if (:available? gh-auth)
-                                        "Run: gh auth login"
-                                        "Install: brew install gh")}))
-
-              (let [release-meta (or (invoke-releaser releaser code-artifacts task-description context logger)
-                                     (make-fallback-release-metadata code-artifacts task-description))
-                    branch-name (:release/branch-name release-meta)
-                    branch-result (create-branch! worktree-path branch-name)]
-                (if-not (:success? branch-result)
-                  (do
-                    (when logger
-                      (log/error logger :release-executor :branch-failed
-                                 {:message (:error branch-result)}))
-                    (phase-failure :branch-create-failed (:error branch-result)))
-
-                  (let [actual-branch (:branch branch-result)
-                        base-branch (:base-branch branch-result)
-                        write-result (write-and-stage-files! worktree-path code-artifacts logger)]
-
-                    (if-not (:success? write-result)
-                      (do
-                        (when logger
-                          (log/error logger :release-executor :write-stage-failed
-                                     {:data {:errors (:errors write-result)}}))
-                        {:success? false
-                         :artifacts []
-                         :errors (:errors write-result)
-                         :metrics (:metrics write-result)})
-
-                      (let [commit-result (commit-changes! worktree-path (:release/commit-message release-meta))]
-                        (if-not (:success? commit-result)
-                          (do
-                            (when logger
-                              (log/error logger :release-executor :commit-failed
-                                         {:message (:error commit-result)}))
-                            (phase-failure :commit-failed (:error commit-result)
-                                           {:metrics (:metrics write-result)}))
-
-                          (let [push-result (when create-pr?
-                                              (push-branch! worktree-path actual-branch))]
-                            (if (and create-pr? (not (:success? push-result)))
-                              (do
-                                (when logger
-                                  (log/error logger :release-executor :push-failed
-                                             {:message (:error push-result)}))
-                                (phase-failure :push-failed (:error push-result)
-                                               {:metrics (:metrics write-result)}))
-
-                              (let [pr-result (when create-pr?
-                                                (create-pr! worktree-path
-                                                            {:title (:release/pr-title release-meta)
-                                                             :body (:release/pr-description release-meta)
-                                                             :base-branch base-branch}))]
-
-                                (if (and create-pr? (not (:success? pr-result)))
-                                  (do
-                                    (when logger
-                                      (log/error logger :release-executor :pr-failed
-                                                 {:message (:error pr-result)}))
-                                    (phase-failure :pr-create-failed (:error pr-result)
-                                                   {:metrics (:metrics write-result)}))
-
-                                  (let [release-content (merge
-                                                         (:metrics write-result)
-                                                         {:git-staged? true
-                                                          :worktree-path (str worktree-path)
-                                                          :branch actual-branch
-                                                          :base-branch base-branch
-                                                          :commit-sha (:commit-sha commit-result)
-                                                          :pr-created? (boolean create-pr?)
-                                                          :pr-number (:pr-number pr-result)
-                                                          :pr-url (:pr-url pr-result)
-                                                          :release-metadata release-meta})
-                                        release-artifact (artifact/build-artifact
-                                                          {:id (random-uuid)
-                                                           :type :release
-                                                           :version "1.0.0"
-                                                           :content release-content
-                                                           :metadata {:phase :release
-                                                                      :code-artifacts-count (count code-artifacts)}})]
-
-                                    (when artifact-store
-                                      (try
-                                        (artifact/save! artifact-store release-artifact)
-                                        (catch Exception _e nil)))
-
-                                    (when logger
-                                      (log/info logger :release-executor :phase-completed
-                                                {:data {:branch actual-branch
-                                                        :commit (:commit-sha commit-result)
-                                                        :pr-url (:pr-url pr-result)
-                                                        :files-written (get-in write-result [:metrics :files-written])}}))
-
-                                    (phase-success
-                                     [release-artifact]
-                                     (merge (:metrics write-result)
-                                            {:pr-number (:pr-number pr-result)
-                                             :pr-url (:pr-url pr-result)
-                                             :commit-sha (:commit-sha commit-result)
-                                             :branch actual-branch}))))))))))))))))))))
+    (-> initial-state
+        step-validate-inputs
+        step-check-gh-auth
+        step-generate-metadata
+        step-create-branch
+        step-write-and-stage
+        step-commit
+        step-push
+        step-create-pr
+        step-build-artifact
+        step-save-artifact
+        pipeline->result)))

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -46,6 +46,40 @@
     false))
 
 ;------------------------------------------------------------------------------ Layer 0.5
+;; Result helpers
+
+(defn- shell-success
+  "Create a shell operation success result."
+  [data]
+  (merge {:success? true} data))
+
+(defn- shell-failure
+  "Create a shell operation failure result."
+  ([error-msg]
+   (shell-failure error-msg {}))
+  ([error-msg data]
+   (merge {:success? false :error error-msg} data)))
+
+(defn- phase-success
+  "Create a release phase success result."
+  [artifacts metrics]
+  {:success? true
+   :artifacts artifacts
+   :errors []
+   :metrics metrics})
+
+(defn- phase-failure
+  "Create a release phase failure result."
+  ([error-type error-msg]
+   (phase-failure error-type error-msg {}))
+  ([error-type error-msg opts]
+   {:success? false
+    :artifacts []
+    :errors [(merge {:type error-type :message error-msg}
+                    (select-keys opts [:hint :data]))]
+    :metrics (or (:metrics opts) {})}))
+
+;------------------------------------------------------------------------------ Layer 0.6
 ;; String utilities
 
 (defn- slugify
@@ -87,13 +121,26 @@
                          :err :string
                          :continue true}
                         git-args)]
-      {:success? (zero? (:exit result))
-       :output (:out result "")
-       :error (:err result "")})
+      (if (zero? (:exit result))
+        (shell-success {:output (:out result "")})
+        (shell-failure (:err result "") {:output (:out result "")})))
     (catch Exception e
-      {:success? false
-       :output ""
-       :error (.getMessage e)})))
+      (shell-failure (.getMessage e)))))
+
+(defn- gh-unavailable
+  "Create result for gh CLI not available."
+  [error-msg]
+  {:available? false :authenticated? false :error error-msg})
+
+(defn- gh-available-unauthenticated
+  "Create result for gh CLI available but not authenticated."
+  [error-msg]
+  {:available? true :authenticated? false :error error-msg})
+
+(defn- gh-authenticated
+  "Create result for gh CLI available and authenticated."
+  [user]
+  {:available? true :authenticated? true :user user})
 
 (defn check-gh-auth!
   "Check if gh CLI is available and authenticated.
@@ -105,26 +152,18 @@
                         {:out :string :err :string :continue true}
                         "which" "gh")]
       (if-not (zero? (:exit which-result))
-        {:available? false
-         :authenticated? false
-         :error "gh CLI not found. Install with: brew install gh"}
-
+        (gh-unavailable "gh CLI not found. Install with: brew install gh")
         (let [auth-result (process/shell
-                          {:out :string :err :string :continue true}
-                          "gh" "auth" "status")]
+                           {:out :string :err :string :continue true}
+                           "gh" "auth" "status")]
           (if (zero? (:exit auth-result))
             (let [output (:out auth-result "")
                   user-match (re-find #"Logged in to [^\s]+ account (\S+)" output)]
-              {:available? true
-               :authenticated? true
-               :user (or (second user-match) "unknown")})
-            {:available? true
-             :authenticated? false
-             :error (str "gh not authenticated. Run: gh auth login\n" (:err auth-result))}))))
+              (gh-authenticated (or (second user-match) "unknown")))
+            (gh-available-unauthenticated
+             (str "gh not authenticated. Run: gh auth login\n" (:err auth-result)))))))
     (catch Exception e
-      {:available? false
-       :authenticated? false
-       :error (.getMessage e)})))
+      (gh-unavailable (.getMessage e)))))
 
 (defn create-branch!
   "Create a new git branch from main/master.
@@ -147,32 +186,22 @@
           fetch-result (process/shell dir-opts "git" "fetch" "origin" default-branch)]
 
       (if-not (zero? (:exit fetch-result))
-        {:success? false
-         :branch nil
-         :error (str "Failed to fetch: " (:err fetch-result))}
-
+        (shell-failure (str "Failed to fetch: " (:err fetch-result)) {:branch nil})
         (let [checkout-result (process/shell dir-opts
                                              "git" "checkout" "-b" branch-name
                                              (str "origin/" default-branch))]
           (if (zero? (:exit checkout-result))
-            {:success? true
-             :branch branch-name
-             :base-branch default-branch}
+            (shell-success {:branch branch-name :base-branch default-branch})
             (let [timestamped-name (str branch-name "-" (System/currentTimeMillis))
                   retry-result (process/shell dir-opts
                                               "git" "checkout" "-b" timestamped-name
                                               (str "origin/" default-branch))]
               (if (zero? (:exit retry-result))
-                {:success? true
-                 :branch timestamped-name
-                 :base-branch default-branch}
-                {:success? false
-                 :branch nil
-                 :error (str "Failed to create branch: " (:err retry-result))}))))))
+                (shell-success {:branch timestamped-name :base-branch default-branch})
+                (shell-failure (str "Failed to create branch: " (:err retry-result))
+                               {:branch nil})))))))
     (catch Exception e
-      {:success? false
-       :branch nil
-       :error (.getMessage e)})))
+      (shell-failure (.getMessage e) {:branch nil}))))
 
 (defn commit-changes!
   "Commit staged changes with the given message.
@@ -187,16 +216,11 @@
         (let [sha-result (process/shell
                           {:dir (str worktree-path) :out :string :err :string :continue true}
                           "git" "rev-parse" "HEAD")]
-          {:success? true
-           :commit-sha (str/trim (:out sha-result ""))
-           :output (:out result)})
-        {:success? false
-         :commit-sha nil
-         :error (:err result)}))
+          (shell-success {:commit-sha (str/trim (:out sha-result ""))
+                          :output (:out result)}))
+        (shell-failure (:err result) {:commit-sha nil})))
     (catch Exception e
-      {:success? false
-       :commit-sha nil
-       :error (.getMessage e)})))
+      (shell-failure (.getMessage e) {:commit-sha nil}))))
 
 (defn push-branch!
   "Push the current branch to origin.
@@ -208,13 +232,10 @@
                   {:dir (str worktree-path) :out :string :err :string :continue true}
                   "git" "push" "-u" "origin" branch-name)]
       (if (zero? (:exit result))
-        {:success? true
-         :output (:out result)}
-        {:success? false
-         :error (:err result)}))
+        (shell-success {:output (:out result)})
+        (shell-failure (:err result))))
     (catch Exception e
-      {:success? false
-       :error (.getMessage e)})))
+      (shell-failure (.getMessage e)))))
 
 (defn create-pr!
   "Create a pull request using gh CLI.
@@ -234,18 +255,10 @@
         (let [pr-url (str/trim (:out result ""))
               pr-num (when-let [match (re-find #"/pull/(\d+)" pr-url)]
                        (parse-long (second match)))]
-          {:success? true
-           :pr-url pr-url
-           :pr-number pr-num})
-        {:success? false
-         :pr-url nil
-         :pr-number nil
-         :error (:err result)}))
+          (shell-success {:pr-url pr-url :pr-number pr-num}))
+        (shell-failure (:err result) {:pr-url nil :pr-number nil})))
     (catch Exception e
-      {:success? false
-       :pr-url nil
-       :pr-number nil
-       :error (.getMessage e)})))
+      (shell-failure (.getMessage e) {:pr-url nil :pr-number nil}))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; File action processing
@@ -437,11 +450,8 @@
         (when logger
           (log/error logger :release-executor :missing-worktree-path
                      {:message "Context must include :worktree-path"}))
-        {:success? false
-         :artifacts []
-         :errors [{:type :missing-worktree-path
-                   :message "Context must include :worktree-path for release phase"}]
-         :metrics {}})
+        (phase-failure :missing-worktree-path
+                       "Context must include :worktree-path for release phase"))
 
       (let [code-artifacts (extract-code-artifacts (:workflow/artifacts workflow-state))]
 
@@ -450,11 +460,8 @@
             (when logger
               (log/warn logger :release-executor :no-code-artifacts
                         {:message "No code artifacts found to release"}))
-            {:success? false
-             :artifacts []
-             :errors [{:type :no-code-artifacts
-                       :message "No code artifacts found in workflow state"}]
-             :metrics {}})
+            (phase-failure :no-code-artifacts
+                           "No code artifacts found in workflow state"))
 
           (let [gh-auth (when create-pr? (check-gh-auth!))
                 gh-ok? (or (not create-pr?) (:authenticated? gh-auth))]
@@ -464,14 +471,10 @@
                 (when logger
                   (log/error logger :release-executor :gh-auth-failed
                              {:message (:error gh-auth)}))
-                {:success? false
-                 :artifacts []
-                 :errors [{:type :gh-auth-failed
-                           :message (:error gh-auth)
-                           :hint (if (:available? gh-auth)
-                                   "Run: gh auth login"
-                                   "Install: brew install gh")}]
-                 :metrics {}})
+                (phase-failure :gh-auth-failed (:error gh-auth)
+                               {:hint (if (:available? gh-auth)
+                                        "Run: gh auth login"
+                                        "Install: brew install gh")}))
 
               (let [release-meta (or (invoke-releaser releaser code-artifacts task-description context logger)
                                      (make-fallback-release-metadata code-artifacts task-description))
@@ -482,11 +485,7 @@
                     (when logger
                       (log/error logger :release-executor :branch-failed
                                  {:message (:error branch-result)}))
-                    {:success? false
-                     :artifacts []
-                     :errors [{:type :branch-create-failed
-                               :message (:error branch-result)}]
-                     :metrics {}})
+                    (phase-failure :branch-create-failed (:error branch-result)))
 
                   (let [actual-branch (:branch branch-result)
                         base-branch (:base-branch branch-result)
@@ -508,11 +507,8 @@
                             (when logger
                               (log/error logger :release-executor :commit-failed
                                          {:message (:error commit-result)}))
-                            {:success? false
-                             :artifacts []
-                             :errors [{:type :commit-failed
-                                       :message (:error commit-result)}]
-                             :metrics (:metrics write-result)})
+                            (phase-failure :commit-failed (:error commit-result)
+                                           {:metrics (:metrics write-result)}))
 
                           (let [push-result (when create-pr?
                                               (push-branch! worktree-path actual-branch))]
@@ -521,11 +517,8 @@
                                 (when logger
                                   (log/error logger :release-executor :push-failed
                                              {:message (:error push-result)}))
-                                {:success? false
-                                 :artifacts []
-                                 :errors [{:type :push-failed
-                                           :message (:error push-result)}]
-                                 :metrics (:metrics write-result)})
+                                (phase-failure :push-failed (:error push-result)
+                                               {:metrics (:metrics write-result)}))
 
                               (let [pr-result (when create-pr?
                                                 (create-pr! worktree-path
@@ -538,11 +531,8 @@
                                     (when logger
                                       (log/error logger :release-executor :pr-failed
                                                  {:message (:error pr-result)}))
-                                    {:success? false
-                                     :artifacts []
-                                     :errors [{:type :pr-create-failed
-                                               :message (:error pr-result)}]
-                                     :metrics (:metrics write-result)})
+                                    (phase-failure :pr-create-failed (:error pr-result)
+                                                   {:metrics (:metrics write-result)}))
 
                                   (let [release-content (merge
                                                          (:metrics write-result)
@@ -575,11 +565,10 @@
                                                         :pr-url (:pr-url pr-result)
                                                         :files-written (get-in write-result [:metrics :files-written])}}))
 
-                                    {:success? true
-                                     :artifacts [release-artifact]
-                                     :errors []
-                                     :metrics (merge (:metrics write-result)
-                                                     {:pr-number (:pr-number pr-result)
-                                                      :pr-url (:pr-url pr-result)
-                                                      :commit-sha (:commit-sha commit-result)
-                                                      :branch actual-branch})}))))))))))))))))))
+                                    (phase-success
+                                     [release-artifact]
+                                     (merge (:metrics write-result)
+                                            {:pr-number (:pr-number pr-result)
+                                             :pr-url (:pr-url pr-result)
+                                             :commit-sha (:commit-sha commit-result)
+                                             :branch actual-branch}))))))))))))))))))))

--- a/components/release-executor/src/ai/miniforge/release_executor/files.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/files.clj
@@ -1,0 +1,127 @@
+(ns ai.miniforge.release-executor.files
+  "File operations for the release executor.
+   Handles writing, deleting, and staging code artifact files."
+  (:require
+   [ai.miniforge.release-executor.git :as git]
+   [ai.miniforge.logging.interface :as log]
+   [babashka.fs :as fs]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; File operation helpers
+
+(defn- ensure-parent-dir!
+  "Create parent directories for a file path if they don't exist."
+  [file-path]
+  (let [parent (fs/parent file-path)]
+    (when parent
+      (fs/create-dirs parent))
+    parent))
+
+(defn- write-file!
+  "Write content to a file, creating parent directories as needed."
+  [file-path content]
+  (ensure-parent-dir! file-path)
+  (spit (str file-path) content)
+  file-path)
+
+(defn- delete-file!
+  "Delete a file if it exists. Returns true if deleted, false if file didn't exist."
+  [file-path]
+  (if (fs/exists? file-path)
+    (do
+      (fs/delete file-path)
+      true)
+    false))
+
+;------------------------------------------------------------------------------ Layer 1
+;; File action processing
+
+(defmulti process-file-action
+  "Process a file action based on its :action keyword."
+  (fn [_worktree-path file-spec _logger] (:action file-spec)))
+
+(defmethod process-file-action :create
+  [worktree-path {:keys [path content]} logger]
+  (try
+    (let [full-path (fs/path worktree-path path)]
+      (write-file! full-path content)
+      (when logger
+        (log/debug logger :release-executor :file-created {:data {:path path}}))
+      {:success? true :action :create :path path})
+    (catch Exception e
+      (when logger
+        (log/error logger :release-executor :file-create-failed
+                  {:message (.getMessage e) :data {:path path}}))
+      {:success? false :action :create :path path :error (.getMessage e)})))
+
+(defmethod process-file-action :modify
+  [worktree-path {:keys [path content]} logger]
+  (try
+    (let [full-path (fs/path worktree-path path)]
+      (write-file! full-path content)
+      (when logger
+        (log/debug logger :release-executor :file-modified {:data {:path path}}))
+      {:success? true :action :modify :path path})
+    (catch Exception e
+      (when logger
+        (log/error logger :release-executor :file-modify-failed
+                  {:message (.getMessage e) :data {:path path}}))
+      {:success? false :action :modify :path path :error (.getMessage e)})))
+
+(defmethod process-file-action :delete
+  [worktree-path {:keys [path]} logger]
+  (try
+    (let [full-path (fs/path worktree-path path)
+          deleted? (delete-file! full-path)]
+      (when logger
+        (log/debug logger :release-executor :file-deleted {:data {:path path :existed? deleted?}}))
+      {:success? true :action :delete :path path :deleted? deleted?})
+    (catch Exception e
+      (when logger
+        (log/error logger :release-executor :file-delete-failed
+                  {:message (.getMessage e) :data {:path path}}))
+      {:success? false :action :delete :path path :error (.getMessage e)})))
+
+(defmethod process-file-action :default
+  [_worktree-path {:keys [path action]} logger]
+  (when logger
+    (log/warn logger :release-executor :unknown-action {:data {:path path :action action}}))
+  {:success? false :action action :path path :error (str "Unknown action: " action)})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Batch file operations
+
+(defn write-and-stage-files!
+  "Write files to worktree and stage them. Returns result map."
+  [worktree-path code-artifacts logger]
+  (let [results (atom {:created 0 :modified 0 :deleted 0 :errors []})
+        all-files (mapcat :code/files code-artifacts)]
+
+    (doseq [file-spec all-files]
+      (let [result (process-file-action worktree-path file-spec logger)]
+        (if (:success? result)
+          (case (:action result)
+            :create (swap! results update :created inc)
+            :modify (swap! results update :modified inc)
+            :delete (swap! results update :deleted inc)
+            nil)
+          (swap! results update :errors conj
+                 {:type :file-operation-failed
+                  :message (:error result)
+                  :file (:path result)
+                  :action (:action result)}))))
+
+    (let [{:keys [created modified deleted errors]} @results
+          total-operations (+ created modified deleted)]
+      (if (seq errors)
+        {:success? false
+         :errors errors
+         :metrics {:files-written created :files-modified modified :files-deleted deleted}}
+        (let [stage-result (git/stage-files! worktree-path :all)]
+          (if (:success? stage-result)
+            {:success? true
+             :metrics {:files-written created :files-modified modified :files-deleted deleted
+                       :total-operations total-operations}}
+            {:success? false
+             :errors [{:type :git-stage-failed :message (:error stage-result)}]
+             :metrics {:files-written created :files-modified modified :files-deleted deleted}}))))))

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -1,0 +1,165 @@
+(ns ai.miniforge.release-executor.git
+  "Git operations for the release executor.
+   Provides shell-based git and gh CLI operations."
+  (:require
+   [ai.miniforge.release-executor.result :as result]
+   [babashka.process :as process]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; gh auth result helpers
+
+(defn- gh-unavailable
+  "Create result for gh CLI not available."
+  [error-msg]
+  {:available? false :authenticated? false :error error-msg})
+
+(defn- gh-available-unauthenticated
+  "Create result for gh CLI available but not authenticated."
+  [error-msg]
+  {:available? true :authenticated? false :error error-msg})
+
+(defn- gh-authenticated
+  "Create result for gh CLI available and authenticated."
+  [user]
+  {:available? true :authenticated? true :user user})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Git operations
+
+(defn stage-files!
+  "Stage files in git worktree using git add."
+  [worktree-path file-paths]
+  (try
+    (let [git-args (if (= file-paths :all)
+                     ["git" "add" "."]
+                     (into ["git" "add"] (map str file-paths)))
+          result (apply process/shell
+                        {:dir (str worktree-path)
+                         :out :string
+                         :err :string
+                         :continue true}
+                        git-args)]
+      (if (zero? (:exit result))
+        (result/shell-success {:output (:out result "")})
+        (result/shell-failure (:err result "") {:output (:out result "")})))
+    (catch Exception e
+      (result/shell-failure (.getMessage e)))))
+
+(defn check-gh-auth!
+  "Check if gh CLI is available and authenticated.
+
+   Returns {:available? bool :authenticated? bool :user string :error string}"
+  []
+  (try
+    (let [which-result (process/shell
+                        {:out :string :err :string :continue true}
+                        "which" "gh")]
+      (if-not (zero? (:exit which-result))
+        (gh-unavailable "gh CLI not found. Install with: brew install gh")
+        (let [auth-result (process/shell
+                           {:out :string :err :string :continue true}
+                           "gh" "auth" "status")]
+          (if (zero? (:exit auth-result))
+            (let [output (:out auth-result "")
+                  user-match (re-find #"Logged in to [^\s]+ account (\S+)" output)]
+              (gh-authenticated (or (second user-match) "unknown")))
+            (gh-available-unauthenticated
+             (str "gh not authenticated. Run: gh auth login\n" (:err auth-result)))))))
+    (catch Exception e
+      (gh-unavailable (.getMessage e)))))
+
+(defn create-branch!
+  "Create a new git branch from main/master.
+
+   Arguments:
+   - worktree-path - Path to git worktree root
+   - branch-name   - Name for the new branch
+
+   Returns {:success? bool :branch string :base-branch string :error string}"
+  [worktree-path branch-name]
+  (try
+    (let [dir-opts {:dir (str worktree-path) :out :string :err :string :continue true}
+          default-branch-result (process/shell dir-opts
+                                               "git" "symbolic-ref" "refs/remotes/origin/HEAD")
+          default-branch (if (zero? (:exit default-branch-result))
+                           (-> (:out default-branch-result)
+                               str/trim
+                               (str/replace #"refs/remotes/origin/" ""))
+                           "main")
+          fetch-result (process/shell dir-opts "git" "fetch" "origin" default-branch)]
+
+      (if-not (zero? (:exit fetch-result))
+        (result/shell-failure (str "Failed to fetch: " (:err fetch-result)) {:branch nil})
+        (let [checkout-result (process/shell dir-opts
+                                             "git" "checkout" "-b" branch-name
+                                             (str "origin/" default-branch))]
+          (if (zero? (:exit checkout-result))
+            (result/shell-success {:branch branch-name :base-branch default-branch})
+            (let [timestamped-name (str branch-name "-" (System/currentTimeMillis))
+                  retry-result (process/shell dir-opts
+                                              "git" "checkout" "-b" timestamped-name
+                                              (str "origin/" default-branch))]
+              (if (zero? (:exit retry-result))
+                (result/shell-success {:branch timestamped-name :base-branch default-branch})
+                (result/shell-failure (str "Failed to create branch: " (:err retry-result))
+                                      {:branch nil})))))))
+    (catch Exception e
+      (result/shell-failure (.getMessage e) {:branch nil}))))
+
+(defn commit-changes!
+  "Commit staged changes with the given message.
+
+   Returns {:success? bool :commit-sha string :error string}"
+  [worktree-path commit-message]
+  (try
+    (let [result (process/shell
+                  {:dir (str worktree-path) :out :string :err :string :continue true}
+                  "git" "commit" "-m" commit-message)]
+      (if (zero? (:exit result))
+        (let [sha-result (process/shell
+                          {:dir (str worktree-path) :out :string :err :string :continue true}
+                          "git" "rev-parse" "HEAD")]
+          (result/shell-success {:commit-sha (str/trim (:out sha-result ""))
+                                 :output (:out result)}))
+        (result/shell-failure (:err result) {:commit-sha nil})))
+    (catch Exception e
+      (result/shell-failure (.getMessage e) {:commit-sha nil}))))
+
+(defn push-branch!
+  "Push the current branch to origin.
+
+   Returns {:success? bool :error string}"
+  [worktree-path branch-name]
+  (try
+    (let [result (process/shell
+                  {:dir (str worktree-path) :out :string :err :string :continue true}
+                  "git" "push" "-u" "origin" branch-name)]
+      (if (zero? (:exit result))
+        (result/shell-success {:output (:out result)})
+        (result/shell-failure (:err result))))
+    (catch Exception e
+      (result/shell-failure (.getMessage e)))))
+
+(defn create-pr!
+  "Create a pull request using gh CLI.
+
+   Returns {:success? bool :pr-number int :pr-url string :error string}"
+  [worktree-path {:keys [title body base-branch]}]
+  (try
+    (let [base (or base-branch "main")
+          args ["gh" "pr" "create"
+                "--title" title
+                "--body" body
+                "--base" base]
+          result (apply process/shell
+                        {:dir (str worktree-path) :out :string :err :string :continue true}
+                        args)]
+      (if (zero? (:exit result))
+        (let [pr-url (str/trim (:out result ""))
+              pr-num (when-let [match (re-find #"/pull/(\d+)" pr-url)]
+                       (parse-long (second match)))]
+          (result/shell-success {:pr-url pr-url :pr-number pr-num}))
+        (result/shell-failure (:err result) {:pr-url nil :pr-number nil})))
+    (catch Exception e
+      (result/shell-failure (.getMessage e) {:pr-url nil :pr-number nil}))))

--- a/components/release-executor/src/ai/miniforge/release_executor/interface.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/interface.clj
@@ -1,0 +1,59 @@
+(ns ai.miniforge.release-executor.interface
+  "Public API for the release-executor component.
+
+   Provides release phase execution for creating PRs from code artifacts.
+   This component is extracted to avoid circular dependencies between
+   workflow and phase components."
+  (:require [ai.miniforge.release-executor.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Main execution function
+
+(def execute-release-phase
+  "Execute the release phase.
+
+   Arguments:
+   - workflow-state - Workflow state with :workflow/artifacts
+   - context        - Execution context with :worktree-path, :logger, etc.
+   - opts           - Options with :releaser (optional)
+
+   Returns:
+   {:success? bool
+    :artifacts [release-artifact]
+    :errors []
+    :metrics {...}}
+
+   Example:
+     (execute-release-phase workflow-state
+                            {:worktree-path \"/path/to/repo\"
+                             :create-pr? false}
+                            {:releaser my-releaser-agent})"
+  core/execute-release-phase)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Git operations (for testing and advanced use)
+
+(def check-gh-auth!
+  "Check if GitHub CLI is available and authenticated.
+   Returns {:available? bool :authenticated? bool :error string}"
+  core/check-gh-auth!)
+
+(def create-branch!
+  "Create a new git branch from main.
+   Returns {:success? bool :branch string :base-branch string :error string}"
+  core/create-branch!)
+
+(def commit-changes!
+  "Commit staged changes.
+   Returns {:success? bool :commit-sha string :error string}"
+  core/commit-changes!)
+
+(def push-branch!
+  "Push branch to remote.
+   Returns {:success? bool :error string}"
+  core/push-branch!)
+
+(def create-pr!
+  "Create a PR using gh CLI.
+   Returns {:success? bool :pr-number int :pr-url string :error string}"
+  core/create-pr!)

--- a/components/release-executor/src/ai/miniforge/release_executor/interface.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/interface.clj
@@ -4,7 +4,9 @@
    Provides release phase execution for creating PRs from code artifacts.
    This component is extracted to avoid circular dependencies between
    workflow and phase components."
-  (:require [ai.miniforge.release-executor.core :as core]))
+  (:require
+   [ai.miniforge.release-executor.core :as core]
+   [ai.miniforge.release-executor.git :as git]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Main execution function
@@ -36,24 +38,24 @@
 (def check-gh-auth!
   "Check if GitHub CLI is available and authenticated.
    Returns {:available? bool :authenticated? bool :error string}"
-  core/check-gh-auth!)
+  git/check-gh-auth!)
 
 (def create-branch!
   "Create a new git branch from main.
    Returns {:success? bool :branch string :base-branch string :error string}"
-  core/create-branch!)
+  git/create-branch!)
 
 (def commit-changes!
   "Commit staged changes.
    Returns {:success? bool :commit-sha string :error string}"
-  core/commit-changes!)
+  git/commit-changes!)
 
 (def push-branch!
   "Push branch to remote.
    Returns {:success? bool :error string}"
-  core/push-branch!)
+  git/push-branch!)
 
 (def create-pr!
   "Create a PR using gh CLI.
    Returns {:success? bool :pr-number int :pr-url string :error string}"
-  core/create-pr!)
+  git/create-pr!)

--- a/components/release-executor/src/ai/miniforge/release_executor/metadata.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/metadata.clj
@@ -1,0 +1,93 @@
+(ns ai.miniforge.release-executor.metadata
+  "Release metadata generation for the release executor.
+   Handles invoking the releaser agent and generating fallback metadata."
+  (:require
+   [ai.miniforge.logging.interface :as log]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; String utilities
+
+(defn- slugify
+  "Convert a string to a URL-safe slug.
+   Handles basic ASCII transliteration and normalizes spacing."
+  [s]
+  (let [input (or s "change")
+        ;; Basic ASCII transliteration for common characters
+        transliterated (-> input
+                           (str/replace #"[àáâãäå]" "a")
+                           (str/replace #"[èéêë]" "e")
+                           (str/replace #"[ìíîï]" "i")
+                           (str/replace #"[òóôõö]" "o")
+                           (str/replace #"[ùúûü]" "u")
+                           (str/replace #"[ñ]" "n")
+                           (str/replace #"[ç]" "c")
+                           (str/replace #"[ß]" "ss"))
+        slug (-> transliterated
+                 str/lower-case
+                 (str/replace #"[^a-z0-9\s-]" "")
+                 (str/replace #"\s+" "-")
+                 (str/replace #"-+" "-")
+                 (str/replace #"^-|-$" ""))]
+    (subs slug 0 (min 40 (count slug)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Releaser agent integration
+
+(defn invoke-releaser
+  "Invoke the releaser agent to generate release metadata.
+   Falls back to nil if agent fails (caller should use fallback)."
+  [releaser code-artifacts task-description context logger]
+  (let [llm-backend (:llm-backend context)
+        first-artifact (first code-artifacts)
+        input {:code-artifact first-artifact
+               :task-description (or task-description
+                                     (:code/summary first-artifact)
+                                     "implement changes")}]
+    (if (and releaser llm-backend)
+      (try
+        (let [result ((:invoke-fn releaser)
+                      (assoc context :llm-backend llm-backend)
+                      input)]
+          (when logger
+            (log/debug logger :release-executor :releaser-invoked
+                       {:data {:status (:status result)}}))
+          (if (= :success (:status result))
+            (:output result)
+            (do
+              (when logger
+                (log/warn logger :release-executor :releaser-failed-fallback
+                          {:message "Releaser agent failed, using fallback"}))
+              nil)))
+        (catch Exception e
+          (when logger
+            (log/warn logger :release-executor :releaser-exception
+                      {:message (.getMessage e)}))
+          nil))
+      nil)))
+
+(defn make-fallback-release-metadata
+  "Generate fallback release metadata when releaser agent is unavailable."
+  [code-artifacts task-description]
+  (let [first-artifact (first code-artifacts)
+        files (:code/files first-artifact)
+        summary (or (:code/summary first-artifact) "code changes")
+        task-desc (or task-description summary)
+        slug (slugify task-desc)]
+    {:release/id (random-uuid)
+     :release/branch-name (str "feature/" slug)
+     :release/commit-message (str "feat: " task-desc)
+     :release/pr-title (str "feat: " (subs task-desc 0 (min 60 (count task-desc))))
+     :release/pr-description (str "## Summary\n" task-desc "\n\n"
+                                  "## Changes\n"
+                                  (if files
+                                    (str/join "\n" (map #(str "- " (name (:action %)) " `" (:path %) "`") files))
+                                    "See commits for details"))
+     :release/created-at (java.util.Date.)}))
+
+(defn generate-release-metadata
+  "Generate release metadata using releaser agent or fallback.
+   Returns release metadata map."
+  [releaser code-artifacts task-description context logger]
+  (or (invoke-releaser releaser code-artifacts task-description context logger)
+      (make-fallback-release-metadata code-artifacts task-description)))

--- a/components/release-executor/src/ai/miniforge/release_executor/result.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/result.clj
@@ -1,0 +1,40 @@
+(ns ai.miniforge.release-executor.result
+  "Result builders for release-executor operations.
+   Provides consistent result structures across all operations.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Shell operation results
+
+(defn shell-success
+  "Create a shell operation success result."
+  [data]
+  (merge {:success? true} data))
+
+(defn shell-failure
+  "Create a shell operation failure result."
+  ([error-msg]
+   (shell-failure error-msg {}))
+  ([error-msg data]
+   (merge {:success? false :error error-msg} data)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Phase execution results
+
+(defn phase-success
+  "Create a release phase success result."
+  [artifacts metrics]
+  {:success? true
+   :artifacts artifacts
+   :errors []
+   :metrics metrics})
+
+(defn phase-failure
+  "Create a release phase failure result."
+  ([error-type error-msg]
+   (phase-failure error-type error-msg {}))
+  ([error-type error-msg opts]
+   {:success? false
+    :artifacts []
+    :errors [(merge {:type error-type :message error-msg}
+                    (select-keys opts [:hint :data]))]
+    :metrics (or (:metrics opts) {})}))

--- a/deps.edn
+++ b/deps.edn
@@ -37,6 +37,8 @@
                        "components/gate/resources"
                        "components/workflow/src"
                        "components/workflow/resources"
+                       "components/release-executor/src"
+                       "components/release-executor/resources"
                        "components/operator/src"
                        "components/operator/resources"
                        "components/observer/src"
@@ -62,6 +64,7 @@
                       ai.miniforge/phase {:local/root "components/phase"}
                       ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}
+                      ai.miniforge/release-executor {:local/root "components/release-executor"}
                       ai.miniforge/operator {:local/root "components/operator"}
                       ai.miniforge/observer {:local/root "components/observer"}
                       ai.miniforge/orchestrator {:local/root "components/orchestrator"}
@@ -106,6 +109,7 @@
                       ai.miniforge/phase {:local/root "components/phase"}
                       ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}
+                      ai.miniforge/release-executor {:local/root "components/release-executor"}
                       ai.miniforge/operator {:local/root "components/operator"}
                       ai.miniforge/observer {:local/root "components/observer"}
                       ai.miniforge/orchestrator {:local/root "components/orchestrator"}

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -20,6 +20,7 @@
         ai.miniforge/fsm {:local/root "../../components/fsm"}
         ai.miniforge/phase {:local/root "../../components/phase"}
         ai.miniforge/gate {:local/root "../../components/gate"}
+        ai.miniforge/release-executor {:local/root "../../components/release-executor"}
         ai.miniforge/evidence-bundle {:local/root "../../components/evidence-bundle"}}
 
  :aliases

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -17,11 +17,11 @@ drill-down without scraping logs.
 
 **The interesting parts for experts:**
 
-* **Event stream as product surface area** (not just logging): it powers UX,
+- **Event stream as product surface area** (not just logging): it powers UX,
   replay/debuggability, and later learning/analytics.
-* **Evidence bundles + semantic intent validation** as the primitive that makes "autonomous"
+- **Evidence bundles + semantic intent validation** as the primitive that makes "autonomous"
   credible to platform/security teams.
-* **High-throughput triage UI** optimized for 100+ PR/day (email-triage model + batch operations).
+- **High-throughput triage UI** optimized for 100+ PR/day (email-triage model + batch operations).
 
 ---
 
@@ -42,11 +42,11 @@ They use RFC 2119 terminology (MUST, SHALL, SHOULD, MAY).
 
 Defines:
 
-* Core nouns: workflow, phase, agent, subagent, tool, gate, policy pack, evidence bundle, artifact, provenance
-* Three-layer architecture: Control Plane, Agent Layer, Learning Layer
-* Polylith component boundaries (OSS component catalog)
-* Operational model: local-first execution, reproducibility, failure semantics
-* Agent protocols: communication patterns, context handoff, inter-agent messaging
+- Core nouns: workflow, phase, agent, subagent, tool, gate, policy pack, evidence bundle, artifact, provenance
+- Three-layer architecture: Control Plane, Agent Layer, Learning Layer
+- Polylith component boundaries (OSS component catalog)
+- Operational model: local-first execution, reproducibility, failure semantics
+- Agent protocols: communication patterns, context handoff, inter-agent messaging
 
 ### N2 — Workflow Execution Model ✅
 
@@ -56,12 +56,12 @@ Defines:
 
 Defines:
 
-* Phase graph: Plan → Design → Implement → Verify → Review → Release → Observe
-* Phase responsibilities: detailed requirements for each phase (inputs, outputs, gates)
-* Inner loop: validate → feedback → repair → re-validate with multi-strategy repair
-* Outer loop: phase transition state machine with prerequisites and failure handling
-* Gate contract: check/repair function signatures, violation schema, enforcement rules
-* Context handoff: protocol for passing context between phases
+- Phase graph: Plan → Design → Implement → Verify → Review → Release → Observe
+- Phase responsibilities: detailed requirements for each phase (inputs, outputs, gates)
+- Inner loop: validate → feedback → repair → re-validate with multi-strategy repair
+- Outer loop: phase transition state machine with prerequisites and failure handling
+- Gate contract: check/repair function signatures, violation schema, enforcement rules
+- Context handoff: protocol for passing context between phases
 
 ### N3 — Event Stream & Observability Contract ✅
 
@@ -71,11 +71,11 @@ Defines:
 
 Defines:
 
-* Event envelope fields; required event types (workflow, agent, status, subagent, tool, LLM, messages, milestone, gate)
-* Ordering guarantees (per-workflow sequence, causal ordering, replay determinism)
-* Streaming API (SSE/WebSocket) with subscription protocol
-* Throttling and performance requirements
-* Minimal fields needed to render "live" progress and drill-down
+- Event envelope fields; required event types (workflow, agent, status, subagent, tool, LLM, messages, milestone, gate)
+- Ordering guarantees (per-workflow sequence, causal ordering, replay determinism)
+- Streaming API (SSE/WebSocket) with subscription protocol
+- Throttling and performance requirements
+- Minimal fields needed to render "live" progress and drill-down
 
 ### N4 — Policy Packs & Gates Standard ✅
 
@@ -85,11 +85,11 @@ Defines:
 
 Defines:
 
-* Pack structure: schema, versioning, signature requirements, rule definitions
-* Gate execution contract: check/repair function interfaces with complete protocols
-* Semantic intent validation: IMPORT/CREATE/UPDATE/DESTROY/REFACTOR/MIGRATE rules
-* Violation schema: severity levels, remediation templates, auto-fix capabilities
-* Terraform/Kubernetes-specific validation rules
+- Pack structure: schema, versioning, signature requirements, rule definitions
+- Gate execution contract: check/repair function interfaces with complete protocols
+- Semantic intent validation: IMPORT/CREATE/UPDATE/DESTROY/REFACTOR/MIGRATE rules
+- Violation schema: severity levels, remediation templates, auto-fix capabilities
+- Terraform/Kubernetes-specific validation rules
 
 ### N5 — Interface Standard: CLI/TUI/API ✅
 
@@ -99,11 +99,11 @@ Defines:
 
 Defines:
 
-* CLI command taxonomy: six namespaces (init, workflow, fleet, policy, evidence, artifact)
-* TUI primitives: workflow list, detail view, evidence viewer, artifact browser
-* API surface: minimal REST endpoints for workflow control, event streaming, evidence/artifact access
-* Operations console purpose: monitoring autonomous factory (NOT PR management)
-* Manual override mechanisms: plan approval, gate handling, budget escalation
+- CLI command taxonomy: six namespaces (init, workflow, fleet, policy, evidence, artifact)
+- TUI primitives: workflow list, detail view, evidence viewer, artifact browser
+- API surface: minimal REST endpoints for workflow control, event streaming, evidence/artifact access
+- Operations console purpose: monitoring autonomous factory (NOT PR management)
+- Manual override mechanisms: plan approval, gate handling, budget escalation
 
 ### N6 — Evidence & Provenance Standard ✅
 
@@ -113,11 +113,11 @@ Defines:
 
 Defines:
 
-* Evidence bundle schema: intent → phases → validation → outcome
-* Artifact provenance: source inputs, tool executions, content hashes, timestamps
-* Semantic intent validation rules with Terraform/Kubernetes specifics
-* Queryable provenance API: trace artifact chains, find intent mismatches
-* Compliance metadata: sensitive data handling, audit requirements (SOCII/FedRAMP)
+- Evidence bundle schema: intent → phases → validation → outcome
+- Artifact provenance: source inputs, tool executions, content hashes, timestamps
+- Semantic intent validation rules with Terraform/Kubernetes specifics
+- Queryable provenance API: trace artifact chains, find intent mismatches
+- Compliance metadata: sensitive data handling, audit requirements (SOCII/FedRAMP)
 
 ### N7 — Operational Policy Synthesis With Verification ✅
 
@@ -127,12 +127,12 @@ Defines:
 
 Defines:
 
-* Experiment Pack schema: workload models, guardrails, convergence strategies
-* Operational Policy schema: scaling signals, resource sizing, runtime guardrails
-* OPSV workflow family: DISCOVER → PLAN → EXECUTE → CONVERGE → SYNTHESIZE → VERIFY → ACTUATE
-* Verification requirements: pass/fail semantics, success criteria evaluation
-* Fleet Mode integration: per-service policy state, experiment governance
-* Risk scoring and actuation modes (RECOMMEND_ONLY, PR_ONLY, APPLY_ALLOWED)
+- Experiment Pack schema: workload models, guardrails, convergence strategies
+- Operational Policy schema: scaling signals, resource sizing, runtime guardrails
+- OPSV workflow family: DISCOVER → PLAN → EXECUTE → CONVERGE → SYNTHESIZE → VERIFY → ACTUATE
+- Verification requirements: pass/fail semantics, success criteria evaluation
+- Fleet Mode integration: per-service policy state, experiment governance
+- Risk scoring and actuation modes (RECOMMEND_ONLY, PR_ONLY, APPLY_ALLOWED)
 
 ### N8 — Observability Control Interface 🆕
 
@@ -142,14 +142,14 @@ Defines:
 
 Defines:
 
-* Listener capability model: OBSERVE, ADVISE, CONTROL levels with RBAC
-* Control action surface: pause, resume, rollback, quarantine, approve, emergency-stop
-* Advisory annotation system: non-blocking recommendations and warnings
-* Privacy and redaction: metadata-only, redacted, full privacy levels
-* OpenTelemetry interoperability: GenAI span mapping, OTLP export
-* Cost and volume controls: sampling rules, aggregation boundaries
-* Fleet and enterprise extensions: multi-tenancy, pattern detection
-* CLI/TUI extensions: listener commands, control palette, approval queue
+- Listener capability model: OBSERVE, ADVISE, CONTROL levels with RBAC
+- Control action surface: pause, resume, rollback, quarantine, approve, emergency-stop
+- Advisory annotation system: non-blocking recommendations and warnings
+- Privacy and redaction: metadata-only, redacted, full privacy levels
+- OpenTelemetry interoperability: GenAI span mapping, OTLP export
+- Cost and volume controls: sampling rules, aggregation boundaries
+- Fleet and enterprise extensions: multi-tenancy, pattern detection
+- CLI/TUI extensions: listener commands, control palette, approval queue
 
 ---
 
@@ -159,25 +159,29 @@ These documents provide guidance, examples, and context but do NOT define contra
 
 ### UX References
 
-* [informative/ux-tui-mockups.md](informative/ux-tui-mockups.md) - Visual design for CLI/TUI (informs N5)
-* [informative/ai-ux-flows.md](informative/ai-ux-flows.md) - AI-powered features (informs N3, N5)
+- [informative/ux-tui-mockups.md](informative/ux-tui-mockups.md) - Visual design for CLI/TUI (informs N5)
+- [informative/ai-ux-flows.md](informative/ai-ux-flows.md) - AI-powered features (informs N3, N5)
 
 ### Guides (How-To)
 
-* [informative/getting-started.md](informative/getting-started.md) - First workflow guide
-* [informative/authoring-policies.md](informative/authoring-policies.md) - Policy pack development
-* [informative/writing-workflows.md](informative/writing-workflows.md) - Workflow spec authoring
-* [informative/building-scanners.md](informative/building-scanners.md) - Scanner development
+- [informative/getting-started.md](informative/getting-started.md) - First workflow guide
+- [informative/authoring-policies.md](informative/authoring-policies.md) - Policy pack development
+- [informative/writing-workflows.md](informative/writing-workflows.md) - Workflow spec authoring
+- [informative/building-scanners.md](informative/building-scanners.md) - Scanner development
 
 ### Vision & Positioning
 
-* [informative/software-factory-vision.md](informative/software-factory-vision.md) - Product vision and differentiation
-* [informative/operational-modes.md](informative/operational-modes.md) - OSS vs Paid operational differences
+- [informative/software-factory-vision.md](informative/software-factory-vision.md) - Product vision and differentiation
+- [informative/operational-modes.md](informative/operational-modes.md) - OSS vs Paid operational differences
+
+### Future Workflows
+
+- [informative/pr-monitoring-workflow.md](informative/pr-monitoring-workflow.md) - PR monitoring and conflict resolution
 
 ### Roadmaps (Experimental/Future)
 
-* [informative/learning-meta-loop.md](informative/learning-meta-loop.md) - Future learning system (post-OSS)
-* [informative/oss-paid-roadmap.md](informative/oss-paid-roadmap.md) - Product roadmap and go-to-market
+- [informative/learning-meta-loop.md](informative/learning-meta-loop.md) - Future learning system (post-OSS)
+- [informative/oss-paid-roadmap.md](informative/oss-paid-roadmap.md) - Product roadmap and go-to-market
 
 ---
 
@@ -187,20 +191,20 @@ Concrete examples that demonstrate compliance with normative specs.
 
 ### Workflow Examples
 
-* [examples/workflows/rds-import.edn](examples/workflows/rds-import.edn) - Import existing RDS to Terraform
-* [examples/workflows/k8s-deployment.edn](examples/workflows/k8s-deployment.edn) - Deploy to Kubernetes
-* [examples/workflows/vpc-network-changes.edn](examples/workflows/vpc-network-changes.edn) - Network infrastructure
+- [examples/workflows/rds-import.edn](examples/workflows/rds-import.edn) - Import existing RDS to Terraform
+- [examples/workflows/k8s-deployment.edn](examples/workflows/k8s-deployment.edn) - Deploy to Kubernetes
+- [examples/workflows/vpc-network-changes.edn](examples/workflows/vpc-network-changes.edn) - Network infrastructure
 
 ### Evidence Bundle Examples
 
-* [examples/evidence/rds-import-bundle.edn](examples/evidence/rds-import-bundle.edn) - Complete evidence bundle
-* [examples/evidence/semantic-validation.edn](examples/evidence/semantic-validation.edn) - Intent validation example
+- [examples/evidence/rds-import-bundle.edn](examples/evidence/rds-import-bundle.edn) - Complete evidence bundle
+- [examples/evidence/semantic-validation.edn](examples/evidence/semantic-validation.edn) - Intent validation example
 
 ### Policy Pack Examples
 
-* [examples/policy-packs/terraform-aws/](examples/policy-packs/terraform-aws/) - Terraform AWS safety checks
-* [examples/policy-packs/kubernetes/](examples/policy-packs/kubernetes/) - K8s manifest validation
-* [examples/policy-packs/foundations/](examples/policy-packs/foundations/) - General code quality
+- [examples/policy-packs/terraform-aws/](examples/policy-packs/terraform-aws/) - Terraform AWS safety checks
+- [examples/policy-packs/kubernetes/](examples/policy-packs/kubernetes/) - K8s manifest validation
+- [examples/policy-packs/foundations/](examples/policy-packs/foundations/) - General code quality
 
 ---
 
@@ -208,11 +212,11 @@ Concrete examples that demonstrate compliance with normative specs.
 
 Documents superseded by normative specs. Retained for reference during migration.
 
-* [deprecated/BUILD_PLAN.md](deprecated/BUILD_PLAN.md) - Superseded by informative roadmap
-* [deprecated/BUILD_PLAN_REVISED.md](deprecated/BUILD_PLAN_REVISED.md) - Content extracted to N2, N3, N6
-* [deprecated/OSS_PAID_ROADMAP.md](deprecated/OSS_PAID_ROADMAP.md) - Superseded by informative/oss-paid-roadmap.md
-* [deprecated/REVISED_TIMELINE.md](deprecated/REVISED_TIMELINE.md) - Merged into roadmap
-* [deprecated/AGENT_STATUS_STREAMING.md](deprecated/AGENT_STATUS_STREAMING.md) - Content extracted to N3
+- [deprecated/BUILD_PLAN.md](deprecated/BUILD_PLAN.md) - Superseded by informative roadmap
+- [deprecated/BUILD_PLAN_REVISED.md](deprecated/BUILD_PLAN_REVISED.md) - Content extracted to N2, N3, N6
+- [deprecated/OSS_PAID_ROADMAP.md](deprecated/OSS_PAID_ROADMAP.md) - Superseded by informative/oss-paid-roadmap.md
+- [deprecated/REVISED_TIMELINE.md](deprecated/REVISED_TIMELINE.md) - Merged into roadmap
+- [deprecated/AGENT_STATUS_STREAMING.md](deprecated/AGENT_STATUS_STREAMING.md) - Content extracted to N3
 
 ---
 
@@ -222,15 +226,15 @@ Documents superseded by normative specs. Retained for reference during migration
 
 **Normative specs (N1-N8):**
 
-* MUST use RFC 2119 keywords: MUST, SHALL, SHOULD, MAY, MUST NOT, SHALL NOT
-* MUST define versioning and compatibility expectations
-* Breaking changes require version bump
+- MUST use RFC 2119 keywords: MUST, SHALL, SHOULD, MAY, MUST NOT, SHALL NOT
+- MUST define versioning and compatibility expectations
+- Breaking changes require version bump
 
 **Informative docs:**
 
-* MUST NOT use RFC 2119 keywords
-* Use descriptive language
-* Can change without version bump
+- MUST NOT use RFC 2119 keywords
+- Use descriptive language
+- Can change without version bump
 
 ### Amendment Process
 
@@ -263,10 +267,10 @@ They MUST:
 
 Normative specs are enforced by:
 
-* Schema validation tests (events/evidence/policy packs)
-* Golden-file examples
-* CLI contract tests
-* Gate validation (specs enforced by gates)
+- Schema validation tests (events/evidence/policy packs)
+- Golden-file examples
+- CLI contract tests
+- Gate validation (specs enforced by gates)
 
 ---
 
@@ -276,9 +280,9 @@ Normative specs are enforced by:
 
 **Why start with N3 & N6?**
 
-* Event stream powers UX, replay, debugging, and future learning
-* Evidence bundles enable credibility and compliance
-* These two specs force clarity across workflow engine, TUI, policy gates, and learning
+- Event stream powers UX, replay, debugging, and future learning
+- Evidence bundles enable credibility and compliance
+- These two specs force clarity across workflow engine, TUI, policy gates, and learning
 
 **Implementation priority:**
 
@@ -293,5 +297,5 @@ Normative specs are enforced by:
 
 ## Version History
 
-* **0.2.0-draft** (2026-02-01) - Added N7 (OPSV) and N8 (OCI), updated governance for extension specs
-* **0.1.0-draft** (2026-01-23) - Initial spec index, normative spec structure established
+- **0.2.0-draft** (2026-02-01) - Added N7 (OPSV) and N8 (OCI), updated governance for extension specs
+- **0.1.0-draft** (2026-01-23) - Initial spec index, normative spec structure established

--- a/specs/informative/pr-monitoring-workflow.md
+++ b/specs/informative/pr-monitoring-workflow.md
@@ -1,0 +1,344 @@
+# PR Monitoring Workflow
+
+**Date:** 2026-02-01
+**Status:** Informative (Future Feature)
+**Informs:** N2 (Workflows), N3 (Events), N6 (Evidence)
+
+---
+
+## Overview
+
+The **PR Monitoring Workflow** is a reactive workflow that watches open PRs and responds to
+external events to get them to a "ready to merge" state. Unlike the Release phase (which
+_creates_ PRs), PR Monitoring _maintains_ them through their lifecycle.
+
+This is separate from the release phase by design:
+
+- **Release** = proposing changes (branch → commit → push → PR)
+- **PR Monitoring** = shepherding PRs to completion (conflicts, comments, CI)
+
+The human remains in the loop for final review and merge.
+
+---
+
+## Problem Statement
+
+After miniforge creates a PR, several things can happen:
+
+1. **Main branch advances** → PR has merge conflicts
+2. **CI fails** → Tests break, linting fails, security scan flags issues
+3. **Bot comments** → Dependabot, CodeQL, coverage tools leave feedback
+4. **Human comments** → Reviewers ask questions or request changes
+5. **Approval conditions** → Required reviewers, status checks pending
+
+Currently, these require human intervention. A PR Monitoring workflow can handle most of these autonomously.
+
+---
+
+## Workflow Model
+
+```text
+┌─────────────────────────────────────────────────────────────────┐
+│                      PR Monitoring Workflow                      │
+│                                                                  │
+│  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐  │
+│  │  Watch   │───▶│  Triage  │───▶│  Handle  │───▶│  Signal  │  │
+│  │  Events  │    │  Event   │    │  Event   │    │  Ready   │  │
+│  └──────────┘    └──────────┘    └──────────┘    └──────────┘  │
+│       ▲                                               │         │
+│       └───────────────────────────────────────────────┘         │
+│                         (loop until ready or abandoned)         │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### Event Sources
+
+The workflow monitors:
+
+1. **GitHub webhooks** - Push events (main updated), PR comments, reviews, status checks
+2. **Polling** - Fallback for webhook-less environments
+3. **Internal events** - Retry timers, budget exhaustion signals
+
+### Event Types and Handlers
+
+| Event Type               | Detection               | Handler                   |
+| ------------------------ | ----------------------- | ------------------------- |
+| Merge conflict           | `mergeable: false`      | Conflict Resolution Agent |
+| CI failure               | Status check failed     | Re-implement or fix       |
+| Bot comment              | Comment from known bots | Parse and act             |
+| Human comment            | Comment from humans     | Comment Response Agent    |
+| Review requested changes | Review state            | Address feedback          |
+| All checks pass          | All green               | Signal ready              |
+
+---
+
+## Component: Conflict Resolution Agent
+
+A specialized agent for resolving git merge conflicts.
+
+### Input
+
+```clojure
+{:conflict/pr-url "https://github.com/org/repo/pull/123"
+ :conflict/files ["src/auth/login.clj" "src/config.clj"]
+ :conflict/base-branch "main"
+ :conflict/head-branch "feature/add-auth"
+ :conflict/markers [...] ;; Parsed conflict markers per file
+ :conflict/original-intent "Implement user authentication"
+ :conflict/our-changes {...} ;; What our PR changed
+ :conflict/their-changes {...}} ;; What main changed
+```
+
+### Output
+
+```clojure
+{:resolution/id #uuid "..."
+ :resolution/strategy :auto|:manual-required
+ :resolution/files [{:path "src/auth/login.clj"
+                     :resolved-content "..."
+                     :confidence :high|:medium|:low
+                     :explanation "Kept our auth logic, integrated their config refactor"}]
+ :resolution/verification-needed? true
+ :resolution/commit-message "fix: resolve merge conflicts with main"}
+```
+
+### Resolution Strategies
+
+1. **Trivial conflicts** - Whitespace, import ordering → auto-resolve with high confidence
+2. **Additive conflicts** - Both sides added code → merge both, verify tests pass
+3. **Semantic conflicts** - Both sides modified same logic → requires understanding
+4. **Structural conflicts** - Refactoring vs. feature changes → may need re-implementation
+
+### Confidence Levels and Actions
+
+| Confidence | Action                                            |
+| ---------- | ------------------------------------------------- |
+| High       | Auto-apply, push, continue                        |
+| Medium     | Apply, run tests, if pass continue, else escalate |
+| Low        | Create draft resolution, request human review     |
+
+### Semantic Conflict Detection
+
+Git doesn't detect semantic conflicts:
+
+```clojure
+;; Main renamed user-id → account-id everywhere
+;; Our branch added code using user-id
+;; Git: "no conflict!"
+;; Reality: broken code
+```
+
+The agent should:
+
+1. After resolution, run full test suite
+2. Run static analysis (undefined symbols, type errors)
+3. If issues found, treat as conflict requiring re-implementation
+
+---
+
+## Component: Comment Response Agent
+
+Handles comments on PRs from bots and humans.
+
+### Bot Comment Handling
+
+| Bot        | Comment Pattern          | Action                           |
+| ---------- | ------------------------ | -------------------------------- |
+| Dependabot | Version update available | Evaluate and update if safe      |
+| CodeQL     | Security finding         | Assess severity, fix if critical |
+| Codecov    | Coverage decreased       | Add tests or justify             |
+| Renovate   | Dependency update        | Same as Dependabot               |
+
+### Human Comment Handling
+
+1. **Parse intent** - Question? Request for change? Approval?
+2. **Categorize** - Code style, logic, design, clarification
+3. **Generate response** - Answer question or implement change
+4. **Push update** - If change made, push and respond with summary
+
+### Response Format
+
+```clojure
+{:response/comment-id 12345
+ :response/in-reply-to "Can you add error handling for network timeouts?"
+ :response/action :code-change|:clarification|:question
+ :response/body "Added timeout handling in `fetch-user`. The default is 30s, configurable via `FETCH_TIMEOUT_MS`."
+ :response/commits-pushed ["abc1234"]
+ :response/files-changed ["src/api/client.clj"]}
+```
+
+---
+
+## Component: CI Failure Handler
+
+When CI fails after PR creation or after conflict resolution:
+
+1. **Parse failure** - Which check failed? What's the error?
+2. **Categorize** - Test failure, lint error, build error, security scan
+3. **Route to appropriate agent**:
+   - Test failure → Tester agent (fix test or fix code)
+   - Lint error → Implementer agent (auto-fix)
+   - Build error → Implementer agent (fix compilation)
+   - Security scan → Security review, may need human
+
+### Retry Budget
+
+The workflow has a budget for CI fix attempts:
+
+```clojure
+{:budget/max-ci-fix-attempts 3
+ :budget/max-conflict-resolution-attempts 2
+ :budget/max-comment-responses 5
+ :budget/abandon-after-hours 72}
+```
+
+If budget exhausted → signal for human intervention.
+
+---
+
+## Integration with Existing Specs
+
+### N2 - Workflows
+
+PR Monitoring is a new workflow type:
+
+```clojure
+{:workflow/type :pr-monitoring
+ :workflow/trigger :webhook|:poll|:manual
+ :workflow/phases [:watch :triage :handle :signal]
+ :workflow/budget {...}}
+```
+
+### N3 - Events
+
+New event types for PR monitoring:
+
+```clojure
+;; Conflict detected
+{:event/type :pr-monitor/conflict-detected
+ :pr/url "..."
+ :conflict/files [...]}
+
+;; Conflict resolved
+{:event/type :pr-monitor/conflict-resolved
+ :resolution/strategy :auto
+ :resolution/confidence :high}
+
+;; Comment received
+{:event/type :pr-monitor/comment-received
+ :comment/author "reviewer"
+ :comment/type :human|:bot}
+
+;; PR ready
+{:event/type :pr-monitor/ready-for-merge
+ :pr/url "..."
+ :checks/all-passed true}
+```
+
+### N6 - Evidence
+
+PR monitoring adds to the evidence bundle:
+
+```clojure
+{:evidence/pr-lifecycle
+ {:created-at #inst "..."
+  :conflicts-resolved [{:at #inst "..." :strategy :auto}]
+  :comments-addressed [{:comment-id 123 :response "..."}]
+  :ci-failures-fixed [{:check "lint" :fixed-at #inst "..."}]
+  :ready-at #inst "..."
+  :total-monitoring-duration-hours 4.5}}
+```
+
+---
+
+## Operational Modes
+
+### Fully Autonomous
+
+```clojure
+{:mode :autonomous
+ :auto-resolve-conflicts true
+ :auto-respond-comments true
+ :auto-fix-ci true
+ :human-merge-required true} ;; Human still clicks merge
+```
+
+### Supervised
+
+```clojure
+{:mode :supervised
+ :auto-resolve-conflicts false ;; Creates draft, waits for approval
+ :auto-respond-comments :bots-only
+ :auto-fix-ci true
+ :human-approval-required-for [:conflict-resolution :human-comments]}
+```
+
+### Monitor Only
+
+```clojure
+{:mode :monitor-only
+ :notify-on [:conflict :ci-failure :comment]
+ :auto-actions false}
+```
+
+---
+
+## Future Considerations
+
+### Learning from Resolutions
+
+Over time, the system can learn:
+
+- Common conflict patterns in this codebase
+- Which bot comments can be auto-addressed
+- Reviewer preferences and common feedback
+
+### Multi-PR Coordination
+
+When multiple PRs conflict with each other:
+
+- Detect PR-to-PR conflicts
+- Suggest merge order
+- Rebase dependent PRs after merge
+
+### Merge Automation
+
+With sufficient confidence and policy approval:
+
+- Auto-merge when all checks pass
+- Respect branch protection rules
+- Honor merge queue if configured
+
+---
+
+## Implementation Priority
+
+1. **Phase 1: Conflict Resolution Agent** - Core capability, most common need
+2. **Phase 2: Bot Comment Handler** - Low-risk automation
+3. **Phase 3: CI Failure Handler** - Ties into existing agents
+4. **Phase 4: Human Comment Response** - Requires careful prompt engineering
+5. **Phase 5: Full Workflow Integration** - Webhook handling, polling, event loop
+
+---
+
+## Relationship to Release Phase
+
+```text
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│  Implement      │────▶│  Release        │────▶│  PR Monitoring  │
+│  Phase          │     │  Phase          │     │  Workflow       │
+│                 │     │                 │     │                 │
+│  Writes code    │     │  Creates PR     │     │  Shepherds PR   │
+│                 │     │  with artifacts │     │  to merge-ready │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+                                                        │
+                                                        ▼
+                                                 Human merges
+```
+
+The release phase we just built creates the PR. PR Monitoring takes over from there.
+
+---
+
+**Version:** 0.1.0-draft
+**Last Updated:** 2026-02-01


### PR DESCRIPTION
## Summary

- Add new `release-executor` component with full release flow for creating PRs from code artifacts
- Add `releaser` agent for LLM-generated release metadata (branch names, commit messages, PR titles/descriptions)
- Add PR Monitoring Workflow spec (informative) documenting future conflict resolution capabilities

## Changes

### New release-executor component
- Check GitHub CLI authentication
- Generate release metadata (fallback when LLM unavailable)
- Create git branch from main/master
- Write files, stage, commit, push, and create PR
- Full test coverage

### Releaser agent
- LLM-based agent following specialized agent pattern
- Generates conventional commit messages, descriptive PR titles
- Falls back to template-based metadata when unavailable

### Architecture
Extracted `release-executor` to separate component to avoid circular dependency between `workflow` and `phase` components (workflow → phase → workflow).

### Specs
- Added `specs/informative/pr-monitoring-workflow.md` documenting future:
  - Conflict Resolution Agent
  - Comment Response Agent  
  - CI Failure Handler
  - Multi-PR coordination

## Test plan

- [x] All pre-commit checks pass
- [x] All 500+ tests pass
- [x] Poly check passes (no circular dependencies)
- [x] Integration tests for release flow (17 tests, 71 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)