### PR TITLE
feat(response): canonical anomaly system with boundary translators

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/web/handlers.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/handlers.clj
@@ -8,7 +8,8 @@
    [ai.miniforge.cli.web.github :as github]
    [ai.miniforge.cli.web.fleet :as fleet]
    [ai.miniforge.cli.web.components :as c]
-   [ai.miniforge.cli.web.sse :as sse]))
+   [ai.miniforge.cli.web.sse :as sse]
+   [ai.miniforge.response.interface :as anomaly]))
 
 (defn- parse-pr-path [uri]
   (let [path-parts (str/split (subs uri 8) #"/")]
@@ -86,10 +87,12 @@
 (defn summary [uri]
   (let [{:keys [repo number]} (parse-pr-path uri)
         result (github/generate-pr-summary repo number)]
-    (response/html
-     (if (:success result)
-       (c/ai-summary result)
-       (c/ai-summary-error (:summary result))))))
+    (if (and (not (:success result)) (anomaly/anomaly-map? (:anomaly result)))
+      (response/from-anomaly (:anomaly result))
+      (response/html
+       (if (:success result)
+         (c/ai-summary result)
+         (c/ai-summary-error (:summary result)))))))
 
 (defn workflows [repos]
   (response/html (c/workflow-status repos)))

--- a/bases/cli/src/ai/miniforge/cli/web/response.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/response.clj
@@ -1,5 +1,7 @@
 (ns ai.miniforge.cli.web.response
-  "HTTP response constructors.")
+  "HTTP response constructors."
+  (:require
+   [ai.miniforge.response.interface :as anomaly]))
 
 (defn html [body]
   {:status 200
@@ -11,6 +13,12 @@
 
 (defn bad-request [msg]
   {:status 400 :body msg})
+
+(defn from-anomaly
+  "Create an HTTP response from a canonical anomaly map.
+   Uses the boundary translator — only call at HTTP edges."
+  [anomaly-map]
+  (anomaly/anomaly->http-response anomaly-map))
 
 (defn sse-headers []
   {:status 200

--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -8,6 +8,7 @@
   (:require
    [ai.miniforge.agent.protocol :as protocol]
    [ai.miniforge.agent.memory :as memory]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.tool.interface :as tool]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -372,6 +373,7 @@ Output execution logs and status reports."})
                      {:success false
                       :error (.getMessage e)
                       :exception-type (type e)
+                      :anomaly (response/from-exception e)
                       :outputs []
                       :decisions [:execution-error]
                       :signals [:task-failed]

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -15,7 +15,8 @@
 (ns ai.miniforge.event-stream.core
   "Event bus and event constructors for workflow observability."
   (:require
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants
@@ -150,14 +151,29 @@
       (cond-> duration-ms (assoc :workflow/duration-ms duration-ms))))
 
 (defn workflow-failed [stream workflow-id error]
-  (let [error-map (if (instance? Throwable error)
+  (let [;; Handle anomaly maps, Throwables, and plain error maps
+        anomaly-map (cond
+                      (response/anomaly-map? error) error
+                      (instance? Throwable error) (response/from-exception error)
+                      (and (map? error) (:anomaly error)) (:anomaly error)
+                      :else nil)
+        error-map (cond
+                    (instance? Throwable error)
                     {:message (.getMessage ^Throwable error)
                      :type (str (type error))}
-                    error)]
+                    (response/anomaly-map? error)
+                    (response/anomaly->event-data error)
+                    :else error)
+        event-data (response/anomaly->event-data
+                    (or anomaly-map
+                        (response/make-anomaly :anomalies/fault
+                                               (or (:message error-map) "unknown error"))))]
     (-> (create-envelope stream :workflow/failed workflow-id
                          (str "Workflow failed: " (:message error-map "unknown error")))
-        (assoc :workflow/failure-reason (:message error-map)
-               :workflow/error-details error-map))))
+        (assoc :workflow/failure-reason (:message error-map (:message event-data))
+               :workflow/error-details error-map
+               :workflow/anomaly-code (:anomaly-code event-data)
+               :workflow/retryable? (:retryable? event-data false)))))
 
 (defn llm-request [stream workflow-id agent-id model & [prompt-tokens]]
   (-> (create-envelope stream :llm/request workflow-id

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/collector.clj
@@ -2,7 +2,8 @@
   "Utilities for collecting evidence during workflow execution.
    Provides helpers for gathering phase results, artifacts, and metadata."
   (:require
-   [ai.miniforge.evidence-bundle.schema :as schema]))
+   [ai.miniforge.evidence-bundle.schema :as schema]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Intent Collection
@@ -128,11 +129,17 @@
 
 (defn build-outcome-evidence
   "Build outcome evidence from workflow final state.
+   Uses anomaly->outcome-evidence when anomaly maps are available.
    Returns outcome evidence per N6 spec."
   [workflow-state]
   (let [status (:workflow/status workflow-state)
         pr-info (:workflow/pr-info workflow-state)
-        error-info (:workflow/error workflow-state)]
+        error-info (:workflow/error workflow-state)
+        ;; Check for anomaly map in error-info or workflow state
+        anomaly-map (cond
+                      (response/anomaly-map? error-info) error-info
+                      (response/anomaly-map? (:anomaly error-info)) (:anomaly error-info)
+                      :else nil)]
     (merge
      {:outcome/success (= status :completed)}
      (when pr-info
@@ -140,10 +147,14 @@
         :outcome/pr-url (:url pr-info)
         :outcome/pr-status (:status pr-info)
         :outcome/pr-merged-at (:merged-at pr-info)})
-     (when error-info
-       {:outcome/error-message (:message error-info)
-        :outcome/error-phase (:phase error-info)
-        :outcome/error-details error-info}))))
+     (if anomaly-map
+       ;; Use boundary translator for anomaly maps
+       (response/anomaly->outcome-evidence anomaly-map)
+       ;; Fall back to legacy error shape
+       (when error-info
+         {:outcome/error-message (:message error-info)
+          :outcome/error-phase (:phase error-info)
+          :outcome/error-details error-info})))))
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Complete Bundle Assembly

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -5,7 +5,8 @@
    [cheshire.core :as json]
    [babashka.process :as p]
    [ai.miniforge.logging.interface :as log]
-   [ai.miniforge.llm.progress-monitor :as pm])
+   [ai.miniforge.llm.progress-monitor :as pm]
+   [ai.miniforge.response.interface :as response])
   (:import
    [java.io ByteArrayInputStream]))
 
@@ -60,6 +61,10 @@
              :message (str/trim error-message)
              :stderr stderr
              :stdout output}
+     :anomaly (response/make-anomaly
+               :anomalies.agent/llm-error
+               (str/trim error-message)
+               {:anomaly/operation :llm-complete})
      :exit-code exit-code}))
 
 (defn parse-cli-output
@@ -200,13 +205,18 @@
 (defn- streaming-error-response [content exit-code err-result timeout-info]
   (let [error-message (or err-result
                           (when (str/blank? content) "Process failed with no output")
-                          "Process failed")]
+                          "Process failed")
+        category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)]
     {:success false
      :error {:type (if timeout-info "adaptive_timeout" "cli_error")
              :message (str/trim error-message)
              :stderr err-result
              :stdout content
              :timeout timeout-info}
+     :anomaly (response/make-anomaly
+               category
+               (str/trim error-message)
+               {:anomaly/operation :llm-stream})
      :exit-code exit-code}))
 
 (defn- handle-streaming [client request on-chunk backend-config progress-monitor]

--- a/components/loop/src/ai/miniforge/loop/escalation.clj
+++ b/components/loop/src/ai/miniforge/loop/escalation.clj
@@ -12,11 +12,17 @@
 ;; Prompt formatting (pure functions)
 
 (defn format-error-entry
-  "Format a single error entry for display."
+  "Format a single error entry for display.
+   Reads :anomaly/message and :anomaly/category when available,
+   falls back to :message and :code for legacy shapes."
   [idx err]
-  (str "  " (inc idx) ". " (:message err)
-       (when-let [code (:code err)]
-         (str " [" (name code) "]"))))
+  (let [anomaly (:anomaly err)
+        msg (or (when anomaly (:anomaly/message anomaly))
+                (:message err))
+        code (or (when anomaly (name (:anomaly/category anomaly)))
+                 (when-let [c (:code err)] (name c)))]
+    (str "  " (inc idx) ". " msg
+         (when code (str " [" code "]")))))
 
 (defn format-error-context
   "Format error context for user display.

--- a/components/loop/src/ai/miniforge/loop/gates.clj
+++ b/components/loop/src/ai/miniforge/loop/gates.clj
@@ -11,6 +11,7 @@
   (:require
    [ai.miniforge.loop.interface.protocols.gate :as p]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.response.interface :as response]
    [clojure.string]))
 
 ;; Re-export protocol for backward compatibility
@@ -33,12 +34,17 @@
     duration-ms (assoc :gate/duration-ms duration-ms)))
 
 (defn fail-result
-  "Create a failing gate result."
+  "Create a failing gate result.
+   Includes :gate/anomaly — a canonical anomaly map preserving gate error richness."
   [gate-id gate-type errors & {:keys [warnings duration-ms]}]
   (cond-> {:gate/id gate-id
            :gate/type gate-type
            :gate/passed? false
-           :gate/errors errors}
+           :gate/errors errors
+           :gate/anomaly (response/gate-anomaly
+                          :anomalies.gate/validation-failed
+                          (str "Gate " (name gate-id) " (" (name gate-type) ") failed")
+                          errors)}
     warnings (assoc :gate/warnings warnings)
     duration-ms (assoc :gate/duration-ms duration-ms)))
 

