### PR TITLE
Hook fleet repo onboarding into PR trains

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -125,7 +125,8 @@
                             "ai.miniforge.artifact.interface-integration-test"
                             "ai.miniforge.loop.interface-integration-test"
                             "ai.miniforge.observer.interface-integration-test"
-                            "ai.miniforge.task.interface-integration-test"]
+                            "ai.miniforge.task.interface-integration-test"
+                            "ai.miniforge.web-dashboard.fleet-onboarding-integration-test"]
                  require-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
                  run-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
                  expr (str "(require 'clojure.test" require-expr ") "

--- a/components/pr-train/src/ai/miniforge/pr_train/core.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/core.clj
@@ -349,12 +349,12 @@
 (defn list-trains
   "List all trains in a manager.
 
-   Returns vector of train summaries: [{:train/id :train/name :train/status}]"
+   Returns full train maps."
   [manager]
   (->> @(:trains manager)
        vals
-       (mapv #(select-keys % [:train/id :train/name :train/status
-                              :train/progress :train/created-at]))))
+       (sort-by :train/created-at)
+       vec))
 
 (defn find-trains-by-status
   "Find trains with a given status.

--- a/components/web-dashboard/resources/public/js/app.js
+++ b/components/web-dashboard/resources/public/js/app.js
@@ -130,6 +130,93 @@ function postWorkflowCommand(workflowId, command) {
   });
 }
 
+function dispatchRefresh() {
+  document.body.dispatchEvent(new CustomEvent('refresh'));
+}
+
+function postJson(url) {
+  return fetch(url, { method: 'POST' }).then((r) => r.json());
+}
+
+function apiErrorMessage(res, fallback) {
+  return (res && (res.error || res.message)) || fallback;
+}
+
+function fleetAddRepo() {
+  const repo = prompt('Repository (owner/name):');
+  if (!repo) return;
+
+  postJson('/api/fleet/repos/add?repo=' + encodeURIComponent(repo))
+    .then((res) => {
+      if (res.success) {
+        const prefix = res['added?'] ? 'Added: ' : 'Already configured: ';
+        showToast(prefix + (res.repo || repo), 'success');
+        dispatchRefresh();
+        return;
+      }
+      showToast('Error: ' + apiErrorMessage(res, 'Unable to add repo'), 'error');
+    })
+    .catch((err) => showToast('Error: ' + err.message, 'error'));
+}
+
+function fleetDiscoverRepos() {
+  const owner = prompt('Owner/org (leave blank for current user):', '') || '';
+  const suffix = owner.trim() ? ('?owner=' + encodeURIComponent(owner.trim())) : '';
+
+  postJson('/api/fleet/repos/discover' + suffix)
+    .then((res) => {
+      if (res.success) {
+        showToast(
+          'Discovered ' + (res.discovered || 0) + ' repos, added ' + (res.added || 0) + '.',
+          'success'
+        );
+        dispatchRefresh();
+        return;
+      }
+      showToast('Error: ' + apiErrorMessage(res, 'Repository discovery failed'), 'error');
+    })
+    .catch((err) => showToast('Error: ' + err.message, 'error'));
+}
+
+function fleetSyncPrs() {
+  postJson('/api/fleet/prs/sync')
+    .then((res) => {
+      if (res.success) {
+        const summary = res.summary || {};
+        showToast(
+          'Synced repos: ' + (res.synced || 0) + ', tracked PRs: ' + (summary['tracked-prs'] || 0),
+          'success'
+        );
+      } else {
+        showToast(
+          'Error: ' + apiErrorMessage(res, 'Sync failed for ' + (res.failed || 0) + ' repo(s)'),
+          'error'
+        );
+      }
+      dispatchRefresh();
+    })
+    .catch((err) => showToast('Error: ' + err.message, 'error'));
+}
+
+function fleetDiscoverAndSync() {
+  postJson('/api/fleet/repos/discover')
+    .then((res) => {
+      if (!res.success) {
+        throw new Error(apiErrorMessage(res, 'Discovery failed'));
+      }
+      return postJson('/api/fleet/prs/sync');
+    })
+    .then((syncRes) => {
+      if (syncRes.success) {
+        showToast('Discovery and PR sync completed.', 'success');
+      } else {
+        showToast('Sync error: ' + apiErrorMessage(syncRes, 'Unable to synchronize PRs'), 'error');
+      }
+      dispatchRefresh();
+    })
+    .catch((err) => showToast('Error: ' + err.message, 'error'));
+}
+
 // Export functions for global use
 window.miniforge = {
   switchTheme,
@@ -139,7 +226,13 @@ window.miniforge = {
   postWorkflowCommand,
   addFilterChip,
   removeFilterChip,
-  getActiveFilters: () => Array.from(activeFilters.entries())
+  getActiveFilters: () => Array.from(activeFilters.entries()),
+  fleet: {
+    addRepo: fleetAddRepo,
+    discoverRepos: fleetDiscoverRepos,
+    syncPrs: fleetSyncPrs,
+    discoverAndSync: fleetDiscoverAndSync
+  }
 };
 
 // WebSocket connection management

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
@@ -129,6 +129,21 @@
           (= uri "/api/fleet/grid")
           (handlers/handle-api-fleet-grid state params)
 
+          (= uri "/api/fleet/repos")
+          (handlers/handle-api-fleet-repos state)
+
+          (and (= uri "/api/fleet/repos/add")
+               (= (:request-method req) :post))
+          (handlers/handle-api-fleet-add-repo state params)
+
+          (and (= uri "/api/fleet/repos/discover")
+               (= (:request-method req) :post))
+          (handlers/handle-api-fleet-discover state params)
+
+          (and (= uri "/api/fleet/prs/sync")
+               (= (:request-method req) :post))
+          (handlers/handle-api-fleet-sync state)
+
           (= uri "/api/trains")
           (handlers/handle-api-trains state params)
 

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -217,6 +217,31 @@
     (state/train-action! state train-id action)
     (responses/json-response {:success true})))
 
+(defn handle-api-fleet-repos
+  "API: Get configured fleet repositories."
+  [state]
+  (responses/json-response {:success true
+                            :repos (state/get-configured-repos state)}))
+
+(defn handle-api-fleet-add-repo
+  "API: Add one configured repository (owner/name)."
+  [state params]
+  (let [repo (filters/param-value params :repo nil)
+        result (state/add-configured-repo! state repo)]
+    (responses/json-response result)))
+
+(defn handle-api-fleet-discover
+  "API: Discover repositories from provider and add to fleet config."
+  [state params]
+  (let [owner (filters/param-value params :owner nil)
+        result (state/discover-configured-repos! state {:owner owner})]
+    (responses/json-response result)))
+
+(defn handle-api-fleet-sync
+  "API: Sync configured repositories and import open PRs into trains."
+  [state]
+  (responses/json-response (state/sync-configured-repos! state)))
+
 (defn handle-api-filter-fields
   "API: Get available filter fields with faceted counts."
   [state params]
@@ -312,4 +337,3 @@
   [state workflow-id]
   (let [commands (state/dequeue-commands! state workflow-id)]
     (responses/json-response {:commands commands})))
-

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state.clj
@@ -34,6 +34,10 @@
 (def train-action! trains/train-action!)
 (def get-dags trains/get-dags)
 (def get-dag-state trains/get-dag-state)
