### PR TITLE
feat(tool-registry): add extensible tool registry with LSP support

### DIFF
--- a/components/tool-registry/deps.edn
+++ b/components/tool-registry/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/logging {:local/root "../logging"}
+        ai.miniforge/schema {:local/root "../schema"}
+        metosin/malli {:mvn/version "0.16.4"}
+        org.clojure/core.async {:mvn/version "1.6.681"}
+        cheshire/cheshire {:mvn/version "5.13.0"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/tool-registry/resources/tools/lsp/clojure.edn
+++ b/components/tool-registry/resources/tools/lsp/clojure.edn
@@ -1,0 +1,29 @@
+;; Clojure Language Server Protocol configuration
+;; https://clojure-lsp.io/
+
+{:tool/id          :lsp/clojure
+ :tool/type        :lsp
+ :tool/name        "Clojure LSP"
+ :tool/description "Language server for Clojure and ClojureScript providing code intelligence, refactoring, and diagnostics"
+ :tool/version     "1.0.0"
+
+ :tool/config
+ {:lsp/command        ["clojure-lsp"]
+  :lsp/languages      #{"clojure" "clojurescript" "edn"}
+  :lsp/file-patterns  ["**/*.clj" "**/*.cljs" "**/*.cljc" "**/*.edn"]
+  :lsp/capabilities   #{:diagnostics :format :hover :completion
+                        :definition :references :rename
+                        :code-action :document-symbol :workspace-symbol}
+  :lsp/start-mode     :on-demand
+  :lsp/shutdown-after-ms 300000  ; 5 minutes idle timeout
+  :lsp/init-options   {:dependency-scheme "jar"
+                       :text-document-sync-kind 1
+                       :hover {:arity-on-same-line? true}}}
+
+ :tool/capabilities  #{:code/diagnostics :code/format :code/hover
+                       :code/completion :code/navigation :code/refactor
+                       :code/symbols}
+
+ :tool/requires      #{:subprocess/spawn}
+ :tool/enabled       true
+ :tool/tags          #{:language-server :clojure :clojurescript :lisp}}

