### PR TITLE
feat: N3/N5/N8 event constructors, evidence API, OCI listeners & control actions

### DIFF
--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -162,6 +162,19 @@ Output execution logs and status reports."})
    :iterations 0
    :llm-calls 0})
 
+(defn- execution-failure
+  "Build a canonical execution failure response from an exception.
+   Uses response/failure as the base and merges domain-specific agent keys."
+  [^Throwable e & [extra]]
+  (merge (response/failure (ex-message e)
+                           {:data {:exception-type (str (type e))}})
+         {:anomaly (response/from-exception e)
+          :outputs []
+          :decisions [:execution-error]
+          :signals [:task-failed]
+          :metrics (make-metrics)}
+         extra))
+
 (defn update-metrics
   "Update metrics with new values."
   [metrics {:keys [input-tokens output-tokens duration-ms cost]}]
@@ -258,13 +271,13 @@ Output execution logs and status reports."})
     ;; Default repair - wrap invalid output
     (if (empty? errors)
       {:repaired output :changes [] :success true}
-      {:repaired {:success false
-                  :outputs []
-                  :decisions [:repair-failed]
-                  :signals [:validation-error]
-                  :metrics (make-metrics)
-                  :original output
-                  :errors errors}
+      {:repaired (merge (response/failure "Repair failed")
+                        {:original output
+                         :errors errors
+                         :outputs []
+                         :decisions [:repair-failed]
+                         :signals [:validation-error]
+                         :metrics (make-metrics)})
        :changes [:wrapped-invalid-output]
        :success false}))
 
@@ -474,27 +487,13 @@ Output execution logs and status reports."})
                              (assoc retry-result :self-healing/workaround-applied true))
                            (catch Exception retry-e
                              (record-backend-health! exec-context false)
-                             {:success false
-                              :error (ex-message retry-e)
-                              :exception-type (type retry-e)
-                              :anomaly (response/from-exception retry-e)
-                              :error-classification error-classification
-                              :self-healing/workaround-applied true
-                              :self-healing/retry-failed true
-                              :outputs []
-                              :decisions [:execution-error]
-                              :signals [:task-failed]
-                              :metrics (make-metrics)}))
+                             (execution-failure retry-e
+                                                {:error-classification error-classification
+                                                 :self-healing/workaround-applied true
+                                                 :self-healing/retry-failed true})))
                          ;; No workaround — return error (existing behavior)
-                         {:success false
-                          :error (ex-message e)
-                          :exception-type (type e)
-                          :anomaly (response/from-exception e)
-                          :error-classification error-classification
-                          :outputs []
-                          :decisions [:execution-error]
-                          :signals [:task-failed]
-                          :metrics (make-metrics)}))))
+                         (execution-failure e
+                                            {:error-classification error-classification})))))
 
           ;; Validate output
           validation (protocol/validate agent result exec-context)

--- a/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
@@ -217,6 +217,14 @@
 ;------------------------------------------------------------------------------ Layer 5
 ;; InterAgentMessaging protocol implementations
 
+(defn- publish-to-event-stream!
+  "Publish an event to the event stream if available (no hard dep on event-stream)."
+  [agent-messaging event]
+  (try
+    (when-let [stream (:event-stream agent-messaging)]
+      ((requiring-resolve 'ai.miniforge.event-stream.interface/publish!) stream event))
+    (catch Exception _ nil)))
+
 (defn send-message-impl
   "Send message from agent to another agent.
    Returns {:message message-map :event event-map}"
@@ -236,6 +244,8 @@
     ;; Route message
     (let [routed-msg (route-message-impl router message)
           event (create-message-sent-event routed-msg)]
+      ;; Publish to event stream if available
+      (publish-to-event-stream! agent-messaging event)
       {:message routed-msg
        :event event})))
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/state.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/state.clj
@@ -362,6 +362,18 @@
                          :new-status (get-in result [:run/tasks task-id :task/status])}}))
     result))
 
