### PR TITLE
fix: artifact persistence & fail-fast validation

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -125,7 +125,8 @@
                             "ai.miniforge.artifact.interface-integration-test"
                             "ai.miniforge.loop.interface-integration-test"
                             "ai.miniforge.observer.interface-integration-test"
-                            "ai.miniforge.task.interface-integration-test"]
+                            "ai.miniforge.task.interface-integration-test"
+                            "ai.miniforge.release-executor.artifact-validation-integration-test"]
                  require-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
                  run-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
                  expr (str "(require 'clojure.test" require-expr ") "

--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -143,12 +143,14 @@
         end-time (System/currentTimeMillis)
         duration-ms (- end-time start-time)
         result (get-in ctx [:phase :result])
+        agent-status (:status result)
+        phase-status (if (= :error agent-status) :failed :completed)
         metrics (get result :metrics {:tokens 0 :duration-ms duration-ms})
         iterations (get-in ctx [:phase :iterations] 1)
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)
                         (assoc-in [:phase :duration-ms] duration-ms)
-                        (assoc-in [:phase :status] :completed)
+                        (assoc-in [:phase :status] phase-status)
                         (assoc-in [:phase :metrics] metrics)
                         (assoc-in [:metrics :implementation :duration-ms] duration-ms)
                         (assoc-in [:metrics :implementation :repair-cycles] (dec iterations))
@@ -156,11 +158,15 @@
                         ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
