### PR TITLE
docs(specs): amend N1-N6 with OSS pack runtime

### DIFF
--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -1,7 +1,7 @@
 # miniforge Specification Index
 
-**Version:** 0.3.0-draft
-**Date:** 2026-02-07
+**Version:** 0.4.0-draft
+**Date:** 2026-02-16
 **Status:** Living specification during OSS development
 
 ---
@@ -42,7 +42,8 @@ They use RFC 2119 terminology (MUST, SHALL, SHOULD, MAY).
 
 Defines:
 
-- Core nouns: workflow, phase, agent, subagent, tool, gate, policy pack, evidence bundle, artifact, provenance
+- Core nouns: workflow, phase, agent, subagent, tool, gate, policy pack, evidence bundle,
+  artifact, provenance, workflow pack, capability, pack run
 - Three-layer architecture: Control Plane, Agent Layer, Learning Layer
 - Polylith component boundaries (OSS component catalog)
 - Operational model: local-first execution, reproducibility, failure semantics
@@ -62,6 +63,7 @@ Defines:
 - Outer loop: phase transition state machine with prerequisites and failure handling
 - Gate contract: check/repair function signatures, violation schema, enforcement rules
 - Context handoff: protocol for passing context between phases
+- Workflow chaining: typed outputs, input binding, cross-boundary provenance
 
 ### N3 — Event Stream & Observability Contract ✅
 
@@ -71,7 +73,8 @@ Defines:
 
 Defines:
 
-- Event envelope fields; required event types (workflow, agent, status, subagent, tool, LLM, messages, milestone, gate)
+- Event envelope fields; required event types (workflow, agent, status, subagent, tool,
+  LLM, messages, milestone, gate, pack lifecycle, pack run, chain edge)
 - Ordering guarantees (per-workflow sequence, causal ordering, replay determinism)
 - Streaming API (SSE/WebSocket) with subscription protocol
 - Throttling and performance requirements
@@ -90,6 +93,7 @@ Defines:
 - Semantic intent validation: IMPORT/CREATE/UPDATE/DESTROY/REFACTOR/MIGRATE rules
 - Violation schema: severity levels, remediation templates, auto-fix capabilities
 - Terraform/Kubernetes-specific validation rules
+- Pack trust, capability grant, and high-risk action gates for Workflow Packs
 
 ### N5 — Interface Standard: CLI/TUI/API ✅
 
@@ -99,8 +103,8 @@ Defines:
 
 Defines:
 
-- CLI command taxonomy: six namespaces (init, workflow, fleet, policy, evidence, artifact)
-- TUI primitives: workflow list, detail view, evidence viewer, artifact browser
+- CLI command taxonomy: seven namespaces (init, workflow, fleet, policy, evidence, artifact, pack)
+- TUI primitives: workflow list, detail view, evidence viewer, artifact browser, pack browser, run launcher
 - API surface: minimal REST endpoints for workflow control, event streaming, evidence/artifact access
 - Operations console purpose: monitoring autonomous factory (NOT PR management)
 - Manual override mechanisms: plan approval, gate handling, budget escalation
@@ -117,6 +121,7 @@ Defines:
 - Artifact provenance: source inputs, tool executions, content hashes, timestamps
 - Semantic intent validation rules with Terraform/Kubernetes specifics
 - Queryable provenance API: trace artifact chains, find intent mismatches
+- Pack Run evidence: pack identity, capabilities, connector actions, metrics snapshots, report artifacts
 - Compliance metadata: sensitive data handling, audit requirements (SOCII/FedRAMP)
 
 ### N7 — Operational Policy Synthesis With Verification ✅
@@ -328,6 +333,9 @@ Normative specs are enforced by:
 
 ## Version History
 
+- **0.4.0-draft** (2026-02-16) - OSS pack runtime amendments: Workflow Pack, Capability, Pack Run
+  concepts in N1; workflow chaining in N2; pack lifecycle/run events in N3; pack trust/capability
+  gates in N4; pack CLI + browser/launcher TUI in N5; Pack Run evidence in N6
 - **0.3.0-draft** (2026-02-07) - Added N9 (External PR Integration), Fleet Mode disambiguation
 - **0.2.0-draft** (2026-02-01) - Added N7 (OPSV) and N8 (OCI), updated governance for extension specs
 - **0.1.0-draft** (2026-01-23) - Initial spec index, normative spec structure established

--- a/specs/normative/N1-architecture.md
+++ b/specs/normative/N1-architecture.md
@@ -1,7 +1,7 @@
 # N1 — Core Architecture & Concepts
 
-**Version:** 0.2.0-draft
-**Date:** 2026-02-07
+**Version:** 0.3.0-draft
+**Date:** 2026-02-16
 **Status:** Draft
 **Conformance:** MUST
 
@@ -409,10 +409,19 @@ during pack loading and workflow execution.
 
 miniforge treats structured "packs" as first-class knowledge units and artifacts. Packs are EDN-serialized and schema-validated.
 
+**Core pack types (OSS):**
+
 - **Feature Pack** (`:feature-pack`) — normalized feature intent, acceptance criteria, constraints, and references
 - **Policy Pack** (`:policy-pack`) — deterministic validation rules and scanners (see N4)
 - **Agent Profile Pack** (`:agent-profile-pack`) — agent routing, allowed capabilities, and scopes
 - **Pack Index** (`:pack-index`) — manifest of generated packs, hashes, trust labels, and provenance
+- **Workflow Pack** (`:workflow-pack`) — versioned bundle containing workflows, schemas, templates,
+  and metadata for distributable domain workflows (see §2.24)
+
+Policy Packs (N4) are a specialization of the general pack model: they follow the same
+versioning, signing, and trust semantics but their content is deterministic validation
+rules rather than workflow definitions. Workflow Packs generalize the pack model to
+arbitrary domain workflows (e.g., reporting, product-brief pipelines).
 
 Packs MUST be machine-readable and MUST NOT embed freeform prose as executable instruction.
 
