### PR TITLE
feat: LSP-to-MCP bridge for Claude Code integration

### DIFF
--- a/bases/lsp-mcp-bridge/deps.edn
+++ b/bases/lsp-mcp-bridge/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["src"]
+ :deps {}}

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/config.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/config.clj
@@ -1,0 +1,183 @@
+(ns ai.miniforge.lsp-mcp-bridge.config
+  "Configuration reader for the LSP-to-MCP bridge.
+
+   Reads EDN tool configs from 3-tier discovery:
+   1. Built-in (classpath resources/tools/lsp/*.edn)
+   2. User (~/.miniforge/tools/lsp/*.edn)
+   3. Project (.miniforge/tools/lsp/*.edn)
+
+   Layer 0: File discovery and reading
+   Layer 1: Language routing
+   Layer 2: Config assembly"
+  (:require
+   [babashka.fs :as fs]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; File discovery and reading
+
+(defn- read-edn-file
+  "Read and parse an EDN file. Returns nil on error."
+  [path]
+  (try
+    (edn/read-string (slurp (str path)))
+    (catch Exception e
+      (binding [*out* *err*]
+        (println "Warning: Failed to read" (str path) "-" (.getMessage e)))
+      nil)))
+
+(defn- discover-resource-configs
+  "Discover built-in LSP configs from classpath resources."
+  []
+  (let [resource-dir (io/resource "tools/lsp")]
+    (when resource-dir
+      ;; When running from a jar, we list known configs
+      ;; When running from source, we can list the directory
+      (let [dir-path (str resource-dir)]
+        (if (str/starts-with? dir-path "file:")
+          ;; Running from filesystem — list directory
+          (let [dir (io/file (java.net.URI. dir-path))]
+            (->> (file-seq dir)
+                 (filter #(str/ends-with? (str %) ".edn"))
+                 (map #(edn/read-string (slurp %)))))
+          ;; Running from jar — read known configs
+          (keep (fn [name]
+                  (when-let [r (io/resource (str "tools/lsp/" name))]
+                    (edn/read-string (slurp r))))
+                ["clojure.edn" "typescript.edn" "python.edn"
+                 "go.edn" "rust.edn" "lua.edn" "java.edn"]))))))
+
+(defn- discover-directory-configs
+  "Discover LSP configs from a directory."
+  [dir-path]
+  (let [dir (io/file (str dir-path))]
+    (when (and dir (.exists dir) (.isDirectory dir))
+      (->> (file-seq dir)
+           (filter #(str/ends-with? (.getName ^java.io.File %) ".edn"))
+           (keep read-edn-file)))))
+
+(defn- user-tools-dir
+  "Get the user tools directory (~/.miniforge/tools/lsp/)."
+  []
+  (str (fs/home) "/.miniforge/tools/lsp"))
+
+(defn- project-tools-dir
+  "Get the project tools directory (.miniforge/tools/lsp/)."
+  [project-dir]
+  (str project-dir "/.miniforge/tools/lsp"))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Language routing
+
+(def ^:private extension->language
+  "Map file extensions to LSP language identifiers."
+  {"clj"  "clojure"
+   "cljs" "clojurescript"
+   "cljc" "clojure"
+   "edn"  "clojure"
+   "ts"   "typescript"
+   "tsx"  "typescriptreact"
+   "js"   "javascript"
+   "jsx"  "javascriptreact"
+   "mts"  "typescript"
+   "mjs"  "javascript"
+   "py"   "python"
+   "pyi"  "python"
+   "go"   "go"
+   "rs"   "rust"
+   "lua"  "lua"
+   "java" "java"})
+
+(defn file-extension
+  "Get the file extension from a path."
+  [file-path]
+  (let [name (fs/file-name file-path)]
+    (when-let [idx (str/last-index-of name ".")]
+      (subs name (inc idx)))))
+
+(defn language-id
+  "Get the LSP language ID for a file path."
+  [file-path]
+  (get extension->language (file-extension file-path)))
+
+(defn- build-language-to-tool-index
+  "Build a lookup table from language ID to tool config."
+  [tools]
+  (reduce (fn [index tool]
+            (let [languages (get-in tool [:tool/config :lsp/languages])]
+              (reduce (fn [idx lang]
+                        (assoc idx lang tool))
+                      index
+                      languages)))
+          {}
+          tools))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Config assembly
+
+(defn read-lsp-registry
+  "Read the LSP installation registry from classpath."
+  []
+  (when-let [r (io/resource "lsp-registry.edn")]
+    (edn/read-string (slurp r))))
+
+(defn load-config
+  "Load all LSP tool configurations.
+
+   Arguments:
+   - project-dir - Project root directory (optional)
+
+   Returns:
+   {:tools        [tool-config ...]      ;; All LSP tool configs
+    :tool-index   {tool-id -> config}    ;; By tool ID
+    :lang-index   {language -> config}   ;; By language ID
+    :registry     registry-data}         ;; Installation registry"
+  ([]
+   (load-config nil))
+  ([project-dir]
+   (let [;; Discover from 3 tiers (later overrides earlier)
+         builtin-tools  (or (discover-resource-configs) [])
+         user-tools     (or (discover-directory-configs (user-tools-dir)) [])
+         project-tools  (if project-dir
+                          (or (discover-directory-configs (project-tools-dir project-dir)) [])
+                          [])
+         ;; Merge: later tools override earlier by :tool/id
+         all-tools (->> (concat builtin-tools user-tools project-tools)
+                        (reduce (fn [m tool]
+                                  (assoc m (:tool/id tool) tool))
+                                {})
+                        vals
+                        (filter #(get % :tool/enabled true))
+                        vec)
+         tool-index (into {} (map (juxt :tool/id identity)) all-tools)
+         lang-index (build-language-to-tool-index all-tools)
+         registry   (read-lsp-registry)]
+
+     {:tools all-tools
+      :tool-index tool-index
+      :lang-index lang-index
+      :registry registry})))
+
+(defn resolve-tool-for-file
+  "Find the LSP tool config for a given file path.
+
+   Arguments:
+   - config    - Config map from load-config
+   - file-path - Absolute file path
+
+   Returns tool config map or nil."
+  [config file-path]
+  (when-let [lang (language-id file-path)]
+    (get (:lang-index config) lang)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def cfg (load-config))
+  (:tools cfg)
+  (resolve-tool-for-file cfg "/foo/bar.clj")
+  (resolve-tool-for-file cfg "/foo/bar.ts")
+  (language-id "/foo/bar.py")
+
+  :leave-this-here)

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/installer.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/installer.clj
@@ -1,0 +1,208 @@
+(ns ai.miniforge.lsp-mcp-bridge.installer
+  "Auto-installation of LSP server binaries.
+
+   Checks if LSP binaries are available on PATH, and downloads/installs
+   them to ~/.miniforge/bin/ if not found.
+
+   Layer 0: Platform detection
+   Layer 1: Binary resolution
+   Layer 2: Download and extraction
+   Layer 3: Installation orchestration"
+  (:require
+   [babashka.fs :as fs]
+   [babashka.process :as bp]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Platform detection
+
+(defn platform-key
+  "Detect the current platform. Returns a string like 'macos-aarch64'."
+  []
+  (let [os-name (str/lower-case (System/getProperty "os.name"))
+        os-arch (System/getProperty "os.arch")
+        os (cond
+             (str/includes? os-name "mac") "macos"
+             (str/includes? os-name "linux") "linux"
+             (str/includes? os-name "win") "windows"
+             :else "unknown")
+        arch (case os-arch
+               "aarch64" "aarch64"
+               "arm64"   "aarch64"
+               "amd64"   "x86_64"
+               "x86_64"  "x86_64"
+               os-arch)]
+    (str os "-" arch)))
+
+(defn bin-dir
+  "Get the miniforge binary directory."
+  []
+  (str (fs/home) "/.miniforge/bin"))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Binary resolution
+
+(defn which
+  "Find a binary on PATH. Returns the path or nil."
+  [binary]
+  (try
+    (let [result (bp/sh ["which" binary])]
+      (when (zero? (:exit result))
+        (str/trim (:out result))))
+    (catch Exception _ nil)))
+
+(defn resolve-binary
+  "Find a binary, checking PATH first then ~/.miniforge/bin/.
+   Returns the full path to the binary or nil."
+  [binary]
+  (or (which binary)
+      (let [local-path (str (bin-dir) "/" binary)]
+        (when (fs/exists? local-path)
+          local-path))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Download and extraction
+
+(defn- download-file
+  "Download a file from a URL to a local path."
+  [url dest-path]
+  (binding [*out* *err*]
+    (println "Downloading" url "..."))
+  (let [result (bp/sh ["curl" "-L" "-o" (str dest-path) "--progress-bar" url])]
+    (when-not (zero? (:exit result))
+      (throw (ex-info "Download failed" {:url url :exit (:exit result)})))))
+
+(defn- extract-zip
+  "Extract a zip archive to a directory."
+  [archive-path dest-dir]
+  (bp/sh ["unzip" "-o" (str archive-path) "-d" (str dest-dir)]))
+
+(defn- extract-tar-gz
+  "Extract a tar.gz archive to a directory."
+  [archive-path dest-dir]
+  (bp/sh ["tar" "xzf" (str archive-path) "-C" (str dest-dir)]))
+
+(defn- extract-gzip
+  "Extract a gzip file (single file, not tar)."
+  [archive-path dest-path]
+  (bp/sh ["sh" "-c" (str "gunzip -c " (str archive-path) " > " (str dest-path))]))
+
+(defn- extract-archive
+  "Extract an archive based on its type."
+  [archive-path dest-dir extract-type binary-name]
+  (case extract-type
+    :zip (extract-zip archive-path dest-dir)
+    :tar-gz (extract-tar-gz archive-path dest-dir)
+    :gzip (let [dest (str dest-dir "/" binary-name)]
+            (extract-gzip archive-path dest)
+            (bp/sh ["chmod" "+x" dest]))
+    :none (let [dest (str dest-dir "/" binary-name)]
+            (fs/copy archive-path dest {:replace-existing true})
+            (bp/sh ["chmod" "+x" dest]))))
+
+(defn- github-release-url
+  "Build a GitHub Releases download URL."
+  [github-repo version filename]
+  (str "https://github.com/" github-repo "/releases/download/" version "/" filename))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Installation orchestration
+
+(defn- install-via-github
+  "Install an LSP binary from GitHub Releases."
+  [server-entry platform]
+  (let [{:keys [github version assets binary]} server-entry
+        platform-asset (get assets platform)]
+    (if-not platform-asset
+      {:error (str "No binary available for platform: " platform)}
+      (let [url (github-release-url github version (:file platform-asset))
+            dest-dir (bin-dir)
+            temp-dir (str (fs/create-temp-dir {:prefix "miniforge-install-"}))
+            archive-path (str temp-dir "/" (:file platform-asset))]
+        (try
+          (fs/create-dirs dest-dir)
+          (download-file url archive-path)
+          (extract-archive archive-path dest-dir (:extract platform-asset) binary)
+          ;; Handle binary-in-archive (nested binary location)
+          (when-let [nested (:binary-in-archive platform-asset)]
+            (let [nested-path (str dest-dir "/" nested)
+                  final-path (str dest-dir "/" binary)]
+              (when (and (not= nested-path final-path) (fs/exists? nested-path))
+                (fs/move nested-path final-path {:replace-existing true}))))
+          (let [final-binary (str dest-dir "/" binary)]
+            (bp/sh ["chmod" "+x" final-binary])
+            {:installed final-binary})
+          (finally
+            (fs/delete-tree temp-dir)))))))
+
+(defn- install-via-npm
+  "Install an LSP binary via npm."
+  [server-entry]
+  (let [{:keys [npm-package also-requires]} server-entry
+        packages (cons npm-package (or also-requires []))]
+    (binding [*out* *err*]
+      (println "Installing via npm:" (str/join " " packages)))
+    (let [result (bp/sh (into ["npm" "install" "-g"] packages))]
+      (if (zero? (:exit result))
+        {:installed (which (:binary server-entry))}
+        {:error (str "npm install failed: " (:err result))}))))
+
+(defn- install-via-go
+  "Install an LSP binary via go install."
+  [server-entry]
+  (let [{:keys [go-package]} server-entry]
+    (binding [*out* *err*]
+      (println "Installing via go install:" go-package))
+    (let [result (bp/sh ["go" "install" go-package])]
+      (if (zero? (:exit result))
+        {:installed (which (:binary server-entry))}
+        {:error (str "go install failed: " (:err result))}))))
+
+(defn ensure-installed
+  "Ensure an LSP binary is installed. Downloads if not found on PATH.
+
+   Arguments:
+   - registry     - LSP registry data (from lsp-registry.edn)
+   - tool-id      - Tool identifier keyword (e.g. :lsp/clojure)
+   - command      - Original command vector (e.g. [\"clojure-lsp\"])
+
+   Returns:
+   - {:command updated-command} on success
+   - {:error message} on failure"
+  [registry tool-id command]
+  (let [binary (first command)]
+    (if (resolve-binary binary)
+      ;; Already installed
+      {:command command}
+      ;; Need to install
+      (let [;; Find in registry by tool-id
+            server-entry (->> (:servers registry)
+                              vals
+                              (filter #(= tool-id (:tool-id %)))
+                              first)]
+        (if-not server-entry
+          {:error (str "LSP binary not found and no install info for: " binary
+                       ". Install it manually and ensure it's on your PATH.")}
+          (let [install-method (or (:install-method server-entry) :github)
+                result (case install-method
+                         :github (install-via-github server-entry (platform-key))
+                         :npm (install-via-npm server-entry)
+                         :go-install (install-via-go server-entry)
+                         :custom {:error (str "Manual installation required. "
+                                              (:install-instructions server-entry))})]
+            (if (:error result)
+              result
+              ;; Update command to use the installed binary path
+              (let [installed-path (:installed result)]
+                (if installed-path
+                  {:command (assoc command 0 installed-path)}
+                  {:error "Installation succeeded but binary not found"})))))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (platform-key)        ;; => "macos-aarch64"
+  (which "clojure-lsp") ;; => "/opt/homebrew/bin/clojure-lsp"
+  (resolve-binary "clojure-lsp")
+  (bin-dir)             ;; => "/Users/chris/.miniforge/bin"
+
+  :leave-this-here)

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/installer.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/installer.clj
@@ -7,11 +7,13 @@
    Layer 0: Platform detection
    Layer 1: Binary resolution
    Layer 2: Download and extraction
-   Layer 3: Installation orchestration"
+   Layer 3: Installation pipeline
+   Layer 4: Installation orchestration"
   (:require
    [babashka.fs :as fs]
    [babashka.process :as bp]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Platform detection
@@ -85,7 +87,7 @@
 (defn- extract-gzip
   "Extract a gzip file (single file, not tar)."
   [archive-path dest-path]
-  (bp/sh ["sh" "-c" (str "gunzip -c " (str archive-path) " > " (str dest-path))]))
+  (bp/sh ["sh" "-c" (str "gunzip -c " archive-path " > " dest-path)]))
 
 (defn- extract-archive
   "Extract an archive based on its type."
@@ -106,24 +108,63 @@
   (str "https://github.com/" github-repo "/releases/download/" version "/" filename))
 
 ;------------------------------------------------------------------------------ Layer 3
-;; Installation orchestration
+;; Installation pipeline — GitHub releases
 
-(defn- install-via-github
-  "Install an LSP binary from GitHub Releases."
-  [server-entry platform]
-  (let [{:keys [github version assets binary]} server-entry
-        platform-asset (get assets platform)]
-    (if-not platform-asset
-      {:error (str "No binary available for platform: " platform)}
-      (let [url (github-release-url github version (:file platform-asset))
-            dest-dir (bin-dir)
+(defn- failed? [state] (contains? state :failure))
+
+(defn- fail
+  "Mark pipeline as failed with anomaly."
+  [state message]
+  (assoc state :failure (response/make-anomaly :anomalies/fault message)))
+
+(defn- step-resolve-asset
+  "Resolve the platform-specific asset from the server entry."
+  [state]
+  (if (failed? state) state
+      (let [{:keys [server-entry platform]} state
+            {:keys [assets]} server-entry
+            platform-asset (get assets platform)]
+        (if-not platform-asset
+          (fail state (str "No binary available for platform: " platform))
+          (assoc state :platform-asset platform-asset)))))
+
+(defn- step-download
+  "Download the asset archive to a temp directory."
+  [state]
+  (if (failed? state) state
+      (let [{:keys [server-entry platform-asset]} state
+            {:keys [github version binary]} server-entry
+            url (github-release-url github version (:file platform-asset))
             temp-dir (str (fs/create-temp-dir {:prefix "miniforge-install-"}))
-            archive-path (str temp-dir "/" (:file platform-asset))]
+            archive-path (str temp-dir "/" (:file platform-asset))
+            dest-dir (bin-dir)]
         (try
           (fs/create-dirs dest-dir)
           (download-file url archive-path)
+          (assoc state
+                 :url url :temp-dir temp-dir :archive-path archive-path
+                 :dest-dir dest-dir :binary binary)
+          (catch Exception e
+            (fs/delete-tree temp-dir)
+            (fail state (str "Download failed: " (.getMessage e))))))))
+
+(defn- step-extract
+  "Extract the archive and place binary."
+  [state]
+  (if (failed? state) state
+      (let [{:keys [archive-path dest-dir platform-asset binary]} state]
+        (try
           (extract-archive archive-path dest-dir (:extract platform-asset) binary)
-          ;; Handle binary-in-archive (nested binary location)
+          state
+          (catch Exception e
+            (fail state (str "Extraction failed: " (.getMessage e))))))))
+
+(defn- step-place-binary
+  "Handle nested binary location and set permissions."
+  [state]
+  (if (failed? state) state
+      (let [{:keys [dest-dir platform-asset binary temp-dir]} state]
+        (try
           (when-let [nested (:binary-in-archive platform-asset)]
             (let [nested-path (str dest-dir "/" nested)
                   final-path (str dest-dir "/" binary)]
@@ -131,32 +172,77 @@
                 (fs/move nested-path final-path {:replace-existing true}))))
           (let [final-binary (str dest-dir "/" binary)]
             (bp/sh ["chmod" "+x" final-binary])
-            {:installed final-binary})
-          (finally
-            (fs/delete-tree temp-dir)))))))
+            (fs/delete-tree temp-dir)
+            (assoc state :installed final-binary))
+          (catch Exception e
+            (fs/delete-tree temp-dir)
+            (fail state (str "Binary placement failed: " (.getMessage e))))))))
+
+(defn- install-pipeline->result
+  "Convert pipeline state to result."
+  [state]
+  (if (failed? state)
+    (:failure state)
+    {:installed (:installed state)}))
+
+(defn- install-via-github
+  "Install an LSP binary from GitHub Releases."
+  [server-entry platform]
+  (-> {:server-entry server-entry :platform platform}
+      step-resolve-asset
+      step-download
+      step-extract
+      step-place-binary
+      install-pipeline->result))
 
 (defn- install-via-npm
   "Install an LSP binary via npm."
   [server-entry]
-  (let [{:keys [npm-package also-requires]} server-entry
+  (let [{:keys [npm-package also-requires binary]} server-entry
         packages (cons npm-package (or also-requires []))]
     (binding [*out* *err*]
       (println "Installing via npm:" (str/join " " packages)))
     (let [result (bp/sh (into ["npm" "install" "-g"] packages))]
       (if (zero? (:exit result))
-        {:installed (which (:binary server-entry))}
-        {:error (str "npm install failed: " (:err result))}))))
+        {:installed (which binary)}
+        (response/make-anomaly :anomalies/fault
+                               (str "npm install failed: " (:err result)))))))
 
 (defn- install-via-go
   "Install an LSP binary via go install."
   [server-entry]
-  (let [{:keys [go-package]} server-entry]
+  (let [{:keys [go-package binary]} server-entry]
     (binding [*out* *err*]
       (println "Installing via go install:" go-package))
     (let [result (bp/sh ["go" "install" go-package])]
       (if (zero? (:exit result))
-        {:installed (which (:binary server-entry))}
-        {:error (str "go install failed: " (:err result))}))))
+        {:installed (which binary)}
+        (response/make-anomaly :anomalies/fault
+                               (str "go install failed: " (:err result)))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Installation orchestration
+
+(defn- find-server-entry
+  "Find server entry in registry by tool-id."
+  [registry tool-id]
+  (->> (:servers registry)
+       vals
+       (filter #(= tool-id (:tool-id %)))
+       first))
+
+(defn- run-install
+  "Run the appropriate install method for a server entry."
+  [server-entry]
+  (let [install-method (or (:install-method server-entry) :github)]
+    (case install-method
+      :github     (install-via-github server-entry (platform-key))
+      :npm        (install-via-npm server-entry)
+      :go-install (install-via-go server-entry)
+      :custom     (response/make-anomaly
+                   :anomalies/unsupported
+                   (str "Manual installation required. "
+                        (:install-instructions server-entry))))))
 
 (defn ensure-installed
   "Ensure an LSP binary is installed. Downloads if not found on PATH.
@@ -168,35 +254,24 @@
 
    Returns:
    - {:command updated-command} on success
-   - {:error message} on failure"
+   - Anomaly map on failure"
   [registry tool-id command]
   (let [binary (first command)]
     (if (resolve-binary binary)
-      ;; Already installed
       {:command command}
-      ;; Need to install
-      (let [;; Find in registry by tool-id
-            server-entry (->> (:servers registry)
-                              vals
-                              (filter #(= tool-id (:tool-id %)))
-                              first)]
+      (let [server-entry (find-server-entry registry tool-id)]
         (if-not server-entry
-          {:error (str "LSP binary not found and no install info for: " binary
-                       ". Install it manually and ensure it's on your PATH.")}
-          (let [install-method (or (:install-method server-entry) :github)
-                result (case install-method
-                         :github (install-via-github server-entry (platform-key))
-                         :npm (install-via-npm server-entry)
-                         :go-install (install-via-go server-entry)
-                         :custom {:error (str "Manual installation required. "
-                                              (:install-instructions server-entry))})]
-            (if (:error result)
+          (response/make-anomaly
+           :anomalies/not-found
+           (str "LSP binary not found and no install info for: " binary
+                ". Install it manually and ensure it's on your PATH."))
+          (let [result (run-install server-entry)]
+            (if (response/anomaly-map? result)
               result
-              ;; Update command to use the installed binary path
-              (let [installed-path (:installed result)]
-                (if installed-path
-                  {:command (assoc command 0 installed-path)}
-                  {:error "Installation succeeded but binary not found"})))))))))
+              (if-let [installed-path (:installed result)]
+                {:command (assoc command 0 installed-path)}
+                (response/make-anomaly :anomalies/fault
+                                       "Installation succeeded but binary not found")))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/client.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/client.clj
@@ -5,12 +5,14 @@
    Uses Thread + atoms/promises for async message handling.
 
    Layer 0: Client state
-   Layer 1: Message I/O
-   Layer 2: Request/response handling
-   Layer 3: High-level operations"
+   Layer 1: Message dispatch (extracted from reader loop)
+   Layer 2: Message I/O (reader loop, send)
+   Layer 3: Request/response handling
+   Layer 4: High-level operations"
   (:require
    [ai.miniforge.lsp-mcp-bridge.lsp.protocol :as proto]
-   [ai.miniforge.lsp-mcp-bridge.lsp.process :as process])
+   [ai.miniforge.lsp-mcp-bridge.lsp.process :as process]
+   [ai.miniforge.response.interface :as response])
   (:import
    [java.io BufferedReader InputStreamReader BufferedWriter OutputStreamWriter]))
 
@@ -32,50 +34,61 @@
 (def default-timeout-ms 30000)
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Message I/O — delegated to LSP protocol
+;; Message dispatch — extracted from reader loop
+
+(defn- dispatch-response
+  "Deliver a response to its pending promise."
+  [pending-requests msg]
+  (let [id (:id msg)
+        pending @pending-requests]
+    (when (contains? pending id)
+      (let [p (get pending id)]
+        (swap! pending-requests dissoc id)
+        (deliver p msg)))))
+
+(defn- dispatch-notification
+  "Buffer diagnostics and invoke notification handler."
+  [diagnostics-buffer notification-handler msg]
+  (when (and diagnostics-buffer
+             (= (:method msg) "textDocument/publishDiagnostics"))
+    (let [uri (get-in msg [:params :uri])
+          diags (get-in msg [:params :diagnostics])]
+      (swap! diagnostics-buffer assoc uri (vec diags))))
+  (when notification-handler
+    (try
+      (notification-handler msg)
+      (catch Exception e
+        (binding [*out* *err*]
+          (println "Notification handler error:" (.getMessage e)))))))
+
+(defn- dispatch-message
+  "Route an incoming LSP message to the appropriate handler."
+  [client msg]
+  (let [{:keys [pending-requests diagnostics-buffer notification-handler]} client]
+    (cond
+      (proto/response? msg)
+      (dispatch-response pending-requests msg)
+
+      (proto/notification? msg)
+      (dispatch-notification diagnostics-buffer notification-handler msg)
+
+      (proto/request? msg)
+      (binding [*out* *err*]
+        (println "Server request (unhandled):" (:method msg))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Message I/O
 
 (defn- start-reader-loop
   "Start a background thread reading messages from the LSP server."
   [client]
-  (let [{:keys [reader pending-requests notification-handler diagnostics-buffer]} client
+  (let [{:keys [reader]} client
         thread (Thread.
                 (fn []
                   (try
                     (loop []
                       (when-let [msg (proto/read-message reader)]
-                        (cond
-                          ;; Response to a pending request
-                          (proto/response? msg)
-                          (let [id (:id msg)
-                                p  (let [pending @pending-requests]
-                                     (when (contains? pending id)
-                                       (swap! pending-requests dissoc id)
-                                       (get pending id)))]
-                            (when p
-                              (deliver p msg)))
-
-                          ;; Notification from server
-                          (proto/notification? msg)
-                          (do
-                            ;; Buffer diagnostics
-                            (when (and diagnostics-buffer
-                                       (= (:method msg) "textDocument/publishDiagnostics"))
-                              (let [uri (get-in msg [:params :uri])
-                                    diags (get-in msg [:params :diagnostics])]
-                                (swap! diagnostics-buffer assoc uri (vec diags))))
-                            ;; Call notification handler
-                            (when notification-handler
-                              (try
-                                (notification-handler msg)
-                                (catch Exception e
-                                  (binding [*out* *err*]
-                                    (println "Notification handler error:" (.getMessage e)))))))
-
-                          ;; Request from server (rare)
-                          (proto/request? msg)
-                          (binding [*out* *err*]
-                            (println "Server request (unhandled):" (:method msg))))
-
+                        (dispatch-message client msg)
                         (recur)))
                     (catch Exception e
                       (when (process/process-alive? (:process client))
@@ -86,7 +99,7 @@
     (.start thread)
     thread))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 3
 ;; Request/response handling
 
 (defn send-request
@@ -104,7 +117,7 @@
 
    Returns:
    - {:result any} on success
-   - {:error message} on failure/timeout"
+   - Anomaly map on failure/timeout"
   ([client request]
    (send-request-sync client request default-timeout-ms))
   ([client request timeout-ms]
@@ -115,26 +128,28 @@
            (= result ::timeout)
            (do
              (swap! (:pending-requests client) dissoc (:id request))
-             {:error "Request timed out"})
+             (response/make-anomaly :anomalies/timeout "Request timed out"
+                                    {:lsp/method (:method request)}))
 
            (nil? result)
-           {:error "No response received"}
+           (response/make-anomaly :anomalies/fault "No response received")
 
            (proto/error? result)
-           {:error (get-in result [:error :message] "Unknown error")
-            :code (get-in result [:error :code])}
+           (response/make-anomaly :anomalies/fault
+                                  (get-in result [:error :message] "Unknown error")
+                                  {:lsp/code (get-in result [:error :code])})
 
            :else
            {:result (:result result)}))
        (catch Exception e
-         {:error (.getMessage e)})))))
+         (response/from-exception e))))))
 
 (defn send-notification
   "Send a notification (no response expected)."
   [client notification]
   (proto/write-message (:writer client) notification))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 4
 ;; High-level operations
 
 (defn create-client
@@ -158,21 +173,20 @@
                  :initialized? (atom false)
                  :notification-handler notification-handler
                  :diagnostics-buffer (atom {})
-                 :reader-thread nil})]
-    ;; Start background reader
-    (let [thread (start-reader-loop client)]
-      (assoc client :reader-thread thread))))
+                 :reader-thread nil})
+        thread (start-reader-loop client)]
+    (assoc client :reader-thread thread)))
 
 (defn initialize
   "Initialize the LSP server.
 
    Returns:
    - {:capabilities server-capabilities} on success
-   - {:error message} on failure"
+   - Anomaly map on failure"
   [client root-uri capabilities]
   (let [request (proto/initialize-request root-uri capabilities)
         result (send-request-sync client request 60000)]
-    (if (:error result)
+    (if (response/anomaly-map? result)
       result
       (do
         (reset! (:server-capabilities client) (:capabilities (:result result)))
@@ -184,7 +198,7 @@
   "Shutdown the LSP server gracefully."
   [client]
   (let [result (send-request-sync client (proto/shutdown-request) 10000)]
-    (if (:error result)
+    (if (response/anomaly-map? result)
       result
       (do
         (send-notification client (proto/exit-notification))

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/client.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/client.clj
@@ -1,0 +1,283 @@
+(ns ai.miniforge.lsp-mcp-bridge.lsp.client
+  "LSP client for Babashka.
+
+   Port of ai.miniforge.tool-registry.lsp.client without core.async.
+   Uses Thread + atoms/promises for async message handling.
+
+   Layer 0: Client state
+   Layer 1: Message I/O
+   Layer 2: Request/response handling
+   Layer 3: High-level operations"
+  (:require
+   [ai.miniforge.lsp-mcp-bridge.lsp.protocol :as proto]
+   [ai.miniforge.lsp-mcp-bridge.lsp.process :as process])
+  (:import
+   [java.io BufferedReader InputStreamReader BufferedWriter OutputStreamWriter]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Client state
+
+(defrecord LSPClient
+  [process           ; LSPProcess record
+   tool-id           ; Tool identifier keyword
+   reader            ; BufferedReader (from LSP stdout)
+   writer            ; BufferedWriter (to LSP stdin)
+   pending-requests  ; atom: {id -> promise}
+   server-capabilities ; atom
+   initialized?      ; atom
+   notification-handler ; fn or nil
+   diagnostics-buffer   ; atom: {uri -> [diagnostic ...]}
+   reader-thread])      ; Thread
+
+(def default-timeout-ms 30000)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Message I/O — delegated to LSP protocol
+
+(defn- start-reader-loop
+  "Start a background thread reading messages from the LSP server."
+  [client]
+  (let [{:keys [reader pending-requests notification-handler diagnostics-buffer]} client
+        thread (Thread.
+                (fn []
+                  (try
+                    (loop []
+                      (when-let [msg (proto/read-message reader)]
+                        (cond
+                          ;; Response to a pending request
+                          (proto/response? msg)
+                          (let [id (:id msg)
+                                p  (let [pending @pending-requests]
+                                     (when (contains? pending id)
+                                       (swap! pending-requests dissoc id)
+                                       (get pending id)))]
+                            (when p
+                              (deliver p msg)))
+
+                          ;; Notification from server
+                          (proto/notification? msg)
+                          (do
+                            ;; Buffer diagnostics
+                            (when (and diagnostics-buffer
+                                       (= (:method msg) "textDocument/publishDiagnostics"))
+                              (let [uri (get-in msg [:params :uri])
+                                    diags (get-in msg [:params :diagnostics])]
+                                (swap! diagnostics-buffer assoc uri (vec diags))))
+                            ;; Call notification handler
+                            (when notification-handler
+                              (try
+                                (notification-handler msg)
+                                (catch Exception e
+                                  (binding [*out* *err*]
+                                    (println "Notification handler error:" (.getMessage e)))))))
+
+                          ;; Request from server (rare)
+                          (proto/request? msg)
+                          (binding [*out* *err*]
+                            (println "Server request (unhandled):" (:method msg))))
+
+                        (recur)))
+                    (catch Exception e
+                      (when (process/process-alive? (:process client))
+                        (binding [*out* *err*]
+                          (println "LSP reader error:" (.getMessage e))))))))]
+    (.setDaemon thread true)
+    (.setName thread (str "lsp-reader-" (name (:tool-id client))))
+    (.start thread)
+    thread))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Request/response handling
+
+(defn send-request
+  "Send a request and return a promise for the response."
+  [client request]
+  (let [{:keys [writer pending-requests]} client
+        id (:id request)
+        p  (promise)]
+    (swap! pending-requests assoc id p)
+    (proto/write-message writer request)
+    p))
+
+(defn send-request-sync
+  "Send a request and wait for the response synchronously.
+
+   Returns:
+   - {:result any} on success
+   - {:error message} on failure/timeout"
+  ([client request]
+   (send-request-sync client request default-timeout-ms))
+  ([client request timeout-ms]
+   (let [p (send-request client request)]
+     (try
+       (let [result (deref p timeout-ms ::timeout)]
+         (cond
+           (= result ::timeout)
+           (do
+             (swap! (:pending-requests client) dissoc (:id request))
+             {:error "Request timed out"})
+
+           (nil? result)
+           {:error "No response received"}
+
+           (proto/error? result)
+           {:error (get-in result [:error :message] "Unknown error")
+            :code (get-in result [:error :code])}
+
+           :else
+           {:result (:result result)}))
+       (catch Exception e
+         {:error (.getMessage e)})))))
+
+(defn send-notification
+  "Send a notification (no response expected)."
+  [client notification]
+  (proto/write-message (:writer client) notification))
+
+;------------------------------------------------------------------------------ Layer 3
+;; High-level operations
+
+(defn create-client
+  "Create an LSP client from a running process.
+
+   Arguments:
+   - lsp-process          - Process record from process/start-process
+   - notification-handler - Optional fn to handle server notifications"
+  [lsp-process notification-handler]
+  (let [in-stream (process/get-input-stream lsp-process)
+        out-stream (process/get-output-stream lsp-process)
+        reader (BufferedReader. (InputStreamReader. in-stream "UTF-8"))
+        writer (BufferedWriter. (OutputStreamWriter. out-stream "UTF-8"))
+        client (map->LSPClient
+                {:process lsp-process
+                 :tool-id (:tool-id lsp-process)
+                 :reader reader
+                 :writer writer
+                 :pending-requests (atom {})
+                 :server-capabilities (atom nil)
+                 :initialized? (atom false)
+                 :notification-handler notification-handler
+                 :diagnostics-buffer (atom {})
+                 :reader-thread nil})]
+    ;; Start background reader
+    (let [thread (start-reader-loop client)]
+      (assoc client :reader-thread thread))))
+
+(defn initialize
+  "Initialize the LSP server.
+
+   Returns:
+   - {:capabilities server-capabilities} on success
+   - {:error message} on failure"
+  [client root-uri capabilities]
+  (let [request (proto/initialize-request root-uri capabilities)
+        result (send-request-sync client request 60000)]
+    (if (:error result)
+      result
+      (do
+        (reset! (:server-capabilities client) (:capabilities (:result result)))
+        (send-notification client (proto/initialized-notification))
+        (reset! (:initialized? client) true)
+        {:capabilities (:capabilities (:result result))}))))
+
+(defn shutdown
+  "Shutdown the LSP server gracefully."
+  [client]
+  (let [result (send-request-sync client (proto/shutdown-request) 10000)]
+    (if (:error result)
+      result
+      (do
+        (send-notification client (proto/exit-notification))
+        (reset! (:initialized? client) false)
+        {}))))
+
+(defn initialized?
+  "Check if the client has been initialized."
+  [client]
+  @(:initialized? client))
+
+;; Document operations
+
+(defn open-document
+  "Notify server that a document was opened."
+  [client uri language-id text]
+  (send-notification client
+                     (proto/did-open-notification uri language-id 1 text)))
+
+(defn close-document
+  "Notify server that a document was closed."
+  [client uri]
+  (send-notification client
+                     (proto/did-close-notification uri)))
+
+;; Language features
+
+(defn hover
+  "Get hover information at a position."
+  [client uri line character]
+  (send-request-sync client
+                     (proto/hover-request uri line character)))
+
+(defn completion
+  "Get completion items at a position."
+  [client uri line character]
+  (send-request-sync client
+                     (proto/completion-request uri line character)))
+
+(defn definition
+  "Get definition location for symbol at position."
+  [client uri line character]
+  (send-request-sync client
+                     (proto/definition-request uri line character)))
+
+(defn references
+  "Get references to symbol at position."
+  [client uri line character include-declaration?]
+  (send-request-sync client
+                     (proto/references-request uri line character include-declaration?)))
+
+(defn format-document
+  "Format a document."
+  [client uri options]
+  (send-request-sync client
+                     (proto/formatting-request uri options)))
+
+(defn document-symbols
+  "Get symbols in a document."
+  [client uri]
+  (send-request-sync client
+                     (proto/document-symbol-request uri)))
+
+(defn code-actions
+  "Get available code actions for a range."
+  [client uri range diagnostics]
+  (send-request-sync client
+                     (proto/code-action-request uri range diagnostics)))
+
+(defn rename-symbol
+  "Rename a symbol."
+  [client uri line character new-name]
+  (send-request-sync client
+                     (proto/rename-request uri line character new-name)))
+
+(defn get-diagnostics
+  "Get buffered diagnostics for a URI.
+   Returns vector of diagnostics or empty vector."
+  [client uri]
+  (get @(:diagnostics-buffer client) uri []))
+
+(defn clear-diagnostics
+  "Clear buffered diagnostics for a URI."
+  [client uri]
+  (swap! (:diagnostics-buffer client) dissoc uri))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Example usage (requires running LSP server)
+  ;; (def proc (process/start-process :lsp/clojure ["clojure-lsp"] {}))
+  ;; (def client (create-client proc nil))
+  ;; (initialize client "file:///workspace" {})
+  ;; (hover client "file:///workspace/src/foo.clj" 10 5)
+  ;; (shutdown client)
+
+  :leave-this-here)

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/manager.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/manager.clj
@@ -1,0 +1,182 @@
+(ns ai.miniforge.lsp-mcp-bridge.lsp.manager
+  "Multi-server LSP manager for the MCP bridge.
+
+   Manages multiple LSP server instances, one per language.
+   Starts servers on-demand and tracks open documents.
+
+   Layer 0: Manager state
+   Layer 1: Server lifecycle
+   Layer 2: Client access and document management
+   Layer 3: Status and cleanup"
+  (:require
+   [ai.miniforge.lsp-mcp-bridge.lsp.process :as process]
+   [ai.miniforge.lsp-mcp-bridge.lsp.client :as client]
+   [ai.miniforge.lsp-mcp-bridge.config :as config]
+   [ai.miniforge.lsp-mcp-bridge.installer :as installer]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Manager state
+
+(defn create-manager
+  "Create a new LSP manager.
+
+   Arguments:
+   - config      - Config map from config/load-config
+   - project-dir - Project root directory
+
+   Returns manager state map."
+  [cfg project-dir]
+  {:config cfg
+   :project-dir project-dir
+   :servers (atom {})         ; {tool-id {:process :client :open-docs :started-at :last-used}}
+   :log-fn (fn [& args]
+             (binding [*out* *err*]
+               (apply println args)))})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Server lifecycle
+
+(defn- start-server
+  "Start an LSP server for a tool.
+
+   Returns {:client LSPClient} on success, {:error msg} on failure."
+  [manager tool-config]
+  (let [{:keys [config project-dir log-fn]} manager
+        tool-id (:tool/id tool-config)
+        lsp-config (:tool/config tool-config)
+        command (:lsp/command lsp-config)
+        registry (:registry config)]
+
+    ;; Ensure binary is installed
+    (let [install-result (installer/ensure-installed registry tool-id command)]
+      (if (:error install-result)
+        install-result
+        (let [actual-command (:command install-result)
+              root-uri (str "file://" (or project-dir (System/getProperty "user.dir")))
+              opts {:env (:lsp/env lsp-config)
+                    :working-dir (or (:lsp/working-dir lsp-config) project-dir)}]
+
+          (log-fn "Starting LSP server:" (name tool-id) "command:" actual-command)
+
+          (let [proc-result (process/start-process tool-id actual-command opts)]
+            (if (:error proc-result)
+              proc-result
+              (let [lsp-client (client/create-client proc-result nil)
+                    init-opts (:lsp/init-options lsp-config {})
+                    init-result (client/initialize lsp-client root-uri init-opts)]
+                (if (:error init-result)
+                  (do
+                    (process/stop-process proc-result)
+                    init-result)
+                  (let [entry {:process proc-result
+                               :client lsp-client
+                               :open-docs (atom #{})
+                               :started-at (System/currentTimeMillis)
+                               :last-used (atom (System/currentTimeMillis))}]
+                    (swap! (:servers manager) assoc tool-id entry)
+                    (log-fn "LSP server started:" (name tool-id))
+                    {:client lsp-client}))))))))))
+
+(defn stop-server
+  "Stop an LSP server."
+  [manager tool-id]
+  (when-let [entry (get @(:servers manager) tool-id)]
+    (try
+      (client/shutdown (:client entry))
+      (catch Exception _))
+    (process/stop-process (:process entry))
+    (swap! (:servers manager) dissoc tool-id)
+    ((:log-fn manager) "LSP server stopped:" (name tool-id))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Client access and document management
+
+(defn get-client
+  "Get the LSP client for a tool, starting the server if needed.
+
+   Returns {:client LSPClient} or {:error msg}."
+  [manager tool-id]
+  (let [entry (get @(:servers manager) tool-id)]
+    (cond
+      ;; Running and alive
+      (and entry (process/process-alive? (:process entry)))
+      (do
+        (reset! (:last-used entry) (System/currentTimeMillis))
+        {:client (:client entry)})
+
+      ;; Dead — clean up and restart
+      entry
+      (do
+        (swap! (:servers manager) dissoc tool-id)
+        (when-let [tool-config (get-in (:config manager) [:tool-index tool-id])]
+          (start-server manager tool-config)))
+
+      ;; Not started — start
+      :else
+      (when-let [tool-config (get-in (:config manager) [:tool-index tool-id])]
+        (start-server manager tool-config)))))
+
+(defn resolve-client-for-file
+  "Get the LSP client for a file, starting the server if needed.
+
+   Arguments:
+   - manager   - Manager state
+   - file-path - Absolute file path
+
+   Returns {:client LSPClient :tool-id keyword} or {:error msg}."
+  [manager file-path]
+  (if-let [tool-config (config/resolve-tool-for-file (:config manager) file-path)]
+    (let [tool-id (:tool/id tool-config)
+          result (get-client manager tool-id)]
+      (if (:error result)
+        result
+        (assoc result :tool-id tool-id)))
+    {:error (str "No LSP server configured for file: " file-path)}))
+
+(defn ensure-document-open
+  "Ensure a document is open on the LSP server.
+   Reads the file from disk and sends didOpen if not already open."
+  [manager tool-id lsp-client file-path]
+  (let [uri (str "file://" file-path)
+        entry (get @(:servers manager) tool-id)
+        open-docs (:open-docs entry)]
+    (when (and open-docs (not (contains? @open-docs uri)))
+      (let [language (config/language-id file-path)
+            content (slurp file-path)]
+        (client/open-document lsp-client uri (or language "text") content)
+        (swap! open-docs conj uri)))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Status and cleanup
+
+(defn list-servers
+  "List all LSP servers with their status."
+  [manager]
+  (for [[tool-id entry] @(:servers manager)]
+    {:tool-id tool-id
+     :alive? (process/process-alive? (:process entry))
+     :uptime-ms (- (System/currentTimeMillis) (:started-at entry))
+     :open-docs (count @(:open-docs entry))
+     :last-used @(:last-used entry)}))
+
+(defn stop-all-servers
+  "Stop all running LSP servers."
+  [manager]
+  (doseq [tool-id (keys @(:servers manager))]
+    (stop-server manager tool-id)))
+
+(defn available-tools
+  "List all available LSP tool configs."
+  [manager]
+  (get-in manager [:config :tools]))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Usage:
+  ;; (def cfg (config/load-config "/path/to/project"))
+  ;; (def mgr (create-manager cfg "/path/to/project"))
+  ;; (resolve-client-for-file mgr "/path/to/project/src/foo.clj")
+  ;; (list-servers mgr)
+  ;; (stop-all-servers mgr)
+
+  :leave-this-here)

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/manager.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/manager.clj
@@ -5,14 +5,16 @@
    Starts servers on-demand and tracks open documents.
 
    Layer 0: Manager state
-   Layer 1: Server lifecycle
-   Layer 2: Client access and document management
-   Layer 3: Status and cleanup"
+   Layer 1: Pipeline helpers and steps
+   Layer 2: Server lifecycle
+   Layer 3: Client access and document management
+   Layer 4: Status and cleanup"
   (:require
    [ai.miniforge.lsp-mcp-bridge.lsp.process :as process]
    [ai.miniforge.lsp-mcp-bridge.lsp.client :as client]
    [ai.miniforge.lsp-mcp-bridge.config :as config]
-   [ai.miniforge.lsp-mcp-bridge.installer :as installer]))
+   [ai.miniforge.lsp-mcp-bridge.installer :as installer]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Manager state
@@ -34,48 +36,96 @@
                (apply println args)))})
 
 ;------------------------------------------------------------------------------ Layer 1
+;; Pipeline helpers and steps
+
+(defn- failed? [state] (contains? state :failure))
+
+(defn- step-ensure-installed
+  "Ensure the LSP binary is installed."
+  [state]
+  (if (failed? state) state
+      (let [{:keys [registry tool-id command]} state
+            install-result (installer/ensure-installed registry tool-id command)]
+        (if (response/anomaly-map? install-result)
+          (assoc state :failure install-result)
+          (assoc state :actual-command (:command install-result))))))
+
+(defn- step-start-process
+  "Start the LSP server subprocess."
+  [state]
+  (if (failed? state) state
+      (let [{:keys [tool-id actual-command opts log-fn]} state]
+        (log-fn "Starting LSP server:" (name tool-id) "command:" actual-command)
+        (let [proc-result (process/start-process tool-id actual-command opts)]
+          (if (response/anomaly-map? proc-result)
+            (assoc state :failure proc-result)
+            (assoc state :process proc-result))))))
+
+(defn- step-create-client
+  "Create the LSP client from the running process."
+  [state]
+  (if (failed? state) state
+      (assoc state :client (client/create-client (:process state) nil))))
+
+(defn- step-initialize
+  "Initialize the LSP server connection."
+  [state]
+  (if (failed? state) state
+      (let [{:keys [client root-uri init-opts process]} state
+            init-result (client/initialize client root-uri init-opts)]
+        (if (response/anomaly-map? init-result)
+          (do
+            (process/stop-process process)
+            (assoc state :failure init-result))
+          state))))
+
+(defn- step-register
+  "Register the running server in the manager's servers atom."
+  [state]
+  (if (failed? state) state
+      (let [{:keys [manager tool-id process client log-fn]} state
+            entry {:process process
+                   :client client
+                   :open-docs (atom #{})
+                   :started-at (System/currentTimeMillis)
+                   :last-used (atom (System/currentTimeMillis))}]
+        (swap! (:servers manager) assoc tool-id entry)
+        (log-fn "LSP server started:" (name tool-id))
+        state)))
+
+(defn- pipeline->result
+  "Convert pipeline state to result."
+  [state]
+  (if (failed? state)
+    (:failure state)
+    {:client (:client state)}))
+
+;------------------------------------------------------------------------------ Layer 2
 ;; Server lifecycle
 
 (defn- start-server
   "Start an LSP server for a tool.
 
-   Returns {:client LSPClient} on success, {:error msg} on failure."
+   Returns {:client LSPClient} on success, anomaly map on failure."
   [manager tool-config]
-  (let [{:keys [config project-dir log-fn]} manager
-        tool-id (:tool/id tool-config)
+  (let [tool-id (:tool/id tool-config)
         lsp-config (:tool/config tool-config)
-        command (:lsp/command lsp-config)
-        registry (:registry config)]
-
-    ;; Ensure binary is installed
-    (let [install-result (installer/ensure-installed registry tool-id command)]
-      (if (:error install-result)
-        install-result
-        (let [actual-command (:command install-result)
-              root-uri (str "file://" (or project-dir (System/getProperty "user.dir")))
-              opts {:env (:lsp/env lsp-config)
-                    :working-dir (or (:lsp/working-dir lsp-config) project-dir)}]
-
-          (log-fn "Starting LSP server:" (name tool-id) "command:" actual-command)
-
-          (let [proc-result (process/start-process tool-id actual-command opts)]
-            (if (:error proc-result)
-              proc-result
-              (let [lsp-client (client/create-client proc-result nil)
-                    init-opts (:lsp/init-options lsp-config {})
-                    init-result (client/initialize lsp-client root-uri init-opts)]
-                (if (:error init-result)
-                  (do
-                    (process/stop-process proc-result)
-                    init-result)
-                  (let [entry {:process proc-result
-                               :client lsp-client
-                               :open-docs (atom #{})
-                               :started-at (System/currentTimeMillis)
-                               :last-used (atom (System/currentTimeMillis))}]
-                    (swap! (:servers manager) assoc tool-id entry)
-                    (log-fn "LSP server started:" (name tool-id))
-                    {:client lsp-client}))))))))))
+        project-dir (:project-dir manager)]
+    (-> {:manager manager
+         :tool-id tool-id
+         :registry (get-in manager [:config :registry])
+         :command (:lsp/command lsp-config)
+         :root-uri (str "file://" (or project-dir (System/getProperty "user.dir")))
+         :init-opts (:lsp/init-options lsp-config {})
+         :opts {:env (:lsp/env lsp-config)
+                :working-dir (or (:lsp/working-dir lsp-config) project-dir)}
+         :log-fn (:log-fn manager)}
+        step-ensure-installed
+        step-start-process
+        step-create-client
+        step-initialize
+        step-register
+        pipeline->result)))
 
 (defn stop-server
   "Stop an LSP server."
@@ -88,13 +138,13 @@
     (swap! (:servers manager) dissoc tool-id)
     ((:log-fn manager) "LSP server stopped:" (name tool-id))))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 3
 ;; Client access and document management
 
 (defn get-client
   "Get the LSP client for a tool, starting the server if needed.
 
-   Returns {:client LSPClient} or {:error msg}."
+   Returns {:client LSPClient} or anomaly map."
   [manager tool-id]
   (let [entry (get @(:servers manager) tool-id)]
     (cond
@@ -108,13 +158,17 @@
       entry
       (do
         (swap! (:servers manager) dissoc tool-id)
-        (when-let [tool-config (get-in (:config manager) [:tool-index tool-id])]
-          (start-server manager tool-config)))
+        (if-let [tool-config (get-in (:config manager) [:tool-index tool-id])]
+          (start-server manager tool-config)
+          (response/make-anomaly :anomalies/not-found
+                                 (str "No tool config for: " tool-id))))
 
       ;; Not started — start
       :else
-      (when-let [tool-config (get-in (:config manager) [:tool-index tool-id])]
-        (start-server manager tool-config)))))
+      (if-let [tool-config (get-in (:config manager) [:tool-index tool-id])]
+        (start-server manager tool-config)
+        (response/make-anomaly :anomalies/not-found
+                               (str "No tool config for: " tool-id))))))
 
 (defn resolve-client-for-file
   "Get the LSP client for a file, starting the server if needed.
@@ -123,15 +177,16 @@
    - manager   - Manager state
    - file-path - Absolute file path
 
-   Returns {:client LSPClient :tool-id keyword} or {:error msg}."
+   Returns {:client LSPClient :tool-id keyword} or anomaly map."
   [manager file-path]
   (if-let [tool-config (config/resolve-tool-for-file (:config manager) file-path)]
     (let [tool-id (:tool/id tool-config)
           result (get-client manager tool-id)]
-      (if (:error result)
+      (if (response/anomaly-map? result)
         result
         (assoc result :tool-id tool-id)))
-    {:error (str "No LSP server configured for file: " file-path)}))
+    (response/make-anomaly :anomalies/not-found
+                           (str "No LSP server configured for file: " file-path))))
 
 (defn ensure-document-open
   "Ensure a document is open on the LSP server.
@@ -146,7 +201,7 @@
         (client/open-document lsp-client uri (or language "text") content)
         (swap! open-docs conj uri)))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 4
 ;; Status and cleanup
 
 (defn list-servers

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/process.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/process.clj
@@ -1,0 +1,104 @@
+(ns ai.miniforge.lsp-mcp-bridge.lsp.process
+  "LSP server process management for Babashka.
+
+   Uses babashka.process for subprocess management.
+
+   Layer 0: Process lifecycle
+   Layer 1: Process state and health"
+  (:require
+   [babashka.process :as bp]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Process lifecycle
+
+(defn start-process
+  "Start an LSP server subprocess.
+
+   Arguments:
+   - tool-id - Tool identifier keyword
+   - command - Vector of command + args (e.g. [\"clojure-lsp\"])
+   - opts    - Options map with :env, :working-dir
+
+   Returns:
+   - {:process Process :tool-id :command :state atom :started-at ms}
+   - {:error message} on failure"
+  [tool-id command opts]
+  (try
+    (let [env (merge {} (:env opts))
+          dir (:working-dir opts)
+          proc (bp/process (into command [])
+                           (cond-> {:in :pipe
+                                    :out :pipe
+                                    :err :pipe
+                                    :shutdown bp/destroy-tree}
+                             (seq env) (assoc :extra-env env)
+                             dir (assoc :dir dir)))]
+      {:process proc
+       :tool-id tool-id
+       :command command
+       :state (atom :running)
+       :started-at (System/currentTimeMillis)})
+    (catch Exception e
+      {:error (str "Failed to start LSP server: " (.getMessage e))})))
+
+(defn stop-process
+  "Stop an LSP server process gracefully."
+  [lsp-process]
+  (when-let [proc (:process lsp-process)]
+    (try
+      (bp/destroy-tree proc)
+      (reset! (:state lsp-process) :stopped)
+      (catch Exception _))))
+
+(defn process-alive?
+  "Check if the LSP server process is still running."
+  [lsp-process]
+  (when-let [proc (:process lsp-process)]
+    (.isAlive ^Process (:proc proc))))
+
+(defn get-input-stream
+  "Get the stdout stream from the LSP process (for reading responses)."
+  [lsp-process]
+  (:out (:process lsp-process)))
+
+(defn get-output-stream
+  "Get the stdin stream of the LSP process (for sending requests)."
+  [lsp-process]
+  (:in (:process lsp-process)))
+
+(defn get-error-stream
+  "Get the stderr stream of the LSP process."
+  [lsp-process]
+  (:err (:process lsp-process)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Process state and health
+
+(defn get-state
+  "Get the current state of the process."
+  [lsp-process]
+  @(:state lsp-process))
+
+(defn uptime-ms
+  "Get the uptime of the process in milliseconds."
+  [lsp-process]
+  (- (System/currentTimeMillis) (:started-at lsp-process)))
+
+(defn process-info
+  "Get summary info about the process."
+  [lsp-process]
+  {:tool-id (:tool-id lsp-process)
+   :command (:command lsp-process)
+   :state (get-state lsp-process)
+   :alive? (process-alive? lsp-process)
+   :uptime-ms (uptime-ms lsp-process)})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Start a process
+  (def proc (start-process :lsp/clojure ["clojure-lsp"] {}))
+  (process-alive? proc)
+  (process-info proc)
+  (stop-process proc)
+
+  :leave-this-here)

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/process.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/process.clj
@@ -6,7 +6,8 @@
    Layer 0: Process lifecycle
    Layer 1: Process state and health"
   (:require
-   [babashka.process :as bp]))
+   [babashka.process :as bp]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Process lifecycle
@@ -21,7 +22,7 @@
 
    Returns:
    - {:process Process :tool-id :command :state atom :started-at ms}
-   - {:error message} on failure"
+   - Anomaly map on failure"
   [tool-id command opts]
   (try
     (let [env (merge {} (:env opts))
@@ -39,7 +40,7 @@
        :state (atom :running)
        :started-at (System/currentTimeMillis)})
     (catch Exception e
-      {:error (str "Failed to start LSP server: " (.getMessage e))})))
+      (response/from-exception e))))
 
 (defn stop-process
   "Stop an LSP server process gracefully."

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/protocol.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/protocol.clj
@@ -1,0 +1,224 @@
+(ns ai.miniforge.lsp-mcp-bridge.lsp.protocol
+  "LSP JSON-RPC protocol types and message builders.
+
+   Port of ai.miniforge.tool-registry.lsp.protocol for Babashka compatibility.
+   Uses Content-Length framed messages (standard LSP transport).
+
+   Layer 0: Constants and message IDs
+   Layer 1: Message builders
+   Layer 2: Message encoding/decoding (Content-Length framing)
+   Layer 3: Standard LSP methods"
+  (:require
+   [cheshire.core :as json]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants and message IDs
+
+(def ^:private id-counter (atom 0))
+
+(defn- next-id
+  "Generate the next message ID."
+  []
+  (swap! id-counter inc))
+
+(def jsonrpc-version "2.0")
+
+;------------------------------------------------------------------------------ Layer 1
+;; Message builders
+
+(defn request
+  "Build a JSON-RPC request message."
+  ([method]
+   (request method nil))
+  ([method params]
+   (cond-> {:id (next-id)
+            :jsonrpc jsonrpc-version
+            :method method}
+     params (assoc :params params))))
+
+(defn response
+  "Build a JSON-RPC response message."
+  [id result]
+  {:id id
+   :jsonrpc jsonrpc-version
+   :result result})
+
+(defn notification
+  "Build a JSON-RPC notification message."
+  ([method]
+   (notification method nil))
+  ([method params]
+   (cond-> {:jsonrpc jsonrpc-version
+            :method method}
+     params (assoc :params params))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Message encoding/decoding — Content-Length framing
+
+(defn encode-message
+  "Encode a message for LSP transport (with Content-Length header).
+   Returns a string with headers and JSON body."
+  [msg]
+  (let [body (json/generate-string msg)
+        length (count (.getBytes ^String body "UTF-8"))]
+    (str "Content-Length: " length "\r\n\r\n" body)))
+
+(defn decode-message
+  "Decode a JSON-RPC message from JSON string."
+  [json-str]
+  (json/parse-string json-str true))
+
+(defn read-headers
+  "Read LSP headers from a reader until blank line.
+   Returns headers map or nil on EOF."
+  [^java.io.BufferedReader reader]
+  (loop [headers {}]
+    (let [line (.readLine reader)]
+      (cond
+        (nil? line)
+        nil
+
+        (str/blank? line)
+        headers
+
+        :else
+        (let [[_ key value] (re-matches #"([^:]+):\s*(.+)" line)]
+          (recur (assoc headers (str/lower-case (or key "")) (str/trim (or value "")))))))))
+
+(defn read-message
+  "Read a single LSP message from the reader.
+   Returns the parsed message or nil on EOF/error."
+  [^java.io.BufferedReader reader]
+  (try
+    (when-let [headers (read-headers reader)]
+      (when-let [content-length (some-> (get headers "content-length") parse-long)]
+        (let [buffer (char-array content-length)
+              _ (.read reader buffer 0 content-length)
+              json-str (String. buffer)]
+          (decode-message json-str))))
+    (catch Exception _e
+      nil)))
+
+(defn write-message
+  "Write an LSP message to a writer (with Content-Length header)."
+  [^java.io.BufferedWriter writer msg]
+  (let [encoded (encode-message msg)]
+    (.write writer ^String encoded)
+    (.flush writer)))
+
+(defn request?
+  "Check if a message is a request."
+  [msg]
+  (and (contains? msg :id)
+       (contains? msg :method)))
+
+(defn response?
+  "Check if a message is a response."
+  [msg]
+  (and (contains? msg :id)
+       (not (contains? msg :method))))
+
+(defn notification?
+  "Check if a message is a notification."
+  [msg]
+  (and (not (contains? msg :id))
+       (contains? msg :method)))
+
+(defn error?
+  "Check if a message is an error response."
+  [msg]
+  (contains? msg :error))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Standard LSP methods
+
+;; Lifecycle
+(defn initialize-request
+  "Build an initialize request."
+  [root-uri capabilities]
+  (request "initialize"
+           {:processId (.pid (java.lang.ProcessHandle/current))
+            :rootUri root-uri
+            :capabilities (or capabilities {})
+            :trace "off"}))
+
+(defn initialized-notification []
+  (notification "initialized" {}))
+
+(defn shutdown-request []
+  (request "shutdown"))
+
+(defn exit-notification []
+  (notification "exit"))
+
+;; Text synchronization
+(defn did-open-notification
+  "Build a textDocument/didOpen notification."
+  [uri language-id version text]
+  (notification "textDocument/didOpen"
+                {:textDocument {:uri uri
+                                :languageId language-id
+                                :version version
+                                :text text}}))
+
+(defn did-close-notification [uri]
+  (notification "textDocument/didClose"
+                {:textDocument {:uri uri}}))
+
+(defn did-change-notification [uri version changes]
+  (notification "textDocument/didChange"
+                {:textDocument {:uri uri :version version}
+                 :contentChanges changes}))
+
+;; Language features
+(defn hover-request [uri line character]
+  (request "textDocument/hover"
+           {:textDocument {:uri uri}
+            :position {:line line :character character}}))
+
+(defn completion-request [uri line character]
+  (request "textDocument/completion"
+           {:textDocument {:uri uri}
+            :position {:line line :character character}}))
+
+(defn definition-request [uri line character]
+  (request "textDocument/definition"
+           {:textDocument {:uri uri}
+            :position {:line line :character character}}))
+
+(defn references-request [uri line character include-declaration?]
+  (request "textDocument/references"
+           {:textDocument {:uri uri}
+            :position {:line line :character character}
+            :context {:includeDeclaration include-declaration?}}))
+
+(defn formatting-request [uri options]
+  (request "textDocument/formatting"
+           {:textDocument {:uri uri}
+            :options (or options {:tabSize 2 :insertSpaces true})}))
+
+(defn document-symbol-request [uri]
+  (request "textDocument/documentSymbol"
+           {:textDocument {:uri uri}}))
+
+(defn code-action-request [uri range diagnostics]
+  (request "textDocument/codeAction"
+           {:textDocument {:uri uri}
+            :range range
+            :context {:diagnostics (or diagnostics [])}}))
+
+(defn rename-request [uri line character new-name]
+  (request "textDocument/rename"
+           {:textDocument {:uri uri}
+            :position {:line line :character character}
+            :newName new-name}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (encode-message (hover-request "file:///foo.clj" 10 5))
+  (request? {:id 1 :method "initialize"})
+  (notification? {:method "initialized"})
+  (response? {:id 1 :result {}})
+
+  :leave-this-here)

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/main.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/main.clj
@@ -1,0 +1,46 @@
+(ns ai.miniforge.lsp-mcp-bridge.main
+  "Entry point for the LSP-to-MCP bridge.
+
+   Spawned by Claude Code (or any MCP client) as a subprocess.
+   Reads MCP JSON-RPC from stdin, manages LSP servers, writes
+   responses to stdout.
+
+   Usage:
+     bb --jar miniforge.jar -m ai.miniforge.lsp-mcp-bridge.main
+     bb lsp-mcp-bridge  (dev mode)"
+  (:require
+   [ai.miniforge.lsp-mcp-bridge.config :as config]
+   [ai.miniforge.lsp-mcp-bridge.lsp.manager :as manager]
+   [ai.miniforge.lsp-mcp-bridge.mcp.server :as server]))
+
+(defn -main
+  "Main entry point."
+  [& _args]
+  (let [project-dir (or (System/getenv "MINIFORGE_PROJECT_DIR")
+                        (System/getProperty "user.dir"))
+        log-level   (or (System/getenv "MINIFORGE_LOG_LEVEL") "info")]
+
+    (binding [*out* *err*]
+      (println "miniforge-lsp: loading config from" project-dir)
+      (println "miniforge-lsp: log level" log-level))
+
+    ;; Load configuration
+    (let [cfg (config/load-config project-dir)
+          mgr (manager/create-manager cfg project-dir)]
+
+      (binding [*out* *err*]
+        (println "miniforge-lsp:" (count (:tools cfg)) "LSP tool configs loaded")
+        (println "miniforge-lsp: languages supported:"
+                 (vec (keys (:lang-index cfg)))))
+
+      ;; Register shutdown hook
+      (.addShutdownHook (Runtime/getRuntime)
+                        (Thread. (fn []
+                                   (binding [*out* *err*]
+                                     (println "miniforge-lsp: shutting down..."))
+                                   (manager/stop-all-servers mgr)
+                                   (binding [*out* *err*]
+                                     (println "miniforge-lsp: shutdown complete")))))
+
+      ;; Start MCP server (blocking)
+      (server/start-server mgr))))

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/protocol.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/protocol.clj
@@ -1,0 +1,162 @@
+(ns ai.miniforge.lsp-mcp-bridge.mcp.protocol
+  "MCP (Model Context Protocol) JSON-RPC message builders.
+
+   The MCP protocol uses JSON-RPC 2.0 over stdio with newline-delimited JSON.
+   This is distinct from LSP which uses Content-Length headers.
+
+   Layer 0: Constants and message IDs
+   Layer 1: Message builders (request, response, notification)
+   Layer 2: Message I/O (JSON lines — read/write)
+   Layer 3: MCP-specific response builders"
+  (:require
+   [cheshire.core :as json]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants and message IDs
+
+(def ^:private id-counter (atom 0))
+
+(defn- next-id
+  "Generate the next message ID."
+  []
+  (swap! id-counter inc))
+
+(def jsonrpc-version "2.0")
+
+(def mcp-protocol-version "2024-11-05")
+
+(def mcp-server-info
+  {:name "miniforge-lsp"
+   :version "1.0.0"})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Message builders
+
+(defn response
+  "Build a JSON-RPC response message.
+
+   Arguments:
+   - id     - Request ID to respond to
+   - result - Result value"
+  [id result]
+  {:id id
+   :jsonrpc jsonrpc-version
+   :result result})
+
+(defn error-response
+  "Build a JSON-RPC error response message.
+
+   Arguments:
+   - id      - Request ID to respond to
+   - code    - Error code (integer)
+   - message - Error message
+   - data    - Optional additional data"
+  ([id code message]
+   (error-response id code message nil))
+  ([id code message data]
+   (cond-> {:id id
+            :jsonrpc jsonrpc-version
+            :error {:code code
+                    :message message}}
+     data (assoc-in [:error :data] data))))
+
+(defn notification
+  "Build a JSON-RPC notification message (no response expected).
+
+   Arguments:
+   - method - Method name
+   - params - Parameters map (optional)"
+  ([method]
+   (notification method nil))
+  ([method params]
+   (cond-> {:jsonrpc jsonrpc-version
+            :method method}
+     params (assoc :params params))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Message I/O — JSON lines (newline-delimited JSON)
+
+(defn write-message
+  "Write an MCP message as a JSON line to a writer.
+   MCP stdio transport uses newline-delimited JSON (NOT Content-Length headers)."
+  [^java.io.Writer writer msg]
+  (let [json-str (json/generate-string msg)]
+    (.write writer json-str)
+    (.write writer "\n")
+    (.flush writer)))
+
+(defn read-message
+  "Read an MCP message (JSON line) from a reader.
+   Returns the parsed message map, or nil on EOF."
+  [^java.io.BufferedReader reader]
+  (try
+    (when-let [line (.readLine reader)]
+      (when-not (clojure.string/blank? line)
+        (json/parse-string line true)))
+    (catch Exception _e
+      nil)))
+
+(defn request?
+  "Check if a message is a request (has id and method)."
+  [msg]
+  (and (contains? msg :id)
+       (contains? msg :method)))
+
+(defn response?
+  "Check if a message is a response (has id, no method)."
+  [msg]
+  (and (contains? msg :id)
+       (not (contains? msg :method))))
+
+(defn notification?
+  "Check if a message is a notification (no id, has method)."
+  [msg]
+  (and (not (contains? msg :id))
+       (contains? msg :method)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; MCP-specific response builders
+
+(defn initialize-result
+  "Build the result for an MCP initialize response."
+  [tool-definitions]
+  {:protocolVersion mcp-protocol-version
+   :capabilities {:tools {:listChanged false}}
+   :serverInfo mcp-server-info})
+
+(defn tools-list-result
+  "Build the result for a tools/list response.
+
+   Arguments:
+   - tools - Vector of tool definition maps with :name, :description, :inputSchema"
+  [tools]
+  {:tools tools})
+
+(defn tool-call-result
+  "Build a successful tool call result.
+
+   Arguments:
+   - content - String content to return"
+  [content]
+  {:content [{:type "text"
+              :text content}]})
+
+(defn tool-call-error
+  "Build an error tool call result.
+
+   Arguments:
+   - message - Error message string"
+  [message]
+  {:content [{:type "text"
+              :text message}]
+   :isError true})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Build responses
+  (response 1 (initialize-result []))
+  (response 2 (tools-list-result [{:name "lsp_hover" :description "..." :inputSchema {}}]))
+  (response 3 (tool-call-result "hover info here"))
+  (error-response 4 -32600 "Invalid request")
+
+  :leave-this-here)

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/protocol.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/protocol.clj
@@ -9,17 +9,11 @@
    Layer 2: Message I/O (JSON lines — read/write)
    Layer 3: MCP-specific response builders"
   (:require
-   [cheshire.core :as json]))
+   [cheshire.core :as json]
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants and message IDs
-
-(def ^:private id-counter (atom 0))
-
-(defn- next-id
-  "Generate the next message ID."
-  []
-  (swap! id-counter inc))
 
 (def jsonrpc-version "2.0")
 
@@ -91,7 +85,7 @@
   [^java.io.BufferedReader reader]
   (try
     (when-let [line (.readLine reader)]
-      (when-not (clojure.string/blank? line)
+      (when-not (str/blank? line)
         (json/parse-string line true)))
     (catch Exception _e
       nil)))
@@ -119,7 +113,7 @@
 
 (defn initialize-result
   "Build the result for an MCP initialize response."
-  [tool-definitions]
+  []
   {:protocolVersion mcp-protocol-version
    :capabilities {:tools {:listChanged false}}
    :serverInfo mcp-server-info})
@@ -154,7 +148,7 @@
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Build responses
-  (response 1 (initialize-result []))
+  (response 1 (initialize-result))
   (response 2 (tools-list-result [{:name "lsp_hover" :description "..." :inputSchema {}}]))
   (response 3 (tool-call-result "hover info here"))
   (error-response 4 -32600 "Invalid request")

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/server.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/server.clj
@@ -1,0 +1,91 @@
+(ns ai.miniforge.lsp-mcp-bridge.mcp.server
+  "MCP server — stdio JSON-RPC loop.
+
+   Reads JSON-RPC requests from stdin, dispatches to handlers,
+   writes responses to stdout. Logs to stderr.
+
+   Layer 0: Request handlers
+   Layer 1: Server loop"
+  (:require
+   [ai.miniforge.lsp-mcp-bridge.mcp.protocol :as proto]
+   [ai.miniforge.lsp-mcp-bridge.mcp.tools :as tools])
+  (:import
+   [java.io BufferedReader InputStreamReader BufferedWriter OutputStreamWriter]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Request handlers
+
+(defn- handle-initialize
+  "Handle MCP initialize request."
+  [_params]
+  (proto/initialize-result tools/tool-definitions))
+
+(defn- handle-tools-list
+  "Handle MCP tools/list request."
+  [_params]
+  (proto/tools-list-result tools/tool-definitions))
+
+(defn- handle-tools-call
+  "Handle MCP tools/call request."
+  [params manager]
+  (tools/call-tool params manager))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Server loop
+
+(defn- dispatch-request
+  "Dispatch a JSON-RPC request to the appropriate handler.
+
+   Returns the result to include in the response."
+  [method params manager]
+  (case method
+    "initialize"                  (handle-initialize params)
+    "tools/list"                  (handle-tools-list params)
+    "tools/call"                  (handle-tools-call params manager)
+    ;; Notifications (no response needed)
+    "notifications/initialized"   ::notification
+    "notifications/cancelled"     ::notification
+    ;; Unknown method
+    (throw (ex-info (str "Method not found: " method)
+                    {:code -32601}))))
+
+(defn start-server
+  "Start the MCP server.
+
+   Reads JSON-RPC messages from stdin, dispatches to handlers,
+   writes responses to stdout. Blocks until stdin closes.
+
+   Arguments:
+   - manager - LSP manager state"
+  [manager]
+  (let [reader (BufferedReader. (InputStreamReader. System/in "UTF-8"))
+        writer (BufferedWriter. (OutputStreamWriter. System/out "UTF-8"))]
+
+    (binding [*out* *err*]
+      (println "miniforge-lsp MCP server started"))
+
+    (loop []
+      (when-let [msg (proto/read-message reader)]
+        (when (proto/request? msg)
+          (let [id (:id msg)
+                method (:method msg)
+                params (:params msg)]
+            (try
+              (let [result (dispatch-request method params manager)]
+                (when-not (= result ::notification)
+                  (proto/write-message writer (proto/response id result))))
+              (catch Exception e
+                (let [code (or (:code (ex-data e)) -32603)
+                      message (.getMessage e)]
+                  (binding [*out* *err*]
+                    (println "Error handling" method ":" message))
+                  (proto/write-message writer
+                                      (proto/error-response id code message)))))))
+        (recur)))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; The server is started from main.clj:
+  ;; (start-server manager)
+
+  :leave-this-here)

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/server.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/server.clj
@@ -8,7 +8,8 @@
    Layer 1: Server loop"
   (:require
    [ai.miniforge.lsp-mcp-bridge.mcp.protocol :as proto]
-   [ai.miniforge.lsp-mcp-bridge.mcp.tools :as tools])
+   [ai.miniforge.lsp-mcp-bridge.mcp.tools :as tools]
+   [ai.miniforge.response.interface :as response])
   (:import
    [java.io BufferedReader InputStreamReader BufferedWriter OutputStreamWriter]))
 
@@ -18,7 +19,7 @@
 (defn- handle-initialize
   "Handle MCP initialize request."
   [_params]
-  (proto/initialize-result tools/tool-definitions))
+  (proto/initialize-result))
 
 (defn- handle-tools-list
   "Handle MCP tools/list request."
@@ -36,15 +37,15 @@
 (defn- dispatch-request
   "Dispatch a JSON-RPC request to the appropriate handler.
 
-   Returns the result to include in the response."
+   Returns the result to include in the response, or nil for notifications."
   [method params manager]
   (case method
     "initialize"                  (handle-initialize params)
     "tools/list"                  (handle-tools-list params)
     "tools/call"                  (handle-tools-call params manager)
-    ;; Notifications (no response needed)
-    "notifications/initialized"   ::notification
-    "notifications/cancelled"     ::notification
+    ;; Notifications — no response needed
+    "notifications/initialized"   nil
+    "notifications/cancelled"     nil
     ;; Unknown method
     (throw (ex-info (str "Method not found: " method)
                     {:code -32601}))))
@@ -71,16 +72,15 @@
                 method (:method msg)
                 params (:params msg)]
             (try
-              (let [result (dispatch-request method params manager)]
-                (when-not (= result ::notification)
-                  (proto/write-message writer (proto/response id result))))
+              (when-let [result (dispatch-request method params manager)]
+                (proto/write-message writer (proto/response id result)))
               (catch Exception e
-                (let [code (or (:code (ex-data e)) -32603)
-                      message (.getMessage e)]
+                (let [anomaly (response/from-exception e)
+                      code (or (:code (ex-data e)) -32603)]
                   (binding [*out* *err*]
-                    (println "Error handling" method ":" message))
+                    (println "Error handling" method ":" (:anomaly/message anomaly)))
                   (proto/write-message writer
-                                      (proto/error-response id code message)))))))
+                                      (proto/error-response id code (:anomaly/message anomaly))))))))
         (recur)))))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/tools.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/tools.clj
@@ -1,0 +1,261 @@
+(ns ai.miniforge.lsp-mcp-bridge.mcp.tools
+  "MCP tool definitions and handlers.
+
+   Each tool maps an MCP tool invocation to an LSP operation.
+
+   Layer 0: Tool definitions (schemas)
+   Layer 1: Tool handlers
+   Layer 2: Tool dispatch"
+  (:require
+   [ai.miniforge.lsp-mcp-bridge.lsp.manager :as manager]
+   [ai.miniforge.lsp-mcp-bridge.lsp.client :as client]
+   [ai.miniforge.lsp-mcp-bridge.config :as config]
+   [ai.miniforge.lsp-mcp-bridge.mcp.protocol :as mcp-proto]
+   [cheshire.core :as json]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Tool definitions
+
+(def tool-definitions
+  "MCP tool definitions with JSON Schema for inputSchema."
+  [{:name "lsp_hover"
+    :description "Get type information, documentation, and details about the symbol at a given position in a file."
+    :inputSchema
+    {:type "object"
+     :properties
+     {:file_path {:type "string" :description "Absolute path to the file"}
+      :line {:type "integer" :description "0-based line number"}
+      :character {:type "integer" :description "0-based character offset"}}
+     :required ["file_path" "line" "character"]}}
+
+   {:name "lsp_definition"
+    :description "Find the definition location of the symbol at a given position. Returns the file path and position of the definition."
+    :inputSchema
+    {:type "object"
+     :properties
+     {:file_path {:type "string" :description "Absolute path to the file"}
+      :line {:type "integer" :description "0-based line number"}
+      :character {:type "integer" :description "0-based character offset"}}
+     :required ["file_path" "line" "character"]}}
+
+   {:name "lsp_references"
+    :description "Find all references (usages) of the symbol at a given position across the project."
+    :inputSchema
+    {:type "object"
+     :properties
+     {:file_path {:type "string" :description "Absolute path to the file"}
+      :line {:type "integer" :description "0-based line number"}
+      :character {:type "integer" :description "0-based character offset"}
+      :include_declaration {:type "boolean" :description "Include the declaration itself (default true)"}}
+     :required ["file_path" "line" "character"]}}
+
+   {:name "lsp_rename"
+    :description "Rename a symbol at a given position. Returns the workspace edit (set of file changes) needed to rename the symbol everywhere."
+    :inputSchema
+    {:type "object"
+     :properties
+     {:file_path {:type "string" :description "Absolute path to the file"}
+      :line {:type "integer" :description "0-based line number"}
+      :character {:type "integer" :description "0-based character offset"}
+      :new_name {:type "string" :description "The new name for the symbol"}}
+     :required ["file_path" "line" "character" "new_name"]}}
+
+   {:name "lsp_format"
+    :description "Format a file using the language server's formatter. Returns the text edits to apply."
+    :inputSchema
+    {:type "object"
+     :properties
+     {:file_path {:type "string" :description "Absolute path to the file"}
+      :tab_size {:type "integer" :description "Tab size (default 2)"}
+      :insert_spaces {:type "boolean" :description "Use spaces instead of tabs (default true)"}}
+     :required ["file_path"]}}
+
+   {:name "lsp_document_symbols"
+    :description "Get all symbols (functions, classes, variables, etc.) defined in a file. Useful for understanding file structure."
+    :inputSchema
+    {:type "object"
+     :properties
+     {:file_path {:type "string" :description "Absolute path to the file"}}
+     :required ["file_path"]}}
+
+   {:name "lsp_code_actions"
+    :description "Get available code actions (quick fixes, refactorings) for a given range in a file."
+    :inputSchema
+    {:type "object"
+     :properties
+     {:file_path {:type "string" :description "Absolute path to the file"}
+      :start_line {:type "integer" :description "0-based start line"}
+      :start_character {:type "integer" :description "0-based start character"}
+      :end_line {:type "integer" :description "0-based end line"}
+      :end_character {:type "integer" :description "0-based end character"}}
+     :required ["file_path" "start_line" "start_character" "end_line" "end_character"]}}
+
+   {:name "lsp_completion"
+    :description "Get code completion suggestions at a given position in a file."
+    :inputSchema
+    {:type "object"
+     :properties
+     {:file_path {:type "string" :description "Absolute path to the file"}
+      :line {:type "integer" :description "0-based line number"}
+      :character {:type "integer" :description "0-based character offset"}}
+     :required ["file_path" "line" "character"]}}
+
+   {:name "lsp_diagnostics"
+    :description "Get diagnostics (errors, warnings, hints) for a file from the language server."
+    :inputSchema
+    {:type "object"
+     :properties
+     {:file_path {:type "string" :description "Absolute path to the file"}}
+     :required ["file_path"]}}
+
+   {:name "lsp_servers"
+    :description "List all available LSP servers, their supported languages, and current status (running/stopped)."
+    :inputSchema
+    {:type "object"
+     :properties {}
+     :required []}}])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Tool handlers
+
+(defn- format-result
+  "Format an LSP result as a readable string for MCP response."
+  [result]
+  (if (:error result)
+    (mcp-proto/tool-call-error (:error result))
+    (mcp-proto/tool-call-result
+     (json/generate-string (:result result) {:pretty true}))))
+
+(defn- ensure-and-call
+  "Resolve LSP client for file, ensure document is open, and call the LSP method.
+
+   Arguments:
+   - mgr       - Manager state
+   - file-path - Absolute file path
+   - lsp-fn    - Function (fn [client uri] ...) that calls the LSP method"
+  [mgr file-path lsp-fn]
+  (let [resolve-result (manager/resolve-client-for-file mgr file-path)]
+    (if (:error resolve-result)
+      (mcp-proto/tool-call-error (:error resolve-result))
+      (let [{:keys [client tool-id]} resolve-result
+            uri (str "file://" file-path)]
+        (manager/ensure-document-open mgr tool-id client file-path)
+        (format-result (lsp-fn client uri))))))
+
+(defmulti handle-tool
+  "Handle an MCP tool call. Dispatches on tool name."
+  (fn [tool-name _args _manager] tool-name))
+
+(defmethod handle-tool "lsp_hover"
+  [_ args mgr]
+  (ensure-and-call mgr (:file_path args)
+    (fn [c uri] (client/hover c uri (:line args) (:character args)))))
+
+(defmethod handle-tool "lsp_definition"
+  [_ args mgr]
+  (ensure-and-call mgr (:file_path args)
+    (fn [c uri] (client/definition c uri (:line args) (:character args)))))
+
+(defmethod handle-tool "lsp_references"
+  [_ args mgr]
+  (ensure-and-call mgr (:file_path args)
+    (fn [c uri]
+      (client/references c uri (:line args) (:character args)
+                         (get args :include_declaration true)))))
+
+(defmethod handle-tool "lsp_rename"
+  [_ args mgr]
+  (ensure-and-call mgr (:file_path args)
+    (fn [c uri]
+      (client/rename-symbol c uri (:line args) (:character args) (:new_name args)))))
+
+(defmethod handle-tool "lsp_format"
+  [_ args mgr]
+  (ensure-and-call mgr (:file_path args)
+    (fn [c uri]
+      (client/format-document c uri {:tabSize (get args :tab_size 2)
+                                     :insertSpaces (get args :insert_spaces true)}))))
+
+(defmethod handle-tool "lsp_document_symbols"
+  [_ args mgr]
+  (ensure-and-call mgr (:file_path args)
+    (fn [c uri] (client/document-symbols c uri))))
+
+(defmethod handle-tool "lsp_code_actions"
+  [_ args mgr]
+  (ensure-and-call mgr (:file_path args)
+    (fn [c uri]
+      (client/code-actions c uri
+                           {:start {:line (:start_line args) :character (:start_character args)}
+                            :end {:line (:end_line args) :character (:end_character args)}}
+                           []))))
+
+(defmethod handle-tool "lsp_completion"
+  [_ args mgr]
+  (ensure-and-call mgr (:file_path args)
+    (fn [c uri] (client/completion c uri (:line args) (:character args)))))
+
+(defmethod handle-tool "lsp_diagnostics"
+  [_ args mgr]
+  (let [file-path (:file_path args)
+        resolve-result (manager/resolve-client-for-file mgr file-path)]
+    (if (:error resolve-result)
+      (mcp-proto/tool-call-error (:error resolve-result))
+      (let [{:keys [client tool-id]} resolve-result
+            uri (str "file://" file-path)]
+        (manager/ensure-document-open mgr tool-id client file-path)
+        ;; Wait briefly for diagnostics to arrive via notification
+        (Thread/sleep 2000)
+        (let [diags (client/get-diagnostics client uri)]
+          (mcp-proto/tool-call-result
+           (json/generate-string diags {:pretty true})))))))
+
+(defmethod handle-tool "lsp_servers"
+  [_ _args mgr]
+  (let [running (manager/list-servers mgr)
+        available (manager/available-tools mgr)
+        result {:available (mapv (fn [t]
+                                   {:tool-id (name (:tool/id t))
+                                    :name (:tool/name t)
+                                    :languages (vec (get-in t [:tool/config :lsp/languages]))
+                                    :running? (some #(= (:tool-id %) (:tool/id t)) running)})
+                                 available)
+                :running (mapv (fn [s]
+                                 {:tool-id (name (:tool-id s))
+                                  :alive? (:alive? s)
+                                  :uptime-ms (:uptime-ms s)
+                                  :open-docs (:open-docs s)})
+                               running)}]
+    (mcp-proto/tool-call-result
+     (json/generate-string result {:pretty true}))))
+
+(defmethod handle-tool :default
+  [tool-name _ _]
+  (mcp-proto/tool-call-error (str "Unknown tool: " tool-name)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Tool dispatch
+
+(defn call-tool
+  "Dispatch an MCP tools/call request.
+
+   Arguments:
+   - params  - MCP tools/call params map with :name and :arguments
+   - manager - LSP manager state
+
+   Returns MCP tool result map."
+  [params manager]
+  (let [tool-name (:name params)
+        args (or (:arguments params) {})]
+    (try
+      (handle-tool tool-name args manager)
+      (catch Exception e
+        (mcp-proto/tool-call-error
+         (str "Tool error: " (.getMessage e)))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (count tool-definitions) ;; => 10
+  (map :name tool-definitions)
+
+  :leave-this-here)

--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/tools.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/mcp/tools.clj
@@ -9,8 +9,8 @@
   (:require
    [ai.miniforge.lsp-mcp-bridge.lsp.manager :as manager]
    [ai.miniforge.lsp-mcp-bridge.lsp.client :as client]
-   [ai.miniforge.lsp-mcp-bridge.config :as config]
    [ai.miniforge.lsp-mcp-bridge.mcp.protocol :as mcp-proto]
+   [ai.miniforge.response.interface :as response]
    [cheshire.core :as json]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -115,14 +115,18 @@
      :properties {}
      :required []}}])
 
+(def ^:private diagnostics-wait-ms
+  "Time to wait for diagnostics to arrive via notification."
+  2000)
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Tool handlers
 
 (defn- format-result
-  "Format an LSP result as a readable string for MCP response."
+  "Format an LSP result as MCP response. Checks for anomaly maps."
   [result]
-  (if (:error result)
-    (mcp-proto/tool-call-error (:error result))
+  (if (response/anomaly-map? result)
+    (mcp-proto/tool-call-error (:anomaly/message result))
     (mcp-proto/tool-call-result
      (json/generate-string (:result result) {:pretty true}))))
 
@@ -135,8 +139,8 @@
    - lsp-fn    - Function (fn [client uri] ...) that calls the LSP method"
   [mgr file-path lsp-fn]
   (let [resolve-result (manager/resolve-client-for-file mgr file-path)]
-    (if (:error resolve-result)
-      (mcp-proto/tool-call-error (:error resolve-result))
+    (if (response/anomaly-map? resolve-result)
+      (mcp-proto/tool-call-error (:anomaly/message resolve-result))
       (let [{:keys [client tool-id]} resolve-result
             uri (str "file://" file-path)]
         (manager/ensure-document-open mgr tool-id client file-path)
@@ -197,18 +201,10 @@
 
 (defmethod handle-tool "lsp_diagnostics"
   [_ args mgr]
-  (let [file-path (:file_path args)
-        resolve-result (manager/resolve-client-for-file mgr file-path)]
-    (if (:error resolve-result)
-      (mcp-proto/tool-call-error (:error resolve-result))
-      (let [{:keys [client tool-id]} resolve-result
-            uri (str "file://" file-path)]
-        (manager/ensure-document-open mgr tool-id client file-path)
-        ;; Wait briefly for diagnostics to arrive via notification
-        (Thread/sleep 2000)
-        (let [diags (client/get-diagnostics client uri)]
-          (mcp-proto/tool-call-result
-           (json/generate-string diags {:pretty true})))))))
+  (ensure-and-call mgr (:file_path args)
+    (fn [c uri]
+      (Thread/sleep diagnostics-wait-ms)
+      {:result (client/get-diagnostics c uri)})))
 
 (defmethod handle-tool "lsp_servers"
   [_ _args mgr]

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/config_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/config_test.clj
@@ -1,0 +1,83 @@
+(ns ai.miniforge.lsp-mcp-bridge.config-test
+  "Tests for configuration reader."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.lsp-mcp-bridge.config :as config]))
+
+;------------------------------------------------------------------------------ Language routing
+
+(deftest file-extension-test
+  (testing "extracts file extensions"
+    (is (= "clj" (config/file-extension "/foo/bar.clj")))
+    (is (= "ts" (config/file-extension "/foo/bar.ts")))
+    (is (= "py" (config/file-extension "/foo/bar.py")))
+    (is (= "go" (config/file-extension "/foo/bar.go")))
+    (is (= "rs" (config/file-extension "/foo/bar.rs")))
+    (is (= "lua" (config/file-extension "/foo/bar.lua")))
+    (is (= "java" (config/file-extension "/foo/bar.java")))))
+
+(deftest language-id-test
+  (testing "maps extensions to language IDs"
+    (is (= "clojure" (config/language-id "/foo/bar.clj")))
+    (is (= "clojurescript" (config/language-id "/foo/bar.cljs")))
+    (is (= "clojure" (config/language-id "/foo/bar.cljc")))
+    (is (= "clojure" (config/language-id "/foo/bar.edn")))
+    (is (= "typescript" (config/language-id "/foo/bar.ts")))
+    (is (= "typescriptreact" (config/language-id "/foo/bar.tsx")))
+    (is (= "javascript" (config/language-id "/foo/bar.js")))
+    (is (= "javascriptreact" (config/language-id "/foo/bar.jsx")))
+    (is (= "python" (config/language-id "/foo/bar.py")))
+    (is (= "go" (config/language-id "/foo/bar.go")))
+    (is (= "rust" (config/language-id "/foo/bar.rs")))
+    (is (= "lua" (config/language-id "/foo/bar.lua")))
+    (is (= "java" (config/language-id "/foo/bar.java"))))
+
+  (testing "returns nil for unknown extensions"
+    (is (nil? (config/language-id "/foo/bar.xyz")))
+    (is (nil? (config/language-id "/foo/bar.txt")))))
+
+;------------------------------------------------------------------------------ Config loading
+
+(deftest load-config-test
+  (testing "loads built-in configs from classpath"
+    (let [cfg (config/load-config)]
+      (is (seq (:tools cfg))
+          "Should have at least one tool config")
+      (is (contains? (:tool-index cfg) :lsp/clojure)
+          "Should include the built-in Clojure LSP config")
+      (is (contains? (:lang-index cfg) "clojure")
+          "Should have clojure in language index"))))
+
+(deftest load-config-language-routing-test
+  (testing "resolves tool for Clojure files"
+    (let [cfg (config/load-config)
+          tool (config/resolve-tool-for-file cfg "/foo/bar.clj")]
+      (is (some? tool))
+      (is (= :lsp/clojure (:tool/id tool)))))
+
+  (testing "resolves tool for TypeScript files"
+    (let [cfg (config/load-config)
+          tool (config/resolve-tool-for-file cfg "/foo/bar.ts")]
+      (is (some? tool))
+      (is (= :lsp/typescript (:tool/id tool)))))
+
+  (testing "resolves tool for Python files"
+    (let [cfg (config/load-config)
+          tool (config/resolve-tool-for-file cfg "/foo/bar.py")]
+      (is (some? tool))
+      (is (= :lsp/python (:tool/id tool)))))
+
+  (testing "returns nil for unsupported files"
+    (let [cfg (config/load-config)]
+      (is (nil? (config/resolve-tool-for-file cfg "/foo/bar.xyz"))))))
+
+;------------------------------------------------------------------------------ Registry
+
+(deftest read-lsp-registry-test
+  (testing "reads the LSP installation registry"
+    (let [reg (config/read-lsp-registry)]
+      (is (some? reg))
+      (is (string? (:registry/version reg)))
+      (is (map? (:servers reg)))
+      (is (contains? (:servers reg) :clojure-lsp)
+          "Should have clojure-lsp in registry"))))

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/installer_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/installer_test.clj
@@ -1,0 +1,54 @@
+(ns ai.miniforge.lsp-mcp-bridge.installer-test
+  "Tests for LSP auto-installer (unit tests, no actual downloads)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.lsp-mcp-bridge.installer :as installer]))
+
+;------------------------------------------------------------------------------ Platform detection
+
+(deftest platform-key-test
+  (testing "returns a valid platform string"
+    (let [pk (installer/platform-key)]
+      (is (string? pk))
+      (is (re-matches #"(macos|linux|windows|unknown)-(aarch64|x86_64|.+)" pk)
+          (str "Unexpected platform key: " pk)))))
+
+;------------------------------------------------------------------------------ Binary resolution
+
+(deftest bin-dir-test
+  (testing "returns a path under home directory"
+    (let [bd (installer/bin-dir)]
+      (is (string? bd))
+      (is (.endsWith bd "/.miniforge/bin")))))
+
+(deftest which-test
+  (testing "finds existing binary"
+    ;; 'bb' must exist since we're running under it
+    (let [result (installer/which "bb")]
+      (is (some? result))
+      (is (string? result))))
+
+  (testing "returns nil for non-existent binary"
+    (is (nil? (installer/which "nonexistent-binary-xyz-12345")))))
+
+(deftest resolve-binary-test
+  (testing "resolves existing binary from PATH"
+    (let [result (installer/resolve-binary "bb")]
+      (is (some? result))))
+
+  (testing "returns nil for non-existent binary"
+    (is (nil? (installer/resolve-binary "nonexistent-binary-xyz-12345")))))
+
+;------------------------------------------------------------------------------ ensure-installed (unit, no downloads)
+
+(deftest ensure-installed-already-on-path-test
+  (testing "returns command unchanged when binary is on PATH"
+    (let [result (installer/ensure-installed nil :lsp/test ["bb"])]
+      (is (= ["bb"] (:command result)))
+      (is (nil? (:error result))))))
+
+(deftest ensure-installed-not-found-no-registry-test
+  (testing "returns error when binary not found and no registry"
+    (let [result (installer/ensure-installed nil :lsp/test ["nonexistent-xyz"])]
+      (is (string? (:error result)))
+      (is (.contains (:error result) "not found")))))

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/installer_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/installer_test.clj
@@ -2,7 +2,8 @@
   "Tests for LSP auto-installer (unit tests, no actual downloads)."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.lsp-mcp-bridge.installer :as installer]))
+   [ai.miniforge.lsp-mcp-bridge.installer :as installer]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Platform detection
 
@@ -45,10 +46,10 @@
   (testing "returns command unchanged when binary is on PATH"
     (let [result (installer/ensure-installed nil :lsp/test ["bb"])]
       (is (= ["bb"] (:command result)))
-      (is (nil? (:error result))))))
+      (is (not (response/anomaly-map? result))))))
 
 (deftest ensure-installed-not-found-no-registry-test
-  (testing "returns error when binary not found and no registry"
+  (testing "returns anomaly when binary not found and no registry"
     (let [result (installer/ensure-installed nil :lsp/test ["nonexistent-xyz"])]
-      (is (string? (:error result)))
-      (is (.contains (:error result) "not found")))))
+      (is (response/anomaly-map? result))
+      (is (.contains (:anomaly/message result) "not found")))))

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/lsp/client_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/lsp/client_test.clj
@@ -1,0 +1,70 @@
+(ns ai.miniforge.lsp-mcp-bridge.lsp.client-test
+  "Tests for LSP client (promise-based, bb-compatible)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.lsp-mcp-bridge.lsp.protocol :as proto]))
+
+;; Note: Full client tests require a running LSP server.
+;; These tests verify the protocol layer and message building
+;; that the client depends on.
+
+(deftest promise-based-pending-requests-test
+  (testing "atom+promise pattern works for request tracking"
+    (let [pending (atom {})
+          p (promise)]
+      ;; Simulate registering a pending request
+      (swap! pending assoc 1 p)
+      (is (= 1 (count @pending)))
+
+      ;; Simulate delivering a response (as the reader thread would)
+      (let [id 1
+            msg {:id 1 :result {:hover "info"}}
+            stored-promise (let [m @pending]
+                             (when (contains? m id)
+                               (swap! pending dissoc id)
+                               (get m id)))]
+        (when stored-promise
+          (deliver stored-promise msg)))
+
+      ;; Verify the promise was delivered
+      (is (= {:id 1 :result {:hover "info"}}
+             (deref p 100 ::timeout)))
+      ;; Verify pending was cleaned up
+      (is (= 0 (count @pending))))))
+
+(deftest promise-timeout-test
+  (testing "deref with timeout returns sentinel on timeout"
+    (let [p (promise)
+          result (deref p 50 ::timeout)]
+      (is (= ::timeout result)))))
+
+(deftest send-request-sync-timeout-pattern-test
+  (testing "timeout handling pattern cleans up pending request"
+    (let [pending (atom {})
+          p (promise)
+          request-id 42]
+      ;; Register pending
+      (swap! pending assoc request-id p)
+      ;; Simulate timeout
+      (let [result (deref p 50 ::timeout)]
+        (when (= result ::timeout)
+          (swap! pending dissoc request-id)))
+      ;; Verify cleanup
+      (is (= 0 (count @pending))))))
+
+(deftest diagnostics-buffer-pattern-test
+  (testing "diagnostics buffer accumulates per URI"
+    (let [buffer (atom {})]
+      ;; Simulate receiving diagnostics notifications
+      (swap! buffer assoc "file:///foo.clj"
+             [{:range {:start {:line 0}} :message "Error" :severity 1}])
+      (swap! buffer assoc "file:///bar.clj"
+             [{:range {:start {:line 5}} :message "Warning" :severity 2}])
+
+      (is (= 1 (count (get @buffer "file:///foo.clj"))))
+      (is (= 1 (count (get @buffer "file:///bar.clj"))))
+      (is (= [] (get @buffer "file:///baz.clj" [])))
+
+      ;; Clear diagnostics for one URI
+      (swap! buffer dissoc "file:///foo.clj")
+      (is (= [] (get @buffer "file:///foo.clj" []))))))

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/lsp/protocol_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/lsp/protocol_test.clj
@@ -1,0 +1,159 @@
+(ns ai.miniforge.lsp-mcp-bridge.lsp.protocol-test
+  "Tests for LSP JSON-RPC protocol layer (Content-Length framing)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.lsp-mcp-bridge.lsp.protocol :as proto]
+   [cheshire.core :as json])
+  (:import
+   [java.io BufferedReader BufferedWriter StringReader StringWriter]))
+
+;------------------------------------------------------------------------------ Layer 1: Message builders
+
+(deftest request-builder-test
+  (testing "builds request with params"
+    (let [req (proto/request "textDocument/hover"
+                             {:textDocument {:uri "file:///foo"}})]
+      (is (integer? (:id req)))
+      (is (= "2.0" (:jsonrpc req)))
+      (is (= "textDocument/hover" (:method req)))
+      (is (= "file:///foo" (get-in req [:params :textDocument :uri])))))
+
+  (testing "builds request without params"
+    (let [req (proto/request "shutdown")]
+      (is (= "shutdown" (:method req)))
+      (is (not (contains? req :params))))))
+
+(deftest response-builder-test
+  (testing "builds response"
+    (let [resp (proto/response 1 {:value "ok"})]
+      (is (= 1 (:id resp)))
+      (is (= "2.0" (:jsonrpc resp)))
+      (is (= {:value "ok"} (:result resp))))))
+
+(deftest notification-builder-test
+  (testing "builds notification without params"
+    (let [n (proto/notification "initialized")]
+      (is (= "2.0" (:jsonrpc n)))
+      (is (= "initialized" (:method n)))
+      (is (not (contains? n :id)))
+      (is (not (contains? n :params)))))
+
+  (testing "builds notification with params"
+    (let [n (proto/notification "textDocument/didOpen" {:textDocument {:uri "file:///foo"}})]
+      (is (= {:textDocument {:uri "file:///foo"}} (:params n))))))
+
+;------------------------------------------------------------------------------ Layer 2: Encoding/Decoding
+
+(deftest encode-decode-roundtrip-test
+  (testing "encode then decode a message via Content-Length framing"
+    (let [msg {:id 1 :jsonrpc "2.0" :method "initialize" :params {:processId 123}}
+          encoded (proto/encode-message msg)
+          ;; Parse the encoded string
+          reader (BufferedReader. (StringReader. encoded))
+          decoded (proto/read-message reader)]
+      (is (= 1 (:id decoded)))
+      (is (= "initialize" (:method decoded)))
+      (is (= 123 (get-in decoded [:params :processId]))))))
+
+(deftest write-read-message-roundtrip-test
+  (testing "write-message and read-message roundtrip"
+    (let [sw (StringWriter.)
+          writer (BufferedWriter. sw)
+          msg (proto/request "textDocument/hover"
+                             {:textDocument {:uri "file:///foo"}
+                              :position {:line 10 :character 5}})]
+      (proto/write-message writer msg)
+      (let [reader (BufferedReader. (StringReader. (.toString sw)))
+            read-msg (proto/read-message reader)]
+        (is (= (:id msg) (:id read-msg)))
+        (is (= "textDocument/hover" (:method read-msg)))
+        (is (= 10 (get-in read-msg [:params :position :line])))
+        (is (= 5 (get-in read-msg [:params :position :character])))))))
+
+(deftest read-message-eof-test
+  (testing "returns nil on empty input"
+    (let [reader (BufferedReader. (StringReader. ""))]
+      (is (nil? (proto/read-message reader))))))
+
+;------------------------------------------------------------------------------ Layer 2: Predicates
+
+(deftest message-predicates-test
+  (testing "request?"
+    (is (proto/request? {:id 1 :method "test"}))
+    (is (not (proto/request? {:id 1 :result {}})))
+    (is (not (proto/request? {:method "test"}))))
+
+  (testing "response?"
+    (is (proto/response? {:id 1 :result {}}))
+    (is (proto/response? {:id 1 :error {:code -1 :message "x"}}))
+    (is (not (proto/response? {:id 1 :method "test"}))))
+
+  (testing "notification?"
+    (is (proto/notification? {:method "test"}))
+    (is (not (proto/notification? {:id 1 :method "test"}))))
+
+  (testing "error?"
+    (is (proto/error? {:id 1 :error {:code -1 :message "x"}}))
+    (is (not (proto/error? {:id 1 :result {}})))))
+
+;------------------------------------------------------------------------------ Layer 3: Standard LSP methods
+
+(deftest hover-request-test
+  (testing "builds hover request"
+    (let [req (proto/hover-request "file:///foo.clj" 10 5)]
+      (is (= "textDocument/hover" (:method req)))
+      (is (= "file:///foo.clj" (get-in req [:params :textDocument :uri])))
+      (is (= 10 (get-in req [:params :position :line])))
+      (is (= 5 (get-in req [:params :position :character]))))))
+
+(deftest completion-request-test
+  (testing "builds completion request"
+    (let [req (proto/completion-request "file:///foo.clj" 5 3)]
+      (is (= "textDocument/completion" (:method req)))
+      (is (= "file:///foo.clj" (get-in req [:params :textDocument :uri]))))))
+
+(deftest definition-request-test
+  (testing "builds definition request"
+    (let [req (proto/definition-request "file:///foo.clj" 20 10)]
+      (is (= "textDocument/definition" (:method req))))))
+
+(deftest references-request-test
+  (testing "builds references request with includeDeclaration"
+    (let [req (proto/references-request "file:///foo.clj" 10 5 true)]
+      (is (= "textDocument/references" (:method req)))
+      (is (true? (get-in req [:params :context :includeDeclaration]))))))
+
+(deftest formatting-request-test
+  (testing "builds formatting request with defaults"
+    (let [req (proto/formatting-request "file:///foo.clj" nil)]
+      (is (= "textDocument/formatting" (:method req)))
+      (is (= 2 (get-in req [:params :options :tabSize])))))
+
+  (testing "builds formatting request with custom options"
+    (let [req (proto/formatting-request "file:///foo.clj" {:tabSize 4 :insertSpaces false})]
+      (is (= 4 (get-in req [:params :options :tabSize]))))))
+
+(deftest did-open-notification-test
+  (testing "builds didOpen notification"
+    (let [n (proto/did-open-notification "file:///foo.clj" "clojure" 1 "(ns foo)")]
+      (is (= "textDocument/didOpen" (:method n)))
+      (is (= "clojure" (get-in n [:params :textDocument :languageId])))
+      (is (= "(ns foo)" (get-in n [:params :textDocument :text]))))))
+
+(deftest did-close-notification-test
+  (testing "builds didClose notification"
+    (let [n (proto/did-close-notification "file:///foo.clj")]
+      (is (= "textDocument/didClose" (:method n)))
+      (is (= "file:///foo.clj" (get-in n [:params :textDocument :uri]))))))
+
+(deftest rename-request-test
+  (testing "builds rename request"
+    (let [req (proto/rename-request "file:///foo.clj" 10 5 "new-name")]
+      (is (= "textDocument/rename" (:method req)))
+      (is (= "new-name" (get-in req [:params :newName]))))))
+
+(deftest document-symbol-request-test
+  (testing "builds documentSymbol request"
+    (let [req (proto/document-symbol-request "file:///foo.clj")]
+      (is (= "textDocument/documentSymbol" (:method req)))
+      (is (= "file:///foo.clj" (get-in req [:params :textDocument :uri]))))))

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/mcp/protocol_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/mcp/protocol_test.clj
@@ -1,0 +1,110 @@
+(ns ai.miniforge.lsp-mcp-bridge.mcp.protocol-test
+  "Tests for MCP JSON-RPC protocol layer."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.lsp-mcp-bridge.mcp.protocol :as proto]
+   [cheshire.core :as json])
+  (:import
+   [java.io BufferedReader BufferedWriter StringReader StringWriter]))
+
+;------------------------------------------------------------------------------ Layer 1: Message builders
+
+(deftest response-test
+  (testing "builds a valid JSON-RPC response"
+    (let [resp (proto/response 1 {:foo "bar"})]
+      (is (= 1 (:id resp)))
+      (is (= "2.0" (:jsonrpc resp)))
+      (is (= {:foo "bar"} (:result resp))))))
+
+(deftest error-response-test
+  (testing "builds error response without data"
+    (let [resp (proto/error-response 1 -32600 "Invalid")]
+      (is (= 1 (:id resp)))
+      (is (= -32600 (get-in resp [:error :code])))
+      (is (= "Invalid" (get-in resp [:error :message])))
+      (is (nil? (get-in resp [:error :data])))))
+
+  (testing "builds error response with data"
+    (let [resp (proto/error-response 1 -32600 "Invalid" {:detail "extra"})]
+      (is (= {:detail "extra"} (get-in resp [:error :data]))))))
+
+(deftest notification-test
+  (testing "builds notification without params"
+    (let [n (proto/notification "notifications/initialized")]
+      (is (= "2.0" (:jsonrpc n)))
+      (is (= "notifications/initialized" (:method n)))
+      (is (not (contains? n :params)))))
+
+  (testing "builds notification with params"
+    (let [n (proto/notification "test/method" {:key "val"})]
+      (is (= {:key "val"} (:params n))))))
+
+;------------------------------------------------------------------------------ Layer 2: Message I/O
+
+(deftest write-and-read-message-roundtrip-test
+  (testing "write then read a message via JSON lines"
+    (let [sw (StringWriter.)
+          writer (BufferedWriter. sw)
+          msg {:id 1 :jsonrpc "2.0" :result {:hover "info"}}]
+      ;; Write
+      (proto/write-message writer msg)
+      ;; Read back
+      (let [reader (BufferedReader. (StringReader. (.toString sw)))
+            read-msg (proto/read-message reader)]
+        (is (= 1 (:id read-msg)))
+        (is (= "2.0" (:jsonrpc read-msg)))
+        (is (= "info" (get-in read-msg [:result :hover])))))))
+
+(deftest read-message-eof-test
+  (testing "returns nil on empty input"
+    (let [reader (BufferedReader. (StringReader. ""))]
+      (is (nil? (proto/read-message reader))))))
+
+(deftest read-message-blank-line-test
+  (testing "skips blank lines"
+    (let [reader (BufferedReader. (StringReader. "\n"))]
+      (is (nil? (proto/read-message reader))))))
+
+;------------------------------------------------------------------------------ Layer 2: Predicates
+
+(deftest request-predicate-test
+  (testing "identifies requests (has id + method)"
+    (is (proto/request? {:id 1 :method "initialize"}))
+    (is (not (proto/request? {:id 1 :result {}})))
+    (is (not (proto/request? {:method "initialized"})))))
+
+(deftest response-predicate-test
+  (testing "identifies responses (has id, no method)"
+    (is (proto/response? {:id 1 :result {}}))
+    (is (not (proto/response? {:id 1 :method "initialize"})))))
+
+(deftest notification-predicate-test
+  (testing "identifies notifications (no id, has method)"
+    (is (proto/notification? {:method "initialized"}))
+    (is (not (proto/notification? {:id 1 :method "initialize"})))))
+
+;------------------------------------------------------------------------------ Layer 3: MCP-specific builders
+
+(deftest initialize-result-test
+  (testing "builds MCP initialize result"
+    (let [result (proto/initialize-result [{:name "lsp_hover"}])]
+      (is (string? (:protocolVersion result)))
+      (is (= {:tools {:listChanged false}} (:capabilities result)))
+      (is (= "miniforge-lsp" (get-in result [:serverInfo :name]))))))
+
+(deftest tools-list-result-test
+  (testing "builds tools list result"
+    (let [tools [{:name "lsp_hover" :description "hover"}]
+          result (proto/tools-list-result tools)]
+      (is (= tools (:tools result))))))
+
+(deftest tool-call-result-test
+  (testing "builds successful tool call result"
+    (let [result (proto/tool-call-result "some content")]
+      (is (= [{:type "text" :text "some content"}] (:content result)))
+      (is (not (contains? result :isError)))))
+
+  (testing "builds error tool call result"
+    (let [result (proto/tool-call-error "something failed")]
+      (is (= [{:type "text" :text "something failed"}] (:content result)))
+      (is (true? (:isError result))))))

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/mcp/protocol_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/mcp/protocol_test.clj
@@ -2,8 +2,7 @@
   "Tests for MCP JSON-RPC protocol layer."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.lsp-mcp-bridge.mcp.protocol :as proto]
-   [cheshire.core :as json])
+   [ai.miniforge.lsp-mcp-bridge.mcp.protocol :as proto])
   (:import
    [java.io BufferedReader BufferedWriter StringReader StringWriter]))
 
@@ -87,7 +86,7 @@
 
 (deftest initialize-result-test
   (testing "builds MCP initialize result"
-    (let [result (proto/initialize-result [{:name "lsp_hover"}])]
+    (let [result (proto/initialize-result)]
       (is (string? (:protocolVersion result)))
       (is (= {:tools {:listChanged false}} (:capabilities result)))
       (is (= "miniforge-lsp" (get-in result [:serverInfo :name]))))))

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/mcp/server_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/mcp/server_test.clj
@@ -1,0 +1,134 @@
+(ns ai.miniforge.lsp-mcp-bridge.mcp.server-test
+  "Integration test: MCP server protocol via subprocess.
+
+   Spawns the MCP bridge as a subprocess and exchanges
+   MCP JSON-RPC messages over stdio."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [cheshire.core :as json])
+  (:import
+   [java.io BufferedReader BufferedWriter InputStreamReader OutputStreamWriter]))
+
+;; Helper: send a JSON line and read response
+(defn- send-recv
+  "Send a JSON-RPC message and read one line response."
+  [^BufferedWriter writer ^BufferedReader reader msg]
+  (let [json-str (json/generate-string msg)]
+    (.write writer json-str)
+    (.write writer "\n")
+    (.flush writer)
+    ;; Read response line
+    (when-let [line (.readLine reader)]
+      (json/parse-string line true))))
+
+(deftest mcp-initialize-and-tools-list-test
+  (testing "MCP server responds to initialize and tools/list"
+    (let [proc (ProcessBuilder.
+                 (into-array String
+                   ["bb" "-cp"
+                    "bases/lsp-mcp-bridge/src:components/tool-registry/resources"
+                    "-m" "ai.miniforge.lsp-mcp-bridge.main"]))
+          _ (.redirectErrorStream proc false)
+          _ (doto (.environment proc)
+              (.put "MINIFORGE_PROJECT_DIR" (System/getProperty "user.dir")))
+          process (.start proc)
+          writer (BufferedWriter.
+                   (OutputStreamWriter. (.getOutputStream process) "UTF-8"))
+          reader (BufferedReader.
+                   (InputStreamReader. (.getInputStream process) "UTF-8"))]
+
+      (try
+        ;; 1. Send initialize
+        (let [init-resp (send-recv writer reader
+                          {:jsonrpc "2.0"
+                           :id 1
+                           :method "initialize"
+                           :params {:capabilities {}}})]
+          (is (= 1 (:id init-resp))
+              "Response ID should match request")
+          (is (some? (:result init-resp))
+              "Should have a result")
+          (is (string? (get-in init-resp [:result :protocolVersion]))
+              "Should have protocol version")
+          (is (= "miniforge-lsp" (get-in init-resp [:result :serverInfo :name]))
+              "Should identify as miniforge-lsp"))
+
+        ;; 2. Send notifications/initialized
+        (let [json-str (json/generate-string
+                         {:jsonrpc "2.0"
+                          :method "notifications/initialized"})]
+          (.write writer json-str)
+          (.write writer "\n")
+          (.flush writer))
+
+        ;; 3. Send tools/list
+        (let [tools-resp (send-recv writer reader
+                           {:jsonrpc "2.0"
+                            :id 2
+                            :method "tools/list"
+                            :params {}})]
+          (is (= 2 (:id tools-resp))
+              "Response ID should match request")
+          (is (vector? (get-in tools-resp [:result :tools]))
+              "Should have tools array")
+          (is (= 10 (count (get-in tools-resp [:result :tools])))
+              "Should have 10 tools")
+          (let [tool-names (set (map :name (get-in tools-resp [:result :tools])))]
+            (is (contains? tool-names "lsp_hover"))
+            (is (contains? tool-names "lsp_definition"))
+            (is (contains? tool-names "lsp_references"))
+            (is (contains? tool-names "lsp_rename"))
+            (is (contains? tool-names "lsp_format"))
+            (is (contains? tool-names "lsp_document_symbols"))
+            (is (contains? tool-names "lsp_code_actions"))
+            (is (contains? tool-names "lsp_completion"))
+            (is (contains? tool-names "lsp_diagnostics"))
+            (is (contains? tool-names "lsp_servers"))))
+
+        ;; 4. Send tools/call for lsp_servers (meta tool, no LSP server needed)
+        (let [servers-resp (send-recv writer reader
+                             {:jsonrpc "2.0"
+                              :id 3
+                              :method "tools/call"
+                              :params {:name "lsp_servers"
+                                       :arguments {}}})]
+          (is (= 3 (:id servers-resp)))
+          (is (some? (get-in servers-resp [:result :content]))
+              "Should have content in result"))
+
+        (finally
+          (.destroy process))))))
+
+(deftest mcp-tools-call-unknown-tool-test
+  (testing "MCP server returns error for unknown tool"
+    (let [proc (ProcessBuilder.
+                 (into-array String
+                   ["bb" "-cp"
+                    "bases/lsp-mcp-bridge/src:components/tool-registry/resources"
+                    "-m" "ai.miniforge.lsp-mcp-bridge.main"]))
+          _ (doto (.environment proc)
+              (.put "MINIFORGE_PROJECT_DIR" (System/getProperty "user.dir")))
+          process (.start proc)
+          writer (BufferedWriter.
+                   (OutputStreamWriter. (.getOutputStream process) "UTF-8"))
+          reader (BufferedReader.
+                   (InputStreamReader. (.getInputStream process) "UTF-8"))]
+
+      (try
+        ;; Initialize first
+        (send-recv writer reader
+          {:jsonrpc "2.0" :id 1 :method "initialize" :params {:capabilities {}}})
+
+        ;; Call unknown tool
+        (let [resp (send-recv writer reader
+                     {:jsonrpc "2.0"
+                      :id 2
+                      :method "tools/call"
+                      :params {:name "nonexistent_tool"
+                               :arguments {}}})]
+          (is (= 2 (:id resp)))
+          (is (true? (get-in resp [:result :isError]))
+              "Should be marked as error"))
+
+        (finally
+          (.destroy process))))))

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/mcp/server_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/mcp/server_test.clj
@@ -26,7 +26,7 @@
     (let [proc (ProcessBuilder.
                  (into-array String
                    ["bb" "-cp"
-                    "bases/lsp-mcp-bridge/src:components/tool-registry/resources"
+                    "bases/lsp-mcp-bridge/src:components/tool-registry/resources:components/response/src"
                     "-m" "ai.miniforge.lsp-mcp-bridge.main"]))
           _ (.redirectErrorStream proc false)
           _ (doto (.environment proc)
@@ -104,7 +104,7 @@
     (let [proc (ProcessBuilder.
                  (into-array String
                    ["bb" "-cp"
-                    "bases/lsp-mcp-bridge/src:components/tool-registry/resources"
+                    "bases/lsp-mcp-bridge/src:components/tool-registry/resources:components/response/src"
                     "-m" "ai.miniforge.lsp-mcp-bridge.main"]))
           _ (doto (.environment proc)
               (.put "MINIFORGE_PROJECT_DIR" (System/getProperty "user.dir")))

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/mcp/tools_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/mcp/tools_test.clj
@@ -1,0 +1,56 @@
+(ns ai.miniforge.lsp-mcp-bridge.mcp.tools-test
+  "Tests for MCP tool definitions."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.lsp-mcp-bridge.mcp.tools :as tools]))
+
+;------------------------------------------------------------------------------ Tool definitions
+
+(deftest tool-definitions-test
+  (testing "has exactly 10 tools"
+    (is (= 10 (count tools/tool-definitions))))
+
+  (testing "all tools have required fields"
+    (doseq [tool tools/tool-definitions]
+      (is (string? (:name tool))
+          (str "Tool should have a name: " tool))
+      (is (string? (:description tool))
+          (str "Tool should have a description: " (:name tool)))
+      (is (map? (:inputSchema tool))
+          (str "Tool should have inputSchema: " (:name tool)))))
+
+  (testing "all tool names are unique"
+    (let [names (map :name tools/tool-definitions)]
+      (is (= (count names) (count (set names)))
+          "Tool names should be unique")))
+
+  (testing "all tools have valid JSON Schema inputSchema"
+    (doseq [tool tools/tool-definitions]
+      (let [schema (:inputSchema tool)]
+        (is (= "object" (:type schema))
+            (str "inputSchema type should be 'object': " (:name tool)))
+        (is (map? (:properties schema))
+            (str "inputSchema should have properties: " (:name tool)))
+        (is (vector? (:required schema))
+            (str "inputSchema should have required: " (:name tool)))))))
+
+(deftest tool-names-test
+  (testing "expected tool names are present"
+    (let [names (set (map :name tools/tool-definitions))]
+      (is (= #{"lsp_hover" "lsp_definition" "lsp_references" "lsp_rename"
+               "lsp_format" "lsp_document_symbols" "lsp_code_actions"
+               "lsp_completion" "lsp_diagnostics" "lsp_servers"}
+             names)))))
+
+(deftest file-path-tools-require-file-path
+  (testing "tools that operate on files require file_path"
+    (let [file-tools (remove #(= "lsp_servers" (:name %)) tools/tool-definitions)]
+      (doseq [tool file-tools]
+        (is (some #(= "file_path" %) (:required (:inputSchema tool)))
+            (str "Tool " (:name tool) " should require file_path"))))))
+
+(deftest call-tool-unknown-test
+  (testing "calling an unknown tool returns error"
+    (let [result (tools/call-tool {:name "nonexistent" :arguments {}} nil)]
+      (is (true? (:isError result)))
+      (is (some? (:content result))))))

--- a/bb.edn
+++ b/bb.edn
@@ -479,6 +479,17 @@
            (p/shell "bb" "dogfood:dry-run"))}
 
   ;; ──────────────────────────────────────────────────────────────────────────
+  ;; LSP-to-MCP Bridge
+  ;; ──────────────────────────────────────────────────────────────────────────
+
+  lsp-mcp-bridge
+  {:doc     "Run LSP-to-MCP bridge (for Claude Code integration)"
+   :extra-paths ["bases/lsp-mcp-bridge/src"
+                 "components/tool-registry/resources"]
+   :requires ([ai.miniforge.lsp-mcp-bridge.main :as bridge])
+   :task    (bridge/-main)}
+
+  ;; ──────────────────────────────────────────────────────────────────────────
   ;; CLI Development
   ;; ──────────────────────────────────────────────────────────────────────────
 
@@ -486,6 +497,7 @@
   {:doc     "Run miniforge CLI in development mode"
    :extra-paths ["bases/cli/src"
                  "bases/cli/resources"
+                 "bases/lsp-mcp-bridge/src"
                  "components/algorithms/src"
                  "components/schema/src"
                  "components/schema/resources"

--- a/bb.edn
+++ b/bb.edn
@@ -485,7 +485,8 @@
   lsp-mcp-bridge
   {:doc     "Run LSP-to-MCP bridge (for Claude Code integration)"
    :extra-paths ["bases/lsp-mcp-bridge/src"
-                 "components/tool-registry/resources"]
+                 "components/tool-registry/resources"
+                 "components/response/src"]
    :requires ([ai.miniforge.lsp-mcp-bridge.main :as bridge])
    :task    (bridge/-main)}
 

--- a/components/tool-registry/resources/lsp-registry.edn
+++ b/components/tool-registry/resources/lsp-registry.edn
@@ -1,0 +1,115 @@
+;; LSP Server Installation Registry
+;;
+;; Platform-specific download information for auto-installing LSP binaries.
+;; Used by the MCP bridge installer when an LSP binary is not found on PATH.
+;;
+;; Install methods:
+;;   :github     — Download pre-built binary from GitHub Releases (default)
+;;   :npm        — Install via npm install -g
+;;   :go-install — Install via go install
+;;   :custom     — Requires manual installation (instructions provided)
+;;
+;; Platform keys: "macos-aarch64", "macos-x86_64", "linux-x86_64", "linux-aarch64"
+
+{:registry/version "1.0.0"
+ :registry/bin-dir "~/.miniforge/bin"
+
+ :servers
+ {;; ─────────────────────────────────────────────────────────────────────────
+  ;; Clojure LSP
+  :clojure-lsp
+  {:binary "clojure-lsp"
+   :tool-id :lsp/clojure
+   :github "clojure-lsp/clojure-lsp"
+   :version "2024.08.05-18.16.00"
+   :version-command ["clojure-lsp" "--version"]
+   :assets
+   {"macos-aarch64" {:file "clojure-lsp-native-macos-aarch64.zip"
+                     :extract :zip
+                     :binary-in-archive "clojure-lsp"}
+    "macos-x86_64"  {:file "clojure-lsp-native-macos-amd64.zip"
+                     :extract :zip
+                     :binary-in-archive "clojure-lsp"}
+    "linux-x86_64"  {:file "clojure-lsp-native-static-linux-amd64.zip"
+                     :extract :zip
+                     :binary-in-archive "clojure-lsp"}
+    "linux-aarch64"  {:file "clojure-lsp-native-linux-aarch64.zip"
+                     :extract :zip
+                     :binary-in-archive "clojure-lsp"}}}
+
+  ;; ─────────────────────────────────────────────────────────────────────────
+  ;; TypeScript Language Server
+  :typescript-language-server
+  {:binary "typescript-language-server"
+   :tool-id :lsp/typescript
+   :install-method :npm
+   :npm-package "typescript-language-server"
+   :also-requires ["typescript"]
+   :version-command ["typescript-language-server" "--version"]}
+
+  ;; ─────────────────────────────────────────────────────────────────────────
+  ;; Pyright (Python)
+  :pyright
+  {:binary "pyright-langserver"
+   :tool-id :lsp/python
+   :install-method :npm
+   :npm-package "pyright"
+   :version-command ["pyright-langserver" "--version"]}
+
+  ;; ─────────────────────────────────────────────────────────────────────────
+  ;; gopls (Go)
+  :gopls
+  {:binary "gopls"
+   :tool-id :lsp/go
+   :install-method :go-install
+   :go-package "golang.org/x/tools/gopls@latest"
+   :version-command ["gopls" "version"]}
+
+  ;; ─────────────────────────────────────────────────────────────────────────
+  ;; rust-analyzer
+  :rust-analyzer
+  {:binary "rust-analyzer"
+   :tool-id :lsp/rust
+   :github "rust-lang/rust-analyzer"
+   :version "2024-08-05"
+   :version-command ["rust-analyzer" "--version"]
+   :assets
+   {"macos-aarch64" {:file "rust-analyzer-aarch64-apple-darwin.gz"
+                     :extract :gzip}
+    "macos-x86_64"  {:file "rust-analyzer-x86_64-apple-darwin.gz"
+                     :extract :gzip}
+    "linux-x86_64"  {:file "rust-analyzer-x86_64-unknown-linux-gnu.gz"
+                     :extract :gzip}
+    "linux-aarch64"  {:file "rust-analyzer-aarch64-unknown-linux-gnu.gz"
+                     :extract :gzip}}}
+
+  ;; ─────────────────────────────────────────────────────────────────────────
+  ;; Lua Language Server
+  :lua-language-server
+  {:binary "lua-language-server"
+   :tool-id :lsp/lua
+   :github "LuaLS/lua-language-server"
+   :version "3.10.6"
+   :version-command ["lua-language-server" "--version"]
+   :assets
+   {"macos-aarch64" {:file "lua-language-server-3.10.6-darwin-arm64.tar.gz"
+                     :extract :tar-gz
+                     :binary-in-archive "bin/lua-language-server"}
+    "macos-x86_64"  {:file "lua-language-server-3.10.6-darwin-x64.tar.gz"
+                     :extract :tar-gz
+                     :binary-in-archive "bin/lua-language-server"}
+    "linux-x86_64"  {:file "lua-language-server-3.10.6-linux-x64.tar.gz"
+                     :extract :tar-gz
+                     :binary-in-archive "bin/lua-language-server"}
+    "linux-aarch64"  {:file "lua-language-server-3.10.6-linux-arm64.tar.gz"
+                     :extract :tar-gz
+                     :binary-in-archive "bin/lua-language-server"}}}
+
+  ;; ─────────────────────────────────────────────────────────────────────────
+  ;; Eclipse JDT Language Server (Java)
+  :jdtls
+  {:binary "jdtls"
+   :tool-id :lsp/java
+   :install-method :custom
+   :install-instructions "Install via your system package manager or download from https://download.eclipse.org/jdtls/snapshots/. Requires JDK 17+."
+   :version-command ["jdtls" "--version"]}}}

--- a/components/tool-registry/resources/tools/lsp/go.edn
+++ b/components/tool-registry/resources/tools/lsp/go.edn
@@ -1,0 +1,26 @@
+;; Go Language Server Protocol configuration (gopls)
+;; https://pkg.go.dev/golang.org/x/tools/gopls
+
+{:tool/id          :lsp/go
+ :tool/type        :lsp
+ :tool/name        "gopls"
+ :tool/description "Official Go language server providing diagnostics, formatting, refactoring, and code intelligence"
+ :tool/version     "1.0.0"
+
+ :tool/config
+ {:lsp/command        ["gopls" "serve"]
+  :lsp/languages      #{"go" "gomod" "gowork" "gotmpl"}
+  :lsp/file-patterns  ["**/*.go" "**/go.mod" "**/go.sum" "**/go.work"]
+  :lsp/capabilities   #{:diagnostics :format :hover :completion
+                        :definition :references :rename
+                        :code-action :document-symbol :workspace-symbol}
+  :lsp/start-mode     :on-demand
+  :lsp/shutdown-after-ms 300000}
+
+ :tool/capabilities  #{:code/diagnostics :code/format :code/hover
+                       :code/completion :code/navigation :code/refactor
+                       :code/symbols}
+
+ :tool/requires      #{:subprocess/spawn}
+ :tool/enabled       true
+ :tool/tags          #{:language-server :go :golang}}