+    ;; Warn if result has no output and isn't already-implemented
+    (when (and (not= :already-implemented agent-status)
+               (nil? (:output result)))
+      (println "WARNING: implement phase result has no :output — artifact may be nil"))
     ;; Emit phase completed event
     (emit-phase-completed! updated-ctx :implement result)
     ;; Add skip metadata when work was already implemented
     (cond-> updated-ctx
-      (= :already-implemented (:status result))
+      (= :already-implemented agent-status)
       (assoc-in [:phase :skipped-reason] :already-implemented))))
 
 (defn- error-implement

--- a/components/phase/src/ai/miniforge/phase/release.clj
+++ b/components/phase/src/ai/miniforge/phase/release.clj
@@ -79,6 +79,14 @@
   ;; This is the canonical location where workflow runner stores phase outputs
   ;; Phase results contain the full phase map, so extract :result :output
   (let [implement-result (get-in ctx [:execution/phase-results :implement :result :output])
+        _ (when-not implement-result
+            (throw (ex-info "Release phase has no code artifact from implement phase"
+                            {:phase :release
+                             :implement-status (get-in ctx [:execution/phase-results :implement :result :status])
+                             :hint "Implement phase may have failed or produced no output"})))
+        _ (when (and (map? implement-result) (empty? (:code/files implement-result)))
+            (throw (ex-info "Release phase received code artifact with zero files"
+                            {:phase :release :artifact-id (:code/id implement-result)})))
         code-artifacts (if-let [artifacts (:artifacts implement-result)]
                          (map (fn [a] {:artifact/type :code
                                        :artifact/content a})

--- a/components/phase/src/ai/miniforge/phase/review.clj
+++ b/components/phase/src/ai/miniforge/phase/review.clj
@@ -89,9 +89,8 @@
 
         ;; Build task from workflow input and previous phase results
         input (get-in ctx [:execution/input])
-        implement-result (get-in ctx [:phase :result]) ; From implement phase
-        verify-result (or (get-in ctx [:phases :verify :result])
-                          (get-in ctx [:previous-phase :result]))
+        implement-result (get-in ctx [:execution/phase-results :implement :result :output])
+        verify-result (get-in ctx [:execution/phase-results :verify :result :output])
         task {:task/id (random-uuid)
               :task/type :review
               :task/description (:description input)

--- a/components/phase/src/ai/miniforge/phase/verify.clj
+++ b/components/phase/src/ai/miniforge/phase/verify.clj
@@ -95,6 +95,12 @@
         code-artifact (or implement-result
                          (:task/code-artifact input)
                          (:code-artifact input))
+        ;; Fail fast if no code artifact is available
+        _ (when-not code-artifact
+            (throw (ex-info "Verify phase received no code artifact from implement phase"
+                            {:phase :verify
+                             :available-keys (keys (get-in ctx [:execution/phase-results :implement :result]))
+                             :hint "Check implement phase agent result"})))
         ;; Build task using canonical builder
         task (task/verify-task code-artifact input)
 

--- a/components/phase/test/ai/miniforge/phase/artifact_persistence_test.clj
+++ b/components/phase/test/ai/miniforge/phase/artifact_persistence_test.clj
@@ -1,0 +1,185 @@
+(ns ai.miniforge.phase.artifact-persistence-test
+  "Integration tests for artifact persistence and fail-fast validation.
+
+  Verifies that:
+  - Phases fail fast when required artifacts are missing
+  - Implement phase propagates agent errors correctly
+  - Release phase validates artifacts before execution
+  - Full pipeline writes files to disk"
+  (:require
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [clojure.java.io :as io]
+   [babashka.fs :as fs]
+   ;; Required for defmethod side effects (register phase handlers)
+   #_{:clj-kondo/ignore [:unused-namespace]}
+   [ai.miniforge.phase.plan]
+   #_{:clj-kondo/ignore [:unused-namespace]}
+   [ai.miniforge.phase.implement]
+   #_{:clj-kondo/ignore [:unused-namespace]}
+   [ai.miniforge.phase.verify]
+   #_{:clj-kondo/ignore [:unused-namespace]}
+   [ai.miniforge.phase.release]
+   [ai.miniforge.phase.registry :as registry]
+   [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.response.interface :as response]
+   [ai.miniforge.release-executor.interface :as release-executor]))
+
+;------------------------------------------------------------------------------ Test Fixtures
+
+(def ^:dynamic *test-worktree* nil)
+
+(defn- create-temp-worktree []
+  (let [temp-dir (io/file (System/getProperty "java.io.tmpdir")
+                          (str "artifact-persist-test-" (random-uuid)))]
+    (.mkdirs temp-dir)
+    (.getPath temp-dir)))
+
+(defn- cleanup-temp-worktree [dir-path]
+  (when dir-path
+    (try (fs/delete-tree dir-path) (catch Exception _e nil))))
+
+(defn worktree-fixture [f]
+  (let [worktree (create-temp-worktree)]
+    (binding [*test-worktree* worktree]
+      (try (f)
+           (finally (cleanup-temp-worktree worktree))))))
+
+(use-fixtures :each worktree-fixture)
+
+;------------------------------------------------------------------------------ Mock Data
+
+(def mock-code-artifact
+  {:code/id (random-uuid)
+   :code/files [{:path "src/feature.clj"
+                 :content "(ns feature)\n(defn new-feature [] :implemented)"
+                 :action :create}
+                {:path "test/feature_test.clj"
+                 :content "(ns feature-test)\n(deftest t (is true))"
+                 :action :create}]
+   :code/language "clojure"})
+
+;------------------------------------------------------------------------------ Test Helpers
+
+(defn- create-base-context []
+  {:execution/id (random-uuid)
+   :execution/input {:description "Test implementation"
+                     :title "Add feature"
+                     :intent "testing"}
+   :execution/metrics {:tokens 0 :duration-ms 0}
+   :execution/phase-results {}})
+
+(defn- execute-phase-enter [phase-name ctx]
+  (let [interceptor (registry/get-phase-interceptor {:phase phase-name})
+        enter-fn (:enter interceptor)]
+    (enter-fn ctx)))
+
+(defn- execute-phase-leave [phase-name ctx]
+  (let [interceptor (registry/get-phase-interceptor {:phase phase-name})
+        leave-fn (:leave interceptor)
+        updated-ctx (leave-fn ctx)]
+    (assoc-in updated-ctx [:execution/phase-results phase-name]
+              (:phase updated-ctx))))
+
+;------------------------------------------------------------------------------ Tests
+
+(deftest test-verify-fails-without-artifact
+  (testing "verify phase throws when no implement result is present"
+    (with-redefs [agent/create-tester (fn [_] {:type :mock-tester})
+                  agent/invoke (fn [_ _ _]
+                                 (response/success {:result :ok} {:tokens 0 :duration-ms 0}))]
+      (let [ctx (create-base-context)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Verify phase received no code artifact"
+                              (execute-phase-enter :verify ctx)))
+        ;; Verify ex-data contains diagnostic info
+        (try
+          (execute-phase-enter :verify ctx)
+          (catch clojure.lang.ExceptionInfo e
+            (let [data (ex-data e)]
+              (is (= :verify (:phase data)))
+              (is (some? (:hint data))))))))))
+
+(deftest test-release-fails-with-nil-artifact
+  (testing "release phase throws when implement result is nil"
+    (let [ctx (-> (create-base-context)
+                  ;; Simulate implement phase that stored nil output
+                  (assoc-in [:execution/phase-results :implement :result :output] nil)
+                  (assoc :worktree-path *test-worktree*))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Release phase has no code artifact"
+                            (execute-phase-enter :release ctx))))))
+
+(deftest test-release-fails-with-empty-files
+  (testing "release phase throws when code artifact has empty :code/files"
+    (let [ctx (-> (create-base-context)
+                  (assoc-in [:execution/phase-results :implement :result :output]
+                            {:code/id (random-uuid) :code/files []})
+                  (assoc :worktree-path *test-worktree*))]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Release phase received code artifact with zero files"
+                            (execute-phase-enter :release ctx))))))
+
+(deftest test-full-pipeline-writes-files
+  (testing "full pipeline with mock agent writes files to temp dir"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                 (response/success mock-code-artifact
+                                                   {:tokens 1000 :duration-ms 2000}))
+                  release-executor/execute-release-phase
+                  (fn [workflow-state exec-context _opts]
+                    ;; Actually write files to the worktree
+                    (let [worktree (:worktree-path exec-context)
+                          code-artifacts (map :artifact/content (:workflow/artifacts workflow-state))
+                          files (mapcat :code/files code-artifacts)]
+                      (doseq [{:keys [path content]} files]
+                        (let [file (io/file worktree path)]
+                          (io/make-parents file)
+                          (spit file content)))
+                      {:success? true
+                       :artifacts [{:artifact/id (random-uuid)
+                                    :artifact/type :release
+                                    :artifact/content {:files-written (count files)
+                                                       :branch "test-branch"
+                                                       :commit-sha "abc123"}}]
+                       :metrics {:files-written (count files)}}))]
+      (let [;; Run implement phase
+            ctx1 (execute-phase-enter :implement (create-base-context))
+            ctx2 (execute-phase-leave :implement ctx1)
+            ;; Run release phase
+            ctx2-with-path (assoc ctx2 :worktree-path *test-worktree*)
+            ctx3 (execute-phase-enter :release ctx2-with-path)]
+
+        ;; Verify release succeeded
+        (is (= :success (get-in ctx3 [:phase :result :status]))
+            "Release phase should succeed")
+
+        ;; Verify files exist on disk
+        (is (.exists (io/file *test-worktree* "src/feature.clj"))
+            "Source file should exist on disk")
+        (is (.exists (io/file *test-worktree* "test/feature_test.clj"))
+            "Test file should exist on disk")
+
+        ;; Verify file contents
+        (is (= "(ns feature)\n(defn new-feature [] :implemented)"
+               (slurp (io/file *test-worktree* "src/feature.clj")))
+            "Source file content should match artifact")))))
+
+(deftest test-implement-fails-on-agent-error
+  (testing "leave-implement sets phase status to :failed when agent returns :error"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                 ;; Simulate agent returning error status
+                                 (response/error "LLM timeout" {:tokens 0 :duration-ms 5000}))]
+      (let [ctx (create-base-context)
+            ctx-entered (execute-phase-enter :implement ctx)
+            ctx-left (execute-phase-leave :implement ctx-entered)]
+        ;; Agent returned :error status, so leave-implement should set :failed
+        (is (= :failed (get-in ctx-left [:phase :status]))
+            "Phase status should be :failed when agent returns error")
+        (is (= :failed (get-in ctx-left [:execution/phase-results :implement :status]))
+            "Stored phase result should also show :failed")))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.phase.artifact-persistence-test)
+  :leave-this-here)

