### PR TITLE
refactor(event-stream): extract control-state into shared primitives

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -280,7 +280,7 @@
           event-stream (es/create-event-stream)
           workflow-id (or (get-in enriched-spec [:spec/metadata :session-id]) (random-uuid))
           ;; Control state for dashboard commands (pause/resume/stop)
-          control-state (atom {:paused false :stopped false :adjustments {}})
+          control-state (es/create-control-state)
           command-poller-cleanup (dashboard/start-command-poller! workflow-id control-state)
           ;; Create workflow-specific LLM client for execution
           llm-client (context/create-llm-client workflow spec quiet)

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/dashboard.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/dashboard.clj
@@ -71,11 +71,11 @@
                                     data (edn/read-string content)
                                     command (keyword (:command data))]
                                 (case command
-                                  :pause (do (swap! control-state assoc :paused true)
+                                  :pause (do ((requiring-resolve 'ai.miniforge.event-stream.interface/pause!) control-state)
                                              (println "\u23f8  Workflow paused by dashboard"))
-                                  :resume (do (swap! control-state assoc :paused false)
+                                  :resume (do ((requiring-resolve 'ai.miniforge.event-stream.interface/resume!) control-state)
                                               (println "\u25b6  Workflow resumed by dashboard"))
-                                  :stop (do (swap! control-state assoc :stopped true)
+                                  :stop (do ((requiring-resolve 'ai.miniforge.event-stream.interface/cancel!) control-state)
                                             (println "\u23f9  Workflow stopped by dashboard"))
                                   nil)
                                 (.delete file))

--- a/components/event-stream/src/ai/miniforge/event_stream/control.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/control.clj
@@ -12,6 +12,40 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Control state management
+
+(defn create-control-state
+  "Create a canonical control-state atom for workflow execution.
+   Used by both CLI dashboard poller and TUI to drive pause/resume/cancel."
+  []
+  (atom {:paused false :stopped false :adjustments {}}))
+
+(defn pause!
+  "Pause workflow execution."
+  [control-state]
+  (swap! control-state assoc :paused true))
+
+(defn resume!
+  "Resume paused workflow execution."
+  [control-state]
+  (swap! control-state assoc :paused false))
+
+(defn cancel!
+  "Cancel workflow execution."
+  [control-state]
+  (swap! control-state assoc :stopped true))
+
+(defn paused?
+  "Check if workflow is paused."
+  [control-state]
+  (:paused @control-state))
+
+(defn cancelled?
+  "Check if workflow is cancelled."
+  [control-state]
+  (:stopped @control-state))
+
+;------------------------------------------------------------------------------ Layer 1a
 ;; RBAC role definitions
 
 (def default-roles
@@ -29,7 +63,7 @@
   "Valid target types for control actions."
   #{:workflow :agent :fleet})
 
-;------------------------------------------------------------------------------ Layer 1
+;------------------------------------------------------------------------------ Layer 1b
 ;; Control action creation
 
 (defn create-control-action
@@ -53,7 +87,7 @@
     (:justification opts) (assoc :action/justification (:justification opts))
     (:parameters opts) (assoc :action/parameters (:parameters opts))))
 
-;------------------------------------------------------------------------------ Layer 1
+;------------------------------------------------------------------------------ Layer 1c
 ;; RBAC authorization
 
 (def ^:private target-type->category
@@ -107,7 +141,7 @@
                                          :action-type action-type
                                          :target-type target-type})})))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 2a
 ;; Control action execution
 
 (defn execute-control-action!
@@ -140,7 +174,7 @@
                       stream workflow-id action-id result))
       result)))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 2b
 ;; Approval-aware control action execution
 
 (def ^:private actions-requiring-approval

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -53,6 +53,34 @@
    [ai.miniforge.event-stream.approval :as approval]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Control state primitives
+
+(def create-control-state
+  "Create a canonical control-state atom for workflow execution.
+   Used by both CLI dashboard poller and TUI to drive pause/resume/cancel."
+  control/create-control-state)
+
+(def pause!
+  "Pause workflow execution."
+  control/pause!)
+
+(def resume!
+  "Resume paused workflow execution."
+  control/resume!)
+
+(def cancel!
+  "Cancel workflow execution."
+  control/cancel!)
+
+(def paused?
+  "Check if workflow is paused."
+  control/paused?)
+
+(def cancelled?
+  "Check if workflow is cancelled."
+  control/cancelled?)
+
+;------------------------------------------------------------------------------ Layer 0b
 ;; Event stream lifecycle
 
 (defn create-event-stream

--- a/components/event-stream/test/ai/miniforge/event_stream/control_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/control_test.clj
@@ -5,6 +5,65 @@
    [ai.miniforge.event-stream.control :as control]
    [ai.miniforge.response.interface :as response]))
 