--- a/components/loop/src/ai/miniforge/loop/inner.clj
+++ b/components/loop/src/ai/miniforge/loop/inner.clj
@@ -9,7 +9,8 @@
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.loop.escalation :as escalation]
    [ai.miniforge.loop.gates :as gates]
-   [ai.miniforge.loop.repair :as repair]))
+   [ai.miniforge.loop.repair :as repair]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; State machine transitions (pure functions)
@@ -210,12 +211,14 @@
             (log/error logger :loop :inner/validation-failed
                        {:message "Generation failed"
                         :data {:error (.getMessage e)}}))
-          (-> loop-state
-              (set-errors [{:code :generation-error
-                            :message (.getMessage e)}])
-              (set-termination :unrecoverable-error
-                               :message (.getMessage e))
-              (transition :failed)))))))
+          (let [anom (response/from-exception e)]
+            (-> loop-state
+                (set-errors [{:code :generation-error
+                              :message (.getMessage e)
+                              :anomaly anom}])
+                (set-termination :unrecoverable-error
+                                 :message (.getMessage e))
+                (transition :failed))))))))
 
 (defn validate-step
   "Execute the validate step using provided gates.

--- a/components/response/src/ai/miniforge/response/anomaly.clj
+++ b/components/response/src/ai/miniforge/response/anomaly.clj
@@ -13,15 +13,23 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.response.anomaly
-  "Anomaly taxonomy for miniforge operations.
+  "Anomaly taxonomy and canonical anomaly maps for miniforge operations.
 
-   Anomalies are keywords that categorize failures. They provide:
-   - Consistent error classification across components
-   - Mapping to appropriate responses (HTTP status, retry behavior, etc.)
-   - Clear semantics for error handling
+   Anomalies are the single internal error representation. They are plain data
+   maps that flow through the system as return values (never exceptions).
+   Conversion to HTTP responses, user messages, log entries, or events happens
+   only at system boundaries via the translate namespace.
+
+   An anomaly map has one required key:
+     :anomaly/category - keyword from the taxonomy below
+     :anomaly/message  - programmer-facing diagnostic string
+
+   Optional keys carry domain context via namespaced keys:
+     :anomaly/id, :anomaly/timestamp, :anomaly/phase, :anomaly/operation
+     :anomaly.gate/errors, :anomaly.agent/role, :anomaly.llm/model, etc.
 
    Categories:
-   - :anomalies/... - General errors
+   - :anomalies/... - General errors (Cognitect-compatible)
    - :anomalies.phase/... - Phase execution errors
    - :anomalies.gate/... - Gate validation errors
    - :anomalies.agent/... - Agent errors
@@ -118,6 +126,98 @@
     (contains? workflow-anomalies anomaly) :workflow
     :else nil))
 