--- a/components/tool-registry/resources/tools/lsp/java.edn
+++ b/components/tool-registry/resources/tools/lsp/java.edn
@@ -1,0 +1,26 @@
+;; Java Language Server Protocol configuration (Eclipse JDT.LS)
+;; https://github.com/eclipse-jdtls/eclipse.jdt.ls
+
+{:tool/id          :lsp/java
+ :tool/type        :lsp
+ :tool/name        "Eclipse JDT Language Server"
+ :tool/description "Language server for Java providing diagnostics, formatting, refactoring, and code intelligence"
+ :tool/version     "1.0.0"
+
+ :tool/config
+ {:lsp/command        ["jdtls"]
+  :lsp/languages      #{"java"}
+  :lsp/file-patterns  ["**/*.java"]
+  :lsp/capabilities   #{:diagnostics :format :hover :completion
+                        :definition :references :rename
+                        :code-action :document-symbol :workspace-symbol}
+  :lsp/start-mode     :on-demand
+  :lsp/shutdown-after-ms 600000}  ; 10 minutes — JDT.LS is slow to start
+
+ :tool/capabilities  #{:code/diagnostics :code/format :code/hover
+                       :code/completion :code/navigation :code/refactor
+                       :code/symbols}
+
+ :tool/requires      #{:subprocess/spawn}
+ :tool/enabled       true
+ :tool/tags          #{:language-server :java :jvm}}