@@ -423,9 +432,12 @@ All packs MUST include versioning information following this schema:
 ```clojure
 {:pack/id string                      ; REQUIRED: unique identifier (e.g., "com.example/feature-auth")
  :pack/version string                 ; REQUIRED: semantic version (e.g., "1.2.3")
- :pack/type keyword                   ; REQUIRED: :feature-pack | :policy-pack | :agent-profile-pack
+ :pack/type keyword                   ; REQUIRED: :feature-pack | :policy-pack | :agent-profile-pack | :workflow-pack
  :pack/created-at inst                ; REQUIRED: creation timestamp
  :pack/content-hash string            ; REQUIRED: sha256 over canonical EDN representation
+
+ :pack/publisher string               ; REQUIRED for :workflow-pack: publisher identity
+ :pack/miniforge-min-version string   ; REQUIRED for :workflow-pack: minimum runtime version
 
  :pack/dependencies                   ; OPTIONAL: dependencies on other packs
  [{:pack/id string
@@ -435,6 +447,20 @@ All packs MUST include versioning information following this schema:
  :pack/trust-level keyword            ; REQUIRED: :trusted | :untrusted | :tainted
  :pack/authority keyword              ; REQUIRED: :authority/instruction | :authority/data
  :pack/signature string               ; OPTIONAL: cryptographic signature over content-hash
+
+ :pack/capabilities-required          ; REQUIRED for :workflow-pack: connector-scoped permissions
+ [{:capability/id string              ; e.g., "github.pr.read", "jira.issue.write"
+   :capability/scope keyword}]        ; :read | :write
+
+ :pack/data-handling                  ; OPTIONAL: redaction and egress constraints
+ {:redaction-policy keyword           ; :none | :pii-redact | :full-redact
+  :egress-allowed? boolean}           ; default false
+
+ :pack/entrypoints                    ; REQUIRED for :workflow-pack: named workflow entrypoints
+ [{:entrypoint/name string
+   :entrypoint/workflow-ref string    ; path within pack
+   :entrypoint/input-schema {...}
+   :entrypoint/output-schema {...}}]
 
  :pack/content {...}}                 ; Pack-specific content
 ```
@@ -747,6 +773,119 @@ an evidence artifact (N6) with traceable factors. Risk scoring MUST be explainab
 factor evidence refs and MUST NOT be a black-box number without factors.
 
 See N9 §5 for risk artifact schema.
+
+### 2.24 Workflow Pack
+
+A **Workflow Pack** is a versioned, distributable bundle containing one or more workflow
+entrypoints with their schemas, templates, and metadata. Workflow Packs are the primary
+mechanism for delivering domain workflows (e.g., reporting, product-brief pipelines)
+without bloating Miniforge core.
+
+Workflow Packs are specializations of Packs (§2.10.3) with `:pack/type :workflow-pack`.
+
+```clojure
+{:workflow-pack/id string              ; REQUIRED: stable identifier (e.g., "com.miniforge/pr-review")
+ :workflow-pack/version string         ; REQUIRED: semantic version
+ :workflow-pack/publisher string       ; REQUIRED: publisher identity
+
+ :workflow-pack/entrypoints            ; REQUIRED: at least one
+ [{:entrypoint/name string
+   :entrypoint/workflow-ref string     ; path within pack bundle
+   :entrypoint/input-schema {...}      ; EDN schema for inputs
+   :entrypoint/output-schema {...}}]   ; EDN schema for outputs
+
+ :workflow-pack/capabilities-required  ; REQUIRED: connector-scoped permissions
+ [{:capability/id string               ; e.g., "github.pr.read"
+   :capability/scope keyword}]         ; :read | :write
+
+ :workflow-pack/templates [...]        ; OPTIONAL: rendering templates
+ :workflow-pack/policy-fragments [...] ; OPTIONAL: advisory by default
+ :workflow-pack/data-handling {...}}    ; OPTIONAL: redaction/egress constraints
+```
+
+#### 2.24.1 Workflow Pack Requirements
+
+Implementations MUST:
+
+1. Verify pack signature before installation (if signature is present)
+2. Record pack digest (`pack/content-hash`) in all Pack Run evidence
+3. Present required capabilities to the user before install and before run
+4. Deny connector actions not covered by granted capabilities
+5. Enforce deny-by-default for write capabilities (`:capability/scope :write`)
+6. Require re-approval when a pack update increases required capabilities
+7. Resolve pack dependencies deterministically and record resolved versions/digests
+8. Support loading packs from local bundles and configured registry roots
+
+#### 2.24.2 No Ambient Authority
+
+Packs MUST NOT inherit implicit privileges from the runtime environment. All connector
+actions MUST be mediated by the capability enforcement layer. A pack that declares
+`github.pr.read` MUST NOT be able to invoke `github.pr.comment.write` unless that
+capability is also declared and granted.
+
+### 2.25 Capability (Pack Permissions)
+
+A **Capability** is a connector-scoped permission unit that a Workflow Pack declares
+and the runtime enforces. Capabilities follow the pattern `<connector>.<resource>.<action>`.
+
+Examples:
+
+- `github.pr.read` — read PR metadata and diffs
+- `github.pr.comment.write` — post comments on PRs
+- `jira.issue.read` — read Jira issues
+- `jira.issue.write` — create/update Jira issues
+- `git.repo.checkout` — checkout repository content
+- `metrics.query.read` — query metrics endpoints
+
+#### 2.25.1 Capability Enforcement Requirements
+
+Implementations MUST:
+
+1. Maintain an explicit grant set per Pack Run (capabilities granted at install/run time)
+2. Intercept all connector actions and validate against the grant set
+3. Block and log denied actions with the attempted capability
+4. Default write capabilities (any `*.write`) to denied unless explicitly granted
+5. Record granted capabilities in Pack Run evidence (N6)
+6. Record capability denials as events (N3)
+
+### 2.26 Pack Run
+
+A **Pack Run** is an execution instance of a Workflow Pack entrypoint. Each Pack Run
+is an observable, auditable unit of work that produces evidence and artifacts.
+
+```clojure
+{:pack-run/id uuid                     ; REQUIRED: unique run identifier
+ :pack-run/pack-id string              ; REQUIRED: workflow pack identifier
+ :pack-run/pack-version string         ; REQUIRED: pack version executed
+ :pack-run/pack-digest string          ; REQUIRED: content hash at run time
+ :pack-run/entrypoint string           ; REQUIRED: entrypoint name
+ :pack-run/status keyword              ; REQUIRED: :pending, :executing, :completed, :failed, :cancelled
+
+ :pack-run/signature-verified? boolean ; REQUIRED: whether signature was verified
+ :pack-run/capabilities-granted        ; REQUIRED: capabilities granted for this run
+ [{:capability/id string
+   :capability/scope keyword}]
+
+ :pack-run/inputs {...}                ; REQUIRED: input values (redacted per data-handling)
+ :pack-run/outputs {...}               ; OPTIONAL: output values upon completion
+
+ :pack-run/workflow-id uuid            ; REQUIRED: workflow created for this run
+ :pack-run/evidence-bundle-id uuid     ; OPTIONAL: created upon completion
+
+ :pack-run/started-at inst             ; OPTIONAL
+ :pack-run/completed-at inst}          ; OPTIONAL
+```
+
+#### 2.26.1 Pack Run Requirements
+
+Implementations MUST:
+
+1. Create a workflow (§2.1) for each Pack Run
+2. Emit Pack Run events (see N3) for lifecycle transitions
+3. Generate an evidence bundle (N6) that includes pack identity, digest, signature
+   verification result, and granted capabilities
+4. Enforce capabilities throughout the run (§2.25.1)
+5. Support re-running with a pinned pack version/digest
 
 ---
 
