### PR TITLE
feat(specs): add N9 — External PR Integration + amend core specs

### DIFF
--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -1,7 +1,7 @@
 # miniforge Specification Index
 
-**Version:** 0.2.0-draft
-**Date:** 2026-02-01
+**Version:** 0.3.0-draft
+**Date:** 2026-02-07
 **Status:** Living specification during OSS development
 
 ---
@@ -151,6 +151,25 @@ Defines:
 - Fleet and enterprise extensions: multi-tenancy, pattern detection
 - CLI/TUI extensions: listener commands, control palette, approval queue
 
+### N9 — External PR Integration 🆕
+
+**File:** [normative/N9-external-pr-integration.md](normative/N9-external-pr-integration.md)
+**Status:** Draft
+**Purpose:** Treat external PRs as first-class Fleet Mode work items with monitoring, policy, and governance
+
+Defines:
+
+- PR Work Item model: canonical representation of any PR (external or Miniforge-originated)
+- Provider ingestion: webhook/polling normalization from GitHub/GitLab to N3 events
+- Readiness computation: deterministic merge-readiness from CI, reviews, conflicts, policy
+- Risk assessment: explainable risk scoring as N6 evidence artifacts
+- Policy evaluation: N4 policy packs applied to external PR diffs with provider feedback
+- Automation tiers: Observe/Advise/Converse/Govern as N8 capability level specializations
+- PR trains: explicit dependency ordering with governed merge sequencing
+- Multi-repo configuration: per-repo opt-in with org-level defaults
+- Fleet Mode disambiguation: N9 (SDLC governance) vs N7 (runtime policy synthesis)
+- CLI/TUI/API extensions: `fleet prs`, `fleet trains` commands and views
+
 ---
 
 ## Informative Documentation (Non-Normative)
@@ -230,7 +249,7 @@ Documents superseded by normative specs. Retained for reference during migration
 
 ### Language Rules
 
-**Normative specs (N1-N8):**
+**Normative specs (N1-N9):**
 
 - MUST use RFC 2119 keywords: MUST, SHALL, SHOULD, MAY, MUST NOT, SHALL NOT
 - MUST define versioning and compatibility expectations
@@ -303,5 +322,6 @@ Normative specs are enforced by:
 
 ## Version History
 
+- **0.3.0-draft** (2026-02-07) - Added N9 (External PR Integration), Fleet Mode disambiguation
 - **0.2.0-draft** (2026-02-01) - Added N7 (OPSV) and N8 (OCI), updated governance for extension specs
 - **0.1.0-draft** (2026-01-23) - Initial spec index, normative spec structure established

--- a/specs/normative/N1-architecture.md
+++ b/specs/normative/N1-architecture.md
@@ -1,7 +1,7 @@
 # N1 — Core Architecture & Concepts
 
-**Version:** 0.1.0-draft
-**Date:** 2026-01-23
+**Version:** 0.2.0-draft
+**Date:** 2026-02-07
 **Status:** Draft
 **Conformance:** MUST
 
@@ -18,7 +18,7 @@ miniforge.ai, the autonomous software factory. It establishes:
 - **Operational model** principles (local-first, reproducibility, failure semantics)
 - **Agent protocols** and communication patterns
 
-All other normative specifications (N2-N6) build upon the concepts defined here.
+All other normative specifications (N2-N9) build upon the concepts defined here.
 
 ### 1.1 Design Principles
 
@@ -515,6 +515,238 @@ Incremental ETL MUST:
 5. **Maintain pack index:** Update pack index incrementally, preserving provenance of unchanged packs.
 
 Implementations MAY cache intermediate classification and scanner results for performance.
+
+### 2.11 Operational Policy (N7)
+
+An **Operational Policy** is a versioned set of runtime configuration artifacts that control
+service behavior under load. Operational Policies are specializations of Artifacts (§2.9)
+with provenance per N6.
+
+```clojure
+{:operational-policy/id string       ; REQUIRED: policy identifier
+ :operational-policy/version string  ; REQUIRED: semantic version
+ :operational-policy/target-services [string ...] ; REQUIRED
+ :operational-policy/target-envs [string ...]     ; REQUIRED
+
+ :operational-policy/scaling {...}   ; Scaling signals, thresholds, bounds
+ :operational-policy/resources {...} ; Requests/limits recommendations
+ :operational-policy/guardrails {...} ; Rate limits, concurrency caps
+ :operational-policy/verification-summary
+ {:passed? boolean
+  :confidence keyword
+  :caveats [string ...]}
+
+ :operational-policy/evidence-refs [uuid ...]} ; N6 evidence artifacts
+```
+
+See N7 for detailed Operational Policy specification.
+
+### 2.12 Experiment Pack (N7)
+
+An **Experiment Pack** is a versioned, declarative artifact that defines workload models,
+guardrails, success criteria, and convergence strategies for operational policy synthesis.
+Experiment Packs are specializations of Packs (§2.10.3).
+
+```clojure
+{:experiment-pack/id string          ; REQUIRED: stable identifier
+ :experiment-pack/version string     ; REQUIRED: semantic version or revision
+
+ :experiment-pack/targets
+ {:services [...]                    ; Repo and/or runtime selectors
+  :environments [...]}               ; Cluster/namespace selectors
+
+ :experiment-pack/workload
+ {:profile keyword                   ; step/ramp/spike
+  :mix [...]                         ; Request classes and weights
+  :warmup-seconds long
+  :cooldown-seconds long}
+
+ :experiment-pack/success-criteria {...}
+ :experiment-pack/guardrails {...}
+ :experiment-pack/convergence {...}
+ :experiment-pack/actuation-intent keyword} ; :recommend-only, :pr-only, :apply-allowed
+```
+
+Experiment Packs SHALL be hash-addressed and recorded in the event stream and evidence bundle.
+See N7 for detailed Experiment Pack specification.
+
+### 2.13 Actuation Mode (N7)
+
+An **Actuation Mode** governs whether OPSV workflows produce recommendations, PRs, or
+direct changes:
+
+- **RECOMMEND_ONLY**: produce policy proposals and evidence; no changes emitted.
+- **PR_ONLY**: produce changes as PRs against declared repos.
+- **APPLY_ALLOWED**: apply changes directly when permitted by policy packs and gates.
+
+`APPLY_ALLOWED` MUST be disabled by default. See N7 §1.4.
+
+### 2.14 Verification (N7)
+
+**Verification** is the process of executing an Experiment Pack against a candidate
+Operational Policy and producing an evidence bundle showing whether success criteria
+are satisfied. Verification produces pass/fail with per-criterion results and
+confidence/caveat fields. See N7 §6.
+
+### 2.15 Listener (N8)
+
+A **Listener** is an external actor that subscribes to workflow events and MAY interact
+with workflow execution. Listeners are specializations of the Observer concept (§3.3)
+extended with capability levels and identity.
+
+```clojure
+{:listener/id uuid                   ; REQUIRED: unique listener identifier
+ :listener/type keyword              ; REQUIRED: :watcher, :dashboard, :fleet, :enterprise
+ :listener/capability keyword        ; REQUIRED: :observe, :advise, :control
+
+ :listener/identity                  ; REQUIRED for ADVISE/CONTROL
+ {:principal string
+  :credentials {...}
+  :roles [keyword ...]}
+
+ :listener/filters                   ; OPTIONAL
+ {:workflow-ids [uuid ...]
+  :event-types [keyword ...]
+  :phases [keyword ...]
+  :agents [keyword ...]}}
+```
+
+See N8 for detailed Listener specification.
+
+### 2.16 Capability Level (N8)
+
+Listeners operate at one of three **Capability Levels**:
+
+| Level     | Permissions                                     | Use Case                          |
+| --------- | ----------------------------------------------- | --------------------------------- |
+| `OBSERVE` | Read-only event stream access                   | Monitoring, analytics, audit      |
+| `ADVISE`  | Emit advisory annotations (non-blocking)        | Recommendations, warnings         |
+| `CONTROL` | Request control actions (subject to gates)      | Pause, rollback, approve, adjust  |
+
+Capability levels are hierarchical: CONTROL includes ADVISE includes OBSERVE.
+See N8 §2 for enforcement requirements.
+
+### 2.17 Control Action (N8)
+
+A **Control Action** is a command that modifies workflow execution state. All control
+actions MUST be authorized by RBAC, pass through policy gates, and be audit-logged.
+
+```clojure
+{:action/id uuid                     ; REQUIRED: unique action identifier
+ :action/type keyword                ; REQUIRED: see N8 §3.1
+ :action/timestamp inst              ; REQUIRED
+
+ :action/target
+ {:target-type keyword               ; :workflow, :agent, :gate, :fleet
+  :target-id uuid}
+
+ :action/requester
+ {:principal string
+  :capability keyword                ; Must be :control
+  :listener-id uuid}
+
+ :action/justification string        ; REQUIRED for High/Critical risk
+ :action/result
+ {:status keyword                    ; :success, :failure, :pending
+  :executed-at inst}}
+```
+
+See N8 §3 for the complete control action surface.
+
+### 2.18 Advisory Annotation (N8)
+
+An **Advisory Annotation** is a non-blocking message attached to a workflow or event.
+Annotations MUST NOT block workflow execution but MAY be surfaced in UI and MAY
+trigger alerts if patterns match.
+
+```clojure
+{:annotation/id uuid                 ; REQUIRED
+ :annotation/type keyword            ; REQUIRED: :recommendation, :warning, :insight, :question
+ :annotation/source {:listener-id uuid :principal string}
+ :annotation/target {:workflow-id uuid :event-id uuid}
+ :annotation/content {:title string :body string :severity keyword}}
+```
+
+See N8 §4 for the annotation system specification.
+
+### 2.19 PR Work Item (N9)
+
+A **PR Work Item** is the canonical internal model of a pull request used by the
+Fleet control plane. All PRs — Miniforge-originated and external — MUST be represented
+as PR Work Items. This is distinct from Workflow (§2.1); a PR Work Item tracks
+provider state, not workflow execution state.
+
+```clojure
+{:pr/id uuid                         ; REQUIRED: stable internal id
+ :pr/provider keyword                ; REQUIRED: :github, :gitlab, etc.
+ :pr/repo string                     ; REQUIRED: "org/name"
+ :pr/number long                     ; REQUIRED: provider PR number
+ :pr/external? boolean               ; REQUIRED: true if not Miniforge-originated
+
+ :pr/readiness                       ; REQUIRED: deterministic merge-readiness
+ {:readiness/state keyword           ; :merge-ready, :needs-review, :ci-failing, etc.
+  :readiness/blockers [...]}
+
+ :pr/risk                            ; REQUIRED: explainable risk assessment
+ {:risk/level keyword                ; :low, :medium, :high, :critical
+  :risk/factors [...]
+  :risk/requires-human? boolean}
+
+ :pr/automation-tier keyword         ; REQUIRED: see N9 §10
+
+ :pr/workflow-id uuid}               ; OPTIONAL: absent for external PRs
+```
+
+See N9 for the complete PR Work Item schema and semantics.
+
+### 2.20 Provider (N9)
+
+A **Provider** is an external code hosting platform (GitHub, GitLab, etc.) that is a
+source of PR events and state. Providers are analogous to N7's Environment Targets —
+they are external systems that Miniforge connects to but does not own.
+
+Implementations MUST support at least one provider and MUST normalize provider-native
+events to canonical N3 event types. See N9 §3.
+
+### 2.21 PR Train (N9)
+
+A **PR Train** is an ordered set of PR Work Items with explicit dependency relationships
+that MUST be merged in sequence. Trains are analogous to N2's DAG task dependencies,
+applied to PR merge ordering.
+
+```clojure
+{:train/id uuid                      ; REQUIRED: stable train identifier
+ :train/members                      ; REQUIRED: ordered PR Work Item refs
+ [{:pr/id uuid
+   :pr/repo string
+   :pr/number long
+   :train/position long}]            ; 1-indexed merge order
+
+ :train/policy
+ {:train/merge-strategy keyword      ; :sequential, :batch
+  :train/required-readiness keyword
+  :train/auto-merge? boolean}}       ; Requires Tier 3
+```
+
+See N9 §13 for train operations and governance.
+
+### 2.22 Readiness (N9)
+
+**Readiness** is a deterministic assessment of whether a PR is ready to merge, computed
+from provider signals (CI, reviews, merge conflicts) and policy evaluation results.
+
+Readiness states: `:merge-ready`, `:needs-review`, `:changes-requested`, `:ci-failing`,
+`:policy-failing`, `:merge-conflicts`, `:unknown`.
+
+See N9 §2.2 for readiness computation requirements.
+
+### 2.23 Risk Assessment (N9)
+
+A **Risk Assessment** is an explainable evaluation of change risk for a PR, produced as
+an evidence artifact (N6) with traceable factors. Risk scoring MUST be explainable via
+factor evidence refs and MUST NOT be a black-box number without factors.
+
+See N9 §5 for risk artifact schema.
 
 ---
 
