### PR TITLE
Stream E: readiness scoring, risk assessment, and automation tiers

### DIFF
--- a/components/pr-train/src/ai/miniforge/pr_train/interface.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/interface.clj
@@ -4,7 +4,10 @@
   (:require
    [ai.miniforge.pr-train.core :as core]
    [ai.miniforge.pr-train.schema :as schema]
-   [ai.miniforge.pr-train.state :as state]))
+   [ai.miniforge.pr-train.state :as state]
+   [ai.miniforge.pr-train.readiness :as readiness]
+   [ai.miniforge.pr-train.risk :as risk]
+   [ai.miniforge.pr-train.tiers :as tiers]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocol and schema re-exports
@@ -245,6 +248,43 @@
   "Check if a PR is ready to merge within a train context."
   [train pr]
   (state/ready-to-merge? train pr))
+
+;------------------------------------------------------------------------------ Layer 10
+;; Readiness scoring (N9)
+
+(def compute-readiness-score
+  "Compute weighted readiness score for a PR in a train. Returns double in [0.0, 1.0]."
+  readiness/compute-readiness-score)
+
+(def explain-readiness
+  "Explain readiness score breakdown. Returns map with :readiness/score, :readiness/factors."
+  readiness/explain-readiness)
+
+;------------------------------------------------------------------------------ Layer 11
+;; Risk assessment (N9)
+
+(def assess-risk
+  "Assess overall risk for a PR. Returns {:risk/score :risk/level :risk/factors}."
+  risk/assess-risk)
+
+;------------------------------------------------------------------------------ Layer 12
+;; Automation tiers (N9)
+
+(def get-automation-tier
+  "Get effective automation tier for a repository."
+  tiers/get-automation-tier)
+
+(def tier-allows?
+  "Check if a tier allows a specific operation given readiness and risk."
+  tiers/tier-allows?)
+
+(def can-auto-approve?
+  "Check if a PR can be auto-approved."
+  tiers/can-auto-approve?)
+
+(def can-auto-merge?
+  "Check if a PR can be auto-merged."
+  tiers/can-auto-merge?)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-train/src/ai/miniforge/pr_train/readiness.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/readiness.clj
@@ -1,0 +1,176 @@
+(ns ai.miniforge.pr-train.readiness
+  "Deterministic readiness scoring (0.0–1.0) for PR merge decisions.
+
+   Replaces boolean `ready-to-merge?` with a weighted numeric score
+   that accounts for dependency state, CI, approvals, gates, age, and staleness.
+
+   Layer 0: Weights and thresholds
+   Layer 1: Factor scoring functions
+   Layer 2: Aggregation and explainability"
+)
+
+;------------------------------------------------------------------------------ Layer 0
+;; Weights and thresholds
+
+(def readiness-weights
+  "Weights for each readiness factor. Must sum to 1.0."
+  {:deps-merged       0.30
+   :ci-passed         0.25
+   :approved          0.20
+   :gates-passed      0.15
+   :age-penalty       0.05
+   :staleness-penalty 0.05})
+
+(def ^:const default-merge-threshold
+  "Default readiness score required for merge."
+  0.85)
+
+(def ^:const max-age-days
+  "PRs older than this incur full age penalty."
+  14)
+
+(def ^:const max-staleness-hours
+  "PRs with no activity for this many hours incur full staleness penalty."
+  72)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Factor scoring functions — each returns 0.0 (bad) to 1.0 (good)
+
+(defn score-deps-factor
+  "Score based on how many dependencies are already merged.
+   1.0 = all deps merged or no deps, 0.0 = no deps merged."
+  [train pr]
+  (let [deps (:pr/depends-on pr [])]
+    (if (empty? deps)
+      1.0
+      (let [merged-prs (->> (:train/prs train)
+                            (filter #(= :merged (:pr/status %)))
+                            (map :pr/number)
+                            set)
+            merged-count (count (filter merged-prs deps))]
+        (double (/ merged-count (count deps)))))))
+
+(defn score-ci-factor
+  "Score based on CI status. 1.0 = passed, 0.5 = running/pending, 0.0 = failed."
+  [_train pr]
+  (case (:pr/ci-status pr)
+    :passed  1.0
+    :running 0.5
+    :pending 0.5
+    :skipped 0.75
+    :failed  0.0
+    0.0))
+
+(defn score-approved-factor
+  "Score based on PR approval status.
+   1.0 = approved/merged, 0.5 = reviewing, 0.0 = other."
+  [_train pr]
+  (case (:pr/status pr)
+    :approved 1.0
+    :merged   1.0
+    :merging  1.0
+    :reviewing 0.5
+    :changes-requested 0.25
+    0.0))
+
+(defn score-gates-factor
+  "Score based on gate pass rate.
+   1.0 = all gates passed (or no gates), 0.0 = all gates failed."
+  [_train pr]
+  (let [gates (:pr/gate-results pr [])]
+    (if (empty? gates)
+      1.0
+      (let [passed (count (filter :gate/passed? gates))]
+        (double (/ passed (count gates)))))))
+
+(defn score-age-factor
+  "Score based on PR age. Older PRs score lower (freshness bonus).
+   1.0 = brand new, 0.0 = older than max-age-days."
+  [_train pr]
+  (let [derived (:pr/derived-state pr)
+        age-days (get derived :age-days 0)]
+    (max 0.0 (- 1.0 (/ (double (min age-days max-age-days)) max-age-days)))))
+
+(defn score-staleness-factor
+  "Score based on time since last activity.
+   1.0 = just updated, 0.0 = stale beyond max-staleness-hours."
+  [_train pr]
+  (let [derived (:pr/derived-state pr)
+        staleness-hours (get derived :staleness-hours 0)]
+    (max 0.0 (- 1.0 (/ (double (min staleness-hours max-staleness-hours)) max-staleness-hours)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Aggregation and explainability
+
+(def factor-fns
+  "Map from factor keyword to scoring function."
+  {:deps-merged       score-deps-factor
+   :ci-passed         score-ci-factor
+   :approved          score-approved-factor
+   :gates-passed      score-gates-factor
+   :age-penalty       score-age-factor
+   :staleness-penalty score-staleness-factor})
+
+(defn compute-readiness-score
+  "Compute weighted readiness score for a PR in a train.
+
+   Arguments:
+   - train - PRTrain map
+   - pr - TrainPR map
+
+   Returns: Double in [0.0, 1.0]"
+  [train pr]
+  (reduce-kv
+   (fn [total factor weight]
+     (let [score-fn (get factor-fns factor)
+           factor-score (score-fn train pr)]
+       (+ total (* weight factor-score))))
+   0.0
+   readiness-weights))
+
+(defn explain-readiness
+  "Explain readiness score breakdown for a PR.
+
+   Arguments:
+   - train - PRTrain map
+   - pr - TrainPR map
+
+   Returns: {:readiness/score double
+             :readiness/threshold double
+             :readiness/ready? bool
+             :readiness/factors [{:factor kw :weight double :score double :contribution double}]}"
+  [train pr]
+  (let [factors (mapv (fn [[factor weight]]
+                        (let [score-fn (get factor-fns factor)
+                              factor-score (score-fn train pr)
+                              contribution (* weight factor-score)]
+                          {:factor factor
+                           :weight weight
+                           :score factor-score
+                           :contribution contribution}))
+                      readiness-weights)
+        total (reduce + 0.0 (map :contribution factors))]
+    {:readiness/score total
+     :readiness/threshold default-merge-threshold
+     :readiness/ready? (>= total default-merge-threshold)
+     :readiness/factors factors}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Example: score a PR with all deps merged, CI passed, approved
+  (def example-train
+    {:train/prs [{:pr/number 1 :pr/status :merged}
+                 {:pr/number 2 :pr/status :approved
+                  :pr/depends-on [1] :pr/ci-status :passed
+                  :pr/gate-results [{:gate/passed? true}]}]})
+
+  (def example-pr
+    {:pr/number 2 :pr/status :approved
+     :pr/depends-on [1] :pr/ci-status :passed
+     :pr/gate-results [{:gate/passed? true}]
+     :pr/derived-state {:age-days 2 :staleness-hours 6}})
+
+  (compute-readiness-score example-train example-pr)
+  (explain-readiness example-train example-pr)
+
+  :leave-this-here)

--- a/components/pr-train/src/ai/miniforge/pr_train/readiness.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/readiness.clj
@@ -4,34 +4,49 @@
    Replaces boolean `ready-to-merge?` with a weighted numeric score
    that accounts for dependency state, CI, approvals, gates, age, and staleness.
 
-   Layer 0: Weights and thresholds
+   All scoring parameters are stored as data in `default-config` and can
+   be overridden at call time by passing a custom config.
+
+   Layer 0: Configuration (data)
    Layer 1: Factor scoring functions
    Layer 2: Aggregation and explainability"
 )
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Weights and thresholds
+;; Configuration — all tunable data in one place
 
-(def readiness-weights
-  "Weights for each readiness factor. Must sum to 1.0."
-  {:deps-merged       0.30
-   :ci-passed         0.25
-   :approved          0.20
-   :gates-passed      0.15
-   :age-penalty       0.05
-   :staleness-penalty 0.05})
+(def default-config
+  "Default readiness scoring configuration. All weights, thresholds, and
+   score maps are pure data. Override by passing a custom config to
+   `compute-readiness-score` and `explain-readiness`."
+  {:weights {:deps-merged       0.30
+             :ci-passed         0.25
+             :approved          0.20
+             :gates-passed      0.15
+             :age-penalty       0.05
+             :staleness-penalty 0.05}
 
-(def ^:const default-merge-threshold
-  "Default readiness score required for merge."
-  0.85)
+   :merge-threshold 0.85
 
-(def ^:const max-age-days
-  "PRs older than this incur full age penalty."
-  14)
+   :ci-scores {:passed  1.0
+               :running 0.5
+               :pending 0.5
+               :skipped 0.75
+               :failed  0.0}
 
-(def ^:const max-staleness-hours
-  "PRs with no activity for this many hours incur full staleness penalty."
-  72)
+   :approval-scores {:approved          1.0
+                     :merged            1.0
+                     :merging           1.0
+                     :reviewing         0.5
+                     :changes-requested 0.25}
+
+   :age {:max-days 14}
+
+   :staleness {:max-hours 72}})
+
+;; Backward-compatible aliases
+(def readiness-weights (:weights default-config))
+(def ^:const default-merge-threshold (:merge-threshold default-config))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Factor scoring functions — each returns 0.0 (bad) to 1.0 (good)
@@ -39,7 +54,7 @@
 (defn score-deps-factor
   "Score based on how many dependencies are already merged.
    1.0 = all deps merged or no deps, 0.0 = no deps merged."
-  [train pr]
+  [train pr _cfg]
   (let [deps (:pr/depends-on pr [])]
     (if (empty? deps)
       1.0
@@ -51,53 +66,41 @@
         (double (/ merged-count (count deps)))))))
 
 (defn score-ci-factor
-  "Score based on CI status. 1.0 = passed, 0.5 = running/pending, 0.0 = failed."
-  [_train pr]
-  (case (:pr/ci-status pr)
-    :passed  1.0
-    :running 0.5
-    :pending 0.5
-    :skipped 0.75
-    :failed  0.0
-    0.0))
+  "Score based on CI status. Scores looked up from :ci-scores config."
+  [_train pr cfg]
+  (get (:ci-scores cfg) (:pr/ci-status pr) 0.0))
 
 (defn score-approved-factor
-  "Score based on PR approval status.
-   1.0 = approved/merged, 0.5 = reviewing, 0.0 = other."
-  [_train pr]
-  (case (:pr/status pr)
-    :approved 1.0
-    :merged   1.0
-    :merging  1.0
-    :reviewing 0.5
-    :changes-requested 0.25
-    0.0))
+  "Score based on PR approval status. Scores looked up from :approval-scores config."
+  [_train pr cfg]
+  (get (:approval-scores cfg) (:pr/status pr) 0.0))
 
 (defn score-gates-factor
   "Score based on gate pass rate.
    1.0 = all gates passed (or no gates), 0.0 = all gates failed."
-  [_train pr]
+  [_train pr _cfg]
   (let [gates (:pr/gate-results pr [])]
     (if (empty? gates)
       1.0
       (let [passed (count (filter :gate/passed? gates))]
         (double (/ passed (count gates)))))))
 
+(defn- score-decay
+  "Linear decay from 1.0 to 0.0 as value approaches max-value."
+  [value max-value]
+  (max 0.0 (- 1.0 (/ (double (min value max-value)) max-value))))
+
 (defn score-age-factor
-  "Score based on PR age. Older PRs score lower (freshness bonus).
-   1.0 = brand new, 0.0 = older than max-age-days."
-  [_train pr]
-  (let [derived (:pr/derived-state pr)
-        age-days (get derived :age-days 0)]
-    (max 0.0 (- 1.0 (/ (double (min age-days max-age-days)) max-age-days)))))
+  "Score based on PR age. Older PRs score lower (freshness bonus)."
+  [_train pr cfg]
+  (let [age-days (get-in pr [:pr/derived-state :age-days] 0)]
+    (score-decay age-days (get-in cfg [:age :max-days]))))
 
 (defn score-staleness-factor
-  "Score based on time since last activity.
-   1.0 = just updated, 0.0 = stale beyond max-staleness-hours."
-  [_train pr]
-  (let [derived (:pr/derived-state pr)
-        staleness-hours (get derived :staleness-hours 0)]
-    (max 0.0 (- 1.0 (/ (double (min staleness-hours max-staleness-hours)) max-staleness-hours)))))
+  "Score based on time since last activity."
+  [_train pr cfg]
+  (let [staleness-hours (get-in pr [:pr/derived-state :staleness-hours] 0)]
+    (score-decay staleness-hours (get-in cfg [:staleness :max-hours]))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Aggregation and explainability
@@ -111,22 +114,31 @@
    :age-penalty       score-age-factor
    :staleness-penalty score-staleness-factor})
 