@@ -1373,6 +1512,7 @@ Research directions:
 - **Advisory Annotation** - Non-blocking message attached to a workflow or event by a Listener (N8)
 - **Agent** - Autonomous software entity that executes workflow phases
 - **Artifact** - Work product created during workflow execution
+- **Capability** - Connector-scoped permission unit required by a Workflow Pack; deny-by-default for writes
 - **Capability Level** - Listener permission tier: OBSERVE, ADVISE, or CONTROL (N8)
 - **Control Action** - Command that modifies workflow execution state, subject to RBAC and gates (N8)
 - **Evidence Bundle** - Immutable audit trail from intent to outcome
@@ -1384,7 +1524,8 @@ Research directions:
 - **Operational Policy** - Versioned runtime configuration artifacts controlling service behavior under load (N7)
 - **Outer Loop** - Phase transition state machine
 - **Phase** - Logical SDLC stage (Plan, Implement, Verify, etc.)
-- **Policy Pack** - Collection of validation rules
+- **Pack Run** - Execution instance of a Workflow Pack entrypoint, producing evidence and audit linkage
+- **Policy Pack** - Collection of validation rules; specialization of pack model (§2.10.3) (N4)
 - **PR Train** - Ordered set of PR Work Items with dependency relationships for sequential merge (N9)
 - **PR Work Item** - Canonical internal model of a PR in the Fleet control plane (N9)
 - **Provider** - External code hosting platform (GitHub, GitLab) as source of PR events (N9)
@@ -1394,11 +1535,14 @@ Research directions:
 - **Tool** - External capability invoked by agent
 - **Verification** - Executing an Experiment Pack against a candidate Operational Policy to produce pass/fail evidence (N7)
 - **Workflow** - Top-level unit of autonomous execution
+- **Workflow Pack** - Versioned bundle containing workflows, schemas, templates, and metadata
 
 ---
 
 **Version History:**
 
+- 0.3.0-draft (2026-02-16): Added Workflow Pack, Capability, Pack Run concepts
+  (§2.10.3 extended, §2.24–§2.26, §12 glossary)
 - 0.2.0-draft (2026-02-07): Added extension spec concepts from N7, N8, N9
   (§2.11–§2.23, §12 glossary)
 - 0.1.0-draft (2026-01-23): Initial core architecture specification

--- a/specs/normative/N2-workflows.md
+++ b/specs/normative/N2-workflows.md
@@ -1,7 +1,7 @@
 # N2 — Workflow Execution Model
 
-**Version:** 0.1.0-draft
-**Date:** 2026-01-23
+**Version:** 0.4.0-draft
+**Date:** 2026-02-16
 **Status:** Draft
 **Conformance:** MUST
 
@@ -1298,9 +1298,78 @@ Merge order: archetype defaults → DAG defaults → task overrides.
 
 ---
 
-## 14. Future Extensions
+## 14. Workflow Chaining
 
