### PR TITLE
feat(specs): add N9 — External PR Integration

### DIFF
--- a/components/tui-engine/src/ai/miniforge/tui_engine/interface.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/interface.clj
@@ -76,15 +76,48 @@
 ;; Re-exports for convenience
 
 ;; Screen
-(def create-screen screen/create-screen)
-(def create-mock-screen screen/create-mock-screen)
-(def mock-enqueue-input! screen/mock-enqueue-input!)
-(def mock-get-cells screen/mock-get-cells)
-(def mock-read-line screen/mock-read-line)
+
+(def create-screen
+  "Create a Lanterna terminal screen for rendering.
+   Dynamically loads the Lanterna implementation (for Babashka compatibility).
+   Returns an IScreen instance."
+  screen/create-screen)
+
+(def create-mock-screen
+  "Create a mock screen for testing.
+   Returns a MockScreen instance that captures renders to a cell buffer."
+  screen/create-mock-screen)
+
+(def mock-enqueue-input!
+  "Enqueue input events into a mock screen's input queue.
+   For testing keyboard interactions."
+  screen/mock-enqueue-input!)
+
+(def mock-get-cells
+  "Get the current cell buffer from a mock screen.
+   Returns a 2D vector of cell maps."
+  screen/mock-get-cells)
+
+(def mock-read-line
+  "Read a line of text from a mock screen's cell buffer.
+   Returns a string representation of the specified row."
+  screen/mock-read-line)
 
 ;; Style
-(def default-theme style/default-theme)
-(def resolve-style style/resolve-style)
+
+(def default-theme
+  "Default color theme for TUI rendering.
+   Map of semantic color names to ANSI color keywords."
+  style/default-theme)
+
+(def resolve-style
+  "Resolve a style map into Lanterna TextCharacter attributes.
+   Converts {:fg :bg :bold?} to Lanterna-compatible representation."
+  style/resolve-style)
 
 ;; Input
-(def normalize-key input/normalize-key)
+
+(def normalize-key
+  "Normalize Lanterna KeyStroke to a semantic keyword.
+   Maps raw key events to keywords like :key/j, :key/enter, :key/escape."
+  input/normalize-key)

--- a/components/tui-engine/src/ai/miniforge/tui_engine/interface/layout.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/interface/layout.clj
@@ -23,19 +23,78 @@
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Cell buffer operations
 
-(def empty-cell layout/empty-cell)
-(def make-buffer layout/make-buffer)
-(def buf-put-char layout/buf-put-char)
-(def buf-put-string layout/buf-put-string)
-(def blit layout/blit)
-(def buf->strings layout/buf->strings)
+(def empty-cell
+  "Default empty cell: {:char \\space :fg :white :bg :black :bold? false}"
+  layout/empty-cell)
+
+(def make-buffer
+  "Create an empty cell buffer of [cols rows].
+   Returns a 2D vector of empty-cell maps."
+  layout/make-buffer)
+
+(def buf-put-char
+  "Put a single character at [col row] in buffer.
+   cell is a map: {:char :fg :bg :bold?}
+   Returns updated buffer."
+  layout/buf-put-char)
+
+(def buf-put-string
+  "Write a string into the buffer at [col row] with given style.
+   style is a map: {:fg :bg :bold?}
+   Returns updated buffer."
+  layout/buf-put-string)
+
+(def blit
+  "Copy source buffer onto dest buffer at [col row] offset.
+   Returns updated dest buffer."
+  layout/blit)
+
+(def buf->strings
+  "Convert a cell buffer to a vector of plain strings (for testing).
+   Returns vector of strings, one per row."
+  layout/buf->strings)
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Layout primitives
 
-(def text layout/text)
-(def box layout/box)
-(def split-h layout/split-h)
-(def split-v layout/split-v)
-(def table layout/table)
-(def pad layout/pad)
+(def text
+  "Render styled text span into a buffer.
+   Signature: [[cols rows] content opts]
+   opts: {:fg :bg :bold? :align}
+   Returns cell buffer."
+  layout/text)
+
+(def box
+  "Render a bordered box with optional content.
+   Signature: [[cols rows] opts]
+   opts: {:border :title :fg :bg :bold? :content-fn}
+   Returns cell buffer."
+  layout/box)
+
+(def split-h
+  "Split horizontally into left/right panes.
+   Signature: [[cols rows] ratio left-fn right-fn]
+   ratio is fraction [0.0, 1.0] for left pane.
+   Returns cell buffer."
+  layout/split-h)
+
+(def split-v
+  "Split vertically into top/bottom panes.
+   Signature: [[cols rows] ratio top-fn bottom-fn]
+   ratio is fraction [0.0, 1.0] for top pane.
+   Returns cell buffer."
+  layout/split-v)
+
+(def table
+  "Render a data table with column headers and rows.
+   Signature: [[cols rows] opts]
+   opts: {:columns :data :selected-row :header-fg :header-bg :row-fg :row-bg}
+   Returns cell buffer."
+  layout/table)
+
+(def pad
+  "Add padding around content-fn's output.
+   Signature: [[cols rows] padding content-fn]
+   padding: [top right bottom left] or single int.
+   Returns cell buffer."
+  layout/pad)

--- a/components/tui-engine/src/ai/miniforge/tui_engine/interface/widget.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/interface/widget.clj
@@ -23,10 +23,55 @@
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Widgets
 
-(def status-indicator widget/status-indicator)
-(def status-text widget/status-text)
-(def progress-bar widget/progress-bar)
-(def tree widget/tree)
-(def kanban widget/kanban)
-(def scrollable widget/scrollable)
-(def sparkline widget/sparkline)
+(def status-indicator
+  "Render a single status indicator character with color.
+   Signature: [status]
+   status: :running :success :failed :blocked :pending :skipped :spinning
+   Returns 1x1 cell buffer."
+  widget/status-indicator)
+
+(def status-text
+  "Render status indicator followed by label text.
+   Signature: [[cols rows] status label]
+   Returns cell buffer of [cols 1]."
+  widget/status-text)
+
+(def progress-bar
+  "Render a progress bar with optional percentage.
+   Signature: [[cols rows] opts]
+   opts: {:percent :fill-fg :empty-fg :show-pct?}
+   Returns cell buffer."
+  widget/progress-bar)
+
+(def tree
+  "Render a tree with expand/collapse navigation.
+   Signature: [[cols rows] opts]
+   opts: {:nodes :expanded :selected :fg :selected-fg :selected-bg}
+   nodes: [{:label :depth :expandable?}]
+   Returns cell buffer."
+  widget/tree)
+
+(def kanban
+  "Render kanban-style columns.
+   Signature: [[cols rows] opts]
+   opts: {:columns}
+   columns: [{:title :color :cards}]
+   cards: [{:label :status}]
+   Returns cell buffer."
+  widget/kanban)
+
+(def scrollable
+  "Render a scrollable viewport with scrollbar.
+   Signature: [[cols rows] opts]
+   opts: {:lines :offset :fg :bg}
+   lines: vector of strings
+   Returns cell buffer."
+  widget/scrollable)
+
+(def sparkline
+  "Render a braille-based mini sparkline chart.
+   Signature: [[cols rows] opts]
+   opts: {:values :fg}
+   values: vector of numbers
+   Returns cell buffer."
+  widget/sparkline)

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout.clj
@@ -15,264 +15,34 @@
 (ns ai.miniforge.tui-engine.layout
   "Layout primitives for TUI rendering.
 
-   Each function takes a size [cols rows] and options, returning a cell buffer --
-   a 2D vector of {:char :fg :bg :bold?} maps. These buffers compose via
-   split-h/split-v to build full screen layouts.
+   Convenience namespace that re-exports all layout functions from stratified
+   sub-namespaces (buffer, container, table). Each function takes a size
+   [cols rows] and options, returning a cell buffer -- a 2D vector of
+   {:char :fg :bg :bold?} maps.
 
    Layout functions are pure -- they take data and return data. No side effects."
   (:require
-   [clojure.string :as str]))
+   [ai.miniforge.tui-engine.layout.buffer :as buffer]
+   [ai.miniforge.tui-engine.layout.container :as container]
+   [ai.miniforge.tui-engine.layout.table :as table]))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Cell buffer operations
+;; Re-export from buffer
+(def empty-cell buffer/empty-cell)
+(def make-buffer buffer/make-buffer)
+(def buf-put-char buffer/buf-put-char)
+(def buf-put-string buffer/buf-put-string)
+(def blit buffer/blit)
+(def buf->strings buffer/buf->strings)
+(def text buffer/text)
 
-(def empty-cell {:char \space :fg :white :bg :black :bold? false})
+;; Re-export from container
+(def box container/box)
+(def split-h container/split-h)
+(def split-v container/split-v)
 