+(defn- emit-task-state-event!
+  "Emit task/state-changed event via requiring-resolve (no hard dep on event-stream)."
+  [run-state task-id from-status to-status]
+  (try
+    (when-let [stream (get-in run-state [:run/config :event-stream])]
+      (when-let [publish-fn (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
+        (when-let [constructor (requiring-resolve 'ai.miniforge.event-stream.interface/task-state-changed)]
+          (let [workflow-id (get-in run-state [:run/config :workflow-id])
+                dag-id (:dag/id run-state)]
+            (publish-fn stream (constructor stream workflow-id dag-id task-id from-status to-status))))))
+    (catch Exception _ nil)))
+
 (defn transition-task!
   "Atomically transition a task to a new status within a run atom.
    Returns result with updated run state or error."
@@ -372,15 +384,17 @@
       (result/err :task-not-found
                   (str "Task " task-id " not found in run")
                   {:task-id task-id})
-      (let [transition-result (transition-task task-state new-status)]
+      (let [from-status (:task/status task-state)
+            transition-result (transition-task task-state new-status)]
         (if (result/ok? transition-result)
           (do
             (swap! run-atom update-run-task task-id (constantly (:data transition-result)))
+            (emit-task-state-event! @run-atom task-id from-status new-status)
             (when logger
               (log/info logger :dag-executor :task/transitioned
                         {:message "Task status changed"
                          :data {:task-id task-id
-                                :from (:task/status task-state)
+                                :from from-status
                                 :to new-status}}))
             (result/ok @run-atom))
           (do

--- a/components/dag-executor/test/ai/miniforge/dag_executor/state_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/state_test.clj
@@ -1,0 +1,103 @@
+(ns ai.miniforge.dag-executor.state-test
+  "Tests for DAG task state management and event emission wiring."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.dag-executor.state :as state]
+   [ai.miniforge.dag-executor.result :as result]
+   [ai.miniforge.event-stream.interface :as es]))
+
+;; ============================================================================
+;; State transition tests
+;; ============================================================================
+
+(deftest transition-task-pure-test
+  (testing "valid transition returns ok result"
+    (let [task (state/create-task-state (random-uuid) #{})
+          result (state/transition-task task :ready)]
+      (is (result/ok? result))
+      (is (= :ready (:task/status (:data result))))))
+
+  (testing "invalid transition returns error"
+    (let [task (state/create-task-state (random-uuid) #{})
+          result (state/transition-task task :merged)]
+      (is (result/err? result)))))
+
+(deftest transition-task!-test
+  (testing "atomically transitions task in run state"
+    (let [task-id (random-uuid)
+          task (state/create-task-state task-id #{})
+          run (state/create-run-state (random-uuid) {task-id task})
+          run-atom (state/create-run-atom run)
+          result (state/transition-task! run-atom task-id :ready nil)]
+      (is (result/ok? result))
+      (is (= :ready (get-in @run-atom [:run/tasks task-id :task/status])))))
+
+  (testing "returns error for nonexistent task"
+    (let [run (state/create-run-state (random-uuid) {})
+          run-atom (state/create-run-atom run)
+          result (state/transition-task! run-atom (random-uuid) :ready nil)]
+      (is (result/err? result)))))
+
+;; ============================================================================
+;; Event emission wiring tests
+;; ============================================================================
+
+(deftest transition-task!-emits-event-test
+  (testing "transition-task! emits task/state-changed when event-stream is configured"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          dag-id (random-uuid)
+          task-id (random-uuid)
+          task (state/create-task-state task-id #{})
+          run (-> (state/create-run-state dag-id {task-id task})
+                  (assoc-in [:run/config :event-stream] stream)
+                  (assoc-in [:run/config :workflow-id] wf-id))
+          run-atom (state/create-run-atom run)
+          result (state/transition-task! run-atom task-id :ready nil)]
+      (is (result/ok? result))
+      (let [events (es/get-events stream)]
+        (is (= 1 (count events)))
+        (let [event (first events)]
+          (is (= :task/state-changed (:event/type event)))
+          (is (= dag-id (:dag/id event)))
+          (is (= task-id (:task/id event)))
+          (is (= :pending (:task/from-state event)))
+          (is (= :ready (:task/to-state event))))))))
+
+(deftest transition-task!-works-without-event-stream-test
+  (testing "transition-task! works normally without event-stream in config"
+    (let [task-id (random-uuid)
+          task (state/create-task-state task-id #{})
+          run (state/create-run-state (random-uuid) {task-id task})
+          run-atom (state/create-run-atom run)
+          result (state/transition-task! run-atom task-id :ready nil)]
+      (is (result/ok? result))
+      (is (= :ready (get-in @run-atom [:run/tasks task-id :task/status]))))))
+
+;; ============================================================================
+;; Query tests
+;; ============================================================================
+
+(deftest ready-tasks-test
+  (testing "finds tasks with all deps satisfied"
+    (let [task-a-id (random-uuid)
+          task-b-id (random-uuid)
+          task-a (state/create-task-state task-a-id #{})
+          task-b (state/create-task-state task-b-id #{task-a-id})
+          run (state/create-run-state (random-uuid) {task-a-id task-a
+                                                      task-b-id task-b})]
+      ;; Only task-a is ready (no deps)
+      (is (= #{task-a-id} (state/ready-tasks run)))
+      ;; After marking task-a merged, task-b becomes ready
+      (let [run' (-> run
+                     (assoc-in [:run/tasks task-a-id :task/status] :merged)
+                     (state/mark-task-merged task-a-id))]
+        (is (contains? (state/ready-tasks run') task-b-id))))))
+
+(deftest terminal?-test
+  (testing "terminal statuses"
+    (is (state/terminal? :merged))
+    (is (state/terminal? :failed))
+    (is (state/terminal? :skipped))
+    (is (not (state/terminal? :pending)))
+    (is (not (state/terminal? :implementing)))))

--- a/components/event-stream/src/ai/miniforge/event_stream/control.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/control.clj
@@ -7,7 +7,8 @@
 
    RBAC roles define which action types are permitted per target category."
   (:require
-   [ai.miniforge.event-stream.core :as core]))
+   [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; RBAC role definitions
@@ -81,10 +82,18 @@
         permitted-actions (get role-perms category #{})]
     (cond
       (nil? role-perms)
-      {:authorized? false :reason (str "Unknown role: " role)}
+      {:authorized? false
+       :reason (str "Unknown role: " role)
+       :anomaly (response/make-anomaly :anomalies/not-found
+                                        (str "Unknown role: " role)
+                                        {:role role})}
 
       (nil? category)
-      {:authorized? false :reason (str "Unknown target type: " target-type)}
+      {:authorized? false
+       :reason (str "Unknown target type: " target-type)
+       :anomaly (response/make-anomaly :anomalies/incorrect
+                                        (str "Unknown target type: " target-type)
+                                        {:target-type target-type})}
 
       (contains? permitted-actions action-type)
       {:authorized? true :reason "Action permitted by role"}
@@ -92,7 +101,13 @@
       :else
       {:authorized? false
        :reason (str "Role " (name role) " cannot perform " (name action-type)
-                    " on " (name target-type))})))
+                    " on " (name target-type))
+       :anomaly (response/make-anomaly :anomalies/forbidden
+                                        (str "Role " (name role) " cannot perform "
+                                             (name action-type) " on " (name target-type))
+                                        {:role role
+                                         :action-type action-type
+                                         :target-type target-type})})))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Control action execution
@@ -118,10 +133,9 @@
     ;; Execute
     (let [result (try
                    (let [r (execution-fn action)]
-                     {:status :success :result r})
+                     (response/success r))
                    (catch Exception e
-                     {:status :failure
-                      :result {:error (.getMessage e)}}))]
+                     (response/failure (.getMessage e) {:data (ex-data e)})))]
       ;; Emit executed event
       (core/publish! stream
                      (core/control-action-executed

--- a/components/event-stream/src/ai/miniforge/event_stream/control.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/control.clj
@@ -1,0 +1,129 @@
+(ns ai.miniforge.event-stream.control
+  "Structured control actions with RBAC for N8 OCI compliance.
+
+   Control actions are commands issued by authorized listeners to affect
+   workflow execution (pause, resume, retry, rollback, etc.). Each action
+   carries requester identity, justification, and authorization context.
+
+   RBAC roles define which action types are permitted per target category."
+  (:require
+   [ai.miniforge.event-stream.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; RBAC role definitions
+
+(def default-roles
+  "Default RBAC roles mapping role -> target-category -> permitted actions."
+  {:operator {:workflows #{:pause :resume :retry :cancel}
+              :agents #{:quarantine :adjust-budget}
+              :fleet #{}
+              :approvals #{}}
+   :admin {:workflows #{:pause :resume :retry :cancel :rollback}
+           :agents #{:quarantine :adjust-budget}
+           :fleet #{:emergency-stop :drain}
+           :approvals #{:gate-override :budget-escalation}}})
+
+(def target-categories
+  "Valid target types for control actions."
+  #{:workflow :agent :fleet})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Control action creation
+
+(defn create-control-action
+  "Create a structured control action.
+
+   Arguments:
+   - action-type: Keyword — :pause, :resume, :retry, :rollback, :cancel,
+                  :quarantine, :adjust-budget, :emergency-stop, :gate-override
+   - target: Map with :target-type (:workflow, :agent, :fleet) and :target-id
+   - requester: Map with :principal (string), :role (keyword), :listener-id (optional)
+   - opts: Optional map with :justification (string) and :parameters (map)
+
+   Returns: Control action map."
+  [action-type target requester & [opts]]
+  (cond-> {:action/id (random-uuid)
+           :action/type action-type
+           :action/target target
+           :action/requester requester
+           :action/status :pending
+           :action/created-at (java.util.Date.)}
+    (:justification opts) (assoc :action/justification (:justification opts))
+    (:parameters opts) (assoc :action/parameters (:parameters opts))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; RBAC authorization
+
+(defn- target-type->category
+  "Map target type to RBAC category."
+  [target-type]
+  (case target-type
+    :workflow :workflows
+    :agent :agents
+    :fleet :fleet
+    nil))
+
+(defn authorize-action
+  "Check RBAC authorization for a control action.
+
+   Arguments:
+   - roles: RBAC role definitions map (use default-roles or custom)
+   - action: Control action map from create-control-action
+   - requester: Map with :role keyword
+
+   Returns: {:authorized? bool :reason string}"
+  [roles action requester]
+  (let [role (:role requester)
+        role-perms (get roles role)
+        target-type (get-in action [:action/target :target-type])
+        category (target-type->category target-type)
+        action-type (:action/type action)
+        permitted-actions (get role-perms category #{})]
+    (cond
+      (nil? role-perms)
+      {:authorized? false :reason (str "Unknown role: " role)}
+
+      (nil? category)
+      {:authorized? false :reason (str "Unknown target type: " target-type)}
+
+      (contains? permitted-actions action-type)
+      {:authorized? true :reason "Action permitted by role"}
+
+      :else
+      {:authorized? false
+       :reason (str "Role " (name role) " cannot perform " (name action-type)
+                    " on " (name target-type))})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Control action execution
+
+(defn execute-control-action!
+  "Execute an authorized control action.
+
+   Arguments:
+   - stream: Event stream atom
+   - action: Control action map
+   - execution-fn: (fn [action] -> result-map) that performs the actual action
+
+   Emits :control-action/requested before execution and
+   :control-action/executed after. Returns result map with :status and :result."
+  [stream action execution-fn]
+  (let [workflow-id (get-in action [:action/target :target-id])
+        action-id (:action/id action)]
+    ;; Emit requested event
+    (core/publish! stream
+                   (core/control-action-requested
+                    stream workflow-id action-id (:action/type action)
+                    (:action/requester action)))
+    ;; Execute
+    (let [result (try
+                   (let [r (execution-fn action)]
+                     {:status :success :result r})
+                   (catch Exception e
+                     {:status :failure
+                      :result {:error (.getMessage e)}}))]
+      ;; Emit executed event
+      (core/publish! stream
+                     (core/control-action-executed
+                      stream workflow-id action-id result))
+      result)))

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -90,10 +90,11 @@
         (sink event)
         (catch Exception e
           (when logger
-            (log/warn logger :event-stream :sink-error
-                     {:message "Event sink failed"
-                      :data {:event-type (:event/type event)
-                             :error (.getMessage e)}})))))
+            (let [anomaly (response/from-exception e)]
+              (log/warn logger :event-stream :sink-error
+                       {:message "Event sink failed"
+                        :data {:event-type (:event/type event)
+                               :anomaly anomaly}}))))))
 
     ;; In-memory event log
     (swap! stream update :events conj event)
@@ -106,11 +107,12 @@
             (callback event)
             (catch Exception e
               (when logger
-                (log/error logger :event-stream :event/callback-error
-                           {:message "Event callback failed"
-                            :data {:subscriber-id sub-id
-                                   :event-type (:event/type event)
-                                   :error (.getMessage e)}})))))))
+                (let [anomaly (response/from-exception e)]
+                  (log/error logger :event-stream :event/callback-error
+                             {:message "Event callback failed"
+                              :data {:subscriber-id sub-id
+                                     :event-type (:event/type event)
+                                     :anomaly anomaly}}))))))))
     (when logger
       (log/debug logger :event-stream :event/published
                  {:message "Event published"

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -246,6 +246,158 @@
         (:duration-ms metrics) (assoc :llm/duration-ms (:duration-ms metrics))
         (:cost-usd metrics) (assoc :llm/cost-usd (:cost-usd metrics)))))
 
+;------------------------------------------------------------------------------ Layer 4
+;; Agent lifecycle events
+
+(defn agent-started [stream workflow-id agent-id & [context]]
+  (-> (create-envelope stream :agent/started workflow-id
+                       (str "Agent " (name agent-id) " started"))
+      (assoc :agent/id agent-id)
+      (cond-> context (assoc :agent/context context))))
+
+(defn agent-completed [stream workflow-id agent-id & [result]]
+  (-> (create-envelope stream :agent/completed workflow-id
+                       (str "Agent " (name agent-id) " completed"))
+      (assoc :agent/id agent-id)
+      (cond-> result (assoc :agent/result result))))
+
+(defn agent-failed [stream workflow-id agent-id & [error]]
+  (-> (create-envelope stream :agent/failed workflow-id
+                       (str "Agent " (name agent-id) " failed"))
+      (assoc :agent/id agent-id)
+      (cond-> error (assoc :agent/error error))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Gate lifecycle events
+
+(defn gate-started [stream workflow-id gate-id & [artifact-summary]]
+  (-> (create-envelope stream :gate/started workflow-id
+                       (str "Gate " (name gate-id) " started"))
+      (assoc :gate/id gate-id)
+      (cond-> artifact-summary (assoc :gate/artifact-summary artifact-summary))))
+
+(defn gate-passed [stream workflow-id gate-id & [duration-ms]]
+  (-> (create-envelope stream :gate/passed workflow-id
+                       (str "Gate " (name gate-id) " passed"))
+      (assoc :gate/id gate-id)
+      (cond-> duration-ms (assoc :gate/duration-ms duration-ms))))
+
+(defn gate-failed [stream workflow-id gate-id & [violations]]
+  (-> (create-envelope stream :gate/failed workflow-id
+                       (str "Gate " (name gate-id) " failed"))
+      (assoc :gate/id gate-id)
+      (cond-> violations (assoc :gate/violations violations))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Tool lifecycle events
+
+(defn tool-invoked [stream workflow-id agent-id tool-id & [params-summary]]
+  (-> (create-envelope stream :tool/invoked workflow-id
+                       (str "Tool " (name tool-id) " invoked by " (name agent-id)))
+      (assoc :agent/id agent-id
+             :tool/id tool-id)
+      (cond-> params-summary (assoc :tool/params-summary params-summary))))
+
+(defn tool-completed [stream workflow-id agent-id tool-id & [result-summary]]
+  (-> (create-envelope stream :tool/completed workflow-id
+                       (str "Tool " (name tool-id) " completed"))
+      (assoc :agent/id agent-id
+             :tool/id tool-id)
+      (cond-> result-summary (assoc :tool/result-summary result-summary))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Milestone event
+
+(defn milestone-reached [stream workflow-id milestone-id & [description]]
+  (-> (create-envelope stream :workflow/milestone-reached workflow-id
+                       (or description (str "Milestone " (name milestone-id) " reached")))
+      (assoc :milestone/id milestone-id)))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Task lifecycle (DAG) events
+
+(defn task-state-changed [stream workflow-id dag-id task-id from-state to-state & [context]]
+  (-> (create-envelope stream :task/state-changed workflow-id
+                       (str "Task " task-id " " (name from-state) " -> " (name to-state)))
+      (assoc :dag/id dag-id
+             :task/id task-id
+             :task/from-state from-state
+             :task/to-state to-state)
+      (cond-> context (assoc :task/context context))))
+
+(defn task-frontier-entered [stream workflow-id dag-id task-id & [frontier-size]]
+  (-> (create-envelope stream :task/frontier-entered workflow-id
+                       (str "Task " task-id " entered frontier"))
+      (assoc :dag/id dag-id
+             :task/id task-id)
+      (cond-> frontier-size (assoc :task/frontier-size frontier-size))))
+
+(defn task-skip-propagated [stream workflow-id dag-id task-id & [cause-task]]
+  (-> (create-envelope stream :task/skip-propagated workflow-id
+                       (str "Task " task-id " skip propagated"))
+      (assoc :dag/id dag-id
+             :task/id task-id)
+      (cond-> cause-task (assoc :task/cause-task cause-task))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Inter-agent messaging events
+
+(defn inter-agent-message-sent [stream workflow-id from-agent to-agent & [message-type]]
+  (-> (create-envelope stream :agent/message-sent workflow-id
+                       (str (name from-agent) " -> " (name to-agent)
+                            (when message-type (str " (" (name message-type) ")"))))
+      (assoc :from-agent/id from-agent
+             :to-agent/id to-agent)
+      (cond-> message-type (assoc :message/type message-type))))
+
+(defn inter-agent-message-received [stream workflow-id from-agent to-agent & [message-type]]
+  (-> (create-envelope stream :agent/message-received workflow-id
+                       (str (name to-agent) " <- " (name from-agent)
+                            (when message-type (str " (" (name message-type) ")"))))
+      (assoc :from-agent/id from-agent
+             :to-agent/id to-agent)
+      (cond-> message-type (assoc :message/type message-type))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Listener lifecycle events (N8)
+
+(defn listener-attached [stream workflow-id listener-id & [listener-type capability]]
+  (-> (create-envelope stream :listener/attached workflow-id
+                       (str "Listener " listener-id " attached"))
+      (assoc :listener/id listener-id)
+      (cond->
+        listener-type (assoc :listener/type listener-type)
+        capability (assoc :listener/capability capability))))
+
+(defn listener-detached [stream workflow-id listener-id & [reason]]
+  (-> (create-envelope stream :listener/detached workflow-id
+                       (str "Listener " listener-id " detached"))
+      (assoc :listener/id listener-id)
+      (cond-> reason (assoc :listener/reason reason))))
+
+(defn annotation-created [stream workflow-id listener-id annotation-type & [content]]
+  (-> (create-envelope stream :annotation/created workflow-id
+                       (str "Annotation from " listener-id ": " (name annotation-type)))
+      (assoc :listener/id listener-id
+             :annotation/type annotation-type)
+      (cond-> content (assoc :annotation/content content))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Control action events (N8)
+
+(defn control-action-requested [stream workflow-id action-id action-type & [requester]]
+  (-> (create-envelope stream :control-action/requested workflow-id
+                       (str "Control action " (name action-type) " requested"))
+      (assoc :action/id action-id
+             :action/type action-type)
+      (cond-> requester (assoc :action/requester requester))))
+
+(defn control-action-executed [stream workflow-id action-id & [result]]
+  (-> (create-envelope stream :control-action/executed workflow-id
+                       (str "Control action " action-id " executed"))
+      (assoc :action/id action-id)
+      (cond-> result (assoc :action/result result))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Create event stream

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -47,7 +47,9 @@
      (publish! stream (phase-completed stream workflow-id :plan {:outcome :success}))
      (publish! stream (workflow-completed stream workflow-id :success))"
   (:require
-   [ai.miniforge.event-stream.core :as core]))
+   [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.event-stream.listeners :as listeners]
+   [ai.miniforge.event-stream.control :as control]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event stream lifecycle
@@ -317,7 +319,168 @@
   [stream workflow-id agent-id model request-id & [metrics]]
   (core/llm-response stream workflow-id agent-id model request-id metrics))
 
+;------------------------------------------------------------------------------ Layer 2b
+;; Agent lifecycle event constructors
+
+(defn agent-started
+  "Create an agent/started event."
+  [stream workflow-id agent-id & [context]]
+  (core/agent-started stream workflow-id agent-id context))
+
+(defn agent-completed
+  "Create an agent/completed event."
+  [stream workflow-id agent-id & [result]]
+  (core/agent-completed stream workflow-id agent-id result))
+
+(defn agent-failed
+  "Create an agent/failed event."
+  [stream workflow-id agent-id & [error]]
+  (core/agent-failed stream workflow-id agent-id error))
+
+;------------------------------------------------------------------------------ Layer 2c
+;; Gate lifecycle event constructors
+
+(defn gate-started
+  "Create a gate/started event."
+  [stream workflow-id gate-id & [artifact-summary]]
+  (core/gate-started stream workflow-id gate-id artifact-summary))
+
+(defn gate-passed
+  "Create a gate/passed event."
+  [stream workflow-id gate-id & [duration-ms]]
+  (core/gate-passed stream workflow-id gate-id duration-ms))
+
+(defn gate-failed
+  "Create a gate/failed event."
+  [stream workflow-id gate-id & [violations]]
+  (core/gate-failed stream workflow-id gate-id violations))
+
+;------------------------------------------------------------------------------ Layer 2d
+;; Tool lifecycle event constructors
+
+(defn tool-invoked
+  "Create a tool/invoked event."
+  [stream workflow-id agent-id tool-id & [params-summary]]
+  (core/tool-invoked stream workflow-id agent-id tool-id params-summary))
+
+(defn tool-completed
+  "Create a tool/completed event."
+  [stream workflow-id agent-id tool-id & [result-summary]]
+  (core/tool-completed stream workflow-id agent-id tool-id result-summary))
+
+;------------------------------------------------------------------------------ Layer 2e
+;; Milestone event constructor
+
+(defn milestone-reached
+  "Create a workflow/milestone-reached event."
+  [stream workflow-id milestone-id & [description]]
+  (core/milestone-reached stream workflow-id milestone-id description))
+
+;------------------------------------------------------------------------------ Layer 2f
+;; Task lifecycle (DAG) event constructors
+
+(defn task-state-changed
+  "Create a task/state-changed event."
+  [stream workflow-id dag-id task-id from-state to-state & [context]]
+  (core/task-state-changed stream workflow-id dag-id task-id from-state to-state context))
+
+(defn task-frontier-entered
+  "Create a task/frontier-entered event."
+  [stream workflow-id dag-id task-id & [frontier-size]]
+  (core/task-frontier-entered stream workflow-id dag-id task-id frontier-size))
+
+(defn task-skip-propagated
+  "Create a task/skip-propagated event."
+  [stream workflow-id dag-id task-id & [cause-task]]
+  (core/task-skip-propagated stream workflow-id dag-id task-id cause-task))
+
+;------------------------------------------------------------------------------ Layer 2g
+;; Inter-agent messaging event constructors
+
+(defn inter-agent-message-sent
+  "Create an agent/message-sent event."
+  [stream workflow-id from-agent to-agent & [message-type]]
+  (core/inter-agent-message-sent stream workflow-id from-agent to-agent message-type))
+
+(defn inter-agent-message-received
+  "Create an agent/message-received event."
+  [stream workflow-id from-agent to-agent & [message-type]]
+  (core/inter-agent-message-received stream workflow-id from-agent to-agent message-type))
+
+;------------------------------------------------------------------------------ Layer 2h
+;; Listener lifecycle event constructors (N8)
+
+(defn listener-attached
+  "Create a listener/attached event."
+  [stream workflow-id listener-id & [listener-type capability]]
+  (core/listener-attached stream workflow-id listener-id listener-type capability))
+
+(defn listener-detached
+  "Create a listener/detached event."
+  [stream workflow-id listener-id & [reason]]
+  (core/listener-detached stream workflow-id listener-id reason))
+
+(defn annotation-created
+  "Create an annotation/created event."
+  [stream workflow-id listener-id annotation-type & [content]]
+  (core/annotation-created stream workflow-id listener-id annotation-type content))
+
+;------------------------------------------------------------------------------ Layer 2i
+;; Control action event constructors (N8)
+
+(defn control-action-requested
+  "Create a control-action/requested event."
+  [stream workflow-id action-id action-type & [requester]]
+  (core/control-action-requested stream workflow-id action-id action-type requester))
+
+(defn control-action-executed
+  "Create a control-action/executed event."
+  [stream workflow-id action-id & [result]]
+  (core/control-action-executed stream workflow-id action-id result))
+
 ;------------------------------------------------------------------------------ Layer 3
+;; Listener management API (N8)
+
+(defn register-listener!
+  "Register a listener with capability level.
+   See ai.miniforge.event-stream.listeners for full docs."
+  [stream listener-spec]
+  (listeners/register-listener! stream listener-spec))
+
+(defn deregister-listener!
+  "Deregister a listener and remove its subscription."
+  [stream listener-id & [reason]]
+  (listeners/deregister-listener! stream listener-id reason))
+
+(defn list-listeners
+  "List all registered listeners."
+  [stream]
+  (listeners/list-listeners stream))
+
+(defn submit-annotation!
+  "Submit an advisory annotation (requires :advise or :control capability)."
+  [stream listener-id annotation]
+  (listeners/submit-annotation! stream listener-id annotation))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Control action API (N8)
+
+(defn create-control-action
+  "Create a structured control action."
+  [action-type target requester & [opts]]
+  (control/create-control-action action-type target requester opts))
+
+(defn authorize-action
+  "Check RBAC authorization for a control action."
+  [roles action requester]
+  (control/authorize-action roles action requester))
+
+(defn execute-control-action!
+  "Execute an authorized control action with event emission."
+  [stream action execution-fn]
+  (control/execute-control-action! stream action execution-fn))
+
+;------------------------------------------------------------------------------ Layer 4
 ;; Convenience functions
 
 (defn create-streaming-callback

--- a/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
@@ -10,7 +10,8 @@
    The registry wraps event-stream subscription with capability metadata and
    enforcement."
   (:require
-   [ai.miniforge.event-stream.core :as core]))
+   [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants
@@ -53,8 +54,11 @@
     ;; Validate capability
     (when-not (contains? capability-levels capability)
       (throw (ex-info "Invalid capability level"
-                      {:capability capability
-                       :valid capability-levels})))
+                      {:anomaly (response/make-anomaly
+                                 :anomalies/incorrect
+                                 (str "Invalid capability level: " capability)
+                                 {:capability capability
+                                  :valid capability-levels})})))
     ;; Build filter function from listener filters
     (let [filter-fn (cond
                       (nil? filters) (constantly true)
@@ -130,12 +134,19 @@
   [stream listener-id annotation]
   (let [listener (get-listener stream listener-id)]
     (when-not listener
-      (throw (ex-info "Listener not found" {:listener-id listener-id})))
+      (throw (ex-info "Listener not found"
+                      {:anomaly (response/make-anomaly
+                                 :anomalies/not-found
+                                 (str "Listener not found: " listener-id)
+                                 {:listener-id listener-id})})))
     (when-not (capability-sufficient? (:listener/capability listener) :advise)
       (throw (ex-info "Insufficient capability for annotation"
-                      {:listener-id listener-id
-                       :capability (:listener/capability listener)
-                       :required :advise})))
+                      {:anomaly (response/make-anomaly
+                                 :anomalies/forbidden
+                                 "Insufficient capability for annotation"
+                                 {:listener-id listener-id
+                                  :capability (:listener/capability listener)
+                                  :required :advise})})))
     (let [event (core/annotation-created
                  stream
                  (:annotation/workflow-id annotation)

--- a/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/listeners.clj
@@ -1,0 +1,146 @@
+(ns ai.miniforge.event-stream.listeners
+  "Listener registry with capability enforcement for N8 OCI compliance.
+
+   Listeners are external observers (dashboards, fleet controllers, enterprise
+   systems) that subscribe to workflow events with explicit capability levels:
+   - :observe  — read-only event stream access
+   - :advise   — can submit advisory annotations
+   - :control  — can submit annotations and control actions
+
+   The registry wraps event-stream subscription with capability metadata and
+   enforcement."
+  (:require
+   [ai.miniforge.event-stream.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants
+
+(def capability-levels
+  "Valid listener capability levels, ordered by privilege."
+  #{:observe :advise :control})
+
+(def capability-rank
+  "Numeric rank for capability comparison."
+  {:observe 0 :advise 1 :control 2})
+
+(defn capability-sufficient?
+  "Check if actual capability meets or exceeds required capability."
+  [actual required]
+  (>= (get capability-rank actual 0)
+      (get capability-rank required 0)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Listener registration
+
+(defn register-listener!
+  "Register a listener with capability level.
+
+   Arguments:
+   - stream: Event stream atom
+   - listener-spec: Map with:
+     - :listener/type      — :watcher, :dashboard, :fleet, :enterprise
+     - :listener/capability — :observe, :advise, or :control
+     - :listener/identity   — {:principal string}
+     - :listener/filters    — {:workflow-ids [...] :event-types [...]} (optional)
+     - :listener/callback   — (fn [event]) for event delivery
+     - :listener/options    — {:buffer-size int :include-payloads? bool} (optional)
+
+   Returns: listener-id (UUID)"
+  [stream listener-spec]
+  (let [listener-id (random-uuid)
+        {:keys [listener/type listener/capability listener/identity
+                listener/filters listener/callback listener/options]} listener-spec]
+    ;; Validate capability
+    (when-not (contains? capability-levels capability)
+      (throw (ex-info "Invalid capability level"
+                      {:capability capability
+                       :valid capability-levels})))
+    ;; Build filter function from listener filters
+    (let [filter-fn (cond
+                      (nil? filters) (constantly true)
+                      :else (fn [event]
+                              (let [wf-ids (:workflow-ids filters)
+                                    event-types (:event-types filters)]
+                                (and (or (nil? wf-ids)
+                                         (empty? wf-ids)
+                                         (contains? (set wf-ids) (:workflow/id event)))
+                                     (or (nil? event-types)
+                                         (empty? event-types)
+                                         (contains? (set event-types) (:event/type event)))))))]
+      ;; Subscribe to event stream
+      (core/subscribe! stream listener-id callback filter-fn)
+      ;; Store listener metadata
+      (swap! stream assoc-in [:listeners listener-id]
+             {:listener/id listener-id
+              :listener/type type
+              :listener/capability capability
+              :listener/identity identity
+              :listener/filters filters
+              :listener/options options
+              :listener/registered-at (java.util.Date.)})
+      ;; Emit listener/attached event
+      (core/publish! stream
+                     (core/listener-attached stream nil listener-id type capability))
+      listener-id)))
+
+(defn deregister-listener!
+  "Deregister a listener and remove its subscription.
+
+   Arguments:
+   - stream: Event stream atom
+   - listener-id: UUID returned from register-listener!
+   - reason: Optional reason string"
+  [stream listener-id & [reason]]
+  (let [listener (get-in @stream [:listeners listener-id])]
+    (when listener
+      ;; Unsubscribe from event stream
+      (core/unsubscribe! stream listener-id)
+      ;; Remove listener metadata
+      (swap! stream update :listeners dissoc listener-id)
+      ;; Emit listener/detached event
+      (core/publish! stream
+                     (core/listener-detached stream nil listener-id reason))
+      true)))
+
+(defn get-listener
+  "Get listener metadata by ID."
+  [stream listener-id]
+  (get-in @stream [:listeners listener-id]))
+
+(defn list-listeners
+  "List all registered listeners."
+  [stream]
+  (vals (get @stream :listeners {})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Advisory annotations
+
+(defn submit-annotation!
+  "Submit an advisory annotation (requires :advise or :control capability).
+
+   Arguments:
+   - stream: Event stream atom
+   - listener-id: UUID of the listener submitting
+   - annotation: Map with:
+     - :annotation/type — keyword (e.g. :warning, :suggestion, :flag)
+     - :annotation/content — string or map content
+     - :annotation/workflow-id — optional workflow to annotate
+
+   Returns: annotation event or throws if insufficient capability."
+  [stream listener-id annotation]
+  (let [listener (get-listener stream listener-id)]
+    (when-not listener
+      (throw (ex-info "Listener not found" {:listener-id listener-id})))
+    (when-not (capability-sufficient? (:listener/capability listener) :advise)
+      (throw (ex-info "Insufficient capability for annotation"
+                      {:listener-id listener-id
+                       :capability (:listener/capability listener)
+                       :required :advise})))
+    (let [event (core/annotation-created
+                 stream
+                 (:annotation/workflow-id annotation)
+                 listener-id
+                 (:annotation/type annotation)
+                 (:annotation/content annotation))]
+      (core/publish! stream event)
+      event)))

--- a/components/event-stream/test/ai/miniforge/event_stream/control_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/control_test.clj
@@ -1,0 +1,129 @@
+(ns ai.miniforge.event-stream.control-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.event-stream.control :as control]))
+
+(deftest create-control-action-test
+  (testing "creates action with required fields"
+    (let [action (es/create-control-action
+                  :pause
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "admin" :role :admin})]
+      (is (uuid? (:action/id action)))
+      (is (= :pause (:action/type action)))
+      (is (= :pending (:action/status action)))
+      (is (inst? (:action/created-at action)))
+      (is (= :workflow (get-in action [:action/target :target-type])))))
+
+  (testing "creates action with justification and parameters"
+    (let [action (es/create-control-action
+                  :rollback
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "admin" :role :admin}
+                  {:justification "Deployment failed"
+                   :parameters {:to-commit "abc123"}})]
+      (is (= "Deployment failed" (:action/justification action)))
+      (is (= {:to-commit "abc123"} (:action/parameters action))))))
+
+(deftest authorize-action-test
+  (testing "operator can pause workflow"
+    (let [action (es/create-control-action
+                  :pause
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "ops" :role :operator})
+          result (es/authorize-action
+                  control/default-roles action {:role :operator})]
+      (is (true? (:authorized? result)))))
+
+  (testing "operator cannot rollback workflow"
+    (let [action (es/create-control-action
+                  :rollback
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "ops" :role :operator})
+          result (es/authorize-action
+                  control/default-roles action {:role :operator})]
+      (is (false? (:authorized? result)))
+      (is (string? (:reason result)))))
+
+  (testing "admin can rollback workflow"
+    (let [action (es/create-control-action
+                  :rollback
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "admin" :role :admin})
+          result (es/authorize-action
+                  control/default-roles action {:role :admin})]
+      (is (true? (:authorized? result)))))
+
+  (testing "operator cannot emergency-stop fleet"
+    (let [action (es/create-control-action
+                  :emergency-stop
+                  {:target-type :fleet :target-id (random-uuid)}
+                  {:principal "ops" :role :operator})
+          result (es/authorize-action
+                  control/default-roles action {:role :operator})]
+      (is (false? (:authorized? result)))))
+
+  (testing "admin can emergency-stop fleet"
+    (let [action (es/create-control-action
+                  :emergency-stop
+                  {:target-type :fleet :target-id (random-uuid)}
+                  {:principal "admin" :role :admin})
+          result (es/authorize-action
+                  control/default-roles action {:role :admin})]
+      (is (true? (:authorized? result)))))
+
+  (testing "unknown role is unauthorized"
+    (let [action (es/create-control-action
+                  :pause
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "unknown" :role :intern})
+          result (es/authorize-action
+                  control/default-roles action {:role :intern})]
+      (is (false? (:authorized? result))))))
+
+(deftest execute-control-action-test
+  (testing "successful execution emits events and returns success"
+    (let [stream (es/create-event-stream {:sinks []})
+          events (atom [])
+          _ (es/subscribe! stream :test (fn [e] (swap! events conj e)))
+          action (es/create-control-action
+                  :pause
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "admin" :role :admin})
+          result (es/execute-control-action!
+                  stream action
+                  (fn [_act] {:paused true}))]
+      (is (= :success (:status result)))
+      (is (= {:paused true} (:result result)))
+      ;; Should have emitted requested + executed events
+      (let [action-events (filter #(#{:control-action/requested :control-action/executed}
+                                     (:event/type %)) @events)]
+        (is (= 2 (count action-events)))
+        (is (= :control-action/requested (:event/type (first action-events))))
+        (is (= :control-action/executed (:event/type (second action-events)))))))
+
+  (testing "failed execution emits events and returns failure"
+    (let [stream (es/create-event-stream {:sinks []})
+          action (es/create-control-action
+                  :rollback
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "admin" :role :admin})
+          result (es/execute-control-action!
+                  stream action
+                  (fn [_act] (throw (ex-info "Rollback failed" {}))))]
+      (is (= :failure (:status result)))
+      (is (string? (get-in result [:result :error]))))))
+
+(deftest default-roles-test
+  (testing "operator has expected workflow permissions"
+    (is (= #{:pause :resume :retry :cancel}
+           (get-in control/default-roles [:operator :workflows]))))
+
+  (testing "admin has superset of operator permissions"
+    (let [op-wf (get-in control/default-roles [:operator :workflows])
+          admin-wf (get-in control/default-roles [:admin :workflows])]
+      (is (every? admin-wf op-wf))))
+
+  (testing "admin has approval permissions"
+    (is (seq (get-in control/default-roles [:admin :approvals])))))

--- a/components/event-stream/test/ai/miniforge/event_stream/control_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/control_test.clj
@@ -2,7 +2,8 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.event-stream.interface :as es]
-   [ai.miniforge.event-stream.control :as control]))
+   [ai.miniforge.event-stream.control :as control]
+   [ai.miniforge.response.interface :as response]))
 
 (deftest create-control-action-test
   (testing "creates action with required fields"
@@ -80,7 +81,17 @@
                   {:principal "unknown" :role :intern})
           result (es/authorize-action
                   control/default-roles action {:role :intern})]
-      (is (false? (:authorized? result))))))
+      (is (false? (:authorized? result)))))
+
+  (testing "unauthorized result includes anomaly"
+    (let [action (es/create-control-action
+                  :rollback
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "ops" :role :operator})
+          result (es/authorize-action
+                  control/default-roles action {:role :operator})]
+      (is (false? (:authorized? result)))
+      (is (response/anomaly-map? (:anomaly result))))))
 
 (deftest execute-control-action-test
   (testing "successful execution emits events and returns success"
@@ -95,7 +106,7 @@
                   stream action
                   (fn [_act] {:paused true}))]
       (is (= :success (:status result)))
-      (is (= {:paused true} (:result result)))
+      (is (= {:paused true} (:output result)))
       ;; Should have emitted requested + executed events
       (let [action-events (filter #(#{:control-action/requested :control-action/executed}
                                      (:event/type %)) @events)]
@@ -112,8 +123,8 @@
           result (es/execute-control-action!
                   stream action
                   (fn [_act] (throw (ex-info "Rollback failed" {}))))]
-      (is (= :failure (:status result)))
-      (is (string? (get-in result [:result :error]))))))
+      (is (false? (:success result)))
+      (is (string? (get-in result [:error :message]))))))
 
 (deftest default-roles-test
   (testing "operator has expected workflow permissions"

--- a/components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
@@ -270,3 +270,179 @@
           output (with-out-str
                    (callback {:delta "test" :done? false}))]
       (is (= "test" output)))))
