### PR TITLE
feat: detect already-implemented work via file context and agent-behavior injection

### DIFF
--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -89,5 +89,18 @@ You must output a structured code artifact as a Clojure map:
    - Use transducers when transforming collections
    - Consider memory implications of data structures
 
+## Already-Implemented Response
+
+If the task is already fully implemented in the existing files provided to you,
+do NOT generate new code. Instead, output:
+
+```clojure
+{:status :already-implemented
+ :summary \"Brief explanation: what exists, why no changes are needed\"}
+```
+
+Only use this when ALL acceptance criteria are already met by existing code.
+If even partial changes are needed, proceed with normal code generation.
+
 Remember: Your code will be validated, tested, and reviewed by other agents.
 Write code that is easy to understand, test, and maintain."}

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -94,15 +94,44 @@
           "rs" "rust"
           most-common))))
 
+(defn- format-existing-files
+  "Format existing file contents for inclusion in the user prompt.
+
+   Arguments:
+   - files - Vector of {:path :content :truncated? :lines} maps
+
+   Returns:
+   - Formatted markdown string, or nil if no files"
+  [files]
+  (when (seq files)
+    (str "\n\n## Existing Files in Scope\n\n"
+         "The following files already exist. Review them before generating code.\n"
+         (->> files
+              (map (fn [{:keys [path content truncated?]}]
+                     (str "\n### " path
+                          (when truncated? " (truncated)")
+                          "\n```\n" content "\n```")))
+              (str/join "\n")))))
+
 (defn- task->text
-  "Convert a task to text for the LLM."
+  "Convert a task to text for the LLM.
+   Includes plan and intent when available for richer context."
   [task]
   (cond
     (string? task) task
-    (map? task) (or (:task/description task)
-                    (:description task)
-                    (:content task)
-                    (pr-str task))
+    (map? task) (let [desc (or (:task/description task)
+                               (:description task)
+                               (:content task))
+                      plan (:task/plan task)
+                      intent (:task/intent task)
+                      parts (cond-> []
+                              desc (conj desc)
+                              plan (conj (str "\n\n## Plan\n\n" (if (string? plan) plan (pr-str plan))))
+                              (and intent (map? intent))
+                              (conj (str "\n\n## Intent\n\n" (pr-str intent))))]
+                  (if (seq parts)
+                    (str/join "" parts)
+                    (pr-str task)))
     :else (str task)))
 
 (defn- parse-code-response
@@ -240,17 +269,25 @@
         (let [llm-client (or (:llm-backend opts) (:llm-backend context))
               on-chunk (:on-chunk context)
               task-text (task->text input)
+              ;; Append behavior addendum to system prompt if present
+              effective-system-prompt (str @implementer-system-prompt
+                                          (or (:task/behavior-addendum input) ""))
+              ;; Include existing files and already-implemented escape hatch
               user-prompt (str "Implement the following task:\n\n"
                                task-text
+                               (format-existing-files (:task/existing-files input))
                                "\n\nOutput your code as a Clojure map following the format in your system prompt. "
-                               "Include full file contents, not placeholders.")]
+                               "Include full file contents, not placeholders."
+                               "\n\nIf the task is already fully implemented in the existing files, respond with:\n"
+                               "```clojure\n{:status :already-implemented\n"
+                               " :summary \"Brief explanation of why no changes are needed\"}\n```")]
           (if llm-client
             ;; Use the real LLM with streaming if callback provided
             (let [response (if on-chunk
                              (llm/chat-stream llm-client user-prompt on-chunk
-                                              {:system @implementer-system-prompt})
+                                              {:system effective-system-prompt})
                              (llm/chat llm-client user-prompt
-                                       {:system @implementer-system-prompt}))
+                                       {:system effective-system-prompt}))
                   tokens (or (:tokens response) 0)]
               (log/info logger :implementer :implementer/llm-called
                         {:data {:success (llm/success? response)
@@ -258,31 +295,44 @@
                                 :streaming? (boolean on-chunk)}})
               (if (llm/success? response)
                 (let [content (llm/get-content response)
-                      parsed (parse-code-response content)
-                      ;; Try multiple parsing strategies
-                      code (or parsed
-                               (when-let [files (extract-code-blocks content)]
-                                 {:code/id (random-uuid)
-                                  :code/files files
-                                  :code/tests-needed? true
-                                  :code/summary "Implementation from code blocks"
-                                  :code/created-at (java.util.Date.)})
-                               (make-fallback-code task-text))
-                      ;; Ensure proper ID and language
-                      code-with-meta (-> code
-                                         (update :code/id #(or % (random-uuid)))
-                                         (assoc :code/language (extract-language (:code/files code) context))
-                                         (assoc :code/created-at (java.util.Date.)))
-                      lang (:code/language code-with-meta)]
-                  {:status :success
-                   :output code-with-meta
-                   :artifact code-with-meta
-                   :tokens tokens
-                   :metrics {:files-created (count (filter #(= :create (:action %)) (:code/files code-with-meta)))
-                             :files-modified (count (filter #(= :modify (:action %)) (:code/files code-with-meta)))
-                             :files-deleted (count (filter #(= :delete (:action %)) (:code/files code-with-meta)))
-                             :language lang
-                             :tokens tokens}})
+                      parsed (parse-code-response content)]
+                  ;; Check for already-implemented response
+                  (if (= :already-implemented (:status parsed))
+                    {:status :already-implemented
+                     :output {:code/id (random-uuid)
+                              :code/files []
+                              :code/summary (:summary parsed)
+                              :code/language nil
+                              :code/tests-needed? false
+                              :code/created-at (java.util.Date.)}
+                     :summary (:summary parsed)
+                     :metrics {:tokens tokens
+                               :files-created 0
+                               :skipped-reason :already-implemented}}
+                    ;; Normal code artifact parsing
+                    (let [code (or parsed
+                                   (when-let [files (extract-code-blocks content)]
+                                     {:code/id (random-uuid)
+                                      :code/files files
+                                      :code/tests-needed? true
+                                      :code/summary "Implementation from code blocks"
+                                      :code/created-at (java.util.Date.)})
+                                   (make-fallback-code task-text))
+                          ;; Ensure proper ID and language
+                          code-with-meta (-> code
+                                             (update :code/id #(or % (random-uuid)))
+                                             (assoc :code/language (extract-language (:code/files code) context))
+                                             (assoc :code/created-at (java.util.Date.)))
+                          lang (:code/language code-with-meta)]
+                      {:status :success
+                       :output code-with-meta
+                       :artifact code-with-meta
+                       :tokens tokens
+                       :metrics {:files-created (count (filter #(= :create (:action %)) (:code/files code-with-meta)))
+                                 :files-modified (count (filter #(= :modify (:action %)) (:code/files code-with-meta)))
+                                 :files-deleted (count (filter #(= :delete (:action %)) (:code/files code-with-meta)))
+                                 :language lang
+                                 :tokens tokens}})))
                 ;; LLM call failed
                 (let [fallback (make-fallback-code task-text)]
                   {:status :error

--- a/components/phase/resources/packs/miniforge-builtin.pack.edn
+++ b/components/phase/resources/packs/miniforge-builtin.pack.edn
@@ -1,0 +1,23 @@
+;; Built-in policy pack for miniforge agent behaviors.
+;; Loaded from the classpath by ai.miniforge.phase.agent-behavior.
+
+{:pack/id "ai.miniforge/builtin-agent-behaviors"
+ :pack/name "Miniforge Built-in Agent Behaviors"
+ :pack/version "2026.02.12"
+ :pack/description "Built-in rules that inject behavioral guidance into agent prompts. These rules use :rule/agent-behavior to influence how agents respond, rather than detecting violations in artifacts."
+ :pack/author "miniforge.ai"
+ :pack/license "Apache-2.0"
+ :pack/categories [{:id "900" :name "Agent Behavior" :description "Rules governing agent prompt behaviors"}]
+ :pack/rules
+ [{:rule/id :400-check-existing-work
+   :rule/title "Check Existing Work Before Implementing"
+   :rule/description "Instructs the implementer agent to examine existing files before generating code. Prevents duplicate implementations when tasks are already done."
+   :rule/severity :info
+   :rule/category "900"
+   :rule/applies-to {:phases [:implement]}
+   :rule/detection {:type :custom}
+   :rule/enforcement {:action :audit
+                      :message "Agent should check existing files before implementing"}
+   :rule/agent-behavior "BEFORE generating any code, carefully examine all existing files provided in the context. If the task described is already fully implemented in those files (all acceptance criteria met, no missing functionality), respond with {:status :already-implemented :summary \"...\"} instead of generating new code. Only generate code when changes are actually needed."}]
+ :pack/created-at #inst "2026-02-12T00:00:00.000Z"
+ :pack/updated-at #inst "2026-02-12T00:00:00.000Z"}

--- a/components/phase/src/ai/miniforge/phase/agent_behavior.clj
+++ b/components/phase/src/ai/miniforge/phase/agent_behavior.clj
@@ -1,0 +1,168 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.agent-behavior
+  "Extract :rule/agent-behavior from policy packs and format as prompt addendum.
+
+   Bridges policy-pack rules and agent prompts. Uses requiring-resolve for
+   the policy-pack dependency (same soft-dependency pattern as event-stream).
+   Loads built-in rules from a classpath EDN resource.
+
+   Layer 0: Behavior extraction and formatting
+   Layer 1: Rule loading (built-in + user packs)
+   Layer 2: Full pipeline"
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Behavior extraction
+
+(defn extract-agent-behaviors
+  "Extract non-nil :rule/agent-behavior strings from a seq of rules.
+
+   Arguments:
+   - rules - Seq of rule maps
+
+   Returns:
+   - Vector of behavior strings"
+  [rules]
+  (->> rules
+       (map :rule/agent-behavior)
+       (filterv some?)))
+
+(defn format-behavior-addendum
+  "Format behavior strings as a numbered markdown section for prompt injection.
+
+   Arguments:
+   - behaviors - Seq of behavior strings
+
+   Returns:
+   - Formatted string or nil if no behaviors"
+  [behaviors]
+  (when (seq behaviors)
+    (str "\n\n## Policy Rules \u2014 Required Behaviors\n\n"
+         (->> behaviors
+              (map-indexed (fn [i b] (str (inc i) ". " b)))
+              (str/join "\n"))
+         "\n")))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Rule loading
+
+(defn load-builtin-rules
+  "Load built-in rules from the classpath EDN resource.
+
+   Reads packs/miniforge-builtin.pack.edn from the classpath,
+   parses with edn/read-string, and extracts :pack/rules.
+   Normalizes :phases vectors to sets (matching the loader pattern).
+
+   Returns:
+   - Vector of rules, or empty vector on failure"
+  []
+  (try
+    (if-let [resource (io/resource "packs/miniforge-builtin.pack.edn")]
+      (let [pack (edn/read-string (slurp resource))
+            rules (:pack/rules pack [])]
+        ;; Normalize :phases vectors to sets for filter-applicable-rules compatibility
+        (mapv (fn [rule]
+                (if-let [phases (get-in rule [:rule/applies-to :phases])]
+                  (assoc-in rule [:rule/applies-to :phases] (set phases))
+                  rule))
+              rules))
+      [])
+    (catch Exception _
+      [])))
+
+(defn- load-user-pack-rules
+  "Load rules from user packs in ~/.miniforge/packs/ via requiring-resolve.
+
+   Uses the same soft-dependency pattern as event-stream to avoid
+   a hard dependency on the policy-pack component.
+
+   Returns:
+   - Vector of rules, or empty vector on failure"
+  []
+  (try
+    (let [packs-dir (io/file (System/getProperty "user.home") ".miniforge" "packs")]
+      (if (.isDirectory packs-dir)
+        (when-let [load-all (requiring-resolve 'ai.miniforge.policy-pack.interface/load-all-packs)]
+          (let [result (load-all (str packs-dir))]
+            (->> (:loaded result)
+                 (mapcat :pack/rules)
+                 vec)))
+        []))
+    (catch Exception _
+      [])))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Full pipeline
+
+(defn load-and-filter-behaviors
+  "Full pipeline: load rules, filter by phase, extract and format behaviors.
+
+   1. Load built-in rules from classpath EDN resource
+   2. Optionally load user packs from ~/.miniforge/packs/
+   3. Combine all rules, filter by phase
+   4. Extract behaviors and format as prompt addendum
+
+   Arguments:
+   - phase - Keyword phase (e.g. :implement)
+   - context - Context map passed to filter-applicable-rules
+
+   Returns:
+   - Formatted string addendum or nil. Fail-safe (catches all exceptions)."
+  [phase context]
+  (try
+    (let [builtin-rules (load-builtin-rules)
+          user-rules (load-user-pack-rules)
+          all-rules (into builtin-rules user-rules)
+          ;; Use requiring-resolve for filter-applicable-rules (soft dep on policy-pack)
+          filtered (if-let [filter-fn (requiring-resolve
+                                        'ai.miniforge.policy-pack.core/filter-applicable-rules)]
+                     (filter-fn all-rules (assoc context :phase phase))
+                     ;; Fallback: manual phase filtering
+                     (filterv (fn [rule]
+                                (let [phases (get-in rule [:rule/applies-to :phases])]
+                                  (or (nil? phases)
+                                      (empty? phases)
+                                      (contains? phases phase))))
+                              all-rules))
+          behaviors (extract-agent-behaviors filtered)]
+      (format-behavior-addendum behaviors))
+    (catch Exception _
+      nil)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Load built-in rules
+  (load-builtin-rules)
+
+  ;; Full pipeline for :implement phase
+  (load-and-filter-behaviors :implement {:task {:task/intent {:intent/type :implement}}})
+
+  ;; Extract behaviors from rules
+  (extract-agent-behaviors [{:rule/agent-behavior "Check existing files"}
+                            {:rule/agent-behavior nil}
+                            {:rule/agent-behavior "Validate inputs"}])
+  ;; => ["Check existing files" "Validate inputs"]
+
+  ;; Format as prompt addendum
+  (format-behavior-addendum ["Check existing files" "Validate inputs"])
+
+  :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/file_context.clj
+++ b/components/phase/src/ai/miniforge/phase/file_context.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.file-context
+  "Load existing file contents for agent context.
+
+   Layer 0 utility that reads files from disk with safety limits,
+   providing agents visibility into existing implementations."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants
+
+(def ^:private max-files
+  "Maximum number of files to load into context."
+  10)
+
+(def ^:private max-lines-per-file
+  "Maximum number of lines to read per file."
+  500)
+
+;------------------------------------------------------------------------------ Layer 0
+;; File reading
+
+(defn read-file-limited
+  "Read a single file, truncating to max-lines.
+
+   Arguments:
+   - worktree-path - Root directory of the worktree
+   - path - Relative file path
+   - max-lines - Maximum number of lines to include
+
+   Returns:
+   - {:path :content :truncated? :lines} or nil for non-existent/directory paths"
+  [worktree-path path max-lines]
+  (try
+    (let [f (io/file worktree-path path)]
+      (when (and (.exists f) (.isFile f))
+        (let [all-lines (str/split-lines (slurp f))
+              line-count (count all-lines)
+              truncated? (> line-count max-lines)
+              kept-lines (if truncated?
+                           (take max-lines all-lines)
+                           all-lines)]
+          {:path path
+           :content (str/join "\n" kept-lines)
+           :truncated? truncated?
+           :lines (min line-count max-lines)})))
+    (catch Exception _
+      nil)))
+
+(defn load-files-in-scope
+  "Load existing file contents for files in scope.
+
+   Arguments:
+   - worktree-path - Root directory of the worktree
+   - files-in-scope - Seq of relative file paths
+
+   Returns:
+   - Vector of file maps {:path :content :truncated? :lines},
+     capped at max-files. Nil entries are removed."
+  [worktree-path files-in-scope]
+  (when (seq files-in-scope)
+    (->> files-in-scope
+         (take max-files)
+         (map #(read-file-limited worktree-path % max-lines-per-file))
+         (filterv some?))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Load files from the current directory
+  (load-files-in-scope "." ["deps.edn" "README.md"])
+
+  ;; Read a single file with limit
+  (read-file-limited "." "deps.edn" 50)
+
+  :leave-this-here)

--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -23,6 +23,8 @@
    Agent: :implementer
    Default gates: [:syntax :lint]"
   (:require [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.phase.file-context :as file-ctx]
+            [ai.miniforge.phase.agent-behavior :as agent-beh]
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.response.interface :as response]))
 
@@ -88,13 +90,26 @@
         ;; Read from execution phase results where plan phase stored its output
         ;; Phase results contain the full phase map, so extract :result :output
         plan-result (get-in ctx [:execution/phase-results :plan :result :output])
+
+        ;; Load existing file contents for agent visibility
+        worktree-path (or (:worktree-path ctx) (System/getProperty "user.dir"))
+        files-in-scope (or (get-in input [:context :files-in-scope])
+                           (get-in input [:intent :scope]))
+        existing-files (file-ctx/load-files-in-scope worktree-path files-in-scope)
+
+        ;; Load agent-behavior addendum from policy rules
+        behavior-addendum (agent-beh/load-and-filter-behaviors
+                            :implement {:task {:task/intent (:intent input)}})
+
         task {:task/id (random-uuid)
               :task/type :implement
               :task/description (:description input)
               :task/title (:title input)
               :task/intent (:intent input)
               :task/constraints (:constraints input)
-              :task/plan plan-result} ; Pass plan output to implementer
+              :task/plan plan-result
+              :task/existing-files existing-files
+              :task/behavior-addendum behavior-addendum}
 
         ;; Create streaming callback for agent output
         on-chunk (when-let [es (:event-stream ctx)]
@@ -143,7 +158,10 @@
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
     ;; Emit phase completed event
     (emit-phase-completed! updated-ctx :implement result)
-    updated-ctx))
+    ;; Add skip metadata when work was already implemented
+    (cond-> updated-ctx
+      (= :already-implemented (:status result))
+      (assoc-in [:phase :skipped-reason] :already-implemented))))
 
 (defn- error-implement
   "Handle implementation phase errors.


### PR DESCRIPTION
## Summary

- **File context loading**: The implement phase now reads existing files in scope from disk (capped at 10 files, 500 lines each) and passes them to the implementer agent, giving it visibility into what already exists
- **Agent-behavior injection**: Policy-pack rules with `:rule/agent-behavior` are extracted, filtered by phase, and appended to the implementer's system prompt — allowing rules to shape agent responses without code changes
- **Already-implemented escape hatch**: When the agent determines the task is fully implemented in the existing files, it can respond with `{:status :already-implemented :summary "..."}` instead of generating stub code, producing an empty code artifact that downstream phases naturally short-circuit on

## Problem

When miniforge runs a workflow task that has already been implemented (e.g., by a human or a previous session), the implementer agent generates a stub function because:

1. The implement phase never loads existing file contents — the agent is blind to what exists on disk
2. The `:rule/agent-behavior` field in policy-pack rules is populated but never injected into agent prompts
3. The implementer has no response path for "this is already done" — it must always produce code

## Changes

### New files
| File | Purpose |
|------|---------|
| `components/phase/src/ai/miniforge/phase/file_context.clj` | `read-file-limited` + `load-files-in-scope` — reads files with size limits |
| `components/phase/src/ai/miniforge/phase/agent_behavior.clj` | Extracts `:rule/agent-behavior` from policy packs, formats as prompt addendum |
| `components/phase/resources/packs/miniforge-builtin.pack.edn` | Built-in EDN pack with `:400-check-existing-work` rule |

### Modified files
| File | Change |
|------|--------|
| `components/phase/src/ai/miniforge/phase/implement.clj` | Loads file context + agent behaviors, passes as `:task/existing-files` and `:task/behavior-addendum` |
| `components/agent/src/ai/miniforge/agent/implementer.clj` | `format-existing-files` helper, `:already-implemented` response handling, richer `task->text` with plan/intent |
| `components/agent/resources/prompts/implementer.edn` | Documents the already-implemented response format |

### Architecture
- **No new component dependencies** — `file-context` uses `clojure.java.io`; `agent-behavior` uses `requiring-resolve` for policy-pack (same soft-dep pattern as event-stream)
- **Fail-safe** — All new code paths catch exceptions and return nil/empty; a failure in file loading or behavior extraction never blocks the workflow
- **Size-bounded** — 10 files max, 500 lines each prevents context window blowup

## Test plan

- [x] clj-kondo lint: 0 errors, 0 warnings
- [x] Full `poly test` suite: all passing (including `implement-test` and `implementer-test`)
- [x] EDN pack resource parses correctly from classpath
- [ ] Manual: run workflow on already-implemented task — agent returns `:already-implemented`
- [ ] Manual: run workflow on new task — agent generates code normally
- [ ] Manual: verify 1000-line file truncates to 500 lines in prompt
- [ ] Manual: add custom rule in `~/.miniforge/packs/`, verify it appears in system prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)