-(defn make-buffer
-  "Create an empty cell buffer of [cols rows]."
-  [[cols rows]]
-  (vec (repeat rows (vec (repeat cols empty-cell)))))
-
-(defn buf-put-char
-  "Put a single character at [col row] in buffer."
-  [buf col row cell]
-  (if (and (< row (count buf))
-           (>= row 0)
-           (< col (count (first buf)))
-           (>= col 0))
-    (assoc-in buf [row col] cell)
-    buf))
-
-(defn buf-put-string
-  "Write a string into the buffer at [col row] with given style."
-  [buf col row text {:keys [fg bg bold?] :or {fg :white bg :black bold? false}}]
-  (reduce (fn [b i]
-            (if (< (+ col i) (count (first b)))
-              (buf-put-char b (+ col i) row
-                            {:char (.charAt text i) :fg fg :bg bg :bold? bold?})
-              b))
-          buf
-          (range (count text))))
-
-(defn blit
-  "Copy source buffer onto dest buffer at [col row] offset."
-  [dest src col row]
-  (reduce (fn [d r]
-            (reduce (fn [d2 c]
-                      (let [cell (get-in src [r c])]
-                        (if (and cell
-                                 (< (+ row r) (count d2))
-                                 (< (+ col c) (count (first d2))))
-                          (assoc-in d2 [(+ row r) (+ col c)] cell)
-                          d2)))
-                    d
-                    (range (count (first src)))))
-          dest
-          (range (count src))))
-
-(defn buf->strings
-  "Convert a cell buffer to a vector of plain strings (for testing)."
-  [buf]
-  (mapv (fn [row] (apply str (map :char row))) buf))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Text primitives
-
-(defn- truncate-str
-  "Truncate string to max-width, adding ellipsis if truncated."
-  [s max-width]
-  (if (<= (count s) max-width)
-    s
-    (str (subs s 0 (max 0 (- max-width 1))) "…")))
-
-(defn- pad-right
-  "Pad string to width with spaces."
-  [s width]
-  (let [s (or s "")]
-    (if (>= (count s) width)
-      (subs s 0 width)
-      (str s (apply str (repeat (- width (count s)) \space))))))
-
-(defn text
-  "Render a styled text span into a buffer.
-   Truncates to fit within [cols rows]."
-  [[cols rows] content & [{:keys [fg bg bold? align]
-                            :or {fg :white bg :black bold? false align :left}}]]
-  (let [buf (make-buffer [cols rows])
-        lines (str/split-lines (or content ""))
-        lines (take rows lines)]
-    (reduce (fn [b [idx line]]
-              (let [truncated (truncate-str line cols)
-                    padded (case align
-                             :right (str (apply str (repeat (max 0 (- cols (count truncated))) \space))
-                                         truncated)
-                             :center (let [pad (max 0 (quot (- cols (count truncated)) 2))]
-                                       (str (apply str (repeat pad \space)) truncated))
-                             (pad-right truncated cols))]
-                (buf-put-string b 0 idx padded {:fg fg :bg bg :bold? bold?})))
-            buf
-            (map-indexed vector lines))))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Box drawing
-
-(def ^:private box-chars
-  {:single {:tl \┌ :tr \┐ :bl \└ :br \┘ :h \─ :v \│ :lt \├ :rt \┤ :tt \┬ :bt \┴}
-   :double {:tl \╔ :tr \╗ :bl \╚ :br \╝ :h \═ :v \║ :lt \╠ :rt \╣ :tt \╦ :bt \╩}
-   :none   {:tl \space :tr \space :bl \space :br \space
-            :h \space :v \space :lt \space :rt \space :tt \space :bt \space}})
-
-(defn box
-  "Render a bordered box.
-   Options:
-   - :border - :single (default), :double, or :none
-   - :title  - Optional string for top border
-   - :fg, :bg, :bold? - Border style
-   - :content-fn - (fn [[inner-cols inner-rows]] -> cell-buffer) for box contents"
-  [[cols rows] & [{:keys [border title fg bg bold? content-fn]
-                    :or {border :single fg :default bg :black bold? false}}]]
-  (when (and (>= cols 2) (>= rows 2))
-    (let [chars (get box-chars border (:single box-chars))
-          style {:fg fg :bg bg :bold? bold?}
-          buf (make-buffer [cols rows])
-          ;; Top border
-          top-line (str (:tl chars)
-                        (if title
-                          (let [t (truncate-str title (- cols 4))
-                                remaining (- cols 2 (count t) 2)]
-                            (str (:h chars) t (apply str (repeat (max 0 (+ remaining 1)) (:h chars)))))
-                          (apply str (repeat (- cols 2) (:h chars))))
-                        (:tr chars))
-          ;; Bottom border
-          bot-line (str (:bl chars) (apply str (repeat (- cols 2) (:h chars))) (:br chars))
-          buf (buf-put-string buf 0 0 top-line style)
-          buf (buf-put-string buf 0 (dec rows) bot-line style)
-          ;; Side borders
-          buf (reduce (fn [b r]
-                        (-> b
-                            (buf-put-char 0 r (assoc style :char (:v chars)))
-                            (buf-put-char (dec cols) r (assoc style :char (:v chars)))))
-                      buf
-                      (range 1 (dec rows)))]
-      (if content-fn
-        (let [inner-cols (- cols 2)
-              inner-rows (- rows 2)
-              content (content-fn [inner-cols inner-rows])]
-          (blit buf content 1 1))
-        buf))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Split layouts
-
-(defn split-h
-  "Split horizontally into left/right panes.
-   ratio is the fraction [0.0, 1.0] for the left pane.
-   left-fn, right-fn: (fn [[cols rows]] -> cell-buffer)"
-  [[cols rows] ratio left-fn right-fn]
-  (let [left-cols (max 1 (int (* cols ratio)))
-        right-cols (- cols left-cols)
-        left-buf (left-fn [left-cols rows])
-        right-buf (right-fn [right-cols rows])
-        buf (make-buffer [cols rows])]
-    (-> buf
-        (blit left-buf 0 0)
-        (blit right-buf left-cols 0))))
-
-(defn split-v
-  "Split vertically into top/bottom panes.
-   ratio is the fraction [0.0, 1.0] for the top pane.
-   top-fn, bottom-fn: (fn [[cols rows]] -> cell-buffer)"
-  [[cols rows] ratio top-fn bottom-fn]
-  (let [top-rows (max 1 (int (* rows ratio)))
-        bottom-rows (- rows top-rows)
-        top-buf (top-fn [cols top-rows])
-        bottom-buf (bottom-fn [cols bottom-rows])
-        buf (make-buffer [cols rows])]
-    (-> buf
-        (blit top-buf 0 0)
-        (blit bottom-buf 0 top-rows))))
-
-;------------------------------------------------------------------------------ Layer 4
-;; Table
-
-(defn- compute-col-widths
-  "Compute column widths from specs. Fixed :width honored, remainder distributed."
-  [col-specs total-width]
-  (let [fixed-used (reduce + 0 (keep :width col-specs))
-        flex-count (count (remove :width col-specs))
-        flex-each (if (pos? flex-count)
-                    (max 1 (quot (- total-width fixed-used) flex-count))
-                    0)]
-    (mapv (fn [spec] (or (:width spec) flex-each)) col-specs)))
-
-(defn table
-  "Render a table with column headers and data rows.
-   Options:
-   - :columns - vector of {:key kw, :header str, :width int (opt), :align :left/:right/:center}
-   - :rows    - vector of maps keyed by column :key
-   - :selected-row - index of highlighted row (nil for none)
-   - :header-fg, :header-bg - Header style
-   - :row-fg, :row-bg - Default row style
-   - :selected-fg, :selected-bg - Selected row style"
-  [[cols rows] & [{:keys [columns data selected-row
-                           header-fg header-bg row-fg row-bg selected-fg selected-bg]
-                    :or {header-fg :cyan header-bg :black
-                         row-fg :white row-bg :black
-                         selected-fg :white selected-bg :blue}}]]
-  (let [col-widths (compute-col-widths columns cols)
-        buf (make-buffer [cols rows])
-        ;; Render header
-        buf (reduce (fn [b [idx {:keys [header]} width]]
-                      (let [txt (pad-right (truncate-str (or header "") width) width)]
-                        (buf-put-string b
-                                        (reduce + 0 (take idx col-widths))
-                                        0 txt
-                                        {:fg header-fg :bg header-bg :bold? true})))
-                    buf
-                    (map vector (range) columns col-widths))
-        ;; Render separator
-        buf (if (>= rows 2)
-              (buf-put-string buf 0 1
-                              (apply str (repeat cols \─))
-                              {:fg :default :bg :black :bold? false})
-              buf)
-        ;; Render data rows
-        visible-rows (take (max 0 (- rows 2)) (or data []))
-        buf (reduce (fn [b [row-idx row-data]]
-                      (let [selected? (= row-idx selected-row)
-                            fg (if selected? selected-fg row-fg)
-                            bg (if selected? selected-bg row-bg)
-                            render-row (+ row-idx 2)]
-                        (if (>= render-row rows)
-                          (reduced b)
-                          (reduce (fn [b2 [col-idx {:keys [key]} width]]
-                                    (let [val (str (get row-data key ""))
-                                          txt (pad-right (truncate-str val width) width)]
-                                      (buf-put-string b2
-                                                      (reduce + 0 (take col-idx col-widths))
-                                                      render-row txt
-                                                      {:fg fg :bg bg :bold? false})))
-                                  b
-                                  (map vector (range) columns col-widths)))))
-                    buf
-                    (map-indexed vector visible-rows))]
-    buf))
-
-;------------------------------------------------------------------------------ Layer 5
-;; Padding
-
-(defn pad
-  "Add padding around a content-fn's output.
-   padding: [top right bottom left] or single int for all sides."
-  [[cols rows] padding content-fn]
-  (let [[pt pr pb pl] (if (vector? padding)
-                         padding
-                         [padding padding padding padding])
-        inner-cols (max 0 (- cols pl pr))
-        inner-rows (max 0 (- rows pt pb))
-        inner-buf (content-fn [inner-cols inner-rows])
-        buf (make-buffer [cols rows])]
-    (blit buf inner-buf pl pt)))
+;; Re-export from table
+(def table table/table)
+(def pad table/pad)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout/buffer.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout/buffer.clj
@@ -1,0 +1,111 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.layout.buffer
+  "Cell buffer operations and text primitives for TUI rendering.
+
+   Provides low-level cell buffer manipulation and basic text rendering.
+   Pure functions with no side effects."
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Cell buffer operations
+
+(def empty-cell {:char \space :fg :white :bg :black :bold? false})
+
+(defn make-buffer
+  "Create an empty cell buffer of [cols rows]."
+  [[cols rows]]
+  (vec (repeat rows (vec (repeat cols empty-cell)))))
+
+(defn buf-put-char
+  "Put a single character at [col row] in buffer."
+  [buf col row cell]
+  (if (and (< row (count buf))
+           (>= row 0)
+           (< col (count (first buf)))
+           (>= col 0))
+    (assoc-in buf [row col] cell)
+    buf))
+
+(defn buf-put-string
+  "Write a string into the buffer at [col row] with given style."
+  [buf col row text {:keys [fg bg bold?] :or {fg :white bg :black bold? false}}]
+  (reduce (fn [b i]
+            (if (< (+ col i) (count (first b)))
+              (buf-put-char b (+ col i) row
+                            {:char (.charAt text i) :fg fg :bg bg :bold? bold?})
+              b))
+          buf
+          (range (count text))))
+
+(defn blit
+  "Copy source buffer onto dest buffer at [col row] offset."
+  [dest src col row]
+  (reduce (fn [d r]
+            (reduce (fn [d2 c]
+                      (let [cell (get-in src [r c])]
+                        (if (and cell
+                                 (< (+ row r) (count d2))
+                                 (< (+ col c) (count (first d2))))
+                          (assoc-in d2 [(+ row r) (+ col c)] cell)
+                          d2)))
+                    d
+                    (range (count (first src)))))
+          dest
+          (range (count src))))
+
+(defn buf->strings
+  "Convert a cell buffer to a vector of plain strings (for testing)."
+  [buf]
+  (mapv (fn [row] (apply str (map :char row))) buf))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Text primitives
+
+(defn- truncate-str
+  "Truncate string to max-width, adding ellipsis if truncated."
+  [s max-width]
+  (if (<= (count s) max-width)
+    s
+    (str (subs s 0 (max 0 (- max-width 1))) "…")))
+
+(defn- pad-right
+  "Pad string to width with spaces."
+  [s width]
+  (let [s (or s "")]
+    (if (>= (count s) width)
+      (subs s 0 width)
+      (str s (apply str (repeat (- width (count s)) \space))))))
+
+(defn text
+  "Render a styled text span into a buffer.
+   Truncates to fit within [cols rows]."
+  [[cols rows] content & [{:keys [fg bg bold? align]
+                            :or {fg :white bg :black bold? false align :left}}]]
+  (let [buf (make-buffer [cols rows])
+        lines (str/split-lines (or content ""))
+        lines (take rows lines)]
+    (reduce (fn [b [idx line]]
+              (let [truncated (truncate-str line cols)
+                    padded (case align
+                             :right (str (apply str (repeat (max 0 (- cols (count truncated))) \space))
+                                         truncated)
+                             :center (let [pad (max 0 (quot (- cols (count truncated)) 2))]
+                                       (str (apply str (repeat pad \space)) truncated))
+                             (pad-right truncated cols))]
+                (buf-put-string b 0 idx padded {:fg fg :bg bg :bold? bold?})))
+            buf
+            (map-indexed vector lines))))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout/container.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout/container.clj
@@ -1,0 +1,107 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.layout.container
+  "Box drawing and split layout primitives.
+
+   Provides bordered boxes and horizontal/vertical layout splits.
+   Pure functions with no side effects."
+  (:require
+   [ai.miniforge.tui-engine.layout.buffer :as buf]))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Box drawing
+
+(def ^:private box-chars
+  {:single {:tl \┌ :tr \┐ :bl \└ :br \┘ :h \─ :v \│ :lt \├ :rt \┤ :tt \┬ :bt \┴}
+   :double {:tl \╔ :tr \╗ :bl \╚ :br \╝ :h \═ :v \║ :lt \╠ :rt \╣ :tt \╦ :bt \╩}
+   :none   {:tl \space :tr \space :bl \space :br \space
+            :h \space :v \space :lt \space :rt \space :tt \space :bt \space}})
+
+(defn- truncate-str
+  "Truncate string to max-width, adding ellipsis if truncated."
+  [s max-width]
+  (if (<= (count s) max-width)
+    s
+    (str (subs s 0 (max 0 (- max-width 1))) "…")))
+
+(defn box
+  "Render a bordered box.
+   Options:
+   - :border - :single (default), :double, or :none
+   - :title  - Optional string for top border
+   - :fg, :bg, :bold? - Border style
+   - :content-fn - (fn [[inner-cols inner-rows]] -> cell-buffer) for box contents"
+  [[cols rows] & [{:keys [border title fg bg bold? content-fn]
+                    :or {border :single fg :default bg :black bold? false}}]]
+  (when (and (>= cols 2) (>= rows 2))
+    (let [chars (get box-chars border (:single box-chars))
+          style {:fg fg :bg bg :bold? bold?}
+          buffer (buf/make-buffer [cols rows])
+          ;; Top border
+          top-line (str (:tl chars)
+                        (if title
+                          (let [t (truncate-str title (- cols 4))
+                                remaining (- cols 2 (count t) 2)]
+                            (str (:h chars) t (apply str (repeat (max 0 (+ remaining 1)) (:h chars)))))
+                          (apply str (repeat (- cols 2) (:h chars))))
+                        (:tr chars))
+          ;; Bottom border
+          bot-line (str (:bl chars) (apply str (repeat (- cols 2) (:h chars))) (:br chars))
+          buffer (buf/buf-put-string buffer 0 0 top-line style)
+          buffer (buf/buf-put-string buffer 0 (dec rows) bot-line style)
+          ;; Side borders
+          buffer (reduce (fn [b r]
+                        (-> b
+                            (buf/buf-put-char 0 r (assoc style :char (:v chars)))
+                            (buf/buf-put-char (dec cols) r (assoc style :char (:v chars)))))
+                      buffer
+                      (range 1 (dec rows)))]
+      (if content-fn
+        (let [inner-cols (- cols 2)
+              inner-rows (- rows 2)
+              content (content-fn [inner-cols inner-rows])]
+          (buf/blit buffer content 1 1))
+        buffer))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Split layouts
+
+(defn split-h
+  "Split horizontally into left/right panes.
+   ratio is the fraction [0.0, 1.0] for the left pane.
+   left-fn, right-fn: (fn [[cols rows]] -> cell-buffer)"
+  [[cols rows] ratio left-fn right-fn]
+  (let [left-cols (max 1 (int (* cols ratio)))
+        right-cols (- cols left-cols)
+        left-buf (left-fn [left-cols rows])
+        right-buf (right-fn [right-cols rows])
+        buffer (buf/make-buffer [cols rows])]
+    (-> buffer
+        (buf/blit left-buf 0 0)
+        (buf/blit right-buf left-cols 0))))
+
+(defn split-v
+  "Split vertically into top/bottom panes.
+   ratio is the fraction [0.0, 1.0] for the top pane.
+   top-fn, bottom-fn: (fn [[cols rows]] -> cell-buffer)"
+  [[cols rows] ratio top-fn bottom-fn]
+  (let [top-rows (max 1 (int (* rows ratio)))
+        bottom-rows (- rows top-rows)
+        top-buf (top-fn [cols top-rows])
+        bottom-buf (bottom-fn [cols bottom-rows])
+        buffer (buf/make-buffer [cols rows])]
+    (-> buffer
+        (buf/blit top-buf 0 0)
+        (buf/blit bottom-buf 0 top-rows))))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout/table.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout/table.clj
@@ -55,7 +55,7 @@
 
 (defn- render-header-row
   "Render table header row."
-  [buffer cols columns col-widths header-fg header-bg]
+  [buffer columns col-widths header-fg header-bg]
   (reduce (fn [b [idx {:keys [header]} width]]
             (let [txt (pad-right (truncate-str (or header "") width) width)
                   x-offset (compute-col-offset col-widths idx)]
@@ -112,7 +112,7 @@
                          selected-fg :white selected-bg :blue}}]]
   (let [col-widths (compute-col-widths columns cols)
         buffer (buf/make-buffer [cols rows])
-        buffer (render-header-row buffer cols columns col-widths header-fg header-bg)
+        buffer (render-header-row buffer columns col-widths header-fg header-bg)
         buffer (render-separator buffer cols rows)
         visible-rows (take (max 0 (- rows 2)) (or data []))]
     (reduce (fn [b [row-idx row-data]]

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout/table.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout/table.clj
@@ -48,6 +48,54 @@
                     0)]
     (mapv (fn [spec] (or (:width spec) flex-each)) col-specs)))
 
+(defn- compute-col-offset
+  "Compute x-offset for column at index."
+  [col-widths idx]
+  (reduce + 0 (take idx col-widths)))
+
+(defn- render-header-row
+  "Render table header row."
+  [buffer cols columns col-widths header-fg header-bg]
+  (reduce (fn [b [idx {:keys [header]} width]]
+            (let [txt (pad-right (truncate-str (or header "") width) width)
+                  x-offset (compute-col-offset col-widths idx)]
+              (buf/buf-put-string b x-offset 0 txt
+                                  {:fg header-fg :bg header-bg :bold? true})))
+          buffer
+          (map vector (range) columns col-widths)))
+
+(defn- render-separator
+  "Render horizontal separator line."
+  [buffer cols rows]
+  (if (>= rows 2)
+    (buf/buf-put-string buffer 0 1
+                        (apply str (repeat cols \─))
+                        {:fg :default :bg :black :bold? false})
+    buffer))
+
+(defn- render-data-cell
+  "Render single data cell."
+  [buffer row-data col-idx col-spec width col-widths render-row fg bg]
+  (let [val (str (get row-data (:key col-spec) ""))
+        txt (pad-right (truncate-str val width) width)
+        x-offset (compute-col-offset col-widths col-idx)]
+    (buf/buf-put-string buffer x-offset render-row txt
+                        {:fg fg :bg bg :bold? false})))
+
+(defn- render-data-row
+  "Render single data row across all columns."
+  [buffer row-idx row-data columns col-widths rows selected-row row-fg row-bg selected-fg selected-bg]
+  (let [selected? (= row-idx selected-row)
+        fg (if selected? selected-fg row-fg)
+        bg (if selected? selected-bg row-bg)
+        render-row (+ row-idx 2)]
+    (if (>= render-row rows)
+      (reduced buffer)
+      (reduce (fn [b [col-idx col-spec width]]
+                (render-data-cell b row-data col-idx col-spec width col-widths render-row fg bg))
+              buffer
+              (map vector (range) columns col-widths)))))
+
 (defn table
   "Render a table with column headers and data rows.
    Options:
@@ -64,42 +112,14 @@
                          selected-fg :white selected-bg :blue}}]]
   (let [col-widths (compute-col-widths columns cols)
         buffer (buf/make-buffer [cols rows])
-        ;; Render header
-        buffer (reduce (fn [b [idx {:keys [header]} width]]
-                      (let [txt (pad-right (truncate-str (or header "") width) width)]
-                        (buf/buf-put-string b
-                                        (reduce + 0 (take idx col-widths))
-                                        0 txt
-                                        {:fg header-fg :bg header-bg :bold? true})))
-                    buffer
-                    (map vector (range) columns col-widths))
-        ;; Render separator
-        buffer (if (>= rows 2)
-              (buf/buf-put-string buffer 0 1
-                              (apply str (repeat cols \─))
-                              {:fg :default :bg :black :bold? false})
-              buffer)
-        ;; Render data rows
-        visible-rows (take (max 0 (- rows 2)) (or data []))
-        buffer (reduce (fn [b [row-idx row-data]]
-                      (let [selected? (= row-idx selected-row)
-                            fg (if selected? selected-fg row-fg)
-                            bg (if selected? selected-bg row-bg)
-                            render-row (+ row-idx 2)]
-                        (if (>= render-row rows)
-                          (reduced b)
-                          (reduce (fn [b2 [col-idx {:keys [key]} width]]
-                                    (let [val (str (get row-data key ""))
-                                          txt (pad-right (truncate-str val width) width)]
-                                      (buf/buf-put-string b2
-                                                      (reduce + 0 (take col-idx col-widths))
-                                                      render-row txt
-                                                      {:fg fg :bg bg :bold? false})))
-                                  b
-                                  (map vector (range) columns col-widths)))))
-                    buffer
-                    (map-indexed vector visible-rows))]
-    buffer))
+        buffer (render-header-row buffer cols columns col-widths header-fg header-bg)
+        buffer (render-separator buffer cols rows)
+        visible-rows (take (max 0 (- rows 2)) (or data []))]
+    (reduce (fn [b [row-idx row-data]]
+              (render-data-row b row-idx row-data columns col-widths rows
+                               selected-row row-fg row-bg selected-fg selected-bg))
+            buffer
+            (map-indexed vector visible-rows))))
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Padding

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout/table.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout/table.clj
@@ -1,0 +1,118 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.layout.table
+  "Table rendering and padding utilities.
+
+   Provides data table rendering with column specs and content padding.
+   Pure functions with no side effects."
+  (:require
+   [ai.miniforge.tui-engine.layout.buffer :as buf]))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Table
+
+(defn- truncate-str
+  "Truncate string to max-width, adding ellipsis if truncated."
+  [s max-width]
+  (if (<= (count s) max-width)
+    s
+    (str (subs s 0 (max 0 (- max-width 1))) "…")))
+
+(defn- pad-right
+  "Pad string to width with spaces."
+  [s width]
+  (let [s (or s "")]
+    (if (>= (count s) width)
+      (subs s 0 width)
+      (str s (apply str (repeat (- width (count s)) \space))))))
+
+(defn- compute-col-widths
+  "Compute column widths from specs. Fixed :width honored, remainder distributed."
+  [col-specs total-width]
+  (let [fixed-used (reduce + 0 (keep :width col-specs))
+        flex-count (count (remove :width col-specs))
+        flex-each (if (pos? flex-count)
+                    (max 1 (quot (- total-width fixed-used) flex-count))
+                    0)]
+    (mapv (fn [spec] (or (:width spec) flex-each)) col-specs)))
+
+(defn table
+  "Render a table with column headers and data rows.
+   Options:
+   - :columns - vector of {:key kw, :header str, :width int (opt), :align :left/:right/:center}
+   - :rows    - vector of maps keyed by column :key
+   - :selected-row - index of highlighted row (nil for none)
+   - :header-fg, :header-bg - Header style
+   - :row-fg, :row-bg - Default row style
+   - :selected-fg, :selected-bg - Selected row style"
+  [[cols rows] & [{:keys [columns data selected-row
+                           header-fg header-bg row-fg row-bg selected-fg selected-bg]
+                    :or {header-fg :cyan header-bg :black
+                         row-fg :white row-bg :black
+                         selected-fg :white selected-bg :blue}}]]
+  (let [col-widths (compute-col-widths columns cols)
+        buffer (buf/make-buffer [cols rows])
+        ;; Render header
+        buffer (reduce (fn [b [idx {:keys [header]} width]]
+                      (let [txt (pad-right (truncate-str (or header "") width) width)]
+                        (buf/buf-put-string b
+                                        (reduce + 0 (take idx col-widths))
+                                        0 txt
+                                        {:fg header-fg :bg header-bg :bold? true})))
+                    buffer
+                    (map vector (range) columns col-widths))
+        ;; Render separator
+        buffer (if (>= rows 2)
+              (buf/buf-put-string buffer 0 1
+                              (apply str (repeat cols \─))
+                              {:fg :default :bg :black :bold? false})
+              buffer)
+        ;; Render data rows
+        visible-rows (take (max 0 (- rows 2)) (or data []))
+        buffer (reduce (fn [b [row-idx row-data]]
+                      (let [selected? (= row-idx selected-row)
+                            fg (if selected? selected-fg row-fg)
+                            bg (if selected? selected-bg row-bg)
+                            render-row (+ row-idx 2)]
+                        (if (>= render-row rows)
+                          (reduced b)
+                          (reduce (fn [b2 [col-idx {:keys [key]} width]]
+                                    (let [val (str (get row-data key ""))
+                                          txt (pad-right (truncate-str val width) width)]
+                                      (buf/buf-put-string b2
+                                                      (reduce + 0 (take col-idx col-widths))
+                                                      render-row txt
+                                                      {:fg fg :bg bg :bold? false})))
+                                  b
+                                  (map vector (range) columns col-widths)))))
+                    buffer
+                    (map-indexed vector visible-rows))]
+    buffer))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Padding
+
+(defn pad
+  "Add padding around a content-fn's output.
+   padding: [top right bottom left] or single int for all sides."
+  [[cols rows] padding content-fn]
+  (let [[pt pr pb pl] (if (vector? padding)
+                         padding
+                         [padding padding padding padding])
+        inner-cols (max 0 (- cols pl pr))
+        inner-rows (max 0 (- rows pt pb))
+        inner-buf (content-fn [inner-cols inner-rows])
+        buffer (buf/make-buffer [cols rows])]
+    (buf/blit buffer inner-buf pl pt)))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/widget.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/widget.clj
@@ -15,244 +15,33 @@
 (ns ai.miniforge.tui-engine.widget
   "Composite TUI widgets built on layout primitives.
 
-   Each widget is a pure function: (widget-fn [cols rows] opts) -> cell-buffer.
+   Convenience namespace that re-exports all widget functions from stratified
+   sub-namespaces (status, tree, scroll). Each widget is a pure function:
+   (widget-fn [cols rows] opts) -> cell-buffer.
+
    Widgets compose with layout/blit and layout/split-h/v."
   (:require
-   [ai.miniforge.tui-engine.layout :as layout]))
+   [ai.miniforge.tui-engine.widget.status :as status]
+   [ai.miniforge.tui-engine.widget.tree :as tree]
+   [ai.miniforge.tui-engine.widget.scroll :as scroll]))
 
-;------------------------------------------------------------------------------ Layer 0
-;; Status indicators
+;; Re-export from status
+(def status-indicator status/status-indicator)
+(def status-text status/status-text)
+(def progress-bar status/progress-bar)
 
-(def ^:private status-chars
-  {:running  \●
-   :success  \✓
-   :failed   \✗
-   :blocked  \◐
-   :pending  \○
-   :skipped  \─
-   :spinning \⟳})
+;; Re-export from tree
+(def tree tree/tree)
+(def kanban tree/kanban)
 
