### PR TITLE
spec(N2-N5): capability contracts, frontier semantics, kanban projection

### DIFF
--- a/specs/normative/N2-workflows.md
+++ b/specs/normative/N2-workflows.md
@@ -1227,6 +1227,22 @@ Implementations MUST:
 - Support configurable parallelism limits
 - Release all locks on task completion or failure
 
+#### 13.4.1 Frontier Computation
+
+The **frontier** is the set of tasks eligible for dispatch at any point in time.
+
+Implementations MUST compute the frontier as:
+
+```text
+frontier(run) = { t ∈ tasks | status(t) = :pending ∧ ∀d ∈ deps(t): status(d) = :merged }
+```
+
+Implementations MUST:
+
+1. **Recompute frontier** after every task terminal transition (:merged, :failed, :skipped)
+2. **Skip-propagate** — when a task reaches :failed, all transitive dependents MUST transition to :skipped
+3. **Emit frontier events** — see N3 §3.12 for required event schemas
+
 ### 13.5 Rebase and Conflict Handling
 
 When the base branch moves during task execution:
@@ -1235,6 +1251,50 @@ When the base branch moves during task execution:
 2. **Conflict detection:** If rebase fails, detect conflicting files
 3. **Conflict repair:** Invoke fix loop to resolve conflicts (per policy)
 4. **Restart:** If API changes affect task, may restart from `:implementing`
+
+### 13.6 Node Capability Contracts
+
+Each task node in a DAG MAY declare a **capability contract** specifying required tools,
+allowed file paths, and knowledge scope. When present, the contract constrains the agent
+instance dispatched to execute the task.
+
+#### 13.6.1 Capability Contract Schema
+
+```clojure
+{:task/capabilities
+ {:cap/tools [keyword ...]          ; Tools agent may invoke (e.g., :write-file, :run-cmd, :gh-pr-create)
+  :cap/paths [string ...]           ; Glob patterns for allowed file paths (e.g., "src/auth/**")
+  :cap/knowledge [string ...]       ; Knowledge pack IDs available to agent
+  :cap/archetype keyword            ; Agent archetype (e.g., :implementer, :tester, :reviewer)
+  :cap/timeout-ms long              ; Max wall-clock time for task execution
+  :cap/resource-locks [keyword ...] ; Resource locks required (from §13.4)
+  }}
+```
+
+Fields are OPTIONAL. When omitted, the agent receives default capabilities for its archetype.
+
+#### 13.6.2 Agent Scoping Rules
+
+When a task declares capabilities, implementations MUST:
+
+1. **Select archetype** — dispatch agent matching `:cap/archetype` (default: `:implementer`)
+2. **Restrict tool set** — agent MUST only have access to tools listed in `:cap/tools`
+3. **Restrict file scope** — file operations MUST be validated against `:cap/paths` globs
+4. **Restrict knowledge** — agent context MUST only include packs listed in `:cap/knowledge`
+5. **Enforce timeout** — kill agent if `:cap/timeout-ms` exceeded
+
+When a task does NOT declare capabilities, the agent receives the full default tool set
+for its archetype as defined in agent profile packs.
+
+#### 13.6.3 Capability Inheritance
+
+For tasks that share common requirements, implementations MAY support:
+
+- **DAG-level defaults** — capabilities declared at DAG level apply to all tasks unless overridden
+- **Task override** — task-level capabilities merge with (and override) DAG-level defaults
+- **Archetype defaults** — agent profile packs define baseline capabilities per archetype
+
+Merge order: archetype defaults → DAG defaults → task overrides.
 
 ---
 
@@ -1273,10 +1333,12 @@ PR train orchestration will enable:
 - N3 (Event Stream): Defines phase lifecycle events
 - N4 (Policy Packs): Defines policy validation gates
 - N6 (Evidence & Provenance): Defines evidence bundle generation
+- N4 (Policy Packs): Capability enforcement via policy rules
 
 ---
 
 **Version History:**
 