-### 14.1 Parallel Phase Execution (Post-OSS)
+Workflow chaining enables the output of one workflow to serve as input to another,
+creating composable pipelines. This is the mechanism by which Workflow Packs (N1 §2.24)
+compose multi-step domain workflows.
+
+### 14.1 Typed Outputs
+
+Workflows MUST be able to emit typed outputs conforming to a declared output schema:
+
+```clojure
+{:workflow/outputs
+ {:output/schema {...}                 ; EDN schema defining output shape
+  :output/values {...}                 ; Actual output values
+  :output/artifact-refs [uuid ...]}}   ; References to output artifacts
+```
+
+When a workflow is an entrypoint of a Workflow Pack, the output MUST conform to the
+entrypoint's `:entrypoint/output-schema` (N1 §2.24).
+
+### 14.2 Input Binding
+
+Downstream workflows MUST be able to bind inputs to upstream workflow outputs:
+
+```clojure
+{:chain/bindings
+ [{:binding/target-input string        ; Input parameter name in downstream workflow
+   :binding/source-workflow-id uuid    ; Upstream workflow that produced the value
+   :binding/source-output-path string  ; Path within upstream output values
+   :binding/required? boolean}]}       ; FAIL chain if binding unresolvable
+```
+
+Implementations MUST:
+
+1. Resolve bindings before starting the downstream workflow
+2. Fail the chain edge if a required binding cannot be resolved
+3. Record all resolved bindings in the chain edge evidence
+
+### 14.3 Cross-Boundary Provenance
+
+Chained execution MUST preserve provenance across workflow boundaries:
+
+1. Each workflow in a chain MUST link to its upstream workflow(s) via chain edge references
+2. Evidence bundles for downstream workflows MUST reference upstream evidence bundles
+3. Artifact provenance chains MUST be traceable across workflow boundaries
+4. The complete chain MUST be reconstructable from evidence alone
+
+### 14.4 Chain Execution
+
+```clojure
+{:chain/id uuid                        ; REQUIRED: unique chain identifier
+ :chain/edges
+ [{:edge/id uuid                       ; REQUIRED: unique edge identifier
+   :edge/from-workflow-id uuid         ; Upstream workflow
+   :edge/to-workflow-id uuid           ; Downstream workflow
+   :edge/bindings [...]                ; Input bindings (§14.2)
+   :edge/status keyword                ; :pending, :executing, :completed, :failed
+   :edge/started-at inst
+   :edge/completed-at inst}]}
+```
+
+Implementations MUST:
+
+1. Emit chain edge events (see N3) for edge lifecycle transitions
+2. Support pausing/retrying/rolling back at edge granularity via OCI (N8) when available
+3. Record chain structure and edge results in evidence bundles (N6)
+
+---
+
+## 15. Future Extensions
+
+### 15.1 Parallel Phase Execution (Post-OSS)
 
 Future versions will support:
 
@@ -1308,7 +1377,7 @@ Future versions will support:
 - Conditional phase branching (if-then-else)
 - Phase retry with backoff
 
-### 14.2 Custom Phase Plugins (Enterprise)
+### 15.2 Custom Phase Plugins (Enterprise)
 
 Enterprise features will add:
 
@@ -1316,7 +1385,7 @@ Enterprise features will add:
 - Phase plugin marketplace
 - Phase composition (nested phases)
 
-### 14.3 Cross-Workflow Dependencies (Enterprise)
+### 15.3 Cross-Workflow Dependencies (Enterprise)
 
 PR train orchestration will enable:
 
@@ -1326,7 +1395,7 @@ PR train orchestration will enable:
 
 ---
 
-## 15. References
+## 16. References
 
 - RFC 2119: Key words for use in RFCs to Indicate Requirement Levels
 - N1 (Architecture): Defines core concepts (workflow, phase, agent, gate)
@@ -1339,6 +1408,8 @@ PR train orchestration will enable:
 
 **Version History:**
 
+- 0.4.0-draft (2026-02-16): Added workflow chaining (§14) — typed outputs, input binding,
+  cross-boundary provenance, chain execution
 - 0.3.0-draft (2026-02-04): Added node capability contracts (§13.6) and frontier semantics (§13.4.1)
 - 0.2.0-draft (2026-02-03): Added DAG-based multi-task execution model (Section 13)
 - 0.1.0-draft (2026-01-23): Initial workflow execution model specification

--- a/specs/normative/N3-event-stream.md
+++ b/specs/normative/N3-event-stream.md
@@ -1,7 +1,7 @@
 # N3 — Event Stream & Observability Contract
 
-**Version:** 0.4.0-draft
-**Date:** 2026-02-07
+**Version:** 0.5.0-draft
+**Date:** 2026-02-16
 **Status:** Draft
 **Conformance:** MUST
 
@@ -728,7 +728,199 @@ ETL workflows MUST emit this event if any critical failure prevents completion.
 Implementations SHOULD include enough detail in `:etl/error-details` to enable
 debugging without log diving.
 
