### PR TITLE
test(graalvm): complete brick coverage with auto-discovery

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -289,6 +289,27 @@
   [value]
   (validate PackManifest value))
 
+;------------------------------------------------------------------------------ Layer 2
+;; Result helpers (used by loader.clj)
+
+(defn success
+  "Create a success result.
+   (success :pack pack {:errors nil}) => {:success? true :pack pack :errors nil}"
+  [key value extras]
+  (merge {:success? true key value} extras))
+
+(defn failure
+  "Create a failure result.
+   (failure :data \"error msg\") => {:success? false :error \"error msg\"}"
+  [_key message]
+  {:success? false :error message})
+
+(defn failure-with-errors
+  "Create a failure result with error list.
+   (failure-with-errors :pack [...]) => {:success? false :errors [...]}"
+  [_key errors]
+  {:success? false :errors errors})
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Validate a rule

--- a/deps.edn
+++ b/deps.edn
@@ -54,7 +54,15 @@
                        "components/pr-lifecycle/src"
                        "components/pr-lifecycle/resources"
                        "components/evidence-bundle/src"
-                       "components/evidence-bundle/resources"]
+                       "components/evidence-bundle/resources"
+                       "components/policy-pack/src"
+                       "components/policy-pack/resources"
+                       "components/pr-train/src"
+                       "components/pr-train/resources"
+                       "components/repo-dag/src"
+                       "components/repo-dag/resources"
+                       "bases/cli/src"
+                       "bases/cli/resources"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
                       ai.miniforge/logging {:local/root "components/logging"}
@@ -80,7 +88,11 @@
                       ai.miniforge/tool-registry {:local/root "components/tool-registry"}
                      ai.miniforge/dag-executor {:local/root "components/dag-executor"}
                      ai.miniforge/pr-lifecycle {:local/root "components/pr-lifecycle"}
-                     ai.miniforge/evidence-bundle {:local/root "components/evidence-bundle"}}}
+                     ai.miniforge/evidence-bundle {:local/root "components/evidence-bundle"}
+                     ai.miniforge/policy-pack {:local/root "components/policy-pack"}
+                     ai.miniforge/pr-train {:local/root "components/pr-train"}
+                     ai.miniforge/repo-dag {:local/root "components/repo-dag"}
+                     ai.miniforge/cli {:local/root "bases/cli"}}}
 
   :test {:extra-paths ["development/test"
                        "components/schema/test"
@@ -108,7 +120,10 @@
                        "components/dag-executor/test"
                        "components/pr-lifecycle/test"
                        "components/release-executor/test"
-                       "components/evidence-bundle/test"]
+                       "components/evidence-bundle/test"
+                       "components/policy-pack/test"
+                       "components/pr-train/test"
+                       "components/repo-dag/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
                       ai.miniforge/logging {:local/root "components/logging"}
@@ -134,7 +149,10 @@
                       ai.miniforge/tool-registry {:local/root "components/tool-registry"}
                       ai.miniforge/dag-executor {:local/root "components/dag-executor"}
                       ai.miniforge/pr-lifecycle {:local/root "components/pr-lifecycle"}
-                      ai.miniforge/evidence-bundle {:local/root "components/evidence-bundle"}}}
+                      ai.miniforge/evidence-bundle {:local/root "components/evidence-bundle"}
+                      ai.miniforge/policy-pack {:local/root "components/policy-pack"}
+                      ai.miniforge/pr-train {:local/root "components/pr-train"}
+                      ai.miniforge/repo-dag {:local/root "components/repo-dag"}}}
 
   :conformance {:extra-paths ["development/test"
                               "tests/conformance"

--- a/tests/graalvm_compatibility_test.clj
+++ b/tests/graalvm_compatibility_test.clj
@@ -35,6 +35,34 @@
                                            [(symbol (str "ai.miniforge." brick-name ".interface"))])))))]
     (sort-by str interface-files)))
 