+- 0.3.0-draft (2026-02-04): Added node capability contracts (§13.6) and frontier semantics (§13.4.1)
 - 0.2.0-draft (2026-02-03): Added DAG-based multi-task execution model (Section 13)
 - 0.1.0-draft (2026-01-23): Initial workflow execution model specification

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -716,6 +716,110 @@ ETL workflows MUST emit this event if any critical failure prevents completion.
 Implementations SHOULD include enough detail in `:etl/error-details` to enable
 debugging without log diving.
 
+### 3.12 Task Lifecycle Events (DAG Orchestration)
+
+For DAG-based multi-task execution (see N2 Section 13), implementations MUST emit
+task lifecycle events that track frontier computation, agent dispatch, and capability
+binding. These events enable Kanban projections and capability audit trails.
+
+#### Common Correlation Fields
+
+All task lifecycle events MUST include:
+
+```clojure
+{:dag/id uuid                    ; REQUIRED: DAG run ID
+ :run/id uuid                    ; REQUIRED: Run instance ID
+ :task/id uuid                   ; REQUIRED: Task ID
+ :timestamp inst}                ; REQUIRED: Event timestamp
+```
+
+#### task/frontier-entered
+
+Emitted when a task's dependencies are all satisfied and it becomes eligible for dispatch.
+
+```clojure
+{:event/type :task/frontier-entered
+ :dag/id uuid
+ :run/id uuid
+ :task/id uuid
+ :frontier/size long             ; Current frontier size after this task entered
+ :frontier/trigger-task uuid     ; Task whose terminal state caused this entry
+ :timestamp inst
+
+ :message "Task entered frontier (frontier size: 3)"}
+```
+
+#### task/claimed
+
+Emitted when a task is dispatched to an agent for execution.
+
+```clojure
+{:event/type :task/claimed
+ :dag/id uuid
+ :run/id uuid
+ :task/id uuid
+ :agent/archetype keyword        ; e.g., :implementer
+ :agent/instance-id uuid         ; Unique agent instance
+ :claim/lease-ms long            ; OPTIONAL: Lease duration if time-boxed
+ :timestamp inst
+
+ :message "Task claimed by implementer agent"}
+```
+
+#### task/capability-bound
+
+Emitted when an agent is scoped to a task's capability contract.
+
+```clojure
+{:event/type :task/capability-bound
+ :dag/id uuid
+ :run/id uuid
+ :task/id uuid
+ :agent/instance-id uuid
+ :cap/tools [keyword ...]        ; Tools granted
+ :cap/paths [string ...]         ; File paths granted
+ :cap/knowledge [string ...]     ; Knowledge packs granted
+ :cap/source keyword             ; :task-contract, :archetype-default, :dag-default
+ :timestamp inst
+
+ :message "Agent capabilities bound: 4 tools, 2 path patterns"}
+```
+
+#### task/scope-violation
+
+Emitted when an agent attempts an operation outside its capability contract.
+This is a WARN-level event; the operation MUST be blocked.
+
+```clojure
+{:event/type :task/scope-violation
+ :dag/id uuid
+ :run/id uuid
+ :task/id uuid
+ :agent/instance-id uuid
+ :violation/type keyword          ; :tool-denied, :path-denied, :knowledge-denied
+ :violation/requested string      ; What was requested (e.g., tool name, file path)
+ :violation/allowed [string ...]  ; What was allowed
+ :timestamp inst
+
+ :message "Scope violation: agent requested :delete-branch but allowed tools are [:write-file :run-cmd]"}
+```
+
+#### task/skip-propagated
+
+Emitted when a task is skipped due to a dependency failure.
+
+```clojure
+{:event/type :task/skip-propagated
+ :dag/id uuid
+ :run/id uuid
+ :task/id uuid
+ :skip/cause-task uuid            ; The task whose failure triggered the skip
+ :skip/cause-chain [uuid ...]     ; Full chain from root failure to this task
+ :timestamp inst
+
+ :message "Task skipped: dependency task-abc failed"}
+```
+
 ## 4. Event Emission Requirements
 
 ### 4.1 Emission Points