-### 3.12 Task Lifecycle Events (DAG Orchestration)
+### 3.12 Pack Lifecycle and Pack Run Events
+
+For Workflow Pack management and execution (see N1 §2.24–§2.26), implementations MUST emit
+pack lifecycle events and Pack Run events.
+
+#### pack/installed
+
+```clojure
+{:event/type :pack/installed
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :pack/id string
+ :pack/version string
+ :pack/type keyword                    ; :workflow-pack | :policy-pack | etc.
+ :pack/publisher string
+ :pack/content-hash string
+ :pack/signature-verified? boolean
+ :pack/capabilities-required [{:capability/id string :capability/scope keyword}]
+ :pack/capabilities-granted [{:capability/id string :capability/scope keyword}]
+
+ :message "Pack installed: {pack.id}@{pack.version}"}
+```
+
+#### pack/updated
+
+```clojure
+{:event/type :pack/updated
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :pack/id string
+ :pack/from-version string
+ :pack/to-version string
+ :pack/content-hash string
+ :pack/capabilities-changed? boolean   ; true if capabilities differ from prior version
+ :pack/re-approval-required? boolean   ; true if capability upgrade requires re-approval
+
+ :message "Pack updated: {pack.id} {from-version} → {to-version}"}
+```
+
+#### pack/removed
+
+```clojure
+{:event/type :pack/removed
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :pack/id string
+ :pack/version string
+ :pack/content-hash string
+
+ :message "Pack removed: {pack.id}@{pack.version}"}
+```
+
+#### pack.run/started
+
+```clojure
+{:event/type :pack.run/started
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :workflow/id uuid                     ; workflow created for this run
+ :pack-run/id uuid
+ :pack/id string
+ :pack/version string
+ :pack/content-hash string
+ :pack/entrypoint string
+ :pack/signature-verified? boolean
+ :pack/capabilities-granted [{:capability/id string :capability/scope keyword}]
+
+ :message "Pack run started: {pack.id}@{pack.version} / {entrypoint}"}
+```
+
+#### pack.run/completed
+
+```clojure
+{:event/type :pack.run/completed
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :workflow/id uuid
+ :pack-run/id uuid
+ :pack/id string
+ :pack/version string
+ :pack-run/duration-ms long
+ :pack-run/evidence-bundle-id uuid
+
+ :message "Pack run completed: {pack.id}@{pack.version}"}
+```
+
+#### pack.run/failed
+
+```clojure
+{:event/type :pack.run/failed
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :workflow/id uuid
+ :pack-run/id uuid
+ :pack/id string
+ :pack/version string
+ :pack-run/failure-reason string
+ :pack-run/duration-ms long
+
+ :message "Pack run failed: {pack.id}@{pack.version} — {failure-reason}"}
+```
+
+#### capability/denied
+
+```clojure
+{:event/type :capability/denied
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :workflow/id uuid
+ :pack-run/id uuid
+ :pack/id string
+ :capability/attempted string          ; e.g., "github.pr.comment.write"
+ :capability/granted-set [string ...]  ; capabilities that were granted
+
+ :message "Capability denied: {capability.attempted} not in grant set for {pack.id}"}
+```
+
+#### chain.edge/started
+
+```clojure
+{:event/type :chain.edge/started
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :chain/id uuid
+ :edge/id uuid
+ :edge/from-workflow-id uuid
+ :edge/to-workflow-id uuid
+ :edge/bindings-count long
+
+ :message "Chain edge started: {from-workflow} → {to-workflow}"}
+```
+
+#### chain.edge/completed
+
+```clojure
+{:event/type :chain.edge/completed
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :chain/id uuid
+ :edge/id uuid
+ :edge/from-workflow-id uuid
+ :edge/to-workflow-id uuid
+ :edge/duration-ms long
+
+ :message "Chain edge completed: {from-workflow} → {to-workflow}"}
+```
+
+#### chain.edge/failed
+
+```clojure
+{:event/type :chain.edge/failed
+ :event/id uuid
+ :event/timestamp inst
+ :event/version "1.0.0"
+ :event/sequence-number long
+
+ :chain/id uuid
+ :edge/id uuid
+ :edge/from-workflow-id uuid
+ :edge/to-workflow-id uuid
+ :edge/failure-reason string
+
+ :message "Chain edge failed: {from-workflow} → {to-workflow} — {failure-reason}"}
+```
+
+### 3.13 Task Lifecycle Events (DAG Orchestration)
 
 For DAG-based multi-task execution (see N2 Section 13), implementations MUST emit
 task lifecycle events that track frontier computation, agent dispatch, and capability
@@ -832,7 +1024,7 @@ Emitted when a task is skipped due to a dependency failure.
  :message "Task skipped: dependency task-abc failed"}
 ```
 
-### 3.13 OPSV Events (N7)
+### 3.14 OPSV Events (N7)
 
 For Operational Policy Synthesis workflows (see N7), implementations MUST emit these
 event types:
@@ -938,7 +1130,7 @@ event types:
 
 All OPSV events MUST link to the corresponding evidence bundle id per N6.
 
-### 3.14 Observability Control Interface Events (N8)
+### 3.15 Observability Control Interface Events (N8)
 
 For the Observability Control Interface (see N8), implementations MUST emit these
 event types:
@@ -1010,7 +1202,7 @@ event types:
  :message "Advisory annotation: {title}"}
 ```
 
-### 3.15 External PR Integration Events (N9)
+### 3.16 External PR Integration Events (N9)
 
 For external PR integration (see N9), implementations MUST emit these event types.
 These events MAY have nil `:workflow/id` — see §2.3 for scope key rules.
@@ -1388,8 +1580,10 @@ Event stream will extend to:
 
 **Version History:**
 
+- 0.5.0-draft (2026-02-16): Added pack lifecycle, Pack Run, capability denial, and chain
+  edge events (§3.12); renumbered §3.13–§3.16
 - 0.4.0-draft (2026-02-07): Added extension spec events from N7, N8, N9
-  (§3.13–§3.15, §2.3 scope key)
+  (§3.14–§3.16, §2.3 scope key)
 - 0.3.0-draft (2026-02-04): Added task lifecycle events for DAG orchestration (§3.12)
 - 0.2.0-draft (2026-02-03): Add PR lifecycle events for DAG orchestration (Section 3.10)
 - 0.1.0-draft (2026-01-23): Initial event stream specification

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -1,7 +1,7 @@
 # N4 — Policy Packs & Gates Standard
 
-**Version:** 0.3.0-draft
-**Date:** 2026-02-07
+**Version:** 0.4.0-draft
+**Date:** 2026-02-16
 **Status:** Draft
 **Conformance:** MUST
 
