### PR TITLE
feat(workflow): add chain executor for sequential workflow chaining

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -1,0 +1,159 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.chain
+  "Workflow chaining — execute a sequence of workflows where each step's
+   output feeds into the next step's input via configurable bindings.
+
+   Schemas (as documentation):
+   - ChainStep: {:step/id keyword
+                  :step/workflow-id keyword
+                  :step/input-bindings {keyword path-expr}}
+   - ChainDef:  {:chain/id keyword
+                  :chain/steps [ChainStep...]
+                  :chain/version string
+                  :chain/description string}
+
+   Path expressions for input bindings:
+   - string literal          — passed through as-is
+   - :chain/input.KEY        — reads KEY from the chain's initial input
+   - [:prev/phase-results ...] — navigates into previous step's :execution/output
+   - [:prev/artifacts ...]     — navigates into previous step's artifacts
+   - [:prev/last-phase-result ...] — navigates into previous step's last phase result
+   - keyword                 — reads from chain input"
+  (:require
+   [ai.miniforge.workflow.runner :as runner]))
+
+;------------------------------------------------------------------------------ Layer 0: Binding resolution
+
+(defn- resolve-binding
+  "Resolve a single input binding against previous output and chain input.
+   Path expressions:
+   - :chain/input.KEY — reads KEY from the chain's initial input
+   - [:prev/KEY1 :KEY2 ...] — reads from previous step's :execution/output
+   - string literal — passed through as-is"
+  [binding prev-output chain-input]
+  (cond
+    ;; String literal — pass through
+    (string? binding) binding
+
+    ;; Keyword starting with :chain/input. — read from chain input
+    (and (keyword? binding)
+         (.startsWith (name binding) "chain/input."))
+    (let [input-key (keyword (subs (name binding) (count "chain/input.")))]
+      (get chain-input input-key))
+
+    ;; Vector path — navigate into prev-output
+    (vector? binding)
+    (let [[root & path] binding
+          source (case root
+                   :prev/phase-results (:phase-results prev-output)
+                   :prev/artifacts (:artifacts prev-output)
+                   :prev/last-phase-result (:last-phase-result prev-output)
+                   prev-output)]
+      (if (seq path)
+        (get-in source (vec path))
+        source))
+
+    ;; Keyword — try chain-input
+    (keyword? binding) (get chain-input binding)))
+
+(defn- resolve-bindings
+  "Resolve all input bindings for a step."
+  [input-bindings prev-output chain-input]
+  (reduce-kv
+    (fn [acc k binding]
+      (assoc acc k (resolve-binding binding prev-output chain-input)))
+    {}
+    input-bindings))
+
+;------------------------------------------------------------------------------ Layer 1: Chain execution
+
+(defn run-chain
+  "Execute a chain of workflows sequentially.
+
+   Arguments:
+   - chain-def: Chain definition map with :chain/steps
+   - chain-input: Initial input map for the chain
+   - opts: Execution options passed to each run-pipeline call
+     Must include everything run-pipeline needs (e.g. :llm-backend)
+
+   Returns:
+   {:chain/id keyword
+    :chain/status :completed | :failed
+    :chain/step-results [step-result...]
+    :chain/duration-ms long}"
+  [chain-def chain-input opts]
+  (let [start-time (System/currentTimeMillis)
+        steps (:chain/steps chain-def)
+        load-workflow (requiring-resolve 'ai.miniforge.workflow.interface/load-workflow)]
+    (loop [remaining steps
+           prev-output nil
+           step-results []]
+      (if (empty? remaining)
+        ;; All steps completed successfully
+        {:chain/id (:chain/id chain-def)
+         :chain/status :completed
+         :chain/step-results step-results
+         :chain/duration-ms (- (System/currentTimeMillis) start-time)}
+
+        ;; Execute next step
+        (let [step (first remaining)
+              input-bindings (:step/input-bindings step)
+              resolved-input (resolve-bindings input-bindings prev-output chain-input)
+              workflow-result (load-workflow (:step/workflow-id step) :latest {})
+              workflow (:workflow workflow-result)
+              result (runner/run-pipeline workflow resolved-input opts)
+              output (:execution/output result)
+              step-result {:step/id (:step/id step)
+                           :step/workflow-id (:step/workflow-id step)
+                           :step/status (:execution/status result)
+                           :step/output output}
+              updated-results (conj step-results step-result)]
+          (if (= :failed (:execution/status result))
+            ;; Step failed — stop the chain immediately
+            {:chain/id (:chain/id chain-def)
+             :chain/status :failed
+             :chain/step-results updated-results
+             :chain/duration-ms (- (System/currentTimeMillis) start-time)}
+
+            ;; Step succeeded — continue with next step
+            (recur (rest remaining)
+                   output
+                   updated-results)))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Example chain definition
+  (def example-chain
+    {:chain/id :plan-then-implement
+     :chain/version "1.0.0"
+     :chain/description "Plan a feature, then implement it"
+     :chain/steps
+     [{:step/id :plan
+       :step/workflow-id :planning-v1
+       :step/input-bindings {:task :chain/input.task}}
+      {:step/id :implement
+       :step/workflow-id :implementation-v1
+       :step/input-bindings {:plan [:prev/last-phase-result :plan]
+                             :task :chain/input.task}}]})
+
+  ;; Run a chain
+  #_(run-chain example-chain {:task "Build login page"} {:llm-backend nil})
+
+  :leave-this-here)

--- a/components/workflow/src/ai/miniforge/workflow/interface.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface.clj
@@ -231,6 +231,13 @@
   [workflow]
   ((requiring-resolve 'ai.miniforge.workflow.runner/validate-pipeline) workflow))
 
+(defn run-chain
+  "Execute a chain of workflows sequentially.
+   See workflow.chain for details."
+  [chain-def chain-input opts]
+  ((requiring-resolve 'ai.miniforge.workflow.chain/run-chain)
+   chain-def chain-input opts))
+
 ;------------------------------------------------------------------------------ Layer 6
 ;; Configurable workflow API (Legacy)
 

--- a/components/workflow/test/ai/miniforge/workflow/chain_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_test.clj
@@ -1,0 +1,156 @@
+(ns ai.miniforge.workflow.chain-test
+  "Tests for workflow chain executor."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.workflow.chain :as chain]
+   [ai.miniforge.workflow.runner :as runner]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; resolve-binding tests
+
+(deftest resolve-binding-string-literal-test
+  (testing "string literal passes through unchanged"
+    (is (= "hello" (#'chain/resolve-binding "hello" nil nil)))
+    (is (= "some/path" (#'chain/resolve-binding "some/path" {} {})))))
+
+(deftest resolve-binding-chain-input-test
+  (testing ":chain/input.KEY reads from chain input"
+    (is (= "my-task"
+           (#'chain/resolve-binding :chain/input.task nil {:task "my-task"})))
+    (is (= 42
+           (#'chain/resolve-binding :chain/input.count nil {:count 42}))))
+  (testing ":chain/input.KEY returns nil for missing key"
+    (is (nil? (#'chain/resolve-binding :chain/input.missing nil {:task "x"})))))
+
+(deftest resolve-binding-vector-path-test
+  (testing "vector path navigates into prev-output"
+    (let [prev-output {:phase-results {:plan {:success? true :data "planned"}}
+                       :artifacts [{:title "doc"}]
+                       :last-phase-result {:success? true :output "done"}}]
+      (testing ":prev/phase-results root"
+        (is (= {:success? true :data "planned"}
+               (#'chain/resolve-binding [:prev/phase-results :plan] prev-output nil))))
+      (testing ":prev/artifacts root"
+        (is (= [{:title "doc"}]
+               (#'chain/resolve-binding [:prev/artifacts] prev-output nil))))
+      (testing ":prev/last-phase-result root with path"
+        (is (= "done"
+               (#'chain/resolve-binding [:prev/last-phase-result :output] prev-output nil)))))))
+
+(deftest resolve-binding-keyword-fallback-test
+  (testing "plain keyword reads from chain input"
+    (is (= "value" (#'chain/resolve-binding :my-key nil {:my-key "value"})))
+    (is (nil? (#'chain/resolve-binding :missing nil {:other "x"})))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; resolve-bindings tests
+
+(deftest resolve-bindings-test
+  (testing "resolves a full bindings map"
+    (let [bindings {:task :chain/input.task
+                    :plan [:prev/last-phase-result :plan]
+                    :label "static-label"
+                    :extra :chain/input.extra}
+          prev-output {:last-phase-result {:plan "the plan" :other "x"}}
+          chain-input {:task "build feature" :extra "bonus"}
+          result (#'chain/resolve-bindings bindings prev-output chain-input)]
+      (is (= "build feature" (:task result)))
+      (is (= "the plan" (:plan result)))
+      (is (= "static-label" (:label result)))
+      (is (= "bonus" (:extra result))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; run-chain tests
+
+(deftest run-chain-two-steps-test
+  (testing "chain with 2 steps where step 2 receives step 1 output"
+    (let [call-log (atom [])
+          chain-def {:chain/id :test-chain
+                     :chain/version "1.0.0"
+                     :chain/description "Test chain"
+                     :chain/steps
+                     [{:step/id :step-1
+                       :step/workflow-id :workflow-a
+                       :step/input-bindings {:task :chain/input.task}}
+                      {:step/id :step-2
+                       :step/workflow-id :workflow-b
+                       :step/input-bindings {:plan [:prev/last-phase-result :plan]
+                                             :task :chain/input.task}}]}]
+      (with-redefs [runner/run-pipeline
+                    (fn [_workflow input _opts]
+                      (swap! call-log conj input)
+                      {:execution/status :completed
+                       :execution/output {:artifacts [{:title (:task input)}]
+                                          :phase-results {}
+                                          :last-phase-result {:success? true
+                                                              :plan (str "plan-for-" (:task input))}
+                                          :status :completed}})
+                    ;; Mock load-workflow via requiring-resolve
+                    ;; We need to mock at the requiring-resolve level
+                    ]
+        ;; Mock load-workflow by redefining requiring-resolve behavior
+        (let [orig-requiring-resolve requiring-resolve]
+          (with-redefs [requiring-resolve
+                        (fn [sym]
+                          (if (= sym 'ai.miniforge.workflow.interface/load-workflow)
+                            (fn [_wf-id _version _opts]
+                              {:workflow {:workflow/id :mock
+                                          :workflow/pipeline [{:phase :plan}]}
+                               :source :mock})
+                            (orig-requiring-resolve sym)))]
+            (let [result (chain/run-chain chain-def {:task "build-login"} {})]
+              (is (= :test-chain (:chain/id result)))
+              (is (= :completed (:chain/status result)))
+              (is (= 2 (count (:chain/step-results result))))
+              (is (pos? (:chain/duration-ms result)))
+
+              ;; Verify step 1 received chain input
+              (is (= {:task "build-login"} (first @call-log)))
+
+              ;; Verify step 2 received resolved bindings from step 1 output
+              (let [step2-input (second @call-log)]
+                (is (= "build-login" (:task step2-input)))
+                (is (= "plan-for-build-login" (:plan step2-input))))
+
+              ;; Verify step results structure
+              (is (= :step-1 (get-in result [:chain/step-results 0 :step/id])))
+              (is (= :step-2 (get-in result [:chain/step-results 1 :step/id])))
+              (is (= :completed (get-in result [:chain/step-results 0 :step/status])))
+              (is (= :completed (get-in result [:chain/step-results 1 :step/status]))))))))))
+
+(deftest run-chain-stops-on-failure-test
+  (testing "chain stops immediately when a step fails"
+    (let [call-count (atom 0)
+          chain-def {:chain/id :fail-chain
+                     :chain/version "1.0.0"
+                     :chain/description "Chain that fails"
+                     :chain/steps
+                     [{:step/id :step-1
+                       :step/workflow-id :workflow-a
+                       :step/input-bindings {:task :chain/input.task}}
+                      {:step/id :step-2
+                       :step/workflow-id :workflow-b
+                       :step/input-bindings {:task :chain/input.task}}]}]
+      (with-redefs [runner/run-pipeline
+                    (fn [_workflow _input _opts]
+                      (swap! call-count inc)
+                      {:execution/status :failed
+                       :execution/output {:artifacts []
+                                          :phase-results {}
+                                          :last-phase-result {:success? false}
+                                          :status :failed}})]
+        (let [orig-requiring-resolve requiring-resolve]
+          (with-redefs [requiring-resolve
+                        (fn [sym]
+                          (if (= sym 'ai.miniforge.workflow.interface/load-workflow)
+                            (fn [_wf-id _version _opts]
+                              {:workflow {:workflow/id :mock
+                                          :workflow/pipeline [{:phase :plan}]}
+                               :source :mock})
+                            (orig-requiring-resolve sym)))]
+            (let [result (chain/run-chain chain-def {:task "doomed"} {})]
+              (is (= :failed (:chain/status result)))
+              (is (= 1 (count (:chain/step-results result))))
+              (is (= 1 @call-count) "step 2 should never execute")
+              (is (= :failed (get-in result [:chain/step-results 0 :step/status])))
+              (is (pos? (:chain/duration-ms result))))))))))

--- a/docs/pull-requests/2026-02-25-feat-chain-executor.md
+++ b/docs/pull-requests/2026-02-25-feat-chain-executor.md
@@ -1,0 +1,58 @@
+# feat(workflow): Add chain executor for sequential workflow chaining
+
+**Branch**: `feat/chain-executor`
+**Date**: 2026-02-25
+**Status**: Open
+
+## Overview
+
+Add a chain executor that runs a sequence of workflows where each step's output feeds into the next step's input via configurable bindings. This builds on PR1a's `:execution/output` addition to `run-pipeline`.
+
+## Motivation
+
+Complex tasks often require multiple workflows executed in sequence (e.g., plan then implement). The chain executor provides a declarative way to define these multi-step pipelines with data flowing between steps via input bindings.
+
+## Changes in Detail
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `components/workflow/src/ai/miniforge/workflow/chain.clj` | Chain executor with binding resolution and sequential execution |
+| `components/workflow/test/ai/miniforge/workflow/chain_test.clj` | Tests for binding resolution and chain execution |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `components/workflow/src/ai/miniforge/workflow/interface.clj` | Added `run-chain` to Layer 5 public API |
+
+## Architecture
+
+### Binding Resolution
+
+Input bindings map keys to path expressions that resolve against previous step output and chain input:
+
+- **String literal** — passed through as-is
+- **`:chain/input.KEY`** — reads KEY from the chain's initial input
+- **`[:prev/phase-results ...]`** — navigates into previous step's `:execution/output`
+- **`[:prev/artifacts ...]`** — navigates into previous step's artifacts
+- **`[:prev/last-phase-result ...]`** — navigates into previous step's last phase result
+- **Keyword** — reads from chain input
+
+### Chain Execution
+
+`run-chain` loops through steps sequentially. Each step:
+
+1. Resolves input bindings against previous output and chain input
+2. Loads the workflow via `load-workflow`
+3. Calls `runner/run-pipeline` with resolved input
+4. Extracts `:execution/output` for the next step
+5. Stops immediately on failure
+
+## Testing
+
+- `resolve-binding` handles all four path types (string, `:chain/input.*`, vector, keyword)
+- `resolve-bindings` resolves a complete bindings map
+- `run-chain` with 2 steps verifies output flows from step 1 to step 2
+- `run-chain` stops on failure — step 1 fails, step 2 never runs


### PR DESCRIPTION
## Summary

- Add `chain.clj` with `run-chain` for executing a sequence of workflows where each step's output feeds into the next step's input via configurable bindings
- Add binding resolution supporting string literals, `:chain/input.*` keys, vector paths into previous output, and keyword fallbacks
- Add `run-chain` to workflow interface (Layer 5) using `requiring-resolve`
- Add comprehensive tests for binding resolution and chain execution (including failure short-circuit)

## Test plan

- [ ] `resolve-binding` handles all 4 path types: string literal, `:chain/input.*`, vector path, keyword
- [ ] `resolve-bindings` resolves a full bindings map correctly
- [ ] `run-chain` with 2 steps passes output from step 1 to step 2 via bindings
- [ ] `run-chain` stops immediately when a step fails (step 2 never executes)
- [ ] Chain result includes `:chain/id`, `:chain/status`, `:chain/step-results`, `:chain/duration-ms`

🤖 Generated with [Claude Code](https://claude.com/claude-code)