@@ -1106,8 +1338,8 @@ Future versions will support:
 
 Enterprise features will add:
 
-- **PR Trains** - Linked workflows across repos (see roadmap)
-- **DAG Dependencies** - Workflow execution order based on dependencies
+- **PR Trains** - Linked workflows across repos (now specified in N9 §13)
+- **DAG Dependencies** - Workflow execution order based on dependencies (now specified in N2 §13)
 - **Cross-Workflow Context** - Share learnings across related workflows
 
 ### 10.3 Federated Learning (Future Research)
@@ -1129,25 +1361,44 @@ Research directions:
 - N4 (Policy Packs): Defines gate validation rules
 - N5 (CLI/TUI/API): Defines user-facing interfaces
 - N6 (Evidence & Provenance): Defines evidence bundles and artifact provenance
+- N7 (Operational Policy Synthesis): Defines OPSV workflow, Experiment Packs, Operational Policies
+- N8 (Observability Control Interface): Defines Listeners, Capability Levels, Control Actions
+- N9 (External PR Integration): Defines PR Work Items, Providers, PR Trains, Readiness
 
 ---
 
 ## 12. Glossary
 
+- **Actuation Mode** - Governance mode for OPSV outputs: RECOMMEND_ONLY, PR_ONLY, or APPLY_ALLOWED (N7)
+- **Advisory Annotation** - Non-blocking message attached to a workflow or event by a Listener (N8)
 - **Agent** - Autonomous software entity that executes workflow phases
 - **Artifact** - Work product created during workflow execution
+- **Capability Level** - Listener permission tier: OBSERVE, ADVISE, or CONTROL (N8)
+- **Control Action** - Command that modifies workflow execution state, subject to RBAC and gates (N8)
 - **Evidence Bundle** - Immutable audit trail from intent to outcome
+- **Experiment Pack** - Declarative artifact defining workload models, guardrails, and convergence for OPSV (N7)
+- **External PR** - Pull request whose diff was created outside Miniforge's authoring workflow (N9)
 - **Gate** - Validation checkpoint for artifacts
 - **Inner Loop** - Validate → Repair cycle within a phase
+- **Listener** - External actor that subscribes to workflow events with OBSERVE/ADVISE/CONTROL capability (N8)
+- **Operational Policy** - Versioned runtime configuration artifacts controlling service behavior under load (N7)
 - **Outer Loop** - Phase transition state machine
 - **Phase** - Logical SDLC stage (Plan, Implement, Verify, etc.)
 - **Policy Pack** - Collection of validation rules
+- **PR Train** - Ordered set of PR Work Items with dependency relationships for sequential merge (N9)
+- **PR Work Item** - Canonical internal model of a PR in the Fleet control plane (N9)
+- **Provider** - External code hosting platform (GitHub, GitLab) as source of PR events (N9)
+- **Readiness** - Deterministic merge-readiness assessment from provider signals and policy results (N9)
+- **Risk Assessment** - Explainable evaluation of change risk for a PR, produced as N6 evidence artifact (N9)
 - **Subagent** - Specialized agent spawned by parent agent
 - **Tool** - External capability invoked by agent
+- **Verification** - Executing an Experiment Pack against a candidate Operational Policy to produce pass/fail evidence (N7)
 - **Workflow** - Top-level unit of autonomous execution
 
 ---
 
 **Version History:**
 
+- 0.2.0-draft (2026-02-07): Added extension spec concepts from N7, N8, N9
+  (§2.11–§2.23, §12 glossary)
 - 0.1.0-draft (2026-01-23): Initial core architecture specification

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1,7 +1,7 @@
 # N3 — Event Stream & Observability Contract
 
-**Version:** 0.1.0-draft
-**Date:** 2026-01-23
+**Version:** 0.4.0-draft
+**Date:** 2026-02-07
 **Status:** Draft
 **Conformance:** MUST
 
@@ -59,8 +59,20 @@ All events MUST conform to this base envelope:
 - **event/id** - MUST be globally unique UUID
 - **event/timestamp** - MUST be ISO-8601 instant
 - **event/version** - MUST be semantic version string
-- **workflow/id** - MUST reference a valid workflow
-- **event/sequence-number** - MUST be monotonically increasing per workflow
+- **workflow/id** - MUST reference a valid workflow. MAY be nil for external PR events (N9); see §2.3.
+- **event/sequence-number** - MUST be monotonically increasing per workflow (or per PR Work Item for external PR events)
+
+### 2.3 Scope Key for Non-Workflow Events
+
+Some event types originate outside a Miniforge workflow (e.g., external PR state changes
+from N9). For these events:
+
+- `:workflow/id` MAY be nil.
+- Events MUST instead include `:pr/id` (the PR Work Item UUID) as a correlation key.
+- Implementations MUST support subscribing to events by `:pr/id` in addition to `:workflow/id`.
+- Events MUST be ordered per PR Work Item when no workflow scope exists.
+- For Miniforge-originated PRs, `:workflow/id` MUST reference the originating workflow AND
+  `:pr/id` MAY also be present for cross-referencing.
 
 ### 2.2 Ordering Guarantees
 