+;------------------------------------------------------------------------------ Layer 3
+;; Anomaly map constructors
+
+(defn anomaly
+  "Create a canonical anomaly map.
+
+   Arguments:
+     category - Keyword from the anomaly taxonomy (e.g. :anomalies/fault)
+     message  - Programmer-facing diagnostic string
+     context  - Optional map of namespaced domain context keys
+
+   Returns:
+     {:anomaly/category category
+      :anomaly/message  message
+      :anomaly/id       uuid
+      :anomaly/timestamp inst
+      ...context}"
+  ([category message]
+   (anomaly category message {}))
+  ([category message context]
+   (merge context
+          {:anomaly/category category
+           :anomaly/message  message
+           :anomaly/id       (random-uuid)
+           :anomaly/timestamp (java.time.Instant/now)})))
+
+(defn from-exception
+  "Convert an exception to a canonical anomaly map.
+
+   Uses classifier-fn to determine the anomaly category. Falls back to
+   :anomaly key in ex-data, then to :anomalies/fault.
+
+   Arguments:
+     ex            - Exception to convert
+     classifier-fn - Optional (Exception -> anomaly-keyword)
+
+   Returns: Anomaly map with exception provenance keys."
+  ([ex]
+   (from-exception ex nil))
+  ([ex classifier-fn]
+   (let [category (or (when classifier-fn (classifier-fn ex))
+                      (:anomaly (ex-data ex))
+                      :anomalies/fault)]
+     (anomaly category
+              (or (ex-message ex) (str (type ex)))
+              (cond-> {:anomaly/ex-message (ex-message ex)
+                       :anomaly/ex-class   (str (type ex))}
+                (ex-data ex) (assoc :anomaly/ex-data (ex-data ex)))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Anomaly map predicates
+
+(defn anomaly-map?
+  "Check if a value is a canonical anomaly map (has :anomaly/category)."
+  [x]
+  (and (map? x) (contains? x :anomaly/category)))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Domain-specific anomaly constructors
+
+(defn gate-anomaly
+  "Create a gate-specific anomaly preserving gate error richness.
+
+   Arguments:
+     category    - Gate anomaly keyword (e.g. :anomalies.gate/validation-failed)
+     message     - Diagnostic message
+     gate-errors - Vector of gate error maps [{:code :message :location}]
+     context     - Optional additional context map
+
+   Returns: Anomaly map with :anomaly.gate/errors attached."
+  ([category message gate-errors]
+   (gate-anomaly category message gate-errors {}))
+  ([category message gate-errors context]
+   (anomaly category message
+            (merge {:anomaly.gate/errors gate-errors} context))))
+
+(defn agent-anomaly
+  "Create an agent-specific anomaly.
+
+   Arguments:
+     category   - Agent anomaly keyword (e.g. :anomalies.agent/invoke-failed)
+     message    - Diagnostic message
+     agent-role - Agent role keyword (:planner, :implementer, etc.)
+     context    - Optional additional context map
+
+   Returns: Anomaly map with :anomaly.agent/role attached."
+  ([category message agent-role]
+   (agent-anomaly category message agent-role {}))
+  ([category message agent-role context]
+   (anomaly category message
+            (merge {:anomaly.agent/role agent-role} context))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (anomaly? :anomalies/fault)
@@ -134,5 +234,40 @@
 
   (anomaly-category :anomalies.phase/enter-failed)
   ;; => :phase
+
+  ;; Anomaly maps
+  (anomaly :anomalies/fault "Something broke")
+  ;; => {:anomaly/category :anomalies/fault
+  ;;     :anomaly/message "Something broke"
+  ;;     :anomaly/id #uuid "..."
+  ;;     :anomaly/timestamp #inst "..."}
+
+  (anomaly :anomalies.gate/validation-failed "Test failed"
+           {:anomaly/phase :verify
+            :anomaly/operation :validate})
+
+  (anomaly-map? (anomaly :anomalies/fault "broken"))
+  ;; => true
+
+  (anomaly-map? {:not "an anomaly"})
+  ;; => false
+
+  ;; From exception
+  (from-exception (ex-info "Timeout" {:phase :verify}))
+  ;; => {:anomaly/category :anomalies/fault
+  ;;     :anomaly/message "Timeout"
+  ;;     :anomaly/ex-data {:phase :verify}
+  ;;     ...}
+
+  (from-exception (ex-info "oops" {:anomaly :anomalies/timeout}))
+  ;; => {:anomaly/category :anomalies/timeout ...}
+
+  ;; Gate anomaly
+  (gate-anomaly :anomalies.gate/validation-failed
+                "Syntax gate failed"
+                [{:code :syntax-error :message "Parse error" :location {:file "foo.clj" :line 10}}])
+
+  ;; Agent anomaly
+  (agent-anomaly :anomalies.agent/invoke-failed "Agent timed out" :implementer)
 
   :leave-this-here)

--- a/components/response/src/ai/miniforge/response/chain.clj
+++ b/components/response/src/ai/miniforge/response/chain.clj
@@ -28,6 +28,7 @@
    Each chain entry structure:
    {:operation keyword        ; Operation name
     :anomaly keyword|nil      ; Anomaly code if failed, nil if succeeded
+    :anomaly-map map|nil      ; Full anomaly map when available
     :succeeded? boolean       ; True if this operation succeeded
     :response any}            ; Operation result data
 
@@ -37,7 +38,8 @@
          (add-response :step-2 nil {:result \"done\"})
          (succeeded?))
      ;; => true"
-)
+  (:require
+   [ai.miniforge.response.anomaly :as anomaly]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Chain creation
@@ -65,19 +67,31 @@
 
    Arguments:
      operation - Keyword identifying the operation
-     anomaly   - Anomaly keyword if failed, nil if succeeded
+     anomaly   - Anomaly keyword, anomaly map, or nil if succeeded
      response  - Operation result data
+
+   When anomaly is a map (anomaly map), both :anomaly (keyword) and
+   :anomaly-map (full map) are set. When anomaly is a keyword (legacy),
+   only :anomaly is set. This provides backward compatibility.
 
    Returns:
      {:operation operation
-      :anomaly anomaly
+      :anomaly keyword|nil       ; Always a keyword for backward compat
+      :anomaly-map map|nil       ; Full anomaly map when available
       :succeeded? (nil? anomaly)
       :response response}"
   [operation anomaly response]
-  {:operation operation
-   :anomaly anomaly
-   :succeeded? (nil? anomaly)
-   :response response})
+  (let [anomaly-map (when (map? anomaly) anomaly)
+        anomaly-kw (cond
+                     (nil? anomaly) nil
+                     (keyword? anomaly) anomaly
+                     (map? anomaly) (:anomaly/category anomaly)
+                     :else anomaly)]
+    {:operation operation
+     :anomaly anomaly-kw
+     :anomaly-map anomaly-map
+     :succeeded? (nil? anomaly)
+     :response response}))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Chain operations
@@ -174,21 +188,24 @@
    Returns a vector of error maps with:
    - :type - The operation name as a keyword prefixed with 'error-'
    - :operation - The original operation name
-   - :anomaly - The anomaly code
-   - :message - Error message from response
+   - :anomaly - The anomaly code (keyword)
+   - :anomaly-map - Full anomaly map when available (nil for legacy entries)
+   - :message - Error message from response or anomaly map
    - :data - Additional error data from response
 
    This provides a migration path from :execution/errors to response chains."
   [chain]
   (->> (all-failures chain)
-       (mapv (fn [{:keys [operation anomaly response]}]
-               {:type (keyword (str "error-" (name operation)))
-                :operation operation
-                :anomaly anomaly
-                :message (or (:error response)
-                             (:message response)
-                             (str "Operation " operation " failed"))
-                :data (dissoc response :error :message)}))))
+       (mapv (fn [{:keys [operation anomaly anomaly-map response]}]
+               (cond-> {:type (keyword (str "error-" (name operation)))
+                        :operation operation
+                        :anomaly anomaly
+                        :message (or (:anomaly/message anomaly-map)
+                                     (:error response)
+                                     (:message response)
+                                     (str "Operation " operation " failed"))
+                        :data (dissoc response :error :message)}
+                 anomaly-map (assoc :anomaly-map anomaly-map))))))
 
 (defn operations
   "Get the sequence of operation names in order."
@@ -258,7 +275,7 @@
   "Execute a function and add its result to the chain.
 
    On success: adds (operation, nil, result) to chain
-   On exception: adds (operation, anomaly, {:error message :data ex-data})
+   On exception: adds (operation, anomaly-map, {:error message :data ex-data})
 
    Arguments:
      chain      - Response chain
@@ -273,8 +290,9 @@
     (let [result (f)]
       (add-success chain operation result))
     (catch Exception ex
-      (let [anomaly (or (anomaly-fn ex) :anomalies/fault)]
-        (add-failure chain operation anomaly
+      (let [category (or (anomaly-fn ex) :anomalies/fault)
+            anom (anomaly/from-exception ex (constantly category))]
+        (add-failure chain operation anom
                      {:error (ex-message ex)
                       :data (ex-data ex)})))))
 

--- a/components/response/src/ai/miniforge/response/interface.clj
+++ b/components/response/src/ai/miniforge/response/interface.clj
@@ -27,7 +27,8 @@
   (:require
    [ai.miniforge.response.chain :as chain]
    [ai.miniforge.response.anomaly :as anomaly]
-   [ai.miniforge.response.builder :as builder]))
+   [ai.miniforge.response.builder :as builder]
+   [ai.miniforge.response.translate :as translate]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Chain creation
@@ -237,7 +238,7 @@
   chain/default-anomaly-classifier)
 
 ;------------------------------------------------------------------------------ Layer 5
-;; Anomaly utilities
+;; Anomaly utilities (keyword-based)
 
 (def anomaly?
   "Check if a keyword is a known anomaly."
@@ -252,6 +253,82 @@
 
    Returns :general, :phase, :gate, :agent, :workflow, or nil."
   anomaly/anomaly-category)
+
+;------------------------------------------------------------------------------ Layer 5.1
+;; Anomaly map constructors
+
+(def make-anomaly
+  "Create a canonical anomaly map.
+
+   Arguments:
+     category - Keyword from the anomaly taxonomy (e.g. :anomalies/fault)
+     message  - Programmer-facing diagnostic string
+     context  - Optional map of namespaced domain context keys
+
+   Returns:
+     {:anomaly/category category
+      :anomaly/message  message
+      :anomaly/id       uuid
+      :anomaly/timestamp inst
+      ...context}
+
+   Example:
+     (make-anomaly :anomalies/fault \"Something broke\")
+     (make-anomaly :anomalies.gate/validation-failed \"Test failed\"
+                   {:anomaly/phase :verify})"
+  anomaly/anomaly)
+
+(def from-exception
+  "Convert an exception to a canonical anomaly map.
+
+   Uses classifier-fn to determine the anomaly category. Falls back to
+   :anomaly key in ex-data, then to :anomalies/fault.
+
+   Arguments:
+     ex            - Exception to convert
+     classifier-fn - Optional (Exception -> anomaly-keyword)
+
+   Returns: Anomaly map with exception provenance keys.
+
+   Example:
+     (from-exception (ex-info \"Timeout\" {:phase :verify}))
+     (from-exception ex my-classifier)"
+  anomaly/from-exception)
+
+(def anomaly-map?
+  "Check if a value is a canonical anomaly map (has :anomaly/category).
+
+   Example:
+     (anomaly-map? (make-anomaly :anomalies/fault \"broken\")) ;; => true
+     (anomaly-map? {:not \"an anomaly\"})                      ;; => false"
+  anomaly/anomaly-map?)
+
+(def gate-anomaly
+  "Create a gate-specific anomaly preserving gate error richness.
+
+   Arguments:
+     category    - Gate anomaly keyword (e.g. :anomalies.gate/validation-failed)
+     message     - Diagnostic message
+     gate-errors - Vector of gate error maps [{:code :message :location}]
+     context     - Optional additional context map
+
+   Example:
+     (gate-anomaly :anomalies.gate/validation-failed \"Syntax check failed\"
+                   [{:code :syntax-error :message \"Parse error\" :location {:file \"foo.clj\" :line 10}}])"
+  anomaly/gate-anomaly)
+
+(def agent-anomaly
+  "Create an agent-specific anomaly.
+
+   Arguments:
+     category   - Agent anomaly keyword (e.g. :anomalies.agent/invoke-failed)
+     message    - Diagnostic message
+     agent-role - Agent role keyword (:planner, :implementer, etc.)
+     context    - Optional additional context map
+
+   Example:
+     (agent-anomaly :anomalies.agent/invoke-failed \"Agent timed out\" :implementer)"
+  anomaly/agent-anomaly)
 
 ;------------------------------------------------------------------------------ Layer 6
 ;; Response Builders
@@ -313,6 +390,47 @@
                              :message \"Making progress\"
                              :data {:chunks 5}})"
   builder/status-check)
+
+;------------------------------------------------------------------------------ Layer 8
+;; Boundary translators
+
+(def anomaly->http-status
+  "Get the HTTP status code for an anomaly category keyword."
+  translate/anomaly->http-status)
+
+(def anomaly->http-response
+  "Translate an anomaly map to a Ring HTTP response.
+   BOUNDARY function — only call at HTTP edges.
+
+   Returns:
+     {:status int
+      :headers {\"Content-Type\" \"application/json\"}
+      :body {:error {:code string :message string}}}"
+  translate/anomaly->http-response)
+
+(def anomaly->user-message
+  "Get a user-facing message for an anomaly map.
+   Falls back to a generic message — never exposes internal details."
+  translate/anomaly->user-message)
+
+(def anomaly->log-data
+  "Translate an anomaly map to structured log entry data.
+   Returns a map suitable for the :data field in logging."
+  translate/anomaly->log-data)
+
+(def anomaly->event-data
+  "Translate an anomaly map to event-stream compatible failure data.
+   Returns {:message :anomaly-code :retryable? :phase}."
+  translate/anomaly->event-data)
+
+(def anomaly->outcome-evidence
+  "Translate an anomaly map to evidence-bundle outcome fields."
+  translate/anomaly->outcome-evidence)
+
+(def coerce
+  "Coerce any error shape to a canonical anomaly map.
+   Handles all known shapes. Passes through existing anomaly maps."
+  translate/coerce)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/response/src/ai/miniforge/response/translate.clj
+++ b/components/response/src/ai/miniforge/response/translate.clj
@@ -1,0 +1,320 @@
+(ns ai.miniforge.response.translate
+  "Boundary translators for anomaly maps.
+
+   These functions convert canonical anomaly maps to external representations.
+   They are the ONLY places where anomaly maps should be converted to
+   HTTP responses, user messages, log entries, events, or evidence data.
+
+   Internal code passes anomaly maps unchanged. Translation happens at:
+   - HTTP boundary: anomaly->http-response
+   - User display:  anomaly->user-message
+   - Logging:       anomaly->log-data
+   - Events:        anomaly->event-data
+   - Evidence:      anomaly->outcome-evidence
+   - Inbound:       coerce (legacy error -> anomaly map)"
+  (:require
+   [ai.miniforge.response.anomaly :as anomaly]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; User-facing message translation (defined first — used by HTTP translator)
+
+(def category->user-message
+  "Map anomaly categories to user-friendly messages.
+   These messages are safe to show to end users — no internal details."
+  {;; General
+   :anomalies/unavailable    "The service is temporarily unavailable. Please try again."
+   :anomalies/interrupted    "The operation was interrupted. Please try again."
+   :anomalies/incorrect      "The request contains invalid data. Please check your input."
+   :anomalies/forbidden      "You do not have permission to perform this action."
+   :anomalies/not-found      "The requested resource was not found."
+   :anomalies/conflict       "The operation conflicts with the current state. Please retry."
+   :anomalies/fault          "An internal error occurred."
+   :anomalies/unsupported    "This operation is not supported."
+   :anomalies/busy           "The system is currently busy. Please try again shortly."
+   :anomalies/timeout        "The operation timed out. Please try again."
+   ;; Phase
+   :anomalies.phase/unknown-phase     "An unknown workflow phase was encountered."
+   :anomalies.phase/enter-failed      "Failed to start a workflow phase."
+   :anomalies.phase/leave-failed      "Failed to complete a workflow phase."
+   :anomalies.phase/budget-exceeded   "The operation exceeded its resource budget."
+   :anomalies.phase/no-agent          "No agent is configured for this workflow phase."
+   :anomalies.phase/agent-failed      "The agent failed during this workflow phase."
+   ;; Gate
+   :anomalies.gate/unknown-gate       "An unknown validation gate was encountered."
+   :anomalies.gate/check-failed       "A validation check encountered an error."
+   :anomalies.gate/validation-failed  "Code validation failed. The agent will attempt repair."
+   :anomalies.gate/repair-failed      "Automatic repair was attempted but failed."
+   :anomalies.gate/no-repair          "No automatic repair is available for this error."
+   ;; Agent
+   :anomalies.agent/unknown-agent     "An unknown agent type was encountered."
+   :anomalies.agent/invoke-failed     "The agent encountered an error during execution."
+   :anomalies.agent/parse-failed      "Failed to parse the agent's output."
+   :anomalies.agent/llm-error         "The AI model encountered an error. Retrying may help."
+   ;; Workflow
+   :anomalies.workflow/empty-pipeline     "The workflow has no phases configured."
+   :anomalies.workflow/invalid-config     "The workflow configuration is invalid."
+   :anomalies.workflow/max-phases         "The workflow exceeded the maximum number of phase iterations."
+   :anomalies.workflow/invalid-transition "An invalid workflow state transition was attempted."
+   :anomalies.workflow/rollback-limit     "The workflow exceeded the maximum number of rollbacks."})
+
+(defn anomaly->user-message
+  "Get a user-facing message for an anomaly map.
+
+   Falls back to a generic message — never exposes internal details.
+
+   Arguments:
+     anomaly-map - Canonical anomaly map
+
+   Returns: Human-friendly string."
+  [anomaly-map]
+  (let [category (:anomaly/category anomaly-map)]
+    (or (get category->user-message category)
+        (str "An error occurred: " (name category)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; HTTP boundary translation
+
+(def category->http-status
+  "Map anomaly categories to HTTP status codes."
+  {;; General anomalies
+   :anomalies/unavailable    503
+   :anomalies/interrupted    503
+   :anomalies/incorrect      400
+   :anomalies/forbidden      403
+   :anomalies/not-found      404
+   :anomalies/conflict       409
+   :anomalies/fault          500
+   :anomalies/unsupported    501
+   :anomalies/busy           429
+   :anomalies/timeout        504
+   ;; Phase anomalies
+   :anomalies.phase/unknown-phase     500
+   :anomalies.phase/enter-failed      500
+   :anomalies.phase/leave-failed      500
+   :anomalies.phase/budget-exceeded   429
+   :anomalies.phase/no-agent          500
+   :anomalies.phase/agent-failed      502
+   ;; Gate anomalies -> 422 Unprocessable Entity
+   :anomalies.gate/unknown-gate       500
+   :anomalies.gate/check-failed       422
+   :anomalies.gate/validation-failed  422
+   :anomalies.gate/repair-failed      422
+   :anomalies.gate/no-repair          422
+   ;; Agent anomalies
+   :anomalies.agent/unknown-agent     500
+   :anomalies.agent/invoke-failed     502
+   :anomalies.agent/parse-failed      422
+   :anomalies.agent/llm-error         502
+   ;; Workflow anomalies
+   :anomalies.workflow/empty-pipeline     400
+   :anomalies.workflow/invalid-config     400
+   :anomalies.workflow/max-phases         500
+   :anomalies.workflow/invalid-transition 500
+   :anomalies.workflow/rollback-limit     500})
+
+(defn anomaly->http-status
+  "Get the HTTP status code for an anomaly category keyword.
+   Returns 500 as default for unknown categories."
+  [category]
+  (get category->http-status category 500))
+
+(defn anomaly->http-response
+  "Translate an anomaly map to a Ring HTTP response.
+
+   This is a BOUNDARY function — only call at HTTP edges.
+
+   Returns:
+     {:status int
+      :headers {\"Content-Type\" \"application/json\"}
+      :body {:error {:code string :message string}}}"
+  [anomaly-map]
+  (let [category (:anomaly/category anomaly-map)
+        status (anomaly->http-status category)]
+    {:status status
+     :headers {"Content-Type" "application/json"}
+     :body {:error {:code (name category)
+                    :message (anomaly->user-message anomaly-map)}}}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Logging translation
+
+(defn anomaly->log-data
+  "Translate an anomaly map to structured log entry data.
+
+   Returns a map suitable for passing as the :data field to logging/core.
+
+   Arguments:
+     anomaly-map - Canonical anomaly map
+
+   Returns: Map with selected anomaly fields for structured logging."
+  [anomaly-map]
+  (let [category (:anomaly/category anomaly-map)]
+    (cond-> {:anomaly/category category
+             :anomaly/message  (:anomaly/message anomaly-map)}
+      (anomaly/retryable? category)
+      (assoc :anomaly/retryable? true)
+
+      (:anomaly/phase anomaly-map)
+      (assoc :anomaly/phase (:anomaly/phase anomaly-map))
+
+      (:anomaly/operation anomaly-map)
+      (assoc :anomaly/operation (:anomaly/operation anomaly-map))
+
+      (:anomaly.gate/errors anomaly-map)
+      (assoc :anomaly.gate/error-count (count (:anomaly.gate/errors anomaly-map)))
+
+      (:anomaly.agent/role anomaly-map)
+      (assoc :anomaly.agent/role (:anomaly.agent/role anomaly-map))
+
+      (:anomaly/ex-class anomaly-map)
+      (assoc :anomaly/ex-class (:anomaly/ex-class anomaly-map)))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Event stream translation
+
+(defn anomaly->event-data
+  "Translate an anomaly map to event-stream compatible failure data.
+
+   Returns a map suitable for the workflow-failed event constructor.
+
+   Arguments:
+     anomaly-map - Canonical anomaly map
+
+   Returns:
+     {:message string
+      :anomaly-code keyword
+      :retryable? boolean
+      :phase keyword|nil}"
+  [anomaly-map]
+  (let [category (:anomaly/category anomaly-map)]
+    {:message (:anomaly/message anomaly-map)
+     :anomaly-code category
+     :retryable? (boolean (anomaly/retryable? category))
+     :phase (:anomaly/phase anomaly-map)}))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Evidence bundle translation
+
+(defn anomaly->outcome-evidence
+  "Translate an anomaly map to evidence-bundle outcome fields.
+
+   Returns a map that can be merged into an evidence bundle's outcome section.
+
+   Arguments:
+     anomaly-map - Canonical anomaly map
+
+   Returns:
+     {:outcome/success false
+      :outcome/anomaly-code keyword
+      :outcome/error-message string
+      :outcome/error-phase keyword|nil
+      :outcome/error-details map}"
+  [anomaly-map]
+  {:outcome/success false
+   :outcome/anomaly-code (:anomaly/category anomaly-map)
+   :outcome/error-message (:anomaly/message anomaly-map)
+   :outcome/error-phase (:anomaly/phase anomaly-map)
+   :outcome/error-details (select-keys anomaly-map
+                            [:anomaly/id
+                             :anomaly/category
+                             :anomaly.gate/errors
+                             :anomaly.agent/role
+                             :anomaly.llm/model
+                             :anomaly.repair/strategy
+                             :anomaly.repair/attempts])})
+
+;------------------------------------------------------------------------------ Layer 5
+;; Error coercion (any shape -> anomaly map)
+
+(defn coerce
+  "Coerce any error shape to a canonical anomaly map.
+
+   Handles all known error shapes in the codebase:
+   1. Builder {:status :error :error {:message ...}}
+   2. Builder {:success false :error {:message ...}}
+   3. Schema  {:success? false :error ...}
+   4. Tool    {:success false :error {:type ... :message ...}}
+   5. Gate    {:gate/passed? false :gate/errors [...]}
+   6. Ad-hoc  {:code keyword :message string}
+
+   Passes through values that are already anomaly maps unchanged.
+
+   Arguments:
+     error-data       - Any error shape
+     default-category - Optional fallback category (default :anomalies/fault)
+
+   Returns: Canonical anomaly map."
+  ([error-data]
+   (coerce error-data :anomalies/fault))
+  ([error-data default-category]
+   (cond
+     ;; Already an anomaly map — pass through
+     (anomaly/anomaly-map? error-data)
+     error-data
+
+     ;; Shape 1: {:status :error :error {:message ...}}
+     (= :error (:status error-data))
+     (anomaly/anomaly (or default-category :anomalies/fault)
+                      (or (get-in error-data [:error :message]) "Unknown error")
+                      {:anomaly/legacy-shape :builder-error})
+
+     ;; Shape 5: gate result {:gate/passed? false}
+     (false? (:gate/passed? error-data))
+     (anomaly/gate-anomaly :anomalies.gate/validation-failed
+                           (str "Gate " (or (:gate/id error-data) "unknown") " failed")
+                           (or (:gate/errors error-data) []))
+
+     ;; Shape 2/3/4: {:success false} or {:success? false}
+     (or (false? (:success error-data))
+         (false? (:success? error-data)))
+     (let [msg (or (get-in error-data [:error :message])
+                   (when (string? (:error error-data)) (:error error-data))
+                   (first (:errors error-data))
+                   "Operation failed")]
+       (anomaly/anomaly (or default-category :anomalies/fault)
+                        (if (string? msg) msg (pr-str msg))
+                        {:anomaly/legacy-shape :success-false}))
+
+     ;; Shape 6: ad-hoc {:code ... :message ...}
+     (and (:code error-data) (:message error-data))
+     (anomaly/anomaly (or default-category :anomalies/fault)
+                      (:message error-data)
+                      {:anomaly/legacy-code (:code error-data)})
+
+     ;; Fallback — wrap anything else
+     :else
+     (anomaly/anomaly (or default-category :anomalies/fault)
+                      (pr-str error-data)))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; HTTP translation
+  (anomaly->http-status :anomalies/not-found)
+  ;; => 404
+
+  (anomaly->http-response (anomaly/anomaly :anomalies/not-found "User 123 not found"))
+  ;; => {:status 404
+  ;;     :headers {"Content-Type" "application/json"}
+  ;;     :body {:error {:code "not-found"
+  ;;                    :message "The requested resource was not found."}}}
+
+  ;; User message
+  (anomaly->user-message (anomaly/anomaly :anomalies/timeout "LLM call timed out after 30s"))
+  ;; => "The operation timed out. Please try again."
+
+  ;; Log data
+  (anomaly->log-data (anomaly/anomaly :anomalies.agent/llm-error "Model returned 500"
+                                       {:anomaly/phase :implement
+                                        :anomaly.agent/role :implementer}))
+
+  ;; Event data
+  (anomaly->event-data (anomaly/anomaly :anomalies/timeout "Phase timed out"
+                                         {:anomaly/phase :verify}))
+
+  ;; Coercion from legacy shapes
+  (coerce {:status :error :error {:message "bad input"}})
+  (coerce {:gate/passed? false :gate/id :syntax
+           :gate/errors [{:code :syntax-error :message "parse error"}]})
+  (coerce {:success false :error "timeout"})
+
+  :leave-this-here)

--- a/components/response/test/ai/miniforge/response/interface_test.clj
+++ b/components/response/test/ai/miniforge/response/interface_test.clj
@@ -30,13 +30,26 @@
       (is (= {:result "ok"} (r/last-response chain))))))
 
 (deftest add-failure-test
-  (testing "add-failure adds entry with anomaly"
+  (testing "add-failure adds entry with anomaly keyword"
     (let [chain (-> (r/create :test)
                     (r/add-failure :step-1 :anomalies/fault {:error "boom"}))]
       (is (= 1 (r/entry-count chain)))
       (is (r/failed? chain))
       (is (= :anomalies/fault (r/last-anomaly chain)))
-      (is (= {:error "boom"} (r/last-response chain))))))
+      (is (= {:error "boom"} (r/last-response chain)))))
+
+  (testing "add-failure accepts anomaly map"
+    (let [anom (r/make-anomaly :anomalies.gate/validation-failed "Test failed"
+                               {:anomaly/phase :verify})
+          chain (-> (r/create :test)
+                    (r/add-failure :step-1 anom {:errors ["e1"]}))]
+      (is (r/failed? chain))
+      ;; :anomaly key still holds the keyword for backward compat
+      (is (= :anomalies.gate/validation-failed (r/last-anomaly chain)))
+      ;; :anomaly-map holds the full map
+      (let [entry (r/last-entry chain)]
+        (is (r/anomaly-map? (:anomaly-map entry)))
+        (is (= :verify (get-in entry [:anomaly-map :anomaly/phase])))))))
 
 (deftest add-response-test
   (testing "add-response with nil anomaly succeeds"
@@ -179,14 +192,18 @@
       (is (= {:result "ok"} (r/last-response chain))))))
 
 (deftest execute-with-handling-failure-test
-  (testing "exception adds failure entry"
+  (testing "exception adds failure entry with anomaly map"
     (let [chain (-> (r/create :test)
                     (r/execute-with-handling :step-1 r/default-anomaly-classifier
                                              #(throw (ex-info "boom" {:code 123}))))]
       (is (r/failed? chain))
       (is (= :anomalies/fault (r/last-anomaly chain)))
       (is (= "boom" (:error (r/last-response chain))))
-      (is (= {:code 123} (:data (r/last-response chain)))))))
+      (is (= {:code 123} (:data (r/last-response chain))))
+      ;; New: anomaly-map is present
+      (let [entry (r/last-entry chain)]
+        (is (r/anomaly-map? (:anomaly-map entry)))
+        (is (= "boom" (:anomaly/message (:anomaly-map entry))))))))
 
 (deftest execute-with-handling-custom-classifier-test
   (testing "custom classifier maps exceptions"
@@ -259,3 +276,245 @@
     (let [chain (-> (r/create :test)
                     (r/add-success :step-1 {}))]
       (is (= [] (r/errors chain))))))
+
+;; ============================================================================
+;; Anomaly map constructor tests
+;; ============================================================================
+
+(deftest make-anomaly-test
+  (testing "creates anomaly map with required keys"
+    (let [anom (r/make-anomaly :anomalies/fault "Something broke")]
+      (is (= :anomalies/fault (:anomaly/category anom)))
+      (is (= "Something broke" (:anomaly/message anom)))
+      (is (uuid? (:anomaly/id anom)))
+      (is (inst? (:anomaly/timestamp anom)))))
+
+  (testing "merges domain context"
+    (let [anom (r/make-anomaly :anomalies.gate/validation-failed "Test failed"
+                               {:anomaly/phase :verify
+                                :anomaly/operation :validate})]
+      (is (= :anomalies.gate/validation-failed (:anomaly/category anom)))
+      (is (= :verify (:anomaly/phase anom)))
+      (is (= :validate (:anomaly/operation anom)))))
+
+  (testing "context does not overwrite required keys"
+    (let [anom (r/make-anomaly :anomalies/fault "original"
+                               {:anomaly/category :anomalies/timeout
+                                :anomaly/message "overwritten"})]
+      ;; merge puts context first, then required keys, so required wins
+      (is (= :anomalies/fault (:anomaly/category anom)))
+      (is (= "original" (:anomaly/message anom))))))
+
+(deftest anomaly-map?-test
+  (testing "recognizes anomaly maps"
+    (is (r/anomaly-map? (r/make-anomaly :anomalies/fault "broken")))
+    (is (r/anomaly-map? {:anomaly/category :anomalies/fault})))
+
+  (testing "rejects non-anomaly values"
+    (is (not (r/anomaly-map? nil)))
+    (is (not (r/anomaly-map? :anomalies/fault)))
+    (is (not (r/anomaly-map? "error")))
+    (is (not (r/anomaly-map? {:error "not an anomaly"})))
+    (is (not (r/anomaly-map? 42)))))
+
+(deftest from-exception-test
+  (testing "converts ex-info to anomaly map"
+    (let [ex (ex-info "Timeout" {:phase :verify})
+          anom (r/from-exception ex)]
+      (is (r/anomaly-map? anom))
+      (is (= :anomalies/fault (:anomaly/category anom)))
+      (is (= "Timeout" (:anomaly/message anom)))
+      (is (= "Timeout" (:anomaly/ex-message anom)))
+      (is (= {:phase :verify} (:anomaly/ex-data anom)))))
+
+  (testing "uses :anomaly key from ex-data when present"
+    (let [ex (ex-info "oops" {:anomaly :anomalies/timeout})
+          anom (r/from-exception ex)]
+      (is (= :anomalies/timeout (:anomaly/category anom)))))
+
+  (testing "uses classifier-fn when provided"
+    (let [ex (ex-info "boom" {})
+          classifier (fn [_] :anomalies/busy)
+          anom (r/from-exception ex classifier)]
+      (is (= :anomalies/busy (:anomaly/category anom)))))
+
+  (testing "classifier-fn takes precedence over ex-data :anomaly"
+    (let [ex (ex-info "boom" {:anomaly :anomalies/timeout})
+          classifier (fn [_] :anomalies/busy)
+          anom (r/from-exception ex classifier)]
+      (is (= :anomalies/busy (:anomaly/category anom)))))
+
+  (testing "captures exception class"
+    (let [ex (java.util.concurrent.TimeoutException. "timed out")
+          anom (r/from-exception ex)]
+      (is (string? (:anomaly/ex-class anom))))))
+
+(deftest gate-anomaly-test
+  (testing "creates anomaly with gate errors"
+    (let [gate-errors [{:code :syntax-error
+                        :message "Parse error"
+                        :location {:file "foo.clj" :line 10 :column 5}}]
+          anom (r/gate-anomaly :anomalies.gate/validation-failed
+                               "Syntax gate failed"
+                               gate-errors)]
+      (is (r/anomaly-map? anom))
+      (is (= :anomalies.gate/validation-failed (:anomaly/category anom)))
+      (is (= gate-errors (:anomaly.gate/errors anom)))))
+
+  (testing "merges additional context"
+    (let [anom (r/gate-anomaly :anomalies.gate/check-failed
+                               "Gate threw"
+                               [{:code :test-failed :message "assertion"}]
+                               {:anomaly/phase :verify})]
+      (is (= :verify (:anomaly/phase anom))))))
+
+(deftest agent-anomaly-test
+  (testing "creates anomaly with agent role"
+    (let [anom (r/agent-anomaly :anomalies.agent/invoke-failed
+                                "Agent timed out"
+                                :implementer)]
+      (is (r/anomaly-map? anom))
+      (is (= :anomalies.agent/invoke-failed (:anomaly/category anom)))
+      (is (= :implementer (:anomaly.agent/role anom)))))
+
+  (testing "merges additional context"
+    (let [anom (r/agent-anomaly :anomalies.agent/llm-error
+                                "Model error"
+                                :planner
+                                {:anomaly.llm/model "claude-sonnet-4"})]
+      (is (= "claude-sonnet-4" (:anomaly.llm/model anom))))))
+
+;; ============================================================================
+;; Boundary translator tests
+;; ============================================================================
+
+(deftest anomaly->http-status-test
+  (testing "maps general anomalies to HTTP status codes"
+    (is (= 400 (r/anomaly->http-status :anomalies/incorrect)))
+    (is (= 403 (r/anomaly->http-status :anomalies/forbidden)))
+    (is (= 404 (r/anomaly->http-status :anomalies/not-found)))
+    (is (= 409 (r/anomaly->http-status :anomalies/conflict)))
+    (is (= 429 (r/anomaly->http-status :anomalies/busy)))
+    (is (= 500 (r/anomaly->http-status :anomalies/fault)))
+    (is (= 501 (r/anomaly->http-status :anomalies/unsupported)))
+    (is (= 503 (r/anomaly->http-status :anomalies/unavailable)))
+    (is (= 504 (r/anomaly->http-status :anomalies/timeout))))
+
+  (testing "maps domain anomalies"
+    (is (= 422 (r/anomaly->http-status :anomalies.gate/validation-failed)))
+    (is (= 502 (r/anomaly->http-status :anomalies.agent/llm-error)))
+    (is (= 429 (r/anomaly->http-status :anomalies.phase/budget-exceeded))))
+
+  (testing "defaults to 500 for unknown"
+    (is (= 500 (r/anomaly->http-status :unknown/anomaly)))))
+
+(deftest anomaly->http-response-test
+  (testing "produces Ring response map"
+    (let [anom (r/make-anomaly :anomalies/not-found "User 123 not found")
+          resp (r/anomaly->http-response anom)]
+      (is (= 404 (:status resp)))
+      (is (= "application/json" (get-in resp [:headers "Content-Type"])))
+      (is (= "not-found" (get-in resp [:body :error :code])))
+      (is (string? (get-in resp [:body :error :message]))))))
+
+(deftest anomaly->user-message-test
+  (testing "returns user-friendly message for known categories"
+    (let [anom (r/make-anomaly :anomalies/timeout "LLM call timed out after 30s")]
+      (is (= "The operation timed out. Please try again."
+             (r/anomaly->user-message anom)))))
+
+  (testing "never exposes internal message"
+    (let [anom (r/make-anomaly :anomalies/fault "NullPointerException at foo.clj:42")]
+      (is (not (clojure.string/includes? (r/anomaly->user-message anom) "NullPointer")))))
+
+  (testing "falls back to generic message for unknown categories"
+    (let [anom (r/make-anomaly :anomalies.custom/something "internal detail")]
+      (is (string? (r/anomaly->user-message anom))))))
+
+(deftest anomaly->log-data-test
+  (testing "extracts structured log data"
+    (let [anom (r/make-anomaly :anomalies.agent/llm-error "Model returned 500"
+                               {:anomaly/phase :implement
+                                :anomaly.agent/role :implementer})
+          log-data (r/anomaly->log-data anom)]
+      (is (= :anomalies.agent/llm-error (:anomaly/category log-data)))
+      (is (= "Model returned 500" (:anomaly/message log-data)))
+      (is (true? (:anomaly/retryable? log-data)))
+      (is (= :implement (:anomaly/phase log-data)))
+      (is (= :implementer (:anomaly.agent/role log-data)))))
+
+  (testing "omits nil optional fields"
+    (let [anom (r/make-anomaly :anomalies/fault "broke")
+          log-data (r/anomaly->log-data anom)]
+      (is (not (contains? log-data :anomaly/phase)))
+      (is (not (contains? log-data :anomaly.agent/role))))))
+
+(deftest anomaly->event-data-test
+  (testing "produces event-compatible map"
+    (let [anom (r/make-anomaly :anomalies/timeout "Phase timed out"
+                               {:anomaly/phase :verify})
+          event-data (r/anomaly->event-data anom)]
+      (is (= "Phase timed out" (:message event-data)))
+      (is (= :anomalies/timeout (:anomaly-code event-data)))
+      (is (true? (:retryable? event-data)))
+      (is (= :verify (:phase event-data))))))
+
+(deftest anomaly->outcome-evidence-test
+  (testing "produces evidence-bundle outcome fields"
+    (let [anom (r/make-anomaly :anomalies.gate/validation-failed "Test failed"
+                               {:anomaly/phase :verify
+                                :anomaly.gate/errors [{:code :test-failed}]})
+          outcome (r/anomaly->outcome-evidence anom)]
+      (is (false? (:outcome/success outcome)))
+      (is (= :anomalies.gate/validation-failed (:outcome/anomaly-code outcome)))
+      (is (= "Test failed" (:outcome/error-message outcome)))
+      (is (= :verify (:outcome/error-phase outcome)))
+      (is (= [{:code :test-failed}]
+             (get-in outcome [:outcome/error-details :anomaly.gate/errors]))))))
+
+(deftest coerce-test
+  (testing "passes through existing anomaly maps"
+    (let [anom (r/make-anomaly :anomalies/fault "already good")]
+      (is (identical? anom (r/coerce anom)))))
+
+  (testing "converts builder error shape"
+    (let [anom (r/coerce {:status :error
+                                          :error {:message "bad input"}})]
+      (is (r/anomaly-map? anom))
+      (is (= "bad input" (:anomaly/message anom)))))
+
+  (testing "converts gate result shape"
+    (let [anom (r/coerce {:gate/passed? false
+                                          :gate/id :syntax
+                                          :gate/errors [{:code :syntax-error
+                                                         :message "parse error"}]})]
+      (is (r/anomaly-map? anom))
+      (is (= :anomalies.gate/validation-failed (:anomaly/category anom)))
+      (is (= 1 (count (:anomaly.gate/errors anom))))))
+
+  (testing "converts success-false shape"
+    (let [anom (r/coerce {:success false :error "timeout"})]
+      (is (r/anomaly-map? anom))
+      (is (= "timeout" (:anomaly/message anom)))))
+
+  (testing "converts success?-false shape"
+    (let [anom (r/coerce {:success? false :error "nope"})]
+      (is (r/anomaly-map? anom))
+      (is (= "nope" (:anomaly/message anom)))))
+
+  (testing "converts ad-hoc code/message shape"
+    (let [anom (r/coerce {:code :generation-error
+                                          :message "LLM failed"})]
+      (is (r/anomaly-map? anom))
+      (is (= "LLM failed" (:anomaly/message anom)))
+      (is (= :generation-error (:anomaly/legacy-code anom)))))
+
+  (testing "accepts custom default category"
+    (let [anom (r/coerce {:success false :error "oops"}
+                                         :anomalies/timeout)]
+      (is (= :anomalies/timeout (:anomaly/category anom)))))
+
+  (testing "handles unknown shape as fallback"
+    (let [anom (r/coerce "just a string")]
+      (is (r/anomaly-map? anom))
+      (is (= :anomalies/fault (:anomaly/category anom))))))

--- a/components/schema/src/ai/miniforge/schema/interface.clj
+++ b/components/schema/src/ai/miniforge/schema/interface.clj
@@ -5,7 +5,8 @@
    [malli.core :as m]
    [malli.error :as me]
    [ai.miniforge.schema.core :as core]
-   [ai.miniforge.schema.logging :as logging]))
+   [ai.miniforge.schema.logging :as logging]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports (allow other components to reference schemas)
@@ -122,18 +123,21 @@
    - opts       - Optional map with additional fields
 
    Returns:
-   - {:success? false data-key nil :error error ...opts}
+   - {:success? false data-key nil :error error :anomaly anomaly-map ...opts}
 
    Example:
      (failure :pack \"File not found\")
-     ;; => {:success? false :pack nil :error \"File not found\"}
+     ;; => {:success? false :pack nil :error \"File not found\" :anomaly {...}}
 
      (failure :pack {:message \"Invalid\" :stage :parsing})
-     ;; => {:success? false :pack nil :error {:message \"Invalid\" :stage :parsing}}"
+     ;; => {:success? false :pack nil :error {:message \"Invalid\" :stage :parsing} :anomaly {...}}"
   ([data-key error]
    (failure data-key error nil))
   ([data-key error opts]
-   (merge {:success? false data-key nil :error error} opts)))
+   (let [msg (if (string? error) error (or (:message error) (pr-str error)))]
+     (merge {:success? false data-key nil :error error
+             :anomaly (response/make-anomaly :anomalies/fault msg)}
+            opts))))
 
 (defn failure-with-errors
   "Create a failure response with multiple errors.
@@ -163,20 +167,22 @@
    - opts     - Optional map with additional fields (e.g., :stage)
 
    Returns:
-   - {:success? false data-key nil :error {:message ... :data ...} ...opts}
+   - {:success? false data-key nil :error {:message ... :data ...} :anomaly anomaly-map ...opts}
 
    Example:
      (exception-failure :pack (Exception. \"IO error\"))
-     ;; => {:success? false :pack nil :error {:message \"IO error\"}}
+     ;; => {:success? false :pack nil :error {:message \"IO error\"} :anomaly {...}}
 
      (exception-failure :pack ex {:stage :extraction})
-     ;; => {:success? false :pack nil :error {:message ... :stage :extraction}}"
+     ;; => {:success? false :pack nil :error {:message ... :stage :extraction} :anomaly {...}}"
   ([data-key ex]
    (exception-failure data-key ex nil))
   ([data-key ex opts]
    (let [error-map (cond-> {:message (ex-message ex)}
                      (ex-data ex) (assoc :data (ex-data ex)))]
-     (merge {:success? false data-key nil :error error-map} opts))))
+     (merge {:success? false data-key nil :error error-map
+             :anomaly (response/from-exception ex)}
+            opts))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation response helpers

--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -6,6 +6,7 @@
    [clojure.set :as set]
    [clojure.string :as str]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.tool.tracking :as tracking]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -107,10 +108,15 @@
                      (catch Exception e
                        {:success false
                         :error {:type "execution_error"
-                                :message (.getMessage e)}}))
+                                :message (.getMessage e)}
+                        :anomaly (response/from-exception e)}))
                    {:success false
                     :error {:type "validation_error"
-                            :errors (:errors validation)}})
+                            :errors (:errors validation)}
+                    :anomaly (response/make-anomaly
+                              :anomalies/incorrect
+                              (str "Tool parameter validation failed: "
+                                   (first (:errors validation))))})
           end-ms (System/currentTimeMillis)
           invocation (tracking/build-invocation id params start-ms end-ms result)]
       (tracking/record-invocation context invocation)
@@ -191,7 +197,10 @@
     (execute tool params context)
     {:success false
      :error {:type "not_found"
-             :message (str "Tool not found: " tool-id)}}))
+             :message (str "Tool not found: " tool-id)}
+     :anomaly (response/make-anomaly
+               :anomalies/not-found
+               (str "Tool not found: " tool-id))}))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -34,18 +34,21 @@
         (catch Exception ex
           (if-let [error-fn (:error interceptor)]
             (error-fn ctx ex)
-            (-> ctx
-                (assoc :execution/status :failed)
-                (update :execution/errors conj
-                        {:type :phase-error
-                         :phase phase-name
-                         :message (ex-message ex)
-                         :data (ex-data ex)})
-                (update :execution/response-chain
-                        response/add-failure phase-name
-                        :anomalies.phase/enter-failed
-                        {:error (ex-message ex)
-                         :data (ex-data ex)})))))
+            (let [anom (response/from-exception ex)]
+              (-> ctx
+                  (assoc :execution/status :failed)
+                  (update :execution/errors conj
+                          {:type :phase-error
+                           :phase phase-name
+                           :message (ex-message ex)
+                           :data (ex-data ex)
+                           :anomaly anom})
+                  (update :execution/response-chain
+                          response/add-failure phase-name
+                          (assoc anom :anomaly/category :anomalies.phase/enter-failed
+                                      :anomaly/phase phase-name)
+                          {:error (ex-message ex)
+                           :data (ex-data ex)}))))))
       ctx)))
 
 (defn- execute-leave
@@ -58,15 +61,18 @@
       (try
         (leave-fn ctx)
         (catch Exception ex
-          (-> ctx
-              (update :execution/errors conj
-                      {:type :leave-error
-                       :phase phase-name
-                       :message (ex-message ex)})
-              (update :execution/response-chain
-                      response/add-failure phase-name
-                      :anomalies.phase/leave-failed
-                      {:error (ex-message ex)}))))
+          (let [anom (response/from-exception ex)]
+            (-> ctx
+                (update :execution/errors conj
+                        {:type :leave-error
+                         :phase phase-name
+                         :message (ex-message ex)
+                         :anomaly anom})
+                (update :execution/response-chain
+                        response/add-failure phase-name
+                        (assoc anom :anomaly/category :anomalies.phase/leave-failed
+                                    :anomaly/phase phase-name)
+                        {:error (ex-message ex)})))))
       ctx)))
 
 (defn- extract-phase-result
@@ -102,12 +108,21 @@
   (if (phase-succeeded? phase-result)
     (update ctx :execution/response-chain
             response/add-success phase-name phase-result)
-    (update ctx :execution/response-chain
-            response/add-failure phase-name
-            (if (:phase/gate-errors phase-result)
-              :anomalies.gate/validation-failed
-              :anomalies.phase/agent-failed)
-            phase-result)))
+    (let [gate-errors (:phase/gate-errors phase-result)
+          anomaly (if gate-errors
+                    (response/gate-anomaly
+                     :anomalies.gate/validation-failed
+                     (str "Gate validation failed for phase " (name phase-name))
+                     gate-errors
+                     {:anomaly/phase phase-name})
+                    (response/make-anomaly
+                     :anomalies.phase/agent-failed
+                     (str "Agent failed in phase " (name phase-name))
+                     {:anomaly/phase phase-name}))]
+      (update ctx :execution/response-chain
+              response/add-failure phase-name
+              anomaly
+              phase-result))))
 
 (defn- record-phase-metrics
   "Record phase metrics in execution context."
@@ -218,16 +233,20 @@
       (transition-to-completed-fn ctx))
 
     :else
