### PR TITLE
refactor(dag-executor): decompose executor into protocol/impl pattern

### DIFF
--- a/components/dag-executor/resources/executor/docker/Dockerfile.task-runner
+++ b/components/dag-executor/resources/executor/docker/Dockerfile.task-runner
@@ -1,0 +1,52 @@
+# Task Runner Container Image
+# Used by DockerExecutor and KubernetesExecutor for isolated task execution
+#
+# This image provides the minimal environment for:
+# - Git operations (clone, checkout, commit, push)
+# - Shell command execution
+# - File manipulation
+#
+# Build: docker build -t miniforge/task-runner:latest -f Dockerfile.task-runner .
+# Usage: docker run -d --name task-123 miniforge/task-runner:latest
+
+FROM alpine:3.19
+
+# Install essential tools
+RUN apk add --no-cache \
+    # Git for repo operations
+    git \
+    # SSH for git operations over SSH
+    openssh-client \
+    # Shell utilities
+    bash \
+    coreutils \
+    # Build essentials (for compilation tasks)
+    build-base \
+    # Curl for API calls
+    curl \
+    # jq for JSON processing
+    jq \
+    # ca-certificates for HTTPS
+    ca-certificates
+
+# Configure git
+RUN git config --global user.email "miniforge@miniforge.ai" && \
+    git config --global user.name "Miniforge Task Runner" && \
+    git config --global init.defaultBranch main
+
+# Create workspace directory
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# Default command: keep container alive for exec
+# Uses trap to handle SIGTERM gracefully
+CMD ["sh", "-c", "trap 'exit 0' TERM; sleep infinity & wait"]
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD pgrep -f "sleep infinity" > /dev/null || exit 1
+
+# Labels
+LABEL maintainer="miniforge@miniforge.ai"
+LABEL description="Task runner container for Miniforge DAG executor"
+LABEL version="1.0.0"

--- a/components/dag-executor/resources/executor/docker/Dockerfile.task-runner-clojure
+++ b/components/dag-executor/resources/executor/docker/Dockerfile.task-runner-clojure
@@ -1,0 +1,64 @@
+# Clojure Task Runner Container Image
+# Extended image with Clojure tooling for Clojure/ClojureScript projects
+#
+# Build: docker build -t miniforge/task-runner-clojure:latest -f Dockerfile.task-runner-clojure .
+
+FROM eclipse-temurin:21-jdk-alpine
+
+# Install essential tools
+RUN apk add --no-cache \
+    git \
+    openssh-client \
+    bash \
+    coreutils \
+    curl \
+    jq \
+    ca-certificates \
+    # For native compilation
+    build-base \
+    # Node.js for ClojureScript
+    nodejs \
+    npm
+
+# Install Clojure CLI tools
+RUN curl -L -O https://github.com/clojure/brew-install/releases/latest/download/linux-install.sh && \
+    chmod +x linux-install.sh && \
+    ./linux-install.sh && \
+    rm linux-install.sh
+
+# Install Babashka for scripting
+RUN curl -sLO https://raw.githubusercontent.com/babashka/babashka/master/install && \
+    chmod +x install && \
+    ./install && \
+    rm install
+
+# Install clj-kondo for linting
+RUN curl -sLO https://raw.githubusercontent.com/clj-kondo/clj-kondo/master/script/install-clj-kondo && \
+    chmod +x install-clj-kondo && \
+    ./install-clj-kondo && \
+    rm install-clj-kondo
+
+# Configure git
+RUN git config --global user.email "miniforge@miniforge.ai" && \
+    git config --global user.name "Miniforge Task Runner" && \
+    git config --global init.defaultBranch main
+
+# Pre-download Clojure dependencies cache location
+ENV CLJ_CONFIG=/root/.clojure
+ENV CLJ_CACHE=/root/.clojure/.cpcache
+
+# Create workspace directory
+RUN mkdir -p /workspace
+WORKDIR /workspace
+
+# Default command: keep container alive for exec
+CMD ["sh", "-c", "trap 'exit 0' TERM; sleep infinity & wait"]
+
+# Health check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+    CMD pgrep -f "sleep infinity" > /dev/null || exit 1
+
+# Labels
+LABEL maintainer="miniforge@miniforge.ai"
+LABEL description="Clojure task runner container for Miniforge DAG executor"
+LABEL version="1.0.0"

--- a/components/dag-executor/resources/executor/kubernetes/job-template.yaml
+++ b/components/dag-executor/resources/executor/kubernetes/job-template.yaml
@@ -1,0 +1,88 @@
+# Kubernetes Job Template for Task Execution
+# This template is used by KubernetesExecutor to create isolated task environments
+#
+# Placeholders (replaced at runtime):
+# - {{JOB_NAME}} - Unique job name (e.g., miniforge-task-abc12345)
+# - {{NAMESPACE}} - Kubernetes namespace
+# - {{IMAGE}} - Container image to use
+# - {{TASK_ID}} - UUID of the task
+# - {{WORKDIR}} - Working directory inside container
+# - {{ENV_VARS}} - Environment variables (injected as array)
+# - {{RESOURCES}} - Resource limits/requests
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{JOB_NAME}}"
+  namespace: "{{NAMESPACE}}"
+  labels:
+    app: miniforge
+    component: task-executor
+    task-id: "{{TASK_ID}}"
+  annotations:
+    miniforge.ai/task-id: "{{TASK_ID}}"
+    miniforge.ai/created-by: dag-executor
+spec:
+  # Cleanup completed jobs after 5 minutes
+  ttlSecondsAfterFinished: 300
+  # No retries - we handle retries at the DAG scheduler level
+  backoffLimit: 0
+  # Parallelism settings
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: miniforge
+        component: task-executor
+        job-name: "{{JOB_NAME}}"
+    spec:
+      # Don't restart on failure - let scheduler handle it
+      restartPolicy: Never
+      # Terminate quickly on deletion
+      terminationGracePeriodSeconds: 10
+      containers:
+        - name: task
+          image: "{{IMAGE}}"
+          imagePullPolicy: IfNotPresent
+          workingDir: "{{WORKDIR}}"
+          # Keep container alive for interactive execution
+          command:
+            - sh
+            - -c
+            - "trap 'exit 0' TERM; sleep infinity & wait"
+          env: []
+          # {{ENV_VARS}} - injected at runtime
+          resources:
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+          # {{RESOURCES}} - can override at runtime
+          # Security context for non-root execution
+          securityContext:
+            runAsNonRoot: false
+            readOnlyRootFilesystem: false
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          # Volume mounts for workspace persistence
+          volumeMounts:
+            - name: workspace
+              mountPath: /workspace
+      volumes:
+        - name: workspace
+          emptyDir:
+            sizeLimit: 1Gi
+      # Node selection (optional - can be customized)
+      # nodeSelector:
+      #   miniforge.ai/task-runner: "true"
+      # Tolerations for dedicated nodes (optional)
+      # tolerations:
+      #   - key: "miniforge.ai/task-runner"
+      #     operator: "Equal"
+      #     value: "true"
+      #     effect: "NoSchedule"

--- a/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
@@ -1,137 +1,87 @@
 (ns ai.miniforge.dag-executor.executor
   "Pluggable task execution backends.
 
-   Defines the executor protocol and provides implementations for:
+   Provides a unified interface for task isolation using:
    - Kubernetes (K8s Jobs)
    - Docker containers
    - Local worktree with semaphores (fallback)
 
    The executor contract abstracts how tasks get isolated environments
-   for code generation and PR lifecycle operations."
+   for code generation and PR lifecycle operations.
+
+   See:
+   - protocols/executor.clj - Protocol definition
+   - protocols/impl/docker.clj - Docker implementation
+   - protocols/impl/kubernetes.clj - Kubernetes implementation
+   - protocols/impl/worktree.clj - Worktree fallback implementation"
   (:require
    [ai.miniforge.dag-executor.result :as result]
-   [clojure.java.shell :as shell]
-   [clojure.string :as str]))
+   [ai.miniforge.dag-executor.protocols.executor :as proto]
+   [ai.miniforge.dag-executor.protocols.impl.docker :as docker]
+   [ai.miniforge.dag-executor.protocols.impl.kubernetes :as k8s]
+   [ai.miniforge.dag-executor.protocols.impl.worktree :as worktree]))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Executor Protocol
+;; ============================================================================
+;; Protocol Re-exports
+;; ============================================================================
 
