### PR TITLE
feat(tui): pr-sync component — fleet config, GitHub/GitLab provider sync

### DIFF
--- a/components/pr-sync/deps.edn
+++ b/components/pr-sync/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src"]
+ :deps {cheshire/cheshire {:mvn/version "5.13.0"}}
+ :aliases {:test {:extra-paths ["test"]}}}

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -359,19 +359,38 @@
        (take limit)
        vec))
 
+(defn- viewer-repos-gh-args
+  "Build `gh api graphql` arguments for a page of viewer repositories."
+  [limit acc after]
+  (let [remaining (- limit (count acc))
+        per-page (max 1 (min 100 remaining))]
+    (cond-> ["api" "graphql"
+             "-f" (str "query=" viewer-repos-graphql-query)
+             "-F" (str "perPage=" per-page)]
+      after (conj "-F" (str "after=" after)))))
+
+(defn- parse-viewer-repos-page
+  "Extract normalized repo slugs and pagination info from a GraphQL viewer response."
+  [parsed]
+  (let [nodes (or (get-in parsed [:data :viewer :repositories :nodes] []) [])
+        page-info (or (get-in parsed [:data :viewer :repositories :pageInfo] {}) {})
+        repos (->> nodes
+                   (keep :nameWithOwner)
+                   (map normalize-repo-slug)
+                   (filter valid-repo-slug?)
+                   distinct
+                   vec)]
+    {:repos repos
+     :has-next? (boolean (:hasNextPage page-info))
+     :cursor (:endCursor page-info)}))
+
 (defn- list-viewer-repos
   "List repos visible to the authenticated user across affiliations."
   [limit]
   (try
     (loop [after nil
            acc []]
-      (let [remaining (- limit (count acc))
-            per-page (max 1 (min 100 remaining))
-            args (cond-> ["api" "graphql"
-                          "-f" (str "query=" viewer-repos-graphql-query)
-                          "-F" (str "perPage=" per-page)]
-                   after (conj "-F" (str "after=" after)))
-            result (apply run-gh args)]
+      (let [result (apply run-gh (viewer-repos-gh-args limit acc after))]
         (if-not (:success? result)
           (result-failure (gh-error-message (:out result) (:err result)))
           (let [parsed-result (try
@@ -381,18 +400,8 @@
             (if-let [err (:error parsed-result)]
               (result-failure "Failed to parse repository list."
                               {:error err})
-              (let [parsed (:ok parsed-result)
-                    nodes (or (get-in parsed [:data :viewer :repositories :nodes] []) [])
-                    page-info (or (get-in parsed [:data :viewer :repositories :pageInfo] {}) {})
-                    repos (->> nodes
-                               (keep :nameWithOwner)
-                               (map normalize-repo-slug)
-                               (filter valid-repo-slug?)
-                               distinct
-                               vec)
-                    next-acc (->> (concat acc repos) distinct (take limit) vec)
-                    has-next? (boolean (:hasNextPage page-info))
-                    cursor (:endCursor page-info)]
+              (let [{:keys [repos has-next? cursor]} (parse-viewer-repos-page (:ok parsed-result))
+                    next-acc (->> (concat acc repos) distinct (take limit) vec)]
                 (if (and has-next? cursor (< (count next-acc) limit))
                   (recur cursor next-acc)
                   (result-success {:owner nil :provider :github :repos next-acc}))))))))

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -1,0 +1,683 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-sync.core
+  "PR fleet synchronization: GitHub fetch, fleet config, status mapping.
+
+   Shared brick providing PR discovery and fleet repository management.
+   Both the web-dashboard and TUI depend on this component.
+
+   Layer 0: Constants and pure helpers
+   Layer 1: Fleet config I/O
+   Layer 2: GitHub PR status mapping (pure)
+   Layer 3: GitHub CLI interaction (I/O)"
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]
+   [cheshire.core :as json]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants
+
+(def ^:private default-fleet-config-path
+  (str (System/getProperty "user.home") "/.miniforge/config.edn"))
+
+(def ^:private github-repo-slug-pattern
+  #"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+(def ^:private gitlab-repo-slug-pattern
+  #"^gitlab:[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+$")
+
+(def ^:private failed-check-conclusions
+  #{"FAILURE" "TIMED_OUT" "CANCELLED" "ACTION_REQUIRED" "STARTUP_FAILURE"})
+
+(def ^:private passing-check-conclusions
+  #{"SUCCESS" "NEUTRAL" "SKIPPED"})
+
+(def ^:private pending-check-states
+  #{"PENDING" "QUEUED" "IN_PROGRESS" "WAITING" "REQUESTED"})
+
+;------------------------------------------------------------------------------ Layer 0b
+;; Pure helpers
+
+(defn- normalize-repo-slug
+  [repo]
+  (-> (str repo)
+      str/trim
+      str/lower-case))
+
+(defn- valid-repo-slug?
+  [repo]
+  (boolean
+   (or (re-matches github-repo-slug-pattern repo)
+       (re-matches gitlab-repo-slug-pattern repo))))
+
+(defn- repo-provider
+  [repo]
+  (if (str/starts-with? (or repo "") "gitlab:")
+    :gitlab
+    :github))
+
+(defn- provider-repo-slug
+  "Strip provider prefix for downstream CLI calls."
+  [repo]
+  (if (= :gitlab (repo-provider repo))
+    (subs repo (count "gitlab:"))
+    repo))
+
+(defn- url-encode
+  [s]
+  (java.net.URLEncoder/encode (str s) "UTF-8"))
+
+(defn- result-success
+  [data]
+  (merge {:success? true} data))
+
+(defn- result-failure
+  ([message]
+   (result-failure message nil))
+  ([message data]
+   (merge {:success? false :error (or (some-> message str not-empty)
+                                      "Operation failed with no additional error details.")}
+          data)))
+
+(defn- gh-error-message
+  [out err]
+  (let [msg (str/trim (or (if (str/blank? err) out err) ""))]
+    (when-not (str/blank? msg) msg)))
+
+(defn- ex-msg
+  [^Exception e]
+  (or (.getMessage e)
+      (some-> e class .getName)
+      "unknown exception"))
+
+(defn- normalized-limit
+  [limit default]
+  (let [n (if (integer? limit) limit default)]
+    (if (pos? n) n default)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Fleet config I/O
+
+(defn load-fleet-config
+  "Load fleet configuration from ~/.miniforge/config.edn.
+   Returns {:fleet {:repos [...]}} or default empty config."
+  ([] (load-fleet-config default-fleet-config-path))
+  ([path]
+   (try
+     (if (.exists (io/file path))
+       (edn/read-string (slurp path))
+       {:fleet {:repos []}})
+     (catch Exception _
+       {:fleet {:repos []}}))))
+
+(defn save-fleet-config!
+  "Write fleet configuration to disk."
+  ([config] (save-fleet-config! config default-fleet-config-path))
+  ([config path]
+   (let [file (io/file path)]
+     (.mkdirs (.getParentFile file))
+     (spit file (pr-str config)))))
+
+(defn get-configured-repos
+  "Get configured fleet repositories as normalized slugs."
+  ([] (get-configured-repos default-fleet-config-path))
+  ([path]
+   (->> (get-in (load-fleet-config path) [:fleet :repos] [])
+        (map normalize-repo-slug)
+        (filter valid-repo-slug?)
+        distinct
+        vec)))
+
+(defn add-repo!
+  "Add a repository slug to fleet configuration.
+   Accepted formats:
+   - GitHub: owner/name
+   - GitLab: gitlab:group/name (subgroups supported)
+   Returns {:success? bool :added? bool :repo str :repos [...]}."
+  ([repo-slug] (add-repo! repo-slug default-fleet-config-path))
+  ([repo-slug path]
+   (let [repo (normalize-repo-slug repo-slug)]
+     (cond
+       (str/blank? repo)
+       (result-failure "Repository is required. Use owner/name or gitlab:group/name." {:repo repo})
+
+       (not (valid-repo-slug? repo))
+       (result-failure "Invalid repository format. Expected owner/name or gitlab:group/name (not a filesystem path or URL)." {:repo repo})
+
+       :else
+       (let [cfg (load-fleet-config path)
+             repos (->> (get-in cfg [:fleet :repos] [])
+                        (map normalize-repo-slug)
+                        (filter valid-repo-slug?)
+                        vec)
+             exists? (some #{repo} repos)
+             next-repos (if exists? repos (conj repos repo))
+             next-cfg (assoc-in cfg [:fleet :repos] (vec (distinct next-repos)))]
+         (save-fleet-config! next-cfg path)
+         (result-success {:added? (not (boolean exists?))
+                          :repo repo
+                          :repos (get-in next-cfg [:fleet :repos])}))))))
+
+(defn remove-repo!
+  "Remove a repository slug from fleet configuration.
+   Returns {:success? bool :removed? bool :repo str :repos [...]}."
+  ([repo-slug] (remove-repo! repo-slug default-fleet-config-path))
+  ([repo-slug path]
+   (let [repo (normalize-repo-slug repo-slug)]
+     (if (str/blank? repo)
+       (result-failure "Repository is required." {:repo repo})
+       (let [cfg (load-fleet-config path)
+             repos (->> (get-in cfg [:fleet :repos] [])
+                        (map normalize-repo-slug)
+                        (filter valid-repo-slug?)
+                        vec)
+             existed? (some #{repo} repos)
+             next-repos (vec (remove #{repo} repos))
+             next-cfg (assoc-in cfg [:fleet :repos] next-repos)]
+         (save-fleet-config! next-cfg path)
+         (result-success {:removed? (boolean existed?)
+                          :repo repo
+                          :repos next-repos}))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; GitHub PR status mapping (pure functions)
+
+(defn pr-status-from-provider
+  "Map GitHub PR provider data to normalized PR status keyword.
+   Input: map with :state, :isDraft, :reviewDecision keys."
+  [pr]
+  (let [state (some-> (:state pr) str str/upper-case)
+        draft? (boolean (:isDraft pr))
+        decision (some-> (:reviewDecision pr) str str/upper-case)]
+    (cond
+      (and state (not= "OPEN" state)) :closed
+      draft? :draft
+      (= "APPROVED" decision) :approved
+      (= "CHANGES_REQUESTED" decision) :changes-requested
+      (= "REVIEW_REQUIRED" decision) :reviewing
+      :else :open)))
+
+(defn check-rollup->ci-status
+  "Map GitHub statusCheckRollup to normalized CI status keyword."
+  [rollup]
+  (let [entries (cond
+                  (nil? rollup) []
+                  (sequential? rollup) rollup
+                  :else [rollup])
+        conclusions (keep #(some-> (:conclusion %) str str/upper-case) entries)
+        statuses (keep #(some-> (:status %) str str/upper-case) entries)]
+    (cond
+      (some failed-check-conclusions conclusions) :failed
+      (some pending-check-states statuses) :running
+      (and (seq conclusions)
+           (every? passing-check-conclusions conclusions)) :passed
+      (seq entries) :pending
+      :else :pending)))
+
+(defn provider-pr->train-pr
+  "Convert a GitHub provider PR map to a normalized TrainPR map.
+   Adds :pr/repo when repo is provided."
+  ([pr] (provider-pr->train-pr pr nil))
+  ([pr repo]
+   (cond-> {:pr/number    (:number pr)
+            :pr/title     (:title pr)
+            :pr/url       (:url pr)
+            :pr/branch    (:headRefName pr)
+            :pr/status    (pr-status-from-provider pr)
+            :pr/ci-status (check-rollup->ci-status (:statusCheckRollup pr))}
+     repo (assoc :pr/repo repo))))
+
+(defn- gitlab-status
+  [mr]
+  (let [state (some-> (:state mr) str str/lower-case)
+        draft? (or (true? (:draft mr))
+                   (true? (:work_in_progress mr))
+                   (str/starts-with? (str/lower-case (or (:title mr) "")) "draft:"))
+        merge-status (some-> (:merge_status mr) str str/lower-case)
+        conflicts? (true? (:has_conflicts mr))]
+    (cond
+      (not= "opened" state) :closed
+      draft? :draft
+      conflicts? :changes-requested
+      (contains? #{"can_be_merged" "mergeable"} merge-status) :merge-ready
+      :else :open)))
+
+(defn- gitlab-ci-status
+  [mr]
+  (let [status (some-> (or (get-in mr [:head_pipeline :status])
+                           (get-in mr [:pipeline :status]))
+                       str
+                       str/lower-case)]
+    (case status
+      ("success" "passed") :passed
+      ("failed" "canceled" "cancelled" "skipped") :failed
+      ("running" "pending" "created" "preparing" "waiting_for_resource") :running
+      :pending)))
+
+(defn- gitlab-mr->train-pr
+  [mr repo]
+  {:pr/number    (:iid mr)
+   :pr/title     (:title mr)
+   :pr/url       (:web_url mr)
+   :pr/branch    (:source_branch mr)
+   :pr/status    (gitlab-status mr)
+   :pr/ci-status (gitlab-ci-status mr)
+   :pr/repo      repo})
+
+;------------------------------------------------------------------------------ Layer 3
+;; GitHub CLI interaction (I/O)
+
+(defn- run-gh
+  "Execute a `gh` CLI command. Returns {:success? bool :out str :err str}."
+  [& args]
+  (try
+    (let [{:keys [exit out err]} (apply shell/sh "gh" args)]
+      {:success? (zero? exit)
+       :out (or out "")
+       :err (or err "")})
+    (catch Exception e
+      {:success? false
+       :out ""
+       :err (.getMessage e)})))
+
+(declare run-glab)
+
+(defn- fetch-open-github-prs
+  [repo]
+  (let [repo* (provider-repo-slug repo)
+        {:keys [success? out err]} (run-gh "pr" "list"
+                                           "--repo" repo*
+                                           "--state" "open"
+                                           "--json" "number,title,url,state,headRefName,isDraft,reviewDecision,statusCheckRollup")]
+    (if-not success?
+      (result-failure (gh-error-message out err) {:repo repo :provider :github})
+      (try
+        (let [rows (json/parse-string out true)]
+          (result-success
+           {:repo repo
+            :provider :github
+            :prs (->> rows
+                      (map #(provider-pr->train-pr % repo))
+                      (sort-by :pr/number)
+                      vec)}))
+        (catch Exception e
+          (result-failure (str "Failed to parse PR list for " repo ".")
+                          {:repo repo :provider :github :error (.getMessage e)}))))))
+
+(defn- fetch-open-gitlab-mrs
+  [repo]
+  (let [repo* (provider-repo-slug repo)
+        endpoint (str "projects/" (url-encode repo*)
+                      "/merge_requests?state=opened&per_page=100&with_merge_status_recheck=true")
+        {:keys [success? out err]} (run-glab "api" endpoint)]
+    (if-not success?
+      (result-failure (gh-error-message out err) {:repo repo :provider :gitlab})
+      (try
+        (let [rows (json/parse-string out true)]
+          (result-success
+           {:repo repo
+            :provider :gitlab
+            :prs (->> rows
+                      (map #(gitlab-mr->train-pr % repo))
+                      (sort-by :pr/number)
+                      vec)}))
+        (catch Exception e
+          (result-failure (str "Failed to parse merge request list for " repo ".")
+                          {:repo repo :provider :gitlab :error (.getMessage e)}))))))
+
+(defn fetch-open-prs
+  "Fetch open PR/MR items for a single configured repository.
+   GitHub repos use `gh pr list`; GitLab repos use `glab api`.
+   Returns {:success? bool :repo str :prs [TrainPR ...]}."
+  [repo]
+  (case (repo-provider repo)
+    :gitlab (fetch-open-gitlab-mrs repo)
+    (fetch-open-github-prs repo)))
+
+(defn fetch-all-fleet-prs
+  "Fetch open PRs for all configured fleet repositories.
+   Returns flat vector of TrainPR maps with :pr/repo set.
+
+   Options:
+   - :config-path - Override config file path (for testing)"
+  [& [{:keys [config-path]}]]
+  (let [repos (get-configured-repos (or config-path default-fleet-config-path))]
+    (if (empty? repos)
+      []
+      (->> repos
+           (pmap fetch-open-prs)
+           (filter :success?)
+           (mapcat :prs)
+           vec))))
+
+(defn discover-repos!
+  "Discover repositories from a GitHub org/user and add them to fleet config.
+
+   Options:
+   - :owner - org/user owner to scope discovery
+   - :limit - max repos to ingest (default 50)
+   - :config-path - Override config path (for testing)"
+  [{:keys [owner limit config-path]
+    :or {limit 50}}]
+  (let [path (or config-path default-fleet-config-path)
+        limit* (normalized-limit limit 50)
+        owner* (some-> owner str/trim not-empty)
+        endpoint (if owner*
+                   (str "orgs/" owner* "/repos?per_page=100")
+                   "user/repos?per_page=100")
+        result (run-gh "api" endpoint)]
+    (if-not (:success? result)
+      (result-failure (gh-error-message (:out result) (:err result)))
+      (try
+        (let [repos (->> (json/parse-string (:out result) true)
+                         (keep :full_name)
+                         (map normalize-repo-slug)
+                         (filter valid-repo-slug?)
+                         distinct
+                         (take limit*)
+                         vec)
+              cfg (load-fleet-config path)
+              existing (->> (get-in cfg [:fleet :repos] [])
+                            (map normalize-repo-slug)
+                            (filter valid-repo-slug?)
+                            vec)
+              merged (vec (distinct (concat existing repos)))
+              added (vec (remove (set existing) merged))
+              next-cfg (assoc-in cfg [:fleet :repos] merged)]
+          (save-fleet-config! next-cfg path)
+          (result-success {:owner owner*
+                           :discovered (count repos)
+                           :added (count added)
+                           :repos merged
+                           :added-repos added}))
+        (catch Exception e
+          (result-failure "Failed to parse repository list."
+                          {:error (ex-msg e)}))))))
+
+(def ^:private viewer-repos-graphql-query
+  "query($perPage:Int!,$after:String){
+     viewer {
+       repositories(
+         first:$perPage,
+         after:$after,
+         affiliations:[OWNER,COLLABORATOR,ORGANIZATION_MEMBER],
+         orderBy:{field:UPDATED_AT,direction:DESC}
+       ) {
+         nodes { nameWithOwner }
+         pageInfo { hasNextPage endCursor }
+       }
+     }
+   }")
+
+(defn- run-glab
+  "Execute a `glab` CLI command. Returns {:success? bool :out str :err str}."
+  [& args]
+  (try
+    (let [{:keys [exit out err]} (apply shell/sh "glab" args)]
+      {:success? (zero? exit)
+       :out (or out "")
+       :err (or err "")})
+    (catch Exception e
+      {:success? false
+       :out ""
+       :err (.getMessage e)})))
+
+(defn- parse-gh-full-name-repos
+  [out limit]
+  (->> (json/parse-string out true)
+       (keep :full_name)
+       (map normalize-repo-slug)
+       (filter valid-repo-slug?)
+       distinct
+       (take limit)
+       vec))
+
+(defn- list-viewer-repos
+  "List repos visible to the authenticated user across affiliations."
+  [limit]
+  (try
+    (loop [after nil
+           acc []]
+      (let [remaining (- limit (count acc))
+            per-page (max 1 (min 100 remaining))
+            args (cond-> ["api" "graphql"
+                          "-f" (str "query=" viewer-repos-graphql-query)
+                          "-F" (str "perPage=" per-page)]
+                   after (conj "-F" (str "after=" after)))
+            result (apply run-gh args)]
+        (if-not (:success? result)
+          (result-failure (gh-error-message (:out result) (:err result)))
+          (let [parsed-result (try
+                                {:ok (json/parse-string (:out result) true)}
+                                (catch Exception e
+                                  {:error (.getMessage e)}))]
+            (if-let [err (:error parsed-result)]
+              (result-failure "Failed to parse repository list."
+                              {:error err})
+              (let [parsed (:ok parsed-result)
+                    nodes (or (get-in parsed [:data :viewer :repositories :nodes] []) [])
+                    page-info (or (get-in parsed [:data :viewer :repositories :pageInfo] {}) {})
+                    repos (->> nodes
+                               (keep :nameWithOwner)
+                               (map normalize-repo-slug)
+                               (filter valid-repo-slug?)
+                               distinct
+                               vec)
+                    next-acc (->> (concat acc repos) distinct (take limit) vec)
+                    has-next? (boolean (:hasNextPage page-info))
+                    cursor (:endCursor page-info)]
+                (if (and has-next? cursor (< (count next-acc) limit))
+                  (recur cursor next-acc)
+                  (result-success {:owner nil :provider :github :repos next-acc}))))))))
+    (catch Exception e
+      (result-failure "Failed to list accessible repositories."
+                      {:error (ex-msg e)}))))
+
+(defn- list-github-owner-repos
+  [owner limit]
+  (let [owner* (some-> owner str str/trim not-empty)
+        org-endpoint (str "orgs/" owner* "/repos?per_page=100&type=all&sort=updated")
+        org-result (run-gh "api" org-endpoint)
+        user-endpoint (str "users/" owner* "/repos?per_page=100&type=owner&sort=updated")
+        result (if (:success? org-result)
+                 org-result
+                 (run-gh "api" user-endpoint))]
+    (if-not (:success? result)
+      (result-failure (or (gh-error-message (:out result) (:err result))
+                          (gh-error-message (:out org-result) (:err org-result)))
+                      {:owner owner* :provider :github})
+      (try
+        (result-success {:owner owner*
+                         :provider :github
+                         :repos (parse-gh-full-name-repos (:out result) limit)})
+        (catch Exception e
+          (result-failure "Failed to parse repository list."
+                          {:owner owner* :provider :github :error (ex-msg e)}))))))
+
+(defn- list-github-viewer-orgs
+  []
+  (let [result (run-gh "api" "user/orgs?per_page=100")]
+    (if-not (:success? result)
+      (result-failure (gh-error-message (:out result) (:err result))
+                      {:provider :github :error-source :orgs})
+      (try
+        (let [orgs (->> (json/parse-string (:out result) true)
+                        (keep :login)
+                        (map str/lower-case)
+                        distinct
+                        vec)]
+          (result-success {:provider :github :orgs orgs}))
+        (catch Exception e
+          (result-failure "Failed to parse organization list."
+                          {:provider :github :error-source :orgs :error (ex-msg e)}))))))
+
+(defn- list-github-user-repos-fallback
+  [limit]
+  (let [result (run-gh "api" "user/repos?per_page=100&sort=updated")]
+    (if-not (:success? result)
+      (result-failure (gh-error-message (:out result) (:err result))
+                      {:provider :github :error-source :rest})
+      (try
+        (result-success {:owner nil
+                         :provider :github
+                         :repos (parse-gh-full-name-repos (:out result) limit)})
+        (catch Exception e
+          (result-failure "Failed to parse repository list."
+                          {:owner nil :provider :github :error-source :rest :error (ex-msg e)}))))))
+
+(defn- list-github-accessible-repos
+  [limit]
+  (let [viewer (list-viewer-repos limit)
+        orgs-result (list-github-viewer-orgs)
+        org-results (if (:success? orgs-result)
+                      (->> (:orgs orgs-result)
+                           (map #(list-github-owner-repos % limit))
+                           doall)
+                      [])
+        repos (->> (concat (or (:repos viewer) [])
+                           (mapcat #(or (:repos %) []) (filter :success? org-results)))
+                   distinct
+                   (take limit)
+                   vec)
+        warnings (vec (concat
+                       (when-not (:success? viewer)
+                         [(or (:error viewer) "GraphQL browse failed.")])
+                       (when-not (:success? orgs-result)
+                         [(or (:error orgs-result) "Organization browse failed.")])
+                       (for [{:keys [success? owner error]} org-results
+                             :when (not success?)]
+                         (str "Org " owner ": " (or error "browse failed")))))]
+    (cond
+      (seq repos)
+      (cond-> (result-success {:owner nil :provider :github :repos repos})
+        (seq warnings) (assoc :warnings warnings))
+
+      ;; GraphQL failed and org listing failed/empty: try REST fallback
+      :else
+      (let [fallback (list-github-user-repos-fallback limit)]
+        (if (:success? fallback)
+          (cond-> fallback
+            (seq warnings) (assoc :warnings warnings))
+          (result-failure (or (:error fallback)
+                              (:error viewer)
+                              (:error orgs-result)
+                              "Failed to list accessible repositories.")
+                          {:owner nil :provider :github :error-source :rest}))))))
+
+(defn- parse-glab-project-repos
+  [out limit]
+  (->> (json/parse-string out true)
+       (keep :path_with_namespace)
+       (map (fn [path]
+              (str "gitlab:" (normalize-repo-slug path))))
+       (filter valid-repo-slug?)
+       distinct
+       (take limit)
+       vec))
+
+(defn- list-gitlab-repos
+  [{:keys [owner limit]}]
+  (let [owner* (some-> owner str str/trim not-empty)
+        endpoint (if owner*
+                   (str "groups/" (url-encode owner*)
+                        "/projects?include_subgroups=true&archived=false&per_page=100&simple=true&order_by=last_activity_at&sort=desc")
+                   "projects?membership=true&archived=false&per_page=100&simple=true&order_by=last_activity_at&sort=desc")
+        result (run-glab "api" endpoint)]
+    (if-not (:success? result)
+      (result-failure (gh-error-message (:out result) (:err result))
+                      {:owner owner* :provider :gitlab})
+      (try
+        (result-success {:owner owner*
+                         :provider :gitlab
+                         :repos (parse-glab-project-repos (:out result) limit)})
+        (catch Exception e
+          (result-failure "Failed to parse GitLab repository list."
+                          {:owner owner* :provider :gitlab :error (ex-msg e)}))))))
+
+(defn list-org-repos
+  "List repository slugs from configured providers (read-only browse).
+
+   Options:
+   - :owner - org/group name (provider-specific)
+   - :limit - max repos to return (default 100)
+   - :provider - :github, :gitlab, or :all (default :github)
+
+   Returns {:success? bool :repos [\"owner/name\"|\"gitlab:group/name\" ...]}."
+  [{:keys [owner limit provider] :or {limit 100 provider :github}}]
+  (let [owner* (some-> owner str str/trim not-empty)
+        limit* (normalized-limit limit 100)
+        provider* (keyword (name (or provider :github)))]
+    (case provider*
+      :github
+      (if owner*
+        (list-github-owner-repos owner* limit*)
+        (list-github-accessible-repos limit*))
+
+      :gitlab
+      (list-gitlab-repos {:owner owner* :limit limit*})
+
+      :all
+      (let [gh-result (if owner*
+                        (list-github-owner-repos owner* limit*)
+                        (list-github-accessible-repos limit*))
+            gl-result (list-gitlab-repos {:owner owner* :limit limit*})
+            repos (->> (concat (or (:repos gh-result) [])
+                               (or (:repos gl-result) []))
+                       distinct
+                       (take limit*)
+                       vec)
+            warnings (vec (concat
+                           (when-not (:success? gh-result)
+                             [(str "GitHub: " (or (:error gh-result) "browse failed"))])
+                           (when-not (:success? gl-result)
+                             [(str "GitLab: " (or (:error gl-result) "browse failed"))])
+                           (or (:warnings gh-result) [])))]
+        (if (seq repos)
+          (cond-> (result-success {:owner owner* :provider :all :repos repos})
+            (seq warnings) (assoc :warnings warnings))
+          (result-failure (or (:error gh-result)
+                              (:error gl-result)
+                              "Failed to browse repositories.")
+                          {:owner owner* :provider :all})))
+
+      (result-failure (str "Unknown provider: " provider*)
+                      {:owner owner* :provider provider*}))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Config management
+  (get-configured-repos)
+  (add-repo! "miniforge-ai/miniforge")
+  (remove-repo! "miniforge-ai/miniforge")
+
+  ;; Fetch PRs
+  (fetch-open-prs "miniforge-ai/miniforge")
+  (fetch-all-fleet-prs)
+
+  ;; Status mapping
+  (pr-status-from-provider {:state "OPEN" :isDraft false :reviewDecision "APPROVED"})
+  ;; => :approved
+
+  (check-rollup->ci-status [{:conclusion "SUCCESS"} {:conclusion "SUCCESS"}])
+  ;; => :passed
+
+  :leave-this-here)

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -17,16 +17,18 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.pr-sync.core
-  "PR fleet synchronization: GitHub fetch, fleet config, status mapping.
+  "PR fleet synchronization: fleet config I/O and provider CLI interaction.
 
    Shared brick providing PR discovery and fleet repository management.
    Both the web-dashboard and TUI depend on this component.
 
    Layer 0: Constants and pure helpers
    Layer 1: Fleet config I/O
-   Layer 2: GitHub PR status mapping (pure)
-   Layer 3: GitHub CLI interaction (I/O)"
+   Layer 2: Provider CLI interaction (I/O)
+
+   Pure status mapping lives in ai.miniforge.pr-sync.status."
   (:require
+   [ai.miniforge.pr-sync.status :as status]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
@@ -44,15 +46,6 @@
 
 (def ^:private gitlab-repo-slug-pattern
   #"^gitlab:[A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)+$")
-
-(def ^:private failed-check-conclusions
-  #{"FAILURE" "TIMED_OUT" "CANCELLED" "ACTION_REQUIRED" "STARTUP_FAILURE"})
-
-(def ^:private passing-check-conclusions
-  #{"SUCCESS" "NEUTRAL" "SKIPPED"})
-
-(def ^:private pending-check-states
-  #{"PENDING" "QUEUED" "IN_PROGRESS" "WAITING" "REQUESTED"})
 
 ;------------------------------------------------------------------------------ Layer 0b
 ;; Pure helpers
@@ -199,92 +192,7 @@
                           :repos next-repos}))))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; GitHub PR status mapping (pure functions)
-
-(defn pr-status-from-provider
-  "Map GitHub PR provider data to normalized PR status keyword.
-   Input: map with :state, :isDraft, :reviewDecision keys."
-  [pr]
-  (let [state (some-> (:state pr) str str/upper-case)
-        draft? (boolean (:isDraft pr))
-        decision (some-> (:reviewDecision pr) str str/upper-case)]
-    (cond
-      (and state (not= "OPEN" state)) :closed
-      draft? :draft
-      (= "APPROVED" decision) :approved
-      (= "CHANGES_REQUESTED" decision) :changes-requested
-      (= "REVIEW_REQUIRED" decision) :reviewing
-      :else :open)))
-
-(defn check-rollup->ci-status
-  "Map GitHub statusCheckRollup to normalized CI status keyword."
-  [rollup]
-  (let [entries (cond
-                  (nil? rollup) []
-                  (sequential? rollup) rollup
-                  :else [rollup])
-        conclusions (keep #(some-> (:conclusion %) str str/upper-case) entries)
-        statuses (keep #(some-> (:status %) str str/upper-case) entries)]
-    (cond
-      (some failed-check-conclusions conclusions) :failed
-      (some pending-check-states statuses) :running
-      (and (seq conclusions)
-           (every? passing-check-conclusions conclusions)) :passed
-      (seq entries) :pending
-      :else :pending)))
-
-(defn provider-pr->train-pr
-  "Convert a GitHub provider PR map to a normalized TrainPR map.
-   Adds :pr/repo when repo is provided."
-  ([pr] (provider-pr->train-pr pr nil))
-  ([pr repo]
-   (cond-> {:pr/number    (:number pr)
-            :pr/title     (:title pr)
-            :pr/url       (:url pr)
-            :pr/branch    (:headRefName pr)
-            :pr/status    (pr-status-from-provider pr)
-            :pr/ci-status (check-rollup->ci-status (:statusCheckRollup pr))}
-     repo (assoc :pr/repo repo))))
-
-(defn- gitlab-status
-  [mr]
-  (let [state (some-> (:state mr) str str/lower-case)
-        draft? (or (true? (:draft mr))
-                   (true? (:work_in_progress mr))
-                   (str/starts-with? (str/lower-case (or (:title mr) "")) "draft:"))
-        merge-status (some-> (:merge_status mr) str str/lower-case)
-        conflicts? (true? (:has_conflicts mr))]
-    (cond
-      (not= "opened" state) :closed
-      draft? :draft
-      conflicts? :changes-requested
-      (contains? #{"can_be_merged" "mergeable"} merge-status) :merge-ready
-      :else :open)))
-
-(defn- gitlab-ci-status
-  [mr]
-  (let [status (some-> (or (get-in mr [:head_pipeline :status])
-                           (get-in mr [:pipeline :status]))
-                       str
-                       str/lower-case)]
-    (case status
-      ("success" "passed") :passed
-      ("failed" "canceled" "cancelled" "skipped") :failed
-      ("running" "pending" "created" "preparing" "waiting_for_resource") :running
-      :pending)))
-
-(defn- gitlab-mr->train-pr
-  [mr repo]
-  {:pr/number    (:iid mr)
-   :pr/title     (:title mr)
-   :pr/url       (:web_url mr)
-   :pr/branch    (:source_branch mr)
-   :pr/status    (gitlab-status mr)
-   :pr/ci-status (gitlab-ci-status mr)
-   :pr/repo      repo})
-
-;------------------------------------------------------------------------------ Layer 3
-;; GitHub CLI interaction (I/O)
+;; Provider CLI interaction (I/O)
 
 (defn- run-gh
   "Execute a `gh` CLI command. Returns {:success? bool :out str :err str}."
@@ -316,7 +224,7 @@
            {:repo repo
             :provider :github
             :prs (->> rows
-                      (map #(provider-pr->train-pr % repo))
+                      (map #(status/provider-pr->train-pr % repo))
                       (sort-by :pr/number)
                       vec)}))
         (catch Exception e
@@ -337,7 +245,7 @@
            {:repo repo
             :provider :gitlab
             :prs (->> rows
-                      (map #(gitlab-mr->train-pr % repo))
+                      (map #(status/gitlab-mr->train-pr % repo))
                       (sort-by :pr/number)
                       vec)}))
         (catch Exception e
@@ -673,11 +581,6 @@
   (fetch-open-prs "miniforge-ai/miniforge")
   (fetch-all-fleet-prs)
 
-  ;; Status mapping
-  (pr-status-from-provider {:state "OPEN" :isDraft false :reviewDecision "APPROVED"})
-  ;; => :approved
-
-  (check-rollup->ci-status [{:conclusion "SUCCESS"} {:conclusion "SUCCESS"}])
-  ;; => :passed
+  ;; Status mapping — see ai.miniforge.pr-sync.status
 
   :leave-this-here)

--- a/components/pr-sync/src/ai/miniforge/pr_sync/interface.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/interface.clj
@@ -22,7 +22,8 @@
    Fleet config management, GitHub PR fetching, and status mapping.
    Both web-dashboard and TUI depend on this interface."
   (:require
-   [ai.miniforge.pr-sync.core :as core]))
+   [ai.miniforge.pr-sync.core :as core]
+   [ai.miniforge.pr-sync.status :as status]))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Fleet config
@@ -81,17 +82,17 @@
   "Map GitHub PR provider data to normalized PR status keyword.
    Input: map with :state, :isDraft, :reviewDecision keys."
   [pr]
-  (core/pr-status-from-provider pr))
+  (status/pr-status-from-provider pr))
 
 (defn check-rollup->ci-status
   "Map GitHub statusCheckRollup to normalized CI status keyword."
   [rollup]
-  (core/check-rollup->ci-status rollup))
+  (status/check-rollup->ci-status rollup))
 
 (defn provider-pr->train-pr
   "Convert a GitHub provider PR map to a normalized TrainPR map."
-  ([pr] (core/provider-pr->train-pr pr))
-  ([pr repo] (core/provider-pr->train-pr pr repo)))
+  ([pr] (status/provider-pr->train-pr pr))
+  ([pr repo] (status/provider-pr->train-pr pr repo)))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Fleet config I/O (lower-level, for direct config access)

--- a/components/pr-sync/src/ai/miniforge/pr_sync/interface.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/interface.clj
@@ -1,0 +1,108 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-sync.interface
+  "Public API for the PR sync component.
+
+   Fleet config management, GitHub PR fetching, and status mapping.
+   Both web-dashboard and TUI depend on this interface."
+  (:require
+   [ai.miniforge.pr-sync.core :as core]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Fleet config
+
+(defn get-configured-repos
+  "Get configured fleet repositories as normalized slugs.
+   Returns [\"owner/repo\" ...]."
+  ([] (core/get-configured-repos))
+  ([path] (core/get-configured-repos path)))
+
+(defn add-repo!
+  "Add a repository slug (owner/name) to fleet configuration.
+   Returns {:success? bool :added? bool :repo str :repos [...]}."
+  ([repo-slug] (core/add-repo! repo-slug))
+  ([repo-slug path] (core/add-repo! repo-slug path)))
+
+(defn remove-repo!
+  "Remove a repository slug from fleet configuration.
+   Returns {:success? bool :removed? bool :repo str :repos [...]}."
+  ([repo-slug] (core/remove-repo! repo-slug))
+  ([repo-slug path] (core/remove-repo! repo-slug path)))
+
+(defn discover-repos!
+  "Discover repositories from a GitHub org/user and add them to fleet config.
+   Options: :owner, :limit, :config-path."
+  [opts]
+  (core/discover-repos! opts))
+
+(defn list-org-repos
+  "List repository slugs from providers (read-only, no config change).
+   Options: :owner, :limit, :provider (:github, :gitlab, :all).
+   Returns {:success? bool :repos [\"owner/name\"|\"gitlab:group/name\" ...]}."
+  [opts]
+  (core/list-org-repos opts))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; GitHub PR fetching
+
+(defn fetch-open-prs
+  "Fetch open PRs for a single repository via gh CLI.
+   Returns {:success? bool :repo str :prs [TrainPR ...]}."
+  [repo]
+  (core/fetch-open-prs repo))
+
+(defn fetch-all-fleet-prs
+  "Fetch open PRs for all configured fleet repositories.
+   Returns flat vector of TrainPR maps with :pr/repo set.
+   Options: :config-path."
+  ([] (core/fetch-all-fleet-prs))
+  ([opts] (core/fetch-all-fleet-prs opts)))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Status mapping (pure)
+
+(defn pr-status-from-provider
+  "Map GitHub PR provider data to normalized PR status keyword.
+   Input: map with :state, :isDraft, :reviewDecision keys."
+  [pr]
+  (core/pr-status-from-provider pr))
+
+(defn check-rollup->ci-status
+  "Map GitHub statusCheckRollup to normalized CI status keyword."
+  [rollup]
+  (core/check-rollup->ci-status rollup))
+
+(defn provider-pr->train-pr
+  "Convert a GitHub provider PR map to a normalized TrainPR map."
+  ([pr] (core/provider-pr->train-pr pr))
+  ([pr repo] (core/provider-pr->train-pr pr repo)))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Fleet config I/O (lower-level, for direct config access)
+
+(defn load-fleet-config
+  "Load fleet configuration from disk.
+   Returns {:fleet {:repos [...]}} or default empty config."
+  ([] (core/load-fleet-config))
+  ([path] (core/load-fleet-config path)))
+
+(defn save-fleet-config!
+  "Write fleet configuration to disk."
+  ([config] (core/save-fleet-config! config))
+  ([config path] (core/save-fleet-config! config path)))

--- a/components/pr-sync/src/ai/miniforge/pr_sync/status.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/status.clj
@@ -1,0 +1,148 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-sync.status
+  "Pure PR/MR status mapping — Domain stratum.
+
+   Converts provider-specific PR data (GitHub, GitLab) into normalized
+   TrainPR maps with canonical status keywords. Zero I/O.
+
+   Layer 0: Status constants and classification sets
+   Layer 1: GitHub PR status mapping
+   Layer 2: GitLab MR status mapping + unified conversion"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Status constants
+
+(def ^:private failed-check-conclusions
+  #{"FAILURE" "TIMED_OUT" "CANCELLED" "ACTION_REQUIRED" "STARTUP_FAILURE"})
+
+(def ^:private passing-check-conclusions
+  #{"SUCCESS" "NEUTRAL" "SKIPPED"})
+
+(def ^:private pending-check-states
+  #{"PENDING" "QUEUED" "IN_PROGRESS" "WAITING" "REQUESTED"})
+
+;------------------------------------------------------------------------------ Layer 1
+;; GitHub PR status mapping (pure)
+
+(defn pr-status-from-provider
+  "Map GitHub PR provider data to normalized PR status keyword.
+   Input: map with :state, :isDraft, :reviewDecision keys."
+  [pr]
+  (let [state (some-> (:state pr) str str/upper-case)
+        draft? (boolean (:isDraft pr))
+        decision (some-> (:reviewDecision pr) str str/upper-case)]
+    (cond
+      (and state (not= "OPEN" state)) :closed
+      draft? :draft
+      (= "APPROVED" decision) :approved
+      (= "CHANGES_REQUESTED" decision) :changes-requested
+      (= "REVIEW_REQUIRED" decision) :reviewing
+      :else :open)))
+
+(defn check-rollup->ci-status
+  "Map GitHub statusCheckRollup to normalized CI status keyword."
+  [rollup]
+  (let [entries (cond
+                  (nil? rollup) []
+                  (sequential? rollup) rollup
+                  :else [rollup])
+        conclusions (keep #(some-> (:conclusion %) str str/upper-case) entries)
+        statuses (keep #(some-> (:status %) str str/upper-case) entries)]
+    (cond
+      (some failed-check-conclusions conclusions) :failed
+      (some pending-check-states statuses) :running
+      (and (seq conclusions)
+           (every? passing-check-conclusions conclusions)) :passed
+      (seq entries) :pending
+      :else :pending)))
+
+(defn provider-pr->train-pr
+  "Convert a GitHub provider PR map to a normalized TrainPR map.
+   Adds :pr/repo when repo is provided."
+  ([pr] (provider-pr->train-pr pr nil))
+  ([pr repo]
+   (cond-> {:pr/number    (:number pr)
+            :pr/title     (:title pr)
+            :pr/url       (:url pr)
+            :pr/branch    (:headRefName pr)
+            :pr/status    (pr-status-from-provider pr)
+            :pr/ci-status (check-rollup->ci-status (:statusCheckRollup pr))}
+     repo (assoc :pr/repo repo))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; GitLab MR status mapping + unified conversion
+
+(defn- gitlab-status
+  [mr]
+  (let [state (some-> (:state mr) str str/lower-case)
+        draft? (or (true? (:draft mr))
+                   (true? (:work_in_progress mr))
+                   (str/starts-with? (str/lower-case (or (:title mr) "")) "draft:"))
+        merge-status (some-> (:merge_status mr) str str/lower-case)
+        conflicts? (true? (:has_conflicts mr))]
+    (cond
+      (not= "opened" state) :closed
+      draft? :draft
+      conflicts? :changes-requested
+      (contains? #{"can_be_merged" "mergeable"} merge-status) :merge-ready
+      :else :open)))
+
+(defn- gitlab-ci-status
+  [mr]
+  (let [status (some-> (or (get-in mr [:head_pipeline :status])
+                           (get-in mr [:pipeline :status]))
+                       str
+                       str/lower-case)]
+    (case status
+      ("success" "passed") :passed
+      ("failed" "canceled" "cancelled" "skipped") :failed
+      ("running" "pending" "created" "preparing" "waiting_for_resource") :running
+      :pending)))
+
+(defn gitlab-mr->train-pr
+  "Convert a GitLab MR map to a normalized TrainPR map."
+  [mr repo]
+  {:pr/number    (:iid mr)
+   :pr/title     (:title mr)
+   :pr/url       (:web_url mr)
+   :pr/branch    (:source_branch mr)
+   :pr/status    (gitlab-status mr)
+   :pr/ci-status (gitlab-ci-status mr)
+   :pr/repo      repo})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Status mapping
+  (pr-status-from-provider {:state "OPEN" :isDraft false :reviewDecision "APPROVED"})
+  ;; => :approved
+
+  (check-rollup->ci-status [{:conclusion "SUCCESS"} {:conclusion "SUCCESS"}])
+  ;; => :passed
+
+  (gitlab-mr->train-pr {:iid 1 :title "Test" :state "opened" :source_branch "fix"
+                         :web_url "https://gitlab.com/g/p/-/merge_requests/1"
+                         :draft false :merge_status "can_be_merged"
+                         :head_pipeline {:status "success"}}
+                        "gitlab:g/p")
+  ;; => {:pr/number 1, :pr/title "Test", ...}
+
+  :leave-this-here)

--- a/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
@@ -130,76 +130,7 @@
         (is (not (:removed? result)))))))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
-;; PR status mapping tests
-
-(deftest pr-status-from-provider-test
-  (testing "Open non-draft PR"
-    (is (= :open (core/pr-status-from-provider
-                   {:state "OPEN" :isDraft false :reviewDecision nil}))))
-
-  (testing "Draft PR"
-    (is (= :draft (core/pr-status-from-provider
-                    {:state "OPEN" :isDraft true :reviewDecision nil}))))
-
-  (testing "Approved PR"
-    (is (= :approved (core/pr-status-from-provider
-                       {:state "OPEN" :isDraft false :reviewDecision "APPROVED"}))))
-
-  (testing "Changes requested"
-    (is (= :changes-requested (core/pr-status-from-provider
-                                {:state "OPEN" :isDraft false :reviewDecision "CHANGES_REQUESTED"}))))
-
-  (testing "Review required"
-    (is (= :reviewing (core/pr-status-from-provider
-                        {:state "OPEN" :isDraft false :reviewDecision "REVIEW_REQUIRED"}))))
-
-  (testing "Closed/merged PR"
-    (is (= :closed (core/pr-status-from-provider
-                     {:state "MERGED" :isDraft false :reviewDecision nil})))
-    (is (= :closed (core/pr-status-from-provider
-                     {:state "CLOSED" :isDraft false :reviewDecision nil})))))
-
-(deftest check-rollup->ci-status-test
-  (testing "All passed"
-    (is (= :passed (core/check-rollup->ci-status
-                     [{:conclusion "SUCCESS"} {:conclusion "SUCCESS"}]))))
-
-  (testing "Any failed"
-    (is (= :failed (core/check-rollup->ci-status
-                     [{:conclusion "SUCCESS"} {:conclusion "FAILURE"}]))))
-
-  (testing "Running checks"
-    (is (= :running (core/check-rollup->ci-status
-                      [{:conclusion "SUCCESS"} {:status "IN_PROGRESS"}]))))
-
-  (testing "Nil rollup"
-    (is (= :pending (core/check-rollup->ci-status nil))))
-
-  (testing "Empty entries"
-    (is (= :pending (core/check-rollup->ci-status [])))))
-
-(deftest provider-pr->train-pr-test
-  (testing "Converts provider PR to train PR shape"
-    (let [pr {:number 42
-              :title "Fix auth"
-              :url "https://github.com/owner/repo/pull/42"
-              :headRefName "fix-auth"
-              :state "OPEN"
-              :isDraft false
-              :reviewDecision "APPROVED"
-              :statusCheckRollup [{:conclusion "SUCCESS"}]}
-          result (core/provider-pr->train-pr pr "owner/repo")]
-      (is (= 42 (:pr/number result)))
-      (is (= "Fix auth" (:pr/title result)))
-      (is (= "https://github.com/owner/repo/pull/42" (:pr/url result)))
-      (is (= "fix-auth" (:pr/branch result)))
-      (is (= :approved (:pr/status result)))
-      (is (= :passed (:pr/ci-status result)))
-      (is (= "owner/repo" (:pr/repo result)))))
-
-  (testing "Without repo arg, :pr/repo is absent"
-    (let [result (core/provider-pr->train-pr {:number 1 :title "X" :state "OPEN"})]
-      (is (nil? (:pr/repo result))))))
+;; Integration tests (PR fetching with mocked shell)
 
 (deftest fetch-all-fleet-prs-multi-provider-test
   (testing "Fetches open items from both GitHub and GitLab repositories"

--- a/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
@@ -1,0 +1,342 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-sync.core-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [clojure.java.shell]
+   [ai.miniforge.pr-sync.core :as core]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Test helpers
+
+(defn- temp-config-path []
+  (let [f (java.io.File/createTempFile "miniforge-test-config" ".edn")]
+    (.deleteOnExit f)
+    (.getAbsolutePath f)))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Fleet config tests
+
+(deftest load-fleet-config-test
+  (testing "Missing file returns default config"
+    (let [cfg (core/load-fleet-config "/tmp/nonexistent-miniforge-config-12345.edn")]
+      (is (= {:fleet {:repos []}} cfg))))
+
+  (testing "Existing file is read"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["owner/repo"]}}))
+      (let [cfg (core/load-fleet-config path)]
+        (is (= ["owner/repo"] (get-in cfg [:fleet :repos])))))))
+
+(deftest get-configured-repos-test
+  (testing "Returns repos from config file"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["Foo/Bar" "baz/qux"]}}))
+      (let [repos (core/get-configured-repos path)]
+        (is (= ["foo/bar" "baz/qux"] repos)))))
+
+  (testing "Filters invalid slugs"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["valid/repo" "" "no-slash"]}}))
+      (let [repos (core/get-configured-repos path)]
+        (is (= ["valid/repo"] repos)))))
+
+  (testing "Empty config returns empty vec"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {}))
+      (let [repos (core/get-configured-repos path)]
+        (is (= [] repos)))))
+
+  (testing "Keeps valid gitlab-prefixed slugs"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["gitlab:Group/Sub/Repo"]}}))
+      (let [repos (core/get-configured-repos path)]
+        (is (= ["gitlab:group/sub/repo"] repos))))))
+
+(deftest add-repo-test
+  (testing "Adds valid repo to empty config"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos []}}))
+      (let [result (core/add-repo! "owner/name" path)]
+        (is (:success? result))
+        (is (:added? result))
+        (is (= "owner/name" (:repo result)))
+        (is (some #{"owner/name"} (:repos result))))))
+
+  (testing "Normalizes to lowercase"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos []}}))
+      (let [result (core/add-repo! "Owner/Name" path)]
+        (is (= "owner/name" (:repo result))))))
+
+  (testing "Does not duplicate existing repo"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["owner/name"]}}))
+      (let [result (core/add-repo! "owner/name" path)]
+        (is (:success? result))
+        (is (not (:added? result))))))
+
+  (testing "Rejects blank repo"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos []}}))
+      (let [result (core/add-repo! "" path)]
+        (is (not (:success? result))))))
+
+  (testing "Rejects invalid format"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos []}}))
+      (let [result (core/add-repo! "no-slash" path)]
+        (is (not (:success? result))))))
+
+  (testing "Accepts gitlab repository format"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos []}}))
+      (let [result (core/add-repo! "gitlab:Group/Sub/Repo" path)]
+        (is (:success? result))
+        (is (:added? result))
+        (is (= "gitlab:group/sub/repo" (:repo result)))))))
+
+(deftest remove-repo-test
+  (testing "Removes existing repo"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["owner/name" "other/repo"]}}))
+      (let [result (core/remove-repo! "owner/name" path)]
+        (is (:success? result))
+        (is (:removed? result))
+        (is (not (some #{"owner/name"} (:repos result))))
+        (is (some #{"other/repo"} (:repos result))))))
+
+  (testing "Handles non-existent repo gracefully"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["owner/name"]}}))
+      (let [result (core/remove-repo! "not/here" path)]
+        (is (:success? result))
+        (is (not (:removed? result)))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; PR status mapping tests
+
+(deftest pr-status-from-provider-test
+  (testing "Open non-draft PR"
+    (is (= :open (core/pr-status-from-provider
+                   {:state "OPEN" :isDraft false :reviewDecision nil}))))
+
+  (testing "Draft PR"
+    (is (= :draft (core/pr-status-from-provider
+                    {:state "OPEN" :isDraft true :reviewDecision nil}))))
+
+  (testing "Approved PR"
+    (is (= :approved (core/pr-status-from-provider
+                       {:state "OPEN" :isDraft false :reviewDecision "APPROVED"}))))
+
+  (testing "Changes requested"
+    (is (= :changes-requested (core/pr-status-from-provider
+                                {:state "OPEN" :isDraft false :reviewDecision "CHANGES_REQUESTED"}))))
+
+  (testing "Review required"
+    (is (= :reviewing (core/pr-status-from-provider
+                        {:state "OPEN" :isDraft false :reviewDecision "REVIEW_REQUIRED"}))))
+
+  (testing "Closed/merged PR"
+    (is (= :closed (core/pr-status-from-provider
+                     {:state "MERGED" :isDraft false :reviewDecision nil})))
+    (is (= :closed (core/pr-status-from-provider
+                     {:state "CLOSED" :isDraft false :reviewDecision nil})))))
+
+(deftest check-rollup->ci-status-test
+  (testing "All passed"
+    (is (= :passed (core/check-rollup->ci-status
+                     [{:conclusion "SUCCESS"} {:conclusion "SUCCESS"}]))))
+
+  (testing "Any failed"
+    (is (= :failed (core/check-rollup->ci-status
+                     [{:conclusion "SUCCESS"} {:conclusion "FAILURE"}]))))
+
+  (testing "Running checks"
+    (is (= :running (core/check-rollup->ci-status
+                      [{:conclusion "SUCCESS"} {:status "IN_PROGRESS"}]))))
+
+  (testing "Nil rollup"
+    (is (= :pending (core/check-rollup->ci-status nil))))
+
+  (testing "Empty entries"
+    (is (= :pending (core/check-rollup->ci-status [])))))
+
+(deftest provider-pr->train-pr-test
+  (testing "Converts provider PR to train PR shape"
+    (let [pr {:number 42
+              :title "Fix auth"
+              :url "https://github.com/owner/repo/pull/42"
+              :headRefName "fix-auth"
+              :state "OPEN"
+              :isDraft false
+              :reviewDecision "APPROVED"
+              :statusCheckRollup [{:conclusion "SUCCESS"}]}
+          result (core/provider-pr->train-pr pr "owner/repo")]
+      (is (= 42 (:pr/number result)))
+      (is (= "Fix auth" (:pr/title result)))
+      (is (= "https://github.com/owner/repo/pull/42" (:pr/url result)))
+      (is (= "fix-auth" (:pr/branch result)))
+      (is (= :approved (:pr/status result)))
+      (is (= :passed (:pr/ci-status result)))
+      (is (= "owner/repo" (:pr/repo result)))))
+
+  (testing "Without repo arg, :pr/repo is absent"
+    (let [result (core/provider-pr->train-pr {:number 1 :title "X" :state "OPEN"})]
+      (is (nil? (:pr/repo result))))))
+
+(deftest fetch-all-fleet-prs-multi-provider-test
+  (testing "Fetches open items from both GitHub and GitLab repositories"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["owner/repo" "gitlab:team/service"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& args]
+                      (cond
+                        (and (= "gh" (first args))
+                             (some #{"pr"} args)
+                             (some #{"list"} args))
+                        {:exit 0
+                         :out "[{\"number\":12,\"title\":\"Fix GH\",\"url\":\"https://github.com/owner/repo/pull/12\",\"state\":\"OPEN\",\"headRefName\":\"fix-gh\",\"isDraft\":false,\"reviewDecision\":null,\"statusCheckRollup\":[{\"conclusion\":\"SUCCESS\"}]}]"
+                         :err ""}
+
+                        (and (= "glab" (first args))
+                             (some #(and (string? %) (.contains ^String % "/merge_requests")) args))
+                        {:exit 0
+                         :out "[{\"iid\":34,\"title\":\"Fix GL\",\"web_url\":\"https://gitlab.com/team/service/-/merge_requests/34\",\"source_branch\":\"fix-gl\",\"state\":\"opened\",\"draft\":false,\"merge_status\":\"can_be_merged\",\"head_pipeline\":{\"status\":\"success\"}}]"
+                         :err ""}
+
+                        :else
+                        {:exit 1 :out "" :err (str "unexpected call: " args)}))]
+        (let [prs (core/fetch-all-fleet-prs {:config-path path})]
+          (is (= 2 (count prs)))
+          (is (some #(= "owner/repo" (:pr/repo %)) prs))
+          (is (some #(= "gitlab:team/service" (:pr/repo %)) prs))
+          (is (some #(= :merge-ready (:pr/status %)) prs)))))))
+
+(deftest list-org-repos-test
+  (testing "Without owner, lists viewer-accessible repos plus org repositories"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (cond
+                      (and (= "gh" (first args))
+                           (some #{"graphql"} args))
+                      {:exit 0
+                       :out "{\"data\":{\"viewer\":{\"repositories\":{\"nodes\":[{\"nameWithOwner\":\"Org/RepoA\"},{\"nameWithOwner\":\"me/repo-b\"}],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}}"
+                       :err ""}
+
+                      (and (= "gh" (first args))
+                           (some #(and (string? %) (.contains ^String % "user/orgs")) args))
+                      {:exit 0
+                       :out "[{\"login\":\"kiddom\"}]"
+                       :err ""}
+
+                      (and (= "gh" (first args))
+                           (some #(and (string? %) (.contains ^String % "orgs/kiddom/repos")) args))
+                      {:exit 0
+                       :out "[{\"full_name\":\"kiddom/platform\"}]"
+                       :err ""}
+
+                      :else
+                      {:exit 1 :out "" :err "unexpected call"}))]
+      (let [result (core/list-org-repos {})]
+        (is (:success? result))
+        (is (= ["org/repoa" "me/repo-b" "kiddom/platform"] (:repos result))))))
+
+  (testing "Falls back to user/repos when GraphQL listing fails"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (cond
+                      (and (= "gh" (first args))
+                           (some #{"graphql"} args))
+                      {:exit 1 :out "" :err "forbidden"}
+
+                      (and (= "gh" (first args))
+                           (some #(and (string? %) (.contains ^String % "user/orgs")) args))
+                      {:exit 1 :out "" :err "sso required"}
+
+                      (and (= "gh" (first args))
+                           (some #(and (string? %) (.contains ^String % "user/repos")) args))
+                      {:exit 0
+                       :out "[{\"full_name\":\"fallback/repo1\"},{\"full_name\":\"fallback/repo2\"}]"
+                       :err ""}
+
+                      :else
+                      {:exit 1 :out "" :err "unexpected call"}))]
+      (let [result (core/list-org-repos {:limit 10})]
+        (is (:success? result))
+        (is (= ["fallback/repo1" "fallback/repo2"] (:repos result))))))
+
+  (testing "Nil limit is normalized and does not throw"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (cond
+                      (and (= "gh" (first args))
+                           (some #{"graphql"} args))
+                      {:exit 0
+                       :out "{\"data\":{\"viewer\":{\"repositories\":{\"nodes\":[{\"nameWithOwner\":\"Org/RepoA\"}],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}}"
+                       :err ""}
+
+                      (and (= "gh" (first args))
+                           (some #(and (string? %) (.contains ^String % "user/orgs")) args))
+                      {:exit 0 :out "[]" :err ""}
+
+                      :else
+                      {:exit 1 :out "" :err "unexpected call"}))]
+      (let [result (core/list-org-repos {:limit nil})]
+        (is (:success? result))
+        (is (= ["org/repoa"] (:repos result))))))
+
+  (testing "GitLab provider returns prefixed repositories"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (cond
+                      (and (= "glab" (first args))
+                           (some #(and (string? %) (.contains ^String % "projects?membership=true")) args))
+                      {:exit 0
+                       :out "[{\"path_with_namespace\":\"Platform/API\"},{\"path_with_namespace\":\"Data/ETL\"}]"
+                       :err ""}
+                      :else
+                      {:exit 1 :out "" :err "unexpected call"}))]
+      (let [result (core/list-org-repos {:provider :gitlab})]
+        (is (:success? result))
+        (is (= ["gitlab:platform/api" "gitlab:data/etl"] (:repos result))))))
+
+  (testing "Provider :all merges GitHub and GitLab repositories"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (cond
+                      (and (= "gh" (first args))
+                           (some #{"graphql"} args))
+                      {:exit 0
+                       :out "{\"data\":{\"viewer\":{\"repositories\":{\"nodes\":[{\"nameWithOwner\":\"Org/RepoA\"}],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}}"
+                       :err ""}
+
+                      (and (= "gh" (first args))
+                           (some #(and (string? %) (.contains ^String % "user/orgs")) args))
+                      {:exit 0 :out "[]" :err ""}
+
+                      (and (= "glab" (first args))
+                           (some #(and (string? %) (.contains ^String % "projects?membership=true")) args))
+                      {:exit 0 :out "[{\"path_with_namespace\":\"Platform/API\"}]" :err ""}
+
+                      :else
+                      {:exit 1 :out "" :err "unexpected call"}))]
+      (let [result (core/list-org-repos {:provider :all})]
+        (is (:success? result))
+        (is (= ["org/repoa" "gitlab:platform/api"] (:repos result)))))))

--- a/components/pr-sync/test/ai/miniforge/pr_sync/status_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/status_test.clj
@@ -1,0 +1,118 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-sync.status-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.pr-sync.status :as status]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; PR status mapping tests
+
+(deftest pr-status-from-provider-test
+  (testing "Open non-draft PR"
+    (is (= :open (status/pr-status-from-provider
+                   {:state "OPEN" :isDraft false :reviewDecision nil}))))
+
+  (testing "Draft PR"
+    (is (= :draft (status/pr-status-from-provider
+                    {:state "OPEN" :isDraft true :reviewDecision nil}))))
+
+  (testing "Approved PR"
+    (is (= :approved (status/pr-status-from-provider
+                       {:state "OPEN" :isDraft false :reviewDecision "APPROVED"}))))
+
+  (testing "Changes requested"
+    (is (= :changes-requested (status/pr-status-from-provider
+                                {:state "OPEN" :isDraft false :reviewDecision "CHANGES_REQUESTED"}))))
+
+  (testing "Review required"
+    (is (= :reviewing (status/pr-status-from-provider
+                        {:state "OPEN" :isDraft false :reviewDecision "REVIEW_REQUIRED"}))))
+
+  (testing "Closed/merged PR"
+    (is (= :closed (status/pr-status-from-provider
+                     {:state "MERGED" :isDraft false :reviewDecision nil})))
+    (is (= :closed (status/pr-status-from-provider
+                     {:state "CLOSED" :isDraft false :reviewDecision nil})))))
+
+(deftest check-rollup->ci-status-test
+  (testing "All passed"
+    (is (= :passed (status/check-rollup->ci-status
+                     [{:conclusion "SUCCESS"} {:conclusion "SUCCESS"}]))))
+
+  (testing "Any failed"
+    (is (= :failed (status/check-rollup->ci-status
+                     [{:conclusion "SUCCESS"} {:conclusion "FAILURE"}]))))
+
+  (testing "Running checks"
+    (is (= :running (status/check-rollup->ci-status
+                      [{:conclusion "SUCCESS"} {:status "IN_PROGRESS"}]))))
+
+  (testing "Nil rollup"
+    (is (= :pending (status/check-rollup->ci-status nil))))
+
+  (testing "Empty entries"
+    (is (= :pending (status/check-rollup->ci-status [])))))
+
+(deftest provider-pr->train-pr-test
+  (testing "Converts provider PR to train PR shape"
+    (let [pr {:number 42
+              :title "Fix auth"
+              :url "https://github.com/owner/repo/pull/42"
+              :headRefName "fix-auth"
+              :state "OPEN"
+              :isDraft false
+              :reviewDecision "APPROVED"
+              :statusCheckRollup [{:conclusion "SUCCESS"}]}
+          result (status/provider-pr->train-pr pr "owner/repo")]
+      (is (= 42 (:pr/number result)))
+      (is (= "Fix auth" (:pr/title result)))
+      (is (= "https://github.com/owner/repo/pull/42" (:pr/url result)))
+      (is (= "fix-auth" (:pr/branch result)))
+      (is (= :approved (:pr/status result)))
+      (is (= :passed (:pr/ci-status result)))
+      (is (= "owner/repo" (:pr/repo result)))))
+
+  (testing "Without repo arg, :pr/repo is absent"
+    (let [result (status/provider-pr->train-pr {:number 1 :title "X" :state "OPEN"})]
+      (is (nil? (:pr/repo result))))))
+
+(deftest gitlab-mr->train-pr-test
+  (testing "Converts GitLab MR to train PR shape"
+    (let [mr {:iid 34
+              :title "Fix GL"
+              :web_url "https://gitlab.com/team/service/-/merge_requests/34"
+              :source_branch "fix-gl"
+              :state "opened"
+              :draft false
+              :merge_status "can_be_merged"
+              :head_pipeline {:status "success"}}
+          result (status/gitlab-mr->train-pr mr "gitlab:team/service")]
+      (is (= 34 (:pr/number result)))
+      (is (= "Fix GL" (:pr/title result)))
+      (is (= :merge-ready (:pr/status result)))
+      (is (= :passed (:pr/ci-status result)))
+      (is (= "gitlab:team/service" (:pr/repo result)))))
+
+  (testing "Draft MR"
+    (let [result (status/gitlab-mr->train-pr {:iid 1 :title "Draft: WIP" :state "opened"
+                                              :draft true :source_branch "wip"
+                                              :web_url "https://gl.com/x/y/-/merge_requests/1"}
+                                             "gitlab:x/y")]
+      (is (= :draft (:pr/status result))))))


### PR DESCRIPTION
## Layer
Domain

## Depends on
- None

## Overview
New Polylith component for fleet repository management and PR/MR synchronization across GitHub and GitLab providers.

## What this adds
- Fleet config I/O (`~/.miniforge/config.edn`) with add/remove/list
- GitHub PR fetch via `gh` CLI with status + CI rollup normalization
- GitLab MR fetch via `glab` CLI with equivalent normalization
- Provider-aware browse (GitHub viewer repos, org traversal, REST fallback)
- GitLab group project browsing
- GitLab repo slug validation/normalization (`gitlab:group/subgroup/repo`)

## Strata affected
- `components/pr-sync/core.clj` — all implementation (683 lines)
- `components/pr-sync/interface.clj` — public API surface
- `components/pr-sync/core_test.clj` — comprehensive tests (342 lines)
- `components/pr-sync/deps.edn` — cheshire JSON dependency

## PR DAG Context
```
PR-A (this) ──────────┐
PR-B (themes)  ───────┤
PR-C (input)   ──┐    ├──► PR-D (repo manager + views)
                  └──► PR-E (nav) ──► PR-F (commands) ──┘
```

## Test plan
- `clojure -M:dev:test` — pr-sync tests pass
- All functions are pure or shell-out with error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)