### PR TITLE
fix(bb): complete classpath for all components in development mode

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -507,7 +507,17 @@
                  "components/event-stream/src"
                  "components/dag-executor/src"
                  "components/task-executor/src"
-                 "components/pr-lifecycle/src"]
+                 "components/pr-lifecycle/src"
+                 "components/release-executor/src"
+                 "components/evidence-bundle/src"
+                 "components/operator/src"
+                 "components/orchestrator/src"
+                 "components/reporting/src"
+                 "components/observer/src"
+                 "components/tool-registry/src"
+                 "components/pr-train/src"
+                 "components/repo-dag/src"
+                 "components/policy-pack/src"]
    :extra-deps {metosin/malli {:mvn/version "0.16.1"}
                 clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}
                 aero/aero        {:mvn/version "1.1.6"}


### PR DESCRIPTION
## Summary
Completes the bb.edn classpath configuration for `bb miniforge` development mode by adding all remaining component source paths.

## Changes
- Added 10 missing component source paths to :extra-paths:
  - release-executor
  - evidence-bundle
  - operator
  - orchestrator
  - reporting
  - observer
  - tool-registry
  - pr-train
  - repo-dag
  - policy-pack

## Context
Previous PR #124 added event-stream, aero/core, and workflow resources. This PR completes the classpath by adding all remaining components discovered during autonomous workflow testing.

## Test plan
- [x] All existing tests pass (2734 assertions)
- [x] Pre-commit hooks pass
- [x] Fixes "Could not locate ai/miniforge/release_executor/interface.clj" error
- [ ] Enables successful execution of `bb miniforge run work/fix-artifact-persistence.spec.edn`

## Related
- Part of dogfooding initiative
- Unblocks autonomous workflow execution
- Follows PR #123 (dogfooding enhancements) and PR #124 (initial classpath fixes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)