--- a/components/phase/test/ai/miniforge/phase/handoff_test.clj
+++ b/components/phase/test/ai/miniforge/phase/handoff_test.clj
@@ -291,20 +291,14 @@
             "Should accumulate token metrics from all phases")))))
 
 (deftest handoff-with-missing-artifact-test
-  (testing "Verify phase handles missing implement artifact"
+  (testing "Verify phase fails fast when no implement artifact is available"
     (with-redefs [agent/create-tester (fn [_] {:type :mock-tester})
-                  ;; Mock that doesn't assert on missing artifacts
                   agent/invoke (fn [_agent _task _ctx]
-                                 ;; Just return success without assertions
                                  (response/success {:result :ok} {:tokens 0 :duration-ms 0}))]
 
-      ;; Create context WITHOUT implement phase result
-      (let [ctx (create-base-context)
-            result (execute-phase-enter :verify ctx)]
-
-        ;; Verify phase should execute even without implement result
-        ;; (it has fallback to read from input if implement is missing)
-        (is (some? result)
-            "Verify phase should return a result")
-        (is (some? (get-in result [:phase :result]))
-            "Phase result should be present")))))
+      ;; Create context WITHOUT implement phase result — verify should throw
+      (let [ctx (create-base-context)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Verify phase received no code artifact"
+                              (execute-phase-enter :verify ctx))
+            "Verify phase should throw when no code artifact is available")))))