@@ -730,6 +834,7 @@ Implementations MUST emit events at these points:
 6. **Gate execution** - start, pass, fail
 7. **Inter-agent messages** - all communications
 8. **Milestones** - significant progress points
+9. **Task lifecycle** - frontier entry, claims, capability binding, scope violations
 
 ### 4.2 Throttling
 
@@ -989,5 +1094,6 @@ Event stream will extend to:
 
 **Version History:**
 
+- 0.3.0-draft (2026-02-04): Added task lifecycle events for DAG orchestration (§3.12)
 - 0.2.0-draft (2026-02-03): Add PR lifecycle events for DAG orchestration (Section 3.10)
 - 0.1.0-draft (2026-01-23): Initial event stream specification

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -604,6 +604,31 @@ Rules:
 - Require liveness/readiness probes
 - No host network mode
 
+#### 5.1.4 Task Scope Pack
+
+**ID:** `task-scope`
+**Purpose:** Enforce node capability contracts during DAG execution (see N2 §13.6)
+
+Rules:
+
+- `require-capability-declaration` (severity: medium)
+  - WARN if a task node in a DAG has no `:task/capabilities` declared
+  - Tasks without contracts run with full archetype defaults (less safe)
+- `enforce-tool-scope` (severity: critical)
+  - FAIL if agent invokes a tool not listed in `:cap/tools`
+  - Implementations MUST intercept tool calls and validate against contract
+- `enforce-path-scope` (severity: critical)
+  - FAIL if agent writes/reads files outside `:cap/paths` glob patterns
+  - Implementations MUST validate file operations against contract
+- `enforce-knowledge-scope` (severity: high)
+  - FAIL if agent accesses knowledge packs not listed in `:cap/knowledge`
+- `enforce-timeout` (severity: high)
+  - FAIL if agent execution exceeds `:cap/timeout-ms`
+  - Implementations MUST terminate agent and transition task to `:failed`
+
+This pack is OPTIONAL for single-task workflows but RECOMMENDED for DAG execution
+with multiple concurrent agents.
+
 ### 5.2 Pack Discovery & Installation
 
 Implementations SHOULD support:
@@ -972,4 +997,5 @@ Research directions:
 
 **Version History:**
 
+- 0.2.0-draft (2026-02-04): Added task-scope policy pack for capability enforcement (§5.1.4)
 - 0.1.0-draft (2026-01-23): Initial policy packs and gates specification

--- a/specs/normative/N5-cli-tui-api.md
+++ b/specs/normative/N5-cli-tui-api.md
@@ -125,6 +125,13 @@ Flags:
   --limit N           Show last N workflows (default: 10)
   --json              Output as JSON
 
+# Show DAG kanban board (TUI)
+miniforge workflow kanban DAG_ID [flags]
+
+Flags:
+  --refresh SECONDS   Refresh interval (default: 5)
+  --json              Output task states as JSON (non-interactive)
+
 # Cancel workflow
 miniforge workflow cancel WORKFLOW_ID [flags]
 
@@ -683,6 +690,49 @@ Implementations MUST provide these views:
 - MUST allow viewing artifact provenance
 - MUST support syntax highlighting for code artifacts
 
