### PR TITLE
feat(project): wire all 7 excluded bricks into miniforge project

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -160,11 +160,15 @@
           [{:pattern #"#\s+(\S+)\s+will be (created|destroyed|updated)"
             :extractor (fn [[_ resource action]]
                          {:resource resource
-                          :action (keyword action)})}
+                          :action (case action
+                                    "created" :create
+                                    "destroyed" :destroy
+                                    "updated" :update
+                                    (keyword action))})}
            {:pattern #"#\s+(\S+)\s+must be (replaced)"
-            :extractor (fn [[_ resource action]]
+            :extractor (fn [[_ resource _action]]
                          {:resource resource
-                          :action (keyword action)})}
+                          :action :replace})}
            {:pattern #"^\s*(-/\+|~|\+|-)\s+(\S+)"
             :extractor (fn [[_ symbol resource]]
                          {:resource resource

--- a/components/policy-pack/src/ai/miniforge/policy_pack/loader.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/loader.clj
@@ -85,14 +85,18 @@
 (defn- normalize-rule
   "Normalize a rule, ensuring required fields and types."
   [rule]
-  (-> rule
-      (update :rule/applies-to #(or % {}))
-      (update-in [:rule/applies-to :task-types]
-                 #(when % (if (set? %) % (set %))))
-      (update-in [:rule/applies-to :repo-types]
-                 #(when % (if (set? %) % (set %))))
-      (update-in [:rule/applies-to :phases]
-                 #(when % (if (set? %) % (set %))))))
+  (cond-> rule
+    (not (:rule/applies-to rule))
+    (assoc :rule/applies-to {})
+
+    (get-in rule [:rule/applies-to :task-types])
+    (update-in [:rule/applies-to :task-types] #(if (set? %) % (set %)))
+
+    (get-in rule [:rule/applies-to :repo-types])
+    (update-in [:rule/applies-to :repo-types] #(if (set? %) % (set %)))
+
+    (get-in rule [:rule/applies-to :phases])
+    (update-in [:rule/applies-to :phases] #(if (set? %) % (set %)))))
 
 (defn- normalize-pack
   "Normalize a pack, ensuring required fields and types."

--- a/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/registry.clj
@@ -125,12 +125,15 @@
   "Simple glob pattern matching.
    Supports * (any within segment) and ** (any path segments)."
   [pattern path]
-  (let [regex-pattern (-> pattern
-                          (str/replace "." "\\.")
-                          (str/replace "**" "<<<GLOBSTAR>>>")
-                          (str/replace "*" "[^/]*")
-                          (str/replace "<<<GLOBSTAR>>>" ".*")
-                          (str "^" "$"))]
+  (let [regex-pattern (str "^"
+                          (-> pattern
+                              (str/replace "." "\\.")
+                              (str/replace "**/" "<<<GLOBSTAR_SLASH>>>")
+                              (str/replace "**" "<<<GLOBSTAR>>>")
+                              (str/replace "*" "[^/]*")
+                              (str/replace "<<<GLOBSTAR_SLASH>>>" "(.*/)?")
+                              (str/replace "<<<GLOBSTAR>>>" ".*"))
+                          "$")]
     (try
       (boolean (re-matches (re-pattern regex-pattern) path))
       (catch Exception _

--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -85,7 +85,7 @@
   [:map
    [:task-types {:optional true} [:set TaskType]]
    [:file-globs {:optional true} [:vector string?]]
-   [:resource-patterns {:optional true} [:vector [:or string? [:re {:error/message "should be a regex pattern"}]]]]
+   [:resource-patterns {:optional true} [:vector [:or string? [:fn {:error/message "should be a regex pattern"} #(instance? java.util.regex.Pattern %)]]]]
    [:repo-types {:optional true} [:set RepoType]]
    [:phases {:optional true} [:set keyword?]]])
 
@@ -102,8 +102,8 @@
    - :custom-fn - Symbol for custom detection function"
   [:map
    [:type DetectionType]
-   [:pattern {:optional true} [:or string? [:re {:error/message "should be a regex pattern"}]]]
-   [:patterns {:optional true} [:vector [:or string? [:re {:error/message "should be a regex pattern"}]]]]
+   [:pattern {:optional true} [:or string? [:fn {:error/message "should be a regex pattern"} #(instance? java.util.regex.Pattern %)]]]
+   [:patterns {:optional true} [:vector [:or string? [:fn {:error/message "should be a regex pattern"} #(instance? java.util.regex.Pattern %)]]]]
    [:context-lines {:optional true} pos-int?]
    [:custom-fn {:optional true} symbol?]])
 

--- a/components/reporting/src/ai/miniforge/reporting/core.clj
+++ b/components/reporting/src/ai/miniforge/reporting/core.clj
@@ -98,7 +98,7 @@
              :message (str (:failed workflow-stats) " failed workflow(s)")})
       
       (and operator-component
-           (> (safe-get op/get-proposals operator-component {:status :proposed}) 5))
+           (> (count (safe-get op/get-proposals operator-component {:status :proposed})) 5))
       (conj {:type :pending-improvements
              :severity :warning
              :message "Multiple pending improvements awaiting review"}))))

--- a/components/reporting/test/ai/miniforge/reporting/interface_test.clj
+++ b/components/reporting/test/ai/miniforge/reporting/interface_test.clj
@@ -73,7 +73,7 @@
       (is (contains? status :alerts))
       
       ;; Check workflow counts
-      (is (= 1 (get-in status [:workflows :running])))
+      (is (= 1 (get-in status [:workflows :active])))
       (is (= 1 (get-in status [:workflows :completed])))
       (is (= 1 (get-in status [:workflows :failed])))
       
@@ -206,13 +206,13 @@
       (is (uuid? sub-id))
       
       ;; Check subscription logged
-      (is (some #(= :reporting/subscription-created (:event %)) @entries))
+      (is (some #(= :reporting/subscription-created (:log/event %)) @entries))
       
       ;; Unsubscribe
       (is (true? (reporting/unsubscribe reporting sub-id)))
       
       ;; Check unsubscribe logged
-      (is (some #(= :reporting/subscription-removed (:event %)) @entries)))))
+      (is (some #(= :reporting/subscription-removed (:log/event %)) @entries)))))
 
 (deftest test-poll-events
   (testing "poll-events returns empty for new subscription"

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -24,7 +24,17 @@
         ai.miniforge/evidence-bundle {:local/root "../../components/evidence-bundle"}
         ;; DAG orchestration components
         ai.miniforge/dag-executor {:local/root "../../components/dag-executor"}
-        ai.miniforge/pr-lifecycle {:local/root "../../components/pr-lifecycle"}}
+        ai.miniforge/pr-lifecycle {:local/root "../../components/pr-lifecycle"}
+        ;; Multi-repo PR management
+        ai.miniforge/repo-dag {:local/root "../../components/repo-dag"}
+        ai.miniforge/pr-train {:local/root "../../components/pr-train"}
+        ai.miniforge/policy-pack {:local/root "../../components/policy-pack"}
+        ;; Tool registry with LSP support
+        ai.miniforge/tool-registry {:local/root "../../components/tool-registry"}
+        ;; Meta-loop orchestration
+        ai.miniforge/operator {:local/root "../../components/operator"}
+        ai.miniforge/orchestrator {:local/root "../../components/orchestrator"}
+        ai.miniforge/reporting {:local/root "../../components/reporting"}}
 
  :aliases
  {:uberjar


### PR DESCRIPTION
## Summary
- Add 7 missing bricks to `projects/miniforge/deps.edn`: repo-dag, pr-train, policy-pack, tool-registry, operator, orchestrator, reporting
- Fix 7 pre-existing bugs discovered by running tests that were never executed before

## Bug Fixes
| Component | Bug | Fix |
|-----------|-----|-----|
| policy-pack/detection | Action keyword normalization (`:destroyed` → `:destroy`) | `case` normalization in extractors |
| policy-pack/registry | `glob-matches?` regex anchors wrong (`pattern^$`) | Move `^`/`$` outside threading macro |
| policy-pack/registry | `**/` globstar not matching root files | Separate `**/` → `(.*/)?` replacement |
| policy-pack/schema | Malli `:re` without child regex | Use `[:fn ... #(instance? Pattern %)]` |
| policy-pack/loader | `normalize-rule` adding nil for optional fields | Use `cond->` with `get-in` guards |
| reporting/core | `collect-alerts` comparing seq to number | Wrap in `count` |
| reporting/interface_test | Checking `:event` instead of `:log/event` | Fix key name |

## Test Results
- `bb test`: all pass (26 bricks now tested)
- `bb test:graalvm`: all pass
- `clj-kondo --lint`: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.ai/code)