### PR TITLE
fix(tui): force Lanterna DELTA refresh to eliminate flashing

### DIFF
--- a/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
@@ -25,7 +25,7 @@
    [ai.miniforge.tui-engine.screen :as screen])
   (:import
    [com.googlecode.lanterna TextCharacter TextColor$ANSI TextColor$Indexed TextColor$RGB]
-   [com.googlecode.lanterna.screen TerminalScreen]
+   [com.googlecode.lanterna.screen TerminalScreen Screen$RefreshType]
    [com.googlecode.lanterna.terminal DefaultTerminalFactory]))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
@@ -89,7 +89,7 @@
     (.clear screen))
 
   (refresh! [_]
-    (.refresh screen))
+    (.refresh screen Screen$RefreshType/DELTA))
 
   (poll-input [_]
     (when-let [key (.pollInput screen)]


### PR DESCRIPTION
## Summary
- Forces Lanterna's `refresh!` to use `Screen$RefreshType/DELTA` instead of the default `AUTOMATIC` mode
- When >75% of the back buffer differs from the front buffer (e.g. tabbing between pr-fleet → workflow → evidence), Lanterna's AUTOMATIC mode chooses COMPLETE refresh — clearing the terminal and redrawing line-by-line, causing visible flashing
- DELTA mode only writes changed cells, matching our cell-level diffing in `core.clj`

## Test plan
- [ ] All existing tests pass (verified in pre-commit hook)
- [ ] Launch TUI and tab through pr-fleet → workflow → evidence — no flashing
- [ ] Verify other view transitions still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)