### PR TITLE
fix: correct artifact handoff paths in workflow phases

### DIFF
--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -79,7 +79,8 @@
 
         ;; Build task from workflow input and plan result
         input (get-in ctx [:execution/input])
-        plan-result (get-in ctx [:phase :result]) ; From plan phase
+        ;; Read from execution phase results where plan phase stored its output
+        plan-result (get-in ctx [:execution/phase-results :plan])
         task {:task/id (random-uuid)
               :task/type :implement
               :task/description (:description input)

--- a/components/phase/src/ai/miniforge/phase/release.clj
+++ b/components/phase/src/ai/miniforge/phase/release.clj
@@ -47,7 +47,9 @@
 (defn- build-workflow-state
   "Build workflow state from phase context for the release executor."
   [ctx]
-  (let [implement-result (get-in ctx [:phases :implement :result])
+  ;; Read implement result from execution phase results (not :phases)
+  ;; This is the canonical location where workflow runner stores phase outputs
+  (let [implement-result (get-in ctx [:execution/phase-results :implement])
         code-artifacts (if-let [artifacts (:artifacts implement-result)]
                          (map (fn [a] {:artifact/type :code
                                        :artifact/content a})

--- a/components/phase/src/ai/miniforge/phase/verify.clj
+++ b/components/phase/src/ai/miniforge/phase/verify.clj
@@ -57,7 +57,8 @@
         ;; Code can come from:
         ;; 1. Previous implement phase result (in multi-phase workflows)
         ;; 2. Direct input as :task/code-artifact (in test-only workflows)
-        implement-result (get-in ctx [:phase :result])
+        ;; Read from execution phase results where implement phase stored its output
+        implement-result (get-in ctx [:execution/phase-results :implement])
         code-artifact (or implement-result
                          (:task/code-artifact input)
                          (:code-artifact input))

--- a/components/phase/test/ai/miniforge/phase/verify_test.clj
+++ b/components/phase/test/ai/miniforge/phase/verify_test.clj
@@ -99,7 +99,7 @@
                                  :output mock-test-artifact
                                  :metrics {:tokens 200 :duration-ms 600}})]
       (let [ctx (-> (create-base-context)
-                    (assoc-in [:phase :result] mock-code-artifact)
+                    (assoc-in [:execution/phase-results :implement] mock-code-artifact)
                     (assoc :phase-config {:phase :verify}))
             result (#'verify/enter-verify ctx)]
         (is (= mock-test-artifact (get-in result [:phase :result :output])))))))


### PR DESCRIPTION
## Summary

Fixes the artifact persistence bug where workflow phases weren't passing artifacts correctly, causing `:files-written 0` in the release phase.

## Root Cause

Phase results were being read from incorrect context paths:
- **Wrong paths:** `[:phases :implement :result]` or `[:phase :result]`
- **Correct path:** `[:execution/phase-results :phase-name]`

## Changes

- `implement.clj`: Read plan from `[:execution/phase-results :plan]`
- `verify.clj`: Read implement from `[:execution/phase-results :implement]`
- `release.clj`: Read implement from `[:execution/phase-results :implement]`
- `verify_test.clj`: Update test to use correct execution context path

## Testing

- All existing tests pass (2734 assertions)
- Fixed test that was validating the buggy behavior

## Impact

This enables autonomous workflows to write files to disk, unblocking the "dogfooding" capability where miniforge can work on itself.

🤖 Generated with Claude Code