-    (-> ctx
-        (update :execution/errors conj
-                {:type :invalid-transition
-                 :message (str "Invalid next index: " next-index)})
-        (update :execution/response-chain
-                response/add-failure :pipeline
+    (let [anom (response/make-anomaly
                 :anomalies.workflow/invalid-transition
-                {:error (str "Invalid next index: " next-index)
-                 :next-index next-index})
-        (transition-to-failed-fn))))
+                (str "Invalid next index: " next-index))]
+      (-> ctx
+          (update :execution/errors conj
+                  {:type :invalid-transition
+                   :message (str "Invalid next index: " next-index)
+                   :anomaly anom})
+          (update :execution/response-chain
+                  response/add-failure :pipeline
+                  anom
+                  {:error (str "Invalid next index: " next-index)
+                   :next-index next-index})
+          (transition-to-failed-fn)))))
 
 ;------------------------------------------------------------------------------ Layer 2: Phase step execution
 

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -178,6 +178,12 @@ These documents provide guidance, examples, and context but do NOT define contra
 
 - [informative/pr-monitoring-workflow.md](informative/pr-monitoring-workflow.md) - PR monitoring and conflict resolution
 
+### Architecture & Internals
+
+- [informative/I-ANOMALY-SYSTEM.md](informative/I-ANOMALY-SYSTEM.md) - Canonical error representation and boundary translators
+- [informative/I-DAG-ORCHESTRATION.md](informative/I-DAG-ORCHESTRATION.md) - DAG executor with PR lifecycle
+- [informative/I-TASK-EXECUTOR.md](informative/I-TASK-EXECUTOR.md) - DAG-to-PR lifecycle integration
+
 ### Roadmaps (Experimental/Future)
 
 - [informative/learning-meta-loop.md](informative/learning-meta-loop.md) - Future learning system (post-OSS)

