### PR TITLE
feat: LSP management tasks and lint cleanup

### DIFF
--- a/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/tasks.clj
+++ b/bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/tasks.clj
@@ -1,0 +1,252 @@
+(ns ai.miniforge.lsp-mcp-bridge.tasks
+  "bb task implementations for LSP server management.
+
+   Provides CLI commands for installing LSP servers and configuring
+   Claude Code / Claude Desktop to use the miniforge LSP-MCP bridge.
+
+   Layer 0: Name resolution and display helpers
+   Layer 1: lsp:status — show installed/available LSP servers
+   Layer 2: lsp:install — install LSP servers
+   Layer 3: lsp:setup — generate MCP config for Claude Code / Claude Desktop"
+  (:require
+   [ai.miniforge.lsp-mcp-bridge.config :as config]
+   [ai.miniforge.lsp-mcp-bridge.installer :as installer]
+   [ai.miniforge.response.interface :as response]
+   [babashka.fs :as fs]
+   [cheshire.core :as json]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Name resolution and display helpers
+
+(defn- build-name-index
+  "Build lookup from user-friendly names to registry server entries.
+
+   Accepts short language names (clojure, typescript, go) and exact
+   registry keys (clojure-lsp, gopls, pyright). Case-insensitive."
+  [registry]
+  (reduce-kv
+   (fn [idx server-key entry]
+     (let [tool-id-name (name (:tool-id entry))
+           server-key-str (name server-key)]
+       (-> idx
+           (assoc (str/lower-case tool-id-name) {:server-key server-key :entry entry})
+           (assoc (str/lower-case server-key-str) {:server-key server-key :entry entry}))))
+   {}
+   (:servers registry)))
+
+(defn- resolve-server-names
+  "Resolve CLI arg names to server entries.
+   Returns seq of {:server-key :entry} or prints error for unknown names."
+  [registry names]
+  (let [idx (build-name-index registry)]
+    (keep (fn [n]
+            (let [n (str/lower-case n)]
+              (if-let [found (get idx n)]
+                found
+                (do (println (str "  Unknown LSP server: " n))
+                    (println (str "  Available: "
+                                  (str/join ", " (sort (map #(name (-> % val :tool-id))
+                                                            (:servers registry))))))
+                    nil))))
+          names)))
+
+(defn- all-server-entries
+  "Get all server entries from the registry."
+  [registry]
+  (map (fn [[k v]] {:server-key k :entry v})
+       (:servers registry)))
+
+(defn- method-label
+  "Human-readable label for an install method."
+  [entry]
+  (case (or (:install-method entry) :github)
+    :github     "github release"
+    :npm        "npm"
+    :go-install "go install"
+    :custom     "manual install"
+    (name (or (:install-method entry) :github))))
+
+(defn- pad
+  "Right-pad a string to the given width."
+  [s width]
+  (str s (apply str (repeat (max 1 (- width (count s))) " "))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; lsp:status — show installed/available LSP servers
+
+(defn status
+  "Show installation status of all LSP servers."
+  []
+  (let [cfg (config/load-config)
+        registry (:registry cfg)
+        platform (installer/platform-key)]
+    (println (str "LSP Server Status (platform: " platform ")"))
+    (println (apply str (repeat 55 "\u2500")))
+    (doseq [[server-key entry] (sort-by key (:servers registry))]
+      (let [binary (:binary entry)
+            resolved (installer/resolve-binary binary)]
+        (if resolved
+          (println (str "  \u2713 " (pad (name server-key) 30) resolved))
+          (println (str "  \u2717 " (pad (name server-key) 30)
+                        "not installed (" (method-label entry) ")")))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; lsp:install — install LSP servers
+
+(defn install
+  "Install LSP servers. With no args, installs all enabled servers.
+   With args, installs only the named servers.
+
+   Arguments:
+   - args - Command-line args (server names or empty for all)"
+  [args]
+  (let [cfg (config/load-config)
+        registry (:registry cfg)
+        targets (if (seq args)
+                  (resolve-server-names registry args)
+                  (all-server-entries registry))]
+    (when (empty? targets)
+      (println "No LSP servers to install.")
+      (System/exit 1))
+    (println (str "Installing " (count targets) " LSP server(s)...\n"))
+    (let [results
+          (doall
+           (for [{:keys [entry]} targets]
+             (let [binary (:binary entry)
+                   tool-id (:tool-id entry)
+                   resolved (installer/resolve-binary binary)]
+               (if resolved
+                 (do (println (str "  \u2713 " (name tool-id) " already installed (" resolved ")"))
+                     :already-installed)
+                 (do (print (str "  \u2026 Installing " (name tool-id) "..."))
+                     (flush)
+                     (let [result (installer/ensure-installed registry tool-id [binary])]
+                       (if (response/anomaly-map? result)
+                         (do (println (str "\r  \u2717 " (name tool-id) " failed: "
+                                          (:anomaly/message result)))
+                             :failed)
+                         (do (println (str "\r  \u2713 " (name tool-id) " installed ("
+                                          (first (:command result)) ")"))
+                             :installed))))))))]
+      (println)
+      (let [freqs (frequencies results)]
+        (println (str "Done: "
+                      (get freqs :installed 0) " installed, "
+                      (get freqs :already-installed 0) " already present, "
+                      (get freqs :failed 0) " failed"))
+        (when (pos? (get freqs :failed 0))
+          (System/exit 1))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; lsp:setup — generate MCP config for Claude Code / Claude Desktop
+
+(defn- project-dir
+  "Get the absolute project directory."
+  []
+  (System/getProperty "user.dir"))
+
+(defn- mcp-server-entry-claude-code
+  "Build MCP server config for Claude Code CLI (.mcp.json)."
+  []
+  {"command" "bb"
+   "args"    ["lsp-mcp-bridge"]
+   "env"     {"MINIFORGE_PROJECT_DIR" "."}})
+
+(defn- mcp-server-entry-claude-desktop
+  "Build MCP server config for Claude Desktop."
+  []
+  (let [dir (project-dir)]
+    {"command" "bb"
+     "args"    ["--file" (str dir "/bb.edn") "lsp-mcp-bridge"]
+     "cwd"     dir
+     "env"     {"MINIFORGE_PROJECT_DIR" dir}}))
+
+(defn- claude-desktop-config-path
+  "Path to Claude Desktop config file."
+  []
+  (let [platform (installer/platform-key)]
+    (if (str/starts-with? platform "macos")
+      (str (fs/home) "/Library/Application Support/Claude/claude_desktop_config.json")
+      (str (fs/home) "/.config/Claude/claude_desktop_config.json"))))
+
+(defn- read-json-file
+  "Read and parse a JSON file. Returns {} if missing or invalid."
+  [path]
+  (if (fs/exists? path)
+    (try (json/parse-string (slurp path))
+         (catch Exception _ {}))
+    {}))
+
+(defn- write-json-file
+  "Write data as formatted JSON to a file."
+  [path data]
+  (spit path (json/generate-string data {:pretty true}))
+  (println (str "  Wrote: " path)))
+
+(defn- setup-claude-code
+  "Write or update .mcp.json in the project root for Claude Code CLI."
+  []
+  (let [path (str (project-dir) "/.mcp.json")
+        existing (read-json-file path)
+        servers (get existing "mcpServers" {})
+        updated (assoc existing
+                       "mcpServers" (assoc servers
+                                          "miniforge-lsp" (mcp-server-entry-claude-code)))]
+    (write-json-file path updated)
+    (println "  Claude Code configured. Restart Claude Code to pick up changes.")))
+
+(defn- setup-claude-desktop
+  "Merge miniforge-lsp entry into Claude Desktop config."
+  []
+  (let [path (claude-desktop-config-path)]
+    (if-not (fs/exists? path)
+      (println (str "  Claude Desktop config not found at: " path
+                    "\n  Is Claude Desktop installed?"))
+      (let [existing (read-json-file path)
+            servers (get existing "mcpServers" {})
+            updated (assoc existing
+                           "mcpServers" (assoc servers
+                                              "miniforge-lsp" (mcp-server-entry-claude-desktop)))]
+        (write-json-file path updated)
+        (println "  Claude Desktop configured. Restart Claude Desktop to pick up changes.")))))
+
+(defn- print-config-preview
+  "Print what the MCP configs would look like, without writing anything."
+  []
+  (println "\nClaude Code CLI (.mcp.json):")
+  (println (json/generate-string
+            {"mcpServers" {"miniforge-lsp" (mcp-server-entry-claude-code)}}
+            {:pretty true}))
+  (println "\nClaude Desktop (claude_desktop_config.json):")
+  (println (json/generate-string
+            {"mcpServers" {"miniforge-lsp" (mcp-server-entry-claude-desktop)}}
+            {:pretty true}))
+  (println "\nRun with --claude-code or --claude-desktop to write config files."))
+
+(defn setup
+  "Generate MCP config for Claude Code and/or Claude Desktop.
+
+   Arguments:
+   - args - Command-line args (--claude-code, --claude-desktop, or empty for preview)"
+  [args]
+  (let [args-set (set args)]
+    (cond
+      (contains? args-set "--claude-code")
+      (setup-claude-code)
+
+      (contains? args-set "--claude-desktop")
+      (setup-claude-desktop)
+
+      :else
+      (print-config-preview))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (status)
+  (install [])
+  (install ["clojure"])
+  (setup [])
+  (setup ["--claude-code"])
+
+  :leave-this-here)

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/lsp/client_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/lsp/client_test.clj
@@ -1,8 +1,7 @@
 (ns ai.miniforge.lsp-mcp-bridge.lsp.client-test
   "Tests for LSP client (promise-based, bb-compatible)."
   (:require
-   [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.lsp-mcp-bridge.lsp.protocol :as proto]))
+   [clojure.test :refer [deftest is testing]]))
 
 ;; Note: Full client tests require a running LSP server.
 ;; These tests verify the protocol layer and message building

--- a/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/lsp/protocol_test.clj
+++ b/bases/lsp-mcp-bridge/test/ai/miniforge/lsp_mcp_bridge/lsp/protocol_test.clj
@@ -2,8 +2,7 @@
   "Tests for LSP JSON-RPC protocol layer (Content-Length framing)."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.lsp-mcp-bridge.lsp.protocol :as proto]
-   [cheshire.core :as json])
+   [ai.miniforge.lsp-mcp-bridge.lsp.protocol :as proto])
   (:import
    [java.io BufferedReader BufferedWriter StringReader StringWriter]))
 

--- a/bb.edn
+++ b/bb.edn
@@ -490,6 +490,30 @@
    :requires ([ai.miniforge.lsp-mcp-bridge.main :as bridge])
    :task    (bridge/-main)}
 
+  lsp:status
+  {:doc     "Show installed/available LSP servers"
+   :extra-paths ["bases/lsp-mcp-bridge/src"
+                 "components/tool-registry/resources"
+                 "components/response/src"]
+   :requires ([ai.miniforge.lsp-mcp-bridge.tasks :as tasks])
+   :task    (tasks/status)}
+
+  lsp:install
+  {:doc     "Install LSP servers (all or specific: bb lsp:install clojure typescript)"
+   :extra-paths ["bases/lsp-mcp-bridge/src"
+                 "components/tool-registry/resources"
+                 "components/response/src"]
+   :requires ([ai.miniforge.lsp-mcp-bridge.tasks :as tasks])
+   :task    (tasks/install *command-line-args*)}
+
+  lsp:setup
+  {:doc     "Generate MCP config for Claude Code/Desktop (--claude-code or --claude-desktop)"
+   :extra-paths ["bases/lsp-mcp-bridge/src"
+                 "components/tool-registry/resources"
+                 "components/response/src"]
+   :requires ([ai.miniforge.lsp-mcp-bridge.tasks :as tasks])
+   :task    (tasks/setup *command-line-args*)}
+
   ;; ──────────────────────────────────────────────────────────────────────────
   ;; CLI Development
   ;; ──────────────────────────────────────────────────────────────────────────

--- a/components/phase/test/ai/miniforge/phase/handoff_test.clj
+++ b/components/phase/test/ai/miniforge/phase/handoff_test.clj
@@ -7,10 +7,15 @@
   Mocks all agent invocations to focus purely on the handoff plumbing."
   (:require
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.phase.plan :as plan]
-   [ai.miniforge.phase.implement :as implement]
-   [ai.miniforge.phase.verify :as verify]
-   [ai.miniforge.phase.release :as release]
+   ;; Required for defmethod side effects (register phase handlers)
+   #_{:clj-kondo/ignore [:unused-namespace]}
+   [ai.miniforge.phase.plan]
+   #_{:clj-kondo/ignore [:unused-namespace]}
+   [ai.miniforge.phase.implement]
+   #_{:clj-kondo/ignore [:unused-namespace]}
+   [ai.miniforge.phase.verify]
+   #_{:clj-kondo/ignore [:unused-namespace]}
+   [ai.miniforge.phase.release]
    [ai.miniforge.phase.registry :as registry]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.response.interface :as response]
@@ -214,14 +219,14 @@
             ctx2 (execute-phase-leave :implement ctx1)
 
             ;; Add worktree-path for release executor
-            ctx2-with-path (assoc ctx2 :worktree-path "/tmp/test-repo")]
+            ctx2-with-path (assoc ctx2 :worktree-path "/tmp/test-repo")
 
-        ;; Execute release phase - should read code from execution context
-        (let [ctx3 (execute-phase-enter :release ctx2-with-path)]
-          (is (= :success (get-in ctx3 [:phase :result :status]))
-              "Release phase should succeed")
-          (is (some? (get-in ctx3 [:phase :result :output]))
-              "Release phase should produce release artifact"))))))
+            ;; Execute release phase - should read code from execution context
+            ctx3 (execute-phase-enter :release ctx2-with-path)]
+        (is (= :success (get-in ctx3 [:phase :result :status]))
+            "Release phase should succeed")
+        (is (some? (get-in ctx3 [:phase :result :output]))
+            "Release phase should produce release artifact")))))
 
 (deftest full-pipeline-handoff-test
   (testing "Artifacts flow correctly through entire pipeline: plan → implement → verify → release"
@@ -289,7 +294,7 @@
   (testing "Verify phase handles missing implement artifact"
     (with-redefs [agent/create-tester (fn [_] {:type :mock-tester})
                   ;; Mock that doesn't assert on missing artifacts
-                  agent/invoke (fn [_agent task _ctx]
+                  agent/invoke (fn [_agent _task _ctx]
                                  ;; Just return success without assertions
                                  (response/success {:result :ok} {:tokens 0 :duration-ms 0}))]
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/integration_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/integration_test.clj
@@ -6,7 +6,11 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.pr-lifecycle.controller :as controller]
-   [ai.miniforge.pr-lifecycle.events :as events]
+   ;; Required for with-redefs targets
+   #_{:clj-kondo/ignore [:unused-namespace]}
+   [ai.miniforge.pr-lifecycle.merge]
+   #_{:clj-kondo/ignore [:unused-namespace]}
+   [ai.miniforge.release-executor.interface]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Mock Data
@@ -46,7 +50,7 @@
 (defn mock-release-executor
   "Mock release executor that simulates PR creation."
   [success?]
-  (fn [workflow-state exec-context opts]
+  (fn [_workflow-state _exec-context _opts]
     (if success?
       {:success? true
        :artifacts [{:artifact/type :release
@@ -60,7 +64,7 @@
   "Mock CI monitor that returns predefined CI status."
   [ci-results-seq]
   (let [results (atom ci-results-seq)]
-    (fn [repo-path pr-number]
+    (fn [_repo-path _pr-number]
       (let [result (first @results)]
         (swap! results rest)
         result))))
@@ -69,7 +73,7 @@
   "Mock review monitor that returns predefined review status."
   [review-results-seq]
   (let [results (atom review-results-seq)]
-    (fn [repo-path pr-number]
+    (fn [_repo-path _pr-number]
       (let [result (first @results)]
         (swap! results rest)
         result))))
@@ -77,7 +81,7 @@
 (defn mock-merge-operation
   "Mock merge operation."
   [success?]
-  (fn [repo-path pr-number merge-policy]
+  (fn [_repo-path _pr-number merge-policy]
     (if success?
       {:success? true
        :merged-sha "def789abc123"
@@ -88,7 +92,7 @@
 (defn mock-fix-generator
   "Mock fix generator that returns a code artifact."
   [success?]
-  (fn [task error-details context]
+  (fn [_task error-details _context]
     (if success?
       (response/success
        {:code/id (random-uuid)
@@ -112,11 +116,8 @@
 
 (defn create-test-controller
   "Create a controller with mocked dependencies."
-  [& {:keys [generate-fn ci-monitor-fn review-monitor-fn merge-fn]
-      :or {generate-fn (mock-fix-generator true)
-           ci-monitor-fn (mock-ci-monitor [mock-ci-success])
-           review-monitor-fn (mock-review-monitor [mock-review-approved])
-           merge-fn (mock-merge-operation true)}}]
+  [& {:keys [generate-fn _ci-monitor-fn _review-monitor-fn _merge-fn]
+      :or {generate-fn (mock-fix-generator true)}}]
   (let [event-collector (collect-events)]
     {:controller (controller/create-controller
                   "test-dag" "test-run" "test-task" mock-task
@@ -197,9 +198,9 @@
 
 (deftest ci-failure-triggers-fix-loop-test
   (testing "CI failure triggers fix loop"
-    (let [{:keys [controller events]} (create-test-controller
-                                       :ci-monitor-fn (mock-ci-monitor [mock-ci-failure])
-                                       :generate-fn (mock-fix-generator true))]
+    (let [{:keys [controller]} (create-test-controller
+                                :ci-monitor-fn (mock-ci-monitor [mock-ci-failure])
+                                :generate-fn (mock-fix-generator true))]
 
       ;; Set up controller with PR created
       (simulate-pr-creation! controller mock-pr-info)
@@ -349,7 +350,7 @@
 
 (deftest full-happy-path-simulation-test
   (testing "Full lifecycle: PR → CI pass → Review approve → Merge"
-    (let [{:keys [controller events]} (create-test-controller)]
+    (let [{:keys [controller]} (create-test-controller)]
 
       ;; 1. Start in pending state
       (is (= :pending (get-status controller)))

--- a/components/response/test/ai/miniforge/response/interface_test.clj
+++ b/components/response/test/ai/miniforge/response/interface_test.clj
@@ -2,6 +2,7 @@
   "Tests for the response component."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [clojure.string :as str]
    [ai.miniforge.response.interface :as r]))
 
 ;; ============================================================================
@@ -425,7 +426,7 @@
 
   (testing "never exposes internal message"
     (let [anom (r/make-anomaly :anomalies/fault "NullPointerException at foo.clj:42")]
-      (is (not (clojure.string/includes? (r/anomaly->user-message anom) "NullPointer")))))
+      (is (not (str/includes? (r/anomaly->user-message anom) "NullPointer")))))
 
   (testing "falls back to generic message for unknown categories"
     (let [anom (r/make-anomaly :anomalies.custom/something "internal detail")]


### PR DESCRIPTION
## Summary
- Add `bb lsp:status`, `bb lsp:install`, and `bb lsp:setup` tasks for managing LSP servers and configuring Claude Code CLI / Claude Desktop
- Fix all 31 pre-existing clj-kondo warnings across bridge, phase, pr-lifecycle, and response test files

## Test plan
- [x] `bb lsp:status` prints server table with ✓/✗ indicators
- [x] `bb lsp:install clojure` reports "already installed"
- [x] `bb lsp:setup` previews MCP config JSON
- [x] `bb lint:clj:all` — 0 errors, 0 warnings
- [x] Pre-commit hooks pass (lint + poly test + bb compatibility)

🤖 Generated with [Claude Code](https://claude.com/claude-code)