--- a/components/tool-registry/src/ai/miniforge/tool_registry/interface.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/interface.clj
@@ -1,0 +1,375 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool-registry.interface
+  "Public API for the tool-registry component.
+
+   Provides an extensible tool registry that agents can use, with LSP
+   servers as a first-class tool type. Tools are defined via EDN files
+   that can be dropped into standard locations for easy management.
+
+   Layer structure:
+   Layer 0: Schema re-exports and type definitions
+   Layer 1: Registry creation and tool management
+   Layer 2: LSP server lifecycle management
+   Layer 3: Tool discovery and loading
+   Layer 4: Dashboard integration helpers
+
+   File locations (discovery order, later overrides earlier):
+   1. Built-in: resources/tools/**/*.edn
+   2. User: ~/.miniforge/tools/**/*.edn
+   3. Project: .miniforge/tools/**/*.edn
+
+   Tool types supported:
+   - :function - Simple function-based tools
+   - :lsp - Language Server Protocol servers
+   - :mcp - Model Context Protocol servers (future)
+   - :external - External process tools (future)
+
+   Example:
+     ;; Create a registry with auto-loading
+     (def registry (create-registry {:auto-load? true}))
+
+     ;; List available tools
+     (list-tools registry)
+
+     ;; Start an LSP server
+     (start-lsp registry :lsp/clojure)
+
+     ;; Get tools for a specific context
+     (tools-for-context registry #{:code/diagnostics})
+
+   See docs/specs/extensibility.spec for full specification."
+  (:require
+   [ai.miniforge.tool-registry.schema :as schema]
+   [ai.miniforge.tool-registry.registry :as registry]
+   [ai.miniforge.tool-registry.loader :as loader]
+   [ai.miniforge.tool-registry.lsp.manager :as lsp-manager]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema re-exports
+
+(def ToolConfig
+  "Malli schema for tool configuration."
+  schema/ToolConfig)
+
+(def LSPConfig
+  "Malli schema for LSP-specific configuration."
+  schema/LSPConfig)
+
+(def tool-types
+  "Set of supported tool types."
+  schema/tool-types)
+
+(def lsp-capabilities
+  "Set of supported LSP capabilities."
+  schema/lsp-capabilities)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registry creation and management
+
+(defn create-registry
+  "Create a new tool registry.
+
+   Options:
+   - :auto-load?  - Load tools from standard locations on creation (default: false)
+   - :watch?      - Watch for file changes and hot-reload (default: false)
+   - :logger      - Logger instance for events
+   - :project-dir - Project directory for .miniforge/tools/ lookup
+
+   Returns a ToolRegistry instance.
+
+   Example:
+     (create-registry)
+     (create-registry {:auto-load? true :watch? true})"
+  ([] (create-registry {}))
+  ([opts] (registry/create-registry opts)))
+
+(defn register!
+  "Register a tool in the registry.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - tool     - Tool configuration map
+
+   Returns the tool ID on success.
+   Throws if tool config is invalid.
+
+   Example:
+     (register! registry {:tool/id :lsp/python
+                          :tool/type :lsp
+                          :tool/name \"Python LSP\"
+                          ...})"
+  [registry tool]
+  (registry/register-tool registry tool))
+
+(defn unregister!
+  "Remove a tool from the registry.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - tool-id  - Tool identifier keyword
+
+   Returns the tool ID."
+  [registry tool-id]
+  (registry/unregister-tool registry tool-id))
+
+(defn get-tool
+  "Retrieve a tool by ID.
+
+   Returns the tool configuration map or nil if not found."
+  [registry tool-id]
+  (registry/get-tool registry tool-id))
+
+(defn list-tools
+  "List all registered tools.
+
+   Returns a sequence of tool configuration maps."
+  [registry]
+  (registry/list-tools registry))
+
+(defn find-tools
+  "Find tools matching a query.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - query    - Map with optional keys:
+                :type - Tool type (:function, :lsp, :mcp, :external)
+                :capabilities - Set of required capabilities
+                :tags - Set of tags to match
+                :enabled - Boolean filter for enabled status
+                :text - Text search in name/description
+
+   Returns sequence of matching tools.
+
+   Example:
+     (find-tools registry {:type :lsp})
+     (find-tools registry {:capabilities #{:code/diagnostics}})
+     (find-tools registry {:tags #{:clojure} :enabled true})"
+  [registry query]
+  (registry/find-tools registry query))
+
+(defn update-tool!
+  "Update a tool's configuration.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - tool-id  - Tool identifier
+   - updates  - Map of updates to merge
+
+   Returns updated tool configuration."
+  [registry tool-id updates]
+  (registry/update-tool registry tool-id updates))
+
+(defn enable-tool!
+  "Enable a tool."
+  [registry tool-id]
+  (registry/update-tool registry tool-id {:tool/enabled true}))
+
+(defn disable-tool!
+  "Disable a tool."
+  [registry tool-id]
+  (registry/update-tool registry tool-id {:tool/enabled false}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; LSP server lifecycle
+
+(defn start-lsp
+  "Start an LSP server for a tool.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - tool-id  - LSP tool identifier
+
+   Returns:
+   - {:success? true :client LSPClient} on success
+   - {:success? false :error string} on failure
+
+   Example:
+     (start-lsp registry :lsp/clojure)"
+  [registry tool-id]
+  (lsp-manager/start-server registry tool-id))
+
+(defn stop-lsp
+  "Stop an LSP server.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - tool-id  - LSP tool identifier
+
+   Returns:
+   - {:success? true} on success
+   - {:success? false :error string} on failure"
+  [registry tool-id]
+  (lsp-manager/stop-server registry tool-id))
+
+(defn lsp-status
+  "Get the status of an LSP server.
+
+   Returns one of:
+   - :stopped  - Server is not running
+   - :starting - Server is starting up
+   - :running  - Server is running and healthy
+   - :error    - Server encountered an error"
+  [registry tool-id]
+  (lsp-manager/server-status registry tool-id))
+
+(defn get-lsp-client
+  "Get the LSP client for a tool, starting the server if needed.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - tool-id  - LSP tool identifier
+
+   Returns LSP client or nil if unavailable."
+  [registry tool-id]
+  (lsp-manager/get-client registry tool-id))
+
+(defn list-lsp-servers
+  "List all LSP servers with their status.
+
+   Returns sequence of {:tool-id :status :uptime-ms}."
+  [registry]
+  (lsp-manager/list-servers registry))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Tool discovery and loading
+
+(defn load-tools
+  "Load tools from standard locations into the registry.
+
+   Discovery order (later overrides earlier):
+   1. Built-in: resources/tools/**/*.edn
+   2. User: ~/.miniforge/tools/**/*.edn
+   3. Project: .miniforge/tools/**/*.edn (if :project-dir set)
+
+   Arguments:
+   - registry - ToolRegistry instance
+
+   Returns:
+   - {:loaded [tool-ids...] :failed [{:path :error}...]}
+
+   Example:
+     (load-tools registry)"
+  [registry]
+  (loader/load-all-tools registry))
+
+(defn load-tool-file
+  "Load a single tool configuration file.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - path     - Path to .edn file
+
+   Returns:
+   - {:success? true :tool-id keyword} on success
+   - {:success? false :error string} on failure"
+  [registry path]
+  (loader/load-tool-file registry path))
+
+(defn discover-tools
+  "Discover tool files without loading them.
+
+   Arguments:
+   - registry - ToolRegistry instance
+
+   Returns sequence of {:path :type :source} where source is
+   :builtin, :user, or :project."
+  [registry]
+  (loader/discover-tools registry))
+
+(defn reload-tools
+  "Reload all tools from disk.
+
+   Clears and reloads the entire registry.
+
+   Returns:
+   - {:loaded [tool-ids...] :failed [{:path :error}...]}"
+  [registry]
+  (loader/reload-all-tools registry))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Agent and dashboard integration
+
+(defn tools-for-context
+  "Get tools available for a given capability context.
+
+   Filters tools by:
+   - Enabled status
+   - Required capabilities match
+
+   Arguments:
+   - registry     - ToolRegistry instance
+   - capabilities - Set of required capability keywords
+
+   Returns sequence of tool configurations.
+
+   Example:
+     (tools-for-context registry #{:code/diagnostics :code/format})"
+  [registry capabilities]
+  (registry/tools-for-context registry capabilities))
+
+(defn tools-with-status
+  "Get all tools with their current runtime status.
+
+   For LSP tools, includes server status.
+   For function tools, always :available.
+
+   Returns sequence of maps with :tool and :status keys.
+
+   Example:
+     (tools-with-status registry)
+     ;; => [{:tool {...} :status :running}
+     ;;     {:tool {...} :status :stopped}]"
+  [registry]
+  (registry/tools-with-status registry))
+
+(defn registry-stats
+  "Get statistics about the registry.
+
+   Returns:
+   - {:total count
+      :by-type {:lsp n :function n ...}
+      :enabled count
+      :lsp-running count}"
+  [registry]
+  (registry/registry-stats registry))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create a registry
+  (def reg (create-registry {:auto-load? true}))
+
+  ;; List all tools
+  (list-tools reg)
+
+  ;; Find LSP tools
+  (find-tools reg {:type :lsp})
+
+  ;; Find tools with specific capabilities
+  (find-tools reg {:capabilities #{:code/diagnostics}})
+
+  ;; Start Clojure LSP
+  (start-lsp reg :lsp/clojure)
+
+  ;; Check status
+  (lsp-status reg :lsp/clojure)
+
+  ;; Get stats
+  (registry-stats reg)
+
+  ;; Tools for agent context
+  (tools-for-context reg #{:code/format})
+
+  :leave-this-here)

--- a/components/tool-registry/src/ai/miniforge/tool_registry/loader.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/loader.clj
@@ -1,0 +1,253 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool-registry.loader
+  "Load tool configurations from EDN files.
+
+   Layer 0: File discovery and path utilities
+   Layer 1: EDN parsing and validation
+   Layer 2: Single file loader
+   Layer 3: Bulk loading orchestration
+
+   Discovery order (later overrides earlier):
+   1. Built-in: resources/tools/**/*.edn
+   2. User: ~/.miniforge/tools/**/*.edn
+   3. Project: .miniforge/tools/**/*.edn"
+  (:require
+   [ai.miniforge.tool-registry.schema :as schema]
+   [ai.miniforge.logging.interface :as log]
+   [clojure.java.io :as io]
+   [clojure.edn :as edn]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; File discovery and path utilities
+
+(defn- user-tools-dir
+  "Get the user tools directory (~/.miniforge/tools)."
+  []
+  (io/file (System/getProperty "user.home") ".miniforge" "tools"))
+
+(defn- project-tools-dir
+  "Get the project tools directory (.miniforge/tools)."
+  [project-dir]
+  (when project-dir
+    (io/file project-dir ".miniforge" "tools")))
+
+(defn- builtin-tools-dirs
+  "Get built-in tools directories from classpath resources."
+  []
+  ;; Look for tools directory in resources
+  (when-let [url (io/resource "tools")]
+    (when (= "file" (.getProtocol url))
+      [(io/file (.toURI url))])))
+
+(defn- tool-file?
+  "Check if a file is a tool configuration file (.edn)."
+  [file]
+  (and (.isFile file)
+       (str/ends-with? (.getName file) ".edn")
+       (not (str/starts-with? (.getName file) "."))))
+
+(defn- find-tool-files
+  "Find all .edn files in a directory, recursively."
+  [dir]
+  (when (and dir (.exists dir) (.isDirectory dir))
+    (->> (file-seq dir)
+         (filter tool-file?)
+         (vec))))
+
+(defn- infer-tool-type
+  "Infer tool type from file path.
+
+   Path patterns:
+   - tools/lsp/*.edn -> :lsp
+   - tools/mcp/*.edn -> :mcp
+   - tools/function/*.edn -> :function
+   - tools/custom/*.edn -> :external"
+  [file]
+  (let [path (.getPath file)
+        parent-name (some-> file .getParentFile .getName)]
+    (case parent-name
+      "lsp" :lsp
+      "mcp" :mcp
+      "function" :function
+      "custom" :external
+      nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; EDN parsing and validation
+
+(defn- safe-read-edn
+  "Safely read EDN from a file.
+   Returns {:success? bool :data any :error string}."
+  [file]
+  (try
+    (let [content (slurp file)
+          data (edn/read-string content)]
+      (schema/success :data data))
+    (catch Exception e
+      (schema/failure :data (.getMessage e)))))
+
+(defn- validate-and-normalize
+  "Validate and normalize a tool configuration."
+  [tool file-path]
+  (let [normalized (schema/normalize-tool tool)
+        {:keys [valid? errors]} (schema/validate-tool normalized)]
+    (if valid?
+      (schema/success :tool normalized)
+      (schema/failure-with-errors :tool
+                                  [{:file file-path :errors errors}]))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Single file loader
+
+(defn load-tool-from-file
+  "Load a tool configuration from a single EDN file.
+
+   Arguments:
+   - file-path - Path to the .edn file
+
+   Returns:
+   - {:success? true :tool ToolConfig}
+   - {:success? false :errors [...]}
+
+   Example:
+     (load-tool-from-file \"~/.miniforge/tools/lsp/clojure.edn\")"
+  [file-path]
+  (let [file (io/file file-path)]
+    (if-not (.exists file)
+      (schema/failure-with-errors :tool [{:file file-path :error "File not found"}])
+      (let [{:keys [success? data error]} (safe-read-edn file)]
+        (if-not success?
+          (schema/failure-with-errors :tool [{:file file-path :error error}])
+          ;; Infer type if not specified
+          (let [inferred-type (infer-tool-type file)
+                tool (cond-> data
+                       (and inferred-type (not (:tool/type data)))
+                       (assoc :tool/type inferred-type))]
+            (validate-and-normalize tool file-path)))))))
+
+(defn load-tool-file
+  "Load a tool file and register it in the registry.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - path     - Path to .edn file
+
+   Returns:
+   - {:success? true :tool-id keyword}
+   - {:success? false :error string}"
+  [registry path]
+  (let [{:keys [success? tool errors]} (load-tool-from-file path)]
+    (if success?
+      (try
+        (let [register-fn (:register-fn @(:state registry))]
+          (register-fn tool)
+          (schema/success :tool-id (:tool/id tool)))
+        (catch Exception e
+          (schema/failure :tool-id (.getMessage e))))
+      (schema/failure-with-errors :tool-id errors))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Discovery and bulk loading
+
+(defn discover-tools
+  "Discover tool files without loading them.
+
+   Arguments:
+   - registry - ToolRegistry instance (for project-dir)
+
+   Returns sequence of {:path :source :inferred-type}"
+  [registry]
+  (let [project-dir (:project-dir @(:state registry))
+        builtin-dirs (builtin-tools-dirs)
+        user-dir (user-tools-dir)
+        project-dir-file (project-tools-dir project-dir)
+
+        discover-in-dir (fn [dir source]
+                          (for [file (find-tool-files dir)]
+                            {:path (.getPath file)
+                             :source source
+                             :inferred-type (infer-tool-type file)}))]
+
+    (concat
+     ;; Built-in tools
+     (mapcat #(discover-in-dir % :builtin) builtin-dirs)
+     ;; User tools
+     (discover-in-dir user-dir :user)
+     ;; Project tools
+     (when project-dir-file
+       (discover-in-dir project-dir-file :project)))))
+
+(defn load-all-tools
+  "Load all tools from standard locations into the registry.
+
+   Discovery order (later overrides earlier):
+   1. Built-in: resources/tools/**/*.edn
+   2. User: ~/.miniforge/tools/**/*.edn
+   3. Project: .miniforge/tools/**/*.edn
+
+   Arguments:
+   - registry - ToolRegistry instance
+
+   Returns:
+   - {:loaded [tool-ids...] :failed [{:path :error}...]}"
+  [registry]
+  (let [discovered (discover-tools registry)
+        logger (:logger @(:state registry))
+        results (for [{:keys [path]} discovered]
+                  (let [result (load-tool-file registry path)]
+                    (when logger
+                      (if (:success? result)
+                        (log/debug logger :system :tool-registry/loaded
+                                   {:data {:tool-id (:tool-id result) :path path}})
+                        (log/warn logger :system :tool-registry/load-failed
+                                  {:data {:path path :error (:error result)}})))
+                    (assoc result :path path)))
+        loaded (vec (keep :tool-id (filter :success? results)))
+        failed (vec (for [r (remove :success? results)]
+                      {:path (:path r) :error (or (:error r) (:errors r))}))]
+    {:loaded loaded
+     :failed failed}))
+
+(defn reload-all-tools
+  "Clear registry and reload all tools from disk.
+
+   Arguments:
+   - registry - ToolRegistry instance
+
+   Returns:
+   - {:loaded [tool-ids...] :failed [{:path :error}...]}"
+  [registry]
+  (let [clear-fn (:clear-fn @(:state registry))]
+    (clear-fn)
+    (load-all-tools registry)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Discover tools
+  (discover-tools {:state (atom {:project-dir "."})})
+
+  ;; Load a single tool file
+  (load-tool-from-file "path/to/tool.edn")
+
+  ;; User tools directory
+  (user-tools-dir)
+  ;; => #object[java.io.File ... "~/.miniforge/tools"]
+
+  ;; Find tool files
+  (find-tool-files (user-tools-dir))
+
+  :leave-this-here)

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/client.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/client.clj
@@ -22,6 +22,7 @@
   (:require
    [ai.miniforge.tool-registry.lsp.protocol :as proto]
    [ai.miniforge.tool-registry.lsp.process :as process]
+   [ai.miniforge.tool-registry.schema :as schema]
    [cheshire.core :as json]
    [clojure.core.async :as async :refer [go go-loop <! >! chan close!]]
    [clojure.string :as str])
@@ -148,15 +149,14 @@
          result (deref p timeout-ms ::timeout)]
      (cond
        (= result ::timeout)
-       {:success? false :error "Request timed out"}
+       (schema/err "Request timed out")
 
        (proto/error? result)
-       {:success? false
-        :error (get-in result [:error :message] "Unknown error")
-        :code (get-in result [:error :code])}
+       (schema/err :code (get-in result [:error :code])
+                   (get-in result [:error :message] "Unknown error"))
 
        :else
-       {:success? true :result (:result result)}))))
+       (schema/ok :result (:result result))))))
 
 (defn send-notification
   "Send a notification (no response expected).
@@ -218,8 +218,8 @@
         (send-notification client (proto/initialized-notification))
         (reset! (:initialized? client) true)
         (process/mark-running! (:process client))
-        {:success? true :capabilities (:capabilities result)})
-      {:success? false :error error})))
+        (schema/ok :capabilities (:capabilities result)))
+      (schema/err error))))
 
 (defn shutdown
   "Shutdown the LSP server gracefully.
@@ -233,8 +233,8 @@
       (do
         (send-notification client (proto/exit-notification))
         (reset! (:initialized? client) false)
-        {:success? true})
-      {:success? false :error error})))
+        (schema/ok))
+      (schema/err error))))
 
 (defn initialized?
   "Check if the client has been initialized."

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/client.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/client.clj
@@ -1,0 +1,360 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool-registry.lsp.client
+  "LSP client for communicating with language servers.
+
+   Layer 0: Client state and protocol
+   Layer 1: Message I/O (read/write)
+   Layer 2: Request/response handling
+   Layer 3: High-level operations"
+  (:require
+   [ai.miniforge.tool-registry.lsp.protocol :as proto]
+   [ai.miniforge.tool-registry.lsp.process :as process]
+   [cheshire.core :as json]
+   [clojure.core.async :as async :refer [go go-loop <! >! chan close!]]
+   [clojure.string :as str])
+  (:import
+   [java.io BufferedReader InputStreamReader BufferedWriter OutputStreamWriter]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Client state and protocol
+
+(defrecord LSPClient
+  [process
+   tool-id
+   reader
+   writer
+   pending-requests  ; atom: {id -> {:promise :timeout-ch}}
+   server-capabilities
+   initialized?
+   notification-handler])
+
+(def default-timeout-ms 30000)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Message I/O
+
+(defn- read-headers
+  "Read LSP headers from the reader until blank line."
+  [^BufferedReader reader]
+  (loop [headers {}]
+    (let [line (.readLine reader)]
+      (cond
+        (nil? line)
+        nil ; EOF
+
+        (str/blank? line)
+        headers
+
+        :else
+        (let [[_ key value] (re-matches #"([^:]+):\s*(.+)" line)]
+          (recur (assoc headers (str/lower-case (or key "")) value)))))))
+
+(defn- read-message
+  "Read a single LSP message from the reader.
+   Returns the parsed message or nil on EOF/error."
+  [^BufferedReader reader]
+  (try
+    (when-let [headers (read-headers reader)]
+      (when-let [content-length (some-> (get headers "content-length") parse-long)]
+        (let [buffer (char-array content-length)
+              _ (.read reader buffer 0 content-length)
+              json-str (String. buffer)]
+          (proto/decode-message json-str))))
+    (catch Exception e
+      (println "LSP read error:" (.getMessage e))
+      nil)))
+
+(defn- write-message
+  "Write an LSP message to the writer."
+  [^BufferedWriter writer msg]
+  (let [encoded (proto/encode-message msg)]
+    (.write writer encoded)
+    (.flush writer)))
+
+(defn- start-reader-loop
+  "Start a background loop reading messages from the server."
+  [client]
+  (let [{:keys [reader pending-requests notification-handler]} client]
+    (go-loop []
+      (when-let [msg (read-message reader)]
+        (cond
+          ;; Response to a request
+          (proto/response? msg)
+          (when-let [{:keys [promise]} (get @pending-requests (:id msg))]
+            (swap! pending-requests dissoc (:id msg))
+            (deliver promise msg))
+
+          ;; Notification from server
+          (proto/notification? msg)
+          (when notification-handler
+            (try
+              (notification-handler msg)
+              (catch Exception e
+                (println "Notification handler error:" (.getMessage e)))))
+
+          ;; Request from server (not common, but possible)
+          (proto/request? msg)
+          (println "Server request (unhandled):" (:method msg)))
+
+        (recur)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Request/response handling
+
+(defn send-request
+  "Send a request and return a promise for the response.
+
+   Arguments:
+   - client  - LSPClient instance
+   - request - Request message map
+
+   Returns a promise that will be delivered with the response."
+  [client request]
+  (let [{:keys [writer pending-requests]} client
+        id (:id request)
+        p (promise)]
+    (swap! pending-requests assoc id {:promise p})
+    (write-message writer request)
+    p))
+
+(defn send-request-sync
+  "Send a request and wait for the response synchronously.
+
+   Arguments:
+   - client     - LSPClient instance
+   - request    - Request message map
+   - timeout-ms - Timeout in milliseconds (default 30000)
+
+   Returns:
+   - {:success? true :result any} on success
+   - {:success? false :error string} on failure/timeout"
+  ([client request]
+   (send-request-sync client request default-timeout-ms))
+  ([client request timeout-ms]
+   (let [p (send-request client request)
+         result (deref p timeout-ms ::timeout)]
+     (cond
+       (= result ::timeout)
+       {:success? false :error "Request timed out"}
+
+       (proto/error? result)
+       {:success? false
+        :error (get-in result [:error :message] "Unknown error")
+        :code (get-in result [:error :code])}
+
+       :else
+       {:success? true :result (:result result)}))))
+
+(defn send-notification
+  "Send a notification (no response expected).
+
+   Arguments:
+   - client       - LSPClient instance
+   - notification - Notification message map"
+  [client notification]
+  (let [{:keys [writer]} client]
+    (write-message writer notification)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; High-level operations
+
+(defn create-client
+  "Create an LSP client from a running process.
+
+   Arguments:
+   - lsp-process          - LSPProcess record
+   - notification-handler - Optional fn to handle server notifications
+
+   Returns an LSPClient record."
+  [lsp-process notification-handler]
+  (let [in-stream (process/get-input-stream lsp-process)
+        out-stream (process/get-output-stream lsp-process)
+        reader (BufferedReader. (InputStreamReader. in-stream "UTF-8"))
+        writer (BufferedWriter. (OutputStreamWriter. out-stream "UTF-8"))
+        client (->LSPClient lsp-process
+                            (:tool-id lsp-process)
+                            reader
+                            writer
+                            (atom {})
+                            (atom nil)
+                            (atom false)
+                            notification-handler)]
+    ;; Start background reader
+    (start-reader-loop client)
+    client))
+
+(defn initialize
+  "Initialize the LSP server.
+
+   Arguments:
+   - client     - LSPClient instance
+   - root-uri   - Workspace root URI
+   - capabilities - Client capabilities map
+
+   Returns:
+   - {:success? true :capabilities server-capabilities}
+   - {:success? false :error string}"
+  [client root-uri capabilities]
+  (let [request (proto/initialize-request root-uri capabilities)
+        {:keys [success? result error]} (send-request-sync client request 60000)]
+    (if success?
+      (do
+        ;; Store server capabilities
+        (reset! (:server-capabilities client) (:capabilities result))
+        ;; Send initialized notification
+        (send-notification client (proto/initialized-notification))
+        (reset! (:initialized? client) true)
+        (process/mark-running! (:process client))
+        {:success? true :capabilities (:capabilities result)})
+      {:success? false :error error})))
+
+(defn shutdown
+  "Shutdown the LSP server gracefully.
+
+   Returns:
+   - {:success? true}
+   - {:success? false :error string}"
+  [client]
+  (let [{:keys [success? error]} (send-request-sync client (proto/shutdown-request) 10000)]
+    (if success?
+      (do
+        (send-notification client (proto/exit-notification))
+        (reset! (:initialized? client) false)
+        {:success? true})
+      {:success? false :error error})))
+
+(defn initialized?
+  "Check if the client has been initialized."
+  [client]
+  @(:initialized? client))
+
+(defn server-capabilities
+  "Get the server's capabilities."
+  [client]
+  @(:server-capabilities client))
+
+;; Document operations
+
+(defn open-document
+  "Notify server that a document was opened."
+  [client uri language-id text]
+  (send-notification client
+                     (proto/did-open-notification uri language-id 1 text)))
+
+(defn close-document
+  "Notify server that a document was closed."
+  [client uri]
+  (send-notification client
+                     (proto/did-close-notification uri)))
+
+(defn change-document
+  "Notify server of document changes."
+  [client uri version changes]
+  (send-notification client
+                     (proto/did-change-notification uri version changes)))
+
+;; Language features
+
+(defn hover
+  "Get hover information at a position.
+
+   Returns:
+   - {:success? true :result hover-info}
+   - {:success? false :error string}"
+  [client uri line character]
+  (send-request-sync client
+                     (proto/hover-request uri line character)))
+
+(defn completion
+  "Get completion items at a position.
+
+   Returns:
+   - {:success? true :result completion-list}
+   - {:success? false :error string}"
+  [client uri line character]
+  (send-request-sync client
+                     (proto/completion-request uri line character)))
+
+(defn definition
+  "Get definition location for symbol at position.
+
+   Returns:
+   - {:success? true :result location(s)}
+   - {:success? false :error string}"
+  [client uri line character]
+  (send-request-sync client
+                     (proto/definition-request uri line character)))
+
+(defn references
+  "Get references to symbol at position.
+
+   Returns:
+   - {:success? true :result locations}
+   - {:success? false :error string}"
+  [client uri line character include-declaration?]
+  (send-request-sync client
+                     (proto/references-request uri line character include-declaration?)))
+
+(defn format-document
+  "Format a document.
+
+   Returns:
+   - {:success? true :result text-edits}
+   - {:success? false :error string}"
+  [client uri options]
+  (send-request-sync client
+                     (proto/formatting-request uri options)))
+
+(defn document-symbols
+  "Get symbols in a document.
+
+   Returns:
+   - {:success? true :result symbols}
+   - {:success? false :error string}"
+  [client uri]
+  (send-request-sync client
+                     (proto/document-symbol-request uri)))
+
+(defn code-actions
+  "Get available code actions for a range.
+
+   Returns:
+   - {:success? true :result code-actions}
+   - {:success? false :error string}"
+  [client uri range diagnostics]
+  (send-request-sync client
+                     (proto/code-action-request uri range diagnostics)))
+
+(defn rename-symbol
+  "Rename a symbol.
+
+   Returns:
+   - {:success? true :result workspace-edit}
+   - {:success? false :error string}"
+  [client uri line character new-name]
+  (send-request-sync client
+                     (proto/rename-request uri line character new-name)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Example usage (requires running LSP server)
+  ;; (def proc (process/start-process :lsp/clojure ["clojure-lsp"] {}))
+  ;; (def client (create-client (:process proc) println))
+  ;; (initialize client "file:///workspace" {})
+  ;; (hover client "file:///workspace/src/foo.clj" 10 5)
+  ;; (shutdown client)
+
+  :leave-this-here)

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/manager.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/manager.clj
@@ -1,0 +1,286 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool-registry.lsp.manager
+  "LSP server lifecycle orchestration.
+
+   Manages starting, stopping, and accessing LSP servers for registered tools.
+
+   Layer 0: Manager state
+   Layer 1: Server lifecycle (start/stop)
+   Layer 2: Client access
+   Layer 3: Status and listing"
+  (:require
+   [ai.miniforge.tool-registry.lsp.process :as process]
+   [ai.miniforge.tool-registry.lsp.client :as client]
+   [ai.miniforge.tool-registry.schema :as schema]
+   [ai.miniforge.logging.interface :as log]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Manager state
+
+(defn- get-servers-atom
+  "Get the servers atom from registry state."
+  [registry]
+  (or (:lsp-servers @(:state registry))
+      (let [servers (atom {})]
+        (swap! (:state registry) assoc :lsp-servers servers)
+        servers)))
+
+(defn- get-logger
+  "Get logger from registry state."
+  [registry]
+  (:logger @(:state registry)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Server lifecycle
+
+(defn start-server
+  "Start an LSP server for a tool.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - tool-id  - LSP tool identifier
+
+   Returns:
+   - {:success? true :client LSPClient} on success
+   - {:success? false :error string} on failure"
+  [registry tool-id]
+  (let [servers (get-servers-atom registry)
+        logger (get-logger registry)
+        tool ((:get-tool-fn @(:state registry)) tool-id)]
+
+    (cond
+      ;; Tool not found
+      (nil? tool)
+      {:success? false :error (str "Tool not found: " tool-id)}
+
+      ;; Not an LSP tool
+      (not (schema/lsp-tool? tool))
+      {:success? false :error (str "Not an LSP tool: " tool-id)}
+
+      ;; Tool disabled
+      (not (schema/enabled? tool))
+      {:success? false :error (str "Tool is disabled: " tool-id)}
+
+      ;; Already running
+      (get @servers tool-id)
+      (let [entry (get @servers tool-id)]
+        (if (process/process-alive? (:process entry))
+          {:success? true :client (:client entry)}
+          ;; Process died, clean up and restart
+          (do
+            (swap! servers dissoc tool-id)
+            (start-server registry tool-id))))
+
+      :else
+      (let [config (:tool/config tool)
+            command (:lsp/command config)
+            opts {:env (:lsp/env config)
+                  :working-dir (:lsp/working-dir config)}]
+
+        (when logger
+          (log/info logger :system :lsp/starting
+                    {:data {:tool-id tool-id :command command}}))
+
+        (let [{:keys [success? process error]} (process/start-process tool-id command opts)]
+          (if-not success?
+            (do
+              (when logger
+                (log/error logger :system :lsp/start-failed
+                           {:data {:tool-id tool-id :error error}}))
+              {:success? false :error error})
+
+            ;; Create client and initialize
+            (let [notification-handler (fn [msg]
+                                         (when logger
+                                           (log/debug logger :system :lsp/notification
+                                                      {:data {:tool-id tool-id
+                                                              :method (:method msg)}})))
+                  lsp-client (client/create-client process notification-handler)
+                  ;; Initialize with workspace root
+                  root-uri (str "file://" (or (:lsp/working-dir config)
+                                              (System/getProperty "user.dir")))
+                  init-opts (:lsp/init-options config {})
+                  {:keys [success? capabilities error]} (client/initialize lsp-client root-uri init-opts)]
+
+              (if success?
+                (do
+                  (swap! servers assoc tool-id {:process process
+                                                :client lsp-client
+                                                :started-at (System/currentTimeMillis)
+                                                :capabilities capabilities})
+                  (when logger
+                    (log/info logger :system :lsp/started
+                              {:data {:tool-id tool-id}}))
+                  {:success? true :client lsp-client})
+
+                ;; Initialization failed, clean up
+                (do
+                  (process/stop-process process)
+                  (when logger
+                    (log/error logger :system :lsp/init-failed
+                               {:data {:tool-id tool-id :error error}}))
+                  {:success? false :error (str "Initialization failed: " error)})))))))))
+
+(defn stop-server
+  "Stop an LSP server.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - tool-id  - LSP tool identifier
+
+   Returns:
+   - {:success? true} on success
+   - {:success? false :error string} on failure"
+  [registry tool-id]
+  (let [servers (get-servers-atom registry)
+        logger (get-logger registry)
+        entry (get @servers tool-id)]
+
+    (if-not entry
+      {:success? false :error (str "Server not running: " tool-id)}
+
+      (do
+        (when logger
+          (log/info logger :system :lsp/stopping
+                    {:data {:tool-id tool-id}}))
+
+        ;; Graceful shutdown
+        (try
+          (client/shutdown (:client entry))
+          (catch Exception _))
+
+        ;; Stop process
+        (process/stop-process (:process entry))
+
+        (swap! servers dissoc tool-id)
+
+        (when logger
+          (log/info logger :system :lsp/stopped
+                    {:data {:tool-id tool-id}}))
+
+        {:success? true}))))
+
+(defn restart-server
+  "Restart an LSP server.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - tool-id  - LSP tool identifier
+
+   Returns result of start-server."
+  [registry tool-id]
+  (stop-server registry tool-id)
+  (start-server registry tool-id))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Client access
+
+(defn get-client
+  "Get the LSP client for a tool, starting the server if needed.
+
+   Arguments:
+   - registry - ToolRegistry instance
+   - tool-id  - LSP tool identifier
+
+   Returns LSP client or nil if unavailable."
+  [registry tool-id]
+  (let [servers (get-servers-atom registry)
+        entry (get @servers tool-id)]
+    (cond
+      ;; Already running
+      (and entry (process/process-alive? (:process entry)))
+      (:client entry)
+
+      ;; Not running, try to start
+      :else
+      (let [{:keys [success? client]} (start-server registry tool-id)]
+        (when success? client)))))
+
+(defn server-capabilities
+  "Get the capabilities of a running LSP server.
+
+   Returns the capabilities map or nil if not running."
+  [registry tool-id]
+  (let [servers (get-servers-atom registry)
+        entry (get @servers tool-id)]
+    (when entry
+      (:capabilities entry))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Status and listing
+
+(defn server-status
+  "Get the status of an LSP server.
+
+   Returns one of:
+   - :stopped  - Server is not running
+   - :starting - Server is starting up
+   - :running  - Server is running and healthy
+   - :error    - Server encountered an error"
+  [registry tool-id]
+  (let [servers (get-servers-atom registry)
+        entry (get @servers tool-id)]
+    (if-not entry
+      :stopped
+      (process/get-state (:process entry)))))
+
+(defn list-servers
+  "List all LSP servers with their status.
+
+   Returns sequence of {:tool-id :status :uptime-ms :capabilities}."
+  [registry]
+  (let [servers (get-servers-atom registry)]
+    (for [[tool-id entry] @servers]
+      (let [info (process/process-info (:process entry))]
+        {:tool-id tool-id
+         :status (:state info)
+         :uptime-ms (:uptime-ms info)
+         :capabilities (:capabilities entry)}))))
+
+(defn stop-all-servers
+  "Stop all running LSP servers.
+
+   Returns {:stopped [tool-ids...]}."
+  [registry]
+  (let [servers (get-servers-atom registry)
+        tool-ids (keys @servers)]
+    (doseq [tool-id tool-ids]
+      (stop-server registry tool-id))
+    {:stopped (vec tool-ids)}))
+
+;------------------------------------------------------------------------------ Integration
+
+(defn attach-to-registry
+  "Attach LSP manager functions to a registry.
+
+   This allows the registry to report LSP status for tools."
+  [registry]
+  (swap! (:state registry) assoc
+         :lsp-manager {:status-fn (fn [tool-id] (server-status registry tool-id))}
+         :get-tool-fn (fn [tool-id]
+                        (get @(:tools @(:state registry)) tool-id))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Example usage
+  ;; (def reg (registry/create-registry))
+  ;; (attach-to-registry reg)
+  ;; (start-server reg :lsp/clojure)
+  ;; (server-status reg :lsp/clojure)
+  ;; (list-servers reg)
+  ;; (stop-server reg :lsp/clojure)
+
+  :leave-this-here)

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/manager.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/manager.clj
@@ -18,9 +18,11 @@
    Manages starting, stopping, and accessing LSP servers for registered tools.
 
    Layer 0: Manager state
-   Layer 1: Server lifecycle (start/stop)
-   Layer 2: Client access
-   Layer 3: Status and listing"
+   Layer 1: Pipeline helpers
+   Layer 2: Pipeline steps
+   Layer 3: Server lifecycle (start/stop)
+   Layer 4: Client access
+   Layer 5: Status and listing"
   (:require
    [ai.miniforge.tool-registry.lsp.process :as process]
    [ai.miniforge.tool-registry.lsp.client :as client]
@@ -44,6 +46,149 @@
   (:logger @(:state registry)))
 
 ;------------------------------------------------------------------------------ Layer 1
+;; Pipeline helpers
+
+(defn- failed?
+  "Check if pipeline has failed."
+  [state]
+  (contains? state :failure))
+
+(defn- fail
+  "Mark pipeline as failed with error."
+  [state error-msg]
+  (when-let [logger (:logger state)]
+    (log/error logger :system :lsp/error
+               {:data {:tool-id (:tool-id state) :error error-msg}}))
+  (assoc state :failure {:error error-msg}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Pipeline steps
+
+(defn- step-validate-tool
+  "Validate tool exists, is LSP type, and is enabled."
+  [state]
+  (if (failed? state) state
+      (let [{:keys [tool tool-id]} state]
+        (cond
+          (nil? tool)
+          (fail state (str "Tool not found: " tool-id))
+
+          (not (schema/lsp-tool? tool))
+          (fail state (str "Not an LSP tool: " tool-id))
+
+          (not (schema/enabled? tool))
+          (fail state (str "Tool is disabled: " tool-id))
+
+          :else state))))
+
+(defn- step-check-existing
+  "Check if server already running; return early or clean up dead process."
+  [state]
+  (if (failed? state) state
+      (let [{:keys [servers tool-id]} state
+            entry (get @servers tool-id)]
+        (cond
+          ;; Not running
+          (nil? entry)
+          state
+
+          ;; Running and alive - short circuit with success
+          (process/process-alive? (:process entry))
+          (assoc state :early-return (schema/ok :client (:client entry)))
+
+          ;; Dead process - clean up and continue
+          :else
+          (do
+            (swap! servers dissoc tool-id)
+            state)))))
+
+(defn- step-start-process
+  "Start the LSP server process."
+  [state]
+  (cond
+    (failed? state) state
+    (:early-return state) state
+    :else
+    (let [{:keys [tool tool-id logger]} state
+          config (:tool/config tool)
+          command (:lsp/command config)
+          opts {:env (:lsp/env config)
+                :working-dir (:lsp/working-dir config)}]
+
+      (when logger
+        (log/info logger :system :lsp/starting
+                  {:data {:tool-id tool-id :command command}}))
+
+      (let [{:keys [success? process error]} (process/start-process tool-id command opts)]
+        (if success?
+          (assoc state :process process :config config)
+          (fail state error))))))
+
+(defn- step-create-client
+  "Create LSP client from running process."
+  [state]
+  (cond
+    (failed? state) state
+    (:early-return state) state
+    :else
+    (let [{:keys [process tool-id logger]} state
+          notification-handler (fn [msg]
+                                 (when logger
+                                   (log/debug logger :system :lsp/notification
+                                              {:data {:tool-id tool-id
+                                                      :method (:method msg)}})))
+          lsp-client (client/create-client process notification-handler)]
+      (assoc state :client lsp-client))))
+
+(defn- step-initialize
+  "Initialize LSP server connection."
+  [state]
+  (cond
+    (failed? state) state
+    (:early-return state) state
+    :else
+    (let [{:keys [client config process]} state
+          root-uri (str "file://" (or (:lsp/working-dir config)
+                                      (System/getProperty "user.dir")))
+          init-opts (:lsp/init-options config {})
+          {:keys [success? capabilities error]} (client/initialize client root-uri init-opts)]
+      (if success?
+        (assoc state :capabilities capabilities)
+        (do
+          (process/stop-process process)
+          (fail state (str "Initialization failed: " error)))))))
+
+(defn- step-register
+  "Register running server in servers atom."
+  [state]
+  (cond
+    (failed? state) state
+    (:early-return state) state
+    :else
+    (let [{:keys [servers tool-id process client capabilities logger]} state]
+      (swap! servers assoc tool-id {:process process
+                                    :client client
+                                    :started-at (System/currentTimeMillis)
+                                    :capabilities capabilities})
+      (when logger
+        (log/info logger :system :lsp/started
+                  {:data {:tool-id tool-id}}))
+      state)))
+
+(defn- pipeline->result
+  "Convert pipeline state to result."
+  [state]
+  (cond
+    (:early-return state)
+    (:early-return state)
+
+    (:failure state)
+    (schema/err (get-in state [:failure :error]))
+
+    :else
+    (schema/ok :client (:client state))))
+
+;------------------------------------------------------------------------------ Layer 3
 ;; Server lifecycle
 
 (defn start-server
@@ -59,80 +204,20 @@
   [registry tool-id]
   (let [servers (get-servers-atom registry)
         logger (get-logger registry)
-        tool ((:get-tool-fn @(:state registry)) tool-id)]
+        tool ((:get-tool-fn @(:state registry)) tool-id)
+        initial-state {:servers servers
+                       :logger logger
+                       :tool tool
+                       :tool-id tool-id}]
 
-    (cond
-      ;; Tool not found
-      (nil? tool)
-      (schema/err "Tool not found: " tool-id)
-
-      ;; Not an LSP tool
-      (not (schema/lsp-tool? tool))
-      (schema/err "Not an LSP tool: " tool-id)
-
-      ;; Tool disabled
-      (not (schema/enabled? tool))
-      (schema/err "Tool is disabled: " tool-id)
-
-      ;; Already running
-      (get @servers tool-id)
-      (let [entry (get @servers tool-id)]
-        (if (process/process-alive? (:process entry))
-          (schema/ok :client (:client entry))
-          ;; Process died, clean up and restart
-          (do
-            (swap! servers dissoc tool-id)
-            (start-server registry tool-id))))
-
-      :else
-      (let [config (:tool/config tool)
-            command (:lsp/command config)
-            opts {:env (:lsp/env config)
-                  :working-dir (:lsp/working-dir config)}]
-
-        (when logger
-          (log/info logger :system :lsp/starting
-                    {:data {:tool-id tool-id :command command}}))
-
-        (let [{:keys [success? process error]} (process/start-process tool-id command opts)]
-          (if-not success?
-            (do
-              (when logger
-                (log/error logger :system :lsp/start-failed
-                           {:data {:tool-id tool-id :error error}}))
-              (schema/err error))
-
-            ;; Create client and initialize
-            (let [notification-handler (fn [msg]
-                                         (when logger
-                                           (log/debug logger :system :lsp/notification
-                                                      {:data {:tool-id tool-id
-                                                              :method (:method msg)}})))
-                  lsp-client (client/create-client process notification-handler)
-                  ;; Initialize with workspace root
-                  root-uri (str "file://" (or (:lsp/working-dir config)
-                                              (System/getProperty "user.dir")))
-                  init-opts (:lsp/init-options config {})
-                  {:keys [success? capabilities error]} (client/initialize lsp-client root-uri init-opts)]
-
-              (if success?
-                (do
-                  (swap! servers assoc tool-id {:process process
-                                                :client lsp-client
-                                                :started-at (System/currentTimeMillis)
-                                                :capabilities capabilities})
-                  (when logger
-                    (log/info logger :system :lsp/started
-                              {:data {:tool-id tool-id}}))
-                  (schema/ok :client lsp-client))
-
-                ;; Initialization failed, clean up
-                (do
-                  (process/stop-process process)
-                  (when logger
-                    (log/error logger :system :lsp/init-failed
-                               {:data {:tool-id tool-id :error error}}))
-                  (schema/err "Initialization failed: " error))))))))))
+    (-> initial-state
+        step-validate-tool
+        step-check-existing
+        step-start-process
+        step-create-client
+        step-initialize
+        step-register
+        pipeline->result)))
 
 (defn stop-server
   "Stop an LSP server.
@@ -185,7 +270,7 @@
   (stop-server registry tool-id)
   (start-server registry tool-id))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 4
 ;; Client access
 
 (defn get-client
@@ -219,7 +304,7 @@
     (when entry
       (:capabilities entry))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 5
 ;; Status and listing
 
 (defn server-status

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/manager.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/manager.clj
@@ -64,21 +64,21 @@
     (cond
       ;; Tool not found
       (nil? tool)
-      {:success? false :error (str "Tool not found: " tool-id)}
+      (schema/err "Tool not found: " tool-id)
 
       ;; Not an LSP tool
       (not (schema/lsp-tool? tool))
-      {:success? false :error (str "Not an LSP tool: " tool-id)}
+      (schema/err "Not an LSP tool: " tool-id)
 
       ;; Tool disabled
       (not (schema/enabled? tool))
-      {:success? false :error (str "Tool is disabled: " tool-id)}
+      (schema/err "Tool is disabled: " tool-id)
 
       ;; Already running
       (get @servers tool-id)
       (let [entry (get @servers tool-id)]
         (if (process/process-alive? (:process entry))
-          {:success? true :client (:client entry)}
+          (schema/ok :client (:client entry))
           ;; Process died, clean up and restart
           (do
             (swap! servers dissoc tool-id)
@@ -100,7 +100,7 @@
               (when logger
                 (log/error logger :system :lsp/start-failed
                            {:data {:tool-id tool-id :error error}}))
-              {:success? false :error error})
+              (schema/err error))
 
             ;; Create client and initialize
             (let [notification-handler (fn [msg]
@@ -124,7 +124,7 @@
                   (when logger
                     (log/info logger :system :lsp/started
                               {:data {:tool-id tool-id}}))
-                  {:success? true :client lsp-client})
+                  (schema/ok :client lsp-client))
 
                 ;; Initialization failed, clean up
                 (do
@@ -132,7 +132,7 @@
                   (when logger
                     (log/error logger :system :lsp/init-failed
                                {:data {:tool-id tool-id :error error}}))
-                  {:success? false :error (str "Initialization failed: " error)})))))))))
+                  (schema/err "Initialization failed: " error))))))))))
 
 (defn stop-server
   "Stop an LSP server.
@@ -150,7 +150,7 @@
         entry (get @servers tool-id)]
 
     (if-not entry
-      {:success? false :error (str "Server not running: " tool-id)}
+      (schema/err "Server not running: " tool-id)
 
       (do
         (when logger
@@ -171,7 +171,7 @@
           (log/info logger :system :lsp/stopped
                     {:data {:tool-id tool-id}}))
 
-        {:success? true}))))
+        (schema/ok)))))
 
 (defn restart-server
   "Restart an LSP server.

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/process.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/process.clj
@@ -20,6 +20,7 @@
    Layer 2: Health checking
    Layer 3: Process info and cleanup"
   (:require
+   [ai.miniforge.tool-registry.schema :as schema]
    [clojure.java.io :as io]
    [clojure.string :as str])
   (:import
@@ -76,19 +77,17 @@
           stdin (.getOutputStream process)   ; We write to process stdin
           stdout (.getInputStream process)   ; We read from process stdout
           state-atom (atom :starting)]
-      {:success? true
-       :process (->LSPProcess process
-                              stdout  ; LSP messages come from process stdout
-                              stdin   ; We send to process stdin
-                              tool-id
-                              command
-                              (System/currentTimeMillis)
-                              state-atom
-                              env
-                              working-dir)})
+      (schema/ok :process (->LSPProcess process
+                                        stdout  ; LSP messages come from process stdout
+                                        stdin   ; We send to process stdin
+                                        tool-id
+                                        command
+                                        (System/currentTimeMillis)
+                                        state-atom
+                                        env
+                                        working-dir)))
     (catch Exception e
-      {:success? false
-       :error (str "Failed to start process: " (.getMessage e))})))
+      (schema/err "Failed to start process: " (.getMessage e)))))
 
 (defn stop-process
   "Stop an LSP server process.
@@ -118,10 +117,9 @@
             (.destroyForcibly process))))
 
       (reset! state-atom :stopped)