--- a/components/phase/test/ai/miniforge/phase/release_test.clj
+++ b/components/phase/test/ai/miniforge/phase/release_test.clj
@@ -212,29 +212,15 @@
               "Release should succeed when verification passes"))))))
 
 (deftest release-handles-zero-files-artifact-test
-  (testing "release phase handles artifact with zero files"
-    (with-redefs [release-executor/execute-release-phase
-                  (fn [_workflow-state _exec-context _opts]
-                    ;; No files to write
-                    {:success? true
-                     :artifacts [{:artifact/id (random-uuid)
-                                :artifact/type :release
-                                :artifact/content {:files-written 0
-                                                 :branch "test-branch"
-                                                 :commit-sha "abc123"}}]
-                     :metrics {:files-written 0}})]
-      (let [ctx (-> (create-base-context)
-                   (assoc-in [:execution/phase-results :implement :result :output :code/files] []))
-            ctx-with-config (assoc ctx :phase-config {:phase :release})
-            interceptor (registry/get-phase-interceptor {:phase :release})
-            result ((:enter interceptor) ctx-with-config)]
-        
-        ;; Phase completes (it's up to workflow to decide if 0 files is an error)
-        (is (= :success (get-in result [:phase :result :status]))
-            "Release should complete with zero files")
-        
-        (is (zero? (get-in result [:phase :result :output :release/metrics :files-written] -1))
-            "Should report zero files written")))))
+  (testing "release phase fails fast when code artifact has zero files"
+    (let [ctx (-> (create-base-context)
+                  (assoc-in [:execution/phase-results :implement :result :output :code/files] []))
+          ctx-with-config (assoc ctx :phase-config {:phase :release})
+          interceptor (registry/get-phase-interceptor {:phase :release})]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Release phase received code artifact with zero files"
+                            ((:enter interceptor) ctx-with-config))
+          "Release should fail fast when code artifact has empty files"))))
 
 (deftest release-includes-pr-info-test
   (testing "release phase includes PR info in result"

--- a/components/phase/test/ai/miniforge/phase/verify_failure_modes_test.clj
+++ b/components/phase/test/ai/miniforge/phase/verify_failure_modes_test.clj
@@ -90,7 +90,7 @@
             "Phase should return a result")))))
 
 (deftest verify-with-missing-implement-result-test
-  (testing "verify phase when implement phase result is completely missing"
+  (testing "verify phase fails fast when implement phase result is completely missing"
     (with-redefs [agent/create-tester (fn [_] {:type :mock-tester})
                   agent/invoke (fn [_agent _task _ctx]
                                 (response/success {:test/passed? true}
@@ -98,15 +98,11 @@
       (let [ctx (-> (create-base-context)
                    ;; NO implement phase result at all
                    (assoc :phase-config {:phase :verify}))
-            interceptor (registry/get-phase-interceptor {:phase :verify})
-            result ((:enter interceptor) ctx)]
-        
-        ;; Phase has fallback to read from input if implement is missing
-        (is (some? result)
-            "Verify should return a result even without implement")
-        
-        (is (some? (get-in result [:phase :result]))
-            "Phase result should be present")))))
+            interceptor (registry/get-phase-interceptor {:phase :verify})]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Verify phase received no code artifact"
+                              ((:enter interceptor) ctx))
+            "Verify should throw when no code artifact is available")))))
 
 (deftest verify-descriptive-error-on-agent-failure-test
   (testing "verify phase provides descriptive error when agent fails"

--- a/components/phase/test/ai/miniforge/phase/verify_test.clj
+++ b/components/phase/test/ai/miniforge/phase/verify_test.clj
@@ -69,7 +69,10 @@
                                 {:success true
                                  :output mock-test-artifact
                                  :metrics {:tokens 100 :duration-ms 500}})]
