### PR TITLE
feat(pr-train): emit :pr/merged event from complete-merge

### DIFF
--- a/components/pr-train/src/ai/miniforge/pr_train/core.clj
+++ b/components/pr-train/src/ai/miniforge/pr_train/core.clj
@@ -111,7 +111,7 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; In-memory implementation
 
-(defrecord InMemoryPRTrainManager [trains evidence-bundles]
+(defrecord InMemoryPRTrainManager [trains evidence-bundles event-stream]
   PRTrainManager
 
   ;; Lifecycle
@@ -223,6 +223,15 @@
                         state/recompute-train-state
                         state/auto-transition-train)]
           (swap! trains assoc train-id final)
+          (when event-stream
+            (try
+              (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
+                (publish! event-stream
+                          {:event/type :pr/merged
+                           :pr/number pr-number
+                           :train/id train-id
+                           :timestamp (java.util.Date.)}))
+              (catch Exception _ nil)))
           final))))
 
   (fail-merge [_this train-id pr-number _reason]
@@ -338,10 +347,12 @@
 
 (defn create-manager
   "Create a new in-memory PR train manager.
-
+   Options:
+   - :event-stream - Optional event stream for publishing merge events
    Returns an InMemoryPRTrainManager instance."
-  []
-  (->InMemoryPRTrainManager (atom {}) (atom {})))
+  ([] (create-manager nil))
+  ([opts]
+   (->InMemoryPRTrainManager (atom {}) (atom {}) (:event-stream opts))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Utility functions for working with trains

--- a/components/pr-train/test/ai/miniforge/pr_train/event_stream_test.clj
+++ b/components/pr-train/test/ai/miniforge/pr_train/event_stream_test.clj
@@ -1,0 +1,66 @@
+(ns ai.miniforge.pr-train.event-stream-test
+  "Tests for event-stream integration in PR train manager."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.pr-train.interface :as train]))
+
+(deftest complete-merge-emits-pr-merged-event
+  (testing "complete-merge publishes :pr/merged event to event-stream"
+    (let [;; Mock event-stream: an atom that collects published events
+          published (atom [])
+          mock-stream (reify Object)
+          ;; Stub requiring-resolve to return our mock publish! fn
+          mgr (train/create-manager {:event-stream mock-stream})]
+
+      ;; Override the publish! call by redefining the resolved var behavior.
+      ;; Since complete-merge uses requiring-resolve, we can use with-redefs
+      ;; on the resolved function directly.
+      (with-redefs [ai.miniforge.event-stream.interface/publish!
+                    (fn [stream event]
+                      (swap! published conj {:stream stream :event event})
+                      event)]
+
+        ;; Set up a train with one PR and drive it through to merge
+        (let [train-id (train/create-train mgr "Event Test" (random-uuid) nil)]
+          (train/add-pr mgr train-id "acme/repo" 42 "url" "branch" "PR 42")
+          (train/link-prs mgr train-id)
+
+          ;; Transition PR through: draft -> open -> reviewing -> approved
+          (train/update-pr-status mgr train-id 42 :open)
+          (train/update-pr-status mgr train-id 42 :reviewing)
+          (train/update-pr-status mgr train-id 42 :approved)
+          (train/update-pr-ci-status mgr train-id 42 :passed)
+
+          ;; Merge next marks it as :merging
+          (train/merge-next mgr train-id)
+
+          ;; Complete the merge — should emit event
+          (let [result (train/complete-merge mgr train-id 42)]
+            (is (some? result) "complete-merge should return updated train")
+            (is (= :merged (:pr/status (train/get-pr-from-train mgr train-id 42))))
+
+            ;; Verify event was published
+            (is (= 1 (count @published)) "exactly one event should be published")
+            (let [{:keys [stream event]} (first @published)]
+              (is (= mock-stream stream) "event should be published to the manager's event-stream")
+              (is (= :pr/merged (:event/type event)))
+              (is (= 42 (:pr/number event)))
+              (is (= train-id (:train/id event)))
+              (is (inst? (:timestamp event))))))))))
+
+(deftest complete-merge-without-event-stream
+  (testing "complete-merge works normally when no event-stream is configured"
+    (let [mgr (train/create-manager)
+          train-id (train/create-train mgr "No Stream" (random-uuid) nil)]
+      (train/add-pr mgr train-id "acme/repo" 99 "url" "branch" "PR 99")
+      (train/link-prs mgr train-id)
+
+      (train/update-pr-status mgr train-id 99 :open)
+      (train/update-pr-status mgr train-id 99 :reviewing)
+      (train/update-pr-status mgr train-id 99 :approved)
+      (train/update-pr-ci-status mgr train-id 99 :passed)
+      (train/merge-next mgr train-id)
+
+      (let [result (train/complete-merge mgr train-id 99)]
+        (is (some? result))
+        (is (= :merged (:pr/status (train/get-pr-from-train mgr train-id 99))))))))

--- a/docs/pull-requests/2026-02-25-feat-pr-train-events.md
+++ b/docs/pull-requests/2026-02-25-feat-pr-train-events.md
@@ -1,0 +1,53 @@
+# feat/pr-train-events — PR2a
+
+## Layer
+
+Domain (PR Train)
+
+## Depends on
+
+- None (base of merge trigger stack)
+
+## Overview
+
+Adds event emission to the PR train manager so that `complete-merge` publishes
+a `:pr/merged` event to a configurable event stream.
+
+## Motivation
+
+The meta-loop merge trigger system needs to know when a PR merges so it can
+kick off downstream workflows (e.g., promoting the next PR in the train,
+triggering evidence collection). By emitting events from `complete-merge`, the
+PR train becomes observable without polling.
+
+## Changes In Detail
+
+| File | What changed |
+|------|-------------|
+| `components/pr-train/src/ai/miniforge/pr_train/core.clj` | Added `event-stream` field to `InMemoryPRTrainManager` defrecord; `create-manager` accepts optional opts map with `:event-stream`; `complete-merge` emits `:pr/merged` event via `requiring-resolve` |
+| `components/pr-train/test/ai/miniforge/pr_train/event_stream_test.clj` | 2 new tests verifying event emission on merge and nil-stream safety |
+
+**+81 LOC** across 2 files.
+
+## Testing Plan
+
+- [x] 2 unit tests for event emission (merge event content, nil-stream no-op)
+- [ ] Pre-commit hooks pass (lint, format, test, graalvm)
+- [ ] Integration with PR2b (merge trigger) once that lands
+
+## Deployment Plan
+
+No runtime impact — additive field on defrecord, backward-compatible
+`create-manager` arity. Merges to `main` and is consumed by PR2b.
+
+## Related Issues / PRs
+
+- **PR2b** (merge trigger) depends on this PR
+- Part of the meta-loop merge trigger work
+
+## Checklist
+
+- [x] Tests written and passing
+- [x] No breaking changes to existing interfaces
+- [x] Polylith interface boundaries respected
+- [x] Babashka / GraalVM compatible (requiring-resolve pattern)


### PR DESCRIPTION
## Summary
- Add `event-stream` field to `InMemoryPRTrainManager` defrecord
- `create-manager` accepts optional opts map with `:event-stream`
- `complete-merge` emits `:pr/merged` event via `requiring-resolve`
- 2 unit tests for event emission

## Part of Meta-Loop Implementation
This is PR2a in the [meta-loop plan](PLAN-meta-loop.md). PR2b (merge trigger) depends on this.

## Test plan
- [x] Unit tests pass (2 tests)
- [ ] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)