### PR TITLE
fix(phase): extract :result :output from phase results correctly

### DIFF
--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -80,7 +80,8 @@
         ;; Build task from workflow input and plan result
         input (get-in ctx [:execution/input])
         ;; Read from execution phase results where plan phase stored its output
-        plan-result (get-in ctx [:execution/phase-results :plan])
+        ;; Phase results contain the full phase map, so extract :result :output
+        plan-result (get-in ctx [:execution/phase-results :plan :result :output])
         task {:task/id (random-uuid)
               :task/type :implement
               :task/description (:description input)

--- a/components/phase/src/ai/miniforge/phase/release.clj
+++ b/components/phase/src/ai/miniforge/phase/release.clj
@@ -49,7 +49,8 @@
   [ctx]
   ;; Read implement result from execution phase results (not :phases)
   ;; This is the canonical location where workflow runner stores phase outputs
-  (let [implement-result (get-in ctx [:execution/phase-results :implement])
+  ;; Phase results contain the full phase map, so extract :result :output
+  (let [implement-result (get-in ctx [:execution/phase-results :implement :result :output])
         code-artifacts (if-let [artifacts (:artifacts implement-result)]
                          (map (fn [a] {:artifact/type :code
                                        :artifact/content a})

--- a/components/phase/src/ai/miniforge/phase/verify.clj
+++ b/components/phase/src/ai/miniforge/phase/verify.clj
@@ -58,7 +58,8 @@
         ;; 1. Previous implement phase result (in multi-phase workflows)
         ;; 2. Direct input as :task/code-artifact (in test-only workflows)
         ;; Read from execution phase results where implement phase stored its output
-        implement-result (get-in ctx [:execution/phase-results :implement])
+        ;; Phase results contain the full phase map, so extract :result :output
+        implement-result (get-in ctx [:execution/phase-results :implement :result :output])
         code-artifact (or implement-result
                          (:task/code-artifact input)
                          (:code-artifact input))

--- a/components/phase/test/ai/miniforge/phase/handoff_test.clj
+++ b/components/phase/test/ai/miniforge/phase/handoff_test.clj
@@ -118,11 +118,11 @@
   [phase-name ctx]
   (let [interceptor (registry/get-phase-interceptor {:phase phase-name})
         leave-fn (:leave interceptor)
-        result (get-in ctx [:phase :result])
         updated-ctx (leave-fn ctx)]
-    ;; Store phase result in execution context (mimics workflow runner)
+    ;; Store entire phase map in execution context (mimics workflow runner)
+    ;; The real workflow runner stores the full :phase map via extract-phase-result
     (assoc-in updated-ctx [:execution/phase-results phase-name]
-              (:output result))))
+              (:phase updated-ctx))))
 
 ;------------------------------------------------------------------------------ Tests
 
@@ -138,9 +138,12 @@
                      "Plan phase should succeed")
             ctx2 (execute-phase-leave :plan ctx1)
 
-            plan-result (get-in ctx2 [:execution/phase-results :plan])
+            plan-phase-result (get-in ctx2 [:execution/phase-results :plan])
+            plan-result (get-in plan-phase-result [:result :output])
+            _    (is (some? plan-phase-result)
+                     "Plan phase result should be stored in execution context")
             _    (is (some? plan-result)
-                     "Plan result should be stored in execution context")
+                     "Plan output should be present in phase result")
             _    (is (= (:plan/id mock-plan-result) (:plan/id plan-result))
                      "Stored plan should match mock data")]
 
@@ -164,9 +167,12 @@
                      "Implement phase should succeed")
             ctx2 (execute-phase-leave :implement ctx1)
 
-            impl-result (get-in ctx2 [:execution/phase-results :implement])
+            impl-phase-result (get-in ctx2 [:execution/phase-results :implement])
+            impl-result (get-in impl-phase-result [:result :output])
+            _    (is (some? impl-phase-result)
+                     "Implement phase result should be stored in execution context")
             _    (is (some? impl-result)
-                     "Implement result should be stored in execution context")
+                     "Implement output should be present in phase result")
             _    (is (= (:code/id mock-code-artifact) (:code/id impl-result))
                      "Stored code artifact should match mock data")]
 

--- a/components/phase/test/ai/miniforge/phase/verify_test.clj
+++ b/components/phase/test/ai/miniforge/phase/verify_test.clj
@@ -99,7 +99,10 @@
                                  :output mock-test-artifact
                                  :metrics {:tokens 200 :duration-ms 600}})]
       (let [ctx (-> (create-base-context)
-                    (assoc-in [:execution/phase-results :implement] mock-code-artifact)
+                    ;; Mock the phase result structure as stored by workflow runner
+                    (assoc-in [:execution/phase-results :implement]
+                              {:result {:status :success
+                                        :output mock-code-artifact}})
                     (assoc :phase-config {:phase :verify}))
             result (#'verify/enter-verify ctx)]
         (is (= mock-test-artifact (get-in result [:phase :result :output])))))))


### PR DESCRIPTION
## Summary

Completes the artifact handoff fix from #128 by correctly extracting the output from the phase result structure.

## Root Cause (Deeper)

PR #128 fixed the path to read phase results from `[:execution/phase-results :phase-name]` instead of wrong paths. However, the workflow runner stores the **entire :phase map** at that location, not just the output.

The :phase map contains: `{:name :implement, :agent :implementer, :result {:status :success, :output <artifact>}, ...}`

## This Fix

Extract the actual artifact from the nested structure:
- **Before:** `(get-in ctx [:execution/phase-results :implement])`  
  Returns entire phase map
- **After:** `(get-in ctx [:execution/phase-results :implement :result :output])`  
  Returns the actual artifact

## Changes

- implement.clj: Read `[:execution/phase-results :plan :result :output]`
- verify.clj: Read `[:execution/phase-results :implement :result :output]`  
- release.clj: Read `[:execution/phase-results :implement :result :output]`
- handoff_test.clj: Update test to match real phase result structure
- verify_test.clj: Update test to match real phase result structure

## Testing

- All 2768 assertions pass
- Handoff test validates the complete flow with proper structure

This should finally enable autonomous workflows to write files to disk!

🤖 Generated with Claude Code