+(defn- score-factor
+  "Score a single factor, returning its contribution map."
+  [train pr cfg [factor weight]]
+  (let [score-fn (get factor-fns factor)
+        score (score-fn train pr cfg)]
+    {:factor factor
+     :weight weight
+     :score score
+     :contribution (* weight score)}))
+
 (defn compute-readiness-score
   "Compute weighted readiness score for a PR in a train.
 
    Arguments:
    - train - PRTrain map
    - pr - TrainPR map
+   - config - Optional config map to override `default-config`
 
    Returns: Double in [0.0, 1.0]"
-  [train pr]
-  (reduce-kv
-   (fn [total factor weight]
-     (let [score-fn (get factor-fns factor)
-           factor-score (score-fn train pr)]
-       (+ total (* weight factor-score))))
-   0.0
-   readiness-weights))
+  ([train pr] (compute-readiness-score train pr {}))
+  ([train pr config]
+   (let [cfg (merge default-config config)]
+     (->> (:weights cfg)
+          (map (partial score-factor train pr cfg))
+          (transduce (map :contribution) + 0.0)))))
 
 (defn explain-readiness
   "Explain readiness score breakdown for a PR.
@@ -134,26 +146,22 @@
    Arguments:
    - train - PRTrain map
    - pr - TrainPR map
+   - config - Optional config map to override `default-config`
 
    Returns: {:readiness/score double
              :readiness/threshold double
              :readiness/ready? bool
              :readiness/factors [{:factor kw :weight double :score double :contribution double}]}"
-  [train pr]
-  (let [factors (mapv (fn [[factor weight]]
-                        (let [score-fn (get factor-fns factor)
-                              factor-score (score-fn train pr)
-                              contribution (* weight factor-score)]
-                          {:factor factor
-                           :weight weight
-                           :score factor-score
-                           :contribution contribution}))
-                      readiness-weights)
-        total (reduce + 0.0 (map :contribution factors))]
-    {:readiness/score total
-     :readiness/threshold default-merge-threshold
-     :readiness/ready? (>= total default-merge-threshold)
-     :readiness/factors factors}))
+  ([train pr] (explain-readiness train pr {}))
+  ([train pr config]
+   (let [cfg (merge default-config config)
+         factors (mapv (partial score-factor train pr cfg) (:weights cfg))
+         total (transduce (map :contribution) + 0.0 factors)
+         threshold (:merge-threshold cfg)]
+     {:readiness/score total
+      :readiness/threshold threshold
+      :readiness/ready? (>= total threshold)
+      :readiness/factors factors})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-train/src/ai/miniforge/pr_train/risk.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/risk.clj
@@ -1,0 +1,219 @@
+(ns ai.miniforge.pr-train.risk
+  "Explainable risk assessment for PRs with concrete factors.
+
+   Scores PRs on 0.0–1.0 risk scale based on change size, dependency fanout,
+   test coverage, author experience, review staleness, complexity, and
+   critical file modifications.
+
+   Layer 0: Risk factors and thresholds
+   Layer 1: Factor assessment functions
+   Layer 2: Aggregation and risk level classification")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Risk factors and thresholds
+
+(def risk-factors
+  "Risk factor definitions with weights."
+  {:change-size        {:weight 0.25 :description "Lines added/removed"}
+   :dependency-fanout  {:weight 0.20 :description "Number of dependent PRs"}
+   :test-coverage-delta {:weight 0.15 :description "Change in test coverage"}
+   :author-experience  {:weight 0.10 :description "Author's familiarity with codebase"}
+   :review-staleness   {:weight 0.10 :description "Time since last review activity"}
+   :complexity-delta   {:weight 0.10 :description "Change in cyclomatic complexity"}
+   :critical-files     {:weight 0.10 :description "Modifications to critical files"}})
+
+(def risk-levels
+  "Risk level thresholds."
+  {:critical 0.75
+   :high     0.50
+   :medium   0.25})
+
+(def ^:private critical-file-patterns
+  "File patterns considered critical (high risk when modified)."
+  [#"(?i)terraform.*state"
+   #"(?i)\.env"
+   #"(?i)credentials"
+   #"(?i)secrets?"
+   #"(?i)migration"
+   #"(?i)schema\.sql"
+   #"(?i)Dockerfile"
+   #"(?i)\.github/workflows"
+   #"(?i)ci\.ya?ml"])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Factor assessment functions — each returns {:value any :score 0.0-1.0 :explanation str}
+
+(defn- assess-change-size
+  "Assess risk from change size. Larger changes = higher risk."
+  [pr-data]
+  (let [{:keys [additions deletions]} (get pr-data :change-size {:additions 0 :deletions 0})
+        total (+ (or additions 0) (or deletions 0))
+        score (cond
+                (> total 1000) 1.0
+                (> total 500)  0.75
+                (> total 200)  0.50
+                (> total 50)   0.25
+                :else          0.0)]
+    {:value {:additions additions :deletions deletions :total total}
+     :score score
+     :explanation (str total " lines changed"
+                       (when (> total 500) " (large change)"))}))
+
+(defn- assess-dependency-fanout
+  "Assess risk from dependency fanout. More dependents = higher risk."
+  [_train pr]
+  (let [blocks (:pr/blocks pr [])
+        fanout (count blocks)
+        score (cond
+                (> fanout 5) 1.0
+                (> fanout 3) 0.75
+                (> fanout 1) 0.50
+                (= fanout 1) 0.25
+                :else        0.0)]
+    {:value fanout
+     :score score
+     :explanation (str fanout " downstream PRs depend on this")}))
+
+(defn- assess-test-coverage-delta
+  "Assess risk from test coverage changes. Decreased coverage = higher risk."
+  [pr-data]
+  (let [delta (get pr-data :test-coverage-delta 0.0)
+        score (cond
+                (< delta -10.0) 1.0
+                (< delta -5.0)  0.75
+                (< delta 0.0)   0.50
+                (< delta 5.0)   0.25
+                :else           0.0)]
+    {:value delta
+     :score score
+     :explanation (if (neg? delta)
+                    (str "Coverage decreased by " (Math/abs delta) "%")
+                    (str "Coverage changed by " (if (pos? delta) "+" "") delta "%"))}))
+
+(defn- assess-author-experience
+  "Assess risk from author experience. Less experience = higher risk."
+  [author-history]
+  (let [commits (get author-history :total-commits 0)
+        recent (get author-history :recent-commits 0)
+        score (cond
+                (and (> commits 50) (> recent 10)) 0.0
+                (and (> commits 20) (> recent 5))  0.25
+                (> commits 5)                       0.50
+                (> commits 0)                       0.75
+                :else                               1.0)]
+    {:value {:total-commits commits :recent-commits recent}
+     :score score
+     :explanation (str commits " total commits, " recent " recent")}))
+
+(defn- assess-review-staleness
+  "Assess risk from review staleness. Stale reviews = higher risk."
+  [pr-data]
+  (let [hours (get pr-data :hours-since-last-review 0)
+        score (cond
+                (> hours 168) 1.0    ; > 1 week
+                (> hours 72)  0.75   ; > 3 days
+                (> hours 24)  0.50   ; > 1 day
+                (> hours 4)   0.25   ; > 4 hours
+                :else         0.0)]
+    {:value hours
+     :score score
+     :explanation (str hours " hours since last review")}))
+
+(defn- assess-complexity-delta
+  "Assess risk from complexity changes. Increased complexity = higher risk."
+  [pr-data]
+  (let [delta (get pr-data :complexity-delta 0)
+        score (cond
+                  (> delta 20) 1.0
+                  (> delta 10) 0.75
+                  (> delta 5)  0.50
+                  (> delta 0)  0.25
+                  :else        0.0)]
+      {:value delta
+       :score score
+       :explanation (str "Complexity " (if (pos? delta) "increased" "changed")
+                         " by " delta)}))
+
+(defn- assess-critical-files
+  "Assess risk from modifications to critical files."
+  [pr-data]
+  (let [changed-files (get pr-data :changed-files [])
+        critical (filter (fn [path]
+                           (some #(re-find % path) critical-file-patterns))
+                         changed-files)
+        count-critical (count critical)
+        score (cond
+                (> count-critical 3) 1.0
+                (> count-critical 1) 0.75
+                (= count-critical 1) 0.50
+                :else                0.0)]
+    {:value {:critical-files critical :count count-critical}
+     :score score
+     :explanation (if (pos? count-critical)
+                    (str count-critical " critical file(s) modified")
+                    "No critical files modified")}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Aggregation and risk level classification
+
+(defn score->level
+  "Convert risk score to risk level keyword."
+  [score]
+  (cond
+    (>= score (:critical risk-levels)) :critical
+    (>= score (:high risk-levels))     :high
+    (>= score (:medium risk-levels))   :medium
+    :else                              :low))
+
+(defn assess-risk
+  "Assess overall risk for a PR.
+
+   Arguments:
+   - train - PRTrain map
+   - pr - TrainPR map
+   - pr-data - Map with :change-size, :test-coverage-delta, :changed-files,
+               :hours-since-last-review, :complexity-delta
+   - author-history - Map with :total-commits, :recent-commits
+
+   Returns:
+   {:risk/score float
+    :risk/level :low|:medium|:high|:critical
+    :risk/factors [{:factor kw :weight float :value any :score float :explanation str}]}"
+  [train pr pr-data author-history]
+  (let [assessments {:change-size       (assess-change-size pr-data)
+                     :dependency-fanout  (assess-dependency-fanout train pr)
+                     :test-coverage-delta (assess-test-coverage-delta pr-data)
+                     :author-experience  (assess-author-experience author-history)
+                     :review-staleness   (assess-review-staleness pr-data)
+                     :complexity-delta   (assess-complexity-delta pr-data)
+                     :critical-files     (assess-critical-files pr-data)}
+        factors (mapv (fn [[factor-key {:keys [weight]}]]
+                        (let [{:keys [value score explanation]} (get assessments factor-key)]
+                          {:factor factor-key
+                           :weight weight
+                           :value value
+                           :score score
+                           :explanation explanation}))
+                      risk-factors)
+        total-score (reduce + 0.0
+                            (map (fn [{:keys [weight score]}]
+                                   (* weight score))
+                                 factors))]
+    {:risk/score total-score
+     :risk/level (score->level total-score)
+     :risk/factors factors}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Example risk assessment
+  (assess-risk
+   {:train/prs []}
+   {:pr/number 1 :pr/blocks [2 3 4]}
+   {:change-size {:additions 600 :deletions 100}
+    :test-coverage-delta -3.0
+    :changed-files ["main.tf" "Dockerfile" "schema.sql"]
+    :hours-since-last-review 48
+    :complexity-delta 8}
+   {:total-commits 15 :recent-commits 3})
+
+  :leave-this-here)

--- a/components/pr-train/src/ai/miniforge/pr_train/risk.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/risk.clj
@@ -5,55 +5,98 @@
    test coverage, author experience, review staleness, complexity, and
    critical file modifications.
 
-   Layer 0: Risk factors and thresholds
+   All thresholds are configurable via the `default-config` map. Callers can
+   pass an override config to `assess-risk` to tune scoring without code changes.
+
+   Layer 0: Configuration and risk factor definitions
    Layer 1: Factor assessment functions
    Layer 2: Aggregation and risk level classification")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Risk factors and thresholds
+;; Configuration
 
+(def default-config
+  "Default risk assessment configuration. All thresholds and weights are
+   tunable — pass overrides to `assess-risk` via the `:config` key."
+  {:weights {:change-size        0.25
+             :dependency-fanout  0.20
+             :test-coverage-delta 0.15
+             :author-experience  0.10
+             :review-staleness   0.10
+             :complexity-delta   0.10
+             :critical-files     0.10}
+
+   :levels {:critical 0.75
+            :high     0.50
+            :medium   0.25}
+
+   :change-size {:thresholds [1000 500 200 50]
+                 :scores     [1.0  0.75 0.50 0.25]}
+
+   :dependency-fanout {:thresholds [5 3 1]
+                       :scores     [1.0 0.75 0.50]
+                       :exact-one  0.25}
+
+   :test-coverage-delta {:thresholds [-10.0 -5.0 0.0 5.0]
+                         :scores     [1.0   0.75 0.50 0.25]}
+
+   :author-experience {:tiers [{:min-total 50 :min-recent 10 :score 0.0}
+                               {:min-total 20 :min-recent 5  :score 0.25}
+                               {:min-total 5  :min-recent 0  :score 0.50}
+                               {:min-total 1  :min-recent 0  :score 0.75}]
+                       :default 1.0}
+
+   :review-staleness {:thresholds [168 72 24 4]
+                      :scores     [1.0 0.75 0.50 0.25]}
+
+   :complexity-delta {:thresholds [20 10 5 0]
+                      :scores     [1.0 0.75 0.50 0.25]}
+
+   :critical-files {:patterns [#"(?i)terraform.*state"
+                               #"(?i)\.env"
+                               #"(?i)credentials"
+                               #"(?i)secrets?"
+                               #"(?i)migration"
+                               #"(?i)schema\.sql"
+                               #"(?i)Dockerfile"
+                               #"(?i)\.github/workflows"
+                               #"(?i)ci\.ya?ml"]
+                    :thresholds [3 1]
+                    :scores     [1.0 0.75]
+                    :exact-one  0.50}})
+
+;; Derived public vars for backward compatibility and external use
 (def risk-factors
   "Risk factor definitions with weights."
-  {:change-size        {:weight 0.25 :description "Lines added/removed"}
-   :dependency-fanout  {:weight 0.20 :description "Number of dependent PRs"}
-   :test-coverage-delta {:weight 0.15 :description "Change in test coverage"}
-   :author-experience  {:weight 0.10 :description "Author's familiarity with codebase"}
-   :review-staleness   {:weight 0.10 :description "Time since last review activity"}
-   :complexity-delta   {:weight 0.10 :description "Change in cyclomatic complexity"}
-   :critical-files     {:weight 0.10 :description "Modifications to critical files"}})
+  (into {} (map (fn [[k v]] [k {:weight v :description (name k)}])
+                (:weights default-config))))
 
 (def risk-levels
   "Risk level thresholds."
-  {:critical 0.75
-   :high     0.50
-   :medium   0.25})
+  (:levels default-config))
 
-(def ^:private critical-file-patterns
-  "File patterns considered critical (high risk when modified)."
-  [#"(?i)terraform.*state"
-   #"(?i)\.env"
-   #"(?i)credentials"
-   #"(?i)secrets?"
-   #"(?i)migration"
-   #"(?i)schema\.sql"
-   #"(?i)Dockerfile"
-   #"(?i)\.github/workflows"
-   #"(?i)ci\.ya?ml"])
+;------------------------------------------------------------------------------ Layer 0
+;; Threshold scoring helper
+
+(defn- score-by-thresholds
+  "Score a value against descending thresholds. Returns the score for the first
+   threshold exceeded, or 0.0 if none match."
+  [value thresholds scores compare-fn]
+  (or (some (fn [[threshold score]]
+              (when (compare-fn value threshold) score))
+            (map vector thresholds scores))
+      0.0))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Factor assessment functions — each returns {:value any :score 0.0-1.0 :explanation str}
 
 (defn- assess-change-size
   "Assess risk from change size. Larger changes = higher risk."
-  [pr-data]
+  [pr-data cfg]
   (let [{:keys [additions deletions]} (get pr-data :change-size {:additions 0 :deletions 0})
         total (+ (or additions 0) (or deletions 0))
-        score (cond
-                (> total 1000) 1.0
-                (> total 500)  0.75
-                (> total 200)  0.50
-                (> total 50)   0.25
-                :else          0.0)]
+        {:keys [thresholds scores]} (:change-size cfg)
+        score (score-by-thresholds total thresholds scores >)]
     {:value {:additions additions :deletions deletions :total total}
      :score score
      :explanation (str total " lines changed"
@@ -61,29 +104,23 @@
 
 (defn- assess-dependency-fanout
   "Assess risk from dependency fanout. More dependents = higher risk."
-  [_train pr]
+  [_train pr cfg]
   (let [blocks (:pr/blocks pr [])
         fanout (count blocks)
-        score (cond
-                (> fanout 5) 1.0
-                (> fanout 3) 0.75
-                (> fanout 1) 0.50
-                (= fanout 1) 0.25
-                :else        0.0)]
+        {:keys [thresholds scores exact-one]} (:dependency-fanout cfg)
+        score (if (= fanout 1)
+                exact-one
+                (score-by-thresholds fanout thresholds scores >))]
     {:value fanout
      :score score
      :explanation (str fanout " downstream PRs depend on this")}))
 
 (defn- assess-test-coverage-delta
   "Assess risk from test coverage changes. Decreased coverage = higher risk."
-  [pr-data]
+  [pr-data cfg]
   (let [delta (get pr-data :test-coverage-delta 0.0)
-        score (cond
-                (< delta -10.0) 1.0
-                (< delta -5.0)  0.75
-                (< delta 0.0)   0.50
-                (< delta 5.0)   0.25
-                :else           0.0)]
+        {:keys [thresholds scores]} (:test-coverage-delta cfg)
+        score (score-by-thresholds delta thresholds scores <)]
     {:value delta
      :score score
      :explanation (if (neg? delta)
@@ -92,61 +129,54 @@
 
 (defn- assess-author-experience
   "Assess risk from author experience. Less experience = higher risk."
-  [author-history]
+  [author-history cfg]
   (let [commits (get author-history :total-commits 0)
         recent (get author-history :recent-commits 0)
-        score (cond
-                (and (> commits 50) (> recent 10)) 0.0
-                (and (> commits 20) (> recent 5))  0.25
-                (> commits 5)                       0.50
-                (> commits 0)                       0.75
-                :else                               1.0)]
+        {:keys [tiers default]} (:author-experience cfg)
+        score (or (some (fn [{:keys [min-total min-recent score]}]
+                          (when (and (> commits (or min-total 0))
+                                     (> recent (or min-recent 0)))
+                            score))
+                        tiers)
+                  default)]
     {:value {:total-commits commits :recent-commits recent}
      :score score
      :explanation (str commits " total commits, " recent " recent")}))
 
 (defn- assess-review-staleness
   "Assess risk from review staleness. Stale reviews = higher risk."
-  [pr-data]
+  [pr-data cfg]
   (let [hours (get pr-data :hours-since-last-review 0)
-        score (cond
-                (> hours 168) 1.0    ; > 1 week
-                (> hours 72)  0.75   ; > 3 days
-                (> hours 24)  0.50   ; > 1 day
-                (> hours 4)   0.25   ; > 4 hours
-                :else         0.0)]
+        {:keys [thresholds scores]} (:review-staleness cfg)
+        score (score-by-thresholds hours thresholds scores >)]
     {:value hours
      :score score
      :explanation (str hours " hours since last review")}))
 
 (defn- assess-complexity-delta
   "Assess risk from complexity changes. Increased complexity = higher risk."
-  [pr-data]
+  [pr-data cfg]
   (let [delta (get pr-data :complexity-delta 0)
-        score (cond
-                  (> delta 20) 1.0
-                  (> delta 10) 0.75
-                  (> delta 5)  0.50
-                  (> delta 0)  0.25
-                  :else        0.0)]
-      {:value delta
-       :score score
-       :explanation (str "Complexity " (if (pos? delta) "increased" "changed")
-                         " by " delta)}))
+        {:keys [thresholds scores]} (:complexity-delta cfg)
+        score (score-by-thresholds delta thresholds scores >)]
+    {:value delta
+     :score score
+     :explanation (str "Complexity " (if (pos? delta) "increased" "changed")
+                       " by " delta)}))
 
 (defn- assess-critical-files
   "Assess risk from modifications to critical files."
-  [pr-data]
+  [pr-data cfg]
   (let [changed-files (get pr-data :changed-files [])
+        patterns (:patterns (:critical-files cfg))
         critical (filter (fn [path]
-                           (some #(re-find % path) critical-file-patterns))
+                           (some #(re-find % path) patterns))
                          changed-files)
         count-critical (count critical)
-        score (cond
-                (> count-critical 3) 1.0
-                (> count-critical 1) 0.75
-                (= count-critical 1) 0.50
-                :else                0.0)]
+        {:keys [thresholds scores exact-one]} (:critical-files cfg)
+        score (if (= count-critical 1)
+                exact-one
+                (score-by-thresholds count-critical thresholds scores >))]
     {:value {:critical-files critical :count count-critical}
      :score score
      :explanation (if (pos? count-critical)
@@ -158,12 +188,13 @@
 
 (defn score->level
   "Convert risk score to risk level keyword."
-  [score]
-  (cond
-    (>= score (:critical risk-levels)) :critical
-    (>= score (:high risk-levels))     :high
-    (>= score (:medium risk-levels))   :medium
-    :else                              :low))
+  ([score] (score->level score (:levels default-config)))
+  ([score levels]
+   (cond
+     (>= score (:critical levels)) :critical
+     (>= score (:high levels))     :high
+     (>= score (:medium levels))   :medium
+     :else                         :low)))
 
 (defn assess-risk
   "Assess overall risk for a PR.
@@ -174,34 +205,39 @@
    - pr-data - Map with :change-size, :test-coverage-delta, :changed-files,
                :hours-since-last-review, :complexity-delta
    - author-history - Map with :total-commits, :recent-commits
+   - opts - Optional map with :config to override default-config
 
    Returns:
    {:risk/score float
     :risk/level :low|:medium|:high|:critical
     :risk/factors [{:factor kw :weight float :value any :score float :explanation str}]}"
-  [train pr pr-data author-history]
-  (let [assessments {:change-size       (assess-change-size pr-data)
-                     :dependency-fanout  (assess-dependency-fanout train pr)
-                     :test-coverage-delta (assess-test-coverage-delta pr-data)
-                     :author-experience  (assess-author-experience author-history)
-                     :review-staleness   (assess-review-staleness pr-data)
-                     :complexity-delta   (assess-complexity-delta pr-data)
-                     :critical-files     (assess-critical-files pr-data)}
-        factors (mapv (fn [[factor-key {:keys [weight]}]]
-                        (let [{:keys [value score explanation]} (get assessments factor-key)]
-                          {:factor factor-key
-                           :weight weight
-                           :value value
-                           :score score
-                           :explanation explanation}))
-                      risk-factors)
-        total-score (reduce + 0.0
-                            (map (fn [{:keys [weight score]}]
-                                   (* weight score))
-                                 factors))]
-    {:risk/score total-score
-     :risk/level (score->level total-score)
-     :risk/factors factors}))
+  ([train pr pr-data author-history]
+   (assess-risk train pr pr-data author-history {}))
+  ([train pr pr-data author-history opts]
+   (let [cfg (merge default-config (:config opts))
+         weights (:weights cfg)
+         assessments {:change-size        (assess-change-size pr-data cfg)
+                      :dependency-fanout  (assess-dependency-fanout train pr cfg)
+                      :test-coverage-delta (assess-test-coverage-delta pr-data cfg)
+                      :author-experience  (assess-author-experience author-history cfg)
+                      :review-staleness   (assess-review-staleness pr-data cfg)
+                      :complexity-delta   (assess-complexity-delta pr-data cfg)
+                      :critical-files     (assess-critical-files pr-data cfg)}
+         factors (mapv (fn [[factor-key weight]]
+                         (let [{:keys [value score explanation]} (get assessments factor-key)]
+                           {:factor factor-key
+                            :weight weight
+                            :value value
+                            :score score
+                            :explanation explanation}))
+                       weights)
+         total-score (reduce + 0.0
+                             (map (fn [{:keys [weight score]}]
+                                    (* weight score))
+                                  factors))]
+     {:risk/score total-score
+      :risk/level (score->level total-score (:levels cfg))
+      :risk/factors factors})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
@@ -215,5 +251,14 @@
     :hours-since-last-review 48
     :complexity-delta 8}
    {:total-commits 15 :recent-commits 3})
+
+  ;; With custom config — stricter thresholds
+  (assess-risk
+   {:train/prs []}
+   {:pr/number 1 :pr/blocks []}
+   {:change-size {:additions 100 :deletions 50}}
+   {}
+   {:config {:change-size {:thresholds [500 200 100 25]
+                           :scores     [1.0 0.75 0.50 0.25]}}})
 
   :leave-this-here)

--- a/components/pr-train/src/ai/miniforge/pr_train/schema.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/schema.clj
@@ -123,7 +123,24 @@
    [:pr/blocks [:vector :pr/number]]
    [:pr/ci-status :pr/ci-status]
    [:pr/gate-results {:optional true} [:vector GateResult]]
-   [:pr/intent {:optional true} TaskIntent]])
+   [:pr/intent {:optional true} TaskIntent]
+
+   ;; Tier 2 governance fields (backward-compatible)
+   [:pr/readiness-score {:optional true} [:double {:min 0.0 :max 1.0}]]
+   [:pr/risk {:optional true}
+    [:map
+     [:risk/score :common/pos-number]
+     [:risk/level [:enum :low :medium :high :critical]]
+     [:risk/factors {:optional true} [:vector [:map-of keyword? any?]]]]]
+   [:pr/automation-tier {:optional true} [:enum :tier-0 :tier-1 :tier-2 :tier-3]]
+   [:pr/derived-state {:optional true}
+    [:map
+     [:age-days :common/non-neg-int]
+     [:staleness-hours :common/non-neg-int]
+     [:change-size {:optional true}
+      [:map
+       [:additions :common/non-neg-int]
+       [:deletions :common/non-neg-int]]]]]])
 
 ;------------------------------------------------------------------------------ Layer 5
 ;; Progress schema

--- a/components/pr-train/src/ai/miniforge/pr_train/tiers.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/tiers.clj
@@ -11,14 +11,17 @@
    | 2    | yes           | yes         | Risk <= medium, readiness >= 0.90  |
    | 3    | yes           | yes         | Risk <= high, readiness >= 0.75    |
 
-   Layer 0: Tier definitions
+   Tier definitions are pure data and can be overridden by passing a custom
+   definitions map to `tier-allows?` and related functions.
+
+   Layer 0: Tier definitions (data)
    Layer 1: Tier enforcement functions")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Tier definitions
+;; Tier definitions — pure data, no code
 
-(def tier-definitions
-  "Automation tier constraint definitions."
+(def default-tier-definitions
+  "Default automation tier constraint definitions."
   {:tier-0 {:auto-approve? false
             :auto-merge?   false
             :description   "Human-only: no automation"
@@ -38,7 +41,12 @@
             :constraints   {:max-risk-level :high
                             :min-readiness  0.75}}})
 
-(def ^:private risk-level-order
+;; Backward-compatible alias
+(def tier-definitions
+  "Automation tier constraint definitions."
+  default-tier-definitions)
+
+(def risk-level-order
   "Risk levels ordered from lowest to highest."
   {:low 0 :medium 1 :high 2 :critical 3})
 
@@ -51,39 +59,37 @@
   (<= (get risk-level-order actual-level 99)
       (get risk-level-order max-level 99)))
 
+(defn- check-operation
+  "Check if a tier definition allows an operation given readiness and risk."
+  [tier-def operation-key readiness risk-level]
+  (and (get tier-def operation-key)
+       (let [{:keys [max-risk-level min-readiness]} (:constraints tier-def)]
+         (and (or (nil? max-risk-level)
+                  (risk-within-limit? risk-level max-risk-level))
+              (or (nil? min-readiness)
+                  (>= readiness min-readiness))))))
+
 (defn tier-allows?
   "Check if a tier allows a specific operation given readiness and risk.
 
    Arguments:
-   - tier - Keyword :tier-0 through :tier-3
+   - tier - Keyword :tier-0 through :tier-3 (or custom)
    - operation - Keyword :auto-approve or :auto-merge
    - readiness - Readiness score (0.0–1.0)
    - risk - Risk map with :risk/level keyword
+   - tiers - Optional tier definitions map (default: default-tier-definitions)
 
    Returns: boolean"
-  [tier operation readiness risk]
-  (let [tier-def (get tier-definitions tier)
-        risk-level (or (:risk/level risk) :low)]
-    (when tier-def
-      (case operation
-        :auto-approve
-        (and (:auto-approve? tier-def)
-             (let [{:keys [max-risk-level min-readiness]} (:constraints tier-def)]
-               (and (or (nil? max-risk-level)
-                        (risk-within-limit? risk-level max-risk-level))
-                    (or (nil? min-readiness)
-                        (>= readiness min-readiness)))))
-
-        :auto-merge
-        (and (:auto-merge? tier-def)
-             (let [{:keys [max-risk-level min-readiness]} (:constraints tier-def)]
-               (and (or (nil? max-risk-level)
-                        (risk-within-limit? risk-level max-risk-level))
-                    (or (nil? min-readiness)
-                        (>= readiness min-readiness)))))
-
-        ;; Unknown operation
-        false))))
+  ([tier operation readiness risk]
+   (tier-allows? tier operation readiness risk default-tier-definitions))
+  ([tier operation readiness risk tiers]
+   (let [tier-def (get tiers tier)
+         risk-level (or (:risk/level risk) :low)]
+     (when tier-def
+       (case operation
+         :auto-approve (check-operation tier-def :auto-approve? readiness risk-level)
+         :auto-merge   (check-operation tier-def :auto-merge? readiness risk-level)
+         false)))))
 
 (defn get-repo-tier
   "Look up the automation tier for a repository.
@@ -98,13 +104,17 @@
 
 (defn can-auto-approve?
   "Convenience: check if a PR can be auto-approved given its tier, readiness, and risk."
-  [tier readiness risk]
-  (tier-allows? tier :auto-approve readiness risk))
+  ([tier readiness risk]
+   (tier-allows? tier :auto-approve readiness risk))
+  ([tier readiness risk tiers]
+   (tier-allows? tier :auto-approve readiness risk tiers)))
 
 (defn can-auto-merge?
   "Convenience: check if a PR can be auto-merged given its tier, readiness, and risk."
-  [tier readiness risk]
-  (tier-allows? tier :auto-merge readiness risk))
+  ([tier readiness risk]
+   (tier-allows? tier :auto-merge readiness risk))
+  ([tier readiness risk tiers]
+   (tier-allows? tier :auto-merge readiness risk tiers)))
 
 (defn get-automation-tier
   "Get the effective automation tier with full definition.
@@ -112,12 +122,15 @@
    Arguments:
    - repo-config - Repository configuration map
    - repo-id - Repository identifier
+   - tiers - Optional tier definitions map
 
    Returns: {:tier kw :definition map}"
-  [repo-config repo-id]
-  (let [tier (get-repo-tier repo-config repo-id)]
-    {:tier tier
-     :definition (get tier-definitions tier)}))
+  ([repo-config repo-id]
+   (get-automation-tier repo-config repo-id default-tier-definitions))
+  ([repo-config repo-id tiers]
+   (let [tier (get-repo-tier repo-config repo-id)]
+     {:tier tier
+      :definition (get tiers tier)})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
@@ -134,14 +147,13 @@
   (tier-allows? :tier-2 :auto-approve 0.80 {:risk/level :low})    ;; => false (below 0.90)
   (tier-allows? :tier-2 :auto-approve 0.95 {:risk/level :high})   ;; => false (above medium)
 
-  ;; Tier 3: both, relaxed constraints
-  (tier-allows? :tier-3 :auto-approve 0.80 {:risk/level :high})   ;; => true
-  (tier-allows? :tier-3 :auto-approve 0.80 {:risk/level :critical}) ;; => false
+  ;; Custom tier definitions
+  (tier-allows? :tier-2 :auto-approve 0.80 {:risk/level :low}
+                (assoc-in default-tier-definitions [:tier-2 :constraints :min-readiness] 0.75))
+  ;; => true (relaxed readiness to 0.75)
 
   ;; Config lookup
   (get-repo-tier {"acme/terraform" {:automation-tier :tier-2}} "acme/terraform")
   ;; => :tier-2
-  (get-repo-tier {} "unknown-repo")
-  ;; => :tier-1 (default)
 
   :leave-this-here)

--- a/components/pr-train/src/ai/miniforge/pr_train/tiers.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/tiers.clj
@@ -1,0 +1,147 @@
+(ns ai.miniforge.pr-train.tiers
+  "Automation tier enforcement for PR trains.
+
+   Defines four automation tiers controlling auto-approve and auto-merge
+   capabilities based on risk and readiness thresholds.
+
+   | Tier | Auto-approve? | Auto-merge? | Constraints                        |
+   |------|---------------|-------------|------------------------------------|
+   | 0    | no            | no          | Human-only                         |
+   | 1    | no            | yes         | Human approves, system merges      |
+   | 2    | yes           | yes         | Risk <= medium, readiness >= 0.90  |
+   | 3    | yes           | yes         | Risk <= high, readiness >= 0.75    |
+
+   Layer 0: Tier definitions
+   Layer 1: Tier enforcement functions")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Tier definitions
+
+(def tier-definitions
+  "Automation tier constraint definitions."
+  {:tier-0 {:auto-approve? false
+            :auto-merge?   false
+            :description   "Human-only: no automation"
+            :constraints   {}}
+   :tier-1 {:auto-approve? false
+            :auto-merge?   true
+            :description   "Human approves, system merges"
+            :constraints   {}}
+   :tier-2 {:auto-approve? true
+            :auto-merge?   true
+            :description   "Full automation with tight guardrails"
+            :constraints   {:max-risk-level :medium
+                            :min-readiness  0.90}}
+   :tier-3 {:auto-approve? true
+            :auto-merge?   true
+            :description   "Full automation with relaxed guardrails"
+            :constraints   {:max-risk-level :high
+                            :min-readiness  0.75}}})
+
+(def ^:private risk-level-order
+  "Risk levels ordered from lowest to highest."
+  {:low 0 :medium 1 :high 2 :critical 3})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Tier enforcement functions
+
+(defn risk-within-limit?
+  "Check if a risk level is within the tier's maximum allowed level."
+  [actual-level max-level]
+  (<= (get risk-level-order actual-level 99)
+      (get risk-level-order max-level 99)))
+
+(defn tier-allows?
+  "Check if a tier allows a specific operation given readiness and risk.
+
+   Arguments:
+   - tier - Keyword :tier-0 through :tier-3
+   - operation - Keyword :auto-approve or :auto-merge
+   - readiness - Readiness score (0.0–1.0)
+   - risk - Risk map with :risk/level keyword
+
+   Returns: boolean"
+  [tier operation readiness risk]
+  (let [tier-def (get tier-definitions tier)
+        risk-level (or (:risk/level risk) :low)]
+    (when tier-def
+      (case operation
+        :auto-approve
+        (and (:auto-approve? tier-def)
+             (let [{:keys [max-risk-level min-readiness]} (:constraints tier-def)]
+               (and (or (nil? max-risk-level)
+                        (risk-within-limit? risk-level max-risk-level))
+                    (or (nil? min-readiness)
+                        (>= readiness min-readiness)))))
+
+        :auto-merge
+        (and (:auto-merge? tier-def)
+             (let [{:keys [max-risk-level min-readiness]} (:constraints tier-def)]
+               (and (or (nil? max-risk-level)
+                        (risk-within-limit? risk-level max-risk-level))
+                    (or (nil? min-readiness)
+                        (>= readiness min-readiness)))))
+
+        ;; Unknown operation
+        false))))
+
+(defn get-repo-tier
+  "Look up the automation tier for a repository.
+
+   Arguments:
+   - repo-config - Map of repo-id -> config with :automation-tier
+   - repo-id - Repository identifier string
+
+   Returns: Keyword :tier-0 through :tier-3 (default: :tier-1)"
+  [repo-config repo-id]
+  (get-in repo-config [repo-id :automation-tier] :tier-1))
+
+(defn can-auto-approve?
+  "Convenience: check if a PR can be auto-approved given its tier, readiness, and risk."
+  [tier readiness risk]
+  (tier-allows? tier :auto-approve readiness risk))
+
+(defn can-auto-merge?
+  "Convenience: check if a PR can be auto-merged given its tier, readiness, and risk."
+  [tier readiness risk]
+  (tier-allows? tier :auto-merge readiness risk))
+
+(defn get-automation-tier
+  "Get the effective automation tier with full definition.
+
+   Arguments:
+   - repo-config - Repository configuration map
+   - repo-id - Repository identifier
+
+   Returns: {:tier kw :definition map}"
+  [repo-config repo-id]
+  (let [tier (get-repo-tier repo-config repo-id)]
+    {:tier tier
+     :definition (get tier-definitions tier)}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Tier 0: nothing auto
+  (tier-allows? :tier-0 :auto-merge 1.0 {:risk/level :low})    ;; => false
+  (tier-allows? :tier-0 :auto-approve 1.0 {:risk/level :low})  ;; => false
+
+  ;; Tier 1: auto-merge but not auto-approve
+  (tier-allows? :tier-1 :auto-merge 0.5 {:risk/level :low})    ;; => true
+  (tier-allows? :tier-1 :auto-approve 1.0 {:risk/level :low})  ;; => false
+
+  ;; Tier 2: both, but tight constraints
+  (tier-allows? :tier-2 :auto-approve 0.95 {:risk/level :low})    ;; => true
+  (tier-allows? :tier-2 :auto-approve 0.80 {:risk/level :low})    ;; => false (below 0.90)
+  (tier-allows? :tier-2 :auto-approve 0.95 {:risk/level :high})   ;; => false (above medium)
+
+  ;; Tier 3: both, relaxed constraints
+  (tier-allows? :tier-3 :auto-approve 0.80 {:risk/level :high})   ;; => true
+  (tier-allows? :tier-3 :auto-approve 0.80 {:risk/level :critical}) ;; => false
+
+  ;; Config lookup
+  (get-repo-tier {"acme/terraform" {:automation-tier :tier-2}} "acme/terraform")
+  ;; => :tier-2
+  (get-repo-tier {} "unknown-repo")
+  ;; => :tier-1 (default)
+
+  :leave-this-here)

--- a/components/pr-train/test/ai/miniforge/pr_train/readiness_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/readiness_test.clj
@@ -11,71 +11,73 @@
   (testing "no dependencies scores 1.0"
     (let [train {:train/prs []}
           pr {:pr/depends-on []}]
-      (is (= 1.0 (readiness/score-deps-factor train pr)))))
+      (is (= 1.0 (readiness/score-deps-factor train pr readiness/default-config)))))
 
   (testing "all deps merged scores 1.0"
     (let [train {:train/prs [{:pr/number 1 :pr/status :merged}
                               {:pr/number 2 :pr/status :merged}]}
           pr {:pr/depends-on [1 2]}]
-      (is (= 1.0 (readiness/score-deps-factor train pr)))))
+      (is (= 1.0 (readiness/score-deps-factor train pr readiness/default-config)))))
 
   (testing "no deps merged scores 0.0"
     (let [train {:train/prs [{:pr/number 1 :pr/status :open}
                               {:pr/number 2 :pr/status :open}]}
           pr {:pr/depends-on [1 2]}]
-      (is (= 0.0 (readiness/score-deps-factor train pr)))))
+      (is (= 0.0 (readiness/score-deps-factor train pr readiness/default-config)))))
 
   (testing "half deps merged scores 0.5"
     (let [train {:train/prs [{:pr/number 1 :pr/status :merged}
                               {:pr/number 2 :pr/status :open}]}
           pr {:pr/depends-on [1 2]}]
-      (is (= 0.5 (readiness/score-deps-factor train pr))))))
+      (is (= 0.5 (readiness/score-deps-factor train pr readiness/default-config))))))
 
 (deftest score-ci-factor-test
   (testing "passed CI scores 1.0"
-    (is (= 1.0 (readiness/score-ci-factor nil {:pr/ci-status :passed}))))
+    (is (= 1.0 (readiness/score-ci-factor nil {:pr/ci-status :passed} readiness/default-config))))
 
   (testing "running CI scores 0.5"
-    (is (= 0.5 (readiness/score-ci-factor nil {:pr/ci-status :running}))))
+    (is (= 0.5 (readiness/score-ci-factor nil {:pr/ci-status :running} readiness/default-config))))
 
   (testing "failed CI scores 0.0"
-    (is (= 0.0 (readiness/score-ci-factor nil {:pr/ci-status :failed})))))
+    (is (= 0.0 (readiness/score-ci-factor nil {:pr/ci-status :failed} readiness/default-config)))))
 
 (deftest score-approved-factor-test
   (testing "approved PR scores 1.0"
-    (is (= 1.0 (readiness/score-approved-factor nil {:pr/status :approved}))))
+    (is (= 1.0 (readiness/score-approved-factor nil {:pr/status :approved} readiness/default-config))))
 
   (testing "reviewing PR scores 0.5"
-    (is (= 0.5 (readiness/score-approved-factor nil {:pr/status :reviewing}))))
+    (is (= 0.5 (readiness/score-approved-factor nil {:pr/status :reviewing} readiness/default-config))))
 
   (testing "draft PR scores 0.0"
-    (is (= 0.0 (readiness/score-approved-factor nil {:pr/status :draft})))))
+    (is (= 0.0 (readiness/score-approved-factor nil {:pr/status :draft} readiness/default-config)))))
 
 (deftest score-gates-factor-test
   (testing "no gates scores 1.0"
-    (is (= 1.0 (readiness/score-gates-factor nil {:pr/gate-results []}))))
+    (is (= 1.0 (readiness/score-gates-factor nil {:pr/gate-results []} readiness/default-config))))
 
   (testing "all gates passed scores 1.0"
     (is (= 1.0 (readiness/score-gates-factor nil
-                 {:pr/gate-results [{:gate/passed? true} {:gate/passed? true}]}))))
+                 {:pr/gate-results [{:gate/passed? true} {:gate/passed? true}]}
+                 readiness/default-config))))
 
   (testing "half gates passed scores 0.5"
     (is (= 0.5 (readiness/score-gates-factor nil
-                 {:pr/gate-results [{:gate/passed? true} {:gate/passed? false}]})))))
+                 {:pr/gate-results [{:gate/passed? true} {:gate/passed? false}]}
+                 readiness/default-config)))))
 
 (deftest score-age-factor-test
   (testing "brand new PR scores 1.0"
-    (is (= 1.0 (readiness/score-age-factor nil {:pr/derived-state {:age-days 0}}))))
+    (is (= 1.0 (readiness/score-age-factor nil {:pr/derived-state {:age-days 0}} readiness/default-config))))
 
   (testing "max age PR scores 0.0"
-    (is (= 0.0 (readiness/score-age-factor nil {:pr/derived-state {:age-days 14}})))))
+    (is (= 0.0 (readiness/score-age-factor nil {:pr/derived-state {:age-days 14}} readiness/default-config)))))
 
 (deftest score-staleness-factor-test
   (testing "just updated PR scores 1.0"
-    (is (= 1.0 (readiness/score-staleness-factor nil {:pr/derived-state {:staleness-hours 0}}))))
+    (is (= 1.0 (readiness/score-staleness-factor nil {:pr/derived-state {:staleness-hours 0}} readiness/default-config))))
 
   (testing "max stale PR scores 0.0"
-    (is (= 0.0 (readiness/score-staleness-factor nil {:pr/derived-state {:staleness-hours 72}})))))
+    (is (= 0.0 (readiness/score-staleness-factor nil {:pr/derived-state {:staleness-hours 72}} readiness/default-config)))))
 
 ;; ============================================================================
 ;; Weighted aggregation tests