+#### 3.2.5 DAG Kanban View
+
+For DAG-based multi-task execution, implementations SHOULD provide a Kanban board
+view derived as a **projection** of the DAG state and event stream.
+
+The Kanban view is NOT a separate data model — it is computed from task states.
+
+```text
+╭────────────────────────────────────────────────────────────────────────────────╮
+│ DAG: feature-auth-overhaul (5 tasks)                             ⟳ 5s ago     │
+├──────────┬───────────┬───────────┬───────────┬───────────┬──────────────────┤
+│ BLOCKED  │ READY     │ ACTIVE    │ IN REVIEW │ MERGING   │ DONE             │
+├──────────┼───────────┼───────────┼───────────┼───────────┼──────────────────┤
+│ ○ models │ ◉ routes  │ ● auth-svc│           │           │ ✓ schema-migrate │
+│   └ auth │           │   impl    │           │           │                  │
+│   └ svc  │           │   ⏱ 2m30s │           │           │                  │
+│          │           │           │           │           │                  │
+│ ○ tests  │           │           │           │           │                  │
+│   └ auth │           │           │           │           │                  │
+│   └ svc  │           │           │           │           │                  │
+╰──────────┴───────────┴───────────┴───────────┴───────────┴──────────────────╯
+[j/k] Navigate  [Enter] Task detail  [d] Dependency graph  [Esc] Back
+```
+
+**Column Mapping:**
+
+| Column    | Task Statuses                                |
+|-----------|----------------------------------------------|
+| BLOCKED   | `:pending` with unmet dependencies            |
+| READY     | `:pending` with all deps `:merged` (frontier) |
+| ACTIVE    | `:implementing`, `:pr-opening`, `:responding` |
+| IN REVIEW | `:ci-running`, `:review-pending`              |
+| MERGING   | `:ready-to-merge`, `:merging`                 |
+| DONE      | `:merged`, `:failed`, `:skipped`              |
+
+**Requirements:**
+
+- MUST derive columns from task state machine (N2 §13.2), NOT from separate state
+- MUST show dependency edges for blocked tasks (which tasks they're waiting on)
+- MUST update in real-time via event stream subscription
+- SHOULD show elapsed time for active tasks
+- SHOULD show `:failed` and `:skipped` tasks distinctly in DONE column (✗ vs ○)
+
 ### 3.3 TUI Keyboard Navigation
 
 Implementations MUST support:
@@ -700,6 +750,7 @@ Implementations MUST support:
 | `c`       | Cancel workflow                 |
 | `q`       | Quit TUI                        |
 | `r`       | Refresh now                     |
+| `b`       | Kanban board (DAG view)         |
 | `?`       | Show help                       |
 
 ### 3.4 TUI Real-Time Updates
@@ -1174,4 +1225,5 @@ Research directions:
 
 **Version History:**
 
+- 0.2.0-draft (2026-02-04): Added DAG Kanban view and task lifecycle CLI command (§3.2.5)
 - 0.1.0-draft (2026-01-23): Initial CLI/TUI/API specification


### PR DESCRIPTION
## Summary

- **N2 §13.4.1** — Formal frontier computation: defines the frontier as the set of tasks whose deps are all `:merged`, with skip-propagation and event emission rules
- **N2 §13.6** — Node capability contracts: schema for `:task/capabilities` (tools, paths, knowledge, archetype, timeout, resource-locks), agent scoping rules, and DAG→task inheritance model
- **N3 §3.12** — Five new task lifecycle events: `task/frontier-entered`, `task/claimed`, `task/capability-bound`, `task/scope-violation`, `task/skip-propagated`
- **N4 §5.1.4** — `task-scope` policy pack with 5 enforcement rules (tool scope, path scope, knowledge scope, timeout, capability declaration)
- **N5 §3.2.5** — DAG Kanban view as a state projection (TUI mockup, column→status mapping, `miniforge workflow kanban` CLI command, `b` keybinding)

All changes are additive — no existing sections modified. Cross-references verified across all four specs (N2↔N3↔N4↔N5).

## Files changed

| File | Sections |
|------|----------|
| `specs/normative/N2-workflows.md` | §13.4.1, §13.6, §15 refs, version history |
| `specs/normative/N3-event-stream.md` | §3.12, §4.1 item 9, version history |
| `specs/normative/N4-policy-packs.md` | §5.1.4, version history |
| `specs/normative/N5-cli-tui-api.md` | §2.3.2 CLI cmd, §3.2.5, §3.3 keybinding, version history |

## Test plan

- [ ] Verify no existing spec sections were modified (diff review)
- [ ] Verify cross-references: N2→N3 (§13.4.1→§3.12), N4→N2 (§5.1.4→§13.6), N5→N2 (§3.2.5→§13.2)
- [ ] Verify kanban column mapping covers all 12 task statuses from `state.clj`
- [ ] Verify capability contract schema aligns with `create-task-state` in `dag-executor/state.clj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)