### PR TITLE
feat(tui): input normalization, side-effect runtime, cell-level rendering

### DIFF
--- a/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
@@ -40,20 +40,28 @@
   "Create a TUI application from a config map.
 
    Config:
-   - :init          - (fn [] model)
-   - :update        - (fn [model msg] model')
-   - :view          - (fn [model [cols rows]] cell-buffer)
-   - :subscriptions - (fn [dispatch-fn] cleanup-fn) -- optional
-   - :screen        - IScreen implementation (optional, auto-created if nil)
-   - :fps           - Target frame rate for external messages (default 1)
+   - :init           - (fn [] model)
+   - :update         - (fn [model msg] model')
+   - :view           - (fn [model [cols rows]] cell-buffer)
+   - :subscriptions  - (fn [dispatch-fn] cleanup-fn) -- optional
+   - :effect-handler - (fn [effect-map] msg-vector) -- optional, executes side-effects
+   - :screen         - IScreen implementation (optional, auto-created if nil)
+   - :fps            - Target frame rate for external messages (default 1)
+
+   Side-effect protocol:
+   When update-fn returns a model with a :side-effect key, the runtime strips it
+   and calls effect-handler on a background thread. The effect-handler should return
+   a message vector (e.g. [:msg/prs-synced {:pr-items [...]}]) which is dispatched
+   back into the update loop.
 
    Returns an atom holding the app state."
-  [{:keys [init update view subscriptions screen fps]
+  [{:keys [init update view subscriptions effect-handler screen fps]
     :or {fps 1}}]
   (atom {:model          (init)
          :update-fn      update
          :view-fn        view
          :subscriptions  subscriptions
+         :effect-handler effect-handler
          :screen         (or screen (screen/create-screen))
          :fps            fps
          :running?       false
@@ -65,38 +73,84 @@
 ;; Rendering
 
 (defn render!
-  "Render the current model to screen. Only writes changed cells."
+  "Render the current model to screen. Only writes changed cells.
+   Uses cell-level diffing against prev-buffer to avoid full-screen
+   rewrites that cause visible flashing."
   [app-state]
-  (let [{:keys [model view-fn screen]} app-state
+  (let [{:keys [model view-fn screen prev-buffer]} app-state
         [cols rows] (screen/get-size screen)
-        new-buffer (view-fn model [cols rows])]
-    (screen/clear! screen)
-    ;; Write all cells (Lanterna handles delta internally via refresh)
+        new-buffer (view-fn model [cols rows])
+        resized? (or (nil? prev-buffer)
+                     (not= (count new-buffer) (count prev-buffer))
+                     (and (seq new-buffer) (seq prev-buffer)
+                          (not= (count (first new-buffer))
+                                (count (first prev-buffer)))))]
+    ;; Only clear on first render or resize — never on normal frames
+    (when resized? (screen/clear! screen))
+    ;; Cell-level diff: only write cells that actually changed
     (doseq [row (range (min rows (count new-buffer)))
             col (range (min cols (count (nth new-buffer row))))]
-      (let [{:keys [char fg bg bold?]} (get-in new-buffer [row col])]
-        (when char
-          (screen/put-string! screen col row (str char) fg bg (boolean bold?)))))
+      (let [new-cell (get-in new-buffer [row col])
+            old-cell (when-not resized? (get-in prev-buffer [row col]))]
+        (when (or resized? (not= new-cell old-cell))
+          (let [{:keys [char fg bg bold?]} new-cell]
+            (when char
+              (screen/put-string! screen col row (str char) fg bg (boolean bold?)))))))
     (screen/refresh! screen)
     (assoc app-state :prev-buffer new-buffer)))
 
 ;------------------------------------------------------------------------------ Layer 2
+;; Side-effect execution
+
+(defn- execute-side-effect!
+  "Execute a side-effect on a background daemon thread.
+   Calls effect-handler-fn with the effect map, then dispatches the result
+   message back into the Elm loop via dispatch-fn."
+  [effect effect-handler-fn dispatch-fn]
+  (let [thread (Thread.
+                (fn []
+                  (try
+                    (when-let [result-msg (effect-handler-fn effect)]
+                      (dispatch-fn result-msg))
+                    (catch Exception e
+                      (dispatch-fn [:msg/side-effect-error
+                                    {:type (:type effect)
+                                     :error (.getMessage e)}])))))]
+    (.setDaemon thread true)
+    (.setName thread (str "tui-effect-" (name (or (:type effect) "unknown"))))
+    (.start thread)))
+
+;------------------------------------------------------------------------------ Layer 3
 ;; Message dispatch
 
 (defn dispatch!
   "Dispatch a message into the Elm update loop.
-   Calls update, then re-renders."
+   Calls update, then re-renders.
+
+   Side-effect protocol:
+   If the new model contains a :side-effect key, it is stripped from the model
+   and executed asynchronously via the registered :effect-handler. The handler
+   runs on a background thread and its result message is dispatched back into
+   the update loop."
   [app msg]
-  (swap! app (fn [state]
-               (let [new-model ((:update-fn state) (:model state) msg)]
-                 (render! (assoc state :model new-model))))))
+  (let [pending-effect (atom nil)]
+    (swap! app (fn [state]
+                 (let [new-model ((:update-fn state) (:model state) msg)
+                       fx (:side-effect new-model)
+                       clean-model (dissoc new-model :side-effect)]
+                   (when fx (reset! pending-effect fx))
+                   (render! (assoc state :model clean-model)))))
+    ;; Execute side-effect outside swap! to avoid re-entrancy issues
+    (when-let [fx @pending-effect]
+      (when-let [handler (:effect-handler @app)]
+        (execute-side-effect! fx handler (fn [result-msg] (dispatch! app result-msg)))))))
 
 (defn get-model
   "Get current model snapshot."
   [app]
   (:model @app))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 4
 ;; Input polling thread
 
 (defn- start-input-thread!
@@ -118,7 +172,7 @@
     (.start thread)
     thread))
 
-;------------------------------------------------------------------------------ Layer 4
+;------------------------------------------------------------------------------ Layer 5
 ;; Application lifecycle
 
 (defn start!

--- a/components/tui-engine/src/ai/miniforge/tui_engine/input.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/input.clj
@@ -42,24 +42,45 @@
    \3     :key/d3
    \4     :key/d4
    \5     :key/d5
+   \6     :key/d6
+   \7     :key/d7
+   \8     :key/d8
+   \9     :key/d9
+   \0     :key/d0
+   \r     :key/r
+   \s     :key/s
+   \b     :key/b
+   \e     :key/e
+   \f     :key/f
+   \o     :key/o
+   \x     :key/x
+   \a     :key/a
+   \v     :key/v
+   \c     :key/c
    \/     :key/slash
    \:     :key/colon
    \space :key/space
    \tab   :key/tab
-   \?     :key/question})
+   \?     :key/question
+   \y     :key/y
+   \n     :key/n
+   \N     :key/N})
 
 (defn normalize-key
-  "Convert a raw Lanterna key event map to a normalized keyword message.
+  "Convert a raw Lanterna key event map to a normalized message.
 
-   Returns a keyword like :key/j, :key/enter, :key/escape, or
-   {:type :char :char c} for unmapped characters."
+   Character keys return {:key :key/r :char \\r} (mapped) or {:key nil :char \\x}
+   (unmapped). This allows mode-aware dispatching: normal mode uses :key for
+   vi commands, while command/search mode uses :char for text input.
+
+   Special keys return bare keywords: :key/enter, :key/escape, etc."
   [raw-event]
   (when raw-event
     (case (:type raw-event)
       :character
-      (let [ch (:char raw-event)]
-        (or (get char-key-map ch)
-            {:type :char :char ch}))
+      (let [ch (:char raw-event)
+            semantic (get char-key-map ch)]
+        {:key semantic :char ch})
 
       :enter     :key/enter
       :escape    :key/escape
@@ -68,8 +89,9 @@
       :arrow-down :key/down
       :arrow-left :key/left
       :arrow-right :key/right
-      :tab       :key/tab
-      :eof       :key/eof
+      :tab         :key/tab
+      :reverse-tab :key/shift-tab
+      :eof         :key/eof
 
       ;; Unknown key type
       nil)))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/interface.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/interface.clj
@@ -41,11 +41,17 @@
   "Create a TUI application.
 
    config map:
-   - :init          - (fn [] model) -- returns initial model state
-   - :update        - (fn [model msg] model') -- pure state transition
-   - :view          - (fn [model size] render-tree) -- pure render function
-   - :subscriptions - (fn [app] unsub-fn) -- registers external msg sources
-   - :screen        - Optional: IScreen instance (for testing with MockScreen)
+   - :init           - (fn [] model) -- returns initial model state
+   - :update         - (fn [model msg] model') -- pure state transition
+   - :view           - (fn [model size] render-tree) -- pure render function
+   - :subscriptions  - (fn [app] unsub-fn) -- registers external msg sources
+   - :effect-handler - (fn [effect-map] msg-vector) -- executes side-effects async
+   - :screen         - Optional: IScreen instance (for testing with MockScreen)
+
+   Side-effect protocol:
+   When update returns a model with a :side-effect key, the runtime strips it
+   and calls effect-handler on a background thread. The handler returns a result
+   message that is dispatched back into the update loop.
 
    Returns: app atom suitable for start!, stop!, dispatch!."
   [config]
@@ -107,12 +113,37 @@
    Returns a string representation of the specified row."
   screen/mock-read-line)
 
-;; Style
+;; Style / Themes
 
 (def default-theme
-  "Default color theme for TUI rendering.
-   Map of semantic color names to ANSI color keywords."
+  "Default color theme for TUI rendering (miniforge brand dark).
+   Map of semantic color names to color values (keywords, ints, or [r g b])."
   style/default-theme)
+
+(def dark-theme
+  "Miniforge brand dark: charcoal background, gold/flame accents."
+  style/dark-theme)
+
+(def light-theme
+  "Miniforge brand light: parchment background, ember accents."
+  style/light-theme)
+
+(def high-contrast-theme
+  "High-contrast dark: pure black bg, white fg, bright ANSI accents."
+  style/high-contrast-theme)
+
+(def high-contrast-light-theme
+  "High-contrast light: pure white bg, black fg, bold ANSI accents."
+  style/high-contrast-light-theme)
+
+(def themes
+  "Registry of available themes: {:dark, :light, :high-contrast, :high-contrast-light, :default}."
+  style/themes)
+
+(def get-theme
+  "Resolve a theme keyword to a theme map.
+   (get-theme :dark) => dark-theme, (get-theme :light) => light-theme."
+  style/get-theme)
 
 (def resolve-style
   "Resolve a style map into Lanterna TextCharacter attributes.

--- a/components/tui-engine/src/ai/miniforge/tui_engine/interface/layout.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/interface/layout.clj
@@ -28,7 +28,7 @@
 ;; Cell buffer operations
 
 (def empty-cell
-  "Default empty cell: {:char \\space :fg :white :bg :black :bold? false}"
+  "Default empty cell: {:char \\space :fg :default :bg :default :bold? false}"
   layout/empty-cell)
 
 (def make-buffer

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout/buffer.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout/buffer.clj
@@ -27,7 +27,7 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Cell buffer operations
 
-(def empty-cell {:char \space :fg :white :bg :black :bold? false})
+(def empty-cell {:char \space :fg :default :bg :default :bold? false})
 
 (defn make-buffer
   "Create an empty cell buffer of [cols rows]."
@@ -46,7 +46,7 @@
 
 (defn buf-put-string
   "Write a string into the buffer at [col row] with given style."
-  [buf col row text {:keys [fg bg bold?] :or {fg :white bg :black bold? false}}]
+  [buf col row text {:keys [fg bg bold?] :or {fg :default bg :default bold? false}}]
   (reduce (fn [b i]
             (if (< (+ col i) (count (first b)))
               (buf-put-char b (+ col i) row
@@ -98,7 +98,7 @@
   "Render a styled text span into a buffer.
    Truncates to fit within [cols rows]."
   [[cols rows] content & [{:keys [fg bg bold? align]
-                            :or {fg :white bg :black bold? false align :left}}]]
+                            :or {fg :default bg :default bold? false align :left}}]]
   (let [buf (make-buffer [cols rows])
         lines (str/split-lines (or content ""))
         lines (take rows lines)]

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout/container.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout/container.clj
@@ -48,7 +48,7 @@
    - :fg, :bg, :bold? - Border style
    - :content-fn - (fn [[inner-cols inner-rows]] -> cell-buffer) for box contents"
   [[cols rows] & [{:keys [border title fg bg bold? content-fn]
-                    :or {border :single fg :default bg :black bold? false}}]]
+                    :or {border :single fg :default bg :default bold? false}}]]
   (when (and (>= cols 2) (>= rows 2))
     (let [chars (get box-chars border (:single box-chars))
           style {:fg fg :bg bg :bold? bold?}

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout/table.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout/table.clj
@@ -70,11 +70,11 @@
 
 (defn- render-separator
   "Render horizontal separator line."
-  [buffer cols rows]
+  [buffer cols rows separator-fg]
   (if (>= rows 2)
     (buf/buf-put-string buffer 0 1
                         (apply str (repeat cols \─))
-                        {:fg :default :bg :black :bold? false})
+                        {:fg (or separator-fg :default) :bg :default :bold? false})
     buffer))
 
 (defn- render-data-cell
@@ -108,16 +108,18 @@
    - :selected-row - index of highlighted row (nil for none)
    - :header-fg, :header-bg - Header style
    - :row-fg, :row-bg - Default row style
-   - :selected-fg, :selected-bg - Selected row style"
+   - :selected-fg, :selected-bg - Selected row style
+   - :separator-fg - Separator line color (defaults to header-fg)"
   [[cols rows] & [{:keys [columns data selected-row
-                           header-fg header-bg row-fg row-bg selected-fg selected-bg]
-                    :or {header-fg :cyan header-bg :black
-                         row-fg :white row-bg :black
+                           header-fg header-bg row-fg row-bg
+                           selected-fg selected-bg separator-fg]
+                    :or {header-fg :cyan header-bg :default
+                         row-fg :default row-bg :default
                          selected-fg :white selected-bg :blue}}]]
   (let [col-widths (compute-col-widths columns cols)
         buffer (buf/make-buffer [cols rows])
         buffer (render-header-row buffer columns col-widths header-fg header-bg)
-        buffer (render-separator buffer cols rows)
+        buffer (render-separator buffer cols rows (or separator-fg header-fg))
         visible-rows (take (max 0 (- rows 2)) (or data []))]
     (reduce (fn [b [row-idx row-data]]
               (render-data-row b row-idx row-data columns col-widths rows

--- a/components/tui-engine/src/ai/miniforge/tui_engine/screen.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/screen.clj
@@ -53,6 +53,7 @@
     (:size @state))
 
   (put-string! [_ col row text fg bg bold?]
+    (swap! state update :put-count (fnil inc 0))
     (doseq [i (range (count text))]
       (swap! state assoc-in [:cells [(+ col i) row]]
              {:char (.charAt text i) :fg fg :bg bg :bold? bold?})))
@@ -96,6 +97,16 @@
                  (if-let [cell (get cells [c row])]
                    (:char cell)
                    \space)))))
+
+(defn mock-get-put-count
+  "Get the number of put-string! calls on a mock screen."
+  [mock-screen]
+  (or (:put-count @(:state mock-screen)) 0))
+
+(defn mock-reset-put-count!
+  "Reset the put-string! call counter to zero."
+  [mock-screen]
+  (swap! (:state mock-screen) assoc :put-count 0))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Factory (dynamically loads Lanterna)

--- a/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
@@ -24,7 +24,7 @@
   (:require
    [ai.miniforge.tui-engine.screen :as screen])
   (:import
-   [com.googlecode.lanterna TextCharacter TextColor$ANSI]
+   [com.googlecode.lanterna TextCharacter TextColor$ANSI TextColor$Indexed TextColor$RGB]
    [com.googlecode.lanterna.screen TerminalScreen]
    [com.googlecode.lanterna.terminal DefaultTerminalFactory]))
 
@@ -43,8 +43,19 @@
    :white   TextColor$ANSI/WHITE
    :default TextColor$ANSI/DEFAULT})
 
-(defn- resolve-lanterna-color [kw]
-  (get color-map kw TextColor$ANSI/DEFAULT))
+(defn- resolve-lanterna-color
+  "Resolve a color value to a Lanterna TextColor.
+   Accepts:
+   - keyword  (:cyan, :red, etc.)  → TextColor.ANSI
+   - integer  (0–255)              → TextColor.Indexed
+   - vector   [r g b]              → TextColor.RGB"
+  [color]
+  (cond
+    (keyword? color) (get color-map color TextColor$ANSI/DEFAULT)
+    (integer? color) (TextColor$Indexed. (int color))
+    (vector? color)  (let [[r g b] color]
+                       (TextColor$RGB. (int r) (int g) (int b)))
+    :else            TextColor$ANSI/DEFAULT))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Lanterna implementation
@@ -110,6 +121,9 @@
 
           (= kind com.googlecode.lanterna.input.KeyType/Tab)
           {:type :tab}
+
+          (= kind com.googlecode.lanterna.input.KeyType/ReverseTab)
+          {:type :reverse-tab}
 
           (= kind com.googlecode.lanterna.input.KeyType/EOF)
           {:type :eof}

--- a/components/tui-engine/src/ai/miniforge/tui_engine/widget/scroll.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/widget/scroll.clj
@@ -30,20 +30,28 @@
 (defn scrollable
   "Render a scrollable viewport with scrollbar.
    Options:
-   - :lines   - vector of strings (total content)
-   - :offset  - scroll offset (first visible line index)
-   - :fg, :bg - colors"
-  [[cols rows] & [{:keys [lines offset fg bg]
-                    :or {offset 0 fg :white bg :black}}]]
+   - :lines             - vector of strings (total content)
+   - :offset            - scroll offset (first visible line index)
+   - :fg, :bg           - colors
+   - :highlight-lines   - set of absolute line indices to highlight (search matches)
+   - :current-highlight - absolute line index of current match (brighter highlight)"
+  [[cols rows] & [{:keys [lines offset fg bg highlight-lines current-highlight]
+                    :or {offset 0 fg :white bg :default}}]]
   (let [total (count (or lines []))
         content-w (max 1 (- cols 1)) ; 1 col for scrollbar
         visible (take rows (drop offset (or lines [])))
         buffer (buf/make-buffer [cols rows])
         ;; Render visible lines
         buffer (reduce (fn [b [idx line]]
-                      (let [truncated (subs line 0 (min (count line) content-w))]
+                      (let [abs-line (+ offset idx) ; absolute line index
+                            truncated (subs line 0 (min (count line) content-w))
+                            current? (= abs-line current-highlight)
+                            hl? (and highlight-lines (contains? highlight-lines abs-line))
+                            line-fg (cond current? :white hl? :yellow :else fg)
+                            line-bg (cond current? :blue  hl? :default :else bg)
+                            line-bold? (or current? hl?)]
                         (buf/buf-put-string b 0 idx truncated
-                                               {:fg fg :bg bg :bold? false})))
+                                               {:fg line-fg :bg line-bg :bold? line-bold?})))
                     buffer
                     (map-indexed vector visible))
         ;; Scrollbar
@@ -88,6 +96,6 @@
                     level (max 0 (min 8 level))
                     ch (nth braille-chars level)]
                 (buf/buf-put-char b idx 0
-                                     {:char ch :fg fg :bg :black :bold? false})))
+                                     {:char ch :fg fg :bg :default :bold? false})))
             buffer
             (map-indexed vector visible))))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/widget/status.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/widget/status.clj