--- a/components/pr-train/test/ai/miniforge/pr_train/readiness_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/readiness_test.clj
@@ -1,0 +1,152 @@
+(ns ai.miniforge.pr-train.readiness-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.pr-train.readiness :as readiness]))
+
+;; ============================================================================
+;; Factor scoring tests
+;; ============================================================================
+
+(deftest score-deps-factor-test
+  (testing "no dependencies scores 1.0"
+    (let [train {:train/prs []}
+          pr {:pr/depends-on []}]
+      (is (= 1.0 (readiness/score-deps-factor train pr)))))
+
+  (testing "all deps merged scores 1.0"
+    (let [train {:train/prs [{:pr/number 1 :pr/status :merged}
+                              {:pr/number 2 :pr/status :merged}]}
+          pr {:pr/depends-on [1 2]}]
+      (is (= 1.0 (readiness/score-deps-factor train pr)))))
+
+  (testing "no deps merged scores 0.0"
+    (let [train {:train/prs [{:pr/number 1 :pr/status :open}
+                              {:pr/number 2 :pr/status :open}]}
+          pr {:pr/depends-on [1 2]}]
+      (is (= 0.0 (readiness/score-deps-factor train pr)))))
+
+  (testing "half deps merged scores 0.5"
+    (let [train {:train/prs [{:pr/number 1 :pr/status :merged}
+                              {:pr/number 2 :pr/status :open}]}
+          pr {:pr/depends-on [1 2]}]
+      (is (= 0.5 (readiness/score-deps-factor train pr))))))
+
+(deftest score-ci-factor-test
+  (testing "passed CI scores 1.0"
+    (is (= 1.0 (readiness/score-ci-factor nil {:pr/ci-status :passed}))))
+
+  (testing "running CI scores 0.5"
+    (is (= 0.5 (readiness/score-ci-factor nil {:pr/ci-status :running}))))
+
+  (testing "failed CI scores 0.0"
+    (is (= 0.0 (readiness/score-ci-factor nil {:pr/ci-status :failed})))))
+
+(deftest score-approved-factor-test
+  (testing "approved PR scores 1.0"
+    (is (= 1.0 (readiness/score-approved-factor nil {:pr/status :approved}))))
+
+  (testing "reviewing PR scores 0.5"
+    (is (= 0.5 (readiness/score-approved-factor nil {:pr/status :reviewing}))))
+
+  (testing "draft PR scores 0.0"
+    (is (= 0.0 (readiness/score-approved-factor nil {:pr/status :draft})))))
+
+(deftest score-gates-factor-test
+  (testing "no gates scores 1.0"
+    (is (= 1.0 (readiness/score-gates-factor nil {:pr/gate-results []}))))
+
+  (testing "all gates passed scores 1.0"
+    (is (= 1.0 (readiness/score-gates-factor nil
+                 {:pr/gate-results [{:gate/passed? true} {:gate/passed? true}]}))))
+
+  (testing "half gates passed scores 0.5"
+    (is (= 0.5 (readiness/score-gates-factor nil
+                 {:pr/gate-results [{:gate/passed? true} {:gate/passed? false}]})))))
+
+(deftest score-age-factor-test
+  (testing "brand new PR scores 1.0"
+    (is (= 1.0 (readiness/score-age-factor nil {:pr/derived-state {:age-days 0}}))))
+
+  (testing "max age PR scores 0.0"
+    (is (= 0.0 (readiness/score-age-factor nil {:pr/derived-state {:age-days 14}})))))
+
+(deftest score-staleness-factor-test
+  (testing "just updated PR scores 1.0"
+    (is (= 1.0 (readiness/score-staleness-factor nil {:pr/derived-state {:staleness-hours 0}}))))
+
+  (testing "max stale PR scores 0.0"
+    (is (= 0.0 (readiness/score-staleness-factor nil {:pr/derived-state {:staleness-hours 72}})))))
+
+;; ============================================================================
+;; Weighted aggregation tests
+;; ============================================================================
+
+(deftest compute-readiness-score-test
+  (testing "perfect PR scores near 1.0"
+    (let [train {:train/prs [{:pr/number 1 :pr/status :merged}]}
+          pr {:pr/number 2
+              :pr/depends-on [1]
+              :pr/ci-status :passed
+              :pr/status :approved
+              :pr/gate-results [{:gate/passed? true}]
+              :pr/derived-state {:age-days 0 :staleness-hours 0}}
+          score (readiness/compute-readiness-score train pr)]
+      (is (>= score 0.95))
+      (is (<= score 1.0))))
+
+  (testing "terrible PR scores near 0.0"
+    (let [train {:train/prs [{:pr/number 1 :pr/status :open}]}
+          pr {:pr/number 2
+              :pr/depends-on [1]
+              :pr/ci-status :failed
+              :pr/status :draft
+              :pr/gate-results [{:gate/passed? false}]
+              :pr/derived-state {:age-days 14 :staleness-hours 72}}
+          score (readiness/compute-readiness-score train pr)]
+      (is (<= score 0.1)))))
+
+;; ============================================================================
+;; Explainability tests
+;; ============================================================================
+
+(deftest explain-readiness-test
+  (testing "explain returns all factors"
+    (let [train {:train/prs []}
+          pr {:pr/depends-on [] :pr/ci-status :passed :pr/status :approved
+              :pr/gate-results [] :pr/derived-state {:age-days 0 :staleness-hours 0}}
+          result (readiness/explain-readiness train pr)]
+      (is (contains? result :readiness/score))
+      (is (contains? result :readiness/threshold))
+      (is (contains? result :readiness/ready?))
+      (is (= 6 (count (:readiness/factors result))))
+
+      (testing "factors have required keys"
+        (doseq [f (:readiness/factors result)]
+          (is (contains? f :factor))
+          (is (contains? f :weight))
+          (is (contains? f :score))
+          (is (contains? f :contribution))))))
+
+  (testing "score matches explicit computation"
+    (let [train {:train/prs []}
+          pr {:pr/depends-on [] :pr/ci-status :passed :pr/status :approved
+              :pr/gate-results [] :pr/derived-state {:age-days 0 :staleness-hours 0}}
+          explained (readiness/explain-readiness train pr)
+          computed (readiness/compute-readiness-score train pr)]
+      (is (< (Math/abs (- (:readiness/score explained) computed)) 0.001)))))
+
+;; ============================================================================
+;; Threshold tests
+;; ============================================================================
+
+(deftest threshold-test
+  (testing "ready? reflects threshold comparison"
+    (let [train {:train/prs []}
+          good-pr {:pr/depends-on [] :pr/ci-status :passed :pr/status :approved
+                   :pr/gate-results [{:gate/passed? true}]
+                   :pr/derived-state {:age-days 0 :staleness-hours 0}}
+          bad-pr {:pr/depends-on [] :pr/ci-status :failed :pr/status :draft
+                  :pr/gate-results [{:gate/passed? false}]
+                  :pr/derived-state {:age-days 14 :staleness-hours 72}}]
+      (is (true? (:readiness/ready? (readiness/explain-readiness train good-pr))))
+      (is (false? (:readiness/ready? (readiness/explain-readiness train bad-pr)))))))

