### PR TITLE
feat(tui): navigation, selection, search, mode overhaul

### DIFF
--- a/components/tui-engine/resources/config/tui/key-tokens.edn
+++ b/components/tui-engine/resources/config/tui/key-tokens.edn
@@ -1,0 +1,60 @@
+;; TUI key token lexer table — maps raw terminal events to semantic key tokens.
+;;
+;; This is the first stage of the input pipeline:
+;;   raw Lanterna event -> key token (this file) -> action token (keybindings.edn)
+;;
+;; Two sections:
+;;   :char-keys   — maps character literals to :key/* tokens.
+;;                  Characters not listed here still pass through as {:key nil :char ch}
+;;                  for text input in command/search modes.
+;;   :special-keys — maps Lanterna event type keywords to :key/* tokens.
+;;                   These are non-character keys (enter, arrows, etc.)
+
+{:char-keys
+ {"j"     :key/j
+  "k"     :key/k
+  "h"     :key/h
+  "l"     :key/l
+  "g"     :key/g
+  "G"     :key/G
+  "q"     :key/q
+  "1"     :key/d1
+  "2"     :key/d2
+  "3"     :key/d3
+  "4"     :key/d4
+  "5"     :key/d5
+  "6"     :key/d6
+  "7"     :key/d7
+  "8"     :key/d8
+  "9"     :key/d9
+  "0"     :key/d0
+  "r"     :key/r
+  "s"     :key/s
+  "b"     :key/b
+  "e"     :key/e
+  "f"     :key/f
+  "o"     :key/o
+  "x"     :key/x
+  "a"     :key/a
+  "v"     :key/v
+  "c"     :key/c
+  "/"     :key/slash
+  ":"     :key/colon
+  " "     :key/space
+  "\t"    :key/tab
+  "?"     :key/question
+  "y"     :key/y
+  "n"     :key/n
+  "N"     :key/N}
+
+ :special-keys
+ {:enter      :key/enter
+  :escape     :key/escape
+  :backspace  :key/backspace
+  :arrow-up   :key/up
+  :arrow-down :key/down
+  :arrow-left :key/left
+  :arrow-right :key/right
+  :tab        :key/tab
+  :reverse-tab :key/shift-tab
+  :eof        :key/eof}}

--- a/components/tui-engine/src/ai/miniforge/tui_engine/input.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/input.clj
@@ -17,54 +17,50 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.tui-engine.input
-  "Key event parsing -- normalizes raw Lanterna key events into
-   semantic message keywords for the Elm update loop.
+  "Key event lexer -- normalizes raw Lanterna key events into
+   semantic key tokens for the Elm update loop.
 
-   Raw Lanterna events are maps like {:type :character :char \\j}.
-   This module translates them into normalized TUI messages like :key/j, :key/enter, etc."
+   The lexer table is loaded from config/tui/key-tokens.edn, making
+   the full input pipeline data-driven:
+
+     raw Lanterna event -> key token (this ns, via key-tokens.edn)
+                        -> action token (keybindings.edn)
+                        -> handler fn (action registry)
+
+   Character keys return {:key :key/j :char \\j} (mapped) or
+   {:key nil :char \\x} (unmapped). Special keys return bare
+   keywords like :key/enter."
   (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [ai.miniforge.tui-engine.screen :as screen]))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
-;; Key normalization
+;; Lexer table (EDN-driven)
+
+(def ^:private key-tokens
+  "Lexer config loaded from EDN. Two sections:
+   :char-keys    — string->keyword map (converted to char->keyword at load time)
+   :special-keys — Lanterna event type keyword -> key token keyword"
+  (-> (io/resource "config/tui/key-tokens.edn")
+      slurp
+      edn/read-string))
 
 (def ^:private char-key-map
-  "Map single characters to semantic key names."
-  {\j     :key/j
-   \k     :key/k
-   \h     :key/h
-   \l     :key/l
-   \g     :key/g
-   \G     :key/G
-   \q     :key/q
-   \1     :key/d1
-   \2     :key/d2
-   \3     :key/d3
-   \4     :key/d4
-   \5     :key/d5
-   \6     :key/d6
-   \7     :key/d7
-   \8     :key/d8
-   \9     :key/d9
-   \0     :key/d0
-   \r     :key/r
-   \s     :key/s
-   \b     :key/b
-   \e     :key/e
-   \f     :key/f
-   \o     :key/o
-   \x     :key/x
-   \a     :key/a
-   \v     :key/v
-   \c     :key/c
-   \/     :key/slash
-   \:     :key/colon
-   \space :key/space
-   \tab   :key/tab
-   \?     :key/question
-   \y     :key/y
-   \n     :key/n
-   \N     :key/N})
+  "Map single characters to semantic key tokens.
+   Built from :char-keys in key-tokens.edn.
+   Single-char strings are converted to char keys for O(1) lookup."
+  (into {}
+    (map (fn [[s token]] [(first s) token]))
+    (:char-keys key-tokens)))
+
+(def ^:private special-key-map
+  "Map Lanterna event type keywords to semantic key tokens.
+   Loaded directly from :special-keys in key-tokens.edn."
+  (:special-keys key-tokens))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Key normalization
 
 (defn normalize-key
   "Convert a raw Lanterna key event map to a normalized message.
@@ -76,25 +72,12 @@
    Special keys return bare keywords: :key/enter, :key/escape, etc."
   [raw-event]
   (when raw-event
-    (case (:type raw-event)
-      :character
-      (let [ch (:char raw-event)
-            semantic (get char-key-map ch)]
-        {:key semantic :char ch})
-
-      :enter     :key/enter
-      :escape    :key/escape
-      :backspace :key/backspace
-      :arrow-up  :key/up
-      :arrow-down :key/down
-      :arrow-left :key/left
-      :arrow-right :key/right
-      :tab         :key/tab
-      :reverse-tab :key/shift-tab
-      :eof         :key/eof
-
-      ;; Unknown key type
-      nil)))
+    (let [event-type (:type raw-event)]
+      (if (= :character event-type)
+        (let [ch (:char raw-event)
+              semantic (get char-key-map ch)]
+          {:key semantic :char ch})
+        (get special-key-map event-type)))))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
 ;; Input polling

--- a/components/tui-engine/test/ai/miniforge/tui_engine/input_test.clj
+++ b/components/tui-engine/test/ai/miniforge/tui_engine/input_test.clj
@@ -18,6 +18,8 @@
 
 (ns ai.miniforge.tui-engine.input-test
   (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.tui-engine.input :as input]))
 
@@ -66,5 +68,41 @@
     (let [result (input/normalize-key {:type :character :char \m})]
       (is (= {:key nil :char \m} result))))
 
+  (testing "Unknown event types return nil"
+    (is (nil? (input/normalize-key {:type :unknown-key-type})))
+    (is (nil? (input/normalize-key {:type :f1}))))
+
   (testing "nil input returns nil"
     (is (nil? (input/normalize-key nil)))))
+
+(deftest key-tokens-edn-test
+  (testing "key-tokens.edn is loadable and well-formed"
+    (let [tokens (-> (io/resource "config/tui/key-tokens.edn")
+                     slurp
+                     edn/read-string)]
+      (is (map? (:char-keys tokens))
+          "char-keys section exists and is a map")
+      (is (map? (:special-keys tokens))
+          "special-keys section exists and is a map")
+
+      (testing "all char-keys are single-char strings -> :key/* keywords"
+        (doseq [[s token] (:char-keys tokens)]
+          (is (string? s) (str "char-key key must be a string: " s))
+          (is (= 1 (count s)) (str "char-key must be single char: " s))
+          (is (= "key" (namespace token))
+              (str "char-key value must be :key/* keyword: " token))))
+
+      (testing "all special-keys are keyword -> :key/* keyword"
+        (doseq [[event-type token] (:special-keys tokens)]
+          (is (keyword? event-type)
+              (str "special-key key must be a keyword: " event-type))
+          (is (= "key" (namespace token))
+              (str "special-key value must be :key/* keyword: " token))))
+
+      (testing "char-keys and special-keys cover expected tokens"
+        (let [all-tokens (set (concat (vals (:char-keys tokens))
+                                      (vals (:special-keys tokens))))]
+          (is (contains? all-tokens :key/j))
+          (is (contains? all-tokens :key/enter))
+          (is (contains? all-tokens :key/escape))
+          (is (contains? all-tokens :key/tab)))))))

--- a/components/tui-views/resources/config/tui/keybindings.edn
+++ b/components/tui-views/resources/config/tui/keybindings.edn
@@ -1,0 +1,80 @@
+;; TUI keybinding configuration — maps key tokens to semantic actions.
+;;
+;; Key tokens (:key/j, :key/enter, etc.) are produced by tui-engine input.clj.
+;; Actions (:action/navigate-down, etc.) are resolved to handler functions at
+;; runtime by the action registry in update.clj.
+;;
+;; Keybindings are grouped by mode. Within :normal mode, :context-keys are
+;; actions that depend on the current view (repo-manager, pr-fleet, etc.)
+;; and are resolved by the context-action-handlers registry.
+
+{:help
+ {:key/question :action/toggle-help
+  :key/escape   :action/toggle-help
+  :key/q        :action/quit}
+
+ :normal
+ {;; Navigation
+  :key/j         :action/navigate-down
+  :key/k         :action/navigate-up
+  :key/down      :action/navigate-down
+  :key/up        :action/navigate-up
+  :key/g         :action/navigate-top
+  :key/G         :action/navigate-bottom
+  :key/left      :action/navigate-prev-item
+  :key/right     :action/navigate-next-item
+
+  ;; Drill in/out
+  :key/l         :action/enter-detail
+  :key/h         :action/go-back
+  :key/enter     :action/enter-or-confirm
+  :key/escape    :action/escape-cascade
+
+  ;; Mode switching
+  :key/colon     :action/enter-command-mode
+  :key/slash     :action/enter-search-mode
+
+  ;; Search navigation
+  :key/n         :action/next-search-match
+  :key/N         :action/prev-search-match
+
+  ;; Selection
+  :key/space     :action/toggle-or-expand
+  :key/v         :action/enter-visual-mode
+  :key/a         :action/select-all
+  :key/c         :action/clear-selection
+
+  ;; View-context actions
+  :key/r         :action/refresh-or-sync
+  :key/s         :action/sync
+  :key/b         :action/browse-or-kanban
+  :key/e         :action/evidence-view
+  :key/f         :action/fleet-view
+  :key/o         :action/open-browse
+  :key/x         :action/remove-repos
+  :key/question  :action/toggle-help
+  :key/q         :action/quit
+
+  ;; Pane cycling
+  :key/tab       :action/cycle-tab
+  :key/shift-tab :action/cycle-tab-reverse}
+
+ :command
+ {:key/escape    :action/command-escape
+  :key/enter     :action/command-enter
+  :key/tab       :action/completion-tab
+  :key/shift-tab :action/completion-shift-tab
+  :key/backspace :action/command-backspace
+  ;; :key/down and :key/up handled contextually when completing
+  :key/down      :action/completion-next
+  :key/up        :action/completion-prev}
+
+ :search
+ {:key/escape    :action/exit-mode
+  :key/enter     :action/confirm-search
+  :key/backspace :action/search-backspace}
+
+ ;; Number keys → view switching (shared across modes)
+ :number-keys
+ {:key/d1 0 :key/d2 1 :key/d3 2 :key/d4 3 :key/d5 4
+  :key/d6 5 :key/d7 6 :key/d8 7 :key/d9 8 :key/d0 9}}

--- a/components/tui-views/src/ai/miniforge/tui_views/model.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/model.clj
@@ -30,34 +30,69 @@
   "Create the initial application model.
 
    Model shape:
-   {:view          kw           ; Active view (:workflow-list :workflow-detail :evidence :artifact-browser :dag-kanban)
+   {:view          kw           ; Active view (see `views` vector below)
     :workflows     [...]        ; Vector of workflow summary maps
+    :trains        [...]        ; Vector of train summary maps (N9)
+    :pr-items      [...]        ; Flat list of PR work items across trains (N9)
+   :fleet-repos   [...]        ; Configured fleet repositories
+    :repo-manager-source kw    ; :fleet or :browse list in Repos view
     :selected-idx  int          ; Selected item in current list
     :scroll-offset int          ; Scroll offset for long lists
     :detail        map          ; Drill-down state for detail views
     :mode          kw           ; :normal :command :search
     :command-buf   str          ; Command/search input buffer
     :search-results [...]       ; Fuzzy search results
+    :filtered-indices set       ; Set of matching visible-list indices during search (nil = show all)
     :last-updated  inst         ; Timestamp of last data update
     :flash-message str          ; Temporary status bar message
-    :theme         kw}          ; Active theme name"
+    :help-visible? bool         ; Whether help overlay is shown
+    :theme         kw           ; Active theme name
+    :selected-ids    set          ; Set of selected item IDs (UUIDs or composite keys)
+    :visual-anchor   int-or-nil   ; Index where visual mode started (nil = not active)
+    :confirm         map-or-nil   ; Confirmation prompt {:action :label :ids} or nil
+    :search-matches  vec          ; Vector of {:line-idx N} match descriptors (find-in-page)
+    :search-match-idx int-or-nil} ; Current match index into search-matches (nil = none)"
   []
-  {:view          :workflow-list
+  {:view          :pr-fleet
    :workflows     []
+   :trains        []
+   :pr-items      []
+   :fleet-repos   []
+   :repo-manager-source :fleet
    :selected-idx  0
    :scroll-offset 0
-   :detail        {:workflow-id nil
-                   :phases      []
-                   :current-agent nil
-                   :agent-output ""
-                   :evidence    nil
-                   :artifacts   []}
+   :detail        {:workflow-id    nil
+                   :phases         []
+                   :current-agent  nil
+                   :agent-output   ""
+                   :evidence       nil
+                   :artifacts      []
+                   :expanded-nodes #{}
+                   :focused-pane   0
+                   :selected-pr    nil
+                   :pr-readiness   nil
+                   :pr-risk        nil
+                   :selected-train nil}
    :mode          :normal
    :command-buf   ""
    :search-results []
+   :filtered-indices nil
    :last-updated  nil
    :flash-message nil
-   :theme         :default})
+   :help-visible? false
+   :theme         :default
+   :selected-ids    #{}
+   :visual-anchor   nil
+   :confirm         nil
+   :search-matches  []
+   :search-match-idx nil
+   ;; Tab completion
+   :completions    []
+   :completion-idx nil
+   :completing?    false
+   ;; Browse repos cache (populated by :browse-repos side-effect)
+   :browse-repos   []
+   :browse-repos-loading? false})
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Workflow data shape
@@ -65,27 +100,63 @@
 (defn make-workflow
   "Create a workflow summary map for the model."
   [{:keys [id name status phase progress started-at]}]
-  {:id         id
-   :name       (or name (str "workflow-" (subs (str id) 0 8)))
-   :status     (or status :pending)
-   :phase      phase
-   :progress   (or progress 0)
-   :started-at started-at
-   :agents     {}})
+  {:id           id
+   :name         (or name (str "workflow-" (subs (str id) 0 8)))
+   :status       (or status :pending)
+   :phase        phase
+   :progress     (or progress 0)
+   :started-at   started-at
+   :agents       {}
+   :gate-results []})
 
 ;------------------------------------------------------------------------------ Layer 2
+;; Repo manager helpers
+
+(defn fleet-repos
+  "Configured repositories in fleet."
+  [model]
+  (vec (or (:fleet-repos model) [])))
+
+(defn browse-candidate-repos
+  "Remote browse candidates that are NOT already configured in fleet."
+  [model]
+  (let [fleet (set (fleet-repos model))]
+    (->> (or (:browse-repos model) [])
+         (remove fleet)
+         vec)))
+
+(defn repo-manager-items
+  "Visible repository rows for repo-manager based on :repo-manager-source."
+  [model]
+  (if (= :browse (:repo-manager-source model))
+    (browse-candidate-repos model)
+    (fleet-repos model)))
+
+;------------------------------------------------------------------------------ Layer 3
 ;; View predicates
 
+(def top-level-views
+  "Top-level aggregate views reachable by Tab cycling."
+  [:pr-fleet :workflow-list :evidence :artifact-browser :dag-kanban :repo-manager])
+
+(def detail-views
+  "Detail views entered via Enter from an aggregate."
+  [:workflow-detail :pr-detail :train-view])
+
 (def views
-  "All available views in navigation order."
-  [:workflow-list :workflow-detail :evidence :artifact-browser :dag-kanban])
+  "All available views in canonical order."
+  (vec (concat top-level-views detail-views)))
 
 (def view-labels
-  {:workflow-list    "Workflows"
-   :workflow-detail  "Detail"
+  {:pr-fleet         "PR Fleet"
+   :workflow-list    "Workflows"
    :evidence         "Evidence"
    :artifact-browser "Artifacts"
-   :dag-kanban       "DAG Kanban"})
+   :dag-kanban       "DAG Kanban"
+   :repo-manager     "Repos"
+   :workflow-detail  "Detail"
+   :pr-detail        "PR Detail"
+   :train-view       "Train"})
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tui-views/src/ai/miniforge/tui_views/update.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update.clj
@@ -25,56 +25,339 @@
 
    Layers 4-5: Input handling + root update function."
   (:require
+   [clojure.set :as set]
+   [clojure.string :as str]
    [ai.miniforge.tui-views.model :as model]
    [ai.miniforge.tui-views.update.navigation :as nav]
    [ai.miniforge.tui-views.update.events :as events]
-   [ai.miniforge.tui-views.update.mode :as mode]))
+   [ai.miniforge.tui-views.update.mode :as mode]
+   [ai.miniforge.tui-views.update.command :as command]
+   [ai.miniforge.tui-views.update.completion :as completion]
+   [ai.miniforge.tui-views.update.selection :as sel]))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Input message handling
 
-(defn- handle-normal-input [model key]
-  (case key
-    :key/j         (nav/navigate-down model)
-    :key/k         (nav/navigate-up model)
-    :key/down      (nav/navigate-down model)
-    :key/up        (nav/navigate-up model)
-    :key/g         (nav/navigate-top model)
-    :key/G         (nav/navigate-bottom model)
-    :key/enter     (nav/enter-detail model)
-    :key/escape    (nav/go-back model)
-    :key/l         (nav/enter-detail model)
-    :key/h         (nav/go-back model)
-    :key/colon     (mode/enter-command-mode model)
-    :key/slash     (mode/enter-search-mode model)
-    :key/d1        (nav/switch-view model :workflow-list model/views)
-    :key/d2        (nav/switch-view model :workflow-detail model/views)
-    :key/d3        (nav/switch-view model :evidence model/views)
-    :key/d4        (nav/switch-view model :artifact-browser model/views)
-    :key/d5        (nav/switch-view model :dag-kanban model/views)
-    :key/q         (assoc model :quit? true)
-    ;; Unknown key -- no-op
+(defn- extract-key
+  "Extract the semantic key from a normalized input event.
+   Maps return :key, bare keywords pass through."
+  [key]
+  (if (map? key) (:key key) key))
+
+(defn- extract-char
+  "Extract the raw character from a normalized input event.
+   Maps return :char, bare keywords return nil."
+  [key]
+  (when (map? key) (:char key)))
+
+(defn- in-repo-manager?
+  [model]
+  (= :repo-manager (:view model)))
+
+(defn- repo-manager-source
+  [model]
+  (if (= :browse (:repo-manager-source model)) :browse :fleet))
+
+(defn- reset-repo-manager-state
+  [model source]
+  (assoc model
+         :repo-manager-source source
+         :selected-idx 0
+         :filtered-indices nil
+         :search-matches []
+         :search-match-idx nil
+         :selected-ids #{}
+         :visual-anchor nil))
+
+(defn- selected-repos
+  [model]
+  (->> (sel/effective-ids model)
+       (filter string?)
+       distinct
+       vec))
+
+(defn- repo-manager-open-browse
+  [model provider]
+  (let [m (reset-repo-manager-state model :browse)]
+    (if (:browse-repos-loading? model)
+      (assoc m :flash-message "Browsing remote repos...")
+      (assoc m
+             :side-effect {:type :browse-repos
+                           :source :repo-manager
+                           :provider provider}
+             :browse-repos-loading? true
+             :flash-message (str "Browsing " (name provider) " repos...")))))
+
+(defn- repo-manager-add-selected
+  [model]
+  (let [repos (selected-repos model)]
+    (if (empty? repos)
+      (assoc model :flash-message "No remote repository selected.")
+      (let [before (set (:fleet-repos model))
+            m (reduce (fn [acc repo]
+                        (command/execute-command acc (str ":add-repo " repo)))
+                      model
+                      repos)
+            after (set (:fleet-repos m))
+            added (count (set/difference after before))]
+        (if (pos? added)
+          (-> (reset-repo-manager-state m :browse)
+              (assoc :side-effect {:type :sync-prs}
+                     :flash-message (str "Added " added " repo(s) to fleet. Syncing PRs...")))
+          (-> (reset-repo-manager-state m :browse)
+              (assoc :flash-message "Selected repos already in fleet.")))))))
+
+(defn- repo-manager-request-remove
+  [model]
+  (let [repos (selected-repos model)]
+    (if (empty? repos)
+      (assoc model :flash-message "No configured repository selected.")
+      (assoc model :confirm
+             {:action :remove-repos
+              :label "Remove Repositories"
+              :ids (set repos)}))))
+
+(defn- number-key-index
+  [k]
+  (case k
+    :key/d1 0
+    :key/d2 1
+    :key/d3 2
+    :key/d4 3
+    :key/d5 4
+    :key/d6 5
+    :key/d7 6
+    :key/d8 7
+    :key/d9 8
+    :key/d0 9
+    nil))
+
+(defn- clear-detail-context
+  [model]
+  (-> model
+      (assoc-in [:detail :workflow-id] nil)
+      (assoc-in [:detail :selected-pr] nil)
+      (assoc-in [:detail :selected-train] nil)))
+
+(defn- switch-numbered-view
+  "Switch view by number within the current abstraction level (1-0)."
+  [model key]
+  (if-let [idx (number-key-index key)]
+    (let [level-views (nav/current-level-views model)
+          target (nth level-views idx nil)]
+      (if target
+        (let [m (nav/switch-view model target model/views)]
+          (if (= level-views model/top-level-views)
+            (clear-detail-context m)
+            m))
+        model))
     model))
 
+(defn- handle-normal-input [model key]
+  (let [k (extract-key key)]
+    ;; When help overlay is visible, only allow dismiss keys
+    (if (:help-visible? model)
+      (case k
+        :key/question  (nav/toggle-help model)
+        :key/escape    (nav/toggle-help model)
+        :key/q         (assoc model :quit? true)
+        ;; All other keys blocked while help is showing
+        model)
+      ;; Normal mode -- vi-style key handling
+      (case k
+        ;; Navigation (+ visual range update)
+        :key/j         (-> (nav/navigate-down model) sel/update-visual-selection)
+        :key/k         (-> (nav/navigate-up model) sel/update-visual-selection)
+        :key/down      (-> (nav/navigate-down model) sel/update-visual-selection)
+        :key/up        (-> (nav/navigate-up model) sel/update-visual-selection)
+        :key/g         (-> (nav/navigate-top model) sel/update-visual-selection)
+        :key/G         (-> (nav/navigate-bottom model) sel/update-visual-selection)
+
+        ;; Drill in / out
+        :key/enter     (if (and (in-repo-manager? model)
+                                (= :browse (repo-manager-source model)))
+                         (repo-manager-add-selected model)
+                         (nav/enter-detail model))
+        :key/escape    (cond
+                         (:visual-anchor model)          (sel/exit-visual-mode model)
+                         (seq (:selected-ids model))     (sel/clear-selection model)
+                         (:filtered-indices model)       (assoc model :filtered-indices nil
+                                                                      :selected-idx 0)
+                         (seq (:search-matches model))   (assoc model :search-matches []
+                                                                      :search-match-idx nil)
+                         :else                           (nav/go-back model))
+        :key/l         (nav/enter-detail model)
+        :key/h         (nav/go-back model)
+
+        ;; Mode switching
+        :key/colon     (mode/enter-command-mode model)
+        :key/slash     (mode/enter-search-mode model)
+
+        ;; Search match navigation (n/N — like vim)
+        :key/n         (nav/next-search-match model)
+        :key/N         (nav/prev-search-match model)
+
+        ;; Selection
+        :key/space     (if (#{:workflow-list :pr-fleet :artifact-browser :train-view :repo-manager}
+                            (:view model))
+                         (sel/toggle-selection model)
+                         (nav/toggle-expand model))
+        :key/v         (sel/enter-visual-mode model)
+        :key/a         (sel/select-all model)
+        :key/c         (sel/clear-selection model)
+
+        ;; Detail sibling navigation (left/right arrows)
+        :key/left      (nav/navigate-prev-item model)
+        :key/right     (nav/navigate-next-item model)
+
+        ;; Actions & views
+        :key/r         (if (#{:pr-fleet :repo-manager} (:view model))
+                         (command/execute-command model ":sync")
+                         (nav/refresh model))
+        :key/s         (if (#{:pr-fleet :repo-manager} (:view model))
+                         (command/execute-command model ":sync")
+                         model)
+        :key/b         (if (in-repo-manager? model)
+                         (repo-manager-open-browse model :all)
+                         (nav/switch-view model :dag-kanban model/views))
+        :key/e         (nav/switch-view model :evidence model/views)
+        :key/f         (if (in-repo-manager? model)
+                         (-> (reset-repo-manager-state model :fleet)
+                             (assoc :flash-message "Showing configured repositories."))
+                         model)
+        :key/o         (if (in-repo-manager? model)
+                         (repo-manager-open-browse model :all)
+                         model)
+        :key/x         (if (in-repo-manager? model)
+                         (if (= :fleet (repo-manager-source model))
+                           (repo-manager-request-remove model)
+                           (assoc model :flash-message "Switch to fleet (f) to remove repositories."))
+                         model)
+        :key/question  (nav/toggle-help model)
+        :key/tab       (cond
+                         ;; In workflow detail sub-view context: cycle sub-panes only
+                         ;; (workflow-detail → evidence → artifact-browser → ...)
+                         ;; Esc goes back to the aggregate level.
+                         (nav/in-detail-subview? model)
+                         (nav/cycle-detail-subview model)
+                         ;; Other detail views (pr-detail, train-view): cycle panes
+                         (some #{(:view model)} model/detail-views)
+                         (nav/cycle-pane model)
+                         ;; Top-level aggregate views: cycle among them
+                         (some #{(:view model)} model/top-level-views)
+                         (nav/cycle-top-level-view model)
+                         ;; Fallback
+                         :else model)
+        :key/shift-tab (cond
+                         (nav/in-detail-subview? model)
+                         (nav/cycle-detail-subview-reverse model)
+                         (some #{(:view model)} model/detail-views)
+                         (nav/cycle-pane-reverse model)
+                         (some #{(:view model)} model/top-level-views)
+                         (nav/cycle-top-level-view-reverse model)
+                         :else model)
+        ;; Number keys switch within current abstraction level:
+        ;; top-level (1..N), detail-level (1..N), etc. with 0 as slot 10.
+        :key/d1        (switch-numbered-view model k)
+        :key/d2        (switch-numbered-view model k)
+        :key/d3        (switch-numbered-view model k)
+        :key/d4        (switch-numbered-view model k)
+        :key/d5        (switch-numbered-view model k)
+        :key/d6        (switch-numbered-view model k)
+        :key/d7        (switch-numbered-view model k)
+        :key/d8        (switch-numbered-view model k)
+        :key/d9        (switch-numbered-view model k)
+        :key/d0        (switch-numbered-view model k)
+        :key/q         (assoc model :quit? true)
+        ;; Unknown key -- no-op
+        model))))
+
 (defn- handle-command-input [model key]
-  (case key
-    :key/escape   (mode/exit-mode model)
-    :key/enter    (-> model
-                      (assoc :flash-message (str "Executed: " (:command-buf model)))
-                      mode/exit-mode)
-    :key/backspace (mode/command-backspace model)
-    ;; Character input
-    (if (and (map? key) (= :char (:type key)))
-      (mode/command-append model (:char key))
-      model)))
+  (let [k (extract-key key)]
+    (cond
+      ;; Escape: dismiss completions if open, otherwise exit command mode
+      (= k :key/escape)
+      (if (:completing? model)
+        (completion/dismiss model)
+        (mode/exit-mode model))
+
+      ;; Enter: accept completion if popup open with selection, otherwise execute
+      (= k :key/enter)
+      (if (and (:completing? model) (:completion-idx model))
+        (completion/accept model)
+        (let [buf (:command-buf model)
+              cmd-name (subs buf 1)
+              exact-cmd? (and (not (str/blank? cmd-name))
+                              (not (str/includes? cmd-name " "))
+                              (some #{cmd-name} (command/complete-command-name cmd-name)))
+              arg-completion? (when exact-cmd?
+                                (let [result (command/compute-completions model (str ":" cmd-name " "))]
+                                  (or (seq (:completions result))
+                                      (:side-effect result))))]
+          (if arg-completion?
+            ;; For commands like :theme or :add-repo, Enter opens argument picker.
+            (completion/handle-tab model)
+            (-> (command/execute-command model (:command-buf model))
+                mode/exit-mode))))
+
+      ;; Tab: open or cycle completions
+      (= k :key/tab)
+      (completion/handle-tab model)
+
+      ;; Shift+Tab: open or reverse-cycle completions
+      (= k :key/shift-tab)
+      (completion/handle-shift-tab model)
+
+      ;; Arrow keys: navigate completions if popup is open
+      (and (:completing? model) (= k :key/down))
+      (completion/next-completion model)
+
+      (and (:completing? model) (= k :key/up))
+      (completion/prev-completion model)
+
+      ;; Backspace: delete char and dismiss completions
+      (= k :key/backspace)
+      (-> (mode/command-backspace model)
+          completion/dismiss)
+
+      ;; Character input — all chars (mapped and unmapped) carry :char
+      :else
+      (if-let [ch (extract-char key)]
+        (-> (mode/command-append model ch)
+            completion/dismiss)
+        model))))
 
 (defn- handle-search-input [model key]
-  (case key
-    :key/escape   (mode/exit-mode model)
-    :key/enter    (mode/exit-mode model)
-    :key/backspace (mode/command-backspace model)
-    (if (and (map? key) (= :char (:type key)))
-      (mode/command-append model (:char key))
+  (let [k (extract-key key)]
+    (case k
+      :key/escape   (mode/exit-mode model)         ;; abort — clear filter
+      :key/enter    (mode/confirm-search model)     ;; confirm — keep filter active
+      :key/backspace (mode/command-backspace model)
+      ;; Character input — all chars (mapped and unmapped) carry :char
+      (if-let [ch (extract-char key)]
+        (-> model
+            (mode/command-append ch)
+            mode/compute-search-results)
+        model))))
+
+(defn- refresh-add-repo-completions-if-active
+  "If command-mode add-repo picker is currently open, refresh its options."
+  [model]
+  (try
+    (let [active? (and (= :command (:mode model))
+                       (:completing? model)
+                       (str/starts-with? (:command-buf model "") ":add-repo "))]
+      (if-not active?
+        model
+        (let [result (command/compute-completions model (:command-buf model))
+              completions (vec (or (:completions result) []))
+              n (count completions)
+              prior-idx (or (:completion-idx model) 0)]
+          (assoc model
+                 :completions completions
+                 :completion-idx (when (pos? n) (min prior-idx (dec n)))
+                 :completing? (pos? n)))))
+    (catch Exception _
       model)))
 
 ;------------------------------------------------------------------------------ Layer 5
@@ -92,11 +375,22 @@
     (case msg-type
       ;; User input
       :input
-      (case (:mode model)
-        :normal  (handle-normal-input model payload)
-        :command (handle-command-input model payload)
-        :search  (handle-search-input model payload)
-        model)
+      (if (:confirm model)
+        ;; Confirmation prompt active -- only y/n/escape accepted
+        (let [k (extract-key payload)]
+          (case k
+            :key/y     (-> model
+                           (command/execute-confirmed-action)
+                           (assoc :confirm nil))
+            :key/n     (assoc model :confirm nil :flash-message "Cancelled")
+            :key/escape (assoc model :confirm nil :flash-message "Cancelled")
+            model))
+        ;; Normal input routing by mode
+        (case (:mode model)
+          :normal  (handle-normal-input model payload)
+          :command (handle-command-input model payload)
+          :search  (handle-search-input model payload)
+          model))
 
       ;; Event stream messages
       :msg/workflow-added   (events/handle-workflow-added model payload)
@@ -107,6 +401,22 @@
       :msg/workflow-done    (events/handle-workflow-done model payload)
       :msg/workflow-failed  (events/handle-workflow-failed model payload)
       :msg/gate-result      (events/handle-gate-result model payload)
+
+      ;; PR fleet messages
+      :msg/prs-synced       (events/handle-prs-synced model payload)
+      :msg/pr-updated       (events/handle-pr-updated model payload)
+      :msg/pr-removed       (events/handle-pr-removed model payload)
+      :msg/repos-discovered (events/handle-repos-discovered model payload)
+      :msg/repos-browsed    (-> (events/handle-repos-browsed model payload)
+                                refresh-add-repo-completions-if-active)
+
+      ;; Side-effect error
+      :msg/side-effect-error
+      (cond-> (assoc model :flash-message
+                     (str "Effect error (" (name (or (:type payload) :unknown)) "): "
+                          (:error payload)))
+        (= :browse-repos (:type payload))
+        (assoc :browse-repos-loading? false))
 
       ;; Tick (for clock/timing updates, currently unused)
       :tick model
@@ -122,7 +432,7 @@
   (-> m
       (update-model [:msg/workflow-added {:workflow-id (random-uuid) :name "test"}])
       (update-model [:msg/workflow-added {:workflow-id (random-uuid) :name "test-2"}])
-      (update-model [:input :key/j])
+      (update-model [:input {:key :key/j :char \j}])
       :selected-idx)
   ;; => 1
 

--- a/components/tui-views/src/ai/miniforge/tui_views/update.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update.clj
@@ -23,8 +23,14 @@
    stratified sub-namespaces (navigation, events, mode) and provides input
    handling and root update dispatch.
 
+   Keybindings are loaded from config/tui/keybindings.edn as data.
+   Each key maps to a semantic :action/* token, and action tokens
+   resolve to handler fns via the action registry (parser pattern).
+
    Layers 4-5: Input handling + root update function."
   (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.set :as set]
    [clojure.string :as str]
    [ai.miniforge.tui-views.model :as model]
@@ -36,7 +42,25 @@
    [ai.miniforge.tui-views.update.selection :as sel]))
 
 ;------------------------------------------------------------------------------ Layer 4
-;; Input message handling
+;; Keybinding configuration (EDN-driven parser pattern)
+;;
+;; Flow: raw char → key token (input.clj) → action token (keybindings.edn)
+;;       → handler fn (action registry below)
+
+(def ^:private keybindings
+  "Keybinding config loaded from EDN. Maps key tokens to action tokens,
+   grouped by mode (:help, :normal, :command, :search, :number-keys)."
+  (-> (io/resource "config/tui/keybindings.edn")
+      slurp
+      edn/read-string))
+
+(def ^:private normal-keybindings  (:normal keybindings))
+(def ^:private help-keybindings    (:help keybindings))
+(def ^:private command-keybindings (:command keybindings))
+(def ^:private search-keybindings  (:search keybindings))
+(def ^:private number-key->index   (:number-keys keybindings))
+
+;; ── Input event helpers ──
 
 (defn- extract-key
   "Extract the semantic key from a normalized input event.
@@ -49,6 +73,8 @@
    Maps return :char, bare keywords return nil."
   [key]
   (when (map? key) (:char key)))
+
+;; ── Repo manager helpers ──
 
 (defn- in-repo-manager?
   [model]
@@ -117,21 +143,6 @@
               :label "Remove Repositories"
               :ids (set repos)}))))
 
-(defn- number-key-index
-  [k]
-  (case k
-    :key/d1 0
-    :key/d2 1
-    :key/d3 2
-    :key/d4 3
-    :key/d5 4
-    :key/d6 5
-    :key/d7 6
-    :key/d8 7
-    :key/d9 8
-    :key/d0 9
-    nil))
-
 (defn- clear-detail-context
   [model]
   (-> model
@@ -142,7 +153,7 @@
 (defn- switch-numbered-view
   "Switch view by number within the current abstraction level (1-0)."
   [model key]
-  (if-let [idx (number-key-index key)]
+  (if-let [idx (number-key->index key)]
     (let [level-views (nav/current-level-views model)
           target (nth level-views idx nil)]
       (if target
@@ -153,186 +164,218 @@
         model))
     model))
 
+;; ── Navigation with visual selection ──
+
+(defn- nav-down-with-visual  [m] (-> (nav/navigate-down m)   sel/update-visual-selection))
+(defn- nav-up-with-visual    [m] (-> (nav/navigate-up m)     sel/update-visual-selection))
+(defn- nav-top-with-visual   [m] (-> (nav/navigate-top m)    sel/update-visual-selection))
+(defn- nav-bottom-with-visual [m] (-> (nav/navigate-bottom m) sel/update-visual-selection))
+
+;; ── Action registries ──
+;;
+;; Maps :action/* tokens → handler (fn [model] -> model').
+;; The keybinding EDN maps key tokens → action tokens; these registries
+;; resolve action tokens to concrete handler functions.
+
+(def ^:private selectable-views
+  #{:workflow-list :pr-fleet :artifact-browser :train-view :repo-manager})
+
+(def ^:private action-handlers
+  "Action token → handler function registry.
+   Actions that are context-free (same behavior regardless of view)."
+  {:action/navigate-down      nav-down-with-visual
+   :action/navigate-up        nav-up-with-visual
+   :action/navigate-top       nav-top-with-visual
+   :action/navigate-bottom    nav-bottom-with-visual
+   :action/navigate-prev-item nav/navigate-prev-item
+   :action/navigate-next-item nav/navigate-next-item
+   :action/enter-detail       nav/enter-detail
+   :action/go-back            nav/go-back
+   :action/enter-command-mode mode/enter-command-mode
+   :action/enter-search-mode  mode/enter-search-mode
+   :action/next-search-match  nav/next-search-match
+   :action/prev-search-match  nav/prev-search-match
+   :action/enter-visual-mode  sel/enter-visual-mode
+   :action/select-all         sel/select-all
+   :action/clear-selection    sel/clear-selection
+   :action/evidence-view      #(nav/switch-view % :evidence model/views)
+   :action/toggle-help        nav/toggle-help
+   :action/quit               #(assoc % :quit? true)})
+
+(def ^:private context-action-handlers
+  "Action token → handler for actions that depend on view context."
+  {:action/enter-or-confirm
+   (fn [model]
+     (if (and (in-repo-manager? model) (= :browse (repo-manager-source model)))
+       (repo-manager-add-selected model)
+       (nav/enter-detail model)))
+
+   :action/escape-cascade
+   (fn [model]
+     (cond
+       (:visual-anchor model)        (sel/exit-visual-mode model)
+       (seq (:selected-ids model))   (sel/clear-selection model)
+       (:filtered-indices model)     (assoc model :filtered-indices nil :selected-idx 0)
+       (seq (:search-matches model)) (assoc model :search-matches [] :search-match-idx nil)
+       :else                         (nav/go-back model)))
+
+   :action/toggle-or-expand
+   (fn [model]
+     (if (selectable-views (:view model))
+       (sel/toggle-selection model)
+       (nav/toggle-expand model)))
+
+   :action/refresh-or-sync
+   (fn [model]
+     (if (#{:pr-fleet :repo-manager} (:view model))
+       (command/execute-command model ":sync")
+       (nav/refresh model)))
+
+   :action/sync
+   (fn [model]
+     (if (#{:pr-fleet :repo-manager} (:view model))
+       (command/execute-command model ":sync")
+       model))
+
+   :action/browse-or-kanban
+   (fn [model]
+     (if (in-repo-manager? model)
+       (repo-manager-open-browse model :all)
+       (nav/switch-view model :dag-kanban model/views)))
+
+   :action/fleet-view
+   (fn [model]
+     (if (in-repo-manager? model)
+       (-> (reset-repo-manager-state model :fleet)
+           (assoc :flash-message "Showing configured repositories."))
+       model))
+
+   :action/open-browse
+   (fn [model]
+     (if (in-repo-manager? model)
+       (repo-manager-open-browse model :all)
+       model))
+
+   :action/remove-repos
+   (fn [model]
+     (if (in-repo-manager? model)
+       (if (= :fleet (repo-manager-source model))
+         (repo-manager-request-remove model)
+         (assoc model :flash-message "Switch to fleet (f) to remove repositories."))
+       model))
+
+   :action/cycle-tab
+   (fn [model]
+     (cond
+       (nav/in-detail-subview? model)                (nav/cycle-detail-subview model)
+       (some #{(:view model)} model/detail-views)    (nav/cycle-pane model)
+       (some #{(:view model)} model/top-level-views) (nav/cycle-top-level-view model)
+       :else                                         model))
+
+   :action/cycle-tab-reverse
+   (fn [model]
+     (cond
+       (nav/in-detail-subview? model)                (nav/cycle-detail-subview-reverse model)
+       (some #{(:view model)} model/detail-views)    (nav/cycle-pane-reverse model)
+       (some #{(:view model)} model/top-level-views) (nav/cycle-top-level-view-reverse model)
+       :else                                         model))})
+
+(defn- resolve-action
+  "Look up handler fn for an action token."
+  [action]
+  (or (action-handlers action)
+      (context-action-handlers action)))
+
+;; ── Normal mode input ──
+
 (defn- handle-normal-input [model key]
   (let [k (extract-key key)]
-    ;; When help overlay is visible, only allow dismiss keys
     (if (:help-visible? model)
-      (case k
-        :key/question  (nav/toggle-help model)
-        :key/escape    (nav/toggle-help model)
-        :key/q         (assoc model :quit? true)
-        ;; All other keys blocked while help is showing
+      ;; Help overlay: only help-keybinding actions accepted
+      (if-let [action (help-keybindings k)]
+        (if-let [handler (resolve-action action)]
+          (handler model)
+          model)
         model)
-      ;; Normal mode -- vi-style key handling
-      (case k
-        ;; Navigation (+ visual range update)
-        :key/j         (-> (nav/navigate-down model) sel/update-visual-selection)
-        :key/k         (-> (nav/navigate-up model) sel/update-visual-selection)
-        :key/down      (-> (nav/navigate-down model) sel/update-visual-selection)
-        :key/up        (-> (nav/navigate-up model) sel/update-visual-selection)
-        :key/g         (-> (nav/navigate-top model) sel/update-visual-selection)
-        :key/G         (-> (nav/navigate-bottom model) sel/update-visual-selection)
+      ;; Normal mode: resolve key → action → handler, then number keys
+      (if-let [action (normal-keybindings k)]
+        (if-let [handler (resolve-action action)]
+          (handler model)
+          model)
+        (if (number-key->index k)
+          (switch-numbered-view model k)
+          model)))))
 
-        ;; Drill in / out
-        :key/enter     (if (and (in-repo-manager? model)
-                                (= :browse (repo-manager-source model)))
-                         (repo-manager-add-selected model)
-                         (nav/enter-detail model))
-        :key/escape    (cond
-                         (:visual-anchor model)          (sel/exit-visual-mode model)
-                         (seq (:selected-ids model))     (sel/clear-selection model)
-                         (:filtered-indices model)       (assoc model :filtered-indices nil
-                                                                      :selected-idx 0)
-                         (seq (:search-matches model))   (assoc model :search-matches []
-                                                                      :search-match-idx nil)
-                         :else                           (nav/go-back model))
-        :key/l         (nav/enter-detail model)
-        :key/h         (nav/go-back model)
+;; ── Command mode input ──
 
-        ;; Mode switching
-        :key/colon     (mode/enter-command-mode model)
-        :key/slash     (mode/enter-search-mode model)
+(defn- command-escape
+  "Escape in command mode: dismiss completions if open, else exit."
+  [model]
+  (if (:completing? model)
+    (completion/dismiss model)
+    (mode/exit-mode model)))
 
-        ;; Search match navigation (n/N — like vim)
-        :key/n         (nav/next-search-match model)
-        :key/N         (nav/prev-search-match model)
+(defn- command-enter
+  "Enter in command mode: accept completion, open arg picker, or execute."
+  [model]
+  (if (and (:completing? model) (:completion-idx model))
+    (completion/accept model)
+    (let [buf (:command-buf model)
+          cmd-name (subs buf 1)
+          exact-cmd? (and (not (str/blank? cmd-name))
+                          (not (str/includes? cmd-name " "))
+                          (some #{cmd-name} (command/complete-command-name cmd-name)))
+          arg-completion? (when exact-cmd?
+                            (let [result (command/compute-completions model (str ":" cmd-name " "))]
+                              (or (seq (:completions result))
+                                  (:side-effect result))))]
+      (if arg-completion?
+        (completion/handle-tab model)
+        (-> (command/execute-command model buf)
+            mode/exit-mode)))))
 
-        ;; Selection
-        :key/space     (if (#{:workflow-list :pr-fleet :artifact-browser :train-view :repo-manager}
-                            (:view model))
-                         (sel/toggle-selection model)
-                         (nav/toggle-expand model))
-        :key/v         (sel/enter-visual-mode model)
-        :key/a         (sel/select-all model)
-        :key/c         (sel/clear-selection model)
-
-        ;; Detail sibling navigation (left/right arrows)
-        :key/left      (nav/navigate-prev-item model)
-        :key/right     (nav/navigate-next-item model)
-
-        ;; Actions & views
-        :key/r         (if (#{:pr-fleet :repo-manager} (:view model))
-                         (command/execute-command model ":sync")
-                         (nav/refresh model))
-        :key/s         (if (#{:pr-fleet :repo-manager} (:view model))
-                         (command/execute-command model ":sync")
-                         model)
-        :key/b         (if (in-repo-manager? model)
-                         (repo-manager-open-browse model :all)
-                         (nav/switch-view model :dag-kanban model/views))
-        :key/e         (nav/switch-view model :evidence model/views)
-        :key/f         (if (in-repo-manager? model)
-                         (-> (reset-repo-manager-state model :fleet)
-                             (assoc :flash-message "Showing configured repositories."))
-                         model)
-        :key/o         (if (in-repo-manager? model)
-                         (repo-manager-open-browse model :all)
-                         model)
-        :key/x         (if (in-repo-manager? model)
-                         (if (= :fleet (repo-manager-source model))
-                           (repo-manager-request-remove model)
-                           (assoc model :flash-message "Switch to fleet (f) to remove repositories."))
-                         model)
-        :key/question  (nav/toggle-help model)
-        :key/tab       (cond
-                         ;; In workflow detail sub-view context: cycle sub-panes only
-                         ;; (workflow-detail → evidence → artifact-browser → ...)
-                         ;; Esc goes back to the aggregate level.
-                         (nav/in-detail-subview? model)
-                         (nav/cycle-detail-subview model)
-                         ;; Other detail views (pr-detail, train-view): cycle panes
-                         (some #{(:view model)} model/detail-views)
-                         (nav/cycle-pane model)
-                         ;; Top-level aggregate views: cycle among them
-                         (some #{(:view model)} model/top-level-views)
-                         (nav/cycle-top-level-view model)
-                         ;; Fallback
-                         :else model)
-        :key/shift-tab (cond
-                         (nav/in-detail-subview? model)
-                         (nav/cycle-detail-subview-reverse model)
-                         (some #{(:view model)} model/detail-views)
-                         (nav/cycle-pane-reverse model)
-                         (some #{(:view model)} model/top-level-views)
-                         (nav/cycle-top-level-view-reverse model)
-                         :else model)
-        ;; Number keys switch within current abstraction level:
-        ;; top-level (1..N), detail-level (1..N), etc. with 0 as slot 10.
-        :key/d1        (switch-numbered-view model k)
-        :key/d2        (switch-numbered-view model k)
-        :key/d3        (switch-numbered-view model k)
-        :key/d4        (switch-numbered-view model k)
-        :key/d5        (switch-numbered-view model k)
-        :key/d6        (switch-numbered-view model k)
-        :key/d7        (switch-numbered-view model k)
-        :key/d8        (switch-numbered-view model k)
-        :key/d9        (switch-numbered-view model k)
-        :key/d0        (switch-numbered-view model k)
-        :key/q         (assoc model :quit? true)
-        ;; Unknown key -- no-op
-        model))))
+(def ^:private command-action-handlers
+  "Action token → handler for command-mode actions."
+  {:action/command-escape       command-escape
+   :action/command-enter        command-enter
+   :action/completion-tab       completion/handle-tab
+   :action/completion-shift-tab completion/handle-shift-tab
+   :action/command-backspace    #(-> (mode/command-backspace %) completion/dismiss)
+   :action/completion-next      completion/next-completion
+   :action/completion-prev      completion/prev-completion})
 
 (defn- handle-command-input [model key]
   (let [k (extract-key key)]
-    (cond
-      ;; Escape: dismiss completions if open, otherwise exit command mode
-      (= k :key/escape)
-      (if (:completing? model)
-        (completion/dismiss model)
-        (mode/exit-mode model))
+    (if-let [action (command-keybindings k)]
+      (let [handler (command-action-handlers action)]
+        (cond
+          ;; Completion arrow keys only active when completing
+          (and (#{:action/completion-next :action/completion-prev} action)
+               (not (:completing? model)))
+          model
 
-      ;; Enter: accept completion if popup open with selection, otherwise execute
-      (= k :key/enter)
-      (if (and (:completing? model) (:completion-idx model))
-        (completion/accept model)
-        (let [buf (:command-buf model)
-              cmd-name (subs buf 1)
-              exact-cmd? (and (not (str/blank? cmd-name))
-                              (not (str/includes? cmd-name " "))
-                              (some #{cmd-name} (command/complete-command-name cmd-name)))
-              arg-completion? (when exact-cmd?
-                                (let [result (command/compute-completions model (str ":" cmd-name " "))]
-                                  (or (seq (:completions result))
-                                      (:side-effect result))))]
-          (if arg-completion?
-            ;; For commands like :theme or :add-repo, Enter opens argument picker.
-            (completion/handle-tab model)
-            (-> (command/execute-command model (:command-buf model))
-                mode/exit-mode))))
+          handler
+          (handler model)
 
-      ;; Tab: open or cycle completions
-      (= k :key/tab)
-      (completion/handle-tab model)
-
-      ;; Shift+Tab: open or reverse-cycle completions
-      (= k :key/shift-tab)
-      (completion/handle-shift-tab model)
-
-      ;; Arrow keys: navigate completions if popup is open
-      (and (:completing? model) (= k :key/down))
-      (completion/next-completion model)
-
-      (and (:completing? model) (= k :key/up))
-      (completion/prev-completion model)
-
-      ;; Backspace: delete char and dismiss completions
-      (= k :key/backspace)
-      (-> (mode/command-backspace model)
-          completion/dismiss)
-
-      ;; Character input — all chars (mapped and unmapped) carry :char
-      :else
+          :else model))
+      ;; No keybinding — character input
       (if-let [ch (extract-char key)]
         (-> (mode/command-append model ch)
             completion/dismiss)
         model))))
 
+(def ^:private search-action-handlers
+  "Action token → handler for search-mode actions."
+  {:action/exit-mode        mode/exit-mode
+   :action/confirm-search   mode/confirm-search
+   :action/search-backspace mode/command-backspace})
+
 (defn- handle-search-input [model key]
   (let [k (extract-key key)]
-    (case k
-      :key/escape   (mode/exit-mode model)         ;; abort — clear filter
-      :key/enter    (mode/confirm-search model)     ;; confirm — keep filter active
-      :key/backspace (mode/command-backspace model)
+    (if-let [action (search-keybindings k)]
+      (if-let [handler (search-action-handlers action)]
+        (handler model)
+        model)
       ;; Character input — all chars (mapped and unmapped) carry :char
       (if-let [ch (extract-char key)]
         (-> model

--- a/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
@@ -157,79 +157,84 @@
 ;------------------------------------------------------------------------------ Layer 3
 ;; Confirmed action execution
 
+(defn- set-status-where
+  "Map over workflows, setting :status to `new-status` where the workflow id
+   is in `ids` and `pred?` (if supplied) is truthy. Default pred: always true."
+  ([wfs ids new-status]
+   (set-status-where wfs ids new-status (constantly true)))
+  ([wfs ids new-status pred?]
+   (mapv (fn [wf]
+           (if (and (contains? ids (:id wf)) (pred? wf))
+             (assoc wf :status new-status)
+             wf))
+         wfs)))
+
+(defn- confirm-set-status
+  "Confirmed action helper: update matching workflows to `new-status`,
+   flash `label`, and clear selection. Optionally accepts a `pred?`
+   filter (default: all matched ids)."
+  ([model ids label new-status]
+   (confirm-set-status model ids label new-status (constantly true)))
+  ([model ids label new-status pred?]
+   (-> model
+       (update :workflows set-status-where ids new-status pred?)
+       (assoc :flash-message (str label " " (count ids) " item(s)"))
+       sel/clear-selection)))
+
+(defn- confirm-delete
+  [model ids]
+  (-> model
+      (update :workflows (fn [wfs] (vec (remove #(contains? ids (:id %)) wfs))))
+      (assoc :flash-message (str "Deleted " (count ids) " item(s)")
+             :selected-idx 0)
+      sel/clear-selection))
+
+(defn- confirm-remove-repos
+  [model ids]
+  (let [targets (->> ids (filter string?) distinct vec)
+        result (reduce
+                (fn [{:keys [repos removed errors]} repo]
+                  (let [r (pr-sync/remove-repo! repo)]
+                    (if (:success? r)
+                      {:repos (:repos r)
+                       :removed (+ removed (if (:removed? r) 1 0))
+                       :errors errors}
+                      {:repos repos
+                       :removed removed
+                       :errors (conj errors (str repo ": " (or (:error r) "unknown error")))})))
+                {:repos (:fleet-repos model) :removed 0 :errors []}
+                targets)
+        next-model (-> (with-fleet-repos model (:repos result))
+                       sel/clear-selection)
+        removed (:removed result)
+        failures (count (:errors result))]
+    (assoc next-model
+           :flash-message
+           (cond
+             (zero? (count targets))
+             "No repositories selected for removal."
+
+             (and (pos? removed) (zero? failures))
+             (str "Removed " removed " repo(s) from fleet")
+
+             (and (zero? removed) (pos? failures))
+             (str "Failed to remove selected repos: "
+                  (str/join "; " (:errors result)))
+
+             :else
+             (str "Removed " removed " repo(s), " failures " failed")))))
+
 (defn execute-confirmed-action
   "Execute the action stored in :confirm after user presses 'y'.
    Pure: (model) -> model'."
   [model]
   (let [{:keys [action ids]} (:confirm model)]
     (case action
-      :delete
-      (-> model
-          (update :workflows
-                  (fn [wfs] (vec (remove #(contains? ids (:id %)) wfs))))
-          (assoc :flash-message (str "Deleted " (count ids) " item(s)")
-                 :selected-idx 0)
-          sel/clear-selection)
-
-      :archive
-      (-> model
-          (update :workflows
-                  (fn [wfs]
-                    (mapv (fn [wf]
-                            (if (contains? ids (:id wf))
-                              (assoc wf :status :archived)
-                              wf))
-                          wfs)))
-          (assoc :flash-message (str "Archived " (count ids) " item(s)"))
-          sel/clear-selection)
-
-      :cancel
-      (-> model
-          (update :workflows
-                  (fn [wfs]
-                    (mapv (fn [wf]
-                            (if (and (contains? ids (:id wf))
-                                     (= :running (:status wf)))
-                              (assoc wf :status :cancelled)
-                              wf))
-                          wfs)))
-          (assoc :flash-message (str "Cancelled " (count ids) " workflow(s)"))
-          sel/clear-selection)
-
-      :remove-repos
-      (let [targets (->> ids (filter string?) distinct vec)
-            result (reduce
-                    (fn [{:keys [repos removed errors]} repo]
-                      (let [r (pr-sync/remove-repo! repo)]
-                        (if (:success? r)
-                          {:repos (:repos r)
-                           :removed (+ removed (if (:removed? r) 1 0))
-                           :errors errors}
-                          {:repos repos
-                           :removed removed
-                           :errors (conj errors (str repo ": " (or (:error r) "unknown error")))})))
-                    {:repos (:fleet-repos model) :removed 0 :errors []}
-                    targets)
-            next-model (-> (with-fleet-repos model (:repos result))
-                           sel/clear-selection)
-            removed (:removed result)
-            failures (count (:errors result))]
-        (assoc next-model
-               :flash-message
-               (cond
-                 (zero? (count targets))
-                 "No repositories selected for removal."
-
-                 (and (pos? removed) (zero? failures))
-                 (str "Removed " removed " repo(s) from fleet")
-
-                 (and (zero? removed) (pos? failures))
-                 (str "Failed to remove selected repos: "
-                      (str/join "; " (:errors result)))
-
-                 :else
-                 (str "Removed " removed " repo(s), " failures " failed"))))
-
+      :delete       (confirm-delete model ids)
+      :archive      (confirm-set-status model ids "Archived" :archived)
+      :cancel       (confirm-set-status model ids "Cancelled" :cancelled
+                                        #(= :running (:status %)))
+      :remove-repos (confirm-remove-repos model ids)
       ;; Unknown action -- no-op
       model)))
 

--- a/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
@@ -1,0 +1,49 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update.command
+  "Command mode routing — stub.
+   Full implementation in feat/tui-command-completion PR."
+  (:require [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Stub: command dispatch (no-op until command system lands)
+
+(defn execute-command
+  "Execute a command string. Stub — returns model with flash message."
+  [model cmd-str]
+  (assoc model :flash-message (str "Command not yet available: " cmd-str)))
+
+(defn execute-confirmed-action
+  "Execute confirmed action. Stub — no-op."
+  [model]
+  model)
+
+(defn complete-command-name
+  "Return matching command names for a partial input. Stub — empty."
+  [_partial]
+  [])
+
+(defn compute-completions
+  "Given a command buffer, return completions. Stub — nil."
+  [_model _cmd-buf]
+  nil)
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
@@ -17,33 +17,322 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.tui-views.update.command
-  "Command mode routing — stub.
-   Full implementation in feat/tui-command-completion PR."
-  (:require [clojure.string :as str]))
+  "Command mode routing.
+
+   Parses :-prefixed command strings and dispatches to model-modifying
+   functions. Pure: (model, cmd-str) -> model'.
+   Layer 3."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update.selection :as sel]
+   [ai.miniforge.pr-sync.interface :as pr-sync]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Stub: command dispatch (no-op until command system lands)
+;; Command parsing
 
-(defn execute-command
-  "Execute a command string. Stub — returns model with flash message."
-  [model cmd-str]
-  (assoc model :flash-message (str "Command not yet available: " cmd-str)))
+(defn- parse-command
+  "Parse a command string into [cmd-name args-string].
+   Strips leading ':' prefix."
+  [cmd-str]
+  (let [trimmed (str/trim (if (str/starts-with? (or cmd-str "") ":")
+                            (subs cmd-str 1)
+                            (or cmd-str "")))
+        parts (str/split trimmed #"\s+" 2)]
+    [(first parts) (second parts)]))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Command handlers
+
+(defn- cmd-quit [model _args]
+  (assoc model :quit? true))
+
+(defn- cmd-view [model args]
+  (if (str/blank? args)
+    (assoc model :flash-message
+           (str "Views: " (str/join ", " (map name model/views))))
+    (let [view-kw (keyword args)]
+      (if (some #{view-kw} model/views)
+        (assoc model :view view-kw :selected-idx 0 :scroll-offset 0)
+        (assoc model :flash-message (str "Unknown view: " args))))))
+
+(defn- cmd-refresh [model _args]
+  (assoc model :flash-message "Refreshed" :last-updated (java.util.Date.)))
+
+(defn- cmd-help [model _args]
+  (assoc model :help-visible? true))
+
+;------------------------------------------------------------------------------ Layer 1b
+;; Fleet management commands
+
+(defn- with-fleet-repos
+  [model repos]
+  (let [repos* (vec (or repos []))
+        max-idx (max 0 (dec (count repos*)))
+        idx (or (:selected-idx model) 0)]
+    (assoc model
+           :fleet-repos repos*
+           :selected-idx (min idx max-idx))))
+
+(defn- cmd-add-repo [model args]
+  (if (str/blank? args)
+    (assoc model :flash-message "Usage: :add-repo owner/name OR :add-repo gitlab:group/name")
+    (let [result (pr-sync/add-repo! (str/trim args))]
+      (if (:success? result)
+        (-> (with-fleet-repos model (:repos result))
+            (assoc :flash-message
+                   (if (:added? result)
+                     (str "Added " (:repo result) " to fleet")
+                     (str (:repo result) " already in fleet"))))
+        (assoc model :flash-message (str "Error: " (:error result)))))))
+
+(defn- cmd-remove-repo [model args]
+  (if (str/blank? args)
+    (assoc model :flash-message "Usage: :remove-repo owner/name")
+    (let [result (pr-sync/remove-repo! (str/trim args))]
+      (if (:success? result)
+        (-> (with-fleet-repos model (:repos result))
+            (assoc :flash-message
+                   (if (:removed? result)
+                     (str "Removed " (:repo result) " from fleet")
+                     (str (:repo result) " not in fleet"))))
+        (assoc model :flash-message (str "Error: " (:error result)))))))
+
+(defn- cmd-sync [model _args]
+  (assoc model
+         :side-effect {:type :sync-prs}
+         :flash-message "Syncing PRs..."))
+
+(defn- cmd-repos [model _args]
+  (let [repos (or (:fleet-repos model) (pr-sync/get-configured-repos))]
+    (if (seq repos)
+      (assoc model :flash-message
+             (str "Fleet repos (" (count repos) "): "
+                  (str/join ", " repos)))
+      (assoc model :flash-message "No repos configured. Use :add-repo owner/name"))))
+
+(defn- cmd-discover [model args]
+  (let [owner (when-not (str/blank? args) (str/trim args))]
+    (assoc model
+           :side-effect {:type :discover-repos :owner owner}
+           :flash-message (str "Discovering repos"
+                               (when owner (str " from " owner)) "..."))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Batch action handlers (destructive actions prompt for confirmation)
+
+(defn- request-confirmation
+  "Set confirm state on model for destructive actions."
+  [model action label]
+  (let [ids (sel/effective-ids model)]
+    (if (seq ids)
+      (assoc model :confirm {:action action :label label :ids ids})
+      (assoc model :flash-message (str "Nothing to " (name action))))))
+
+(defn- cmd-archive [model _args]
+  (request-confirmation model :archive "Archive"))
+
+(defn- cmd-delete [model _args]
+  (request-confirmation model :delete "Delete"))
+
+(defn- cmd-cancel [model _args]
+  (request-confirmation model :cancel "Cancel"))
+
+(defn- cmd-rerun [model _args]
+  (let [ids (sel/effective-ids model)]
+    (if (seq ids)
+      (-> model
+          (update :workflows
+                  (fn [wfs]
+                    (mapv (fn [wf]
+                            (if (and (contains? ids (:id wf))
+                                     (#{:failed :cancelled} (:status wf)))
+                              (assoc wf :status :pending :progress 0)
+                              wf))
+                          wfs)))
+          (assoc :flash-message (str "Rerunning " (count ids) " workflow(s)"))
+          sel/clear-selection)
+      (assoc model :flash-message "Nothing to rerun"))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Confirmed action execution
 
 (defn execute-confirmed-action
-  "Execute confirmed action. Stub — no-op."
+  "Execute the action stored in :confirm after user presses 'y'.
+   Pure: (model) -> model'."
   [model]
-  model)
+  (let [{:keys [action ids]} (:confirm model)]
+    (case action
+      :delete
+      (-> model
+          (update :workflows
+                  (fn [wfs] (vec (remove #(contains? ids (:id %)) wfs))))
+          (assoc :flash-message (str "Deleted " (count ids) " item(s)")
+                 :selected-idx 0)
+          sel/clear-selection)
+
+      :archive
+      (-> model
+          (update :workflows
+                  (fn [wfs]
+                    (mapv (fn [wf]
+                            (if (contains? ids (:id wf))
+                              (assoc wf :status :archived)
+                              wf))
+                          wfs)))
+          (assoc :flash-message (str "Archived " (count ids) " item(s)"))
+          sel/clear-selection)
+
+      :cancel
+      (-> model
+          (update :workflows
+                  (fn [wfs]
+                    (mapv (fn [wf]
+                            (if (and (contains? ids (:id wf))
+                                     (= :running (:status wf)))
+                              (assoc wf :status :cancelled)
+                              wf))
+                          wfs)))
+          (assoc :flash-message (str "Cancelled " (count ids) " workflow(s)"))
+          sel/clear-selection)
+
+      :remove-repos
+      (let [targets (->> ids (filter string?) distinct vec)
+            result (reduce
+                    (fn [{:keys [repos removed errors]} repo]
+                      (let [r (pr-sync/remove-repo! repo)]
+                        (if (:success? r)
+                          {:repos (:repos r)
+                           :removed (+ removed (if (:removed? r) 1 0))
+                           :errors errors}
+                          {:repos repos
+                           :removed removed
+                           :errors (conj errors (str repo ": " (or (:error r) "unknown error")))})))
+                    {:repos (:fleet-repos model) :removed 0 :errors []}
+                    targets)
+            next-model (-> (with-fleet-repos model (:repos result))
+                           sel/clear-selection)
+            removed (:removed result)
+            failures (count (:errors result))]
+        (assoc next-model
+               :flash-message
+               (cond
+                 (zero? (count targets))
+                 "No repositories selected for removal."
+
+                 (and (pos? removed) (zero? failures))
+                 (str "Removed " removed " repo(s) from fleet")
+
+                 (and (zero? removed) (pos? failures))
+                 (str "Failed to remove selected repos: "
+                      (str/join "; " (:errors result)))
+
+                 :else
+                 (str "Removed " removed " repo(s), " failures " failed"))))
+
+      ;; Unknown action -- no-op
+      model)))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Completion data helpers
+
+(defn- safe-configured-repos
+  []
+  (try
+    (pr-sync/get-configured-repos)
+    (catch Exception _ [])))
+
+(defn- add-repo-completions
+  [model]
+  (let [local-repos (safe-configured-repos)
+        remote-repos (or (:browse-repos model) [])]
+    (->> (concat ["browse"] local-repos remote-repos)
+         (remove str/blank?)
+         distinct
+         sort
+         vec)))
+
+(defn- remove-repo-completions
+  [_]
+  (safe-configured-repos))
+
+(defn- maybe-browse-side-effect
+  [model cmd-name]
+  (when (and (= cmd-name "add-repo")
+             (empty? (:browse-repos model))
+             (not (:browse-repos-loading? model)))
+    {:type :browse-repos :provider :all}))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Command table and dispatch
+
+(def ^:private commands
+  {"q"           {:handler cmd-quit        :help "Quit the TUI"}
+   "quit"        {:handler cmd-quit        :help "Quit the TUI"}
+   "view"        {:handler cmd-view        :help "Switch to view (e.g. :view evidence)"
+                  :completions (fn [_] (mapv name model/views))}
+   "refresh"     {:handler cmd-refresh     :help "Refresh data"}
+   "help"        {:handler cmd-help        :help "Show help overlay"}
+   "archive"     {:handler cmd-archive     :help "Archive selected workflows"}
+   "delete"      {:handler cmd-delete      :help "Delete selected workflows"}
+   "cancel"      {:handler cmd-cancel      :help "Cancel running workflows"}
+   "rerun"       {:handler cmd-rerun       :help "Rerun failed workflows"}
+   "add-repo"    {:handler cmd-add-repo    :help "Add repo to fleet (e.g. :add-repo owner/name or gitlab:group/name)"
+                  :completions add-repo-completions}
+   "remove-repo" {:handler cmd-remove-repo :help "Remove repo from fleet"
+                  :completions remove-repo-completions}
+   "sync"        {:handler cmd-sync        :help "Sync PRs from all fleet repos"}
+   "repos"       {:handler cmd-repos       :help "List configured fleet repos"}
+   "discover"    {:handler cmd-discover    :help "Discover repos from org (e.g. :discover my-org)"}})
+
+(defn execute-command
+  "Execute a command string. Returns updated model.
+   Pure: (model, cmd-str) -> model'."
+  [model cmd-str]
+  (let [[cmd-name args] (parse-command cmd-str)]
+    (if-let [{:keys [handler]} (get commands cmd-name)]
+      (handler model args)
+      (assoc model :flash-message (str "Unknown command: " cmd-name)))))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Tab-completion support
 
 (defn complete-command-name
-  "Return matching command names for a partial input. Stub — empty."
-  [_partial]
-  [])
+  "Return matching command names for a partial input.
+   Excludes aliases (e.g. 'q' when 'quit' exists)."
+  [partial]
+  (let [p (str/lower-case (or partial ""))]
+    (->> (keys commands)
+         (filterv #(str/starts-with? % p))
+         sort
+         vec)))
 
 (defn compute-completions
-  "Given a command buffer, return completions. Stub — nil."
-  [_model _cmd-buf]
-  nil)
+  "Given a command buffer string, return completions for the current argument.
+   Returns {:cmd cmd-name :completions [str ...] :partial str} or nil."
+  [model cmd-buf]
+  (let [[cmd-name partial-arg] (parse-command cmd-buf)
+        cmd-entry (get commands cmd-name)]
+    (when-let [comp-fn (:completions cmd-entry)]
+      (let [all-completions (comp-fn model)
+            side-effect (maybe-browse-side-effect model cmd-name)
+            filtered (if (str/blank? partial-arg)
+                       all-completions
+                       (filterv #(str/starts-with?
+                                   (str/lower-case %)
+                                   (str/lower-case partial-arg))
+                                all-completions))]
+        {:cmd cmd-name
+         :completions (vec filtered)
+         :partial (or partial-arg "")
+         :side-effect side-effect}))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
+  (def m (model/init-model))
+  (execute-command m ":q")
+  (execute-command m ":view evidence")
+  (execute-command m ":unknown")
+  (complete-command-name "th")
+  (compute-completions m ":add-repo ")
   :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/update/completion.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/completion.clj
@@ -1,0 +1,52 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update.completion
+  "Tab-completion state machine — stub.
+   Full implementation in feat/tui-command-completion PR.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Stub: completion (no-op until command+completion system lands)
+
+(defn handle-tab
+  "Handle Tab in command mode. Stub — no-op."
+  [model] model)
+
+(defn handle-shift-tab
+  "Handle Shift+Tab in command mode. Stub — no-op."
+  [model] model)
+
+(defn dismiss
+  "Dismiss completion popup. Stub — no-op."
+  [model] model)
+
+(defn accept
+  "Accept selected completion. Stub — no-op."
+  [model] model)
+
+(defn next-completion
+  "Cycle to next completion. Stub — no-op."
+  [model] model)
+
+(defn prev-completion
+  "Cycle to previous completion. Stub — no-op."
+  [model] model)
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -49,50 +49,167 @@
     (update-fn model)
     model))
 
+;; Timestamp wrapper
+
+(defn- with-timestamp
+  "Wrap a handler result with :last-updated timestamp."
+  [model]
+  (assoc model :last-updated (java.util.Date.)))
+
 ;; Event handlers
 
 (defn handle-workflow-added [model {:keys [workflow-id name spec]}]
   (let [wf (model/make-workflow {:id workflow-id
                                   :name (or name (:name spec))
                                   :status :running})]
-    (update model :workflows conj wf)))
+    (-> (update model :workflows conj wf)
+        with-timestamp)))
 
 (defn handle-phase-changed [model {:keys [workflow-id phase]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (cond-> model
-      idx (assoc-in [:workflows idx :phase] phase)
-      true (update-detail-if-active workflow-id
-             #(update-in % [:detail :phases] conj {:phase phase :status :running})))))
+    (-> (cond-> model
+          idx (assoc-in [:workflows idx :phase] phase)
+          true (update-detail-if-active workflow-id
+                 #(update-in % [:detail :phases] conj {:phase phase :status :running})))
+        with-timestamp)))
 
 (defn handle-phase-done [model {:keys [workflow-id]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (update-workflow-at model idx
-      #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))))
+    (-> (update-workflow-at model idx
+          #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))
+        with-timestamp)))
 
 (defn handle-agent-status [model {:keys [workflow-id agent status message]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (cond-> model
-      idx (assoc-in [:workflows idx :agents agent] {:status status :message message})
-      true (update-detail-if-active workflow-id
-             #(assoc-in % [:detail :current-agent] {:agent agent :status status :message message})))))
+    (-> (cond-> model
+          idx (assoc-in [:workflows idx :agents agent] {:status status :message message})
+          true (update-detail-if-active workflow-id
+                 #(assoc-in % [:detail :current-agent] {:agent agent :status status :message message})))
+        with-timestamp)))
 
 (defn handle-agent-output [model {:keys [workflow-id delta]}]
-  (update-detail-if-active model workflow-id
-    #(update-in % [:detail :agent-output] str delta)))
+  (-> (update-detail-if-active model workflow-id
+        #(update-in % [:detail :agent-output] str delta))
+      with-timestamp))
 
 (defn handle-workflow-done [model {:keys [workflow-id status]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (update-workflow-at model idx
-      #(-> %
-           (assoc :status (or status :success))
-           (assoc :progress 100)))))
+    (-> (update-workflow-at model idx
+          #(-> %
+               (assoc :status (or status :success))
+               (assoc :progress 100)))
+        with-timestamp)))
 
 (defn handle-workflow-failed [model {:keys [workflow-id error]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (update-workflow-at model idx
-      #(-> %
-           (assoc :status :failed)
-           (assoc :error error)))))
+    (-> (update-workflow-at model idx
+          #(-> %
+               (assoc :status :failed)
+               (assoc :error error)))
+        with-timestamp)))
 
-(defn handle-gate-result [model _payload]
-  model)
+(defn handle-gate-result [model {:keys [workflow-id gate passed?] :as payload}]
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
+    (-> (cond-> model
+          idx (update-in [:workflows idx :gate-results] conj payload)
+          (not passed?)
+          (assoc :flash-message (str "Gate FAILED: " (when gate (name gate))))
+          true (update-detail-if-active workflow-id
+                 (fn [m]
+                   (update-in m [:detail :evidence :validation :results]
+                              (fnil conj []) payload))))
+        with-timestamp)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; PR event handlers
+
+(defn handle-prs-synced
+  "Handle result of a :sync-prs side effect.
+   Replaces :pr-items with freshly fetched data."
+  [model {:keys [pr-items]}]
+  (let [prs (or pr-items [])]
+    (-> model
+        (assoc :pr-items (vec prs))
+        (assoc :flash-message (str "Synced " (count prs) " PRs from "
+                                   (count (distinct (map :pr/repo prs))) " repo(s)"))
+        with-timestamp)))
+
+(defn handle-pr-updated
+  "Update a single PR in :pr-items by [repo, number] match."
+  [model {:keys [pr/repo pr/number] :as pr-data}]
+  (let [match? (fn [pr] (and (= (:pr/repo pr) repo) (= (:pr/number pr) number)))]
+    (-> model
+        (update :pr-items
+                (fn [prs]
+                  (mapv (fn [pr]
+                          (if (match? pr)
+                            (merge pr (dissoc pr-data :pr/repo :pr/number))
+                            pr))
+                        (or prs []))))
+        with-timestamp)))
+
+(defn handle-pr-removed
+  "Remove a PR from :pr-items by [repo, number] match."
+  [model {:keys [pr/repo pr/number]}]
+  (-> model
+      (update :pr-items
+              (fn [prs]
+                (vec (remove (fn [pr]
+                               (and (= (:pr/repo pr) repo)
+                                    (= (:pr/number pr) number)))
+                             (or prs [])))))
+      with-timestamp))
+
+(defn handle-repos-discovered
+  "Handle result of a :discover-repos side effect.
+   Shows discovery results and triggers a PR sync."
+  [model {:keys [success? added discovered owner repos error]}]
+  (if success?
+    (assoc model
+           :fleet-repos (vec (or repos (:fleet-repos model) []))
+           :flash-message (str "Discovered " discovered " repo(s)"
+                               (when owner (str " from " owner))
+                               " — " added " new. Syncing PRs...")
+           :side-effect {:type :sync-prs})
+    (assoc model :flash-message (str "Discover failed: " (or error "unknown error")))))
+
+(defn handle-repos-browsed
+  "Handle result of a :browse-repos side effect.
+   Populates :browse-repos cache used by :add-repo completion."
+  [model {:keys [success? repos owner provider warnings error error-source source]}]
+  (if success?
+    (let [repo-list (vec (or repos []))
+          base (assoc model
+                      :browse-repos repo-list
+                      :browse-repos-loading? false)
+          candidate-count (count (model/browse-candidate-repos base))
+          provider-name (name (or provider :github))
+          warnings* (vec (or warnings []))
+          base (if (= source :repo-manager)
+                 (assoc base
+                        :repo-manager-source :browse
+                        :selected-idx 0
+                        :filtered-indices nil
+                        :search-matches []
+                        :search-match-idx nil
+                        :selected-ids #{}
+                        :visual-anchor nil)
+                 base)]
+      (-> base
+          (assoc :flash-message
+                 (str "Loaded " (count repo-list) " remote repo(s)"
+                      " via " provider-name
+                      (when owner (str " from " owner))
+                      " — " candidate-count " new candidate(s)"
+                      (when (seq warnings*)
+                        (str " | warnings: " (count warnings*)))))
+          with-timestamp))
+    (-> model
+        (assoc :browse-repos-loading? false
+               :flash-message (str "Repo browse failed"
+                                   (when error-source (str " (" (name error-source) ")"))
+                                   (when provider (str " [" (name provider) "]"))
+                                   ": "
+                                   (or (some-> error str not-empty)
+                                       "no error details were provided")))
+        with-timestamp)))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -199,43 +199,52 @@
            :side-effect {:type :sync-prs})
     (assoc model :flash-message (str "Discover failed: " (or error "unknown error")))))
 
+(defn- repos-browsed-ok
+  "Success path: populate browse-repos cache, reset repo-manager if source
+   is :repo-manager, and flash a summary."
+  [model {:keys [repos owner provider warnings source]}]
+  (let [repo-list (vec (or repos []))
+        base (assoc model
+                    :browse-repos repo-list
+                    :browse-repos-loading? false)
+        candidate-count (count (model/browse-candidate-repos base))
+        provider-name (name (or provider :github))
+        warnings* (vec (or warnings []))
+        base (if (= source :repo-manager)
+               (assoc base
+                      :repo-manager-source :browse
+                      :selected-idx 0
+                      :filtered-indices nil
+                      :search-matches []
+                      :search-match-idx nil
+                      :selected-ids #{}
+                      :visual-anchor nil)
+               base)]
+    (assoc base :flash-message
+           (str "Loaded " (count repo-list) " remote repo(s)"
+                " via " provider-name
+                (when owner (str " from " owner))
+                " — " candidate-count " new candidate(s)"
+                (when (seq warnings*)
+                  (str " | warnings: " (count warnings*)))))))
+
+(defn- repos-browsed-err
+  "Failure path: clear loading flag and flash error details."
+  [model {:keys [error error-source provider]}]
+  (assoc model
+         :browse-repos-loading? false
+         :flash-message (str "Repo browse failed"
+                             (when error-source (str " (" (name error-source) ")"))
+                             (when provider (str " [" (name provider) "]"))
+                             ": "
+                             (or (some-> error str not-empty)
+                                 "no error details were provided"))))
+
 (defn handle-repos-browsed
   "Handle result of a :browse-repos side effect.
    Populates :browse-repos cache used by :add-repo completion."
-  [model {:keys [success? repos owner provider warnings error error-source source]}]
-  (if success?
-    (let [repo-list (vec (or repos []))
-          base (assoc model
-                      :browse-repos repo-list
-                      :browse-repos-loading? false)
-          candidate-count (count (model/browse-candidate-repos base))
-          provider-name (name (or provider :github))
-          warnings* (vec (or warnings []))
-          base (if (= source :repo-manager)
-                 (assoc base
-                        :repo-manager-source :browse
-                        :selected-idx 0
-                        :filtered-indices nil
-                        :search-matches []
-                        :search-match-idx nil
-                        :selected-ids #{}
-                        :visual-anchor nil)
-                 base)]
-      (-> base
-          (assoc :flash-message
-                 (str "Loaded " (count repo-list) " remote repo(s)"
-                      " via " provider-name
-                      (when owner (str " from " owner))
-                      " — " candidate-count " new candidate(s)"
-                      (when (seq warnings*)
-                        (str " | warnings: " (count warnings*)))))
-          with-timestamp))
-    (-> model
-        (assoc :browse-repos-loading? false
-               :flash-message (str "Repo browse failed"
-                                   (when error-source (str " (" (name error-source) ")"))
-                                   (when provider (str " [" (name provider) "]"))
-                                   ": "
-                                   (or (some-> error str not-empty)
-                                       "no error details were provided")))
-        with-timestamp)))
+  [model {:keys [success?] :as payload}]
+  (-> (if success?
+        (repos-browsed-ok model payload)
+        (repos-browsed-err model payload))
+      with-timestamp))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -56,68 +56,87 @@
   [model]
   (assoc model :last-updated (java.util.Date.)))
 
+;; Event helpers — extracted to avoid cond-> inside -> antipattern
+
+(defn- apply-phase-change
+  "Update workflow phase in list and detail context."
+  [model idx workflow-id phase]
+  (as-> model m
+    (if idx (assoc-in m [:workflows idx :phase] phase) m)
+    (update-detail-if-active m workflow-id
+      #(update-in % [:detail :phases] conj {:phase phase :status :running}))))
+
+(defn- apply-agent-status-update
+  "Update agent status in workflow list and detail context."
+  [model idx workflow-id agent status message]
+  (let [agent-entry {:status status :message message}]
+    (as-> model m
+      (if idx (assoc-in m [:workflows idx :agents agent] agent-entry) m)
+      (update-detail-if-active m workflow-id
+        #(assoc-in % [:detail :current-agent] (assoc agent-entry :agent agent))))))
+
+(defn- apply-gate-result
+  "Record gate result in workflow list, flash on failure, and update detail."
+  [model idx workflow-id gate passed? payload]
+  (as-> model m
+    (if idx (update-in m [:workflows idx :gate-results] conj payload) m)
+    (if (not passed?)
+      (assoc m :flash-message (str "Gate FAILED: " (when gate (name gate))))
+      m)
+    (update-detail-if-active m workflow-id
+      (fn [m'] (update-in m' [:detail :evidence :validation :results]
+                           (fnil conj []) payload)))))
+
 ;; Event handlers
 
 (defn handle-workflow-added [model {:keys [workflow-id name spec]}]
   (let [wf (model/make-workflow {:id workflow-id
                                   :name (or name (:name spec))
                                   :status :running})]
-    (-> (update model :workflows conj wf)
+    (-> model
+        (update :workflows conj wf)
         with-timestamp)))
 
 (defn handle-phase-changed [model {:keys [workflow-id phase]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (-> (cond-> model
-          idx (assoc-in [:workflows idx :phase] phase)
-          true (update-detail-if-active workflow-id
-                 #(update-in % [:detail :phases] conj {:phase phase :status :running})))
+    (-> model
+        (apply-phase-change idx workflow-id phase)
         with-timestamp)))
 
 (defn handle-phase-done [model {:keys [workflow-id]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (-> (update-workflow-at model idx
-          #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))
+    (-> model
+        (update-workflow-at idx #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))
         with-timestamp)))
 
 (defn handle-agent-status [model {:keys [workflow-id agent status message]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (-> (cond-> model
-          idx (assoc-in [:workflows idx :agents agent] {:status status :message message})
-          true (update-detail-if-active workflow-id
-                 #(assoc-in % [:detail :current-agent] {:agent agent :status status :message message})))
+    (-> model
+        (apply-agent-status-update idx workflow-id agent status message)
         with-timestamp)))
 
 (defn handle-agent-output [model {:keys [workflow-id delta]}]
-  (-> (update-detail-if-active model workflow-id
+  (-> model
+      (update-detail-if-active workflow-id
         #(update-in % [:detail :agent-output] str delta))
       with-timestamp))
 
 (defn handle-workflow-done [model {:keys [workflow-id status]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (-> (update-workflow-at model idx
-          #(-> %
-               (assoc :status (or status :success))
-               (assoc :progress 100)))
+    (-> model
+        (update-workflow-at idx #(assoc % :status (or status :success) :progress 100))
         with-timestamp)))
 
 (defn handle-workflow-failed [model {:keys [workflow-id error]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (-> (update-workflow-at model idx
-          #(-> %
-               (assoc :status :failed)
-               (assoc :error error)))
+    (-> model
+        (update-workflow-at idx #(assoc % :status :failed :error error))
         with-timestamp)))
 
 (defn handle-gate-result [model {:keys [workflow-id gate passed?] :as payload}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
-    (-> (cond-> model
-          idx (update-in [:workflows idx :gate-results] conj payload)
-          (not passed?)
-          (assoc :flash-message (str "Gate FAILED: " (when gate (name gate))))
-          true (update-detail-if-active workflow-id
-                 (fn [m]
-                   (update-in m [:detail :evidence :validation :results]
-                              (fnil conj []) payload))))
+    (-> model
+        (apply-gate-result idx workflow-id gate passed? payload)
         with-timestamp)))
 
 ;------------------------------------------------------------------------------ Layer 3
@@ -134,30 +153,37 @@
                                    (count (distinct (map :pr/repo prs))) " repo(s)"))
         with-timestamp)))
 
+(defn- pr-match?
+  "True when pr matches by [repo, number]."
+  [repo number pr]
+  (and (= (:pr/repo pr) repo) (= (:pr/number pr) number)))
+
+(defn- merge-matching-pr
+  "Merge updated fields into the PR matching [repo, number]; pass others through."
+  [repo number pr-data prs]
+  (mapv (fn [pr]
+          (if (pr-match? repo number pr)
+            (merge pr (dissoc pr-data :pr/repo :pr/number))
+            pr))
+        (or prs [])))
+
+(defn- remove-matching-pr
+  "Remove the PR matching [repo, number] from the vector."
+  [repo number prs]
+  (into [] (remove #(pr-match? repo number %)) (or prs [])))
+
 (defn handle-pr-updated
   "Update a single PR in :pr-items by [repo, number] match."
   [model {:keys [pr/repo pr/number] :as pr-data}]
-  (let [match? (fn [pr] (and (= (:pr/repo pr) repo) (= (:pr/number pr) number)))]
-    (-> model
-        (update :pr-items
-                (fn [prs]
-                  (mapv (fn [pr]
-                          (if (match? pr)
-                            (merge pr (dissoc pr-data :pr/repo :pr/number))
-                            pr))
-                        (or prs []))))
-        with-timestamp)))
+  (-> model
+      (update :pr-items (partial merge-matching-pr repo number pr-data))
+      with-timestamp))
 
 (defn handle-pr-removed
   "Remove a PR from :pr-items by [repo, number] match."
   [model {:keys [pr/repo pr/number]}]
   (-> model
-      (update :pr-items
-              (fn [prs]
-                (vec (remove (fn [pr]
-                               (and (= (:pr/repo pr) repo)
-                                    (= (:pr/number pr) number)))
-                             (or prs [])))))
+      (update :pr-items (partial remove-matching-pr repo number))
       with-timestamp))
 
 (defn handle-repos-discovered

--- a/components/tui-views/src/ai/miniforge/tui_views/update/mode.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/mode.clj
@@ -79,20 +79,24 @@
             {:line-idx idx :text line})))
       lines)))
 
+(defn- matching-indices
+  "Return set of indices whose item matches query via name-fn."
+  [items name-fn query]
+  (->> items
+       (map-indexed (fn [idx item] [idx (or (name-fn item) "")]))
+       (filter (fn [[_ label]] (str/includes? (str/lower-case label) query)))
+       (map first)
+       set))
+
 (defn- compute-aggregate-search
   "Filter items by name match. Sets :filtered-indices."
   [model query items name-fn]
   (if (str/blank? query)
     (assoc model :filtered-indices nil :search-matches [])
-    (let [q (str/lower-case query)
-          matches (set (keep-indexed
-                         (fn [idx item]
-                           (when (str/includes?
-                                   (str/lower-case (or (name-fn item) ""))
-                                   q)
-                             idx))
-                         items))]
-      (assoc model :filtered-indices matches :selected-idx 0 :search-matches []))))
+    (-> model
+        (assoc :filtered-indices (matching-indices items name-fn (str/lower-case query))
+               :selected-idx 0
+               :search-matches []))))
 
 (defn- compute-detail-search
   "Find matches in scrollable content. Sets :search-matches."
@@ -103,6 +107,29 @@
       (assoc model :search-matches matches
                    :search-match-idx (when (seq matches) 0)
                    :filtered-indices nil))))
+
+(defn- evidence-labels
+  "Build searchable label strings from evidence tree."
+  [model]
+  (let [phases (get-in model [:detail :phases] [])
+        evidence (get-in model [:detail :evidence])]
+    (into []
+      (concat
+        ["Intent"
+         (or (get-in evidence [:intent :description]) "")]
+        ["Phases"]
+        (map #(str (name (:phase %)) " " (name (or (:status %) :pending))) phases)
+        ["Validation"
+         (if (get-in evidence [:validation :passed?])
+           "All gates passed" "Errors")]
+        ["Policy"
+         (if (get-in evidence [:policy :compliant?])
+           "Policy compliant" "Policy violations")]))))
+
+(defn- compute-evidence-search
+  "Search evidence tree node labels."
+  [model query]
+  (compute-detail-search model query (evidence-labels model)))
 
 (defn compute-search-results
   "Dispatch search by current view.
@@ -130,34 +157,7 @@
         (compute-detail-search model query lines))
 
       :evidence
-      (let [phases (get-in model [:detail :phases] [])
-            evidence (get-in model [:detail :evidence])
-            ;; Build searchable text from evidence tree node labels
-            labels (into []
-                     (concat
-                       ["Intent"
-                        (or (get-in evidence [:intent :description]) "")]
-                       ["Phases"]
-                       (map #(str (name (:phase %)) " " (name (or (:status %) :pending))) phases)
-                       ["Validation"
-                        (if (get-in evidence [:validation :passed?])
-                          "All gates passed" "Errors")]
-                       ["Policy"
-                        (if (get-in evidence [:policy :compliant?])
-                          "Policy compliant" "Policy violations")]))]
-        ;; For evidence, matches map to tree node indices
-        (if (str/blank? query)
-          (assoc model :search-matches [] :search-match-idx nil)
-          (let [q (str/lower-case query)
-                matches (into []
-                          (keep-indexed
-                            (fn [idx label]
-                              (when (str/includes? (str/lower-case label) q)
-                                {:line-idx idx :text label})))
-                          labels)]
-            (assoc model :search-matches matches
-                         :search-match-idx (when (seq matches) 0)
-                         :filtered-indices nil))))
+      (compute-evidence-search model query)
 
       :artifact-browser
       (compute-aggregate-search model query

--- a/components/tui-views/src/ai/miniforge/tui_views/update/mode.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/mode.clj
@@ -20,7 +20,10 @@
   "Mode switching and command buffer manipulation.
 
    Pure functions for switching between normal/command/search modes.
-   Layer 3.")
+   Layer 3."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.model :as model]))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Mode switching
@@ -31,8 +34,26 @@
 (defn enter-search-mode [model]
   (assoc model :mode :search :command-buf "/" :search-results []))
 
-(defn exit-mode [model]
-  (assoc model :mode :normal :command-buf "" :search-results []))
+(defn exit-mode
+  "Exit command/search mode back to normal.
+   Clears command buffer, search results, filtered-indices, and search-matches."
+  [model]
+  (assoc model :mode :normal :command-buf "" :search-results []
+         :filtered-indices nil :search-matches [] :search-match-idx nil))
+
+(defn confirm-search
+  "Confirm search: exit to normal mode but KEEP results.
+   For aggregate views: keeps filtered-indices for browse/select.
+   For detail views: keeps search-matches for n/N navigation.
+   Jumps to first match if any exist."
+  [model]
+  (let [m (assoc model :mode :normal :command-buf "" :search-results [])]
+    (if (seq (:search-matches m))
+      ;; Detail view: jump to first match
+      (let [first-match (get (:search-matches m) 0)]
+        (assoc m :search-match-idx 0
+                 :scroll-offset (:line-idx first-match 0)))
+      m)))
 
 (defn command-append [model ch]
   (update model :command-buf str ch))
@@ -42,3 +63,106 @@
     (if (> (count buf) 1)
       (assoc model :command-buf (subs buf 0 (dec (count buf))))
       (exit-mode model))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Search filtering
+
+(defn- search-lines
+  "Find line indices matching query in a vector of strings.
+   Returns vector of {:line-idx N :text line}."
+  [lines query]
+  (let [q (str/lower-case query)]
+    (into []
+      (keep-indexed
+        (fn [idx line]
+          (when (str/includes? (str/lower-case (or line "")) q)
+            {:line-idx idx :text line})))
+      lines)))
+
+(defn- compute-aggregate-search
+  "Filter items by name match. Sets :filtered-indices."
+  [model query items name-fn]
+  (if (str/blank? query)
+    (assoc model :filtered-indices nil :search-matches [])
+    (let [q (str/lower-case query)
+          matches (set (keep-indexed
+                         (fn [idx item]
+                           (when (str/includes?
+                                   (str/lower-case (or (name-fn item) ""))
+                                   q)
+                             idx))
+                         items))]
+      (assoc model :filtered-indices matches :selected-idx 0 :search-matches []))))
+
+(defn- compute-detail-search
+  "Find matches in scrollable content. Sets :search-matches."
+  [model query lines]
+  (if (str/blank? query)
+    (assoc model :search-matches [] :search-match-idx nil)
+    (let [matches (search-lines lines query)]
+      (assoc model :search-matches matches
+                   :search-match-idx (when (seq matches) 0)
+                   :filtered-indices nil))))
+
+(defn compute-search-results
+  "Dispatch search by current view.
+   Aggregate views: filter list items via :filtered-indices.
+   Detail views: find-in-page via :search-matches."
+  [model]
+  (let [query (subs (:command-buf model) 1) ;; strip leading "/"
+        view (:view model)]
+    (case view
+      ;; Aggregate views — filter the list
+      :workflow-list (compute-aggregate-search model query (:workflows model) :name)
+      :pr-fleet      (compute-aggregate-search model query (:pr-items model)
+                       #(or (:pr/title %) (:name %)))
+      :train-view    (compute-aggregate-search model query
+                       (get-in model [:detail :selected-train :train/prs] [])
+                       #(or (:pr/title %) (:name %)))
+      :repo-manager  (compute-aggregate-search model query
+                       (model/repo-manager-items model)
+                       identity)
+
+      ;; Detail views — find-in-page
+      :workflow-detail
+      (let [output (get-in model [:detail :agent-output] "")
+            lines (str/split-lines output)]
+        (compute-detail-search model query lines))
+
+      :evidence
+      (let [phases (get-in model [:detail :phases] [])
+            evidence (get-in model [:detail :evidence])
+            ;; Build searchable text from evidence tree node labels
+            labels (into []
+                     (concat
+                       ["Intent"
+                        (or (get-in evidence [:intent :description]) "")]
+                       ["Phases"]
+                       (map #(str (name (:phase %)) " " (name (or (:status %) :pending))) phases)
+                       ["Validation"
+                        (if (get-in evidence [:validation :passed?])
+                          "All gates passed" "Errors")]
+                       ["Policy"
+                        (if (get-in evidence [:policy :compliant?])
+                          "Policy compliant" "Policy violations")]))]
+        ;; For evidence, matches map to tree node indices
+        (if (str/blank? query)
+          (assoc model :search-matches [] :search-match-idx nil)
+          (let [q (str/lower-case query)
+                matches (into []
+                          (keep-indexed
+                            (fn [idx label]
+                              (when (str/includes? (str/lower-case label) q)
+                                {:line-idx idx :text label})))
+                          labels)]
+            (assoc model :search-matches matches
+                         :search-match-idx (when (seq matches) 0)
+                         :filtered-indices nil))))
+
+      :artifact-browser
+      (compute-aggregate-search model query
+        (get-in model [:detail :artifacts] [])
+        #(or (:name %) (:path %) ""))
+
+      ;; Default — no search behavior
+      model)))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
@@ -20,23 +20,51 @@
   "Navigation helpers and view transitions.
 
    Pure functions for list navigation and view switching.
-   Layers 0-1.")
+   Layers 0-1."
+  (:require
+   [ai.miniforge.tui-views.model :as model]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Navigation helpers
 
-(defn list-count [model]
-  (case (:view model)
-    :workflow-list (count (:workflows model))
-    :artifact-browser (count (get-in model [:detail :artifacts]))
-    0))
+(defn list-count
+  "Count of items visible in the current list. Respects filtered-indices."
+  [model]
+  (let [raw-count (case (:view model)
+                    :workflow-list    (count (:workflows model))
+                    :artifact-browser (count (get-in model [:detail :artifacts]))
+                    :pr-fleet         (count (:pr-items model))
+                    :repo-manager     (count (model/repo-manager-items model))
+                    :train-view       (count (get-in model [:detail :selected-train :train/prs]))
+                    0)]
+    (if-let [fi (:filtered-indices model)]
+      (count fi)
+      raw-count)))
+
+(defn- raw-workflow-index
+  "Map a cursor index to a raw workflow vector index via filtered-indices.
+   Returns cursor index directly when no filter is active."
+  [model idx]
+  (if-let [fi (:filtered-indices model)]
+    (nth (vec (sort fi)) idx nil)
+    idx))
+
+(defn- scrollable-view?
+  "Views where j/k scroll content rather than moving a list cursor."
+  [view]
+  (= :workflow-detail view))
 
 (defn navigate-up [model]
-  (update model :selected-idx #(max 0 (dec %))))
+  (if (scrollable-view? (:view model))
+    (update model :scroll-offset #(max 0 (dec (or % 0))))
+    (update model :selected-idx #(max 0 (dec %)))))
 
 (defn navigate-down [model]
-  (let [max-idx (max 0 (dec (list-count model)))]
-    (update model :selected-idx #(min max-idx (inc %)))))
+  (if (scrollable-view? (:view model))
+    ;; scroll-offset upper bound is clamped at render time
+    (update model :scroll-offset #(inc (or % 0)))
+    (let [max-idx (max 0 (dec (list-count model)))]
+      (update model :selected-idx #(min max-idx (inc %))))))
 
 (defn navigate-top [model]
   (assoc model :selected-idx 0 :scroll-offset 0))
@@ -49,24 +77,325 @@
 ;; View navigation
 
 (defn enter-detail [model]
-  (let [workflows (:workflows model)
-        idx (:selected-idx model)]
-    (if-let [wf (get workflows idx)]
-      (-> model
-          (assoc :view :workflow-detail)
-          (assoc-in [:detail :workflow-id] (:id wf))
-          (assoc :selected-idx 0))
-      model)))
+  (case (:view model)
+    :workflow-list
+    (let [workflows (:workflows model)
+          idx (:selected-idx model)
+          raw-idx (raw-workflow-index model idx)]
+      (if-let [wf (when raw-idx (get workflows raw-idx))]
+        (-> model
+            (assoc :view :workflow-detail)
+            (assoc-in [:detail :workflow-id] (:id wf))
+            (assoc :selected-idx 0 :selected-ids #{} :visual-anchor nil
+                   :scroll-offset nil :search-matches [] :search-match-idx nil))
+        model))
+
+    :pr-fleet
+    (let [prs (:pr-items model)
+          idx (:selected-idx model)]
+      (if-let [pr (get prs idx)]
+        (-> model
+            (assoc :view :pr-detail)
+            (assoc-in [:detail :selected-pr] pr)
+            (assoc :selected-idx 0 :selected-ids #{} :visual-anchor nil))
+        model))
+
+    :train-view
+    (let [prs (get-in model [:detail :selected-train :train/prs])
+          idx (:selected-idx model)]
+      (if-let [pr (get (vec prs) idx)]
+        (-> model
+            (assoc :view :pr-detail)
+            (assoc-in [:detail :selected-pr] pr)
+            (assoc :selected-idx 0 :selected-ids #{} :visual-anchor nil))
+        model))
+
+    ;; Default: no-op
+    model))
 
 (defn go-back [model]
-  (case (:view model)
-    :workflow-detail (assoc model :view :workflow-list :selected-idx 0)
-    :evidence        (assoc model :view :workflow-detail :selected-idx 0)
-    :artifact-browser (assoc model :view :workflow-detail :selected-idx 0)
-    :dag-kanban       (assoc model :view :workflow-list :selected-idx 0)
-    model))
+  (let [clear {:selected-idx 0 :selected-ids #{} :visual-anchor nil
+               :search-matches [] :search-match-idx nil :scroll-offset 0}]
+    (case (:view model)
+      ;; Detail views go back to their parent aggregate
+      ;; Clear :detail :workflow-id so Tab stays at the aggregate tier
+      :workflow-detail  (-> (merge model clear {:view :workflow-list})
+                            (assoc-in [:detail :workflow-id] nil))
+      :pr-detail        (-> (merge model clear {:view :pr-fleet})
+                            (assoc-in [:detail :selected-pr] nil))
+      :train-view       (-> (merge model clear {:view :pr-fleet})
+                            (assoc-in [:detail :selected-train] nil))
+      ;; Evidence / artifact-browser as detail sub-views → back to workflow-list
+      ;; As top-level aggregates (no workflow-id) → no-op
+      (:evidence :artifact-browser)
+      (if (some? (get-in model [:detail :workflow-id]))
+        (-> (merge model clear {:view :workflow-list})
+            (assoc-in [:detail :workflow-id] nil))
+        model)
+      ;; Top-level aggregate views: no-op (use Tab to cycle)
+      model)))
 
 (defn switch-view [model view-key views]
   (if (some #{view-key} views)
-    (assoc model :view view-key :selected-idx 0 :scroll-offset 0)
+    (assoc model :view view-key :selected-idx 0 :scroll-offset 0
+           :selected-ids #{} :visual-anchor nil)
     model))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Action helpers
+
+(defn refresh [model]
+  (assoc model
+         :flash-message "Refreshed"
+         :last-updated (java.util.Date.)))
+
+(defn toggle-help [model]
+  (update model :help-visible? not))
+
+(defn toggle-expand [model]
+  (let [idx (:selected-idx model)]
+    (update-in model [:detail :expanded-nodes]
+               (fn [nodes]
+                 (let [nodes (or nodes #{})]
+                   (if (contains? nodes idx)
+                     (disj nodes idx)
+                     (conj nodes idx)))))))
+
+(defn cycle-pane
+  "Cycle Tab focus between panes in multi-pane views.
+   Views with multiple columns/panes define their pane count;
+   single-pane views are a no-op."
+  [model]
+  (let [pane-count (case (:view model)
+                     :workflow-detail 2   ;; phases | agent output
+                     :pr-detail       3   ;; readiness | risk | gates
+                     :dag-kanban      6   ;; 6 kanban columns
+                     1)
+        current (get-in model [:detail :focused-pane] 0)]
+    (assoc-in model [:detail :focused-pane]
+              (mod (inc current) pane-count))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Detail screen navigation — sibling items + sub-view cycling
+
+(def ^:private workflow-subviews
+  "Sub-views for a workflow item, cycled with Tab."
+  [:workflow-detail :evidence :artifact-browser])
+
+(def ^:private workflow-subview-set
+  (set workflow-subviews))
+
+(defn in-detail-subview?
+  "True when the model is in a workflow detail sub-view context.
+   This means the current view is one of the workflow sub-views AND
+   a workflow-id is present in :detail (i.e. we drilled in from a list,
+   not navigated directly to a top-level aggregate)."
+  [model]
+  (and (contains? workflow-subview-set (:view model))
+       (some? (get-in model [:detail :workflow-id]))))
+
+(defn current-level-views
+  "Return views for the current abstraction level (max 10 keys per level).
+   - Top-level aggregate: model/top-level-views
+   - Workflow detail context: workflow sub-views
+   - Other detail views: model/detail-views"
+  [model]
+  (cond
+    (in-detail-subview? model)
+    workflow-subviews
+
+    (some #{(:view model)} model/detail-views)
+    model/detail-views
+
+    :else
+    model/top-level-views))
+
+(defn- find-workflow-idx
+  "Find the index of a workflow-id in the workflows vector."
+  [workflows wf-id]
+  (some (fn [[i wf]] (when (= (:id wf) wf-id) i))
+        (map-indexed vector workflows)))
+
+(defn navigate-prev-item
+  "Navigate to the previous item's detail view.
+   In workflow detail/evidence/artifact-browser: show previous workflow.
+   In pr-detail: show previous PR.
+   No-op in list views or at boundary."
+  [model]
+  (case (:view model)
+    (:workflow-detail :evidence :artifact-browser)
+    (let [workflows (:workflows model)
+          wf-id (get-in model [:detail :workflow-id])
+          current-idx (find-workflow-idx workflows wf-id)
+          prev-idx (when current-idx (dec current-idx))]
+      (if (and prev-idx (>= prev-idx 0))
+        (let [wf (get workflows prev-idx)]
+          (-> model
+              (assoc-in [:detail :workflow-id] (:id wf))
+              (assoc :selected-idx 0)
+              (assoc-in [:detail :expanded-nodes] #{})))
+        model))
+
+    :pr-detail
+    (let [prs (:pr-items model)
+          current-pr (get-in model [:detail :selected-pr])
+          current-idx (some (fn [[i pr]] (when (= pr current-pr) i))
+                            (map-indexed vector prs))
+          prev-idx (when current-idx (dec current-idx))]
+      (if (and prev-idx (>= prev-idx 0))
+        (-> model
+            (assoc-in [:detail :selected-pr] (get prs prev-idx))
+            (assoc :selected-idx 0))
+        model))
+
+    ;; Non-detail views: no-op
+    model))
+
+(defn navigate-next-item
+  "Navigate to the next item's detail view.
+   In workflow detail/evidence/artifact-browser: show next workflow.
+   In pr-detail: show next PR.
+   No-op in list views or at boundary."
+  [model]
+  (case (:view model)
+    (:workflow-detail :evidence :artifact-browser)
+    (let [workflows (:workflows model)
+          wf-id (get-in model [:detail :workflow-id])
+          current-idx (find-workflow-idx workflows wf-id)
+          next-idx (when current-idx (inc current-idx))]
+      (if (and next-idx (< next-idx (count workflows)))
+        (let [wf (get workflows next-idx)]
+          (-> model
+              (assoc-in [:detail :workflow-id] (:id wf))
+              (assoc :selected-idx 0)
+              (assoc-in [:detail :expanded-nodes] #{})))
+        model))
+
+    :pr-detail
+    (let [prs (:pr-items model)
+          current-pr (get-in model [:detail :selected-pr])
+          current-idx (some (fn [[i pr]] (when (= pr current-pr) i))
+                            (map-indexed vector prs))
+          next-idx (when current-idx (inc current-idx))]
+      (if (and next-idx (< next-idx (count prs)))
+        (-> model
+            (assoc-in [:detail :selected-pr] (get prs next-idx))
+            (assoc :selected-idx 0))
+        model))
+
+    ;; Non-detail views: no-op
+    model))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Search match navigation
+
+(defn next-search-match
+  "Jump to the next search match. Wraps around.
+   In scrollable views (workflow-detail): updates scroll-offset.
+   In tree/table views (evidence): updates selected-idx.
+   No-op when no matches active."
+  [model]
+  (let [matches (:search-matches model)
+        idx (:search-match-idx model)]
+    (if (or (empty? matches) (nil? idx))
+      model
+      (let [next-idx (mod (inc idx) (count matches))
+            match (get matches next-idx)
+            line-idx (:line-idx match 0)]
+        (cond-> (assoc model :search-match-idx next-idx)
+          (scrollable-view? (:view model))
+          (assoc :scroll-offset line-idx)
+          (not (scrollable-view? (:view model)))
+          (assoc :selected-idx line-idx))))))
+
+(defn prev-search-match
+  "Jump to the previous search match. Wraps around."
+  [model]
+  (let [matches (:search-matches model)
+        idx (:search-match-idx model)]
+    (if (or (empty? matches) (nil? idx))
+      model
+      (let [prev-idx (mod (+ idx (dec (count matches))) (count matches))
+            match (get matches prev-idx)
+            line-idx (:line-idx match 0)]
+        (cond-> (assoc model :search-match-idx prev-idx)
+          (scrollable-view? (:view model))
+          (assoc :scroll-offset line-idx)
+          (not (scrollable-view? (:view model)))
+          (assoc :selected-idx line-idx))))))
+
+(defn cycle-detail-subview
+  "Cycle Tab through sub-views for the same item.
+   workflow-detail → evidence → artifact-browser → workflow-detail."
+  [model]
+  (let [current (:view model)
+        idx (.indexOf workflow-subviews current)
+        next-view (if (>= idx 0)
+                    (get workflow-subviews (mod (inc idx) (count workflow-subviews)))
+                    current)]
+    (-> model
+        (assoc :view next-view)
+        (assoc :selected-idx 0)
+        (assoc-in [:detail :expanded-nodes] #{}))))
+
+(defn cycle-detail-subview-reverse
+  "Cycle Shift+Tab through sub-views in reverse.
+   workflow-detail ← evidence ← artifact-browser ← workflow-detail."
+  [model]
+  (let [current (:view model)
+        n (count workflow-subviews)
+        idx (.indexOf workflow-subviews current)
+        prev-view (if (>= idx 0)
+                    (get workflow-subviews (mod (+ idx (dec n)) n))
+                    current)]
+    (-> model
+        (assoc :view prev-view)
+        (assoc :selected-idx 0)
+        (assoc-in [:detail :expanded-nodes] #{}))))
+
+(defn cycle-top-level-view
+  "Cycle Tab through top-level aggregate views.
+   pr-fleet → workflow-list → evidence → artifact-browser → dag-kanban → repo-manager → pr-fleet.
+   Clears detail context so Tab stays at the aggregate tier."
+  [model]
+  (let [current (:view model)
+        views model/top-level-views
+        idx (.indexOf views current)
+        next-view (if (>= idx 0)
+                    (get views (mod (inc idx) (count views)))
+                    (first views))]
+    (-> model
+        (assoc :view next-view :selected-idx 0 :scroll-offset 0
+               :selected-ids #{} :visual-anchor nil
+               :filtered-indices nil :search-matches [] :search-match-idx nil)
+        (assoc-in [:detail :workflow-id] nil))))
+
+(defn cycle-top-level-view-reverse
+  "Cycle Shift+Tab through top-level aggregate views in reverse.
+   pr-fleet ← repo-manager ← dag-kanban ← artifact-browser ← evidence ← workflow-list ← pr-fleet.
+   Clears detail context so Tab stays at the aggregate tier."
+  [model]
+  (let [current (:view model)
+        views model/top-level-views
+        n (count views)
+        idx (.indexOf views current)
+        prev-view (if (>= idx 0)
+                    (get views (mod (+ idx (dec n)) n))
+                    (last views))]
+    (-> model
+        (assoc :view prev-view :selected-idx 0 :scroll-offset 0
+               :selected-ids #{} :visual-anchor nil
+               :filtered-indices nil :search-matches [] :search-match-idx nil)
+        (assoc-in [:detail :workflow-id] nil))))
+
+(defn cycle-pane-reverse
+  "Cycle Shift+Tab focus between panes in reverse."
+  [model]
+  (let [pane-count (case (:view model)
+                     :workflow-detail 2
+                     :pr-detail       3
+                     :dag-kanban      6
+                     1)
+        current (get-in model [:detail :focused-pane] 0)]
+    (assoc-in model [:detail :focused-pane]
+              (mod (+ current (dec pane-count)) pane-count))))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/selection.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/selection.clj
@@ -1,0 +1,164 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update.selection
+  "Selection manipulation -- multi-select and visual mode.
+
+   Pure functions for managing selected-ids set. Provides toggle,
+   visual range selection, select-all, and clear operations.
+   Layer 2."
+  (:require
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update.navigation :as nav]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Filtered index resolution
+
+(defn- raw-index
+  "Map a cursor index to a raw list index, respecting filtered-indices.
+   When a search filter is active, cursor index n refers to the nth visible
+   item, not the nth item in the raw vector."
+  [model idx]
+  (if-let [fi (:filtered-indices model)]
+    (let [sorted-fi (vec (sort fi))]
+      (get sorted-fi idx))
+    idx))
+
+;; ID resolution
+
+(defn item-id-at
+  "Get the selectable ID for the item at the given index in the current view.
+   Respects filtered-indices when active.
+   Returns nil if index is out of bounds."
+  [model idx]
+  (case (:view model)
+    :workflow-list
+    (let [raw-idx (raw-index model idx)]
+      (when raw-idx
+        (:id (get (:workflows model) raw-idx))))
+
+    :pr-fleet
+    (let [raw-idx (raw-index model idx)]
+      (when-let [pr (get (:pr-items model) raw-idx)]
+        [(:pr/repo pr) (:pr/number pr)]))
+
+    :artifact-browser
+    (let [raw-idx (raw-index model idx)]
+      (when (get (get-in model [:detail :artifacts] []) raw-idx)
+        [:artifact raw-idx]))
+
+    :train-view
+    (let [prs (vec (sort-by :pr/merge-order
+                     (get-in model [:detail :selected-train :train/prs] [])))
+          raw-idx (raw-index model idx)]
+      (when-let [pr (get prs raw-idx)]
+        [(:pr/repo pr) (:pr/number pr)]))
+
+    :repo-manager
+    (let [raw-idx (raw-index model idx)]
+      (get (model/repo-manager-items model) raw-idx))
+
+    nil))
+
+(defn current-item-id
+  "Get ID of item at cursor position."
+  [model]
+  (item-id-at model (:selected-idx model)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Individual toggle
+
+(defn toggle-selection
+  "Toggle selection of item at cursor, then advance cursor down.
+   Standard TUI multi-select pattern (like mc/ranger)."
+  [model]
+  (if-let [id (current-item-id model)]
+    (-> model
+        (update :selected-ids
+                (fn [ids]
+                  (let [ids (or ids #{})]
+                    (if (contains? ids id)
+                      (disj ids id)
+                      (conj ids id)))))
+        (nav/navigate-down))
+    model))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Visual mode
+
+(defn enter-visual-mode
+  "Set visual anchor at current cursor position."
+  [model]
+  (let [id (current-item-id model)]
+    (-> model
+        (assoc :visual-anchor (:selected-idx model))
+        (assoc :selected-ids (if id #{id} #{})))))
+
+(defn exit-visual-mode
+  "Clear visual anchor without clearing selections."
+  [model]
+  (assoc model :visual-anchor nil))
+
+(defn update-visual-selection
+  "Recompute selected-ids from visual anchor to current cursor.
+   No-op when visual-anchor is nil -- safe to call after every j/k."
+  [model]
+  (if-let [anchor (:visual-anchor model)]
+    (let [lo (min anchor (:selected-idx model))
+          hi (max anchor (:selected-idx model))
+          ids (set (keep #(item-id-at model %) (range lo (inc hi))))]
+      (assoc model :selected-ids ids))
+    model))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Bulk operations
+
+(defn select-all
+  "Select all items in current list."
+  [model]
+  (let [cnt (nav/list-count model)
+        ids (set (keep #(item-id-at model %) (range cnt)))]
+    (assoc model :selected-ids ids)))
+
+(defn clear-selection
+  "Clear all selections and exit visual mode."
+  [model]
+  (assoc model :selected-ids #{} :visual-anchor nil))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Query helpers
+
+(defn has-selection?
+  "True if any items are selected."
+  [model]
+  (boolean (seq (:selected-ids model))))
+
+(defn effective-ids
+  "Return selected IDs for batch operation.
+   If nothing selected, return the single cursor item ID wrapped in a set."
+  [model]
+  (if (has-selection? model)
+    (:selected-ids model)
+    (if-let [id (current-item-id model)]
+      #{id}
+      #{})))
+
+(defn selection-count
+  "Number of currently selected items."
+  [model]
+  (count (:selected-ids model)))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/selection.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/selection.clj
@@ -41,6 +41,18 @@
 
 ;; ID resolution
 
+(defn- item-at
+  "Get the item at cursor idx, resolving through filtered-indices.
+   Returns nil if index is out of bounds."
+  [model items idx]
+  (when-let [raw-idx (raw-index model idx)]
+    (get items raw-idx)))
+
+(defn- pr-id
+  "Extract selectable ID [repo, number] from a PR map."
+  [pr]
+  (when pr [(:pr/repo pr) (:pr/number pr)]))
+
 (defn item-id-at
   "Get the selectable ID for the item at the given index in the current view.
    Respects filtered-indices when active.
@@ -48,30 +60,22 @@
   [model idx]
   (case (:view model)
     :workflow-list
-    (let [raw-idx (raw-index model idx)]
-      (when raw-idx
-        (:id (get (:workflows model) raw-idx))))
+    (:id (item-at model (:workflows model) idx))
 
     :pr-fleet
-    (let [raw-idx (raw-index model idx)]
-      (when-let [pr (get (:pr-items model) raw-idx)]
-        [(:pr/repo pr) (:pr/number pr)]))
+    (pr-id (item-at model (:pr-items model) idx))
 
     :artifact-browser
-    (let [raw-idx (raw-index model idx)]
-      (when (get (get-in model [:detail :artifacts] []) raw-idx)
-        [:artifact raw-idx]))
+    (when (item-at model (get-in model [:detail :artifacts] []) idx)
+      [:artifact (raw-index model idx)])
 
     :train-view
     (let [prs (vec (sort-by :pr/merge-order
-                     (get-in model [:detail :selected-train :train/prs] [])))
-          raw-idx (raw-index model idx)]
-      (when-let [pr (get prs raw-idx)]
-        [(:pr/repo pr) (:pr/number pr)]))
+                     (get-in model [:detail :selected-train :train/prs] [])))]
+      (pr-id (item-at model prs idx)))
 
     :repo-manager
-    (let [raw-idx (raw-index model idx)]
-      (get (model/repo-manager-items model) raw-idx))
+    (item-at model (model/repo-manager-items model) idx)
 
     nil))
 
@@ -83,18 +87,19 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Individual toggle
 
+(defn- toggle-id
+  "Add id to set if absent, remove if present."
+  [ids id]
+  (let [ids (or ids #{})]
+    (if (contains? ids id) (disj ids id) (conj ids id))))
+
 (defn toggle-selection
   "Toggle selection of item at cursor, then advance cursor down.
    Standard TUI multi-select pattern (like mc/ranger)."
   [model]
   (if-let [id (current-item-id model)]
     (-> model
-        (update :selected-ids
-                (fn [ids]
-                  (let [ids (or ids #{})]
-                    (if (contains? ids id)
-                      (disj ids id)
-                      (conj ids id)))))
+        (update :selected-ids toggle-id id)
         (nav/navigate-down))
     model))
 

--- a/components/tui-views/src/ai/miniforge/tui_views/view.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view.clj
@@ -28,7 +28,12 @@
    [ai.miniforge.tui-views.views.workflow-detail :as wf-detail]
    [ai.miniforge.tui-views.views.evidence :as evidence]
    [ai.miniforge.tui-views.views.artifact-browser :as artifact-browser]
-   [ai.miniforge.tui-views.views.dag-kanban :as dag-kanban]))
+   [ai.miniforge.tui-views.views.dag-kanban :as dag-kanban]
+   [ai.miniforge.tui-views.views.pr-fleet :as pr-fleet]
+   [ai.miniforge.tui-views.views.pr-detail :as pr-detail]
+   [ai.miniforge.tui-views.views.train-view :as train-view]
+   [ai.miniforge.tui-views.views.repo-manager :as repo-manager]
+   [ai.miniforge.tui-views.views.help :as help]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; View dispatch
@@ -42,6 +47,10 @@
     :evidence         (evidence/render model size)
     :artifact-browser (artifact-browser/render model size)
     :dag-kanban       (dag-kanban/render model size)
+    :pr-fleet         (pr-fleet/render model size)
+    :pr-detail        (pr-detail/render model size)
+    :train-view       (train-view/render model size)
+    :repo-manager     (repo-manager/render model size)
     ;; Fallback
     (layout/text size "Unknown view")))
 
@@ -58,6 +67,18 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Root view function
 
+(defn- apply-help-overlay
+  "Composite the help overlay centered on the buffer when visible."
+  [buf [cols rows] model]
+  (if (:help-visible? model)
+    (let [overlay (help/render-overlay [cols rows])
+          ov-cols (count (first overlay))
+          ov-rows (count overlay)
+          x (max 0 (quot (- cols ov-cols) 2))
+          y (max 0 (quot (- rows ov-rows) 2))]
+      (layout/blit buf overlay x y))
+    buf))
+
 (defn root-view
   "Root view function for the Elm runtime.
    model -> [cols rows] -> cell-buffer"
@@ -68,14 +89,16 @@
           cmd-active? (not= :normal (:mode model))
           content-rows (if cmd-active? (dec rows) rows)
           ;; Render main view
-          content (render-active-view model [cols content-rows])]
-      (if cmd-active?
-        ;; Build full-size buffer: content on top, command bar on last row
-        (let [buf (layout/make-buffer [cols rows])
-              buf (layout/blit buf content 0 0)
-              cmd-bar (render-command-bar [cols 1] model)]
-          (layout/blit buf cmd-bar 0 (dec rows)))
-        content))))
+          content (render-active-view model [cols content-rows])
+          ;; Build composite buffer
+          buf (if cmd-active?
+                (let [buf (layout/make-buffer [cols rows])
+                      buf (layout/blit buf content 0 0)
+                      cmd-bar (render-command-bar [cols 1] model)]
+                  (layout/blit buf cmd-bar 0 (dec rows)))
+                content)]
+      ;; Apply help overlay on top if visible
+      (apply-help-overlay buf [cols rows] model))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tui-views/src/ai/miniforge/tui_views/views/help.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/help.clj
@@ -1,0 +1,91 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.help
+  "Help overlay -- shows keybinding reference.
+
+   Renders a centered overlay box with key bindings and their descriptions.
+   Displayed when :help-visible? is true in model."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.tui-engine.interface.layout :as layout]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Help content
+
+(def ^:private help-sections
+  "Keybinding help content organized by section."
+  [["Navigation"
+    [["j / k / ↓ / ↑" "Move cursor down / up"]
+     ["g / G"          "Jump to top / bottom"]
+     ["h / l"          "Go back / Enter detail"]
+     ["Enter"          "Enter detail or confirm"]
+     ["Tab / Shift-Tab" "Cycle panes or views"]
+     ["1-9"            "Switch to view by number"]]]
+   ["Selection"
+    [["Space"  "Toggle selection"]
+     ["v"      "Enter visual mode"]
+     ["a"      "Select all"]
+     ["c"      "Clear selection"]]]
+   ["Commands"
+    [[":"      "Enter command mode"]
+     ["/"      "Enter search mode"]
+     ["n / N"  "Next / previous search match"]
+     ["Tab"    "Tab-complete command or argument"]]]
+   ["Actions"
+    [["r"      "Refresh / sync"]
+     ["s"      "Sync PRs"]
+     ["b"      "Browse repos / kanban"]
+     ["e"      "Evidence view"]
+     ["o"      "Open browse"]
+     ["x"      "Remove repos"]
+     ["?"      "Toggle this help"]
+     ["q"      "Quit"]]]])
+
+(defn- format-help-lines
+  "Build flat lines from help sections."
+  []
+  (into []
+    (mapcat
+      (fn [[section-title bindings]]
+        (concat
+          [(str "  " section-title)]
+          (map (fn [[key desc]]
+                 (str "    " (format "%-18s %s" key desc)))
+               bindings)
+          [""])))
+    help-sections))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Overlay rendering
+
+(defn render-overlay
+  "Render the help overlay centered on the screen.
+   Returns a cell buffer to be blitted on top of the main view."
+  [[cols rows]]
+  (let [lines (format-help-lines)
+        box-w (min (- cols 4) 52)
+        box-h (min (- rows 2) (+ (count lines) 2))]
+    (layout/box [box-w box-h]
+      {:title "Help — Key Bindings" :border :single
+       :fg :cyan
+       :content-fn
+       (fn [[ic ir]]
+         (layout/text [ic ir]
+           (str/join "\n" (take ir lines))
+           {:fg :white}))})))

--- a/components/tui-views/src/ai/miniforge/tui_views/views/pr_detail.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/pr_detail.clj
@@ -1,0 +1,66 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.pr-detail
+  "PR detail view -- shows detailed information about a single PR.
+
+   Displays PR title, readiness score, risk level, CI status,
+   and review information."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.tui-engine.interface.layout :as layout]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Rendering helpers
+
+(defn- render-title-bar [pr [cols rows]]
+  (layout/text [cols rows]
+    (str " MINIFORGE │ "
+         (or (:pr/title pr) "PR Detail"))
+    {:fg :cyan :bold? true}))
+
+(defn- render-info-panel [pr [cols rows]]
+  (layout/box [cols rows]
+    {:title "PR Info" :border :single :fg :default
+     :content-fn
+     (fn [[ic ir]]
+       (let [lines [(str "  Title:     " (or (:pr/title pr) "—"))
+                    (str "  Repo:      " (or (:pr/repo pr) "—"))
+                    (str "  Readiness: " (int (* 100 (or (:pr/readiness pr) 0))) "%")
+                    (str "  Risk:      " (name (or (:pr/risk pr) :unknown)))
+                    (str "  CI:        " (name (or (:pr/ci-status pr) :unknown)))
+                    (str "  Author:    " (or (:pr/author pr) "—"))]]
+         (layout/text [ic ir] (str/join "\n" lines))))}))
+
+(defn- render-footer [[cols rows]]
+  (layout/text [cols rows]
+    " Esc:back  Tab:pane  e:evidence  /:search  q:quit"
+    {:fg :default}))
+
+(defn render
+  "Render the PR detail view.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [pr (get-in model [:detail :selected-pr])]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      (fn [size] (render-title-bar pr size))
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          (fn [size] (render-info-panel pr size))
+          render-footer)))))

--- a/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
@@ -1,0 +1,87 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.pr-fleet
+  "PR Fleet view -- shows all tracked pull requests across repositories.
+
+   Displays a table of PRs with title, readiness score, risk level,
+   CI status, and repo information."
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Rendering helpers
+
+(defn- risk-indicator [risk]
+  (case risk
+    :low    "LOW"
+    :medium "MED"
+    :high   "HIGH"
+    "---"))
+
+(defn- readiness-bar [readiness cols]
+  (let [pct (int (* (or readiness 0) 100))
+        bar-width (max 1 (- cols 5))
+        filled (int (* bar-width (or readiness 0)))]
+    (str (apply str (repeat filled "█"))
+         (apply str (repeat (- bar-width filled) "░"))
+         " " pct "%")))
+
+(defn- format-pr-row [pr cols]
+  {:title (or (:pr/title pr) "Untitled")
+   :repo  (or (:pr/repo pr) "")
+   :readiness (readiness-bar (:pr/readiness pr) (min 15 (max 8 (quot cols 6))))
+   :risk (risk-indicator (:pr/risk pr))})
+
+(defn- render-title-bar [[cols rows]]
+  (layout/text [cols rows] " MINIFORGE │ PR Fleet"
+               {:fg :cyan :bold? true}))
+
+(defn- render-table [pr-items selected [cols rows]]
+  (if (empty? pr-items)
+    (layout/text [cols rows] "  No PRs tracked. Use :add-repo to add repositories."
+                 {:fg :default})
+    (let [title-width (max 10 (- cols 60))]
+      (layout/table [cols rows]
+        {:columns [{:key :title :header "PR Title" :width title-width}
+                   {:key :repo :header "Repository" :width 25}
+                   {:key :readiness :header "Readiness" :width 18}
+                   {:key :risk :header "Risk" :width 6}]
+         :data (mapv #(format-pr-row % cols) pr-items)
+         :selected-row selected}))))
+
+(defn- render-footer [flash-message [cols rows]]
+  (layout/text [cols rows]
+    (str " j/k:navigate  Enter:detail  r:sync  b:kanban  ::cmd  q:quit"
+         (when flash-message (str "  │ " flash-message)))
+    {:fg :default}))
+
+(defn render
+  "Render the PR fleet view.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [pr-items (:pr-items model)
+        selected (:selected-idx model)
+        flash (:flash-message model)]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      (fn [size] (render-title-bar size))
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          (fn [size] (render-table pr-items selected size))
+          (fn [size] (render-footer flash size)))))))

--- a/components/tui-views/src/ai/miniforge/tui_views/views/repo_manager.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/repo_manager.clj
@@ -1,0 +1,87 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.repo-manager
+  "Repo manager view -- add/remove repositories from the fleet.
+
+   Shows configured fleet repos or browse-mode remote repos.
+   Supports selection for batch add/remove operations."
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.model :as model]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Rendering helpers
+
+(defn- source-label [model]
+  (if (= :browse (:repo-manager-source model))
+    "Browse"
+    "Fleet"))
+
+(defn- format-repo-row [repo selected-ids]
+  (let [selected? (contains? (or selected-ids #{}) repo)]
+    {:marker (if selected? "●" " ")
+     :repo repo}))
+
+(defn- view-number
+  "1-based view number for the tab bar display."
+  []
+  (let [idx (.indexOf ^java.util.List model/top-level-views :repo-manager)]
+    (when (>= idx 0) (inc idx))))
+
+(defn- render-title-bar [model [cols rows]]
+  (let [items (model/repo-manager-items model)
+        vnum (view-number)
+        label (str " MINIFORGE │ [Repos (" vnum ")] "
+                   (source-label model) " — "
+                   (count items) " repo(s)")]
+    (layout/text [cols rows] label
+                 {:fg :cyan :bold? true})))
+
+(defn- render-table [items selected selected-ids [cols rows]]
+  (if (empty? items)
+    (layout/text [cols rows] "  No repositories configured. Use :add-repo or b to browse."
+                 {:fg :default})
+    (layout/table [cols rows]
+      {:columns [{:key :marker :header " " :width 2}
+                 {:key :repo :header "Repository" :width (max 10 (- cols 8))}]
+       :data (mapv #(format-repo-row % selected-ids) items)
+       :selected-row selected})))
+
+(defn- render-footer [model [cols rows]]
+  (let [source (if (= :browse (:repo-manager-source model)) :browse :fleet)]
+    (layout/text [cols rows]
+      (if (= :browse source)
+        " Enter:add  space:select  f:fleet  Esc:back  q:quit"
+        " b:browse  x:remove  space:select  a:all  /:search  q:quit")
+      {:fg :default})))
+
+(defn render
+  "Render the repo manager view.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [items (model/repo-manager-items model)
+        selected (:selected-idx model)
+        selected-ids (:selected-ids model)]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      (fn [size] (render-title-bar model size))
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          (fn [size] (render-table items selected selected-ids size))
+          (fn [size] (render-footer model size)))))))

--- a/components/tui-views/src/ai/miniforge/tui_views/views/train_view.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/train_view.clj
@@ -1,0 +1,71 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.views.train-view
+  "Train view -- shows PRs ordered for merge in a release train.
+
+   Displays the train name and a table of PRs in merge order
+   with readiness and status."
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Rendering helpers
+
+(defn- format-pr-row [pr]
+  {:title (or (:pr/title pr) "Untitled")
+   :readiness (str (int (* 100 (or (:pr/readiness pr) 0))) "%")
+   :order (str (or (:pr/merge-order pr) "—"))})
+
+(defn- render-title-bar [train [cols rows]]
+  (layout/text [cols rows]
+    (str " MINIFORGE │ Train: "
+         (or (:train/name train) "Release Train"))
+    {:fg :cyan :bold? true}))
+
+(defn- render-table [prs selected [cols rows]]
+  (if (empty? prs)
+    (layout/text [cols rows] "  No PRs in this train."
+                 {:fg :default})
+    (layout/table [cols rows]
+      {:columns [{:key :order :header "#" :width 4}
+                 {:key :title :header "PR Title" :width (max 10 (- cols 30))}
+                 {:key :readiness :header "Ready" :width 8}]
+       :data (mapv format-pr-row
+               (sort-by :pr/merge-order prs))
+       :selected-row selected})))
+
+(defn- render-footer [[cols rows]]
+  (layout/text [cols rows]
+    " Esc:back  j/k:navigate  space:select  q:quit"
+    {:fg :default}))
+
+(defn render
+  "Render the train view.
+   model: full app model
+   [cols rows]: available screen area"
+  [model [cols rows]]
+  (let [train (get-in model [:detail :selected-train])
+        prs (or (:train/prs train) [])
+        selected (:selected-idx model)]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      (fn [size] (render-title-bar train size))
+      (fn [[c r]]
+        (layout/split-v [c r] (/ (- r 2.0) r)
+          (fn [size] (render-table prs selected size))
+          render-footer)))))

--- a/components/tui-views/test/ai/miniforge/tui_views/search_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/search_test.clj
@@ -1,0 +1,286 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.search-test
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.test-util :as util]
+   [ai.miniforge.tui-views.update :as update]
+   [ai.miniforge.tui-views.update.mode :as mode]
+   [ai.miniforge.tui-views.update.navigation :as nav]))
+
+(def wf-id-1 (random-uuid))
+(def wf-id-2 (random-uuid))
+(def wf-id-3 (random-uuid))
+
+(defn- three-workflows []
+  (-> (util/fresh-model)
+      (util/with-workflows
+        [{:workflow-id wf-id-1 :name "deploy-api"}
+         {:workflow-id wf-id-2 :name "deploy-web"}
+         {:workflow-id wf-id-3 :name "build-infra"}])
+      (assoc :view :workflow-list)))
+
+(deftest search-filtering-test
+  (testing "Search filters workflows by name"
+    (let [m (-> (three-workflows)
+                (assoc :mode :search :command-buf "/deploy")
+                mode/compute-search-results)]
+      (is (= #{0 1} (:filtered-indices m)))))
+
+  (testing "Search is case-insensitive"
+    (let [m (-> (three-workflows)
+                (assoc :mode :search :command-buf "/DEPLOY")
+                mode/compute-search-results)]
+      (is (= #{0 1} (:filtered-indices m)))))
+
+  (testing "Empty query clears filter"
+    (let [m (-> (three-workflows)
+                (assoc :mode :search :command-buf "/")
+                mode/compute-search-results)]
+      (is (nil? (:filtered-indices m)))))
+
+  (testing "No matches gives empty set"
+    (let [m (-> (three-workflows)
+                (assoc :mode :search :command-buf "/zzzzz")
+                mode/compute-search-results)]
+      (is (empty? (:filtered-indices m)))))
+
+  (testing "Single match"
+    (let [m (-> (three-workflows)
+                (assoc :mode :search :command-buf "/infra")
+                mode/compute-search-results)]
+      (is (= #{2} (:filtered-indices m)))))
+
+  (testing "Repo-manager search filters configured repositories"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :repo-manager
+                       :fleet-repos ["acme/api" "acme/web" "infra/ops"]
+                       :mode :search
+                       :command-buf "/acme")
+                mode/compute-search-results)]
+      (is (= #{0 1} (:filtered-indices m)))))
+
+  (testing "Repo-manager search in browse mode filters browse candidates"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :repo-manager
+                       :repo-manager-source :browse
+                       :fleet-repos ["acme/api"]
+                       :browse-repos ["acme/api" "acme/new-service" "org/other"]
+                       :mode :search
+                       :command-buf "/new")
+                mode/compute-search-results)]
+      ;; browse candidates excludes acme/api because it's already in fleet
+      (is (= #{0} (:filtered-indices m))))))
+
+(deftest search-mode-escape-test
+  (testing "Escape from search mode clears filtered-indices"
+    (let [m (-> (three-workflows)
+                (update/update-model [:input :key/slash])
+                (update/update-model [:input {:type :char :char \d}])
+                (update/update-model [:input :key/escape]))]
+      (is (util/mode-is? m :normal))
+      (is (nil? (:filtered-indices m))))))
+
+(deftest search-resets-selection-test
+  (testing "Search resets selected-idx to 0"
+    (let [m (-> (three-workflows)
+                (assoc :selected-idx 2 :mode :search :command-buf "/deploy")
+                mode/compute-search-results)]
+      (is (= 0 (:selected-idx m))))))
+
+;; ---------------------------------------------------------------------------
+;; Selection survives search exit
+;; ---------------------------------------------------------------------------
+
+(deftest search-confirm-keeps-filter-test
+  (testing "confirm-search keeps filtered-indices but exits to normal"
+    (let [m (-> (three-workflows)
+                (assoc :mode :search :command-buf "/deploy")
+                mode/compute-search-results
+                mode/confirm-search)]
+      (is (= :normal (:mode m)))
+      (is (= "" (:command-buf m)))
+      ;; Filter persists!
+      (is (= #{0 1} (:filtered-indices m)))))
+
+  (testing "exit-mode clears filtered-indices"
+    (let [m (-> (three-workflows)
+                (assoc :mode :search :command-buf "/deploy")
+                mode/compute-search-results
+                mode/exit-mode)]
+      (is (= :normal (:mode m)))
+      (is (nil? (:filtered-indices m)))))
+
+  (testing "Selection persists through filter clear"
+    (let [m (-> (three-workflows)
+                (assoc :filtered-indices #{0})
+                (assoc :selected-ids #{wf-id-1})
+                (assoc :mode :search :command-buf "/deploy-api"))]
+      ;; Even exit-mode (Escape) preserves selection
+      (is (= 1 (count (:selected-ids (mode/exit-mode m)))))
+      (is (contains? (:selected-ids (mode/exit-mode m)) wf-id-1)))))
+
+;; ---------------------------------------------------------------------------
+;; Detail view search — find-in-page
+;; ---------------------------------------------------------------------------
+
+(defn- detail-model-with-output
+  "Create a model in workflow-detail with agent output text."
+  [output-text]
+  (let [wf-id (random-uuid)]
+    (-> (util/fresh-model)
+        (assoc :view :workflow-detail)
+        (assoc-in [:detail :workflow-id] wf-id)
+        (assoc-in [:detail :agent-output] output-text)
+        (assoc :workflows [{:id wf-id :name "test-wf" :status :running}]))))
+
+(deftest workflow-detail-search-test
+  (testing "Search in workflow-detail finds matching lines"
+    (let [m (-> (detail-model-with-output "line one\nerror here\nline three\nanother error")
+                (assoc :mode :search :command-buf "/error")
+                mode/compute-search-results)]
+      (is (= 2 (count (:search-matches m))))
+      (is (= 1 (:line-idx (first (:search-matches m)))))
+      (is (= 3 (:line-idx (second (:search-matches m)))))
+      (is (nil? (:filtered-indices m)) "Detail search doesn't set filtered-indices")))
+
+  (testing "Empty query clears search-matches"
+    (let [m (-> (detail-model-with-output "some text")
+                (assoc :mode :search :command-buf "/")
+                mode/compute-search-results)]
+      (is (empty? (:search-matches m)))))
+
+  (testing "No matches gives empty vector"
+    (let [m (-> (detail-model-with-output "no matches here")
+                (assoc :mode :search :command-buf "/zzzzz")
+                mode/compute-search-results)]
+      (is (empty? (:search-matches m)))))
+
+  (testing "Search is case-insensitive"
+    (let [m (-> (detail-model-with-output "Error on line 1\nerror on line 2")
+                (assoc :mode :search :command-buf "/ERROR")
+                mode/compute-search-results)]
+      (is (= 2 (count (:search-matches m)))))))
+
+(deftest workflow-detail-confirm-search-test
+  (testing "Confirm search jumps to first match"
+    (let [m (-> (detail-model-with-output "line one\ntarget here\nline three")
+                (assoc :mode :search :command-buf "/target")
+                mode/compute-search-results
+                mode/confirm-search)]
+      (is (= :normal (:mode m)))
+      (is (= 0 (:search-match-idx m)))
+      (is (= 1 (:scroll-offset m)) "Scrolls to match line")))
+
+  (testing "Exit-mode clears search-matches"
+    (let [m (-> (detail-model-with-output "target here")
+                (assoc :mode :search :command-buf "/target")
+                mode/compute-search-results
+                mode/exit-mode)]
+      (is (empty? (:search-matches m)))
+      (is (nil? (:search-match-idx m))))))
+
+(deftest search-match-navigation-test
+  (testing "n jumps to next match"
+    (let [m (-> (detail-model-with-output "match\nno\nmatch\nno\nmatch")
+                (assoc :mode :search :command-buf "/match")
+                mode/compute-search-results
+                mode/confirm-search)]
+      ;; Start at match 0 (line 0)
+      (is (= 0 (:search-match-idx m)))
+      ;; n → match 1 (line 2)
+      (let [m2 (nav/next-search-match m)]
+        (is (= 1 (:search-match-idx m2)))
+        (is (= 2 (:scroll-offset m2))))
+      ;; n twice → match 2 (line 4)
+      (let [m3 (-> m nav/next-search-match nav/next-search-match)]
+        (is (= 2 (:search-match-idx m3)))
+        (is (= 4 (:scroll-offset m3))))
+      ;; n three times → wraps to match 0 (line 0)
+      (let [m4 (-> m nav/next-search-match nav/next-search-match nav/next-search-match)]
+        (is (= 0 (:search-match-idx m4)))
+        (is (= 0 (:scroll-offset m4))))))
+
+  (testing "N jumps to previous match, wrapping"
+    (let [m (-> (detail-model-with-output "match\nno\nmatch")
+                (assoc :mode :search :command-buf "/match")
+                mode/compute-search-results
+                mode/confirm-search)]
+      ;; N from match 0 → wraps to match 1 (line 2)
+      (is (= 1 (:search-match-idx (nav/prev-search-match m))))
+      (is (= 2 (:scroll-offset (nav/prev-search-match m))))))
+
+  (testing "n/N no-op without matches"
+    (let [m (util/fresh-model)]
+      (is (= m (nav/next-search-match m)))
+      (is (= m (nav/prev-search-match m))))))
+
+(deftest evidence-search-test
+  (testing "Search in evidence view finds matching tree nodes"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :evidence)
+                (assoc-in [:detail :phases]
+                  [{:phase :plan :status :success}
+                   {:phase :implement :status :running}])
+                (assoc :mode :search :command-buf "/plan")
+                mode/compute-search-results)]
+      (is (pos? (count (:search-matches m))))
+      ;; Should match "Phases" section's "plan" entry
+      (is (some #(str/includes? (:text %) "plan") (:search-matches m))))))
+
+(deftest search-match-navigation-via-keys-test
+  (testing "n key navigates to next match via update-model"
+    (let [m (-> (detail-model-with-output "match\nno\nmatch\nno\nmatch")
+                (assoc :mode :search :command-buf "/match")
+                mode/compute-search-results
+                mode/confirm-search)]
+      (is (= 0 (:search-match-idx m)))
+      ;; Press n → match 1
+      (let [m2 (update/update-model m [:input {:key :key/n :char \n}])]
+        (is (= 1 (:search-match-idx m2)))
+        (is (= 2 (:scroll-offset m2))))))
+
+  (testing "N key navigates to previous match via update-model"
+    (let [m (-> (detail-model-with-output "match\nno\nmatch")
+                (assoc :mode :search :command-buf "/match")
+                mode/compute-search-results
+                mode/confirm-search)]
+      (is (= 0 (:search-match-idx m)))
+      ;; Press N → wraps to last match
+      (let [m2 (update/update-model m [:input {:key :key/N :char \N}])]
+        (is (= 1 (:search-match-idx m2)))
+        (is (= 2 (:scroll-offset m2)))))))
+
+(deftest escape-clears-search-matches-test
+  (testing "Escape cascade: search-matches cleared before go-back"
+    (let [m (-> (detail-model-with-output "match here")
+                (assoc :mode :search :command-buf "/match")
+                mode/compute-search-results
+                mode/confirm-search)]
+      (is (seq (:search-matches m)))
+      ;; First Escape clears search-matches
+      (let [m2 (update/update-model m [:input {:key :key/escape :char (char 27)}])]
+        (is (empty? (:search-matches m2)))
+        (is (= :workflow-detail (:view m2)) "Stays in view, just clears matches"))
+      ;; Second Escape goes back
+      (let [m3 (-> m
+                   (update/update-model [:input {:key :key/escape :char (char 27)}])
+                   (update/update-model [:input {:key :key/escape :char (char 27)}]))]
+        (is (= :workflow-list (:view m3)))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/selection_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/selection_test.clj
@@ -1,0 +1,260 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.selection-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.test-util :as util]
+   [ai.miniforge.tui-views.update.selection :as sel]))
+
+(def wf-id-1 (random-uuid))
+(def wf-id-2 (random-uuid))
+(def wf-id-3 (random-uuid))
+
+(defn- three-workflows []
+  (-> (util/fresh-model)
+      (util/with-workflows
+        [{:workflow-id wf-id-1 :name "wf-1"}
+         {:workflow-id wf-id-2 :name "wf-2"}
+         {:workflow-id wf-id-3 :name "wf-3"}])
+      (assoc :view :workflow-list)))
+
+;; ---------------------------------------------------------------------------
+;; Space toggle selection
+;; ---------------------------------------------------------------------------
+
+(deftest toggle-selection-test
+  (testing "Space selects item at cursor and advances cursor"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/space :char \space}]])]
+      (is (util/selection-count-is? m 1))
+      (is (= 1 (:selected-idx m)))  ;; cursor advanced
+      ;; Verify the ID of the first workflow is selected
+      (is (= wf-id-1 (:id (first (:workflows m)))))
+      (is (contains? (:selected-ids m) wf-id-1))))
+
+  (testing "Space deselects already-selected item"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/space :char \space}]   ;; select wf-1, cursor → 1
+               [:input {:key :key/k :char \k}]           ;; cursor → 0
+               [:input {:key :key/space :char \space}]])] ;; deselect wf-1
+      (is (util/selection-count-is? m 0))))
+
+  (testing "Space selects multiple items"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/space :char \space}]   ;; select wf-1, cursor → 1
+               [:input {:key :key/space :char \space}]])] ;; select wf-2, cursor → 2
+      (is (util/selection-count-is? m 2)))))
+
+;; ---------------------------------------------------------------------------
+;; Visual mode
+;; ---------------------------------------------------------------------------
+
+(deftest visual-mode-test
+  (testing "v enters visual mode"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/v :char \v}]])]
+      (is (util/visual-mode? m))
+      (is (util/selection-count-is? m 1))))  ;; anchor item selected
+
+  (testing "v + j extends selection range"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/v :char \v}]
+               [:input {:key :key/j :char \j}]
+               [:input {:key :key/j :char \j}]])]
+      (is (util/visual-mode? m))
+      (is (util/selection-count-is? m 3))))
+
+  (testing "Escape exits visual mode but keeps selection"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/v :char \v}]
+               [:input {:key :key/j :char \j}]
+               [:input :key/escape]])]
+      (is (not (util/visual-mode? m)))
+      (is (util/selection-count-is? m 2)))))  ;; selection kept
+
+;; ---------------------------------------------------------------------------
+;; Select all / clear
+;; ---------------------------------------------------------------------------
+
+(deftest select-all-test
+  (testing "a selects all items"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/a :char \a}]])]
+      (is (util/selection-count-is? m 3))))
+
+  (testing "c clears all selections"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/a :char \a}]
+               [:input {:key :key/c :char \c}]])]
+      (is (util/selection-count-is? m 0)))))
+
+;; ---------------------------------------------------------------------------
+;; View switch clears selection
+;; ---------------------------------------------------------------------------
+
+(deftest view-switch-clears-selection-test
+  (testing "Switching view clears selection"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/a :char \a}]           ;; select all
+               [:input {:key :key/d3 :char \3}]])]       ;; switch to evidence
+      (is (util/selection-count-is? m 0))))
+
+  (testing "Escape clears selection before going back"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/a :char \a}]           ;; select all
+               [:input :key/escape]])]                   ;; first Escape clears selection
+      (is (util/selection-count-is? m 0))
+      (is (util/view-is? m :workflow-list))))             ;; still in workflow-list
+
+  (testing "Second Escape goes back after selection is cleared"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input :key/enter]                        ;; enter detail
+               [:input :key/escape]])]                   ;; go back (no selection to clear)
+      (is (util/view-is? m :workflow-list)))))
+
+;; ---------------------------------------------------------------------------
+;; Effective IDs (batch action helper)
+;; ---------------------------------------------------------------------------
+
+(deftest effective-ids-test
+  (testing "Returns selected-ids when non-empty"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/space :char \space}]])]
+      (is (= 1 (count (sel/effective-ids m))))))
+
+  (testing "Falls back to cursor item when nothing selected"
+    (let [m (three-workflows)]
+      (is (= 1 (count (sel/effective-ids m))))
+      (is (= wf-id-1 (first (sel/effective-ids m)))))))
+
+;; ---------------------------------------------------------------------------
+;; Space is context-sensitive
+;; ---------------------------------------------------------------------------
+
+(deftest space-context-sensitive-test
+  (testing "Space in detail view toggles expand, not selection"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-detail)
+                (util/apply-updates [[:input {:key :key/space :char \space}]]))]
+      ;; should have toggled expand, not selection
+      (is (contains? (get-in m [:detail :expanded-nodes]) 0))
+      (is (util/selection-count-is? m 0))))
+
+  (testing "Space in artifact-browser toggles selection"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :artifact-browser)
+                (assoc-in [:detail :artifacts] [{:type :code :name "a.clj"}
+                                                {:type :test :name "b.clj"}])
+                (util/apply-updates [[:input {:key :key/space :char \space}]]))]
+      (is (util/selection-count-is? m 1))
+      (is (contains? (:selected-ids m) [:artifact 0]))))
+
+  (testing "Space in train-view toggles selection"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :train-view)
+                (assoc-in [:detail :selected-train :train/prs]
+                          [{:pr/repo "r1" :pr/number 1 :pr/merge-order 1}
+                           {:pr/repo "r1" :pr/number 2 :pr/merge-order 2}])
+                (util/apply-updates [[:input {:key :key/space :char \space}]]))]
+      (is (util/selection-count-is? m 1))
+      (is (contains? (:selected-ids m) ["r1" 1]))))
+
+  (testing "Space in repo-manager toggles repository selection"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :repo-manager
+                       :fleet-repos ["acme/api" "acme/web"])
+                (util/apply-updates [[:input {:key :key/space :char \space}]]))]
+      (is (util/selection-count-is? m 1))
+      (is (contains? (:selected-ids m) "acme/api")))))
+
+;; ---------------------------------------------------------------------------
+;; Search + select (filter-aware selection)
+;; ---------------------------------------------------------------------------
+
+(deftest search-select-test
+  (testing "Enter confirms search, keeps filter active"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/slash :char \/}]     ;; enter search
+               [:input {:key nil :char \1}]             ;; type "1" → matches "wf-1"
+               [:input :key/enter]])]                   ;; confirm search
+      (is (util/mode-is? m :normal))
+      (is (some? (:filtered-indices m)))                ;; filter stays!
+      (is (= #{0} (:filtered-indices m)))))             ;; only wf-1 (idx 0) matches
+
+  (testing "Escape aborts search, clears filter"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/slash :char \/}]     ;; enter search
+               [:input {:key nil :char \1}]             ;; type "1"
+               [:input :key/escape]])]                  ;; abort search
+      (is (util/mode-is? m :normal))
+      (is (nil? (:filtered-indices m)))))               ;; filter cleared
+
+  (testing "item-id-at maps correctly with filtered-indices"
+    (let [m (-> (three-workflows)
+                (assoc :filtered-indices #{1 2}))]  ;; only wf-2, wf-3 visible
+      ;; Cursor 0 → first visible item → wf-2
+      (is (= wf-id-2 (sel/item-id-at m 0)))
+      ;; Cursor 1 → second visible item → wf-3
+      (is (= wf-id-3 (sel/item-id-at m 1)))))
+
+  (testing "select-all with filtered-indices selects only visible items"
+    (let [m (-> (three-workflows)
+                (assoc :filtered-indices #{0 2}))    ;; wf-1, wf-3 visible
+          m (sel/select-all m)]
+      (is (= 2 (count (:selected-ids m))))
+      (is (contains? (:selected-ids m) wf-id-1))
+      (is (contains? (:selected-ids m) wf-id-3))
+      (is (not (contains? (:selected-ids m) wf-id-2)))))
+
+  (testing "Full flow: search → confirm → select-all → Esc clears filter, selection persists"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/slash :char \/}]     ;; enter search
+               [:input {:key nil :char \1}]             ;; type "1" → matches wf-1
+               [:input :key/enter]                      ;; confirm → filter active, normal mode
+               [:input {:key :key/a :char \a}]])]       ;; select-all on filtered results
+      ;; Filter is active, only 1 item selected
+      (is (some? (:filtered-indices m)))
+      (is (= 1 (count (:selected-ids m))))
+      (is (contains? (:selected-ids m) wf-id-1))
+      ;; Now Escape: clears selection first (cascade)
+      (let [m2 (util/apply-updates m [[:input :key/escape]])]
+        (is (= 0 (count (:selected-ids m2))))
+        (is (some? (:filtered-indices m2)))             ;; filter still active
+        ;; Second Escape: clears filter
+        (let [m3 (util/apply-updates m2 [[:input :key/escape]])]
+          (is (nil? (:filtered-indices m3)))             ;; filter cleared
+          (is (util/view-is? m3 :workflow-list))))))     ;; still in list
+
+  (testing "Space selects individual items in filtered results"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/slash :char \/}]     ;; enter search
+               [:input {:key nil :char \1}]             ;; type "1" → matches wf-1
+               [:input :key/enter]                      ;; confirm search
+               [:input {:key :key/space :char \space}]])] ;; toggle-select wf-1
+      (is (= 1 (count (:selected-ids m))))
+      (is (contains? (:selected-ids m) wf-id-1))))
+
+  (testing "repo-manager select-all with filtered-indices selects only visible repos"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :repo-manager
+                       :fleet-repos ["acme/api" "acme/web" "infra/ops"]
+                       :filtered-indices #{0 2}))
+          m (sel/select-all m)]
+      (is (= #{"acme/api" "infra/ops"} (:selected-ids m)))
+      (is (= 2 (count (:selected-ids m)))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/test_util.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/test_util.clj
@@ -77,3 +77,25 @@
   "Check if model's mode matches expected."
   [model expected-mode]
   (= expected-mode (:mode model)))
+
+;; Selection assertion helpers
+
+(defn selection-count-is?
+  "Check if model has expected number of selected items."
+  [model expected-count]
+  (= expected-count (count (:selected-ids model))))
+
+(defn has-selection?
+  "Check if model has a specific ID selected."
+  [model id]
+  (contains? (:selected-ids model) id))
+
+(defn visual-mode?
+  "Check if visual mode is active."
+  [model]
+  (some? (:visual-anchor model)))
+
+(defn confirm-active?
+  "Check if a confirmation prompt is active."
+  [model]
+  (some? (:confirm model)))

--- a/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
@@ -18,68 +18,85 @@
 
 (ns ai.miniforge.tui-views.update-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.pr-sync.interface :as pr-sync]
+   [ai.miniforge.tui-views.model :as model]
    [ai.miniforge.tui-views.test-util :as util]
    [ai.miniforge.tui-views.update :as update]))
 
 (def wf-id-1 (random-uuid))
 (def wf-id-2 (random-uuid))
 
-(defn- two-workflows []
-  (util/with-workflows (util/fresh-model)
-    [{:workflow-id wf-id-1 :name "wf-1"}
-     {:workflow-id wf-id-2 :name "wf-2"}]))
+(defn- two-workflows
+  "Create a model with 2 workflows in the workflow-list view."
+  []
+  (-> (util/fresh-model)
+      (util/with-workflows [{:workflow-id wf-id-1 :name "wf-1"}
+                            {:workflow-id wf-id-2 :name "wf-2"}])
+      (assoc :view :workflow-list)))
 
 (deftest navigation-test
   (testing "j moves down in workflow list"
-    (let [m (util/apply-updates (two-workflows) [[:input :key/j]])]
+    (let [m (util/apply-updates (two-workflows) [[:input {:key :key/j :char \j}]])]
       (is (util/selected-idx-is? m 1))))
 
   (testing "k moves up in workflow list"
     (let [m (util/apply-updates (two-workflows)
-              [[:input :key/j]
-               [:input :key/k]])]
+              [[:input {:key :key/j :char \j}]
+               [:input {:key :key/k :char \k}]])]
       (is (util/selected-idx-is? m 0))))
 
   (testing "k at top stays at 0"
-    (let [m (util/apply-updates (two-workflows) [[:input :key/k]])]
+    (let [m (util/apply-updates (two-workflows) [[:input {:key :key/k :char \k}]])]
       (is (util/selected-idx-is? m 0))))
 
   (testing "j at bottom stays at max"
     (let [m (util/apply-updates (two-workflows)
-              [[:input :key/j]
-               [:input :key/j]
-               [:input :key/j]])]
+              [[:input {:key :key/j :char \j}]
+               [:input {:key :key/j :char \j}]
+               [:input {:key :key/j :char \j}]])]
       (is (util/selected-idx-is? m 1))))
 
   (testing "g goes to top"
     (let [m (util/apply-updates (two-workflows)
-              [[:input :key/j]
-               [:input :key/g]])]
+              [[:input {:key :key/j :char \j}]
+               [:input {:key :key/g :char \g}]])]
       (is (util/selected-idx-is? m 0))))
 
   (testing "G goes to bottom"
-    (let [m (util/apply-updates (two-workflows) [[:input :key/G]])]
+    (let [m (util/apply-updates (two-workflows) [[:input {:key :key/G :char \G}]])]
       (is (util/selected-idx-is? m 1)))))
 
 (deftest view-navigation-test
-  (testing "Enter drills into workflow detail"
-    (let [m (util/apply-updates (two-workflows) [[:input :key/enter]])]
+  (testing "Enter from workflow-list drills into workflow detail"
+    (let [m (util/apply-updates
+              (assoc (two-workflows) :view :workflow-list)
+              [[:input :key/enter]])]
       (is (util/view-is? m :workflow-detail))
       (is (= wf-id-1 (get-in m [:detail :workflow-id])))))
 
-  (testing "Escape returns to workflow list"
-    (let [m (util/apply-updates (two-workflows)
+  (testing "Escape from workflow-detail returns to workflow-list"
+    (let [m (util/apply-updates
+              (assoc (two-workflows) :view :workflow-list)
               [[:input :key/enter]
                [:input :key/escape]])]
       (is (util/view-is? m :workflow-list))))
 
-  (testing "Number keys switch views"
-    (is (util/view-is? (update/update-model (util/fresh-model) [:input :key/d1]) :workflow-list))
-    (is (util/view-is? (update/update-model (util/fresh-model) [:input :key/d2]) :workflow-detail))
-    (is (util/view-is? (update/update-model (util/fresh-model) [:input :key/d3]) :evidence))
-    (is (util/view-is? (update/update-model (util/fresh-model) [:input :key/d4]) :artifact-browser))
-    (is (util/view-is? (update/update-model (util/fresh-model) [:input :key/d5]) :dag-kanban))))
+  (testing "Number keys switch top-level views (1-6)"
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input {:key :key/d1 :char \1}]) :pr-fleet))
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input {:key :key/d2 :char \2}]) :workflow-list))
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input {:key :key/d3 :char \3}]) :evidence))
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input {:key :key/d4 :char \4}]) :artifact-browser))
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input {:key :key/d5 :char \5}]) :dag-kanban))
+    (is (util/view-is? (update/update-model (util/fresh-model) [:input {:key :key/d6 :char \6}]) :repo-manager)))
+
+  (testing "Number keys above available top-level count are no-ops"
+    (let [m (util/fresh-model)]
+      (is (util/view-is? (update/update-model m [:input {:key :key/d7 :char \7}]) :pr-fleet))
+      (is (util/view-is? (update/update-model m [:input {:key :key/d8 :char \8}]) :pr-fleet))
+      (is (util/view-is? (update/update-model m [:input {:key :key/d9 :char \9}]) :pr-fleet))
+      (is (util/view-is? (update/update-model m [:input {:key :key/d0 :char \0}]) :pr-fleet)))))
 
 (deftest workflow-events-test
   (testing "Workflow added appears in list"
@@ -103,18 +120,676 @@
 
 (deftest mode-switching-test
   (testing "Colon enters command mode"
-    (let [m (util/apply-updates (util/fresh-model) [[:input :key/colon]])]
+    (let [m (util/apply-updates (util/fresh-model) [[:input {:key :key/colon :char \:}]])]
       (is (util/mode-is? m :command))
       (is (= ":" (:command-buf m)))))
 
   (testing "Slash enters search mode"
-    (let [m (util/apply-updates (util/fresh-model) [[:input :key/slash]])]
+    (let [m (util/apply-updates (util/fresh-model) [[:input {:key :key/slash :char \/}]])]
       (is (util/mode-is? m :search))
       (is (= "/" (:command-buf m)))))
 
   (testing "Escape exits mode"
     (let [m (util/apply-updates (util/fresh-model)
-              [[:input :key/colon]
+              [[:input {:key :key/colon :char \:}]
                [:input :key/escape]])]
       (is (util/mode-is? m :normal))
       (is (= "" (:command-buf m))))))
+
+;; ---------------------------------------------------------------------------
+;; New tests: keybindings, help overlay, gate results, PR navigation
+;; ---------------------------------------------------------------------------
+
+(deftest new-keybinding-test
+  (testing "r key triggers local refresh outside PR/repo views"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-list)
+                (update/update-model [:input {:key :key/r :char \r}]))]
+      (is (= "Refreshed" (:flash-message m)))
+      (is (some? (:last-updated m)))))
+
+  (testing "r key in pr-fleet triggers PR sync side-effect"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :pr-fleet)
+                (update/update-model [:input {:key :key/r :char \r}]))]
+      (is (= {:type :sync-prs} (:side-effect m)))
+      (is (str/includes? (:flash-message m) "Syncing"))))
+
+  (testing "s key in pr-fleet also triggers PR sync side-effect"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :pr-fleet)
+                (update/update-model [:input {:key :key/s :char \s}]))]
+      (is (= {:type :sync-prs} (:side-effect m)))
+      (is (str/includes? (:flash-message m) "Syncing"))))
+
+  (testing "b key switches to dag-kanban view"
+    (let [m (update/update-model (util/fresh-model) [:input {:key :key/b :char \b}])]
+      (is (util/view-is? m :dag-kanban))
+      (is (util/selected-idx-is? m 0))))
+
+  (testing "e key switches to evidence view"
+    (let [m (update/update-model (util/fresh-model) [:input {:key :key/e :char \e}])]
+      (is (util/view-is? m :evidence))
+      (is (util/selected-idx-is? m 0))))
+
+  (testing "a key selects all items in workflow list"
+    (let [m (util/apply-updates (two-workflows)
+              [[:input {:key :key/a :char \a}]])]
+      (is (util/selection-count-is? m 2))))
+
+  (testing "? key toggles help overlay on"
+    (let [m (update/update-model (util/fresh-model) [:input {:key :key/question :char \?}])]
+      (is (true? (:help-visible? m)))))
+
+  (testing "Space key toggles expand in detail view"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-detail)
+                (util/apply-updates [[:input {:key :key/space :char \space}]]))]
+      (is (contains? (get-in m [:detail :expanded-nodes]) 0))))
+
+  (testing "Space key toggles expand off when pressed again in detail view"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-detail)
+                (util/apply-updates [[:input {:key :key/space :char \space}]
+                                     [:input {:key :key/space :char \space}]]))]
+      (is (not (contains? (get-in m [:detail :expanded-nodes]) 0)))))
+
+  (testing "6 key switches to repo-manager view"
+    (let [m (update/update-model (util/fresh-model) [:input {:key :key/d6 :char \6}])]
+      (is (util/view-is? m :repo-manager))
+      (is (util/selected-idx-is? m 0))))
+
+  (testing "In workflow detail context, number keys switch within detail subviews"
+    (let [m (-> (two-workflows)
+                (update/update-model [:input :key/enter])             ;; workflow-detail
+                (update/update-model [:input {:key :key/d2 :char \2}]))] ;; evidence
+      (is (util/view-is? m :evidence))
+      (let [m2 (update/update-model m [:input {:key :key/d3 :char \3}])]
+        (is (util/view-is? m2 :artifact-browser))))))
+
+(deftest repo-manager-actions-test
+  (testing "b opens remote browse mode and triggers browse side-effect"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :repo-manager)
+                (update/update-model [:input {:key :key/b :char \b}]))]
+      (is (= :browse (:repo-manager-source m)))
+      (is (= {:type :browse-repos :source :repo-manager :provider :all} (:side-effect m)))
+      (is (true? (:browse-repos-loading? m)))))
+
+  (testing "repos-browsed from repo-manager source enters browse mode"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :repo-manager
+                       :fleet-repos ["acme/already"])
+                (update/update-model [:msg/repos-browsed {:success? true
+                                                          :source :repo-manager
+                                                          :repos ["acme/already" "acme/new"]}]))]
+      (is (= :browse (:repo-manager-source m)))
+      ;; already-configured repo is excluded from browse candidates
+      (is (= ["acme/new"] (model/browse-candidate-repos m)))))
+
+  (testing "Enter in browse mode adds selected remote repo to fleet"
+    (with-redefs [pr-sync/add-repo! (fn [_repo] {:success? true
+                                                 :added? true
+                                                 :repo "acme/new"
+                                                 :repos ["acme/new"]})]
+      (let [m (-> (util/fresh-model)
+                  (assoc :view :repo-manager
+                         :repo-manager-source :browse
+                         :browse-repos ["acme/new"])
+                  (update/update-model [:input :key/enter]))]
+        (is (= ["acme/new"] (:fleet-repos m)))
+        (is (= {:type :sync-prs} (:side-effect m)))
+        (is (str/includes? (:flash-message m) "Syncing")))))
+
+  (testing "x requests repo removal confirm in fleet mode; y removes"
+    (with-redefs [pr-sync/remove-repo! (fn [_repo] {:success? true
+                                                    :removed? true
+                                                    :repo "acme/one"
+                                                    :repos []})]
+      (let [m (-> (util/fresh-model)
+                  (assoc :view :repo-manager
+                         :repo-manager-source :fleet
+                         :fleet-repos ["acme/one"])
+                  (update/update-model [:input {:key :key/x :char \x}]))]
+        (is (= :remove-repos (get-in m [:confirm :action])))
+        (is (= #{"acme/one"} (get-in m [:confirm :ids])))
+        (let [m2 (update/update-model m [:input {:key :key/y :char \y}])]
+          (is (nil? (:confirm m2)))
+          (is (empty? (:fleet-repos m2)))
+          (is (str/includes? (:flash-message m2) "Removed")))))))
+
+(deftest help-overlay-dismissal-test
+  (testing "? toggles help on then off"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/question :char \?}]
+               [:input {:key :key/question :char \?}]])]
+      (is (false? (:help-visible? m)))))
+
+  (testing "Escape dismisses help overlay"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/question :char \?}]
+               [:input :key/escape]])]
+      (is (false? (:help-visible? m)))))
+
+  (testing "Navigation keys blocked while help is visible"
+    (let [m (util/apply-updates (two-workflows)
+              [[:input {:key :key/question :char \?}]
+               [:input {:key :key/j :char \j}]])]
+      (is (util/selected-idx-is? m 0))
+      (is (true? (:help-visible? m)))))
+
+  (testing "q still quits even with help visible"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/question :char \?}]
+               [:input {:key :key/q :char \q}]])]
+      (is (true? (:quit? m))))))
+
+(deftest gate-result-event-test
+  (testing "Passing gate result is stored on workflow"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:msg/workflow-added {:workflow-id wf-id-1 :name "gated"}]
+               [:msg/gate-result {:workflow-id wf-id-1 :gate :lint :passed? true}]])]
+      (is (= 1 (count (get-in m [:workflows 0 :gate-results]))))
+      (is (nil? (:flash-message m)))))
+
+  (testing "Failing gate result sets flash message"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:msg/workflow-added {:workflow-id wf-id-1 :name "gated"}]
+               [:msg/gate-result {:workflow-id wf-id-1 :gate :security :passed? false}]])]
+      (is (= 1 (count (get-in m [:workflows 0 :gate-results]))))
+      (is (str/includes? (:flash-message m) "FAILED"))))
+
+  (testing "Gate result includes timestamp"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:msg/workflow-added {:workflow-id wf-id-1 :name "gated"}]
+               [:msg/gate-result {:workflow-id wf-id-1 :gate :test :passed? true}]])]
+      (is (some? (:last-updated m))))))
+
+(deftest pr-navigation-test
+  (testing "Enter from pr-fleet drills into pr-detail"
+    (let [pr-item {:pr/id 42 :pr/title "Fix the thing" :pr/readiness 0.8}
+          m (-> (util/fresh-model)
+                (assoc :view :pr-fleet)
+                (assoc :pr-items [pr-item])
+                (update/update-model [:input :key/enter]))]
+      (is (util/view-is? m :pr-detail))
+      (is (= pr-item (get-in m [:detail :selected-pr])))))
+
+  (testing "Escape from pr-detail returns to pr-fleet"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :pr-detail)
+                (update/update-model [:input :key/escape]))]
+      (is (util/view-is? m :pr-fleet))))
+
+  (testing "Escape from train-view returns to pr-fleet"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :train-view)
+                (update/update-model [:input :key/escape]))]
+      (is (util/view-is? m :pr-fleet))))
+
+  (testing "Escape from evidence in detail context returns to workflow-list"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :evidence)
+                (assoc-in [:detail :workflow-id] wf-id-1)
+                (update/update-model [:input :key/escape]))]
+      (is (util/view-is? m :workflow-list))))
+
+  (testing "Escape from evidence as top-level aggregate is a no-op"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :evidence)
+                (update/update-model [:input :key/escape]))]
+      (is (util/view-is? m :evidence))))
+
+  (testing "Enter from train-view drills into pr-detail"
+    (let [pr-item {:pr/id 99 :pr/title "Train PR"}
+          m (-> (util/fresh-model)
+                (assoc :view :train-view)
+                (assoc-in [:detail :selected-train :train/prs] [pr-item])
+                (update/update-model [:input :key/enter]))]
+      (is (util/view-is? m :pr-detail))
+      (is (= pr-item (get-in m [:detail :selected-pr]))))))
+
+;; ---------------------------------------------------------------------------
+;; Search/command mode with mapped letters — regression test for letter capture
+;; ---------------------------------------------------------------------------
+
+(deftest search-mode-mapped-letters-test
+  (testing "Typing /release in search mode captures all letters"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/slash :char \/}]    ;; enter search mode
+               [:input {:key :key/r :char \r}]        ;; mapped letter
+               [:input {:key :key/e :char \e}]        ;; mapped letter
+               [:input {:key :key/l :char \l}]        ;; mapped letter
+               [:input {:key :key/e :char \e}]        ;; mapped letter
+               [:input {:key :key/a :char \a}]        ;; mapped letter
+               [:input {:key nil :char \s}]            ;; unmapped letter
+               [:input {:key :key/e :char \e}]])]     ;; mapped letter
+      (is (util/mode-is? m :search))
+      (is (= "/release" (:command-buf m)))))
+
+  (testing "Typing :theme dark in command mode captures all letters"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/colon :char \:}]     ;; enter command mode
+               [:input {:key nil :char \t}]             ;; unmapped
+               [:input {:key :key/h :char \h}]          ;; mapped
+               [:input {:key :key/e :char \e}]          ;; mapped
+               [:input {:key nil :char \m}]             ;; unmapped
+               [:input {:key :key/e :char \e}]          ;; mapped
+               [:input {:key :key/space :char \space}]  ;; space
+               [:input {:key nil :char \d}]             ;; unmapped
+               [:input {:key :key/a :char \a}]          ;; mapped
+               [:input {:key :key/r :char \r}]          ;; mapped
+               [:input {:key :key/k :char \k}]])]       ;; mapped
+      (is (util/mode-is? m :command))
+      (is (= ":theme dark" (:command-buf m)))))
+
+  (testing "Escape exits search mode and clears buffer"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/slash :char \/}]
+               [:input {:key :key/r :char \r}]
+               [:input :key/escape]])]
+      (is (util/mode-is? m :normal))
+      (is (= "" (:command-buf m))))))
+
+(deftest workflow-detail-scroll-test
+  (testing "j/k in workflow-detail scroll agent output (not selected-idx)"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-detail)
+                (assoc-in [:detail :agent-output] "line1\nline2\nline3\nline4\nline5")
+                (update/update-model [:input {:key :key/j :char \j}]))]
+      ;; scroll-offset should increase, selected-idx stays 0
+      (is (= 1 (:scroll-offset m)))
+      (is (= 0 (:selected-idx m)))))
+
+  (testing "k decreases scroll-offset in workflow-detail"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-detail :scroll-offset 5)
+                (update/update-model [:input {:key :key/k :char \k}]))]
+      (is (= 4 (:scroll-offset m)))))
+
+  (testing "k at scroll-offset 0 stays at 0"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-detail :scroll-offset 0)
+                (update/update-model [:input {:key :key/k :char \k}]))]
+      (is (= 0 (:scroll-offset m))))))
+
+(deftest tab-navigation-test
+  (testing "Tab in workflow-detail (with context) cycles to evidence sub-view"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-detail)
+                (assoc-in [:detail :workflow-id] wf-id-1)
+                (update/update-model [:input :key/tab]))]
+      (is (util/view-is? m :evidence))))
+
+  (testing "Tab stays within detail sub-views — does not leak to aggregate tier"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-detail)
+                (assoc-in [:detail :workflow-id] wf-id-1)
+                (update/update-model [:input :key/tab])    ;; → evidence (sub-view)
+                (update/update-model [:input :key/tab])    ;; → artifact-browser (sub-view)
+                (update/update-model [:input :key/tab]))]  ;; → workflow-detail (wraps)
+      ;; Tab cycles within detail sub-views only; Esc goes back to aggregate
+      (is (util/view-is? m :workflow-detail))))
+
+  (testing "Tab in workflow-detail without context falls through to detail pane cycling"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-detail)
+                ;; No workflow-id → not in detail subview context
+                (update/update-model [:input :key/tab]))]
+      ;; workflow-detail is in detail-views, so cycle-pane is called
+      (is (util/view-is? m :workflow-detail))
+      (is (= 1 (get-in m [:detail :focused-pane])))))
+
+  (testing "Tab in workflow-list cycles to next top-level view (evidence)"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-list)
+                (update/update-model [:input :key/tab]))]
+      (is (util/view-is? m :evidence))))
+
+  (testing "Tab in dag-kanban cycles to repo-manager"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :dag-kanban)
+                (update/update-model [:input :key/tab]))]
+      (is (util/view-is? m :repo-manager))))
+
+  (testing "Tab in repo-manager wraps to pr-fleet"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :repo-manager)
+                (update/update-model [:input :key/tab]))]
+      (is (util/view-is? m :pr-fleet))))
+
+  (testing "Tab cycles through all top-level views and wraps"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :pr-fleet)
+                (update/update-model [:input :key/tab])    ;; → workflow-list
+                (update/update-model [:input :key/tab])    ;; → evidence
+                (update/update-model [:input :key/tab])    ;; → artifact-browser
+                (update/update-model [:input :key/tab])    ;; → dag-kanban
+                (update/update-model [:input :key/tab])    ;; → repo-manager
+                (update/update-model [:input :key/tab]))]  ;; → pr-fleet (wrap)
+      (is (util/view-is? m :pr-fleet)))))
+
+(deftest shift-tab-navigation-test
+  (testing "Shift+Tab in workflow-list cycles to previous top-level view"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-list)
+                (update/update-model [:input :key/shift-tab]))]
+      (is (util/view-is? m :pr-fleet))))
+
+  (testing "Shift+Tab in pr-fleet wraps to repo-manager"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :pr-fleet)
+                (update/update-model [:input :key/shift-tab]))]
+      (is (util/view-is? m :repo-manager))))
+
+  (testing "Shift+Tab in workflow detail subview cycles reverse within sub-views"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :evidence)
+                (assoc-in [:detail :workflow-id] wf-id-1)
+                (update/update-model [:input :key/shift-tab]))]
+      (is (util/view-is? m :workflow-detail)))))
+
+;; ---------------------------------------------------------------------------
+;; Regression: Tab after going back from detail stays at aggregate tier
+;; ---------------------------------------------------------------------------
+
+(deftest tab-after-go-back-regression-test
+  (testing "Tab on workflow-list after Esc from detail stays at aggregate tier"
+    (let [m (-> (two-workflows)
+                (update/update-model [:input :key/enter])   ;; drill into wf-1 detail
+                (update/update-model [:input :key/escape])  ;; back to workflow-list
+                (update/update-model [:input :key/tab]))]   ;; Tab should cycle top-level
+      ;; Should go to evidence as top-level aggregate, NOT enter detail subview
+      (is (util/view-is? m :evidence))
+      ;; workflow-id should be cleared so we're not in detail context
+      (is (nil? (get-in m [:detail :workflow-id])))))
+
+  (testing "Tab on evidence after Esc from detail sub-view cycles top-level"
+    (let [m (-> (two-workflows)
+                (update/update-model [:input :key/enter])   ;; drill into wf-1 detail
+                (update/update-model [:input :key/tab])     ;; → evidence (sub-view)
+                (update/update-model [:input :key/escape])  ;; back to workflow-list
+                (update/update-model [:input :key/tab]))]   ;; Tab: top-level cycle
+      (is (util/view-is? m :evidence))
+      (is (nil? (get-in m [:detail :workflow-id])))))
+
+  (testing "Tab cycles all top-level views cleanly after detail visit"
+    (let [m (-> (two-workflows)
+                (update/update-model [:input :key/enter])   ;; drill in
+                (update/update-model [:input :key/escape])  ;; back out
+                ;; Now cycle through all top-level views
+                (update/update-model [:input :key/tab])     ;; → evidence
+                (update/update-model [:input :key/tab])     ;; → artifact-browser
+                (update/update-model [:input :key/tab])     ;; → dag-kanban
+                (update/update-model [:input :key/tab])     ;; → repo-manager
+                (update/update-model [:input :key/tab])     ;; → pr-fleet
+                (update/update-model [:input :key/tab]))]   ;; → workflow-list (wrap)
+      (is (util/view-is? m :workflow-list)))))
+
+;; ---------------------------------------------------------------------------
+;; Detail sibling navigation — left/right arrows
+;; ---------------------------------------------------------------------------
+
+(deftest detail-sibling-navigation-test
+  (testing "Right arrow in workflow-detail moves to next workflow"
+    (let [m (-> (two-workflows)
+                (update/update-model [:input :key/enter])  ;; enter wf-1 detail
+                (update/update-model [:input :key/right]))]
+      (is (util/view-is? m :workflow-detail))
+      (is (= wf-id-2 (get-in m [:detail :workflow-id])))))
+
+  (testing "Left arrow in workflow-detail moves to previous workflow"
+    (let [m (-> (two-workflows)
+                ;; Navigate to wf-2 detail
+                (update/update-model [:input {:key :key/j :char \j}])  ;; cursor → 1
+                (update/update-model [:input :key/enter])              ;; enter wf-2
+                (update/update-model [:input :key/left]))]             ;; ← back to wf-1
+      (is (util/view-is? m :workflow-detail))
+      (is (= wf-id-1 (get-in m [:detail :workflow-id])))))
+
+  (testing "Left arrow at first item is a no-op"
+    (let [m (-> (two-workflows)
+                (update/update-model [:input :key/enter])   ;; enter wf-1 detail
+                (update/update-model [:input :key/left]))]  ;; ← at boundary
+      (is (util/view-is? m :workflow-detail))
+      (is (= wf-id-1 (get-in m [:detail :workflow-id])))))
+
+  (testing "Right arrow at last item is a no-op"
+    (let [m (-> (two-workflows)
+                (update/update-model [:input {:key :key/j :char \j}])  ;; cursor → 1
+                (update/update-model [:input :key/enter])              ;; enter wf-2
+                (update/update-model [:input :key/right]))]            ;; → at boundary
+      (is (util/view-is? m :workflow-detail))
+      (is (= wf-id-2 (get-in m [:detail :workflow-id])))))
+
+  (testing "Right arrow in pr-detail moves to next PR"
+    (let [pr-1 {:pr/id 1 :pr/title "PR One"}
+          pr-2 {:pr/id 2 :pr/title "PR Two"}
+          m (-> (util/fresh-model)
+                (assoc :view :pr-fleet)
+                (assoc :pr-items [pr-1 pr-2])
+                (update/update-model [:input :key/enter])   ;; enter pr-1 detail
+                (update/update-model [:input :key/right]))]  ;; → pr-2
+      (is (util/view-is? m :pr-detail))
+      (is (= pr-2 (get-in m [:detail :selected-pr])))))
+
+  (testing "Left/right arrows in list views are no-ops"
+    (let [m (-> (two-workflows)
+                (update/update-model [:input :key/right]))]
+      (is (util/view-is? m :workflow-list))
+      (is (util/selected-idx-is? m 0)))))
+
+;; ---------------------------------------------------------------------------
+;; Batch command tests — archive, delete, cancel, rerun via command mode
+;; ---------------------------------------------------------------------------
+
+(defn- execute-command
+  "Apply a command string to model: enters command mode, types it, presses Enter."
+  [model cmd-str]
+  (util/apply-updates model
+    (into [[:input {:key :key/colon :char \:}]]   ;; enter command mode
+          (conj (vec (for [ch cmd-str]
+                       [:input {:key nil :char ch}]))
+                [:input :key/enter]))))             ;; execute
+
+(deftest batch-archive-test
+  (testing ":archive with selection triggers confirmation"
+    (let [m (-> (two-workflows)
+                (util/apply-updates [[:input {:key :key/space :char \space}]])  ;; select wf-1
+                (execute-command "archive"))]
+      (is (util/confirm-active? m))
+      (is (= :archive (get-in m [:confirm :action])))
+      (is (= 1 (count (get-in m [:confirm :ids]))))))
+
+  (testing "y confirms archive — sets status to :archived"
+    (let [m (-> (two-workflows)
+                (util/apply-updates [[:input {:key :key/space :char \space}]])
+                (execute-command "archive")
+                (update/update-model [:input {:key :key/y :char \y}]))]
+      (is (not (util/confirm-active? m)))
+      (is (util/workflow-has-status? m 0 :archived))
+      (is (str/includes? (:flash-message m) "Archived"))))
+
+  (testing "n cancels confirmation"
+    (let [m (-> (two-workflows)
+                (util/apply-updates [[:input {:key :key/space :char \space}]])
+                (execute-command "archive")
+                (update/update-model [:input {:key :key/n :char \n}]))]
+      (is (not (util/confirm-active? m)))
+      (is (= "Cancelled" (:flash-message m)))
+      ;; Workflow status unchanged (still :running from default)
+      (is (not= :archived (get-in m [:workflows 0 :status])))))
+
+  (testing "Escape cancels confirmation"
+    (let [m (-> (two-workflows)
+                (util/apply-updates [[:input {:key :key/space :char \space}]])
+                (execute-command "archive")
+                (update/update-model [:input :key/escape]))]
+      (is (not (util/confirm-active? m)))
+      (is (= "Cancelled" (:flash-message m))))))
+
+(deftest batch-delete-test
+  (testing ":delete with selection triggers confirmation"
+    (let [m (-> (two-workflows)
+                (util/apply-updates [[:input {:key :key/a :char \a}]])   ;; select all
+                (execute-command "delete"))]
+      (is (util/confirm-active? m))
+      (is (= :delete (get-in m [:confirm :action])))
+      (is (= 2 (count (get-in m [:confirm :ids]))))))
+
+  (testing "y confirms delete — removes workflows"
+    (let [m (-> (two-workflows)
+                (util/apply-updates [[:input {:key :key/a :char \a}]])
+                (execute-command "delete")
+                (update/update-model [:input {:key :key/y :char \y}]))]
+      (is (not (util/confirm-active? m)))
+      (is (util/workflow-count-is? m 0))
+      (is (str/includes? (:flash-message m) "Deleted")))))
+
+(deftest batch-cancel-test
+  (testing ":cancel with running workflow triggers confirmation"
+    (let [m (-> (two-workflows)
+                (util/apply-updates [[:input {:key :key/space :char \space}]])
+                (execute-command "cancel"))]
+      (is (util/confirm-active? m))
+      (is (= :cancel (get-in m [:confirm :action])))))
+
+  (testing "y confirms cancel — sets running workflow to :cancelled"
+    (let [m (-> (two-workflows)
+                (util/apply-updates [[:input {:key :key/space :char \space}]])
+                (execute-command "cancel")
+                (update/update-model [:input {:key :key/y :char \y}]))]
+      (is (not (util/confirm-active? m)))
+      (is (util/workflow-has-status? m 0 :cancelled))
+      (is (str/includes? (:flash-message m) "Cancelled")))))
+
+(deftest batch-rerun-test
+  (testing ":rerun is immediate — no confirmation prompt"
+    (let [m (-> (two-workflows)
+                ;; Set first workflow to :failed so rerun applies
+                (assoc-in [:workflows 0 :status] :failed)
+                (util/apply-updates [[:input {:key :key/space :char \space}]])
+                (execute-command "rerun"))]
+      (is (not (util/confirm-active? m)))
+      (is (util/workflow-has-status? m 0 :pending))
+      (is (str/includes? (:flash-message m) "Rerunning"))))
+
+  (testing ":rerun with no failed workflows shows message"
+    (let [m (-> (two-workflows)
+                (util/apply-updates [[:input {:key :key/space :char \space}]])
+                (execute-command "rerun"))]
+      ;; Running workflows aren't eligible for rerun, so status unchanged
+      (is (not (util/confirm-active? m)))
+      (is (str/includes? (:flash-message m) "Rerunning")))))
+
+;; ---------------------------------------------------------------------------
+;; PR event handler tests
+;; ---------------------------------------------------------------------------
+
+(deftest pr-synced-test
+  (testing ":msg/prs-synced replaces pr-items"
+    (let [prs [{:pr/repo "r1" :pr/number 1 :pr/title "First"}
+               {:pr/repo "r2" :pr/number 2 :pr/title "Second"}]
+          m (update/update-model (util/fresh-model)
+              [:msg/prs-synced {:pr-items prs}])]
+      (is (= 2 (count (:pr-items m))))
+      (is (str/includes? (:flash-message m) "Synced"))
+      (is (str/includes? (:flash-message m) "2 PRs"))))
+
+  (testing ":msg/prs-synced with empty list clears items"
+    (let [m (-> (util/fresh-model)
+                (assoc :pr-items [{:pr/repo "r1" :pr/number 1}])
+                (update/update-model [:msg/prs-synced {:pr-items []}]))]
+      (is (= 0 (count (:pr-items m)))))))
+
+(deftest repos-browsed-test
+  (testing ":msg/repos-browsed success caches remote repos"
+    (let [m (-> (util/fresh-model)
+                (assoc :browse-repos-loading? true)
+                (update/update-model
+                  [:msg/repos-browsed {:success? true
+                                       :repos ["acme/repo1" "acme/repo2"]}]))]
+      (is (= ["acme/repo1" "acme/repo2"] (:browse-repos m)))
+      (is (false? (:browse-repos-loading? m)))
+      (is (str/includes? (:flash-message m) "Loaded 2 remote repo(s)"))))
+
+  (testing ":msg/repos-browsed failure clears loading and sets error flash"
+    (let [m (-> (util/fresh-model)
+                (assoc :browse-repos-loading? true)
+                (update/update-model
+                  [:msg/repos-browsed {:success? false :error "auth failed"}]))]
+      (is (false? (:browse-repos-loading? m)))
+      (is (str/includes? (:flash-message m) "Repo browse failed"))
+      (is (str/includes? (:flash-message m) "auth failed"))))
+
+  (testing ":msg/repos-browsed failure includes source and no-details fallback"
+    (let [m (-> (util/fresh-model)
+                (assoc :browse-repos-loading? true)
+                (update/update-model
+                  [:msg/repos-browsed {:success? false
+                                       :error-source :graphql
+                                       :error nil}]))]
+      (is (false? (:browse-repos-loading? m)))
+      (is (str/includes? (:flash-message m) "(graphql)"))
+      (is (str/includes? (:flash-message m) "no error details"))))
+
+  (testing ":msg/repos-browsed refreshes active :add-repo completion popup"
+    (with-redefs [pr-sync/get-configured-repos (fn [] [])]
+      (let [m (-> (util/fresh-model)
+                  (assoc :mode :command
+                         :command-buf ":add-repo "
+                         :completing? true
+                         :completions ["browse"]
+                         :completion-idx 0
+                         :browse-repos-loading? true)
+                  (update/update-model
+                    [:msg/repos-browsed {:success? true
+                                         :repos ["acme/new-repo"]}]))]
+        (is (false? (:browse-repos-loading? m)))
+        (is (true? (:completing? m)))
+        (is (some #{"acme/new-repo"} (:completions m)))))))
+
+(deftest pr-updated-test
+  (testing ":msg/pr-updated merges into existing PR"
+    (let [m (-> (util/fresh-model)
+                (assoc :pr-items [{:pr/repo "r1" :pr/number 1 :pr/title "Old"
+                                   :pr/status :open}])
+                (update/update-model
+                  [:msg/pr-updated {:pr/repo "r1" :pr/number 1
+                                    :pr/status :merge-ready}]))]
+      (is (= :merge-ready (get-in m [:pr-items 0 :pr/status])))
+      (is (= "Old" (get-in m [:pr-items 0 :pr/title]))))))
+
+(deftest pr-removed-test
+  (testing ":msg/pr-removed removes matching PR"
+    (let [m (-> (util/fresh-model)
+                (assoc :pr-items [{:pr/repo "r1" :pr/number 1 :pr/title "A"}
+                                  {:pr/repo "r2" :pr/number 2 :pr/title "B"}])
+                (update/update-model
+                  [:msg/pr-removed {:pr/repo "r1" :pr/number 1}]))]
+      (is (= 1 (count (:pr-items m))))
+      (is (= "B" (get-in m [:pr-items 0 :pr/title]))))))
+
+(deftest side-effect-error-test
+  (testing ":msg/side-effect-error sets flash message"
+    (let [m (update/update-model (util/fresh-model)
+              [:msg/side-effect-error {:type :sync-prs :error "Network timeout"}])]
+      (is (str/includes? (:flash-message m) "Effect error"))
+      (is (str/includes? (:flash-message m) "sync-prs"))
+      (is (str/includes? (:flash-message m) "Network timeout"))))
+
+  (testing ":msg/side-effect-error for browse clears browse loading flag"
+    (let [m (-> (util/fresh-model)
+                (assoc :browse-repos-loading? true)
+                (update/update-model
+                  [:msg/side-effect-error {:type :browse-repos
+                                           :error "Rate limited"}]))]
+      (is (false? (:browse-repos-loading? m)))
+      (is (str/includes? (:flash-message m) "browse-repos"))
+      (is (str/includes? (:flash-message m) "Rate limited")))))
+
+(deftest sync-command-sets-side-effect-test
+  (testing ":sync command sets :side-effect on model"
+    (let [m (execute-command (util/fresh-model) "sync")]
+      (is (= {:type :sync-prs} (:side-effect m)))
+      (is (str/includes? (:flash-message m) "Syncing")))))

--- a/components/tui-views/test/ai/miniforge/tui_views/view_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/view_test.clj
@@ -35,6 +35,7 @@
 
   (testing "Workflow list with data renders"
     (let [m (-> (model/init-model)
+                (assoc :view :workflow-list)
                 (update/update-model [:msg/workflow-added
                                       {:workflow-id (random-uuid) :name "deploy-v2"}]))
           buf (view/root-view m [80 24])
@@ -46,6 +47,7 @@
   (testing "Detail view renders without error"
     (let [wf-id (random-uuid)
           m (-> (model/init-model)
+                (assoc :view :workflow-list)
                 (update/update-model [:msg/workflow-added {:workflow-id wf-id :name "test"}])
                 (update/update-model [:input :key/enter]))
           buf (view/root-view m [80 24])]
@@ -70,6 +72,27 @@
           buf (view/root-view m [80 24])]
       (is (some? buf)))))
 
+(deftest repo-manager-view-renders-test
+  (testing "Repo manager view renders with empty state"
+    (let [m (assoc (model/init-model) :view :repo-manager)
+          buf (view/root-view m [80 24])
+          strings (layout/buf->strings buf)]
+      (is (some? buf))
+      (is (some #(str/includes? % "No repositories configured") strings))))
+
+  (testing "Repo manager view renders configured repositories"
+    (let [m (-> (model/init-model)
+                (assoc :view :repo-manager
+                       :fleet-repos ["acme/service-a" "gitlab:team/service-b"]
+                       :pr-items [{:pr/repo "acme/service-a"}
+                                  {:pr/repo "acme/service-a"}
+                                  {:pr/repo "gitlab:team/service-b"}]))
+          buf (view/root-view m [100 24])
+          strings (layout/buf->strings buf)]
+      (is (some #(str/includes? % "[Repos (6)]") strings))
+      (is (some #(str/includes? % "acme/service-a") strings))
+      (is (some #(str/includes? % "gitlab:team/service-b") strings)))))
+
 (deftest minimum-terminal-size-test
   (testing "Graceful behavior at minimum size"
     (let [m (model/init-model)
@@ -90,3 +113,90 @@
           strings (layout/buf->strings buf)
           last-line (last strings)]
       (is (str/includes? last-line ":")))))
+
+;; ---------------------------------------------------------------------------
+;; New tests: PR fleet, PR detail, train view, help overlay rendering
+;; ---------------------------------------------------------------------------
+
+(deftest pr-fleet-view-renders-test
+  (testing "PR fleet view renders without error"
+    (let [m (assoc (model/init-model) :view :pr-fleet)
+          buf (view/root-view m [80 24])]
+      (is (some? buf))
+      (is (= 24 (count buf)))
+      (is (= 80 (count (first buf))))))
+
+  (testing "PR fleet with data renders PR titles"
+    (let [m (-> (model/init-model)
+                (assoc :view :pr-fleet)
+                (assoc :pr-items [{:pr/id 1 :pr/title "Add auth layer" :pr/readiness 0.9 :pr/risk :low}
+                                  {:pr/id 2 :pr/title "Fix race condition" :pr/readiness 0.5 :pr/risk :high}]))
+          buf (view/root-view m [80 24])
+          strings (layout/buf->strings buf)]
+      (is (some #(str/includes? % "auth") strings))
+      (is (some #(str/includes? % "race") strings)))))
+
+(deftest pr-detail-view-renders-test
+  (testing "PR detail view renders without error"
+    (let [m (-> (model/init-model)
+                (assoc :view :pr-detail)
+                (assoc-in [:detail :selected-pr] {:pr/id 1 :pr/title "Test PR"
+                                                   :pr/readiness 0.75 :pr/risk :medium}))
+          buf (view/root-view m [80 24])]
+      (is (some? buf))
+      (is (= 24 (count buf)))))
+
+  (testing "PR detail shows PR title"
+    (let [m (-> (model/init-model)
+                (assoc :view :pr-detail)
+                (assoc-in [:detail :selected-pr] {:pr/id 1 :pr/title "Refactor parser"
+                                                   :pr/readiness 0.95 :pr/risk :low}))
+          buf (view/root-view m [80 24])
+          strings (layout/buf->strings buf)]
+      (is (some #(str/includes? % "Refactor parser") strings)))))
+
+(deftest train-view-renders-test
+  (testing "Train view renders without error"
+    (let [m (-> (model/init-model)
+                (assoc :view :train-view)
+                (assoc-in [:detail :selected-train]
+                          {:train/id (random-uuid)
+                           :train/name "release-2026.02"
+                           :train/prs [{:pr/id 1 :pr/title "PR-A" :pr/readiness 1.0}
+                                       {:pr/id 2 :pr/title "PR-B" :pr/readiness 0.6}]}))
+          buf (view/root-view m [80 24])]
+      (is (some? buf))
+      (is (= 24 (count buf)))))
+
+  (testing "Train view shows train name and PRs"
+    (let [m (-> (model/init-model)
+                (assoc :view :train-view)
+                (assoc-in [:detail :selected-train]
+                          {:train/id (random-uuid)
+                           :train/name "release-2026.02"
+                           :train/prs [{:pr/id 1 :pr/title "PR-Alpha" :pr/readiness 1.0}]}))
+          buf (view/root-view m [80 24])
+          strings (layout/buf->strings buf)]
+      (is (some #(str/includes? % "release-2026.02") strings))
+      (is (some #(str/includes? % "PR-Alpha") strings)))))
+
+(deftest help-overlay-renders-test
+  (testing "Help overlay renders when help-visible? is true"
+    (let [m (-> (model/init-model)
+                (assoc :help-visible? true))
+          buf (view/root-view m [80 24])
+          strings (layout/buf->strings buf)]
+      (is (some? buf))
+      (is (= 24 (count buf)))
+      ;; Help overlay should show key bindings
+      (is (some #(or (str/includes? % "Help")
+                     (str/includes? % "help")
+                     (str/includes? % "KEY")
+                     (str/includes? % "key")) strings))))
+
+  (testing "Help overlay does not appear when help-visible? is false"
+    (let [m (model/init-model)]
+      (view/root-view m [80 24])
+      ;; The word "Help" may appear in status bar, but not as an overlay title
+      ;; We just verify the model flag is false
+      (is (false? (:help-visible? m))))))

--- a/deps.edn
+++ b/deps.edn
@@ -162,7 +162,7 @@
                        "components/tui-views/test"
                        "components/web-dashboard/test"
                        "components/self-healing/test"
-                       "components/pr-sync/test"]
+                       "components/pr-sync/test"
                        "components/spec-parser/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/config {:local/root "components/config"}
@@ -200,7 +200,7 @@
                       ai.miniforge/tui-views {:local/root "components/tui-views"}
                       ai.miniforge/web-dashboard {:local/root "components/web-dashboard"}
                       ai.miniforge/self-healing {:local/root "components/self-healing"}
-                      ai.miniforge/pr-sync {:local/root "components/pr-sync"}}}
+                      ai.miniforge/pr-sync {:local/root "components/pr-sync"}
                       ai.miniforge/spec-parser {:local/root "components/spec-parser"}}}
 
   :conformance {:extra-paths ["development/test"

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -46,7 +46,9 @@
         ai.miniforge/orchestrator {:local/root "../../components/orchestrator"}
         ai.miniforge/reporting {:local/root "../../components/reporting"}
         ;; Self-healing
-        ai.miniforge/self-healing {:local/root "../../components/self-healing"}}
+        ai.miniforge/self-healing {:local/root "../../components/self-healing"}
+        ;; Spec parsing
+        ai.miniforge/spec-parser {:local/root "../../components/spec-parser"}}
 
  :aliases
  {:uberjar


### PR DESCRIPTION
## Layer
Application

## Depends on
- #189 feat(tui): input normalization (PR-C) — [open]

## Overview
Core behavioral changes for the TUI update layer: navigation fixes, multi-select, search filtering, and mode management.

## What this adds

### Navigation
- Fixed stale detail-context bug (Tab at top-level leaked into detail views)
- Shift+Tab reverse cycling for views, panes, and detail subviews
- Level-local number navigation (1-0 keys switch within current abstraction level)
- Detail sibling navigation (left/right arrows)
- Search match navigation (n/N like vim)

### Selection
- Multi-select with space toggle, v for visual mode, a for select-all
- Visual range selection (contiguous selection)
- Selection state carried through navigation

### Search
- Real-time case-insensitive filtering for aggregate views
- Find-in-page for detail views
- Filtered-indices for scroll-aware search

### Mode
- Command mode (: prefix), search mode (/ prefix)
- Layered Escape dismiss (visual → selection → filter → search → go-back)

### Model
- Extended for repo-manager state, browse cache, fleet repos
- View classification: top-level vs detail views

## Strata affected
- `tui-views/model.clj` — extended model shape
- `tui-views/update.clj` — root input dispatch
- `tui-views/update/navigation.clj` — all navigation logic
- `tui-views/update/selection.clj` — new selection module
- `tui-views/update/mode.clj` — command/search mode
- `tui-views/update/events.clj` — PR/browse event handlers
- Tests: update_test, search_test, selection_test, view_test, test_util

Includes command/completion stubs (replaced in follow-up PR #F).

## PR DAG Context
```
PR-C (input) ──► PR-E (this) ──► PR-F (commands) ──► PR-D (views)
```

## Test plan
- update_test.clj: 25 tests covering navigation, mode switching, events
- search_test.clj: search filtering tests
- selection_test.clj: multi-select, visual mode tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)