@@ -749,6 +749,64 @@ Policy result schema for external PR evaluation:
    :policy-pack/version string}]}
 ```
 
+#### 5.1.8 Pack Trust Gate
+
+**ID:** `pack-trust`
+**Purpose:** Enforce trust requirements when installing and running Workflow Packs (see N1 §2.24)
+
+Rules:
+
+- `require-signature-verification` (severity: high)
+  - WARN if a pack is installed without a valid signature
+  - Implementations SHOULD allow configuring this to FAIL for production environments
+- `enforce-publisher-allowlist` (severity: critical)
+  - FAIL if pack publisher is not in the configured allowlist (when allowlist is enabled)
+  - Implementations MUST support publisher allowlists in pack trust configuration
+- `enforce-minimum-trust-level` (severity: high)
+  - FAIL if pack trust level is below the configured minimum for the environment
+  - Default minimum: `:untrusted` (no restriction); configurable per environment
+
+This pack is RECOMMENDED for all Workflow Pack installations.
+
+#### 5.1.9 Capability Grant Gate
+
+**ID:** `capability-grant`
+**Purpose:** Enforce capability declarations and grants for Workflow Pack runs (see N1 §2.25)
+
+Rules:
+
+- `require-capability-declaration` (severity: critical)
+  - FAIL if a Workflow Pack does not declare its required capabilities in the manifest
+- `enforce-deny-default-writes` (severity: critical)
+  - FAIL if a write capability (`*.write`) is invoked without explicit user grant
+  - Write capabilities MUST default to denied; read capabilities MAY default to granted
+- `enforce-capability-scope` (severity: critical)
+  - FAIL if a pack invokes a connector action not covered by its declared and granted capabilities
+  - Implementations MUST intercept connector actions and validate against the grant set
+- `require-re-approval-on-upgrade` (severity: high)
+  - FAIL if a pack update increases required capabilities without re-approval
+  - Capability changes MUST be presented to the user before the update takes effect
+
+This pack is REQUIRED for all Workflow Pack runs.
+
+#### 5.1.10 High-Risk Pack Action Gate
+
+**ID:** `pack-high-risk-action`
+**Purpose:** Govern high-risk actions triggered by pack runs (see N1 §2.26)
+
+Rules:
+
+- `require-justification-for-writes` (severity: medium)
+  - WARN if a pack run performs write actions without a justification record
+- `enforce-production-restrictions` (severity: critical)
+  - FAIL if a pack run targets production resources without explicit approval
+  - Production targets MUST be defined in pack trust configuration
+- `audit-all-connector-actions` (severity: high)
+  - FAIL if connector actions during a pack run are not logged in the evidence bundle
+  - All connector actions (read and write) MUST be recorded with timestamps and principals
+
+This pack is RECOMMENDED for production environments.
+
 ### 5.2 Pack Discovery & Installation
 
 Implementations SHOULD support:
@@ -1120,6 +1178,8 @@ Research directions:
 
 **Version History:**
 
+- 0.4.0-draft (2026-02-16): Added Pack Trust Gate (§5.1.8), Capability Grant Gate
+  (§5.1.9), High-Risk Pack Action Gate (§5.1.10)
 - 0.3.0-draft (2026-02-07): Added extension spec gates from N7, N8, N9
   (§5.1.5–§5.1.7)
 - 0.2.0-draft (2026-02-04): Added task-scope policy pack for capability enforcement (§5.1.4)

--- a/specs/normative/N5-cli-tui-api.md
+++ b/specs/normative/N5-cli-tui-api.md
@@ -1,7 +1,7 @@
 # N5 — Interface Standard: CLI/TUI/API
 
-**Version:** 0.3.0-draft
-**Date:** 2026-02-07
+**Version:** 0.4.0-draft
+**Date:** 2026-02-16
 **Status:** Draft
 **Conformance:** MUST
 
@@ -549,19 +549,46 @@ Flags:
 
 #### 2.3.8 Pack Namespace
 
-**Purpose:** Inspect, verify, and promote packs.
+**Purpose:** Manage, inspect, install, and run packs (including Workflow Packs per N1 §2.24).
 
 ```bash
-# List packs in registry roots
+# Search for packs across configured registry roots
+miniforge pack search QUERY [flags]
+
+Flags:
+  --type TYPE          Filter by pack type (feature|policy|agent-profile|workflow|index)
+  --publisher PUB      Filter by publisher
+  --capability CAP     Filter by required capability
+  --json               Output as JSON
+
+# List installed packs
 miniforge pack list [flags]
 
 Flags:
   --root DIR           Add an additional registry root
-  --type TYPE          Filter by pack type (feature|policy|agent-profile|index)
+  --type TYPE          Filter by pack type (feature|policy|agent-profile|workflow|index)
   --json               Output as JSON
 
-# Show pack details (including provenance + hash)
+# Show pack details (including provenance, hash, capabilities, entrypoints)
 miniforge pack show PACK_ID [flags]
+
+# Install a pack from a registry root or local bundle
+miniforge pack install PACK_ID[@VERSION] [flags]
+
+Flags:
+  --root DIR           Registry root to install from (or local path)
+  --grant CAP          Pre-grant capability (repeatable; prompted interactively if omitted)
+  --dry-run            Show what would be installed without installing
+
+# Update an installed pack
+miniforge pack update PACK_ID [flags]
+
+Flags:
+  --to VERSION         Target version (default: latest)
+  --accept-capabilities  Accept capability changes without interactive prompt
+
+# Remove an installed pack
+miniforge pack remove PACK_ID [flags]
 
 # Promote pack trust level (local OSS workflow)
 miniforge pack promote PACK_ID [flags]
@@ -579,6 +606,26 @@ Policy Enforcement:
 
 # Verify pack signature/hash
 miniforge pack verify PACK_ID [flags]