@@ -820,6 +832,282 @@ Emitted when a task is skipped due to a dependency failure.
  :message "Task skipped: dependency task-abc failed"}
 ```
 
+### 3.13 OPSV Events (N7)
+
+For Operational Policy Synthesis workflows (see N7), implementations MUST emit these
+event types:
+
+#### opsv.experiment/planned
+
+```clojure
+{:event/type :opsv.experiment/planned
+ :workflow/id uuid
+ :opsv/pack-hash string              ; Experiment Pack content hash
+ :opsv/targets {:services [...] :environments [...]}
+ :opsv/risk-score {:level keyword :factors [...]}
+ :message "OPSV experiment planned: {pack-hash}"}
+```
+
+#### opsv.experiment/started
+
+```clojure
+{:event/type :opsv.experiment/started
+ :workflow/id uuid
+ :opsv/pack-hash string
+ :opsv/environment-fingerprint {...} ; Cluster, node pool, image digests, config
+ :message "OPSV experiment started in {environment}"}
+```
+
+#### opsv/load-step
+
+```clojure
+{:event/type :opsv/load-step
+ :workflow/id uuid
+ :opsv/step-id string
+ :opsv/intended-load {...}
+ :opsv/observed-load {...}
+ :message "OPSV load step {step-id}: {intended} → {observed}"}
+```
+
+#### opsv.guardrail/abort
+
+```clojure
+{:event/type :opsv.guardrail/abort
+ :workflow/id uuid
+ :opsv/trigger keyword               ; Abort trigger type
+ :opsv/threshold {...}
+ :opsv/observed {...}
+ :opsv/rollback-action keyword
+ :message "OPSV guardrail abort: {trigger}"}
+```
+
+#### opsv.convergence/iteration
+
+```clojure
+{:event/type :opsv.convergence/iteration
+ :workflow/id uuid
+ :opsv/iteration-id string
+ :opsv/params {...}
+ :opsv/observed-metrics-summary {...}
+ :message "OPSV convergence iteration {iteration-id}"}
+```
+
+#### opsv.policy/proposed
+
+```clojure
+{:event/type :opsv.policy/proposed
+ :workflow/id uuid
+ :opsv/policy-hash string
+ :opsv/diff-refs [uuid ...]          ; N6 artifact references
+ :opsv/confidence keyword
+ :message "OPSV policy proposed: {policy-hash}"}
+```
+
+#### opsv.verification/result
+
+```clojure
+{:event/type :opsv.verification/result
+ :workflow/id uuid
+ :opsv/passed? boolean
+ :opsv/criteria-evaluation [...]
+ :opsv/evidence-bundle-id uuid
+ :message "OPSV verification {passed?}: {summary}"}
+```
+
+#### opsv.actuation/emitted
+
+```clojure
+{:event/type :opsv.actuation/emitted
+ :workflow/id uuid
+ :opsv/actuation-mode keyword        ; :pr-only or :apply-allowed
+ :opsv/pr-refs [string ...]          ; PR URLs if PR_ONLY
+ :opsv/apply-refs [string ...]       ; Applied resource refs if APPLY_ALLOWED
+ :message "OPSV actuation emitted: {mode}"}
+```
+
+#### opsv.drift/detected
+
+```clojure
+{:event/type :opsv.drift/detected
+ :workflow/id uuid                   ; OPTIONAL: may be nil if detected by monitoring
+ :opsv/signal keyword
+ :opsv/deviation {...}
+ :opsv/suggested-rerun? boolean
+ :message "OPSV drift detected: {signal}"}
+```
+
+All OPSV events MUST link to the corresponding evidence bundle id per N6.
+
+### 3.14 Observability Control Interface Events (N8)
+
+For the Observability Control Interface (see N8), implementations MUST emit these
+event types:
+
+#### listener/attached
+
+```clojure
+{:event/type :listener/attached
+ :listener/id uuid
+ :listener/type keyword              ; :watcher, :dashboard, :fleet, :enterprise
+ :listener/capability keyword        ; :observe, :advise, :control
+ :workflow/id uuid
+ :message "Listener attached: {type} with {capability} capability"}
+```
+
+#### listener/detached
+
+```clojure
+{:event/type :listener/detached
+ :listener/id uuid
+ :workflow/id uuid
+ :listener/reason keyword            ; :disconnect, :timeout, :revoked
+ :message "Listener detached: {reason}"}
+```
+
+#### control-action/requested
+
+```clojure
+{:event/type :control-action/requested
+ :action/id uuid
+ :action/type keyword                ; See N8 §3.1
+ :action/target {:target-type keyword :target-id uuid}
+ :action/requester {:principal string :listener-id uuid}
+ :workflow/id uuid
+ :message "Control action requested: {type}"}
+```
+
+#### control-action/executed
+
+```clojure
+{:event/type :control-action/executed
+ :action/id uuid
+ :action/type keyword
+ :action/result {:status keyword :error {...}}
+ :workflow/id uuid
+ :message "Control action executed: {type} - {status}"}
+```
+
+#### control-action/approval-required
+
+```clojure
+{:event/type :control-action/approval-required
+ :action/id uuid
+ :action/type keyword
+ :approval/required-approvers int
+ :approval/timeout-at inst
+ :workflow/id uuid
+ :message "Approval required for {type}: {required} approvers needed"}
+```
+
+#### annotation/created
+
+```clojure
+{:event/type :annotation/created
+ :workflow/id uuid
+ :annotation/id uuid
+ :annotation/type keyword            ; :recommendation, :warning, :insight, :question
+ :annotation/source {:listener-id uuid :principal string}
+ :message "Advisory annotation: {title}"}
+```
+
+### 3.15 External PR Integration Events (N9)
+
+For external PR integration (see N9), implementations MUST emit these event types.
+These events MAY have nil `:workflow/id` — see §2.3 for scope key rules.
+
+#### provider/event-received
+
+Emitted when a provider event is received and normalized.
+
+```clojure
+{:event/type :provider/event-received
+ :pr/id uuid                         ; PR Work Item id (correlation key)
+ :provider/type keyword              ; :github, :gitlab
+ :provider/event-type keyword        ; Canonical type mapped from provider
+ :provider/repo string               ; "org/name"
+ :provider/pr-number long            ; OPTIONAL
+ :provider/head-sha string           ; OPTIONAL
+ :provider/dedupe-key string         ; For idempotency
+ :message "Provider event received: {type} for {repo}#{pr-number}"}
+```
+
+#### pr.readiness/changed
+
+Emitted when PR readiness state changes (derived-state-change event).
+
+```clojure
+{:event/type :pr.readiness/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+ :readiness/previous-state keyword
+ :readiness/new-state keyword
+ :readiness/blockers [...]
+ :message "PR {repo}#{number} readiness: {previous} → {new}"}
+```
+
+#### pr.risk/changed
+
+```clojure
+{:event/type :pr.risk/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+ :risk/previous-level keyword
+ :risk/new-level keyword
+ :risk/factors [...]
+ :risk/evidence-id uuid              ; N6 artifact id
+ :message "PR {repo}#{number} risk: {previous} → {new}"}
+```
+
+#### pr.policy/changed
+
+```clojure
+{:event/type :pr.policy/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+ :policy/previous-overall keyword
+ :policy/new-overall keyword
+ :policy/results [...]
+ :policy/evidence-id uuid            ; N6 artifact id
+ :message "PR {repo}#{number} policy: {previous} → {new}"}
+```
+
+#### pr.state/changed
+
+```clojure
+{:event/type :pr.state/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+ :pr/previous-state keyword          ; :open, :closed, :merged
+ :pr/new-state keyword
+ :pr/head-sha string
+ :message "PR {repo}#{number} state: {previous} → {new}"}
+```
+
+#### train/changed
+
+```clojure
+{:event/type :train/changed
+ :train/id uuid
+ :train/members [uuid ...]           ; Ordered PR Work Item ids
+ :train/change-type keyword          ; :member-added, :member-removed,
+                                     ; :order-changed, :member-merged
+ :message "Train {id}: {change-type}"}
+```
+
+#### N9 Event Ordering Rules
+
+- Provider ingestion events MUST be idempotent per `:provider/dedupe-key`.
+- Derived-state-change events (`:pr.readiness/changed`, etc.) MUST only fire when
+  computed state actually changes.
+- All events MUST conform to §2.2 ordering guarantees where a workflow scope exists.
+  For external PRs (no workflow), events MUST be ordered per PR Work Item (§2.3).
+
+---
+
 ## 4. Event Emission Requirements
 
 ### 4.1 Emission Points
@@ -835,6 +1123,9 @@ Implementations MUST emit events at these points:
 7. **Inter-agent messages** - all communications
 8. **Milestones** - significant progress points
 9. **Task lifecycle** - frontier entry, claims, capability binding, scope violations
+10. **OPSV lifecycle** - experiment plans, load steps, guardrail aborts, policy proposals, verification results (N7)
+11. **Listener lifecycle** - attach, detach, control actions, annotations (N8)
+12. **External PR lifecycle** - provider events, readiness/risk/policy changes, train changes (N9)
 
 ### 4.2 Throttling
 
@@ -1085,15 +1376,20 @@ Event stream will extend to:
 ## 10. References
 
 - RFC 2119: Key words for use in RFCs to Indicate Requirement Levels
-- N6 (Evidence & Provenance): Evidence bundles reference event streams
-- N5 (CLI/TUI/API): UI consumes event stream via subscription API
 - N2 (Workflow Execution): Workflow engine emits lifecycle events
+- N5 (CLI/TUI/API): UI consumes event stream via subscription API
+- N6 (Evidence & Provenance): Evidence bundles reference event streams
+- N7 (Operational Policy Synthesis): OPSV event types (§3.13)
+- N8 (Observability Control Interface): Listener/control action event types (§3.14)
+- N9 (External PR Integration): Provider/PR/train event types (§3.15)
 - I-DAG-ORCHESTRATION: DAG executor with PR lifecycle (Section 12: PR Lifecycle Events)
 
 ---
 
 **Version History:**
 
+- 0.4.0-draft (2026-02-07): Added extension spec events from N7, N8, N9
+  (§3.13–§3.15, §2.3 scope key)
 - 0.3.0-draft (2026-02-04): Added task lifecycle events for DAG orchestration (§3.12)
 - 0.2.0-draft (2026-02-03): Add PR lifecycle events for DAG orchestration (Section 3.10)
 - 0.1.0-draft (2026-01-23): Initial event stream specification

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -1,7 +1,7 @@
 # N4 — Policy Packs & Gates Standard
 
-**Version:** 0.1.0-draft
-**Date:** 2026-01-23
+**Version:** 0.3.0-draft
+**Date:** 2026-02-07
 **Status:** Draft
 **Conformance:** MUST
 
@@ -9,7 +9,8 @@
 
 ## 1. Purpose & Scope
 
-This specification defines the **policy pack** and **gate validation** contracts for miniforge autonomous software factory. It establishes:
+This specification defines the **policy pack** and **gate validation** contracts for miniforge
+autonomous software factory. It establishes:
 
 - **Policy pack structure** - Format, versioning, signature requirements
 - **Gate execution contract** - Check and repair function interfaces
@@ -127,13 +128,16 @@ Policy packs enable **policy-as-code** enforcement at workflow gates, preventing
 
 ### 2.4 Knowledge Safety and Pack Validation (Reference)
 
-miniforge MUST support deterministic policy packs that protect the system from prompt-injection and untrusted input escalation during ingestion and execution.
+miniforge MUST support deterministic policy packs that protect the system from prompt-injection
+and untrusted input escalation during ingestion and execution.
 
 A reference policy pack named `knowledge-safety` SHOULD be provided.
 
 #### 2.4.1 Threat Model
 
-Untrusted repository content (markdown, issues, wikis, etc.) may contain instructions that attempt to override agent behavior. The platform MUST treat such content as *data* unless it is normalized into schema-valid packs and promoted to `:trusted` under policy.
+Untrusted repository content (markdown, issues, wikis, etc.) may contain instructions that
+attempt to override agent behavior. The platform MUST treat such content as *data* unless it
+is normalized into schema-valid packs and promoted to `:trusted` under policy.
 
 #### 2.4.2 Reference Rules (knowledge-safety)
 
@@ -169,18 +173,32 @@ The `knowledge-safety` pack SHOULD include rules such as:
 
 #### 2.4.3 Deterministic Prompt Injection Tripwire Scanner
 
-The platform SHOULD ship a deterministic scanner that emits findings on suspicious directives, including (non-exhaustive):
+The platform SHOULD ship a deterministic scanner that emits findings on suspicious
+directives, including (non-exhaustive):
 
-- **Role and instruction overrides:** `SYSTEM:`, `DEVELOPER:`, "ignore previous instructions", "you are now", "disregard all prior"
-- **Tool invocation bait:** "run this command", "call tool", "execute the following", "invoke function"
-- **Data exfiltration attempts:** "send output to", "POST to", "curl http", "webhook", patterns suggesting data leakage to external endpoints
-- **Embedded execution patterns:** Unusual code blocks in documentation context (e.g., shell scripts, base64 blobs with `eval`, obfuscated JavaScript/Python)
-- **Time-based triggers:** Patterns suggesting delayed or conditional execution ("wait until", "after N days", "when timestamp", "cron-like expressions" in unexpected contexts)
-- **Obfuscation indicators:** Large base64 blobs, repeated encoding markers (multiple layers of encoding), hexadecimal or unicode escape sequences suggesting hidden content
-- **Authority escalation:** "this is the system prompt", "highest priority", "override all policies", "administrator mode", "root access"
-- **Context confusion:** Attempts to blur boundaries between documentation and instructions ("the following is a system message", "internal use only: execute")
+- **Role and instruction overrides:** `SYSTEM:`, `DEVELOPER:`,
+  "ignore previous instructions", "you are now", "disregard all prior"
+- **Tool invocation bait:** "run this command", "call tool",
+  "execute the following", "invoke function"
+- **Data exfiltration attempts:** "send output to", "POST to", "curl http",
+  "webhook", patterns suggesting data leakage to external endpoints
+- **Embedded execution patterns:** Unusual code blocks in documentation context
+  (e.g., shell scripts, base64 blobs with `eval`, obfuscated JavaScript/Python)
+- **Time-based triggers:** Patterns suggesting delayed or conditional execution
+  ("wait until", "after N days", "when timestamp", "cron-like expressions"
+  in unexpected contexts)
+- **Obfuscation indicators:** Large base64 blobs, repeated encoding markers
+  (multiple layers of encoding), hexadecimal or unicode escape sequences
+  suggesting hidden content
+- **Authority escalation:** "this is the system prompt", "highest priority",
+  "override all policies", "administrator mode", "root access"
+- **Context confusion:** Attempts to blur boundaries between documentation
+  and instructions ("the following is a system message",
+  "internal use only: execute")
 
-The scanner SHOULD use pattern matching (regex, keyword detection) combined with contextual heuristics (e.g., code blocks in markdown files that aren't in fenced code syntax).
+The scanner SHOULD use pattern matching (regex, keyword detection) combined with
+contextual heuristics (e.g., code blocks in markdown files that aren't in fenced
+code syntax).
 
 Implementations SHOULD tune sensitivity based on content type:
 
@@ -188,7 +206,9 @@ Implementations SHOULD tune sensitivity based on content type:
 - Code files with inline documentation → moderate sensitivity
 - Structured data files (JSON, YAML, EDN) → context-dependent
 
-This scanner MUST be treated as a *tripwire* rather than a complete security solution. The primary defense MUST remain trust labeling, schema validation, and instruction/data separation.
+This scanner MUST be treated as a *tripwire* rather than a complete security solution.
+The primary defense MUST remain trust labeling, schema validation, and
+instruction/data separation.
 
 ---
 
@@ -462,7 +482,7 @@ Semantic intent validation MUST enforce these rules:
 
 Implementations MUST parse Terraform plan output to categorize changes:
 
-```
+```text
 # Example Terraform plan output
 
 Terraform will perform the following actions:
@@ -629,6 +649,106 @@ Rules:
 This pack is OPTIONAL for single-task workflows but RECOMMENDED for DAG execution
 with multiple concurrent agents.
 
+#### 5.1.5 OPSV Gates Pack (N7)
+
+**ID:** `opsv-governance`
+**Purpose:** Govern operational policy synthesis experiments and actuation (see N7 §5)
+
+Gates:
+
+- `instrumentation-gate` (severity: critical)
+  - FAIL if required metric/trace signals do not exist or are unreliable
+  - MUST validate signal availability before experiment execution
+- `environment-gate` (severity: critical)
+  - FAIL if target environments are not in the allowed set or outside time windows
+  - Production targets MUST require explicit allowlisting
+- `blast-radius-gate` (severity: critical)
+  - FAIL if proposed changes exceed configured max replicas delta, max node delta, or namespace limits
+- `abort-gate` (severity: critical)
+  - FAIL if abort triggers are not configured before experiment execution
+  - MUST verify error budget burn, saturation, and tail latency thresholds are set
+- `actuation-gate` (severity: critical)
+  - FAIL if `APPLY_ALLOWED` is requested but not explicitly enabled in policy pack
+  - `APPLY_ALLOWED` MUST be disabled by default
+  - Apply requires explicit per-service allowlist
+- `evidence-completeness-gate` (severity: high)
+  - FAIL if evidence bundle is missing required fields before actuation
+  - MUST verify experiment pack hash, environment fingerprint, metric snapshots
+
+If any gate fails, OPSV MUST produce remediation guidance as machine-readable output
+and human-readable summary.
+
+#### 5.1.6 Control Action Governance (N8)
+
+**ID:** `control-action-governance`
+**Purpose:** RBAC and policy gates governing control actions (see N8 §2.3, §3)
+
+Rules:
+
+- `require-rbac-authorization` (severity: critical)
+  - FAIL if control action requester lacks required RBAC role for the action type
+  - MUST validate against RBAC schema (see N8 §2.3)
+- `require-multi-party-approval` (severity: critical)
+  - FAIL if High/Critical risk actions proceed without configured number of approvers
+  - Requester MUST NOT be their own approver (when `require-different-principal?` is true)
+- `control-action-audit` (severity: high)
+  - FAIL if control action is not audit-logged with pre-state, post-state, and justification
+- `control-action-risk-classification` (severity: medium)
+  - WARN if action risk level is not classified per N8 §3.1 risk levels
+  - MUST enforce justification requirement for High/Critical actions
+
+RBAC role schema for control action governance:
+
+```clojure
+{:rbac/role keyword
+ :rbac/permissions
+ {:workflows {:pause boolean :resume boolean :retry boolean
+              :cancel boolean :rollback boolean :force-complete boolean}
+  :agents {:quarantine boolean :adjust-budget boolean :inject-context boolean}
+  :fleet {:emergency-stop boolean :drain boolean :scale boolean}
+  :approvals {:gate-override boolean :budget-escalation boolean}}
+ :rbac/constraints
+ {:workflow-patterns [string ...]
+  :time-windows [{:start inst :end inst} ...]
+  :require-mfa? boolean}}
+```
+
+#### 5.1.7 External PR Evaluation (N9)
+
+**ID:** `external-pr-evaluation`
+**Purpose:** Policy evaluation for external PRs (see N9 §8)
+
+Rules:
+
+- `external-pr-policy-check` (severity: configurable)
+  - Evaluate existing policy pack rules against external PR diffs
+  - Context differs from workflow gate evaluation: artifacts are the PR diff and
+    metadata, context is PR author/repo/labels/base branch (not workflow spec)
+  - MUST NOT invoke repair functions (N4 §3.2) — external PRs are read-only unless adopted
+- `policy-evaluation-trigger` (severity: high)
+  - MUST run policy evaluation on: PR opened, PR synchronized (new commits),
+    check run completed, configuration changed
+- `provider-feedback-governance` (severity: medium)
+  - If `:policies/mode` is `:enforcing`, MAY publish outcomes as provider-native
+    signals (e.g., GitHub Check Runs) with stable check names per policy pack
+  - If `:policies/mode` is `:advisory`, MUST NOT publish enforcing checks
+  - MUST respect automation tier constraints (N9 §10)
+
+Policy result schema for external PR evaluation:
+
+```clojure
+{:policy/overall keyword              ; :pass, :fail, :unknown
+ :policy/results
+ [{:rule/id string                    ; From N4 policy pack rule
+   :rule/outcome keyword              ; :pass, :fail, :warn, :skip, :unknown
+   :rule/message string
+   :rule/evidence-id uuid}]           ; N6 artifact with full details
+ :policy/evaluated-at inst
+ :policy/packs-applied
+ [{:policy-pack/id string
+   :policy-pack/version string}]}
+```
+
 ### 5.2 Pack Discovery & Installation
 
 Implementations SHOULD support:
@@ -655,7 +775,7 @@ miniforge policy show terraform-aws
 
 All violations MUST provide remediation guidance in this format:
 
-```
+```text
 [SEVERITY] Rule: [RULE_NAME]
 
 Problem:
@@ -674,7 +794,7 @@ Docs: [DOCUMENTATION_URL]
 
 Example:
 
-```
+```text
 [CRITICAL] Rule: No Public S3 Buckets
 
 Problem:
@@ -992,10 +1112,15 @@ Research directions:
 - N2 (Workflow Execution): Defines gate execution in phases
 - N3 (Event Stream): Defines gate lifecycle events
 - N6 (Evidence & Provenance): Stores policy check results in evidence
+- N7 (Operational Policy Synthesis): OPSV gate requirements (§5.1.5)
+- N8 (Observability Control Interface): RBAC and control action governance (§5.1.6)
+- N9 (External PR Integration): External PR policy evaluation (§5.1.7)
 
 ---
 
 **Version History:**
 
+- 0.3.0-draft (2026-02-07): Added extension spec gates from N7, N8, N9
+  (§5.1.5–§5.1.7)
 - 0.2.0-draft (2026-02-04): Added task-scope policy pack for capability enforcement (§5.1.4)
 - 0.1.0-draft (2026-01-23): Initial policy packs and gates specification

--- a/specs/normative/N5-cli-tui-api.md
+++ b/specs/normative/N5-cli-tui-api.md
@@ -1,7 +1,7 @@
 # N5 — Interface Standard: CLI/TUI/API
 
-**Version:** 0.1.0-draft
-**Date:** 2026-01-23
+**Version:** 0.3.0-draft
+**Date:** 2026-02-07
 **Status:** Draft
 **Conformance:** MUST
 
@@ -33,7 +33,7 @@ The operations console (CLI/TUI/API) is the **window into the factory**, not the
 
 ### 2.1 Command Structure
 
-```
+```text
 miniforge <namespace> <command> [arguments] [flags]
 ```
 
