### PR TITLE
fix(lint): resolve all 65 clj-kondo warnings

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/tui.clj
+++ b/bases/cli/src/ai/miniforge/cli/tui.clj
@@ -133,7 +133,7 @@
     :summary string
     :suggested-action string
     :reasons [string]}"
-  [{:keys [title additions deletions changedFiles] :as pr}]
+  [{:keys [title additions deletions changedFiles] :as _pr}]
   (let [;; Size-based heuristics
         total-changes (+ (or additions 0) (or deletions 0))
         file-count (or changedFiles 0)
@@ -308,7 +308,7 @@
 
 (defn render-pr-detail
   "Render detailed view of a PR for the right pane."
-  [{:keys [number title author state url repo] :as pr} analysis]
+  [{:keys [number title author state repo] :as _pr} analysis]
   (let [{:keys [risk complexity summary suggested-action reasons]} analysis]
     {:title (str "PR #" number " " (truncate repo 30))
      :sections

--- a/components/agent/src/ai/miniforge/agent/meta_coordinator.clj
+++ b/components/agent/src/ai/miniforge/agent/meta_coordinator.clj
@@ -108,7 +108,7 @@
   (doseq [agent (:agents coordinator)]
     (try
       (mp/reset-state! agent)
-      (catch Exception e
+      (catch Exception _e
         ;; Silently continue on reset errors - caller can check if needed
         nil)))
   (reset! (:last-checks coordinator) {})

--- a/components/agent/test/ai/miniforge/agent/messaging_test.clj
+++ b/components/agent/test/ai/miniforge/agent/messaging_test.clj
@@ -330,13 +330,13 @@
                        :planner
                        test-planner-id
                        test-workflow-id
-                       router)]
-      ;; Implementer sends clarification request
-      (let [request-result (agent/send-clarification-request
-                            implementer-msg
-                            :planner
-                            "How should we handle X?")
-            original-msg (:message request-result)]
+                       router)
+          ;; Implementer sends clarification request
+          request-result (agent/send-clarification-request
+                          implementer-msg
+                          :planner
+                          "How should we handle X?")
+          original-msg (:message request-result)]
 
         ;; Planner responds
         (let [response-result (agent/respond-to-message
@@ -353,7 +353,7 @@
         ;; Implementer receives response
         (let [received (agent/receive-messages implementer-msg)]
           (is (= 1 (count received)))
-          (is (= :clarification-response (:message/type (first received)))))))))
+          (is (= :clarification-response (:message/type (first received))))))))
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Convenience Function Tests

--- a/components/artifact/src/ai/miniforge/artifact/datalevin_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/datalevin_store.clj
@@ -6,7 +6,6 @@
    or transit store is needed (Babashka compatibility)."
   (:require
    [datalevin.core :as d]
-   [ai.miniforge.artifact.core :as core]
    [ai.miniforge.artifact.interface.protocols.artifact-store :as p]
    [ai.miniforge.logging.interface :as log]))
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
@@ -10,6 +10,7 @@
   (:require
    [ai.miniforge.dag-executor.result :as result]
    [ai.miniforge.dag-executor.protocols.executor :as proto]
+   [clojure.java.io]
    [clojure.java.shell :as shell]
    [clojure.string :as str]))
 
