### PR TITLE
feat: wire self-healing system into execution pipeline

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -126,8 +126,9 @@
                             "ai.miniforge.loop.interface-integration-test"
                             "ai.miniforge.observer.interface-integration-test"
                             "ai.miniforge.task.interface-integration-test"
-                            "ai.miniforge.release-executor.artifact-validation-integration-test"]
-                            "ai.miniforge.web-dashboard.fleet-onboarding-integration-test"]
+                            "ai.miniforge.release-executor.artifact-validation-integration-test"
+                            "ai.miniforge.web-dashboard.fleet-onboarding-integration-test"
+                            "ai.miniforge.self-healing.integration-test"]
                  require-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
                  run-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
                  expr (str "(require 'clojure.test" require-expr ") "

--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -411,6 +411,25 @@ Output execution logs and status reports."})
       :agent/memory (:memory-id agent)
       :agent/config (:config agent)})))
 
+(defn- record-backend-health!
+  "Record backend call success/failure via self-healing (optional dep)."
+  [context success?]
+  (try
+    (when-let [record-fn (requiring-resolve 'ai.miniforge.self-healing.interface/record-backend-call!)]
+      (let [backend (or (get-in context [:llm-backend :config :backend]) :anthropic)]
+        (record-fn backend success?)))
+    (catch Exception _ nil)))
+
+(defn- try-self-healing-on-failure
+  "Attempt workaround when agent execution fails. Returns {:retry? bool} or nil."
+  [exception]
+  (try
+    (when-let [detect-fn (requiring-resolve 'ai.miniforge.self-healing.interface/detect-and-apply-workaround)]
+      (let [result (detect-fn exception {})]
+        (when (and (:workaround-found? result) (:applied? result) (:success? result))
+          {:retry? true :workaround-result result})))
+    (catch Exception _ nil)))
+
 (defrecord DefaultExecutor [logger memory-store]
   protocol/AgentExecutor
   (execute [_this agent task context]
@@ -435,23 +454,47 @@ Output execution logs and status reports."})
 
           ;; Execute
           result (try
-                   (protocol/invoke initialized-agent task exec-context)
+                   (let [invoke-result (protocol/invoke initialized-agent task exec-context)]
+                     (record-backend-health! exec-context true)
+                     invoke-result)
                    (catch Exception e
+                     (record-backend-health! exec-context false)
                      (let [;; Try to classify the error if agent-runtime is available
                            error-classification (try
                                                  (let [classifier (requiring-resolve 'ai.miniforge.agent-runtime.interface/classify-error)]
                                                    (when classifier
                                                      (classifier e {:task-id task-id})))
-                                                 (catch Exception _ nil))]
-                       {:success false
-                        :error (.getMessage e)
-                        :exception-type (type e)
-                        :anomaly (response/from-exception e)
-                        :error-classification error-classification
-                        :outputs []
-                        :decisions [:execution-error]
-                        :signals [:task-failed]
-                        :metrics (make-metrics)})))
+                                                 (catch Exception _ nil))
+                           healing (try-self-healing-on-failure e)]
+                       (if (:retry? healing)
+                         ;; Workaround applied — retry once
+                         (try
+                           (let [retry-result (protocol/invoke initialized-agent task exec-context)]
+                             (record-backend-health! exec-context true)
+                             (assoc retry-result :self-healing/workaround-applied true))
+                           (catch Exception retry-e
+                             (record-backend-health! exec-context false)
+                             {:success false
+                              :error (ex-message retry-e)
+                              :exception-type (type retry-e)
+                              :anomaly (response/from-exception retry-e)
+                              :error-classification error-classification
+                              :self-healing/workaround-applied true
+                              :self-healing/retry-failed true
+                              :outputs []
+                              :decisions [:execution-error]
+                              :signals [:task-failed]
+                              :metrics (make-metrics)}))
+                         ;; No workaround — return error (existing behavior)
+                         {:success false
+                          :error (ex-message e)
+                          :exception-type (type e)
+                          :anomaly (response/from-exception e)
+                          :error-classification error-classification
+                          :outputs []
+                          :decisions [:execution-error]
+                          :signals [:task-failed]
+                          :metrics (make-metrics)}))))
 
           ;; Validate output
           validation (protocol/validate agent result exec-context)

--- a/components/agent/src/ai/miniforge/agent/protocols/impl/specialized.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/impl/specialized.clj
@@ -67,11 +67,11 @@
         result)
       (catch Exception e
         (log/error logger :agent :agent/invoke-failed
-                   {:message (.getMessage e)
+                   {:message (ex-message e)
                     :data {:role role
                            :duration-ms (- (System/currentTimeMillis) start-time)}})
         {:status :error
-         :error (.getMessage e)
+         :error (ex-message e)
          :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}}))))
 
 (defn validate-impl

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -62,7 +62,7 @@
    :gate-type :unknown
    :passed? false
    :errors [{:type :gate-exception
-             :message (str "Gate execution failed: " (.getMessage exception))}]
+             :message (str "Gate execution failed: " (ex-message exception))}]
    :duration-ms duration})
 
 (defn- run-single-gate
@@ -86,7 +86,7 @@
         (let [duration (- (System/currentTimeMillis) gate-start)]
           (log/error logger :reviewer :reviewer/gate-error
                      {:data {:gate-idx idx
-                             :error (.getMessage e)}})
+                             :error (ex-message e)}})
           (create-exception-feedback gate idx e duration))))))
 
 (defn- run-gates-on-artifact

--- a/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
@@ -138,7 +138,7 @@
                          (assoc :successful-calls new-successful)
                          (assoc :success-rate new-success-rate)
                          (assoc :last-failure (when-not success?
-                                                (java.time.Instant/now))))
+                                                (str (java.time.Instant/now)))))
         new-health (assoc-in health [:backends backend-key] updated-stats)]
     (save-health! new-health)
     updated-stats))
