### PR TITLE
Web dashboard: governance API endpoints

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/approval.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/approval.clj
@@ -1,0 +1,301 @@
+(ns ai.miniforge.event-stream.approval
+  "Multi-party approval state machine for N8 OCI compliance.
+
+   Implements structured approval requests requiring quorum-based
+   signing from authorized signers. Approval states flow:
+   pending → approved | rejected | expired | cancelled.
+
+   Layer 0: Approval request creation
+   Layer 1: Approval signing and status checking
+   Layer 2: Approval manager (atom-backed store)
+   Layer 3: Approval event constructors"
+  (:require
+   [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.response.interface :as response]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Response predicates for builder responses
+
+(defn succeeded?
+  "Check if a builder response (from response/success) succeeded."
+  [r]
+  (= :success (:status r)))
+
+(defn failed?
+  "Check if a builder response (from response/failure) failed."
+  [r]
+  (false? (:success r)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Approval request creation
+
+(def ^:const default-expiry-hours
+  "Default approval request expiry in hours."
+  24)
+
+(defn create-approval-request
+  "Create a new approval request.
+
+   Arguments:
+   - action-id - UUID of the control action requiring approval
+   - required-signers - Vector of authorized signer identifiers (strings)
+   - quorum - Number of approvals needed
+   - opts - Optional map:
+     - :expires-in-hours - Hours until expiry (default: 24)
+     - :metadata - Additional metadata map
+
+   Returns: Approval request map."
+  [action-id required-signers quorum & [opts]]
+  (let [hours (get opts :expires-in-hours default-expiry-hours)
+        now (java.util.Date.)
+        expires-at (java.util.Date. (+ (.getTime now) (* hours 60 60 1000)))]
+    (cond-> {:approval/id (random-uuid)
+             :approval/action-id action-id
+             :approval/status :pending
+             :approval/required-signers (vec required-signers)
+             :approval/quorum quorum
+             :approval/signatures []
+             :approval/created-at now
+             :approval/expires-at expires-at}
+      (:metadata opts) (assoc :approval/metadata (:metadata opts)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Approval signing
+
+(defn- signer-authorized?
+  "Check if a signer is in the required-signers list."
+  [approval-request signer]
+  (some #{signer} (:approval/required-signers approval-request)))
+
+(defn- already-signed?
+  "Check if a signer has already signed."
+  [approval-request signer]
+  (some #(= signer (:signer %)) (:approval/signatures approval-request)))
+
+(defn- expired?
+  "Check if an approval request has expired."
+  [approval-request]
+  (let [now (java.util.Date.)
+        expires-at (:approval/expires-at approval-request)]
+    (when expires-at
+      (.after now expires-at))))
+
+(defn submit-approval
+  "Submit an approval or rejection for a request.
+
+   Arguments:
+   - approval-request - Approval request map
+   - signer - Signer identifier string
+   - decision - :approve or :reject
+   - opts - Optional map with :reason string
+
+   Returns:
+   - response/success with updated request on success
+   - response/failure with anomaly on error"
+  [approval-request signer decision & [opts]]
+  (cond
+    ;; Must be pending
+    (not= :pending (:approval/status approval-request))
+    (response/failure "Approval request is not pending"
+                      {:data {:status (:approval/status approval-request)}})
+
+    ;; Check expiry
+    (expired? approval-request)
+    (response/failure "Approval request has expired"
+                      {:data {:expires-at (:approval/expires-at approval-request)}})
+
+    ;; Must be authorized signer
+    (not (signer-authorized? approval-request signer))
+    (response/failure "Signer not authorized"
+                      {:data {:signer signer
+                              :required (:approval/required-signers approval-request)}})
+
+    ;; No duplicate signatures
+    (already-signed? approval-request signer)
+    (response/failure "Signer has already signed"
+                      {:data {:signer signer}})
+
+    ;; Valid decision
+    (not (#{:approve :reject} decision))
+    (response/failure "Invalid decision" {:data {:decision decision}})
+
+    :else
+    (let [signature {:signer signer
+                     :decision decision
+                     :timestamp (java.util.Date.)
+                     :reason (:reason opts)}
+          updated (update approval-request :approval/signatures conj signature)
+          ;; Check for immediate rejection
+          rejected? (= :reject decision)
+          ;; Check for quorum
+          approve-count (count (filter #(= :approve (:decision %))
+                                       (:approval/signatures updated)))
+          approved? (>= approve-count (:approval/quorum updated))
+          ;; Update status
+          new-status (cond rejected? :rejected
+                           approved? :approved
+                           :else :pending)
+          final (assoc updated :approval/status new-status)]
+      (response/success final))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Status checking
+
+(defn check-approval-status
+  "Check the current status of an approval request, accounting for expiry.
+
+   Arguments:
+   - approval-request - Approval request map
+
+   Returns: :pending | :approved | :rejected | :expired | :cancelled"
+  [approval-request]
+  (let [status (:approval/status approval-request)]
+    (if (and (= :pending status) (expired? approval-request))
+      :expired
+      status)))
+
+(defn cancel-approval
+  "Cancel a pending approval request.
+
+   Arguments:
+   - approval-request - Approval request map
+   - canceller - Identifier of the person cancelling
+   - reason - Reason for cancellation
+
+   Returns:
+   - response/success with updated request on success
+   - response/failure if not pending"
+  [approval-request canceller reason]
+  (if (not= :pending (:approval/status approval-request))
+    (response/failure "Can only cancel pending approvals"
+                      {:data {:status (:approval/status approval-request)}})
+    (response/success
+     (assoc approval-request
+            :approval/status :cancelled
+            :approval/cancelled-by canceller
+            :approval/cancel-reason reason
+            :approval/cancelled-at (java.util.Date.)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Approval manager (atom-backed store)
+
+(defn create-approval-manager
+  "Create an atom-backed approval manager.
+
+   Returns: Atom containing {:approvals {uuid approval-request}}"
+  []
+  (atom {:approvals {}}))
+
+(defn store-approval!
+  "Store an approval request in the manager.
+
+   Arguments:
+   - manager - Approval manager atom
+   - approval - Approval request map
+
+   Returns: The stored approval."
+  [manager approval]
+  (let [id (:approval/id approval)]
+    (swap! manager assoc-in [:approvals id] approval)
+    approval))
+
+(defn get-approval
+  "Get an approval request by ID.
+
+   Arguments:
+   - manager - Approval manager atom
+   - approval-id - UUID
+
+   Returns: Approval request or nil."
+  [manager approval-id]
+  (get-in @manager [:approvals approval-id]))
+
+(defn update-approval!
+  "Update an approval request in the manager.
+
+   Arguments:
+   - manager - Approval manager atom
+   - approval - Updated approval request map
+
+   Returns: The updated approval."
+  [manager approval]
+  (let [id (:approval/id approval)]
+    (swap! manager assoc-in [:approvals id] approval)
+    approval))
+
+(defn list-approvals
+  "List all approval requests, optionally filtered.
+
+   Arguments:
+   - manager - Approval manager atom
+   - opts - Optional map with :status keyword to filter by
+
+   Returns: Vector of approval requests."
+  [manager & [opts]]
+  (let [approvals (vals (:approvals @manager))]
+    (if-let [status (:status opts)]
+      (vec (filter #(= status (check-approval-status %)) approvals))
+      (vec approvals))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Approval event constructors
+
+(defn approval-requested
+  "Create an approval/requested event."
+  [stream workflow-id approval-id action-id required-signers]
+  (-> (core/create-envelope stream :approval/requested workflow-id
+                            (str "Approval requested for action " action-id))
+      (assoc :approval/id approval-id
+             :approval/action-id action-id
+             :approval/required-signers required-signers)))
+
+(defn approval-signed
+  "Create an approval/signed event."
+  [stream workflow-id approval-id signer decision]
+  (-> (core/create-envelope stream :approval/signed workflow-id
+                            (str "Approval " (name decision) " by " signer))
+      (assoc :approval/id approval-id
+             :approval/signer signer
+             :approval/decision decision)))
+
+(defn approval-completed
+  "Create an approval/completed event."
+  [stream workflow-id approval-id final-status]
+  (-> (core/create-envelope stream :approval/completed workflow-id
+                            (str "Approval " (name final-status)))
+      (assoc :approval/id approval-id
+             :approval/final-status final-status)))
+
+(defn approval-expired
+  "Create an approval/expired event."
+  [stream workflow-id approval-id]
+  (-> (core/create-envelope stream :approval/expired workflow-id
+                            "Approval request expired")
+      (assoc :approval/id approval-id)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create and sign an approval
+  (def req (create-approval-request
+            (random-uuid) ["alice" "bob" "carol"] 2))
+
+  ;; Alice approves
+  (def r1 (submit-approval req "alice" :approve))
+  ;; => success with updated request (still pending)
+
+  ;; Bob approves → quorum met
+  (def r2 (submit-approval (:output r1) "bob" :approve))
+  ;; => success with status :approved
+
+  ;; Test rejection
+  (def req2 (create-approval-request
+             (random-uuid) ["alice" "bob"] 2))
+  (def r3 (submit-approval req2 "alice" :reject {:reason "Too risky"}))
+  ;; => success with status :rejected (immediate)
+
+  ;; Manager usage
+  (def mgr (create-approval-manager))
+  (store-approval! mgr req)
+  (get-approval mgr (:approval/id req))
+
+  :leave-this-here)

--- a/components/event-stream/src/ai/miniforge/event_stream/control.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/control.clj
@@ -56,14 +56,11 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; RBAC authorization
 
-(defn- target-type->category
-  "Map target type to RBAC category."
-  [target-type]
-  (case target-type
-    :workflow :workflows
-    :agent :agents
-    :fleet :fleet
-    nil))
+(def ^:private target-type->category
+  "Map from target type to RBAC category keyword."
+  {:workflow :workflows
+   :agent    :agents
+   :fleet    :fleet})
 
 (defn authorize-action
   "Check RBAC authorization for a control action.

--- a/components/event-stream/src/ai/miniforge/event_stream/control.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/control.clj
@@ -8,6 +8,7 @@
    RBAC roles define which action types are permitted per target category."
   (:require
    [ai.miniforge.event-stream.core :as core]
+   [ai.miniforge.event-stream.approval :as approval]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -141,3 +142,52 @@
                      (core/control-action-executed
                       stream workflow-id action-id result))
       result)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Approval-aware control action execution
+
+(def ^:private actions-requiring-approval
+  "Action types that require multi-party approval before execution."
+  #{:gate-override :budget-escalation})
+
+(defn requires-approval?
+  "Check if a control action type requires multi-party approval."
+  [action-type]
+  (contains? actions-requiring-approval action-type))
+
+(defn execute-control-action-with-approval!
+  "Execute a control action, checking approval requirements first.
+
+   If the action type requires approval (:gate-override, :budget-escalation),
+   creates an approval request and returns {:status :awaiting-approval}.
+   Otherwise delegates to execute-control-action!.
+
+   Arguments:
+   - stream: Event stream atom
+   - action: Control action map
+   - execution-fn: (fn [action] -> result-map)
+   - approval-opts: Map with :required-signers, :quorum, :approval-manager
+
+   Returns: Result map with :status key."
+  [stream action execution-fn & [approval-opts]]
+  (if (requires-approval? (:action/type action))
+    (let [action-id (:action/id action)
+          signers (get approval-opts :required-signers ["admin"])
+          quorum (get approval-opts :quorum 1)
+          mgr (get approval-opts :approval-manager)
+          req (approval/create-approval-request action-id signers quorum)
+          workflow-id (get-in action [:action/target :target-id])]
+      ;; Store in manager if provided
+      (when mgr
+        (approval/store-approval! mgr req))
+      ;; Emit approval requested event
+      (core/publish! stream
+                     (approval/approval-requested
+                      stream workflow-id (:approval/id req)
+                      action-id signers))
+      {:status :awaiting-approval
+       :approval/id (:approval/id req)
+       :approval/required-signers signers
+       :approval/quorum quorum})
+    ;; No approval needed — execute directly
+    (execute-control-action! stream action execution-fn)))

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -35,7 +35,9 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event envelope constructor
 
-(defn- create-envelope [stream event-type workflow-id message]
+(defn create-envelope
+  "Create an event envelope with sequence numbering."
+  [stream event-type workflow-id message]
   (let [seq-num (get-in @stream [:sequence-numbers workflow-id] 0)]
     (swap! stream assoc-in [:sequence-numbers workflow-id] (inc seq-num))
     {:event/type event-type

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -49,7 +49,8 @@
   (:require
    [ai.miniforge.event-stream.core :as core]
    [ai.miniforge.event-stream.listeners :as listeners]
-   [ai.miniforge.event-stream.control :as control]))
+   [ai.miniforge.event-stream.control :as control]
+   [ai.miniforge.event-stream.approval :as approval]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event stream lifecycle
@@ -479,6 +480,65 @@
   "Execute an authorized control action with event emission."
   [stream action execution-fn]
   (control/execute-control-action! stream action execution-fn))
+
+(def requires-approval?
+  "Check if a control action type requires multi-party approval."
+  control/requires-approval?)
+
+(defn execute-control-action-with-approval!
+  "Execute a control action, creating an approval request if required."
+  [stream action execution-fn & [approval-opts]]
+  (control/execute-control-action-with-approval! stream action execution-fn approval-opts))
+
+;------------------------------------------------------------------------------ Layer 3b
+;; Multi-party approval API (N8)
+
+(def approval-succeeded?
+  "Check if an approval builder response succeeded."
+  approval/succeeded?)
+
+(def approval-failed?
+  "Check if an approval builder response failed."
+  approval/failed?)
+
+(def create-approval-request
+  "Create a new approval request.
+   Arguments: action-id, required-signers, quorum, [opts]"
+  approval/create-approval-request)
+
+(defn submit-approval
+  "Submit an approval or rejection for a request."
+  [approval-request signer decision & [opts]]
+  (approval/submit-approval approval-request signer decision opts))
+
+(def check-approval-status
+  "Check the current status of an approval request."
+  approval/check-approval-status)
+
+(defn cancel-approval
+  "Cancel a pending approval request."
+  [approval-request canceller reason]
+  (approval/cancel-approval approval-request canceller reason))
+
+(def create-approval-manager
+  "Create an atom-backed approval manager."
+  approval/create-approval-manager)
+
+(def store-approval!
+  "Store an approval request in the manager."
+  approval/store-approval!)
+
+(def get-approval
+  "Get an approval request by ID."
+  approval/get-approval)
+
+(def update-approval!
+  "Update an approval request in the manager."
+  approval/update-approval!)
+
+(def list-approvals
+  "List all approval requests."
+  approval/list-approvals)
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Convenience functions

--- a/components/event-stream/test/ai/miniforge/event_stream/approval_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/approval_test.clj
@@ -1,0 +1,206 @@
+(ns ai.miniforge.event-stream.approval-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.event-stream.approval :as approval]))
+
+;; ============================================================================
+;; Quorum approval tests
+;; ============================================================================
+
+(deftest quorum-approval-test
+  (testing "quorum of 2 from 3 signers"
+    (let [action-id (random-uuid)
+          req (es/create-approval-request action-id ["alice" "bob" "carol"] 2)]
+      ;; Initial state
+      (is (= :pending (:approval/status req)))
+      (is (= 2 (:approval/quorum req)))
+      (is (= 3 (count (:approval/required-signers req))))
+
+      ;; First approval — still pending
+      (let [r1 (es/submit-approval req "alice" :approve)]
+        (is (es/approval-succeeded? r1))
+        (is (= :pending (:approval/status (:output r1))))
+        (is (= 1 (count (:approval/signatures (:output r1)))))
+
+        ;; Second approval — quorum met → approved
+        (let [r2 (es/submit-approval (:output r1) "bob" :approve)]
+          (is (es/approval-succeeded? r2))
+          (is (= :approved (:approval/status (:output r2))))
+          (is (= 2 (count (:approval/signatures (:output r2)))))))))
+
+  (testing "quorum of 1 approves immediately"
+    (let [req (es/create-approval-request (random-uuid) ["alice"] 1)
+          r (es/submit-approval req "alice" :approve)]
+      (is (= :approved (:approval/status (:output r)))))))
+
+;; ============================================================================
+;; Immediate rejection tests
+;; ============================================================================
+
+(deftest rejection-test
+  (testing "any rejection immediately rejects"
+    (let [req (es/create-approval-request (random-uuid) ["alice" "bob" "carol"] 3)
+          r (es/submit-approval req "alice" :reject {:reason "Too risky"})]
+      (is (es/approval-succeeded? r))
+      (is (= :rejected (:approval/status (:output r))))
+      (is (= "Too risky" (:reason (first (:approval/signatures (:output r)))))))))
+
+;; ============================================================================
+;; Expiry tests
+;; ============================================================================
+
+(deftest expiry-test
+  (testing "check-approval-status detects expiry"
+    (let [req (es/create-approval-request (random-uuid) ["alice"] 1
+                                          {:expires-in-hours 0})]
+      ;; With 0 hours, it should be expired immediately (or very soon)
+      (Thread/sleep 10) ; ensure time passes
+      (is (= :expired (es/check-approval-status req)))))
+
+  (testing "non-expired request shows correct status"
+    (let [req (es/create-approval-request (random-uuid) ["alice"] 1
+                                          {:expires-in-hours 24})]
+      (is (= :pending (es/check-approval-status req))))))
+
+;; ============================================================================
+;; Duplicate signer prevention tests
+;; ============================================================================
+
+(deftest duplicate-signer-test
+  (testing "same signer cannot sign twice"
+    (let [req (es/create-approval-request (random-uuid) ["alice" "bob"] 2)
+          r1 (es/submit-approval req "alice" :approve)
+          r2 (es/submit-approval (:output r1) "alice" :approve)]
+      (is (es/approval-succeeded? r1))
+      (is (es/approval-failed? r2))
+      (is (string? (get-in r2 [:error :message]))))))
+
+;; ============================================================================
+;; Unauthorized signer tests
+;; ============================================================================
+
+(deftest unauthorized-signer-test
+  (testing "unauthorized signer is rejected"
+    (let [req (es/create-approval-request (random-uuid) ["alice" "bob"] 1)
+          r (es/submit-approval req "eve" :approve)]
+      (is (es/approval-failed? r))
+      (is (string? (get-in r [:error :message]))))))
+
+;; ============================================================================
+;; Cancel tests
+;; ============================================================================
+
+(deftest cancel-test
+  (testing "pending request can be cancelled"
+    (let [req (es/create-approval-request (random-uuid) ["alice"] 1)
+          r (es/cancel-approval req "admin" "No longer needed")]
+      (is (es/approval-succeeded? r))
+      (is (= :cancelled (:approval/status (:output r))))
+      (is (= "admin" (:approval/cancelled-by (:output r))))))
+
+  (testing "non-pending request cannot be cancelled"
+    (let [req (es/create-approval-request (random-uuid) ["alice"] 1)
+          approved (es/submit-approval req "alice" :approve)
+          r (es/cancel-approval (:output approved) "admin" "Too late")]
+      (is (es/approval-failed? r)))))
+
+;; ============================================================================
+;; Approval manager tests
+;; ============================================================================
+
+(deftest approval-manager-test
+  (testing "store and retrieve approval"
+    (let [mgr (es/create-approval-manager)
+          req (es/create-approval-request (random-uuid) ["alice"] 1)]
+      (es/store-approval! mgr req)
+      (let [retrieved (es/get-approval mgr (:approval/id req))]
+        (is (= (:approval/id req) (:approval/id retrieved)))
+        (is (= :pending (:approval/status retrieved))))))
+
+  (testing "update approval"
+    (let [mgr (es/create-approval-manager)
+          req (es/create-approval-request (random-uuid) ["alice"] 1)]
+      (es/store-approval! mgr req)
+      (let [r (es/submit-approval req "alice" :approve)]
+        (es/update-approval! mgr (:output r))
+        (let [updated (es/get-approval mgr (:approval/id req))]
+          (is (= :approved (:approval/status updated)))))))
+
+  (testing "list approvals"
+    (let [mgr (es/create-approval-manager)
+          req1 (es/create-approval-request (random-uuid) ["alice"] 1)
+          req2 (es/create-approval-request (random-uuid) ["bob"] 1)]
+      (es/store-approval! mgr req1)
+      (es/store-approval! mgr req2)
+      (is (= 2 (count (es/list-approvals mgr)))))))
+
+;; ============================================================================
+;; Event emission tests
+;; ============================================================================
+
+(deftest approval-events-test
+  (testing "approval event constructors create correct events"
+    (let [stream (es/create-event-stream {:sinks []})
+          wf-id (random-uuid)
+          approval-id (random-uuid)
+          action-id (random-uuid)]
+
+      ;; approval/requested
+      (let [e (approval/approval-requested stream wf-id approval-id action-id ["alice" "bob"])]
+        (is (= :approval/requested (:event/type e)))
+        (is (= approval-id (:approval/id e)))
+        (is (= action-id (:approval/action-id e))))
+
+      ;; approval/signed
+      (let [e (approval/approval-signed stream wf-id approval-id "alice" :approve)]
+        (is (= :approval/signed (:event/type e)))
+        (is (= "alice" (:approval/signer e)))
+        (is (= :approve (:approval/decision e))))
+
+      ;; approval/completed
+      (let [e (approval/approval-completed stream wf-id approval-id :approved)]
+        (is (= :approval/completed (:event/type e)))
+        (is (= :approved (:approval/final-status e))))
+
+      ;; approval/expired
+      (let [e (approval/approval-expired stream wf-id approval-id)]
+        (is (= :approval/expired (:event/type e)))
+        (is (= approval-id (:approval/id e)))))))
+
+;; ============================================================================
+;; Control action integration tests
+;; ============================================================================
+
+(deftest control-action-with-approval-test
+  (testing "gate-override requires approval"
+    (is (true? (es/requires-approval? :gate-override)))
+    (is (true? (es/requires-approval? :budget-escalation))))
+
+  (testing "regular actions do not require approval"
+    (is (false? (es/requires-approval? :pause)))
+    (is (false? (es/requires-approval? :resume))))
+
+  (testing "execute-with-approval creates approval for gate-override"
+    (let [stream (es/create-event-stream {:sinks []})
+          action (es/create-control-action
+                  :gate-override
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "admin" :role :admin})
+          result (es/execute-control-action-with-approval!
+                  stream action
+                  (fn [_] {:overridden true})
+                  {:required-signers ["alice" "bob"] :quorum 2})]
+      (is (= :awaiting-approval (:status result)))
+      (is (uuid? (:approval/id result)))))
+
+  (testing "execute-with-approval runs directly for regular actions"
+    (let [stream (es/create-event-stream {:sinks []})
+          action (es/create-control-action
+                  :pause
+                  {:target-type :workflow :target-id (random-uuid)}
+                  {:principal "admin" :role :admin})
+          result (es/execute-control-action-with-approval!
+                  stream action
+                  (fn [_] {:paused true}))]
+      (is (= :success (:status result))))))

--- a/components/web-dashboard/deps.edn
+++ b/components/web-dashboard/deps.edn
@@ -1,4 +1,7 @@
 {:paths ["src" "resources"]
  :deps {http-kit/http-kit {:mvn/version "2.8.0"}
         hiccup/hiccup {:mvn/version "2.0.0-RC3"}
-        cheshire/cheshire {:mvn/version "5.13.0"}}}
+        cheshire/cheshire {:mvn/version "5.13.0"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {io.github.cognitect-labs/test-runner
+                               {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
@@ -220,6 +220,22 @@
                          (responses/not-found-response))
               (responses/not-found-response)))
 
+          ;; Approval API endpoints (N8)
+          (and (= uri "/api/approvals") (= (:request-method req) :post))
+          (handlers/handle-api-approval-create state (slurp (:body req)))
+
+          (and (.startsWith uri "/api/approvals/")
+               (.endsWith uri "/sign")
+               (= (:request-method req) :post))
+          (let [rest-uri (subs uri 16)
+                approval-id (first (str/split rest-uri #"/" 2))]
+            (handlers/handle-api-approval-sign state approval-id (slurp (:body req))))
+
+          (and (.startsWith uri "/api/approvals/")
+               (= (:request-method req) :get))
+          (let [approval-id (subs uri 16)]
+            (handlers/handle-api-approval-get state approval-id))
+
           (.startsWith uri "/api/workflow/")
           (let [rest-uri (subs uri 14)
                 [wf-id segment] (str/split rest-uri #"/" 2)]

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
@@ -279,10 +279,8 @@
                                    :repo-dag-manager repo-dag-manager
                                    :start-time (System/currentTimeMillis)})
         handler (create-handler state)
-        server (http/run-server handler {:port port})
-        actual-port (if (zero? port)
-                      (.getLocalPort (:server-socket @server))
-                      port)
+        server (http/run-server handler {:port port :legacy-return-value? false})
+        actual-port (http/server-port server)
         ;; Start file watcher to tail-follow event files
         events-dir (str (System/getProperty "user.home") "/.miniforge/events")
         watcher-cleanup (watcher/start-watcher!
@@ -323,7 +321,7 @@
     (watcher-cleanup))
   (when server
     (delete-discovery-file!)
-    (server :timeout 100)
+    (http/server-stop! server {:timeout 100})
     (println "Web dashboard stopped")))
 
 (defn get-server-port

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -603,7 +603,7 @@
                                 (:signer data)
                                 (keyword (:decision data))
                                 {:reason (:reason data)})]
-          (if (:success result)
+          (if (= :success (:status result))
             (do
               (update-fn mgr (:output result))
               (responses/json-response

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -487,6 +487,57 @@
 ;------------------------------------------------------------------------------ Layer 3
 ;; Structured control action handler (N8)
 
+(def ^:private default-dashboard-requester
+  "Default requester identity when none is provided in the request body."
+  {:principal "dashboard" :role :operator})
+
+(defn- build-control-action
+  "Build a control action map from parsed request data."
+  [data workflow-id]
+  (let [create-fn (requiring-resolve 'ai.miniforge.event-stream.interface/create-control-action)]
+    (create-fn (keyword (:action/type data))
+               {:target-type :workflow :target-id workflow-id}
+               (or (:action/requester data) default-dashboard-requester)
+               {:justification (:action/justification data)
+                :parameters (:action/parameters data)})))
+
+(defn- execute-via-command!
+  "Execution function that bridges control actions to the legacy command system."
+  [state workflow-id action]
+  (let [cmd (name (:action/type action))]
+    (write-command-file! workflow-id cmd)
+    (state/enqueue-command! state workflow-id cmd)
+    {:command cmd :workflow-id workflow-id}))
+
+(defn- execute-authorized-action
+  "Execute a control action that has passed authorization."
+  [state workflow-id action]
+  (let [es (:event-stream @state)
+        exec-fn (requiring-resolve 'ai.miniforge.event-stream.interface/execute-control-action!)
+        result (exec-fn es action (partial execute-via-command! state workflow-id))]
+    (responses/json-response {:status "executed" :result result})))
+
+(defn- authorization-error-response
+  "Build an anomaly response for a failed authorization check."
+  [auth-result action-type]
+  (anomaly-http-response
+   (or (:anomaly auth-result)
+       (make-anomaly :anomalies/forbidden
+                     (:reason auth-result)
+                     {:action-type action-type}))))
+
+(defn- handle-structured-control-action
+  "Handle a structured control action request (has :action/type)."
+  [state workflow-id data]
+  (let [action (build-control-action data workflow-id)
+        roles @(requiring-resolve 'ai.miniforge.event-stream.control/default-roles)
+        requester (:action/requester action)
+        auth-result ((requiring-resolve 'ai.miniforge.event-stream.interface/authorize-action)
+                     roles action requester)]
+    (if (:authorized? auth-result)
+      (execute-authorized-action state workflow-id action)
+      (authorization-error-response auth-result (:action/type action)))))
+
 (defn handle-api-workflow-command-v2
   "API: Enqueue a structured control action for a workflow.
    Accepts both legacy {:command :pause} and structured {:action/type :pause ...} formats."
@@ -494,36 +545,7 @@
   (try
     (let [data (json/parse-string body true)]
       (if (:action/type data)
-        ;; New structured control action
-        (let [es (:event-stream @state)
-              create-fn (requiring-resolve 'ai.miniforge.event-stream.interface/create-control-action)
-              auth-fn (requiring-resolve 'ai.miniforge.event-stream.interface/authorize-action)
-              exec-fn (requiring-resolve 'ai.miniforge.event-stream.interface/execute-control-action!)
-              roles @(requiring-resolve 'ai.miniforge.event-stream.control/default-roles)
-              action-type (keyword (:action/type data))
-              requester (or (:action/requester data)
-                            {:principal "dashboard" :role :operator})
-              action (create-fn action-type
-                                {:target-type :workflow :target-id workflow-id}
-                                requester
-                                {:justification (:action/justification data)
-                                 :parameters (:action/parameters data)})
-              auth-result (auth-fn roles action requester)]
-          (if (:authorized? auth-result)
-            (let [result (exec-fn es action
-                                  (fn [act]
-                                    ;; Execute via existing command infrastructure
-                                    (let [cmd (name (:action/type act))]
-                                      (write-command-file! workflow-id cmd)
-                                      (state/enqueue-command! state workflow-id cmd)
-                                      {:command cmd :workflow-id workflow-id})))]
-              (responses/json-response {:status "executed" :result result}))
-            (anomaly-http-response
-             (or (:anomaly auth-result)
-                 (make-anomaly :anomalies/forbidden
-                               (:reason auth-result)
-                               {:action-type action-type})))))
-        ;; Legacy command format — delegate to existing handler
+        (handle-structured-control-action state workflow-id data)
         (handle-api-workflow-command state workflow-id body)))
     (catch Exception e
       (anomaly-http-response (from-exception e)))))

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -527,3 +527,91 @@
         (handle-api-workflow-command state workflow-id body)))
     (catch Exception e
       (anomaly-http-response (from-exception e)))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Multi-party approval API handlers (N8)
+
+(defn handle-api-approval-create
+  "API: Create an approval request.
+   POST /api/approvals  body: {:action-id uuid-str :required-signers [str] :quorum int}"
+  [state body]
+  (try
+    (let [data (json/parse-string body true)
+          action-id (parse-uuid (str (:action-id data)))
+          signers (vec (:required-signers data))
+          quorum (or (:quorum data) (count signers))
+          create-fn (requiring-resolve 'ai.miniforge.event-stream.interface/create-approval-request)
+          store-fn (requiring-resolve 'ai.miniforge.event-stream.interface/store-approval!)
+          mgr-fn (requiring-resolve 'ai.miniforge.event-stream.interface/create-approval-manager)
+          ;; Get or create approval manager from state
+          mgr (or (:approval-manager @state)
+                  (let [m (mgr-fn)]
+                    (swap! state assoc :approval-manager m)
+                    m))
+          approval (create-fn action-id signers quorum
+                              {:expires-in-hours (or (:expires-in-hours data) 24)})]
+      (store-fn mgr approval)
+      (responses/json-response
+       {:status "created"
+        :approval-id (str (:approval/id approval))
+        :expires-at (str (:approval/expires-at approval))}))
+    (catch Exception e
+      (anomaly-http-response (from-exception e)))))
+
+(defn handle-api-approval-get
+  "API: Get approval status.
+   GET /api/approvals/:id"
+  [state approval-id-str]
+  (try
+    (let [approval-id (parse-uuid approval-id-str)
+          get-fn (requiring-resolve 'ai.miniforge.event-stream.interface/get-approval)
+          status-fn (requiring-resolve 'ai.miniforge.event-stream.interface/check-approval-status)
+          mgr (:approval-manager @state)]
+      (if-let [approval (and mgr (get-fn mgr approval-id))]
+        (responses/json-response
+         {:approval-id (str (:approval/id approval))
+          :status (name (status-fn approval))
+          :quorum (:approval/quorum approval)
+          :signatures (count (:approval/signatures approval))
+          :required-signers (:approval/required-signers approval)
+          :expires-at (str (:approval/expires-at approval))})
+        (anomaly-http-response
+         (make-anomaly :anomalies/not-found
+                       "Approval not found"
+                       {:approval-id approval-id-str}))))
+    (catch Exception e
+      (anomaly-http-response (from-exception e)))))
+
+(defn handle-api-approval-sign
+  "API: Submit an approval signature.
+   POST /api/approvals/:id/sign  body: {:signer str :decision \"approve\"|\"reject\" :reason str}"
+  [state approval-id-str body]
+  (try
+    (let [data (json/parse-string body true)
+          approval-id (parse-uuid approval-id-str)
+          get-fn (requiring-resolve 'ai.miniforge.event-stream.interface/get-approval)
+          submit-fn (requiring-resolve 'ai.miniforge.event-stream.interface/submit-approval)
+          update-fn (requiring-resolve 'ai.miniforge.event-stream.interface/update-approval!)
+          mgr (:approval-manager @state)
+          approval (and mgr (get-fn mgr approval-id))]
+      (if-not approval
+        (anomaly-http-response
+         (make-anomaly :anomalies/not-found
+                       "Approval not found"
+                       {:approval-id approval-id-str}))
+        (let [result (submit-fn approval
+                                (:signer data)
+                                (keyword (:decision data))
+                                {:reason (:reason data)})]
+          (if (:success result)
+            (do
+              (update-fn mgr (:output result))
+              (responses/json-response
+               {:status "signed"
+                :approval-status (name (:approval/status (:output result)))}))
+            (anomaly-http-response
+             (make-anomaly :anomalies/incorrect
+                           (get-in result [:error :message] "Signing failed")
+                           {}))))))
+    (catch Exception e
+      (anomaly-http-response (from-exception e)))))

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/server/handlers_approval_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/server/handlers_approval_test.clj
@@ -1,0 +1,210 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.web-dashboard.server.handlers-approval-test
+  "Tests for the multi-party approval API handlers (N8).
+
+   Tests cover:
+   - POST /api/approvals — create approval request
+   - GET  /api/approvals/:id — get approval status
+   - POST /api/approvals/:id/sign — submit signature
+
+   Handlers are tested at the function level with a real atom state
+   and real event-stream approval functions (in-memory, no I/O)."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [cheshire.core :as json]
+   [ai.miniforge.web-dashboard.server.handlers :as sut]
+   [ai.miniforge.event-stream.interface :as es]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- fresh-state
+  "Create a fresh atom state for handler tests."
+  []
+  (atom {}))
+
+(defn- parse-body
+  "Parse a JSON response body into a Clojure map."
+  [response]
+  (json/parse-string (:body response) true))
+
+(defn- create-approval-body
+  "Build a JSON body string for POST /api/approvals."
+  [action-id signers quorum & [extra]]
+  (json/generate-string
+   (merge {:action-id (str action-id)
+           :required-signers signers
+           :quorum quorum}
+          extra)))
+
+(defn- sign-body
+  "Build a JSON body string for POST /api/approvals/:id/sign."
+  [signer decision & [reason]]
+  (json/generate-string
+   (cond-> {:signer signer :decision (name decision)}
+     reason (assoc :reason reason))))
+
+;------------------------------------------------------------------------------ Tests
+
+(deftest create-approval-test
+  (testing "POST /api/approvals — creates approval and returns id"
+    (let [state (fresh-state)
+          action-id (random-uuid)
+          body (create-approval-body action-id ["alice" "bob"] 2)
+          response (sut/handle-api-approval-create state body)
+          data (parse-body response)]
+      (is (= 200 (:status response)))
+      (is (= "created" (:status data)))
+      (is (string? (:approval-id data)))
+      (is (some? (parse-uuid (:approval-id data))))
+      (is (string? (:expires-at data)))))
+
+  (testing "POST /api/approvals — lazily creates approval manager"
+    (let [state (fresh-state)
+          _ (sut/handle-api-approval-create
+             state (create-approval-body (random-uuid) ["alice"] 1))]
+      (is (some? (:approval-manager @state)))))
+
+  (testing "POST /api/approvals — default quorum is signer count"
+    (let [state (fresh-state)
+          body (json/generate-string {:action-id (str (random-uuid))
+                                      :required-signers ["a" "b" "c"]})
+          response (sut/handle-api-approval-create state body)
+          data (parse-body response)]
+      (is (= "created" (:status data))))))
+
+(deftest get-approval-test
+  (testing "GET /api/approvals/:id — returns approval status"
+    (let [state (fresh-state)
+          action-id (random-uuid)
+          create-resp (sut/handle-api-approval-create
+                       state
+                       (create-approval-body action-id ["alice" "bob"] 2))
+          approval-id (:approval-id (parse-body create-resp))
+          response (sut/handle-api-approval-get state approval-id)
+          data (parse-body response)]
+      (is (= 200 (:status response)))
+      (is (= approval-id (:approval-id data)))
+      (is (= "pending" (:status data)))
+      (is (= 2 (:quorum data)))
+      (is (= 0 (:signatures data)))
+      (is (= ["alice" "bob"] (:required-signers data)))
+      (is (string? (:expires-at data)))))
+
+  (testing "GET /api/approvals/:id — not found returns anomaly"
+    (let [state (fresh-state)
+          ;; Ensure manager exists
+          _ (sut/handle-api-approval-create
+             state (create-approval-body (random-uuid) ["x"] 1))
+          response (sut/handle-api-approval-get state (str (random-uuid)))
+          data (parse-body response)]
+      (is (= 404 (:status response)))
+      (is (= "not-found" (get-in data [:error :code])))))
+
+  (testing "GET /api/approvals/:id — no manager returns not found"
+    (let [state (fresh-state)
+          response (sut/handle-api-approval-get state (str (random-uuid)))]
+      (is (= 404 (:status response))))))
+
+(deftest sign-approval-test
+  (testing "POST /api/approvals/:id/sign — first signature, still pending"
+    (let [state (fresh-state)
+          create-resp (sut/handle-api-approval-create
+                       state
+                       (create-approval-body (random-uuid) ["alice" "bob"] 2))
+          approval-id (:approval-id (parse-body create-resp))
+          response (sut/handle-api-approval-sign
+                    state approval-id (sign-body "alice" :approve "LGTM"))
+          data (parse-body response)]
+      (is (= 200 (:status response)))
+      (is (= "signed" (:status data)))
+      (is (= "pending" (:approval-status data)))))
+
+  (testing "POST /api/approvals/:id/sign — quorum reached, approved"
+    (let [state (fresh-state)
+          create-resp (sut/handle-api-approval-create
+                       state
+                       (create-approval-body (random-uuid) ["alice" "bob"] 2))
+          approval-id (:approval-id (parse-body create-resp))
+          _ (sut/handle-api-approval-sign
+             state approval-id (sign-body "alice" :approve))
+          response (sut/handle-api-approval-sign
+                    state approval-id (sign-body "bob" :approve))
+          data (parse-body response)]
+      (is (= 200 (:status response)))
+      (is (= "approved" (:approval-status data)))))
+
+  (testing "POST /api/approvals/:id/sign — rejection immediately rejects"
+    (let [state (fresh-state)
+          create-resp (sut/handle-api-approval-create
+                       state
+                       (create-approval-body (random-uuid) ["alice" "bob"] 2))
+          approval-id (:approval-id (parse-body create-resp))
+          response (sut/handle-api-approval-sign
+                    state approval-id (sign-body "alice" :reject "not safe"))
+          data (parse-body response)]
+      (is (= 200 (:status response)))
+      (is (= "rejected" (:approval-status data)))))
+
+  (testing "POST /api/approvals/:id/sign — not found returns anomaly"
+    (let [state (fresh-state)
+          _ (sut/handle-api-approval-create
+             state (create-approval-body (random-uuid) ["x"] 1))
+          response (sut/handle-api-approval-sign
+                    state (str (random-uuid)) (sign-body "x" :approve))]
+      (is (= 404 (:status response)))))
+
+  (testing "POST /api/approvals/:id/sign — unauthorized signer rejected"
+    (let [state (fresh-state)
+          create-resp (sut/handle-api-approval-create
+                       state
+                       (create-approval-body (random-uuid) ["alice"] 1))
+          approval-id (:approval-id (parse-body create-resp))
+          response (sut/handle-api-approval-sign
+                    state approval-id (sign-body "mallory" :approve))
+          data (parse-body response)]
+      (is (= 400 (:status response)))
+      (is (= "incorrect" (get-in data [:error :code]))))))
+
+(deftest approval-round-trip-test
+  (testing "Full lifecycle: create → sign → get shows updated status"
+    (let [state (fresh-state)
+          create-resp (sut/handle-api-approval-create
+                       state
+                       (create-approval-body (random-uuid) ["alice" "bob"] 2))
+          approval-id (:approval-id (parse-body create-resp))
+
+          ;; Get before signing
+          before (parse-body (sut/handle-api-approval-get state approval-id))
+          _ (is (= "pending" (:status before)))
+          _ (is (= 0 (:signatures before)))
+
+          ;; First signature
+          _ (sut/handle-api-approval-sign
+             state approval-id (sign-body "alice" :approve))
+          after-one (parse-body (sut/handle-api-approval-get state approval-id))
+          _ (is (= "pending" (:status after-one)))
+          _ (is (= 1 (:signatures after-one)))
+
+          ;; Second signature — quorum
+          _ (sut/handle-api-approval-sign
+             state approval-id (sign-body "bob" :approve))
+          after-two (parse-body (sut/handle-api-approval-get state approval-id))]
+      (is (= "approved" (:status after-two)))
+      (is (= 2 (:signatures after-two))))))


### PR DESCRIPTION
## Summary

Adds REST API endpoints to the web dashboard for multi-party approval management (N8). Also fixes a bug in the sign handler, adds the first handler-level unit tests for the web-dashboard component, decomposes the command handler into a testable pipeline, and fixes the http-kit server lifecycle.

### Endpoints

| Method | Path | Handler | Description |
|--------|------|---------|-------------|
| POST | `/api/approvals` | `handle-api-approval-create` | Create an approval request |
| GET | `/api/approvals/:id` | `handle-api-approval-get` | Get approval status + metadata |
| POST | `/api/approvals/:id/sign` | `handle-api-approval-sign` | Submit approval/rejection signature |

### Request/Response Shapes

**POST /api/approvals**
```json
// Request
{"action-id": "uuid", "required-signers": ["alice", "bob"], "quorum": 2, "expires-in-hours": 24}

// Response (200)
{"status": "created", "approval-id": "uuid", "expires-at": "timestamp"}
```

**GET /api/approvals/:id**
```json
// Response (200)
{"approval-id": "uuid", "status": "pending", "quorum": 2, "signatures": 1,
 "required-signers": ["alice", "bob"], "expires-at": "timestamp"}

// Response (404)
{"error": {"code": "not-found", "message": "Approval not found"}}
```

**POST /api/approvals/:id/sign**
```json
// Request
{"signer": "alice", "decision": "approve", "reason": "LGTM"}

// Response (200)
{"status": "signed", "approval-status": "pending"}

// Response (400) — unauthorized signer, duplicate, etc.
{"error": {"code": "incorrect", "message": "Signer not authorized"}}
```

### Bug Fix

Fixed `handle-api-approval-sign`: was checking `(:success result)` but `response/success` returns `{:status :success ...}` (no `:success` key), so the sign endpoint always returned 400. Changed to `(= :success (:status result))`.

### Refactor: Decompose Command Handler

Decomposed the monolithic `handle-api-workflow-command-v2` into a pipeline of named helpers:

- `build-control-action` — constructs the control action map from the request
- `execute-via-command!` — sends the action through the command channel
- `execute-authorized-action` — coordinates authorization check + execution
- `authorization-error-response` — translates auth failures to anomaly responses
- `handle-structured-control-action` — top-level entry point wiring the pipeline

Also extracted `default-dashboard-requester` as a data constant instead of inline map.

### Fix: http-kit Server Lifecycle

Switched from the legacy http-kit deref pattern (which threw `ClassCastException` on http-kit 2.8) to the modern API:

- `legacy-return-value? false` option on `server/run-server`
- `server-port` to retrieve the bound port
- `server-stop!` for graceful shutdown

### Infrastructure

Added `:test` alias to `web-dashboard/deps.edn` so Polylith discovers the component's test directory. The existing `interface_test.clj` and `state/trains_test.clj` were not being run by `poly test`.

### Design Decisions

- **Lazy manager creation**: The approval manager is created on first `POST /api/approvals` and stored in the server state atom. No upfront initialization required.
- **requiring-resolve**: All event-stream dependencies are resolved at call time to avoid hard compile-time coupling between the web-dashboard and event-stream components.
- **Anomaly translation**: Error responses use the standard `anomaly->http-response` pipeline, producing consistent `{:error {:code :message}}` JSON shapes.

## Files Changed

| File | Change |
|------|--------|
| `web-dashboard/server.clj` | Modified — 3 new route registrations + http-kit 2.8 modern lifecycle API |
| `web-dashboard/server/handlers.clj` | Modified — 3 new handlers + bug fix + decomposed command pipeline |
| `web-dashboard/deps.edn` | Modified — add `:test` alias for Polylith |
| `web-dashboard/test/server/handlers_approval_test.clj` | New — 4 test groups, 33 assertions |

## Dependencies

This PR's handlers call into APIs from:
- #177 (Stream E: readiness/risk/tiers)
- #179 (Stream H: approval/control actions)

## Test Plan

- [x] Handler tests pass: 4 tests, 33 assertions, 0 failures
- [x] Create → sign → get round-trip lifecycle works end-to-end
- [x] Quorum signing (2-of-2) correctly transitions to approved
- [x] Rejection immediately transitions to rejected
- [x] Unauthorized signer returns 400 anomaly
- [x] Not-found approval returns 404 anomaly

🤖 Generated with [Claude Code](https://claude.com/claude-code)