@@ -217,7 +218,7 @@
   [docker-path image-name dockerfile-path]
   (if-let [abs-path (find-dockerfile-path dockerfile-path)]
     (let [context-dir (.getParent (clojure.java.io/file abs-path))
-          dockerfile-name (.getName (clojure.java.io/file abs-path))
+          _dockerfile-name (.getName (clojure.java.io/file abs-path))
           result (run-docker docker-path "build"
                              "-t" image-name
                              "-f" abs-path

--- a/components/gate/src/ai/miniforge/gate/lint.clj
+++ b/components/gate/src/ai/miniforge/gate/lint.clj
@@ -16,8 +16,7 @@
   "Lint validation gate.
 
    Checks that code passes linting rules."
-  (:require [ai.miniforge.gate.registry :as registry]
-            [clojure.string :as str]))
+  (:require [ai.miniforge.gate.registry :as registry]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Lint checking (simplified - real impl would call clj-kondo)
@@ -25,7 +24,7 @@
 (defn- check-unused-vars
   "Check for obvious unused variable patterns."
   [code-str]
-  (let [let-bindings (re-seq #"\[([a-z_][a-z0-9_-]*)\s+" code-str)]
+  (let [_bindings (re-seq #"\[([a-z_][a-z0-9_-]*)\s+" code-str)]
     ;; Simplified: just check if binding is used after definition
     []))
 
@@ -38,7 +37,7 @@
 
    Returns:
      {:passed? bool :errors [] :warnings []}"
-  [artifact ctx]
+  [artifact _ctx]
   (let [content (or (:content artifact)
                     (get-in artifact [:artifact/content])
                     "")

--- a/components/gate/src/ai/miniforge/gate/policy.clj
+++ b/components/gate/src/ai/miniforge/gate/policy.clj
@@ -20,8 +20,7 @@
    - :review-approved - Review approval check
    - :release-ready - Release readiness check
    - :plan-complete - Plan completeness check"
-  (:require [ai.miniforge.gate.registry :as registry]
-            [clojure.string :as str]))
+  (:require [ai.miniforge.gate.registry :as registry]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Policy checks

--- a/components/gate/src/ai/miniforge/gate/precommit_discipline.clj
+++ b/components/gate/src/ai/miniforge/gate/precommit_discipline.clj
@@ -197,7 +197,7 @@
      
    Returns:
      {:passed? bool :errors [...] :warnings [...]}"
-  [artifact ctx]
+  [_artifact ctx]
   (let [config (or (:config ctx) {})
         commits-to-check (get config :commits-to-check 50)
         branch (get config :branch "HEAD")

--- a/components/gate/src/ai/miniforge/gate/syntax.clj
+++ b/components/gate/src/ai/miniforge/gate/syntax.clj
@@ -16,8 +16,7 @@
   "Syntax validation gate.
 
    Checks that code artifacts parse without errors."
-  (:require [ai.miniforge.gate.registry :as registry]
-            [clojure.edn :as edn]))
+  (:require [ai.miniforge.gate.registry :as registry]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Syntax checking
@@ -29,8 +28,8 @@
      {:valid? bool :error string?}"
   [code-str]
   (try
-    (read-string code-str)
-    {:valid? true}
+    (let [_ (read-string code-str)]
+      {:valid? true})
     (catch Exception ex
       {:valid? false
        :error (ex-message ex)})))

--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -10,7 +10,8 @@
    Layer 2: Gate runner and composition"
   (:require
    [ai.miniforge.loop.interface.protocols.gate :as p]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [clojure.string]))
 
 ;; Re-export protocol for backward compatibility
 (def Gate p/Gate)

--- a/components/phase/src/ai/miniforge/phase/interface.clj
+++ b/components/phase/src/ai/miniforge/phase/interface.clj
@@ -99,7 +99,7 @@
       (swap! errors conj {:error :empty-pipeline
                           :message "Workflow pipeline is empty"}))
 
-    (doseq [{:keys [phase on-fail on-success] :as config} pipeline]
+    (doseq [{:keys [phase on-fail on-success] :as _config} pipeline]
       (when-not (contains? known-phases phase)
         (swap! errors conj {:error :unknown-phase
                             :phase phase

--- a/components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj
@@ -201,7 +201,7 @@
 (defn validate-pack-dependencies-wrapper
   "Wrapper for pack dependency validation.
    Delegates to dep-validation namespace."
-  [artifact context]
+  [_artifact context]
   (when-let [packs (:packs context)]
     (let [result (dep-validation/validate-pack-dependencies
                   packs

--- a/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
@@ -145,7 +145,7 @@
    - :repo - Repository with :repo/type
    - :phase - Current workflow phase keyword"
   [rule context]
-  (let [{:keys [task-types file-globs resource-patterns repo-types phases]}
+  (let [{:keys [task-types file-globs repo-types phases]}
         (:rule/applies-to rule)]
     (and
      ;; Task type filter

--- a/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/detection_test.clj
@@ -1,6 +1,7 @@
 (ns ai.miniforge.policy-pack.detection-test
   "Tests for the policy-pack detection logic."
   (:require
+   [clojure.string]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.policy-pack.detection :as detection]))
 
@@ -45,12 +46,12 @@
                                  :pattern "ERROR"
                                  :context-lines 2}
                 :rule/enforcement {:action :warn :message "Error"}}
-          artifact {:artifact/content "line1\nline2\nERROR here\nline4\nline5"}]
-      (let [result (detection/detect-content-scan rule artifact {})
-            match (first (:matches result))]
-        (is (= 3 (:line match)))
-        (is (clojure.string/includes? (:context match) "line2"))
-        (is (clojure.string/includes? (:context match) "line4"))))))
+          artifact {:artifact/content "line1\nline2\nERROR here\nline4\nline5"}
+          result (detection/detect-content-scan rule artifact {})
+          match (first (:matches result))]
+      (is (= 3 (:line match)))
+      (is (clojure.string/includes? (:context match) "line2"))
+      (is (clojure.string/includes? (:context match) "line4")))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Diff analysis detection tests
@@ -64,21 +65,21 @@
                 :rule/enforcement {:action :hard-halt
                                    :message "Cannot remove import blocks"}}
           artifact {:artifact/diff "- import {\n-   to = aws_s3_bucket.example\n- }"
-                    :artifact/path "main.tf"}]
-      (let [result (detection/detect-diff-analysis rule artifact {})]
-        (is (some? result))
-        (is (= :diff-analysis (:type result)))
-        (is (= :import-removal (:rule-id result))))))
+                    :artifact/path "main.tf"}
+          result (detection/detect-diff-analysis rule artifact {})]
+      (is (some? result))
+      (is (= :diff-analysis (:type result)))
+      (is (= :import-removal (:rule-id result)))))
 
   (testing "Uses context diff if artifact diff absent"
     (let [rule {:rule/id :test
                 :rule/detection {:type :diff-analysis
-                                 :pattern "^-"}}]
-      (let [result (detection/detect-diff-analysis
+                                 :pattern "^-"}}
+          result (detection/detect-diff-analysis
                     rule
                     {:artifact/path "test.tf"}
                     {:diff "- removed line\n+ added line"})]
-        (is (some? result)))))
+      (is (some? result))))
 
   (testing "No match in diff"
     (let [rule {:rule/id :test
@@ -98,28 +99,28 @@
                 :rule/applies-to {:resource-patterns ["aws_route"]}
                 :rule/enforcement {:action :require-approval
                                    :message "Network resource recreation"}}
-          context {:terraform-plan "# aws_route.main will be replaced\n  -/+ aws_route.main (tainted)"}]
-      (let [result (detection/detect-plan-output rule {} context)]
-        (is (some? result))
-        (is (= :plan-output (:type result)))
-        (is (seq (:resource-violations result))))))
+          context {:terraform-plan "# aws_route.main will be replaced\n  -/+ aws_route.main (tainted)"}
+          result (detection/detect-plan-output rule {} context)]
+      (is (some? result))
+      (is (= :plan-output (:type result)))
+      (is (seq (:resource-violations result)))))
 
   (testing "Parses resource changes from plan"
     (let [rule {:rule/id :destruction
                 :rule/detection {:type :plan-output}
                 :rule/applies-to {:resource-patterns ["aws_vpc" "aws_subnet"]}
                 :rule/enforcement {:action :require-approval :message "Destruction"}}
-          context {:terraform-plan "# aws_vpc.main will be destroyed\n# aws_subnet.private[0] must be replaced"}]
-      (let [result (detection/detect-plan-output rule {} context)]
-        (is (some? result))
-        (is (= 2 (count (:resource-violations result)))))))
+          context {:terraform-plan "# aws_vpc.main will be destroyed\n# aws_subnet.private[0] must be replaced"}
+          result (detection/detect-plan-output rule {} context)]
+      (is (some? result))
+      (is (= 2 (count (:resource-violations result)))))))
 
   (testing "No violations when no matching resources"
     (let [rule {:rule/id :test
                 :rule/detection {:type :plan-output}
                 :rule/applies-to {:resource-patterns ["aws_vpc"]}}
           context {:terraform-plan "# aws_s3_bucket.example will be created"}]
-      (is (nil? (detection/detect-plan-output rule {} context))))))
+      (is (nil? (detection/detect-plan-output rule {} context)))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Unified detection tests