--- a/components/tool-registry/resources/tools/lsp/lua.edn
+++ b/components/tool-registry/resources/tools/lsp/lua.edn
@@ -1,0 +1,26 @@
+;; Lua Language Server Protocol configuration
+;; https://github.com/LuaLS/lua-language-server
+
+{:tool/id          :lsp/lua
+ :tool/type        :lsp
+ :tool/name        "Lua Language Server"
+ :tool/description "Language server for Lua providing diagnostics, formatting, and code intelligence"
+ :tool/version     "1.0.0"
+
+ :tool/config
+ {:lsp/command        ["lua-language-server" "--stdio"]
+  :lsp/languages      #{"lua"}
+  :lsp/file-patterns  ["**/*.lua"]
+  :lsp/capabilities   #{:diagnostics :format :hover :completion
+                        :definition :references :rename
+                        :document-symbol}
+  :lsp/start-mode     :on-demand
+  :lsp/shutdown-after-ms 300000}
+
+ :tool/capabilities  #{:code/diagnostics :code/format :code/hover
+                       :code/completion :code/navigation :code/refactor
+                       :code/symbols}
+
+ :tool/requires      #{:subprocess/spawn}
+ :tool/enabled       true
+ :tool/tags          #{:language-server :lua}}

--- a/components/tool-registry/resources/tools/lsp/python.edn
+++ b/components/tool-registry/resources/tools/lsp/python.edn
@@ -1,0 +1,26 @@
+;; Python Language Server Protocol configuration (Pyright)
+;; https://github.com/microsoft/pyright
+
+{:tool/id          :lsp/python
+ :tool/type        :lsp
+ :tool/name        "Pyright"
+ :tool/description "Fast type checker and language server for Python providing diagnostics, completions, and code intelligence"
+ :tool/version     "1.0.0"
+
+ :tool/config
+ {:lsp/command        ["pyright-langserver" "--stdio"]
+  :lsp/languages      #{"python"}
+  :lsp/file-patterns  ["**/*.py" "**/*.pyi"]
+  :lsp/capabilities   #{:diagnostics :hover :completion
+                        :definition :references :rename
+                        :code-action :document-symbol}
+  :lsp/start-mode     :on-demand
+  :lsp/shutdown-after-ms 300000}
+
+ :tool/capabilities  #{:code/diagnostics :code/hover
+                       :code/completion :code/navigation :code/refactor
+                       :code/symbols}
+
+ :tool/requires      #{:subprocess/spawn}
+ :tool/enabled       true
+ :tool/tags          #{:language-server :python}}