-(def ^:private status-colors
-  {:running  :cyan
-   :success  :green
-   :failed   :red
-   :blocked  :yellow
-   :pending  :default
-   :skipped  :default
-   :spinning :cyan})
-
-(defn status-indicator
-  "Render a single status indicator character with color.
-   Returns a 1-cell buffer."
-  [status]
-  (let [ch (get status-chars status \?)
-        fg (get status-colors status :white)]
-    (layout/text [1 1] (str ch) {:fg fg})))
-
-(defn status-text
-  "Render a status indicator followed by label text.
-   Returns a buffer of [cols 1]."
-  [[cols _rows] status label]
-  (let [ch (get status-chars status \?)
-        fg (get status-colors status :white)
-        buf (layout/make-buffer [cols 1])
-        buf (layout/buf-put-char buf 0 0 {:char ch :fg fg :bg :black :bold? false})]
-    (if (> cols 2)
-      (layout/buf-put-string buf 2 0 (subs label 0 (min (count label) (- cols 2)))
-                             {:fg :white :bg :black :bold? false})
-      buf)))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Progress bar
-
-(def ^:private bar-chars
-  "Sub-cell progress bar characters (eighths)."
-  [\space \▏ \▎ \▍ \▌ \▋ \▊ \▉ \█])
-
-(defn progress-bar
-  "Render a progress bar.
-   Options:
-   - :percent   - 0-100
-   - :fill-fg   - Color for filled portion (default :cyan)
-   - :empty-fg  - Color for empty portion (default :default)
-   - :show-pct? - Show percentage text (default true)"
-  [[cols _rows] & [{:keys [percent fill-fg empty-fg show-pct?]
-                     :or {percent 0 fill-fg :cyan empty-fg :default show-pct? true}}]]
-  (let [pct (max 0 (min 100 percent))
-        label (when show-pct? (str " " pct "%"))
-        bar-width (max 1 (- cols (if label (count label) 0)))
-        filled-cells (/ (* pct bar-width) 100.0)
-        full-cells (int filled-cells)
-        frac (- filled-cells full-cells)
-        frac-idx (int (* frac 8))
-        buf (layout/make-buffer [cols 1])
-        ;; Fill complete cells
-        buf (reduce (fn [b i]
-                      (layout/buf-put-char b i 0
-                                           {:char \█ :fg fill-fg :bg :black :bold? false}))
-                    buf (range (min full-cells bar-width)))
-        ;; Fractional cell
-        buf (if (and (< full-cells bar-width) (pos? frac-idx))
-              (layout/buf-put-char buf full-cells 0
-                                   {:char (nth bar-chars frac-idx)
-                                    :fg fill-fg :bg :black :bold? false})
-              buf)
-        ;; Empty cells
-        buf (reduce (fn [b i]
-                      (layout/buf-put-char b i 0
-                                           {:char \░ :fg empty-fg :bg :black :bold? false}))
-                    buf
-                    (range (if (pos? frac-idx) (inc full-cells) full-cells)
-                           bar-width))
-        ;; Percentage label
-        buf (if label
-              (layout/buf-put-string buf bar-width 0 label
-                                     {:fg :white :bg :black :bold? false})
-              buf)]
-    buf))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Tree view
-
-(defn tree
-  "Render a tree with expand/collapse.
-   Options:
-   - :nodes    - flat vector of {:label str :depth int :expandable? bool}
-   - :expanded - set of indices that are expanded
-   - :selected - index of selected node
-   - :fg, :selected-fg, :selected-bg - colors"
-  [[cols rows] & [{:keys [nodes expanded selected fg selected-fg selected-bg]
-                    :or {expanded #{} selected 0 fg :white
-                         selected-fg :white selected-bg :blue}}]]
-  (let [buf (layout/make-buffer [cols rows])
-        visible (take rows (or nodes []))]
-    (reduce (fn [b [idx {:keys [label depth expandable?]}]]
-              (let [sel? (= idx selected)
-                    indent (* 2 (or depth 0))
-                    icon (cond
-                           (and expandable? (contains? expanded idx)) "▼ "
-                           expandable? "▸ "
-                           :else "  ")
-                    text (str (apply str (repeat indent \space)) icon (or label ""))
-                    text (subs text 0 (min (count text) cols))]
-                (layout/buf-put-string b 0 idx text
-                                       {:fg (if sel? selected-fg fg)
-                                        :bg (if sel? selected-bg :black)
-                                        :bold? sel?})))
-            buf
-            (map-indexed vector visible))))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Kanban columns
-
-(defn kanban
-  "Render kanban-style columns.
-   Options:
-   - :columns - [{:title str :color kw :cards [{:label str :status kw}]}]
-   Each column gets equal width."
-  [[cols rows] & [{:keys [columns]}]]
-  (let [n (max 1 (count (or columns [])))
-        col-width (max 4 (quot cols n))
-        buf (layout/make-buffer [cols rows])]
-    (reduce (fn [b [idx {:keys [title color cards]}]]
-              (let [x-offset (* idx col-width)
-                    avail-w (min col-width (- cols x-offset))
-                    ;; Header
-                    header (subs (str " " title (apply str (repeat avail-w \space)))
-                                 0 (min avail-w (+ (count title) 2)))
-                    b (layout/buf-put-string b x-offset 0 header
-                                             {:fg (or color :white) :bg :black :bold? true})
-                    ;; Separator
-                    b (if (>= rows 2)
-                        (layout/buf-put-string b x-offset 1
-                                               (apply str (repeat avail-w \─))
-                                               {:fg :default :bg :black :bold? false})
-                        b)]
-                ;; Cards
-                (reduce (fn [b2 [card-idx {:keys [label status]}]]
-                          (let [r (+ card-idx 2)]
-                            (if (>= r rows) (reduced b2)
-                                (let [indicator (get status-chars status \○)
-                                      line (str indicator " " (subs label 0 (min (count label) (- avail-w 2))))
-                                      line (subs line 0 (min (count line) avail-w))]
-                                  (layout/buf-put-string b2 x-offset r line
-                                                         {:fg (get status-colors status :white)
-                                                          :bg :black :bold? false})))))
-                        b
-                        (map-indexed vector (or cards [])))))
-            buf
-            (map-indexed vector (or columns [])))))
-
-;------------------------------------------------------------------------------ Layer 4
-;; Scrollable viewport
-
-(defn scrollable
-  "Render a scrollable viewport with scrollbar.
-   Options:
-   - :lines   - vector of strings (total content)
-   - :offset  - scroll offset (first visible line index)
-   - :fg, :bg - colors"
-  [[cols rows] & [{:keys [lines offset fg bg]
-                    :or {offset 0 fg :white bg :black}}]]
-  (let [total (count (or lines []))
-        content-w (max 1 (- cols 1)) ; 1 col for scrollbar
-        visible (take rows (drop offset (or lines [])))
-        buf (layout/make-buffer [cols rows])
-        ;; Render visible lines
-        buf (reduce (fn [b [idx line]]
-                      (let [truncated (subs line 0 (min (count line) content-w))]
-                        (layout/buf-put-string b 0 idx truncated
-                                               {:fg fg :bg bg :bold? false})))
-                    buf
-                    (map-indexed vector visible))
-        ;; Scrollbar
-        scroll-col (dec cols)
-        bar-height (if (pos? total)
-                     (max 1 (int (* rows (/ (min rows total) total))))
-                     rows)
-        bar-top (if (and (pos? total) (> total rows))
-                  (int (* (- rows bar-height) (/ offset (- total rows))))
-                  0)]
-    (reduce (fn [b r]
-              (let [in-bar? (and (>= r bar-top) (< r (+ bar-top bar-height)))
-                    ch (if in-bar? \▮ \│)]
-                (layout/buf-put-char b scroll-col r
-                                     {:char ch :fg :default :bg bg :bold? false})))
-            buf
-            (range rows))))
-
-;------------------------------------------------------------------------------ Layer 5
-;; Sparkline
-
-(def ^:private braille-chars
-  "Braille characters for sparkline (8 vertical levels)."
-  [\⠀ \⡀ \⡄ \⡆ \⡇ \⣇ \⣧ \⣷ \⣿])
-
-(defn sparkline
-  "Render a braille-based sparkline.
-   Options:
-   - :values - vector of numbers
-   - :fg     - color (default :cyan)"
-  [[cols _rows] & [{:keys [values fg] :or {fg :cyan}}]]
-  (let [vals (or values [])
-        ;; Take last `cols` values
-        visible (if (> (count vals) cols)
-                  (subvec vals (- (count vals) cols))
-                  vals)
-        max-val (if (seq visible) (apply max visible) 1)
-        max-val (if (zero? max-val) 1 max-val)
-        buf (layout/make-buffer [cols 1])]
-    (reduce (fn [b [idx v]]
-              (let [level (int (* 8 (/ v max-val)))
-                    level (max 0 (min 8 level))
-                    ch (nth braille-chars level)]
-                (layout/buf-put-char b idx 0
-                                     {:char ch :fg fg :bg :black :bold? false})))
-            buf
-            (map-indexed vector visible))))
+;; Re-export from scroll
+(def scrollable scroll/scrollable)
+(def sparkline scroll/sparkline)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
+  (require '[ai.miniforge.tui-engine.layout :as layout])
+
   (layout/buf->strings (progress-bar [20 1] {:percent 40}))
   ;; => ["████████░░░░░░░░ 40%"]
 

--- a/components/tui-engine/src/ai/miniforge/tui_engine/widget/scroll.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/widget/scroll.clj
@@ -1,0 +1,89 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.widget.scroll
+  "Scrollable viewport and sparkline widgets.
+
+   Provides scrollable content views and mini data visualizations.
+   Pure functions with no side effects."
+  (:require
+   [ai.miniforge.tui-engine.layout.buffer :as buf]))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Scrollable viewport
+
+(defn scrollable
+  "Render a scrollable viewport with scrollbar.
+   Options:
+   - :lines   - vector of strings (total content)
+   - :offset  - scroll offset (first visible line index)
+   - :fg, :bg - colors"
+  [[cols rows] & [{:keys [lines offset fg bg]
+                    :or {offset 0 fg :white bg :black}}]]
+  (let [total (count (or lines []))
+        content-w (max 1 (- cols 1)) ; 1 col for scrollbar
+        visible (take rows (drop offset (or lines [])))
+        buffer (buf/make-buffer [cols rows])
+        ;; Render visible lines
+        buffer (reduce (fn [b [idx line]]
+                      (let [truncated (subs line 0 (min (count line) content-w))]
+                        (buf/buf-put-string b 0 idx truncated
+                                               {:fg fg :bg bg :bold? false})))
+                    buffer
+                    (map-indexed vector visible))
+        ;; Scrollbar
+        scroll-col (dec cols)
+        bar-height (if (pos? total)
+                     (max 1 (int (* rows (/ (min rows total) total))))
+                     rows)
+        bar-top (if (and (pos? total) (> total rows))
+                  (int (* (- rows bar-height) (/ offset (- total rows))))
+                  0)]
+    (reduce (fn [b r]
+              (let [in-bar? (and (>= r bar-top) (< r (+ bar-top bar-height)))
+                    ch (if in-bar? \▮ \│)]
+                (buf/buf-put-char b scroll-col r
+                                     {:char ch :fg :default :bg bg :bold? false})))
+            buffer
+            (range rows))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Sparkline
+
+(def ^:private braille-chars
+  "Braille characters for sparkline (8 vertical levels)."
+  [\⠀ \⡀ \⡄ \⡆ \⡇ \⣇ \⣧ \⣷ \⣿])
+
+(defn sparkline
+  "Render a braille-based sparkline.
+   Options:
+   - :values - vector of numbers
+   - :fg     - color (default :cyan)"
+  [[cols _rows] & [{:keys [values fg] :or {fg :cyan}}]]
+  (let [vals (or values [])
+        ;; Take last `cols` values
+        visible (if (> (count vals) cols)
+                  (subvec vals (- (count vals) cols))
+                  vals)
+        max-val (if (seq visible) (apply max visible) 1)
+        max-val (if (zero? max-val) 1 max-val)
+        buffer (buf/make-buffer [cols 1])]
+    (reduce (fn [b [idx v]]
+              (let [level (int (* 8 (/ v max-val)))
+                    level (max 0 (min 8 level))
+                    ch (nth braille-chars level)]
+                (buf/buf-put-char b idx 0
+                                     {:char ch :fg fg :bg :black :bold? false})))
+            buffer
+            (map-indexed vector visible))))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/widget/status.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/widget/status.clj
@@ -1,0 +1,112 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.widget.status
+  "Status indicators and progress bar widgets.
+
+   Provides visual indicators for status states and progress visualization.
+   Pure functions with no side effects."
+  (:require
+   [ai.miniforge.tui-engine.layout.buffer :as buf]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Status indicators
+
+(def ^:private status-chars
+  {:running  \●
+   :success  \✓
+   :failed   \✗
+   :blocked  \◐
+   :pending  \○
+   :skipped  \─
+   :spinning \⟳})
+
+(def ^:private status-colors
+  {:running  :cyan
+   :success  :green
+   :failed   :red
+   :blocked  :yellow
+   :pending  :default
+   :skipped  :default
+   :spinning :cyan})
+
+(defn status-indicator
+  "Render a single status indicator character with color.
+   Returns a 1-cell buffer."
+  [status]
+  (let [ch (get status-chars status \?)
+        fg (get status-colors status :white)]
+    (buf/text [1 1] (str ch) {:fg fg})))
+
+(defn status-text
+  "Render a status indicator followed by label text.
+   Returns a buffer of [cols 1]."
+  [[cols _rows] status label]
+  (let [ch (get status-chars status \?)
+        fg (get status-colors status :white)
+        buffer (buf/make-buffer [cols 1])
+        buffer (buf/buf-put-char buffer 0 0 {:char ch :fg fg :bg :black :bold? false})]
+    (if (> cols 2)
+      (buf/buf-put-string buffer 2 0 (subs label 0 (min (count label) (- cols 2)))
+                             {:fg :white :bg :black :bold? false})
+      buffer)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Progress bar
+
+(def ^:private bar-chars
+  "Sub-cell progress bar characters (eighths)."
+  [\space \▏ \▎ \▍ \▌ \▋ \▊ \▉ \█])
+
+(defn progress-bar
+  "Render a progress bar.
+   Options:
+   - :percent   - 0-100
+   - :fill-fg   - Color for filled portion (default :cyan)
+   - :empty-fg  - Color for empty portion (default :default)
+   - :show-pct? - Show percentage text (default true)"
+  [[cols _rows] & [{:keys [percent fill-fg empty-fg show-pct?]
+                     :or {percent 0 fill-fg :cyan empty-fg :default show-pct? true}}]]
+  (let [pct (max 0 (min 100 percent))
+        label (when show-pct? (str " " pct "%"))
+        bar-width (max 1 (- cols (if label (count label) 0)))
+        filled-cells (/ (* pct bar-width) 100.0)
+        full-cells (int filled-cells)
+        frac (- filled-cells full-cells)
+        frac-idx (int (* frac 8))
+        buffer (buf/make-buffer [cols 1])
+        ;; Fill complete cells
+        buffer (reduce (fn [b i]
+                      (buf/buf-put-char b i 0
+                                           {:char \█ :fg fill-fg :bg :black :bold? false}))
+                    buffer (range (min full-cells bar-width)))
+        ;; Fractional cell
+        buffer (if (and (< full-cells bar-width) (pos? frac-idx))
+              (buf/buf-put-char buffer full-cells 0
+                                   {:char (nth bar-chars frac-idx)
+                                    :fg fill-fg :bg :black :bold? false})
+              buffer)
+        ;; Empty cells
+        buffer (reduce (fn [b i]
+                      (buf/buf-put-char b i 0
+                                           {:char \░ :fg empty-fg :bg :black :bold? false}))
+                    buffer
+                    (range (if (pos? frac-idx) (inc full-cells) full-cells)
+                           bar-width))
+        ;; Percentage label
+        buffer (if label
+              (buf/buf-put-string buffer bar-width 0 label
+                                     {:fg :white :bg :black :bold? false})
+              buffer)]
+    buffer))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/widget/status.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/widget/status.clj
@@ -69,6 +69,41 @@
   "Sub-cell progress bar characters (eighths)."
   [\space \▏ \▎ \▍ \▌ \▋ \▊ \▉ \█])
 
+(defn- render-filled-cells
+  "Render complete filled cells."
+  [buffer full-cells bar-width fill-fg]
+  (reduce (fn [b i]
+            (buf/buf-put-char b i 0
+                              {:char \█ :fg fill-fg :bg :black :bold? false}))
+          buffer
+          (range (min full-cells bar-width))))
+
+(defn- render-fractional-cell
+  "Render partial fill for fractional progress."
+  [buffer full-cells bar-width frac-idx fill-fg]
+  (if (and (< full-cells bar-width) (pos? frac-idx))
+    (buf/buf-put-char buffer full-cells 0
+                      {:char (nth bar-chars frac-idx)
+                       :fg fill-fg :bg :black :bold? false})
+    buffer))
+
+(defn- render-empty-cells
+  "Render remaining empty cells."
+  [buffer full-cells frac-idx bar-width empty-fg]
+  (reduce (fn [b i]
+            (buf/buf-put-char b i 0
+                              {:char \░ :fg empty-fg :bg :black :bold? false}))
+          buffer
+          (range (if (pos? frac-idx) (inc full-cells) full-cells) bar-width)))
+
+(defn- add-percentage-label
+  "Add percentage text label at end of bar."
+  [buffer bar-width label]
+  (if label
+    (buf/buf-put-string buffer bar-width 0 label
+                        {:fg :white :bg :black :bold? false})
+    buffer))
+
 (defn progress-bar
   "Render a progress bar.
    Options:
@@ -84,29 +119,9 @@
         filled-cells (/ (* pct bar-width) 100.0)
         full-cells (int filled-cells)
         frac (- filled-cells full-cells)
-        frac-idx (int (* frac 8))
-        buffer (buf/make-buffer [cols 1])
-        ;; Fill complete cells
-        buffer (reduce (fn [b i]
-                      (buf/buf-put-char b i 0
-                                           {:char \█ :fg fill-fg :bg :black :bold? false}))
-                    buffer (range (min full-cells bar-width)))
-        ;; Fractional cell
-        buffer (if (and (< full-cells bar-width) (pos? frac-idx))
-              (buf/buf-put-char buffer full-cells 0
-                                   {:char (nth bar-chars frac-idx)
-                                    :fg fill-fg :bg :black :bold? false})
-              buffer)
-        ;; Empty cells
-        buffer (reduce (fn [b i]
-                      (buf/buf-put-char b i 0
-                                           {:char \░ :fg empty-fg :bg :black :bold? false}))
-                    buffer
-                    (range (if (pos? frac-idx) (inc full-cells) full-cells)
-                           bar-width))
-        ;; Percentage label
-        buffer (if label
-              (buf/buf-put-string buffer bar-width 0 label
-                                     {:fg :white :bg :black :bold? false})
-              buffer)]
-    buffer))
+        frac-idx (int (* frac 8))]
+    (-> (buf/make-buffer [cols 1])
+        (render-filled-cells full-cells bar-width fill-fg)
+        (render-fractional-cell full-cells bar-width frac-idx fill-fg)
+        (render-empty-cells full-cells frac-idx bar-width empty-fg)
+        (add-percentage-label bar-width label))))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/widget/tree.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/widget/tree.clj
@@ -1,0 +1,111 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.widget.tree
+  "Tree view and kanban column widgets.
+
+   Provides hierarchical tree navigation and kanban-style column displays.
+   Pure functions with no side effects."
+  (:require
+   [ai.miniforge.tui-engine.layout.buffer :as buf]))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Tree view
+
+(defn tree
+  "Render a tree with expand/collapse.
+   Options:
+   - :nodes    - flat vector of {:label str :depth int :expandable? bool}
+   - :expanded - set of indices that are expanded
+   - :selected - index of selected node
+   - :fg, :selected-fg, :selected-bg - colors"
+  [[cols rows] & [{:keys [nodes expanded selected fg selected-fg selected-bg]
+                    :or {expanded #{} selected 0 fg :white
+                         selected-fg :white selected-bg :blue}}]]
+  (let [buffer (buf/make-buffer [cols rows])
+        visible (take rows (or nodes []))]
+    (reduce (fn [b [idx {:keys [label depth expandable?]}]]
+              (let [sel? (= idx selected)
+                    indent (* 2 (or depth 0))
+                    icon (cond
+                           (and expandable? (contains? expanded idx)) "▼ "
+                           expandable? "▸ "
+                           :else "  ")
+                    text (str (apply str (repeat indent \space)) icon (or label ""))
+                    text (subs text 0 (min (count text) cols))]
+                (buf/buf-put-string b 0 idx text
+                                       {:fg (if sel? selected-fg fg)
+                                        :bg (if sel? selected-bg :black)
+                                        :bold? sel?})))
+            buffer
+            (map-indexed vector visible))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Kanban columns
+
+(def ^:private status-chars
+  {:running  \●
+   :success  \✓
+   :failed   \✗
+   :blocked  \◐
+   :pending  \○
+   :skipped  \─
+   :spinning \⟳})
+
+(def ^:private status-colors
+  {:running  :cyan
+   :success  :green
+   :failed   :red
+   :blocked  :yellow
+   :pending  :default
+   :skipped  :default
+   :spinning :cyan})
+
+(defn kanban
+  "Render kanban-style columns.
+   Options:
+   - :columns - [{:title str :color kw :cards [{:label str :status kw}]}]
+   Each column gets equal width."
+  [[cols rows] & [{:keys [columns]}]]
+  (let [n (max 1 (count (or columns [])))
+        col-width (max 4 (quot cols n))
+        buffer (buf/make-buffer [cols rows])]
+    (reduce (fn [b [idx {:keys [title color cards]}]]
+              (let [x-offset (* idx col-width)
+                    avail-w (min col-width (- cols x-offset))
+                    ;; Header
+                    header (subs (str " " title (apply str (repeat avail-w \space)))
+                                 0 (min avail-w (+ (count title) 2)))
+                    b (buf/buf-put-string b x-offset 0 header
+                                             {:fg (or color :white) :bg :black :bold? true})
+                    ;; Separator
+                    b (if (>= rows 2)
+                        (buf/buf-put-string b x-offset 1
+                                               (apply str (repeat avail-w \─))
+                                               {:fg :default :bg :black :bold? false})
+                        b)]
+                ;; Cards
+                (reduce (fn [b2 [card-idx {:keys [label status]}]]
+                          (let [r (+ card-idx 2)]
+                            (if (>= r rows) (reduced b2)
+                                (let [indicator (get status-chars status \○)
+                                      line (str indicator " " (subs label 0 (min (count label) (- avail-w 2))))
+                                      line (subs line 0 (min (count line) avail-w))]
+                                  (buf/buf-put-string b2 x-offset r line
+                                                         {:fg (get status-colors status :white)
+                                                          :bg :black :bold? false})))))
+                        b
+                        (map-indexed vector (or cards [])))))
+            buffer
+            (map-indexed vector (or columns [])))))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/widget/tree.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/widget/tree.clj
@@ -72,6 +72,53 @@
    :skipped  :default
    :spinning :cyan})
 