@@ -189,6 +189,67 @@ Flags:
   --json              Output as JSON
 ```
 
+##### OPSV Commands (N7)
+
+```bash
+# Operational policy synthesis
+miniforge fleet opsv plan SERVICE [flags]     # Generate Experiment Packs and risk/gate status
+miniforge fleet opsv run SERVICE [flags]      # Execute experiment and converge
+miniforge fleet opsv verify SERVICE [flags]   # Run verification suite
+miniforge fleet opsv propose SERVICE [flags]  # Emit policy proposals without actuation
+miniforge fleet opsv emit SERVICE [flags]     # PR-only emission
+miniforge fleet opsv apply SERVICE [flags]    # Gated apply (if enabled)
+```
+
+##### Listener and Control Commands (N8)
+
+```bash
+# Listener management
+miniforge listener list                       # List active listeners
+miniforge listener attach WORKFLOW_ID         # Attach as OBSERVE listener
+miniforge listener advise WORKFLOW_ID         # Attach as ADVISE listener
+miniforge listener control WORKFLOW_ID        # Attach as CONTROL listener (requires auth)
+
+# Workflow control actions
+miniforge workflow pause WORKFLOW_ID          # Pause workflow execution
+miniforge workflow resume WORKFLOW_ID         # Resume paused workflow
+miniforge workflow retry WORKFLOW_ID          # Retry current phase
+miniforge workflow rollback WORKFLOW_ID       # Rollback to checkpoint
+
+# Agent control actions
+miniforge agent quarantine AGENT_ID           # Quarantine agent
+miniforge agent budget AGENT_ID --tokens=N    # Adjust agent budget
+
+# Gate control actions
+miniforge gate approve GATE_ID               # Approve pending gate
+miniforge gate override GATE_ID --reason=     # Override gate failure
+
+# Fleet control actions
+miniforge fleet emergency-stop                # Emergency stop all workflows
+miniforge fleet drain                         # Drain fleet (stop accepting, complete existing)
+```
+
+##### External PR Commands (N9)
+
+```bash
+# PR monitoring
+miniforge fleet prs [flags]                   # List PR Work Items across repos
+  --repo REPO                                 # Filter by repo
+  --author AUTHOR                             # Filter by author
+  --readiness STATE                           # Filter by readiness state
+  --risk LEVEL                                # Filter by risk level
+  --policy OUTCOME                            # Filter by policy outcome
+  --json                                      # Output as JSON
+
+miniforge fleet pr REPO#NUMBER [flags]        # Show PR Work Item detail
+  --evidence                                  # Include evidence artifact pointers
+  --json                                      # Output as JSON
+
+# Train management (if trains enabled)
+miniforge fleet trains [flags]                # List active trains
+miniforge fleet train TRAIN_ID [flags]        # Show train detail and membership
+```
+
 **Requirements:**
 
 - MUST show real-time workflow status
@@ -198,7 +259,7 @@ Flags:
 
 **Example TUI (see Section 3):**
 
-```
+```text
 ╭─────────────────────────────────────────────────────────────╮
 │ miniforge local fleet  [Workflows: 5 | Active: 2]   ⟳ 15s  │
 ├─────────────────────────────────────────────────────────────┤
@@ -550,7 +611,7 @@ Implementations MUST provide these views:
 
 #### 3.2.1 Workflow List View (Primary View)
 
-```
+```text
 ╭─────────────────────────────────────────────────────────────────────────────╮
 │ miniforge local fleet  [Workflows: 5 | Agents: 4 | Active: 2]   ⟳ 15s ago  │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -575,7 +636,7 @@ Implementations MUST provide these views:
 
 #### 3.2.2 Workflow Detail View
 
-```
+```text
 ╭─────────────────────────────────────────────────────────────────────────────╮
 │ Workflow: rds-import (abc123-def456)                                        │
 │ Status: Executing | Phase: Implement | Started: 2h ago                      │
@@ -618,7 +679,7 @@ Implementations MUST provide these views:
 
 #### 3.2.3 Evidence Viewer
 
-```
+```text
 ╭─────────────────────────────────────────────────────────────────────────────╮
 │ Evidence Bundle: abc123-def456                                              │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -667,7 +728,7 @@ Implementations MUST provide these views:
 
 #### 3.2.4 Artifact Browser
 
-```
+```text
 ╭─────────────────────────────────────────────────────────────────────────────╮
 │ Artifacts: abc123-def456                                                    │
 ├─────────────────────────────────────────────────────────────────────────────┤
@@ -733,6 +794,67 @@ The Kanban view is NOT a separate data model — it is computed from task states
 - SHOULD show elapsed time for active tasks
 - SHOULD show `:failed` and `:skipped` tasks distinctly in DONE column (✗ vs ○)
 
+#### 3.2.6 OPSV Drill-Down View (N7)
+
+For operational policy synthesis, the TUI SHALL provide drill-down navigation:
+
+```text
+Fleet → Service → OPSV Runs → (Experiment Pack, Events, Evidence, Policy Diff, Verification)
+```
+
+**Requirements:**
+
+- MUST show per-service "policy state" view (current vs proposed vs verified)
+- MUST allow drill-down into evidence bundles and event streams per N6
+- MUST show experiment progress, convergence iterations, and verification results
+
+#### 3.2.7 Listener and Control Panel (N8)
+
+The TUI MUST provide:
+
+- **Listener panel**: Show active listeners and their capabilities (OBSERVE/ADVISE/CONTROL)
+- **Control palette**: Quick access to control actions via keyboard shortcuts
+- **Annotation overlay**: Display advisory annotations inline with workflow events
+- **Approval queue**: Pending multi-party approvals for High/Critical actions
+
+#### 3.2.8 PR Fleet View (N9)
+
+```text
+╭─────────────────────────────────────────────────────────────────────────────╮
+│ miniforge fleet PRs  [Repos: 12 | PRs: 34 | Merge-Ready: 8]   ⟳ 15s ago   │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ REPO              PR#   TITLE              READINESS       RISK   POLICY   │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ acme/api          #42   Add auth endpoint  ✓ merge-ready   low    pass     │
+│ acme/api          #45   Fix rate limiter   ● ci-failing    med    pass     │
+│ acme/infra        #18   Scale RDS          ✓ merge-ready   high   pass     │
+│ acme/frontend     #99   Dark mode          ● needs-review  low    unknown  │
+╰─────────────────────────────────────────────────────────────────────────────╯
+[j/k] Navigate  [Enter] PR Detail  [f] Filter  [t] Trains  [Esc] Back
+```
+
+**Requirements:**
+
+- MUST show PR Work Items across repos with readiness/risk/policy columns
+- MUST support sorting and filtering by readiness, risk, repo, author
+- MUST derive from event stream (N3) and PR Work Item state — projections, not separate data
+
+#### 3.2.9 PR Detail View (N9)
+
+**Requirements:**
+
+- MUST show readiness blockers, risk factors, policy results
+- MUST allow drill-down to evidence artifacts (N6)
+- MUST show automation tier and recent provider actions
+
+#### 3.2.10 Train View (N9)
+
+**Requirements:**
+
+- MUST show ordered train members with merge readiness status
+- MUST indicate which member is next for merge
+- MUST show dependency edges between train members
+
 ### 3.3 TUI Keyboard Navigation
 
 Implementations MUST support:
@@ -784,7 +906,7 @@ Implementations SHOULD provide HTTP REST API:
 
 #### 4.2.1 Workflow Control
 
-```
+```text
 POST /api/workflows
   Body: Workflow spec (JSON or EDN)
   Returns: {:workflow-id uuid}
@@ -803,7 +925,7 @@ DELETE /api/workflows/:id
 
 #### 4.2.2 Event Stream Subscription
 
-```
+```text
 GET /api/workflows/:id/stream
   Returns: Server-Sent Events (SSE) stream
 
@@ -820,7 +942,7 @@ Event format:
 
 #### 4.2.3 Evidence & Artifacts
 
-```
+```text
 GET /api/evidence/:workflow-id
   Returns: Evidence bundle (JSON or EDN)
 
@@ -831,11 +953,31 @@ GET /api/artifacts/:artifact-id/provenance
   Returns: Provenance chain
 ```
 