@@ -187,7 +187,10 @@
          cooldown-until (get-in health [:switch-cooldowns backend-key])]
      (when cooldown-until
        (let [now (java.time.Instant/now)
-             cooldown-end (.plusMillis cooldown-until cooldown-ms)]
+             instant (if (string? cooldown-until)
+                       (java.time.Instant/parse cooldown-until)
+                       cooldown-until)
+             cooldown-end (.plusMillis instant cooldown-ms)]
          (.isBefore now cooldown-end))))))
 
 (defn select-best-backend
@@ -235,14 +238,14 @@
          now (java.time.Instant/now)
          from-key (keyword from-backend)
          to-key (keyword to-backend)
-         cooldown-until now
+         cooldown-until-str (str now)
          updated-health (-> health
-                           (assoc-in [:switch-cooldowns from-key] cooldown-until)
+                           (assoc-in [:switch-cooldowns from-key] cooldown-until-str)
                            (assoc :default-backend to-key))]
      (save-health! updated-health)
      {:from from-key
       :to to-key
-      :cooldown-until cooldown-until
+      :cooldown-until now
       :cooldown-ms cooldown-ms})))
 
 ;;------------------------------------------------------------------------------ Layer 3

--- a/components/self-healing/src/ai/miniforge/self_healing/workaround_detector.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/workaround_detector.clj
@@ -76,7 +76,7 @@
                     error-result
                     (or (:message error-result)
                         (when (instance? Exception error-result)
-                          (.getMessage error-result))
+                          (ex-message error-result))
                         (str error-result)))]
     (first (filter #(matches-workaround-pattern? error-msg %) workaround-patterns))))
 
@@ -154,7 +154,7 @@
        :exit-code exit-code})
     (catch Exception e
       {:success? false
-       :error (.getMessage e)})))
+       :error (ex-message e)})))
 
 (defn- apply-shell-workaround
   "Apply shell command workaround.

--- a/components/self-healing/src/ai/miniforge/self_healing/workaround_registry.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/workaround_registry.clj
@@ -113,7 +113,7 @@
   [workaround]
   (let [registry (load-workarounds)
         id (or (:id workaround) (java.util.UUID/randomUUID))
-        now (java.time.Instant/now)
+        now (str (java.time.Instant/now))
         new-workaround (merge {:id id
                                :success-count 0
                                :failure-count 0
@@ -144,7 +144,7 @@
       (let [workaround (nth workarounds idx)
             updated (-> workaround
                        (update (if success? :success-count :failure-count) inc)
-                       (assoc :last-used (java.time.Instant/now)))
+                       (assoc :last-used (str (java.time.Instant/now))))
             total (+ (:success-count updated) (:failure-count updated))
             confidence (if (> total 0)
                         (double (/ (:success-count updated) total))

--- a/components/self-healing/test/ai/miniforge/self_healing/backend_health_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/backend_health_test.clj
@@ -261,4 +261,4 @@
     (let [health-data (health/load-health)
           backend-stats (get-in health-data [:backends :anthropic])]
       (is (some? (:last-failure backend-stats)))
-      (is (instance? java.time.Instant (:last-failure backend-stats))))))
+      (is (string? (:last-failure backend-stats))))))

--- a/components/self-healing/test/ai/miniforge/self_healing/workaround_detector_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/workaround_detector_test.clj
@@ -137,7 +137,7 @@
                    :description "Test with denial"
                    :workaround {:type :backend-switch
                                 :to-backend :codex
-                                :requires-sudo false
+                                :requires-sudo true
                                 :auto-apply false}}
           prompt-fn (fn [_msg _opts] "no")
           result (detector/apply-workaround pattern prompt-fn)]