--- a/components/pr-train/test/ai/miniforge/pr_train/risk_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/risk_test.clj
@@ -1,0 +1,117 @@
+(ns ai.miniforge.pr-train.risk-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.pr-train.risk :as risk]))
+
+;; ============================================================================
+;; Risk level classification tests
+;; ============================================================================
+
+(deftest score->level-test
+  (testing "critical threshold"
+    (is (= :critical (risk/score->level 0.75)))
+    (is (= :critical (risk/score->level 1.0))))
+
+  (testing "high threshold"
+    (is (= :high (risk/score->level 0.50)))
+    (is (= :high (risk/score->level 0.74))))
+
+  (testing "medium threshold"
+    (is (= :medium (risk/score->level 0.25)))
+    (is (= :medium (risk/score->level 0.49))))
+
+  (testing "low threshold"
+    (is (= :low (risk/score->level 0.0)))
+    (is (= :low (risk/score->level 0.24)))))
+
+;; ============================================================================
+;; Risk assessment tests
+;; ============================================================================
+
+(deftest assess-risk-test
+  (testing "low-risk PR"
+    (let [result (risk/assess-risk
+                  {:train/prs []}
+                  {:pr/number 1 :pr/blocks []}
+                  {:change-size {:additions 10 :deletions 5}
+                   :test-coverage-delta 2.0
+                   :changed-files ["src/utils.clj"]
+                   :hours-since-last-review 1
+                   :complexity-delta 0}
+                  {:total-commits 100 :recent-commits 20})]
+      (is (= :low (:risk/level result)))
+      (is (< (:risk/score result) 0.25))))
+
+  (testing "high-risk PR with large changes and critical files"
+    (let [result (risk/assess-risk
+                  {:train/prs []}
+                  {:pr/number 1 :pr/blocks [2 3 4]}
+                  {:change-size {:additions 800 :deletions 300}
+                   :test-coverage-delta -8.0
+                   :changed-files ["Dockerfile" "schema.sql" ".env"]
+                   :hours-since-last-review 96
+                   :complexity-delta 15}
+                  {:total-commits 2 :recent-commits 1})]
+      (is (#{:high :critical} (:risk/level result)))
+      (is (>= (:risk/score result) 0.50))))
+
+  (testing "result contains factors"
+    (let [result (risk/assess-risk
+                  {:train/prs []}
+                  {:pr/number 1 :pr/blocks []}
+                  {} {})]
+      (is (vector? (:risk/factors result)))
+      (is (= 7 (count (:risk/factors result))))))
+
+  (testing "factors have required keys"
+    (let [result (risk/assess-risk
+                  {:train/prs []}
+                  {:pr/number 1 :pr/blocks []}
+                  {:change-size {:additions 50 :deletions 10}}
+                  {:total-commits 10})]
+      (doseq [f (:risk/factors result)]
+        (is (contains? f :factor))
+        (is (contains? f :weight))
+        (is (contains? f :score))
+        (is (contains? f :explanation)))))
+
+  (testing "risk score is weighted sum of factors"
+    (let [result (risk/assess-risk
+                  {:train/prs []}
+                  {:pr/number 1 :pr/blocks []}
+                  {:change-size {:additions 200 :deletions 50}}
+                  {:total-commits 10})
+          expected-score (reduce + 0.0
+                                 (map (fn [f] (* (:weight f) (:score f)))
+                                      (:risk/factors result)))]
+      (is (< (Math/abs (- (:risk/score result) expected-score)) 0.001)))))
+
+;; ============================================================================
+;; Factor detail tests
+;; ============================================================================
+
+(deftest change-size-factor-test
+  (testing "small change is low risk"
+    (let [result (risk/assess-risk {:train/prs []} {:pr/number 1 :pr/blocks []}
+                                   {:change-size {:additions 10 :deletions 5}} {})
+          factor (first (filter #(= :change-size (:factor %)) (:risk/factors result)))]
+      (is (= 0.0 (:score factor)))))
+
+  (testing "huge change is high risk"
+    (let [result (risk/assess-risk {:train/prs []} {:pr/number 1 :pr/blocks []}
+                                   {:change-size {:additions 800 :deletions 300}} {})
+          factor (first (filter #(= :change-size (:factor %)) (:risk/factors result)))]
+      (is (= 1.0 (:score factor))))))
+
+(deftest critical-files-factor-test
+  (testing "no critical files is zero risk"
+    (let [result (risk/assess-risk {:train/prs []} {:pr/number 1 :pr/blocks []}
+                                   {:changed-files ["src/core.clj"]} {})
+          factor (first (filter #(= :critical-files (:factor %)) (:risk/factors result)))]
+      (is (= 0.0 (:score factor)))))
+
+  (testing "Dockerfile modification is risky"
+    (let [result (risk/assess-risk {:train/prs []} {:pr/number 1 :pr/blocks []}
+                                   {:changed-files ["Dockerfile"]} {})
+          factor (first (filter #(= :critical-files (:factor %)) (:risk/factors result)))]
+      (is (= 0.50 (:score factor))))))

--- a/components/pr-train/test/ai/miniforge/pr_train/tiers_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/tiers_test.clj
@@ -1,0 +1,87 @@
+(ns ai.miniforge.pr-train.tiers-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.pr-train.tiers :as tiers]))
+
+;; ============================================================================
+;; Tier constraint tests
+;; ============================================================================
+
+(deftest tier-0-test
+  (testing "tier-0 disallows all automation"
+    (is (false? (tiers/tier-allows? :tier-0 :auto-approve 1.0 {:risk/level :low})))
+    (is (false? (tiers/tier-allows? :tier-0 :auto-merge 1.0 {:risk/level :low})))))
+
+(deftest tier-1-test
+  (testing "tier-1 allows auto-merge but not auto-approve"
+    (is (false? (tiers/tier-allows? :tier-1 :auto-approve 1.0 {:risk/level :low})))
+    (is (true? (tiers/tier-allows? :tier-1 :auto-merge 0.5 {:risk/level :low})))))
+
+(deftest tier-2-test
+  (testing "tier-2 allows both when constraints met"
+    (is (true? (tiers/tier-allows? :tier-2 :auto-approve 0.95 {:risk/level :low})))
+    (is (true? (tiers/tier-allows? :tier-2 :auto-merge 0.95 {:risk/level :medium}))))
+
+  (testing "tier-2 rejects when readiness too low"
+    (is (false? (tiers/tier-allows? :tier-2 :auto-approve 0.80 {:risk/level :low}))))
+
+  (testing "tier-2 rejects when risk too high"
+    (is (false? (tiers/tier-allows? :tier-2 :auto-approve 0.95 {:risk/level :high})))
+    (is (false? (tiers/tier-allows? :tier-2 :auto-merge 0.95 {:risk/level :critical})))))
+
+(deftest tier-3-test
+  (testing "tier-3 allows with relaxed constraints"
+    (is (true? (tiers/tier-allows? :tier-3 :auto-approve 0.80 {:risk/level :high})))
+    (is (true? (tiers/tier-allows? :tier-3 :auto-merge 0.80 {:risk/level :medium}))))
+
+  (testing "tier-3 rejects critical risk"
+    (is (false? (tiers/tier-allows? :tier-3 :auto-approve 0.80 {:risk/level :critical}))))
+
+  (testing "tier-3 rejects low readiness"
+    (is (false? (tiers/tier-allows? :tier-3 :auto-approve 0.70 {:risk/level :low})))))
+
+;; ============================================================================
+;; Operation gating tests
+;; ============================================================================
+
+(deftest can-auto-approve-test
+  (testing "convenience function matches tier-allows?"
+    (is (= (tiers/tier-allows? :tier-2 :auto-approve 0.95 {:risk/level :low})
+           (tiers/can-auto-approve? :tier-2 0.95 {:risk/level :low})))
+    (is (= (tiers/tier-allows? :tier-0 :auto-approve 1.0 {:risk/level :low})
+           (tiers/can-auto-approve? :tier-0 1.0 {:risk/level :low})))))
+
+(deftest can-auto-merge-test
+  (testing "convenience function matches tier-allows?"
+    (is (= (tiers/tier-allows? :tier-1 :auto-merge 0.5 {:risk/level :low})
+           (tiers/can-auto-merge? :tier-1 0.5 {:risk/level :low})))
+    (is (= (tiers/tier-allows? :tier-0 :auto-merge 1.0 {:risk/level :low})
+           (tiers/can-auto-merge? :tier-0 1.0 {:risk/level :low})))))
+
+;; ============================================================================
+;; Config lookup tests
+;; ============================================================================
+
+(deftest get-repo-tier-test
+  (testing "returns configured tier"
+    (is (= :tier-2
+           (tiers/get-repo-tier {"acme/terraform" {:automation-tier :tier-2}} "acme/terraform"))))
+
+  (testing "defaults to tier-1 for unknown repos"
+    (is (= :tier-1 (tiers/get-repo-tier {} "unknown/repo")))))
+
+(deftest get-automation-tier-test
+  (testing "returns tier with definition"
+    (let [result (tiers/get-automation-tier
+                  {"acme/repo" {:automation-tier :tier-2}} "acme/repo")]
+      (is (= :tier-2 (:tier result)))
+      (is (map? (:definition result)))
+      (is (true? (get-in result [:definition :auto-approve?]))))))
+
+;; ============================================================================
+;; Unknown operation test
+;; ============================================================================
+
+(deftest unknown-operation-test
+  (testing "unknown operations return false"
+    (is (false? (tiers/tier-allows? :tier-3 :unknown-op 1.0 {:risk/level :low})))))


### PR DESCRIPTION
## Summary

Implements Stream E governance primitives: readiness scoring, risk assessment, and automation tier enforcement for PR trains.

### Readiness Scoring (`readiness.clj`)

Weighted 6-factor readiness score (0.0–1.0) that answers "is this PR ready to merge?":

| Factor | Weight | What it measures |
|--------|--------|------------------|
| deps-merged | 0.30 | All blocking PRs in the train are merged |
| ci-passed | 0.25 | CI checks have passed |
| approved | 0.20 | PR has human approval |
| gates-passed | 0.15 | Policy gates have passed |
| age-penalty | 0.05 | Penalty for PRs open > threshold hours |
| staleness-penalty | 0.05 | Penalty for stale reviews |

Threshold: 0.85. `explain-readiness` returns the full factor breakdown for dashboard display.

### Risk Assessment (`risk.clj`)

Weighted 7-factor risk score (0.0–1.0) with explainable per-factor breakdown:

| Factor | Weight | Signal |
|--------|--------|--------|
| change-size | 0.25 | Lines added + deleted |
| dependency-fanout | 0.20 | Downstream PRs blocked by this one |
| test-coverage-delta | 0.15 | Coverage increase/decrease |
| author-experience | 0.10 | Total + recent commit history |
| review-staleness | 0.10 | Hours since last review |
| complexity-delta | 0.10 | Cyclomatic complexity change |
| critical-files | 0.10 | Modifications to .env, Dockerfile, migrations, CI, etc. |

Risk levels: `:low` (< 0.25), `:medium` (0.25–0.49), `:high` (0.50–0.74), `:critical` (>= 0.75).

**Data-driven configuration**: All thresholds, weights, patterns, and scoring tiers are stored in a single `default-config` map. Callers can override any config key by passing `{:config overrides}` to `assess-risk` — no code changes required for tuning.

### Automation Tiers (`tiers.clj`)

Four automation tiers controlling auto-approve and auto-merge:

| Tier | Auto-approve? | Auto-merge? | Constraints |
|------|---------------|-------------|-------------|
| 0 | no | no | Human-only |
| 1 | no | yes | Human approves, system merges |
| 2 | yes | yes | Risk <= medium, readiness >= 0.90 |
| 3 | yes | yes | Risk <= high, readiness >= 0.75 |

**Overridable**: `default-tier-definitions` can be replaced by passing custom definitions to `tier-allows?`, `can-auto-approve?`, `can-auto-merge?`, and `get-automation-tier`.

### Design Decisions

- **Config-as-data**: All scoring parameters are pure EDN data in `default-config` maps, not code. Users can tune thresholds, weights, and patterns without modifying source.
- **Explainability**: Both readiness and risk return structured factor breakdowns, not just a number, enabling dashboard drill-down.
- **Backward compatibility**: Renamed vars (e.g., `tier-definitions` → `default-tier-definitions`) retain aliases. All functions accept optional config/definitions as last param.

## Files Changed

| File | Change |
|------|--------|
| `pr-train/readiness.clj` | New — weighted scoring engine |
| `pr-train/risk.clj` | New — risk factor assessment |
| `pr-train/tiers.clj` | New — tier definitions + enforcement |
| `pr-train/interface.clj` | Modified — expose new APIs via `def` delegation |
| `pr-train/schema.clj` | Modified — new schema fields for readiness/risk |
| `pr-train/test/readiness_test.clj` | New — unit tests |
| `pr-train/test/risk_test.clj` | New — unit tests |
| `pr-train/test/tiers_test.clj` | New — unit tests |

## API Surface

```clojure
;; Readiness
(pr-train/compute-readiness-score train pr)        ;=> 0.0–1.0
(pr-train/explain-readiness train pr)              ;=> {:score 0.92 :factors [...]}

;; Risk
(pr-train/assess-risk train pr pr-data author-history)
(pr-train/assess-risk train pr pr-data author-history {:config overrides})
;=> {:risk/score 0.45 :risk/level :medium :risk/factors [...]}

;; Tiers
(pr-train/tier-allows? :tier-2 :auto-merge readiness risk)
(pr-train/can-auto-approve? :tier-2 readiness risk)
(pr-train/can-auto-merge? :tier-2 readiness risk)
(pr-train/get-automation-tier repo-config repo-id)
```

## Test Plan

- [x] `bb test` passes (all pr-train brick tests)
- [x] Readiness scores match expected ranges for perfect/terrible PRs
- [x] Risk levels classify correctly (low < 0.25, critical >= 0.75)
- [x] Tier constraint matrix verified across all tier/readiness/risk combos
- [x] E2E governance integration tests pass (PR #176)

🤖 Generated with [Claude Code](https://claude.com/claude-code)