+#### 4.2.4 Fleet PR API (N9)
+
+```text
+GET /api/fleet/prs
+  Query params: ?repo=org/name&readiness=merge-ready&risk=high
+  Returns: List of PR Work Items
+
+GET /api/fleet/prs/:pr-id
+  Returns: PR Work Item with evidence pointers
+
+GET /api/fleet/trains
+  Returns: List of active trains
+
+GET /api/fleet/trains/:train-id
+  Returns: Train detail with ordered members
+```
+
+The Fleet event stream (§4.2.2) MUST support subscription filters for N9 event types,
+enabling clients to subscribe to PR state changes, readiness changes, and policy changes.
+
 ### 4.3 API Authentication
 
 Implementations SHOULD require authentication:
 
-```
+```text
 Authorization: Bearer <token>
 ```
 
@@ -1220,10 +1362,15 @@ Research directions:
 - N3 (Event Stream): API consumes event stream
 - N4 (Policy Packs): CLI manages policy packs
 - N6 (Evidence & Provenance): CLI/TUI views evidence bundles
+- N7 (Operational Policy Synthesis): OPSV CLI commands and TUI drill-down (§2.3.3, §3.2.6)
+- N8 (Observability Control Interface): Listener/control CLI commands and TUI panels (§2.3.3, §3.2.7)
+- N9 (External PR Integration): Fleet PR CLI/TUI/API commands (§2.3.3, §3.2.8-3.2.10, §4.2.4)
 
 ---
 
 **Version History:**
 
+- 0.3.0-draft (2026-02-07): Added extension spec interfaces from N7, N8, N9
+  (§2.3.3, §3.2.6–§3.2.10, §4.2.4)
 - 0.2.0-draft (2026-02-04): Added DAG Kanban view and task lifecycle CLI command (§3.2.5)
 - 0.1.0-draft (2026-01-23): Initial CLI/TUI/API specification

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -1,7 +1,7 @@
 # N6 — Evidence & Provenance Standard
 
-**Version:** 0.1.0-draft
-**Date:** 2026-01-23
+**Version:** 0.3.0-draft
+**Date:** 2026-02-07
 **Status:** Draft
 **Conformance:** MUST
 
@@ -297,6 +297,83 @@ For tasks reaching `:merged` terminal state:
   :merge/branch-up-to-date? boolean}}
 ```
 
+### 2.8 OPSV Evidence (N7)
+
+For Operational Policy Synthesis workflows (see N7), evidence bundles MUST include:
+
+```clojure
+{:evidence/opsv
+ {:opsv/experiment-pack-hash string   ; Content hash of Experiment Pack used
+  :opsv/experiment-pack-id string
+  :opsv/environment-fingerprint       ; Cluster, node pool, image digests, config
+  {:cluster string
+   :node-pools [string ...]
+   :image-digests {...}}
+
+  :opsv/convergence-iterations long   ; Number of convergence iterations
+  :opsv/policy-proposals              ; Proposed operational policies
+  [{:policy-hash string
+    :confidence keyword
+    :scaling {...}
+    :resources {...}
+    :artifact-id uuid}]               ; Link to :operational-policy-proposal artifact
+
+  :opsv/verification
+  {:passed? boolean
+   :criteria-evaluation [...]         ; Per-criterion results
+   :confidence keyword
+   :caveats [string ...]}
+
+  :opsv/actuation
+  {:mode keyword                      ; :recommend-only, :pr-only, :apply-allowed
+   :pr-refs [string ...]              ; PR URLs if PR_ONLY
+   :apply-refs [string ...]}          ; Applied resource refs if APPLY_ALLOWED
+
+  :opsv/metric-snapshots [uuid ...]}} ; Links to :opsv-metric-snapshot artifacts
+```
+
+### 2.9 Control Action Evidence (N8)
+
+Control actions (see N8) MUST be recorded in evidence bundles:
+
+```clojure
+{:evidence/control-actions
+ [{:action/id uuid
+   :action/type keyword               ; See N8 §3.1
+   :action/timestamp inst
+   :action/requester {:principal string :listener-id uuid}
+   :action/justification string
+   :action/approval {:status keyword :approvers [...]}
+   :action/result {:status keyword :error {...}}
+   :action/pre-state {...}            ; State before action
+   :action/post-state {...}}]         ; State after action
+
+ :evidence/annotations
+ [{:annotation/id uuid
+   :annotation/type keyword           ; :recommendation, :warning, :insight, :question
+   :annotation/source {:listener-id uuid :principal string}
+   :annotation/target {:workflow-id uuid :event-id uuid}
+   :annotation/content {:title string :body string :severity keyword}
+   :annotation/timestamp inst}]}
+```
+
+### 2.10 External PR Evidence (N9)
+
+External PR evaluations produce evidence using the existing schema. N9 does NOT
+define a separate evidence model. Evidence for external PRs uses:
+
+- `:risk-assessment` artifacts with explainable factors (see N9 §5.1)
+- `:pr-policy-result` artifacts with per-rule outcomes
+- `:pr-readiness-snapshot` artifacts with point-in-time state
+
+All artifacts MUST have `:artifact/content-hash`, `:artifact/provenance`, and
+`:artifact/created-at` per §3. Evidence artifacts produced by N9 MUST be immutable
+and addressable per §5.1. Policy results and risk factors MUST reference evidence
+artifacts, not inline their content.
+
+For external PRs (no workflow), `:provenance/workflow-id` MAY be nil and
+`:provenance/phase` SHOULD be `:external-pr-eval`.
+
 ---
 
 ## 3. Artifact Provenance Schema
@@ -320,6 +397,8 @@ For tasks reaching `:merged` terminal state:
 
 Implementations MUST support:
 
+**Core artifact types:**
+
 - `:terraform-plan` - Terraform plan output
 - `:terraform-state` - Terraform state file
 - `:code-changes` - Code diff or patch
@@ -329,12 +408,32 @@ Implementations MUST support:
 - `:architecture-diagram` - Design artifacts
 - `:evidence-bundle` - Evidence bundle itself (meta)
 
+**Pack artifact types:**
+
 - `:feature-pack` - Normalized feature pack (EDN)
 - `:policy-pack` - Policy pack (EDN)
 - `:agent-profile-pack` - Agent profile pack (EDN)
 - `:pack-index` - Pack manifest (EDN)
 - `:etl-report` - ETL run report (classifications, coverage)
 - `:risk-report` - Static scanner findings (knowledge-safety)
+
+**OPSV artifact types (N7):**
+
+- `:experiment-pack` - OPSV Experiment Pack definition
+- `:operational-policy-proposal` - Proposed operational policy with scaling/sizing config
+- `:opsv-verification-report` - Verification pass/fail with per-criterion results
+- `:opsv-metric-snapshot` - Metric queries and snapshots used for OPSV conclusions
+
+**Control action artifact types (N8):**
+
+- `:control-action-record` - Audit record of a control action (pre-state, post-state, justification)
+- `:annotation-record` - Record of advisory annotations for evidence
+
+**External PR artifact types (N9):**
+
+- `:risk-assessment` - Risk evaluation for a PR with explainable factors (see N9 §5.1)
+- `:pr-policy-result` - Policy evaluation result for an external PR
+- `:pr-readiness-snapshot` - Point-in-time readiness assessment for a PR
 
 Artifacts of type `:feature-pack`, `:policy-pack`, and `:agent-profile-pack` MUST include:
 
@@ -789,14 +888,19 @@ Fleet-wide evidence will enable:
 ## 13. References
 
 - RFC 2119: Key words for use in RFCs to Indicate Requirement Levels
-- N3 (Event Stream): Evidence bundles link to event streams via sequence ranges
 - N2 (Workflow Execution): Workflows produce evidence bundles
+- N3 (Event Stream): Evidence bundles link to event streams via sequence ranges
 - N4 (Policy Packs): Policy check results stored in evidence
+- N7 (Operational Policy Synthesis): OPSV evidence requirements (§2.8)
+- N8 (Observability Control Interface): Control action and annotation evidence (§2.9)
+- N9 (External PR Integration): External PR evidence artifacts (§2.10, §3.1.1)
 - I-DAG-ORCHESTRATION: DAG executor with PR lifecycle evidence requirements
 
 ---
 
 **Version History:**
 
+- 0.3.0-draft (2026-02-07): Added extension spec evidence from N7, N8, N9
+  (§2.8–§2.10, §3.1.1 artifact types)
 - 0.2.0-draft (2026-02-03): Add DAG orchestration evidence (Section 2.7: DAG Run, Task Workflow, Merge Evidence)
 - 0.1.0-draft (2026-01-23): Initial evidence & provenance specification

--- a/specs/normative/N7-Operational-Policy-Synthesis.md
+++ b/specs/normative/N7-Operational-Policy-Synthesis.md
@@ -13,14 +13,19 @@ them against explicit acceptance criteria, and emits fixes as auditable artifact
 
 OPSV is an extension of existing Miniforge normative contracts:
 
-- **N1**: introduces new *concepts* (Experiment Pack, Operational Policy, Actuation Mode) as
-          specializations of Workflow/Policy Pack/Artifact/Evidence.
+- **N1**: introduces new *concepts* (Experiment Pack, Operational Policy, Actuation Mode,
+          Verification) as specializations of Workflow/Policy Pack/Artifact/Evidence.
+          Now landed in N1 §2.11–§2.14 and §12 (glossary).
 - **N2**: defines a new workflow family (`opsv.*`) and convergence loops as instances of the
           validate→feedback→repair→re-validate pattern.
-- **N3**: adds required event types and event payload fields for experiments and verification.
+- **N3**: adds required event types for experiments and verification.
+          Now landed in N3 §3.13 (OPSV Events).
 - **N4**: defines new gates and policy-pack controls for experiment governance, safety, and actuation.
+          Now landed in N4 §5.1.5 (OPSV Gates Pack).
 - **N5**: defines Fleet Mode command surfaces and navigation primitives for experiments and policy diffs.
-- **N6**: defines evidence bundle requirements for experiment provenance, reproducibility, and verification artifacts.
+          Now landed in N5 §2.3.3 (OPSV Commands) and §3.2.6 (OPSV Drill-Down View).
+- **N6**: defines evidence bundle requirements for experiment provenance, reproducibility, and
+          verification artifacts. Now landed in N6 §2.8 (OPSV Evidence) and §3.1.1 (artifact types).
 
 ### 0.3 Non-goals
 