--- a/components/pr-train/src/ai/miniforge/pr_train/core.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/core.clj
@@ -2,7 +2,6 @@
   "Core implementation of PR Train management.
    Provides PRTrainManager protocol and in-memory implementation."
   (:require
-   [ai.miniforge.pr-train.schema :as schema]
    [ai.miniforge.pr-train.state :as state]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -226,7 +225,7 @@
           (swap! trains assoc train-id final)
           final))))
 
-  (fail-merge [_this train-id pr-number reason]
+  (fail-merge [_this train-id pr-number _reason]
     (when-let [train (get @trains train-id)]
       (let [updated (-> train
                         (state/update-pr pr-number

--- a/components/pr-train/src/ai/miniforge/pr_train/state.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/state.clj
@@ -1,8 +1,6 @@
 (ns ai.miniforge.pr-train.state
   "State machine for PR trains and individual PRs.
-   Manages valid transitions and state computations."
-  (:require
-   [ai.miniforge.pr-train.schema :as schema]))
+   Manages valid transitions and state computations.")
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; State machine definitions
@@ -294,7 +292,7 @@
    Returns updated train."
   [train]
   (let [prs (:train/prs train)
-        pr-numbers (set (map :pr/number prs))
+        _pr-numbers (set (map :pr/number prs))
         linked-prs (mapv (fn [pr]
                            (let [order (:pr/merge-order pr)
                                  deps (->> prs

--- a/components/pr-train/test/ai/miniforge/pr_train/interface_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/interface_test.clj
@@ -320,11 +320,10 @@
 (deftest abandon-train-test
   (testing "abandon-train marks train as abandoned"
     (let [mgr (train/create-manager)
-          train-id (train/create-train mgr "Test" (random-uuid) nil)]
-
-      (let [abandoned (train/abandon-train mgr train-id "Project cancelled")]
-        (is (= :abandoned (:train/status abandoned)))
-        (is (= "Project cancelled" (:train/abandon-reason abandoned)))))))
+          train-id (train/create-train mgr "Test" (random-uuid) nil)
+          abandoned (train/abandon-train mgr train-id "Project cancelled")]
+      (is (= :abandoned (:train/status abandoned)))
+      (is (= "Project cancelled" (:train/abandon-reason abandoned))))))
 
 ;; ============================================================================
 ;; Evidence tests
@@ -385,7 +384,7 @@
   (testing "find-trains-by-status filters by status"
     (let [mgr (train/create-manager)
           t1 (train/create-train mgr "Train 1" (random-uuid) nil)
-          t2 (train/create-train mgr "Train 2" (random-uuid) nil)]
+          _t2 (train/create-train mgr "Train 2" (random-uuid) nil)]
 
       (is (= 2 (count (train/find-trains-by-status mgr :drafting))))
 

--- a/components/pr-train/test/ai/miniforge/pr_train/state_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/state_test.clj
@@ -328,17 +328,16 @@
           pr3 (state/create-pr-state "acme/c" 300 "url" "branch" "PR 3" 3)
           train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
                     (assoc :train/prs [pr1 pr2 pr3]))
-          linked (state/link-pr-dependencies train)]
-
-      (let [p1 (state/find-pr linked 100)
-            p2 (state/find-pr linked 200)
-            p3 (state/find-pr linked 300)]
-        (is (= [] (:pr/depends-on p1)))
-        (is (= [200 300] (:pr/blocks p1)))
-        (is (= [100] (:pr/depends-on p2)))
-        (is (= [300] (:pr/blocks p2)))
-        (is (= [100 200] (:pr/depends-on p3)))
-        (is (= [] (:pr/blocks p3)))))))
+          linked (state/link-pr-dependencies train)
+          p1 (state/find-pr linked 100)
+          p2 (state/find-pr linked 200)
+          p3 (state/find-pr linked 300)]
+      (is (= [] (:pr/depends-on p1)))
+      (is (= [200 300] (:pr/blocks p1)))
+      (is (= [100] (:pr/depends-on p2)))
+      (is (= [300] (:pr/blocks p2)))
+      (is (= [100 200] (:pr/depends-on p3)))
+      (is (= [] (:pr/blocks p3))))))
 
 ;; ============================================================================
 ;; Rollback planning tests
@@ -354,13 +353,12 @@
                   (assoc :pr/status :failed))
           train (-> (state/create-train-state (random-uuid) "Test" (random-uuid))
                     (assoc :train/prs [pr1 pr2 pr3]))
-          planned (state/compute-rollback-plan train :ci-failure :revert-all)]
-
-      (let [plan (:train/rollback-plan planned)]
-        (is (= :ci-failure (:trigger plan)))
-        (is (= :revert-all (:action plan)))
-        (is (= 100 (:checkpoint plan)))
-        (is (= [200 100] (:prs-to-revert plan)))))))
+          planned (state/compute-rollback-plan train :ci-failure :revert-all)
+          plan (:train/rollback-plan planned)]
+      (is (= :ci-failure (:trigger plan)))
+      (is (= :revert-all (:action plan)))
+      (is (= 100 (:checkpoint plan)))
+      (is (= [200 100] (:prs-to-revert plan))))))
 
 ;; ============================================================================
 ;; Auto-transition tests