--- a/specs/informative/I-ANOMALY-SYSTEM.md
+++ b/specs/informative/I-ANOMALY-SYSTEM.md
@@ -1,0 +1,234 @@
+# I-ANOMALY-SYSTEM — Canonical Error Representation
+
+**Status:** Informative
+**Date:** 2026-02-07
+**Version:** 1.0.0
+**Related specs:** N1-architecture.md, N2-workflows.md, N3-event-stream.md, N6-evidence-provenance.md
+
+---
+
+## 1. Purpose
+
+Establish a single internal error representation — canonical anomaly maps — that flows
+through the entire miniforge system as plain data. Translation to external formats
+(HTTP, events, user messages, logs, evidence) happens only at system boundaries.
+
+Prior to this work, six competing error shapes existed across the codebase with no
+systematic mapping to any external format.
+
+---
+
+## 2. Problem: Six Competing Error Shapes
+
+| Shape | Pattern | Primary Consumers |
+|-------|---------|-------------------|
+| 1. Builder `:status :error` | `{:status :error :error {:message s :data m}}` | `response/builder`, specialized agents |
+| 2. Builder `:success false` | `{:success false :error {:message s}}` | `response/builder/failure` |
+| 3. Schema `:success? false` | `{:success? false :error s}` | schema, policy-pack, tool-registry, observer, loop/outer, workflow |
+| 4. Tool/LLM `:success false` | `{:success false :error {:type "cli_error" :message s}}` | tool/core, llm_client, cli/web/github, repo-dag |
+| 5. Gate `:gate/passed? false` | `{:gate/errors [{:code kw :message s :location m}]}` | loop/gates, gate protocol impls |
+| 6. Ad-hoc loop errors | `{:code :generation-error :message s}` | loop/inner catch blocks, loop/repair |
+
+Additionally, `workflow/execution.clj` carries `:execution/errors` as
+`[{:type :phase-error :phase kw :message s}]`.
+
+No systematic mapping existed from any shape to HTTP responses, events, user messages,
+log entries, or evidence bundle outcomes.
+
+---
+
+## 3. Destination: Canonical Anomaly Maps
+
+Every error becomes a plain data map with one required key:
+
+```clojure
+;; REQUIRED
+{:anomaly/category   keyword          ; From taxonomy (e.g. :anomalies.gate/validation-failed)
+ :anomaly/message    string}          ; Programmer-facing diagnostic
+
+;; STANDARD OPTIONAL
+{:anomaly/id         uuid             ; Unique instance ID for tracing
+ :anomaly/timestamp  inst             ; When it occurred
+ :anomaly/phase      keyword          ; SDLC phase (:plan, :implement, :verify, etc.)
+ :anomaly/operation  keyword}         ; Operation that failed
+
+;; DOMAIN CONTEXT (namespaced, open)
+{:anomaly.gate/errors    [GateError]  ; Preserved gate errors with :code :message :location
+ :anomaly.agent/role     keyword
+ :anomaly.agent/task-id  uuid
+ :anomaly.llm/model      string
+ :anomaly.repair/strategy keyword
+ :anomaly.repair/attempts int}
+
+;; EXCEPTION PROVENANCE (only from catch boundaries)
+{:anomaly/ex-message string
+ :anomaly/ex-data    map
+ :anomaly/ex-class   string}
+```
+
+Design decisions:
+
+- `anomaly-map?` checks for `:anomaly/category` — that discriminates anomaly maps from other maps
+- Categories reuse the existing keyword taxonomy verbatim
+- Gate `:location` data is preserved under `:anomaly.gate/errors`
+- Domain context uses namespaced keys — never conflicts
+- Anomaly maps are return values, not exceptions
+- Translation to HTTP/events/messages/logs happens only at boundaries
+
+---
+
+## 4. Anomaly Taxonomy
+
+Five category groups, all under the `:anomalies` namespace:
+
+### 4.1 General (Cognitect-compatible)
+
+| Category | Retryable? | Meaning |
+|----------|-----------|---------|
+| `:anomalies/unavailable` | yes | Temporarily unavailable |
+| `:anomalies/interrupted` | yes | Operation interrupted |
+| `:anomalies/incorrect` | no | Bad input or configuration |
+| `:anomalies/forbidden` | no | Not authorized |
+| `:anomalies/not-found` | no | Resource not found |
+| `:anomalies/conflict` | no | Conflicting state |
+| `:anomalies/fault` | no | Internal error |
+| `:anomalies/unsupported` | no | Operation not supported |
+| `:anomalies/busy` | yes | Rate limited / overloaded |
+| `:anomalies/timeout` | yes | Operation timed out |
+
+### 4.2 Phase Execution
+
+`:anomalies.phase/unknown-phase`, `enter-failed`, `leave-failed`,
+`budget-exceeded`, `no-agent`, `agent-failed`
+
+### 4.3 Gate Validation
+
+`:anomalies.gate/unknown-gate`, `check-failed`, `validation-failed`,
+`repair-failed`, `no-repair`
+
+### 4.4 Agent
+
+`:anomalies.agent/unknown-agent`, `invoke-failed`, `parse-failed`, `llm-error`
+
+### 4.5 Workflow Orchestration
+
+`:anomalies.workflow/empty-pipeline`, `invalid-config`, `max-phases`,
+`invalid-transition`, `rollback-limit`
+
+---
+
+## 5. Component Architecture
+
+```text
+components/response/src/ai/miniforge/response/
+├── anomaly.clj      ; Taxonomy + anomaly map constructors
+├── translate.clj    ; All boundary translators (6 functions)
+├── chain.clj        ; Response chain (enhanced for anomaly maps)
+├── builder.clj      ; Legacy success/error builders
+└── interface.clj    ; Public API re-exports
+```
+
+### 5.1 Constructors (anomaly.clj)
+
+```clojure
+(make-anomaly :anomalies/fault "Something broke")
+(make-anomaly :anomalies/fault "Something broke" {:anomaly/phase :verify})
+(from-exception ex)
+(from-exception ex classifier-fn)
+(gate-anomaly :anomalies.gate/validation-failed "Gate failed" gate-errors)
+(agent-anomaly :anomalies.agent/invoke-failed "Timeout" :implementer)
+```
+
+### 5.2 Predicates
+
+```clojure
+(anomaly-map? x)        ; Has :anomaly/category?
+(anomaly? kw)           ; Known taxonomy keyword?
+(retryable? kw)         ; Will retry help?
+(anomaly-category kw)   ; -> :general, :phase, :gate, :agent, :workflow
+```
+
+### 5.3 Boundary Translators (translate.clj)
+
+| Function | From | To | Boundary |
+|----------|------|----|----------|
+| `anomaly->http-response` | anomaly map | Ring response | HTTP edge |
+| `anomaly->user-message` | anomaly map | human string | TUI / escalation |
+| `anomaly->log-data` | anomaly map | structured map | logging |
+| `anomaly->event-data` | anomaly map | event fields | event stream |
+| `anomaly->outcome-evidence` | anomaly map | outcome fields | evidence bundle |
+| `coerce` | any error shape | anomaly map | inbound bridge |
+
+### 5.4 Response Chain Enhancement (chain.clj)
+
+`wrap-response` accepts keyword OR anomaly map for the `anomaly` parameter.
+When a map is passed, both `:anomaly` (keyword, backward compat) and
+`:anomaly-map` (full map) are stored. The `errors` function surfaces
+`:anomaly-map` when available.
+
+---
+
+## 6. Migration Pattern
+
+All error producers now include an `:anomaly` key alongside existing keys.
+Old consumers continue reading `:success`, `:success?`, `:code`, `:message`.
+New consumers read `:anomaly`.
+
+### 6.1 Producers (Phase 3 — complete)
+
+| Component | File | Change |
+|-----------|------|--------|
+| Gates | `loop/gates.clj` | `fail-result` adds `:gate/anomaly` |
+| Agent executor | `agent/core.clj` | Catch block adds `:anomaly (from-exception e)` |
+| Inner loop | `loop/inner.clj` | Error maps include `:anomaly` |
+| Tools | `tool/core.clj` | Execute catch + not-found add `:anomaly` |
+| LLM client | `llm/llm_client.clj` | `error-response` adds `:anomaly` |
+| Schema helpers | `schema/interface.clj` | `failure`, `exception-failure` add `:anomaly` |
+| Workflow | `workflow/execution.clj` | Error entries carry anomaly maps |
+
+### 6.2 Boundary Consumers (Phase 4 — complete)
+
+| Boundary | File | Change |
+|----------|------|--------|
+| HTTP | `cli/web/response.clj` | `from-anomaly` using `anomaly->http-response` |
+| HTTP | `cli/web/handlers.clj` | `summary` detects `:anomaly` in results |
+| Events | `event-stream/core.clj` | `workflow-failed` accepts anomaly maps |
+| Evidence | `evidence-bundle/collector.clj` | Uses `anomaly->outcome-evidence` |
+| Escalation | `loop/escalation.clj` | Reads `:anomaly/message` and `:anomaly/category` |
+
+---
+
+## 7. HTTP Status Mapping
+
+| Anomaly Category | HTTP Status |
+|-----------------|-------------|
+| `:anomalies/incorrect` | 400 |
+| `:anomalies/forbidden` | 403 |
+| `:anomalies/not-found` | 404 |
+| `:anomalies/conflict` | 409 |
+| `:anomalies/busy` | 429 |
+| `:anomalies/fault` | 500 |
+| `:anomalies/unsupported` | 501 |
+| `:anomalies/unavailable`, `/interrupted` | 503 |
+| `:anomalies/timeout` | 504 |
+| `:anomalies.gate/*` | 422 |
+| `:anomalies.agent/llm-error`, `/invoke-failed` | 502 |
+| `:anomalies.phase/budget-exceeded` | 429 |
+| `:anomalies.workflow/empty-pipeline`, `/invalid-config` | 400 |
+
+---
+
+## 8. Future Cleanup
+
+The following legacy patterns remain in the codebase and can be migrated
+incrementally as components are modified:
+
+- ~60 sites returning `{:success? false ...}` across schema, tool-registry,
+  workflow, policy-pack, release-executor, and loop components
+- ~26 sites returning `{:success false ...}` across tool, agent, LLM,
+  evidence, and CLI components
+- `builder/failure` function (produces `:success false` shape) — can be
+  replaced with `make-anomaly` at call sites
+
+The `coerce` function handles all known shapes and can be used at any
+boundary where legacy error shapes might still appear.


