### PR TITLE
feat(tui): command system + tab-completion with popup navigation

### DIFF
--- a/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
@@ -24,6 +24,7 @@
    Layer 3."
   (:require
    [clojure.string :as str]
+   [ai.miniforge.tui-engine.interface :as engine]
    [ai.miniforge.tui-views.model :as model]
    [ai.miniforge.tui-views.update.selection :as sel]
    [ai.miniforge.pr-sync.interface :as pr-sync]))
@@ -61,6 +62,21 @@
 
 (defn- cmd-help [model _args]
   (assoc model :help-visible? true))
+
+(defn- cmd-theme [model args]
+  (let [available (keys engine/themes)
+        names-str (str/join ", " (map name available))]
+    (if (str/blank? args)
+      (assoc model :flash-message
+             (str "Current theme: " (name (:theme model))
+                  " | Available: " names-str))
+      (let [theme-kw (keyword args)]
+        (if (contains? engine/themes theme-kw)
+          (assoc model :theme theme-kw
+                 :flash-message (str "Theme: " args))
+          (assoc model :flash-message
+                 (str "Unknown theme: " args
+                      " | Available: " names-str)))))))
 
 ;------------------------------------------------------------------------------ Layer 1b
 ;; Fleet management commands
@@ -278,6 +294,12 @@
                   :completions (fn [_] (mapv name model/views))}
    "refresh"     {:handler cmd-refresh     :help "Refresh data"}
    "help"        {:handler cmd-help        :help "Show help overlay"}
+   "theme"       {:handler cmd-theme       :help "Switch theme (e.g. :theme dark)"
+                  :completions (fn [_] (->> (keys engine/themes)
+                                            (remove #{:default})
+                                            (map name)
+                                            sort
+                                            vec))}
    "archive"     {:handler cmd-archive     :help "Archive selected workflows"}
    "delete"      {:handler cmd-delete      :help "Delete selected workflows"}
    "cancel"      {:handler cmd-cancel      :help "Cancel running workflows"}

--- a/components/tui-views/src/ai/miniforge/tui_views/update/completion.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/completion.clj
@@ -17,36 +17,177 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.tui-views.update.completion
-  "Tab-completion state machine — stub.
-   Full implementation in feat/tui-command-completion PR.")
+  "Tab-completion for command mode.
+
+   Pure functions that manage the completion popup state.
+   Depends on command.clj for completion metadata.
+   Layer 3."
+  (:require
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.update.command :as command]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Stub: completion (no-op until command+completion system lands)
-
-(defn handle-tab
-  "Handle Tab in command mode. Stub — no-op."
-  [model] model)
-
-(defn handle-shift-tab
-  "Handle Shift+Tab in command mode. Stub — no-op."
-  [model] model)
+;; State helpers
 
 (defn dismiss
-  "Dismiss completion popup. Stub — no-op."
-  [model] model)
+  "Clear completion state."
+  [model]
+  (assoc model :completing? false :completions [] :completion-idx nil))
 
-(defn accept
-  "Accept selected completion. Stub — no-op."
-  [model] model)
+(defn- apply-browse-side-effect
+  [model result]
+  (if-let [fx (:side-effect result)]
+    (assoc model
+           :side-effect fx
+           :browse-repos-loading? true
+           :flash-message "Browsing remote repos...")
+    model))
+
+(defn- strip-browse-sentinel
+  [completions]
+  (->> completions
+       (remove #{"browse"})
+       vec))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Navigation
 
 (defn next-completion
-  "Cycle to next completion. Stub — no-op."
-  [model] model)
+  "Move to the next completion option (wraps around)."
+  [model]
+  (let [n (count (:completions model))
+        idx (or (:completion-idx model) 0)]
+    (assoc model :completion-idx (mod (inc idx) n))))
 
 (defn prev-completion
-  "Cycle to previous completion. Stub — no-op."
-  [model] model)
+  "Move to the previous completion option (wraps around)."
+  [model]
+  (let [n (count (:completions model))
+        idx (or (:completion-idx model) 0)]
+    (assoc model :completion-idx (mod (+ idx (dec n)) n))))
 