+
+# Run a Workflow Pack entrypoint
+miniforge pack run PACK_ID[@VERSION] [flags]
+
+Flags:
+  --entry ENTRYPOINT   Entrypoint name (required if pack has multiple entrypoints)
+  --input KEY=VALUE    Input parameter (repeatable)
+  --inputs-file FILE   JSON/EDN file with input parameters
+  --grant CAP          Grant capability for this run (repeatable)
+  --pin-digest         Pin to exact content digest (no auto-update)
+  --dry-run            Show what would be executed without running
+
+# Configure pack trust policies
+miniforge pack trust [flags]
+
+Flags:
+  --allow-publisher PUB    Add publisher to allowlist
+  --deny-publisher PUB     Add publisher to denylist
+  --min-trust-level LEVEL  Set minimum trust level for installs
+  --show                   Show current trust configuration
 ```
 
 **Requirements:**
@@ -586,6 +633,11 @@ miniforge pack verify PACK_ID [flags]
 - MUST treat pack promotion as a policy-gated operation
 - MUST record pack hashes and promotion evidence in N6 evidence bundles
 - MUST NOT allow untrusted packs to gain instruction authority without promotion/signature
+- MUST present required capabilities before install and before run (interactive prompt)
+- MUST deny write capabilities by default unless explicitly granted
+- MUST require re-approval when pack update increases capabilities
+- MUST emit pack lifecycle events (N3 §3.12) for install/update/remove
+- MUST emit Pack Run events (N3 §3.12) for run start/complete/fail
 
 ## 3. TUI Primitives
 
@@ -854,6 +906,65 @@ The TUI MUST provide:
 - MUST show ordered train members with merge readiness status
 - MUST indicate which member is next for merge
 - MUST show dependency edges between train members
+
+#### 3.2.11 Pack Browser View
+
+```text
+╭─────────────────────────────────────────────────────────────────────────────╮
+│ miniforge pack browser  [Installed: 12 | Available: 47]         ⟳ 30s ago  │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ PACK                   PUBLISHER       TYPE       VER    STATUS    TRUST    │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ ✓ pr-review            miniforge       workflow   1.2.0  installed trusted  │
+│ ✓ tf-aws-foundations   miniforge       policy     2.0.1  installed trusted  │
+│ ● risk-report          miniforge       workflow   0.9.0  update    trusted  │
+│ ○ sprint-metrics       acme-co         workflow   1.0.0  available verified │
+│ ○ k8s-drift-check      community       workflow   0.5.2  available unsigned │
+╰─────────────────────────────────────────────────────────────────────────────╯
+
+[j/k] Navigate  [Enter] Details  [i] Install  [u] Update  [x] Remove  [/] Search
+```
+
+**Requirements:**
+
+- MUST list installed and available packs with publisher, type, version, status, trust
+- MUST show signature/trust status prominently
+- MUST support search and filtering by publisher, type, capability
+- MUST allow installing, updating, and removing packs with capability grant review
+- MUST present required capabilities for review before confirming install
+
+#### 3.2.12 Run Launcher View
+
+```text
+╭─────────────────────────────────────────────────────────────────────────────╮
+│ Run Pack: pr-review@1.2.0 (miniforge)                   ✓ signature valid  │
+├─────────────────────────────────────────────────────────────────────────────┤
+│ Entrypoint: [review-pr ▼]                                                  │
+│                                                                             │
+│ Inputs:                                                                     │
+│   repo:     [acme/api         ]                                            │
+│   pr_number:[42               ]                                            │
+│   depth:    [standard ▼       ]                                            │
+│                                                                             │
+│ Capabilities Requested:                     Granted:                        │
+│   github.pr.read                            ✓ auto                         │
+│   github.pr.comment.write                   ○ requires approval            │
+│   git.repo.checkout                         ✓ auto                         │
+│                                                                             │
+│ Trust: trusted | Digest: sha256:a1b2c3...                                  │
+╰─────────────────────────────────────────────────────────────────────────────╯
+
+[Tab] Next field  [Enter] Submit/Grant  [Esc] Cancel  [p] Pin digest
+```
+
+**Requirements:**
+
+- MUST allow entrypoint selection when pack has multiple entrypoints
+- MUST generate input forms from pack entrypoint schemas
+- MUST show required capabilities with grant status (auto-granted reads vs pending writes)
+- MUST show pack trust and signature status
+- MUST support pinning to exact pack digest for reproducible runs
+- MUST allow re-running with same inputs and pinned version
 
 ### 3.3 TUI Keyboard Navigation
 
@@ -1370,6 +1481,8 @@ Research directions:
 
 **Version History:**
 
+- 0.4.0-draft (2026-02-16): Extended pack namespace with search/install/update/remove/run/trust
+  commands (§2.3.8); added Pack Browser (§3.2.11) and Run Launcher (§3.2.12) TUI views
 - 0.3.0-draft (2026-02-07): Added extension spec interfaces from N7, N8, N9
   (§2.3.3, §3.2.6–§3.2.10, §4.2.4)
 - 0.2.0-draft (2026-02-04): Added DAG Kanban view and task lifecycle CLI command (§3.2.5)

--- a/specs/normative/N6-evidence-provenance.md
+++ b/specs/normative/N6-evidence-provenance.md
@@ -1,7 +1,7 @@
 # N6 — Evidence & Provenance Standard
 
-**Version:** 0.3.0-draft
-**Date:** 2026-02-07
+**Version:** 0.4.0-draft
+**Date:** 2026-02-16
 **Status:** Draft
 **Conformance:** MUST
 
@@ -374,6 +374,93 @@ artifacts, not inline their content.
 For external PRs (no workflow), `:provenance/workflow-id` MAY be nil and
 `:provenance/phase` SHOULD be `:external-pr-eval`.
 
+### 2.11 Pack Run Evidence
+
+Pack Runs (N1 §2.26) produce evidence using the existing bundle schema with
+pack-specific fields.
+
+#### 2.11.1 Pack Run Evidence Requirements
+
+Each Pack Run evidence bundle MUST include:
+
+```clojure
+{:evidence/pack-run
+ {:pack-run/id uuid
+  :pack/id string
+  :pack/version string
+  :pack/content-hash string            ; Digest at run time
+  :pack/publisher string
+  :pack/entrypoint string
+
+  :pack/signature-verified? boolean    ; REQUIRED: verification result
+  :pack/signature-error string         ; OPTIONAL: error if verification failed
+
+  :pack/capabilities-required
+  [{:capability/id string
+    :capability/scope keyword}]
+
+  :pack/capabilities-granted
+  [{:capability/id string
+    :capability/scope keyword
+    :capability/granted-by string      ; "user", "policy", "auto"
+    :capability/granted-at inst}]
+
+  :pack/capabilities-denied            ; OPTIONAL: capabilities that were denied
+  [{:capability/id string
+    :capability/scope keyword
+    :capability/denied-reason string}]
+
+  :pack/resolved-dependencies          ; REQUIRED if pack has dependencies
+  [{:pack/id string
+    :pack/version string
+    :pack/content-hash string}]
+
+  :pack-run/inputs {...}               ; Input values (redacted per data-handling)
+  :pack-run/outputs {...}              ; Output values upon completion
+  :pack-run/connector-actions          ; All connector actions taken during run
+  [{:action/capability string
+    :action/timestamp inst
+    :action/result keyword}]}}         ; :success | :failure | :denied
+```
+
+#### 2.11.2 Metrics Snapshot Artifact
+
+When a pack performs reporting or analytics, metric queries MUST produce
+Metrics Snapshot artifacts:
+
+```clojure
+{:artifact/type :metrics-snapshot
+ :artifact/content
+ {:metrics/query string                ; Query expression
+  :metrics/parameters {...}            ; Query parameters
+  :metrics/time-window
+  {:start inst :end inst}
+  :metrics/result-digest string        ; SHA-256 of query results
+  :metrics/source string}              ; Metrics endpoint identifier
+ :artifact/content-hash string}
+```
+
+Metrics Snapshots enable reproducibility by recording the exact query and parameters
+used to produce a result, without requiring storage of raw metric data.
+
+#### 2.11.3 Report Artifact
+
+When a pack renders a report, the output MUST be a Report Artifact:
+
+```clojure
+{:artifact/type :report-artifact
+ :artifact/content
+ {:report/template-ref string          ; Template identifier within pack
+  :report/template-digest string       ; SHA-256 of template at render time
+  :report/input-artifact-refs [uuid ...] ; Input artifacts used
+  :report/output-format keyword        ; :markdown | :html | :pdf | :json
+  :report/rendered-digest string}      ; SHA-256 of rendered output
+ :artifact/content-hash string}
+```
+
+Report Artifacts enable provenance tracing from rendered output back to input data
+and template.
+
 ---
 
 ## 3. Artifact Provenance Schema
@@ -435,7 +522,13 @@ Implementations MUST support:
 - `:pr-policy-result` - Policy evaluation result for an external PR
 - `:pr-readiness-snapshot` - Point-in-time readiness assessment for a PR
 
-Artifacts of type `:feature-pack`, `:policy-pack`, and `:agent-profile-pack` MUST include:
+**Pack Run artifact types:**
+
+- `:pack-run-evidence` - Pack Run execution record (see below)
+- `:metrics-snapshot` - Query + parameters + time window + result digest
+- `:report-artifact` - Rendered report referencing input artifacts and templates by digest
+
+Artifacts of type `:feature-pack`, `:policy-pack`, `:agent-profile-pack`, and `:workflow-pack` MUST include:
 
 - `:artifact/metadata {:trust-level ... :authority ...}`
 - `:artifact/content-hash` computed over canonical EDN
@@ -900,6 +993,9 @@ Fleet-wide evidence will enable:
 
 **Version History:**
 
+- 0.4.0-draft (2026-02-16): Added Pack Run Evidence (§2.11), Metrics Snapshot (§2.11.2),
+  Report Artifact (§2.11.3); added pack-run-evidence, metrics-snapshot, report-artifact
+  to artifact types (§3.1.1)
 - 0.3.0-draft (2026-02-07): Added extension spec evidence from N7, N8, N9
   (§2.8–§2.10, §3.1.1 artifact types)
 - 0.2.0-draft (2026-02-03): Add DAG orchestration evidence (Section 2.7: DAG Run, Task Workflow, Merge Evidence)


### PR DESCRIPTION
## Summary

- Adds **Workflow Pack**, **Capability**, and **Pack Run** as first-class concepts to the
  Miniforge core domain model (N1-N6), enabling distributable domain workflows as an
  OSS extensibility primitive
- Workflow Packs are versioned bundles with capability enforcement, signature verification,
  and evidence-tracked execution — the distribution unit for domain workflows (reporting,
  product-brief pipelines, etc.) without bloating core
- Policy Packs are clarified as a specialization of the general pack model

### Amendments by spec

| Spec | Amendment | Sections |
|------|-----------|----------|
| **N1** | Workflow Pack, Capability, Pack Run concepts; extended pack types; glossary | §2.10.3, §2.24–§2.26, §12 |
| **N2** | Workflow chaining — typed outputs, input binding, cross-boundary provenance | §14 |
| **N3** | Pack lifecycle events, Pack Run events, capability denial, chain edge events | §3.12 |
| **N4** | Pack Trust Gate, Capability Grant Gate, High-Risk Pack Action Gate | §5.1.8–§5.1.10 |
| **N5** | Extended pack CLI (search/install/update/remove/run/trust); Pack Browser + Run Launcher TUI | §2.3.8, §3.2.11–§3.2.12 |
| **N6** | Pack Run Evidence with capability tracking; Metrics Snapshot; Report Artifact | §2.11 |
| **SPEC_INDEX** | Updated descriptions and version history | — |

### Context

These amendments extract the OSS-scope pack runtime concepts from the proposed N10/N11/N12
extension specs (Workflow Pack Marketplace, Native Control Console, Enterprise Add-ons).
Fleet-specific concerns (marketplace governance, certification tiers, native console, enterprise
identity) will land as extension specs in the miniforge-fleet repository.

## Test plan

- [x] All existing tests pass (pre-commit hook: lint, format, 3000+ assertions, GraalVM compat)
- [ ] Review each spec amendment for consistency with existing N1-N6 patterns
- [ ] Verify cross-references between specs are correct
- [ ] Confirm OSS/Fleet boundary is clean (no Fleet-only concepts leaked into core)

🤖 Generated with [Claude Code](https://claude.com/claude-code)