--- a/specs/normative/N8-observability-control-interface.md
+++ b/specs/normative/N8-observability-control-interface.md
@@ -28,13 +28,18 @@ The OCI transforms the event stream (N3) from a passive observability layer into
 
 OCI is an extension of existing Miniforge normative contracts:
 
-- **N1**: introduces new *concepts* (Listener, Capability Level, Control Action) as
-          specializations of Agent/Observer/Policy.
+- **N1**: introduces new *concepts* (Listener, Capability Level, Control Action,
+          Advisory Annotation) as specializations of Agent/Observer/Policy.
+          Now landed in N1 §2.15–§2.18 and §12 (glossary).
 - **N3**: defines listener subscription mechanics, privacy hooks, and OTel interoperability
           as extensions to the event stream contract.
+          Now landed in N3 §3.14 (Observability Control Interface Events).
 - **N4**: defines RBAC rules and policy gates governing control actions.
+          Now landed in N4 §5.1.6 (Control Action Governance).
 - **N5**: defines control-plane commands for CLI/TUI/API.
+          Now landed in N5 §2.3.3 (Listener and Control Commands) and §3.2.7 (Listener and Control Panel).
 - **N6**: defines audit requirements for control actions in evidence bundles.
+          Now landed in N6 §2.9 (Control Action Evidence) and §3.1.1 (artifact types).
 - **N7**: OCI provides the listener infrastructure that OPSV uses for experiment monitoring.
 
 ### 0.3 Non-goals

--- a/specs/normative/N9-external-pr-integration.md
+++ b/specs/normative/N9-external-pr-integration.md
@@ -27,19 +27,23 @@ N9 is an extension of existing Miniforge normative contracts:
 
 - **N1**: introduces new concepts (External PR, PR Work Item, Provider, PR Train,
           Readiness, Risk Assessment) as specializations of Workflow/Artifact/Evidence.
-          These MUST be added to N1 §2 and §12 (glossary).
+          Now landed in N1 §2.19–§2.23 and §12 (glossary).
 - **N2**: does NOT define new workflow phases; external PRs are not executed through
           the Plan→Implement→Verify pipeline. However, external PRs MAY be
           "adopted" into a Miniforge workflow (e.g., PR Monitoring), at which point
           N2 applies.
 - **N3**: adds required event types for provider ingestion and PR state changes
-          as extensions to the event stream contract (§7 of this spec).
+          as extensions to the event stream contract.
+          Now landed in N3 §3.15 (External PR Integration Events) and §2.3 (scope key).
 - **N4**: defines how existing policy packs evaluate external PR diffs and how
-          policy results are published as provider-native signals (§8).
+          policy results are published as provider-native signals.
+          Now landed in N4 §5.1.7 (External PR Evaluation).
 - **N5**: defines CLI/TUI/API extensions for multi-repo PR monitoring, readiness
-          views, and train management (§12).
+          views, and train management.
+          Now landed in N5 §2.3.3 (External PR Commands), §3.2.8–§3.2.10 (TUI views), §4.2.4 (API).
 - **N6**: defines how external PR assessments produce evidence artifacts using
-          the existing evidence bundle schema (§9).
+          the existing evidence bundle schema.
+          Now landed in N6 §2.10 (External PR Evidence) and §3.1.1 (artifact types).
 - **N7**: N7 defines OPSV (operational policy synthesis for service fleets at
           runtime). N9 defines SDLC governance across repository fleets at
           development time. Both operate under the Fleet control plane but address
@@ -85,7 +89,8 @@ operational policies. N9's domain is PRs, reviews, CI checks, and merge readines
 
 ## 1. Terminology (N1 Extension)
 
-The following concepts MUST be added to N1 §2 (Core Domain Model) and §12 (Glossary).
+The following concepts are defined in N1 §2.19–§2.23 and §12 (Glossary).
+Detailed semantics are specified below.
 
 ### 1.1 External PR
 