--- a/components/self-healing/test/ai/miniforge/self_healing/workaround_registry_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/workaround_registry_test.clj
@@ -29,11 +29,15 @@
 
 (defn cleanup-test-registry
   [f]
-  (try
-    (f)
-    (finally
+  (with-redefs [registry/workaround-registry-path (constantly test-registry-path)]
+    (try
+      ;; Clean before test to ensure isolation
       (when (.exists (io/file test-registry-path))
-        (.delete (io/file test-registry-path))))))
+        (.delete (io/file test-registry-path)))
+      (f)
+      (finally
+        (when (.exists (io/file test-registry-path))
+          (.delete (io/file test-registry-path)))))))
 
 (use-fixtures :each cleanup-test-registry)
 

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -99,6 +99,26 @@
                    :success? (:success? result)
                    :timestamp (java.time.Instant/now)}))
 
+(defn- check-backend-health-at-boundary!
+  "Check backend health at phase boundary. Returns switch-result or nil."
+  [event-stream context]
+  (try
+    (when-let [check-fn (requiring-resolve
+                          'ai.miniforge.self-healing.interface/check-backend-health-and-switch)]
+      (let [backend (or (get-in context [:execution/opts :llm-backend :config :backend])
+                        :anthropic)
+            sh-ctx {:llm {:backend backend}
+                    :config (get-in context [:execution/opts :self-healing-config])}
+            switch-result (check-fn sh-ctx)]
+        (when (:switched? switch-result)
+          (when-let [emit-fn (requiring-resolve
+                               'ai.miniforge.self-healing.interface/emit-backend-switch-event)]
+            (publish-event! event-stream (emit-fn sh-ctx switch-result)))
+          switch-result)))
+    (catch Exception e
+      (println "Warning: Self-healing health check failed:" (ex-message e))
+      nil)))
+
 ;------------------------------------------------------------------------------ Layer 0: Pipeline helpers
 
 (defn build-pipeline
@@ -191,11 +211,16 @@
       (monitoring/handle-meta-agent-halt context health-check ctx/transition-to-failed)
 
       ;; Healthy or warning - continue execution
-      (-> (exec/execute-phase-step pipeline context callbacks
-                                   ctx/merge-metrics
-                                   ctx/transition-to-completed
-                                   ctx/transition-to-failed)
-          (monitoring/clear-transient-state)))))
+      (let [phase-ctx (-> (exec/execute-phase-step pipeline context callbacks
+                                                   ctx/merge-metrics
+                                                   ctx/transition-to-completed
+                                                   ctx/transition-to-failed)
+                          (monitoring/clear-transient-state))
+            event-stream (get-in phase-ctx [:execution/opts :event-stream])
+            switch-result (check-backend-health-at-boundary! event-stream phase-ctx)]
+        (if switch-result
+          (assoc phase-ctx :self-healing/backend-switch switch-result)
+          phase-ctx)))))
 
 ;------------------------------------------------------------------------------ Layer 2: Main entry point
 

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -39,6 +39,8 @@
         ai.miniforge/reporting {:local/root "../../components/reporting"}
         ;; Event streaming and observability
         ai.miniforge/event-stream {:local/root "../../components/event-stream"}