+(def get-configured-repos trains/get-configured-repos)
+(def add-configured-repo! trains/add-configured-repo!)
+(def discover-configured-repos! trains/discover-configured-repos!)
+(def sync-configured-repos! trains/sync-configured-repos!)
 
 ;; workflows
 (def get-workflows workflows/get-workflows)

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/core.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/core.clj
@@ -52,6 +52,8 @@
   (atom (merge {:event-stream nil
                 :pr-train-manager nil
                 :repo-dag-manager nil
+                :fleet/default-dag-id nil
+                :fleet/repo-trains {}
                 :workflow-commands {}
                 :archived-workflows (atom {})
                 :archive-loading? (atom true)

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/fleet.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/fleet.clj
@@ -102,6 +102,7 @@
                (fn [state]
                  (let [trains (trains/get-trains state)
                        dags (trains/get-dags state)
+                       configured-repos (trains/get-configured-repos state)
                        total-prs (reduce + 0 (map #(count (:train/prs %)) trains))
                        active-trains (filter #(#{:open :reviewing :merging} (:train/status %)) trains)
                        repos (set (mapcat #(map :pr/repo (:train/prs %)) trains))]
@@ -109,8 +110,10 @@
                               :active-trains (count active-trains)
                               :total-prs total-prs
                               :repos (count repos)
+                              :configured-repos (count configured-repos)
                               :dags (count dags)}
                     :trains trains
+                    :configured-repos configured-repos
                     :repos (group-by identity (mapcat #(map :pr/repo (:train/prs %)) trains))
                     :health {:healthy (count (filter #(< (calculate-risk-score %) 20) trains))
                              :warning (count (filter #(and (>= (calculate-risk-score %) 20)

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -13,20 +13,225 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.web-dashboard.state.trains
-  "PR Train and DAG state accessors."
+  "PR Train, DAG, and fleet repository onboarding/sync accessors."
   (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [cheshire.core :as json]
    [ai.miniforge.web-dashboard.state.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; PR Train state
+;; Fleet repository config and provider helpers
+
+(def ^:private default-fleet-config-path
+  (str (System/getProperty "user.home") "/.miniforge/config.edn"))
+
+(def ^:private external-train-prefix
+  "External PRs: ")
+
+(def ^:private external-dag-name
+  "External PR Fleet")
+
+(def ^:private repo-slug-pattern
+  #"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+(def ^:private failed-check-conclusions
+  #{"FAILURE" "TIMED_OUT" "CANCELLED" "ACTION_REQUIRED" "STARTUP_FAILURE"})
+
+(def ^:private passing-check-conclusions
+  #{"SUCCESS" "NEUTRAL" "SKIPPED"})
+
+(def ^:private pending-check-states
+  #{"PENDING" "QUEUED" "IN_PROGRESS" "WAITING" "REQUESTED"})
+
+(defn- load-fleet-config
+  []
+  (try
+    (if (.exists (io/file default-fleet-config-path))
+      (edn/read-string (slurp default-fleet-config-path))
+      {:fleet {:repos []}})
+    (catch Exception _
+      {:fleet {:repos []}})))
+
+(defn- save-fleet-config!
+  [config]
+  (let [file (io/file default-fleet-config-path)]
+    (.mkdirs (.getParentFile file))
+    (spit file (pr-str config))))
+
+(defn- normalize-repo-slug
+  [repo]
+  (-> (str repo)
+      str/trim
+      str/lower-case))
+
+(defn- valid-repo-slug?
+  [repo]
+  (boolean (re-matches repo-slug-pattern repo)))
+
+(defn get-configured-repos
+  "Get configured fleet repositories from ~/.miniforge/config.edn."
+  [_state]
+  (->> (get-in (load-fleet-config) [:fleet :repos] [])
+       (map normalize-repo-slug)
+       (filter valid-repo-slug?)
+       distinct
+       vec))
+
+(defn add-configured-repo!
+  "Add a repository slug (owner/name) to fleet configuration."
+  [_state repo]
+  (let [repo* (normalize-repo-slug repo)]
+    (cond
+      (str/blank? repo*)
+      {:success false
+       :error "Repository is required. Use owner/name."}
+
+      (not (valid-repo-slug? repo*))
+      {:success false
+       :error "Invalid repository format. Expected owner/name."}
+
+      :else
+      (let [cfg (load-fleet-config)
+            repos (->> (get-in cfg [:fleet :repos] [])
+                       (map normalize-repo-slug)
+                       (filter valid-repo-slug?)
+                       vec)
+            exists? (some #{repo*} repos)
+            next-repos (if exists? repos (conj repos repo*))
+            next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
+        (save-fleet-config! next-cfg)
+        {:success true
+         :added? (not exists?)
+         :repo repo*
+         :repos (:fleet next-cfg)}))))
+
+(defn- run-gh
+  [& args]
+  (let [{:keys [exit out err]} (apply shell/sh "gh" args)]
+    {:success? (zero? exit)
+     :out (or out "")
+     :err (or err "")}))
+
+(defn- gh-api-json
+  [endpoint]
+  (let [{:keys [success? out err]} (run-gh "api" endpoint)]
+    (if success?
+      (try
+        {:success? true
+         :data (json/parse-string out true)}
+        (catch Exception e
+          {:success? false
+           :error (str "Failed to parse provider response: " (.getMessage e))}))
+      {:success? false
+       :error (str/trim (if (str/blank? err) out err))})))
+
+(defn discover-configured-repos!
+  "Discover repositories from GitHub and add them to fleet config.
+
+   Options map supports:
+   - :owner - org/user owner to scope discovery (optional)
+   - :limit - max repos to ingest (default 50)."
+  [_state {:keys [owner limit]
+           :or {limit 50}}]
+  (let [owner* (some-> owner str/trim not-empty)
+        endpoint (if owner*
+                   (str "orgs/" owner* "/repos?per_page=100")
+                   "user/repos?per_page=100")
+        result (gh-api-json endpoint)]
+    (if-not (:success? result)
+      {:success false
+       :error (:error result)}
+      (let [repos (->> (:data result)
+                       (keep :full_name)
+                       (map normalize-repo-slug)
+                       (filter valid-repo-slug?)
+                       distinct
+                       (take limit)
+                       vec)
+            cfg (load-fleet-config)
+            existing (->> (get-in cfg [:fleet :repos] [])
+                          (map normalize-repo-slug)
+                          (filter valid-repo-slug?)
+                          vec)
+            merged (vec (distinct (concat existing repos)))
+            added (vec (remove (set existing) merged))
+            next-cfg (assoc-in cfg [:fleet :repos] merged)]
+        (save-fleet-config! next-cfg)
+        {:success true
+         :owner owner*
+         :discovered (count repos)
+         :added (count added)
+         :repos merged
+         :added-repos added}))))
+
+(defn- pr-status-from-provider
+  [pr]
+  (let [state (some-> (:state pr) str str/upper-case)
+        draft? (boolean (:isDraft pr))
+        decision (some-> (:reviewDecision pr) str str/upper-case)]
+    (cond
+      (and state (not= "OPEN" state)) :closed
+      draft? :draft
+      (= "APPROVED" decision) :approved
+      (= "CHANGES_REQUESTED" decision) :changes-requested
+      (= "REVIEW_REQUIRED" decision) :reviewing
+      :else :open)))
+
+(defn- check-rollup->ci-status
+  [rollup]
+  (let [entries (cond
+                  (nil? rollup) []
+                  (sequential? rollup) rollup
+                  :else [rollup])
+        conclusions (keep #(some-> (:conclusion %) str str/upper-case) entries)
+        statuses (keep #(some-> (:status %) str str/upper-case) entries)]
+    (cond
+      (some failed-check-conclusions conclusions) :failed
+      (some pending-check-states statuses) :running
+      (and (seq conclusions)
+           (every? passing-check-conclusions conclusions)) :passed
+      (seq entries) :pending
+      :else :pending)))
+
+(defn- fetch-open-prs
+  [repo]
+  (let [{:keys [success? out err]} (run-gh "pr" "list"
+                                            "--repo" repo
+                                            "--state" "open"
+                                            "--json" "number,title,url,state,headRefName,isDraft,reviewDecision,statusCheckRollup")]
+    (if-not success?
+      {:success? false
+       :error (str/trim (if (str/blank? err) out err))}
+      (try
+        (let [rows (json/parse-string out true)]
+          {:success? true
+           :prs (->> rows
+                     (map (fn [pr]
+                            {:pr/number (:number pr)
+                             :pr/title (:title pr)
+                             :pr/url (:url pr)
+                             :pr/branch (:headRefName pr)
+                             :pr/status (pr-status-from-provider pr)
+                             :pr/ci-status (check-rollup->ci-status (:statusCheckRollup pr))}))
+                     (sort-by :pr/number)
+                     vec)})
+        (catch Exception e
+          {:success? false
+           :error (str "Failed to parse PR list for " repo ": " (.getMessage e))})))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; PR Train and DAG state
 
 (def get-trains
   "Get all PR trains (cached 10s)."
   (core/ttl-memoize 10000
-               (fn [state]
-                 (if-let [mgr (:pr-train-manager @state)]
-                   (or (core/safe-call 'ai.miniforge.pr-train.interface 'list-trains mgr) [])
-                   []))))
+                    (fn [state]
+                      (if-let [mgr (:pr-train-manager @state)]
+                        (or (core/safe-call 'ai.miniforge.pr-train.interface 'list-trains mgr) [])
+                        []))))
 
 (defn get-train-detail
   "Get detailed view of a PR train."
@@ -47,18 +252,159 @@
         "merge-next" (core/safe-call 'ai.miniforge.pr-train.interface 'merge-next mgr tid)
         nil))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; DAG state
-
 (def get-dags
   "Get all repository DAGs (cached 10s)."
   (core/ttl-memoize 10000
-               (fn [state]
-                 (if-let [mgr (:repo-dag-manager @state)]
-                   (or (core/safe-call 'ai.miniforge.repo-dag.interface 'get-all-dags mgr) [])
-                   []))))
+                    (fn [state]
+                      (if-let [mgr (:repo-dag-manager @state)]
+                        (or (core/safe-call 'ai.miniforge.repo-dag.interface 'get-all-dags mgr) [])
+                        []))))
 
 ;------------------------------------------------------------------------------ Layer 2
+;; External PR onboarding and sync
+
+(defn- ensure-default-dag-id!
+  [state]
+  (or (:fleet/default-dag-id @state)
+      (let [mgr (:repo-dag-manager @state)
+            existing (when mgr
+                       (some (fn [dag]
+                               (when (= external-dag-name (:dag/name dag))
+                                 (:dag/id dag)))
+                             (or (core/safe-call 'ai.miniforge.repo-dag.interface 'get-all-dags mgr) [])))
+            created (when (and mgr (nil? existing))
+                      (some-> (core/safe-call 'ai.miniforge.repo-dag.interface 'create-dag mgr external-dag-name
+                                              "Externally discovered repositories and PR trains")
+                              :dag/id))
+            dag-id (or existing created (random-uuid))]
+        (swap! state assoc :fleet/default-dag-id dag-id)
+        dag-id)))
+
+(defn- ensure-repo-in-dag!
+  [state dag-id repo]
+  (when-let [mgr (:repo-dag-manager @state)]
+    (let [dag (core/safe-call 'ai.miniforge.repo-dag.interface 'get-dag mgr dag-id)
+          exists? (some #(= repo (:repo/name %)) (:dag/repos dag))]
+      (when-not exists?
+        (let [[org _name] (str/split repo #"/" 2)]
+          (try
+            (core/safe-call 'ai.miniforge.repo-dag.interface 'add-repo
+                            mgr dag-id
+                            {:repo/url (str "https://github.com/" repo)
+                             :repo/name repo
+                             :repo/org org
+                             :repo/type :application
+                             :repo/default-branch "main"})
+            (catch Exception _ nil)))))))
+
+(defn- train-name-for-repo
+  [repo]
+  (str external-train-prefix repo))
+
+(defn- find-existing-repo-train-id
+  [state repo]
+  (if-let [mgr (:pr-train-manager @state)]
+    (let [expected (train-name-for-repo repo)]
+      (some (fn [train]
+              (when (= expected (:train/name train))
+                (:train/id train)))
+            (or (core/safe-call 'ai.miniforge.pr-train.interface 'list-trains mgr) [])))
+    nil))
+
+(defn- ensure-repo-train!
+  [state repo]
+  (when-let [mgr (:pr-train-manager @state)]
+    (let [known-id (get-in @state [:fleet/repo-trains repo])
+          known-train (when known-id
+                        (core/safe-call 'ai.miniforge.pr-train.interface 'get-train mgr known-id))
+          existing-id (or (when (and known-id known-train) known-id)
+                          (find-existing-repo-train-id state repo))
+          train-id (or existing-id
+                       (core/safe-call 'ai.miniforge.pr-train.interface 'create-train
+                                       mgr
+                                       (train-name-for-repo repo)
+                                       (ensure-default-dag-id! state)
+                                       (str "Externally managed PR train for " repo))) ]
+      (when train-id
+        (swap! state assoc-in [:fleet/repo-trains repo] train-id)
+        train-id))))
+
+(defn- sync-repo-prs-into-train!
+  [state repo]
+  (let [fetch-result (fetch-open-prs repo)]
+    (if-not (:success? fetch-result)
+      {:success? false
+       :repo repo
+       :error (:error fetch-result)}
+      (if-let [mgr (:pr-train-manager @state)]
+        (if-let [train-id (ensure-repo-train! state repo)]
+          (let [dag-id (ensure-default-dag-id! state)
+                _ (ensure-repo-in-dag! state dag-id repo)
+                prs (:prs fetch-result)
+                open-numbers (set (map :pr/number prs))
+                before-train (or (core/safe-call 'ai.miniforge.pr-train.interface 'get-train mgr train-id)
+                                 {:train/prs []})
+                existing-numbers (set (map :pr/number (:train/prs before-train)))
+                to-add (->> prs (remove #(contains? existing-numbers (:pr/number %))) vec)
+                to-remove (->> existing-numbers (remove open-numbers) vec)
+                _ (doseq [pr to-add]
+                    (core/safe-call 'ai.miniforge.pr-train.interface 'add-pr
+                                    mgr train-id repo (:pr/number pr) (:pr/url pr) (:pr/branch pr)
+                                    (:pr/title pr)))
+                _ (doseq [pr-num to-remove]
+                    (core/safe-call 'ai.miniforge.pr-train.interface 'remove-pr mgr train-id pr-num))
+                status-map (into {}
+                                 (map (fn [pr]
+                                        [(:pr/number pr)
+                                         {:pr/status (:pr/status pr)
+                                          :pr/ci-status (:pr/ci-status pr)}])
+                                      prs))
+                _ (core/safe-call 'ai.miniforge.pr-train.interface 'sync-pr-status mgr train-id status-map)
+                _ (core/safe-call 'ai.miniforge.pr-train.interface 'link-prs mgr train-id)
+                after-train (core/safe-call 'ai.miniforge.pr-train.interface 'get-train mgr train-id)]
+            {:success? true
+             :repo repo
+             :train-id train-id
+             :added (count to-add)
+             :removed (count to-remove)
+             :open-prs (count prs)
+             :tracked-prs (count (:train/prs after-train))})
+          {:success? false
+           :repo repo
+           :error "Unable to create or locate PR train for repository."})
+        {:success? false
+         :repo repo
+         :error "PR train manager is not available."}))))
+
+(defn sync-configured-repos!
+  "Sync configured repositories into PR trains and ingest open PRs from provider."
+  [state]
+  (let [repos (get-configured-repos state)]
+    (cond
+      (empty? repos)
+      {:success false
+       :error "No repositories configured. Add one or discover repositories first."
+       :repos []}
+
+      (nil? (:pr-train-manager @state))
+      {:success false
+       :error "PR train manager is not available in this runtime."
+       :repos repos}
+
+      :else
+      (let [results (mapv #(sync-repo-prs-into-train! state %) repos)
+            ok (filter :success? results)
+            failed (remove :success? results)]
+        {:success (empty? failed)
+         :repos repos
+         :synced (count ok)
+         :failed (count failed)
+         :results results
+         :summary {:added-prs (reduce + 0 (map :added ok))
+                   :removed-prs (reduce + 0 (map :removed ok))
+                   :tracked-prs (reduce + 0 (map :tracked-prs ok))}}))))
+
+;------------------------------------------------------------------------------ Layer 3
 ;; DAG composite state
 
 (defn get-dag-state

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -20,6 +20,7 @@
    [clojure.java.shell :as shell]
    [clojure.string :as str]
    [cheshire.core :as json]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.web-dashboard.state.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -45,6 +46,36 @@
 
 (def ^:private pending-check-states
   #{"PENDING" "QUEUED" "IN_PROGRESS" "WAITING" "REQUESTED"})
+
+(defn- result-success
+  [data]
+  (merge {:success? true
+          :success true}
+         data))
+
+(defn- result-failure
+  ([message]
+   (result-failure message nil))
+  ([message data]
+   (merge {:success? false
+           :success false
+           :error message
+           :anomaly (response/make-anomaly :anomalies/fault message)}
+          data)))
+
+(defn- result-exception
+  ([message ex]
+   (result-exception message ex nil))
+  ([message ex data]
+   (merge {:success? false
+           :success false
+           :error message
+           :anomaly (response/from-exception ex)}
+          data)))
+
+(defn- gh-error-message
+  [out err]
+  (str/trim (if (str/blank? err) out err)))
 
 (defn- load-fleet-config
   []
@@ -86,12 +117,14 @@
   (let [repo* (normalize-repo-slug repo)]
     (cond
       (str/blank? repo*)
-      {:success false
-       :error "Repository is required. Use owner/name."}
+      (result-failure
+       "Repository is required. Use owner/name."
+       {:repo repo*})
 
       (not (valid-repo-slug? repo*))
-      {:success false
-       :error "Invalid repository format. Expected owner/name."}
+      (result-failure
+       "Invalid repository format. Expected owner/name."
+       {:repo repo*})
 
       :else
       (let [cfg (load-fleet-config)
@@ -103,10 +136,10 @@
             next-repos (if exists? repos (conj repos repo*))
             next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
         (save-fleet-config! next-cfg)
-        {:success true
-         :added? (not exists?)
-         :repo repo*
-         :repos (:fleet next-cfg)}))))
+        (result-success
+         {:added? (not exists?)
+          :repo repo*
+          :repos (get-in next-cfg [:fleet :repos])})))))
 
 (defn- run-gh
   [& args]
@@ -120,13 +153,16 @@
   (let [{:keys [success? out err]} (run-gh "api" endpoint)]
     (if success?
       (try
-        {:success? true
-         :data (json/parse-string out true)}
+        (result-success
+         {:data (json/parse-string out true)})
         (catch Exception e
-          {:success? false
-           :error (str "Failed to parse provider response: " (.getMessage e))}))
-      {:success? false
-       :error (str/trim (if (str/blank? err) out err))})))
+          (result-exception
+           "Failed to parse provider response."
+           e
+           {:endpoint endpoint})))
+      (result-failure
+       (gh-error-message out err)
+       {:endpoint endpoint}))))
 
 (defn discover-configured-repos!
   "Discover repositories from GitHub and add them to fleet config.
@@ -142,8 +178,7 @@
                    "user/repos?per_page=100")
         result (gh-api-json endpoint)]
     (if-not (:success? result)
-      {:success false
-       :error (:error result)}
+      result
       (let [repos (->> (:data result)
                        (keep :full_name)
                        (map normalize-repo-slug)
@@ -160,12 +195,12 @@
             added (vec (remove (set existing) merged))
             next-cfg (assoc-in cfg [:fleet :repos] merged)]
         (save-fleet-config! next-cfg)
-        {:success true
-         :owner owner*
-         :discovered (count repos)
-         :added (count added)
-         :repos merged
-         :added-repos added}))))
+        (result-success
+         {:owner owner*
+          :discovered (count repos)
+          :added (count added)
+          :repos merged
+          :added-repos added})))))
 
 (defn- pr-status-from-provider
   [pr]
@@ -196,6 +231,31 @@
       (seq entries) :pending
       :else :pending)))
 
+(defn- provider-pr->train-pr
+  [pr]
+  {:pr/number (:number pr)
+   :pr/title (:title pr)
+   :pr/url (:url pr)
+   :pr/branch (:headRefName pr)
+   :pr/status (pr-status-from-provider pr)
+   :pr/ci-status (check-rollup->ci-status (:statusCheckRollup pr))})
+
+(defn- parse-provider-pr-list
+  [repo out]
+  (try
+    (let [rows (json/parse-string out true)]
+      (result-success
+       {:repo repo
+        :prs (->> rows
+                  (map provider-pr->train-pr)
+                  (sort-by :pr/number)
+                  vec)}))
+    (catch Exception e
+      (result-exception
+       (str "Failed to parse PR list for " repo ".")
+       e
+       {:repo repo}))))
+
 (defn- fetch-open-prs
   [repo]
   (let [{:keys [success? out err]} (run-gh "pr" "list"
@@ -203,24 +263,10 @@
                                             "--state" "open"
                                             "--json" "number,title,url,state,headRefName,isDraft,reviewDecision,statusCheckRollup")]
     (if-not success?
-      {:success? false
-       :error (str/trim (if (str/blank? err) out err))}
-      (try
-        (let [rows (json/parse-string out true)]
-          {:success? true
-           :prs (->> rows
-                     (map (fn [pr]
-                            {:pr/number (:number pr)
-                             :pr/title (:title pr)
-                             :pr/url (:url pr)
-                             :pr/branch (:headRefName pr)
-                             :pr/status (pr-status-from-provider pr)
-                             :pr/ci-status (check-rollup->ci-status (:statusCheckRollup pr))}))
-                     (sort-by :pr/number)
-                     vec)})
-        (catch Exception e
-          {:success? false
-           :error (str "Failed to parse PR list for " repo ": " (.getMessage e))})))))
+      (result-failure
+       (gh-error-message out err)
+       {:repo repo})
+      (parse-provider-pr-list repo out))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; PR Train and DAG state
@@ -329,52 +375,75 @@
         (swap! state assoc-in [:fleet/repo-trains repo] train-id)
         train-id))))
 
+(defn- prs->status-map
+  [prs]
+  (into {}
+        (map (fn [pr]
+               [(:pr/number pr)
+                {:pr/status (:pr/status pr)
+                 :pr/ci-status (:pr/ci-status pr)}])
+             prs)))
+
+(defn- train-sync-plan
+  [before-train prs]
+  (let [open-numbers (set (map :pr/number prs))
+        existing-numbers (set (map :pr/number (:train/prs before-train)))]
+    {:to-add (->> prs
+                  (remove #(contains? existing-numbers (:pr/number %)))
+                  vec)
+     :to-remove (->> existing-numbers
+                     (remove open-numbers)
+                     vec)
+     :status-map (prs->status-map prs)}))
+
+(defn- add-prs!
+  [mgr train-id repo prs]
+  (doseq [pr prs]
+    (core/safe-call 'ai.miniforge.pr-train.interface 'add-pr
+                    mgr train-id repo (:pr/number pr) (:pr/url pr)
+                    (:pr/branch pr) (:pr/title pr))))
+
+(defn- remove-prs!
+  [mgr train-id pr-nums]
+  (doseq [pr-num pr-nums]
+    (core/safe-call 'ai.miniforge.pr-train.interface 'remove-pr mgr train-id pr-num)))
+
+(defn- apply-sync-plan!
+  [mgr train-id repo {:keys [to-add to-remove status-map]}]
+  ;; Side effects are intentionally ordered: membership first, then status, then dependency linking.
+  (add-prs! mgr train-id repo to-add)
+  (remove-prs! mgr train-id to-remove)
+  (core/safe-call 'ai.miniforge.pr-train.interface 'sync-pr-status mgr train-id status-map)
+  (core/safe-call 'ai.miniforge.pr-train.interface 'link-prs mgr train-id))
+
 (defn- sync-repo-prs-into-train!
   [state repo]
   (let [fetch-result (fetch-open-prs repo)]
     (if-not (:success? fetch-result)
-      {:success? false
-       :repo repo
-       :error (:error fetch-result)}
+      (merge fetch-result {:repo repo})
       (if-let [mgr (:pr-train-manager @state)]
         (if-let [train-id (ensure-repo-train! state repo)]
           (let [dag-id (ensure-default-dag-id! state)
                 _ (ensure-repo-in-dag! state dag-id repo)
                 prs (:prs fetch-result)
-                open-numbers (set (map :pr/number prs))
                 before-train (or (core/safe-call 'ai.miniforge.pr-train.interface 'get-train mgr train-id)
                                  {:train/prs []})
-                existing-numbers (set (map :pr/number (:train/prs before-train)))
-                to-add (->> prs (remove #(contains? existing-numbers (:pr/number %))) vec)
-                to-remove (->> existing-numbers (remove open-numbers) vec)
-                _ (doseq [pr to-add]
-                    (core/safe-call 'ai.miniforge.pr-train.interface 'add-pr
-                                    mgr train-id repo (:pr/number pr) (:pr/url pr) (:pr/branch pr)
-                                    (:pr/title pr)))
-                _ (doseq [pr-num to-remove]
-                    (core/safe-call 'ai.miniforge.pr-train.interface 'remove-pr mgr train-id pr-num))
-                status-map (into {}
-                                 (map (fn [pr]
-                                        [(:pr/number pr)
-                                         {:pr/status (:pr/status pr)
-                                          :pr/ci-status (:pr/ci-status pr)}])
-                                      prs))
-                _ (core/safe-call 'ai.miniforge.pr-train.interface 'sync-pr-status mgr train-id status-map)
-                _ (core/safe-call 'ai.miniforge.pr-train.interface 'link-prs mgr train-id)
+                sync-plan (train-sync-plan before-train prs)
+                _ (apply-sync-plan! mgr train-id repo sync-plan)
                 after-train (core/safe-call 'ai.miniforge.pr-train.interface 'get-train mgr train-id)]
-            {:success? true
-             :repo repo
-             :train-id train-id
-             :added (count to-add)
-             :removed (count to-remove)
-             :open-prs (count prs)
-             :tracked-prs (count (:train/prs after-train))})
-          {:success? false
-           :repo repo
-           :error "Unable to create or locate PR train for repository."})
-        {:success? false
-         :repo repo
-         :error "PR train manager is not available."}))))
+            (result-success
+             {:repo repo
+              :train-id train-id
+              :added (count (:to-add sync-plan))
+              :removed (count (:to-remove sync-plan))
+              :open-prs (count prs)
+              :tracked-prs (count (:train/prs after-train))}))
+          (result-failure
+           "Unable to create or locate PR train for repository."
+           {:repo repo}))
+        (result-failure
+         "PR train manager is not available."
+         {:repo repo})))))
 
 (defn sync-configured-repos!
   "Sync configured repositories into PR trains and ingest open PRs from provider."
@@ -382,27 +451,37 @@
   (let [repos (get-configured-repos state)]
     (cond
       (empty? repos)
-      {:success false
-       :error "No repositories configured. Add one or discover repositories first."
-       :repos []}
+      (result-failure
+       "No repositories configured. Add one or discover repositories first."
+       {:repos []})
 
       (nil? (:pr-train-manager @state))
-      {:success false
-       :error "PR train manager is not available in this runtime."
-       :repos repos}
+      (result-failure
+       "PR train manager is not available in this runtime."
+       {:repos repos})
 
       :else
       (let [results (mapv #(sync-repo-prs-into-train! state %) repos)
             ok (filter :success? results)
             failed (remove :success? results)]
-        {:success (empty? failed)
-         :repos repos
-         :synced (count ok)
-         :failed (count failed)
-         :results results
-         :summary {:added-prs (reduce + 0 (map :added ok))
-                   :removed-prs (reduce + 0 (map :removed ok))
-                   :tracked-prs (reduce + 0 (map :tracked-prs ok))}}))))
+        (if (empty? failed)
+          (result-success
+           {:repos repos
+            :synced (count ok)
+            :failed 0
+            :results results
+            :summary {:added-prs (reduce + 0 (map :added ok))
+                      :removed-prs (reduce + 0 (map :removed ok))
+                      :tracked-prs (reduce + 0 (map :tracked-prs ok))}})
+          (result-failure
+           (str "Sync failed for " (count failed) " configured repos.")
+           {:repos repos
+            :synced (count ok)
+            :failed (count failed)
+            :results results
+            :summary {:added-prs (reduce + 0 (map :added ok))
+                      :removed-prs (reduce + 0 (map :removed ok))
+                      :tracked-prs (reduce + 0 (map :tracked-prs ok))}}))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; DAG composite state

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/views/fleet.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/views/fleet.clj
@@ -34,8 +34,8 @@
       [:div.empty-actions
        (c/button "+ Run Workflow" {:variant :primary
                                     :onclick "location.href='/workflows'"})
-       (c/button "Coordinate My PRs" {:variant :secondary
-                                       :onclick "alert('PR coordination coming soon')"})]]
+       (c/button "Discover + Sync" {:variant :secondary
+                                    :onclick "fetch('/api/fleet/repos/discover', { method: 'POST' }).then(r => r.json()).then(res => { if (res.success) { return fetch('/api/fleet/prs/sync', { method: 'POST' }); } throw new Error(res.error || 'Discovery failed'); }).then(r => r.json()).then(syncRes => { if (syncRes.success) { alert('Discovery and PR sync completed.'); document.body.dispatchEvent(new CustomEvent('refresh')); } else { alert('Sync error: ' + (syncRes.error || 'Unable to synchronize PRs')); } }).catch(err => alert('Error: ' + err.message));"})]]
      [:div.train-table
       [:table.fleet-table
        [:thead
@@ -81,14 +81,22 @@
        [:span.summary-divider "•"]
        [:span.pr-count (str (get-in fleet-state [:summary :total-prs] 0) " PRs")]
        [:span.summary-divider "•"]
-       [:span.repo-count (str (get-in fleet-state [:summary :repos] 0) " repos")]]
+       [:span.repo-count (str (get-in fleet-state [:summary :repos] 0) " repos with PRs")]
+       [:span.summary-divider "•"]
+       [:span.repo-count (str (get-in fleet-state [:summary :configured-repos] 0) " configured")]]
       [:div.fleet-actions
        (c/button "+ Run Workflow" {:variant :primary
                                     :onclick "location.href='/workflows'"
                                     :title "Execute a defined workflow spec"})
-       (c/button "Coordinate My PRs" {:variant :secondary
-                                       :onclick "alert('PR coordination: Review repos → Create trains → Setup monitoring')"
-                                       :title "Auto-discover PRs and create trains from DAGs"})
+       (c/button "+ Repo" {:variant :secondary
+                           :onclick "const repo = prompt('Repository (owner/name):'); if (repo) { fetch('/api/fleet/repos/add?repo=' + encodeURIComponent(repo), { method: 'POST' }).then(r => r.json()).then(res => { if (res.success) { alert((res['added?'] ? 'Added: ' : 'Already configured: ') + (res.repo || repo)); document.body.dispatchEvent(new CustomEvent('refresh')); } else { alert('Error: ' + (res.error || 'Unable to add repo')); } }).catch(err => alert('Error: ' + err.message)); }"
+                           :title "Add a repository to fleet configuration"})
+       (c/button "Discover Repos" {:variant :secondary
+                                    :onclick "const owner = prompt('Owner/org (leave blank for current user):', '') || ''; const suffix = owner.trim() ? ('?owner=' + encodeURIComponent(owner.trim())) : ''; fetch('/api/fleet/repos/discover' + suffix, { method: 'POST' }).then(r => r.json()).then(res => { if (res.success) { alert('Discovered ' + (res.discovered || 0) + ' repos, added ' + (res.added || 0) + '.'); document.body.dispatchEvent(new CustomEvent('refresh')); } else { alert('Error: ' + (res.error || 'Repository discovery failed')); } }).catch(err => alert('Error: ' + err.message));"
+                                    :title "Discover repositories via GitHub CLI"})
+       (c/button "Sync PRs" {:variant :secondary
+                              :onclick "fetch('/api/fleet/prs/sync', { method: 'POST' }).then(r => r.json()).then(res => { if (res.success) { const s = res.summary || {}; alert('Synced repos: ' + (res.synced || 0) + ', tracked PRs: ' + (s['tracked-prs'] || 0)); document.body.dispatchEvent(new CustomEvent('refresh')); } else { alert('Error: ' + (res.error || ('Sync failed for ' + (res.failed || 0) + ' repo(s)'))); document.body.dispatchEvent(new CustomEvent('refresh')); } }).catch(err => alert('Error: ' + err.message));"
+                              :title "Import open provider PRs into PR trains"})
        (c/button "Review All PRs" {:variant :ghost
                                     :onclick "alert('PR review: Kick off review workflows for all outstanding PRs')"
                                     :title "Run automated PR review workflows"})]]

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/views/fleet.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/views/fleet.clj
@@ -22,6 +22,15 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Fleet fragments
 
+(defn- fleet-action-onclick
+  [action]
+  (case action
+    :add-repo "window.miniforge.fleet.addRepo()"
+    :discover-repos "window.miniforge.fleet.discoverRepos()"
+    :sync-prs "window.miniforge.fleet.syncPrs()"
+    :discover-sync "window.miniforge.fleet.discoverAndSync()"
+    ""))
+
 (defn train-list-fragment
   "Train list fragment for htmx updates."
   [trains]
@@ -35,7 +44,7 @@
        (c/button "+ Run Workflow" {:variant :primary
                                     :onclick "location.href='/workflows'"})
        (c/button "Discover + Sync" {:variant :secondary
-                                    :onclick "fetch('/api/fleet/repos/discover', { method: 'POST' }).then(r => r.json()).then(res => { if (res.success) { return fetch('/api/fleet/prs/sync', { method: 'POST' }); } throw new Error(res.error || 'Discovery failed'); }).then(r => r.json()).then(syncRes => { if (syncRes.success) { alert('Discovery and PR sync completed.'); document.body.dispatchEvent(new CustomEvent('refresh')); } else { alert('Sync error: ' + (syncRes.error || 'Unable to synchronize PRs')); } }).catch(err => alert('Error: ' + err.message));"})]]
+                                    :onclick (fleet-action-onclick :discover-sync)})]]
      [:div.train-table
       [:table.fleet-table
        [:thead
@@ -89,13 +98,13 @@
                                     :onclick "location.href='/workflows'"
                                     :title "Execute a defined workflow spec"})
        (c/button "+ Repo" {:variant :secondary
-                           :onclick "const repo = prompt('Repository (owner/name):'); if (repo) { fetch('/api/fleet/repos/add?repo=' + encodeURIComponent(repo), { method: 'POST' }).then(r => r.json()).then(res => { if (res.success) { alert((res['added?'] ? 'Added: ' : 'Already configured: ') + (res.repo || repo)); document.body.dispatchEvent(new CustomEvent('refresh')); } else { alert('Error: ' + (res.error || 'Unable to add repo')); } }).catch(err => alert('Error: ' + err.message)); }"
+                           :onclick (fleet-action-onclick :add-repo)
                            :title "Add a repository to fleet configuration"})
        (c/button "Discover Repos" {:variant :secondary
-                                    :onclick "const owner = prompt('Owner/org (leave blank for current user):', '') || ''; const suffix = owner.trim() ? ('?owner=' + encodeURIComponent(owner.trim())) : ''; fetch('/api/fleet/repos/discover' + suffix, { method: 'POST' }).then(r => r.json()).then(res => { if (res.success) { alert('Discovered ' + (res.discovered || 0) + ' repos, added ' + (res.added || 0) + '.'); document.body.dispatchEvent(new CustomEvent('refresh')); } else { alert('Error: ' + (res.error || 'Repository discovery failed')); } }).catch(err => alert('Error: ' + err.message));"
+                                    :onclick (fleet-action-onclick :discover-repos)
                                     :title "Discover repositories via GitHub CLI"})
        (c/button "Sync PRs" {:variant :secondary
-                              :onclick "fetch('/api/fleet/prs/sync', { method: 'POST' }).then(r => r.json()).then(res => { if (res.success) { const s = res.summary || {}; alert('Synced repos: ' + (res.synced || 0) + ', tracked PRs: ' + (s['tracked-prs'] || 0)); document.body.dispatchEvent(new CustomEvent('refresh')); } else { alert('Error: ' + (res.error || ('Sync failed for ' + (res.failed || 0) + ' repo(s)'))); document.body.dispatchEvent(new CustomEvent('refresh')); } }).catch(err => alert('Error: ' + err.message));"
+                              :onclick (fleet-action-onclick :sync-prs)
                               :title "Import open provider PRs into PR trains"})
        (c/button "Review All PRs" {:variant :ghost
                                     :onclick "alert('PR review: Kick off review workflows for all outstanding PRs')"

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj
@@ -1,0 +1,128 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.web-dashboard.state.trains-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [cheshire.core :as json]
+   [ai.miniforge.response.interface :as response]
+   [ai.miniforge.web-dashboard.state.core :as core]
+   [ai.miniforge.web-dashboard.state.trains :as sut]))
+
+(defn- temp-config-path
+  []
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                      "fleet-config"
+                      (make-array java.nio.file.attribute.FileAttribute 0)))]
+    (.deleteOnExit dir)
+    (str (.getAbsolutePath dir) "/config.edn")))
+
+(deftest add-configured-repo-validates-and-dedupes-test
+  (let [config-path (temp-config-path)
+        state (atom {})]
+    (with-redefs-fn {#'sut/default-fleet-config-path config-path}
+      (fn []
+        (let [invalid (sut/add-configured-repo! state "not-a-repo-slug")]
+          (is (false? (:success? invalid)))
+          (is (= :anomalies/fault (get-in invalid [:anomaly :anomaly/category]))))
+
+        (let [first-add (sut/add-configured-repo! state "Acme/Service")
+              second-add (sut/add-configured-repo! state "acme/service")]
+          (is (true? (:success? first-add)))
+          (is (true? (:added? first-add)))
+          (is (= "acme/service" (:repo first-add)))
+          (is (true? (:success? second-add)))
+          (is (false? (:added? second-add)))
+          (is (= ["acme/service"] (sut/get-configured-repos state))))))))
+
+(deftest fetch-open-prs-parses-provider-fields-test
+  (with-redefs-fn {#'sut/run-gh
+                   (fn [& _args]
+                     {:success? true
+                      :out (json/generate-string
+                            [{:number 40
+                              :title "Second PR"
+                              :url "https://github.com/acme/service/pull/40"
+                              :state "OPEN"
+                              :headRefName "feature/two"
+                              :isDraft true
+                              :reviewDecision "REVIEW_REQUIRED"
+                              :statusCheckRollup [{:status "IN_PROGRESS"}]}
+                             {:number 12
+                              :title "First PR"
+                              :url "https://github.com/acme/service/pull/12"
+                              :state "OPEN"
+                              :headRefName "feature/one"
+                              :isDraft false
+                              :reviewDecision "APPROVED"
+                              :statusCheckRollup [{:status "COMPLETED"
+                                                   :conclusion "SUCCESS"}]}])
+                      :err ""})}
+    (fn []
+      (let [result (#'sut/fetch-open-prs "acme/service")
+            prs (:prs result)
+            by-number (into {} (map (juxt :pr/number identity) prs))]
+        (is (true? (:success? result)))
+        (is (= [12 40] (mapv :pr/number prs)))
+        (is (= :approved (get-in by-number [12 :pr/status])))
+        (is (= :passed (get-in by-number [12 :pr/ci-status])))
+        (is (= :draft (get-in by-number [40 :pr/status])))
+        (is (= :running (get-in by-number [40 :pr/ci-status])))))))
+
+(deftest apply-sync-plan-orders-mutations-test
+  (let [calls (atom [])
+        train-id (random-uuid)
+        plan {:to-add [{:pr/number 101
+                        :pr/url "https://github.com/acme/service/pull/101"
+                        :pr/branch "feature/a"
+                        :pr/title "A"}]
+              :to-remove [99]
+              :status-map {101 {:pr/status :open :pr/ci-status :pending}}}]
+    (with-redefs-fn {#'core/safe-call
+                     (fn [_ns-sym fn-sym & _args]
+                       (swap! calls conj fn-sym)
+                       nil)}
+      (fn []
+        (#'sut/apply-sync-plan! :manager train-id "acme/service" plan)
+        (is (= ['add-pr 'remove-pr 'sync-pr-status 'link-prs]
+               @calls))))))
+
+(deftest sync-configured-repos-aggregates-results-and-failures-test
+  (let [state (atom {:pr-train-manager :manager})
+        sync-results {"acme/service"
+                      {:success? true
+                       :success true
+                       :repo "acme/service"
+                       :added 2
+                       :removed 1
+                       :tracked-prs 3}
+                      "acme/web"
+                      {:success? false
+                       :success false
+                       :repo "acme/web"
+                       :error "Provider unavailable"
+                       :anomaly (response/make-anomaly :anomalies/unavailable "Provider unavailable")}}]
+    (with-redefs-fn {#'sut/get-configured-repos (fn [_] ["acme/service" "acme/web"])
+                     #'sut/sync-repo-prs-into-train! (fn [_ repo] (get sync-results repo))}
+      (fn []
+        (let [result (sut/sync-configured-repos! state)]
+          (is (false? (:success? result)))
+          (is (= 1 (:synced result)))
+          (is (= 1 (:failed result)))
+          (is (= 2 (count (:results result))))
+          (is (= {:added-prs 2
+                  :removed-prs 1
+                  :tracked-prs 3}
+                 (:summary result)))
+          (is (= :anomalies/fault (get-in result [:anomaly :anomaly/category]))))))))

--- a/deps.edn
+++ b/deps.edn
@@ -154,6 +154,7 @@
                        "components/event-stream/test"
                        "components/tui-engine/test"
                        "components/tui-views/test"
+                       "components/web-dashboard/test"
                        "components/self-healing/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
@@ -188,6 +189,7 @@
                       ai.miniforge/event-stream {:local/root "components/event-stream"}
                       ai.miniforge/tui-engine {:local/root "components/tui-engine"}
                       ai.miniforge/tui-views {:local/root "components/tui-views"}
+                      ai.miniforge/web-dashboard {:local/root "components/web-dashboard"}
                       ai.miniforge/self-healing {:local/root "components/self-healing"}}}
 
   :conformance {:extra-paths ["development/test"

--- a/docs/pull-requests/2026-02-13-codex-pr-train-repo-onboarding.md
+++ b/docs/pull-requests/2026-02-13-codex-pr-train-repo-onboarding.md
@@ -1,0 +1,83 @@
+# feat: hook fleet repository onboarding into PR trains
+
+## Layer
+
+Application + Adapter
+
+## Depends on
+
+- None
+
+## Overview
+
+Connect fleet-level repository onboarding to PR train state so Miniforge can
+ingest and control external/open PRs from configured repositories.
+
+## Motivation
+
+To start dogfooding N9 external PR integration, Miniforge needs a direct path
+from fleet repo configuration/discovery to train synchronization. Previously,
+fleet controls were mostly placeholders and train list responses did not carry
+enough state for dashboard views.
+
+## What this adds
+
+- Fleet repo onboarding API for list/add/discover/sync flows.
+- Config-backed repo registry persisted under `~/.miniforge/config.edn` at `[:fleet :repos]`.
+- GitHub CLI-backed discovery and open-PR sync into per-repo PR trains.
+- Fleet UI actions wired to real backend endpoints.
+- Full train payloads returned from list APIs so dashboard views can render complete train status.
+
+## Changes in Detail
+
+- `components/pr-train/src/ai/miniforge/pr_train/core.clj`
+  - `list-trains` now returns full train maps (sorted by create time) rather than a reduced summary.
+- `components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj`
+  - Added repo config readers/writers.
+  - Added repo discovery via `gh api`.
+  - Added sync logic to ingest open PRs into per-repo trains, update status/CI fields, and link dependencies.
+- `components/web-dashboard/src/ai/miniforge/web_dashboard/state/core.clj`
+  - Added fleet sync bookkeeping state keys.
+- `components/web-dashboard/src/ai/miniforge/web_dashboard/state.clj`
+  - Re-exported fleet onboarding/sync functions.
+- `components/web-dashboard/src/ai/miniforge/web_dashboard/state/fleet.clj`
+  - Added configured repo counts/details in fleet summary/state payload.
+- `components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj`
+  - Added handlers for fleet repo list/add/discover/sync.
+- `components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj`
+  - Added routes:
+    - `GET /api/fleet/repos`
+    - `POST /api/fleet/repos/add`
+    - `POST /api/fleet/repos/discover`
+    - `POST /api/fleet/prs/sync`
+- `components/web-dashboard/src/ai/miniforge/web_dashboard/views/fleet.clj`
+  - Hooked Fleet buttons to real API calls (`+ Repo`, `Discover Repos`, `Sync PRs`).
+
+## Testing Plan
+
+- Run pre-commit checks:
+  - `bb pre-commit`
+- Verify full suite in hook path:
+  - commit hook (`bb pre-commit`) passed end-to-end on this branch
+- Spot-check functionality:
+  - Fleet view supports adding repos, discovering repos, and syncing open PRs into trains.
+
+## Deployment Plan
+
+- Merge to `main`.
+- After merge, create a fresh stable Polylith tag to reset changed-since
+  baseline and avoid full-suite runs on every local test cycle.
+
+## Related Issues/PRs
+
+- Normative reference: `specs/normative/N9-external-pr-integration.md`
+- PR branch: `codex/pr-train-repo-onboarding`
+
+## Checklist
+
+- [x] Fleet repo onboarding endpoints implemented
+- [x] Fleet view wired to backend repo actions
+- [x] PR train list returns full train state
+- [x] Sync path creates/updates repo trains from open provider PRs
+- [x] Pre-commit validation passed
+- [ ] Reviewer validation in live dogfooding environment

--- a/projects/miniforge/test/ai/miniforge/web_dashboard/fleet_onboarding_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/web_dashboard/fleet_onboarding_integration_test.clj
@@ -1,0 +1,131 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.web-dashboard.fleet-onboarding-integration-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [cheshire.core :as json]
+   [ai.miniforge.pr-train.interface :as pr-train]
+   [ai.miniforge.repo-dag.interface :as repo-dag]
+   [ai.miniforge.web-dashboard.server :as server]
+   [ai.miniforge.web-dashboard.state.core :as state-core]
+   [ai.miniforge.web-dashboard.state.trains :as trains]))
+
+(defn- temp-config-path
+  []
+  (let [dir (.toFile (java.nio.file.Files/createTempDirectory
+                      "fleet-e2e-config"
+                      (make-array java.nio.file.attribute.FileAttribute 0)))]
+    (.deleteOnExit dir)
+    (str (.getAbsolutePath dir) "/config.edn")))
+
+(defn- arg-value
+  [args flag]
+  (some (fn [[a b]]
+          (when (= a flag) b))
+        (partition 2 1 args)))
+
+(defn- fake-run-gh
+  [& args]
+  (let [[cmd subcmd] args]
+    (cond
+      (and (= cmd "api")
+           (= subcmd "orgs/acme/repos?per_page=100"))
+      {:success? true
+       :out (json/generate-string [{:full_name "acme/service"}
+                                   {:full_name "bad slug"}])
+       :err ""}
+
+      (and (= cmd "pr")
+           (= subcmd "list"))
+      (let [repo (arg-value args "--repo")
+            rows (case repo
+                   "acme/service"
+                   [{:number 101
+                     :title "Add service endpoint"
+                     :url "https://github.com/acme/service/pull/101"
+                     :state "OPEN"
+                     :headRefName "feature/add-endpoint"
+                     :isDraft false
+                     :reviewDecision "APPROVED"
+                     :statusCheckRollup [{:status "COMPLETED"
+                                          :conclusion "SUCCESS"}]}
+                    {:number 102
+                     :title "Refactor auth middleware"
+                     :url "https://github.com/acme/service/pull/102"
+                     :state "OPEN"
+                     :headRefName "chore/auth-refactor"
+                     :isDraft false
+                     :reviewDecision "REVIEW_REQUIRED"
+                     :statusCheckRollup [{:status "IN_PROGRESS"}]}]
+                   [])]
+        {:success? true
+         :out (json/generate-string rows)
+         :err ""})
+
+      :else
+      {:success? false
+       :out ""
+       :err (str "Unexpected gh call: " args)})))
+
+(defn- route-json
+  [handler method uri query-string]
+  (let [response (handler {:uri uri
+                           :request-method method
+                           :query-string query-string
+                           :params {}})]
+    {:status (:status response)
+     :json (json/parse-string (:body response) true)}))
+
+(deftest fleet-onboarding-route-flow-integration-test
+  (testing "discover repos + sync PRs through server routes"
+    (let [config-path (temp-config-path)
+          pr-manager (pr-train/create-manager)
+          dag-manager (repo-dag/create-manager)
+          state (state-core/create-state {:pr-train-manager pr-manager
+                                          :repo-dag-manager dag-manager})]
+      (with-redefs-fn {#'trains/default-fleet-config-path config-path
+                       #'trains/run-gh fake-run-gh}
+        (fn []
+          (let [handler (#'server/create-handler state)
+                discover-res (route-json handler :post "/api/fleet/repos/discover" "owner=acme")
+                repos-res (route-json handler :get "/api/fleet/repos" nil)
+                sync-res (route-json handler :post "/api/fleet/prs/sync" nil)
+                trains-list (vec (pr-train/list-trains pr-manager))
+                dag-list (vec (repo-dag/get-all-dags dag-manager))
+                train (first trains-list)
+                prs-by-number (into {} (map (juxt :pr/number identity) (:train/prs train)))]
+            (is (= 200 (:status discover-res)))
+            (is (true? (get-in discover-res [:json :success?])))
+            (is (= 1 (get-in discover-res [:json :added])))
+            (is (= ["acme/service"] (get-in repos-res [:json :repos])))
+
+            (is (= 200 (:status sync-res)))
+            (is (true? (get-in sync-res [:json :success?])))
+            (is (= 1 (get-in sync-res [:json :synced])))
+            (is (= 0 (get-in sync-res [:json :failed])))
+            (is (= 2 (get-in sync-res [:json :summary :added-prs])))
+            (is (= 2 (get-in sync-res [:json :summary :tracked-prs])))
+
+            (is (= 1 (count trains-list)))
+            (is (= "External PRs: acme/service" (:train/name train)))
+            (is (= 2 (count (:train/prs train))))
+            (is (= :approved (get-in prs-by-number [101 :pr/status])))
+            (is (= :passed (get-in prs-by-number [101 :pr/ci-status])))
+            (is (= :reviewing (get-in prs-by-number [102 :pr/status])))
+
+            (is (= 1 (count dag-list)))
+            (is (= "External PR Fleet" (:dag/name (first dag-list))))
+            (is (= #{"acme/service"}
+                   (set (map :repo/name (:dag/repos (first dag-list))))))))))))


### PR DESCRIPTION
# feat: hook fleet repository onboarding into PR trains

## Layer

Application + Adapter

## Depends on

- None

## Overview

Connect fleet-level repository onboarding to PR train state so Miniforge can
ingest and control external/open PRs from configured repositories.

## Motivation

To start dogfooding N9 external PR integration, Miniforge needs a direct path
from fleet repo configuration/discovery to train synchronization. Previously,
fleet controls were mostly placeholders and train list responses did not carry
enough state for dashboard views.

## What this adds

- Fleet repo onboarding API for list/add/discover/sync flows.
- Config-backed repo registry persisted under `~/.miniforge/config.edn` at `[:fleet :repos]`.
- GitHub CLI-backed discovery and open-PR sync into per-repo PR trains.
- Fleet UI actions wired to real backend endpoints.
- Full train payloads returned from list APIs so dashboard views can render complete train status.

## Changes in Detail

- `components/pr-train/src/ai/miniforge/pr_train/core.clj`
  - `list-trains` now returns full train maps (sorted by create time) rather than a reduced summary.
- `components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj`
  - Added repo config readers/writers.
  - Added repo discovery via `gh api`.
  - Added sync logic to ingest open PRs into per-repo trains, update status/CI fields, and link dependencies.
- `components/web-dashboard/src/ai/miniforge/web_dashboard/state/core.clj`
  - Added fleet sync bookkeeping state keys.
- `components/web-dashboard/src/ai/miniforge/web_dashboard/state.clj`
  - Re-exported fleet onboarding/sync functions.
- `components/web-dashboard/src/ai/miniforge/web_dashboard/state/fleet.clj`
  - Added configured repo counts/details in fleet summary/state payload.
- `components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj`
  - Added handlers for fleet repo list/add/discover/sync.
- `components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj`
  - Added routes:
    - `GET /api/fleet/repos`
    - `POST /api/fleet/repos/add`
    - `POST /api/fleet/repos/discover`
    - `POST /api/fleet/prs/sync`
- `components/web-dashboard/src/ai/miniforge/web_dashboard/views/fleet.clj`
  - Hooked Fleet buttons to real API calls (`+ Repo`, `Discover Repos`, `Sync PRs`).

## Testing Plan

- Run pre-commit checks:
  - `bb pre-commit`
- Verify full suite in hook path:
  - commit hook (`bb pre-commit`) passed end-to-end on this branch
- Spot-check functionality:
  - Fleet view supports adding repos, discovering repos, and syncing open PRs into trains.

## Deployment Plan

- Merge to `main`.
- After merge, create a fresh stable Polylith tag to reset changed-since
  baseline and avoid full-suite runs on every local test cycle.

## Related Issues/PRs

- Normative reference: `specs/normative/N9-external-pr-integration.md`
- PR branch: `codex/pr-train-repo-onboarding`

## Checklist

- [x] Fleet repo onboarding endpoints implemented
- [x] Fleet view wired to backend repo actions
- [x] PR train list returns full train state
- [x] Sync path creates/updates repo trains from open provider PRs
- [x] Pre-commit validation passed
- [ ] Reviewer validation in live dogfooding environment