--- a/specs/normative/N9-external-pr-integration.md
+++ b/specs/normative/N9-external-pr-integration.md
@@ -1,0 +1,815 @@
+# N9 — External PR Integration
+
+**Version:** 0.1.0-draft
+**Date:** 2026-02-07
+**Status:** Draft
+**Conformance:** MUST
+
+---
+
+## 0. Status and Scope
+
+### 0.1 Purpose
+
+This specification defines how Miniforge MUST ingest, model, evaluate, and
+(optionally) act on pull requests that were **not created by Miniforge**
+("external PRs"), providing the same monitoring, governance, and workflow
+benefits available to Miniforge-originated PRs.
+
+Miniforge already creates PRs as outputs of its workflow engine (Release phase,
+DAG task executor). This spec extends the system to treat **any** PR — from any
+author, in any connected repo — as a first-class work item inside the Fleet
+control plane.
+
+### 0.2 Relationship to N1–N8
+
+N9 is an extension of existing Miniforge normative contracts:
+
+- **N1**: introduces new concepts (External PR, PR Work Item, Provider, PR Train,
+          Readiness, Risk Assessment) as specializations of Workflow/Artifact/Evidence.
+          These MUST be added to N1 §2 and §12 (glossary).
+- **N2**: does NOT define new workflow phases; external PRs are not executed through
+          the Plan→Implement→Verify pipeline. However, external PRs MAY be
+          "adopted" into a Miniforge workflow (e.g., PR Monitoring), at which point
+          N2 applies.
+- **N3**: adds required event types for provider ingestion and PR state changes
+          as extensions to the event stream contract (§7 of this spec).
+- **N4**: defines how existing policy packs evaluate external PR diffs and how
+          policy results are published as provider-native signals (§8).
+- **N5**: defines CLI/TUI/API extensions for multi-repo PR monitoring, readiness
+          views, and train management (§12).
+- **N6**: defines how external PR assessments produce evidence artifacts using
+          the existing evidence bundle schema (§9).
+- **N7**: N7 defines OPSV (operational policy synthesis for service fleets at
+          runtime). N9 defines SDLC governance across repository fleets at
+          development time. Both operate under the Fleet control plane but address
+          different lifecycle stages. See §0.4 for disambiguation.
+- **N8**: N9's automation tiers are a specialization of N8's capability levels
+          (OBSERVE/ADVISE/CONTROL) scoped to provider interactions. See §10.
+
+### 0.3 Non-goals
+
+N9 SHALL NOT:
+
+- require running full Miniforge "spec→plan→implement" workflows for external PRs.
+- rebase or merge external PRs by default (requires explicit Tier 3 configuration).
+- define any particular UI implementation; only data contracts and event types.
+- replace or duplicate contracts already defined in N3, N4, N6, or N8.
+
+### 0.4 Fleet Mode Disambiguation
+
+The **Fleet control plane** is a shared coordination layer that hosts multiple
+fleet capabilities:
+
+| Capability | Spec | Lifecycle Stage | Target | Summary |
+|---|---|---|---|---|
+| Workflow orchestration | N2 | Development | Individual workflows | Phase graph execution |
+| Operational policy synthesis | N7 | Runtime | Service fleets | Scaling/sizing experiments |
+| Observability control | N8 | Cross-cutting | Agent fleets | Observe/advise/control |
+| **External PR integration** | **N9** | **Development** | **Repository fleets** | **PR monitoring & governance** |
+
+N7 answers: "How should these services scale at runtime?"
+N9 answers: "What is the state of all open PRs across our repos, and are they safe to merge?"
+
+Both share:
+
+- The Fleet API surface (N5 `fleet` namespace)
+- The event stream infrastructure (N3)
+- The evidence and provenance model (N6)
+- The policy evaluation engine (N4)
+
+They do NOT share domain models. N7's domain is experiments, scaling signals, and
+operational policies. N9's domain is PRs, reviews, CI checks, and merge readiness.
+
+---
+
+## 1. Terminology (N1 Extension)
+
+The following concepts MUST be added to N1 §2 (Core Domain Model) and §12 (Glossary).
+
+### 1.1 External PR
+
+An **External PR** is a pull request whose diff was created outside Miniforge's
+own authoring workflow. External PRs have no `:workflow/id` association unless
+explicitly adopted.
+
+### 1.2 PR Work Item
+
+A **PR Work Item** is the canonical internal model of a PR used by the Fleet
+control plane. All PRs — Miniforge-originated and external — MUST be represented
+as PR Work Items. This is distinct from N1's Workflow; a PR Work Item tracks
+provider state, not workflow execution state.
+
+### 1.3 Provider
+
+A **Provider** is an external code hosting platform (GitHub, GitLab, etc.) that
+is a source of PR events and state. Providers are analogous to N7's Environment
+Targets — they are external systems that Miniforge connects to but does not own.
+
+### 1.4 PR Train
+
+A **PR Train** is an ordered set of PR Work Items with explicit dependency
+relationships that MUST be merged in sequence. Trains are analogous to N2's DAG
+task dependencies, applied to PR merge ordering.
+
+### 1.5 Readiness
+
+**Readiness** is a deterministic assessment of whether a PR is ready to merge,
+computed from provider signals (CI, reviews, merge conflicts) and policy
+evaluation results.
+
+### 1.6 Risk Assessment
+
+A **Risk Assessment** is an explainable evaluation of change risk for a PR,
+produced as an evidence artifact (N6) with traceable factors.
+
+---
+
+## 2. PR Work Item Model
+
+### 2.1 Schema
+
+Fleet Mode MUST represent each PR as a PR Work Item with the following schema.
+All fields use Clojure namespaced keywords per N1 convention.
+
+```clojure
+{;; Identity
+ :pr/id uuid                          ; REQUIRED: stable internal id
+ :pr/provider keyword                 ; REQUIRED: :github, :gitlab, etc.
+ :pr/repo string                      ; REQUIRED: "org/name"
+ :pr/number long                      ; REQUIRED: provider PR number
+ :pr/external? boolean                ; REQUIRED: true if not Miniforge-originated
+
+ ;; Head/Base
+ :pr/head-sha string                  ; REQUIRED: current head commit SHA
+ :pr/base-ref string                  ; REQUIRED: target branch
+ :pr/head-ref string                  ; OPTIONAL: source branch
+
+ ;; Metadata
+ :pr/author string                    ; REQUIRED: PR author
+ :pr/title string                     ; REQUIRED: PR title
+ :pr/state keyword                    ; REQUIRED: :open, :closed, :merged
+ :pr/mergeable keyword                ; REQUIRED: :true, :false, :unknown
+ :pr/labels [string ...]              ; OPTIONAL: provider labels
+
+ ;; Timestamps
+ :pr/created-at inst                  ; REQUIRED
+ :pr/updated-at inst                  ; REQUIRED
+ :pr/last-seen-at inst                ; REQUIRED: last provider sync
+
+ ;; Provider Signals
+ :pr/checks                           ; REQUIRED: CI/check run summary
+ {:checks/overall keyword             ; :passing, :failing, :pending, :unknown
+  :checks/items [{:name string :status keyword :url string}]}
+
+ :pr/reviews                          ; REQUIRED: review state summary
+ {:reviews/overall keyword            ; :approved, :changes-requested, :pending, :unknown
+  :reviews/items [{:author string :state keyword :submitted-at inst}]}
+
+ :pr/threads                          ; OPTIONAL: unresolved discussion threads
+ {:threads/unresolved long
+  :threads/total long}
+
+ ;; Derived State (computed by N9)
+ :pr/readiness                        ; REQUIRED: see §2.2
+ {:readiness/state keyword
+  :readiness/blockers [...]}
+
+ :pr/risk                             ; REQUIRED: see §5
+ {:risk/level keyword
+  :risk/factors [...]
+  :risk/requires-human? boolean}
+
+ :pr/policy                           ; REQUIRED: see §8
+ {:policy/overall keyword             ; :pass, :fail, :unknown
+  :policy/results [...]}
+
+ ;; Automation
+ :pr/automation-tier keyword          ; REQUIRED: see §10
+
+ ;; Workflow Linkage (Miniforge PRs only)
+ :pr/workflow-id uuid                 ; OPTIONAL: absent for external PRs
+ :pr/dag-id uuid                      ; OPTIONAL: DAG run that produced this PR
+ :pr/task-id uuid}                    ; OPTIONAL: task that produced this PR
+```
+
+### 2.2 Readiness
+
+`:pr/readiness` MUST be computed deterministically from available signals.
+
+#### 2.2.1 Readiness State
+
+`:readiness/state` MUST be one of:
+
+| State | Condition |
+|---|---|
+| `:merge-ready` | All checks pass, approved, no conflicts, policy pass |
+| `:needs-review` | No reviews or insufficient approvals |
+| `:changes-requested` | At least one reviewer requested changes |
+| `:ci-failing` | One or more required checks failing |
+| `:policy-failing` | One or more policy pack rules failing |
+| `:merge-conflicts` | Provider reports merge conflict |
+| `:unknown` | Provider data incomplete (e.g., first sync) |
+
+#### 2.2.2 Blockers
+
+`:readiness/blockers` MUST be a vector of:
+
+```clojure
+{:blocker/type keyword                ; REQUIRED: :ci, :review, :policy, :conflict, :thread
+ :blocker/message string              ; REQUIRED: human-readable description
+ :blocker/source string               ; REQUIRED: what produced this blocker
+ :blocker/evidence-id uuid}           ; OPTIONAL: link to N6 evidence artifact
+```
+
+### 2.3 Compatibility with Miniforge-Originated PRs
+
+All Miniforge-originated PRs (from Release phase or DAG task executor) MUST also
+be represented as PR Work Items. For these PRs:
+
+- `:pr/external?` MUST be `false`
+- `:pr/workflow-id`, `:pr/dag-id`, `:pr/task-id` MUST be populated
+- The existing N3 PR lifecycle events (§3.10: `pr/opened`, `pr/merged`, etc.)
+  continue to be emitted for workflow correlation
+- N9 readiness/risk/policy are additive enrichments; they do NOT change
+  workflow phase semantics (N2)
+
+---
+
+## 3. Provider Ingestion
+
+### 3.1 Provider Model
+
+N9 implementations MUST support at least one provider. For GitHub-hosted repos,
+the RECOMMENDED implementation is a **GitHub App** for scalable multi-repo
+webhook delivery and token management.
+
+If not using a GitHub App, the system MUST provide equivalent:
+
+- webhook ingestion (or polling)
+- per-repo token management
+- rate limit handling
+
+### 3.2 Event Normalization
+
+Provider-native events (e.g., GitHub webhook payloads) MUST be normalized to
+canonical N3 event types before processing. The normalizer:
+
+- MUST map provider events to canonical types (§7)
+- MUST extract correlation fields (repo, PR number, head SHA)
+- MUST be idempotent: replayed provider events MUST NOT create duplicate state
+- MUST tolerate out-of-order delivery
+- MAY retain raw provider payload for debugging, subject to data minimization (§11.3)
+
+### 3.3 Reconciliation
+
+The system MUST reconcile PR Work Item state against provider state when
+inconsistencies are detected. Reconciliation polling SHOULD exist as a backstop
+for missed webhooks and MUST be bounded to avoid API abuse (see §6).
+
+---
+
+## 4. Multi-Repo Configuration
+
+### 4.1 Configuration Sources
+
+A repo MAY opt into external PR integration via:
+
+1. **Repo-local config:** `.miniforge/config.edn` (or equivalent) in the repository
+2. **Org-level defaults:** in Fleet control plane configuration
+
+Repo-local config MUST override org-level defaults.
+
+### 4.2 Required Configuration Keys
+
+```clojure
+{:external-pr/enabled? boolean        ; REQUIRED: opt-in to external PR monitoring
+
+ :external-pr/automation-tier keyword ; REQUIRED: see §10
+                                      ; default: :tier-1
+
+ :policies/enabled [string ...]       ; OPTIONAL: policy pack ids to evaluate
+                                      ; uses N4 policy pack identifiers
+
+ :policies/mode keyword               ; OPTIONAL: :advisory or :enforcing
+                                      ; default: :advisory
+
+ :notifications {...}                 ; OPTIONAL: routing and thresholds
+
+ :trains/enabled? boolean}            ; OPTIONAL: enable PR train support
+                                      ; default: false
+```
+
+### 4.3 Safe Defaults
+
+If external PR integration is enabled but `:policies/enabled` is not specified:
+
+- The system SHOULD apply a minimal default policy pack set in **advisory** mode.
+- The system MUST NOT publish enforcing checks without explicit configuration.
+
+---
+
+## 5. Risk Assessment (N6 Extension)
+
+Risk assessments MUST be produced as N6 evidence artifacts. They are NOT a
+separate evidence model — they use the existing `:evidence-bundle/*` schema
+with risk-specific content.
+
+### 5.1 Risk Artifact Schema
+
+```clojure
+{:artifact/id uuid
+ :artifact/type :risk-assessment       ; New artifact type for N6 §3.1.1
+ :artifact/content-hash string
+ :artifact/created-at inst
+
+ :artifact/content
+ {:risk/level keyword                  ; REQUIRED: :low, :medium, :high, :critical
+  :risk/factors                        ; REQUIRED: explainable factors
+  [{:factor/code keyword               ; e.g., :large-diff, :sensitive-paths, :no-tests
+    :factor/description string
+    :factor/evidence-refs [uuid ...]}] ; Links to other N6 artifacts
+
+  :risk/blast-radius string            ; REQUIRED: qualitative description
+  :risk/requires-human? boolean}       ; REQUIRED
+
+ :artifact/provenance
+ {:provenance/workflow-id uuid         ; OPTIONAL: nil for external PRs
+  :provenance/phase :external-pr-eval  ; Distinguishes from workflow phases
+  :provenance/agent :pr-evaluator
+  :provenance/created-at inst}}
+```
+
+Risk scoring MUST be explainable via `:factor/evidence-refs` and MUST NOT be a
+black-box number without factors.
+
+---
+
+## 6. Rate Limits, Backpressure, and Resilience
+
+- Provider API calls MUST be rate-limited and retried with exponential backoff.
+- Ingestion MUST queue work and MUST degrade gracefully under load.
+- Reconciliation polling SHOULD be bounded (e.g., one full sync per repo per
+  15 minutes maximum) to avoid API abuse.
+- If policy evaluation fails, the system MUST set `:policy/overall` to `:unknown`
+  and record a diagnostic evidence artifact (N6) explaining the failure.
+
+---
+
+## 7. Event Types (N3 Extension)
+
+N9 adds these event types to the N3 event stream. All events MUST use the N3
+event envelope (N3 §2) with standard required fields.
+
+### 7.1 Scope Key
+
+Because external PR events are not associated with a Miniforge workflow, the
+`:workflow/id` field in the N3 envelope MUST be handled as follows:
+
+- For Miniforge-originated PRs: `:workflow/id` MUST reference the originating workflow
+- For external PRs: `:workflow/id` MAY be nil. Events MUST instead include
+  `:pr/id` (the PR Work Item id) as a correlation key.
+
+Implementations MUST support subscribing to events by `:pr/id` in addition to
+`:workflow/id`.
+
+### 7.2 Provider Ingestion Events
+
+#### provider/event-received
+
+Emitted when a provider event is received and normalized.
+
+```clojure
+{:event/type :provider/event-received
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :pr/id uuid                          ; PR Work Item id (if PR-scoped)
+ :provider/type keyword               ; :github, :gitlab
+ :provider/event-type keyword         ; Canonical type that was mapped
+ :provider/repo string                ; "org/name"
+ :provider/pr-number long             ; OPTIONAL
+ :provider/head-sha string            ; OPTIONAL
+ :provider/dedupe-key string          ; For idempotency
+
+ :message "Provider event received: {type} for {repo}#{pr-number}"}
+```
+
+### 7.3 PR State Events
+
+These events are emitted when PR Work Item derived state changes. They are
+**derived-state-change events** — they fire when computation produces a new
+value, not on every provider event.
+
+#### pr.readiness/changed
+
+```clojure
+{:event/type :pr.readiness/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+
+ :readiness/previous-state keyword
+ :readiness/new-state keyword
+ :readiness/blockers [...]            ; Current blockers
+
+ :message "PR {repo}#{number} readiness: {previous} → {new}"}
+```
+
+#### pr.risk/changed
+
+```clojure
+{:event/type :pr.risk/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+
+ :risk/previous-level keyword
+ :risk/new-level keyword
+ :risk/factors [...]
+ :risk/evidence-id uuid               ; N6 artifact id
+
+ :message "PR {repo}#{number} risk: {previous} → {new}"}
+```
+
+#### pr.policy/changed
+
+```clojure
+{:event/type :pr.policy/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+
+ :policy/previous-overall keyword
+ :policy/new-overall keyword
+ :policy/results [...]
+ :policy/evidence-id uuid             ; N6 artifact id
+
+ :message "PR {repo}#{number} policy: {previous} → {new}"}
+```
+
+#### pr.state/changed
+
+```clojure
+{:event/type :pr.state/changed
+ :pr/id uuid
+ :pr/repo string
+ :pr/number long
+
+ :pr/previous-state keyword           ; :open, :closed, :merged
+ :pr/new-state keyword
+ :pr/head-sha string
+
+ :message "PR {repo}#{number} state: {previous} → {new}"}
+```
+
+### 7.4 Train Events
+
+#### train/changed
+
+```clojure
+{:event/type :train/changed
+ :train/id uuid
+ :train/members [uuid ...]            ; Ordered PR Work Item ids
+ :train/change-type keyword           ; :member-added, :member-removed,
+                                      ; :order-changed, :member-merged
+
+ :message "Train {id}: {change-type}"}
+```
+
+### 7.5 Event Ordering
+
+- Provider ingestion events MUST be idempotent per `:provider/dedupe-key`.
+- Derived-state-change events MUST only fire when computed state actually changes.
+- All events MUST conform to N3 §2.2 ordering guarantees where a workflow scope
+  exists. For external PRs (no workflow), events MUST be ordered per PR Work Item.
+
+---
+
+## 8. Policy Evaluation (N4 Extension)
+
+### 8.1 Evaluation Context
+
+External PRs are evaluated using existing N4 policy packs. The evaluation context
+differs from workflow gate evaluation:
+
+- **Artifacts:** The PR diff, file list, and metadata are presented as artifacts
+  to policy pack check functions (N4 §3.1).
+- **Context:** Instead of a workflow spec with declared intent, the context
+  contains PR metadata (author, repo, labels, base branch).
+- **No repair:** Policy evaluation for external PRs MUST NOT invoke repair
+  functions (N4 §3.2). External PRs are read-only unless adopted.
+
+### 8.2 Evaluation Triggers
+
+Policy evaluation MUST run on at least these provider events:
+
+- PR opened (new PR detected)
+- PR synchronized (new commits pushed)
+- Check run completed (CI results changed)
+- Configuration changed (repo `.miniforge/config.edn` updated)
+
+### 8.3 Policy Result
+
+`:pr/policy` uses the existing N4 violation schema (N4 §3.3) and MUST include:
+
+```clojure
+{:policy/overall keyword              ; :pass, :fail, :unknown
+ :policy/results
+ [{:rule/id string                    ; From N4 policy pack rule
+   :rule/outcome keyword              ; :pass, :fail, :warn, :skip, :unknown
+   :rule/message string               ; Human-readable, concise
+   :rule/evidence-id uuid}]           ; N6 artifact with full details
+
+ :policy/evaluated-at inst
+ :policy/packs-applied                ; Which packs ran
+ [{:policy-pack/id string
+   :policy-pack/version string}]}
+```
+
+### 8.4 Provider Feedback
+
+If `:policies/mode` is `:enforcing`, the system SHOULD publish outcomes as
+provider-native signals (e.g., GitHub Check Runs).
+
+If publishing provider-native checks, the system MUST:
+
+- use a stable check name per policy pack (e.g., `miniforge/terraform-aws`)
+- include a summary linking to evidence
+- respect automation tier constraints (§10)
+
+---
+
+## 9. Evidence (N6 Extension)
+
+External PR evaluations produce evidence using the existing N6 schema. N9 does
+NOT define a separate evidence model.
+
+### 9.1 New Artifact Types
+
+N6 §3.1.1 MUST be extended with:
+
+- `:risk-assessment` — Risk evaluation for a PR (see §5.1)
+- `:pr-policy-result` — Policy evaluation result for an external PR
+- `:pr-readiness-snapshot` — Point-in-time readiness assessment
+
+All artifacts MUST have `:artifact/content-hash`, `:artifact/provenance`, and
+`:artifact/created-at` per N6 §3.
+
+### 9.2 Evidence Immutability
+
+Evidence artifacts produced by N9 MUST be immutable and addressable per N6 §5.1.
+Policy results and risk factors MUST reference evidence artifacts, not inline
+their content.
+
+---
+
+## 10. Automation Tiers (N8 Specialization)
+
+N9's automation tiers are a **specialization** of N8's capability levels, scoped
+to provider interactions (writing comments, checks, reviews on external PRs).
+
+### 10.1 Mapping to N8
+
+| N9 Tier | N8 Level | Provider Permissions |
+|---|---|---|
+| **Tier 0 — Observe** | `OBSERVE` | No provider writes. Compute readiness/risk/policy internally only. |
+| **Tier 1 — Advise** | `ADVISE` | MAY publish non-blocking advisory checks. MAY comment when explicitly requested (e.g., `/miniforge summarize`). |
+| **Tier 2 — Converse** | `ADVISE` + scoped interaction | MAY respond to questions when bot is mentioned or command is used. MUST NOT approve, request changes, or merge. |
+| **Tier 3 — Govern** | `CONTROL` | MAY publish enforcing checks. MAY request changes. MAY manage trains and merge orchestration if configured. MUST log all actions per N8 §3.2 and §11. |
+
+### 10.2 Tier Constraints
+
+- Default tier SHOULD be Tier 1 for external PRs.
+- Tier MUST be configured per repo via §4.2.
+- Tier 3 MUST implement a per-repo allowlist of permitted actions
+  (comment/review/check/merge) per N8 §2.3 RBAC requirements.
+- All provider write actions at Tier 1+ MUST be audit-logged (§11).
+
+### 10.3 Tier Escalation
+
+Moving from a lower tier to a higher tier MUST require explicit configuration
+change. The system MUST NOT auto-escalate tiers based on heuristics.
+
+---
+
+## 11. Audit and Security
+
+### 11.1 Audit Log (N8 Extension)
+
+All provider write actions MUST be logged using the N8 control action evidence
+schema (N8 §11.1), extended with:
+
+```clojure
+{:action/id uuid
+ :action/type keyword                 ; :comment, :check-publish, :review,
+                                      ; :merge, :label, :re-request-review
+ :action/timestamp inst
+ :action/actor string                 ; System identity
+ :action/target
+ {:pr/repo string
+  :pr/number long
+  :pr/id uuid}                        ; PR Work Item id
+
+ :action/inputs {...}                 ; Redacted as needed
+ :action/result {:status keyword}
+ :action/reason                       ; REQUIRED: why this action was taken
+ {:policy/evidence-id uuid            ; Link to policy result evidence
+  :readiness/evidence-id uuid         ; Link to readiness evidence
+  :human-request? boolean}}           ; Was this triggered by a human command?
+```
+
+### 11.2 Secrets and Tokens
+
+- Provider tokens/credentials MUST be stored encrypted at rest.
+- The system MUST support key rotation without downtime.
+- Token scopes MUST be minimized to required permissions per tier.
+
+### 11.3 Data Minimization
+
+- Raw provider payload storage SHOULD be optional and time-bounded.
+- Evidence artifacts MUST NOT include secrets; secret redaction MUST be enforced
+  prior to persistence (per N6 §7.2).
+
+---
+
+## 12. CLI/TUI/API Extensions (N5 Extension)
+
+### 12.1 CLI Commands
+
+N5 §2.2 `fleet` namespace MUST be extended with:
+
+```bash
+# PR monitoring
+mf fleet prs [flags]                  # List PR Work Items across repos
+  --repo REPO                         # Filter by repo
+  --author AUTHOR                     # Filter by author
+  --readiness STATE                   # Filter by readiness state
+  --risk LEVEL                        # Filter by risk level
+  --policy OUTCOME                    # Filter by policy outcome
+  --json                              # Output as JSON
+
+mf fleet pr REPO#NUMBER [flags]       # Show PR Work Item detail
+  --evidence                          # Include evidence artifact pointers
+  --json                              # Output as JSON
+
+# Train management (if trains enabled)
+mf fleet trains [flags]               # List active trains
+mf fleet train TRAIN_ID [flags]       # Show train detail and membership
+```
+
+### 12.2 TUI Extensions
+
+The TUI (N5 §3) SHOULD provide:
+
+- **PR Fleet View:** List of PR Work Items across repos with readiness/risk
+  columns, sortable and filterable
+- **PR Detail View:** Readiness blockers, risk factors, policy results with
+  drill-down to evidence artifacts
+- **Train View:** Ordered train members with merge readiness status
+
+These views derive from the event stream (N3) and PR Work Item state — they
+are projections, not separate data models (same principle as N5 §3.2.5 DAG
+Kanban View).
+
+### 12.3 Fleet API Extensions
+
+N5 §4.2 Fleet API MUST be extended with:
+
+```text
+GET /api/fleet/prs
+  Query params: ?repo=org/name&readiness=merge-ready&risk=high
+  Returns: List of PR Work Items
+
+GET /api/fleet/prs/:pr-id
+  Returns: PR Work Item with evidence pointers
+
+GET /api/fleet/trains
+  Returns: List of active trains
+
+GET /api/fleet/trains/:train-id
+  Returns: Train detail with ordered members
+```
+
+### 12.4 Event Stream Subscriptions
+
+The Fleet event stream (N3 §5, N5 §4.2.2) MUST support subscription filters for
+N9 event types, enabling clients to subscribe to:
+
+- All PR state changes across repos
+- Readiness changes for specific repos
+- Policy changes for specific policy packs
+
+---
+
+## 13. PR Trains
+
+If `:trains/enabled?` is `true` in repo configuration:
+
+### 13.1 Dependency Declaration
+
+The system MUST support explicit dependency declaration via:
+
+- **Labels:** e.g., `train:<train-id>` on provider PRs
+- **PR body directives:** e.g., `depends-on: org/repo#123`
+
+The system MAY infer soft ordering suggestions, but MUST NOT enforce inferred
+dependencies without explicit declaration.
+
+### 13.2 Train Schema
+
+```clojure
+{:train/id uuid                       ; REQUIRED: stable train identifier
+ :train/members                       ; REQUIRED: ordered PR Work Item refs
+ [{:pr/id uuid
+   :pr/repo string
+   :pr/number long
+   :train/position long}]             ; 1-indexed merge order
+
+ :train/policy                        ; REQUIRED
+ {:train/merge-strategy keyword       ; :sequential, :batch
+  :train/required-readiness keyword   ; Minimum readiness for merge
+  :train/auto-merge? boolean}}        ; Requires Tier 3
+```
+
+### 13.3 Train Operations
+
+- Train merge orchestration MUST respect automation tier constraints (Tier 3
+  required for automated merge sequencing).
+- Train membership changes MUST emit `:train/changed` events (§7.4).
+- Train operations MUST be audit-logged (§11).
+
+---
+
+## 14. Versioning
+
+- PR Work Item schema, N9 event types, and API extensions MUST be versioned.
+- Breaking changes MUST increment a major version and MUST be supported in
+  parallel for at least one deprecation cycle.
+- Version is tracked in the N3 event envelope `:event/version` field.
+
+---
+
+## 15. Minimal Compliant Implementation (MCI)
+
+A minimal compliant N9 implementation MUST:
+
+1. Support at least one provider (GitHub recommended)
+2. Normalize provider events to N3 canonical event types (§7)
+3. Represent PRs as PR Work Items with readiness computation (§2)
+4. Evaluate at least one policy pack against external PR diffs (§8)
+5. Produce evidence artifacts per N6 (§9)
+6. Support Tier 0 and Tier 1 automation (§10)
+7. Provide CLI command `mf fleet prs` for listing PR Work Items (§12)
+8. Audit-log all provider write actions (§11)
+
+A minimal compliant implementation MAY defer:
+
+- Tier 2 and Tier 3 automation
+- PR trains
+- Multi-provider support
+- Risk assessment beyond basic diff-size heuristics
+- TUI views (CLI-only is sufficient for MCI)
+
+---
+
+## 16. Packaging Guidance (Informative)
+
+A common pattern that preserves adoption while capturing value:
+
+**Include in core (OSS-friendly):**
+
+- PR Work Item modeling and readiness computation
+- Basic multi-repo monitoring (Tier 0–1)
+- Risk and readiness summaries via CLI
+- Advisory policy evaluation (`:policies/mode :advisory`)
+
+**Charge for (clear willingness-to-pay):**
+
+- GitHub App managed auth/SSO/RBAC for multi-org
+- Enforcing policy checks at scale + evidence retention/analytics
+- PR trains and merge orchestration (Tier 3)
+- Tier 2–3 automation (conversational + governance) with audit
+- Web dashboard PR fleet views + notifications + cross-org aggregation
+- Compliance/reporting exports and long-term evidence retention
+
+---
+
+## 17. References
+
+- **N1**: Core Architecture & Concepts — new concepts land here
+- **N3**: Event Stream & Observability — event envelope and PR lifecycle events
+- **N4**: Policy Packs & Gates — policy evaluation contract
+- **N5**: CLI/TUI/API — command surface and TUI views
+- **N6**: Evidence & Provenance — evidence artifacts and provenance
+- **N7**: Operational Policy Synthesis — Fleet Mode disambiguation
+- **N8**: Observability Control Interface — capability levels and audit
+- **RFC 2119**: Requirement level keywords
+
+---
+
+**Version History:**
+
+- 0.1.0-draft (2026-02-07): Initial external PR integration specification