-(defprotocol TaskExecutor
-  "Protocol for task execution backends.
+(def TaskExecutor
+  "Protocol for task execution backends."
+  proto/TaskExecutor)
 
-   Implementations provide isolated environments where tasks can:
-   - Clone/checkout repositories
-   - Run code generation
-   - Execute tests and validation
-   - Create and push commits
+(def executor-type proto/executor-type)
+(def available? proto/available?)
+(def acquire-environment! proto/acquire-environment!)
+(def execute! proto/execute!)
+(def copy-to! proto/copy-to!)
+(def copy-from! proto/copy-from!)
+(def release-environment! proto/release-environment!)
+(def environment-status proto/environment-status)
 
-   The protocol is designed to be backend-agnostic, supporting
-   containers (Docker, K8s) and local worktree execution."
-
-  (executor-type [this]
-    "Return the executor type keyword: :kubernetes, :docker, :worktree")
-
-  (available? [this]
-    "Check if this executor backend is available.
-     Returns result with {:available? bool :reason string}")
-
-  (acquire-environment! [this task-id config]
-    "Acquire an isolated execution environment for a task.
-
-     Arguments:
-     - task-id: UUID identifying the task
-     - config: Environment configuration map
-       {:repo-url string         ; Git repository URL
-        :branch string           ; Branch to checkout
-        :base-sha string         ; Base commit SHA
-        :workdir string          ; Working directory inside environment
-        :env map                 ; Environment variables
-        :resources map           ; Resource limits {:cpu :memory}
-        :timeout-ms long}        ; Acquisition timeout
-
-     Returns result with:
-     {:environment-id string    ; Unique ID for this environment
-      :type keyword             ; :container, :worktree
-      :workdir string           ; Path to working directory
-      :metadata map}            ; Backend-specific metadata")
-
-  (execute! [this environment-id command opts]
-    "Execute a command in the environment.
-
-     Arguments:
-     - environment-id: ID from acquire-environment!
-     - command: Command to execute (string or vector)
-     - opts: Execution options
-       {:timeout-ms long        ; Command timeout
-        :env map                ; Additional env vars
-        :workdir string         ; Override working directory
-        :capture-output? bool}  ; Capture stdout/stderr
-
-     Returns result with:
-     {:exit-code int
-      :stdout string            ; If capture-output?
-      :stderr string            ; If capture-output?
-      :duration-ms long}")
-
-  (copy-to! [this environment-id local-path remote-path]
-    "Copy files from host to environment.
-     Returns result with {:copied-bytes long}")
-
-  (copy-from! [this environment-id remote-path local-path]
-    "Copy files from environment to host.
-     Returns result with {:copied-bytes long}")
-
-  (release-environment! [this environment-id]
-    "Release and cleanup an execution environment.
-     Returns result with {:released? bool}")
-
-  (environment-status [this environment-id]
-    "Get status of an execution environment.
-     Returns result with:
-     {:status keyword           ; :running, :stopped, :error, :unknown
-      :created-at inst
-      :resource-usage map}"))
-
-;------------------------------------------------------------------------------ Layer 0
-;; Environment record
-
-(defrecord ExecutionEnvironment
-  [environment-id
-   executor-type
-   task-id
-   workdir
-   repo-url
-   branch
-   created-at
-   status
-   metadata])
-
-(defn create-environment-record
+(def create-environment-record
   "Create an environment record."
-  [environment-id executor-type task-id workdir opts]
-  (map->ExecutionEnvironment
-   {:environment-id environment-id
-    :executor-type executor-type
-    :task-id task-id
-    :workdir workdir
-    :repo-url (:repo-url opts)
-    :branch (:branch opts)
-    :created-at (java.util.Date.)
-    :status :running
-    :metadata (:metadata opts {})}))
+  proto/create-environment-record)
 
-;------------------------------------------------------------------------------ Layer 1
-;; Executor selection and factory
+;; ============================================================================
+;; Factory Re-exports
+;; ============================================================================
 
-;; Forward declarations for factory functions
-(declare create-kubernetes-executor create-docker-executor create-worktree-executor)
+(def create-docker-executor
+  "Create a Docker executor.
+
+   Config:
+   - :image - Container image for tasks (default: alpine:latest)
+   - :network - Docker network to attach to
+   - :docker-path - Path to docker binary"
+  docker/create-docker-executor)
+
+(def create-kubernetes-executor
+  "Create a Kubernetes executor.
+
+   Config:
+   - :namespace - K8s namespace (default: 'default')
+   - :image - Container image for tasks (default: alpine:latest)
+   - :kubectl-path - Path to kubectl binary"
+  k8s/create-kubernetes-executor)
+
+(def create-worktree-executor
+  "Create a worktree-based executor (fallback).
+
+   Config:
+   - :base-path - Base directory for worktrees (default: /tmp/miniforge-worktrees)
+   - :max-concurrent - Max concurrent worktrees (default: 4)"
+  worktree/create-worktree-executor)
+
+;; ============================================================================
+;; Executor Selection
+;; ============================================================================
 
 (def executor-priority
   "Preferred executor order. First available wins."
   [:kubernetes :docker :worktree])
 
 (defn select-executor
-  "Select the best available executor from a list.
+  "Select the best available executor from a registry.
 
    Arguments:
    - executors: Map of executor-type -> executor instance
@@ -145,9 +95,9 @@
     (->> order
          (map #(get executors %))
          (filter some?)
-         (filter #(let [result (available? %)]
-                    (and (result/ok? result)
-                         (:available? (:data result)))))
+         (filter #(let [r (available? %)]
+                    (and (result/ok? r)
+                         (:available? (:data r)))))
          first)))
 
 (defn create-executor-registry
@@ -161,7 +111,6 @@
 
    Returns map of executor-type -> executor instance."
   [config]
-  ;; Implementations are created lazily - see create-* functions below
   (cond-> {}
     (:kubernetes config)
     (assoc :kubernetes (create-kubernetes-executor (:kubernetes config)))
@@ -171,432 +120,11 @@
 
     ;; Worktree is always available as fallback
     true
-    (assoc :worktree (create-worktree-executor (:worktree config {})))))
+    (assoc :worktree (create-worktree-executor (or (:worktree config) {})))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Kubernetes Executor
-
-(defrecord KubernetesExecutor [config namespace image kubectl-path]
-  TaskExecutor
-
-  (executor-type [_this] :kubernetes)
-
-  (available? [_this]
-    ;; Check if kubectl is available and can connect to cluster
-    (try
-      (let [result (shell/sh
-                    (or kubectl-path "kubectl")
-                    "cluster-info" "--request-timeout=5s")]
-        (if (zero? (:exit result))
-          (result/ok {:available? true
-                      :cluster-info (subs (:out result) 0 (min 200 (count (:out result))))})
-          (result/ok {:available? false
-                      :reason (:err result)})))
-      (catch Exception e
-        (result/ok {:available? false
-                    :reason (.getMessage e)}))))
-
-  (acquire-environment! [_this task-id env-config]
-    (let [job-name (str "miniforge-task-" (subs (str task-id) 0 8))
-          _pod-spec {:apiVersion "batch/v1"
-                    :kind "Job"
-                    :metadata {:name job-name
-                               :namespace namespace
-                               :labels {:app "miniforge"
-                                        :task-id (str task-id)}}
-                    :spec {:template
-                           {:spec {:containers
-                                   [{:name "task"
-                                     :image image
-                                     :workingDir (or (:workdir env-config) "/workspace")
-                                     :env (mapv (fn [[k v]] {:name (name k) :value v})
-                                                (:env env-config))
-                                     :resources {:limits (:resources env-config)}}]
-                                   :restartPolicy "Never"}}
-                           :backoffLimit 0}}]
-      ;; In real impl: kubectl apply -f <pod-spec>
-      ;; For now, return a placeholder
-      (result/ok (create-environment-record
-                  job-name :kubernetes task-id
-                  (or (:workdir env-config) "/workspace")
-                  (assoc env-config :metadata {:job-name job-name
-                                               :namespace namespace})))))
-
-  (execute! [_this environment-id command opts]
-    ;; kubectl exec into the pod
-    (let [_timeout-sec (quot (or (:timeout-ms opts) 300000) 1000)
-          cmd-args (if (string? command)
-                     ["sh" "-c" command]
-                     command)]
-      (try
-        (let [start-time (System/currentTimeMillis)
-              result (apply shell/sh
-                            (or kubectl-path "kubectl")
-                            "exec" "-n" namespace environment-id "--"
-                            cmd-args)]
-          (result/ok {:exit-code (:exit result)
-                      :stdout (:out result)
-                      :stderr (:err result)
-                      :duration-ms (- (System/currentTimeMillis) start-time)}))
-        (catch Exception e
-          (result/err :exec-failed (.getMessage e))))))
-
-  (copy-to! [_this environment-id local-path remote-path]
-    (try
-      (let [result (shell/sh
-                    (or kubectl-path "kubectl")
-                    "cp" local-path
-                    (str namespace "/" environment-id ":" remote-path))]
-        (if (zero? (:exit result))
-          (result/ok {:copied-bytes -1}) ; kubectl cp doesn't report bytes
-          (result/err :copy-failed (:err result))))
-      (catch Exception e
-        (result/err :copy-failed (.getMessage e)))))
-
-  (copy-from! [_this environment-id remote-path local-path]
-    (try
-      (let [result (shell/sh
-                    (or kubectl-path "kubectl")
-                    "cp"
-                    (str namespace "/" environment-id ":" remote-path)
-                    local-path)]
-        (if (zero? (:exit result))
-          (result/ok {:copied-bytes -1})
-          (result/err :copy-failed (:err result))))
-      (catch Exception e
-        (result/err :copy-failed (.getMessage e)))))
-
-  (release-environment! [_this environment-id]
-    (try
-      (let [result (shell/sh
-                    (or kubectl-path "kubectl")
-                    "delete" "job" environment-id "-n" namespace)]
-        (result/ok {:released? (zero? (:exit result))}))
-      (catch Exception e
-        (result/err :release-failed (.getMessage e)))))
-
-  (environment-status [_this environment-id]
-    (try
-      (let [result (shell/sh
-                    (or kubectl-path "kubectl")
-                    "get" "job" environment-id "-n" namespace
-                    "-o" "jsonpath={.status.conditions[0].type}")]
-        (result/ok {:status (case (:out result)
-                              "Complete" :stopped
-                              "Failed" :error
-                              :running)
-                    :raw (:out result)}))
-      (catch Exception e
-        (result/ok {:status :unknown :error (.getMessage e)})))))
-
-(defn create-kubernetes-executor
-  "Create a Kubernetes executor.
-
-   Config:
-   - :namespace - K8s namespace (default: 'miniforge')
-   - :image - Container image for tasks
-   - :kubectl-path - Path to kubectl binary"
-  [config]
-  (map->KubernetesExecutor
-   {:config config
-    :namespace (or (:namespace config) "miniforge")
-    :image (or (:image config) "miniforge/task-runner:latest")
-    :kubectl-path (:kubectl-path config)}))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Docker Executor
-
-(defrecord DockerExecutor [config image network docker-path]
-  TaskExecutor
-
-  (executor-type [_this] :docker)
-
-  (available? [_this]
-    (try
-      (let [result (shell/sh
-                    (or docker-path "docker")
-                    "info" "--format" "{{.ServerVersion}}")]
-        (if (zero? (:exit result))
-          (result/ok {:available? true
-                      :docker-version (clojure.string/trim (:out result))})
-          (result/ok {:available? false
-                      :reason (:err result)})))
-      (catch Exception e
-        (result/ok {:available? false
-                    :reason (.getMessage e)}))))
-
-  (acquire-environment! [_this task-id env-config]
-    (let [container-name (str "miniforge-task-" (subs (str task-id) 0 8))
-          workdir (or (:workdir env-config) "/workspace")
-          env-args (mapcat (fn [[k v]] ["-e" (str (name k) "=" v)])
-                           (:env env-config))
-          resource-args (cond-> []
-                          (get-in env-config [:resources :memory])
-                          (into ["--memory" (get-in env-config [:resources :memory])])
-
-                          (get-in env-config [:resources :cpu])
-                          (into ["--cpus" (str (get-in env-config [:resources :cpu]))]))
-          cmd-args (concat [(or docker-path "docker") "run" "-d"
-                            "--name" container-name
-                            "-w" workdir]
-                           (when network ["--network" network])
-                           env-args
-                           resource-args
-                           [image "sleep" "infinity"])]
-      (try
-        (let [result (apply shell/sh cmd-args)]
-          (if (zero? (:exit result))
-            (let [container-id (clojure.string/trim (:out result))]
-              (result/ok (create-environment-record
-                          container-name :docker task-id workdir
-                          (assoc env-config
-                                 :metadata {:container-id container-id
-                                            :container-name container-name}))))
-            (result/err :container-create-failed (:err result))))
-        (catch Exception e
-          (result/err :container-create-failed (.getMessage e))))))
-
-  (execute! [_this environment-id command opts]
-    (let [cmd-args (if (string? command)
-                     ["sh" "-c" command]
-                     command)
-          workdir-args (when (:workdir opts)
-                         ["-w" (:workdir opts)])
-          env-args (mapcat (fn [[k v]] ["-e" (str (name k) "=" v)])
-                           (:env opts))
-          full-args (concat [(or docker-path "docker") "exec"]
-                            workdir-args
-                            env-args
-                            [environment-id]
-                            cmd-args)]
-      (try
-        (let [start-time (System/currentTimeMillis)
-              result (apply shell/sh full-args)]
-          (result/ok {:exit-code (:exit result)
-                      :stdout (:out result)
-                      :stderr (:err result)
-                      :duration-ms (- (System/currentTimeMillis) start-time)}))
-        (catch Exception e
-          (result/err :exec-failed (.getMessage e))))))
-
-  (copy-to! [_this environment-id local-path remote-path]
-    (try
-      (let [result (shell/sh
-                    (or docker-path "docker")
-                    "cp" local-path
-                    (str environment-id ":" remote-path))]
-        (if (zero? (:exit result))
-          (result/ok {:copied-bytes -1})
-          (result/err :copy-failed (:err result))))
-      (catch Exception e
-        (result/err :copy-failed (.getMessage e)))))
-
-  (copy-from! [_this environment-id remote-path local-path]
-    (try
-      (let [result (shell/sh
-                    (or docker-path "docker")
-                    "cp"
-                    (str environment-id ":" remote-path)
-                    local-path)]
-        (if (zero? (:exit result))
-          (result/ok {:copied-bytes -1})
-          (result/err :copy-failed (:err result))))
-      (catch Exception e
-        (result/err :copy-failed (.getMessage e)))))
-
-  (release-environment! [_this environment-id]
-    (try
-      ;; Stop and remove container
-      (shell/sh (or docker-path "docker") "stop" "-t" "5" environment-id)
-      (let [result (shell/sh (or docker-path "docker") "rm" "-f" environment-id)]
-        (result/ok {:released? (zero? (:exit result))}))
-      (catch Exception e
-        (result/err :release-failed (.getMessage e)))))
-
-  (environment-status [_this environment-id]
-    (try
-      (let [result (shell/sh
-                    (or docker-path "docker")
-                    "inspect" environment-id
-                    "--format" "{{.State.Status}}")]
-        (if (zero? (:exit result))
-          (result/ok {:status (case (clojure.string/trim (:out result))
-                                "running" :running
-                                "exited" :stopped
-                                "dead" :error
-                                :unknown)})
-          (result/ok {:status :unknown :error (:err result)})))
-      (catch Exception e
-        (result/ok {:status :unknown :error (.getMessage e)})))))
-
-(defn create-docker-executor
-  "Create a Docker executor.
-
-   Config:
-   - :image - Container image for tasks
-   - :network - Docker network to attach to
-   - :docker-path - Path to docker binary"
-  [config]
-  (map->DockerExecutor
-   {:config config
-    :image (or (:image config) "miniforge/task-runner:latest")
-    :network (:network config)
-    :docker-path (:docker-path config)}))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Worktree Executor (Fallback)
-
-(defrecord WorktreeExecutor [config base-path max-concurrent lock-pool]
-  TaskExecutor
-
-  (executor-type [_this] :worktree)
-
-  (available? [_this]
-    ;; Worktree executor is always available if git is installed
-    (try
-      (let [result (shell/sh "git" "--version")]
-        (if (zero? (:exit result))
-          (result/ok {:available? true
-                      :git-version (clojure.string/trim (:out result))})
-          (result/ok {:available? false
-                      :reason "git not found"})))
-      (catch Exception e
-        (result/ok {:available? false
-                    :reason (.getMessage e)}))))
-
-  (acquire-environment! [_this task-id env-config]
-    ;; Create a git worktree for the task
-    (let [worktree-name (str "task-" (subs (str task-id) 0 8))
-          worktree-path (str base-path "/" worktree-name)
-          repo-path (or (:repo-path env-config) ".")
-          branch (or (:branch env-config) "main")]
-      (try
-        ;; Create worktree directory
-        (.mkdirs (java.io.File. base-path))
-
-        ;; Add git worktree
-        (let [result (shell/sh
-                      "git" "-C" repo-path
-                      "worktree" "add" "-b" worktree-name
-                      worktree-path branch)]
-          (if (zero? (:exit result))
-            (result/ok (create-environment-record
-                        worktree-name :worktree task-id worktree-path
-                        (assoc env-config
-                               :metadata {:worktree-path worktree-path
-                                          :repo-path repo-path})))
-            ;; Try without -b if branch already exists
-            (let [result2 (shell/sh
-                           "git" "-C" repo-path
-                           "worktree" "add" worktree-path branch)]
-              (if (zero? (:exit result2))
-                (result/ok (create-environment-record
-                            worktree-name :worktree task-id worktree-path
-                            (assoc env-config
-                                   :metadata {:worktree-path worktree-path
-                                              :repo-path repo-path})))
-                (result/err :worktree-create-failed (:err result2))))))
-        (catch Exception e
-          (result/err :worktree-create-failed (.getMessage e))))))
-
-  (execute! [_this environment-id command opts]
-    ;; Execute command in the worktree directory
-    (let [worktree-path (str base-path "/" environment-id)
-          cmd-str (if (string? command)
-                    command
-                    (clojure.string/join " " command))
-          env-map (merge {} (:env opts))]
-      (try
-        (let [start-time (System/currentTimeMillis)
-              pb (ProcessBuilder. ["sh" "-c" cmd-str])
-              _ (.directory pb (java.io.File. (or (:workdir opts) worktree-path)))
-              _ (when (seq env-map)
-                  (let [pb-env (.environment pb)]
-                    (doseq [[k v] env-map]
-                      (.put pb-env (name k) (str v)))))
-              process (.start pb)
-              stdout (slurp (.getInputStream process))
-              stderr (slurp (.getErrorStream process))
-              exit-code (.waitFor process)]
-          (result/ok {:exit-code exit-code
-                      :stdout stdout
-                      :stderr stderr
-                      :duration-ms (- (System/currentTimeMillis) start-time)}))
-        (catch Exception e
-          (result/err :exec-failed (.getMessage e))))))
-
-  (copy-to! [_this environment-id local-path remote-path]
-    ;; For worktree, just copy files
-    (let [worktree-path (str base-path "/" environment-id)
-          dest-path (str worktree-path "/" remote-path)]
-      (try
-        (let [source (java.io.File. local-path)
-              dest (java.io.File. dest-path)]
-          (.mkdirs (.getParentFile dest))
-          (java.nio.file.Files/copy
-           (.toPath source)
-           (.toPath dest)
-           (into-array java.nio.file.CopyOption
-                       [java.nio.file.StandardCopyOption/REPLACE_EXISTING]))
-          (result/ok {:copied-bytes (.length source)}))
-        (catch Exception e
-          (result/err :copy-failed (.getMessage e))))))
-
-  (copy-from! [_this environment-id remote-path local-path]
-    (let [worktree-path (str base-path "/" environment-id)
-          source-path (str worktree-path "/" remote-path)]
-      (try
-        (let [source (java.io.File. source-path)
-              dest (java.io.File. local-path)]
-          (.mkdirs (.getParentFile dest))
-          (java.nio.file.Files/copy
-           (.toPath source)
-           (.toPath dest)
-           (into-array java.nio.file.CopyOption
-                       [java.nio.file.StandardCopyOption/REPLACE_EXISTING]))
-          (result/ok {:copied-bytes (.length source)}))
-        (catch Exception e
-          (result/err :copy-failed (.getMessage e))))))
-
-  (release-environment! [_this environment-id]
-    ;; Remove the git worktree
-    (let [worktree-path (str base-path "/" environment-id)]
-      (try
-        ;; First, try to find the main repo by checking metadata
-        ;; For now, use the worktree to find its main repo
-        (let [result (shell/sh
-                      "git" "-C" worktree-path
-                      "worktree" "remove" "--force" worktree-path)]
-          (if (zero? (:exit result))
-            (result/ok {:released? true})
-            ;; Fallback: just delete the directory
-            (do
-              (shell/sh "rm" "-rf" worktree-path)
-              (result/ok {:released? true}))))
-        (catch Exception e
-          (result/err :release-failed (.getMessage e))))))
-
-  (environment-status [_this environment-id]
-    (let [worktree-path (str base-path "/" environment-id)]
-      (if (.exists (java.io.File. worktree-path))
-        (result/ok {:status :running})
-        (result/ok {:status :stopped})))))
-
-(defn create-worktree-executor
-  "Create a worktree-based executor (fallback).
-
-   Config:
-   - :base-path - Base directory for worktrees (default: /tmp/miniforge-worktrees)
-   - :max-concurrent - Max concurrent worktrees"
-  [config]
-  (map->WorktreeExecutor
-   {:config config
-    :base-path (or (:base-path config) "/tmp/miniforge-worktrees")
-    :max-concurrent (or (:max-concurrent config) 4)
-    :lock-pool (atom {})}))
-
-;------------------------------------------------------------------------------ Layer 3
-;; High-level execution helpers
+;; ============================================================================
+;; High-level Helpers
+;; ============================================================================
 
 (defn with-environment
   "Execute a function within an acquired environment.
@@ -633,25 +161,27 @@
    Returns result with checkout info."
   [executor environment-id repo-url branch opts]
   (let [depth-args (when (:depth opts) ["--depth" (str (:depth opts))])
-        clone-cmd (concat ["git" "clone"]
-                          depth-args
-                          [repo-url "."])
-        clone-result (execute! executor environment-id
-                                 (clojure.string/join " " clone-cmd)
-                                 {:timeout-ms 300000})]
-      (if (and (result/ok? clone-result)
-               (zero? (:exit-code (:data clone-result))))
-        ;; Checkout branch
-        (let [checkout-result (execute! executor environment-id
-                                        (str "git checkout " branch)
-                                        {:timeout-ms 60000})]
-          (if (and (result/ok? checkout-result)
-                   (zero? (:exit-code (:data checkout-result))))
-            (result/ok {:cloned? true :branch branch})
-            checkout-result))
-        clone-result)))
+        clone-cmd (str "git clone "
+                       (when depth-args (str (first depth-args) " " (second depth-args) " "))
+                       repo-url " .")
+        clone-result (execute! executor environment-id clone-cmd
+                               {:timeout-ms 300000})]
+    (if (and (result/ok? clone-result)
+             (zero? (:exit-code (:data clone-result))))
+      ;; Checkout branch
+      (let [checkout-result (execute! executor environment-id
+                                      (str "git checkout " branch)
+                                      {:timeout-ms 60000})]
+        (if (and (result/ok? checkout-result)
+                 (zero? (:exit-code (:data checkout-result))))
+          (result/ok {:cloned? true :branch branch})
+          checkout-result))
+      clone-result)))
 
-;------------------------------------------------------------------------------ Rich Comment
+;; ============================================================================
+;; Rich Comment
+;; ============================================================================
+
 (comment
   ;; Create executor registry
   (def executors (create-executor-registry

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/executor.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/executor.clj
@@ -1,0 +1,114 @@
+(ns ai.miniforge.dag-executor.protocols.executor
+  "TaskExecutor protocol definition.
+
+   Defines the contract for pluggable task execution backends that provide
+   isolated environments for code generation and PR lifecycle operations.")
+
+;; ============================================================================
+;; TaskExecutor Protocol
+;; ============================================================================
+
+(defprotocol TaskExecutor
+  "Protocol for task execution backends.
+
+   Implementations provide isolated environments where tasks can:
+   - Clone/checkout repositories
+   - Run code generation
+   - Execute tests and validation
+   - Create and push commits
+
+   The protocol is designed to be backend-agnostic, supporting
+   containers (Docker, K8s) and local worktree execution."
+
+  (executor-type [this]
+    "Return the executor type keyword: :kubernetes, :docker, :worktree")
+
+  (available? [this]
+    "Check if this executor backend is available.
+     Returns result with {:available? bool :reason string}")
+
+  (acquire-environment! [this task-id config]
+    "Acquire an isolated execution environment for a task.
+
+     Arguments:
+     - task-id: UUID identifying the task
+     - config: Environment configuration map
+       {:repo-url string         ; Git repository URL
+        :branch string           ; Branch to checkout
+        :base-sha string         ; Base commit SHA
+        :workdir string          ; Working directory inside environment
+        :env map                 ; Environment variables
+        :resources map           ; Resource limits {:cpu :memory}
+        :timeout-ms long}        ; Acquisition timeout
+
+     Returns result with:
+     {:environment-id string    ; Unique ID for this environment
+      :type keyword             ; :container, :worktree
+      :workdir string           ; Path to working directory
+      :metadata map}            ; Backend-specific metadata")
+
+  (execute! [this environment-id command opts]
+    "Execute a command in the environment.
+
+     Arguments:
+     - environment-id: ID from acquire-environment!
+     - command: Command to execute (string or vector)
+     - opts: Execution options
+       {:timeout-ms long        ; Command timeout
+        :env map                ; Additional env vars
+        :workdir string         ; Override working directory
+        :capture-output? bool}  ; Capture stdout/stderr
+
+     Returns result with:
+     {:exit-code int
+      :stdout string            ; If capture-output?
+      :stderr string            ; If capture-output?
+      :duration-ms long}")
+
+  (copy-to! [this environment-id local-path remote-path]
+    "Copy files from host to environment.
+     Returns result with {:copied-bytes long}")
+
+  (copy-from! [this environment-id remote-path local-path]
+    "Copy files from environment to host.
+     Returns result with {:copied-bytes long}")
+
+  (release-environment! [this environment-id]
+    "Release and cleanup an execution environment.
+     Returns result with {:released? bool}")
+
+  (environment-status [this environment-id]
+    "Get status of an execution environment.
+     Returns result with:
+     {:status keyword           ; :running, :stopped, :error, :unknown
+      :created-at inst
+      :resource-usage map}"))
+
+;; ============================================================================
+;; Environment Record
+;; ============================================================================
+
+(defrecord ExecutionEnvironment
+  [environment-id
+   executor-type
+   task-id
+   workdir
+   repo-url
+   branch
+   created-at
+   status
+   metadata])
+
+(defn create-environment-record
+  "Create an environment record."
+  [environment-id exec-type task-id workdir opts]
+  (map->ExecutionEnvironment
+   {:environment-id environment-id
+    :executor-type exec-type
+    :task-id task-id
+    :workdir workdir
+    :repo-url (:repo-url opts)
+    :branch (:branch opts)
+    :created-at (java.util.Date.)
+    :status :running
+    :metadata (:metadata opts {})}))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
@@ -1,0 +1,243 @@
+(ns ai.miniforge.dag-executor.protocols.impl.docker
+  "Docker executor implementation.
+
+   Provides task isolation via Docker containers. Each task gets its own
+   container with configurable resource limits and environment variables.
+
+   Pre-built task runner images are available at:
+   - resources/executor/docker/Dockerfile.task-runner       (minimal Alpine)
+   - resources/executor/docker/Dockerfile.task-runner-clojure (with Clojure tooling)"
+  (:require
+   [ai.miniforge.dag-executor.result :as result]
+   [ai.miniforge.dag-executor.protocols.executor :as proto]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]))
+
+;; ============================================================================
+;; Configuration
+;; ============================================================================
+
+(def default-image "alpine:latest")
+(def default-workdir "/workspace")
+(def default-stop-timeout 5)
+
+;; Default resource limits
+(def default-resources
+  {:memory "512m"
+   :cpu 0.5})
+
+;; Resource paths for Dockerfiles (for documentation/building images)
+(def dockerfile-resources
+  {:minimal "executor/docker/Dockerfile.task-runner"
+   :clojure "executor/docker/Dockerfile.task-runner-clojure"})
+
+;; ============================================================================
+;; Helper Functions
+;; ============================================================================
+
+(defn- docker-cmd
+  "Build docker command with optional custom path."
+  [docker-path & args]
+  (apply vector (or docker-path "docker") args))
+
+(defn- run-docker
+  "Execute a docker command and return the result."
+  [docker-path & args]
+  (try
+    (apply shell/sh (apply docker-cmd docker-path args))
+    (catch Exception e
+      {:exit 1 :err (.getMessage e) :out ""})))
+
+(defn- build-env-args
+  "Build -e arguments for environment variables."
+  [env-map]
+  (mapcat (fn [[k v]] ["-e" (str (name k) "=" v)]) env-map))
+
+(defn- build-resource-args
+  "Build resource limit arguments.
+   Merges provided resources with defaults."
+  [resources]
+  (let [merged (merge default-resources resources)]
+    (cond-> []
+      (:memory merged)
+      (into ["--memory" (:memory merged)])
+
+      (:cpu merged)
+      (into ["--cpus" (str (:cpu merged))]))))
+
+;; ============================================================================
+;; Docker Operations
+;; ============================================================================
+
+(defn docker-info
+  "Get Docker server version."
+  [docker-path]
+  (let [result (run-docker docker-path "info" "--format" "{{.ServerVersion}}")]
+    (if (zero? (:exit result))
+      {:available? true
+       :docker-version (str/trim (:out result))}
+      {:available? false
+       :reason (:err result)})))
+
+(defn create-container
+  "Create and start a Docker container.
+
+   Returns {:container-id string :container-name string} on success."
+  [docker-path container-name image workdir env-map resources network]
+  (let [env-args (build-env-args env-map)
+        resource-args (build-resource-args resources)
+        cmd-args (concat ["run" "-d"
+                          "--name" container-name
+                          "-w" workdir]
+                         (when network ["--network" network])
+                         env-args
+                         resource-args
+                         [image "sleep" "infinity"])
+        result (apply run-docker docker-path cmd-args)]
+    (if (zero? (:exit result))
+      (result/ok {:container-id (str/trim (:out result))
+                  :container-name container-name})
+      (result/err :container-create-failed (:err result)))))
+
+(defn exec-in-container
+  "Execute a command in a running container."
+  [docker-path container-id command opts]
+  (let [cmd-args (if (string? command)
+                   ["sh" "-c" command]
+                   command)
+        workdir-args (when (:workdir opts) ["-w" (:workdir opts)])
+        env-args (build-env-args (:env opts))
+        full-args (concat ["exec"]
+                          workdir-args
+                          env-args
+                          [container-id]
+                          cmd-args)
+        start-time (System/currentTimeMillis)
+        result (apply run-docker docker-path full-args)]
+    (result/ok {:exit-code (:exit result)
+                :stdout (:out result)
+                :stderr (:err result)
+                :duration-ms (- (System/currentTimeMillis) start-time)})))
+
+(defn copy-to-container
+  "Copy files from host to container."
+  [docker-path container-id local-path remote-path]
+  (let [result (run-docker docker-path "cp" local-path
+                           (str container-id ":" remote-path))]
+    (if (zero? (:exit result))
+      (result/ok {:copied-bytes -1}) ; docker cp doesn't report bytes
+      (result/err :copy-failed (:err result)))))
+
+(defn copy-from-container
+  "Copy files from container to host."
+  [docker-path container-id remote-path local-path]
+  (let [result (run-docker docker-path "cp"
+                           (str container-id ":" remote-path)
+                           local-path)]
+    (if (zero? (:exit result))
+      (result/ok {:copied-bytes -1})
+      (result/err :copy-failed (:err result)))))
+
+(defn stop-container
+  "Stop a running container."
+  [docker-path container-id timeout]
+  (run-docker docker-path "stop" "-t" (str timeout) container-id))
+
+(defn remove-container
+  "Remove a container (force)."
+  [docker-path container-id]
+  (let [result (run-docker docker-path "rm" "-f" container-id)]
+    (result/ok {:released? (zero? (:exit result))})))
+
+(defn inspect-container
+  "Get container status."
+  [docker-path container-id]
+  (let [result (run-docker docker-path "inspect" container-id
+                           "--format" "{{.State.Status}}")]
+    (if (zero? (:exit result))
+      (result/ok {:status (case (str/trim (:out result))
+                            "running" :running
+                            "exited" :stopped
+                            "dead" :error
+                            :unknown)})
+      (result/ok {:status :unknown :error (:err result)}))))
+
+;; ============================================================================
+;; DockerExecutor Record
+;; ============================================================================
+
+(defrecord DockerExecutor [config image network docker-path]
+  proto/TaskExecutor
+
+  (executor-type [_this] :docker)
+
+  (available? [_this]
+    (try
+      (result/ok (docker-info docker-path))
+      (catch Exception e
+        (result/ok {:available? false :reason (.getMessage e)}))))
+
+  (acquire-environment! [_this task-id env-config]
+    (let [container-name (str "miniforge-task-" (subs (str task-id) 0 8))
+          workdir (or (:workdir env-config) default-workdir)
+          create-result (create-container docker-path
+                                          container-name
+                                          image
+                                          workdir
+                                          (:env env-config)
+                                          (:resources env-config)
+                                          network)]
+      (if (result/ok? create-result)
+        (result/ok (proto/create-environment-record
+                    container-name :docker task-id workdir
+                    (assoc env-config :metadata (:data create-result))))
+        create-result)))
+
+  (execute! [_this environment-id command opts]
+    (try
+      (exec-in-container docker-path environment-id command opts)
+      (catch Exception e
+        (result/err :exec-failed (.getMessage e)))))
+
+  (copy-to! [_this environment-id local-path remote-path]
+    (try
+      (copy-to-container docker-path environment-id local-path remote-path)
+      (catch Exception e
+        (result/err :copy-failed (.getMessage e)))))
+
+  (copy-from! [_this environment-id remote-path local-path]
+    (try
+      (copy-from-container docker-path environment-id remote-path local-path)
+      (catch Exception e
+        (result/err :copy-failed (.getMessage e)))))
+
+  (release-environment! [_this environment-id]
+    (try
+      (stop-container docker-path environment-id default-stop-timeout)
+      (remove-container docker-path environment-id)
+      (catch Exception e
+        (result/err :release-failed (.getMessage e)))))
+
+  (environment-status [_this environment-id]
+    (try
+      (inspect-container docker-path environment-id)
+      (catch Exception e
+        (result/ok {:status :unknown :error (.getMessage e)})))))
+
+;; ============================================================================
+;; Factory
+;; ============================================================================
+
+(defn create-docker-executor
+  "Create a Docker executor.
+
+   Config:
+   - :image - Container image for tasks (default: alpine:latest)
+   - :network - Docker network to attach to
+   - :docker-path - Path to docker binary"
+  [config]
+  (map->DockerExecutor
+   {:config config
+    :image (or (:image config) default-image)
+    :network (:network config)
+    :docker-path (:docker-path config)}))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/kubernetes.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/kubernetes.clj
@@ -1,0 +1,362 @@
+(ns ai.miniforge.dag-executor.protocols.impl.kubernetes
+  "Kubernetes executor implementation.
+
+   Provides task isolation via Kubernetes Jobs. Each task gets its own
+   Job/Pod with configurable resource limits and environment variables.
+
+   The executor creates a Job that runs a sleep container, then uses
+   kubectl exec to run commands in it. This allows interactive execution
+   similar to Docker containers.
+
+   The canonical job configuration is documented in:
+   resources/executor/kubernetes/job-template.yaml"
+  (:require
+   [ai.miniforge.dag-executor.result :as result]
+   [ai.miniforge.dag-executor.protocols.executor :as proto]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [cheshire.core :as json]))
+
+;; ============================================================================
+;; Configuration
+;; ============================================================================
+
+(def default-namespace "default")
+(def default-image "alpine:latest")
+(def default-workdir "/workspace")
+(def pod-ready-timeout-ms 120000)
+(def pod-ready-poll-interval-ms 2000)
+
+;; Default resource limits (matches job-template.yaml)
+(def default-resources
+  {:limits {:memory "512Mi" :cpu "500m"}
+   :requests {:memory "256Mi" :cpu "100m"}})
+
+;; Resource path for job template (for documentation/reference)
+(def job-template-resource "executor/kubernetes/job-template.yaml")
+
+;; ============================================================================
+;; Helper Functions
+;; ============================================================================
+
+(defn- kubectl-cmd
+  "Build kubectl command with optional custom path."
+  [kubectl-path & args]
+  (apply vector (or kubectl-path "kubectl") args))
+
+(defn- run-kubectl
+  "Execute a kubectl command and return the result."
+  [kubectl-path & args]
+  (try
+    (apply shell/sh (apply kubectl-cmd kubectl-path args))
+    (catch Exception e
+      {:exit 1 :err (.getMessage e) :out ""})))
+
+(defn- build-env-vars
+  "Build K8s env var specs from a map."
+  [env-map]
+  (mapv (fn [[k v]] {:name (name k) :value (str v)}) env-map))
+
+(defn- build-resource-spec
+  "Build K8s resource limits/requests spec.
+   Merges provided resources with defaults."
+  [resources]
+  (let [merged (merge-with merge default-resources resources)]
+    {:limits (cond-> {}
+               (get-in merged [:limits :memory])
+               (assoc :memory (get-in merged [:limits :memory]))
+               (get-in merged [:limits :cpu])
+               (assoc :cpu (str (get-in merged [:limits :cpu]))))
+     :requests (cond-> {}
+                 (get-in merged [:requests :memory])
+                 (assoc :memory (get-in merged [:requests :memory]))
+                 (get-in merged [:requests :cpu])
+                 (assoc :cpu (str (get-in merged [:requests :cpu]))))}))
+
+(defn load-job-template
+  "Load the job template YAML from resources.
+   Returns the template string or nil if not found.
+   Useful for documentation and debugging."
+  []
+  (when-let [resource (io/resource job-template-resource)]
+    (slurp resource)))
+
+;; ============================================================================
+;; Job Spec Generation
+;; ============================================================================
+
+(defn build-job-spec
+  "Build a Kubernetes Job spec for task execution.
+
+   Creates a Job with a single container that runs 'sleep infinity' to keep
+   the pod alive for interactive command execution.
+
+   The spec matches the canonical template at:
+   resources/executor/kubernetes/job-template.yaml"
+  [job-name namespace image workdir env-map resources task-id]
+  {:apiVersion "batch/v1"
+   :kind "Job"
+   :metadata {:name job-name
+              :namespace namespace
+              :labels {:app "miniforge"
+                       :component "task-executor"
+                       :task-id (str task-id)}
+              :annotations {:miniforge.ai/task-id (str task-id)
+                            :miniforge.ai/created-by "dag-executor"}}
+   :spec {:ttlSecondsAfterFinished 300  ; Cleanup completed jobs after 5 min
+          :backoffLimit 0               ; No retries - handled at DAG scheduler level
+          :completions 1
+          :parallelism 1
+          :template
+          {:metadata {:labels {:app "miniforge"
+                               :component "task-executor"
+                               :job-name job-name}}
+           :spec {:restartPolicy "Never"
+                  :terminationGracePeriodSeconds 10
+                  :containers
+                  [{:name "task"
+                    :image image
+                    :imagePullPolicy "IfNotPresent"
+                    :workingDir (or workdir default-workdir)
+                    :command ["sh" "-c" "trap 'exit 0' TERM; sleep infinity & wait"]
+                    :env (build-env-vars env-map)
+                    :resources (build-resource-spec resources)
+                    :securityContext {:runAsNonRoot false
+                                      :readOnlyRootFilesystem false
+                                      :allowPrivilegeEscalation false
+                                      :capabilities {:drop ["ALL"]}}
+                    :volumeMounts [{:name "workspace"
+                                    :mountPath "/workspace"}]}]
+                  :volumes [{:name "workspace"
+                             :emptyDir {:sizeLimit "1Gi"}}]}}}})
+
+;; ============================================================================
+;; Kubernetes Operations
+;; ============================================================================
+
+(defn cluster-info
+  "Get Kubernetes cluster info."
+  [kubectl-path]
+  (let [result (run-kubectl kubectl-path "cluster-info" "--request-timeout=5s")]
+    (if (zero? (:exit result))
+      {:available? true
+       :cluster-info (subs (:out result) 0 (min 200 (count (:out result))))}
+      {:available? false
+       :reason (:err result)})))
+
+(defn apply-job
+  "Create a Job from a spec using kubectl apply."
+  [kubectl-path namespace job-spec]
+  (let [spec-json (json/generate-string job-spec)
+        result (shell/sh (or kubectl-path "kubectl")
+                         "apply" "-n" namespace "-f" "-"
+                         :in spec-json)]
+    (if (zero? (:exit result))
+      (result/ok {:applied true})
+      (result/err :job-apply-failed (:err result)))))
+
+(defn get-pod-for-job
+  "Get the pod name for a job."
+  [kubectl-path namespace job-name]
+  (let [result (run-kubectl kubectl-path
+                            "get" "pods" "-n" namespace
+                            "-l" (str "job-name=" job-name)
+                            "-o" "jsonpath={.items[0].metadata.name}")]
+    (if (and (zero? (:exit result)) (not (str/blank? (:out result))))
+      (result/ok {:pod-name (str/trim (:out result))})
+      (result/err :pod-not-found (or (:err result) "No pod found for job")))))
+
+(defn wait-for-pod-ready
+  "Wait for pod to be in Running state with containers ready."
+  [kubectl-path namespace job-name timeout-ms]
+  (let [start-time (System/currentTimeMillis)
+        deadline (+ start-time timeout-ms)]
+    (loop []
+      (if (> (System/currentTimeMillis) deadline)
+        (result/err :pod-timeout "Timed out waiting for pod to be ready")
+        (let [pod-result (get-pod-for-job kubectl-path namespace job-name)]
+          (if (result/err? pod-result)
+            ;; Pod not created yet, wait and retry
+            (do
+              (Thread/sleep pod-ready-poll-interval-ms)
+              (recur))
+            ;; Check pod status
+            (let [pod-name (:pod-name (:data pod-result))
+                  status-result (run-kubectl kubectl-path
+                                             "get" "pod" pod-name "-n" namespace
+                                             "-o" "jsonpath={.status.phase}")]
+              (cond
+                (= "Running" (str/trim (:out status-result)))
+                (result/ok {:pod-name pod-name :status :running})
+
+                (contains? #{"Failed" "Succeeded"} (str/trim (:out status-result)))
+                (result/err :pod-failed (str "Pod ended with status: " (:out status-result)))
+
+                :else
+                (do
+                  (Thread/sleep pod-ready-poll-interval-ms)
+                  (recur))))))))))
+
+(defn exec-in-pod
+  "Execute a command in a pod."
+  [kubectl-path namespace pod-name command _opts]
+  (let [cmd-args (if (string? command)
+                   ["sh" "-c" command]
+                   command)
+        full-args (concat ["exec" pod-name "-n" namespace "--"]
+                          cmd-args)
+        start-time (System/currentTimeMillis)
+        result (apply run-kubectl kubectl-path full-args)]
+    (result/ok {:exit-code (:exit result)
+                :stdout (:out result)
+                :stderr (:err result)
+                :duration-ms (- (System/currentTimeMillis) start-time)})))
+
+(defn copy-to-pod
+  "Copy files from host to pod."
+  [kubectl-path namespace pod-name local-path remote-path]
+  (let [result (run-kubectl kubectl-path "cp" local-path
+                            (str namespace "/" pod-name ":" remote-path))]
+    (if (zero? (:exit result))
+      (result/ok {:copied-bytes -1})
+      (result/err :copy-failed (:err result)))))
+
+(defn copy-from-pod
+  "Copy files from pod to host."
+  [kubectl-path namespace pod-name remote-path local-path]
+  (let [result (run-kubectl kubectl-path "cp"
+                            (str namespace "/" pod-name ":" remote-path)
+                            local-path)]
+    (if (zero? (:exit result))
+      (result/ok {:copied-bytes -1})
+      (result/err :copy-failed (:err result)))))
+
+(defn delete-job
+  "Delete a job and its pods."
+  [kubectl-path namespace job-name]
+  (let [result (run-kubectl kubectl-path
+                            "delete" "job" job-name "-n" namespace
+                            "--grace-period=5")]
+    (result/ok {:released? (zero? (:exit result))})))
+
+(defn get-job-status
+  "Get the status of a job."
+  [kubectl-path namespace job-name]
+  (let [result (run-kubectl kubectl-path
+                            "get" "job" job-name "-n" namespace
+                            "-o" "jsonpath={.status.conditions[0].type}")]
+    (if (zero? (:exit result))
+      (result/ok {:status (case (str/trim (:out result))
+                            "Complete" :stopped
+                            "Failed" :error
+                            "" :running
+                            :unknown)
+                  :raw (:out result)})
+      (result/ok {:status :unknown :error (:err result)}))))
+
+;; ============================================================================
+;; KubernetesExecutor Record
+;; ============================================================================
+
+(defrecord KubernetesExecutor [config namespace image kubectl-path
+                               ;; Runtime state: job-name -> pod-name mapping
+                               pod-cache]
+  proto/TaskExecutor
+
+  (executor-type [_this] :kubernetes)
+
+  (available? [_this]
+    (try
+      (result/ok (cluster-info kubectl-path))
+      (catch Exception e
+        (result/ok {:available? false :reason (.getMessage e)}))))
+
+  (acquire-environment! [_this task-id env-config]
+    (let [job-name (str "miniforge-task-" (subs (str task-id) 0 8))
+          workdir (or (:workdir env-config) "/workspace")
+          job-spec (build-job-spec job-name namespace image workdir
+                                   (:env env-config)
+                                   (:resources env-config)
+                                   task-id)
+          apply-result (apply-job kubectl-path namespace job-spec)]
+      (if (result/err? apply-result)
+        apply-result
+        (let [wait-result (wait-for-pod-ready kubectl-path namespace job-name
+                                              pod-ready-timeout-ms)]
+          (if (result/err? wait-result)
+            (do
+              (delete-job kubectl-path namespace job-name)
+              wait-result)
+            (let [pod-name (:pod-name (:data wait-result))]
+              (swap! pod-cache assoc job-name pod-name)
+              (result/ok (proto/create-environment-record
+                          job-name :kubernetes task-id workdir
+                          (assoc env-config
+                                 :metadata {:job-name job-name
+                                            :pod-name pod-name
+                                            :namespace namespace})))))))))
+
+  (execute! [_this environment-id command opts]
+    (try
+      (if-let [pod-name (get @pod-cache environment-id)]
+        (exec-in-pod kubectl-path namespace pod-name command opts)
+        ;; Pod name not in cache, try to look it up
+        (let [pod-result (get-pod-for-job kubectl-path namespace environment-id)]
+          (if (result/ok? pod-result)
+            (let [pod-name (:pod-name (:data pod-result))]
+              (swap! pod-cache assoc environment-id pod-name)
+              (exec-in-pod kubectl-path namespace pod-name command opts))
+            pod-result)))
+      (catch Exception e
+        (result/err :exec-failed (.getMessage e)))))
+
+  (copy-to! [_this environment-id local-path remote-path]
+    (try
+      (if-let [pod-name (get @pod-cache environment-id)]
+        (copy-to-pod kubectl-path namespace pod-name local-path remote-path)
+        (result/err :pod-not-found "Pod not in cache"))
+      (catch Exception e
+        (result/err :copy-failed (.getMessage e)))))
+
+  (copy-from! [_this environment-id remote-path local-path]
+    (try
+      (if-let [pod-name (get @pod-cache environment-id)]
+        (copy-from-pod kubectl-path namespace pod-name remote-path local-path)
+        (result/err :pod-not-found "Pod not in cache"))
+      (catch Exception e
+        (result/err :copy-failed (.getMessage e)))))
+
+  (release-environment! [_this environment-id]
+    (try
+      ;; Remove from cache
+      (swap! pod-cache dissoc environment-id)
+      ;; Delete the job (will also delete pods)
+      (delete-job kubectl-path namespace environment-id)
+      (catch Exception e
+        (result/err :release-failed (.getMessage e)))))
+
+  (environment-status [_this environment-id]
+    (try
+      (get-job-status kubectl-path namespace environment-id)
+      (catch Exception e
+        (result/ok {:status :unknown :error (.getMessage e)})))))
+
+;; ============================================================================
+;; Factory
+;; ============================================================================
+
+(defn create-kubernetes-executor
+  "Create a Kubernetes executor.
+
+   Config:
+   - :namespace - K8s namespace (default: 'default')
+   - :image - Container image for tasks (default: alpine:latest)
+   - :kubectl-path - Path to kubectl binary"
+  [config]
+  (map->KubernetesExecutor
+   {:config config
+    :namespace (or (:namespace config) default-namespace)
+    :image (or (:image config) default-image)
+    :kubectl-path (:kubectl-path config)
+    :pod-cache (atom {})}))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -1,0 +1,230 @@
+(ns ai.miniforge.dag-executor.protocols.impl.worktree
+  "Worktree executor implementation (fallback).
+
+   Provides task isolation via git worktrees. This is the fallback executor
+   when no container runtime is available. Isolation is limited to filesystem
+   separation - processes run on the host."
+  (:require
+   [ai.miniforge.dag-executor.result :as result]
+   [ai.miniforge.dag-executor.protocols.executor :as proto]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str])
+  (:import
+   [java.io File]
+   [java.nio.file Files StandardCopyOption CopyOption]))
+
+;; ============================================================================
+;; Configuration
+;; ============================================================================
+
+(def default-base-path "/tmp/miniforge-worktrees")
+(def default-max-concurrent 4)
+
+;; ============================================================================
+;; Helper Functions
+;; ============================================================================
+
+(defn- run-git
+  "Execute a git command and return the result."
+  [& args]
+  (try
+    (apply shell/sh "git" args)
+    (catch Exception e
+      {:exit 1 :err (.getMessage e) :out ""})))
+
+(defn- run-shell
+  "Execute a shell command and return the result."
+  [& args]
+  (try
+    (apply shell/sh args)
+    (catch Exception e
+      {:exit 1 :err (.getMessage e) :out ""})))
+
+(defn- ensure-directory
+  "Ensure a directory exists."
+  [path]
+  (.mkdirs (File. ^String path)))
+
+;; ============================================================================
+;; Git Operations
+;; ============================================================================
+
+(defn git-version
+  "Get git version."
+  []
+  (let [result (run-git "--version")]
+    (if (zero? (:exit result))
+      {:available? true
+       :git-version (str/trim (:out result))}
+      {:available? false
+       :reason "git not found"})))
+
+(defn create-worktree
+  "Create a git worktree for the task.
+
+   First tries to create a new branch, then falls back to using existing branch."
+  [base-path repo-path worktree-name branch]
+  (let [worktree-path (str base-path "/" worktree-name)]
+    (ensure-directory base-path)
+    ;; Try creating with a new branch first
+    (let [result (run-git "-C" repo-path
+                          "worktree" "add" "-b" worktree-name
+                          worktree-path branch)]
+      (if (zero? (:exit result))
+        (result/ok {:worktree-path worktree-path})
+        ;; Branch might exist, try without -b
+        (let [result2 (run-git "-C" repo-path
+                               "worktree" "add" worktree-path branch)]
+          (if (zero? (:exit result2))
+            (result/ok {:worktree-path worktree-path})
+            (result/err :worktree-create-failed (:err result2))))))))
+
+(defn remove-worktree
+  "Remove a git worktree."
+  [worktree-path]
+  ;; Try git worktree remove first
+  (let [result (run-git "-C" worktree-path
+                        "worktree" "remove" "--force" worktree-path)]
+    (if (zero? (:exit result))
+      (result/ok {:released? true})
+      ;; Fallback: just delete the directory
+      (do
+        (run-shell "rm" "-rf" worktree-path)
+        (result/ok {:released? true})))))
+
+;; ============================================================================
+;; Command Execution
+;; ============================================================================
+
+(defn execute-command
+  "Execute a command in a directory using ProcessBuilder.
+
+   This allows proper environment variable handling and working directory."
+  [workdir command env-map]
+  (let [cmd-str (if (string? command)
+                  command
+                  (str/join " " command))
+        start-time (System/currentTimeMillis)]
+    (try
+      (let [pb (ProcessBuilder. ["sh" "-c" cmd-str])
+            _ (.directory pb (File. ^String workdir))
+            _ (when (seq env-map)
+                (let [pb-env (.environment pb)]
+                  (doseq [[k v] env-map]
+                    (.put pb-env (name k) (str v)))))
+            process (.start pb)
+            stdout (slurp (.getInputStream process))
+            stderr (slurp (.getErrorStream process))
+            exit-code (.waitFor process)]
+        (result/ok {:exit-code exit-code
+                    :stdout stdout
+                    :stderr stderr
+                    :duration-ms (- (System/currentTimeMillis) start-time)}))
+      (catch Exception e
+        (result/err :exec-failed (.getMessage e))))))
+
+;; ============================================================================
+;; File Operations
+;; ============================================================================
+
+(defn copy-file-to
+  "Copy a file into the worktree."
+  [worktree-path local-path remote-path]
+  (try
+    (let [source (File. ^String local-path)
+          dest-path (str worktree-path "/" remote-path)
+          dest (File. ^String dest-path)]
+      (.mkdirs (.getParentFile dest))
+      (Files/copy (.toPath source)
+                  (.toPath dest)
+                  (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING]))
+      (result/ok {:copied-bytes (.length source)}))
+    (catch Exception e
+      (result/err :copy-failed (.getMessage e)))))
+
+(defn copy-file-from
+  "Copy a file from the worktree."
+  [worktree-path remote-path local-path]
+  (try
+    (let [source-path (str worktree-path "/" remote-path)
+          source (File. ^String source-path)
+          dest (File. ^String local-path)]
+      (.mkdirs (.getParentFile dest))
+      (Files/copy (.toPath source)
+                  (.toPath dest)
+                  (into-array CopyOption [StandardCopyOption/REPLACE_EXISTING]))
+      (result/ok {:copied-bytes (.length source)}))
+    (catch Exception e
+      (result/err :copy-failed (.getMessage e)))))
+
+;; ============================================================================
+;; WorktreeExecutor Record
+;; ============================================================================
+
+(defrecord WorktreeExecutor [config base-path max-concurrent]
+  proto/TaskExecutor
+
+  (executor-type [_this] :worktree)
+
+  (available? [_this]
+    (try
+      (result/ok (git-version))
+      (catch Exception e
+        (result/ok {:available? false :reason (.getMessage e)}))))
+
+  (acquire-environment! [_this task-id env-config]
+    (let [worktree-name (str "task-" (subs (str task-id) 0 8))
+          repo-path (or (:repo-path env-config) ".")
+          branch (or (:branch env-config) "main")
+          create-result (create-worktree base-path repo-path worktree-name branch)]
+      (if (result/ok? create-result)
+        (let [worktree-path (:worktree-path (:data create-result))]
+          (result/ok (proto/create-environment-record
+                      worktree-name :worktree task-id worktree-path
+                      (assoc env-config
+                             :metadata {:worktree-path worktree-path
+                                        :repo-path repo-path}))))
+        create-result)))
+
+  (execute! [_this environment-id command opts]
+    (let [worktree-path (str base-path "/" environment-id)
+          workdir (or (:workdir opts) worktree-path)
+          env-map (merge {} (:env opts))]
+      (execute-command workdir command env-map)))
+
+  (copy-to! [_this environment-id local-path remote-path]
+    (let [worktree-path (str base-path "/" environment-id)]
+      (copy-file-to worktree-path local-path remote-path)))
+
+  (copy-from! [_this environment-id remote-path local-path]
+    (let [worktree-path (str base-path "/" environment-id)]
+      (copy-file-from worktree-path remote-path local-path)))
+
+  (release-environment! [_this environment-id]
+    (let [worktree-path (str base-path "/" environment-id)]
+      (try
+        (remove-worktree worktree-path)
+        (catch Exception e
+          (result/err :release-failed (.getMessage e))))))
+
+  (environment-status [_this environment-id]
+    (let [worktree-path (str base-path "/" environment-id)]
+      (if (.exists (File. ^String worktree-path))
+        (result/ok {:status :running})
+        (result/ok {:status :stopped})))))
+
+;; ============================================================================
+;; Factory
+;; ============================================================================
+
+(defn create-worktree-executor
+  "Create a worktree-based executor (fallback).
+
+   Config:
+   - :base-path - Base directory for worktrees (default: /tmp/miniforge-worktrees)
+   - :max-concurrent - Max concurrent worktrees (default: 4)"
+  [config]
+  (map->WorktreeExecutor
+   {:config config
+    :base-path (or (:base-path config) default-base-path)
+    :max-concurrent (or (:max-concurrent config) default-max-concurrent)}))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/executor_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/executor_test.clj
@@ -1,0 +1,394 @@
+(ns ai.miniforge.dag-executor.executor-test
+  "Integration tests for TaskExecutor implementations.
+
+   These tests validate the full lifecycle of Docker and Kubernetes executors.
+   Tests are skipped gracefully if the respective backend is unavailable."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.dag-executor.executor :as executor]
+   [ai.miniforge.dag-executor.result :as result]))
+
+;; ============================================================================
+;; Test helpers
+;; ============================================================================
+
+(defn docker-available?
+  "Check if Docker is available for testing."
+  []
+  (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+        result (executor/available? exec)]
+    (and (result/ok? result)
+         (:available? (:data result)))))
+
+(defn k8s-available?
+  "Check if Kubernetes is available for testing."
+  []
+  (let [exec (executor/create-kubernetes-executor {})
+        result (executor/available? exec)]
+    (and (result/ok? result)
+         (:available? (:data result)))))
+
+(defmacro when-docker
+  "Execute body only if Docker is available, otherwise skip with message."
+  [& body]
+  `(if (docker-available?)
+     (do ~@body)
+     (println "  SKIPPED: Docker not available")))
+
+(defmacro when-k8s
+  "Execute body only if Kubernetes is available, otherwise skip with message."
+  [& body]
+  `(if (k8s-available?)
+     (do ~@body)
+     (println "  SKIPPED: Kubernetes not available")))
+
+;; ============================================================================
+;; Docker Executor Tests
+;; ============================================================================
+
+(deftest docker-executor-availability-test
+  (testing "Docker executor reports availability correctly"
+    (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+          result (executor/available? exec)]
+      (is (result/ok? result))
+      (is (contains? (:data result) :available?))
+      (when (:available? (:data result))
+        (is (contains? (:data result) :docker-version))))))
+
+(deftest docker-executor-type-test
+  (testing "Docker executor returns correct type"
+    (let [exec (executor/create-docker-executor {})]
+      (is (= :docker (executor/executor-type exec))))))
+
+(deftest docker-executor-lifecycle-test
+  (testing "Docker executor full lifecycle"
+    (when-docker
+      (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+            task-id (random-uuid)]
+
+        (testing "acquire environment creates container"
+          (let [env-result (executor/acquire-environment! exec task-id
+                                                          {:env {:TEST_VAR "hello"}})]
+            (is (result/ok? env-result))
+            (let [env (:data env-result)
+                  env-id (:environment-id env)]
+              (is (some? env-id))
+              (is (= :docker (:executor-type env)))
+
+              (try
+                (testing "execute runs commands in container"
+                  (let [exec-result (executor/execute! exec env-id "echo $TEST_VAR" {})]
+                    (is (result/ok? exec-result))
+                    (is (= 0 (:exit-code (:data exec-result))))
+                    (is (= "hello\n" (:stdout (:data exec-result))))))
+
+                (testing "execute with multiple commands"
+                  (let [exec-result (executor/execute! exec env-id
+                                                       "pwd && whoami"
+                                                       {})]
+                    (is (result/ok? exec-result))
+                    (is (= 0 (:exit-code (:data exec-result))))))
+
+                (testing "environment-status shows running"
+                  (let [status-result (executor/environment-status exec env-id)]
+                    (is (result/ok? status-result))
+                    (is (= :running (:status (:data status-result))))))
+
+                (finally
+                  (testing "release cleans up container"
+                    (let [release-result (executor/release-environment! exec env-id)]
+                      (is (result/ok? release-result))
+                      (is (:released? (:data release-result))))))))))))))
+
+(deftest docker-executor-file-operations-test
+  (testing "Docker executor file copy operations"
+    (when-docker
+      (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+            task-id (random-uuid)
+            temp-file (java.io.File/createTempFile "test" ".txt")
+            temp-out (java.io.File/createTempFile "test-out" ".txt")]
+        (try
+          ;; Write test content to temp file
+          (spit temp-file "test content from host")
+
+          (let [env-result (executor/acquire-environment! exec task-id {})]
+            (is (result/ok? env-result))
+            (let [env (:data env-result)
+                  env-id (:environment-id env)]
+              (try
+                (testing "copy-to! copies files into container"
+                  (let [copy-result (executor/copy-to! exec env-id
+                                                       (.getAbsolutePath temp-file)
+                                                       "/tmp/test-file.txt")]
+                    (is (result/ok? copy-result))))
+
+                (testing "file exists in container"
+                  (let [exec-result (executor/execute! exec env-id
+                                                       "cat /tmp/test-file.txt" {})]
+                    (is (result/ok? exec-result))
+                    (is (= 0 (:exit-code (:data exec-result))))
+                    (is (= "test content from host" (:stdout (:data exec-result))))))
+
+                (testing "create file in container for copy-from"
+                  (let [exec-result (executor/execute! exec env-id
+                                                       "echo 'from container' > /tmp/out.txt"
+                                                       {})]
+                    (is (result/ok? exec-result))
+                    (is (= 0 (:exit-code (:data exec-result))))))
+
+                (testing "copy-from! copies files from container"
+                  (let [copy-result (executor/copy-from! exec env-id
+                                                         "/tmp/out.txt"
+                                                         (.getAbsolutePath temp-out))]
+                    (is (result/ok? copy-result))
+                    (is (= "from container\n" (slurp temp-out)))))
+
+                (finally
+                  (executor/release-environment! exec env-id)))))
+          (finally
+            (.delete temp-file)
+            (.delete temp-out)))))))
+
+(deftest docker-executor-with-environment-test
+  (testing "with-environment helper manages lifecycle"
+    (when-docker
+      (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+            task-id (random-uuid)
+            result (executor/with-environment exec task-id {}
+                     (fn [env]
+                       (executor/execute! exec (:environment-id env)
+                                          "echo 'inside environment'" {})))]
+        (is (result/ok? result))
+        (is (= 0 (:exit-code (:data result))))
+        (is (= "inside environment\n" (:stdout (:data result))))))))
+
+(deftest docker-executor-env-vars-test
+  (testing "Docker executor passes environment variables"
+    (when-docker
+      (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+            task-id (random-uuid)]
+        (executor/with-environment exec task-id
+          {:env {:MY_VAR "my_value"
+                 :ANOTHER "another_value"}}
+          (fn [env]
+            (let [result (executor/execute! exec (:environment-id env)
+                                            "echo $MY_VAR:$ANOTHER" {})]
+              (is (result/ok? result))
+              (is (= "my_value:another_value\n" (:stdout (:data result)))))))))))
+
+(deftest docker-executor-workdir-test
+  (testing "Docker executor respects working directory"
+    (when-docker
+      (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+            task-id (random-uuid)]
+        (executor/with-environment exec task-id
+          {:workdir "/tmp"}
+          (fn [env]
+            (let [result (executor/execute! exec (:environment-id env) "pwd" {})]
+              (is (result/ok? result))
+              (is (= "/tmp\n" (:stdout (:data result)))))))))))
+
+(deftest docker-executor-resource-limits-test
+  (testing "Docker executor applies resource limits"
+    (when-docker
+      (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+            task-id (random-uuid)]
+        ;; Just verify container starts with limits - actual enforcement is Docker's job
+        (executor/with-environment exec task-id
+          {:resources {:memory "64m" :cpu 0.5}}
+          (fn [env]
+            (let [result (executor/execute! exec (:environment-id env)
+                                            "echo 'started with limits'" {})]
+              (is (result/ok? result))
+              (is (= 0 (:exit-code (:data result)))))))))))
+
+;; ============================================================================
+;; Kubernetes Executor Tests
+;; ============================================================================
+
+(deftest k8s-executor-availability-test
+  (testing "Kubernetes executor reports availability correctly"
+    (let [exec (executor/create-kubernetes-executor {})
+          result (executor/available? exec)]
+      (is (result/ok? result))
+      (is (contains? (:data result) :available?)))))
+
+(deftest k8s-executor-type-test
+  (testing "Kubernetes executor returns correct type"
+    (let [exec (executor/create-kubernetes-executor {})]
+      (is (= :kubernetes (executor/executor-type exec))))))
+
+(deftest k8s-executor-lifecycle-test
+  (testing "Kubernetes executor full lifecycle"
+    (when-k8s
+      (let [exec (executor/create-kubernetes-executor
+                  {:namespace "default"
+                   :image "alpine:latest"})
+            task-id (random-uuid)]
+
+        (testing "acquire environment creates job"
+          (let [env-result (executor/acquire-environment! exec task-id {})]
+            (is (result/ok? env-result))
+            (let [env (:data env-result)
+                  env-id (:environment-id env)]
+              (is (some? env-id))
+              (is (= :kubernetes (:executor-type env)))
+
+              (try
+                (testing "execute runs commands in pod"
+                  ;; Note: K8s jobs need time to start
+                  (Thread/sleep 5000)
+                  (let [exec-result (executor/execute! exec env-id "echo hello" {})]
+                    (is (result/ok? exec-result))))
+
+                (finally
+                  (testing "release cleans up job"
+                    (let [release-result (executor/release-environment! exec env-id)]
+                      (is (result/ok? release-result)))))))))))))
+
+;; ============================================================================
+;; Executor Registry Tests
+;; ============================================================================
+
+(deftest executor-registry-test
+  (testing "create-executor-registry creates all configured executors"
+    (let [registry (executor/create-executor-registry
+                    {:docker {:image "alpine:latest"}
+                     :kubernetes {:namespace "default"}
+                     :worktree {:base-path "/tmp/test-worktrees"}})]
+      (is (contains? registry :docker))
+      (is (contains? registry :kubernetes))
+      (is (contains? registry :worktree))
+
+      (is (= :docker (executor/executor-type (:docker registry))))
+      (is (= :kubernetes (executor/executor-type (:kubernetes registry))))
+      (is (= :worktree (executor/executor-type (:worktree registry)))))))
+
+(deftest executor-registry-fallback-test
+  (testing "Worktree executor is always included as fallback"
+    (let [registry (executor/create-executor-registry {})]
+      (is (contains? registry :worktree))
+      (is (= :worktree (executor/executor-type (:worktree registry)))))))
+
+(deftest select-executor-test
+  (testing "select-executor chooses best available"
+    (let [registry (executor/create-executor-registry
+                    {:docker {:image "alpine:latest"}
+                     :worktree {:base-path "/tmp/test-worktrees"}})
+          ;; Should select docker if available, otherwise worktree
+          selected (executor/select-executor registry)]
+      (is (some? selected))
+      (is (#{:docker :worktree} (executor/executor-type selected))))))
+
+(deftest select-executor-preferred-test
+  (testing "select-executor respects preferred option"
+    (let [registry (executor/create-executor-registry
+                    {:docker {:image "alpine:latest"}
+                     :worktree {:base-path "/tmp/test-worktrees"}})
+          ;; Explicitly prefer worktree
+          selected (executor/select-executor registry :preferred :worktree)]
+      (is (some? selected))
+      (is (= :worktree (executor/executor-type selected))))))
+
+;; ============================================================================
+;; Worktree Executor Tests (always available)
+;; ============================================================================
+
+(deftest worktree-executor-availability-test
+  (testing "Worktree executor is always available (git installed)"
+    (let [exec (executor/create-worktree-executor {})
+          result (executor/available? exec)]
+      (is (result/ok? result))
+      (is (:available? (:data result)))
+      (is (contains? (:data result) :git-version)))))
+
+(deftest worktree-executor-type-test
+  (testing "Worktree executor returns correct type"
+    (let [exec (executor/create-worktree-executor {})]
+      (is (= :worktree (executor/executor-type exec))))))
+
+;; ============================================================================
+;; Error Handling Tests
+;; ============================================================================
+
+(deftest docker-executor-invalid-command-test
+  (testing "Docker executor handles command failures"
+    (when-docker
+      (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+            task-id (random-uuid)]
+        (executor/with-environment exec task-id {}
+          (fn [env]
+            (let [result (executor/execute! exec (:environment-id env)
+                                            "nonexistent-command" {})]
+              (is (result/ok? result))
+              (is (not= 0 (:exit-code (:data result)))))))))))
+
+(deftest docker-executor-copy-nonexistent-test
+  (testing "Docker executor handles copy of nonexistent file"
+    (when-docker
+      (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+            task-id (random-uuid)]
+        (executor/with-environment exec task-id {}
+          (fn [env]
+            (let [result (executor/copy-from! exec (:environment-id env)
+                                              "/nonexistent/file.txt"
+                                              "/tmp/out.txt")]
+              (is (result/err? result)))))))))
+
+;; ============================================================================
+;; Concurrent Execution Tests
+;; ============================================================================
+
+(deftest docker-executor-concurrent-test
+  (testing "Docker executor handles concurrent environments"
+    (when-docker
+      (let [exec (executor/create-docker-executor {:image "alpine:latest"})
+            task-ids [(random-uuid) (random-uuid) (random-uuid)]
+            results (atom [])
+            ;; Start 3 containers concurrently
+            futures (mapv (fn [tid]
+                            (future
+                              (executor/with-environment exec tid {}
+                                (fn [env]
+                                  (let [r (executor/execute! exec
+                                                             (:environment-id env)
+                                                             (str "echo " tid)
+                                                             {})]
+                                    (swap! results conj
+                                           {:task-id tid
+                                            :success? (and (result/ok? r)
+                                                           (= 0 (:exit-code
+                                                                 (:data r))))}))))))
+                          task-ids)]
+
+        ;; Wait for all to complete
+        (doseq [f futures]
+          (deref f 60000 :timeout))
+
+        ;; All should succeed
+        (is (= 3 (count @results)))
+        (is (every? :success? @results))))))
+
+;; ============================================================================
+;; Rich Comment for REPL Testing
+;; ============================================================================
+
+(comment
+  ;; Quick REPL test for Docker
+  (def exec (executor/create-docker-executor {:image "alpine:latest"}))
+  (executor/available? exec)
+
+  ;; Test lifecycle
+  (def env-result (executor/acquire-environment! exec (random-uuid) {}))
+  (def env-id (:environment-id (:data env-result)))
+
+  (executor/execute! exec env-id "ls -la" {})
+  (executor/environment-status exec env-id)
+  (executor/release-environment! exec env-id)
+
+  ;; Test with-environment
+  (executor/with-environment exec (random-uuid) {}
+    (fn [env]
+      (executor/execute! exec (:environment-id env) "cat /etc/os-release" {})))
+
+  :leave-this-here)

--- a/components/dag-executor/test/ai/miniforge/dag_executor/result_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/result_test.clj
@@ -1,0 +1,174 @@
+(ns ai.miniforge.dag-executor.result-test
+  "Unit tests for result monad helpers."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.dag-executor.result :as result]))
+
+;; ============================================================================
+;; Result creation tests
+;; ============================================================================
+
+(deftest ok-test
+  (testing "ok creates success result"
+    (let [r (result/ok {:value 42})]
+      (is (map? r))
+      (is (:ok? r))
+      (is (= {:value 42} (:data r))))))
+
+(deftest err-test
+  (testing "err creates error result with code and message"
+    (let [r (result/err :not-found "Item not found")]
+      (is (map? r))
+      (is (not (:ok? r)))
+      (is (= :not-found (get-in r [:error :code])))
+      (is (= "Item not found" (get-in r [:error :message])))))
+
+  (testing "err accepts optional data"
+    (let [r (result/err :validation-failed "Invalid input" {:field :email})]
+      (is (= {:field :email} (get-in r [:error :data]))))))
+
+;; ============================================================================
+;; Result predicate tests
+;; ============================================================================
+
+(deftest ok?-test
+  (testing "ok? returns true for success results"
+    (is (result/ok? (result/ok {})))
+    (is (result/ok? (result/ok {:x 1}))))
+
+  (testing "ok? returns false for error results"
+    (is (not (result/ok? (result/err :error "failed"))))))
+
+(deftest err?-test
+  (testing "err? returns true for error results"
+    (is (result/err? (result/err :error "failed"))))
+
+  (testing "err? returns false for success results"
+    (is (not (result/err? (result/ok {}))))))
+
+;; ============================================================================
+;; Unwrap tests
+;; ============================================================================
+
+(deftest unwrap-test
+  (testing "unwrap returns data from ok result"
+    (is (= {:value 42} (result/unwrap (result/ok {:value 42})))))
+
+  (testing "unwrap throws on error result"
+    (is (thrown? clojure.lang.ExceptionInfo
+                 (result/unwrap (result/err :error "failed"))))))
+
+(deftest unwrap-or-test
+  (testing "unwrap-or returns data from ok result"
+    (is (= {:value 42} (result/unwrap-or (result/ok {:value 42}) :default))))
+
+  (testing "unwrap-or returns default on error result"
+    (is (= :default (result/unwrap-or (result/err :error "failed") :default)))))
+
+;; ============================================================================
+;; Transform tests
+;; ============================================================================
+
+(deftest map-ok-test
+  (testing "map-ok transforms data in ok result"
+    (let [r (result/ok {:value 10})
+          r2 (result/map-ok r #(update % :value inc))]
+      (is (result/ok? r2))
+      (is (= {:value 11} (:data r2)))))
+
+  (testing "map-ok passes through error"
+    (let [r (result/err :error "failed")
+          r2 (result/map-ok r #(update % :value inc))]
+      (is (result/err? r2)))))
+
+(deftest map-err-test
+  (testing "map-err transforms error in err result"
+    (let [r (result/err :error "failed")
+          r2 (result/map-err r #(assoc % :wrapped true))]
+      (is (result/err? r2))
+      (is (:wrapped (:error r2)))))
+
+  (testing "map-err passes through ok result"
+    (let [r (result/ok {:value 42})
+          r2 (result/map-err r #(assoc % :wrapped true))]
+      (is (result/ok? r2))
+      (is (= {:value 42} (:data r2))))))
+
+;; ============================================================================
+;; Chaining tests
+;; ============================================================================
+
+(deftest and-then-test
+  (testing "and-then applies function to ok result"
+    (let [r (result/ok {:value 10})
+          r2 (result/and-then r (fn [data]
+                                  (result/ok {:value (* 2 (:value data))})))]
+      (is (result/ok? r2))
+      (is (= {:value 20} (:data r2)))))
+
+  (testing "and-then passes through error result"
+    (let [r (result/err :error "failed")
+          r2 (result/and-then r (fn [_] (result/ok {:value 999})))]
+      (is (result/err? r2))
+      (is (= :error (get-in r2 [:error :code]))))))
+
+(deftest or-else-test
+  (testing "or-else applies function to error result"
+    (let [r (result/err :not-found "not found")
+          r2 (result/or-else r (fn [_] (result/ok {:default true})))]
+      (is (result/ok? r2))
+      (is (= {:default true} (:data r2)))))
+
+  (testing "or-else passes through ok result"
+    (let [r (result/ok {:value 42})
+          r2 (result/or-else r (fn [_] (result/ok {:default true})))]
+      (is (result/ok? r2))
+      (is (= {:value 42} (:data r2))))))
+
+;; ============================================================================
+;; Collection helpers
+;; ============================================================================
+
+(deftest collect-test
+  (testing "collect returns ok with all data when all results are ok"
+    (let [results [(result/ok {:a 1}) (result/ok {:b 2}) (result/ok {:c 3})]
+          collected (result/collect results)]
+      (is (result/ok? collected))
+      (is (= [{:a 1} {:b 2} {:c 3}] (:data collected)))))
+
+  (testing "collect returns first error when any result is error"
+    (let [results [(result/ok {:a 1})
+                   (result/err :error "failed")
+                   (result/ok {:c 3})]
+          collected (result/collect results)]
+      (is (result/err? collected))
+      (is (= :error (get-in collected [:error :code]))))))
+
+;; ============================================================================
+;; Error codes
+;; ============================================================================
+
+(deftest error-codes-test
+  (testing "error-codes contains standard codes"
+    (is (contains? result/error-codes :invalid-state))
+    (is (contains? result/error-codes :task-not-found))
+    (is (contains? result/error-codes :budget-exhausted))
+    (is (contains? result/error-codes :ci-failed))
+    (is (contains? result/error-codes :merge-failed))))
+
+;; ============================================================================
+;; Rich comment for REPL testing
+;; ============================================================================
+
+(comment
+  (result/ok {:value 42})
+  (result/err :not-found "not found")
+
+  (-> (result/ok {:value 10})
+      (result/map-ok #(update % :value * 2))
+      (result/and-then (fn [{:keys [value]}]
+                         (if (> value 15)
+                           (result/ok {:result :big})
+                           (result/ok {:result :small})))))
+
+  :leave-this-here)

--- a/specs/informative/I-DAG-ORCHESTRATION.md
+++ b/specs/informative/I-DAG-ORCHESTRATION.md
@@ -2,7 +2,7 @@
 
 **Status:** Informative
 **Date:** 2026-02-03
-**Version:** 1.1.0
+**Version:** 1.2.0
 
 Specifies implementation for executing multi-task plans as a DAG where
 **task completion is defined by merge**, including automated PR lifecycle handling.
@@ -265,8 +265,8 @@ protocol provides a pluggable backend system with automatic fallback:
 
 * ✅ Protocol and interface defined
 * ✅ WorktreeExecutor implemented (fallback)
-* ⏳ DockerExecutor shell implemented, needs integration testing
-* ⏳ KubernetesExecutor shell implemented, needs integration testing
+* ✅ DockerExecutor implemented with integration tests
+* ✅ KubernetesExecutor implemented (tests skip if K8s unavailable)
 
 ---
 
@@ -373,13 +373,14 @@ Integration tests:
 5. ✅ **Executor protocol** - `executor.clj` with pluggable backends
 6. ✅ **WorktreeExecutor** - Fallback isolation via git worktrees
 
-### Phase 2: Container Isolation (⏳ Next PR)
+### Phase 2: Container Isolation (✅ Complete)
 
-1. ⏳ **DockerExecutor integration testing** - Validate container lifecycle
-2. ⏳ **KubernetesExecutor integration testing** - Validate K8s Job lifecycle
-3. ⏳ **Executor selection logic** - Auto-detect best available backend
+1. ✅ **DockerExecutor integration testing** - Full lifecycle, file ops, concurrency
+2. ✅ **KubernetesExecutor integration testing** - Availability + lifecycle (skips if unavailable)
+3. ✅ **Executor selection logic** - Auto-detect best available backend
+4. ✅ **Result module tests** - ok/err helpers, transforms, chaining
 
-### Phase 3: PR Lifecycle (Pending)
+### Phase 3: PR Lifecycle (⏳ Next)
 
 1. **Task Workflow state machine + PR controller** with polling, emitting events
 2. **Fix loop on CI failures** (highest ROI)


### PR DESCRIPTION
## Summary

- Extract TaskExecutor protocol and implementations into separate namespaces following the codebase pattern (protocols/executor.clj, protocols/impl/*.clj)
- Add full Docker and Kubernetes executor implementations (no longer stubbed)
- Add external resource files for container images and K8s job templates
- K8s executor now creates actual Jobs and waits for pods to be ready with pod caching

## Changes

### Protocol/Impl Decomposition
- `protocols/executor.clj` - Protocol definition and ExecutionEnvironment record
- `protocols/impl/docker.clj` - Full Docker implementation with container lifecycle management
- `protocols/impl/kubernetes.clj` - Full K8s Job implementation with pod caching
- `protocols/impl/worktree.clj` - Git worktree fallback implementation

### Resource Files
- `resources/executor/docker/Dockerfile.task-runner` - Minimal Alpine image with git, bash, curl, jq
- `resources/executor/docker/Dockerfile.task-runner-clojure` - Extended image with Clojure CLI, Babashka, clj-kondo
- `resources/executor/kubernetes/job-template.yaml` - K8s Job template with security context, volumes, resource defaults

### Key Improvements
- K8s executor actually creates Jobs via `kubectl apply` and waits for pods
- Both implementations include proper security context and resource defaults
- Template loading function for K8s job spec documentation/debugging
- Cleaner facade in executor.clj that re-exports from impl namespaces

## Test plan
- [x] All 32 dag-executor tests pass (Docker lifecycle, file ops, concurrency)
- [x] All 532 poly tests pass
- [x] K8s template loads correctly from resources
- [ ] Manual: Test with real K8s cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)