--- a/components/tool-registry/resources/tools/lsp/rust.edn
+++ b/components/tool-registry/resources/tools/lsp/rust.edn
@@ -1,0 +1,27 @@
+;; Rust Language Server Protocol configuration (rust-analyzer)
+;; https://rust-analyzer.github.io/
+
+{:tool/id          :lsp/rust
+ :tool/type        :lsp
+ :tool/name        "rust-analyzer"
+ :tool/description "Language server for Rust providing diagnostics, formatting, refactoring, and code intelligence"
+ :tool/version     "1.0.0"
+
+ :tool/config
+ {:lsp/command        ["rust-analyzer"]
+  :lsp/languages      #{"rust"}
+  :lsp/file-patterns  ["**/*.rs" "**/Cargo.toml" "**/Cargo.lock"]
+  :lsp/capabilities   #{:diagnostics :format :hover :completion
+                        :definition :references :rename
+                        :code-action :document-symbol :workspace-symbol
+                        :inlay-hints}
+  :lsp/start-mode     :on-demand
+  :lsp/shutdown-after-ms 300000}
+
+ :tool/capabilities  #{:code/diagnostics :code/format :code/hover
+                       :code/completion :code/navigation :code/refactor
+                       :code/symbols :code/semantics}
+
+ :tool/requires      #{:subprocess/spawn}
+ :tool/enabled       true
+ :tool/tags          #{:language-server :rust}}