### PR DESCRIPTION
## Summary

- Add **N9 — External PR Integration** normative specification
- Update `SPEC_INDEX.md` with N9 entry
- **Amend all core specs (N1–N6) with extension contracts from N7, N8, N9**
  - N1: 13 new domain concepts (§2.11–§2.23), expanded glossary (24 terms)
  - N3: 21 new event types across 3 subsystems (§3.13–§3.15), scope key (§2.3)
  - N4: 3 new standard policy packs (§5.1.5–§5.1.7)
  - N5: CLI commands, 5 TUI views (§3.2.6–§3.2.10), Fleet PR API (§4.2.4)
  - N6: 3 evidence sections (§2.8–§2.10), 9 artifact types
- Update N7, N8, N9 cross-references to point to new core spec sections
- Fix pre-existing markdownlint errors in N4 and N5

## Details

The extension specs (N7 Operational Policy Synthesis, N8 Observability Control Interface, N9 External PR Integration) each declare contracts that belong in core specs. This PR lands all those contracts inline rather than leaving them as forward-references.

Total: ~1000 lines added across 8 normative spec files.

## Test plan

- [x] All 37 unit tests pass (`bb test`)
- [x] GraalVM compatibility tests pass (`bb test:graalvm`)
- [x] Markdownlint passes on all 8 modified files
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)