### PR TITLE
feat: The workflow runner and task-executor (DAG orchestration) ar

### DIFF
--- a/integrate-dag-into-workflow.spec.edn
+++ b/integrate-dag-into-workflow.spec.edn
@@ -1,0 +1,121 @@
+{:title "Integrate DAG Orchestration into Workflow Runner"
+ :description
+ "The workflow runner and task-executor (DAG orchestration) are currently separate
+  systems, but they should be integrated. When a workflow's plan phase outputs
+  multiple tasks with dependencies (:plan/tasks), the implement phase should
+  automatically use task-executor's execute-dag! for parallel execution instead
+  of running tasks sequentially or one-at-a-time.
+
+  This enables true dogfooding where complex specs decompose into DAG tasks that
+  execute in parallel with proper dependency management, resource isolation, and
+  concurrent PR workflows."
+
+ :intent
+ {:type :refactor
+  :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+          "components/workflow/src/ai/miniforge/workflow/interface.clj"
+          "bases/cli/src/ai/miniforge/cli/workflow_runner.clj"]}
+
+ :constraints
+ ["Backward compatible - single task specs continue to work as before"
+  "Detect multiple tasks in :plan/tasks and route to DAG orchestration"
+  "Use task-executor/execute-dag! for multi-task execution"
+  "Preserve all workflow phase callbacks and event streams"
+  "Tests must pass: bb test"
+  "Pre-commit hooks must pass"]
+
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :plan/tasks
+ [{:task/id :detect-multi-task-plans
+   :task/description
+   "Update workflow runner to detect when :plan/tasks contains multiple tasks.
+
+    In components/workflow/src/ai/miniforge/workflow/runner.clj:
+    - After plan phase completes, check if plan result has multiple :plan/tasks
+    - If count(:plan/tasks) > 1, set a flag to use DAG orchestration
+    - Pass this flag through to implement phase
+
+    Keep single-task behavior as default for backward compatibility."
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :wire-task-executor-into-implement
+   :task/description
+   "Wire task-executor/execute-dag! into the implement phase for multi-task plans.
+
+    In components/workflow/src/ai/miniforge/workflow/runner.clj:
+    - Import ai.miniforge.task-executor.interface
+    - In implement phase, check if multi-task flag is set
+    - If multi-task: call task-executor/execute-dag! with :plan/tasks
+    - If single-task: use existing implement logic
+    - Convert :plan/tasks format to task-executor's expected format
+    - Map task IDs, dependencies, descriptions, files
+
+    Configuration to pass to execute-dag!:
+    - workflow-id from spec
+    - executor: worktree-based (may need to create wrapper)
+    - llm-backend: from workflow config
+    - logger: from workflow context
+    - max-parallel: from workflow config or default to 4
+    - event-stream: from workflow context
+
+    Context: task-executor/orchestrator.clj:execute-dag! expects:
+    - dag-id: string
+    - task-defs: sequence of {:task/id :task/deps :description :files ...}
+    - config: {:workflow-id :executor :llm-backend :logger :max-parallel}
+
+    The :plan/tasks format uses :task/dependencies (vector) vs :task/deps (set),
+    so convert during mapping."
+   :task/type :implement
+   :task/dependencies [:detect-multi-task-plans]}
+
+  {:task/id :create-executor-wrapper
+   :task/description
+   "Create a worktree-based executor wrapper for DAG execution.
+
+    The task-executor needs an executor that implements the environment protocol.
+    For local dogfooding, create a simple worktree-based executor in:
+    components/workflow/src/ai/miniforge/workflow/executor.clj
+
+    Implement:
+    - acquire-environment: create git worktree for task isolation
+    - release-environment: remove git worktree
+    - Returns {:env-id :session-id :worktree-path :base-commit}
+
+    This provides resource isolation for parallel task execution without
+    needing Docker or K8s infrastructure."
+   :task/type :implement
+   :task/dependencies [:detect-multi-task-plans]}
+
+  {:task/id :test-multi-task-workflow
+   :task/description
+   "Test the integration with a multi-task workflow spec.
+
+    Create test in components/workflow/test/ai/miniforge/workflow/dag_integration_test.clj:
+    - Test spec with 2 independent tasks (should run in parallel)
+    - Test spec with 3 tasks (A -> B, A -> C) diamond dependency
+    - Verify tasks execute in parallel where possible
+    - Verify task state transitions
+    - Verify PR creation for each task
+    - Mock the actual PR operations to avoid real GitHub interactions
+
+    Also test that single-task specs still work (backward compatibility)."
+   :task/type :test
+   :task/dependencies [:wire-task-executor-into-implement
+                       :create-executor-wrapper]}
+
+  {:task/id :update-dogfooding-docs
+   :task/description
+   "Update DOGFOODING.md to reflect the integrated architecture.
+
+    Changes:
+    - Remove mention of separate 'bb dogfood' command
+    - Explain that multi-task specs automatically use DAG orchestration
+    - Update example to show .spec.edn format (not separate DAG format)
+    - Show how planner decomposes work into multiple tasks
+    - Explain that 'miniforge run' handles both single and multi-task workflows
+    - Remove outdated references to separate systems"
+   :task/type :implement
+   :task/dependencies [:test-multi-task-workflow]}]}