--- a/components/tool-registry/resources/tools/lsp/typescript.edn
+++ b/components/tool-registry/resources/tools/lsp/typescript.edn
@@ -1,0 +1,26 @@
+;; TypeScript/JavaScript Language Server Protocol configuration
+;; https://github.com/typescript-language-server/typescript-language-server
+
+{:tool/id          :lsp/typescript
+ :tool/type        :lsp
+ :tool/name        "TypeScript Language Server"
+ :tool/description "Language server for TypeScript and JavaScript providing type checking, refactoring, and code intelligence"
+ :tool/version     "1.0.0"
+
+ :tool/config
+ {:lsp/command        ["typescript-language-server" "--stdio"]
+  :lsp/languages      #{"typescript" "javascript" "typescriptreact" "javascriptreact"}
+  :lsp/file-patterns  ["**/*.ts" "**/*.tsx" "**/*.js" "**/*.jsx" "**/*.mts" "**/*.mjs"]
+  :lsp/capabilities   #{:diagnostics :format :hover :completion
+                        :definition :references :rename
+                        :code-action :document-symbol}
+  :lsp/start-mode     :on-demand
+  :lsp/shutdown-after-ms 300000}
+
+ :tool/capabilities  #{:code/diagnostics :code/format :code/hover
+                       :code/completion :code/navigation :code/refactor
+                       :code/symbols}
+
+ :tool/requires      #{:subprocess/spawn}
+ :tool/enabled       true
+ :tool/tags          #{:language-server :typescript :javascript :web}}

