### PR TITLE
feat: Build a web-based dashboard for miniforge that provides real

### DIFF
--- a/work/web-dashboard.edn
+++ b/work/web-dashboard.edn
@@ -1,0 +1,314 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+{:title "Web Dashboard Component"
+ :description
+ "Build a web-based dashboard for miniforge that provides real-time visibility
+  into workflows, PR trains, policies, and system status.
+
+  The dashboard replicates the TUI's 5 N5 views (3.2.1-3.2.5) but in a web UI
+  accessible via browser. It subscribes to the same event stream, uses similar
+  model/update patterns, and provides a richer visualization experience with
+  mouse interaction and hyperlinks.
+
+  This is miniforge building miniforge's own web dashboard (dogfooding scenario).
+  The workflow agents will use the existing tui-views component as a reference
+  implementation, translating TUI rendering primitives to HTML/CSS/React components."
+
+ :intent
+ {:type :feature
+  :scope ["Create new web-dashboard Polylith component"
+          "HTTP server (Clojure backend) with WebSocket support"
+          "ClojureScript SPA frontend (re-frame + reagent)"
+          "5 web views mirroring TUI views"
+          "CLI integration (miniforge dashboard start)"
+          "Real-time event stream integration"]
+  :context
+  {:existing-components
+   ["tui-engine" "tui-views" "event-stream" "workflow" "pr-train" "policy-pack"]
+
+   :reusable-patterns
+   ["Elm architecture from tui-views (model-update-view)"
+    "Event stream subscription from tui-views/subscription.clj"
+    "Model shapes from tui-views/model.clj"
+    "View structure from tui-views/views/*"]
+
+   :references
+   ["N5 spec sections 3.2.1-3.2.5 for view requirements"
+    "tui-views component for model/update logic"
+    "event-stream component for pub/sub patterns"
+    "Rule 210-clojure.mdc for stratification"
+    "Rule 720-pr-layering for PR sizing"]}}
+
+ :constraints
+ ["Must be a Polylith component: components/web-dashboard/"
+  "HTTP server in Clojure (backend) using http-kit"
+  "ClojureScript SPA frontend (re-frame + reagent)"
+  "WebSocket for real-time event stream"
+  "Serve static assets (HTML/JS/CSS)"
+  "Port configurable via env var (default 8080)"
+  "Zero external dependencies beyond Clojure ecosystem"
+  "All files have ≤3 layers per 210-clojure.mdc"
+  "Implementation split into <400 line PRs per 720-pr-layering"
+  "clj-kondo --lint must have 0 errors, 0 warnings"
+  "bb test must pass with all existing tests"
+  "Pre-commit hooks must pass on final commit"]
+
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :plan/tasks
+ [{:task/id :http-server-websocket
+   :task/description
+   "Create backend HTTP server with WebSocket support.
+
+    Files to create:
+    - components/web-dashboard/deps.edn (http-kit dependency)
+    - components/web-dashboard/src/ai/miniforge/web_dashboard/interface.clj
+      (start!, stop!, get-port public API)
+    - components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
+      (HTTP routes, static file serving)
+    - components/web-dashboard/src/ai/miniforge/web_dashboard/websocket.clj
+      (WebSocket handler, event stream bridge)
+    - components/web-dashboard/src/ai/miniforge/web_dashboard/routes.clj
+      (API endpoints for initial state)
+
+    HTTP routes:
+    - GET / -> index.html
+    - GET /app.js -> compiled ClojureScript
+    - GET /app.css -> styles
+    - GET /api/workflows -> current workflow state (JSON)
+    - GET /api/pr-trains -> current PR train state (JSON)
+    - WS /ws -> WebSocket connection for real-time events
+
+    WebSocket protocol:
+    - Client connects to /ws
+    - Server subscribes to event-stream on client's behalf
+    - Events forwarded as JSON: {:event/type :workflow/started :event/data {...}}
+    - Client can send commands: {:cmd :subscribe :topics [:workflow :pr-train]}
+
+    Server library: http-kit (lightweight, supports WebSockets)
+    Configuration: Port from env var MINIFORGE_DASHBOARD_PORT (default 8080)"
+   :task/type :implement
+   :task/priority :critical
+   :task/dependencies []}
+
+  {:task/id :cljs-frontend-shell
+   :task/description
+   "Create ClojureScript frontend shell with re-frame + WebSocket connection.
+
+    Files to create:
+    - components/web-dashboard/shadow-cljs.edn (compilation config)
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/core.cljs
+      (main entry, initialization)
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/model.cljs
+      (reuse tui-views model shapes)
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/events.cljs
+      (re-frame event handlers)
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/subscriptions.cljs
+      (re-frame subscriptions)
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/views.cljs
+      (main view dispatcher)
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/websocket.cljs
+      (WebSocket connection management)
+    - components/web-dashboard/resources/public/index.html
+    - components/web-dashboard/resources/public/app.css
+
+    Tech stack:
+    - re-frame 1.3.0 (state management)
+    - reagent 1.2.0 (React wrapper)
+    - shadow-cljs for compilation
+    - No CSS framework (custom CSS, keep it simple)
+
+    WebSocket features:
+    - Establish WS connection on app init
+    - Parse incoming events and dispatch to re-frame
+    - Auto-reconnect on disconnect (exponential backoff)
+    - Show connection status indicator in UI"
+   :task/type :implement
+   :task/priority :critical
+   :task/dependencies [:http-server-websocket]}
+
+  {:task/id :workflow-list-view
+   :task/description
+   "Replicate tui-views/views/workflow_list.clj as web view (N5 Section 3.2.1).
+
+    Files to create:
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/views/workflow_list.cljs
+
+    Layout (same as TUI):
+    - Header: 'MINIFORGE | Workflows'
+    - Table columns: Status, Workflow Name, Phase, Progress, Agent Status
+    - Footer: Navigation help (adapted for web)
+
+    Enhancements over TUI:
+    - Click row to navigate to detail (no need for Enter key)
+    - Hover shows tooltip with full agent message
+    - Hyperlink workflow name to GitHub PR
+    - Search box to filter workflows (replaces TUI / search mode)
+    - Sort by clicking column headers
+
+    Status colors (same as TUI):
+    - Running: cyan ●
+    - Success: green ✓
+    - Failed: red ✗
+    - Blocked: yellow ◐
+
+    Reuse model/update logic from tui-views/model.clj and tui-views/update/*.clj"
+   :task/type :implement
+   :task/priority :high
+   :task/dependencies [:cljs-frontend-shell]}
+
+  {:task/id :workflow-detail-view
+   :task/description
+   "Replicate tui-views/views/workflow_detail.clj as web view (N5 Section 3.2.2).
+
+    Files to create:
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/views/workflow_detail.cljs
+
+    Layout (same as TUI):
+    - Header: 'MINIFORGE | <workflow-name> | <phase>'
+    - Left pane: Phase list with status indicators
+    - Right pane: Agent output (scrollable)
+    - Footer: Navigation options
+
+    Enhancements over TUI:
+    - Click phase to jump to that section in evidence view
+    - Agent output auto-scrolls as new content arrives
+    - Copy button for agent output
+    - Syntax highlighting for code in agent output
+    - Timeline visualization of phase progression"
+   :task/type :implement
+   :task/priority :high
+   :task/dependencies [:workflow-list-view]}
+
+  {:task/id :evidence-artifacts-dag-views
+   :task/description
+   "Create remaining 3 web views: Evidence, Artifacts, DAG Kanban.
+
+    Files to create:
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/views/evidence.cljs
+      (N5 Section 3.2.3 - tree view of evidence artifacts)
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/views/artifact_browser.cljs
+      (N5 Section 3.2.4 - file tree + content viewer)
+    - components/web-dashboard/src-cljs/ai/miniforge/web_dashboard/views/dag_kanban.cljs
+      (N5 Section 3.2.5 - Kanban columns: BLOCKED | READY | RUNNING | DONE)
+
+    Evidence viewer: scrollable tree with expand/collapse sections
+    Artifact browser: table + content drill-down with syntax highlighting
+    DAG kanban: columns derived from task states, visual dependency arrows"
+   :task/type :implement
+   :task/priority :medium
+   :task/dependencies [:workflow-detail-view]}
+
+  {:task/id :cli-integration
+   :task/description
+   "Integrate web dashboard into miniforge CLI.
+
+    Files to modify:
+    - bases/cli/src/ai/miniforge/cli/main.clj
+      (add dashboard-cmd, starts HTTP server via web-dashboard/interface)
+    - bases/cli/deps.edn
+      (add web-dashboard dependency)
+
+    CLI command:
+    $ miniforge dashboard start [--port 8080] [--open-browser]
+
+    Features:
+    - Starts HTTP server via web-dashboard/interface
+    - Optionally opens browser to http://localhost:8080
+    - Logs URL to stdout
+    - Ctrl-C stops server gracefully
+    - Or: miniforge dashboard stop
+
+    TUI integration (optional):
+    - Add 'd' key binding in tui-views to launch dashboard
+    - Show notification: 'Dashboard started at http://localhost:8080'"
+   :task/type :implement
+   :task/priority :high
+   :task/dependencies [:evidence-artifacts-dag-views]}
+
+  {:task/id :styling-responsiveness
+   :task/description
+   "CSS styling that matches TUI aesthetic.
+
+    Files to modify:
+    - components/web-dashboard/resources/public/app.css
+
+    Design principles:
+    - Dark theme (match terminal aesthetic)
+    - Monospace font (JetBrains Mono or SF Mono)
+    - Same color palette as TUI (cyan headers, status colors)
+    - Minimal, functional design (no fancy animations)
+
+    Responsive:
+    - Desktop-first (80+ char wide)
+    - Mobile-friendly layouts (stack panes vertically)
+    - Table scrolls horizontally on small screens"
+   :task/type :implement
+   :task/priority :low
+   :task/dependencies [:cli-integration]}
+
+  {:task/id :integration-testing
+   :task/description
+   "Create integration tests and verify all success criteria.
+
+    Files to create:
+    - components/web-dashboard/test/ai/miniforge/web_dashboard/server_test.clj
+    - components/web-dashboard/test/ai/miniforge/web_dashboard/websocket_test.clj
+
+    Verification checklist:
+    1. HTTP server starts on port 8080
+       (curl http://localhost:8080 returns index.html)
+    2. WebSocket connection established
+       (Browser DevTools shows WS connection to ws://localhost:8080/ws)
+    3. Real-time event updates
+       (Start a workflow, see it appear in dashboard within 1 second)
+    4. All 5 views render correctly
+       (Navigate through all views, no console errors)
+    5. TUI integration works
+       (Press 'd' in TUI, dashboard opens in browser)
+    6. Stratification compliance
+       (All files have ≤3 layers per 210-clojure.mdc)
+    7. PR size compliance
+       (Implementation split into <400 line PRs per 720-pr-layering)
+
+    Run: bb test, clj-kondo --lint, pre-commit hooks"
+   :task/type :verify
+   :task/priority :critical
+   :task/dependencies [:styling-responsiveness]}]
+
+ :success-criteria
+ [{:criterion "HTTP server starts successfully"
+   :verification "curl http://localhost:8080 returns HTML"}
+  {:criterion "WebSocket connects and receives events"
+   :verification "Start workflow, see it in dashboard within 1 second"}
+  {:criterion "All 5 views render without errors"
+   :verification "Click through all views, check browser console"}
+  {:criterion "CLI integration works"
+   :verification "miniforge dashboard start launches server"}
+  {:criterion "All tests pass"
+   :verification "bb test shows all passing"}
+  {:criterion "Linting passes"
+   :verification "clj-kondo --lint has 0 errors, 0 warnings"}
+  {:criterion "Stratification compliance"
+   :verification "All files ≤3 layers per 210-clojure.mdc"}]
+
+ :out-of-scope
+ ["Authentication (no login required, local-only for now)"
+  "Multi-user support (single user assumed)"
+  "Mobile app (web-responsive is sufficient)"
+  "Real-time collaboration (no multiplayer features)"
+  "Historical data (only current state, no time-series charts)"
+  "Advanced visualizations (no D3.js graphs, keep it simple)"]}


### PR DESCRIPTION
## Summary
Build a web-based dashboard for miniforge that provides real-time visibility
  into workflows, PR trains, policies, and system status.

  The dashboard replicates the TUI's 5 N5 views (3.2.1-3.2.5) but in a web UI
  accessible via browser. It subscribes to the same event stream, uses similar
  model/update patterns, and provides a richer visualization experience with
  mouse interaction and hyperlinks.

  This is miniforge building miniforge's own web dashboard (dogfooding scenario).
  The workflow agents will use the existing tui-views component as a reference
  implementation, translating TUI rendering primitives to HTML/CSS/React components.

## Changes
- create `src/ai/miniforge/generated/impl.clj`