+(defn- render-column-header
+  "Render column header with title."
+  [buffer x-offset avail-w title color]
+  (let [header (subs (str " " title (apply str (repeat avail-w \space)))
+                     0 (min avail-w (+ (count title) 2)))]
+    (buf/buf-put-string buffer x-offset 0 header
+                        {:fg (or color :white) :bg :black :bold? true})))
+
+(defn- render-column-separator
+  "Render horizontal separator below header."
+  [buffer x-offset avail-w rows]
+  (if (>= rows 2)
+    (buf/buf-put-string buffer x-offset 1
+                        (apply str (repeat avail-w \─))
+                        {:fg :default :bg :black :bold? false})
+    buffer))
+
+(defn- format-card-line
+  "Format card text with status indicator."
+  [label status avail-w]
+  (let [indicator (get status-chars status \○)
+        line (str indicator " " (subs label 0 (min (count label) (- avail-w 2))))]
+    (subs line 0 (min (count line) avail-w))))
+
+(defn- render-card
+  "Render single card in column."
+  [buffer x-offset card-idx label status avail-w rows]
+  (let [r (+ card-idx 2)]
+    (if (>= r rows)
+      (reduced buffer)
+      (let [line (format-card-line label status avail-w)]
+        (buf/buf-put-string buffer x-offset r line
+                            {:fg (get status-colors status :white)
+                             :bg :black :bold? false})))))
+
+(defn- render-column
+  "Render complete kanban column."
+  [buffer idx {:keys [title color cards]} col-width cols rows]
+  (let [x-offset (* idx col-width)
+        avail-w (min col-width (- cols x-offset))
+        buffer (render-column-header buffer x-offset avail-w title color)
+        buffer (render-column-separator buffer x-offset avail-w rows)]
+    (reduce (fn [b [card-idx {:keys [label status]}]]
+              (render-card b x-offset card-idx label status avail-w rows))
+            buffer
+            (map-indexed vector (or cards [])))))
+
 (defn kanban
   "Render kanban-style columns.
    Options:
@@ -81,31 +128,7 @@
   (let [n (max 1 (count (or columns [])))
         col-width (max 4 (quot cols n))
         buffer (buf/make-buffer [cols rows])]
-    (reduce (fn [b [idx {:keys [title color cards]}]]
-              (let [x-offset (* idx col-width)
-                    avail-w (min col-width (- cols x-offset))
-                    ;; Header
-                    header (subs (str " " title (apply str (repeat avail-w \space)))
-                                 0 (min avail-w (+ (count title) 2)))
-                    b (buf/buf-put-string b x-offset 0 header
-                                             {:fg (or color :white) :bg :black :bold? true})
-                    ;; Separator
-                    b (if (>= rows 2)
-                        (buf/buf-put-string b x-offset 1
-                                               (apply str (repeat avail-w \─))
-                                               {:fg :default :bg :black :bold? false})
-                        b)]
-                ;; Cards
-                (reduce (fn [b2 [card-idx {:keys [label status]}]]
-                          (let [r (+ card-idx 2)]
-                            (if (>= r rows) (reduced b2)
-                                (let [indicator (get status-chars status \○)
-                                      line (str indicator " " (subs label 0 (min (count label) (- avail-w 2))))
-                                      line (subs line 0 (min (count line) avail-w))]
-                                  (buf/buf-put-string b2 x-offset r line
-                                                         {:fg (get status-colors status :white)
-                                                          :bg :black :bold? false})))))
-                        b
-                        (map-indexed vector (or cards [])))))
+    (reduce (fn [b [idx column]]
+              (render-column b idx column col-width cols rows))
             buffer
             (map-indexed vector (or columns [])))))

--- a/components/tui-views/deps.edn
+++ b/components/tui-views/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src" "resources"]
+ :deps {}
+ :aliases {:test {:extra-paths ["test"]}}}

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -1,0 +1,86 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.interface
+  "Public API for the TUI views component.
+
+   Provides the top-level entry points to start and stop the miniforge TUI.
+   Wires together the tui-engine (rendering) with domain data (event stream)."
+  (:require
+   [ai.miniforge.tui-engine.interface :as tui]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update :as update]
+   [ai.miniforge.tui-views.view :as view]
+   [ai.miniforge.tui-views.subscription :as subscription]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; TUI lifecycle
+
+(defn start-tui!
+  "Start the miniforge TUI.
+
+   Arguments:
+   - event-stream - Event stream atom from event-stream/create-event-stream
+   - opts         - {:throttle-ms 1000, :screen screen} optional overrides
+
+   Returns: app atom. Call stop-tui! to shut down.
+
+   The TUI will:
+   1. Enter alternate screen mode
+   2. Subscribe to the event stream
+   3. Start the input polling loop
+   4. Render the workflow list view
+
+   The TUI blocks the calling thread until the user quits (q key)."
+  [event-stream & [{:keys [throttle-ms screen] :or {throttle-ms 1000}}]]
+  (let [app (tui/create-app
+             {:init   model/init-model
+              :update update/update-model
+              :view   view/root-view
+              :screen screen
+              :subscriptions
+              (when event-stream
+                (fn [dispatch-fn]
+                  (subscription/subscribe-to-stream!
+                   event-stream dispatch-fn
+                   {:throttle-ms throttle-ms})))})]
+    (tui/start! app)
+    ;; Block until quit
+    (try
+      (while (not (:quit? (tui/get-model app)))
+        (Thread/sleep 100))
+      (finally
+        (tui/stop! app)))
+    app))
+
+(defn stop-tui!
+  "Stop the miniforge TUI. Restores terminal state.
+   Safe to call multiple times."
+  [app]
+  (tui/stop! app))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Start TUI with event stream
+  (require '[ai.miniforge.event-stream.interface :as es])
+  (def stream (es/create-event-stream))
+  (def app (future (start-tui! stream)))
+
+  ;; Send test events
+  (es/publish! stream (es/workflow-started stream (random-uuid) {:name "test-wf"}))
+
+  ;; Stop
+  (stop-tui! @app)
+
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/model.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/model.clj
@@ -1,0 +1,89 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.model
+  "Application model shape and initialization.
+
+   The model is a plain data map that represents the entire TUI state.
+   It is managed by the Elm runtime and updated only through pure
+   update functions.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Model shape
+
+(defn init-model
+  "Create the initial application model.
+
+   Model shape:
+   {:view          kw           ; Active view (:workflow-list :workflow-detail :evidence :artifact-browser :dag-kanban)
+    :workflows     [...]        ; Vector of workflow summary maps
+    :selected-idx  int          ; Selected item in current list
+    :scroll-offset int          ; Scroll offset for long lists
+    :detail        map          ; Drill-down state for detail views
+    :mode          kw           ; :normal :command :search
+    :command-buf   str          ; Command/search input buffer
+    :search-results [...]       ; Fuzzy search results
+    :last-updated  inst         ; Timestamp of last data update
+    :flash-message str          ; Temporary status bar message
+    :theme         kw}          ; Active theme name"
+  []
+  {:view          :workflow-list
+   :workflows     []
+   :selected-idx  0
+   :scroll-offset 0
+   :detail        {:workflow-id nil
+                   :phases      []
+                   :current-agent nil
+                   :agent-output ""
+                   :evidence    nil
+                   :artifacts   []}
+   :mode          :normal
+   :command-buf   ""
+   :search-results []
+   :last-updated  nil
+   :flash-message nil
+   :theme         :default})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Workflow data shape
+
+(defn make-workflow
+  "Create a workflow summary map for the model."
+  [{:keys [id name status phase progress started-at]}]
+  {:id         id
+   :name       (or name (str "workflow-" (subs (str id) 0 8)))
+   :status     (or status :pending)
+   :phase      phase
+   :progress   (or progress 0)
+   :started-at started-at
+   :agents     {}})
+
+;------------------------------------------------------------------------------ Layer 2
+;; View predicates
+
+(def views
+  "All available views in navigation order."
+  [:workflow-list :workflow-detail :evidence :artifact-browser :dag-kanban])
+
+(def view-labels
+  {:workflow-list    "Workflows"
+   :workflow-detail  "Detail"
+   :evidence         "Evidence"
+   :artifact-browser "Artifacts"
+   :dag-kanban       "DAG Kanban"})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (init-model)
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
@@ -1,0 +1,174 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.subscription
+  "Event stream -> TUI message bridge.
+
+   Subscribes to the event stream and translates domain events into
+   TUI messages for the Elm update loop. Handles throttling so rapid
+   agent/chunk events are coalesced into 1 aggregate message per second."
+  (:require
+   [ai.miniforge.event-stream.interface :as es]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Event -> TUI message translation
+
+(defn- translate-event
+  "Translate a single event-stream event to a TUI message vector.
+   Returns nil for events that should be ignored."
+  [event]
+  (case (:event/type event)
+    :workflow/started
+    [:msg/workflow-added {:workflow-id (:workflow/id event)
+                          :name (get-in event [:workflow/spec :name])
+                          :spec (:workflow/spec event)}]
+
+    :workflow/phase-started
+    [:msg/phase-changed {:workflow-id (:workflow/id event)
+                          :phase (:workflow/phase event)}]
+
+    :workflow/phase-completed
+    [:msg/phase-done {:workflow-id (:workflow/id event)
+                       :phase (:workflow/phase event)
+                       :outcome (get-in event [:result :outcome])}]
+
+    :agent/status
+    [:msg/agent-status {:workflow-id (:workflow/id event)
+                         :agent (:agent/id event)
+                         :status (:status-type event)
+                         :message (:message event)}]
+
+    :agent/chunk
+    [:msg/agent-output {:workflow-id (:workflow/id event)
+                         :agent (:agent/id event)
+                         :delta (:delta event)
+                         :done? (:done? event)}]
+
+    :workflow/completed
+    [:msg/workflow-done {:workflow-id (:workflow/id event)
+                          :status (:workflow/status event)}]
+
+    :workflow/failed
+    [:msg/workflow-failed {:workflow-id (:workflow/id event)
+                            :error (:error event)}]
+
+    :gate/passed
+    [:msg/gate-result {:workflow-id (:workflow/id event)
+                        :gate (:gate event)
+                        :passed? true}]
+
+    :gate/failed
+    [:msg/gate-result {:workflow-id (:workflow/id event)
+                        :gate (:gate event)
+                        :passed? false}]
+
+    ;; Unknown event types are ignored
+    nil))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Throttled subscription
+
+(defn- create-chunk-aggregator
+  "Create a throttled aggregator for agent/chunk events.
+   Accumulates deltas and flushes at configurable intervals."
+  [dispatch-fn flush-interval-ms]
+  (let [buffer (atom {})  ; {workflow-id {:delta str :agent kw}}
+        running? (atom true)
+        flush-fn (fn []
+                   (let [buf @buffer]
+                     (reset! buffer {})
+                     (doseq [[wf-id {:keys [delta agent]}] buf]
+                       (when (seq delta)
+                         (dispatch-fn [:msg/agent-output
+                                       {:workflow-id wf-id
+                                        :agent agent
+                                        :delta delta
+                                        :done? false}])))))
+        thread (Thread. (fn []
+                          (try
+                            (while @running?
+                              (Thread/sleep flush-interval-ms)
+                              (flush-fn))
+                            (catch InterruptedException _))))]
+    (.setDaemon thread true)
+    (.setName thread "tui-chunk-aggregator")
+    (.start thread)
+    {:buffer buffer
+     :running? running?
+     :thread thread
+     :stop! (fn []
+              (reset! running? false)
+              (.interrupt thread))}))
+
+(defn- buffer-chunk!
+  "Buffer an agent chunk for throttled delivery."
+  [aggregator workflow-id agent-id delta]
+  (swap! (:buffer aggregator)
+         update workflow-id
+         (fn [existing]
+           {:delta (str (:delta existing) delta)
+            :agent agent-id})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Public subscription API
+
+(defn subscribe-to-stream!
+  "Subscribe to an event stream, translating events into TUI messages.
+
+   Arguments:
+   - stream      - Event stream atom from event-stream/create-event-stream
+   - dispatch-fn - (fn [msg]) to send TUI messages into the Elm loop
+   - opts        - {:throttle-ms 1000} chunk aggregation interval
+
+   Returns: cleanup function (fn [] ...) to call on shutdown."
+  [stream dispatch-fn & [{:keys [throttle-ms] :or {throttle-ms 1000}}]]
+  (let [aggregator (create-chunk-aggregator dispatch-fn throttle-ms)
+        sub-id :tui-subscription]
+    (es/subscribe! stream sub-id
+                   (fn [event]
+                     (if (= :agent/chunk (:event/type event))
+                       ;; Throttle chunk events
+                       (buffer-chunk! aggregator
+                                      (:workflow/id event)
+                                      (:agent/id event)
+                                      (:delta event))
+                       ;; All other events dispatch immediately
+                       (when-let [msg (translate-event event)]
+                         (dispatch-fn msg)))))
+    ;; Return cleanup function
+    (fn []
+      ((:stop! aggregator))
+      (es/unsubscribe! stream sub-id))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Example usage
+  (def stream (es/create-event-stream))
+  (def messages (atom []))
+
+  (def cleanup
+    (subscribe-to-stream! stream
+                          (fn [msg] (swap! messages conj msg))
+                          {:throttle-ms 500}))
+
+  ;; Publish some events
+  (es/publish! stream (es/workflow-started stream (random-uuid) {:name "test"}))
+
+  ;; Check received messages
+  @messages
+
+  ;; Cleanup
+  (cleanup)
+
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/update.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update.clj
@@ -1,0 +1,125 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update
+  "Pure update function: (model, msg) -> model'.
+
+   All state transitions for the TUI application. Imports handlers from
+   stratified sub-namespaces (navigation, events, mode) and provides input
+   handling and root update dispatch.
+
+   Layers 4-5: Input handling + root update function."
+  (:require
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update.navigation :as nav]
+   [ai.miniforge.tui-views.update.events :as events]
+   [ai.miniforge.tui-views.update.mode :as mode]))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Input message handling
+
+(defn- handle-normal-input [model key]
+  (case key
+    :key/j         (nav/navigate-down model)
+    :key/k         (nav/navigate-up model)
+    :key/down      (nav/navigate-down model)
+    :key/up        (nav/navigate-up model)
+    :key/g         (nav/navigate-top model)
+    :key/G         (nav/navigate-bottom model)
+    :key/enter     (nav/enter-detail model)
+    :key/escape    (nav/go-back model)
+    :key/l         (nav/enter-detail model)
+    :key/h         (nav/go-back model)
+    :key/colon     (mode/enter-command-mode model)
+    :key/slash     (mode/enter-search-mode model)
+    :key/d1        (nav/switch-view model :workflow-list model/views)
+    :key/d2        (nav/switch-view model :workflow-detail model/views)
+    :key/d3        (nav/switch-view model :evidence model/views)
+    :key/d4        (nav/switch-view model :artifact-browser model/views)
+    :key/d5        (nav/switch-view model :dag-kanban model/views)
+    :key/q         (assoc model :quit? true)
+    ;; Unknown key -- no-op
+    model))
+
+(defn- handle-command-input [model key]
+  (case key
+    :key/escape   (mode/exit-mode model)
+    :key/enter    (-> model
+                      (assoc :flash-message (str "Executed: " (:command-buf model)))
+                      mode/exit-mode)
+    :key/backspace (mode/command-backspace model)
+    ;; Character input
+    (if (and (map? key) (= :char (:type key)))
+      (mode/command-append model (:char key))
+      model)))
+
+(defn- handle-search-input [model key]
+  (case key
+    :key/escape   (mode/exit-mode model)
+    :key/enter    (mode/exit-mode model)
+    :key/backspace (mode/command-backspace model)
+    (if (and (map? key) (= :char (:type key)))
+      (mode/command-append model (:char key))
+      model)))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Root update function
+
+(defn update-model
+  "Root update function for the TUI application.
+   Pure: (model, msg) -> model'
+
+   Messages are vectors: [msg-type payload]
+   Input messages: [:input key-event]
+   Stream messages: [:msg/workflow-added data], [:msg/phase-changed data], etc."
+  [model msg]
+  (let [[msg-type payload] (if (vector? msg) msg [msg nil])]
+    (case msg-type
+      ;; User input
+      :input
+      (case (:mode model)
+        :normal  (handle-normal-input model payload)
+        :command (handle-command-input model payload)
+        :search  (handle-search-input model payload)
+        model)
+
+      ;; Event stream messages
+      :msg/workflow-added   (events/handle-workflow-added model payload)
+      :msg/phase-changed    (events/handle-phase-changed model payload)
+      :msg/phase-done       (events/handle-phase-done model payload)
+      :msg/agent-status     (events/handle-agent-status model payload)
+      :msg/agent-output     (events/handle-agent-output model payload)
+      :msg/workflow-done    (events/handle-workflow-done model payload)
+      :msg/workflow-failed  (events/handle-workflow-failed model payload)
+      :msg/gate-result      (events/handle-gate-result model payload)
+
+      ;; Tick (for clock/timing updates, currently unused)
+      :tick model
+
+      ;; Unknown message -- no-op
+      model)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def m (model/init-model))
+
+  ;; Navigate
+  (-> m
+      (update-model [:msg/workflow-added {:workflow-id (random-uuid) :name "test"}])
+      (update-model [:msg/workflow-added {:workflow-id (random-uuid) :name "test-2"}])
+      (update-model [:input :key/j])
+      :selected-idx)
+  ;; => 1
+
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -1,0 +1,76 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update.events
+  "Event stream message handlers.
+
+   Pure functions that handle workflow events from the event stream.
+   Layer 2."
+  (:require
+   [ai.miniforge.tui-views.model :as model]))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Event stream message handlers
+
+(defn handle-workflow-added [model {:keys [workflow-id name spec]}]
+  (let [wf (model/make-workflow {:id workflow-id
+                                  :name (or name (:name spec))
+                                  :status :running})]
+    (-> model
+        (update :workflows conj wf))))
+
+(defn handle-phase-changed [model {:keys [workflow-id phase]}]
+  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+                  (map-indexed vector (:workflows model)))]
+    (cond-> model
+      idx (assoc-in [:workflows idx :phase] phase)
+      (= workflow-id (get-in model [:detail :workflow-id]))
+      (update-in [:detail :phases] conj {:phase phase :status :running}))))
+
+(defn handle-phase-done [model {:keys [workflow-id]}]
+  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+                  (map-indexed vector (:workflows model)))]
+    (cond-> model
+      idx (update-in [:workflows idx :progress]
+                     #(min 100 (+ (or % 0) 20))))))
+
+(defn handle-agent-status [model {:keys [workflow-id agent status message]}]
+  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+                  (map-indexed vector (:workflows model)))]
+    (cond-> model
+      idx (assoc-in [:workflows idx :agents agent] {:status status :message message})
+      (= workflow-id (get-in model [:detail :workflow-id]))
+      (assoc-in [:detail :current-agent] {:agent agent :status status :message message}))))
+
+(defn handle-agent-output [model {:keys [workflow-id delta]}]
+  (if (= workflow-id (get-in model [:detail :workflow-id]))
+    (update-in model [:detail :agent-output] str delta)
+    model))
+
+(defn handle-workflow-done [model {:keys [workflow-id status]}]
+  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+                  (map-indexed vector (:workflows model)))]
+    (cond-> model
+      idx (-> (assoc-in [:workflows idx :status] (or status :success))
+              (assoc-in [:workflows idx :progress] 100)))))
+
+(defn handle-workflow-failed [model {:keys [workflow-id error]}]
+  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+                  (map-indexed vector (:workflows model)))]
+    (cond-> model
+      idx (-> (assoc-in [:workflows idx :status] :failed)
+              (assoc-in [:workflows idx :error] error)))))
+
+(defn handle-gate-result [model _payload]
+  model)

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -23,54 +23,72 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Event stream message handlers
 
+;; Helper functions
+
+(defn- find-workflow-idx
+  "Find index of workflow with given ID in workflows vector."
+  [workflows workflow-id]
+  (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
+        (map-indexed vector workflows)))
+
+(defn- update-workflow-at
+  "Update workflow at index using update-fn."
+  [model idx update-fn]
+  (if idx
+    (update-in model [:workflows idx] update-fn)
+    model))
+
+(defn- update-detail-if-active
+  "Apply update-fn to detail if workflow-id matches active detail."
+  [model workflow-id update-fn]
+  (if (= workflow-id (get-in model [:detail :workflow-id]))
+    (update-fn model)
+    model))
+
+;; Event handlers
+
 (defn handle-workflow-added [model {:keys [workflow-id name spec]}]
   (let [wf (model/make-workflow {:id workflow-id
                                   :name (or name (:name spec))
                                   :status :running})]
-    (-> model
-        (update :workflows conj wf))))
+    (update model :workflows conj wf)))
 
 (defn handle-phase-changed [model {:keys [workflow-id phase]}]
-  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
-                  (map-indexed vector (:workflows model)))]
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (cond-> model
       idx (assoc-in [:workflows idx :phase] phase)
-      (= workflow-id (get-in model [:detail :workflow-id]))
-      (update-in [:detail :phases] conj {:phase phase :status :running}))))
+      true (update-detail-if-active workflow-id
+             #(update-in % [:detail :phases] conj {:phase phase :status :running})))))
 
 (defn handle-phase-done [model {:keys [workflow-id]}]
-  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
-                  (map-indexed vector (:workflows model)))]
-    (cond-> model
-      idx (update-in [:workflows idx :progress]
-                     #(min 100 (+ (or % 0) 20))))))
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
+    (update-workflow-at model idx
+      #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))))
 
 (defn handle-agent-status [model {:keys [workflow-id agent status message]}]
-  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
-                  (map-indexed vector (:workflows model)))]
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (cond-> model
       idx (assoc-in [:workflows idx :agents agent] {:status status :message message})
-      (= workflow-id (get-in model [:detail :workflow-id]))
-      (assoc-in [:detail :current-agent] {:agent agent :status status :message message}))))
+      true (update-detail-if-active workflow-id
+             #(assoc-in % [:detail :current-agent] {:agent agent :status status :message message})))))
 
 (defn handle-agent-output [model {:keys [workflow-id delta]}]
-  (if (= workflow-id (get-in model [:detail :workflow-id]))
-    (update-in model [:detail :agent-output] str delta)
-    model))
+  (update-detail-if-active model workflow-id
+    #(update-in % [:detail :agent-output] str delta)))
 
 (defn handle-workflow-done [model {:keys [workflow-id status]}]
-  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
-                  (map-indexed vector (:workflows model)))]
-    (cond-> model
-      idx (-> (assoc-in [:workflows idx :status] (or status :success))
-              (assoc-in [:workflows idx :progress] 100)))))
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
+    (update-workflow-at model idx
+      #(-> %
+           (assoc :status (or status :success))
+           (assoc :progress 100)))))
 
 (defn handle-workflow-failed [model {:keys [workflow-id error]}]
-  (let [idx (some (fn [[i wf]] (when (= (:id wf) workflow-id) i))
-                  (map-indexed vector (:workflows model)))]
-    (cond-> model
-      idx (-> (assoc-in [:workflows idx :status] :failed)
-              (assoc-in [:workflows idx :error] error)))))
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
+    (update-workflow-at model idx
+      #(-> %
+           (assoc :status :failed)
+           (assoc :error error)))))
 
 (defn handle-gate-result [model _payload]
   model)