--- a/deps.edn
+++ b/deps.edn
@@ -66,8 +66,10 @@
                        "components/tui-engine/src"
                        "components/tui-engine/resources"
                        "bases/cli/src"
-                       "bases/cli/resources"]
+                       "bases/cli/resources"
+                       "bases/lsp-mcp-bridge/src"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
+                      ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
                       ai.miniforge/logging {:local/root "components/logging"}
                       ai.miniforge/llm {:local/root "components/llm"}

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -37,7 +37,9 @@
         ai.miniforge/orchestrator {:local/root "../../components/orchestrator"}
         ai.miniforge/reporting {:local/root "../../components/reporting"}
         ;; Event streaming and observability
-        ai.miniforge/event-stream {:local/root "../../components/event-stream"}}
+        ai.miniforge/event-stream {:local/root "../../components/event-stream"}
+        ;; LSP-to-MCP bridge (separate entry point for Claude Code integration)
+        ai.miniforge/lsp-mcp-bridge {:local/root "../../bases/lsp-mcp-bridge"}}
 
  :aliases
  {:uberjar


### PR DESCRIPTION
## Summary

- Add a Babashka-based MCP server (`bases/lsp-mcp-bridge/`) that wraps LSP servers and exposes their capabilities as MCP tools
- Ship auto-installation configs for 7 language servers (Clojure, TypeScript, Python, Go, Rust, Lua, Java)
- Bundle in `miniforge.jar` — ships automatically via `brew install`

## MCP Tools (10)

| Tool | Description |
|------|-------------|
| `lsp_hover` | Type info + docs at position |
| `lsp_definition` | Go-to-definition |
| `lsp_references` | Find all usages |
| `lsp_rename` | Rename symbol across project |
| `lsp_format` | Format file |
| `lsp_document_symbols` | List symbols in file |
| `lsp_code_actions` | Quick fixes + refactorings |
| `lsp_completion` | Code completion at position |
| `lsp_diagnostics` | Errors/warnings for a file |
| `lsp_servers` | List available LSPs + status |

## Architecture

- **Runtime:** Babashka (sub-second startup)
- **Protocol:** MCP (JSON lines) on Claude side ↔ LSP (Content-Length) on server side
- **Config:** 3-tier discovery (built-in → `~/.miniforge/tools/` → `.miniforge/tools/`)
- **Auto-install:** Downloads missing LSP binaries from GitHub Releases / npm / go install
- **Packaging:** Second entry point in same jar (`-m ai.miniforge.lsp-mcp-bridge.main`)

## Test plan

- [x] 49 bb tests, 238 assertions — all pass
- [x] Full poly test suite — all pass (pre-commit hook)
- [x] End-to-end: MCP initialize → tools/list → tools/call roundtrip via subprocess
- [ ] Live test with Claude Code MCP config pointing to bridge

🤖 Generated with [Claude Code](https://claude.com/claude-code)