@@ -60,10 +60,10 @@
   (let [ch (get status-chars status \?)
         fg (get status-colors status :white)
         buffer (buf/make-buffer [cols 1])
-        buffer (buf/buf-put-char buffer 0 0 {:char ch :fg fg :bg :black :bold? false})]
+        buffer (buf/buf-put-char buffer 0 0 {:char ch :fg fg :bg :default :bold? false})]
     (if (> cols 2)
       (buf/buf-put-string buffer 2 0 (subs label 0 (min (count label) (- cols 2)))
-                             {:fg :white :bg :black :bold? false})
+                             {:fg :default :bg :default :bold? false})
       buffer)))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -78,7 +78,7 @@
   [buffer full-cells bar-width fill-fg]
   (reduce (fn [b i]
             (buf/buf-put-char b i 0
-                              {:char \█ :fg fill-fg :bg :black :bold? false}))
+                              {:char \█ :fg fill-fg :bg :default :bold? false}))
           buffer
           (range (min full-cells bar-width))))
 
@@ -88,7 +88,7 @@
   (if (and (< full-cells bar-width) (pos? frac-idx))
     (buf/buf-put-char buffer full-cells 0
                       {:char (nth bar-chars frac-idx)
-                       :fg fill-fg :bg :black :bold? false})
+                       :fg fill-fg :bg :default :bold? false})
     buffer))
 
 (defn- render-empty-cells
@@ -96,7 +96,7 @@
   [buffer full-cells frac-idx bar-width empty-fg]
   (reduce (fn [b i]
             (buf/buf-put-char b i 0
-                              {:char \░ :fg empty-fg :bg :black :bold? false}))
+                              {:char \░ :fg empty-fg :bg :default :bold? false}))
           buffer
           (range (if (pos? frac-idx) (inc full-cells) full-cells) bar-width)))
 