+
+;; --------------------------------------------------------------------------- New N3 event constructors
+
+(deftest agent-lifecycle-event-constructors-test
+  (testing "agent-started creates event with agent-id and optional context"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/agent-started stream wf-id :planner {:budget 10000})]
+      (is (= :agent/started (:event/type event)))
+      (is (= :planner (:agent/id event)))
+      (is (= {:budget 10000} (:agent/context event)))
+      (is (uuid? (:event/id event)))))
+
+  (testing "agent-completed creates event with optional result"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/agent-completed stream wf-id :implementer {:tokens-used 5000})]
+      (is (= :agent/completed (:event/type event)))
+      (is (= :implementer (:agent/id event)))
+      (is (= {:tokens-used 5000} (:agent/result event)))))
+
+  (testing "agent-failed creates event with optional error"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/agent-failed stream wf-id :reviewer {:message "timeout"})]
+      (is (= :agent/failed (:event/type event)))
+      (is (= :reviewer (:agent/id event)))
+      (is (= {:message "timeout"} (:agent/error event))))))
+
+(deftest gate-lifecycle-event-constructors-test
+  (testing "gate-started creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/gate-started stream wf-id :lint)]
+      (is (= :gate/started (:event/type event)))
+      (is (= :lint (:gate/id event)))))
+
+  (testing "gate-passed creates event with duration"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/gate-passed stream wf-id :syntax 150)]
+      (is (= :gate/passed (:event/type event)))
+      (is (= :syntax (:gate/id event)))
+      (is (= 150 (:gate/duration-ms event)))))
+
+  (testing "gate-failed creates event with violations"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          violations [{:line 10 :message "unused var"}]
+          event (es/gate-failed stream wf-id :lint violations)]
+      (is (= :gate/failed (:event/type event)))
+      (is (= :lint (:gate/id event)))
+      (is (= violations (:gate/violations event))))))
+
+(deftest tool-lifecycle-event-constructors-test
+  (testing "tool-invoked creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/tool-invoked stream wf-id :implementer :tools/read-file {:path "src/core.clj"})]
+      (is (= :tool/invoked (:event/type event)))
+      (is (= :implementer (:agent/id event)))
+      (is (= :tools/read-file (:tool/id event)))
+      (is (= {:path "src/core.clj"} (:tool/params-summary event)))))
+
+  (testing "tool-completed creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/tool-completed stream wf-id :implementer :tools/write-file {:success true})]
+      (is (= :tool/completed (:event/type event)))
+      (is (= :tools/write-file (:tool/id event)))
+      (is (= {:success true} (:tool/result-summary event))))))
+
+(deftest milestone-event-constructor-test
+  (testing "milestone-reached creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/milestone-reached stream wf-id :tests-passing "All 42 tests pass")]
+      (is (= :workflow/milestone-reached (:event/type event)))
+      (is (= :tests-passing (:milestone/id event)))
+      (is (= "All 42 tests pass" (:message event))))))
+
+(deftest task-lifecycle-event-constructors-test
+  (testing "task-state-changed creates event with from/to states"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          dag-id (random-uuid)
+          task-id (random-uuid)
+          event (es/task-state-changed stream wf-id dag-id task-id :pending :ready)]
+      (is (= :task/state-changed (:event/type event)))
+      (is (= dag-id (:dag/id event)))
+      (is (= task-id (:task/id event)))
+      (is (= :pending (:task/from-state event)))
+      (is (= :ready (:task/to-state event)))))
+
+  (testing "task-frontier-entered creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/task-frontier-entered stream wf-id (random-uuid) (random-uuid) 3)]
+      (is (= :task/frontier-entered (:event/type event)))
+      (is (= 3 (:task/frontier-size event)))))
+
+  (testing "task-skip-propagated creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          cause (random-uuid)
+          event (es/task-skip-propagated stream wf-id (random-uuid) (random-uuid) cause)]
+      (is (= :task/skip-propagated (:event/type event)))
+      (is (= cause (:task/cause-task event))))))
+
+(deftest inter-agent-message-event-constructors-test
+  (testing "inter-agent-message-sent creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/inter-agent-message-sent stream wf-id :planner :implementer :suggestion)]
+      (is (= :agent/message-sent (:event/type event)))
+      (is (= :planner (:from-agent/id event)))
+      (is (= :implementer (:to-agent/id event)))
+      (is (= :suggestion (:message/type event)))))
+
+  (testing "inter-agent-message-received creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/inter-agent-message-received stream wf-id :planner :implementer)]
+      (is (= :agent/message-received (:event/type event)))
+      (is (= :planner (:from-agent/id event)))
+      (is (= :implementer (:to-agent/id event))))))
+
+(deftest listener-event-constructors-test
+  (testing "listener-attached creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          lid (random-uuid)
+          event (es/listener-attached stream wf-id lid :dashboard :observe)]
+      (is (= :listener/attached (:event/type event)))
+      (is (= lid (:listener/id event)))
+      (is (= :dashboard (:listener/type event)))
+      (is (= :observe (:listener/capability event)))))
+
+  (testing "listener-detached creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          lid (random-uuid)
+          event (es/listener-detached stream wf-id lid "timeout")]
+      (is (= :listener/detached (:event/type event)))
+      (is (= lid (:listener/id event)))
+      (is (= "timeout" (:listener/reason event)))))
+
+  (testing "annotation-created creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          lid (random-uuid)
+          event (es/annotation-created stream wf-id lid :warning "slow response")]
+      (is (= :annotation/created (:event/type event)))
+      (is (= lid (:listener/id event)))
+      (is (= :warning (:annotation/type event)))
+      (is (= "slow response" (:annotation/content event))))))
+
+(deftest control-action-event-constructors-test
+  (testing "control-action-requested creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          aid (random-uuid)
+          event (es/control-action-requested stream wf-id aid :pause {:principal "admin"})]
+      (is (= :control-action/requested (:event/type event)))
+      (is (= aid (:action/id event)))
+      (is (= :pause (:action/type event)))
+      (is (= {:principal "admin"} (:action/requester event)))))
+
+  (testing "control-action-executed creates event"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          aid (random-uuid)
+          event (es/control-action-executed stream wf-id aid {:status :success})]
+      (is (= :control-action/executed (:event/type event)))
+      (is (= aid (:action/id event)))
+      (is (= {:status :success} (:action/result event))))))

