### PR TITLE
fix: add missing dev classpath entries

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -20,6 +20,8 @@
                        "components/agent/resources"
                        "components/task/src"
                        "components/task/resources"
+                       "components/task-executor/src"
+                       "components/task-executor/resources"
                        "components/loop/src"
                        "components/loop/resources"
                        "components/knowledge/src"
@@ -67,6 +69,8 @@
                        "components/tui-engine/resources"
                        "components/tui-views/src"
                        "components/tui-views/resources"
+                       "components/web-dashboard/src"
+                       "components/web-dashboard/resources"
                        "bases/cli/src"
                        "bases/cli/resources"
                        "bases/lsp-mcp-bridge/src"]
@@ -79,6 +83,7 @@
                       ai.miniforge/artifact {:local/root "components/artifact"}
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/task {:local/root "components/task"}
+                      ai.miniforge/task-executor {:local/root "components/task-executor"}
                       ai.miniforge/loop {:local/root "components/loop"}
                       ai.miniforge/knowledge {:local/root "components/knowledge"}
                       ai.miniforge/policy {:local/root "components/policy"}
@@ -103,6 +108,7 @@
                      ai.miniforge/event-stream {:local/root "components/event-stream"}
                      ai.miniforge/tui-engine {:local/root "components/tui-engine"}
                      ai.miniforge/tui-views {:local/root "components/tui-views"}
+                     ai.miniforge/web-dashboard {:local/root "components/web-dashboard"}
                      ai.miniforge/cli {:local/root "bases/cli"}}}
 
   :test {:extra-paths ["development/test"

--- a/docs/pull-requests/2026-02-09-fix-graalvm-dev-classpath.md
+++ b/docs/pull-requests/2026-02-09-fix-graalvm-dev-classpath.md
@@ -1,0 +1,33 @@
+# fix: include missing dev classpath entries
+
+## Overview
+
+Adds the task-executor and web-dashboard components to the dev classpath so
+GraalVM/Babashka compatibility tests no longer warn.
+
+## Motivation
+
+Pre-commit GraalVM checks warned that these components were not present on the :dev
+classpath. Keeping the dev alias complete avoids noisy warnings and catches dev-only
+integration issues sooner.
+
+## Changes in Detail
+
+- Add task-executor and web-dashboard component paths to the :dev alias in deps.edn.
+
+## Testing Plan
+
+- `bb test` (pre-commit) already runs GraalVM compatibility tests.
+
+## Deployment Plan
+
+- No deployment changes.
+
+## Related Issues/PRs
+
+- Addresses GraalVM warnings emitted during pre-commit in PR #149.
+
+## Checklist
+
+- [ ] Confirm GraalVM warnings are gone.
+- [ ] Verify :dev alias still resolves.


### PR DESCRIPTION
# fix: include missing dev classpath entries

## Overview

Adds the task-executor and web-dashboard components to the dev classpath so
GraalVM/Babashka compatibility tests no longer warn.

## Motivation

Pre-commit GraalVM checks warned that these components were not present on the :dev
classpath. Keeping the dev alias complete avoids noisy warnings and catches dev-only
integration issues sooner.

## Changes in Detail

- Add task-executor and web-dashboard component paths to the :dev alias in deps.edn.

## Testing Plan

- `bb test` (pre-commit) already runs GraalVM compatibility tests.

## Deployment Plan

- No deployment changes.

## Related Issues/PRs

- Addresses GraalVM warnings emitted during pre-commit in PR #149.

## Checklist

- [ ] Confirm GraalVM warnings are gone.
- [ ] Verify :dev alias still resolves.