+        ;; Self-healing: workaround detection, backend health tracking
+        ai.miniforge/self-healing {:local/root "../../components/self-healing"}
         ;; TUI framework and views
         ai.miniforge/tui-engine {:local/root "../../components/tui-engine"}
         ai.miniforge/tui-views {:local/root "../../components/tui-views"}

--- a/projects/miniforge/test/ai/miniforge/self_healing/integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/self_healing/integration_test.clj
@@ -1,0 +1,220 @@
+(ns ai.miniforge.self-healing.integration-test
+  "Integration tests for self-healing wiring into execution pipeline."
+  (:require [clojure.test :refer [deftest testing is use-fixtures]]
+            [ai.miniforge.agent.core :as core]
+            [ai.miniforge.agent.protocol :as protocol]
+            [ai.miniforge.self-healing.interface :as sh]
+            [ai.miniforge.self-healing.backend-health :as health]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures — temp files for health/approval data
+
+(def ^:dynamic *test-health-path* nil)
+
+(defn- temp-health-path []
+  (str (System/getProperty "java.io.tmpdir")
+       "/miniforge-test-health-" (random-uuid) ".edn"))
+
+(defn cleanup-fixture [f]
+  (let [path (temp-health-path)]
+    (binding [*test-health-path* path]
+      ;; Redirect health file to temp path
+      (with-redefs [health/load-health (fn []
+                                         (let [file (clojure.java.io/file path)]
+                                           (if (.exists file)
+                                             (clojure.edn/read-string (slurp file))
+                                             {:backends {}
+                                              :switch-cooldowns {}
+                                              :default-backend :anthropic
+                                              :fallback-order [:anthropic :openai :codex :ollama :google]})))
+                    health/save-health! (fn [data]
+                                          (clojure.java.io/make-parents path)
+                                          (spit path (pr-str data)))]
+        (try
+          (f)
+          (finally
+            (let [file (clojure.java.io/file path)]
+              (when (.exists file)
+                (.delete file)))))))))
+
+(use-fixtures :each cleanup-fixture)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Helper: create a throwing agent for testing
+
+(defrecord ThrowingAgent [id role capabilities config memory-id state throw-ex]
+  protocol/Agent
+  (invoke [_this _task _context]
+    (throw throw-ex))
+  (validate [_this output _context]
+    {:valid? true :errors []})
+  (repair [_this output _errors _context]
+    {:repaired output :changes [] :success true})
+
+  protocol/AgentLifecycle
+  (init [this _new-config] this)
+  (status [_this] {:status :ready})
+  (shutdown [this] this)
+  (abort [this _reason] {:aborted true}))
+
+(defrecord SuccessAgent [id role capabilities config memory-id state]
+  protocol/Agent
+  (invoke [_this _task _context]
+    {:success true
+     :outputs [{:artifact/id (random-uuid)
+                :artifact/type :code
+                :artifact/content "ok"}]
+     :decisions [:completed]
+     :signals [:done]
+     :metrics (core/make-metrics)})
+  (validate [_this output _context]
+    {:valid? true :errors []})
+  (repair [_this output _errors _context]
+    {:repaired output :changes [] :success true})
+
+  protocol/AgentLifecycle
+  (init [this _new-config] this)
+  (status [_this] {:status :ready})
+  (shutdown [this] this)
+  (abort [this _reason] {:aborted true}))
+
+(defn- make-throwing-agent [ex]
+  (->ThrowingAgent (random-uuid) :tester #{} {} (random-uuid) {:status :ready} ex))
+
+(defn- make-success-agent []
+  (->SuccessAgent (random-uuid) :tester #{} {} (random-uuid) {:status :ready}))
+
+(defn- make-task []
+  {:task/id (random-uuid)
+   :task/type :test
+   :task/status :pending
+   :task/inputs []})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Tests
+
+(deftest test-agent-failure-records-health
+  (testing "Agent failure records backend health with success?=false"
+    (let [recorded (atom [])
+          executor (core/create-executor)]
+      (with-redefs [sh/record-backend-call! (fn [backend success?]
+                                                   (swap! recorded conj {:backend backend :success? success?})
+                                                   nil)
+                    health/load-health (fn [] {:backends {} :switch-cooldowns {}
+                                               :default-backend :anthropic
+                                               :fallback-order [:anthropic :openai]})]
+        (let [result (protocol/execute executor
+                                        (make-throwing-agent (ex-info "boom" {}))
+                                        (make-task)
+                                        {:llm-backend {:config {:backend :anthropic}}})]
+          (is (false? (:success result)))
+          (is (some #(and (= :anthropic (:backend %))
+                          (false? (:success? %)))
+                    @recorded)))))))
+
+(deftest test-agent-success-records-health
+  (testing "Agent success records backend health with success?=true"
+    (let [recorded (atom [])
+          executor (core/create-executor)]
+      (with-redefs [sh/record-backend-call! (fn [backend success?]
+                                                   (swap! recorded conj {:backend backend :success? success?})
+                                                   nil)
+                    health/load-health (fn [] {:backends {} :switch-cooldowns {}
+                                               :default-backend :anthropic
+                                               :fallback-order [:anthropic :openai]})]
+        (let [result (protocol/execute executor
+                                        (make-success-agent)
+                                        (make-task)
+                                        {:llm-backend {:config {:backend :openai}}})]
+          (is (:success result))
+          (is (some #(and (= :openai (:backend %))
+                          (true? (:success? %)))
+                    @recorded)))))))
+
+(deftest test-known-error-triggers-workaround-retry
+  (testing "Known error pattern triggers workaround detection and retry"
+    (let [call-count (atom 0)
+          executor (core/create-executor)
+          ;; Agent that fails first time, succeeds on retry
+          retry-agent (reify
+                        protocol/Agent
+                        (invoke [_ _task _context]
+                          (let [n (swap! call-count inc)]
+                            (if (= n 1)
+                              (throw (ex-info "simulated error" {}))
+                              {:success true
+                               :outputs []
+                               :decisions [:completed]
+                               :signals [:done]
+                               :metrics (core/make-metrics)})))
+                        (validate [_ output _context]
+                          {:valid? true :errors []})
+                        (repair [_ output _errors _context]
+                          {:repaired output :changes [] :success true})
+                        protocol/AgentLifecycle
+                        (init [this _config] this)
+                        (status [_] {:status :ready})
+                        (shutdown [this] this)
+                        (abort [this _reason] {:aborted true}))]
+      ;; Make self-healing return a successful workaround
+      (with-redefs [sh/record-backend-call! (fn [_ _] nil)
+                    health/load-health (fn [] {:backends {} :switch-cooldowns {}
+                                               :default-backend :anthropic
+                                               :fallback-order [:anthropic :openai]})
+                    sh/detect-and-apply-workaround
+                    (fn [_error _opts]
+                      {:workaround-found? true
+                       :applied? true
+                       :success? true
+                       :message "Test workaround applied"})]
+        (let [result (protocol/execute executor retry-agent (make-task)
+                                        {:llm-backend {:config {:backend :anthropic}}})]
+          (is (:success result))
+          (is (true? (:self-healing/workaround-applied result)))
+          (is (= 2 @call-count)))))))
+
+(deftest test-backend-switch-on-health-degradation
+  (testing "Multiple failures trigger backend switch via check-and-switch-if-needed"
+    (let [switch-called? (atom false)]
+      (with-redefs [sh/record-backend-call! (fn [_ _] nil)
+                    health/check-and-switch-if-needed
+                    (fn [backend _threshold _cooldown]
+                      (when (= backend :anthropic)
+                        (reset! switch-called? true)
+                        {:should-switch? true
+                         :from :anthropic
+                         :to :openai
+                         :cooldown-until (java.time.Instant/now)}))]
+        ;; Directly call the interface function
+        (let [result (sh/check-backend-health-and-switch
+                       {:llm {:backend :anthropic}
+                        :config {:self-healing {:enabled true
+                                                :backend-auto-switch true
+                                                :backend-health-threshold 0.90
+                                                :backend-switch-cooldown-ms 1800000}}})]
+          (is @switch-called?)
+          (is (:switched? result))
+          (is (= :openai (:to result))))))))
+
+(deftest test-self-healing-graceful-degradation
+  (testing "When self-healing is unavailable, execution works normally"
+    (let [executor (core/create-executor)]
+      ;; Simulate requiring-resolve returning nil (self-healing not on classpath)
+      ;; The try/catch in record-backend-health! and try-self-healing-on-failure
+      ;; should swallow errors and let execution proceed normally
+      (with-redefs [sh/record-backend-call! (fn [_ _] (throw (ex-info "not available" {})))
+                    health/load-health (fn [] (throw (ex-info "not available" {})))]
+        ;; Success case — should still work
+        (let [result (protocol/execute executor
+                                        (make-success-agent)
+                                        (make-task)
+                                        {})]
+          (is (:success result)))
+
+        ;; Failure case — should still return error result (not throw)
+        (let [result (protocol/execute executor
+                                        (make-throwing-agent (ex-info "real error" {}))
+                                        (make-task)
+                                        {})]
+          (is (false? (:success result)))
+          (is (= "real error" (:error result))))))))


### PR DESCRIPTION
## Summary

- Wire the self-healing component (workaround detection, backend health tracking) into the agent executor and workflow runner so miniforge automatically recovers from known vendor bugs and degrades gracefully when a backend becomes unreliable
- Agent executor records backend health on success/failure and attempts a single workaround-driven retry before returning errors; workflow runner checks backend health at phase boundaries and emits backend-switch events
- Fix remaining `.getMessage` Java interop → `ex-message` across agent, reviewer, specialized, and workaround-detector for SCI/Babashka compatibility
- Fix pre-existing self-healing EDN serialization bugs (Instant roundtrip), test fixture isolation, and prompt-denied test logic

## Design decisions

- **`requiring-resolve` everywhere**: Neither agent nor workflow add self-healing to their brick `deps.edn`. All calls are lazy-loaded and wrapped in `try/catch`, making self-healing a true optional dependency that degrades gracefully
- **Retry once, not indefinitely**: After workaround application, agent retries exactly once to prevent infinite retry loops
- **Phase boundary health check**: Backend switching at phase boundaries (not per-LLM-call) to avoid thrashing; existing cooldown logic provides additional protection

## Test plan

- [x] `bb test` — all 33 brick test suites pass (including newly-exercised self-healing tests)
- [x] `bb test:graalvm` — GraalVM/Babashka compatibility passes
- [x] Pre-commit hooks pass (lint, format, test, graalvm)
- [ ] `bb test:integration` — run new integration test covering health recording, workaround retry, backend switching, and graceful degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)