+;------------------------------------------------------------------------------ Layer 0
+;; Control state primitive tests
+
+(deftest create-control-state-test
+  (testing "returns atom with expected shape"
+    (let [cs (control/create-control-state)]
+      (is (instance? clojure.lang.Atom cs))
+      (is (= {:paused false :stopped false :adjustments {}} @cs)))))
+
+(deftest pause!-test
+  (testing "sets :paused to true"
+    (let [cs (control/create-control-state)]
+      (control/pause! cs)
+      (is (true? (:paused @cs))))))
+
+(deftest resume!-test
+  (testing "sets :paused to false"
+    (let [cs (control/create-control-state)]
+      (control/pause! cs)
+      (control/resume! cs)
+      (is (false? (:paused @cs))))))
+
+(deftest cancel!-test
+  (testing "sets :stopped to true"
+    (let [cs (control/create-control-state)]
+      (control/cancel! cs)
+      (is (true? (:stopped @cs))))))
+
+(deftest paused?-test
+  (testing "returns correct value"
+    (let [cs (control/create-control-state)]
+      (is (false? (control/paused? cs)))
+      (control/pause! cs)
+      (is (true? (control/paused? cs)))
+      (control/resume! cs)
+      (is (false? (control/paused? cs))))))
+
+(deftest cancelled?-test
+  (testing "returns correct value"
+    (let [cs (control/create-control-state)]
+      (is (false? (control/cancelled? cs)))
+      (control/cancel! cs)
+      (is (true? (control/cancelled? cs))))))
+
+(deftest control-state-interface-delegation-test
+  (testing "interface delegates to control functions"
+    (let [cs (es/create-control-state)]
+      (is (false? (es/paused? cs)))
+      (es/pause! cs)
+      (is (true? (es/paused? cs)))
+      (es/resume! cs)
+      (is (false? (es/paused? cs)))
+      (is (false? (es/cancelled? cs)))
+      (es/cancel! cs)
+      (is (true? (es/cancelled? cs))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; RBAC and control action tests
+
 (deftest create-control-action-test
   (testing "creates action with required fields"
     (let [action (es/create-control-action

--- a/docs/pull-requests/2026-02-25-feat-shared-control-state.md
+++ b/docs/pull-requests/2026-02-25-feat-shared-control-state.md
@@ -1,0 +1,59 @@
+# feat/shared-control-state — PR5a
+
+## Layer
+
+Infrastructure (Event Stream)
+
+## Depends on
+
+- None (base of TUI control stack)
+
+## Overview
+
+Extracts pause/resume/cancel control state into shared primitives in the
+event-stream component, replacing ad-hoc atom management scattered across
+the workflow runner and dashboard.
+
+## Motivation
+
+Both the workflow runner and TUI dashboard need to read and write
+pause/resume/cancel state. Previously each created its own atoms, leading to
+duplication and potential desynchronization. By extracting `create-control-state`,
+`pause!`, `resume!`, `cancel!`, `paused?`, and `cancelled?` into
+`event-stream/control.clj` and exporting them via the component interface,
+all consumers share the same primitives and the same state.
+
+## Changes In Detail
+
+| File | What changed |
+|------|-------------|
+| `components/event-stream/src/ai/miniforge/event_stream/control.clj` | Added `create-control-state`, `pause!`, `resume!`, `cancel!`, `paused?`, `cancelled?` functions |
+| `components/event-stream/src/ai/miniforge/event_stream/interface.clj` | Exported all 6 control-state functions via component interface |
+| `bases/cli/src/ai/miniforge/cli/workflow_runner.clj` | Switched to `es/create-control-state` instead of inline atoms |
+| `bases/cli/src/ai/miniforge/cli/workflow_runner/dashboard.clj` | Uses `requiring-resolve` calls to control-state functions |
+| `components/event-stream/test/ai/miniforge/event_stream/control_test.clj` | 7 new tests covering create, pause/resume cycle, cancel, and predicate queries |
+
+**+129 LOC** across 5 files.
+
+## Testing Plan
+
+- [x] 7 unit tests for control-state lifecycle
+- [ ] Pre-commit hooks pass (lint, format, test, graalvm)
+- [ ] Integration with PR5b (TUI control wiring) once that lands
+
+## Deployment Plan
+
+Refactor only — replaces internal atoms with shared primitives. No
+user-visible behavior change. Merges to `main` and is consumed by PR5b.
+
+## Related Issues / PRs
+
+- **PR5b** (TUI control wiring) depends on this PR
+- Part of the meta-loop TUI control work
+
+## Checklist
+
+- [x] Tests written and passing
+- [x] No breaking changes to existing interfaces
+- [x] Polylith interface boundaries respected
+- [x] Babashka / GraalVM compatible


### PR DESCRIPTION
## Summary
- Add `create-control-state`, `pause!`, `resume!`, `cancel!`, `paused?`, `cancelled?` to event-stream/control.clj
- Export via component interface.clj
- Migrate workflow_runner.clj and dashboard.clj to shared primitives
- 7 unit tests for control-state lifecycle

## Part of Meta-Loop Implementation
This is PR5a in the [meta-loop plan](PLAN-meta-loop.md). PR5b (TUI control wiring) depends on this.

## Test plan
- [x] Unit tests pass (7 tests)
- [ ] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)