--- a/components/event-stream/test/ai/miniforge/event_stream/listeners_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/listeners_test.clj
@@ -1,0 +1,126 @@
+(ns ai.miniforge.event-stream.listeners-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.event-stream.listeners :as listeners]))
+
+(deftest capability-sufficient-test
+  (testing "observe meets observe requirement"
+    (is (true? (listeners/capability-sufficient? :observe :observe))))
+  (testing "advise meets observe requirement"
+    (is (true? (listeners/capability-sufficient? :advise :observe))))
+  (testing "control meets all requirements"
+    (is (true? (listeners/capability-sufficient? :control :observe)))
+    (is (true? (listeners/capability-sufficient? :control :advise)))
+    (is (true? (listeners/capability-sufficient? :control :control))))
+  (testing "observe does not meet advise requirement"
+    (is (false? (listeners/capability-sufficient? :observe :advise))))
+  (testing "observe does not meet control requirement"
+    (is (false? (listeners/capability-sufficient? :observe :control)))))
+
+(deftest register-and-deregister-listener-test
+  (testing "register-listener! returns a UUID and listener appears in list"
+    (let [stream (es/create-event-stream {:sinks []})
+          received (atom [])
+          listener-id (es/register-listener!
+                       stream
+                       {:listener/type :dashboard
+                        :listener/capability :observe
+                        :listener/identity {:principal "test-user"}
+                        :listener/callback (fn [event] (swap! received conj event))})]
+      (is (uuid? listener-id))
+      (is (= 1 (count (es/list-listeners stream))))
+      (let [listener (listeners/get-listener stream listener-id)]
+        (is (= :dashboard (:listener/type listener)))
+        (is (= :observe (:listener/capability listener))))))
+
+  (testing "deregister-listener! removes listener and stops delivery"
+    (let [stream (es/create-event-stream {:sinks []})
+          received (atom [])
+          listener-id (es/register-listener!
+                       stream
+                       {:listener/type :watcher
+                        :listener/capability :observe
+                        :listener/identity {:principal "watcher-1"}
+                        :listener/callback (fn [event] (swap! received conj event))})]
+      ;; Should receive events
+      (es/publish! stream (es/workflow-started stream (random-uuid)))
+      (let [pre-count (count @received)]
+        (is (pos? pre-count))
+        ;; Deregister
+        (es/deregister-listener! stream listener-id)
+        (is (= 0 (count (es/list-listeners stream))))
+        ;; Should no longer receive events
+        (es/publish! stream (es/workflow-started stream (random-uuid)))
+        ;; Only the attach/detach events + the one workflow event from before
+        (is (= pre-count (count @received)))))))
+
+(deftest listener-filtering-test
+  (testing "listener with event-type filter only receives matching events"
+    (let [stream (es/create-event-stream {:sinks []})
+          received (atom [])
+          wf-id (random-uuid)
+          _lid (es/register-listener!
+                stream
+                {:listener/type :dashboard
+                 :listener/capability :observe
+                 :listener/identity {:principal "filter-test"}
+                 :listener/filters {:event-types [:gate/passed :gate/failed]}
+                 :listener/callback (fn [event] (swap! received conj event))})]
+      ;; Publish events of various types
+      (es/publish! stream (es/workflow-started stream wf-id))
+      (es/publish! stream (es/gate-passed stream wf-id :syntax 100))
+      (es/publish! stream (es/gate-failed stream wf-id :lint [{:msg "error"}]))
+      (es/publish! stream (es/workflow-completed stream wf-id :success))
+      ;; Should only have the two gate events
+      (is (= 2 (count @received)))
+      (is (every? #(#{:gate/passed :gate/failed} (:event/type %)) @received)))))
+
+(deftest invalid-capability-test
+  (testing "registering with invalid capability throws"
+    (let [stream (es/create-event-stream {:sinks []})]
+      (is (thrown? Exception
+                   (es/register-listener!
+                    stream
+                    {:listener/type :dashboard
+                     :listener/capability :superuser
+                     :listener/identity {:principal "bad"}
+                     :listener/callback (fn [_] nil)}))))))
+
+(deftest submit-annotation-test
+  (testing "advise-capable listener can submit annotation"
+    (let [stream (es/create-event-stream {:sinks []})
+          listener-id (es/register-listener!
+                       stream
+                       {:listener/type :enterprise
+                        :listener/capability :advise
+                        :listener/identity {:principal "advisor"}
+                        :listener/callback (fn [_] nil)})
+          event (es/submit-annotation!
+                 stream listener-id
+                 {:annotation/type :warning
+                  :annotation/content "Budget nearing limit"})]
+      (is (= :annotation/created (:event/type event)))
+      (is (= :warning (:annotation/type event)))))
+
+  (testing "observe-only listener cannot submit annotation"
+    (let [stream (es/create-event-stream {:sinks []})
+          listener-id (es/register-listener!
+                       stream
+                       {:listener/type :dashboard
+                        :listener/capability :observe
+                        :listener/identity {:principal "watcher"}
+                        :listener/callback (fn [_] nil)})]
+      (is (thrown? Exception
+                   (es/submit-annotation!
+                    stream listener-id
+                    {:annotation/type :warning
+                     :annotation/content "should fail"})))))
+
+  (testing "annotation for non-existent listener throws"
+    (let [stream (es/create-event-stream {:sinks []})]
+      (is (thrown? Exception
+                   (es/submit-annotation!
+                    stream (random-uuid)
+                    {:annotation/type :note
+                     :annotation/content "no such listener"}))))))

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -62,6 +62,19 @@
 ;;------------------------------------------------------------------------------ Layer 1
 ;; Gate operations
 
+(defn- emit-gate-event!
+  "Emit a gate lifecycle event via requiring-resolve (no hard dep on event-stream)."
+  [ctx gate-kw event-type & [extra]]
+  (try
+    (when-let [stream (get ctx :event-stream)]
+      (when-let [publish-fn (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
+        (let [constructor (case event-type
+                            :started (requiring-resolve 'ai.miniforge.event-stream.interface/gate-started)
+                            :passed (requiring-resolve 'ai.miniforge.event-stream.interface/gate-passed)
+                            :failed (requiring-resolve 'ai.miniforge.event-stream.interface/gate-failed))]
+          (publish-fn stream (constructor stream (:workflow/id ctx) gate-kw extra)))))
+    (catch Exception _ nil)))
+
 (defn check-gate
   "Run gate check on an artifact.
 
@@ -73,16 +86,24 @@
    Returns:
      {:passed? bool :errors [...] :gate gate-kw}"
   [gate-kw artifact ctx]
-  (let [{:keys [check]} (get-gate gate-kw)]
+  (let [{:keys [check]} (get-gate gate-kw)
+        start-ms (System/currentTimeMillis)]
+    (emit-gate-event! ctx gate-kw :started)
     (try
-      (let [result (check artifact ctx)]
-        (assoc result :gate gate-kw))
+      (let [result (check artifact ctx)
+            result (assoc result :gate gate-kw)]
+        (if (:passed? result)
+          (emit-gate-event! ctx gate-kw :passed (- (System/currentTimeMillis) start-ms))
+          (emit-gate-event! ctx gate-kw :failed (:errors result)))
+        result)
       (catch Exception ex
-        {:passed? false
-         :gate gate-kw
-         :errors [{:type :check-error
-                   :message (ex-message ex)
-                   :data (ex-data ex)}]}))))
+        (let [result {:passed? false
+                      :gate gate-kw
+                      :errors [{:type :check-error
+                                :message (ex-message ex)
+                                :data (ex-data ex)}]}]
+          (emit-gate-event! ctx gate-kw :failed (:errors result))
+          result)))))
 
 (defn repair-gate
   "Attempt to repair gate failures.
@@ -99,9 +120,14 @@
   (let [{:keys [repair]} (get-gate gate-kw)]
     (if repair
       (try
-        (let [result (repair artifact errors ctx)]
-          (assoc result :gate gate-kw))
+        (let [result (repair artifact errors ctx)
+              result (assoc result :gate gate-kw)]
+          (if (:success? result)
+            (emit-gate-event! ctx gate-kw :passed)
+            (emit-gate-event! ctx gate-kw :failed (:errors result)))
+          result)
         (catch Exception ex
+          (emit-gate-event! ctx gate-kw :failed [{:type :repair-error :message (ex-message ex)}])
           (schema/exception-failure :artifact ex {:gate gate-kw :artifact artifact})))
       (schema/failure :artifact {:message "No repair function for gate"}
                       {:gate gate-kw :artifact artifact}))))

--- a/components/gate/test/ai/miniforge/gate/interface_test.clj
+++ b/components/gate/test/ai/miniforge/gate/interface_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.gate.interface :as gate]
    [ai.miniforge.response.interface :as response]
+   [ai.miniforge.event-stream.interface :as es]
    ;; Require implementations to register methods
    [ai.miniforge.gate.syntax]
    [ai.miniforge.gate.lint]
@@ -173,3 +174,35 @@
     (let [chain (gate/check-gates-chain [] {} {})]
       (is (response/succeeded? chain))
       (is (empty? (response/operations chain))))))
+
+;; ============================================================================
+;; Event emission wiring tests
+;; ============================================================================
+
+(deftest check-gate-emits-events-on-pass-test
+  (testing "check-gate emits gate/started and gate/passed when gate passes"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          ctx {:event-stream stream :workflow/id wf-id}
+          _result (gate/check-gate :syntax {:content "(+ 1 2)"} ctx)
+          events (es/get-events stream)]
+      (is (some #(= :gate/started (:event/type %)) events))
+      (is (some #(= :gate/passed (:event/type %)) events))
+      (is (not (some #(= :gate/failed (:event/type %)) events))))))
+
+(deftest check-gate-emits-events-on-fail-test
+  (testing "check-gate emits gate/started and gate/failed when gate fails"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          ctx {:event-stream stream :workflow/id wf-id}
+          _result (gate/check-gate :syntax {:content "(+ 1 2"} ctx)
+          events (es/get-events stream)]
+      (is (some #(= :gate/started (:event/type %)) events))
+      (is (some #(= :gate/failed (:event/type %)) events))
+      (is (not (some #(= :gate/passed (:event/type %)) events))))))
+
+(deftest check-gate-works-without-event-stream-test
+  (testing "check-gate still works when no event-stream in context"
+    (let [result (gate/check-gate :syntax {:content "(+ 1 2)"} {})]
+      (is (:passed? result))
+      (is (= :syntax (:gate result))))))

--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -89,6 +89,20 @@
   (list-tools [this] "List all registered tools.")
   (find-tools [this query] "Find tools matching query."))
 
+(defn- emit-tool-event!
+  "Emit a tool lifecycle event via requiring-resolve (no hard dep on event-stream)."
+  [context tool-id event-type & [extra]]
+  (try
+    (when-let [stream (:event-stream context)]
+      (when-let [publish-fn (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
+        (let [wf-id (:workflow/id context)
+              agent-id (:agent/id context)
+              constructor (case event-type
+                            :invoked (requiring-resolve 'ai.miniforge.event-stream.interface/tool-invoked)
+                            :completed (requiring-resolve 'ai.miniforge.event-stream.interface/tool-completed))]
+          (publish-fn stream (constructor stream wf-id agent-id tool-id extra)))))
+    (catch Exception _ nil)))
+
 (defrecord FunctionTool [id name description parameters handler metadata]
   Tool
   (tool-id [_this] id)
@@ -99,6 +113,7 @@
      :parameters parameters
      :metadata metadata})
   (execute [_this params context]
+    (emit-tool-event! context id :invoked (select-keys params (take 5 (keys params))))
     (let [start-ms (System/currentTimeMillis)
           validation (validate-params parameters params)
           result (if (:valid? validation)
@@ -120,6 +135,10 @@
           end-ms (System/currentTimeMillis)
           invocation (tracking/build-invocation id params start-ms end-ms result)]
       (tracking/record-invocation context invocation)
+      (emit-tool-event! context id :completed
+                        (if (:success result)
+                          {:success true}
+                          {:success false :error-type (get-in result [:error :type])}))
       result))
   (validate-args [_this args]
     (validate-params parameters args))

--- a/components/tool/test/ai/miniforge/tool/interface_test.clj
+++ b/components/tool/test/ai/miniforge/tool/interface_test.clj
@@ -1,6 +1,7 @@
 (ns ai.miniforge.tool.interface-test
   (:require [clojure.test :as test :refer [deftest testing is]]
-            [ai.miniforge.tool.interface :as tool]))
+            [ai.miniforge.tool.interface :as tool]
+            [ai.miniforge.event-stream.interface :as es]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures
@@ -268,6 +269,35 @@
 
   (testing "get-error extracts error"
     (is (= {:type "err"} (tool/get-error {:success false :error {:type "err"}})))))
+
+;; Event emission wiring tests
+
+(deftest tool-emits-events-on-execution-test
+  (testing "tool emits tool/invoked and tool/completed events when event-stream is in context"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          context {:event-stream stream
+                   :workflow/id wf-id
+                   :agent/id :test-agent}
+          my-tool (tool/create-tool
+                   {:id :test/evented
+                    :parameters {:message {:type :string :required true}}
+                    :handler echo-handler})
+          result (tool/execute my-tool {:message "Hello"} context)
+          events (es/get-events stream)]
+      (is (tool/success? result))
+      (is (some #(= :tool/invoked (:event/type %)) events))
+      (is (some #(= :tool/completed (:event/type %)) events)))))
+
+(deftest tool-works-without-event-stream-test
+  (testing "tool executes normally without event-stream in context"
+    (let [my-tool (tool/create-tool
+                   {:id :test/no-stream
+                    :parameters {:message {:type :string :required true}}
+                    :handler echo-handler})
+          result (tool/execute my-tool {:message "Hello"} {})]
+      (is (tool/success? result))
+      (is (= "Hello" (tool/get-result result))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
@@ -161,6 +161,41 @@
           (= uri "/api/evidence/list")
           (handlers/handle-api-evidence-list state params)
 
+          ;; Evidence detail: /api/evidence/<workflow-id>
+          (and (.startsWith uri "/api/evidence/")
+               (not= uri "/api/evidence/list"))
+          (let [workflow-id (subs uri 15)]
+            (handlers/handle-api-evidence-detail state workflow-id))
+
+          ;; Artifact endpoints: /api/artifacts/<id> and /api/artifacts/<id>/provenance
+          (.startsWith uri "/api/artifacts/")
+          (let [rest-uri (subs uri 16)
+                [artifact-id segment] (str/split rest-uri #"/" 2)]
+            (case segment
+              "provenance" (handlers/handle-api-artifact-provenance state artifact-id)
+              (handlers/handle-api-artifact-detail state artifact-id)))
+
+          ;; Listener endpoints
+          (and (= uri "/api/listeners") (= (:request-method req) :get))
+          (handlers/handle-api-listeners-list state)
+
+          (and (= uri "/api/listeners") (= (:request-method req) :post))
+          (handlers/handle-api-listener-register state (slurp (:body req)))
+
+          (and (.startsWith uri "/api/listeners/")
+               (not= (:request-method req) :delete)
+               (.endsWith uri "/annotate")
+               (= (:request-method req) :post))
+          (let [;; /api/listeners/<id>/annotate
+                rest-uri (subs uri 16)
+                listener-id (first (str/split rest-uri #"/" 2))]
+            (handlers/handle-api-listener-annotate state listener-id (slurp (:body req))))
+
+          (and (.startsWith uri "/api/listeners/")
+               (= (:request-method req) :delete))
+          (let [listener-id (subs uri 16)]
+            (handlers/handle-api-listener-deregister state listener-id))
+
           (= uri "/api/train/action")
           (handlers/handle-api-train-action state params)
 
@@ -192,7 +227,7 @@
               "events" (handlers/handle-api-workflow-events state wf-id)
               "panel" (handlers/handle-api-workflow-panel state wf-id)
               "command" (if (= :post (:request-method req))
-                          (handlers/handle-api-workflow-command state wf-id (slurp (:body req)))
+                          (handlers/handle-api-workflow-command-v2 state wf-id (slurp (:body req)))
                           (responses/not-found-response))
               "commands" (handlers/handle-api-workflow-commands-poll state wf-id)
               (responses/not-found-response)))

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -349,40 +349,44 @@
   (try
     (let [wid (try (parse-uuid workflow-id) (catch Exception _ nil))
           evidence-state (state/get-evidence-state state)
-          ;; Find matching workflow evidence
           wf-evidence (->> (concat (:trains evidence-state) (:workflows evidence-state))
                            (filter #(or (= (str (:workflow/id %)) workflow-id)
                                         (= (str (:id %)) workflow-id)))
                            first)
-          ;; Get events for this workflow from event stream
           events (when wid (state/get-events state {:workflow-id wid :limit 500}))
-          ;; Extract evidence-related events
           gate-events (filter #(#{:gate/started :gate/passed :gate/failed}
                                 (:event/type %)) events)]
       (responses/json-response
-       {:workflow-id workflow-id
+       {:status "success"
+        :workflow-id workflow-id
         :evidence wf-evidence
         :gate-results gate-events
         :event-count (count events)}))
     (catch Exception e
-      (responses/json-response {:error (str "Failed to fetch evidence: " (.getMessage e))}))))
+      {:status 500
+       :headers {"Content-Type" "application/json"}
+       :body (json/generate-string {:status "error"
+                                    :error (.getMessage e)})})))
 
 (defn handle-api-artifact-detail
   "API: Get artifact detail by ID."
   [_state artifact-id]
   (try
-    ;; Query artifact store via requiring-resolve
     (let [artifact (try
                      (when-let [get-fn (requiring-resolve 'ai.miniforge.artifact.interface/get-artifact)]
                        (get-fn artifact-id))
                      (catch Exception _ nil))]
       (if artifact
-        (responses/json-response {:artifact artifact})
-        (responses/json-response {:artifact-id artifact-id
-                                  :status "not-found"
-                                  :message "Artifact not found or artifact store not available"})))
+        (responses/json-response {:status "success" :artifact artifact})
+        {:status 404
+         :headers {"Content-Type" "application/json"}
+         :body (json/generate-string {:status "not-found"
+                                      :artifact-id artifact-id
+                                      :message "Artifact not found or artifact store not available"})}))
     (catch Exception e
-      (responses/json-response {:error (str "Failed to fetch artifact: " (.getMessage e))}))))
+      {:status 500
+       :headers {"Content-Type" "application/json"}
+       :body (json/generate-string {:status "error" :error (.getMessage e)})})))
 
 (defn handle-api-artifact-provenance
   "API: Get provenance chain for an artifact."
@@ -393,12 +397,16 @@
                          (prov-fn artifact-id))
                        (catch Exception _ nil))]
       (if provenance
-        (responses/json-response {:artifact-id artifact-id :provenance provenance})
-        (responses/json-response {:artifact-id artifact-id
-                                  :status "not-found"
-                                  :message "Provenance not available"})))
+        (responses/json-response {:status "success" :artifact-id artifact-id :provenance provenance})
+        {:status 404
+         :headers {"Content-Type" "application/json"}
+         :body (json/generate-string {:status "not-found"
+                                      :artifact-id artifact-id
+                                      :message "Provenance not available"})}))
     (catch Exception e
-      (responses/json-response {:error (str "Failed to fetch provenance: " (.getMessage e))}))))
+      {:status 500
+       :headers {"Content-Type" "application/json"}
+       :body (json/generate-string {:status "error" :error (.getMessage e)})})))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Listener API handlers (N8)
@@ -484,8 +492,7 @@
               create-fn (requiring-resolve 'ai.miniforge.event-stream.interface/create-control-action)
               auth-fn (requiring-resolve 'ai.miniforge.event-stream.interface/authorize-action)
               exec-fn (requiring-resolve 'ai.miniforge.event-stream.interface/execute-control-action!)
-              roles (get (deref (requiring-resolve 'ai.miniforge.event-stream.control/default-roles)) :_not-derefable
-                         ((requiring-resolve 'ai.miniforge.event-stream.control/default-roles)))
+              roles @(requiring-resolve 'ai.miniforge.event-stream.control/default-roles)
               action-type (keyword (:action/type data))
               requester (or (:action/requester data)
                             {:principal "dashboard" :role :operator})
@@ -506,7 +513,11 @@
               (responses/json-response {:status "executed" :result result}))
             {:status 403
              :headers {"Content-Type" "application/json"}
-             :body (json/generate-string {:error "Unauthorized" :reason (:reason auth-result)})}))
+             :body (json/generate-string {:error "Unauthorized"
+                                          :reason (:reason auth-result)
+                                          :anomaly (when-let [a (:anomaly auth-result)]
+                                                     {:category (str (:anomaly/category a))
+                                                      :message (:anomaly/message a)})})}))
         ;; Legacy command format — delegate to existing handler
         (handle-api-workflow-command state workflow-id body)))
     (catch Exception e

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -339,3 +339,177 @@
   [state workflow-id]
   (let [commands (state/dequeue-commands! state workflow-id)]
     (responses/json-response {:commands commands})))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Evidence/Artifact API handlers (N5)
+
+(defn handle-api-evidence-detail
+  "API: Get evidence bundle detail for a workflow."
+  [state workflow-id]
+  (try
+    (let [wid (try (parse-uuid workflow-id) (catch Exception _ nil))
+          evidence-state (state/get-evidence-state state)
+          ;; Find matching workflow evidence
+          wf-evidence (->> (concat (:trains evidence-state) (:workflows evidence-state))
+                           (filter #(or (= (str (:workflow/id %)) workflow-id)
+                                        (= (str (:id %)) workflow-id)))
+                           first)
+          ;; Get events for this workflow from event stream
+          events (when wid (state/get-events state {:workflow-id wid :limit 500}))
+          ;; Extract evidence-related events
+          gate-events (filter #(#{:gate/started :gate/passed :gate/failed}
+                                (:event/type %)) events)]
+      (responses/json-response
+       {:workflow-id workflow-id
+        :evidence wf-evidence
+        :gate-results gate-events
+        :event-count (count events)}))
+    (catch Exception e
+      (responses/json-response {:error (str "Failed to fetch evidence: " (.getMessage e))}))))
+
+(defn handle-api-artifact-detail
+  "API: Get artifact detail by ID."
+  [_state artifact-id]
+  (try
+    ;; Query artifact store via requiring-resolve
+    (let [artifact (try
+                     (when-let [get-fn (requiring-resolve 'ai.miniforge.artifact.interface/get-artifact)]
+                       (get-fn artifact-id))
+                     (catch Exception _ nil))]
+      (if artifact
+        (responses/json-response {:artifact artifact})
+        (responses/json-response {:artifact-id artifact-id
+                                  :status "not-found"
+                                  :message "Artifact not found or artifact store not available"})))
+    (catch Exception e
+      (responses/json-response {:error (str "Failed to fetch artifact: " (.getMessage e))}))))
+
+(defn handle-api-artifact-provenance
+  "API: Get provenance chain for an artifact."
+  [_state artifact-id]
+  (try
+    (let [provenance (try
+                       (when-let [prov-fn (requiring-resolve 'ai.miniforge.artifact.interface/get-provenance)]
+                         (prov-fn artifact-id))
+                       (catch Exception _ nil))]
+      (if provenance
+        (responses/json-response {:artifact-id artifact-id :provenance provenance})
+        (responses/json-response {:artifact-id artifact-id
+                                  :status "not-found"
+                                  :message "Provenance not available"})))
+    (catch Exception e
+      (responses/json-response {:error (str "Failed to fetch provenance: " (.getMessage e))}))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Listener API handlers (N8)
+
+(defn handle-api-listeners-list
+  "API: List active listeners."
+  [state]
+  (try
+    (let [es (:event-stream @state)
+          listeners (when es
+                      ((requiring-resolve 'ai.miniforge.event-stream.interface/list-listeners) es))]
+      (responses/json-response {:listeners (or listeners [])}))
+    (catch Exception e
+      (responses/json-response {:error (str "Failed to list listeners: " (.getMessage e))}))))
+
+(defn handle-api-listener-register
+  "API: Register a new listener."
+  [state body]
+  (try
+    (let [data (json/parse-string body true)
+          es (:event-stream @state)
+          listener-spec {:listener/type (keyword (or (:type data) "watcher"))
+                         :listener/capability (keyword (or (:capability data) "observe"))
+                         :listener/identity {:principal (or (:principal data) "anonymous")}
+                         :listener/filters (when-let [f (:filters data)]
+                                             {:workflow-ids (mapv parse-uuid (or (:workflow-ids f) []))
+                                              :event-types (mapv keyword (or (:event-types f) []))})
+                         :listener/callback (fn [_event] nil) ; HTTP listeners poll
+                         :listener/options (:options data)}
+          register-fn (requiring-resolve 'ai.miniforge.event-stream.interface/register-listener!)
+          listener-id (register-fn es listener-spec)]
+      (responses/json-response {:listener-id (str listener-id) :status "registered"}))
+    (catch Exception e
+      {:status 400
+       :headers {"Content-Type" "application/json"}
+       :body (json/generate-string {:error (str "Failed to register listener: " (.getMessage e))})})))
+
+(defn handle-api-listener-deregister
+  "API: Deregister a listener."
+  [state listener-id-str]
+  (try
+    (let [es (:event-stream @state)
+          listener-id (parse-uuid listener-id-str)
+          deregister-fn (requiring-resolve 'ai.miniforge.event-stream.interface/deregister-listener!)]
+      (deregister-fn es listener-id)
+      (responses/json-response {:status "deregistered" :listener-id listener-id-str}))
+    (catch Exception e
+      {:status 400
+       :headers {"Content-Type" "application/json"}
+       :body (json/generate-string {:error (str "Failed to deregister: " (.getMessage e))})})))
+
+(defn handle-api-listener-annotate
+  "API: Submit an annotation from a listener."
+  [state listener-id-str body]
+  (try
+    (let [data (json/parse-string body true)
+          es (:event-stream @state)
+          listener-id (parse-uuid listener-id-str)
+          annotation {:annotation/type (keyword (or (:type data) "note"))
+                      :annotation/content (:content data)
+                      :annotation/workflow-id (when-let [wid (:workflow-id data)]
+                                                (parse-uuid wid))}
+          submit-fn (requiring-resolve 'ai.miniforge.event-stream.interface/submit-annotation!)]
+      (submit-fn es listener-id annotation)
+      (responses/json-response {:status "created"}))
+    (catch Exception e
+      {:status 400
+       :headers {"Content-Type" "application/json"}
+       :body (json/generate-string {:error (str "Annotation failed: " (.getMessage e))})})))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Structured control action handler (N8)
+
+(defn handle-api-workflow-command-v2
+  "API: Enqueue a structured control action for a workflow.
+   Accepts both legacy {:command :pause} and structured {:action/type :pause ...} formats."
+  [state workflow-id body]
+  (try
+    (let [data (json/parse-string body true)]
+      (if (:action/type data)
+        ;; New structured control action
+        (let [es (:event-stream @state)
+              create-fn (requiring-resolve 'ai.miniforge.event-stream.interface/create-control-action)
+              auth-fn (requiring-resolve 'ai.miniforge.event-stream.interface/authorize-action)
+              exec-fn (requiring-resolve 'ai.miniforge.event-stream.interface/execute-control-action!)
+              roles (get (deref (requiring-resolve 'ai.miniforge.event-stream.control/default-roles)) :_not-derefable
+                         ((requiring-resolve 'ai.miniforge.event-stream.control/default-roles)))
+              action-type (keyword (:action/type data))
+              requester (or (:action/requester data)
+                            {:principal "dashboard" :role :operator})
+              action (create-fn action-type
+                                {:target-type :workflow :target-id workflow-id}
+                                requester
+                                {:justification (:action/justification data)
+                                 :parameters (:action/parameters data)})
+              auth-result (auth-fn roles action requester)]
+          (if (:authorized? auth-result)
+            (let [result (exec-fn es action
+                                  (fn [act]
+                                    ;; Execute via existing command infrastructure
+                                    (let [cmd (name (:action/type act))]
+                                      (write-command-file! workflow-id cmd)
+                                      (state/enqueue-command! state workflow-id cmd)
+                                      {:command cmd :workflow-id workflow-id})))]
+              (responses/json-response {:status "executed" :result result}))
+            {:status 403
+             :headers {"Content-Type" "application/json"}
+             :body (json/generate-string {:error "Unauthorized" :reason (:reason auth-result)})}))
+        ;; Legacy command format — delegate to existing handler
+        (handle-api-workflow-command state workflow-id body)))
+    (catch Exception e
+      {:status 400
+       :headers {"Content-Type" "application/json"}
+       :body (json/generate-string {:error (str "Bad request: " (.getMessage e))})})))

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -25,6 +25,27 @@
    [ai.miniforge.web-dashboard.filters-new :as filters-new]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Anomaly/response helpers (via requiring-resolve, no hard dep on response component)
+
+(defn- make-anomaly
+  "Create an anomaly map via response/make-anomaly."
+  [category message & [context]]
+  ((requiring-resolve 'ai.miniforge.response.interface/make-anomaly)
+   category message (or context {})))
+
+(defn- from-exception
+  "Convert an exception to an anomaly map via response/from-exception."
+  [^Throwable e]
+  ((requiring-resolve 'ai.miniforge.response.interface/from-exception) e))
+
+(defn- anomaly-http-response
+  "Translate an anomaly map to a Ring HTTP response.
+   Body is JSON-encoded for wire transport."
+  [anomaly-map]
+  (let [raw ((requiring-resolve 'ai.miniforge.response.interface/anomaly->http-response) anomaly-map)]
+    (update raw :body json/generate-string)))
+
+;------------------------------------------------------------------------------ Layer 0
 ;; Filter helpers
 
 (defn- maybe-apply-filters
@@ -330,9 +351,10 @@
       (state/enqueue-command! state workflow-id command)
       (responses/json-response {:status "queued" :command command :workflow-id workflow-id}))
     (catch Exception e
-      {:status 400
-       :headers {"Content-Type" "application/json"}
-       :body (json/generate-string {:error (str "Bad request: " (ex-message e))})})))
+      (anomaly-http-response
+       (make-anomaly :anomalies/incorrect
+                     (str "Bad request: " (ex-message e))
+                     {:workflow-id workflow-id})))))
 
 (defn handle-api-workflow-commands-poll
   "API: Poll and dequeue pending commands for a workflow."
@@ -363,10 +385,7 @@
         :gate-results gate-events
         :event-count (count events)}))
     (catch Exception e
-      {:status 500
-       :headers {"Content-Type" "application/json"}
-       :body (json/generate-string {:status "error"
-                                    :error (.getMessage e)})})))
+      (anomaly-http-response (from-exception e)))))
 
 (defn handle-api-artifact-detail
   "API: Get artifact detail by ID."
@@ -378,15 +397,12 @@
                      (catch Exception _ nil))]
       (if artifact
         (responses/json-response {:status "success" :artifact artifact})
-        {:status 404
-         :headers {"Content-Type" "application/json"}
-         :body (json/generate-string {:status "not-found"
-                                      :artifact-id artifact-id
-                                      :message "Artifact not found or artifact store not available"})}))
+        (anomaly-http-response
+         (make-anomaly :anomalies/not-found
+                       "Artifact not found or artifact store not available"
+                       {:artifact-id artifact-id}))))
     (catch Exception e
-      {:status 500
-       :headers {"Content-Type" "application/json"}
-       :body (json/generate-string {:status "error" :error (.getMessage e)})})))
+      (anomaly-http-response (from-exception e)))))
 
 (defn handle-api-artifact-provenance
   "API: Get provenance chain for an artifact."
@@ -398,15 +414,12 @@
                        (catch Exception _ nil))]
       (if provenance
         (responses/json-response {:status "success" :artifact-id artifact-id :provenance provenance})
-        {:status 404
-         :headers {"Content-Type" "application/json"}
-         :body (json/generate-string {:status "not-found"
-                                      :artifact-id artifact-id
-                                      :message "Provenance not available"})}))
+        (anomaly-http-response
+         (make-anomaly :anomalies/not-found
+                       "Provenance not available"
+                       {:artifact-id artifact-id}))))
     (catch Exception e
-      {:status 500
-       :headers {"Content-Type" "application/json"}
-       :body (json/generate-string {:status "error" :error (.getMessage e)})})))
+      (anomaly-http-response (from-exception e)))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Listener API handlers (N8)
@@ -420,7 +433,7 @@
                       ((requiring-resolve 'ai.miniforge.event-stream.interface/list-listeners) es))]
       (responses/json-response {:listeners (or listeners [])}))
     (catch Exception e
-      (responses/json-response {:error (str "Failed to list listeners: " (.getMessage e))}))))
+      (anomaly-http-response (from-exception e)))))
 
 (defn handle-api-listener-register
   "API: Register a new listener."
@@ -440,9 +453,7 @@
           listener-id (register-fn es listener-spec)]
       (responses/json-response {:listener-id (str listener-id) :status "registered"}))
     (catch Exception e
-      {:status 400
-       :headers {"Content-Type" "application/json"}
-       :body (json/generate-string {:error (str "Failed to register listener: " (.getMessage e))})})))
+      (anomaly-http-response (from-exception e)))))
 
 (defn handle-api-listener-deregister
   "API: Deregister a listener."
@@ -454,9 +465,7 @@
       (deregister-fn es listener-id)
       (responses/json-response {:status "deregistered" :listener-id listener-id-str}))
     (catch Exception e
-      {:status 400
-       :headers {"Content-Type" "application/json"}
-       :body (json/generate-string {:error (str "Failed to deregister: " (.getMessage e))})})))
+      (anomaly-http-response (from-exception e)))))
 
 (defn handle-api-listener-annotate
   "API: Submit an annotation from a listener."
@@ -473,9 +482,7 @@
       (submit-fn es listener-id annotation)
       (responses/json-response {:status "created"}))
     (catch Exception e
-      {:status 400
-       :headers {"Content-Type" "application/json"}
-       :body (json/generate-string {:error (str "Annotation failed: " (.getMessage e))})})))
+      (anomaly-http-response (from-exception e)))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Structured control action handler (N8)
@@ -511,16 +518,12 @@
                                       (state/enqueue-command! state workflow-id cmd)
                                       {:command cmd :workflow-id workflow-id})))]
               (responses/json-response {:status "executed" :result result}))