@@ -105,7 +105,7 @@
   [buffer bar-width label]
   (if label
     (buf/buf-put-string buffer bar-width 0 label
-                        {:fg :white :bg :black :bold? false})
+                        {:fg :default :bg :default :bold? false})
     buffer))
 
 (defn progress-bar

--- a/components/tui-engine/src/ai/miniforge/tui_engine/widget/tree.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/widget/tree.clj
@@ -50,7 +50,7 @@
                     text (subs text 0 (min (count text) cols))]
                 (buf/buf-put-string b 0 idx text
                                        {:fg (if sel? selected-fg fg)
-                                        :bg (if sel? selected-bg :black)
+                                        :bg (if sel? selected-bg :default)
                                         :bold? sel?})))
             buffer
             (map-indexed vector visible))))
@@ -82,7 +82,7 @@
   (let [header (subs (str " " title (apply str (repeat avail-w \space)))
                      0 (min avail-w (+ (count title) 2)))]
     (buf/buf-put-string buffer x-offset 0 header
-                        {:fg (or color :white) :bg :black :bold? true})))
+                        {:fg (or color :white) :bg :default :bold? true})))
 
 (defn- render-column-separator
   "Render horizontal separator below header."
@@ -90,7 +90,7 @@
   (if (>= rows 2)
     (buf/buf-put-string buffer x-offset 1
                         (apply str (repeat avail-w \─))
-                        {:fg :default :bg :black :bold? false})
+                        {:fg :default :bg :default :bold? false})
     buffer))
 
 (defn- format-card-line
@@ -109,7 +109,7 @@
       (let [line (format-card-line label status avail-w)]
         (buf/buf-put-string buffer x-offset r line
                             {:fg (get status-colors status :white)
-                             :bg :black :bold? false})))))
+                             :bg :default :bold? false})))))
 
 (defn- render-column
   "Render complete kanban column."

--- a/components/tui-engine/test/ai/miniforge/tui_engine/core_test.clj
+++ b/components/tui-engine/test/ai/miniforge/tui_engine/core_test.clj
@@ -107,3 +107,95 @@
       (let [line (screen/mock-read-line mock 0 40)]
         (is (str/includes? line "pressed-j")))
       (screen/stop-screen! mock))))