### PR DESCRIPTION
## Summary

- Introduces a Cognitect-style anomaly system as the single internal error representation across miniforge
- Anomaly maps (plain data with `:anomaly/category`) flow as return values; translation to HTTP/events/logs/evidence happens only at boundaries
- Adds `translate.clj` with 6 boundary translators and `coerce` for legacy error bridge
- All error producers (gates, agent, loop, tool, LLM, schema, workflow) now emit `:anomaly` key alongside existing keys — backward compatible
- All boundary consumers (HTTP, events, evidence, escalation) use translators instead of ad-hoc formatting
- Includes `I-ANOMALY-SYSTEM.md` informative spec documenting the full design

## Files changed (19)

**Foundation (response component):**
- `anomaly.clj` — taxonomy (30 keywords across 5 categories), constructors, predicates
- `translate.clj` — NEW: 6 boundary translators + `coerce` legacy bridge
- `chain.clj` — enhanced `wrap-response` to accept anomaly maps alongside keywords
- `interface.clj` — re-exports all new public API

**Error producers (7 components):**
- `loop/gates.clj` — `fail-result` adds `:gate/anomaly`
- `agent/core.clj` — executor catch adds `:anomaly`
- `loop/inner.clj` — error maps include `:anomaly`
- `tool/core.clj` — execute catch + not-found add `:anomaly`
- `llm/llm_client.clj` — `error-response` adds `:anomaly`
- `schema/interface.clj` — `failure`, `exception-failure` add `:anomaly`
- `workflow/execution.clj` — error entries carry anomaly maps

**Boundary consumers (5 boundaries):**
- `cli/web/response.clj` — `from-anomaly` using `anomaly->http-response`
- `cli/web/handlers.clj` — `summary` detects anomaly maps in results
- `event-stream/core.clj` — `workflow-failed` accepts anomaly maps
- `evidence-bundle/collector.clj` — uses `anomaly->outcome-evidence`
- `loop/escalation.clj` — reads `:anomaly/message` and `:anomaly/category`

**Specs:**
- `I-ANOMALY-SYSTEM.md` — informative spec documenting the design
- `SPEC_INDEX.md` — updated with new Architecture & Internals section

## Test plan

- [x] 858 tests, 3726 assertions, 0 failures across all components
- [x] Pre-commit hooks pass (clj-kondo lint + markdownlint + poly test)
- [x] All existing tests unchanged except response component tests (expanded)
- [ ] Verify HTTP boundary: start web dashboard, trigger failing workflow, check JSON error response contains anomaly code
- [ ] Verify event stream: subscribe to events, confirm `:workflow/anomaly-code` in failure events

🤖 Generated with [Claude Code](https://claude.com/claude-code)