--- a/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
@@ -5,6 +5,8 @@
    operations when :executor and :environment-id are present in context,
    and falls back to git operations when they are absent."
   (:require
+   [ai.miniforge.dag-executor.protocols.executor]
+   [clojure.string]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.release-executor.core :as core]
    [ai.miniforge.dag-executor.result :as dag-result]))

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -4,6 +4,8 @@
    Uses a mock executor to verify correct command generation
    without requiring Docker."
   (:require
+   [ai.miniforge.dag-executor.protocols.executor]
+   [clojure.string]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.release-executor.sandbox :as sandbox]
    [ai.miniforge.dag-executor.result :as dag-result]))
@@ -50,18 +52,18 @@
 (deftest check-gh-auth-success-test
   (testing "check-gh-auth! returns authenticated when gh auth status succeeds"
     (let [[exec _cmds] (create-mock-executor
-                        :responses {"gh auth status" {:exit-code 0 :stdout "Logged in" :stderr ""}})]
-      (let [result (sandbox/check-gh-auth! exec "env-1")]
-        (is (:available? result))
-        (is (:authenticated? result))))))
+                        :responses {"gh auth status" {:exit-code 0 :stdout "Logged in" :stderr ""}})
+          result (sandbox/check-gh-auth! exec "env-1")]
+      (is (:available? result))
+      (is (:authenticated? result)))))
 
 (deftest check-gh-auth-failure-test
   (testing "check-gh-auth! returns unauthenticated when gh auth status fails"
     (let [[exec _cmds] (create-mock-executor
-                        :responses {"gh auth status" {:exit-code 1 :stdout "" :stderr "not logged in"}})]
-      (let [result (sandbox/check-gh-auth! exec "env-1")]
-        (is (:available? result))
-        (is (not (:authenticated? result)))))))
+                        :responses {"gh auth status" {:exit-code 1 :stdout "" :stderr "not logged in"}})
+          result (sandbox/check-gh-auth! exec "env-1")]
+      (is (:available? result))
+      (is (not (:authenticated? result))))))
 
 ;; ============================================================================
 ;; create-branch! tests