-      (let [ctx (create-base-context)
+      (let [ctx (-> (create-base-context)
+                    (assoc-in [:execution/phase-results :implement]
+                              {:result {:status :success
+                                        :output mock-code-artifact}}))
             ctx-with-config (assoc ctx :phase-config {:phase :verify})
             result (#'verify/enter-verify ctx-with-config)]
 

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -42,7 +42,8 @@
                     (= :code (:artifact/type %))))
        (map (fn [artifact]
               (or (:artifact/content artifact)
-                  (:content artifact))))))
+                  (:content artifact))))
+       (remove nil?)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Pipeline steps
@@ -59,6 +60,8 @@
         (log/warn logger :release-executor :no-code-artifacts
                   {:message "No code artifacts found to release"}))
       (fail state :no-code-artifacts "No code artifacts found in workflow state"))
+    (every? #(empty? (:code/files %)) (:code-artifacts state))
+    (fail state :no-code-files "Code artifacts contain no files")
     :else state))
 
 (defn- step-check-gh-auth [state]
@@ -102,18 +105,24 @@
   (if (failed? state)
     state
     (let [{:keys [worktree-path code-artifacts logger sandbox? executor environment-id]} state
-          result (if sandbox?
-                   (sandbox/write-and-stage-files! executor environment-id code-artifacts)
-                   (files/write-and-stage-files! worktree-path code-artifacts logger))]
-      (if (:success? result)
-        (assoc state :write-metrics (:metrics result))
-        (do
-          (when logger
-            (log/error logger :release-executor :write-stage-failed
-                       {:data {:errors (:errors result)}}))
-          (assoc state
-                 :failure {:type :write-stage-failed :errors (:errors result)}
-                 :write-metrics (:metrics result)))))))
+          all-files (mapcat :code/files code-artifacts)]
+      (if (empty? all-files)
+        (fail state :no-files-to-write "No files in code artifacts")
+        (let [result (if sandbox?
+                       (sandbox/write-and-stage-files! executor environment-id code-artifacts)
+                       (files/write-and-stage-files! worktree-path code-artifacts logger))]
+          (if (:success? result)
+            (let [total-ops (get-in result [:metrics :total-operations] 0)]
+              (if (zero? total-ops)
+                (fail state :no-files-written "Expected files but wrote 0")
+                (assoc state :write-metrics (:metrics result))))
+            (do
+              (when logger
+                (log/error logger :release-executor :write-stage-failed
+                           {:data {:errors (:errors result)}}))
+              (assoc state
+                     :failure {:type :write-stage-failed :errors (:errors result)}
+                     :write-metrics (:metrics result)))))))))
 
 (defn- step-commit [state]
   (if (failed? state)

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -90,7 +90,9 @@
    Returns updated phase-result with :phase/status and :phase/gate-errors if gates fail."
   [interceptor phase-result ctx]
   (let [gate-keywords (get-in interceptor [:config :gates] [])
-        artifact (:artifact phase-result)]
+        artifact (or (:artifact phase-result)
+                     (get-in phase-result [:result :artifact])
+                     (get-in phase-result [:result :output]))]
     (if (and (seq gate-keywords) artifact)
       (let [gate-result (gate/check-gates gate-keywords artifact ctx)]
         (if (:passed? gate-result)

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -49,7 +49,7 @@
               (when-let [send-fn (ns-resolve http-ns 'send!)]
                 (send-fn ws (json/generate-string event)))))
           (catch Exception e
-            (println "Warning: Failed to send event via WebSocket:" (.getMessage e))))
+            (println "Warning: Failed to send event via WebSocket:" (ex-message e))))
 
         ;; In-memory event stream (same process)
         :else
@@ -58,7 +58,7 @@
             (when-let [publish! (ns-resolve es-ns 'publish!)]
               (publish! event-stream event)))))
       (catch Exception e
-        (println "Warning: Failed to publish event:" (.getMessage e))))))
+        (println "Warning: Failed to publish event:" (ex-message e))))))
 
 (defn- publish-workflow-started!
   "Publish workflow started event."

--- a/components/workflow/test/ai/miniforge/workflow/artifact_persistence_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/artifact_persistence_test.clj
@@ -268,7 +268,7 @@
           "No files should exist when write fails"))))
 
 (deftest test-verify-handles-missing-artifact
-  (testing "Verify phase handles missing implement artifact"
+  (testing "Verify phase fails fast when no code artifact is available"
     ;; Create context WITHOUT implement phase result
     (let [ctx {:execution/id (random-uuid)
                :execution/input {:description "Test"
@@ -277,56 +277,35 @@
                :execution/metrics {:tokens 0 :duration-ms 0}
                :execution/phase-results {}
                :phase-config {:phase :verify}}
-          
+
           verify-interceptor (registry/get-phase-interceptor {:phase :verify})]
-      
+
       (with-redefs [agent/create-tester (fn [_] {:type :mock-tester})
                     agent/invoke (fn [_agent _task _ctx]
                                   (response/success {:result :ok} {:tokens 0 :duration-ms 0}))]
-        (let [result ((:enter verify-interceptor) ctx)]
-          
-          ;; Verify phase should execute (it has fallback to read from input)
-          (is (some? result)
-              "Verify phase should return a result")
-          
-          (is (some? (get-in result [:phase :result]))
-              "Phase result should be present"))))))
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Verify phase received no code artifact"
+                              ((:enter verify-interceptor) ctx))
+            "Verify should throw when no code artifact is available")))))
 
 (deftest test-workflow-empty-artifact-handling
-  (testing "Workflow handles empty artifact (zero files) appropriately"
-    (let [result-ctx (execute-phase-pipeline
-                     {:implement-agent-fn
-                      (fn [_agent _task _ctx]
-                        ;; Implementer returns empty artifact
-                        (response/success mock-empty-artifact {:tokens 50 :duration-ms 300}))
-                      
-                      :release-opts
-                      {:executor
-                       (fn [workflow-state _exec-context _opts]
-                         (let [artifacts (:workflow/artifacts workflow-state)
-                               code-artifact (first artifacts)
-                               file-count (count (get-in code-artifact [:artifact/content :code/files]))]
-                           (if (zero? file-count)
-                             ;; Empty artifact - should report appropriately
-                             {:success? true
-                              :artifacts [{:artifact/id (random-uuid)
-                                         :artifact/type :release
-                                         :artifact/content {:files-written 0
-                                                          :branch "test-branch"
-                                                          :commit-sha "abc123"}}]
-                              :metrics {:files-written 0}}
-                             {:success? true
-                              :artifacts []
-                              :metrics {:files-written file-count}})))}})]
-      
-      ;; Verify metrics show zero files written
-      (let [files-written (get-in result-ctx [:phase :result :output :release/metrics :files-written])]
-        (is (zero? files-written)
-            "Should report zero files written for empty artifact"))
-      
-      ;; Verify no files were created
-      (is (not (file-exists-in-worktree? "src/feature.clj"))
-          "No source files should exist with empty artifact"))))
+  (testing "Workflow fails fast when code artifact has zero files"
+    ;; With fail-fast validation, release phase throws on empty :code/files
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Release phase received code artifact with zero files"
+                          (execute-phase-pipeline
+                           {:implement-agent-fn
+                            (fn [_agent _task _ctx]
+                              ;; Implementer returns empty artifact
+                              (response/success mock-empty-artifact {:tokens 50 :duration-ms 300}))
+
+                            :release-opts
+                            {:executor
+                             (fn [_workflow-state _exec-context _opts]
+                               {:success? true
+                                :artifacts []
+                                :metrics {:files-written 0}})}}))
+        "Release should throw when code artifact has empty files")))
 
 (deftest test-artifact-content-verification
   (testing "Files written to disk have correct content"

--- a/projects/miniforge/test/ai/miniforge/release_executor/artifact_validation_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/release_executor/artifact_validation_integration_test.clj
@@ -1,0 +1,102 @@
+(ns ai.miniforge.release-executor.artifact-validation-integration-test
+  "Project-level integration tests for artifact validation in the release executor.
+
+  Validates the fail-fast behavior when artifacts are nil, empty, or have no files.
+  Exercises the release-executor component through its public interface."
+  (:require
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [babashka.fs :as fs]
+   [babashka.process :as process]
+   [ai.miniforge.release-executor.interface :as release-executor]
+   [ai.miniforge.logging.interface :as log]))
+
+;------------------------------------------------------------------------------ Fixtures
+
+(def ^:dynamic *temp-dir* nil)
+
+(defn temp-dir-fixture [f]
+  (let [dir (fs/create-temp-dir {:prefix "artifact-val-test-"})]
+    (process/shell {:dir (str dir)} "git init")
+    (process/shell {:dir (str dir)} "git config user.email" "test@example.com")
+    (process/shell {:dir (str dir)} "git config user.name" "Test User")
+    ;; Create an initial commit so branch operations work
+    (spit (str (fs/path dir "README.md")) "# Test")
+    (process/shell {:dir (str dir)} "git add README.md")
+    (process/shell {:dir (str dir)} "git commit -m" "initial")
+    (binding [*temp-dir* dir]
+      (try (f)
+           (finally (fs/delete-tree dir))))))
+
+(use-fixtures :each temp-dir-fixture)
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- make-workflow-state [artifacts]
+  {:workflow/id (random-uuid)
+   :workflow/phase :release
+   :workflow/spec {:spec/description "test"}
+   :workflow/artifacts artifacts})
+
+(defn- make-context []
+  {:worktree-path *temp-dir*
+   :create-pr? false
+   :logger (log/create-logger {:min-level :warn})})
+
+;------------------------------------------------------------------------------ Tests
+
+(deftest nil-artifacts-rejected-test
+  (testing "release executor rejects workflow with nil artifact content"
+    (let [state (make-workflow-state [{:artifact/type :code
+                                       :artifact/content nil}])
+          result (release-executor/execute-release-phase state (make-context) {})]
+      (is (false? (:success? result))
+          "Should fail when artifact content is nil")
+      (is (some #(= :no-code-artifacts (:type %)) (:errors result))
+          "Error should indicate no code artifacts"))))
+
+(deftest empty-files-rejected-test
+  (testing "release executor rejects artifacts with zero files"
+    (let [state (make-workflow-state [{:artifact/type :code
+                                       :artifact/content {:code/id (random-uuid)
+                                                          :code/files []}}])
+          result (release-executor/execute-release-phase state (make-context) {})]
+      (is (false? (:success? result))
+          "Should fail when artifact has zero files")
+      (is (some #(= :no-code-files (:type %)) (:errors result))
+          "Error should indicate no code files"))))
+
+(deftest valid-artifacts-pass-validation-test
+  (testing "release executor passes validation for valid artifacts with files"
+    (let [state (make-workflow-state
+                 [{:artifact/type :code
+                   :artifact/content {:code/id (random-uuid)
+                                      :code/files [{:path "src/hello.clj"
+                                                    :content "(ns hello)\n(defn greet [] :hi)"
+                                                    :action :create}]}}])
+          result (release-executor/execute-release-phase state (make-context) {})]
+      ;; Pipeline may fail later at git branch (no remote) but should NOT fail at validation
+      (let [error-types (set (map :type (:errors result)))]
+        (is (not (contains? error-types :no-code-artifacts))
+            "Should not fail with no-code-artifacts for valid artifact")
+        (is (not (contains? error-types :no-code-files))
+            "Should not fail with no-code-files for valid artifact")
+        (is (not (contains? error-types :no-files-to-write))
+            "Should not fail with no-files-to-write for valid artifact")))))
+
+(deftest mixed-nil-and-valid-artifacts-test
+  (testing "release executor filters out nil artifacts and processes valid ones"
+    (let [state (make-workflow-state
+                 [{:artifact/type :code
+                   :artifact/content nil}
+                  {:artifact/type :code
+                   :artifact/content {:code/id (random-uuid)
+                                      :code/files [{:path "src/valid.clj"
+                                                    :content "(ns valid)"
+                                                    :action :create}]}}])
+          result (release-executor/execute-release-phase state (make-context) {})]
+      ;; Nil artifact should be filtered out, valid one should pass validation
+      (let [error-types (set (map :type (:errors result)))]
+        (is (not (contains? error-types :no-code-artifacts))
+            "Should not fail with no-code-artifacts — nil was filtered, valid remained")
+        (is (not (contains? error-types :no-code-files))
+            "Should not fail with no-code-files — valid artifact has files")))))


### PR DESCRIPTION
## Summary

- **Fix silent 0-file releases**: Artifacts generated by the implement phase were silently nil, causing the release phase to succeed with 0 files written. Every phase boundary now validates its inputs and fails fast with descriptive error messages instead of silent success.
- **Fix 5 broken data paths**: Gate validation artifact lookup, implement phase error propagation, review phase context reads, and release nil/empty checks — all now correct.
- **Fix SCI `.getMessage` crash**: Replaced Java interop `.getMessage` with `ex-message` in `runner.clj` for SCI compatibility.

### Changes by file

| File | Change |
|------|--------|
| `execution.clj` | Gate validation now finds artifact inside nested agent result (`[:result :artifact]`, `[:result :output]`) |
| `implement.clj` | `leave-implement` sets `:failed` status when agent returns `:error` instead of always `:completed` |
| `verify.clj` | Throws `ExceptionInfo` with diagnostic data when no code artifact available |
| `review.clj` | Reads implement/verify results from canonical `[:execution/phase-results ...]` path |
| `release.clj` | Rejects nil implement result and empty `:code/files` before invoking release executor |
| `release_executor/core.clj` | Filters nil artifacts, rejects empty files at validation, fails on 0 files written |
| `runner.clj` | `.getMessage` → `ex-message` (2 occurrences) |
| `bb.edn` | Registers new integration test namespace |

### New test files

- `components/phase/test/.../artifact_persistence_test.clj` — 5 component-level tests for fail-fast validation and file writing
- `projects/miniforge/test/.../artifact_validation_integration_test.clj` — 4 project-level integration tests exercising the release-executor through its public interface

### Updated existing tests (4 files)

Tests that expected silent success on missing/empty artifacts now expect `thrown-with-msg?` failures matching the new fail-fast behavior.

## Test plan

- [x] `bb test` — all brick unit tests pass (0 failures, 0 errors)
- [x] `bb test:all` — 45 tests, 201 assertions, 0 failures, 0 errors
- [x] Pre-commit hooks pass (lint, format, tests, GraalVM)
- [ ] Manual smoke test: `mf run` with a small spec → files appear on disk


🤖 Generated with [Claude Code](https://claude.com/claude-code)