--- a/scripts/run-dogfood.clj
+++ b/scripts/run-dogfood.clj
@@ -1,0 +1,67 @@
+#!/usr/bin/env bb
+;; Execute dogfooding DAG - miniforge works on itself
+
+(require '[clojure.edn :as edn]
+         '[clojure.java.io :as io])
+
+;; Load task-executor namespace
+(load-file "components/task-executor/src/ai/miniforge/task_executor/interface.clj")
+(load-file "components/dag-executor/src/ai/miniforge/dag_executor/interface.clj")
+(load-file "components/logging/src/ai/miniforge/logging/interface.clj")
+
+(defn load-dag-edn
+  "Load DAG task definitions from EDN file"
+  [file-path]
+  (-> file-path slurp edn/read-string))
+
+(defn print-dag-info
+  "Print DAG information"
+  [dag]
+  (println "\n🤖 MINIFORGE DOGFOODING - AUTONOMOUS MODE")
+  (println "==========================================")
+  (println "DAG ID:" (:dag-id dag))
+  (println "Description:" (:description dag))
+  (println "Base branch:" (:base-branch dag))
+  (println "\nTasks:")
+  (doseq [task (:tasks dag)]
+    (println (format "  [%s] %s" (:task/id task) (:description task)))
+    (when (seq (:task/deps task))
+      (println (format "    ├─ Depends on: %s" (:task/deps task))))
+    (println (format "    └─ Branch: %s" (:branch task)))))
+
+(defn create-config
+  "Create configuration for execute-dag!"
+  [dag]
+  {:workflow-id (str "dogfood-" (:dag-id dag))
+   :executor nil  ;; TODO: Create worktree-based executor
+   :llm-backend nil  ;; TODO: Wire CLI backend
+   :logger nil  ;; TODO: Create logger
+   :max-parallel 2
+   :max-iterations 10
+   :repo-url (str "https://" (:repo dag))
+   :branch (:base-branch dag)})
+
+(defn -main [& args]
+  (let [dag-file (or (first args) "dogfood-tasks.edn")]
+
+    (when-not (.exists (io/file dag-file))
+      (println (format "❌ DAG file not found: %s" dag-file))
+      (System/exit 1))
+
+    (let [dag (load-dag-edn dag-file)]
+      (print-dag-info dag)
+
+      (println "\n⚠️  NOTE: This requires full implementation")
+      (println "Currently needs:")
+      (println "  1. Executor implementation (worktree-based)")
+      (println "  2. LLM backend wiring (claude CLI)")
+      (println "  3. Logger setup")
+      (println "  4. Integration with execute-dag!")
+      (println "\nThe infrastructure exists in orchestrator.clj:execute-dag!")
+      (println "Next step: Wire up executor and backends")
+
+      {:status :not-implemented
+       :tasks (count (:tasks dag))})))
+
+(when (= *file* (System/getProperty "babashka.file"))
+  (apply -main *command-line-args*))


### PR DESCRIPTION
## Summary
The workflow runner and task-executor (DAG orchestration) are currently separate
  systems, but they should be integrated. When a workflow's plan phase outputs
  multiple tasks with dependencies (:plan/tasks), the implement phase should
  automatically use task-executor's execute-dag! for parallel execution instead
  of running tasks sequentially or one-at-a-time.

  This enables true dogfooding where complex specs decompose into DAG tasks that
  execute in parallel with proper dependency management, resource isolation, and
  concurrent PR workflows.

## Changes
See commits for details