+(defn- path->namespace
+  "Convert a .clj file path (relative to src/) to a namespace symbol.
+   e.g. ai/miniforge/cli/main.clj -> ai.miniforge.cli.main"
+  [src-root clj-file]
+  (let [src-path (.getPath src-root)
+        file-path (.getPath clj-file)
+        relative (subs file-path (inc (count src-path)))]
+    (-> relative
+        (str/replace #"\.clj$" "")
+        (str/replace "/" ".")
+        (str/replace "_" "-")
+        symbol)))
+
+(defn- discover-base-namespaces
+  "Scan bases/ for all .clj source files and derive namespace symbols.
+   Returns a sorted seq of namespace symbols."
+  []
+  (let [base-dirs (-> (io/file "bases") .listFiles seq)]
+    (->> base-dirs
+         (filter #(.isDirectory %))
+         (mapcat (fn [dir]
+                   (let [src-dir (io/file dir "src")]
+                     (when (.exists src-dir)
+                       (->> (file-seq src-dir)
+                            (filter #(str/ends-with? (.getName %) ".clj"))
+                            (map #(path->namespace src-dir %)))))))
+         (sort-by str))))
+
 ;; ============================================================================
 ;; Helpers
 ;; ============================================================================
@@ -103,12 +131,39 @@
             :else
             (is false (str "Failed to load " ns-sym ":\n" error-msg))))))))
 
+(deftest test-all-bases-load-in-babashka
+  (testing "All base namespaces should load in Babashka/GraalVM"
+    (let [all-ns (discover-base-namespaces)]
+      ;; Ensure we actually found base namespaces (sanity check)
+      (is (>= (count all-ns) 3)
+          (str "Expected 3+ base namespaces, found " (count all-ns)
+               ". Is the test running from the repo root?"))
+
+      (doseq [ns-sym all-ns]
+        (let [[success? error-msg] (require-namespace ns-sym)]
+          (cond
+            success?
+            (is true (str ns-sym " loaded"))
+
+            (classpath-error? error-msg)
+            (println "  WARN:" ns-sym "- not on :dev classpath (add to deps.edn :dev alias)")
+
+            (jvm-only-error? error-msg)
+            (is false (str "JVM-ONLY DEPENDENCY DETECTED in " ns-sym ":\n"
+                           error-msg
+                           "\n\nThis blocks GraalVM native compilation."
+                           "\nFix: use Babashka-compatible alternatives."))
+
+            :else
+            (is false (str "Failed to load " ns-sym ":\n" error-msg))))))))
+
 (deftest test-no-forbidden-dependencies
   (testing "Forbidden JVM-only dependencies should not be present"
     (let [forbidden-deps {"org.clojure/data.json" "Use cheshire.core instead (bundled in Babashka)"
                           "org.clojure/java.jdbc" "Use next.jdbc instead"}
-          component-dirs (file-seq (io/file "components"))
-          deps-files (->> component-dirs
+          all-dirs (concat (file-seq (io/file "components"))
+                           (file-seq (io/file "bases")))
+          deps-files (->> all-dirs
                           (filter #(= "deps.edn" (.getName %)))
                           (map slurp))]
       (doseq [[dep replacement] forbidden-deps
@@ -120,7 +175,8 @@
 
 (deftest test-no-java-interface-in-defrecord
   (testing "No defrecord should implement Java interfaces (Babashka limitation)"
-    (let [src-files (->> (file-seq (io/file "components"))
+    (let [src-files (->> (concat (file-seq (io/file "components"))
+                                 (file-seq (io/file "bases")))
                          (filter #(str/ends-with? (.getName %) ".clj"))
                          (filter #(str/includes? (.getPath %) "/src/")))]
       (doseq [f src-files]
@@ -160,6 +216,9 @@
 
   ;; Discover all brick interfaces
   (discover-interface-namespaces)
+
+  ;; Discover all base namespaces
+  (discover-base-namespaces)
 
   ;; Test a specific namespace
   (require-namespace 'ai.miniforge.dag-executor.interface)


### PR DESCRIPTION
## Summary

- Wire **all 29 component interfaces + 6 CLI base namespaces** into the GraalVM/Babashka compatibility test suite (up from 16 manually listed components)
- Auto-discover bricks from filesystem so new bricks are tested automatically — no manual list to maintain
- Fix a pre-existing bug in `policy-pack` that prevented it from loading

## Changes

### `deps.edn`
- Add `policy-pack`, `pr-train`, `repo-dag` to `:dev` and `:test` aliases (paths + deps)
- Add CLI base (`bases/cli`) to `:dev` alias for full workspace coverage

### `tests/graalvm_compatibility_test.clj`
- Add `discover-base-namespaces` — scans `bases/*/src/` for all `.clj` source files
- Add `test-all-bases-load-in-babashka` — verifies all base namespaces load in Babashka
- Extend `test-no-forbidden-dependencies` to scan both `components/` and `bases/`
- Extend `test-no-java-interface-in-defrecord` to scan both `components/` and `bases/`

### `components/policy-pack/src/ai/miniforge/policy_pack/schema.clj`
- Add missing `success`, `failure`, `failure-with-errors` result helper functions that `loader.clj` depends on — this was a pre-existing bug that blocked the interface from loading

## Coverage

| Scope | Before | After |
|-------|--------|-------|
| Component interfaces | 16 (hardcoded) | 29 (auto-discovered) |
| Base namespaces | 0 | 6 (auto-discovered) |
| Static scans (forbidden deps, defrecord) | components only | components + bases |
| Total assertions | ~50 | 100 |

## Test plan

- [x] `bb test:graalvm` — 5 tests, 100 assertions, 0 failures
- [x] `bb test` — full Polylith suite (102 test suites), 0 failures
- [x] Pre-commit hooks pass (lint + test + graalvm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)