@@ -72,23 +74,23 @@
     (let [[exec cmds] (create-mock-executor
                        :responses {"git symbolic-ref" {:exit-code 0 :stdout "refs/remotes/origin/main\n" :stderr ""}
                                    "git fetch" {:exit-code 0 :stdout "" :stderr ""}
-                                   "git checkout" {:exit-code 0 :stdout "" :stderr ""}})]
-      (let [result (sandbox/create-branch! exec "env-1" "feat/my-branch")]
-        (is (:success? result))
-        (is (= "feat/my-branch" (:branch result)))
-        (is (= "main" (:base-branch result)))
-        ;; Verify commands were issued
-        (is (some #(clojure.string/includes? % "git fetch origin main") @cmds))
-        (is (some #(clojure.string/includes? % "git checkout -b feat/my-branch") @cmds))))))
+                                   "git checkout" {:exit-code 0 :stdout "" :stderr ""}})
+          result (sandbox/create-branch! exec "env-1" "feat/my-branch")]
+      (is (:success? result))
+      (is (= "feat/my-branch" (:branch result)))
+      (is (= "main" (:base-branch result)))
+      ;; Verify commands were issued
+      (is (some #(clojure.string/includes? % "git fetch origin main") @cmds))
+      (is (some #(clojure.string/includes? % "git checkout -b feat/my-branch") @cmds)))))
 
 (deftest create-branch-fetch-failure-test
   (testing "create-branch! fails when fetch fails"
     (let [[exec _cmds] (create-mock-executor
                         :responses {"git symbolic-ref" {:exit-code 0 :stdout "refs/remotes/origin/main\n" :stderr ""}
-                                    "git fetch" {:exit-code 1 :stdout "" :stderr "fatal: fetch failed"}})]
-      (let [result (sandbox/create-branch! exec "env-1" "feat/branch")]
-        (is (not (:success? result)))
-        (is (clojure.string/includes? (:error result) "fetch"))))))
+                                    "git fetch" {:exit-code 1 :stdout "" :stderr "fatal: fetch failed"}})
+          result (sandbox/create-branch! exec "env-1" "feat/branch")]
+      (is (not (:success? result)))
+      (is (clojure.string/includes? (:error result) "fetch")))))
 
 ;; ============================================================================
 ;; write-file! tests
@@ -96,14 +98,14 @@
 
 (deftest write-file-generates-base64-command-test
   (testing "write-file! encodes content as base64 and creates parent dirs"
-    (let [[exec cmds] (create-mock-executor)]
-      (let [result (sandbox/write-file! exec "env-1" "src/foo.clj" "(ns foo)")]
-        (is (:success? result))
-        (let [cmd (first @cmds)]
-          ;; Should contain mkdir -p for parent dir
-          (is (clojure.string/includes? cmd "mkdir -p"))
-          ;; Should contain base64 decode
-          (is (clojure.string/includes? cmd "base64 -d")))))))
+    (let [[exec cmds] (create-mock-executor)
+          result (sandbox/write-file! exec "env-1" "src/foo.clj" "(ns foo)")]
+      (is (:success? result))
+      (let [cmd (first @cmds)]
+        ;; Should contain mkdir -p for parent dir
+        (is (clojure.string/includes? cmd "mkdir -p"))
+        ;; Should contain base64 decode
+        (is (clojure.string/includes? cmd "base64 -d"))))))
 
 (deftest write-file-roundtrip-base64-test
   (testing "write-file! base64 encoding is valid"
@@ -151,11 +153,11 @@
   (testing "commit-changes! commits and returns sha"
     (let [[exec cmds] (create-mock-executor
                        :responses {"git commit" {:exit-code 0 :stdout "1 file changed" :stderr ""}
-                                   "git rev-parse" {:exit-code 0 :stdout "abc1234\n" :stderr ""}})]
-      (let [result (sandbox/commit-changes! exec "env-1" "feat: add feature")]
-        (is (:success? result))
-        (is (= "abc1234" (:commit-sha result)))
-        (is (some #(clojure.string/includes? % "git commit") @cmds))))))
+                                   "git rev-parse" {:exit-code 0 :stdout "abc1234\n" :stderr ""}})
+          result (sandbox/commit-changes! exec "env-1" "feat: add feature")]
+      (is (:success? result))
+      (is (= "abc1234" (:commit-sha result)))
+      (is (some #(clojure.string/includes? % "git commit") @cmds)))))
 
 (deftest commit-changes-escapes-quotes-test
   (testing "commit-changes! escapes single quotes in commit message"
@@ -173,10 +175,10 @@
 
 (deftest push-branch-command-test
   (testing "push-branch! issues git push -u origin"
-    (let [[exec cmds] (create-mock-executor)]
-      (let [result (sandbox/push-branch! exec "env-1" "feat/branch")]
-        (is (:success? result))
-        (is (clojure.string/includes? (first @cmds) "git push -u origin feat/branch"))))))
+    (let [[exec cmds] (create-mock-executor)
+          result (sandbox/push-branch! exec "env-1" "feat/branch")]
+      (is (:success? result))
+      (is (clojure.string/includes? (first @cmds) "git push -u origin feat/branch")))))
 
 ;; ============================================================================
 ;; create-pr! tests
@@ -187,29 +189,29 @@
     (let [[exec cmds] (create-mock-executor
                        :responses {"gh pr create" {:exit-code 0
                                                    :stdout "https://github.com/org/repo/pull/42\n"
-                                                   :stderr ""}})]
-      (let [result (sandbox/create-pr! exec "env-1"
-                                       {:title "Add feature"
-                                        :body "Description here"
-                                        :base-branch "main"})]
-        (is (:success? result))
-        (is (= 42 (:pr-number result)))
-        (is (= "https://github.com/org/repo/pull/42" (:pr-url result)))
-        (let [cmd (first @cmds)]
-          (is (clojure.string/includes? cmd "gh pr create"))
-          (is (clojure.string/includes? cmd "--title"))
-          (is (clojure.string/includes? cmd "--base main")))))))
+                                                   :stderr ""}})
+          result (sandbox/create-pr! exec "env-1"
+                                     {:title "Add feature"
+                                      :body "Description here"
+                                      :base-branch "main"})]
+      (is (:success? result))
+      (is (= 42 (:pr-number result)))
+      (is (= "https://github.com/org/repo/pull/42" (:pr-url result)))
+      (let [cmd (first @cmds)]
+        (is (clojure.string/includes? cmd "gh pr create"))
+        (is (clojure.string/includes? cmd "--title"))
+        (is (clojure.string/includes? cmd "--base main"))))))
 
 (deftest create-pr-failure-test
   (testing "create-pr! returns failure when gh pr create fails"
     (let [[exec _cmds] (create-mock-executor
                         :responses {"gh pr create" {:exit-code 1
                                                     :stdout ""
-                                                    :stderr "not authenticated"}})]
-      (let [result (sandbox/create-pr! exec "env-1"
-                                       {:title "PR" :body "" :base-branch "main"})]
-        (is (not (:success? result)))
-        (is (some? (:error result)))))))
+                                                    :stderr "not authenticated"}})
+          result (sandbox/create-pr! exec "env-1"
+                                     {:title "PR" :body "" :base-branch "main"})]
+      (is (not (:success? result)))
+      (is (some? (:error result))))))
 
 ;; ============================================================================
 ;; write-and-stage-files! tests