-            {:status 403
-             :headers {"Content-Type" "application/json"}
-             :body (json/generate-string {:error "Unauthorized"
-                                          :reason (:reason auth-result)
-                                          :anomaly (when-let [a (:anomaly auth-result)]
-                                                     {:category (str (:anomaly/category a))
-                                                      :message (:anomaly/message a)})})}))
+            (anomaly-http-response
+             (or (:anomaly auth-result)
+                 (make-anomaly :anomalies/forbidden
+                               (:reason auth-result)
+                               {:action-type action-type})))))
         ;; Legacy command format — delegate to existing handler
         (handle-api-workflow-command state workflow-id body)))
     (catch Exception e
-      {:status 400
-       :headers {"Content-Type" "application/json"}
-       :body (json/generate-string {:error (str "Bad request: " (.getMessage e))})})))
+      (anomaly-http-response (from-exception e)))))

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -61,24 +61,50 @@
         (println "Warning: Failed to publish event:" (ex-message e))))))
 
 (defn- publish-workflow-started!
-  "Publish workflow started event."
+  "Publish workflow started event using N3-compliant constructor."
   [event-stream context]
-  (publish-event! event-stream
-                  {:event/type :workflow/started
-                   :workflow-id (:execution/id context)
-                   :workflow-spec (select-keys (:execution/workflow context)
-                                               [:workflow/id :workflow/version])
-                   :timestamp (java.time.Instant/now)}))
+  (when event-stream
+    (try
+      (when-let [constructor (requiring-resolve 'ai.miniforge.event-stream.interface/workflow-started)]
+        (publish-event! event-stream
+                        (constructor event-stream
+                                     (:execution/id context)
+                                     (select-keys (:execution/workflow context)
+                                                  [:workflow/id :workflow/version]))))
+      (catch Exception _
+        ;; Fallback to ad-hoc event if constructor not available
+        (publish-event! event-stream
+                        {:event/type :workflow/started
+                         :workflow-id (:execution/id context)
+                         :workflow-spec (select-keys (:execution/workflow context)
+                                                     [:workflow/id :workflow/version])
+                         :timestamp (java.time.Instant/now)})))))
 
 (defn- publish-workflow-completed!
-  "Publish workflow completed event."
+  "Publish workflow completed/failed event using N3-compliant constructor."
   [event-stream context]
-  (publish-event! event-stream
-                  {:event/type :workflow/completed
-                   :workflow-id (:execution/id context)
-                   :status (:execution/status context)
-                   :metrics (:execution/metrics context)
-                   :timestamp (java.time.Instant/now)}))
+  (when event-stream
+    (try
+      (let [status (:execution/status context)
+            wf-id (:execution/id context)
+            duration-ms (get-in context [:execution/metrics :duration-ms])]
+        (if (= status :failed)
+          (when-let [constructor (requiring-resolve 'ai.miniforge.event-stream.interface/workflow-failed)]
+            (publish-event! event-stream
+                            (constructor event-stream wf-id
+                                         {:message "Workflow failed"
+                                          :errors (:execution/errors context)})))
+          (when-let [constructor (requiring-resolve 'ai.miniforge.event-stream.interface/workflow-completed)]
+            (publish-event! event-stream
+                            (constructor event-stream wf-id status duration-ms)))))
+      (catch Exception _
+        ;; Fallback to ad-hoc event
+        (publish-event! event-stream
+                        {:event/type :workflow/completed
+                         :workflow-id (:execution/id context)
+                         :status (:execution/status context)
+                         :metrics (:execution/metrics context)
+                         :timestamp (java.time.Instant/now)})))))
 
 (defn- publish-phase-started!
   "Publish phase started event."


### PR DESCRIPTION
## Summary

- **Stream A (N3):** Add 19 event constructors (agent, gate, tool, milestone, task DAG, inter-agent messaging, listener, annotation, control action) and wire them into existing execution points via `requiring-resolve` — gate checks, tool execution, inter-agent messaging, workflow lifecycle, and DAG task transitions all now emit N3-compliant events
- **Stream B (N5):** Add REST endpoints for evidence bundle detail (`/api/evidence/<wf-id>`), artifact detail (`/api/artifacts/<id>`), and artifact provenance (`/api/artifacts/<id>/provenance`)
- **Stream C (N8):** Add listener registry with capability enforcement (`:observe`/`:advise`/`:control`), registration/deregistration API, event filtering, and advisory annotation submission
- **Stream D (N8):** Add structured control actions with RBAC (`default-roles` for operator/admin), `create-control-action`/`authorize-action`/`execute-control-action!`, and backward-compatible command handler accepting both legacy `{:command :pause}` and new `{:action/type :pause :action/justification "..."}` formats

## Files changed (17)

| File | Stream | Change |
|------|--------|--------|
| `event-stream/core.clj` | A,C,D | +19 event constructors |
| `event-stream/interface.clj` | A,C,D | Re-export all new constructors + listener/control APIs |
| `event-stream/listeners.clj` | C | **New** — listener registry with capability enforcement |
| `event-stream/control.clj` | D | **New** — structured control actions + RBAC |
| `gate/interface.clj` | A | Wire gate events via requiring-resolve |
| `tool/core.clj` | A | Wire tool events via requiring-resolve |
| `agent/.../messaging.clj` | A | Publish inter-agent message events to stream |
| `workflow/runner.clj` | A | Upgrade to N3-compliant constructors (with fallback) |
| `dag-executor/state.clj` | A | Emit task-state-changed on transitions |
| `web-dashboard/server.clj` | B,C | Add evidence/artifact/listener routes |
| `web-dashboard/.../handlers.clj` | B,C,D | Add evidence/artifact/listener/control handlers |

### Tests (7 files, 307+ assertions)

| Test file | Tests | Assertions | Covers |
|-----------|-------|------------|--------|
| `event-stream/interface_test.clj` | 17 | 130 | All 19 constructors |
| `event-stream/listeners_test.clj` | 5 | 21 | Registration, filtering, capabilities, annotations |
| `event-stream/control_test.clj` | 4 | 24 | Action creation, RBAC, execution, role structure |
| `gate/interface_test.clj` | +3 | +10 | Gate event emission wiring (pass/fail/no-stream) |
| `tool/interface_test.clj` | +2 | +6 | Tool event emission wiring |
| `dag-executor/state_test.clj` | 6 | 22 | State transitions, event emission, queries |

## Design decisions

- **`requiring-resolve` at emission points:** Gate, tool, and dag-executor don't depend on event-stream in their `deps.edn`. All event emission is optional and gracefully degrades. Same pattern used in PR #174 for self-healing.
- **Event constructors return maps, callers publish:** Follows existing pattern — constructors are pure functions, `publish!` is the side-effect.
- **Backward-compatible command handler:** Dashboard command handler accepts both legacy and structured formats.
- **Multi-party approval (N8) deferred:** Explicitly out of scope per gap analysis.

## Test plan

- [x] `bb test` — all brick tests pass (0 failures, 0 errors across 33 bricks)
- [x] Pre-commit hooks pass (lint, tests, GraalVM compatibility)
- [x] New constructors tested with full envelope field verification
- [x] Listener capability enforcement verified (observe cannot annotate, advise can)
- [x] RBAC authorization verified (operator cannot rollback, admin can)
- [x] Gate/tool/dag-executor emission wiring tested with real event-stream
- [x] Graceful degradation tested (no event-stream in context → no crash)
- [ ] Manual: start dashboard → register listener → observe capability enforcement
- [ ] Manual: submit structured control action → verify events emitted
- [ ] Manual: query `/api/evidence/<workflow-id>` → verify JSON response

🤖 Generated with [Claude Code](https://claude.com/claude-code)