### PR TITLE
feat(tui): add Elm-architecture TUI with tui-engine and tui-views components

### DIFF
--- a/bases/cli/deps.edn
+++ b/bases/cli/deps.edn
@@ -17,4 +17,7 @@
         ;; Web server dependencies (BB-compatible)
         ;; http-kit and hiccup are bundled with Babashka
         http-kit/http-kit {:mvn/version "2.8.0"}
-        hiccup/hiccup     {:mvn/version "2.0.0-RC3"}}}
+        hiccup/hiccup     {:mvn/version "2.0.0-RC3"}
+
+        ;; TUI rendering (Lanterna screen)
+        babashka/clojure-lanterna {:mvn/version "0.9.8"}}}

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -36,7 +36,9 @@
    [cheshire.core :as json]
    [ai.miniforge.cli.web :as web]
    [ai.miniforge.cli.spec-parser :as spec-parser]
-   [ai.miniforge.cli.workflow-runner :as workflow-runner]))
+   [ai.miniforge.cli.workflow-runner :as workflow-runner]
+   [ai.miniforge.tui-views.interface :as tui-views]
+   [ai.miniforge.event-stream.interface :as event-stream]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants and pure helpers
@@ -142,10 +144,10 @@
   (println "\n" (style "Miniforge System Check" :foreground :cyan :bold true) "\n")
 
   (let [checks [["bb" "Babashka" "Required for CLI"]
-                ["gum" "Charm Gum" "Required for TUI"]
                 ["git" "Git" "Required for version control"]
                 ["gh" "GitHub CLI" "Required for PR operations"]
-                ["claude" "Claude CLI" "Required for LLM backend"]]]
+                ["claude" "Claude CLI" "Required for LLM backend"]]
+        terminal-ok? (some? (System/getenv "TERM"))]
 
     (doseq [[cmd name desc] checks]
       (let [available? (check-command cmd)
@@ -154,6 +156,14 @@
                      (style "✗" :foreground :red))
             name-styled (if available? name (style name :foreground :red))]
         (println (format "  %s %-12s %s" status name-styled desc))))
+
+    (println)
+
+    ;; Terminal capability
+    (println (format "  %s %-12s %s"
+                     (if terminal-ok? (style "✓" :foreground :green) (style "✗" :foreground :red))
+                     (if terminal-ok? "Terminal" (style "Terminal" :foreground :red))
+                     "Required for TUI (fleet watch)"))
 
     (println)
 
@@ -306,20 +316,23 @@
     (println (str "  Failed: " (get-in state [:workflows :failed] 0)))
     (println)))
 
-;; Deprecated TUI dashboard functions removed - use web dashboard instead
+(defn fleet-watch-cmd
+  "Start interactive TUI dashboard for real-time workflow monitoring."
+  [_m]
+  (let [stream (event-stream/create-event-stream)]
+    (print-info "Starting TUI dashboard...")
+    (print-info "Press q to quit, ? for help")
+    (try
+      (tui-views/start-tui! stream {:throttle-ms 1000})
+      (catch Exception e
+        (print-error (str "TUI failed: " (ex-message e)))
+        (println "Ensure your terminal supports alternate screen mode.")
+        (println "Fallback: bb miniforge fleet web")))))
 
 (defn fleet-dashboard-cmd
-  "Open interactive two-pane TUI dashboard."
-  [_m]
-  (print-info "TUI dashboard is deprecated. Use the web dashboard instead:")
-  (println "  bb miniforge fleet web")
-  (println)
-  (println "The web dashboard offers:")
-  (println "  - Better UX with htmx-powered interactions")
-  (println "  - AI chat integration")
-  (println "  - PR risk analysis and batch operations")
-  (println "  - Accessible from any browser")
-  nil)
+  "Alias for fleet watch (TUI dashboard)."
+  [m]
+  (fleet-watch-cmd m))
 
 (defn fleet-web-cmd
   "Start web-based fleet dashboard."
@@ -482,7 +495,8 @@ Commands:
     start             Start fleet daemon
     stop              Stop fleet daemon
     status            Show fleet status
-    dashboard         Open TUI dashboard (deprecated - use web)
+    watch             Open interactive TUI dashboard
+    dashboard         Alias for watch
     web [--port N]    Start web dashboard (default port: 8787)
     add <repo>        Add repo to fleet
     remove <repo>     Remove repo from fleet
@@ -559,6 +573,7 @@ Examples:
    {:cmds ["fleet" "start"]     :fn fleet-start-cmd}
    {:cmds ["fleet" "stop"]      :fn fleet-stop-cmd}
    {:cmds ["fleet" "status"]    :fn fleet-status-cmd}
+   {:cmds ["fleet" "watch"]     :fn fleet-watch-cmd}
    {:cmds ["fleet" "dashboard"] :fn fleet-dashboard-cmd}
    {:cmds ["fleet" "web"]       :fn fleet-web-cmd
     :spec {:port {:coerce :int :alias :p :default 8787}}}

--- a/bb.edn
+++ b/bb.edn
@@ -532,12 +532,17 @@
                  "components/pr-train/src"
                  "components/repo-dag/src"
                  "components/policy-pack/src"
-                 "components/policy-pack/resources"]
+                 "components/policy-pack/resources"
+                 "components/tui-engine/src"
+                 "components/tui-engine/resources"
+                 "components/tui-views/src"
+                 "components/tui-views/resources"]
    :extra-deps {metosin/malli {:mvn/version "0.16.1"}
                 clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}
                 aero/aero        {:mvn/version "1.1.6"}
                 io.github.lispyclouds/bblgum {:git/sha "df647fb50f32e05b26e46e58d7249b4798e469e6"}
                 http-kit/http-kit {:mvn/version "2.8.0"}
-                hiccup/hiccup     {:mvn/version "2.0.0-RC3"}}
+                hiccup/hiccup     {:mvn/version "2.0.0-RC3"}
+                babashka/clojure-lanterna {:mvn/version "0.9.8"}}
    :requires ([ai.miniforge.cli.main :as cli])
    :task    (apply cli/-main *command-line-args*)}}}

--- a/components/tui-engine/deps.edn
+++ b/components/tui-engine/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src" "resources"]
+ :deps {babashka/clojure-lanterna {:mvn/version "0.9.8"}}
+ :aliases {:test {:extra-paths ["test"]}}}

--- a/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
@@ -55,8 +55,7 @@
          :running?       false
          :input-thread   nil
          :unsub-fn       nil
-         :prev-buffer    nil
-         :render-pending (atom false)}))
+         :prev-buffer    nil}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Rendering