-;------------------------------------------------------------------------------ Rich Comment
-(comment
-  :leave-this-here)
+;------------------------------------------------------------------------------ Layer 2
+;; Accept / fill
+
+(defn accept
+  "Accept the currently highlighted completion into the command buffer.
+   Returns model with buffer updated and completion dismissed."
+  [model]
+  (let [idx (:completion-idx model)
+        selected (get (:completions model) idx)]
+    (if (nil? selected)
+      (dismiss model)
+      (let [buf (:command-buf model)
+            ;; Check if we're completing a command name or an argument
+            has-space? (str/includes? (subs buf 1) " ")]
+        (if has-space?
+          ;; Replace the partial argument: keep ":cmd " prefix, append selected
+          (let [cmd-part (first (str/split (subs buf 1) #"\s+" 2))]
+            (if (= selected "browse")
+              (let [next-buf (str ":" cmd-part " ")
+                    next-model (assoc model :command-buf next-buf)
+                    result (command/compute-completions next-model next-buf)
+                    completions (strip-browse-sentinel (:completions result))]
+                (-> (apply-browse-side-effect next-model result)
+                    (assoc :completing? (boolean (seq completions))
+                           :completions completions
+                           :completion-idx (when (seq completions) 0))))
+              (-> model
+                  (assoc :command-buf (str ":" cmd-part " " selected))
+                  dismiss)))
+          ;; Replace the command name
+          (-> model
+              (assoc :command-buf (str ":" selected " "))
+              dismiss))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Tab handler
+
+(defn- exact-command-arg-completions
+  [model buf]
+  (let [partial (subs buf 1)]
+    (when (and (not (str/blank? partial))
+               (some #{partial} (command/complete-command-name partial)))
+      {:buffer (str ":" partial " ")
+       :result (command/compute-completions model (str ":" partial " "))})))
+
+(defn handle-tab
+  "Handle Tab press in command mode.
+   If not completing: compute completions and open popup.
+   If already completing: cycle to next option."
+  [model]
+  (if (:completing? model)
+    ;; Already completing -- cycle forward
+    (next-completion model)
+    ;; Not completing -- compute options
+    (let [buf (:command-buf model)
+          has-space? (str/includes? (subs buf 1) " ")
+          exact-arg (when-not has-space? (exact-command-arg-completions model buf))
+          result (cond
+                   has-space?
+                   ;; Completing an argument
+                   (command/compute-completions model buf)
+
+                   exact-arg
+                   (:result exact-arg)
+
+                   :else
+                   ;; Completing a command name
+                   (let [partial (subs buf 1)
+                         names (command/complete-command-name partial)]
+                     {:completions names :partial partial}))]
+      (cond
+        (seq (:completions result))
+        (-> (apply-browse-side-effect model result)
+            (cond-> exact-arg
+              (assoc :command-buf (:buffer exact-arg)))
+            (assoc :completing? true
+                   :completions (:completions result)
+                   :completion-idx 0))
+
+        (:side-effect result)
+        (-> (apply-browse-side-effect model result)
+            (cond-> exact-arg
+              (assoc :command-buf (:buffer exact-arg))))
+
+        ;; No completions available -- no-op
+        :else model))))
+
+(defn handle-shift-tab
+  "Handle Shift+Tab press in command mode.
+   If not completing: compute completions and select last item.
+   If already completing: cycle to previous option."
+  [model]
+  (if (:completing? model)
+    ;; Already completing -- cycle backward
+    (prev-completion model)
+    ;; Not completing -- compute options, select last
+    (let [buf (:command-buf model)
+          has-space? (str/includes? (subs buf 1) " ")
+          exact-arg (when-not has-space? (exact-command-arg-completions model buf))
+          result (cond
+                   has-space?
+                   (command/compute-completions model buf)
+
+                   exact-arg
+                   (:result exact-arg)
+
+                   :else
+                   (let [partial (subs buf 1)
+                         names (command/complete-command-name partial)]
+                     {:completions names :partial partial}))]
+      (cond
+        (seq (:completions result))
+        (-> (apply-browse-side-effect model result)
+            (cond-> exact-arg
+              (assoc :command-buf (:buffer exact-arg)))
+            (assoc :completing? true
+                   :completions (:completions result)
+                   :completion-idx (dec (count (:completions result)))))
+
+        (:side-effect result)
+        (-> (apply-browse-side-effect model result)
+            (cond-> exact-arg
+              (assoc :command-buf (:buffer exact-arg))))
+
+        :else model))))

--- a/components/tui-views/test/ai/miniforge/tui_views/command_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/command_test.clj
@@ -1,0 +1,82 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.command-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update.command :as command]))
+
+(deftest quit-command-test
+  (testing ":q sets quit flag"
+    (let [m (command/execute-command (model/init-model) ":q")]
+      (is (:quit? m))))
+
+  (testing ":quit sets quit flag"
+    (let [m (command/execute-command (model/init-model) ":quit")]
+      (is (:quit? m)))))
+
+(deftest view-command-test
+  (testing ":view evidence switches to evidence"
+    (let [m (command/execute-command (model/init-model) ":view evidence")]
+      (is (= :evidence (:view m)))
+      (is (= 0 (:selected-idx m)))))
+
+  (testing ":view pr-fleet switches to pr-fleet"
+    (let [m (command/execute-command (model/init-model) ":view pr-fleet")]
+      (is (= :pr-fleet (:view m)))))
+
+  (testing ":view with no arg lists views"
+    (let [m (command/execute-command (model/init-model) ":view")]
+      (is (some? (:flash-message m)))))
+
+  (testing ":view unknown sets error flash"
+    (let [m (command/execute-command (model/init-model) ":view nonexistent")]
+      (is (some? (:flash-message m))))))
+
+(deftest refresh-command-test
+  (testing ":refresh sets flash and timestamp"
+    (let [m (command/execute-command (model/init-model) ":refresh")]
+      (is (= "Refreshed" (:flash-message m)))
+      (is (some? (:last-updated m))))))
+
+(deftest help-command-test
+  (testing ":help shows help overlay"
+    (let [m (command/execute-command (model/init-model) ":help")]
+      (is (:help-visible? m)))))
+
+(deftest theme-command-test
+  (testing ":theme dark switches theme"
+    (let [m (command/execute-command (model/init-model) ":theme dark")]
+      (is (= :dark (:theme m)))))
+
+  (testing ":theme with no arg shows current"
+    (let [m (command/execute-command (model/init-model) ":theme")]
+      (is (some? (:flash-message m))))))
+
+(deftest unknown-command-test
+  (testing "Unknown command sets error flash"
+    (let [m (command/execute-command (model/init-model) ":foobar")]
+      (is (some? (:flash-message m))))))
+
+(deftest command-mode-integration-test
+  (testing "Full command mode flow: colon, type, enter"
+    (let [m (model/init-model)
+          m (assoc m :mode :command :command-buf ":q")]
+      (let [result (command/execute-command m (:command-buf m))]
+        (is (:quit? result))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/completion_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/completion_test.clj
@@ -1,0 +1,388 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.completion-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.pr-sync.interface :as pr-sync]
+   [ai.miniforge.tui-views.update :as update]
+   [ai.miniforge.tui-views.update.command :as command]
+   [ai.miniforge.tui-views.update.completion :as completion]
+   [ai.miniforge.tui-views.test-util :as util]))
+
+;; ---------------------------------------------------------------------------
+;; Unit tests: command/complete-command-name
+;; ---------------------------------------------------------------------------
+
+(deftest complete-command-name-test
+  (testing "Empty partial returns all commands"
+    (let [results (command/complete-command-name "")]
+      (is (pos? (count results)))
+      (is (some #{"theme"} results))
+      (is (some #{"view"} results))
+      (is (some #{"quit"} results))))
+
+  (testing "Partial 'th' matches 'theme'"
+    (let [results (command/complete-command-name "th")]
+      (is (some #{"theme"} results))
+      (is (not (some #{"view"} results)))))
+
+  (testing "Partial 'v' matches 'view'"
+    (let [results (command/complete-command-name "v")]
+      (is (some #{"view"} results))))
+
+  (testing "Non-matching partial returns empty"
+    (let [results (command/complete-command-name "zzz")]
+      (is (empty? results)))))
+
+;; ---------------------------------------------------------------------------
+;; Unit tests: command/compute-completions
+;; ---------------------------------------------------------------------------
+
+(deftest compute-completions-test
+  (testing ":theme with no arg shows all themes"
+    (let [result (command/compute-completions (model/init-model) ":theme ")]
+      (is (some? result))
+      (is (pos? (count (:completions result))))
+      (is (some #{"dark"} (:completions result)))
+      (is (some #{"light"} (:completions result)))
+      (is (some #{"high-contrast"} (:completions result)))))
+
+  (testing ":theme d filters to dark"
+    (let [result (command/compute-completions (model/init-model) ":theme d")]
+      (is (some #{"dark"} (:completions result)))
+      (is (not (some #{"light"} (:completions result))))))
+
+  (testing ":view shows all view names"
+    (let [result (command/compute-completions (model/init-model) ":view ")]
+      (is (some? result))
+      (is (some #{"evidence"} (:completions result)))
+      (is (some #{"pr-fleet"} (:completions result)))))
+
+  (testing "Command without :completions returns nil"
+    (let [result (command/compute-completions (model/init-model) ":quit ")]
+      (is (nil? result))))
+
+  (testing ":add-repo merges local configured and browsed remote repos"
+    (with-redefs [pr-sync/get-configured-repos (fn [] ["acme/local" "shared/repo"])]
+      (let [m (assoc (model/init-model) :browse-repos ["acme/remote" "shared/repo"])
+            result (command/compute-completions m ":add-repo ")]
+        (is (= ["acme/local" "acme/remote" "browse" "shared/repo"] (:completions result)))
+        (is (nil? (:side-effect result))))))
+
+  (testing ":add-repo requests browse side-effect when remote cache is empty"
+    (with-redefs [pr-sync/get-configured-repos (fn [] [])]
+      (let [result (command/compute-completions (model/init-model) ":add-repo ")]
+        (is (= {:type :browse-repos :provider :all} (:side-effect result)))))))
+
+;; ---------------------------------------------------------------------------
+;; Unit tests: completion/dismiss
+;; ---------------------------------------------------------------------------
+
+(deftest dismiss-test
+  (testing "dismiss clears completion state"
+    (let [m (-> (model/init-model)
+                (assoc :completing? true
+                       :completions ["a" "b" "c"]
+                       :completion-idx 1))
+          result (completion/dismiss m)]
+      (is (false? (:completing? result)))
+      (is (empty? (:completions result)))
+      (is (nil? (:completion-idx result))))))
+
+;; ---------------------------------------------------------------------------
+;; Unit tests: completion/next-completion, prev-completion
+;; ---------------------------------------------------------------------------
+
+(deftest next-prev-completion-test
+  (testing "next-completion advances index"
+    (let [m (-> (model/init-model)
+                (assoc :completing? true
+                       :completions ["a" "b" "c"]
+                       :completion-idx 0))
+          result (completion/next-completion m)]
+      (is (= 1 (:completion-idx result)))))
+
+  (testing "next-completion wraps around"
+    (let [m (-> (model/init-model)
+                (assoc :completing? true
+                       :completions ["a" "b" "c"]
+                       :completion-idx 2))
+          result (completion/next-completion m)]
+      (is (= 0 (:completion-idx result)))))
+
+  (testing "prev-completion goes back"
+    (let [m (-> (model/init-model)
+                (assoc :completing? true
+                       :completions ["a" "b" "c"]
+                       :completion-idx 2))
+          result (completion/prev-completion m)]
+      (is (= 1 (:completion-idx result)))))
+
+  (testing "prev-completion wraps around"
+    (let [m (-> (model/init-model)
+                (assoc :completing? true
+                       :completions ["a" "b" "c"]
+                       :completion-idx 0))
+          result (completion/prev-completion m)]
+      (is (= 2 (:completion-idx result))))))
+
+;; ---------------------------------------------------------------------------
+;; Unit tests: completion/accept
+;; ---------------------------------------------------------------------------
+
+(deftest accept-test
+  (testing "accept fills command name and adds space"
+    (let [m (-> (model/init-model)
+                (assoc :mode :command
+                       :command-buf ":th"
+                       :completing? true
+                       :completions ["theme"]
+                       :completion-idx 0))
+          result (completion/accept m)]
+      (is (= ":theme " (:command-buf result)))
+      (is (false? (:completing? result)))))
+
+  (testing "accept fills argument"
+    (let [m (-> (model/init-model)
+                (assoc :mode :command
+                       :command-buf ":theme d"
+                       :completing? true
+                       :completions ["dark"]
+                       :completion-idx 0))
+          result (completion/accept m)]
+      (is (= ":theme dark" (:command-buf result)))
+      (is (false? (:completing? result)))))
+
+  (testing "accept with nil index dismisses"
+    (let [m (-> (model/init-model)
+                (assoc :mode :command
+                       :command-buf ":theme "
+                       :completing? true
+                       :completions ["dark" "light"]
+                       :completion-idx nil))
+          result (completion/accept m)]
+      (is (false? (:completing? result))))))
+
+;; ---------------------------------------------------------------------------
+;; Unit tests: completion/handle-tab
+;; ---------------------------------------------------------------------------
+
+(deftest handle-tab-test
+  (testing "Tab with partial command opens completion popup"
+    (let [m (-> (model/init-model)
+                (assoc :mode :command
+                       :command-buf ":th"))
+          result (completion/handle-tab m)]
+      (is (true? (:completing? result)))
+      (is (some #{"theme"} (:completions result)))
+      (is (= 0 (:completion-idx result)))))
+
+  (testing "Tab when already completing cycles forward"
+    (let [m (-> (model/init-model)
+                (assoc :mode :command
+                       :command-buf ":th"
+                       :completing? true
+                       :completions ["theme"]
+                       :completion-idx 0))
+          result (completion/handle-tab m)]
+      ;; Wraps since there's only 1 item
+      (is (= 0 (:completion-idx result)))))
+
+  (testing "Tab with no matches is no-op"
+    (let [m (-> (model/init-model)
+                (assoc :mode :command
+                       :command-buf ":zzz"))
+          result (completion/handle-tab m)]
+      (is (false? (:completing? result)))))
+
+  (testing "Tab on exact :add-repo enters argument completion mode"
+    (with-redefs [pr-sync/get-configured-repos (fn [] ["acme/local"])]
+      (let [m (-> (model/init-model)
+                  (assoc :mode :command
+                         :command-buf ":add-repo"))
+            result (completion/handle-tab m)]
+        (is (= ":add-repo " (:command-buf result)))
+        (is (true? (:completing? result)))
+        (is (some #{"browse"} (:completions result)))
+        (is (some #{"acme/local"} (:completions result))))))
+
+  (testing "Tab on :add-repo triggers browse side-effect when cache is empty"
+    (with-redefs [pr-sync/get-configured-repos (fn [] [])]
+      (let [m (-> (model/init-model)
+                  (assoc :mode :command
+                         :command-buf ":add-repo "))
+            result (completion/handle-tab m)]
+        (is (= {:type :browse-repos :provider :all} (:side-effect result)))
+        (is (true? (:browse-repos-loading? result)))
+        (is (true? (:completing? result)))
+        (is (= ["browse"] (:completions result)))))))
+
+;; ---------------------------------------------------------------------------
+;; Unit tests: completion/handle-shift-tab
+;; ---------------------------------------------------------------------------
+
+(deftest handle-shift-tab-test
+  (testing "Shift+Tab with partial command opens completion popup at last item"
+    (let [m (-> (model/init-model)
+                (assoc :mode :command
+                       :command-buf ":"))
+          result (completion/handle-shift-tab m)]
+      (is (true? (:completing? result)))
+      (is (= (dec (count (:completions result))) (:completion-idx result)))))
+
+  (testing "Shift+Tab on exact :theme enters argument completion mode"
+    (let [m (-> (model/init-model)
+                (assoc :mode :command
+                       :command-buf ":theme"))
+          result (completion/handle-shift-tab m)]
+      (is (= ":theme " (:command-buf result)))
+      (is (true? (:completing? result)))))
+
+  (testing "Shift+Tab when already completing cycles backward"
+    (let [m (-> (model/init-model)
+                (assoc :mode :command
+                       :command-buf ":theme "
+                       :completing? true
+                       :completions ["dark" "light" "high-contrast"]
+                       :completion-idx 0))
+          result (completion/handle-shift-tab m)]
+      (is (= 2 (:completion-idx result))))))
+
+(deftest browse-accept-test
+  (testing "Accepting 'browse' on :add-repo expands into repo choices instead of literal browse arg"
+    (with-redefs [pr-sync/get-configured-repos (fn [] ["acme/local"])]
+      (let [m (-> (model/init-model)
+                  (assoc :mode :command
+                         :command-buf ":add-repo "
+                         :completing? true
+                         :completions ["acme/local" "browse"]
+                         :completion-idx 1))
+            result (completion/accept m)]
+        (is (= ":add-repo " (:command-buf result)))
+        (is (true? (:completing? result)))
+        (is (= ["acme/local"] (:completions result)))
+        (is (= 0 (:completion-idx result)))))))
+
+;; ---------------------------------------------------------------------------
+;; Integration tests: Tab completion through update-model
+;; ---------------------------------------------------------------------------
+
+(deftest tab-completion-integration-test
+  (testing "Full Tab completion flow: type, tab, select, accept"
+    (let [m (util/apply-updates (util/fresh-model)
+              [;; Enter command mode
+               [:input {:key :key/colon :char \:}]
+               ;; Type "th"
+               [:input {:key nil :char \t}]
+               [:input {:key :key/h :char \h}]
+               ;; Tab to open completions
+               [:input :key/tab]])]
+      (is (util/mode-is? m :command))
+      (is (true? (:completing? m)))
+      (is (some #{"theme"} (:completions m)))
+      ;; Accept with Enter
+      (let [m2 (update/update-model m [:input :key/enter])]
+        (is (= ":theme " (:command-buf m2)))
+        (is (false? (:completing? m2))))))
+
+  (testing "Esc dismisses completions without exiting command mode"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/colon :char \:}]
+               [:input {:key nil :char \t}]
+               [:input {:key :key/h :char \h}]
+               [:input :key/tab]         ;; open completions
+               [:input :key/escape]])]   ;; dismiss
+      (is (util/mode-is? m :command))
+      (is (false? (:completing? m)))))
+
+  (testing "Typing a char dismisses completions"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/colon :char \:}]
+               [:input {:key nil :char \t}]
+               [:input {:key :key/h :char \h}]
+               [:input :key/tab]                  ;; open completions
+               [:input {:key :key/e :char \e}]])] ;; type 'e' -> dismiss
+      (is (util/mode-is? m :command))
+      (is (false? (:completing? m)))
+      (is (= ":the" (:command-buf m)))))
+
+  (testing "Backspace dismisses completions"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/colon :char \:}]
+               [:input {:key nil :char \t}]
+               [:input {:key :key/h :char \h}]
+               [:input :key/tab]            ;; open completions
+               [:input :key/backspace]])]   ;; backspace -> dismiss
+      (is (util/mode-is? m :command))
+      (is (false? (:completing? m)))
+      (is (= ":t" (:command-buf m)))))
+
+  (testing "Down/Up arrows navigate completions"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/colon :char \:}]
+               ;; Empty partial -> all commands
+               [:input :key/tab]])]
+      (is (true? (:completing? m)))
+      (is (= 0 (:completion-idx m)))
+      ;; Down arrow
+      (let [m2 (update/update-model m [:input :key/down])]
+        (is (= 1 (:completion-idx m2))))
+      ;; Up arrow wraps to last
+      (let [m2 (update/update-model m [:input :key/up])]
+        (is (= (dec (count (:completions m))) (:completion-idx m2))))))
+
+  (testing "Shift+Tab opens command completions selecting the last item"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/colon :char \:}]
+               [:input :key/shift-tab]])]
+      (is (true? (:completing? m)))
+      (is (= (dec (count (:completions m))) (:completion-idx m)))))
+
+  (testing "Enter on bare :theme opens theme picker instead of executing"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:input {:key :key/colon :char \:}]
+               [:input {:key nil :char \t}]
+               [:input {:key :key/h :char \h}]
+               [:input {:key :key/e :char \e}]
+               [:input {:key nil :char \m}]
+               [:input {:key :key/e :char \e}]
+               [:input :key/enter]])]
+      (is (util/mode-is? m :command))
+      (is (= ":theme " (:command-buf m)))
+      (is (true? (:completing? m)))))
+
+  (testing "Enter on bare :add-repo opens repo picker instead of executing"
+    (with-redefs [pr-sync/get-configured-repos (fn [] ["acme/local"])]
+      (let [m (util/apply-updates (util/fresh-model)
+                [[:input {:key :key/colon :char \:}]
+                 [:input {:key :key/a :char \a}]
+                 [:input {:key :key/d :char \d}]
+                 [:input {:key :key/d :char \d}]
+                 [:input {:key nil :char \-}]
+                 [:input {:key :key/r :char \r}]
+                 [:input {:key :key/e :char \e}]
+                 [:input {:key nil :char \p}]
+                 [:input {:key :key/o :char \o}]
+                 [:input :key/enter]])]
+        (is (util/mode-is? m :command))
+        (is (= ":add-repo " (:command-buf m)))
+        (is (true? (:completing? m)))
+        (is (some #{"browse"} (:completions m)))
+        (is (some #{"acme/local"} (:completions m)))))))


### PR DESCRIPTION
## Summary
- Add `:theme` command with tab-completion for switching between dark/light/high-contrast themes
- Replace completion.clj stubs with full tab-completion implementation: popup state machine, Tab/Shift+Tab navigation, Enter accept, Esc dismiss
- Browse sentinel expansion for `:add-repo` (selecting "browse" triggers remote repo discovery)
- Command and completion test suites (command_test.clj, completion_test.clj)

## What changed from v1
Rebased clean on main (post #193 merge). The previous branch carried merged dependency PRs (#187, #189, #190) creating massive conflicts. This version:
- Builds on the keybinding-driven dispatch architecture (keybindings.edn) from #193
- Uses the existing completion popup overlay already in view.clj
- Keeps main's refactored `execute-confirmed-action` with `set-status-where` helpers
- Only adds the genuinely new code: theme command, full completion.clj, tests

## Strata affected
- `tui-views/update/command.clj` — `:theme` handler + engine import (+22 lines)
- `tui-views/update/completion.clj` — full implementation replacing stubs (+185/-22 lines)
- `tui-views/test/command_test.clj` — 7 tests, 14 assertions (NEW)
- `tui-views/test/completion_test.clj` — 9 tests, 83 assertions (NEW)

## Test plan
- [x] command_test.clj: quit, view, refresh, help, theme, unknown, integration
- [x] completion_test.clj: name completion, arg completion, popup state machine
- [x] Integration tests: full Tab flow through update-model, Esc dismiss, char dismiss, arrow nav
- [x] Full pre-commit suite passes (all poly tests, GraalVM compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)