--- a/components/response/src/ai/miniforge/response/chain.clj
+++ b/components/response/src/ai/miniforge/response/chain.clj
@@ -37,7 +37,7 @@
          (add-response :step-2 nil {:result \"done\"})
          (succeeded?))
      ;; => true"
-  (:require [ai.miniforge.response.anomaly :as anomaly]))
+)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Chain creation

--- a/components/tool-registry/src/ai/miniforge/tool_registry/loader.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/loader.clj
@@ -77,7 +77,7 @@
    - tools/function/*.edn -> :function
    - tools/custom/*.edn -> :external"
   [file]
-  (let [path (.getPath file)
+  (let [_path (.getPath file)
         parent-name (some-> file .getParentFile .getName)]
     (case parent-name
       "lsp" :lsp

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/client.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/client.clj
@@ -23,8 +23,7 @@
    [ai.miniforge.tool-registry.lsp.protocol :as proto]
    [ai.miniforge.tool-registry.lsp.process :as process]
    [ai.miniforge.tool-registry.schema :as schema]
-   [cheshire.core :as json]
-   [clojure.core.async :as async :refer [go go-loop <! >! chan close!]]
+   [clojure.core.async :as async :refer [go-loop]]
    [clojure.string :as str])
   (:import
    [java.io BufferedReader InputStreamReader BufferedWriter OutputStreamWriter]))

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/process.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/process.clj
@@ -21,11 +21,10 @@
    Layer 3: Process info and cleanup"
   (:require
    [ai.miniforge.tool-registry.schema :as schema]
-   [clojure.java.io :as io]
-   [clojure.string :as str])
+   [clojure.java.io :as io])
   (:import
    [java.lang ProcessBuilder ProcessBuilder$Redirect]
-   [java.io InputStream OutputStream BufferedReader InputStreamReader]))
+   [java.io InputStream OutputStream]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Process state definitions

--- a/components/tool-registry/src/ai/miniforge/tool_registry/lsp/protocol.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/lsp/protocol.clj
@@ -23,8 +23,7 @@
    Layer 2: Message parsers
    Layer 3: Standard LSP methods"
   (:require
-   [cheshire.core :as json]
-   [clojure.string :as str]))
+   [cheshire.core :as json]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants and message IDs
@@ -132,19 +131,6 @@
         length (count (.getBytes body "UTF-8"))]
     (str "Content-Length: " length "\r\n\r\n" body)))
 
-(defn- parse-headers
-  "Parse LSP headers from a string.
-   Returns {:content-length int} or nil if invalid."
-  [header-str]
-  (let [lines (str/split header-str #"\r\n")]
-    (reduce (fn [acc line]
-              (when-let [[_ key value] (re-matches #"([^:]+):\s*(.+)" line)]
-                (case (str/lower-case key)
-                  "content-length" (assoc acc :content-length (parse-long value))
-                  "content-type" (assoc acc :content-type value)
-                  acc)))
-            {}
-            lines)))
 
 (defn decode-message
   "Decode a JSON-RPC message from JSON string.

--- a/components/tool-registry/src/ai/miniforge/tool_registry/schema.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/schema.clj
@@ -22,8 +22,7 @@
    Layer 4: Result builders"
   (:require
    [malli.core :as m]
-   [malli.error :as me]
-   [malli.util :as mu]))
+   [malli.error :as me]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Enums and base types

--- a/components/tool-registry/test/ai/miniforge/tool_registry/integration_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/integration_test.clj
@@ -122,34 +122,32 @@
 
         ;; Write a file with mismatched parens
         (let [bad-code "(ns bad.code)\n\n(defn broken [x]\n  (+ x 1))"  ; Missing closing paren
-              file (write-clj-file "src/bad/code.clj" bad-code)]
+              file (write-clj-file "src/bad/code.clj" bad-code)
+              ;; Collect diagnostics from notifications
+              diagnostics-atom (atom nil)
+              _notification-handler (fn [msg]
+                                      (when (= "textDocument/publishDiagnostics" (:method msg))
+                                        (reset! diagnostics-atom (get-in msg [:params :diagnostics]))))
+              ;; Start LSP with custom notification handler
+              {:keys [success? error client]} (tool-registry/start-lsp *registry* :lsp/clojure)]
+          (is success? (str "Failed to start LSP: " error))
 
-          ;; Collect diagnostics from notifications
-          (let [diagnostics-atom (atom nil)
-                notification-handler (fn [msg]
-                                       (when (= "textDocument/publishDiagnostics" (:method msg))
-                                         (reset! diagnostics-atom (get-in msg [:params :diagnostics]))))]
+          (when success?
+            ;; Open the document
+            (lsp-client/open-document client
+                                      (file-uri file)
+                                      "clojure"
+                                      (slurp file))
 
-            ;; Start LSP with custom notification handler
-            (let [{:keys [success? error client]} (tool-registry/start-lsp *registry* :lsp/clojure)]
-              (is success? (str "Failed to start LSP: " error))
+            ;; Wait for diagnostics (clojure-lsp sends them after analysis)
+            (Thread/sleep 3000)
 
+            ;; Get document symbols to verify LSP is responding
+            (let [{:keys [success? result]} (lsp-client/document-symbols client (file-uri file))]
+              (is success? "document-symbols request failed")
+              ;; Should find at least the namespace and function
               (when success?
-                ;; Open the document
-                (lsp-client/open-document client
-                                          (file-uri file)
-                                          "clojure"
-                                          (slurp file))
-
-                ;; Wait for diagnostics (clojure-lsp sends them after analysis)
-                (Thread/sleep 3000)
-
-                ;; Get document symbols to verify LSP is responding
-                (let [{:keys [success? result]} (lsp-client/document-symbols client (file-uri file))]
-                  (is success? "document-symbols request failed")
-                  ;; Should find at least the namespace and function
-                  (when success?
-                    (println "Document symbols found:" (count result))))))))))))
+                (println "Document symbols found:" (count result))))))))))
 
 (deftest ^:integration lsp-hover-test
   (if-not (clojure-lsp-available?)
@@ -162,10 +160,9 @@
 
         ;; Write a valid Clojure file
         (let [code "(ns hover.test)\n\n(defn my-function\n  \"A test function that adds numbers.\"\n  [x y]\n  (+ x y))"
-              file (write-clj-file "src/hover/test.clj" code)]
-
-          ;; Start LSP
-          (let [{:keys [success? client]} (tool-registry/start-lsp *registry* :lsp/clojure)]
+              file (write-clj-file "src/hover/test.clj" code)
+              ;; Start LSP
+              {:keys [success? client]} (tool-registry/start-lsp *registry* :lsp/clojure)]
             (when success?
               ;; Open the document
               (lsp-client/open-document client
@@ -181,7 +178,7 @@
                 (is success? "hover request failed")
                 (when (and success? result)
                   (println "Hover result:" (pr-str (take 100 (str result))))
-                  (is (some? result) "Expected hover info for defn"))))))))))
+                  (is (some? result) "Expected hover info for defn")))))))))
 
 (deftest ^:integration lsp-format-test
   (if-not (clojure-lsp-available?)
@@ -194,10 +191,9 @@
 
         ;; Write poorly formatted code
         (let [ugly-code "(ns format.test)\n(defn   ugly   [x    y]\n(+   x    y))"
-              file (write-clj-file "src/format/test.clj" ugly-code)]
-
-          ;; Start LSP
-          (let [{:keys [success? client]} (tool-registry/start-lsp *registry* :lsp/clojure)]
+              file (write-clj-file "src/format/test.clj" ugly-code)
+              ;; Start LSP
+              {:keys [success? client]} (tool-registry/start-lsp *registry* :lsp/clojure)]
             (when success?
               ;; Open the document
               (lsp-client/open-document client
@@ -214,7 +210,7 @@
                 (when success?
                   (println "Format edits:" (count result))
                   ;; Should return text edits to fix formatting
-                  (is (or (nil? result) (seq result)) "Expected format edits or nil for already-formatted"))))))))))
+                  (is (or (nil? result) (seq result)) "Expected format edits or nil for already-formatted")))))))))
 
 ;------------------------------------------------------------------------------ Tool discovery E2E test
 

--- a/components/tool-registry/test/ai/miniforge/tool_registry/loader_test.clj
+++ b/components/tool-registry/test/ai/miniforge/tool_registry/loader_test.clj
@@ -104,7 +104,7 @@
                         :tool/type :lsp
                         :tool/name "Test 2"
                         :tool/config {:lsp/command ["test2"]}})
-      (let [{:keys [loaded failed]} (loader/load-all-tools *registry*)]
+      (let [{:keys [loaded]} (loader/load-all-tools *registry*)]
         ;; Should load the two project tools (may also include built-in)
         (is (>= (count loaded) 2))
         (is (contains? (set loaded) :lsp/test1))

--- a/components/workflow/src/ai/miniforge/workflow/persistence.clj
+++ b/components/workflow/src/ai/miniforge/workflow/persistence.clj
@@ -36,7 +36,7 @@
   (let [config-dir (ensure-config-dir)
         events-dir (str config-dir "/events")]
     (.mkdirs (java.io.File. events-dir))
-    (str events-dir "/" (str workflow-id) ".edn")))
+    (str events-dir "/" workflow-id ".edn")))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; File I/O operations


### PR DESCRIPTION
## Summary
- Remove unused requires/imports across 15 source files
- Prefix unused bindings with `_` (14 files)
- Add missing namespace requires (`clojure.java.io`, `clojure.string`, executor protocols)
- Merge redundant nested `let` expressions in 6 test files
- Remove unused private var `parse-headers` in lsp/protocol
- Simplify redundant `(str (str ...))` in workflow/persistence

29 files changed, -24 net lines. clj-kondo now reports 0 errors, 0 warnings.

## Test plan
- [x] `clj-kondo --lint components bases` → 0 errors, 0 warnings
- [x] `bb test` → all pass (2000+ assertions, 0 failures)
- [x] `bb test:graalvm` → all pass (100 assertions, 0 failures)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)