+
+(deftest cell-level-diffing-test
+  (testing "Second render with identical model writes zero cells (no flash)"
+    (let [mock (screen/create-mock-screen [40 10])
+          app (core/create-app
+               {:init   (fn [] {:label "static"})
+                :update (fn [model _] model)
+                :view   (fn [model [cols rows]]
+                          (layout/text [cols rows] (:label model)))
+                :screen mock})]
+      (screen/start-screen! mock)
+      ;; First render writes all cells
+      (swap! app core/render!)
+      (let [first-count (screen/mock-get-put-count mock)]
+        (is (pos? first-count) "First render should write cells"))
+      ;; Reset counter
+      (screen/mock-reset-put-count! mock)
+      ;; Second render with identical model should write zero cells
+      (swap! app core/render!)
+      (is (zero? (screen/mock-get-put-count mock))
+          "Identical model should produce zero put-string! calls")
+      (screen/stop-screen! mock)))
+
+  (testing "Render after model change only writes changed cells"
+    (let [mock (screen/create-mock-screen [40 10])
+          model-atom (atom {:label "before"})
+          app (core/create-app
+               {:init   (fn [] @model-atom)
+                :update (fn [_ msg] msg)
+                :view   (fn [model [cols rows]]
+                          (layout/text [cols rows] (:label model)))
+                :screen mock})]
+      (screen/start-screen! mock)
+      ;; First render
+      (swap! app core/render!)
+      (screen/mock-reset-put-count! mock)
+      ;; Change model and re-render
+      (core/dispatch! app {:label "after!"})
+      (let [changed-count (screen/mock-get-put-count mock)]
+        ;; Should write fewer cells than a full screen
+        (is (pos? changed-count) "Changed model should write some cells")
+        (is (< changed-count 400) "Should write far fewer than 400 cells (40×10)"))
+      (screen/stop-screen! mock))))
+
+(deftest side-effect-dispatch-test
+  (testing "Side-effect is stripped from model and executed async"
+    (let [effect-result (promise)
+          mock (screen/create-mock-screen [40 10])
+          app (core/create-app
+               {:init   (fn [] {:value "init"})
+                :update (fn [model msg]
+                          (case (first msg)
+                            :trigger (assoc model :side-effect {:type :test-fx}
+                                                  :value "triggered")
+                            :fx-done (assoc model :value (:result (second msg)))
+                            model))
+                :view   (fn [model [cols rows]]
+                          (layout/text [cols rows] (:value model)))
+                :effect-handler
+                (fn [effect]
+                  (deliver effect-result effect)
+                  [:fx-done {:result "from-effect"}])
+                :screen mock})]
+      (screen/start-screen! mock)
+      (core/dispatch! app [:trigger nil])
+      ;; Model should NOT contain :side-effect (stripped by runtime)
+      (is (nil? (:side-effect (core/get-model app))))
+      (is (= "triggered" (:value (core/get-model app))))
+      ;; Wait for effect to complete
+      (let [fx (deref effect-result 2000 :timeout)]
+        (is (= {:type :test-fx} fx)))
+      ;; Wait for effect result dispatch
+      (Thread/sleep 200)
+      (is (= "from-effect" (:value (core/get-model app))))
+      (screen/stop-screen! mock)))
+
+  (testing "No effect-handler means side-effects are silently ignored"
+    (let [mock (screen/create-mock-screen [40 10])
+          app (core/create-app
+               {:init   (fn [] {:value "init"})
+                :update (fn [model _]
+                          (assoc model :side-effect {:type :ignored}
+                                       :value "set"))
+                :view   (fn [model [cols rows]]
+                          (layout/text [cols rows] (:value model)))
+                :screen mock})]
+      (screen/start-screen! mock)
+      (core/dispatch! app [:any nil])
+      ;; Side-effect stripped, value updated, no crash
+      (is (nil? (:side-effect (core/get-model app))))
+      (is (= "set" (:value (core/get-model app))))
+      (screen/stop-screen! mock))))