--- a/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
@@ -1,0 +1,194 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.core
+  "Elm-architecture runtime for the TUI engine.
+
+   Implements the core application loop:
+   1. Messages arrive via dispatch! (from input polling or external subscriptions)
+   2. The update function produces a new model (pure)
+   3. The view function produces a render tree (pure)
+   4. The render tree is flattened to a cell buffer and diffed against previous
+   5. Changed cells are written to the screen
+
+   Throttling: user input renders immediately. External messages are batched
+   and rendered at a configurable frame rate (default 1 fps)."
+  (:require
+   [ai.miniforge.tui-engine.screen :as screen]
+   [ai.miniforge.tui-engine.input :as input]
+   [ai.miniforge.tui-engine.layout :as layout]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; App state structure
+
+(defn create-app
+  "Create a TUI application from a config map.
+
+   Config:
+   - :init          - (fn [] model)
+   - :update        - (fn [model msg] model')
+   - :view          - (fn [model [cols rows]] cell-buffer)
+   - :subscriptions - (fn [dispatch-fn] cleanup-fn) -- optional
+   - :screen        - IScreen implementation (optional, auto-created if nil)
+   - :fps           - Target frame rate for external messages (default 1)
+
+   Returns an atom holding the app state."
+  [{:keys [init update view subscriptions screen fps]
+    :or {fps 1}}]
+  (atom {:model          (init)
+         :update-fn      update
+         :view-fn        view
+         :subscriptions  subscriptions
+         :screen         (or screen (screen/create-screen))
+         :fps            fps
+         :running?       false
+         :input-thread   nil
+         :unsub-fn       nil
+         :prev-buffer    nil
+         :render-pending (atom false)}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rendering
+
+(defn render!
+  "Render the current model to screen. Only writes changed cells."
+  [app-state]
+  (let [{:keys [model view-fn screen]} app-state
+        [cols rows] (screen/get-size screen)
+        new-buffer (view-fn model [cols rows])]
+    (screen/clear! screen)
+    ;; Write all cells (Lanterna handles delta internally via refresh)
+    (doseq [row (range (min rows (count new-buffer)))
+            col (range (min cols (count (nth new-buffer row))))]
+      (let [{:keys [char fg bg bold?]} (get-in new-buffer [row col])]
+        (when char
+          (screen/put-string! screen col row (str char) fg bg (boolean bold?)))))
+    (screen/refresh! screen)
+    (assoc app-state :prev-buffer new-buffer)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Message dispatch
+
+(defn dispatch!
+  "Dispatch a message into the Elm update loop.
+   Calls update, then re-renders."
+  [app msg]
+  (swap! app (fn [state]
+               (let [new-model ((:update-fn state) (:model state) msg)]
+                 (render! (assoc state :model new-model))))))
+
+(defn get-model
+  "Get current model snapshot."
+  [app]
+  (:model @app))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Input polling thread
+
+(defn- start-input-thread!
+  "Start a daemon thread that polls for keyboard input and dispatches messages."
+  [app]
+  (let [thread (Thread.
+                (fn []
+                  (try
+                    (while (:running? @app)
+                      (let [screen (:screen @app)
+                            key (input/poll-key screen)]
+                        (if key
+                          (dispatch! app [:input key])
+                          (Thread/sleep 16)))) ; ~60Hz polling
+                    (catch InterruptedException _)
+                    (catch Exception _))))]
+    (.setDaemon thread true)
+    (.setName thread "tui-input-poll")
+    (.start thread)
+    thread))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Application lifecycle
+
+(defn start!
+  "Start the TUI application.
+   1. Enter alternate screen
+   2. Start input polling thread
+   3. Register subscriptions
+   4. Render initial view
+
+   Returns the app atom."
+  [app]
+  (let [screen (:screen @app)]
+    (screen/start-screen! screen)
+    (swap! app assoc :running? true)
+    ;; Initial render
+    (swap! app render!)
+    ;; Start input thread
+    (let [thread (start-input-thread! app)]
+      (swap! app assoc :input-thread thread))
+    ;; Register subscriptions
+    (when-let [sub-fn (:subscriptions @app)]
+      (let [unsub (sub-fn (fn [msg] (dispatch! app msg)))]
+        (swap! app assoc :unsub-fn unsub)))
+    ;; JVM shutdown hook for terminal restoration
+    (.addShutdownHook (Runtime/getRuntime)
+                      (Thread. (fn []
+                                 (try
+                                   (screen/stop-screen! screen)
+                                   (catch Exception _)))))
+    app))
+
+(defn stop!
+  "Stop the TUI application.
+   1. Unregister subscriptions
+   2. Stop input thread
+   3. Exit alternate screen
+
+   Safe to call multiple times."
+  [app]
+  (when (:running? @app)
+    (swap! app assoc :running? false)
+    ;; Unsubscribe
+    (when-let [unsub (:unsub-fn @app)]
+      (try (unsub) (catch Exception _)))
+    ;; Stop input thread
+    (when-let [thread (:input-thread @app)]
+      (.interrupt thread))
+    ;; Restore terminal
+    (try
+      (screen/stop-screen! (:screen @app))
+      (catch Exception _))
+    (swap! app assoc :unsub-fn nil :input-thread nil)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Minimal app example
+  (def my-app
+    (create-app
+     {:init   (fn [] {:count 0})
+      :update (fn [model msg]
+                (case (first msg)
+                  :input (let [key (second msg)]
+                           (case key
+                             :key/j (update model :count inc)
+                             :key/k (update model :count dec)
+                             model))
+                  model))
+      :view   (fn [model [cols rows]]
+                (layout/text [cols rows]
+                             (str "Count: " (:count model))))}))
+
+  (start! my-app)
+  ;; Press j/k to increment/decrement
+  (stop! my-app)
+
+  :leave-this-here)

--- a/components/tui-engine/src/ai/miniforge/tui_engine/input.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/input.clj
@@ -1,0 +1,88 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.input
+  "Key event parsing -- normalizes raw Lanterna key events into
+   semantic message keywords for the Elm update loop.
+
+   Raw Lanterna events are maps like {:type :character :char \\j}.
+   This module translates them into normalized TUI messages like :key/j, :key/enter, etc."
+  (:require
+   [ai.miniforge.tui-engine.screen :as screen]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Key normalization
+
+(def ^:private char-key-map
+  "Map single characters to semantic key names."
+  {\j     :key/j
+   \k     :key/k
+   \h     :key/h
+   \l     :key/l
+   \g     :key/g
+   \G     :key/G
+   \q     :key/q
+   \1     :key/d1
+   \2     :key/d2
+   \3     :key/d3
+   \4     :key/d4
+   \5     :key/d5
+   \/     :key/slash
+   \:     :key/colon
+   \space :key/space
+   \tab   :key/tab
+   \?     :key/question})
+
+(defn normalize-key
+  "Convert a raw Lanterna key event map to a normalized keyword message.
+
+   Returns a keyword like :key/j, :key/enter, :key/escape, or
+   {:type :char :char c} for unmapped characters."
+  [raw-event]
+  (when raw-event
+    (case (:type raw-event)
+      :character
+      (let [ch (:char raw-event)]
+        (or (get char-key-map ch)
+            {:type :char :char ch}))
+
+      :enter     :key/enter
+      :escape    :key/escape
+      :backspace :key/backspace
+      :arrow-up  :key/up
+      :arrow-down :key/down
+      :arrow-left :key/left
+      :arrow-right :key/right
+      :tab       :key/tab
+      :eof       :key/eof
+
+      ;; Unknown key type
+      nil)))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Input polling
+
+(defn poll-key
+  "Poll the screen for a key event and normalize it.
+   Returns a normalized key message or nil if no input."
+  [screen]
+  (normalize-key (screen/poll-input screen)))
+
+(defn drain-keys
+  "Drain all pending key events from the screen. Returns vector of normalized keys."
+  [screen]
+  (loop [keys []]
+    (if-let [k (poll-key screen)]
+      (recur (conj keys k))
+      keys)))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/interface.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/interface.clj
@@ -1,0 +1,90 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.interface
+  "Public API for the TUI engine component.
+
+   Provides a terminal-agnostic Elm-architecture TUI framework:
+   - create-app  : Define an application with init/update/view/subscriptions
+   - start!      : Launch the TUI (enters alternate screen, starts input loop)
+   - stop!       : Shut down the TUI (restores terminal)
+   - dispatch!   : Send a message into the update loop
+   - get-model   : Read current application model
+
+   The engine is domain-agnostic -- it knows nothing about workflows,
+   agents, or events. Those are wired in via the tui-views component."
+  (:require
+   [ai.miniforge.tui-engine.core :as core]
+   [ai.miniforge.tui-engine.screen :as screen]
+   [ai.miniforge.tui-engine.input :as input]
+   [ai.miniforge.tui-engine.style :as style]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Application lifecycle
+
+(defn create-app
+  "Create a TUI application.
+
+   config map:
+   - :init          - (fn [] model) -- returns initial model state
+   - :update        - (fn [model msg] model') -- pure state transition
+   - :view          - (fn [model size] render-tree) -- pure render function
+   - :subscriptions - (fn [app] unsub-fn) -- registers external msg sources
+   - :screen        - Optional: IScreen instance (for testing with MockScreen)
+
+   Returns: app atom suitable for start!, stop!, dispatch!."
+  [config]
+  (core/create-app config))
+
+(defn start!
+  "Start the TUI application.
+   Enters alternate screen, starts input polling, renders initial view.
+   Returns the app atom."
+  [app]
+  (core/start! app))
+
+(defn stop!
+  "Stop the TUI application.
+   Unregisters subscriptions, stops input polling, exits alternate screen.
+   Safe to call multiple times."
+  [app]
+  (core/stop! app))
+
+(defn dispatch!
+  "Dispatch a message to the application's update function.
+   The message flows through: update -> view -> render."
+  [app msg]
+  (core/dispatch! app msg))
+
+(defn get-model
+  "Get the current application model (read-only snapshot)."
+  [app]
+  (core/get-model app))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Re-exports for convenience
+
+;; Screen
+(def create-screen screen/create-screen)
+(def create-mock-screen screen/create-mock-screen)
+(def mock-enqueue-input! screen/mock-enqueue-input!)
+(def mock-get-cells screen/mock-get-cells)
+(def mock-read-line screen/mock-read-line)
+
+;; Style
+(def default-theme style/default-theme)
+(def resolve-style style/resolve-style)
+
+;; Input
+(def normalize-key input/normalize-key)

--- a/components/tui-engine/src/ai/miniforge/tui_engine/interface/layout.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/interface/layout.clj
@@ -1,0 +1,41 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.interface.layout
+  "Public layout API for tui-engine.
+
+   Re-exports layout primitives so that consuming components can depend
+   on the interface boundary rather than internal namespaces."
+  (:require
+   [ai.miniforge.tui-engine.layout :as layout]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Cell buffer operations
+
+(def empty-cell layout/empty-cell)
+(def make-buffer layout/make-buffer)
+(def buf-put-char layout/buf-put-char)
+(def buf-put-string layout/buf-put-string)
+(def blit layout/blit)
+(def buf->strings layout/buf->strings)
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Layout primitives
+
+(def text layout/text)
+(def box layout/box)
+(def split-h layout/split-h)
+(def split-v layout/split-v)
+(def table layout/table)
+(def pad layout/pad)

--- a/components/tui-engine/src/ai/miniforge/tui_engine/interface/widget.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/interface/widget.clj
@@ -1,0 +1,32 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.interface.widget
+  "Public widget API for tui-engine.
+
+   Re-exports composite widgets so that consuming components can depend
+   on the interface boundary rather than internal namespaces."
+  (:require
+   [ai.miniforge.tui-engine.widget :as widget]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Widgets
+
+(def status-indicator widget/status-indicator)
+(def status-text widget/status-text)
+(def progress-bar widget/progress-bar)
+(def tree widget/tree)
+(def kanban widget/kanban)
+(def scrollable widget/scrollable)
+(def sparkline widget/sparkline)

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout.clj
@@ -1,0 +1,290 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.layout
+  "Layout primitives for TUI rendering.
+
+   Each function takes a size [cols rows] and options, returning a cell buffer --
+   a 2D vector of {:char :fg :bg :bold?} maps. These buffers compose via
+   split-h/split-v to build full screen layouts.
+
+   Layout functions are pure -- they take data and return data. No side effects."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Cell buffer operations
+
+(def empty-cell {:char \space :fg :white :bg :black :bold? false})
+
+(defn make-buffer
+  "Create an empty cell buffer of [cols rows]."
+  [[cols rows]]
+  (vec (repeat rows (vec (repeat cols empty-cell)))))
+
+(defn buf-put-char
+  "Put a single character at [col row] in buffer."
+  [buf col row cell]
+  (if (and (< row (count buf))
+           (>= row 0)
+           (< col (count (first buf)))
+           (>= col 0))
+    (assoc-in buf [row col] cell)
+    buf))
+
+(defn buf-put-string
+  "Write a string into the buffer at [col row] with given style."
+  [buf col row text {:keys [fg bg bold?] :or {fg :white bg :black bold? false}}]
+  (reduce (fn [b i]
+            (if (< (+ col i) (count (first b)))
+              (buf-put-char b (+ col i) row
+                            {:char (.charAt text i) :fg fg :bg bg :bold? bold?})
+              b))
+          buf
+          (range (count text))))
+
+(defn blit
+  "Copy source buffer onto dest buffer at [col row] offset."
+  [dest src col row]
+  (reduce (fn [d r]
+            (reduce (fn [d2 c]
+                      (let [cell (get-in src [r c])]
+                        (if (and cell
+                                 (< (+ row r) (count d2))
+                                 (< (+ col c) (count (first d2))))
+                          (assoc-in d2 [(+ row r) (+ col c)] cell)
+                          d2)))
+                    d
+                    (range (count (first src)))))
+          dest
+          (range (count src))))
+
+(defn buf->strings
+  "Convert a cell buffer to a vector of plain strings (for testing)."
+  [buf]
+  (mapv (fn [row] (apply str (map :char row))) buf))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Text primitives
+
+(defn- truncate-str
+  "Truncate string to max-width, adding ellipsis if truncated."
+  [s max-width]
+  (if (<= (count s) max-width)
+    s
+    (str (subs s 0 (max 0 (- max-width 1))) "…")))
+
+(defn- pad-right
+  "Pad string to width with spaces."
+  [s width]
+  (let [s (or s "")]
+    (if (>= (count s) width)
+      (subs s 0 width)
+      (str s (apply str (repeat (- width (count s)) \space))))))
+
+(defn text
+  "Render a styled text span into a buffer.
+   Truncates to fit within [cols rows]."
+  [[cols rows] content & [{:keys [fg bg bold? align]
+                            :or {fg :white bg :black bold? false align :left}}]]
+  (let [buf (make-buffer [cols rows])
+        lines (str/split-lines (or content ""))
+        lines (take rows lines)]
+    (reduce (fn [b [idx line]]
+              (let [truncated (truncate-str line cols)
+                    padded (case align
+                             :right (str (apply str (repeat (max 0 (- cols (count truncated))) \space))
+                                         truncated)
+                             :center (let [pad (max 0 (quot (- cols (count truncated)) 2))]
+                                       (str (apply str (repeat pad \space)) truncated))
+                             (pad-right truncated cols))]
+                (buf-put-string b 0 idx padded {:fg fg :bg bg :bold? bold?})))
+            buf
+            (map-indexed vector lines))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Box drawing
+
+(def ^:private box-chars
+  {:single {:tl \┌ :tr \┐ :bl \└ :br \┘ :h \─ :v \│ :lt \├ :rt \┤ :tt \┬ :bt \┴}
+   :double {:tl \╔ :tr \╗ :bl \╚ :br \╝ :h \═ :v \║ :lt \╠ :rt \╣ :tt \╦ :bt \╩}
+   :none   {:tl \space :tr \space :bl \space :br \space
+            :h \space :v \space :lt \space :rt \space :tt \space :bt \space}})
+
+(defn box
+  "Render a bordered box.
+   Options:
+   - :border - :single (default), :double, or :none
+   - :title  - Optional string for top border
+   - :fg, :bg, :bold? - Border style
+   - :content-fn - (fn [[inner-cols inner-rows]] -> cell-buffer) for box contents"
+  [[cols rows] & [{:keys [border title fg bg bold? content-fn]
+                    :or {border :single fg :default bg :black bold? false}}]]
+  (when (and (>= cols 2) (>= rows 2))
+    (let [chars (get box-chars border (:single box-chars))
+          style {:fg fg :bg bg :bold? bold?}
+          buf (make-buffer [cols rows])
+          ;; Top border
+          top-line (str (:tl chars)
+                        (if title
+                          (let [t (truncate-str title (- cols 4))
+                                remaining (- cols 2 (count t) 2)]
+                            (str (:h chars) t (apply str (repeat (max 0 (+ remaining 1)) (:h chars)))))
+                          (apply str (repeat (- cols 2) (:h chars))))
+                        (:tr chars))
+          ;; Bottom border
+          bot-line (str (:bl chars) (apply str (repeat (- cols 2) (:h chars))) (:br chars))
+          buf (buf-put-string buf 0 0 top-line style)
+          buf (buf-put-string buf 0 (dec rows) bot-line style)
+          ;; Side borders
+          buf (reduce (fn [b r]
+                        (-> b
+                            (buf-put-char 0 r (assoc style :char (:v chars)))
+                            (buf-put-char (dec cols) r (assoc style :char (:v chars)))))
+                      buf
+                      (range 1 (dec rows)))]
+      (if content-fn
+        (let [inner-cols (- cols 2)
+              inner-rows (- rows 2)
+              content (content-fn [inner-cols inner-rows])]
+          (blit buf content 1 1))
+        buf))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Split layouts
+
+(defn split-h
+  "Split horizontally into left/right panes.
+   ratio is the fraction [0.0, 1.0] for the left pane.
+   left-fn, right-fn: (fn [[cols rows]] -> cell-buffer)"
+  [[cols rows] ratio left-fn right-fn]
+  (let [left-cols (max 1 (int (* cols ratio)))
+        right-cols (- cols left-cols)
+        left-buf (left-fn [left-cols rows])
+        right-buf (right-fn [right-cols rows])
+        buf (make-buffer [cols rows])]
+    (-> buf
+        (blit left-buf 0 0)
+        (blit right-buf left-cols 0))))
+
+(defn split-v
+  "Split vertically into top/bottom panes.
+   ratio is the fraction [0.0, 1.0] for the top pane.
+   top-fn, bottom-fn: (fn [[cols rows]] -> cell-buffer)"
+  [[cols rows] ratio top-fn bottom-fn]
+  (let [top-rows (max 1 (int (* rows ratio)))
+        bottom-rows (- rows top-rows)
+        top-buf (top-fn [cols top-rows])
+        bottom-buf (bottom-fn [cols bottom-rows])
+        buf (make-buffer [cols rows])]
+    (-> buf
+        (blit top-buf 0 0)
+        (blit bottom-buf 0 top-rows))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Table
+
+(defn- compute-col-widths
+  "Compute column widths from specs. Fixed :width honored, remainder distributed."
+  [col-specs total-width]
+  (let [fixed-used (reduce + 0 (keep :width col-specs))
+        flex-count (count (remove :width col-specs))
+        flex-each (if (pos? flex-count)
+                    (max 1 (quot (- total-width fixed-used) flex-count))
+                    0)]
+    (mapv (fn [spec] (or (:width spec) flex-each)) col-specs)))
+
+(defn table
+  "Render a table with column headers and data rows.
+   Options:
+   - :columns - vector of {:key kw, :header str, :width int (opt), :align :left/:right/:center}
+   - :rows    - vector of maps keyed by column :key
+   - :selected-row - index of highlighted row (nil for none)
+   - :header-fg, :header-bg - Header style
+   - :row-fg, :row-bg - Default row style
+   - :selected-fg, :selected-bg - Selected row style"
+  [[cols rows] & [{:keys [columns data selected-row
+                           header-fg header-bg row-fg row-bg selected-fg selected-bg]
+                    :or {header-fg :cyan header-bg :black
+                         row-fg :white row-bg :black
+                         selected-fg :white selected-bg :blue}}]]
+  (let [col-widths (compute-col-widths columns cols)
+        buf (make-buffer [cols rows])
+        ;; Render header
+        buf (reduce (fn [b [idx {:keys [header]} width]]
+                      (let [txt (pad-right (truncate-str (or header "") width) width)]
+                        (buf-put-string b
+                                        (reduce + 0 (take idx col-widths))
+                                        0 txt
+                                        {:fg header-fg :bg header-bg :bold? true})))
+                    buf
+                    (map vector (range) columns col-widths))
+        ;; Render separator
+        buf (if (>= rows 2)
+              (buf-put-string buf 0 1
+                              (apply str (repeat cols \─))
+                              {:fg :default :bg :black :bold? false})
+              buf)
+        ;; Render data rows
+        visible-rows (take (max 0 (- rows 2)) (or data []))
+        buf (reduce (fn [b [row-idx row-data]]
+                      (let [selected? (= row-idx selected-row)
+                            fg (if selected? selected-fg row-fg)
+                            bg (if selected? selected-bg row-bg)
+                            render-row (+ row-idx 2)]
+                        (if (>= render-row rows)
+                          (reduced b)
+                          (reduce (fn [b2 [col-idx {:keys [key]} width]]
+                                    (let [val (str (get row-data key ""))
+                                          txt (pad-right (truncate-str val width) width)]
+                                      (buf-put-string b2
+                                                      (reduce + 0 (take col-idx col-widths))
+                                                      render-row txt
+                                                      {:fg fg :bg bg :bold? false})))
+                                  b
+                                  (map vector (range) columns col-widths)))))
+                    buf
+                    (map-indexed vector visible-rows))]
+    buf))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Padding
+
+(defn pad
+  "Add padding around a content-fn's output.
+   padding: [top right bottom left] or single int for all sides."
+  [[cols rows] padding content-fn]
+  (let [[pt pr pb pl] (if (vector? padding)
+                         padding
+                         [padding padding padding padding])
+        inner-cols (max 0 (- cols pl pr))
+        inner-rows (max 0 (- rows pt pb))
+        inner-buf (content-fn [inner-cols inner-rows])
+        buf (make-buffer [cols rows])]
+    (blit buf inner-buf pl pt)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Quick layout test
+  (buf->strings (text [20 1] "Hello, world!"))
+  ;; => ["Hello, world!       "]
+
+  (buf->strings (box [20 5] {:title "Test" :border :single}))
+  ;; => ["┌─Test──────────────┐"
+  ;;     "│                  │"
+  ;;     "│                  │"
+  ;;     "│                  │"
+  ;;     "└──────────────────┘"]
+
+  :leave-this-here)

--- a/components/tui-engine/src/ai/miniforge/tui_engine/screen.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/screen.clj
@@ -1,0 +1,105 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.screen
+  "Screen protocol and mock implementation for TUI rendering.
+
+   The protocol defines the terminal abstraction. MockScreen is pure Clojure
+   for testing. LanternaScreen is loaded dynamically via create-screen to
+   avoid Java class loading in Babashka/GraalVM contexts.")
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Screen protocol
+
+(defprotocol IScreen
+  "Abstraction over terminal screen for rendering and input.
+   Implementations: LanternaScreen (real terminal), MockScreen (testing)."
+  (start-screen! [this] "Enter alternate screen mode.")
+  (stop-screen! [this] "Exit alternate screen mode, restore terminal.")
+  (get-size [this] "Return [cols rows].")
+  (put-string! [this col row text fg bg bold?] "Write styled string at position.")
+  (clear! [this] "Clear the screen buffer.")
+  (refresh! [this] "Flush buffer to terminal (delta rendering).")
+  (poll-input [this] "Non-blocking read. Returns key map or nil."))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Mock screen for testing
+
+(defrecord MockScreen [state]
+  ;; state is an atom: {:started? bool, :cells {[col row] {:char :fg :bg :bold?}}, :size [c r]}
+  IScreen
+  (start-screen! [_]
+    (swap! state assoc :started? true))
+
+  (stop-screen! [_]
+    (swap! state assoc :started? false))
+
+  (get-size [_]
+    (:size @state))
+
+  (put-string! [_ col row text fg bg bold?]
+    (doseq [i (range (count text))]
+      (swap! state assoc-in [:cells [(+ col i) row]]
+             {:char (.charAt text i) :fg fg :bg bg :bold? bold?})))
+
+  (clear! [_]
+    (swap! state assoc :cells {}))
+
+  (refresh! [_]
+    (swap! state update :refresh-count (fnil inc 0)))
+
+  (poll-input [_]
+    (let [s @state]
+      (when-let [input (first (:input-queue s))]
+        (swap! state update :input-queue rest)
+        input))))
+
+(defn create-mock-screen
+  "Create a mock screen for testing. Takes [cols rows] size."
+  [[cols rows]]
+  (->MockScreen (atom {:started? false
+                        :cells {}
+                        :size [cols rows]
+                        :refresh-count 0
+                        :input-queue []})))
+
+(defn mock-enqueue-input!
+  "Enqueue input events for a mock screen."
+  [mock-screen events]
+  (swap! (:state mock-screen) update :input-queue concat events))
+
+(defn mock-get-cells
+  "Get cell map from mock screen."
+  [mock-screen]
+  (:cells @(:state mock-screen)))
+
+(defn mock-read-line
+  "Read a line of text from mock screen at row. Returns string."
+  [mock-screen row cols]
+  (let [cells (mock-get-cells mock-screen)]
+    (apply str (for [c (range cols)]
+                 (if-let [cell (get cells [c row])]
+                   (:char cell)
+                   \space)))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Factory (dynamically loads Lanterna)
+
+(defn create-screen
+  "Create a Lanterna terminal screen.
+   Dynamically loads the Lanterna implementation to avoid Java class loading
+   at namespace load time (required for Babashka/GraalVM compatibility)."
+  [& [opts]]
+  (let [create-fn (requiring-resolve 'ai.miniforge.tui-engine.screen.lanterna/create-lanterna-screen)]
+    (create-fn opts)))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
@@ -1,0 +1,125 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.screen.lanterna
+  "Lanterna Screen implementation.
+
+   Loaded dynamically by screen/create-screen to avoid Java class loading
+   at namespace load time (required for Babashka/GraalVM compatibility)."
+  (:require
+   [ai.miniforge.tui-engine.screen :as screen])
+  (:import
+   [com.googlecode.lanterna TextCharacter TextColor$ANSI]
+   [com.googlecode.lanterna.screen TerminalScreen]
+   [com.googlecode.lanterna.terminal DefaultTerminalFactory]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Color mapping
+
+(def ^:private color-map
+  "Map from keyword colors to Lanterna TextColor.ANSI constants."
+  {:black   TextColor$ANSI/BLACK
+   :red     TextColor$ANSI/RED
+   :green   TextColor$ANSI/GREEN
+   :yellow  TextColor$ANSI/YELLOW
+   :blue    TextColor$ANSI/BLUE
+   :magenta TextColor$ANSI/MAGENTA
+   :cyan    TextColor$ANSI/CYAN
+   :white   TextColor$ANSI/WHITE
+   :default TextColor$ANSI/DEFAULT})
+
+(defn- resolve-lanterna-color [kw]
+  (get color-map kw TextColor$ANSI/DEFAULT))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Lanterna implementation
+
+(defrecord LanternaScreen [^TerminalScreen screen]
+  screen/IScreen
+  (start-screen! [_]
+    (.startScreen screen))
+
+  (stop-screen! [_]
+    (.stopScreen screen))
+
+  (get-size [_]
+    (let [size (.getTerminalSize screen)]
+      [(.getColumns size) (.getRows size)]))
+
+  (put-string! [_ col row text fg bg bold?]
+    (let [fg-color (resolve-lanterna-color fg)
+          bg-color (resolve-lanterna-color bg)]
+      (doseq [i (range (count text))]
+        (let [ch (.charAt text i)
+              tc (if bold?
+                   (TextCharacter. ch fg-color bg-color
+                                   (into-array com.googlecode.lanterna.SGR
+                                               [com.googlecode.lanterna.SGR/BOLD]))
+                   (TextCharacter. ch fg-color bg-color
+                                   (into-array com.googlecode.lanterna.SGR [])))]
+          (.setCharacter screen (+ col i) row tc)))))
+
+  (clear! [_]
+    (.clear screen))
+
+  (refresh! [_]
+    (.refresh screen))
+
+  (poll-input [_]
+    (when-let [key (.pollInput screen)]
+      (let [kind (.getKeyType key)]
+        (cond
+          (= kind com.googlecode.lanterna.input.KeyType/Character)
+          {:type :character :char (.getCharacter key)}
+
+          (= kind com.googlecode.lanterna.input.KeyType/Enter)
+          {:type :enter}
+
+          (= kind com.googlecode.lanterna.input.KeyType/Escape)
+          {:type :escape}
+
+          (= kind com.googlecode.lanterna.input.KeyType/Backspace)
+          {:type :backspace}
+
+          (= kind com.googlecode.lanterna.input.KeyType/ArrowUp)
+          {:type :arrow-up}
+
+          (= kind com.googlecode.lanterna.input.KeyType/ArrowDown)
+          {:type :arrow-down}
+
+          (= kind com.googlecode.lanterna.input.KeyType/ArrowLeft)
+          {:type :arrow-left}
+
+          (= kind com.googlecode.lanterna.input.KeyType/ArrowRight)
+          {:type :arrow-right}
+
+          (= kind com.googlecode.lanterna.input.KeyType/Tab)
+          {:type :tab}
+
+          (= kind com.googlecode.lanterna.input.KeyType/EOF)
+          {:type :eof}
+
+          :else
+          {:type :unknown :raw (str kind)})))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Factory
+
+(defn create-lanterna-screen
+  "Create a Lanterna terminal screen."
+  [_opts]
+  (let [factory (DefaultTerminalFactory.)
+        terminal (.createTerminal factory)
+        screen (TerminalScreen. terminal)]
+    (->LanternaScreen screen)))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/style.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/style.clj
@@ -1,0 +1,123 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.style
+  "Theme data and color resolution for TUI rendering.
+
+   Provides a theme system with ANSI-256 color fallback.
+   Auto-detects terminal capabilities via $TERM_PROGRAM.
+
+   Themes are pure data maps -- no side effects.")
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Terminal detection
+
+(defn detect-terminal
+  "Detect terminal type from environment.
+   Returns :iterm2, :terminal-app, :tmux, :screen, or :unknown."
+  []
+  (let [term-program (System/getenv "TERM_PROGRAM")
+        term         (System/getenv "TERM")]
+    (cond
+      (= term-program "iTerm.app")  :iterm2
+      (= term-program "Apple_Terminal") :terminal-app
+      (some? (System/getenv "TMUX")) :tmux
+      (= term "screen")             :screen
+      :else                          :unknown)))
+
+(defn color-depth
+  "Return color depth for terminal: :true-color, :256, or :16."
+  []
+  (let [colorterm (System/getenv "COLORTERM")
+        terminal  (detect-terminal)]
+    (cond
+      (or (= colorterm "truecolor")
+          (= colorterm "24bit")
+          (= terminal :iterm2))       :true-color
+      (= terminal :terminal-app)      :256
+      :else                            :256)))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; ANSI named colors -> Lanterna color keywords
+
+(def named-colors
+  "ANSI named color palette."
+  {:black   :black
+   :red     :red
+   :green   :green
+   :yellow  :yellow
+   :blue    :blue
+   :magenta :magenta
+   :cyan    :cyan
+   :white   :white
+   :default :default})
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Theme definition
+
+(def default-theme
+  "Default dark theme for miniforge TUI."
+  {;; Base colors
+   :bg              :black
+   :fg              :white
+   :fg-dim          :default
+
+   ;; Status indicators
+   :status/running  :cyan
+   :status/success  :green
+   :status/failed   :red
+   :status/blocked  :yellow
+   :status/pending  :default
+   :status/skipped  :default
+
+   ;; UI chrome
+   :border          :default
+   :border-focus    :cyan
+   :title           :white
+   :title-focus     :cyan
+   :header          :cyan
+   :selected-bg     :blue
+   :selected-fg     :white
+
+   ;; Progress
+   :progress-fill   :cyan
+   :progress-empty  :default
+
+   ;; Kanban columns
+   :kanban/blocked  :red
+   :kanban/pending  :yellow
+   :kanban/running  :cyan
+   :kanban/done     :green
+
+   ;; Sparkline
+   :sparkline       :cyan
+
+   ;; Command / search bar
+   :command-bg      :default
+   :command-fg      :white
+   :search-match    :yellow})
+
+(defn resolve-color
+  "Resolve a theme key to a Lanterna-compatible color keyword.
+   Falls back to :default if not found."
+  [theme key]
+  (get theme key :default))
+
+(defn resolve-style
+  "Resolve a style map {:fg theme-key :bg theme-key :bold? bool} against a theme.
+   Returns {:fg color :bg color :bold? bool}."
+  [theme {:keys [fg bg bold?] :or {fg :fg bg :bg bold? false}}]
+  {:fg     (resolve-color theme fg)
+   :bg     (resolve-color theme bg)
+   :bold?  bold?})

--- a/components/tui-engine/src/ai/miniforge/tui_engine/widget.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/widget.clj
@@ -1,0 +1,264 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.widget
+  "Composite TUI widgets built on layout primitives.
+
+   Each widget is a pure function: (widget-fn [cols rows] opts) -> cell-buffer.
+   Widgets compose with layout/blit and layout/split-h/v."
+  (:require
+   [ai.miniforge.tui-engine.layout :as layout]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Status indicators
+
+(def ^:private status-chars
+  {:running  \●
+   :success  \✓
+   :failed   \✗
+   :blocked  \◐
+   :pending  \○
+   :skipped  \─
+   :spinning \⟳})
+
+(def ^:private status-colors
+  {:running  :cyan
+   :success  :green
+   :failed   :red
+   :blocked  :yellow
+   :pending  :default
+   :skipped  :default
+   :spinning :cyan})
+
+(defn status-indicator
+  "Render a single status indicator character with color.
+   Returns a 1-cell buffer."
+  [status]
+  (let [ch (get status-chars status \?)
+        fg (get status-colors status :white)]
+    (layout/text [1 1] (str ch) {:fg fg})))
+
+(defn status-text
+  "Render a status indicator followed by label text.
+   Returns a buffer of [cols 1]."
+  [[cols _rows] status label]
+  (let [ch (get status-chars status \?)
+        fg (get status-colors status :white)
+        buf (layout/make-buffer [cols 1])
+        buf (layout/buf-put-char buf 0 0 {:char ch :fg fg :bg :black :bold? false})]
+    (if (> cols 2)
+      (layout/buf-put-string buf 2 0 (subs label 0 (min (count label) (- cols 2)))
+                             {:fg :white :bg :black :bold? false})
+      buf)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Progress bar
+
+(def ^:private bar-chars
+  "Sub-cell progress bar characters (eighths)."
+  [\space \▏ \▎ \▍ \▌ \▋ \▊ \▉ \█])
+
+(defn progress-bar
+  "Render a progress bar.
+   Options:
+   - :percent   - 0-100
+   - :fill-fg   - Color for filled portion (default :cyan)
+   - :empty-fg  - Color for empty portion (default :default)
+   - :show-pct? - Show percentage text (default true)"
+  [[cols _rows] & [{:keys [percent fill-fg empty-fg show-pct?]
+                     :or {percent 0 fill-fg :cyan empty-fg :default show-pct? true}}]]
+  (let [pct (max 0 (min 100 percent))
+        label (when show-pct? (str " " pct "%"))
+        bar-width (max 1 (- cols (if label (count label) 0)))
+        filled-cells (/ (* pct bar-width) 100.0)
+        full-cells (int filled-cells)
+        frac (- filled-cells full-cells)
+        frac-idx (int (* frac 8))
+        buf (layout/make-buffer [cols 1])
+        ;; Fill complete cells
+        buf (reduce (fn [b i]
+                      (layout/buf-put-char b i 0
+                                           {:char \█ :fg fill-fg :bg :black :bold? false}))
+                    buf (range (min full-cells bar-width)))
+        ;; Fractional cell
+        buf (if (and (< full-cells bar-width) (pos? frac-idx))
+              (layout/buf-put-char buf full-cells 0
+                                   {:char (nth bar-chars frac-idx)
+                                    :fg fill-fg :bg :black :bold? false})
+              buf)
+        ;; Empty cells
+        buf (reduce (fn [b i]
+                      (layout/buf-put-char b i 0
+                                           {:char \░ :fg empty-fg :bg :black :bold? false}))
+                    buf
+                    (range (if (pos? frac-idx) (inc full-cells) full-cells)
+                           bar-width))
+        ;; Percentage label
+        buf (if label
+              (layout/buf-put-string buf bar-width 0 label
+                                     {:fg :white :bg :black :bold? false})
+              buf)]
+    buf))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Tree view
+
+(defn tree
+  "Render a tree with expand/collapse.
+   Options:
+   - :nodes    - flat vector of {:label str :depth int :expandable? bool}
+   - :expanded - set of indices that are expanded
+   - :selected - index of selected node
+   - :fg, :selected-fg, :selected-bg - colors"
+  [[cols rows] & [{:keys [nodes expanded selected fg selected-fg selected-bg]
+                    :or {expanded #{} selected 0 fg :white
+                         selected-fg :white selected-bg :blue}}]]
+  (let [buf (layout/make-buffer [cols rows])
+        visible (take rows (or nodes []))]
+    (reduce (fn [b [idx {:keys [label depth expandable?]}]]
+              (let [sel? (= idx selected)
+                    indent (* 2 (or depth 0))
+                    icon (cond
+                           (and expandable? (contains? expanded idx)) "▼ "
+                           expandable? "▸ "
+                           :else "  ")
+                    text (str (apply str (repeat indent \space)) icon (or label ""))
+                    text (subs text 0 (min (count text) cols))]
+                (layout/buf-put-string b 0 idx text
+                                       {:fg (if sel? selected-fg fg)
+                                        :bg (if sel? selected-bg :black)
+                                        :bold? sel?})))
+            buf
+            (map-indexed vector visible))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Kanban columns
+
+(defn kanban
+  "Render kanban-style columns.
+   Options:
+   - :columns - [{:title str :color kw :cards [{:label str :status kw}]}]
+   Each column gets equal width."
+  [[cols rows] & [{:keys [columns]}]]
+  (let [n (max 1 (count (or columns [])))
+        col-width (max 4 (quot cols n))
+        buf (layout/make-buffer [cols rows])]
+    (reduce (fn [b [idx {:keys [title color cards]}]]
+              (let [x-offset (* idx col-width)
+                    avail-w (min col-width (- cols x-offset))
+                    ;; Header
+                    header (subs (str " " title (apply str (repeat avail-w \space)))
+                                 0 (min avail-w (+ (count title) 2)))
+                    b (layout/buf-put-string b x-offset 0 header
+                                             {:fg (or color :white) :bg :black :bold? true})
+                    ;; Separator
+                    b (if (>= rows 2)
+                        (layout/buf-put-string b x-offset 1
+                                               (apply str (repeat avail-w \─))
+                                               {:fg :default :bg :black :bold? false})
+                        b)]
+                ;; Cards
+                (reduce (fn [b2 [card-idx {:keys [label status]}]]
+                          (let [r (+ card-idx 2)]
+                            (if (>= r rows) (reduced b2)
+                                (let [indicator (get status-chars status \○)
+                                      line (str indicator " " (subs label 0 (min (count label) (- avail-w 2))))
+                                      line (subs line 0 (min (count line) avail-w))]
+                                  (layout/buf-put-string b2 x-offset r line
+                                                         {:fg (get status-colors status :white)
+                                                          :bg :black :bold? false})))))
+                        b
+                        (map-indexed vector (or cards [])))))
+            buf
+            (map-indexed vector (or columns [])))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Scrollable viewport
+
+(defn scrollable
+  "Render a scrollable viewport with scrollbar.
+   Options:
+   - :lines   - vector of strings (total content)
+   - :offset  - scroll offset (first visible line index)
+   - :fg, :bg - colors"
+  [[cols rows] & [{:keys [lines offset fg bg]
+                    :or {offset 0 fg :white bg :black}}]]
+  (let [total (count (or lines []))
+        content-w (max 1 (- cols 1)) ; 1 col for scrollbar
+        visible (take rows (drop offset (or lines [])))
+        buf (layout/make-buffer [cols rows])
+        ;; Render visible lines
+        buf (reduce (fn [b [idx line]]
+                      (let [truncated (subs line 0 (min (count line) content-w))]
+                        (layout/buf-put-string b 0 idx truncated
+                                               {:fg fg :bg bg :bold? false})))
+                    buf
+                    (map-indexed vector visible))
+        ;; Scrollbar
+        scroll-col (dec cols)
+        bar-height (if (pos? total)
+                     (max 1 (int (* rows (/ (min rows total) total))))
+                     rows)
+        bar-top (if (and (pos? total) (> total rows))
+                  (int (* (- rows bar-height) (/ offset (- total rows))))
+                  0)]
+    (reduce (fn [b r]
+              (let [in-bar? (and (>= r bar-top) (< r (+ bar-top bar-height)))
+                    ch (if in-bar? \▮ \│)]
+                (layout/buf-put-char b scroll-col r
+                                     {:char ch :fg :default :bg bg :bold? false})))
+            buf
+            (range rows))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Sparkline
+
+(def ^:private braille-chars
+  "Braille characters for sparkline (8 vertical levels)."
+  [\⠀ \⡀ \⡄ \⡆ \⡇ \⣇ \⣧ \⣷ \⣿])
+
+(defn sparkline
+  "Render a braille-based sparkline.
+   Options:
+   - :values - vector of numbers
+   - :fg     - color (default :cyan)"
+  [[cols _rows] & [{:keys [values fg] :or {fg :cyan}}]]
+  (let [vals (or values [])
+        ;; Take last `cols` values
+        visible (if (> (count vals) cols)
+                  (subvec vals (- (count vals) cols))
+                  vals)
+        max-val (if (seq visible) (apply max visible) 1)
+        max-val (if (zero? max-val) 1 max-val)
+        buf (layout/make-buffer [cols 1])]
+    (reduce (fn [b [idx v]]
+              (let [level (int (* 8 (/ v max-val)))
+                    level (max 0 (min 8 level))
+                    ch (nth braille-chars level)]
+                (layout/buf-put-char b idx 0
+                                     {:char ch :fg fg :bg :black :bold? false})))
+            buf
+            (map-indexed vector visible))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (layout/buf->strings (progress-bar [20 1] {:percent 40}))
+  ;; => ["████████░░░░░░░░ 40%"]
+
+  (layout/buf->strings (status-text [20 1] :running "Generating code"))
+  ;; => ["● Generating code   "]
+
+  (layout/buf->strings (sparkline [10 1] {:values [1 3 5 2 8 4 6 9 3 7]}))
+
+  :leave-this-here)

--- a/components/tui-engine/test/ai/miniforge/tui_engine/core_test.clj
+++ b/components/tui-engine/test/ai/miniforge/tui_engine/core_test.clj
@@ -1,0 +1,105 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.core-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-engine.core :as core]
+   [ai.miniforge.tui-engine.screen :as screen]
+   [ai.miniforge.tui-engine.layout :as layout]))
+
+(defn- test-app
+  "Create a minimal test app with mock screen."
+  []
+  (let [mock (screen/create-mock-screen [40 10])]
+    (core/create-app
+     {:init   (fn [] {:count 0 :messages []})
+      :update (fn [model msg]
+                (-> model
+                    (update :messages conj msg)
+                    (cond->
+                      (= msg [:input :key/j]) (update :count inc)
+                      (= msg [:input :key/k]) (update :count dec))))
+      :view   (fn [model [cols rows]]
+                (layout/text [cols rows]
+                             (str "Count: " (:count model))))
+      :screen mock})))
+
+(deftest create-app-test
+  (testing "App initializes with model from init fn"
+    (let [app (test-app)]
+      (is (= 0 (:count (core/get-model app))))
+      (is (= [] (:messages (core/get-model app)))))))
+
+(deftest dispatch-test
+  (testing "Dispatch calls update and re-renders"
+    (let [app (test-app)]
+      ;; Need to start screen for rendering to work
+      (screen/start-screen! (:screen @app))
+      (core/dispatch! app [:input :key/j])
+      (is (= 1 (:count (core/get-model app))))
+      (is (= [[:input :key/j]] (:messages (core/get-model app))))
+      (screen/stop-screen! (:screen @app))))
+
+  (testing "Multiple dispatches accumulate"
+    (let [app (test-app)]
+      (screen/start-screen! (:screen @app))
+      (core/dispatch! app [:input :key/j])
+      (core/dispatch! app [:input :key/j])
+      (core/dispatch! app [:input :key/k])
+      (is (= 1 (:count (core/get-model app))))
+      (screen/stop-screen! (:screen @app)))))
+
+(deftest view-renders-to-screen-test
+  (testing "View output appears on mock screen"
+    (let [mock (screen/create-mock-screen [40 10])
+          app (core/create-app
+               {:init   (fn [] {:label "Hello TUI"})
+                :update (fn [model _] model)
+                :view   (fn [model [cols rows]]
+                          (layout/text [cols rows] (:label model)))
+                :screen mock})]
+      (screen/start-screen! mock)
+      (swap! app core/render!)
+      (let [line (screen/mock-read-line mock 0 40)]
+        (is (str/includes? line "Hello TUI")))
+      (screen/stop-screen! mock))))
+
+(deftest get-model-returns-snapshot-test
+  (testing "get-model returns current state"
+    (let [app (test-app)]
+      (is (= {:count 0 :messages []} (core/get-model app))))))
+
+(deftest elm-loop-with-mock-input-test
+  (testing "Full Elm loop: input -> update -> view"
+    (let [mock (screen/create-mock-screen [40 10])
+          updates (atom [])
+          app (core/create-app
+               {:init   (fn [] {:value "initial"})
+                :update (fn [model msg]
+                          (swap! updates conj msg)
+                          (case (second msg)
+                            :key/j (assoc model :value "pressed-j")
+                            model))
+                :view   (fn [model [cols rows]]
+                          (layout/text [cols rows] (:value model)))
+                :screen mock})]
+      (screen/start-screen! mock)
+      (core/dispatch! app [:input :key/j])
+      (is (= "pressed-j" (:value (core/get-model app))))
+      (is (= [[:input :key/j]] @updates))
+      (let [line (screen/mock-read-line mock 0 40)]
+        (is (str/includes? line "pressed-j")))
+      (screen/stop-screen! mock))))

--- a/components/tui-engine/test/ai/miniforge/tui_engine/input_test.clj
+++ b/components/tui-engine/test/ai/miniforge/tui_engine/input_test.clj
@@ -1,0 +1,49 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.input-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-engine.input :as input]))
+
+(deftest normalize-key-test
+  (testing "Character keys map to semantic keywords"
+    (is (= :key/j (input/normalize-key {:type :character :char \j})))
+    (is (= :key/k (input/normalize-key {:type :character :char \k})))
+    (is (= :key/q (input/normalize-key {:type :character :char \q})))
+    (is (= :key/slash (input/normalize-key {:type :character :char \/})))
+    (is (= :key/colon (input/normalize-key {:type :character :char \:})))
+    (is (= :key/space (input/normalize-key {:type :character :char \space}))))
+
+  (testing "Number keys map correctly"
+    (is (= :key/d1 (input/normalize-key {:type :character :char \1})))
+    (is (= :key/d5 (input/normalize-key {:type :character :char \5}))))
+
+  (testing "Special keys map correctly"
+    (is (= :key/enter (input/normalize-key {:type :enter})))
+    (is (= :key/escape (input/normalize-key {:type :escape})))
+    (is (= :key/backspace (input/normalize-key {:type :backspace})))
+    (is (= :key/up (input/normalize-key {:type :arrow-up})))
+    (is (= :key/down (input/normalize-key {:type :arrow-down})))
+    (is (= :key/left (input/normalize-key {:type :arrow-left})))
+    (is (= :key/right (input/normalize-key {:type :arrow-right})))
+    (is (= :key/tab (input/normalize-key {:type :tab})))
+    (is (= :key/eof (input/normalize-key {:type :eof}))))
+
+  (testing "Unmapped characters return char map"
+    (let [result (input/normalize-key {:type :character :char \x})]
+      (is (= {:type :char :char \x} result))))
+
+  (testing "nil input returns nil"
+    (is (nil? (input/normalize-key nil)))))

--- a/components/tui-engine/test/ai/miniforge/tui_engine/layout_test.clj
+++ b/components/tui-engine/test/ai/miniforge/tui_engine/layout_test.clj
@@ -1,0 +1,132 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.layout-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-engine.layout :as layout]))
+
+(deftest text-test
+  (testing "Simple text rendering"
+    (let [buf (layout/text [20 1] "Hello")]
+      (is (= ["Hello               "] (layout/buf->strings buf)))))
+
+  (testing "Truncation at width boundary"
+    (let [buf (layout/text [5 1] "Hello, world!")]
+      (is (= ["Hell…"] (layout/buf->strings buf)))))
+
+  (testing "Multi-line text"
+    (let [buf (layout/text [10 3] "Line 1\nLine 2\nLine 3")]
+      (is (= ["Line 1    " "Line 2    " "Line 3    "]
+             (layout/buf->strings buf)))))
+
+  (testing "Text truncated to available rows"
+    (let [buf (layout/text [10 2] "Line 1\nLine 2\nLine 3")]
+      (is (= 2 (count (layout/buf->strings buf))))))
+
+  (testing "Right-aligned text"
+    (let [buf (layout/text [10 1] "Hi" {:align :right})]
+      (is (= ["        Hi"] (layout/buf->strings buf)))))
+
+  (testing "Center-aligned text"
+    (let [buf (layout/text [10 1] "Hi" {:align :center})]
+      (is (= ["    Hi    "] (layout/buf->strings buf))))))
+
+(deftest box-test
+  (testing "Simple box renders corners and borders"
+    (let [strings (layout/buf->strings (layout/box [10 4]))]
+      (is (= \┌ (first (first strings))))
+      (is (= \┐ (last (first strings))))
+      (is (= \└ (first (last strings))))
+      (is (= \┘ (last (last strings))))))
+
+  (testing "Box with title"
+    (let [strings (layout/buf->strings (layout/box [20 4] {:title "Test"}))]
+      (is (str/includes? (first strings) "Test"))))
+
+  (testing "Double border box"
+    (let [strings (layout/buf->strings (layout/box [10 3] {:border :double}))]
+      (is (= \╔ (first (first strings))))
+      (is (= \╗ (last (first strings))))))
+
+  (testing "Box with content"
+    (let [strings (layout/buf->strings
+                   (layout/box [12 4]
+                               {:content-fn
+                                (fn [size] (layout/text size "inner"))}))]
+      (is (str/includes? (second strings) "inner"))))
+
+  (testing "Too-small box returns nil"
+    (is (nil? (layout/box [1 1])))))
+
+(deftest split-h-test
+  (testing "Horizontal split divides columns"
+    (let [buf (layout/split-h [20 3] 0.5
+                              (fn [size] (layout/text size "LEFT"))
+                              (fn [size] (layout/text size "RIGHT")))
+          strings (layout/buf->strings buf)]
+      (is (str/includes? (first strings) "LEFT"))
+      (is (str/includes? (first strings) "RIGHT")))))
+
+(deftest split-v-test
+  (testing "Vertical split divides rows"
+    (let [buf (layout/split-v [20 4] 0.5
+                              (fn [size] (layout/text size "TOP"))
+                              (fn [size] (layout/text size "BOTTOM")))
+          strings (layout/buf->strings buf)]
+      (is (str/includes? (first strings) "TOP"))
+      (is (str/includes? (nth strings 2) "BOTTOM")))))
+
+(deftest table-test
+  (testing "Table renders headers and data"
+    (let [columns [{:key :name :header "Name" :width 10}
+                   {:key :status :header "Status" :width 8}]
+          data [{:name "workflow-1" :status "running"}
+                {:name "workflow-2" :status "done"}]
+          buf (layout/table [18 6] {:columns columns :data data})
+          strings (layout/buf->strings buf)]
+      (is (str/includes? (first strings) "Name"))
+      (is (str/includes? (first strings) "Status"))
+      (is (str/includes? (nth strings 2) "workflow-1"))))
+
+  (testing "Table with selected row"
+    (let [columns [{:key :name :header "Name" :width 10}]
+          data [{:name "first"} {:name "second"}]
+          buf (layout/table [10 5] {:columns columns :data data :selected-row 1})
+          ;; Selected row (index 1) is at render row 3
+          cell (get-in buf [3 0])]
+      (is (= :blue (:bg cell))))))
+
+(deftest pad-test
+  (testing "Padding adds space around content"
+    (let [buf (layout/pad [10 5] [1 1 1 1]
+                          (fn [size] (layout/text size "X")))
+          strings (layout/buf->strings buf)]
+      ;; First row should be all spaces (top padding)
+      (is (= "          " (first strings)))
+      ;; Content should be offset by 1 col
+      (is (= \X (nth (second strings) 1))))))
+
+(deftest make-buffer-test
+  (testing "Buffer has correct dimensions"
+    (let [buf (layout/make-buffer [5 3])]
+      (is (= 3 (count buf)))
+      (is (= 5 (count (first buf)))))))
+
+(deftest minimum-size-test
+  (testing "80x24 minimum renders without error"
+    (let [buf (layout/text [80 24] "Minimum terminal size test")]
+      (is (= 24 (count buf)))
+      (is (= 80 (count (first buf)))))))

--- a/components/tui-engine/test/ai/miniforge/tui_engine/screen_test.clj
+++ b/components/tui-engine/test/ai/miniforge/tui_engine/screen_test.clj
@@ -1,0 +1,73 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.screen-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-engine.screen :as screen]))
+
+(deftest mock-screen-lifecycle-test
+  (testing "Mock screen starts and stops"
+    (let [s (screen/create-mock-screen [80 24])]
+      (screen/start-screen! s)
+      (is (true? (:started? @(:state s))))
+      (screen/stop-screen! s)
+      (is (false? (:started? @(:state s)))))))
+
+(deftest mock-screen-size-test
+  (testing "Mock screen reports correct size"
+    (let [s (screen/create-mock-screen [120 40])]
+      (is (= [120 40] (screen/get-size s))))))
+
+(deftest mock-screen-write-read-test
+  (testing "Writing to mock screen and reading back"
+    (let [s (screen/create-mock-screen [80 24])]
+      (screen/put-string! s 0 0 "Hello" :white :black false)
+      (is (= "Hello" (subs (screen/mock-read-line s 0 80) 0 5)))))
+
+  (testing "Writing at offset"
+    (let [s (screen/create-mock-screen [80 24])]
+      (screen/put-string! s 10 5 "Test" :cyan :black true)
+      (let [cells (screen/mock-get-cells s)]
+        (is (= \T (:char (get cells [10 5]))))
+        (is (= \e (:char (get cells [11 5]))))
+        (is (= :cyan (:fg (get cells [10 5]))))
+        (is (true? (:bold? (get cells [10 5]))))))))
+
+(deftest mock-screen-clear-test
+  (testing "Clear removes all cells"
+    (let [s (screen/create-mock-screen [80 24])]
+      (screen/put-string! s 0 0 "Hello" :white :black false)
+      (screen/clear! s)
+      (is (empty? (screen/mock-get-cells s))))))
+
+(deftest mock-screen-refresh-test
+  (testing "Refresh increments count"
+    (let [s (screen/create-mock-screen [80 24])]
+      (screen/refresh! s)
+      (screen/refresh! s)
+      (is (= 2 (:refresh-count @(:state s)))))))
+
+(deftest mock-screen-input-test
+  (testing "Poll returns nil when no input queued"
+    (let [s (screen/create-mock-screen [80 24])]
+      (is (nil? (screen/poll-input s)))))
+
+  (testing "Poll returns queued input in order"
+    (let [s (screen/create-mock-screen [80 24])]
+      (screen/mock-enqueue-input! s [{:type :character :char \j}
+                                     {:type :enter}])
+      (is (= {:type :character :char \j} (screen/poll-input s)))
+      (is (= {:type :enter} (screen/poll-input s)))
+      (is (nil? (screen/poll-input s))))))

--- a/components/tui-engine/test/ai/miniforge/tui_engine/style_test.clj
+++ b/components/tui-engine/test/ai/miniforge/tui_engine/style_test.clj
@@ -1,0 +1,53 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.style-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-engine.style :as style]))
+
+(deftest resolve-color-test
+  (testing "Known theme keys resolve"
+    (is (= :cyan (style/resolve-color style/default-theme :status/running)))
+    (is (= :green (style/resolve-color style/default-theme :status/success)))
+    (is (= :red (style/resolve-color style/default-theme :status/failed))))
+
+  (testing "Unknown keys fall back to :default"
+    (is (= :default (style/resolve-color style/default-theme :nonexistent)))))
+
+(deftest resolve-style-test
+  (testing "Resolves fg, bg, bold from theme"
+    (let [result (style/resolve-style style/default-theme
+                                      {:fg :status/running :bg :bg :bold? true})]
+      (is (= :cyan (:fg result)))
+      (is (= :black (:bg result)))
+      (is (true? (:bold? result)))))
+
+  (testing "Defaults when keys omitted"
+    (let [result (style/resolve-style style/default-theme {})]
+      (is (= :white (:fg result)))
+      (is (= :black (:bg result)))
+      (is (false? (:bold? result))))))
+
+(deftest default-theme-completeness-test
+  (testing "Theme has all required keys"
+    (let [required #{:bg :fg :border :title :header :selected-bg :selected-fg
+                     :status/running :status/success :status/failed
+                     :status/blocked :status/pending
+                     :progress-fill :progress-empty
+                     :kanban/blocked :kanban/pending :kanban/running :kanban/done
+                     :sparkline :command-bg :command-fg :search-match}]
+      (doseq [k required]
+        (is (contains? style/default-theme k)
+            (str "Missing theme key: " k))))))

--- a/components/tui-engine/test/ai/miniforge/tui_engine/widget_test.clj
+++ b/components/tui-engine/test/ai/miniforge/tui_engine/widget_test.clj
@@ -1,0 +1,130 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.widget-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-engine.widget :as widget]
+   [ai.miniforge.tui-engine.layout :as layout]))
+
+(deftest status-indicator-test
+  (testing "Status chars render correctly"
+    (let [buf (widget/status-indicator :running)]
+      (is (= \● (:char (get-in buf [0 0])))))
+    (let [buf (widget/status-indicator :success)]
+      (is (= \✓ (:char (get-in buf [0 0])))))
+    (let [buf (widget/status-indicator :failed)]
+      (is (= \✗ (:char (get-in buf [0 0]))))))
+
+  (testing "Status colors are correct"
+    (is (= :cyan (:fg (get-in (widget/status-indicator :running) [0 0]))))
+    (is (= :green (:fg (get-in (widget/status-indicator :success) [0 0]))))
+    (is (= :red (:fg (get-in (widget/status-indicator :failed) [0 0]))))))
+
+(deftest status-text-test
+  (testing "Status text shows indicator and label"
+    (let [strings (layout/buf->strings (widget/status-text [20 1] :running "Active"))]
+      (is (= \● (first (first strings))))
+      (is (str/includes? (first strings) "Active")))))
+
+(deftest progress-bar-test
+  (testing "0% progress"
+    (let [buf (widget/progress-bar [20 1] {:percent 0})
+          strings (layout/buf->strings buf)]
+      (is (str/includes? (first strings) "0%"))))
+
+  (testing "100% progress"
+    (let [buf (widget/progress-bar [20 1] {:percent 100})
+          strings (layout/buf->strings buf)]
+      (is (str/includes? (first strings) "100%"))
+      ;; All bar chars should be filled
+      (is (every? #(= \█ %)
+                   (take 15 (map :char (first buf)))))))
+
+  (testing "50% progress has mix of filled and empty"
+    (let [buf (widget/progress-bar [20 1] {:percent 50})
+          chars (map :char (first buf))
+          filled (count (filter #(= \█ %) chars))
+          empty (count (filter #(= \░ %) chars))]
+      (is (pos? filled))
+      (is (pos? empty))))
+
+  (testing "Clamping beyond 100"
+    (let [strings (layout/buf->strings (widget/progress-bar [20 1] {:percent 150}))]
+      (is (str/includes? (first strings) "100%"))))
+
+  (testing "Clamping below 0"
+    (let [strings (layout/buf->strings (widget/progress-bar [20 1] {:percent -10}))]
+      (is (str/includes? (first strings) "0%")))))
+
+(deftest tree-test
+  (testing "Tree renders nodes with indentation"
+    (let [nodes [{:label "Root" :depth 0 :expandable? true}
+                 {:label "Child 1" :depth 1 :expandable? false}
+                 {:label "Child 2" :depth 1 :expandable? true}]
+          buf (widget/tree [30 5] {:nodes nodes :expanded #{0} :selected 0})
+          strings (layout/buf->strings buf)]
+      (is (str/includes? (first strings) "▼"))
+      (is (str/includes? (first strings) "Root"))
+      (is (str/includes? (second strings) "Child 1"))))
+
+  (testing "Collapsed node shows right arrow"
+    (let [nodes [{:label "Folder" :depth 0 :expandable? true}]
+          buf (widget/tree [30 3] {:nodes nodes :expanded #{} :selected 0})
+          strings (layout/buf->strings buf)]
+      (is (str/includes? (first strings) "▸")))))
+
+(deftest kanban-test
+  (testing "Kanban renders columns with titles"
+    (let [columns [{:title "BLOCKED" :color :red :cards [{:label "task-1" :status :blocked}]}
+                   {:title "RUNNING" :color :cyan :cards [{:label "task-2" :status :running}]}
+                   {:title "DONE" :color :green :cards [{:label "task-3" :status :success}]}]
+          buf (widget/kanban [60 10] {:columns columns})
+          strings (layout/buf->strings buf)]
+      (is (str/includes? (first strings) "BLOCKED"))
+      (is (str/includes? (first strings) "RUNNING"))
+      (is (str/includes? (first strings) "DONE")))))
+
+(deftest scrollable-test
+  (testing "Scrollable shows correct viewport"
+    (let [lines (mapv #(str "Line " %) (range 100))
+          buf (widget/scrollable [30 5] {:lines lines :offset 10})
+          strings (layout/buf->strings buf)]
+      (is (str/includes? (first strings) "Line 10"))
+      (is (str/includes? (last strings) "Line 14"))))
+
+  (testing "Scrollbar present on right edge"
+    (let [lines (mapv #(str "Line " %) (range 100))
+          buf (widget/scrollable [30 5] {:lines lines :offset 0})
+          ;; Last column should have scrollbar characters
+          last-col-chars (mapv #(:char (get-in buf [% 29])) (range 5))]
+      (is (some #(or (= % \▮) (= % \│)) last-col-chars)))))
+
+(deftest sparkline-test
+  (testing "Sparkline renders braille characters"
+    (let [buf (widget/sparkline [10 1] {:values [1 3 5 2 8 4 6 9 3 7]})
+          chars (mapv #(:char %) (first buf))]
+      ;; All should be braille characters
+      (is (every? #(>= (int %) 0x2800) chars))))
+
+  (testing "Empty values produce empty sparkline"
+    (let [buf (widget/sparkline [5 1] {:values []})
+          chars (mapv #(:char %) (first buf))]
+      (is (= 5 (count chars)))))
+
+  (testing "Single value fills to max"
+    (let [buf (widget/sparkline [3 1] {:values [5 5 5]})
+          chars (mapv #(:char %) (first buf))]
+      (is (every? #(= \⣿ %) chars)))))

--- a/components/tui-views/deps.edn
+++ b/components/tui-views/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src" "resources"]
+ :deps {}
+ :aliases {:test {:extra-paths ["test"]}}}

--- a/components/tui-views/src/ai/miniforge/tui_views/command.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/command.clj
@@ -1,0 +1,119 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.command
+  "Command mode parser and executor.
+
+   Commands are entered with the : prefix (vim-style).
+   Supported commands:
+   - :workflows [filter]    - Show/filter workflow list
+   - :evidence              - Switch to evidence view
+   - :artifacts             - Switch to artifact browser
+   - :dag                   - Switch to DAG kanban
+   - :help                  - Show available commands
+   - :quit / :q             - Exit TUI"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Command parsing
+
+(defn parse-command
+  "Parse a command string (without the leading :) into a command map.
+
+   Returns {:command kw :args [str]} or nil if unparseable.
+
+   Examples:
+     (parse-command \"workflows\")
+     ;; => {:command :workflows :args []}
+
+     (parse-command \"workflows status:blocked\")
+     ;; => {:command :workflows :args [\"status:blocked\"]}"
+  [input]
+  (when (seq input)
+    (let [parts (str/split (str/trim input) #"\s+")
+          cmd (first parts)
+          args (rest parts)]
+      (when cmd
+        {:command (keyword cmd)
+         :args (vec args)}))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Command execution (returns model updates)
+
+(defn execute-command
+  "Execute a parsed command against the model.
+   Returns an updated model.
+
+   This is a pure function -- no side effects."
+  [model {:keys [command args]}]
+  (case command
+    :workflows
+    (let [filter-str (first args)]
+      (cond-> (assoc model :view :workflow-list :selected-idx 0)
+        (and filter-str (str/includes? filter-str "status:"))
+        (assoc :flash-message (str "Filter: " filter-str))))
+
+    :evidence
+    (assoc model :view :evidence :selected-idx 0)
+
+    :artifacts
+    (assoc model :view :artifact-browser :selected-idx 0)
+
+    :dag
+    (assoc model :view :dag-kanban :selected-idx 0)
+
+    (:quit :q)
+    (assoc model :quit? true)
+
+    :help
+    (assoc model :flash-message "Commands: :workflows :evidence :artifacts :dag :quit :help")
+
+    ;; Unknown command
+    (assoc model :flash-message (str "Unknown command: " (name command)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Integration with update loop
+
+(defn handle-command-submit
+  "Handle command mode Enter key. Parse and execute the command buffer.
+   Returns updated model with mode reset to :normal."
+  [model]
+  (let [buf (:command-buf model)
+        ;; Strip leading ':'
+        input (if (str/starts-with? buf ":")
+                (subs buf 1)
+                buf)
+        parsed (parse-command input)]
+    (if parsed
+      (-> model
+          (execute-command parsed)
+          (assoc :mode :normal :command-buf ""))
+      (assoc model
+             :mode :normal
+             :command-buf ""
+             :flash-message "Invalid command"))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (parse-command "workflows")
+  ;; => {:command :workflows :args []}
+
+  (parse-command "workflows status:blocked")
+  ;; => {:command :workflows :args ["status:blocked"]}
+
+  (parse-command "quit")
+  ;; => {:command :quit :args []}
+
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -1,0 +1,86 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.interface
+  "Public API for the TUI views component.
+
+   Provides the top-level entry points to start and stop the miniforge TUI.
+   Wires together the tui-engine (rendering) with domain data (event stream)."
+  (:require
+   [ai.miniforge.tui-engine.interface :as tui]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update :as update]
+   [ai.miniforge.tui-views.view :as view]
+   [ai.miniforge.tui-views.subscription :as subscription]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; TUI lifecycle
+
+(defn start-tui!
+  "Start the miniforge TUI.
+
+   Arguments:
+   - event-stream - Event stream atom from event-stream/create-event-stream
+   - opts         - {:throttle-ms 1000, :screen screen} optional overrides
+
+   Returns: app atom. Call stop-tui! to shut down.
+
+   The TUI will:
+   1. Enter alternate screen mode
+   2. Subscribe to the event stream
+   3. Start the input polling loop
+   4. Render the workflow list view
+
+   The TUI blocks the calling thread until the user quits (q key)."
+  [event-stream & [{:keys [throttle-ms screen] :or {throttle-ms 1000}}]]
+  (let [app (tui/create-app
+             {:init   model/init-model
+              :update update/update-model
+              :view   view/root-view
+              :screen screen
+              :subscriptions
+              (when event-stream
+                (fn [dispatch-fn]
+                  (subscription/subscribe-to-stream!
+                   event-stream dispatch-fn
+                   {:throttle-ms throttle-ms})))})]
+    (tui/start! app)
+    ;; Block until quit
+    (try
+      (while (not (:quit? (tui/get-model app)))
+        (Thread/sleep 100))
+      (finally
+        (tui/stop! app)))
+    app))
+
+(defn stop-tui!
+  "Stop the miniforge TUI. Restores terminal state.
+   Safe to call multiple times."
+  [app]
+  (tui/stop! app))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Start TUI with event stream
+  (require '[ai.miniforge.event-stream.interface :as es])
+  (def stream (es/create-event-stream))
+  (def app (future (start-tui! stream)))
+
+  ;; Send test events
+  (es/publish! stream (es/workflow-started stream (random-uuid) {:name "test-wf"}))
+
+  ;; Stop
+  (stop-tui! @app)
+
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/model.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/model.clj
@@ -1,0 +1,89 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.model
+  "Application model shape and initialization.
+
+   The model is a plain data map that represents the entire TUI state.
+   It is managed by the Elm runtime and updated only through pure
+   update functions.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Model shape
+
+(defn init-model
+  "Create the initial application model.
+
+   Model shape:
+   {:view          kw           ; Active view (:workflow-list :workflow-detail :evidence :artifact-browser :dag-kanban)
+    :workflows     [...]        ; Vector of workflow summary maps
+    :selected-idx  int          ; Selected item in current list
+    :scroll-offset int          ; Scroll offset for long lists
+    :detail        map          ; Drill-down state for detail views
+    :mode          kw           ; :normal :command :search
+    :command-buf   str          ; Command/search input buffer
+    :search-results [...]       ; Fuzzy search results
+    :last-updated  inst         ; Timestamp of last data update
+    :flash-message str          ; Temporary status bar message
+    :theme         kw}          ; Active theme name"
+  []
+  {:view          :workflow-list
+   :workflows     []
+   :selected-idx  0
+   :scroll-offset 0
+   :detail        {:workflow-id nil
+                   :phases      []
+                   :current-agent nil
+                   :agent-output ""
+                   :evidence    nil
+                   :artifacts   []}
+   :mode          :normal
+   :command-buf   ""
+   :search-results []
+   :last-updated  nil
+   :flash-message nil
+   :theme         :default})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Workflow data shape
+
+(defn make-workflow
+  "Create a workflow summary map for the model."
+  [{:keys [id name status phase progress started-at]}]
+  {:id         id
+   :name       (or name (str "workflow-" (subs (str id) 0 8)))
+   :status     (or status :pending)
+   :phase      phase
+   :progress   (or progress 0)
+   :started-at started-at
+   :agents     {}})
+
+;------------------------------------------------------------------------------ Layer 2
+;; View predicates
+
+(def views
+  "All available views in navigation order."
+  [:workflow-list :workflow-detail :evidence :artifact-browser :dag-kanban])
+
+(def view-labels
+  {:workflow-list    "Workflows"
+   :workflow-detail  "Detail"
+   :evidence         "Evidence"
+   :artifact-browser "Artifacts"
+   :dag-kanban       "DAG Kanban"})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (init-model)
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/search.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/search.clj
@@ -1,0 +1,134 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.search
+  "Fuzzy search for TUI navigation.
+
+   Provides fuzzy matching across workflow names, artifact types, and
+   other searchable content. Uses a simple scoring algorithm:
+   - Consecutive character matches score higher
+   - Matches at word boundaries score higher
+   - Case-insensitive matching"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Fuzzy matching
+
+(defn- char-match-score
+  "Score a single character match.
+   consecutive? - true if previous char also matched
+   boundary?    - true if at word boundary (after space, -, _, /)"
+  [consecutive? boundary?]
+  (cond-> 1
+    consecutive? (+ 2)
+    boundary?    (+ 1)))
+
+(defn fuzzy-score
+  "Compute fuzzy match score for query against text.
+   Returns 0 if no match, higher scores indicate better matches.
+
+   Algorithm:
+   - Walk through query chars, finding each in text (left to right)
+   - Score bonuses for consecutive matches and word boundaries
+   - Returns 0 if any query char not found"
+  [query text]
+  (let [q (str/lower-case (or query ""))
+        t (str/lower-case (or text ""))
+        qlen (count q)
+        tlen (count t)]
+    (if (or (zero? qlen) (zero? tlen))
+      0
+      (loop [qi 0          ; query index
+             ti 0          ; text index
+             score 0
+             last-match -2 ; position of last match in text
+             ]
+        (if (>= qi qlen)
+          ;; All query chars matched -- add length bonus (prefer shorter texts)
+          (+ score (max 0 (- 10 (quot tlen 5))))
+          (if (>= ti tlen)
+            ;; Ran out of text before matching all query chars
+            0
+            (let [qc (nth q qi)
+                  tc (nth t ti)]
+              (if (= qc tc)
+                (let [consecutive? (= (dec ti) last-match)
+                      boundary? (or (zero? ti)
+                                    (let [prev (nth t (dec ti))]
+                                      (or (= prev \space)
+                                          (= prev \-)
+                                          (= prev \_)
+                                          (= prev \/))))]
+                  (recur (inc qi) (inc ti)
+                         (+ score (char-match-score consecutive? boundary?))
+                         ti))
+                (recur qi (inc ti) score last-match)))))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Search across model
+
+(defn search-workflows
+  "Search workflows by name. Returns sorted results.
+
+   Each result: {:workflow wf :score int}"
+  [workflows query]
+  (if (str/blank? query)
+    []
+    (->> workflows
+         (map (fn [wf]
+                {:workflow wf
+                 :score (fuzzy-score query (:name wf))}))
+         (filter #(pos? (:score %)))
+         (sort-by :score >))))
+
+(defn search-all
+  "Search across all searchable content in the model.
+   Returns vector of {:type :label :score :data} maps."
+  [model query]
+  (if (str/blank? query)
+    []
+    (let [wf-results (map (fn [{:keys [workflow score]}]
+                            {:type :workflow
+                             :label (:name workflow)
+                             :score score
+                             :data workflow})
+                          (search-workflows (:workflows model) query))
+          artifact-results (map (fn [a]
+                                  {:type :artifact
+                                   :label (or (:name a) (:path a) "unnamed")
+                                   :score (fuzzy-score query (or (:name a) ""))
+                                   :data a})
+                                (get-in model [:detail :artifacts] []))]
+      (->> (concat wf-results artifact-results)
+           (filter #(pos? (:score %)))
+           (sort-by :score >)
+           (vec)))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (fuzzy-score "dep" "deploy-v2")
+  ;; => high score (consecutive match at start)
+
+  (fuzzy-score "v2" "deploy-v2")
+  ;; => moderate score
+
+  (fuzzy-score "xyz" "deploy-v2")
+  ;; => 0
+
+  (search-workflows [{:name "deploy-v2"} {:name "fix-bug"} {:name "deploy-prod"}]
+                     "dep")
+  ;; => [{:workflow {:name "deploy-v2"} :score ...} {:workflow {:name "deploy-prod"} :score ...}]
+
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
@@ -1,0 +1,174 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.subscription
+  "Event stream -> TUI message bridge.
+
+   Subscribes to the event stream and translates domain events into
+   TUI messages for the Elm update loop. Handles throttling so rapid
+   agent/chunk events are coalesced into 1 aggregate message per second."
+  (:require
+   [ai.miniforge.event-stream.interface :as es]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Event -> TUI message translation
+
+(defn- translate-event
+  "Translate a single event-stream event to a TUI message vector.
+   Returns nil for events that should be ignored."
+  [event]
+  (case (:event/type event)
+    :workflow/started
+    [:msg/workflow-added {:workflow-id (:workflow/id event)
+                          :name (get-in event [:workflow/spec :name])
+                          :spec (:workflow/spec event)}]
+
+    :workflow/phase-started
+    [:msg/phase-changed {:workflow-id (:workflow/id event)
+                          :phase (:workflow/phase event)}]
+
+    :workflow/phase-completed
+    [:msg/phase-done {:workflow-id (:workflow/id event)
+                       :phase (:workflow/phase event)
+                       :outcome (get-in event [:result :outcome])}]
+
+    :agent/status
+    [:msg/agent-status {:workflow-id (:workflow/id event)
+                         :agent (:agent/id event)
+                         :status (:status-type event)
+                         :message (:message event)}]
+
+    :agent/chunk
+    [:msg/agent-output {:workflow-id (:workflow/id event)
+                         :agent (:agent/id event)
+                         :delta (:delta event)
+                         :done? (:done? event)}]
+
+    :workflow/completed
+    [:msg/workflow-done {:workflow-id (:workflow/id event)
+                          :status (:workflow/status event)}]
+
+    :workflow/failed
+    [:msg/workflow-failed {:workflow-id (:workflow/id event)
+                            :error (:error event)}]
+
+    :gate/passed
+    [:msg/gate-result {:workflow-id (:workflow/id event)
+                        :gate (:gate event)
+                        :passed? true}]
+
+    :gate/failed
+    [:msg/gate-result {:workflow-id (:workflow/id event)
+                        :gate (:gate event)
+                        :passed? false}]
+
+    ;; Unknown event types are ignored
+    nil))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Throttled subscription
+
+(defn- create-chunk-aggregator
+  "Create a throttled aggregator for agent/chunk events.
+   Accumulates deltas and flushes at configurable intervals."
+  [dispatch-fn flush-interval-ms]
+  (let [buffer (atom {})  ; {workflow-id {:delta str :agent kw}}
+        running? (atom true)
+        flush-fn (fn []
+                   (let [buf @buffer]
+                     (reset! buffer {})
+                     (doseq [[wf-id {:keys [delta agent]}] buf]
+                       (when (seq delta)
+                         (dispatch-fn [:msg/agent-output
+                                       {:workflow-id wf-id
+                                        :agent agent
+                                        :delta delta
+                                        :done? false}])))))
+        thread (Thread. (fn []
+                          (try
+                            (while @running?
+                              (Thread/sleep flush-interval-ms)
+                              (flush-fn))
+                            (catch InterruptedException _))))]
+    (.setDaemon thread true)
+    (.setName thread "tui-chunk-aggregator")
+    (.start thread)
+    {:buffer buffer
+     :running? running?
+     :thread thread
+     :stop! (fn []
+              (reset! running? false)
+              (.interrupt thread))}))
+
+(defn- buffer-chunk!
+  "Buffer an agent chunk for throttled delivery."
+  [aggregator workflow-id agent-id delta]
+  (swap! (:buffer aggregator)
+         update workflow-id
+         (fn [existing]
+           {:delta (str (:delta existing) delta)
+            :agent agent-id})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Public subscription API
+
+(defn subscribe-to-stream!
+  "Subscribe to an event stream, translating events into TUI messages.
+
+   Arguments:
+   - stream      - Event stream atom from event-stream/create-event-stream
+   - dispatch-fn - (fn [msg]) to send TUI messages into the Elm loop
+   - opts        - {:throttle-ms 1000} chunk aggregation interval
+
+   Returns: cleanup function (fn [] ...) to call on shutdown."
+  [stream dispatch-fn & [{:keys [throttle-ms] :or {throttle-ms 1000}}]]
+  (let [aggregator (create-chunk-aggregator dispatch-fn throttle-ms)
+        sub-id :tui-subscription]
+    (es/subscribe! stream sub-id
+                   (fn [event]
+                     (if (= :agent/chunk (:event/type event))
+                       ;; Throttle chunk events
+                       (buffer-chunk! aggregator
+                                      (:workflow/id event)
+                                      (:agent/id event)
+                                      (:delta event))
+                       ;; All other events dispatch immediately
+                       (when-let [msg (translate-event event)]
+                         (dispatch-fn msg)))))
+    ;; Return cleanup function
+    (fn []
+      ((:stop! aggregator))
+      (es/unsubscribe! stream sub-id))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Example usage
+  (def stream (es/create-event-stream))
+  (def messages (atom []))
+
+  (def cleanup
+    (subscribe-to-stream! stream
+                          (fn [msg] (swap! messages conj msg))
+                          {:throttle-ms 500}))
+
+  ;; Publish some events
+  (es/publish! stream (es/workflow-started stream (random-uuid) {:name "test"}))
+
+  ;; Check received messages
+  @messages
+
+  ;; Cleanup
+  (cleanup)
+
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/update.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update.clj
@@ -76,10 +76,10 @@
   (let [wf (model/make-workflow {:id workflow-id
                                   :name (or name (:name spec))
                                   :status :running
-                                  :started-at (java.time.Instant/now)})]
+})]
     (-> model
         (update :workflows conj wf)
-        (assoc :last-updated (java.time.Instant/now)))))
+)))
 
 (defn- handle-phase-changed [model {:keys [workflow-id phase]}]
   (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
@@ -88,7 +88,7 @@
       idx (assoc-in [:workflows idx :phase] phase)
       (= workflow-id (get-in model [:detail :workflow-id]))
       (update-in [:detail :phases] conj {:phase phase :status :running})
-      true (assoc :last-updated (java.time.Instant/now)))))
+)))
 
 (defn- handle-phase-done [model {:keys [workflow-id]}]
   (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
@@ -96,7 +96,7 @@
     (cond-> model
       idx (update-in [:workflows idx :progress]
                      #(min 100 (+ (or % 0) 20)))
-      true (assoc :last-updated (java.time.Instant/now)))))
+)))
 
 (defn- handle-agent-status [model {:keys [workflow-id agent status message]}]
   (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
@@ -105,7 +105,7 @@
       idx (assoc-in [:workflows idx :agents agent] {:status status :message message})
       (= workflow-id (get-in model [:detail :workflow-id]))
       (assoc-in [:detail :current-agent] {:agent agent :status status :message message})
-      true (assoc :last-updated (java.time.Instant/now)))))
+)))
 
 (defn- handle-agent-output [model {:keys [workflow-id delta]}]
   (if (= workflow-id (get-in model [:detail :workflow-id]))
@@ -118,7 +118,7 @@
     (cond-> model
       idx (-> (assoc-in [:workflows idx :status] (or status :success))
               (assoc-in [:workflows idx :progress] 100))
-      true (assoc :last-updated (java.time.Instant/now)))))
+)))
 
 (defn- handle-workflow-failed [model {:keys [workflow-id error]}]
   (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
@@ -126,10 +126,10 @@
     (cond-> model
       idx (-> (assoc-in [:workflows idx :status] :failed)
               (assoc-in [:workflows idx :error] error))
-      true (assoc :last-updated (java.time.Instant/now)))))
+)))
 
 (defn- handle-gate-result [model _payload]
-  (assoc model :last-updated (java.time.Instant/now)))
+  model)
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Mode switching
@@ -230,8 +230,8 @@
       :msg/workflow-failed  (handle-workflow-failed model payload)
       :msg/gate-result      (handle-gate-result model payload)
 
-      ;; Tick (for clock/timing updates)
-      :tick (assoc model :last-updated (java.time.Instant/now))
+      ;; Tick (for clock/timing updates, currently unused)
+      :tick model
 
       ;; Unknown message -- no-op
       model)))

--- a/components/tui-views/src/ai/miniforge/tui_views/update.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update.clj
@@ -1,0 +1,251 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update
+  "Pure update function: (model, msg) -> model'.
+
+   All state transitions for the TUI application. Each message type
+   has a handler that returns a new model. No side effects."
+  (:require
+   [ai.miniforge.tui-views.model :as model]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Navigation helpers
+
+(defn- list-count [model]
+  (case (:view model)
+    :workflow-list (count (:workflows model))
+    :artifact-browser (count (get-in model [:detail :artifacts]))
+    0))
+
+(defn- navigate-up [model]
+  (update model :selected-idx #(max 0 (dec %))))
+
+(defn- navigate-down [model]
+  (let [max-idx (max 0 (dec (list-count model)))]
+    (update model :selected-idx #(min max-idx (inc %)))))
+
+(defn- navigate-top [model]
+  (assoc model :selected-idx 0 :scroll-offset 0))
+
+(defn- navigate-bottom [model]
+  (let [max-idx (max 0 (dec (list-count model)))]
+    (assoc model :selected-idx max-idx)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; View navigation
+
+(defn- enter-detail [model]
+  (let [workflows (:workflows model)
+        idx (:selected-idx model)]
+    (if-let [wf (get workflows idx)]
+      (-> model
+          (assoc :view :workflow-detail)
+          (assoc-in [:detail :workflow-id] (:id wf))
+          (assoc :selected-idx 0))
+      model)))
+
+(defn- go-back [model]
+  (case (:view model)
+    :workflow-detail (assoc model :view :workflow-list :selected-idx 0)
+    :evidence        (assoc model :view :workflow-detail :selected-idx 0)
+    :artifact-browser (assoc model :view :workflow-detail :selected-idx 0)
+    :dag-kanban       (assoc model :view :workflow-list :selected-idx 0)
+    model))
+
+(defn- switch-view [model view-key]
+  (if (some #{view-key} model/views)
+    (assoc model :view view-key :selected-idx 0 :scroll-offset 0)
+    model))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Event stream message handlers
+
+(defn- handle-workflow-added [model {:keys [workflow-id name spec]}]
+  (let [wf (model/make-workflow {:id workflow-id
+                                  :name (or name (:name spec))
+                                  :status :running
+                                  :started-at (java.time.Instant/now)})]
+    (-> model
+        (update :workflows conj wf)
+        (assoc :last-updated (java.time.Instant/now)))))
+
+(defn- handle-phase-changed [model {:keys [workflow-id phase]}]
+  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+                  (map-indexed vector (:workflows model)))]
+    (cond-> model
+      idx (assoc-in [:workflows idx :phase] phase)
+      (= workflow-id (get-in model [:detail :workflow-id]))
+      (update-in [:detail :phases] conj {:phase phase :status :running})
+      true (assoc :last-updated (java.time.Instant/now)))))
+
+(defn- handle-phase-done [model {:keys [workflow-id]}]
+  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+                  (map-indexed vector (:workflows model)))]
+    (cond-> model
+      idx (update-in [:workflows idx :progress]
+                     #(min 100 (+ (or % 0) 20)))
+      true (assoc :last-updated (java.time.Instant/now)))))
+
+(defn- handle-agent-status [model {:keys [workflow-id agent status message]}]
+  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+                  (map-indexed vector (:workflows model)))]
+    (cond-> model
+      idx (assoc-in [:workflows idx :agents agent] {:status status :message message})
+      (= workflow-id (get-in model [:detail :workflow-id]))
+      (assoc-in [:detail :current-agent] {:agent agent :status status :message message})
+      true (assoc :last-updated (java.time.Instant/now)))))
+
+(defn- handle-agent-output [model {:keys [workflow-id delta]}]
+  (if (= workflow-id (get-in model [:detail :workflow-id]))
+    (update-in model [:detail :agent-output] str delta)
+    model))
+
+(defn- handle-workflow-done [model {:keys [workflow-id status]}]
+  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+                  (map-indexed vector (:workflows model)))]
+    (cond-> model
+      idx (-> (assoc-in [:workflows idx :status] (or status :success))
+              (assoc-in [:workflows idx :progress] 100))
+      true (assoc :last-updated (java.time.Instant/now)))))
+
+(defn- handle-workflow-failed [model {:keys [workflow-id error]}]
+  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+                  (map-indexed vector (:workflows model)))]
+    (cond-> model
+      idx (-> (assoc-in [:workflows idx :status] :failed)
+              (assoc-in [:workflows idx :error] error))
+      true (assoc :last-updated (java.time.Instant/now)))))
+
+(defn- handle-gate-result [model _payload]
+  (assoc model :last-updated (java.time.Instant/now)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Mode switching
+
+(defn- enter-command-mode [model]
+  (assoc model :mode :command :command-buf ":"))
+
+(defn- enter-search-mode [model]
+  (assoc model :mode :search :command-buf "/" :search-results []))
+
+(defn- exit-mode [model]
+  (assoc model :mode :normal :command-buf "" :search-results []))
+
+(defn- command-append [model ch]
+  (update model :command-buf str ch))
+
+(defn- command-backspace [model]
+  (let [buf (:command-buf model)]
+    (if (> (count buf) 1)
+      (assoc model :command-buf (subs buf 0 (dec (count buf))))
+      (exit-mode model))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Input message handling
+
+(defn- handle-normal-input [model key]
+  (case key
+    :key/j         (navigate-down model)
+    :key/k         (navigate-up model)
+    :key/down      (navigate-down model)
+    :key/up        (navigate-up model)
+    :key/g         (navigate-top model)
+    :key/G         (navigate-bottom model)
+    :key/enter     (enter-detail model)
+    :key/escape    (go-back model)
+    :key/l         (enter-detail model)
+    :key/h         (go-back model)
+    :key/colon     (enter-command-mode model)
+    :key/slash     (enter-search-mode model)
+    :key/d1        (switch-view model :workflow-list)
+    :key/d2        (switch-view model :workflow-detail)
+    :key/d3        (switch-view model :evidence)
+    :key/d4        (switch-view model :artifact-browser)
+    :key/d5        (switch-view model :dag-kanban)
+    :key/q         (assoc model :quit? true)
+    ;; Unknown key -- no-op
+    model))
+
+(defn- handle-command-input [model key]
+  (case key
+    :key/escape   (exit-mode model)
+    :key/enter    (-> model
+                      (assoc :flash-message (str "Executed: " (:command-buf model)))
+                      exit-mode)
+    :key/backspace (command-backspace model)
+    ;; Character input
+    (if (and (map? key) (= :char (:type key)))
+      (command-append model (:char key))
+      model)))
+
+(defn- handle-search-input [model key]
+  (case key
+    :key/escape   (exit-mode model)
+    :key/enter    (exit-mode model)
+    :key/backspace (command-backspace model)
+    (if (and (map? key) (= :char (:type key)))
+      (command-append model (:char key))
+      model)))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Root update function
+
+(defn update-model
+  "Root update function for the TUI application.
+   Pure: (model, msg) -> model'
+
+   Messages are vectors: [msg-type payload]
+   Input messages: [:input key-event]
+   Stream messages: [:msg/workflow-added data], [:msg/phase-changed data], etc."
+  [model msg]
+  (let [[msg-type payload] (if (vector? msg) msg [msg nil])]
+    (case msg-type
+      ;; User input
+      :input
+      (case (:mode model)
+        :normal  (handle-normal-input model payload)
+        :command (handle-command-input model payload)
+        :search  (handle-search-input model payload)
+        model)
+
+      ;; Event stream messages
+      :msg/workflow-added   (handle-workflow-added model payload)
+      :msg/phase-changed    (handle-phase-changed model payload)
+      :msg/phase-done       (handle-phase-done model payload)
+      :msg/agent-status     (handle-agent-status model payload)
+      :msg/agent-output     (handle-agent-output model payload)
+      :msg/workflow-done    (handle-workflow-done model payload)
+      :msg/workflow-failed  (handle-workflow-failed model payload)
+      :msg/gate-result      (handle-gate-result model payload)
+
+      ;; Tick (for clock/timing updates)
+      :tick (assoc model :last-updated (java.time.Instant/now))
+
+      ;; Unknown message -- no-op
+      model)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def m (model/init-model))
+
+  ;; Navigate
+  (-> m
+      (update-model [:msg/workflow-added {:workflow-id (random-uuid) :name "test"}])
+      (update-model [:msg/workflow-added {:workflow-id (random-uuid) :name "test-2"}])
+      (update-model [:input :key/j])
+      :selected-idx)
+  ;; => 1
+
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/view.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view.clj
@@ -1,0 +1,80 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.view
+  "View dispatch: model -> cell buffer.
+
+   Routes to the correct view renderer based on :view key in model.
+   Composes the view tab bar, command/search bar, and active view."
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.views.workflow-list :as wf-list]
+   [ai.miniforge.tui-views.views.workflow-detail :as wf-detail]
+   [ai.miniforge.tui-views.views.evidence :as evidence]
+   [ai.miniforge.tui-views.views.artifact-browser :as artifact-browser]
+   [ai.miniforge.tui-views.views.dag-kanban :as dag-kanban]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; View dispatch
+
+(defn- render-active-view
+  "Dispatch to the active view renderer."
+  [model size]
+  (case (:view model)
+    :workflow-list    (wf-list/render model size)
+    :workflow-detail  (wf-detail/render model size)
+    :evidence         (evidence/render model size)
+    :artifact-browser (artifact-browser/render model size)
+    :dag-kanban       (dag-kanban/render model size)
+    ;; Fallback
+    (layout/text size "Unknown view")))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Command/search bar overlay
+
+(defn- render-command-bar
+  "Render the command or search input bar at the bottom of the screen."
+  [[cols _rows] model]
+  (when (not= :normal (:mode model))
+    (layout/text [cols 1] (:command-buf model)
+                 {:fg :white :bg :default :bold? true})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Root view function
+
+(defn root-view
+  "Root view function for the Elm runtime.
+   model -> [cols rows] -> cell-buffer"
+  [model [cols rows]]
+  (if (< rows 4)
+    (layout/text [cols rows] "Terminal too small" {:fg :red})
+    (let [;; Reserve 1 row for command bar if in command/search mode
+          cmd-active? (not= :normal (:mode model))
+          content-rows (if cmd-active? (dec rows) rows)
+          ;; Render main view
+          content (render-active-view model [cols content-rows])]
+      (if cmd-active?
+        ;; Build full-size buffer: content on top, command bar on last row
+        (let [buf (layout/make-buffer [cols rows])
+              buf (layout/blit buf content 0 0)
+              cmd-bar (render-command-bar [cols 1] model)]
+          (layout/blit buf cmd-bar 0 (dec rows)))
+        content))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def m (model/init-model))
+  (layout/buf->strings (root-view m [80 24]))
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/artifact_browser.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/artifact_browser.clj
@@ -1,0 +1,78 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.artifact-browser
+  "Artifact browser -- N5 Section 3.2.4.
+
+   Shows workflow artifacts in a table with drill-down:
+   - Type (plan, code, test, review, evidence)
+   - Name / path
+   - Size
+   - Status"
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Rendering
+
+(defn render
+  "Render the artifact browser.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [artifacts (get-in model [:detail :artifacts] [])
+        selected (:selected-idx model)]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      ;; Title bar
+      (fn [[c r]]
+        (layout/text [c r] " MINIFORGE │ Artifact Browser"
+                     {:fg :cyan :bold? true}))
+      ;; Content + footer
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          ;; Table
+          (fn [[tc tr]]
+            (if (empty? artifacts)
+              (layout/box [tc tr]
+                {:title "Artifacts" :border :single :fg :default
+                 :content-fn
+                 (fn [[ic ir]]
+                   (layout/text [ic ir] "  No artifacts available yet."
+                                {:fg :default}))})
+              (layout/box [tc tr]
+                {:title (str "Artifacts (" (count artifacts) ")")
+                 :border :single :fg :default
+                 :content-fn
+                 (fn [[ic ir]]
+                   (layout/table [ic ir]
+                     {:columns [{:key :type :header "Type" :width 10}
+                                {:key :name :header "Name" :width (max 10 (- ic 35))}
+                                {:key :size :header "Size" :width 8}
+                                {:key :status :header "Status" :width 8}]
+                      :data (mapv (fn [a]
+                                    {:type (some-> (:type a) name)
+                                     :name (or (:name a) (:path a) "unnamed")
+                                     :size (or (:size a) "-")
+                                     :status (some-> (:status a) name)})
+                                  artifacts)
+                      :selected-row selected}))})))
+          ;; Footer
+          (fn [[fc fr]]
+            (layout/text [fc fr]
+              " j/k:navigate  Enter:view  Esc:back  1:workflows  q:quit"
+              {:fg :default})))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/dag_kanban.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/dag_kanban.clj
@@ -1,0 +1,89 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.dag-kanban
+  "DAG Kanban view -- N5 Section 3.2.5.
+
+   Shows tasks from the dependency graph as kanban columns:
+   - BLOCKED: Tasks with unsatisfied dependencies
+   - PENDING: Tasks ready to execute
+   - RUNNING: Tasks currently being executed by agents
+   - DONE: Completed tasks
+
+   Columns are derived from task states. Each card shows the task name,
+   assigned agent, and dependency status."
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-engine.interface.widget :as widget]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Task grouping
+
+(defn- group-tasks-by-status
+  "Group workflow tasks into kanban columns."
+  [workflows]
+  (let [all-wfs (or workflows [])
+        blocked (filterv #(= :blocked (:status %)) all-wfs)
+        pending (filterv #(= :pending (:status %)) all-wfs)
+        running (filterv #(= :running (:status %)) all-wfs)
+        done (filterv #(#{:success :completed} (:status %)) all-wfs)
+        failed (filterv #(= :failed (:status %)) all-wfs)]
+    [{:title "BLOCKED"
+      :color :red
+      :cards (mapv (fn [wf] {:label (:name wf) :status :blocked}) blocked)}
+     {:title "PENDING"
+      :color :yellow
+      :cards (mapv (fn [wf] {:label (:name wf) :status :pending}) pending)}
+     {:title "RUNNING"
+      :color :cyan
+      :cards (mapv (fn [wf] {:label (:name wf) :status :running}) running)}
+     {:title "DONE"
+      :color :green
+      :cards (concat
+              (mapv (fn [wf] {:label (:name wf) :status :success}) done)
+              (mapv (fn [wf] {:label (:name wf) :status :failed}) failed))}]))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rendering
+
+(defn render
+  "Render the DAG kanban view.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [columns (group-tasks-by-status (:workflows model))]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      ;; Title bar
+      (fn [[c r]]
+        (layout/text [c r] " MINIFORGE │ DAG Kanban"
+                     {:fg :cyan :bold? true}))
+      ;; Content + footer
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          ;; Kanban board
+          (fn [[kc kr]]
+            (layout/box [kc kr]
+              {:title "Task Board" :border :single :fg :default
+               :content-fn
+               (fn [[ic ir]]
+                 (widget/kanban [ic ir] {:columns columns}))}))
+          ;; Footer
+          (fn [[fc fr]]
+            (layout/text [fc fr]
+              " 1:workflows  2:detail  3:evidence  4:artifacts  q:quit"
+              {:fg :default})))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/evidence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/evidence.clj
@@ -1,0 +1,105 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.evidence
+  "Evidence viewer -- N5 Section 3.2.3.
+
+   Displays workflow evidence as a scrollable tree with
+   expand/collapse sections:
+   - Intent (original task description)
+   - Phases (plan, implement, verify with outcomes)
+   - Validation (gate results and errors)
+   - Policy (policy check results)"
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-engine.interface.widget :as widget]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Evidence tree construction
+
+(defn- build-evidence-tree
+  "Build a tree node list from model evidence data."
+  [model]
+  (let [detail (:detail model)
+        evidence (:evidence detail)
+        phases (:phases detail)]
+    (into []
+      (concat
+       ;; Intent section
+       [{:label "Intent" :depth 0 :expandable? true}
+        {:label (or (get-in evidence [:intent :description])
+                    "No intent data available")
+         :depth 1 :expandable? false}]
+       ;; Phases section
+       [{:label "Phases" :depth 0 :expandable? true}]
+       (mapv (fn [{:keys [phase status]}]
+               {:label (str (name phase)
+                            (case status
+                              :running  " ● running"
+                              :success  " ✓ passed"
+                              :failed   " ✗ failed"
+                              ""))
+                :depth 1 :expandable? false})
+             phases)
+       ;; Validation section
+       [{:label "Validation" :depth 0 :expandable? true}
+        {:label (if (get-in evidence [:validation :passed?])
+                  "✓ All gates passed"
+                  (str "✗ " (count (get-in evidence [:validation :errors] [])) " error(s)"))
+         :depth 1 :expandable? false}]
+       ;; Policy section
+       [{:label "Policy" :depth 0 :expandable? true}
+        {:label (if (get-in evidence [:policy :compliant?])
+                  "✓ Policy compliant"
+                  "✗ Policy violations detected")
+         :depth 1 :expandable? false}]))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rendering
+
+(defn render
+  "Render the evidence viewer.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [nodes (build-evidence-tree model)
+        selected (:selected-idx model)]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      ;; Title bar
+      (fn [[c r]]
+        (layout/text [c r] " MINIFORGE │ Evidence Bundle"
+                     {:fg :cyan :bold? true}))
+      ;; Content + footer
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          ;; Tree view
+          (fn [[tc tr]]
+            (layout/box [tc tr]
+              {:title "Evidence" :border :single :fg :default
+               :content-fn
+               (fn [[ic ir]]
+                 (widget/tree [ic ir]
+                   {:nodes nodes
+                    :expanded #{0 2 (+ 3 (count (get-in model [:detail :phases])))
+                                (+ 5 (count (get-in model [:detail :phases])))}
+                    :selected selected}))}))
+          ;; Footer
+          (fn [[fc fr]]
+            (layout/text [fc fr]
+              " j/k:navigate  Enter:expand  Esc:back  1:workflows  q:quit"
+              {:fg :default})))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
@@ -1,0 +1,106 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.workflow-detail
+  "Workflow detail view -- N5 Section 3.2.2.
+
+   Shows detailed information for a single workflow:
+   - Phase pipeline with status indicators
+   - Current agent activity and streaming output
+   - Progress breakdown by phase"
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-engine.interface.widget :as widget]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helper: find workflow
+
+(defn- find-workflow [model]
+  (let [wf-id (get-in model [:detail :workflow-id])]
+    (some #(when (= (:id %) wf-id) %) (:workflows model))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rendering
+
+(defn render
+  "Render the workflow detail view.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [wf (find-workflow model)
+        detail (:detail model)
+        phases (:phases detail)
+        agent (:current-agent detail)
+        output (:agent-output detail)]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      ;; Title bar
+      (fn [[c r]]
+        (layout/text [c r]
+                     (str " MINIFORGE │ "
+                          (or (:name wf) "Workflow Detail")
+                          (when-let [phase (:phase wf)]
+                            (str " │ " (name phase))))
+                     {:fg :cyan :bold? true}))
+      ;; Content + footer
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          ;; Main content: left phases + right agent output
+          (fn [[mc mr]]
+            (layout/split-h [mc mr] 0.35
+              ;; Left pane: phase list
+              (fn [[lc lr]]
+                (layout/box [lc lr]
+                  {:title "Phases" :border :single :fg :default
+                   :content-fn
+                   (fn [[ic ir]]
+                     (if (empty? phases)
+                       (layout/text [ic ir] "  Waiting for phases...")
+                       (let [nodes (mapv (fn [{:keys [phase status]}]
+                                           {:label (str (name phase)
+                                                        (case status
+                                                          :running  " ●"
+                                                          :success  " ✓"
+                                                          :failed   " ✗"
+                                                          ""))
+                                            :depth 0
+                                            :expandable? false})
+                                         phases)]
+                         (widget/tree [ic ir] {:nodes nodes :selected 0}))))}))
+              ;; Right pane: agent output
+              (fn [[rc rr]]
+                (layout/box [rc rr]
+                  {:title (if agent
+                            (str (name (:agent agent)) " - " (name (:status agent :idle)))
+                            "Agent Output")
+                   :border :single :fg :default
+                   :content-fn
+                   (fn [[ic ir]]
+                     (let [lines (if (seq output)
+                                   (str/split-lines output)
+                                   ["  Waiting for agent output..."])
+                           offset (max 0 (- (count lines) ir))]
+                       (widget/scrollable [ic ir]
+                         {:lines lines
+                          :offset offset
+                          :fg :white})))}))))
+          ;; Footer
+          (fn [[fc fr]]
+            (layout/text [fc fr]
+              " Esc:back  3:evidence  4:artifacts  5:dag  j/k:scroll  q:quit"
+              {:fg :default})))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
@@ -1,0 +1,85 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.workflow-list
+  "Workflow list view -- N5 Section 3.2.1.
+
+   Shows all active and recent workflows in a table with:
+   - Status indicator (colored dot)
+   - Workflow name
+   - Current phase
+   - Progress bar
+   - Agent status"
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Rendering
+
+(defn render
+  "Render the workflow list view.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [workflows (:workflows model)
+        selected (:selected-idx model)
+]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      ;; Title bar
+      (fn [[c r]]
+        (layout/text [c r] " MINIFORGE │ Workflows"
+                     {:fg :cyan :bold? true}))
+      ;; Main content + footer
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          ;; Table
+          (fn [[tc tr]]
+            (if (empty? workflows)
+              (layout/text [tc tr] "  No active workflows. Waiting for events..."
+                           {:fg :default})
+              (layout/table [tc tr]
+                {:columns [{:key :status-char :header "  " :width 2}
+                           {:key :name :header "Workflow" :width (max 10 (- tc 50))}
+                           {:key :phase :header "Phase" :width 12}
+                           {:key :progress-str :header "Progress" :width 20}
+                           {:key :agent-msg :header "Agent" :width 16}]
+                 :data (mapv (fn [wf]
+                               {:status-char (case (:status wf)
+                                               :running "●"
+                                               :success "✓"
+                                               :failed  "✗"
+                                               :blocked "◐"
+                                               "○")
+                                :name (:name wf)
+                                :phase (some-> (:phase wf) name)
+                                :progress-str (str (:progress wf 0) "%")
+                                :agent-msg (some-> (first (vals (:agents wf)))
+                                                   :message
+                                                   (subs 0 (min 16 (count (or (:message (first (vals (:agents wf)))) "")))))})
+                             workflows)
+                 :selected-row selected})))
+          ;; Footer
+          (fn [[fc fr]]
+            (layout/text [fc fr]
+              (str " j/k:navigate  Enter:detail  1-5:views  /:search  ::cmd  q:quit"
+                   (when-let [flash (:flash-message model)]
+                     (str "  │ " flash)))
+              {:fg :default})))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def m {:workflows [{:name "deploy-v2" :status :running :phase :implement :progress 40}]
+          :selected-idx 0})
+  (layout/buf->strings (render m [80 24]))
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
@@ -64,9 +64,9 @@
                                 :name (:name wf)
                                 :phase (some-> (:phase wf) name)
                                 :progress-str (str (:progress wf 0) "%")
-                                :agent-msg (some-> (first (vals (:agents wf)))
-                                                   :message
-                                                   (subs 0 (min 16 (count (or (:message (first (vals (:agents wf)))) "")))))})
+                                :agent-msg (when-let [agent (first (vals (:agents wf)))]
+                                             (when-let [msg (:message agent)]
+                                               (subs msg 0 (min 16 (count msg)))))})
                              workflows)
                  :selected-row selected})))
           ;; Footer

--- a/components/tui-views/test/ai/miniforge/tui_views/command_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/command_test.clj
@@ -1,0 +1,87 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.command-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.command :as cmd]
+   [ai.miniforge.tui-views.model :as model]))
+
+(deftest parse-command-test
+  (testing "Simple command"
+    (is (= {:command :workflows :args []}
+           (cmd/parse-command "workflows"))))
+
+  (testing "Command with arguments"
+    (is (= {:command :workflows :args ["status:blocked"]}
+           (cmd/parse-command "workflows status:blocked"))))
+
+  (testing "Quit variants"
+    (is (= {:command :quit :args []} (cmd/parse-command "quit")))
+    (is (= {:command :q :args []} (cmd/parse-command "q"))))
+
+  (testing "Empty input returns nil"
+    (is (nil? (cmd/parse-command "")))
+    (is (nil? (cmd/parse-command nil)))))
+
+(deftest execute-command-test
+  (testing ":workflows switches to workflow list"
+    (let [m (cmd/execute-command (model/init-model)
+                                 {:command :workflows :args []})]
+      (is (= :workflow-list (:view m)))))
+
+  (testing ":evidence switches view"
+    (let [m (cmd/execute-command (model/init-model)
+                                 {:command :evidence :args []})]
+      (is (= :evidence (:view m)))))
+
+  (testing ":artifacts switches view"
+    (let [m (cmd/execute-command (model/init-model)
+                                 {:command :artifacts :args []})]
+      (is (= :artifact-browser (:view m)))))
+
+  (testing ":dag switches view"
+    (let [m (cmd/execute-command (model/init-model)
+                                 {:command :dag :args []})]
+      (is (= :dag-kanban (:view m)))))
+
+  (testing ":quit sets quit flag"
+    (let [m (cmd/execute-command (model/init-model)
+                                 {:command :quit :args []})]
+      (is (true? (:quit? m)))))
+
+  (testing ":q also sets quit flag"
+    (let [m (cmd/execute-command (model/init-model)
+                                 {:command :q :args []})]
+      (is (true? (:quit? m)))))
+
+  (testing ":help sets flash message"
+    (let [m (cmd/execute-command (model/init-model)
+                                 {:command :help :args []})]
+      (is (some? (:flash-message m)))))
+
+  (testing "Unknown command shows error flash"
+    (let [m (cmd/execute-command (model/init-model)
+                                 {:command :bogus :args []})]
+      (is (str/includes? (:flash-message m) "Unknown")))))
+
+(deftest handle-command-submit-test
+  (testing "Full command flow: buffer -> parse -> execute"
+    (let [m (-> (model/init-model)
+                (assoc :mode :command :command-buf ":evidence")
+                cmd/handle-command-submit)]
+      (is (= :evidence (:view m)))
+      (is (= :normal (:mode m)))
+      (is (= "" (:command-buf m))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/search_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/search_test.clj
@@ -1,0 +1,78 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.search-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.search :as search]))
+
+(deftest fuzzy-score-test
+  (testing "Exact prefix match scores high"
+    (is (pos? (search/fuzzy-score "dep" "deploy-v2"))))
+
+  (testing "Non-match returns 0"
+    (is (zero? (search/fuzzy-score "xyz" "deploy-v2"))))
+
+  (testing "Empty query returns 0"
+    (is (zero? (search/fuzzy-score "" "deploy-v2"))))
+
+  (testing "Empty text returns 0"
+    (is (zero? (search/fuzzy-score "dep" ""))))
+
+  (testing "Consecutive matches score higher than scattered"
+    (let [consecutive (search/fuzzy-score "dep" "deploy-v2")
+          scattered (search/fuzzy-score "dey" "deploy-v2")]
+      ;; "dey" matches d, e (from deploy), y (from deploy) but scattered
+      (is (> consecutive scattered))))
+
+  (testing "Case insensitive"
+    (is (= (search/fuzzy-score "DEP" "deploy-v2")
+           (search/fuzzy-score "dep" "deploy-v2"))))
+
+  (testing "Word boundary bonus"
+    ;; "v2" starts at word boundary after '-'
+    (is (pos? (search/fuzzy-score "v2" "deploy-v2")))))
+
+(deftest search-workflows-test
+  (testing "Finds matching workflows"
+    (let [wfs [{:name "deploy-v2"}
+               {:name "fix-bug-123"}
+               {:name "deploy-prod"}]
+          results (search/search-workflows wfs "dep")]
+      (is (= 2 (count results)))
+      (is (every? #(pos? (:score %)) results))))
+
+  (testing "Results sorted by score"
+    (let [wfs [{:name "deploy-v2"}
+               {:name "deep-analysis"}
+               {:name "deploy-prod"}]
+          results (search/search-workflows wfs "dep")]
+      ;; All should match, sorted by score descending
+      (is (apply >= (map :score results)))))
+
+  (testing "No match returns empty"
+    (let [results (search/search-workflows [{:name "hello"}] "xyz")]
+      (is (empty? results))))
+
+  (testing "Empty query returns empty"
+    (let [results (search/search-workflows [{:name "hello"}] "")]
+      (is (empty? results)))))
+
+(deftest search-all-test
+  (testing "Searches across workflows and artifacts"
+    (let [model {:workflows [{:name "deploy-v2"}]
+                 :detail {:artifacts [{:name "deploy-plan.edn"}]}}
+          results (search/search-all model "dep")]
+      (is (>= (count results) 1))
+      (is (every? #(pos? (:score %)) results)))))

--- a/components/tui-views/test/ai/miniforge/tui_views/subscription_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/subscription_test.clj
@@ -1,0 +1,96 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.subscription-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.subscription :as sub]
+   [ai.miniforge.event-stream.interface :as es]))
+
+(deftest translate-workflow-events-test
+  (testing "Workflow started translates correctly"
+    (let [stream (es/create-event-stream)
+          messages (atom [])
+          wf-id (random-uuid)
+          cleanup (sub/subscribe-to-stream! stream
+                                            (fn [msg] (swap! messages conj msg))
+                                            {:throttle-ms 5000})]
+      (es/publish! stream (es/workflow-started stream wf-id {:name "test-wf"}))
+      (Thread/sleep 50)
+      (is (= 1 (count @messages)))
+      (is (= :msg/workflow-added (first (first @messages))))
+      (is (= wf-id (get-in (first @messages) [1 :workflow-id])))
+      (cleanup))))
+
+(deftest translate-phase-events-test
+  (testing "Phase started translates correctly"
+    (let [stream (es/create-event-stream)
+          messages (atom [])
+          wf-id (random-uuid)
+          cleanup (sub/subscribe-to-stream! stream
+                                            (fn [msg] (swap! messages conj msg))
+                                            {:throttle-ms 5000})]
+      (es/publish! stream (es/phase-started stream wf-id :plan))
+      (Thread/sleep 50)
+      (is (= :msg/phase-changed (first (first @messages))))
+      (is (= :plan (get-in (first @messages) [1 :phase])))
+      (cleanup))))
+
+(deftest translate-workflow-completed-test
+  (testing "Workflow completed translates correctly"
+    (let [stream (es/create-event-stream)
+          messages (atom [])
+          wf-id (random-uuid)
+          cleanup (sub/subscribe-to-stream! stream
+                                            (fn [msg] (swap! messages conj msg))
+                                            {:throttle-ms 5000})]
+      (es/publish! stream (es/workflow-completed stream wf-id :success 10000))
+      (Thread/sleep 50)
+      (is (= :msg/workflow-done (first (first @messages))))
+      (is (= :success (get-in (first @messages) [1 :status])))
+      (cleanup))))
+
+(deftest chunk-throttling-test
+  (testing "Rapid chunks are coalesced"
+    (let [stream (es/create-event-stream)
+          messages (atom [])
+          wf-id (random-uuid)
+          cleanup (sub/subscribe-to-stream! stream
+                                            (fn [msg] (swap! messages conj msg))
+                                            {:throttle-ms 100})]
+      ;; Send many chunks rapidly
+      (dotimes [i 10]
+        (es/publish! stream (es/agent-chunk stream wf-id :planner (str "chunk-" i " "))))
+      ;; Wait for aggregation flush
+      (Thread/sleep 250)
+      ;; Should have fewer messages than 10 (coalesced)
+      (let [chunk-msgs (filter #(= :msg/agent-output (first %)) @messages)]
+        (is (< (count chunk-msgs) 10)))
+      (cleanup))))
+
+(deftest cleanup-unsubscribes-test
+  (testing "Cleanup function stops the subscription"
+    (let [stream (es/create-event-stream)
+          messages (atom [])
+          wf-id (random-uuid)
+          cleanup (sub/subscribe-to-stream! stream
+                                            (fn [msg] (swap! messages conj msg))
+                                            {:throttle-ms 5000})]
+      (cleanup)
+      (Thread/sleep 50)
+      ;; Events after cleanup should not be received
+      (reset! messages [])
+      (es/publish! stream (es/workflow-started stream wf-id {:name "test"}))
+      (Thread/sleep 50)
+      (is (empty? @messages)))))

--- a/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
@@ -1,0 +1,153 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update :as update]))
+
+(def wf-id-1 (random-uuid))
+(def wf-id-2 (random-uuid))
+
+(defn- with-workflows [model]
+  (-> model
+      (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "wf-1"}])
+      (update/update-model [:msg/workflow-added {:workflow-id wf-id-2 :name "wf-2"}])))
+
+(deftest navigation-test
+  (testing "j moves down in workflow list"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/j]))]
+      (is (= 1 (:selected-idx m)))))
+
+  (testing "k moves up in workflow list"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/j])
+                (update/update-model [:input :key/k]))]
+      (is (= 0 (:selected-idx m)))))
+
+  (testing "k at top stays at 0"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/k]))]
+      (is (= 0 (:selected-idx m)))))
+
+  (testing "j at bottom stays at max"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/j])
+                (update/update-model [:input :key/j])
+                (update/update-model [:input :key/j]))]
+      (is (= 1 (:selected-idx m)))))
+
+  (testing "g goes to top"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/j])
+                (update/update-model [:input :key/g]))]
+      (is (= 0 (:selected-idx m)))))
+
+  (testing "G goes to bottom"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/G]))]
+      (is (= 1 (:selected-idx m))))))
+
+(deftest view-navigation-test
+  (testing "Enter drills into workflow detail"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/enter]))]
+      (is (= :workflow-detail (:view m)))
+      (is (= wf-id-1 (get-in m [:detail :workflow-id])))))
+
+  (testing "Escape returns to workflow list"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/enter])
+                (update/update-model [:input :key/escape]))]
+      (is (= :workflow-list (:view m)))))
+
+  (testing "Number keys switch views"
+    (is (= :workflow-list (:view (update/update-model (model/init-model) [:input :key/d1]))))
+    (is (= :workflow-detail (:view (update/update-model (model/init-model) [:input :key/d2]))))
+    (is (= :evidence (:view (update/update-model (model/init-model) [:input :key/d3]))))
+    (is (= :artifact-browser (:view (update/update-model (model/init-model) [:input :key/d4]))))
+    (is (= :dag-kanban (:view (update/update-model (model/init-model) [:input :key/d5]))))))
+
+(deftest workflow-events-test
+  (testing "Workflow added appears in list"
+    (let [m (update/update-model (model/init-model)
+              [:msg/workflow-added {:workflow-id wf-id-1 :name "test-wf"}])]
+      (is (= 1 (count (:workflows m))))
+      (is (= "test-wf" (:name (first (:workflows m)))))))
+
+  (testing "Phase changed updates workflow"
+    (let [m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
+                (update/update-model [:msg/phase-changed {:workflow-id wf-id-1 :phase :implement}]))]
+      (is (= :implement (:phase (first (:workflows m)))))))
+
+  (testing "Workflow done updates status"
+    (let [m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
+                (update/update-model [:msg/workflow-done {:workflow-id wf-id-1 :status :success}]))]
+      (is (= :success (:status (first (:workflows m)))))
+      (is (= 100 (:progress (first (:workflows m)))))))
+
+  (testing "Workflow failed updates status"
+    (let [m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
+                (update/update-model [:msg/workflow-failed {:workflow-id wf-id-1 :error "timeout"}]))]
+      (is (= :failed (:status (first (:workflows m))))))))
+
+(deftest mode-switching-test
+  (testing ": enters command mode"
+    (let [m (update/update-model (model/init-model) [:input :key/colon])]
+      (is (= :command (:mode m)))
+      (is (= ":" (:command-buf m)))))
+
+  (testing "/ enters search mode"
+    (let [m (update/update-model (model/init-model) [:input :key/slash])]
+      (is (= :search (:mode m)))
+      (is (= "/" (:command-buf m)))))
+
+  (testing "Escape exits command mode"
+    (let [m (-> (model/init-model)
+                (update/update-model [:input :key/colon])
+                (update/update-model [:input :key/escape]))]
+      (is (= :normal (:mode m)))))
+
+  (testing "Character input in command mode appends to buffer"
+    (let [m (-> (model/init-model)
+                (update/update-model [:input :key/colon])
+                (update/update-model [:input {:type :char :char \h}])
+                (update/update-model [:input {:type :char :char \i}]))]
+      (is (= ":hi" (:command-buf m)))))
+
+  (testing "Backspace in command mode removes last char"
+    (let [m (-> (model/init-model)
+                (update/update-model [:input :key/colon])
+                (update/update-model [:input {:type :char :char \x}])
+                (update/update-model [:input :key/backspace]))]
+      (is (= ":" (:command-buf m))))))
+
+(deftest quit-test
+  (testing "q sets quit flag"
+    (let [m (update/update-model (model/init-model) [:input :key/q])]
+      (is (true? (:quit? m))))))
+
+(deftest agent-output-test
+  (testing "Agent output accumulates when viewing detail"
+    (let [m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
+                (update/update-model [:input :key/enter])
+                (update/update-model [:msg/agent-output {:workflow-id wf-id-1 :delta "Hello "}])
+                (update/update-model [:msg/agent-output {:workflow-id wf-id-1 :delta "World"}]))]
+      (is (= "Hello World" (get-in m [:detail :agent-output]))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/view_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/view_test.clj
@@ -1,0 +1,88 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.view-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [clojure.string :as str]
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update :as update]
+   [ai.miniforge.tui-views.view :as view]))
+
+(deftest root-view-renders-test
+  (testing "Workflow list view renders without error"
+    (let [m (model/init-model)
+          buf (view/root-view m [80 24])]
+      (is (some? buf))
+      (is (= 24 (count buf)))
+      (is (= 80 (count (first buf))))))
+
+  (testing "Workflow list with data renders"
+    (let [m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added
+                                      {:workflow-id (random-uuid) :name "deploy-v2"}]))
+          buf (view/root-view m [80 24])
+          strings (layout/buf->strings buf)]
+      (is (some #(str/includes? % "MINIFORGE") strings))
+      (is (some #(str/includes? % "deploy-v2") strings)))))
+
+(deftest workflow-detail-view-renders-test
+  (testing "Detail view renders without error"
+    (let [wf-id (random-uuid)
+          m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added {:workflow-id wf-id :name "test"}])
+                (update/update-model [:input :key/enter]))
+          buf (view/root-view m [80 24])]
+      (is (some? buf))
+      (is (= 24 (count buf))))))
+
+(deftest evidence-view-renders-test
+  (testing "Evidence view renders without error"
+    (let [m (assoc (model/init-model) :view :evidence)
+          buf (view/root-view m [80 24])]
+      (is (some? buf)))))
+
+(deftest artifact-browser-view-renders-test
+  (testing "Artifact browser view renders without error"
+    (let [m (assoc (model/init-model) :view :artifact-browser)
+          buf (view/root-view m [80 24])]
+      (is (some? buf)))))
+
+(deftest dag-kanban-view-renders-test
+  (testing "DAG kanban view renders without error"
+    (let [m (assoc (model/init-model) :view :dag-kanban)
+          buf (view/root-view m [80 24])]
+      (is (some? buf)))))
+
+(deftest minimum-terminal-size-test
+  (testing "Graceful behavior at minimum size"
+    (let [m (model/init-model)
+          buf (view/root-view m [80 24])]
+      (is (= 24 (count buf)))))
+
+  (testing "Very small terminal shows error"
+    (let [m (model/init-model)
+          buf (view/root-view m [20 3])
+          strings (layout/buf->strings buf)]
+      (is (some #(str/includes? % "small") strings)))))
+
+(deftest command-bar-overlay-test
+  (testing "Command mode shows command bar"
+    (let [m (-> (model/init-model)
+                (update/update-model [:input :key/colon]))
+          buf (view/root-view m [80 24])
+          strings (layout/buf->strings buf)
+          last-line (last strings)]
+      (is (str/includes? last-line ":")))))

--- a/deps.edn
+++ b/deps.edn
@@ -63,6 +63,10 @@
                        "components/repo-dag/resources"
                        "components/event-stream/src"
                        "components/event-stream/resources"
+                       "components/tui-engine/src"
+                       "components/tui-engine/resources"
+                       "components/tui-views/src"
+                       "components/tui-views/resources"
                        "bases/cli/src"
                        "bases/cli/resources"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
@@ -95,6 +99,8 @@
                      ai.miniforge/pr-train {:local/root "components/pr-train"}
                      ai.miniforge/repo-dag {:local/root "components/repo-dag"}
                      ai.miniforge/event-stream {:local/root "components/event-stream"}
+                     ai.miniforge/tui-engine {:local/root "components/tui-engine"}
+                     ai.miniforge/tui-views {:local/root "components/tui-views"}
                      ai.miniforge/cli {:local/root "bases/cli"}}}
 
   :test {:extra-paths ["development/test"
@@ -127,7 +133,9 @@
                        "components/policy-pack/test"
                        "components/pr-train/test"
                        "components/repo-dag/test"
-                       "components/event-stream/test"]
+                       "components/event-stream/test"
+                       "components/tui-engine/test"
+                       "components/tui-views/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
                       ai.miniforge/logging {:local/root "components/logging"}
@@ -157,7 +165,9 @@
                       ai.miniforge/policy-pack {:local/root "components/policy-pack"}
                       ai.miniforge/pr-train {:local/root "components/pr-train"}
                       ai.miniforge/repo-dag {:local/root "components/repo-dag"}
-                      ai.miniforge/event-stream {:local/root "components/event-stream"}}}
+                      ai.miniforge/event-stream {:local/root "components/event-stream"}
+                      ai.miniforge/tui-engine {:local/root "components/tui-engine"}
+                      ai.miniforge/tui-views {:local/root "components/tui-views"}}}
 
   :conformance {:extra-paths ["development/test"
                               "tests/conformance"

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -37,7 +37,10 @@
         ai.miniforge/orchestrator {:local/root "../../components/orchestrator"}
         ai.miniforge/reporting {:local/root "../../components/reporting"}
         ;; Event streaming and observability
-        ai.miniforge/event-stream {:local/root "../../components/event-stream"}}
+        ai.miniforge/event-stream {:local/root "../../components/event-stream"}
+        ;; TUI system
+        ai.miniforge/tui-engine {:local/root "../../components/tui-engine"}
+        ai.miniforge/tui-views {:local/root "../../components/tui-views"}}
 
  :aliases
  {:uberjar


### PR DESCRIPTION
## Summary

- Adds `tui-engine` component: domain-agnostic Elm (Model-Update-View) rendering framework with layout primitives (box, split-h/v, table, text, pad), composite widgets (progress bar, tree, kanban, scrollable, sparkline), Lanterna screen abstraction with mock screen for testing, and input normalization
- Adds `tui-views` component: miniforge-specific views wiring event-stream events into the engine -- workflow list, workflow detail, evidence browser, artifact browser, and DAG kanban views with vim-style navigation (j/k/g/G), `:` command mode, `/` search mode
- Adds `fleet watch` CLI command to launch the TUI, replacing the deprecated `fleet dashboard`
- Lanterna Java classes loaded dynamically via `requiring-resolve` to maintain Babashka/GraalVM compatibility
- 40 new files, ~3800 lines, 30 test suites all passing

## Architecture

```
tui-engine (Layer 2)     tui-views (Layer 3)        CLI (Layer 4)
├── screen protocol      ├── subscription bridge    └── fleet watch cmd
├── input normalization  ├── model/update/view
├── layout primitives    └── 5 N5 spec views
└── composite widgets
```

## Test plan

- [x] All 30+ test suites pass via `poly test` (pre-commit enforced)
- [x] clj-kondo lint: 0 errors, 0 warnings
- [x] Polylith boundary check: all tui-views → tui-engine refs go through `interface.layout` / `interface.widget` sub-interfaces
- [x] GraalVM/Babashka compatibility: all interfaces load without Java class errors
- [ ] Manual smoke test: `bb miniforge fleet watch` with a running workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)