### PR TITLE
feat(cli): add --tui monitoring mode to mf run

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -201,6 +201,7 @@ Usage: miniforge <command> [options]
 Commands:
   run <spec-file>     Execute a workflow from a spec file
     --interactive     Interactive mode (chat-based)
+    --tui             Monitor workflow in terminal UI
     --worktree <path> Custom worktree path
 
   status [id]         Show workflow status
@@ -281,6 +282,7 @@ Examples:
     :fn run-cmd
     :args->opts [:spec]
     :spec {:interactive {:coerce :boolean :alias :i}
+           :tui         {:coerce :boolean}
            :worktree    {:alias :w}}}
 
    ;; Status command

--- a/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
@@ -7,12 +7,32 @@
    [ai.miniforge.cli.workflow-runner :as workflow-runner]))
 
 ;------------------------------------------------------------------------------ Layer 1
+;; TUI mode
+
+(defn- run-with-tui
+  "Run workflow with TUI monitoring. Shares event-stream between runner and TUI."
+  [parsed-spec opts]
+  (let [create-event-stream (requiring-resolve 'ai.miniforge.event-stream.interface/create-event-stream)
+        start-tui! (requiring-resolve 'ai.miniforge.tui-views.interface/start-tui!)
+        event-stream (create-event-stream)]
+    ;; Launch workflow on background thread
+    (future
+      (try
+        (workflow-runner/run-workflow-from-spec!
+         parsed-spec
+         (assoc opts :event-stream event-stream))
+        (catch Exception e
+          (println (str "Workflow error: " (ex-message e))))))
+    ;; Block on TUI (main thread)
+    (start-tui! event-stream)))
+
+;------------------------------------------------------------------------------ Layer 2
 ;; Run command
 
 (defn run-cmd
   "Execute a workflow from a spec file."
   [opts]
-  (let [{:keys [spec interactive]} opts]
+  (let [{:keys [spec interactive tui]} opts]
     (cond
       interactive
       (do
@@ -20,10 +40,26 @@
         (println "Coming soon: conversational workflow execution"))
 
       (not spec)
-      (display/print-error "Usage: miniforge run <spec-file> [--interactive]")
+      (display/print-error "Usage: miniforge run <spec-file> [--interactive] [--tui]")
 
       (not (fs/exists? spec))
       (display/print-error (str "Spec file not found: " spec))
+
+      (:tui opts)
+      (try
+        (display/print-info (str "Parsing workflow spec: " spec))
+        (let [parsed-spec (spec-parser/parse-spec-file spec)
+              validation (spec-parser/validate-spec parsed-spec)]
+          (if-not (:valid? validation)
+            (do
+              (display/print-error "Invalid workflow spec:")
+              (doseq [error (:errors validation)]
+                (println (str "  - " error))))
+            (do
+              (display/print-info (str "Running workflow with TUI monitor: " (:spec/title parsed-spec)))
+              (run-with-tui parsed-spec {:output :pretty :quiet true}))))
+        (catch Exception e
+          (display/print-error (str "Failed to run workflow: " (ex-message e)))))
 
       :else
       (try

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -277,7 +277,7 @@
           enriched-spec (context/decorate-spec-with-runtime-context spec opts)
           workflow-input (context/spec->workflow-input enriched-spec)
           artifact-store (create-artifact-store quiet)
-          event-stream (es/create-event-stream)
+          event-stream (or (:event-stream opts) (es/create-event-stream))
           workflow-id (or (get-in enriched-spec [:spec/metadata :session-id]) (random-uuid))
           ;; Control state for dashboard commands (pause/resume/stop)
           control-state (atom {:paused false :stopped false :adjustments {}})

--- a/docs/pull-requests/2026-02-25-feat-cli-tui-mode.md
+++ b/docs/pull-requests/2026-02-25-feat-cli-tui-mode.md
@@ -1,0 +1,55 @@
+# feat/cli-tui-mode — PR3a
+
+## Layer
+
+Application (CLI)
+
+## Depends on
+
+- None (independent)
+
+## Overview
+
+Adds a `--tui` flag to `mf run` that launches the TUI monitoring dashboard
+alongside the workflow execution, giving operators a real-time view of pipeline
+progress.
+
+## Motivation
+
+Running `mf run` currently produces log output but no interactive feedback.
+The TUI monitoring mode lets operators watch workflow phases execute in real
+time, see event streams, and (in future PRs) pause/resume/cancel from the
+dashboard. This is the entry point for the meta-loop TUI monitoring seat.
+
+## Changes In Detail
+
+| File | What changed |
+|------|-------------|
+| `bases/cli/src/ai/miniforge/cli/main/commands/run.clj` | Added `--tui` CLI flag; `run-with-tui` fn creates shared event-stream, launches workflow on background thread via `future`, blocks main thread on `start-tui!` |
+| `bases/cli/src/ai/miniforge/cli/workflow_runner.clj` | Accepts external event-stream via opts map instead of always creating its own |
+| `bases/cli/src/ai/miniforge/cli/main.clj` | Registered `--tui` flag in CLI spec |
+
+**+41 LOC** across 3 files.
+
+## Testing Plan
+
+- [ ] Manual smoke test: `mf run --tui` with a sample workflow
+- [ ] Pre-commit hooks pass (lint, format, test, graalvm)
+- [ ] Verify TUI launches on main thread and workflow runs on background thread
+- [ ] Verify graceful shutdown when TUI exits
+
+## Deployment Plan
+
+Additive CLI flag — no impact on existing `mf run` behavior without `--tui`.
+Ships with next CLI release.
+
+## Related Issues / PRs
+
+- Independent — no blockers or dependents in Wave 1
+- Part of the meta-loop TUI monitoring seat
+
+## Checklist
+
+- [x] No breaking changes to existing CLI behavior
+- [x] Polylith interface boundaries respected
+- [x] Babashka compatible


### PR DESCRIPTION
## Summary
- Add `--tui` flag to CLI `mf run` command
- `run-with-tui` creates shared event-stream, launches workflow on background thread via `future`, blocks main thread on `start-tui!`
- `workflow_runner.clj` accepts external event-stream via opts

## Part of Meta-Loop Implementation
This is PR3a in the [meta-loop plan](PLAN-meta-loop.md). Independent — no blockers or dependents.

## Test plan
- [ ] Manual smoke test: `mf run --tui` with a sample workflow
- [ ] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)