--- a/components/tui-views/src/ai/miniforge/tui_views/update/mode.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/mode.clj
@@ -1,0 +1,40 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update.mode
+  "Mode switching and command buffer manipulation.
+
+   Pure functions for switching between normal/command/search modes.
+   Layer 3.")
+
+;------------------------------------------------------------------------------ Layer 3
+;; Mode switching
+
+(defn enter-command-mode [model]
+  (assoc model :mode :command :command-buf ":"))
+
+(defn enter-search-mode [model]
+  (assoc model :mode :search :command-buf "/" :search-results []))
+
+(defn exit-mode [model]
+  (assoc model :mode :normal :command-buf "" :search-results []))
+
+(defn command-append [model ch]
+  (update model :command-buf str ch))
+
+(defn command-backspace [model]
+  (let [buf (:command-buf model)]
+    (if (> (count buf) 1)
+      (assoc model :command-buf (subs buf 0 (dec (count buf))))
+      (exit-mode model))))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
@@ -1,0 +1,68 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update.navigation
+  "Navigation helpers and view transitions.
+
+   Pure functions for list navigation and view switching.
+   Layers 0-1.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Navigation helpers
+
+(defn list-count [model]
+  (case (:view model)
+    :workflow-list (count (:workflows model))
+    :artifact-browser (count (get-in model [:detail :artifacts]))
+    0))
+
+(defn navigate-up [model]
+  (update model :selected-idx #(max 0 (dec %))))
+
+(defn navigate-down [model]
+  (let [max-idx (max 0 (dec (list-count model)))]
+    (update model :selected-idx #(min max-idx (inc %)))))
+
+(defn navigate-top [model]
+  (assoc model :selected-idx 0 :scroll-offset 0))
+
+(defn navigate-bottom [model]
+  (let [max-idx (max 0 (dec (list-count model)))]
+    (assoc model :selected-idx max-idx)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; View navigation
+
+(defn enter-detail [model]
+  (let [workflows (:workflows model)
+        idx (:selected-idx model)]
+    (if-let [wf (get workflows idx)]
+      (-> model
+          (assoc :view :workflow-detail)
+          (assoc-in [:detail :workflow-id] (:id wf))
+          (assoc :selected-idx 0))
+      model)))
+
+(defn go-back [model]
+  (case (:view model)
+    :workflow-detail (assoc model :view :workflow-list :selected-idx 0)
+    :evidence        (assoc model :view :workflow-detail :selected-idx 0)
+    :artifact-browser (assoc model :view :workflow-detail :selected-idx 0)
+    :dag-kanban       (assoc model :view :workflow-list :selected-idx 0)
+    model))
+
+(defn switch-view [model view-key views]
+  (if (some #{view-key} views)
+    (assoc model :view view-key :selected-idx 0 :scroll-offset 0)
+    model))

--- a/components/tui-views/src/ai/miniforge/tui_views/view.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view.clj
@@ -1,0 +1,80 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.view
+  "View dispatch: model -> cell buffer.
+
+   Routes to the correct view renderer based on :view key in model.
+   Composes the view tab bar, command/search bar, and active view."
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.views.workflow-list :as wf-list]
+   [ai.miniforge.tui-views.views.workflow-detail :as wf-detail]
+   [ai.miniforge.tui-views.views.evidence :as evidence]
+   [ai.miniforge.tui-views.views.artifact-browser :as artifact-browser]
+   [ai.miniforge.tui-views.views.dag-kanban :as dag-kanban]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; View dispatch
+
+(defn- render-active-view
+  "Dispatch to the active view renderer."
+  [model size]
+  (case (:view model)
+    :workflow-list    (wf-list/render model size)
+    :workflow-detail  (wf-detail/render model size)
+    :evidence         (evidence/render model size)
+    :artifact-browser (artifact-browser/render model size)
+    :dag-kanban       (dag-kanban/render model size)
+    ;; Fallback
+    (layout/text size "Unknown view")))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Command/search bar overlay
+
+(defn- render-command-bar
+  "Render the command or search input bar at the bottom of the screen."
+  [[cols _rows] model]
+  (when (not= :normal (:mode model))
+    (layout/text [cols 1] (:command-buf model)
+                 {:fg :white :bg :default :bold? true})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Root view function
+
+(defn root-view
+  "Root view function for the Elm runtime.
+   model -> [cols rows] -> cell-buffer"
+  [model [cols rows]]
+  (if (< rows 4)
+    (layout/text [cols rows] "Terminal too small" {:fg :red})
+    (let [;; Reserve 1 row for command bar if in command/search mode
+          cmd-active? (not= :normal (:mode model))
+          content-rows (if cmd-active? (dec rows) rows)
+          ;; Render main view
+          content (render-active-view model [cols content-rows])]
+      (if cmd-active?
+        ;; Build full-size buffer: content on top, command bar on last row
+        (let [buf (layout/make-buffer [cols rows])
+              buf (layout/blit buf content 0 0)
+              cmd-bar (render-command-bar [cols 1] model)]
+          (layout/blit buf cmd-bar 0 (dec rows)))
+        content))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def m (model/init-model))
+  (layout/buf->strings (root-view m [80 24]))
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/artifact_browser.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/artifact_browser.clj
@@ -1,0 +1,78 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.artifact-browser
+  "Artifact browser -- N5 Section 3.2.4.
+
+   Shows workflow artifacts in a table with drill-down:
+   - Type (plan, code, test, review, evidence)
+   - Name / path
+   - Size
+   - Status"
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Rendering
+
+(defn render
+  "Render the artifact browser.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [artifacts (get-in model [:detail :artifacts] [])
+        selected (:selected-idx model)]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      ;; Title bar
+      (fn [[c r]]
+        (layout/text [c r] " MINIFORGE │ Artifact Browser"
+                     {:fg :cyan :bold? true}))
+      ;; Content + footer
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          ;; Table
+          (fn [[tc tr]]
+            (if (empty? artifacts)
+              (layout/box [tc tr]
+                {:title "Artifacts" :border :single :fg :default
+                 :content-fn
+                 (fn [[ic ir]]
+                   (layout/text [ic ir] "  No artifacts available yet."
+                                {:fg :default}))})
+              (layout/box [tc tr]
+                {:title (str "Artifacts (" (count artifacts) ")")
+                 :border :single :fg :default
+                 :content-fn
+                 (fn [[ic ir]]
+                   (layout/table [ic ir]
+                     {:columns [{:key :type :header "Type" :width 10}
+                                {:key :name :header "Name" :width (max 10 (- ic 35))}
+                                {:key :size :header "Size" :width 8}
+                                {:key :status :header "Status" :width 8}]
+                      :data (mapv (fn [a]
+                                    {:type (some-> (:type a) name)
+                                     :name (or (:name a) (:path a) "unnamed")
+                                     :size (or (:size a) "-")
+                                     :status (some-> (:status a) name)})
+                                  artifacts)
+                      :selected-row selected}))})))
+          ;; Footer
+          (fn [[fc fr]]
+            (layout/text [fc fr]
+              " j/k:navigate  Enter:view  Esc:back  1:workflows  q:quit"
+              {:fg :default})))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/dag_kanban.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/dag_kanban.clj
@@ -1,0 +1,89 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.dag-kanban
+  "DAG Kanban view -- N5 Section 3.2.5.
+
+   Shows tasks from the dependency graph as kanban columns:
+   - BLOCKED: Tasks with unsatisfied dependencies
+   - PENDING: Tasks ready to execute
+   - RUNNING: Tasks currently being executed by agents
+   - DONE: Completed tasks
+
+   Columns are derived from task states. Each card shows the task name,
+   assigned agent, and dependency status."
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-engine.interface.widget :as widget]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Task grouping
+
+(defn- group-tasks-by-status
+  "Group workflow tasks into kanban columns."
+  [workflows]
+  (let [all-wfs (or workflows [])
+        blocked (filterv #(= :blocked (:status %)) all-wfs)
+        pending (filterv #(= :pending (:status %)) all-wfs)
+        running (filterv #(= :running (:status %)) all-wfs)
+        done (filterv #(#{:success :completed} (:status %)) all-wfs)
+        failed (filterv #(= :failed (:status %)) all-wfs)]
+    [{:title "BLOCKED"
+      :color :red
+      :cards (mapv (fn [wf] {:label (:name wf) :status :blocked}) blocked)}
+     {:title "PENDING"
+      :color :yellow
+      :cards (mapv (fn [wf] {:label (:name wf) :status :pending}) pending)}
+     {:title "RUNNING"
+      :color :cyan
+      :cards (mapv (fn [wf] {:label (:name wf) :status :running}) running)}
+     {:title "DONE"
+      :color :green
+      :cards (concat
+              (mapv (fn [wf] {:label (:name wf) :status :success}) done)
+              (mapv (fn [wf] {:label (:name wf) :status :failed}) failed))}]))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rendering
+
+(defn render
+  "Render the DAG kanban view.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [columns (group-tasks-by-status (:workflows model))]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      ;; Title bar
+      (fn [[c r]]
+        (layout/text [c r] " MINIFORGE │ DAG Kanban"
+                     {:fg :cyan :bold? true}))
+      ;; Content + footer
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          ;; Kanban board
+          (fn [[kc kr]]
+            (layout/box [kc kr]
+              {:title "Task Board" :border :single :fg :default
+               :content-fn
+               (fn [[ic ir]]
+                 (widget/kanban [ic ir] {:columns columns}))}))
+          ;; Footer
+          (fn [[fc fr]]
+            (layout/text [fc fr]
+              " 1:workflows  2:detail  3:evidence  4:artifacts  q:quit"
+              {:fg :default})))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/evidence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/evidence.clj
@@ -1,0 +1,105 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.evidence
+  "Evidence viewer -- N5 Section 3.2.3.
+
+   Displays workflow evidence as a scrollable tree with
+   expand/collapse sections:
+   - Intent (original task description)
+   - Phases (plan, implement, verify with outcomes)
+   - Validation (gate results and errors)
+   - Policy (policy check results)"
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-engine.interface.widget :as widget]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Evidence tree construction
+
+(defn- build-evidence-tree
+  "Build a tree node list from model evidence data."
+  [model]
+  (let [detail (:detail model)
+        evidence (:evidence detail)
+        phases (:phases detail)]
+    (into []
+      (concat
+       ;; Intent section
+       [{:label "Intent" :depth 0 :expandable? true}
+        {:label (or (get-in evidence [:intent :description])
+                    "No intent data available")
+         :depth 1 :expandable? false}]
+       ;; Phases section
+       [{:label "Phases" :depth 0 :expandable? true}]
+       (mapv (fn [{:keys [phase status]}]
+               {:label (str (name phase)
+                            (case status
+                              :running  " ● running"
+                              :success  " ✓ passed"
+                              :failed   " ✗ failed"
+                              ""))
+                :depth 1 :expandable? false})
+             phases)
+       ;; Validation section
+       [{:label "Validation" :depth 0 :expandable? true}
+        {:label (if (get-in evidence [:validation :passed?])
+                  "✓ All gates passed"
+                  (str "✗ " (count (get-in evidence [:validation :errors] [])) " error(s)"))
+         :depth 1 :expandable? false}]
+       ;; Policy section
+       [{:label "Policy" :depth 0 :expandable? true}
+        {:label (if (get-in evidence [:policy :compliant?])
+                  "✓ Policy compliant"
+                  "✗ Policy violations detected")
+         :depth 1 :expandable? false}]))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rendering
+
+(defn render
+  "Render the evidence viewer.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [nodes (build-evidence-tree model)
+        selected (:selected-idx model)]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      ;; Title bar
+      (fn [[c r]]
+        (layout/text [c r] " MINIFORGE │ Evidence Bundle"
+                     {:fg :cyan :bold? true}))
+      ;; Content + footer
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          ;; Tree view
+          (fn [[tc tr]]
+            (layout/box [tc tr]
+              {:title "Evidence" :border :single :fg :default
+               :content-fn
+               (fn [[ic ir]]
+                 (widget/tree [ic ir]
+                   {:nodes nodes
+                    :expanded #{0 2 (+ 3 (count (get-in model [:detail :phases])))
+                                (+ 5 (count (get-in model [:detail :phases])))}
+                    :selected selected}))}))
+          ;; Footer
+          (fn [[fc fr]]
+            (layout/text [fc fr]
+              " j/k:navigate  Enter:expand  Esc:back  1:workflows  q:quit"
+              {:fg :default})))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
@@ -15,24 +15,74 @@
 (ns ai.miniforge.tui-views.views.workflow-detail
   "Workflow detail view -- N5 Section 3.2.2.
 
-   Shows detailed information for a single workflow:
-   - Phase pipeline with status indicators
-   - Current agent activity and streaming output
-   - Progress breakdown by phase"
+   Shows detailed information about a single workflow:
+   - Phase progress with status indicators
+   - Real-time agent output streaming
+   - Current phase and agent status"
   (:require
    [clojure.string :as str]
    [ai.miniforge.tui-engine.interface.layout :as layout]
    [ai.miniforge.tui-engine.interface.widget :as widget]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Helper: find workflow
+;; Helpers
 
 (defn- find-workflow [model]
   (let [wf-id (get-in model [:detail :workflow-id])]
     (some #(when (= (:id %) wf-id) %) (:workflows model))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Rendering
+(defn- status-suffix [status]
+  (case status
+    :running  " ●"
+    :success  " ✓"
+    :failed   " ✗"
+    ""))
+
+(defn- format-phase-node [{:keys [phase status]}]
+  {:label (str (name phase) (status-suffix status))
+   :depth 0
+   :expandable? false})
+
+(defn- render-title-bar [wf [cols rows]]
+  (layout/text [cols rows]
+               (str " MINIFORGE │ "
+                    (or (:name wf) "Workflow Detail")
+                    (when-let [phase (:phase wf)]
+                      (str " │ " (name phase))))
+               {:fg :cyan :bold? true}))
+
+(defn- render-phase-list [phases [cols rows]]
+  (layout/box [cols rows]
+    {:title "Phases" :border :single :fg :default
+     :content-fn
+     (fn [[ic ir]]
+       (if (empty? phases)
+         (layout/text [ic ir] "  Waiting for phases...")
+         (widget/tree [ic ir]
+           {:nodes (mapv format-phase-node phases)
+            :selected 0})))}))
+
+(defn- render-agent-output [agent output [cols rows]]
+  (layout/box [cols rows]
+    {:title (if agent
+              (str (name (:agent agent)) " - " (name (:status agent :idle)))
+              "Agent Output")
+     :border :single :fg :default
+     :content-fn
+     (fn [[ic ir]]
+       (let [lines (if (seq output)
+                     (str/split-lines output)
+                     ["  Waiting for agent output..."])
+             offset (max 0 (- (count lines) ir))]
+         (widget/scrollable [ic ir]
+           {:lines lines
+            :offset offset
+            :fg :white})))}))
+
+(defn- render-footer [[cols rows]]
+  (layout/text [cols rows]
+    " Esc:back  3:evidence  4:artifacts  5:dag  j/k:scroll  q:quit"
+    {:fg :default}))
 
 (defn render
   "Render the workflow detail view.
@@ -45,62 +95,22 @@
         agent (:current-agent detail)
         output (:agent-output detail)]
     (layout/split-v [cols rows] (/ 2.0 rows)
-      ;; Title bar
-      (fn [[c r]]
-        (layout/text [c r]
-                     (str " MINIFORGE │ "
-                          (or (:name wf) "Workflow Detail")
-                          (when-let [phase (:phase wf)]
-                            (str " │ " (name phase))))
-                     {:fg :cyan :bold? true}))
-      ;; Content + footer
+      (fn [size] (render-title-bar wf size))
       (fn [[c r]]
         (layout/split-v [c r] (/ (- r 2.0) r)
-          ;; Main content: left phases + right agent output
           (fn [[mc mr]]
             (layout/split-h [mc mr] 0.35
-              ;; Left pane: phase list
-              (fn [[lc lr]]
-                (layout/box [lc lr]
-                  {:title "Phases" :border :single :fg :default
-                   :content-fn
-                   (fn [[ic ir]]
-                     (if (empty? phases)
-                       (layout/text [ic ir] "  Waiting for phases...")
-                       (let [nodes (mapv (fn [{:keys [phase status]}]
-                                           {:label (str (name phase)
-                                                        (case status
-                                                          :running  " ●"
-                                                          :success  " ✓"
-                                                          :failed   " ✗"
-                                                          ""))
-                                            :depth 0
-                                            :expandable? false})
-                                         phases)]
-                         (widget/tree [ic ir] {:nodes nodes :selected 0}))))}))
-              ;; Right pane: agent output
-              (fn [[rc rr]]
-                (layout/box [rc rr]
-                  {:title (if agent
-                            (str (name (:agent agent)) " - " (name (:status agent :idle)))
-                            "Agent Output")
-                   :border :single :fg :default
-                   :content-fn
-                   (fn [[ic ir]]
-                     (let [lines (if (seq output)
-                                   (str/split-lines output)
-                                   ["  Waiting for agent output..."])
-                           offset (max 0 (- (count lines) ir))]
-                       (widget/scrollable [ic ir]
-                         {:lines lines
-                          :offset offset
-                          :fg :white})))}))))
-          ;; Footer
-          (fn [[fc fr]]
-            (layout/text [fc fr]
-              " Esc:back  3:evidence  4:artifacts  5:dag  j/k:scroll  q:quit"
-              {:fg :default})))))))
+              (fn [size] (render-phase-list phases size))
+              (fn [size] (render-agent-output agent output size))))
+          render-footer)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
+  (def m {:workflows [{:id (random-uuid) :name "deploy-v2" :phase :implement}]
+          :detail {:workflow-id (random-uuid)
+                   :phases [{:phase :plan :status :success}
+                            {:phase :implement :status :running}]
+                   :current-agent {:agent :implementer :status :running}
+                   :agent-output "Generating code..."}})
+  (layout/buf->strings (render m [80 24]))
   :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
@@ -1,0 +1,106 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.workflow-detail
+  "Workflow detail view -- N5 Section 3.2.2.
+
+   Shows detailed information for a single workflow:
+   - Phase pipeline with status indicators
+   - Current agent activity and streaming output
+   - Progress breakdown by phase"
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-engine.interface.widget :as widget]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helper: find workflow
+
+(defn- find-workflow [model]
+  (let [wf-id (get-in model [:detail :workflow-id])]
+    (some #(when (= (:id %) wf-id) %) (:workflows model))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rendering
+
+(defn render
+  "Render the workflow detail view.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [wf (find-workflow model)
+        detail (:detail model)
+        phases (:phases detail)
+        agent (:current-agent detail)
+        output (:agent-output detail)]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      ;; Title bar
+      (fn [[c r]]
+        (layout/text [c r]
+                     (str " MINIFORGE │ "
+                          (or (:name wf) "Workflow Detail")
+                          (when-let [phase (:phase wf)]
+                            (str " │ " (name phase))))
+                     {:fg :cyan :bold? true}))
+      ;; Content + footer
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          ;; Main content: left phases + right agent output
+          (fn [[mc mr]]
+            (layout/split-h [mc mr] 0.35
+              ;; Left pane: phase list
+              (fn [[lc lr]]
+                (layout/box [lc lr]
+                  {:title "Phases" :border :single :fg :default
+                   :content-fn
+                   (fn [[ic ir]]
+                     (if (empty? phases)
+                       (layout/text [ic ir] "  Waiting for phases...")
+                       (let [nodes (mapv (fn [{:keys [phase status]}]
+                                           {:label (str (name phase)
+                                                        (case status
+                                                          :running  " ●"
+                                                          :success  " ✓"
+                                                          :failed   " ✗"
+                                                          ""))
+                                            :depth 0
+                                            :expandable? false})
+                                         phases)]
+                         (widget/tree [ic ir] {:nodes nodes :selected 0}))))}))
+              ;; Right pane: agent output
+              (fn [[rc rr]]
+                (layout/box [rc rr]
+                  {:title (if agent
+                            (str (name (:agent agent)) " - " (name (:status agent :idle)))
+                            "Agent Output")
+                   :border :single :fg :default
+                   :content-fn
+                   (fn [[ic ir]]
+                     (let [lines (if (seq output)
+                                   (str/split-lines output)
+                                   ["  Waiting for agent output..."])
+                           offset (max 0 (- (count lines) ir))]
+                       (widget/scrollable [ic ir]
+                         {:lines lines
+                          :offset offset
+                          :fg :white})))}))))
+          ;; Footer
+          (fn [[fc fr]]
+            (layout/text [fc fr]
+              " Esc:back  3:evidence  4:artifacts  5:dag  j/k:scroll  q:quit"
+              {:fg :default})))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
@@ -1,0 +1,85 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.workflow-list
+  "Workflow list view -- N5 Section 3.2.1.
+
+   Shows all active and recent workflows in a table with:
+   - Status indicator (colored dot)
+   - Workflow name
+   - Current phase
+   - Progress bar
+   - Agent status"
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Rendering
+
+(defn render
+  "Render the workflow list view.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [workflows (:workflows model)
+        selected (:selected-idx model)
+]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      ;; Title bar
+      (fn [[c r]]
+        (layout/text [c r] " MINIFORGE │ Workflows"
+                     {:fg :cyan :bold? true}))
+      ;; Main content + footer
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          ;; Table
+          (fn [[tc tr]]
+            (if (empty? workflows)
+              (layout/text [tc tr] "  No active workflows. Waiting for events..."
+                           {:fg :default})
+              (layout/table [tc tr]
+                {:columns [{:key :status-char :header "  " :width 2}
+                           {:key :name :header "Workflow" :width (max 10 (- tc 50))}
+                           {:key :phase :header "Phase" :width 12}
+                           {:key :progress-str :header "Progress" :width 20}
+                           {:key :agent-msg :header "Agent" :width 16}]
+                 :data (mapv (fn [wf]
+                               {:status-char (case (:status wf)
+                                               :running "●"
+                                               :success "✓"
+                                               :failed  "✗"
+                                               :blocked "◐"
+                                               "○")
+                                :name (:name wf)
+                                :phase (some-> (:phase wf) name)
+                                :progress-str (str (:progress wf 0) "%")
+                                :agent-msg (when-let [agent (first (vals (:agents wf)))]
+                                             (when-let [msg (:message agent)]
+                                               (subs msg 0 (min 16 (count msg)))))})
+                             workflows)
+                 :selected-row selected})))
+          ;; Footer
+          (fn [[fc fr]]
+            (layout/text [fc fr]
+              (str " j/k:navigate  Enter:detail  1-5:views  /:search  ::cmd  q:quit"
+                   (when-let [flash (:flash-message model)]
+                     (str "  │ " flash)))
+              {:fg :default})))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def m {:workflows [{:name "deploy-v2" :status :running :phase :implement :progress 40}]
+          :selected-idx 0})
+  (layout/buf->strings (render m [80 24]))
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
@@ -25,7 +25,49 @@
    [ai.miniforge.tui-engine.interface.layout :as layout]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Rendering
+;; Rendering helpers
+
+(defn- status-char [status]
+  (case status
+    :running "●"
+    :success "✓"
+    :failed  "✗"
+    :blocked "◐"
+    "○"))
+
+(defn- format-workflow-row
+  "Transform workflow data into table row format."
+  [wf]
+  {:status-char (status-char (:status wf))
+   :name (:name wf)
+   :phase (some-> (:phase wf) name)
+   :progress-str (str (:progress wf 0) "%")
+   :agent-msg (when-let [agent (first (vals (:agents wf)))]
+                (when-let [msg (:message agent)]
+                  (subs msg 0 (min 16 (count msg)))))})
+
+(defn- render-title-bar [[cols rows]]
+  (layout/text [cols rows] " MINIFORGE │ Workflows"
+               {:fg :cyan :bold? true}))
+
+(defn- render-table [workflows selected [cols rows]]
+  (if (empty? workflows)
+    (layout/text [cols rows] "  No active workflows. Waiting for events..."
+                 {:fg :default})
+    (layout/table [cols rows]
+      {:columns [{:key :status-char :header "  " :width 2}
+                 {:key :name :header "Workflow" :width (max 10 (- cols 50))}
+                 {:key :phase :header "Phase" :width 12}
+                 {:key :progress-str :header "Progress" :width 20}
+                 {:key :agent-msg :header "Agent" :width 16}]
+       :data (mapv format-workflow-row workflows)
+       :selected-row selected})))
+
+(defn- render-footer [flash-message [cols rows]]
+  (layout/text [cols rows]
+    (str " j/k:navigate  Enter:detail  1-5:views  /:search  ::cmd  q:quit"
+         (when flash-message (str "  │ " flash-message)))
+    {:fg :default}))
 
 (defn render
   "Render the workflow list view.
@@ -34,48 +76,13 @@
   [model [cols rows]]
   (let [workflows (:workflows model)
         selected (:selected-idx model)
-]
+        flash (:flash-message model)]
     (layout/split-v [cols rows] (/ 2.0 rows)
-      ;; Title bar
-      (fn [[c r]]
-        (layout/text [c r] " MINIFORGE │ Workflows"
-                     {:fg :cyan :bold? true}))
-      ;; Main content + footer
+      (fn [size] (render-title-bar size))
       (fn [[c r]]
         (layout/split-v [c r] (/ (- r 2.0) r)
-          ;; Table
-          (fn [[tc tr]]
-            (if (empty? workflows)
-              (layout/text [tc tr] "  No active workflows. Waiting for events..."
-                           {:fg :default})
-              (layout/table [tc tr]
-                {:columns [{:key :status-char :header "  " :width 2}
-                           {:key :name :header "Workflow" :width (max 10 (- tc 50))}
-                           {:key :phase :header "Phase" :width 12}
-                           {:key :progress-str :header "Progress" :width 20}
-                           {:key :agent-msg :header "Agent" :width 16}]
-                 :data (mapv (fn [wf]
-                               {:status-char (case (:status wf)
-                                               :running "●"
-                                               :success "✓"
-                                               :failed  "✗"
-                                               :blocked "◐"
-                                               "○")
-                                :name (:name wf)
-                                :phase (some-> (:phase wf) name)
-                                :progress-str (str (:progress wf 0) "%")
-                                :agent-msg (when-let [agent (first (vals (:agents wf)))]
-                                             (when-let [msg (:message agent)]
-                                               (subs msg 0 (min 16 (count msg)))))})
-                             workflows)
-                 :selected-row selected})))
-          ;; Footer
-          (fn [[fc fr]]
-            (layout/text [fc fr]
-              (str " j/k:navigate  Enter:detail  1-5:views  /:search  ::cmd  q:quit"
-                   (when-let [flash (:flash-message model)]
-                     (str "  │ " flash)))
-              {:fg :default})))))))
+          (fn [size] (render-table workflows selected size))
+          (fn [size] (render-footer flash size)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tui-views/test/ai/miniforge/tui_views/subscription_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/subscription_test.clj
@@ -1,0 +1,96 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.subscription-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.subscription :as sub]
+   [ai.miniforge.event-stream.interface :as es]))
+
+(deftest translate-workflow-events-test
+  (testing "Workflow started translates correctly"
+    (let [stream (es/create-event-stream)
+          messages (atom [])
+          wf-id (random-uuid)
+          cleanup (sub/subscribe-to-stream! stream
+                                            (fn [msg] (swap! messages conj msg))
+                                            {:throttle-ms 5000})]
+      (es/publish! stream (es/workflow-started stream wf-id {:name "test-wf"}))
+      (Thread/sleep 50)
+      (is (= 1 (count @messages)))
+      (is (= :msg/workflow-added (first (first @messages))))
+      (is (= wf-id (get-in (first @messages) [1 :workflow-id])))
+      (cleanup))))
+
+(deftest translate-phase-events-test
+  (testing "Phase started translates correctly"
+    (let [stream (es/create-event-stream)
+          messages (atom [])
+          wf-id (random-uuid)
+          cleanup (sub/subscribe-to-stream! stream
+                                            (fn [msg] (swap! messages conj msg))
+                                            {:throttle-ms 5000})]
+      (es/publish! stream (es/phase-started stream wf-id :plan))
+      (Thread/sleep 50)
+      (is (= :msg/phase-changed (first (first @messages))))
+      (is (= :plan (get-in (first @messages) [1 :phase])))
+      (cleanup))))
+
+(deftest translate-workflow-completed-test
+  (testing "Workflow completed translates correctly"
+    (let [stream (es/create-event-stream)
+          messages (atom [])
+          wf-id (random-uuid)
+          cleanup (sub/subscribe-to-stream! stream
+                                            (fn [msg] (swap! messages conj msg))
+                                            {:throttle-ms 5000})]
+      (es/publish! stream (es/workflow-completed stream wf-id :success 10000))
+      (Thread/sleep 50)
+      (is (= :msg/workflow-done (first (first @messages))))
+      (is (= :success (get-in (first @messages) [1 :status])))
+      (cleanup))))
+
+(deftest chunk-throttling-test
+  (testing "Rapid chunks are coalesced"
+    (let [stream (es/create-event-stream)
+          messages (atom [])
+          wf-id (random-uuid)
+          cleanup (sub/subscribe-to-stream! stream
+                                            (fn [msg] (swap! messages conj msg))
+                                            {:throttle-ms 100})]
+      ;; Send many chunks rapidly
+      (dotimes [i 10]
+        (es/publish! stream (es/agent-chunk stream wf-id :planner (str "chunk-" i " "))))
+      ;; Wait for aggregation flush
+      (Thread/sleep 250)
+      ;; Should have fewer messages than 10 (coalesced)
+      (let [chunk-msgs (filter #(= :msg/agent-output (first %)) @messages)]
+        (is (< (count chunk-msgs) 10)))
+      (cleanup))))
+
+(deftest cleanup-unsubscribes-test
+  (testing "Cleanup function stops the subscription"
+    (let [stream (es/create-event-stream)
+          messages (atom [])
+          wf-id (random-uuid)
+          cleanup (sub/subscribe-to-stream! stream
+                                            (fn [msg] (swap! messages conj msg))
+                                            {:throttle-ms 5000})]
+      (cleanup)
+      (Thread/sleep 50)
+      ;; Events after cleanup should not be received
+      (reset! messages [])
+      (es/publish! stream (es/workflow-started stream wf-id {:name "test"}))
+      (Thread/sleep 50)
+      (is (empty? @messages)))))

--- a/components/tui-views/test/ai/miniforge/tui_views/test_util.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/test_util.clj
@@ -1,0 +1,75 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.test-util
+  "Test utilities for tui-views tests.
+
+   Provides common helpers to reduce test duplication."
+  (:require
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update :as update]))
+
+;; Setup helpers
+
+(defn fresh-model
+  "Create a fresh model for testing."
+  []
+  (model/init-model))
+
+(defn with-workflows
+  "Add workflows to model for testing.
+   workflows: vector of {:workflow-id :name} maps"
+  [model workflows]
+  (reduce (fn [m wf]
+            (update/update-model m [:msg/workflow-added wf]))
+          model
+          workflows))
+
+(defn apply-updates
+  "Apply multiple update messages to a model.
+   updates: vector of [msg-type payload] vectors"
+  [model updates]
+  (reduce update/update-model model updates))
+
+;; Assertion helpers
+
+(defn view-is?
+  "Check if model's current view matches expected."
+  [model expected-view]
+  (= expected-view (:view model)))
+
+(defn selected-idx-is?
+  "Check if model's selected index matches expected."
+  [model expected-idx]
+  (= expected-idx (:selected-idx model)))
+
+(defn workflow-count-is?
+  "Check if model has expected number of workflows."
+  [model expected-count]
+  (= expected-count (count (:workflows model))))
+
+(defn workflow-has-status?
+  "Check if workflow at index has expected status."
+  [model idx expected-status]
+  (= expected-status (get-in model [:workflows idx :status])))
+
+(defn workflow-has-phase?
+  "Check if workflow at index has expected phase."
+  [model idx expected-phase]
+  (= expected-phase (get-in model [:workflows idx :phase])))
+
+(defn mode-is?
+  "Check if model's mode matches expected."
+  [model expected-mode]
+  (= expected-mode (:mode model)))

--- a/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
@@ -1,0 +1,153 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update :as update]))
+
+(def wf-id-1 (random-uuid))
+(def wf-id-2 (random-uuid))
+
+(defn- with-workflows [model]
+  (-> model
+      (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "wf-1"}])
+      (update/update-model [:msg/workflow-added {:workflow-id wf-id-2 :name "wf-2"}])))
+
+(deftest navigation-test
+  (testing "j moves down in workflow list"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/j]))]
+      (is (= 1 (:selected-idx m)))))
+
+  (testing "k moves up in workflow list"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/j])
+                (update/update-model [:input :key/k]))]
+      (is (= 0 (:selected-idx m)))))
+
+  (testing "k at top stays at 0"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/k]))]
+      (is (= 0 (:selected-idx m)))))
+
+  (testing "j at bottom stays at max"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/j])
+                (update/update-model [:input :key/j])
+                (update/update-model [:input :key/j]))]
+      (is (= 1 (:selected-idx m)))))
+
+  (testing "g goes to top"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/j])
+                (update/update-model [:input :key/g]))]
+      (is (= 0 (:selected-idx m)))))
+
+  (testing "G goes to bottom"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/G]))]
+      (is (= 1 (:selected-idx m))))))
+
+(deftest view-navigation-test
+  (testing "Enter drills into workflow detail"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/enter]))]
+      (is (= :workflow-detail (:view m)))
+      (is (= wf-id-1 (get-in m [:detail :workflow-id])))))
+
+  (testing "Escape returns to workflow list"
+    (let [m (-> (model/init-model) with-workflows
+                (update/update-model [:input :key/enter])
+                (update/update-model [:input :key/escape]))]
+      (is (= :workflow-list (:view m)))))
+
+  (testing "Number keys switch views"
+    (is (= :workflow-list (:view (update/update-model (model/init-model) [:input :key/d1]))))
+    (is (= :workflow-detail (:view (update/update-model (model/init-model) [:input :key/d2]))))
+    (is (= :evidence (:view (update/update-model (model/init-model) [:input :key/d3]))))
+    (is (= :artifact-browser (:view (update/update-model (model/init-model) [:input :key/d4]))))
+    (is (= :dag-kanban (:view (update/update-model (model/init-model) [:input :key/d5]))))))
+
+(deftest workflow-events-test
+  (testing "Workflow added appears in list"
+    (let [m (update/update-model (model/init-model)
+              [:msg/workflow-added {:workflow-id wf-id-1 :name "test-wf"}])]
+      (is (= 1 (count (:workflows m))))
+      (is (= "test-wf" (:name (first (:workflows m)))))))
+
+  (testing "Phase changed updates workflow"
+    (let [m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
+                (update/update-model [:msg/phase-changed {:workflow-id wf-id-1 :phase :implement}]))]
+      (is (= :implement (:phase (first (:workflows m)))))))
+
+  (testing "Workflow done updates status"
+    (let [m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
+                (update/update-model [:msg/workflow-done {:workflow-id wf-id-1 :status :success}]))]
+      (is (= :success (:status (first (:workflows m)))))
+      (is (= 100 (:progress (first (:workflows m)))))))
+
+  (testing "Workflow failed updates status"
+    (let [m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
+                (update/update-model [:msg/workflow-failed {:workflow-id wf-id-1 :error "timeout"}]))]
+      (is (= :failed (:status (first (:workflows m))))))))
+
+(deftest mode-switching-test
+  (testing ": enters command mode"
+    (let [m (update/update-model (model/init-model) [:input :key/colon])]
+      (is (= :command (:mode m)))
+      (is (= ":" (:command-buf m)))))
+
+  (testing "/ enters search mode"
+    (let [m (update/update-model (model/init-model) [:input :key/slash])]
+      (is (= :search (:mode m)))
+      (is (= "/" (:command-buf m)))))
+
+  (testing "Escape exits command mode"
+    (let [m (-> (model/init-model)
+                (update/update-model [:input :key/colon])
+                (update/update-model [:input :key/escape]))]
+      (is (= :normal (:mode m)))))
+
+  (testing "Character input in command mode appends to buffer"
+    (let [m (-> (model/init-model)
+                (update/update-model [:input :key/colon])
+                (update/update-model [:input {:type :char :char \h}])
+                (update/update-model [:input {:type :char :char \i}]))]
+      (is (= ":hi" (:command-buf m)))))
+
+  (testing "Backspace in command mode removes last char"
+    (let [m (-> (model/init-model)
+                (update/update-model [:input :key/colon])
+                (update/update-model [:input {:type :char :char \x}])
+                (update/update-model [:input :key/backspace]))]
+      (is (= ":" (:command-buf m))))))
+
+(deftest quit-test
+  (testing "q sets quit flag"
+    (let [m (update/update-model (model/init-model) [:input :key/q])]
+      (is (true? (:quit? m))))))
+
+(deftest agent-output-test
+  (testing "Agent output accumulates when viewing detail"
+    (let [m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
+                (update/update-model [:input :key/enter])
+                (update/update-model [:msg/agent-output {:workflow-id wf-id-1 :delta "Hello "}])
+                (update/update-model [:msg/agent-output {:workflow-id wf-id-1 :delta "World"}]))]
+      (is (= "Hello World" (get-in m [:detail :agent-output]))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
@@ -15,139 +15,102 @@
 (ns ai.miniforge.tui-views.update-test
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.test-util :as util]
    [ai.miniforge.tui-views.update :as update]))
 
 (def wf-id-1 (random-uuid))
 (def wf-id-2 (random-uuid))
 
-(defn- with-workflows [model]
-  (-> model
-      (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "wf-1"}])
-      (update/update-model [:msg/workflow-added {:workflow-id wf-id-2 :name "wf-2"}])))
+(defn- two-workflows []
+  (util/with-workflows (util/fresh-model)
+    [{:workflow-id wf-id-1 :name "wf-1"}
+     {:workflow-id wf-id-2 :name "wf-2"}]))
 
 (deftest navigation-test
   (testing "j moves down in workflow list"
-    (let [m (-> (model/init-model) with-workflows
-                (update/update-model [:input :key/j]))]
-      (is (= 1 (:selected-idx m)))))
+    (let [m (util/apply-updates (two-workflows) [[:input :key/j]])]
+      (is (util/selected-idx-is? m 1))))
 
   (testing "k moves up in workflow list"
-    (let [m (-> (model/init-model) with-workflows
-                (update/update-model [:input :key/j])
-                (update/update-model [:input :key/k]))]
-      (is (= 0 (:selected-idx m)))))
+    (let [m (util/apply-updates (two-workflows)
+              [[:input :key/j]
+               [:input :key/k]])]
+      (is (util/selected-idx-is? m 0))))
 
   (testing "k at top stays at 0"
-    (let [m (-> (model/init-model) with-workflows
-                (update/update-model [:input :key/k]))]
-      (is (= 0 (:selected-idx m)))))
+    (let [m (util/apply-updates (two-workflows) [[:input :key/k]])]
+      (is (util/selected-idx-is? m 0))))
 
   (testing "j at bottom stays at max"
-    (let [m (-> (model/init-model) with-workflows
-                (update/update-model [:input :key/j])
-                (update/update-model [:input :key/j])
-                (update/update-model [:input :key/j]))]
-      (is (= 1 (:selected-idx m)))))
+    (let [m (util/apply-updates (two-workflows)
+              [[:input :key/j]
+               [:input :key/j]
+               [:input :key/j]])]
+      (is (util/selected-idx-is? m 1))))
 
   (testing "g goes to top"
-    (let [m (-> (model/init-model) with-workflows
-                (update/update-model [:input :key/j])
-                (update/update-model [:input :key/g]))]
-      (is (= 0 (:selected-idx m)))))
+    (let [m (util/apply-updates (two-workflows)
+              [[:input :key/j]
+               [:input :key/g]])]
+      (is (util/selected-idx-is? m 0))))
 
   (testing "G goes to bottom"
-    (let [m (-> (model/init-model) with-workflows
-                (update/update-model [:input :key/G]))]
-      (is (= 1 (:selected-idx m))))))
+    (let [m (util/apply-updates (two-workflows) [[:input :key/G]])]
+      (is (util/selected-idx-is? m 1)))))
 
 (deftest view-navigation-test
   (testing "Enter drills into workflow detail"
-    (let [m (-> (model/init-model) with-workflows
-                (update/update-model [:input :key/enter]))]
-      (is (= :workflow-detail (:view m)))
+    (let [m (util/apply-updates (two-workflows) [[:input :key/enter]])]
+      (is (util/view-is? m :workflow-detail))
       (is (= wf-id-1 (get-in m [:detail :workflow-id])))))
 
   (testing "Escape returns to workflow list"
-    (let [m (-> (model/init-model) with-workflows
-                (update/update-model [:input :key/enter])
-                (update/update-model [:input :key/escape]))]
-      (is (= :workflow-list (:view m)))))
+    (let [m (util/apply-updates (two-workflows)
+              [[:input :key/enter]
+               [:input :key/escape]])]
+      (is (util/view-is? m :workflow-list))))
 
   (testing "Number keys switch views"
-    (is (= :workflow-list (:view (update/update-model (model/init-model) [:input :key/d1]))))
-    (is (= :workflow-detail (:view (update/update-model (model/init-model) [:input :key/d2]))))
-    (is (= :evidence (:view (update/update-model (model/init-model) [:input :key/d3]))))
-    (is (= :artifact-browser (:view (update/update-model (model/init-model) [:input :key/d4]))))
-    (is (= :dag-kanban (:view (update/update-model (model/init-model) [:input :key/d5]))))))
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input :key/d1]) :workflow-list))
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input :key/d2]) :workflow-detail))
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input :key/d3]) :evidence))
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input :key/d4]) :artifact-browser))
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input :key/d5]) :dag-kanban))))
 
 (deftest workflow-events-test
   (testing "Workflow added appears in list"
-    (let [m (update/update-model (model/init-model)
+    (let [m (update/update-model (util/fresh-model)
               [:msg/workflow-added {:workflow-id wf-id-1 :name "test-wf"}])]
-      (is (= 1 (count (:workflows m))))
+      (is (util/workflow-count-is? m 1))
       (is (= "test-wf" (:name (first (:workflows m)))))))
 
   (testing "Phase changed updates workflow"
-    (let [m (-> (model/init-model)
-                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
-                (update/update-model [:msg/phase-changed {:workflow-id wf-id-1 :phase :implement}]))]
-      (is (= :implement (:phase (first (:workflows m)))))))
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:msg/workflow-added {:workflow-id wf-id-1 :name "test"}]
+               [:msg/phase-changed {:workflow-id wf-id-1 :phase :implement}]])]
+      (is (util/workflow-has-phase? m 0 :implement))))
 
   (testing "Workflow done updates status"
-    (let [m (-> (model/init-model)
-                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
-                (update/update-model [:msg/workflow-done {:workflow-id wf-id-1 :status :success}]))]
-      (is (= :success (:status (first (:workflows m)))))
-      (is (= 100 (:progress (first (:workflows m)))))))
-
-  (testing "Workflow failed updates status"
-    (let [m (-> (model/init-model)
-                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
-                (update/update-model [:msg/workflow-failed {:workflow-id wf-id-1 :error "timeout"}]))]
-      (is (= :failed (:status (first (:workflows m))))))))
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:msg/workflow-added {:workflow-id wf-id-1 :name "test"}]
+               [:msg/workflow-done {:workflow-id wf-id-1 :status :success}]])]
+      (is (util/workflow-has-status? m 0 :success))
+      (is (= 100 (get-in m [:workflows 0 :progress]))))))
 
 (deftest mode-switching-test
-  (testing ": enters command mode"
-    (let [m (update/update-model (model/init-model) [:input :key/colon])]
-      (is (= :command (:mode m)))
+  (testing "Colon enters command mode"
+    (let [m (util/apply-updates (util/fresh-model) [[:input :key/colon]])]
+      (is (util/mode-is? m :command))
       (is (= ":" (:command-buf m)))))
 
-  (testing "/ enters search mode"
-    (let [m (update/update-model (model/init-model) [:input :key/slash])]
-      (is (= :search (:mode m)))
+  (testing "Slash enters search mode"
+    (let [m (util/apply-updates (util/fresh-model) [[:input :key/slash]])]
+      (is (util/mode-is? m :search))
       (is (= "/" (:command-buf m)))))
 
-  (testing "Escape exits command mode"
-    (let [m (-> (model/init-model)
-                (update/update-model [:input :key/colon])
-                (update/update-model [:input :key/escape]))]
-      (is (= :normal (:mode m)))))
-
-  (testing "Character input in command mode appends to buffer"
-    (let [m (-> (model/init-model)
-                (update/update-model [:input :key/colon])
-                (update/update-model [:input {:type :char :char \h}])
-                (update/update-model [:input {:type :char :char \i}]))]
-      (is (= ":hi" (:command-buf m)))))
-
-  (testing "Backspace in command mode removes last char"
-    (let [m (-> (model/init-model)
-                (update/update-model [:input :key/colon])
-                (update/update-model [:input {:type :char :char \x}])
-                (update/update-model [:input :key/backspace]))]
-      (is (= ":" (:command-buf m))))))
-
-(deftest quit-test
-  (testing "q sets quit flag"
-    (let [m (update/update-model (model/init-model) [:input :key/q])]
-      (is (true? (:quit? m))))))
-
-(deftest agent-output-test
-  (testing "Agent output accumulates when viewing detail"
-    (let [m (-> (model/init-model)
-                (update/update-model [:msg/workflow-added {:workflow-id wf-id-1 :name "test"}])
-                (update/update-model [:input :key/enter])
-                (update/update-model [:msg/agent-output {:workflow-id wf-id-1 :delta "Hello "}])
-                (update/update-model [:msg/agent-output {:workflow-id wf-id-1 :delta "World"}]))]
-      (is (= "Hello World" (get-in m [:detail :agent-output]))))))
+  (testing "Escape exits mode"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input :key/colon]
+               [:input :key/escape]])]
+      (is (util/mode-is? m :normal))
+      (is (= "" (:command-buf m))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/view_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/view_test.clj
@@ -1,0 +1,88 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.view-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [clojure.string :as str]
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update :as update]
+   [ai.miniforge.tui-views.view :as view]))
+
+(deftest root-view-renders-test
+  (testing "Workflow list view renders without error"
+    (let [m (model/init-model)
+          buf (view/root-view m [80 24])]
+      (is (some? buf))
+      (is (= 24 (count buf)))
+      (is (= 80 (count (first buf))))))
+
+  (testing "Workflow list with data renders"
+    (let [m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added
+                                      {:workflow-id (random-uuid) :name "deploy-v2"}]))
+          buf (view/root-view m [80 24])
+          strings (layout/buf->strings buf)]
+      (is (some #(str/includes? % "MINIFORGE") strings))
+      (is (some #(str/includes? % "deploy-v2") strings)))))
+
+(deftest workflow-detail-view-renders-test
+  (testing "Detail view renders without error"
+    (let [wf-id (random-uuid)
+          m (-> (model/init-model)
+                (update/update-model [:msg/workflow-added {:workflow-id wf-id :name "test"}])
+                (update/update-model [:input :key/enter]))
+          buf (view/root-view m [80 24])]
+      (is (some? buf))
+      (is (= 24 (count buf))))))
+
+(deftest evidence-view-renders-test
+  (testing "Evidence view renders without error"
+    (let [m (assoc (model/init-model) :view :evidence)
+          buf (view/root-view m [80 24])]
+      (is (some? buf)))))
+
+(deftest artifact-browser-view-renders-test
+  (testing "Artifact browser view renders without error"
+    (let [m (assoc (model/init-model) :view :artifact-browser)
+          buf (view/root-view m [80 24])]
+      (is (some? buf)))))
+
+(deftest dag-kanban-view-renders-test
+  (testing "DAG kanban view renders without error"
+    (let [m (assoc (model/init-model) :view :dag-kanban)
+          buf (view/root-view m [80 24])]
+      (is (some? buf)))))
+
+(deftest minimum-terminal-size-test
+  (testing "Graceful behavior at minimum size"
+    (let [m (model/init-model)
+          buf (view/root-view m [80 24])]
+      (is (= 24 (count buf)))))
+
+  (testing "Very small terminal shows error"
+    (let [m (model/init-model)
+          buf (view/root-view m [20 3])
+          strings (layout/buf->strings buf)]
+      (is (some #(str/includes? % "small") strings)))))
+
+(deftest command-bar-overlay-test
+  (testing "Command mode shows command bar"
+    (let [m (-> (model/init-model)
+                (update/update-model [:input :key/colon]))
+          buf (view/root-view m [80 24])
+          strings (layout/buf->strings buf)
+          last-line (last strings)]
+      (is (str/includes? last-line ":")))))

--- a/deps.edn
+++ b/deps.edn
@@ -65,6 +65,8 @@
                        "components/event-stream/resources"
                        "components/tui-engine/src"
                        "components/tui-engine/resources"
+                       "components/tui-views/src"
+                       "components/tui-views/resources"
                        "bases/cli/src"
                        "bases/cli/resources"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
@@ -98,6 +100,7 @@
                      ai.miniforge/repo-dag {:local/root "components/repo-dag"}
                      ai.miniforge/event-stream {:local/root "components/event-stream"}
                      ai.miniforge/tui-engine {:local/root "components/tui-engine"}
+                     ai.miniforge/tui-views {:local/root "components/tui-views"}
                      ai.miniforge/cli {:local/root "bases/cli"}}}
 
   :test {:extra-paths ["development/test"
@@ -131,7 +134,8 @@
                        "components/pr-train/test"
                        "components/repo-dag/test"
                        "components/event-stream/test"
-                       "components/tui-engine/test"]
+                       "components/tui-engine/test"
+                       "components/tui-views/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
                       ai.miniforge/logging {:local/root "components/logging"}
@@ -162,7 +166,8 @@
                       ai.miniforge/pr-train {:local/root "components/pr-train"}
                       ai.miniforge/repo-dag {:local/root "components/repo-dag"}
                       ai.miniforge/event-stream {:local/root "components/event-stream"}
-                      ai.miniforge/tui-engine {:local/root "components/tui-engine"}}}
+                      ai.miniforge/tui-engine {:local/root "components/tui-engine"}
+                      ai.miniforge/tui-views {:local/root "components/tui-views"}}}
 
   :conformance {:extra-paths ["development/test"
                               "tests/conformance"

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -37,7 +37,10 @@
         ai.miniforge/orchestrator {:local/root "../../components/orchestrator"}
         ai.miniforge/reporting {:local/root "../../components/reporting"}
         ;; Event streaming and observability
-        ai.miniforge/event-stream {:local/root "../../components/event-stream"}}
+        ai.miniforge/event-stream {:local/root "../../components/event-stream"}
+        ;; TUI framework and views
+        ai.miniforge/tui-engine {:local/root "../../components/tui-engine"}
+        ai.miniforge/tui-views {:local/root "../../components/tui-views"}}
 
  :aliases
  {:uberjar

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -1,7 +1,7 @@
 # miniforge Specification Index
 
-**Version:** 0.2.0-draft
-**Date:** 2026-02-01
+**Version:** 0.3.0-draft
+**Date:** 2026-02-07
 **Status:** Living specification during OSS development
 
 ---
@@ -151,6 +151,25 @@ Defines:
 - Fleet and enterprise extensions: multi-tenancy, pattern detection
 - CLI/TUI extensions: listener commands, control palette, approval queue
 
+### N9 — External PR Integration 🆕
+
+**File:** [normative/N9-external-pr-integration.md](normative/N9-external-pr-integration.md)
+**Status:** Draft
+**Purpose:** Treat external PRs as first-class Fleet Mode work items with monitoring, policy, and governance
+
+Defines:
+
+- PR Work Item model: canonical representation of any PR (external or Miniforge-originated)
+- Provider ingestion: webhook/polling normalization from GitHub/GitLab to N3 events
+- Readiness computation: deterministic merge-readiness from CI, reviews, conflicts, policy
+- Risk assessment: explainable risk scoring as N6 evidence artifacts
+- Policy evaluation: N4 policy packs applied to external PR diffs with provider feedback
+- Automation tiers: Observe/Advise/Converse/Govern as N8 capability level specializations
+- PR trains: explicit dependency ordering with governed merge sequencing
+- Multi-repo configuration: per-repo opt-in with org-level defaults
+- Fleet Mode disambiguation: N9 (SDLC governance) vs N7 (runtime policy synthesis)
+- CLI/TUI/API extensions: `fleet prs`, `fleet trains` commands and views
+
 ---
 
 ## Informative Documentation (Non-Normative)
@@ -230,7 +249,7 @@ Documents superseded by normative specs. Retained for reference during migration
 
 ### Language Rules
 
-**Normative specs (N1-N8):**
+**Normative specs (N1-N9):**
 
 - MUST use RFC 2119 keywords: MUST, SHALL, SHOULD, MAY, MUST NOT, SHALL NOT
 - MUST define versioning and compatibility expectations
@@ -303,5 +322,6 @@ Normative specs are enforced by:
 
 ## Version History
 
+- **0.3.0-draft** (2026-02-07) - Added N9 (External PR Integration), Fleet Mode disambiguation
 - **0.2.0-draft** (2026-02-01) - Added N7 (OPSV) and N8 (OCI), updated governance for extension specs
 - **0.1.0-draft** (2026-01-23) - Initial spec index, normative spec structure established

--- a/specs/normative/N9-external-pr-integration.md
+++ b/specs/normative/N9-external-pr-integration.md
@@ -1,0 +1,815 @@
+# N9 — External PR Integration
+
+**Version:** 0.1.0-draft
+**Date:** 2026-02-07
+**Status:** Draft
+**Conformance:** MUST
+
+---
+
+## 0. Status and Scope
+
+### 0.1 Purpose
+
+This specification defines how Miniforge MUST ingest, model, evaluate, and
+(optionally) act on pull requests that were **not created by Miniforge**
+("external PRs"), providing the same monitoring, governance, and workflow
+benefits available to Miniforge-originated PRs.
+
+Miniforge already creates PRs as outputs of its workflow engine (Release phase,
+DAG task executor). This spec extends the system to treat **any** PR — from any
+author, in any connected repo — as a first-class work item inside the Fleet
+control plane.
+
+### 0.2 Relationship to N1–N8
+
+N9 is an extension of existing Miniforge normative contracts:
+
+- **N1**: introduces new concepts (External PR, PR Work Item, Provider, PR Train,
+          Readiness, Risk Assessment) as specializations of Workflow/Artifact/Evidence.
+          These MUST be added to N1 §2 and §12 (glossary).
+- **N2**: does NOT define new workflow phases; external PRs are not executed through
+          the Plan→Implement→Verify pipeline. However, external PRs MAY be
+          "adopted" into a Miniforge workflow (e.g., PR Monitoring), at which point
+          N2 applies.
+- **N3**: adds required event types for provider ingestion and PR state changes
+          as extensions to the event stream contract (§7 of this spec).
+- **N4**: defines how existing policy packs evaluate external PR diffs and how
+          policy results are published as provider-native signals (§8).
+- **N5**: defines CLI/TUI/API extensions for multi-repo PR monitoring, readiness
+          views, and train management (§12).
+- **N6**: defines how external PR assessments produce evidence artifacts using
+          the existing evidence bundle schema (§9).
+- **N7**: N7 defines OPSV (operational policy synthesis for service fleets at
+          runtime). N9 defines SDLC governance across repository fleets at
+          development time. Both operate under the Fleet control plane but address
+          different lifecycle stages. See §0.4 for disambiguation.
+- **N8**: N9's automation tiers are a specialization of N8's capability levels
+          (OBSERVE/ADVISE/CONTROL) scoped to provider interactions. See §10.
+
+### 0.3 Non-goals
+
+N9 SHALL NOT:
+
+- require running full Miniforge "spec→plan→implement" workflows for external PRs.
+- rebase or merge external PRs by default (requires explicit Tier 3 configuration).
+- define any particular UI implementation; only data contracts and event types.
+- replace or duplicate contracts already defined in N3, N4, N6, or N8.
+
+### 0.4 Fleet Mode Disambiguation
+
+The **Fleet control plane** is a shared coordination layer that hosts multiple
+fleet capabilities:
+
+| Capability | Spec | Lifecycle Stage | Target | Summary |
+|---|---|---|---|---|
+| Workflow orchestration | N2 | Development | Individual workflows | Phase graph execution |
+| Operational policy synthesis | N7 | Runtime | Service fleets | Scaling/sizing experiments |
+| Observability control | N8 | Cross-cutting | Agent fleets | Observe/advise/control |
+| **External PR integration** | **N9** | **Development** | **Repository fleets** | **PR monitoring & governance** |
+
+N7 answers: "How should these services scale at runtime?"
+N9 answers: "What is the state of all open PRs across our repos, and are they safe to merge?"
+
+Both share:
+
+- The Fleet API surface (N5 `fleet` namespace)
+- The event stream infrastructure (N3)
+- The evidence and provenance model (N6)
+- The policy evaluation engine (N4)
+
+They do NOT share domain models. N7's domain is experiments, scaling signals, and
+operational policies. N9's domain is PRs, reviews, CI checks, and merge readiness.
+
+---
+
+## 1. Terminology (N1 Extension)
+
+The following concepts MUST be added to N1 §2 (Core Domain Model) and §12 (Glossary).
+
+### 1.1 External PR
+
+An **External PR** is a pull request whose diff was created outside Miniforge's
+own authoring workflow. External PRs have no `:workflow/id` association unless
+explicitly adopted.
+
+### 1.2 PR Work Item
+
+A **PR Work Item** is the canonical internal model of a PR used by the Fleet
+control plane. All PRs — Miniforge-originated and external — MUST be represented
+as PR Work Items. This is distinct from N1's Workflow; a PR Work Item tracks
+provider state, not workflow execution state.
+
+### 1.3 Provider
+
+A **Provider** is an external code hosting platform (GitHub, GitLab, etc.) that
+is a source of PR events and state. Providers are analogous to N7's Environment
+Targets — they are external systems that Miniforge connects to but does not own.
+
+### 1.4 PR Train
+
+A **PR Train** is an ordered set of PR Work Items with explicit dependency
+relationships that MUST be merged in sequence. Trains are analogous to N2's DAG
+task dependencies, applied to PR merge ordering.
+
+### 1.5 Readiness
+
+**Readiness** is a deterministic assessment of whether a PR is ready to merge,
+computed from provider signals (CI, reviews, merge conflicts) and policy
+evaluation results.
+
+### 1.6 Risk Assessment
+
+A **Risk Assessment** is an explainable evaluation of change risk for a PR,
+produced as an evidence artifact (N6) with traceable factors.
+
+---
+
+## 2. PR Work Item Model
+
+### 2.1 Schema
+
+Fleet Mode MUST represent each PR as a PR Work Item with the following schema.
+All fields use Clojure namespaced keywords per N1 convention.
+
+```clojure
+{;; Identity
+ :pr/id uuid                          ; REQUIRED: stable internal id
+ :pr/provider keyword                 ; REQUIRED: :github, :gitlab, etc.
+ :pr/repo string                      ; REQUIRED: "org/name"
+ :pr/number long                      ; REQUIRED: provider PR number
+ :pr/external? boolean                ; REQUIRED: true if not Miniforge-originated
+
+ ;; Head/Base
+ :pr/head-sha string                  ; REQUIRED: current head commit SHA
+ :pr/base-ref string                  ; REQUIRED: target branch
+ :pr/head-ref string                  ; OPTIONAL: source branch
+
+ ;; Metadata
+ :pr/author string                    ; REQUIRED: PR author
+ :pr/title string                     ; REQUIRED: PR title
+ :pr/state keyword                    ; REQUIRED: :open, :closed, :merged
+ :pr/mergeable keyword                ; REQUIRED: :true, :false, :unknown
+ :pr/labels [string ...]              ; OPTIONAL: provider labels
+
+ ;; Timestamps
+ :pr/created-at inst                  ; REQUIRED
+ :pr/updated-at inst                  ; REQUIRED
+ :pr/last-seen-at inst                ; REQUIRED: last provider sync
+
+ ;; Provider Signals
+ :pr/checks                           ; REQUIRED: CI/check run summary
+ {:checks/overall keyword             ; :passing, :failing, :pending, :unknown
+  :checks/items [{:name string :status keyword :url string}]}
+
+ :pr/reviews                          ; REQUIRED: review state summary
+ {:reviews/overall keyword            ; :approved, :changes-requested, :pending, :unknown
+  :reviews/items [{:author string :state keyword :submitted-at inst}]}
+
+ :pr/threads                          ; OPTIONAL: unresolved discussion threads
+ {:threads/unresolved long
+  :threads/total long}
+
+ ;; Derived State (computed by N9)
+ :pr/readiness                        ; REQUIRED: see §2.2
+ {:readiness/state keyword
+  :readiness/blockers [...]}
+
+ :pr/risk                             ; REQUIRED: see §5
+ {:risk/level keyword
+  :risk/factors [...]
+  :risk/requires-human? boolean}
+
+ :pr/policy                           ; REQUIRED: see §8
+ {:policy/overall keyword             ; :pass, :fail, :unknown
+  :policy/results [...]}
+
+ ;; Automation
+ :pr/automation-tier keyword          ; REQUIRED: see §10
+
+ ;; Workflow Linkage (Miniforge PRs only)
+ :pr/workflow-id uuid                 ; OPTIONAL: absent for external PRs
+ :pr/dag-id uuid                      ; OPTIONAL: DAG run that produced this PR
+ :pr/task-id uuid}                    ; OPTIONAL: task that produced this PR
+```
+
+### 2.2 Readiness
+
+`:pr/readiness` MUST be computed deterministically from available signals.
+
+#### 2.2.1 Readiness State
+
+`:readiness/state` MUST be one of:
+
+| State | Condition |
+|---|---|
+| `:merge-ready` | All checks pass, approved, no conflicts, policy pass |
+| `:needs-review` | No reviews or insufficient approvals |
+| `:changes-requested` | At least one reviewer requested changes |
+| `:ci-failing` | One or more required checks failing |
+| `:policy-failing` | One or more policy pack rules failing |
+| `:merge-conflicts` | Provider reports merge conflict |
+| `:unknown` | Provider data incomplete (e.g., first sync) |
+
+#### 2.2.2 Blockers
+
+`:readiness/blockers` MUST be a vector of:
+
+```clojure
+{:blocker/type keyword                ; REQUIRED: :ci, :review, :policy, :conflict, :thread
+ :blocker/message string              ; REQUIRED: human-readable description
+ :blocker/source string               ; REQUIRED: what produced this blocker
+ :blocker/evidence-id uuid}           ; OPTIONAL: link to N6 evidence artifact
+```
+
+### 2.3 Compatibility with Miniforge-Originated PRs
+
+All Miniforge-originated PRs (from Release phase or DAG task executor) MUST also
+be represented as PR Work Items. For these PRs:
+
+- `:pr/external?` MUST be `false`
+- `:pr/workflow-id`, `:pr/dag-id`, `:pr/task-id` MUST be populated
+- The existing N3 PR lifecycle events (§3.10: `pr/opened`, `pr/merged`, etc.)
+  continue to be emitted for workflow correlation
+- N9 readiness/risk/policy are additive enrichments; they do NOT change
+  workflow phase semantics (N2)
+
+---
+
+## 3. Provider Ingestion
+
+### 3.1 Provider Model
+
+N9 implementations MUST support at least one provider. For GitHub-hosted repos,
+the RECOMMENDED implementation is a **GitHub App** for scalable multi-repo
+webhook delivery and token management.
+
+If not using a GitHub App, the system MUST provide equivalent:
+
+- webhook ingestion (or polling)
+- per-repo token management
+- rate limit handling
+
+### 3.2 Event Normalization
+
+Provider-native events (e.g., GitHub webhook payloads) MUST be normalized to
+canonical N3 event types before processing. The normalizer:
+
+- MUST map provider events to canonical types (§7)
+- MUST extract correlation fields (repo, PR number, head SHA)
+- MUST be idempotent: replayed provider events MUST NOT create duplicate state
+- MUST tolerate out-of-order delivery
+- MAY retain raw provider payload for debugging, subject to data minimization (§11.3)
+
+### 3.3 Reconciliation
+
+The system MUST reconcile PR Work Item state against provider state when
+inconsistencies are detected. Reconciliation polling SHOULD exist as a backstop
+for missed webhooks and MUST be bounded to avoid API abuse (see §6).
+
+---
+
+## 4. Multi-Repo Configuration
+
+### 4.1 Configuration Sources
+
+A repo MAY opt into external PR integration via:
+
+1. **Repo-local config:** `.miniforge/config.edn` (or equivalent) in the repository
+2. **Org-level defaults:** in Fleet control plane configuration
+
+Repo-local config MUST override org-level defaults.
+
+### 4.2 Required Configuration Keys
+
+```clojure
+{:external-pr/enabled? boolean        ; REQUIRED: opt-in to external PR monitoring
+
+ :external-pr/automation-tier keyword ; REQUIRED: see §10
+                                      ; default: :tier-1
+
+ :policies/enabled [string ...]       ; OPTIONAL: policy pack ids to evaluate
+                                      ; uses N4 policy pack identifiers
+
+ :policies/mode keyword               ; OPTIONAL: :advisory or :enforcing
+                                      ; default: :advisory
+
+ :notifications {...}                 ; OPTIONAL: routing and thresholds
+
+ :trains/enabled? boolean}            ; OPTIONAL: enable PR train support
+                                      ; default: false
+```
+
+### 4.3 Safe Defaults
+
+If external PR integration is enabled but `:policies/enabled` is not specified:
+
+- The system SHOULD apply a minimal default policy pack set in **advisory** mode.
+- The system MUST NOT publish enforcing checks without explicit configuration.
+
+---
+
+## 5. Risk Assessment (N6 Extension)
+
+Risk assessments MUST be produced as N6 evidence artifacts. They are NOT a
+separate evidence model — they use the existing `:evidence-bundle/*` schema
+with risk-specific content.
+
+### 5.1 Risk Artifact Schema
+
+```clojure
+{:artifact/id uuid
+ :artifact/type :risk-assessment       ; New artifact type for N6 §3.1.1
+ :artifact/content-hash string
+ :artifact/created-at inst
+
+ :artifact/content
+ {:risk/level keyword                  ; REQUIRED: :low, :medium, :high, :critical
+  :risk/factors                        ; REQUIRED: explainable factors
+  [{:factor/code keyword               ; e.g., :large-diff, :sensitive-paths, :no-tests
+    :factor/description string
+    :factor/evidence-refs [uuid ...]}] ; Links to other N6 artifacts
+
+  :risk/blast-radius string            ; REQUIRED: qualitative description
+  :risk/requires-human? boolean}       ; REQUIRED
+
+ :artifact/provenance
+ {:provenance/workflow-id uuid         ; OPTIONAL: nil for external PRs
+  :provenance/phase :external-pr-eval  ; Distinguishes from workflow phases
+  :provenance/agent :pr-evaluator
+  :provenance/created-at inst}}
+```
+
+Risk scoring MUST be explainable via `:factor/evidence-refs` and MUST NOT be a
+black-box number without factors.
+
+---
+
+## 6. Rate Limits, Backpressure, and Resilience
+
+- Provider API calls MUST be rate-limited and retried with exponential backoff.
+- Ingestion MUST queue work and MUST degrade gracefully under load.
+- Reconciliation polling SHOULD be bounded (e.g., one full sync per repo per
+  15 minutes maximum) to avoid API abuse.
+- If policy evaluation fails, the system MUST set `:policy/overall` to `:unknown`
+  and record a diagnostic evidence artifact (N6) explaining the failure.
+
+---
+
+## 7. Event Types (N3 Extension)
+
+N9 adds these event types to the N3 event stream. All events MUST use the N3
+event envelope (N3 §2) with standard required fields.
+
+### 7.1 Scope Key
+
+Because external PR events are not associated with a Miniforge workflow, the
+`:workflow/id` field in the N3 envelope MUST be handled as follows:
+
+- For Miniforge-originated PRs: `:workflow/id` MUST reference the originating workflow
+- For external PRs: `:workflow/id` MAY be nil. Events MUST instead include
+  `:pr/id` (the PR Work Item id) as a correlation key.
+
+Implementations MUST support subscribing to events by `:pr/id` in addition to
+`:workflow/id`.
+
+### 7.2 Provider Ingestion Events
+
+#### provider/event-received
+
+Emitted when a provider event is received and normalized.
+
+```clojure
+{:event/type :provider/event-received
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :pr/id uuid                          ; PR Work Item id (if PR-scoped)
+ :provider/type keyword               ; :github, :gitlab
+ :provider/event-type keyword         ; Canonical type that was mapped
+ :provider/repo string                ; "org/name"
+ :provider/pr-number long             ; OPTIONAL
+ :provider/head-sha string            ; OPTIONAL
+ :provider/dedupe-key string          ; For idempotency
+
+ :message "Provider event received: {type} for {repo}#{pr-number}"}
+```
+
+### 7.3 PR State Events
+
+These events are emitted when PR Work Item derived state changes. They are
+**derived-state-change events** — they fire when computation produces a new
+value, not on every provider event.
+
+#### pr.readiness/changed
+
+```clojure
+{:event/type :pr.readiness/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+
+ :readiness/previous-state keyword
+ :readiness/new-state keyword
+ :readiness/blockers [...]            ; Current blockers
+
+ :message "PR {repo}#{number} readiness: {previous} → {new}"}
+```
+
+#### pr.risk/changed
+
+```clojure
+{:event/type :pr.risk/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+
+ :risk/previous-level keyword
+ :risk/new-level keyword
+ :risk/factors [...]
+ :risk/evidence-id uuid               ; N6 artifact id
+
+ :message "PR {repo}#{number} risk: {previous} → {new}"}
+```
+
+#### pr.policy/changed
+
+```clojure
+{:event/type :pr.policy/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+
+ :policy/previous-overall keyword
+ :policy/new-overall keyword
+ :policy/results [...]
+ :policy/evidence-id uuid             ; N6 artifact id
+
+ :message "PR {repo}#{number} policy: {previous} → {new}"}
+```
+
+#### pr.state/changed
+
+```clojure
+{:event/type :pr.state/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+
+ :pr/previous-state keyword           ; :open, :closed, :merged
+ :pr/new-state keyword
+ :pr/head-sha string
+
+ :message "PR {repo}#{number} state: {previous} → {new}"}
+```
+
+### 7.4 Train Events
+
+#### train/changed
+
+```clojure
+{:event/type :train/changed
+ :train/id uuid
+ :train/members [uuid ...]            ; Ordered PR Work Item ids
+ :train/change-type keyword           ; :member-added, :member-removed,
+                                      ; :order-changed, :member-merged
+
+ :message "Train {id}: {change-type}"}
+```
+
+### 7.5 Event Ordering
+
+- Provider ingestion events MUST be idempotent per `:provider/dedupe-key`.
+- Derived-state-change events MUST only fire when computed state actually changes.
+- All events MUST conform to N3 §2.2 ordering guarantees where a workflow scope
+  exists. For external PRs (no workflow), events MUST be ordered per PR Work Item.
+
+---
+
+## 8. Policy Evaluation (N4 Extension)
+
+### 8.1 Evaluation Context
+
+External PRs are evaluated using existing N4 policy packs. The evaluation context
+differs from workflow gate evaluation:
+
+- **Artifacts:** The PR diff, file list, and metadata are presented as artifacts
+  to policy pack check functions (N4 §3.1).
+- **Context:** Instead of a workflow spec with declared intent, the context
+  contains PR metadata (author, repo, labels, base branch).
+- **No repair:** Policy evaluation for external PRs MUST NOT invoke repair
+  functions (N4 §3.2). External PRs are read-only unless adopted.
+
+### 8.2 Evaluation Triggers
+
+Policy evaluation MUST run on at least these provider events:
+
+- PR opened (new PR detected)
+- PR synchronized (new commits pushed)
+- Check run completed (CI results changed)
+- Configuration changed (repo `.miniforge/config.edn` updated)
+
+### 8.3 Policy Result
+
+`:pr/policy` uses the existing N4 violation schema (N4 §3.3) and MUST include:
+
+```clojure
+{:policy/overall keyword              ; :pass, :fail, :unknown
+ :policy/results
+ [{:rule/id string                    ; From N4 policy pack rule
+   :rule/outcome keyword              ; :pass, :fail, :warn, :skip, :unknown
+   :rule/message string               ; Human-readable, concise
+   :rule/evidence-id uuid}]           ; N6 artifact with full details
+
+ :policy/evaluated-at inst
+ :policy/packs-applied                ; Which packs ran
+ [{:policy-pack/id string
+   :policy-pack/version string}]}
+```
+
+### 8.4 Provider Feedback
+
+If `:policies/mode` is `:enforcing`, the system SHOULD publish outcomes as
+provider-native signals (e.g., GitHub Check Runs).
+
+If publishing provider-native checks, the system MUST:
+
+- use a stable check name per policy pack (e.g., `miniforge/terraform-aws`)
+- include a summary linking to evidence
+- respect automation tier constraints (§10)
+
+---
+
+## 9. Evidence (N6 Extension)
+
+External PR evaluations produce evidence using the existing N6 schema. N9 does
+NOT define a separate evidence model.
+
+### 9.1 New Artifact Types
+
+N6 §3.1.1 MUST be extended with:
+
+- `:risk-assessment` — Risk evaluation for a PR (see §5.1)
+- `:pr-policy-result` — Policy evaluation result for an external PR
+- `:pr-readiness-snapshot` — Point-in-time readiness assessment
+
+All artifacts MUST have `:artifact/content-hash`, `:artifact/provenance`, and
+`:artifact/created-at` per N6 §3.
+
+### 9.2 Evidence Immutability
+
+Evidence artifacts produced by N9 MUST be immutable and addressable per N6 §5.1.
+Policy results and risk factors MUST reference evidence artifacts, not inline
+their content.
+
+---
+
+## 10. Automation Tiers (N8 Specialization)
+
+N9's automation tiers are a **specialization** of N8's capability levels, scoped
+to provider interactions (writing comments, checks, reviews on external PRs).
+
+### 10.1 Mapping to N8
+
+| N9 Tier | N8 Level | Provider Permissions |
+|---|---|---|
+| **Tier 0 — Observe** | `OBSERVE` | No provider writes. Compute readiness/risk/policy internally only. |
+| **Tier 1 — Advise** | `ADVISE` | MAY publish non-blocking advisory checks. MAY comment when explicitly requested (e.g., `/miniforge summarize`). |
+| **Tier 2 — Converse** | `ADVISE` + scoped interaction | MAY respond to questions when bot is mentioned or command is used. MUST NOT approve, request changes, or merge. |
+| **Tier 3 — Govern** | `CONTROL` | MAY publish enforcing checks. MAY request changes. MAY manage trains and merge orchestration if configured. MUST log all actions per N8 §3.2 and §11. |
+
+### 10.2 Tier Constraints
+
+- Default tier SHOULD be Tier 1 for external PRs.
+- Tier MUST be configured per repo via §4.2.
+- Tier 3 MUST implement a per-repo allowlist of permitted actions
+  (comment/review/check/merge) per N8 §2.3 RBAC requirements.
+- All provider write actions at Tier 1+ MUST be audit-logged (§11).
+
+### 10.3 Tier Escalation
+
+Moving from a lower tier to a higher tier MUST require explicit configuration
+change. The system MUST NOT auto-escalate tiers based on heuristics.
+
+---
+
+## 11. Audit and Security
+
+### 11.1 Audit Log (N8 Extension)
+
+All provider write actions MUST be logged using the N8 control action evidence
+schema (N8 §11.1), extended with:
+
+```clojure
+{:action/id uuid
+ :action/type keyword                 ; :comment, :check-publish, :review,
+                                      ; :merge, :label, :re-request-review
+ :action/timestamp inst
+ :action/actor string                 ; System identity
+ :action/target
+ {:pr/repo string
+  :pr/number long
+  :pr/id uuid}                        ; PR Work Item id
+
+ :action/inputs {...}                 ; Redacted as needed
+ :action/result {:status keyword}
+ :action/reason                       ; REQUIRED: why this action was taken
+ {:policy/evidence-id uuid            ; Link to policy result evidence
+  :readiness/evidence-id uuid         ; Link to readiness evidence
+  :human-request? boolean}}           ; Was this triggered by a human command?
+```
+
+### 11.2 Secrets and Tokens
+
+- Provider tokens/credentials MUST be stored encrypted at rest.
+- The system MUST support key rotation without downtime.
+- Token scopes MUST be minimized to required permissions per tier.
+
+### 11.3 Data Minimization
+
+- Raw provider payload storage SHOULD be optional and time-bounded.
+- Evidence artifacts MUST NOT include secrets; secret redaction MUST be enforced
+  prior to persistence (per N6 §7.2).
+
+---
+
+## 12. CLI/TUI/API Extensions (N5 Extension)
+
+### 12.1 CLI Commands
+
+N5 §2.2 `fleet` namespace MUST be extended with:
+
+```bash
+# PR monitoring
+mf fleet prs [flags]                  # List PR Work Items across repos
+  --repo REPO                         # Filter by repo
+  --author AUTHOR                     # Filter by author
+  --readiness STATE                   # Filter by readiness state
+  --risk LEVEL                        # Filter by risk level
+  --policy OUTCOME                    # Filter by policy outcome
+  --json                              # Output as JSON
+
+mf fleet pr REPO#NUMBER [flags]       # Show PR Work Item detail
+  --evidence                          # Include evidence artifact pointers
+  --json                              # Output as JSON
+
+# Train management (if trains enabled)
+mf fleet trains [flags]               # List active trains
+mf fleet train TRAIN_ID [flags]       # Show train detail and membership
+```
+
+### 12.2 TUI Extensions
+
+The TUI (N5 §3) SHOULD provide:
+
+- **PR Fleet View:** List of PR Work Items across repos with readiness/risk
+  columns, sortable and filterable
+- **PR Detail View:** Readiness blockers, risk factors, policy results with
+  drill-down to evidence artifacts
+- **Train View:** Ordered train members with merge readiness status
+
+These views derive from the event stream (N3) and PR Work Item state — they
+are projections, not separate data models (same principle as N5 §3.2.5 DAG
+Kanban View).
+
+### 12.3 Fleet API Extensions
+
+N5 §4.2 Fleet API MUST be extended with:
+
+```text
+GET /api/fleet/prs
+  Query params: ?repo=org/name&readiness=merge-ready&risk=high
+  Returns: List of PR Work Items
+
+GET /api/fleet/prs/:pr-id
+  Returns: PR Work Item with evidence pointers
+
+GET /api/fleet/trains
+  Returns: List of active trains
+
+GET /api/fleet/trains/:train-id
+  Returns: Train detail with ordered members
+```
+
+### 12.4 Event Stream Subscriptions
+
+The Fleet event stream (N3 §5, N5 §4.2.2) MUST support subscription filters for
+N9 event types, enabling clients to subscribe to:
+
+- All PR state changes across repos
+- Readiness changes for specific repos
+- Policy changes for specific policy packs
+
+---
+
+## 13. PR Trains
+
+If `:trains/enabled?` is `true` in repo configuration:
+
+### 13.1 Dependency Declaration
+
+The system MUST support explicit dependency declaration via:
+
+- **Labels:** e.g., `train:<train-id>` on provider PRs
+- **PR body directives:** e.g., `depends-on: org/repo#123`
+
+The system MAY infer soft ordering suggestions, but MUST NOT enforce inferred
+dependencies without explicit declaration.
+
+### 13.2 Train Schema
+
+```clojure
+{:train/id uuid                       ; REQUIRED: stable train identifier
+ :train/members                       ; REQUIRED: ordered PR Work Item refs
+ [{:pr/id uuid
+   :pr/repo string
+   :pr/number long
+   :train/position long}]             ; 1-indexed merge order
+
+ :train/policy                        ; REQUIRED
+ {:train/merge-strategy keyword       ; :sequential, :batch
+  :train/required-readiness keyword   ; Minimum readiness for merge
+  :train/auto-merge? boolean}}        ; Requires Tier 3
+```
+
+### 13.3 Train Operations
+
+- Train merge orchestration MUST respect automation tier constraints (Tier 3
+  required for automated merge sequencing).
+- Train membership changes MUST emit `:train/changed` events (§7.4).
+- Train operations MUST be audit-logged (§11).
+
+---
+
+## 14. Versioning
+
+- PR Work Item schema, N9 event types, and API extensions MUST be versioned.
+- Breaking changes MUST increment a major version and MUST be supported in
+  parallel for at least one deprecation cycle.
+- Version is tracked in the N3 event envelope `:event/version` field.
+
+---
+
+## 15. Minimal Compliant Implementation (MCI)
+
+A minimal compliant N9 implementation MUST:
+
+1. Support at least one provider (GitHub recommended)
+2. Normalize provider events to N3 canonical event types (§7)
+3. Represent PRs as PR Work Items with readiness computation (§2)
+4. Evaluate at least one policy pack against external PR diffs (§8)
+5. Produce evidence artifacts per N6 (§9)
+6. Support Tier 0 and Tier 1 automation (§10)
+7. Provide CLI command `mf fleet prs` for listing PR Work Items (§12)
+8. Audit-log all provider write actions (§11)
+
+A minimal compliant implementation MAY defer:
+
+- Tier 2 and Tier 3 automation
+- PR trains
+- Multi-provider support
+- Risk assessment beyond basic diff-size heuristics
+- TUI views (CLI-only is sufficient for MCI)
+
+---
+
+## 16. Packaging Guidance (Informative)
+
+A common pattern that preserves adoption while capturing value:
+
+**Include in core (OSS-friendly):**
+
+- PR Work Item modeling and readiness computation
+- Basic multi-repo monitoring (Tier 0–1)
+- Risk and readiness summaries via CLI
+- Advisory policy evaluation (`:policies/mode :advisory`)
+
+**Charge for (clear willingness-to-pay):**
+
+- GitHub App managed auth/SSO/RBAC for multi-org
+- Enforcing policy checks at scale + evidence retention/analytics
+- PR trains and merge orchestration (Tier 3)
+- Tier 2–3 automation (conversational + governance) with audit
+- Web dashboard PR fleet views + notifications + cross-org aggregation
+- Compliance/reporting exports and long-term evidence retention
+
+---
+
+## 17. References
+
+- **N1**: Core Architecture & Concepts — new concepts land here
+- **N3**: Event Stream & Observability — event envelope and PR lifecycle events
+- **N4**: Policy Packs & Gates — policy evaluation contract
+- **N5**: CLI/TUI/API — command surface and TUI views
+- **N6**: Evidence & Provenance — evidence artifacts and provenance
+- **N7**: Operational Policy Synthesis — Fleet Mode disambiguation
+- **N8**: Observability Control Interface — capability levels and audit
+- **RFC 2119**: Requirement level keywords
+
+---
+
+**Version History:**
+
+- 0.1.0-draft (2026-02-07): Initial external PR integration specification


### PR DESCRIPTION
## Summary

- Add **N9 — External PR Integration** normative specification that treats external PRs as first-class Fleet Mode work items
- Update SPEC_INDEX.md to register N9 and bump to v0.3.0-draft
- Resolve Fleet Mode semantic tension: N9 = SDLC governance (dev time) vs N7 = OPSV (runtime), both under the shared Fleet control plane

## Design Decisions

**References and extends N1-N8 rather than duplicating contracts:**

- Events use N3 envelope with new canonical types (not a parallel event model)
- Policy evaluation uses N4 check functions and violation schema (not a new policy model)
- Risk assessments and policy results are N6 evidence artifacts (not a separate evidence store)
- Automation tiers are N8 capability level specializations (not a parallel capability model)
- CLI/TUI/API are N5 `fleet` namespace extensions (not standalone surfaces)

**Genuinely new concepts (to be landed in N1):**

- PR Work Item — canonical model for any PR (external or Miniforge-originated)
- Provider — external code hosting platform abstraction (GitHub/GitLab)
- PR Train — explicit dependency ordering across PRs with governed merge sequencing
- Readiness — deterministic merge-readiness computation from provider signals + policy
- Risk Assessment — explainable change risk as N6 evidence artifact

**Fleet Mode disambiguation table (§0.4):**

| Capability | Spec | Lifecycle | Target | Summary |
|---|---|---|---|---|
| Workflow orchestration | N2 | Dev | Individual workflows | Phase graph execution |
| Operational policy synthesis | N7 | Runtime | Service fleets | Scaling/sizing experiments |
| Observability control | N8 | Cross-cutting | Agent fleets | Observe/advise/control |
| External PR integration | N9 | Dev | Repository fleets | PR monitoring & governance |

## Test plan

- [ ] Verify N9 references N3 event envelope correctly (namespaced keywords, not dot-notation)
- [ ] Verify N9 policy evaluation references N4 check/repair contract without duplicating it
- [ ] Verify N9 evidence uses N6 artifact schema and adds new artifact types correctly
- [ ] Verify N9 automation tiers map cleanly to N8 capability levels
- [ ] Verify SPEC_INDEX.md governance section updated to N1-N9
- [ ] Verify no RFC 2119 keyword usage conflicts with existing specs
- [ ] Review MCI (Minimal Compliant Implementation) for feasibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)