-      {:success? true})
+      (schema/ok))
     (catch Exception e
-      {:success? false
-       :error (str "Failed to stop process: " (.getMessage e))})))
+      (schema/err "Failed to stop process: " (.getMessage e)))))
 
 (defn process-alive?
   "Check if a process is still alive."

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/process.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/process.clj
@@ -1,0 +1,204 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool-registry.lsp.process
+  "LSP server process lifecycle management.
+
+   Layer 0: Process state definitions
+   Layer 1: Process start/stop
+   Layer 2: Health checking
+   Layer 3: Process info and cleanup"
+  (:require
+   [clojure.java.io :as io]
+   [clojure.string :as str])
+  (:import
+   [java.lang ProcessBuilder ProcessBuilder$Redirect]
+   [java.io InputStream OutputStream BufferedReader InputStreamReader]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Process state definitions
+
+(def process-states
+  "Valid process states."
+  #{:stopped :starting :running :stopping :error})
+
+(defrecord LSPProcess
+  [^Process process
+   ^InputStream stdin
+   ^OutputStream stdout
+   tool-id
+   command
+   started-at
+   state-atom
+   env
+   working-dir])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Process start/stop
+
+(defn start-process
+  "Start an LSP server process.
+
+   Arguments:
+   - tool-id     - Tool identifier
+   - command     - Vector of command and args [\"clojure-lsp\"]
+   - opts        - Options map:
+                   :env - Environment variables map
+                   :working-dir - Working directory path
+
+   Returns:
+   - {:success? true :process LSPProcess} on success
+   - {:success? false :error string} on failure"
+  [tool-id command opts]
+  (try
+    (let [{:keys [env working-dir]} opts
+          pb (ProcessBuilder. ^java.util.List (vec command))
+          _ (when working-dir
+              (.directory pb (io/file working-dir)))
+          _ (when env
+              (let [pb-env (.environment pb)]
+                (doseq [[k v] env]
+                  (.put pb-env k v))))
+          ;; Don't redirect stderr - let it go to parent process for debugging
+          _ (.redirectError pb ProcessBuilder$Redirect/INHERIT)
+          process (.start pb)
+          stdin (.getOutputStream process)   ; We write to process stdin
+          stdout (.getInputStream process)   ; We read from process stdout
+          state-atom (atom :starting)]
+      {:success? true
+       :process (->LSPProcess process
+                              stdout  ; LSP messages come from process stdout
+                              stdin   ; We send to process stdin
+                              tool-id
+                              command
+                              (System/currentTimeMillis)
+                              state-atom
+                              env
+                              working-dir)})
+    (catch Exception e
+      {:success? false
+       :error (str "Failed to start process: " (.getMessage e))})))
+
+(defn stop-process
+  "Stop an LSP server process.
+
+   Arguments:
+   - lsp-process - LSPProcess record
+
+   Returns:
+   - {:success? true} on success
+   - {:success? false :error string} on failure"
+  [lsp-process]
+  (try
+    (let [{:keys [process state-atom stdin stdout]} lsp-process]
+      (reset! state-atom :stopping)
+
+      ;; Close streams
+      (try (.close stdin) (catch Exception _))
+      (try (.close stdout) (catch Exception _))
+
+      ;; Destroy process
+      (when (.isAlive process)
+        (.destroy process)
+        ;; Wait up to 5 seconds for graceful shutdown
+        (let [exited? (.waitFor process 5 java.util.concurrent.TimeUnit/SECONDS)]
+          (when-not exited?
+            ;; Force kill if still running
+            (.destroyForcibly process))))
+
+      (reset! state-atom :stopped)
+      {:success? true})
+    (catch Exception e
+      {:success? false
+       :error (str "Failed to stop process: " (.getMessage e))})))
+
+(defn process-alive?
+  "Check if a process is still alive."
+  [lsp-process]
+  (when-let [process (:process lsp-process)]
+    (.isAlive process)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Health checking
+
+(defn get-state
+  "Get the current state of an LSP process."
+  [lsp-process]
+  (if lsp-process
+    (let [state @(:state-atom lsp-process)
+          alive? (process-alive? lsp-process)]
+      (cond
+        (and (= state :running) (not alive?)) :error
+        (and (= state :starting) (not alive?)) :error
+        :else state))
+    :stopped))
+
+(defn set-state!
+  "Set the state of an LSP process."
+  [lsp-process new-state]
+  (when (and lsp-process (contains? process-states new-state))
+    (reset! (:state-atom lsp-process) new-state)))
+
+(defn mark-running!
+  "Mark an LSP process as running (after successful initialization)."
+  [lsp-process]
+  (set-state! lsp-process :running))
+
+(defn mark-error!
+  "Mark an LSP process as errored."
+  [lsp-process]
+  (set-state! lsp-process :error))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Process info and cleanup
+
+(defn process-info
+  "Get information about an LSP process."
+  [lsp-process]
+  (when lsp-process
+    {:tool-id (:tool-id lsp-process)
+     :command (:command lsp-process)
+     :started-at (:started-at lsp-process)
+     :state (get-state lsp-process)
+     :alive? (process-alive? lsp-process)
+     :uptime-ms (when (:started-at lsp-process)
+                  (- (System/currentTimeMillis) (:started-at lsp-process)))
+     :pid (when-let [process (:process lsp-process)]
+            (try (.pid process) (catch Exception _ nil)))}))
+
+(defn get-input-stream
+  "Get the input stream (for reading server responses)."
+  [lsp-process]
+  (:stdin lsp-process))
+
+(defn get-output-stream
+  "Get the output stream (for sending requests to server)."
+  [lsp-process]
+  (:stdout lsp-process))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Start a process
+  (def proc (start-process :lsp/test ["echo" "hello"] {}))
+
+  ;; Check state
+  (get-state (:process proc))
+
+  ;; Stop process
+  (stop-process (:process proc))
+
+  ;; Get info
+  (process-info (:process proc))
+
+  :leave-this-here)

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/protocol.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/protocol.clj
@@ -1,0 +1,326 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool-registry.lsp.protocol
+  "LSP JSON-RPC protocol types and message builders.
+
+   Implements the Language Server Protocol as defined at:
+   https://microsoft.github.io/language-server-protocol/
+
+   Layer 0: Constants and message IDs
+   Layer 1: Message builders (request, response, notification)
+   Layer 2: Message parsers
+   Layer 3: Standard LSP methods"
+  (:require
+   [cheshire.core :as json]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants and message IDs
+
+(def ^:private id-counter (atom 0))
+
+(defn- next-id
+  "Generate the next message ID."
+  []
+  (swap! id-counter inc))
+
+(def jsonrpc-version "2.0")
+
+;; LSP Error Codes
+(def error-codes
+  {:parse-error      -32700
+   :invalid-request  -32600
+   :method-not-found -32601
+   :invalid-params   -32602
+   :internal-error   -32603
+   ;; LSP-specific
+   :server-not-initialized -32002
+   :unknown-error    -32001
+   :request-cancelled -32800
+   :content-modified -32801})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Message builders
+
+(defn request
+  "Build a JSON-RPC request message.
+
+   Arguments:
+   - method - LSP method name (string)
+   - params - Parameters map (optional)
+
+   Returns {:id int :jsonrpc \"2.0\" :method string :params map}"
+  ([method]
+   (request method nil))
+  ([method params]
+   (cond-> {:id (next-id)
+            :jsonrpc jsonrpc-version
+            :method method}
+     params (assoc :params params))))
+
+(defn response
+  "Build a JSON-RPC response message.
+
+   Arguments:
+   - id     - Request ID to respond to
+   - result - Result value (on success)
+
+   Returns {:id int :jsonrpc \"2.0\" :result any}"
+  [id result]
+  {:id id
+   :jsonrpc jsonrpc-version
+   :result result})
+
+(defn error-response
+  "Build a JSON-RPC error response message.
+
+   Arguments:
+   - id      - Request ID to respond to
+   - code    - Error code (keyword or int)
+   - message - Error message
+   - data    - Optional additional data
+
+   Returns {:id int :jsonrpc \"2.0\" :error {...}}"
+  ([id code message]
+   (error-response id code message nil))
+  ([id code message data]
+   (let [code-int (if (keyword? code)
+                    (get error-codes code code)
+                    code)]
+     (cond-> {:id id
+              :jsonrpc jsonrpc-version
+              :error {:code code-int
+                      :message message}}
+       data (assoc-in [:error :data] data)))))
+
+(defn notification
+  "Build a JSON-RPC notification message (no response expected).
+
+   Arguments:
+   - method - LSP method name
+   - params - Parameters map (optional)
+
+   Returns {:jsonrpc \"2.0\" :method string :params map}"
+  ([method]
+   (notification method nil))
+  ([method params]
+   (cond-> {:jsonrpc jsonrpc-version
+            :method method}
+     params (assoc :params params))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Message encoding/decoding
+
+(defn encode-message
+  "Encode a message for LSP transport (with Content-Length header).
+
+   Returns a string with headers and JSON body."
+  [msg]
+  (let [body (json/generate-string msg)
+        length (count (.getBytes body "UTF-8"))]
+    (str "Content-Length: " length "\r\n\r\n" body)))
+
+(defn- parse-headers
+  "Parse LSP headers from a string.
+   Returns {:content-length int} or nil if invalid."
+  [header-str]
+  (let [lines (str/split header-str #"\r\n")]
+    (reduce (fn [acc line]
+              (when-let [[_ key value] (re-matches #"([^:]+):\s*(.+)" line)]
+                (case (str/lower-case key)
+                  "content-length" (assoc acc :content-length (parse-long value))
+                  "content-type" (assoc acc :content-type value)
+                  acc)))
+            {}
+            lines)))
+
+(defn decode-message
+  "Decode a JSON-RPC message from JSON string.
+
+   Returns the parsed message map."
+  [json-str]
+  (json/parse-string json-str true))
+
+(defn request?
+  "Check if a message is a request (has id and method)."
+  [msg]
+  (and (contains? msg :id)
+       (contains? msg :method)))
+
+(defn response?
+  "Check if a message is a response (has id, no method)."
+  [msg]
+  (and (contains? msg :id)
+       (not (contains? msg :method))))
+
+(defn notification?
+  "Check if a message is a notification (no id, has method)."
+  [msg]
+  (and (not (contains? msg :id))
+       (contains? msg :method)))
+
+(defn error?
+  "Check if a message is an error response."
+  [msg]
+  (contains? msg :error))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Standard LSP methods
+
+;; Lifecycle
+(defn initialize-request
+  "Build an initialize request.
+
+   Arguments:
+   - root-uri    - Workspace root URI
+   - capabilities - Client capabilities map"
+  [root-uri capabilities]
+  (request "initialize"
+           {:processId (-> (java.lang.ProcessHandle/current) .pid)
+            :rootUri root-uri
+            :capabilities (or capabilities {})
+            :trace "off"}))
+
+(defn initialized-notification
+  "Build an initialized notification (sent after initialize response)."
+  []
+  (notification "initialized" {}))
+
+(defn shutdown-request
+  "Build a shutdown request."
+  []
+  (request "shutdown"))
+
+(defn exit-notification
+  "Build an exit notification."
+  []
+  (notification "exit"))
+
+;; Text synchronization
+(defn did-open-notification
+  "Build a textDocument/didOpen notification.
+
+   Arguments:
+   - uri         - Document URI
+   - language-id - Language identifier
+   - version     - Document version
+   - text        - Document content"
+  [uri language-id version text]
+  (notification "textDocument/didOpen"
+                {:textDocument {:uri uri
+                                :languageId language-id
+                                :version version
+                                :text text}}))
+
+(defn did-change-notification
+  "Build a textDocument/didChange notification.
+
+   Arguments:
+   - uri     - Document URI
+   - version - New version
+   - changes - Vector of content changes"
+  [uri version changes]
+  (notification "textDocument/didChange"
+                {:textDocument {:uri uri
+                                :version version}
+                 :contentChanges changes}))
+
+(defn did-save-notification
+  "Build a textDocument/didSave notification."
+  [uri]
+  (notification "textDocument/didSave"
+                {:textDocument {:uri uri}}))
+
+(defn did-close-notification
+  "Build a textDocument/didClose notification."
+  [uri]
+  (notification "textDocument/didClose"
+                {:textDocument {:uri uri}}))
+
+;; Language features
+(defn hover-request
+  "Build a textDocument/hover request."
+  [uri line character]
+  (request "textDocument/hover"
+           {:textDocument {:uri uri}
+            :position {:line line :character character}}))
+
+(defn completion-request
+  "Build a textDocument/completion request."
+  [uri line character]
+  (request "textDocument/completion"
+           {:textDocument {:uri uri}
+            :position {:line line :character character}}))
+
+(defn definition-request
+  "Build a textDocument/definition request."
+  [uri line character]
+  (request "textDocument/definition"
+           {:textDocument {:uri uri}
+            :position {:line line :character character}}))
+
+(defn references-request
+  "Build a textDocument/references request."
+  [uri line character include-declaration?]
+  (request "textDocument/references"
+           {:textDocument {:uri uri}
+            :position {:line line :character character}
+            :context {:includeDeclaration include-declaration?}}))
+
+(defn formatting-request
+  "Build a textDocument/formatting request."
+  [uri options]
+  (request "textDocument/formatting"
+           {:textDocument {:uri uri}
+            :options (or options {:tabSize 2
+                                  :insertSpaces true})}))
+
+(defn document-symbol-request
+  "Build a textDocument/documentSymbol request."
+  [uri]
+  (request "textDocument/documentSymbol"
+           {:textDocument {:uri uri}}))
+
+(defn code-action-request
+  "Build a textDocument/codeAction request."
+  [uri range diagnostics]
+  (request "textDocument/codeAction"
+           {:textDocument {:uri uri}
+            :range range
+            :context {:diagnostics (or diagnostics [])}}))
+
+(defn rename-request
+  "Build a textDocument/rename request."
+  [uri line character new-name]
+  (request "textDocument/rename"
+           {:textDocument {:uri uri}
+            :position {:line line :character character}
+            :newName new-name}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Build an initialize request
+  (initialize-request "file:///workspace" {:textDocument {:hover {:contentFormat ["markdown"]}}})
+
+  ;; Encode for transport
+  (encode-message (hover-request "file:///foo.clj" 10 5))
+  ;; => "Content-Length: ...\r\n\r\n{...}"
+
+  ;; Check message types
+  (request? {:id 1 :method "initialize"})   ;; => true
+  (notification? {:method "initialized"})    ;; => true
+  (response? {:id 1 :result {}})             ;; => true
+
+  :leave-this-here)

--- a/components/tool-registry/src/ai/miniforge/tool_registry/registry.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/registry.clj
@@ -1,0 +1,250 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool-registry.registry
+  "In-memory tool registry implementation.
+
+   Layer 0: Protocol definitions
+   Layer 1: Registry record implementation
+   Layer 2: Query and filter operations
+   Layer 3: Status and statistics"
+  (:require
+   [ai.miniforge.tool-registry.schema :as schema]
+   [ai.miniforge.logging.interface :as log]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Protocol definitions
+
+(defprotocol ToolRegistry
+  "Protocol for tool registration and lookup."
+  (register-tool [this tool] "Register a tool in the registry.")
+  (unregister-tool [this tool-id] "Remove a tool from the registry.")
+  (get-tool [this tool-id] "Retrieve a tool by ID.")
+  (list-tools [this] "List all registered tools.")
+  (find-tools [this query] "Find tools matching query.")
+  (update-tool [this tool-id updates] "Update a tool's configuration.")
+  (clear-tools [this] "Remove all tools from the registry."))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registry record implementation
+
+(defrecord AtomToolRegistry [state]
+  ToolRegistry
+
+  (register-tool [_this tool]
+    (let [{:keys [valid? errors]} (schema/validate-tool tool)]
+      (when-not valid?
+        (throw (ex-info "Invalid tool configuration"
+                        {:tool-id (:tool/id tool)
+                         :errors errors})))
+      (when-not (schema/valid-tool-id? (:tool/id tool))
+        (throw (ex-info "Tool ID must be a namespaced keyword"
+                        {:tool-id (:tool/id tool)})))
+      (let [normalized (schema/normalize-tool tool)
+            tool-id (:tool/id normalized)
+            logger (:logger @state)]
+        (swap! (:tools @state) assoc tool-id normalized)
+        (when logger
+          (log/debug logger :system :tool-registry/registered
+                     {:data {:tool-id tool-id}}))
+        tool-id)))
+
+  (unregister-tool [_this tool-id]
+    (let [logger (:logger @state)]
+      (swap! (:tools @state) dissoc tool-id)
+      (when logger
+        (log/debug logger :system :tool-registry/unregistered
+                   {:data {:tool-id tool-id}}))
+      tool-id))
+
+  (get-tool [_this tool-id]
+    (get @(:tools @state) tool-id))
+
+  (list-tools [_this]
+    (vals @(:tools @state)))
+
+  (find-tools [this query]
+    (let [tools (list-tools this)
+          {:keys [type capabilities tags enabled text]} query]
+      (->> tools
+           (filter (fn [tool]
+                     (and
+                      ;; Type filter
+                      (or (nil? type)
+                          (= type (:tool/type tool)))
+                      ;; Capabilities filter
+                      (or (nil? capabilities)
+                          (empty? capabilities)
+                          (schema/has-all-capabilities? tool capabilities))
+                      ;; Tags filter
+                      (or (nil? tags)
+                          (empty? tags)
+                          (some (:tool/tags tool #{}) tags))
+                      ;; Enabled filter
+                      (or (nil? enabled)
+                          (= enabled (schema/enabled? tool)))
+                      ;; Text search
+                      (or (nil? text)
+                          (str/blank? text)
+                          (let [q (str/lower-case text)]
+                            (or (str/includes? (str/lower-case (or (:tool/name tool) "")) q)
+                                (str/includes? (str/lower-case (or (:tool/description tool) "")) q)
+                                (str/includes? (str/lower-case (str (:tool/id tool))) q)))))))
+           (vec))))
+
+  (update-tool [_this tool-id updates]
+    (let [current (get @(:tools @state) tool-id)]
+      (when-not current
+        (throw (ex-info "Tool not found" {:tool-id tool-id})))
+      (let [updated (merge current updates)
+            {:keys [valid? errors]} (schema/validate-tool updated)]
+        (when-not valid?
+          (throw (ex-info "Invalid update" {:tool-id tool-id :errors errors})))
+        (swap! (:tools @state) assoc tool-id updated)
+        updated)))
+
+  (clear-tools [_this]
+    (reset! (:tools @state) {})))
+
+(defn create-registry
+  "Create a new tool registry.
+
+   Options:
+   - :auto-load?  - Load tools on creation (default: false)
+   - :watch?      - Watch for file changes (default: false)
+   - :logger      - Logger instance
+   - :project-dir - Project directory for .miniforge/tools lookup
+
+   Returns an AtomToolRegistry instance."
+  ([] (create-registry {}))
+  ([{:keys [auto-load? watch? logger project-dir]
+     :or {auto-load? false watch? false}}]
+   (let [tools-atom (atom {})
+         state (atom {:tools tools-atom
+                      :logger logger
+                      :project-dir project-dir
+                      :auto-load? auto-load?
+                      :watch? watch?
+                      ;; LSP server state
+                      :lsp-servers (atom {})
+                      ;; LSP manager state (populated by lsp/manager)
+                      :lsp-manager nil})
+         registry (->AtomToolRegistry state)]
+
+     ;; Add self-referential functions for loader and LSP manager
+     (swap! state assoc
+            :register-fn (fn [tool] (register-tool registry tool))
+            :clear-fn (fn [] (clear-tools registry))
+            :get-tool-fn (fn [tool-id] (get-tool registry tool-id)))
+
+     ;; Auto-load if requested (requires loader - deferred)
+     ;; Watching is handled by watcher component (Phase 5)
+
+     registry)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Query and filter operations
+
+(defn tools-for-context
+  "Get tools available for a given capability context.
+
+   Arguments:
+   - registry     - ToolRegistry instance
+   - capabilities - Set of required capability keywords
+
+   Returns sequence of enabled tools with matching capabilities."
+  [registry capabilities]
+  (find-tools registry {:capabilities capabilities
+                        :enabled true}))
+
+(defn lsp-tools
+  "Get all LSP tools from the registry."
+  [registry]
+  (find-tools registry {:type :lsp}))
+
+(defn enabled-tools
+  "Get all enabled tools from the registry."
+  [registry]
+  (find-tools registry {:enabled true}))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Status and statistics
+
+(defn tools-with-status
+  "Get all tools with their current runtime status.
+
+   For LSP tools, checks server status.
+   For function tools, returns :available.
+
+   Returns sequence of {:tool ToolConfig :status keyword}."
+  [registry]
+  (let [lsp-manager (:lsp-manager @(:state registry))
+        get-lsp-status (if lsp-manager
+                         (fn [tool-id]
+                           (try
+                             ;; Will be implemented by lsp/manager
+                             (if-let [status-fn (:status-fn lsp-manager)]
+                               (status-fn tool-id)
+                               :unknown)
+                             (catch Exception _ :unknown)))
+                         (constantly :unknown))]
+    (for [tool (list-tools registry)]
+      {:tool tool
+       :status (case (:tool/type tool)
+                 :lsp (get-lsp-status (:tool/id tool))
+                 :function :available
+                 :mcp :not-implemented
+                 :external :not-implemented
+                 :unknown)})))
+
+(defn registry-stats
+  "Get statistics about the registry.
+
+   Returns:
+   - {:total count
+      :by-type {:lsp n :function n ...}
+      :enabled count
+      :lsp-running count}"
+  [registry]
+  (let [tools (list-tools registry)
+        statuses (tools-with-status registry)
+        lsp-running (count (filter #(= :running (:status %)) statuses))]
+    {:total (count tools)
+     :by-type (frequencies (map :tool/type tools))
+     :enabled (count (filter schema/enabled? tools))
+     :lsp-running lsp-running}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create a registry
+  (def reg (create-registry {:logger nil}))
+
+  ;; Register a tool
+  (register-tool reg
+                 {:tool/id :lsp/clojure
+                  :tool/type :lsp
+                  :tool/name "Clojure LSP"
+                  :tool/config {:lsp/command ["clojure-lsp"]}})
+
+  ;; List tools
+  (list-tools reg)
+
+  ;; Find LSP tools
+  (find-tools reg {:type :lsp})
+
+  ;; Get stats
+  (registry-stats reg)
+
+  :leave-this-here)

--- a/components/tool-registry/src/ai/miniforge/tool_registry/schema.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/schema.clj
@@ -236,12 +236,12 @@
 ;; Result builders and normalization
 
 (defn success
-  "Build a success result."
+  "Build a success result with a keyed value."
   [key value & {:as extras}]
   (merge {:success? true key value} extras))
 
 (defn failure
-  "Build a failure result."
+  "Build a failure result with a keyed nil."
   [key error]
   {:success? false key nil :error error})
 
@@ -249,6 +249,35 @@
   "Build a failure result with multiple errors."
   [key errors]
   {:success? false key nil :errors errors})
+
+;; Simple result builders (no keyed value)
+
+(defn ok
+  "Build a simple success result.
+
+   Examples:
+     (ok)                        ;; => {:success? true}
+     (ok :client lsp-client)     ;; => {:success? true :client lsp-client}
+     (ok :a 1 :b 2)              ;; => {:success? true :a 1 :b 2}"
+  [& {:as kvs}]
+  (merge {:success? true} kvs))
+
+(defn err
+  "Build a simple error result.
+
+   Examples:
+     (err \"Something failed\")
+     (err \"Tool not found: \" tool-id)
+     (err :code -1 \"Parse error\")"
+  ([message]
+   {:success? false :error message})
+  ([message-or-key & args]
+   (if (keyword? message-or-key)
+     ;; (err :code -1 "message")
+     (let [[code message] args]
+       {:success? false :error message :code code})
+     ;; (err "Tool not found: " tool-id)
+     {:success? false :error (apply str message-or-key args)})))
 
 (defn normalize-tool
   "Normalize a tool configuration, ensuring defaults.

--- a/components/tool-registry/src/ai/miniforge/tool_registry/schema.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/schema.clj
@@ -1,0 +1,300 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tool-registry.schema
+  "Malli schemas for tool configurations.
+
+   Layer 0: Enums and base types
+   Layer 1: Type-specific config schemas (LSP, MCP, etc.)
+   Layer 2: Base tool schema
+   Layer 3: Validation functions
+   Layer 4: Result builders"
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]
+   [malli.util :as mu]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Enums and base types
+
+(def tool-types
+  "Supported tool types."
+  #{:function :lsp :mcp :external})
+
+(def ToolType
+  "Schema for tool type enum."
+  [:enum :function :lsp :mcp :external])
+
+(def lsp-capabilities
+  "LSP server capabilities."
+  #{:diagnostics :format :hover :completion
+    :definition :references :rename
+    :code-action :document-symbol :workspace-symbol
+    :semantic-tokens :inlay-hints})
+
+(def LSPCapability
+  "Schema for LSP capability enum."
+  [:enum :diagnostics :format :hover :completion
+   :definition :references :rename
+   :code-action :document-symbol :workspace-symbol
+   :semantic-tokens :inlay-hints])
+
+(def tool-capabilities
+  "High-level tool capabilities for agent matching."
+  #{:code/diagnostics :code/format :code/hover
+    :code/completion :code/navigation :code/refactor
+    :code/symbols :code/semantics})
+
+(def ToolCapability
+  "Schema for tool capability enum."
+  [:enum :code/diagnostics :code/format :code/hover
+   :code/completion :code/navigation :code/refactor
+   :code/symbols :code/semantics])
+
+(def start-modes
+  "LSP server start modes."
+  #{:on-demand :eager})
+
+(def StartMode
+  "Schema for start mode enum."
+  [:enum :on-demand :eager])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Type-specific config schemas
+
+(def LSPConfig
+  "Schema for LSP-specific configuration.
+
+   Example:
+     {:lsp/command [\"clojure-lsp\"]
+      :lsp/languages #{\"clojure\" \"clojurescript\"}
+      :lsp/file-patterns [\"**/*.clj\" \"**/*.cljs\"]
+      :lsp/capabilities #{:diagnostics :format :hover}
+      :lsp/start-mode :on-demand
+      :lsp/shutdown-after-ms 300000}"
+  [:map
+   [:lsp/command [:vector :string]]
+   [:lsp/languages {:optional true} [:set :string]]
+   [:lsp/file-patterns {:optional true} [:vector :string]]
+   [:lsp/capabilities {:optional true} [:set LSPCapability]]
+   [:lsp/start-mode {:optional true :default :on-demand} StartMode]
+   [:lsp/shutdown-after-ms {:optional true :default 300000} :int]
+   [:lsp/init-options {:optional true} :map]
+   [:lsp/env {:optional true} [:map-of :string :string]]
+   [:lsp/working-dir {:optional true} :string]])
+
+(def FunctionConfig
+  "Schema for function tool configuration.
+
+   Example:
+     {:function/handler-ns \"my.ns\"
+      :function/handler-fn \"my-handler\"
+      :function/parameters {:name {:type :string :required true}}}"
+  [:map
+   [:function/handler-ns {:optional true} :string]
+   [:function/handler-fn {:optional true} :string]
+   [:function/handler {:optional true} fn?]
+   [:function/parameters {:optional true} :map]])
+
+(def MCPConfig
+  "Schema for MCP (Model Context Protocol) configuration.
+
+   Example:
+     {:mcp/command [\"npx\" \"@github/mcp-server\"]
+      :mcp/transport :stdio}"
+  [:map
+   [:mcp/command [:vector :string]]
+   [:mcp/transport {:optional true :default :stdio} [:enum :stdio :sse]]
+   [:mcp/env {:optional true} [:map-of :string :string]]])
+
+(def ExternalConfig
+  "Schema for external process tool configuration.
+
+   Example:
+     {:external/command [\"my-tool\" \"--json\"]
+      :external/timeout-ms 30000}"
+  [:map
+   [:external/command [:vector :string]]
+   [:external/timeout-ms {:optional true :default 30000} :int]
+   [:external/env {:optional true} [:map-of :string :string]]
+   [:external/working-dir {:optional true} :string]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; Base tool schema
+
+(def ToolConfig
+  "Schema for tool configuration.
+
+   Example:
+     {:tool/id :lsp/clojure
+      :tool/type :lsp
+      :tool/name \"Clojure LSP\"
+      :tool/description \"Language server for Clojure\"
+      :tool/version \"1.0.0\"
+      :tool/config {:lsp/command [\"clojure-lsp\"] ...}
+      :tool/capabilities #{:code/diagnostics :code/format}
+      :tool/requires #{:subprocess/spawn}
+      :tool/enabled true
+      :tool/tags #{:language-server :clojure}}"
+  [:map
+   [:tool/id :keyword]
+   [:tool/type ToolType]
+   [:tool/name :string]
+   [:tool/description {:optional true} [:maybe :string]]
+   [:tool/version {:optional true :default "1.0.0"} [:maybe :string]]
+   [:tool/config {:optional true} [:maybe :map]]
+   [:tool/capabilities {:optional true} [:maybe [:set ToolCapability]]]
+   [:tool/requires {:optional true} [:maybe [:set :keyword]]]
+   [:tool/enabled {:optional true :default true} [:maybe :boolean]]
+   [:tool/tags {:optional true} [:maybe [:set :keyword]]]
+   [:tool/metadata {:optional true} [:maybe :map]]])
+
+(def ToolConfigWithType
+  "Schema that validates tool/config matches tool/type."
+  [:and
+   ToolConfig
+   [:fn {:error/message "tool/config must match tool/type"}
+    (fn [{:tool/keys [type config]}]
+      (case type
+        :lsp (or (nil? config) (m/validate LSPConfig config))
+        :function (or (nil? config) (m/validate FunctionConfig config))
+        :mcp (or (nil? config) (m/validate MCPConfig config))
+        :external (or (nil? config) (m/validate ExternalConfig config))
+        true))]])
+
+;------------------------------------------------------------------------------ Layer 3
+;; Validation functions
+
+(defn validate-tool
+  "Validate a tool configuration.
+
+   Returns {:valid? true} or {:valid? false :errors [...]}."
+  [tool]
+  (if (m/validate ToolConfigWithType tool)
+    {:valid? true}
+    {:valid? false
+     :errors (me/humanize (m/explain ToolConfigWithType tool))}))
+
+(defn validate-lsp-config
+  "Validate LSP-specific configuration.
+
+   Returns {:valid? true} or {:valid? false :errors [...]}."
+  [config]
+  (if (m/validate LSPConfig config)
+    {:valid? true}
+    {:valid? false
+     :errors (me/humanize (m/explain LSPConfig config))}))
+
+(defn valid-tool?
+  "Check if a tool configuration is valid."
+  [tool]
+  (:valid? (validate-tool tool)))
+
+(defn valid-tool-id?
+  "Check if a tool ID is valid (namespaced keyword)."
+  [id]
+  (and (keyword? id)
+       (namespace id)))
+
+(defn lsp-tool?
+  "Check if a tool is an LSP tool."
+  [tool]
+  (= :lsp (:tool/type tool)))
+
+(defn function-tool?
+  "Check if a tool is a function tool."
+  [tool]
+  (= :function (:tool/type tool)))
+
+(defn enabled?
+  "Check if a tool is enabled."
+  [tool]
+  (get tool :tool/enabled true))
+
+(defn has-capability?
+  "Check if a tool has a specific capability."
+  [tool capability]
+  (contains? (or (:tool/capabilities tool) #{}) capability))
+
+(defn has-all-capabilities?
+  "Check if a tool has all specified capabilities."
+  [tool capabilities]
+  (every? #(has-capability? tool %) capabilities))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Result builders and normalization
+
+(defn success
+  "Build a success result."
+  [key value & {:as extras}]
+  (merge {:success? true key value} extras))
+
+(defn failure
+  "Build a failure result."
+  [key error]
+  {:success? false key nil :error error})
+
+(defn failure-with-errors
+  "Build a failure result with multiple errors."
+  [key errors]
+  {:success? false key nil :errors errors})
+
+(defn normalize-tool
+  "Normalize a tool configuration, ensuring defaults.
+
+   Applies:
+   - Default :tool/enabled true
+   - Default :tool/version \"1.0.0\"
+   - Ensures :tool/capabilities is a set
+   - Ensures :tool/tags is a set
+   - Ensures :tool/requires is a set"
+  [tool]
+  (-> tool
+      (update :tool/enabled #(if (nil? %) true %))
+      (update :tool/version #(or % "1.0.0"))
+      (update :tool/capabilities #(when % (if (set? %) % (set %))))
+      (update :tool/tags #(when % (if (set? %) % (set %))))
+      (update :tool/requires #(when % (if (set? %) % (set %))))))
+
+(defn tool-summary
+  "Create a brief summary of a tool for display."
+  [{:tool/keys [id name type]}]
+  (str (or name (clojure.core/name id)) " (" (clojure.core/name type) ")"))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Validate a tool config
+  (validate-tool
+   {:tool/id :lsp/clojure
+    :tool/type :lsp
+    :tool/name "Clojure LSP"
+    :tool/config {:lsp/command ["clojure-lsp"]}})
+
+  ;; Invalid tool - missing required fields
+  (validate-tool {:tool/id :test})
+
+  ;; Check tool capabilities
+  (has-capability?
+   {:tool/id :lsp/clojure
+    :tool/capabilities #{:code/diagnostics :code/format}}
+   :code/format)
+
+  ;; Normalize a tool
+  (normalize-tool
+   {:tool/id :lsp/test
+    :tool/type :lsp
+    :tool/name "Test"
+    :tool/capabilities [:code/format]}) ; vector -> set
+
+  :leave-this-here)

--- a/components/tool-registry/test/ai/miniforge/tool_registry/integration_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/integration_test.clj
@@ -1,0 +1,268 @@
+(ns ai.miniforge.tool-registry.integration-test
+  "End-to-end integration tests for tool-registry with actual LSP usage.
+
+   These tests require clojure-lsp to be installed on the system.
+   Tests will be skipped if clojure-lsp is not available."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [clojure.java.io :as io]
+   [ai.miniforge.tool-registry.interface :as tool-registry]
+   [ai.miniforge.tool-registry.lsp.client :as lsp-client]))
+
+;------------------------------------------------------------------------------ Test setup
+
+(def ^:dynamic *registry* nil)
+(def ^:dynamic *temp-dir* nil)
+
+(defn clojure-lsp-available?
+  "Check if clojure-lsp is available on the system."
+  []
+  (try
+    (let [result (-> (ProcessBuilder. ["which" "clojure-lsp"])
+                     .start
+                     .waitFor)]
+      (zero? result))
+    (catch Exception _ false)))
+
+(defn temp-dir-fixture [f]
+  (let [temp (io/file (System/getProperty "java.io.tmpdir")
+                      (str "tool-registry-e2e-" (System/currentTimeMillis)))]
+    (.mkdirs temp)
+    (binding [*temp-dir* temp]
+      (try
+        (f)
+        (finally
+          (doseq [file (reverse (file-seq temp))]
+            (.delete file)))))))
+
+(defn registry-fixture [f]
+  (binding [*registry* (tool-registry/create-registry {:project-dir (str *temp-dir*)})]
+    ;; Register clojure-lsp tool
+    (tool-registry/register! *registry*
+                             {:tool/id :lsp/clojure
+                              :tool/type :lsp
+                              :tool/name "Clojure LSP"
+                              :tool/description "Language server for Clojure"
+                              :tool/config {:lsp/command ["clojure-lsp"]
+                                            :lsp/working-dir (str *temp-dir*)}
+                              :tool/capabilities #{:code/diagnostics :code/format}})
+    (try
+      (f)
+      (finally
+        ;; Stop any running LSP servers
+        (try
+          (tool-registry/stop-lsp *registry* :lsp/clojure)
+          (catch Exception _))))))
+
+(use-fixtures :each temp-dir-fixture registry-fixture)
+
+;------------------------------------------------------------------------------ Helper functions
+
+(defn write-clj-file
+  "Write a Clojure file to the temp directory."
+  [filename content]
+  (let [file (io/file *temp-dir* filename)]
+    ;; Create parent directories if they don't exist
+    (when-let [parent (.getParentFile file)]
+      (.mkdirs parent))
+    (spit file content)
+    file))
+
+(defn file-uri
+  "Convert a file to a file:// URI."
+  [file]
+  (str "file://" (.getAbsolutePath file)))
+
+(defn wait-for-diagnostics
+  "Wait for diagnostics to be published (via notification).
+   Returns diagnostics or nil after timeout."
+  [diagnostics-atom timeout-ms]
+  (let [start (System/currentTimeMillis)]
+    (loop []
+      (if-let [diags @diagnostics-atom]
+        diags
+        (if (> (- (System/currentTimeMillis) start) timeout-ms)
+          nil
+          (do
+            (Thread/sleep 100)
+            (recur)))))))
+
+;------------------------------------------------------------------------------ E2E Tests
+
+(deftest ^:integration lsp-start-stop-test
+  (if-not (clojure-lsp-available?)
+    (println "SKIPPED: clojure-lsp not available")
+    (testing "LSP server can be started and stopped"
+      ;; Create a minimal deps.edn so clojure-lsp initializes
+      (spit (io/file *temp-dir* "deps.edn") "{:paths [\"src\"]}")
+      (.mkdirs (io/file *temp-dir* "src"))
+
+      ;; Start LSP
+      (let [{:keys [success? error]} (tool-registry/start-lsp *registry* :lsp/clojure)]
+        (is success? (str "Failed to start LSP: " error))
+
+        ;; Check status
+        (is (= :running (tool-registry/lsp-status *registry* :lsp/clojure)))
+
+        ;; Stop LSP
+        (let [{:keys [success?]} (tool-registry/stop-lsp *registry* :lsp/clojure)]
+          (is success? "Failed to stop LSP"))
+
+        ;; Check status after stop
+        (is (= :stopped (tool-registry/lsp-status *registry* :lsp/clojure)))))))
+
+(deftest ^:integration lsp-diagnostics-test
+  (if-not (clojure-lsp-available?)
+    (println "SKIPPED: clojure-lsp not available")
+    (testing "LSP detects mismatched parentheses"
+      ;; Create project structure
+      (spit (io/file *temp-dir* "deps.edn") "{:paths [\"src\"]}")
+      (let [src-dir (io/file *temp-dir* "src")]
+        (.mkdirs src-dir)
+
+        ;; Write a file with mismatched parens
+        (let [bad-code "(ns bad.code)\n\n(defn broken [x]\n  (+ x 1))"  ; Missing closing paren
+              file (write-clj-file "src/bad/code.clj" bad-code)]
+
+          ;; Collect diagnostics from notifications
+          (let [diagnostics-atom (atom nil)
+                notification-handler (fn [msg]
+                                       (when (= "textDocument/publishDiagnostics" (:method msg))
+                                         (reset! diagnostics-atom (get-in msg [:params :diagnostics]))))]
+
+            ;; Start LSP with custom notification handler
+            (let [{:keys [success? error client]} (tool-registry/start-lsp *registry* :lsp/clojure)]
+              (is success? (str "Failed to start LSP: " error))
+
+              (when success?
+                ;; Open the document
+                (lsp-client/open-document client
+                                          (file-uri file)
+                                          "clojure"
+                                          (slurp file))
+
+                ;; Wait for diagnostics (clojure-lsp sends them after analysis)
+                (Thread/sleep 3000)
+
+                ;; Get document symbols to verify LSP is responding
+                (let [{:keys [success? result]} (lsp-client/document-symbols client (file-uri file))]
+                  (is success? "document-symbols request failed")
+                  ;; Should find at least the namespace and function
+                  (when success?
+                    (println "Document symbols found:" (count result))))))))))))
+
+(deftest ^:integration lsp-hover-test
+  (if-not (clojure-lsp-available?)
+    (println "SKIPPED: clojure-lsp not available")
+    (testing "LSP provides hover information"
+      ;; Create project structure
+      (spit (io/file *temp-dir* "deps.edn") "{:paths [\"src\"]}")
+      (let [src-dir (io/file *temp-dir* "src")]
+        (.mkdirs src-dir)
+
+        ;; Write a valid Clojure file
+        (let [code "(ns hover.test)\n\n(defn my-function\n  \"A test function that adds numbers.\"\n  [x y]\n  (+ x y))"
+              file (write-clj-file "src/hover/test.clj" code)]
+
+          ;; Start LSP
+          (let [{:keys [success? client]} (tool-registry/start-lsp *registry* :lsp/clojure)]
+            (when success?
+              ;; Open the document
+              (lsp-client/open-document client
+                                        (file-uri file)
+                                        "clojure"
+                                        code)
+
+              ;; Wait for indexing
+              (Thread/sleep 2000)
+
+              ;; Request hover on 'defn' (line 2, character 1)
+              (let [{:keys [success? result]} (lsp-client/hover client (file-uri file) 2 1)]
+                (is success? "hover request failed")
+                (when (and success? result)
+                  (println "Hover result:" (pr-str (take 100 (str result))))
+                  (is (some? result) "Expected hover info for defn"))))))))))
+
+(deftest ^:integration lsp-format-test
+  (if-not (clojure-lsp-available?)
+    (println "SKIPPED: clojure-lsp not available")
+    (testing "LSP formats code"
+      ;; Create project structure
+      (spit (io/file *temp-dir* "deps.edn") "{:paths [\"src\"]}")
+      (let [src-dir (io/file *temp-dir* "src")]
+        (.mkdirs src-dir)
+
+        ;; Write poorly formatted code
+        (let [ugly-code "(ns format.test)\n(defn   ugly   [x    y]\n(+   x    y))"
+              file (write-clj-file "src/format/test.clj" ugly-code)]
+
+          ;; Start LSP
+          (let [{:keys [success? client]} (tool-registry/start-lsp *registry* :lsp/clojure)]
+            (when success?
+              ;; Open the document
+              (lsp-client/open-document client
+                                        (file-uri file)
+                                        "clojure"
+                                        ugly-code)
+
+              ;; Wait for indexing
+              (Thread/sleep 2000)
+
+              ;; Request formatting
+              (let [{:keys [success? result]} (lsp-client/format-document client (file-uri file) nil)]
+                (is success? "format request failed")
+                (when success?
+                  (println "Format edits:" (count result))
+                  ;; Should return text edits to fix formatting
+                  (is (or (nil? result) (seq result)) "Expected format edits or nil for already-formatted"))))))))))
+
+;------------------------------------------------------------------------------ Tool discovery E2E test
+
+(deftest ^:integration tool-discovery-and-use-test
+  (testing "Tools can be discovered and used by agents"
+    ;; Register multiple tools
+    (tool-registry/register! *registry*
+                             {:tool/id :tools/analyze-code
+                              :tool/type :function
+                              :tool/name "Code Analyzer"
+                              :tool/description "Analyzes code for issues"
+                              :tool/capabilities #{:code/diagnostics}
+                              :tool/tags #{:analysis}})
+
+    (tool-registry/register! *registry*
+                             {:tool/id :tools/format-code
+                              :tool/type :function
+                              :tool/name "Code Formatter"
+                              :tool/description "Formats code according to style guide"
+                              :tool/capabilities #{:code/format}
+                              :tool/tags #{:formatting}})
+
+    ;; Simulate agent discovering tools for a task
+    (let [;; Agent needs diagnostic capabilities
+          diagnostic-tools (tool-registry/tools-for-context *registry* #{:code/diagnostics})
+          ;; Agent needs formatting capabilities
+          format-tools (tool-registry/tools-for-context *registry* #{:code/format})
+          ;; Agent needs both
+          all-tools (tool-registry/tools-for-context *registry* #{:code/diagnostics :code/format})]
+
+      ;; Should find appropriate tools
+      (is (= 2 (count diagnostic-tools)) "Should find clojure LSP + analyze-code")
+      (is (= 2 (count format-tools)) "Should find clojure LSP + format-code")
+      ;; Only clojure-lsp has both capabilities
+      (is (= 1 (count all-tools)) "Only clojure-lsp has both capabilities"))
+
+    ;; Get tool details for agent to use
+    (let [lsp-tool (tool-registry/get-tool *registry* :lsp/clojure)]
+      (is (= :lsp (:tool/type lsp-tool)))
+      (is (contains? (:tool/capabilities lsp-tool) :code/diagnostics))
+      (is (contains? (:tool/capabilities lsp-tool) :code/format)))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Run integration tests (requires clojure-lsp)
+  (clojure.test/run-tests 'ai.miniforge.tool-registry.integration-test)
+
+  ;; Check if clojure-lsp is available
+  (clojure-lsp-available?)
+
+  :leave-this-here)

--- a/components/tool-registry/test/ai/miniforge/tool_registry/interface_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/interface_test.clj
@@ -1,0 +1,125 @@
+(ns ai.miniforge.tool-registry.interface-test
+  "Tests for tool-registry public interface."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [ai.miniforge.tool-registry.interface :as tool-registry]))
+
+;------------------------------------------------------------------------------ Test fixtures
+
+(def ^:dynamic *registry* nil)
+
+(defn registry-fixture [f]
+  (binding [*registry* (tool-registry/create-registry {})]
+    (f)))
+
+(use-fixtures :each registry-fixture)
+
+;------------------------------------------------------------------------------ Sample data
+
+(def sample-tool
+  {:tool/id :test/sample
+   :tool/type :function
+   :tool/name "Sample Tool"
+   :tool/description "A sample function tool"
+   :tool/capabilities #{:code/completion}
+   :tool/tags #{:test}})
+
+;------------------------------------------------------------------------------ Interface tests
+
+(deftest create-registry-test
+  (testing "creates registry with default options"
+    (let [reg (tool-registry/create-registry)]
+      (is (some? reg))
+      (is (empty? (tool-registry/list-tools reg)))))
+
+  (testing "creates registry with options"
+    (let [reg (tool-registry/create-registry {:project-dir "/tmp"})]
+      (is (some? reg)))))
+
+(deftest register-and-get-test
+  (testing "register! and get-tool work together"
+    (tool-registry/register! *registry* sample-tool)
+    (let [tool (tool-registry/get-tool *registry* :test/sample)]
+      (is (some? tool))
+      (is (= "Sample Tool" (:tool/name tool))))))
+
+(deftest list-and-find-test
+  (testing "list-tools returns all tools"
+    (tool-registry/register! *registry* sample-tool)
+    (tool-registry/register! *registry* (assoc sample-tool
+                                               :tool/id :test/another
+                                               :tool/name "Another Tool"))
+    (is (= 2 (count (tool-registry/list-tools *registry*)))))
+
+  (testing "find-tools with query"
+    ;; Note: sample-tool and :test/another from previous test are still registered
+    ;; Register an LSP tool
+    (tool-registry/register! *registry* (assoc sample-tool
+                                               :tool/id :lsp/test
+                                               :tool/type :lsp
+                                               :tool/name "LSP Tool"
+                                               :tool/config {:lsp/command ["test"]}))
+    (let [function-tools (tool-registry/find-tools *registry* {:type :function})
+          lsp-tools (tool-registry/find-tools *registry* {:type :lsp})]
+      ;; 2 function tools from list-tools test + sample-tool
+      (is (= 2 (count function-tools)))
+      (is (= 1 (count lsp-tools))))))
+
+(deftest update-and-enable-test
+  (testing "update-tool! modifies tool"
+    (tool-registry/register! *registry* sample-tool)
+    (tool-registry/update-tool! *registry* :test/sample
+                                {:tool/description "Updated description"})
+    (let [tool (tool-registry/get-tool *registry* :test/sample)]
+      (is (= "Updated description" (:tool/description tool)))))
+
+  (testing "enable-tool! sets enabled to true"
+    (tool-registry/register! *registry* (assoc sample-tool :tool/enabled false))
+    (tool-registry/enable-tool! *registry* :test/sample)
+    (let [tool (tool-registry/get-tool *registry* :test/sample)]
+      (is (:tool/enabled tool))))
+
+  (testing "disable-tool! sets enabled to false"
+    (tool-registry/register! *registry* sample-tool)
+    (tool-registry/disable-tool! *registry* :test/sample)
+    (let [tool (tool-registry/get-tool *registry* :test/sample)]
+      (is (not (:tool/enabled tool))))))
+
+(deftest unregister-test
+  (testing "unregister! removes tool"
+    (tool-registry/register! *registry* sample-tool)
+    (tool-registry/unregister! *registry* :test/sample)
+    (is (nil? (tool-registry/get-tool *registry* :test/sample)))))
+
+(deftest tools-for-context-test
+  (testing "returns enabled tools with required capabilities"
+    (tool-registry/register! *registry* sample-tool)
+    (tool-registry/register! *registry* (assoc sample-tool
+                                               :tool/id :test/disabled
+                                               :tool/enabled false))
+    (let [tools (tool-registry/tools-for-context *registry* #{:code/completion})]
+      (is (= 1 (count tools)))
+      (is (= :test/sample (:tool/id (first tools)))))))
+
+(deftest registry-stats-test
+  (testing "returns correct statistics"
+    (tool-registry/register! *registry* sample-tool)
+    (tool-registry/register! *registry* (assoc sample-tool
+                                               :tool/id :lsp/test
+                                               :tool/type :lsp
+                                               :tool/config {:lsp/command ["test"]}))
+    (let [stats (tool-registry/registry-stats *registry*)]
+      (is (= 2 (:total stats)))
+      (is (= 2 (:enabled stats)))
+      (is (= {:function 1 :lsp 1} (:by-type stats))))))
+
+;------------------------------------------------------------------------------ Schema re-export tests
+
+(deftest schema-re-exports-test
+  (testing "tool-types is available"
+    (is (contains? tool-registry/tool-types :lsp))
+    (is (contains? tool-registry/tool-types :function)))
+
+  (testing "lsp-capabilities is available"
+    (is (contains? tool-registry/lsp-capabilities :diagnostics))
+    (is (contains? tool-registry/lsp-capabilities :format))))

--- a/components/tool-registry/test/ai/miniforge/tool_registry/loader_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/loader_test.clj
@@ -1,0 +1,147 @@
+(ns ai.miniforge.tool-registry.loader-test
+  "Tests for tool-registry loader functionality."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [clojure.java.io :as io]
+   [ai.miniforge.tool-registry.loader :as loader]
+   [ai.miniforge.tool-registry.registry :as registry]))
+
+;------------------------------------------------------------------------------ Test fixtures
+
+(def ^:dynamic *registry* nil)
+(def ^:dynamic *temp-dir* nil)
+
+(defn temp-dir-fixture [f]
+  (let [temp (io/file (System/getProperty "java.io.tmpdir")
+                      (str "tool-registry-test-" (System/currentTimeMillis)))]
+    (.mkdirs temp)
+    (binding [*temp-dir* temp]
+      (try
+        (f)
+        (finally
+          ;; Clean up temp files
+          (doseq [file (reverse (file-seq temp))]
+            (.delete file)))))))
+
+(defn registry-fixture [f]
+  (binding [*registry* (registry/create-registry {:project-dir (str *temp-dir*)})]
+    (f)))
+
+(use-fixtures :each temp-dir-fixture registry-fixture)
+
+;------------------------------------------------------------------------------ Helper functions
+
+(defn- write-tool-file [dir filename content]
+  (let [parent (io/file dir)]
+    (.mkdirs parent)
+    (spit (io/file parent filename) (pr-str content))))
+
+;------------------------------------------------------------------------------ Single file loading tests
+
+(deftest load-tool-from-file-test
+  (testing "loads valid tool from EDN file"
+    (let [tool {:tool/id :test/sample
+                :tool/type :function
+                :tool/name "Sample Tool"}
+          file (io/file *temp-dir* "sample.edn")]
+      (spit file (pr-str tool))
+      (let [{:keys [success? tool errors]} (loader/load-tool-from-file (.getPath file))]
+        (is success?)
+        (is (= :test/sample (:tool/id tool)))
+        (is (nil? errors)))))
+
+  (testing "returns error for non-existent file"
+    (let [{:keys [success? errors]} (loader/load-tool-from-file "/nonexistent/file.edn")]
+      (is (not success?))
+      (is (some? errors))))
+
+  (testing "returns error for invalid EDN"
+    (let [file (io/file *temp-dir* "invalid.edn")]
+      (spit file "{{{{invalid edn")
+      (let [{:keys [success? errors]} (loader/load-tool-from-file (.getPath file))]
+        (is (not success?))
+        (is (some? errors)))))
+
+  (testing "infers type from parent directory"
+    (let [lsp-dir (io/file *temp-dir* "lsp")
+          tool {:tool/id :test/inferred
+                :tool/name "Inferred Type"}]
+      (.mkdirs lsp-dir)
+      (spit (io/file lsp-dir "test.edn") (pr-str tool))
+      (let [{:keys [success? tool]} (loader/load-tool-from-file
+                                     (.getPath (io/file lsp-dir "test.edn")))]
+        (is success?)
+        (is (= :lsp (:tool/type tool)))))))
+
+;------------------------------------------------------------------------------ Discovery tests
+
+(deftest discover-tools-test
+  (testing "discovers tools in project directory"
+    ;; Create project tools directory
+    (let [tools-dir (io/file *temp-dir* ".miniforge" "tools" "lsp")]
+      (.mkdirs tools-dir)
+      (write-tool-file tools-dir "test.edn"
+                       {:tool/id :lsp/test
+                        :tool/type :lsp
+                        :tool/name "Test"})
+      (let [discovered (loader/discover-tools *registry*)]
+        ;; Should find at least the project tool
+        (is (some #(= :project (:source %)) discovered))))))
+
+;------------------------------------------------------------------------------ Bulk loading tests
+
+(deftest load-all-tools-test
+  (testing "loads tools from project directory"
+    (let [tools-dir (io/file *temp-dir* ".miniforge" "tools" "lsp")]
+      (.mkdirs tools-dir)
+      (write-tool-file tools-dir "test1.edn"
+                       {:tool/id :lsp/test1
+                        :tool/type :lsp
+                        :tool/name "Test 1"
+                        :tool/config {:lsp/command ["test1"]}})
+      (write-tool-file tools-dir "test2.edn"
+                       {:tool/id :lsp/test2
+                        :tool/type :lsp
+                        :tool/name "Test 2"
+                        :tool/config {:lsp/command ["test2"]}})
+      (let [{:keys [loaded failed]} (loader/load-all-tools *registry*)]
+        ;; Should load the two project tools (may also include built-in)
+        (is (>= (count loaded) 2))
+        (is (contains? (set loaded) :lsp/test1))
+        (is (contains? (set loaded) :lsp/test2)))))
+
+  (testing "reports failed files"
+    (let [tools-dir (io/file *temp-dir* ".miniforge" "tools" "lsp")]
+      (.mkdirs tools-dir)
+      ;; Create an invalid tool file
+      (spit (io/file tools-dir "invalid.edn") "{{invalid")
+      (let [{:keys [failed]} (loader/load-all-tools *registry*)]
+        (is (some #(re-find #"invalid\.edn" (:path %)) failed))))))
+
+(deftest reload-all-tools-test
+  (testing "clears and reloads registry"
+    (let [tools-dir (io/file *temp-dir* ".miniforge" "tools" "lsp")]
+      (.mkdirs tools-dir)
+      (write-tool-file tools-dir "tool.edn"
+                       {:tool/id :lsp/reloadable
+                        :tool/type :lsp
+                        :tool/name "Reloadable"
+                        :tool/config {:lsp/command ["test"]}})
+
+      ;; Register a tool manually
+      (registry/register-tool *registry*
+                              {:tool/id :manual/tool
+                               :tool/type :function
+                               :tool/name "Manual"})
+
+      ;; Verify manual tool exists
+      (is (some? (registry/get-tool *registry* :manual/tool)))
+
+      ;; Reload
+      (loader/reload-all-tools *registry*)
+
+      ;; Manual tool should be gone (was not in files)
+      (is (nil? (registry/get-tool *registry* :manual/tool)))
+
+      ;; File-based tool should be present
+      (is (some? (registry/get-tool *registry* :lsp/reloadable))))))

--- a/components/tool-registry/test/ai/miniforge/tool_registry/registry_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/registry_test.clj
@@ -1,0 +1,174 @@
+(ns ai.miniforge.tool-registry.registry-test
+  "Tests for tool-registry registry operations."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [ai.miniforge.tool-registry.registry :as registry]))
+
+;------------------------------------------------------------------------------ Test fixtures
+
+(def ^:dynamic *registry* nil)
+
+(defn registry-fixture [f]
+  (binding [*registry* (registry/create-registry {})]
+    (f)))
+
+(use-fixtures :each registry-fixture)
+
+;------------------------------------------------------------------------------ Sample tools
+
+(def sample-lsp-tool
+  {:tool/id :lsp/test
+   :tool/type :lsp
+   :tool/name "Test LSP"
+   :tool/description "Test language server"
+   :tool/config {:lsp/command ["test-lsp"]}
+   :tool/capabilities #{:code/diagnostics :code/format}
+   :tool/tags #{:test :language-server}})
+
+(def sample-function-tool
+  {:tool/id :tools/greet
+   :tool/type :function
+   :tool/name "Greet"
+   :tool/description "Greets users by name"
+   :tool/capabilities #{:code/completion}
+   :tool/tags #{:greeting}})
+
+;------------------------------------------------------------------------------ Registration tests
+
+(deftest register-tool-test
+  (testing "register valid tool returns tool ID"
+    (let [tool-id (registry/register-tool *registry* sample-lsp-tool)]
+      (is (= :lsp/test tool-id))))
+
+  (testing "registered tool can be retrieved"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (let [tool (registry/get-tool *registry* :lsp/test)]
+      (is (some? tool))
+      (is (= "Test LSP" (:tool/name tool)))))
+
+  (testing "register invalid tool throws"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid tool configuration"
+         (registry/register-tool *registry* {:tool/id :bad}))))
+
+  (testing "register tool with non-namespaced ID throws"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Tool ID must be a namespaced keyword"
+         (registry/register-tool *registry*
+                                 {:tool/id :not-namespaced
+                                  :tool/type :function
+                                  :tool/name "Bad ID"})))))
+
+;------------------------------------------------------------------------------ List and find tests
+
+(deftest list-tools-test
+  (testing "empty registry returns empty list"
+    (is (empty? (registry/list-tools *registry*))))
+
+  (testing "lists all registered tools"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (registry/register-tool *registry* sample-function-tool)
+    (let [tools (registry/list-tools *registry*)]
+      (is (= 2 (count tools))))))
+
+(deftest find-tools-test
+  (testing "find by type"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (registry/register-tool *registry* sample-function-tool)
+    (let [lsp-tools (registry/find-tools *registry* {:type :lsp})
+          function-tools (registry/find-tools *registry* {:type :function})]
+      (is (= 1 (count lsp-tools)))
+      (is (= :lsp/test (:tool/id (first lsp-tools))))
+      (is (= 1 (count function-tools)))
+      (is (= :tools/greet (:tool/id (first function-tools))))))
+
+  (testing "find by capabilities"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (registry/register-tool *registry* sample-function-tool)
+    (let [diagnostic-tools (registry/find-tools *registry*
+                                                {:capabilities #{:code/diagnostics}})]
+      (is (= 1 (count diagnostic-tools)))
+      (is (= :lsp/test (:tool/id (first diagnostic-tools))))))
+
+  (testing "find by tags"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (registry/register-tool *registry* sample-function-tool)
+    (let [test-tools (registry/find-tools *registry* {:tags #{:test}})]
+      (is (= 1 (count test-tools)))
+      (is (= :lsp/test (:tool/id (first test-tools))))))
+
+  (testing "find by text"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (registry/register-tool *registry* sample-function-tool)
+    (let [greet-tools (registry/find-tools *registry* {:text "greet"})]
+      (is (= 1 (count greet-tools)))
+      (is (= :tools/greet (:tool/id (first greet-tools))))))
+
+  (testing "find by enabled status"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (registry/register-tool *registry* (assoc sample-function-tool :tool/enabled false))
+    (let [enabled-tools (registry/find-tools *registry* {:enabled true})]
+      (is (= 1 (count enabled-tools)))
+      (is (= :lsp/test (:tool/id (first enabled-tools)))))))
+
+;------------------------------------------------------------------------------ Update tests
+
+(deftest update-tool-test
+  (testing "update tool returns updated config"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (let [updated (registry/update-tool *registry* :lsp/test
+                                        {:tool/description "Updated description"})]
+      (is (= "Updated description" (:tool/description updated)))))
+
+  (testing "update preserves other fields"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (registry/update-tool *registry* :lsp/test {:tool/description "Updated"})
+    (let [tool (registry/get-tool *registry* :lsp/test)]
+      (is (= "Test LSP" (:tool/name tool)))
+      (is (= :lsp (:tool/type tool)))))
+
+  (testing "update non-existent tool throws"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Tool not found"
+         (registry/update-tool *registry* :nonexistent {:tool/name "New"})))))
+
+;------------------------------------------------------------------------------ Unregister tests
+
+(deftest unregister-tool-test
+  (testing "unregister removes tool"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (registry/unregister-tool *registry* :lsp/test)
+    (is (nil? (registry/get-tool *registry* :lsp/test))))
+
+  (testing "unregister returns tool ID"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (let [tool-id (registry/unregister-tool *registry* :lsp/test)]
+      (is (= :lsp/test tool-id)))))
+
+;------------------------------------------------------------------------------ Helper function tests
+
+(deftest tools-for-context-test
+  (testing "returns enabled tools with matching capabilities"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (registry/register-tool *registry* sample-function-tool)
+    (registry/register-tool *registry* (assoc sample-lsp-tool
+                                              :tool/id :lsp/disabled
+                                              :tool/enabled false))
+    (let [tools (registry/tools-for-context *registry* #{:code/diagnostics})]
+      (is (= 1 (count tools)))
+      (is (= :lsp/test (:tool/id (first tools)))))))
+
+(deftest registry-stats-test
+  (testing "returns correct statistics"
+    (registry/register-tool *registry* sample-lsp-tool)
+    (registry/register-tool *registry* sample-function-tool)
+    (registry/register-tool *registry* (assoc sample-function-tool
+                                              :tool/id :tools/disabled
+                                              :tool/enabled false))
+    (let [stats (registry/registry-stats *registry*)]
+      (is (= 3 (:total stats)))
+      (is (= 2 (:enabled stats)))
+      (is (= {:lsp 1 :function 2} (:by-type stats))))))

--- a/components/tool-registry/test/ai/miniforge/tool_registry/schema_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/schema_test.clj
@@ -1,0 +1,163 @@
+(ns ai.miniforge.tool-registry.schema-test
+  "Tests for tool-registry schema validation."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tool-registry.schema :as schema]))
+
+;------------------------------------------------------------------------------ Tool validation
+
+(deftest validate-tool-test
+  (testing "valid LSP tool configuration"
+    (let [tool {:tool/id :lsp/clojure
+                :tool/type :lsp
+                :tool/name "Clojure LSP"
+                :tool/description "Language server for Clojure"
+                :tool/config {:lsp/command ["clojure-lsp"]}}
+          result (schema/validate-tool tool)]
+      (is (:valid? result))
+      (is (nil? (:errors result)))))
+
+  (testing "valid function tool configuration"
+    (let [tool {:tool/id :tools/greet
+                :tool/type :function
+                :tool/name "Greet"
+                :tool/description "Greets users"}
+          result (schema/validate-tool tool)]
+      (is (:valid? result))))
+
+  (testing "invalid tool - missing required fields"
+    (let [tool {:tool/id :test/invalid}
+          result (schema/validate-tool tool)]
+      (is (not (:valid? result)))
+      (is (some? (:errors result)))))
+
+  (testing "invalid tool - bad type"
+    (let [tool {:tool/id :test/invalid
+                :tool/type :unknown-type
+                :tool/name "Test"}
+          result (schema/validate-tool tool)]
+      (is (not (:valid? result))))))
+
+;------------------------------------------------------------------------------ Tool ID validation
+
+(deftest valid-tool-id-test
+  (testing "namespaced keywords are valid"
+    (is (schema/valid-tool-id? :lsp/clojure))
+    (is (schema/valid-tool-id? :tools/greet))
+    (is (schema/valid-tool-id? :my.company/tool)))
+
+  (testing "non-namespaced keywords are invalid"
+    (is (not (schema/valid-tool-id? :clojure)))
+    (is (not (schema/valid-tool-id? :test))))
+
+  (testing "non-keywords are invalid"
+    (is (not (schema/valid-tool-id? "lsp/clojure")))
+    (is (not (schema/valid-tool-id? nil)))))
+
+;------------------------------------------------------------------------------ LSP config validation
+
+(deftest validate-lsp-config-test
+  (testing "valid LSP config"
+    (let [config {:lsp/command ["clojure-lsp"]
+                  :lsp/languages #{"clojure"}
+                  :lsp/capabilities #{:diagnostics :format}}
+          result (schema/validate-lsp-config config)]
+      (is (:valid? result))))
+
+  (testing "LSP config requires command"
+    (let [config {:lsp/languages #{"clojure"}}
+          result (schema/validate-lsp-config config)]
+      (is (not (:valid? result))))))
+
+;------------------------------------------------------------------------------ Capability checks
+
+(deftest capability-checks-test
+  (testing "has-capability? returns true when capability present"
+    (let [tool {:tool/id :test/tool
+                :tool/capabilities #{:code/diagnostics :code/format}}]
+      (is (schema/has-capability? tool :code/diagnostics))
+      (is (schema/has-capability? tool :code/format))))
+
+  (testing "has-capability? returns false when capability absent"
+    (let [tool {:tool/id :test/tool
+                :tool/capabilities #{:code/diagnostics}}]
+      (is (not (schema/has-capability? tool :code/hover)))))
+
+  (testing "has-capability? handles nil capabilities"
+    (let [tool {:tool/id :test/tool}]
+      (is (not (schema/has-capability? tool :code/diagnostics)))))
+
+  (testing "has-all-capabilities? checks all"
+    (let [tool {:tool/id :test/tool
+                :tool/capabilities #{:code/diagnostics :code/format :code/hover}}]
+      (is (schema/has-all-capabilities? tool #{:code/diagnostics :code/format}))
+      (is (not (schema/has-all-capabilities? tool #{:code/diagnostics :code/completion}))))))
+
+;------------------------------------------------------------------------------ Type checks
+
+(deftest type-checks-test
+  (testing "lsp-tool? returns true for LSP tools"
+    (is (schema/lsp-tool? {:tool/type :lsp}))
+    (is (not (schema/lsp-tool? {:tool/type :function}))))
+
+  (testing "function-tool? returns true for function tools"
+    (is (schema/function-tool? {:tool/type :function}))
+    (is (not (schema/function-tool? {:tool/type :lsp}))))
+
+  (testing "enabled? defaults to true"
+    (is (schema/enabled? {:tool/id :test}))
+    (is (schema/enabled? {:tool/id :test :tool/enabled true}))
+    (is (not (schema/enabled? {:tool/id :test :tool/enabled false})))))
+
+;------------------------------------------------------------------------------ Normalization
+
+(deftest normalize-tool-test
+  (testing "normalizes capabilities from vector to set"
+    (let [tool {:tool/id :test/tool
+                :tool/type :lsp
+                :tool/name "Test"
+                :tool/capabilities [:code/diagnostics :code/format]}
+          normalized (schema/normalize-tool tool)]
+      (is (set? (:tool/capabilities normalized)))
+      (is (= #{:code/diagnostics :code/format} (:tool/capabilities normalized)))))
+
+  (testing "sets default enabled to true"
+    (let [tool {:tool/id :test/tool
+                :tool/type :lsp
+                :tool/name "Test"}
+          normalized (schema/normalize-tool tool)]
+      (is (true? (:tool/enabled normalized)))))
+
+  (testing "sets default version"
+    (let [tool {:tool/id :test/tool
+                :tool/type :lsp
+                :tool/name "Test"}
+          normalized (schema/normalize-tool tool)]
+      (is (= "1.0.0" (:tool/version normalized)))))
+
+  (testing "preserves explicit enabled false"
+    (let [tool {:tool/id :test/tool
+                :tool/type :lsp
+                :tool/name "Test"
+                :tool/enabled false}
+          normalized (schema/normalize-tool tool)]
+      (is (false? (:tool/enabled normalized))))))
+
+;------------------------------------------------------------------------------ Result builders
+
+(deftest result-builders-test
+  (testing "success builds success result"
+    (let [result (schema/success :tool {:tool/id :test})]
+      (is (:success? result))
+      (is (= {:tool/id :test} (:tool result)))))
+
+  (testing "failure builds failure result"
+    (let [result (schema/failure :tool "Something went wrong")]
+      (is (not (:success? result)))
+      (is (nil? (:tool result)))
+      (is (= "Something went wrong" (:error result)))))
+
+  (testing "failure-with-errors builds result with errors list"
+    (let [result (schema/failure-with-errors :tool [{:error "err1"} {:error "err2"}])]
+      (is (not (:success? result)))
+      (is (= 2 (count (:errors result)))))))

--- a/deps.edn
+++ b/deps.edn
@@ -46,7 +46,9 @@
                        "components/orchestrator/src"
                        "components/orchestrator/resources"
                        "components/reporting/src"
-                       "components/reporting/resources"]
+                       "components/reporting/resources"
+                       "components/tool-registry/src"
+                       "components/tool-registry/resources"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
                       ai.miniforge/logging {:local/root "components/logging"}
@@ -68,7 +70,8 @@
                       ai.miniforge/operator {:local/root "components/operator"}
                       ai.miniforge/observer {:local/root "components/observer"}
                       ai.miniforge/orchestrator {:local/root "components/orchestrator"}
-                      ai.miniforge/reporting {:local/root "components/reporting"}}}
+                      ai.miniforge/reporting {:local/root "components/reporting"}
+                      ai.miniforge/tool-registry {:local/root "components/tool-registry"}}}
 
   :test {:extra-paths ["development/test"
                        "components/schema/test"
@@ -91,7 +94,8 @@
                        "components/operator/test"
                        "components/observer/test"
                        "components/orchestrator/test"
-                       "components/reporting/test"]
+                       "components/reporting/test"
+                       "components/tool-registry/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
                       ai.miniforge/logging {:local/root "components/logging"}
@@ -113,7 +117,8 @@
                       ai.miniforge/operator {:local/root "components/operator"}
                       ai.miniforge/observer {:local/root "components/observer"}
                       ai.miniforge/orchestrator {:local/root "components/orchestrator"}
-                      ai.miniforge/reporting {:local/root "components/reporting"}}}
+                      ai.miniforge/reporting {:local/root "components/reporting"}
+                      ai.miniforge/tool-registry {:local/root "components/tool-registry"}}}
 
   :conformance {:extra-paths ["development/test"
                               "tests/conformance"
@@ -160,7 +165,9 @@
                               "components/reporting/src"
                               "components/reporting/test"
                               "components/evidence-bundle/src"
-                              "components/evidence-bundle/test"]
+                              "components/evidence-bundle/test"
+                              "components/tool-registry/src"
+                              "components/tool-registry/test"]
                 :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                              ai.miniforge/algorithms {:local/root "components/algorithms"}
                              ai.miniforge/logging {:local/root "components/logging"}
@@ -182,7 +189,8 @@
                              ai.miniforge/observer {:local/root "components/observer"}
                              ai.miniforge/orchestrator {:local/root "components/orchestrator"}
                              ai.miniforge/reporting {:local/root "components/reporting"}
-                             ai.miniforge/evidence-bundle {:local/root "components/evidence-bundle"}}}
+                             ai.miniforge/evidence-bundle {:local/root "components/evidence-bundle"}
+                             ai.miniforge/tool-registry {:local/root "components/tool-registry"}}}
 
   :poly {:main-opts  ["-m" "polylith.clj.core.poly-cli.core"]
          :extra-deps {polylith/clj-poly {:mvn/version "0.2.21"}}}

--- a/specs/informative/tool-registry.md
+++ b/specs/informative/tool-registry.md
@@ -1,0 +1,262 @@
+# Tool/LSP Registry System
+
+**Status:** Implemented (Phases 1-3)
+**Component:** `tool-registry`
+
+**Goal:** Extensible tool registry that agents can use, with LSP servers as a first-class
+tool type. Simple to add (drop a file), manageable via fleet dashboard.
+
+---
+
+## Architecture
+
+```text
+ADAPTERS:    CLI commands, Dashboard panels
+APPLICATION: Tool Orchestrator, LSP Manager
+DOMAIN:      Tool Registry (extends existing tool component)
+FOUNDATIONS: Tool Schema (Malli)
+INFRA:       File Loader, Process Manager, File Watcher
+```
+
+New component: `tool-registry` (separate from existing `tool` protocol component)
+
+---
+
+## Tool Configuration Schema
+
+### Base Tool (EDN)
+
+```clojure
+{:tool/id          :lsp/clojure        ; Namespaced keyword
+ :tool/type        :lsp                ; :function, :lsp, :mcp, :external
+ :tool/name        "Clojure LSP"
+ :tool/description "Language server for Clojure"
+ :tool/version     "1.0.0"
+ :tool/config      {...}               ; Type-specific config
+ :tool/capabilities #{:code/diagnostics :code/format}
+ :tool/requires    #{:subprocess/spawn}
+ :tool/enabled     true
+ :tool/tags        #{:language-server :clojure}}
+```
+
+### LSP Config
+
+```clojure
+:tool/config
+{:lsp/command        ["clojure-lsp"]
+ :lsp/languages      #{"clojure" "clojurescript"}
+ :lsp/file-patterns  ["**/*.clj" "**/*.cljs"]
+ :lsp/capabilities   #{:diagnostics :format :hover}
+ :lsp/start-mode     :on-demand        ; or :eager
+ :lsp/shutdown-after-ms 300000}        ; 5 min idle timeout
+```
+
+---
+
+## File Locations
+
+```text
+~/.miniforge/tools/           # User-installed tools
+├── lsp/
+│   ├── clojure.edn
+│   ├── typescript.edn
+│   └── python.edn
+├── mcp/
+│   └── github.edn
+└── custom/
+    └── my-tool.edn
+
+components/tool-registry/resources/tools/   # Built-in tools
+└── lsp/
+    └── clojure.edn
+```
+
+**Discovery order** (later overrides earlier):
+
+1. Built-in: `resources/tools/**/*.edn`
+2. User: `~/.miniforge/tools/**/*.edn`
+3. Project: `.miniforge/tools/**/*.edn`
+
+---
+
+## Component Structure
+
+```text
+components/tool-registry/
+├── src/ai/miniforge/tool_registry/
+│   ├── interface.clj          # Public API
+│   ├── schema.clj             # Malli schemas + result helpers
+│   ├── loader.clj             # EDN file discovery/loading
+│   ├── registry.clj           # In-memory registry
+│   └── lsp/
+│       ├── protocol.clj       # LSP JSON-RPC types
+│       ├── process.clj        # Process lifecycle
+│       ├── client.clj         # LSP client
+│       └── manager.clj        # Server orchestration (pipeline pattern)
+├── resources/tools/           # Built-in tool configs
+│   └── lsp/
+│       └── clojure.edn
+└── test/                      # Unit + integration tests
+```
+
+---
+
+## Key Functions
+
+### interface.clj
+
+```clojure
+;; Registry
+(create-registry opts)         ; :auto-load? :watch? :logger
+(load-tools)                   ; Load from standard locations
+(register! registry tool)
+(list-tools registry)
+(find-tools registry query)
+
+;; LSP
+(start-lsp registry tool-id)
+(stop-lsp registry tool-id)
+(lsp-status registry tool-id)  ; :stopped :starting :running :error
+
+;; For agents
+(tools-for-context registry capabilities)
+
+;; Dashboard
+(tools-with-status registry)
+```
+
+### LSP Manager Pipeline
+
+```clojure
+;; start-server uses pipeline pattern:
+(-> initial-state
+    step-validate-tool      ; Check tool exists, is LSP, is enabled
+    step-check-existing     ; Handle already-running or clean up dead process
+    step-start-process      ; Spawn the LSP server process
+    step-create-client      ; Create LSP client from process
+    step-initialize         ; Send LSP initialize request
+    step-register           ; Store server in registry
+    pipeline->result)
+```
+
+### Result Helpers (schema.clj)
+
+```clojure
+(ok)                        ;; => {:success? true}
+(ok :client lsp-client)     ;; => {:success? true :client lsp-client}
+(err "Something failed")    ;; => {:success? false :error "Something failed"}
+(err "Tool not found: " id) ;; => {:success? false :error "Tool not found: :lsp/foo"}
+```
+
+---
+
+## Dashboard Integration (Future)
+
+### Web Panel (add to cli/web.clj)
+
+```clojure
+[:div.tools-panel
+ [:div.tools-header "Tools" [:button "Reload"]]
+ [:div.tools-list
+  (for [{:tool/keys [id name type]} tools]
+    [:div.tool-item
+     [:span.tool-icon (type-icon type)]
+     [:span.tool-name name]
+     [:span.tool-status status]
+     (when (= type :lsp)
+       [:button (if running? "Stop" "Start")])])]]
+```
+
+### API Endpoints
+
+- `GET /api/tools` - List all tools with status
+- `GET /api/tools/:id` - Tool detail
+- `POST /api/tools/:id/start` - Start LSP
+- `POST /api/tools/:id/stop` - Stop LSP
+- `POST /api/tools/reload` - Reload configs from disk
+
+### CLI Commands
+
+```bash
+miniforge tools list
+miniforge tools info <id>
+miniforge tools start <id>
+miniforge tools stop <id>
+miniforge tools reload
+```
+
+---
+
+## Agent Integration (Future)
+
+Extend `workflow/context.clj`:
+
+```clojure
+(defn create-context [workflow input opts]
+  (let [tool-registry (or (:tool-registry opts)
+                          (tool-registry/create-registry {}))]
+    (merge existing-context
+           {:tool-registry tool-registry
+            :available-tools (list-tools tool-registry)})))
+```
+
+Agents discover tools via context, filtered by capabilities and role.
+
+---
+
+## Implementation Phases
+
+### Phase 1: Foundation [DONE]
+
+- [x] Create `tool-registry` component skeleton
+- [x] `schema.clj` - Malli schemas for tool configs
+- [x] `loader.clj` - EDN file discovery and loading
+- [x] Unit tests
+
+### Phase 2: Registry Core [DONE]
+
+- [x] `registry.clj` - In-memory registry with CRUD
+- [x] Function tool instantiation
+- [x] `interface.clj` - Public API
+
+### Phase 3: LSP Support [DONE]
+
+- [x] `lsp/protocol.clj` - JSON-RPC message types
+- [x] `lsp/process.clj` - Process start/stop/health
+- [x] `lsp/client.clj` - LSP client communication
+- [x] `lsp/manager.clj` - Lifecycle orchestration (pipeline pattern)
+- [x] Built-in `clojure.edn` config
+- [x] E2E integration tests with clojure-lsp
+
+### Phase 4: Dashboard [TODO]
+
+- [ ] Web panel in `cli/web.clj`
+- [ ] TUI panel in `cli/tui.clj`
+- [ ] API endpoints
+- [ ] CLI commands
+
+### Phase 5: File Watching [TODO]
+
+- [ ] `watcher.clj` - Java WatchService integration
+- [ ] Hot-reload on config changes
+
+### Phase 6: Agent Integration [TODO]
+
+- [ ] Extend workflow context
+- [ ] Tool discovery helpers for agents
+
+---
+
+## Verification
+
+```bash
+# Unit tests
+clj -M:dev:test -e "(require '[clojure.test :as t] '[ai.miniforge.tool-registry.schema-test]) (t/run-tests 'ai.miniforge.tool-registry.schema-test)"
+clj -M:dev:test -e "(require '[clojure.test :as t] '[ai.miniforge.tool-registry.loader-test]) (t/run-tests 'ai.miniforge.tool-registry.loader-test)"
+
+# Integration (requires clojure-lsp)
+clj -M:dev:test -e "(require '[clojure.test :as t] '[ai.miniforge.tool-registry.integration-test]) (t/run-tests 'ai.miniforge.tool-registry.integration-test)"
+
+# Conformance
+clj -M:dev:test:conformance -e "(require '[clojure.test :as t] '[conformance.tool-registry-conformance-test]) (t/run-tests 'conformance.tool-registry-conformance-test)"
+```

--- a/tests/conformance/conformance/tool_registry_conformance_test.clj
+++ b/tests/conformance/conformance/tool_registry_conformance_test.clj
@@ -1,0 +1,211 @@
+(ns conformance.tool-registry-conformance-test
+  "Conformance tests for the tool-registry component.
+
+   Verifies:
+   - Tool registry component loads and provides required interface
+   - LSP support is properly structured
+   - Tool discovery and management works correctly
+   - Integration with agent context for tool selection"
+  (:require
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Component Loading
+
+(deftest tool-registry-component-loads-test
+  (testing "tool-registry component loads successfully"
+    (require 'ai.miniforge.tool-registry.interface)
+    (let [tr-ns (find-ns 'ai.miniforge.tool-registry.interface)]
+      (is (some? tr-ns) "tool-registry interface namespace must exist"))))
+
+(deftest tool-registry-interface-functions-test
+  (testing "tool-registry interface provides required functions"
+    (require 'ai.miniforge.tool-registry.interface)
+    (let [tr-ns (find-ns 'ai.miniforge.tool-registry.interface)]
+      ;; Registry management
+      (is (some? (ns-resolve tr-ns 'create-registry)) "create-registry function exists")
+      (is (some? (ns-resolve tr-ns 'register!)) "register! function exists")
+      (is (some? (ns-resolve tr-ns 'unregister!)) "unregister! function exists")
+      (is (some? (ns-resolve tr-ns 'get-tool)) "get-tool function exists")
+      (is (some? (ns-resolve tr-ns 'list-tools)) "list-tools function exists")
+      (is (some? (ns-resolve tr-ns 'find-tools)) "find-tools function exists")
+
+      ;; LSP lifecycle
+      (is (some? (ns-resolve tr-ns 'start-lsp)) "start-lsp function exists")
+      (is (some? (ns-resolve tr-ns 'stop-lsp)) "stop-lsp function exists")
+      (is (some? (ns-resolve tr-ns 'lsp-status)) "lsp-status function exists")
+
+      ;; Tool loading
+      (is (some? (ns-resolve tr-ns 'load-tools)) "load-tools function exists")
+      (is (some? (ns-resolve tr-ns 'discover-tools)) "discover-tools function exists")
+
+      ;; Agent integration
+      (is (some? (ns-resolve tr-ns 'tools-for-context)) "tools-for-context function exists")
+      (is (some? (ns-resolve tr-ns 'tools-with-status)) "tools-with-status function exists"))))
+
+(deftest tool-registry-schema-exports-test
+  (testing "tool-registry exports Malli schemas"
+    (require 'ai.miniforge.tool-registry.interface)
+    (let [tr-ns (find-ns 'ai.miniforge.tool-registry.interface)]
+      (is (some? (ns-resolve tr-ns 'ToolConfig)) "ToolConfig schema is exported")
+      (is (some? (ns-resolve tr-ns 'LSPConfig)) "LSPConfig schema is exported")
+      (is (some? (ns-resolve tr-ns 'tool-types)) "tool-types set is exported")
+      (is (some? (ns-resolve tr-ns 'lsp-capabilities)) "lsp-capabilities set is exported"))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; LSP Support Structure
+
+(deftest lsp-protocol-namespace-test
+  (testing "LSP protocol namespace loads"
+    (require 'ai.miniforge.tool-registry.lsp.protocol)
+    (let [proto-ns (find-ns 'ai.miniforge.tool-registry.lsp.protocol)]
+      (is (some? proto-ns) "lsp.protocol namespace exists")
+      ;; Check key protocol functions
+      (is (some? (ns-resolve proto-ns 'request)) "request builder exists")
+      (is (some? (ns-resolve proto-ns 'notification)) "notification builder exists")
+      (is (some? (ns-resolve proto-ns 'encode-message)) "encode-message exists")
+      (is (some? (ns-resolve proto-ns 'decode-message)) "decode-message exists"))))
+
+(deftest lsp-client-namespace-test
+  (testing "LSP client namespace loads"
+    (require 'ai.miniforge.tool-registry.lsp.client)
+    (let [client-ns (find-ns 'ai.miniforge.tool-registry.lsp.client)]
+      (is (some? client-ns) "lsp.client namespace exists")
+      ;; Check key client functions
+      (is (some? (ns-resolve client-ns 'create-client)) "create-client exists")
+      (is (some? (ns-resolve client-ns 'initialize)) "initialize exists")
+      (is (some? (ns-resolve client-ns 'shutdown)) "shutdown exists")
+      (is (some? (ns-resolve client-ns 'hover)) "hover exists")
+      (is (some? (ns-resolve client-ns 'completion)) "completion exists")
+      (is (some? (ns-resolve client-ns 'format-document)) "format-document exists"))))
+
+(deftest lsp-manager-namespace-test
+  (testing "LSP manager namespace loads"
+    (require 'ai.miniforge.tool-registry.lsp.manager)
+    (let [manager-ns (find-ns 'ai.miniforge.tool-registry.lsp.manager)]
+      (is (some? manager-ns) "lsp.manager namespace exists")
+      ;; Check key manager functions
+      (is (some? (ns-resolve manager-ns 'start-server)) "start-server exists")
+      (is (some? (ns-resolve manager-ns 'stop-server)) "stop-server exists")
+      (is (some? (ns-resolve manager-ns 'get-client)) "get-client exists")
+      (is (some? (ns-resolve manager-ns 'server-status)) "server-status exists")
+      (is (some? (ns-resolve manager-ns 'list-servers)) "list-servers exists"))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Functional Tests
+
+(deftest registry-crud-operations-test
+  (testing "Registry CRUD operations work correctly"
+    (require '[ai.miniforge.tool-registry.interface :as tr])
+    (let [create-registry (ns-resolve 'ai.miniforge.tool-registry.interface 'create-registry)
+          register! (ns-resolve 'ai.miniforge.tool-registry.interface 'register!)
+          get-tool (ns-resolve 'ai.miniforge.tool-registry.interface 'get-tool)
+          list-tools (ns-resolve 'ai.miniforge.tool-registry.interface 'list-tools)
+          unregister! (ns-resolve 'ai.miniforge.tool-registry.interface 'unregister!)
+
+          registry (create-registry {})
+          tool {:tool/id :test/conformance-tool
+                :tool/type :function
+                :tool/name "Conformance Test Tool"
+                :tool/description "A tool for conformance testing"
+                :tool/capabilities #{:code/diagnostics}}]
+
+      ;; Register
+      (let [tool-id (register! registry tool)]
+        (is (= :test/conformance-tool tool-id) "register! returns tool ID"))
+
+      ;; Get
+      (let [retrieved (get-tool registry :test/conformance-tool)]
+        (is (some? retrieved) "get-tool retrieves registered tool")
+        (is (= "Conformance Test Tool" (:tool/name retrieved))))
+
+      ;; List
+      (let [tools (list-tools registry)]
+        (is (= 1 (count tools)) "list-tools returns all tools"))
+
+      ;; Unregister
+      (unregister! registry :test/conformance-tool)
+      (is (nil? (get-tool registry :test/conformance-tool)) "unregister! removes tool"))))
+
+(deftest tool-discovery-by-capability-test
+  (testing "Tools can be discovered by capability"
+    (require '[ai.miniforge.tool-registry.interface :as tr])
+    (let [create-registry (ns-resolve 'ai.miniforge.tool-registry.interface 'create-registry)
+          register! (ns-resolve 'ai.miniforge.tool-registry.interface 'register!)
+          tools-for-context (ns-resolve 'ai.miniforge.tool-registry.interface 'tools-for-context)
+
+          registry (create-registry {})]
+
+      ;; Register tools with different capabilities
+      (register! registry {:tool/id :tools/diagnostic
+                           :tool/type :function
+                           :tool/name "Diagnostic Tool"
+                           :tool/capabilities #{:code/diagnostics}})
+
+      (register! registry {:tool/id :tools/formatter
+                           :tool/type :function
+                           :tool/name "Format Tool"
+                           :tool/capabilities #{:code/format}})
+
+      (register! registry {:tool/id :tools/both
+                           :tool/type :function
+                           :tool/name "Both Tool"
+                           :tool/capabilities #{:code/diagnostics :code/format}})
+
+      ;; Query by capability
+      (let [diagnostic-tools (tools-for-context registry #{:code/diagnostics})
+            format-tools (tools-for-context registry #{:code/format})
+            both-tools (tools-for-context registry #{:code/diagnostics :code/format})]
+
+        (is (= 2 (count diagnostic-tools)) "2 tools have diagnostics capability")
+        (is (= 2 (count format-tools)) "2 tools have format capability")
+        (is (= 1 (count both-tools)) "1 tool has both capabilities")))))
+
+(deftest builtin-tools-exist-test
+  (testing "Built-in tool configurations exist in resources"
+    (let [clojure-lsp-config (io/resource "tools/lsp/clojure.edn")]
+      (is (some? clojure-lsp-config) "Built-in clojure.edn LSP config exists"))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Schema Validation Tests
+
+(deftest tool-schema-validation-test
+  (testing "Tool schema validates correctly"
+    (require '[ai.miniforge.tool-registry.schema :as schema])
+    (let [validate-tool (ns-resolve 'ai.miniforge.tool-registry.schema 'validate-tool)]
+
+      ;; Valid tool
+      (let [valid-tool {:tool/id :test/valid
+                        :tool/type :function
+                        :tool/name "Valid Tool"}
+            result (validate-tool valid-tool)]
+        (is (:valid? result) "Valid tool passes validation"))
+
+      ;; Invalid tool (missing required fields)
+      (let [invalid-tool {:tool/id :test/invalid}
+            result (validate-tool invalid-tool)]
+        (is (not (:valid? result)) "Invalid tool fails validation")))))
+
+(deftest lsp-config-schema-validation-test
+  (testing "LSP config schema validates correctly"
+    (require '[ai.miniforge.tool-registry.schema :as schema])
+    (let [validate-lsp-config (ns-resolve 'ai.miniforge.tool-registry.schema 'validate-lsp-config)]
+
+      ;; Valid LSP config
+      (let [valid-config {:lsp/command ["clojure-lsp"]
+                          :lsp/languages #{"clojure"}}
+            result (validate-lsp-config valid-config)]
+        (is (:valid? result) "Valid LSP config passes validation"))
+
+      ;; Invalid LSP config (missing command)
+      (let [invalid-config {:lsp/languages #{"clojure"}}
+            result (validate-lsp-config invalid-config)]
+        (is (not (:valid? result)) "Invalid LSP config fails validation")))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Run conformance tests
+  (clojure.test/run-tests 'conformance.tool-registry-conformance-test)
+
+  :leave-this-here)


### PR DESCRIPTION
## Summary

Implement Tool/LSP Registry System that provides an extensible tool registry for agents to discover and use tools. LSP servers are supported as a first-class tool type.

- **EDN-based tool configuration** with Malli schema validation
- **Tool discovery from multiple locations** (builtin, user, project)
- **Full LSP lifecycle management** (start, stop, health monitoring)
- **LSP client** with JSON-RPC protocol support
- **Capability-based tool filtering** for agent context
- **Built-in Clojure LSP configuration**

## Architecture

```
components/tool-registry/
├── deps.edn
├── resources/tools/lsp/
│   └── clojure.edn            # Built-in Clojure LSP config
├── src/ai/miniforge/tool_registry/
│   ├── interface.clj          # Public API (Layer 0-4 pattern)
│   ├── schema.clj             # Malli schemas for tool configs
│   ├── loader.clj             # EDN file discovery and loading
│   ├── registry.clj           # In-memory registry with CRUD
│   └── lsp/
│       ├── protocol.clj       # LSP JSON-RPC message types
│       ├── process.clj        # Process lifecycle management
│       ├── client.clj         # LSP client communication
│       └── manager.clj        # LSP server orchestration
└── test/                      # Unit and integration tests
```

## Tool Configuration Schema

```clojure
{:tool/id          :lsp/clojure        ; Namespaced keyword
 :tool/type        :lsp                ; :function, :lsp, :mcp, :external
 :tool/name        "Clojure LSP"
 :tool/description "Language server for Clojure"
 :tool/version     "1.0.0"
 :tool/config      {:lsp/command ["clojure-lsp"] ...}
 :tool/capabilities #{:code/diagnostics :code/format}
 :tool/enabled     true
 :tool/tags        #{:language-server :clojure}}
```

## Discovery Locations

Tools are discovered from (later overrides earlier):
1. **Built-in**: `resources/tools/**/*.edn`
2. **User**: `~/.miniforge/tools/**/*.edn`
3. **Project**: `.miniforge/tools/**/*.edn`

## Test Plan

- [x] Schema validation tests (8 tests)
- [x] Registry CRUD tests (7 tests)
- [x] Loader file discovery tests (4 tests)
- [x] Interface API tests (7 tests)
- [x] Integration tests with clojure-lsp (5 tests)
- [x] Conformance tests (11 tests)
- [x] All pre-commit checks pass

**Total: 42 tests, 173 assertions**

## Usage Example

```clojure
(require '[ai.miniforge.tool-registry.interface :as tr])

;; Create registry and load tools
(def registry (tr/create-registry {:auto-load? true}))

;; Find tools by capability (for agents)
(tr/tools-for-context registry #{:code/diagnostics})

;; Start LSP server
(tr/start-lsp registry :lsp/clojure)

;; Use LSP client
(let [client (tr/get-lsp-client registry :lsp/clojure)]
  (lsp-client/hover client "file:///foo.clj" 10 5))
```

🤖 Generated with [Claude Code](https://claude.ai/code)