--- a/components/tui-engine/test/ai/miniforge/tui_engine/input_test.clj
+++ b/components/tui-engine/test/ai/miniforge/tui_engine/input_test.clj
@@ -22,19 +22,33 @@
    [ai.miniforge.tui-engine.input :as input]))
 
 (deftest normalize-key-test
-  (testing "Character keys map to semantic keywords"
-    (is (= :key/j (input/normalize-key {:type :character :char \j})))
-    (is (= :key/k (input/normalize-key {:type :character :char \k})))
-    (is (= :key/q (input/normalize-key {:type :character :char \q})))
-    (is (= :key/slash (input/normalize-key {:type :character :char \/})))
-    (is (= :key/colon (input/normalize-key {:type :character :char \:})))
-    (is (= :key/space (input/normalize-key {:type :character :char \space}))))
+  (testing "Character keys return {key char} maps with semantic keyword"
+    (is (= {:key :key/j :char \j} (input/normalize-key {:type :character :char \j})))
+    (is (= {:key :key/k :char \k} (input/normalize-key {:type :character :char \k})))
+    (is (= {:key :key/q :char \q} (input/normalize-key {:type :character :char \q})))
+    (is (= {:key :key/slash :char \/} (input/normalize-key {:type :character :char \/})))
+    (is (= {:key :key/colon :char \:} (input/normalize-key {:type :character :char \:})))
+    (is (= {:key :key/space :char \space} (input/normalize-key {:type :character :char \space}))))
 
-  (testing "Number keys map correctly"
-    (is (= :key/d1 (input/normalize-key {:type :character :char \1})))
-    (is (= :key/d5 (input/normalize-key {:type :character :char \5}))))
+  (testing "Number keys return {key char} maps"
+    (is (= {:key :key/d1 :char \1} (input/normalize-key {:type :character :char \1})))
+    (is (= {:key :key/d5 :char \5} (input/normalize-key {:type :character :char \5})))
+    (is (= {:key :key/d9 :char \9} (input/normalize-key {:type :character :char \9})))
+    (is (= {:key :key/d0 :char \0} (input/normalize-key {:type :character :char \0}))))
 
-  (testing "Special keys map correctly"
+  (testing "Mapped letter keys include both semantic and raw char"
+    (is (= {:key :key/r :char \r} (input/normalize-key {:type :character :char \r})))
+    (is (= {:key :key/s :char \s} (input/normalize-key {:type :character :char \s})))
+    (is (= {:key :key/b :char \b} (input/normalize-key {:type :character :char \b})))
+    (is (= {:key :key/e :char \e} (input/normalize-key {:type :character :char \e})))
+    (is (= {:key :key/f :char \f} (input/normalize-key {:type :character :char \f})))
+    (is (= {:key :key/o :char \o} (input/normalize-key {:type :character :char \o})))
+    (is (= {:key :key/x :char \x} (input/normalize-key {:type :character :char \x})))
+    (is (= {:key :key/a :char \a} (input/normalize-key {:type :character :char \a})))
+    (is (= {:key :key/y :char \y} (input/normalize-key {:type :character :char \y})))
+    (is (= {:key :key/n :char \n} (input/normalize-key {:type :character :char \n}))))
+
+  (testing "Special keys return bare keywords"
     (is (= :key/enter (input/normalize-key {:type :enter})))
     (is (= :key/escape (input/normalize-key {:type :escape})))
     (is (= :key/backspace (input/normalize-key {:type :backspace})))
@@ -43,11 +57,14 @@
     (is (= :key/left (input/normalize-key {:type :arrow-left})))
     (is (= :key/right (input/normalize-key {:type :arrow-right})))
     (is (= :key/tab (input/normalize-key {:type :tab})))
+    (is (= :key/shift-tab (input/normalize-key {:type :reverse-tab})))
     (is (= :key/eof (input/normalize-key {:type :eof}))))
 
-  (testing "Unmapped characters return char map"
-    (let [result (input/normalize-key {:type :character :char \x})]
-      (is (= {:type :char :char \x} result))))
+  (testing "Unmapped characters return {key nil char ch}"
+    (let [result (input/normalize-key {:type :character :char \z})]
+      (is (= {:key nil :char \z} result)))
+    (let [result (input/normalize-key {:type :character :char \m})]
+      (is (= {:key nil :char \m} result))))
 
   (testing "nil input returns nil"
     (is (nil? (input/normalize-key nil)))))


### PR DESCRIPTION
## Layer
Foundations + Application

## Depends on
- None

## Overview
Three foundational tui-engine capabilities: richer input events, async side-effect protocol, and incremental rendering.

## What this adds

### Input normalization
- `normalize-key` now returns `{:key :key/r :char \r}` maps for character keys
- Enables mode-aware dispatch (normal mode uses `:key`, command mode uses `:char`)
- Adds Shift+Tab, number keys 0-9, and interaction keys (r, s, b, e, f, o, x)

### Side-effect runtime
- `:effect-handler` in Elm app config for async I/O operations
- When `update-fn` sets `:side-effect` on model, runtime strips it and executes on daemon thread, dispatching result message back
- Enables pure update functions with side-effect-producing capability

### Rendering
- Cell-level diff rendering (tracks `:prev-buffer`, writes only changed cells)
- Widget/layout functions accept theme colors from callers instead of hardcoding

## Strata affected
- `tui-engine/input.clj` — key map extension
- `tui-engine/core.clj` — side-effect protocol, diff rendering
- `tui-engine/interface.clj` — public API updates
- `tui-engine/screen/*.clj` — screen abstraction
- `tui-engine/layout/*.clj` — theme color threading
- `tui-engine/widget/*.clj` — theme color threading
- Tests: core_test.clj, input_test.clj

## PR DAG Context
```
PR-C (this) ──────┐
                   └──► PR-E (nav/sel/search) ──► PR-F (commands) ──┐
PR-A (pr-sync) ───┐                                                 │
PR-B (themes)  ───┼─────────────────────────────────────────────────► PR-D
```

## Test plan
- `clojure -M:dev:test` — engine tests pass (input normalization, side-effect dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)