### PR TITLE
feat(tui): add file-watcher subscription for standalone mf tui command

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj
@@ -2,6 +2,7 @@
   "Web dashboard and TUI monitoring commands."
   (:require
    [babashka.process :as process]
+   [clojure.string :as str]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.config :as config]))
 
@@ -92,8 +93,9 @@
 (def ^:dynamic *tui-available?* false)
 
 (defn tui-cmd
-  "Start terminal UI for workflow monitoring."
-  [_opts]
+  "Start terminal UI for workflow monitoring.
+   Launches standalone TUI that tail-follows ~/.miniforge/events/ files."
+  [opts]
   (if-not *tui-available?*
     (do
       (display/print-error "TUI not available in this runtime.")
@@ -107,20 +109,17 @@
       (println "  miniforge web")
       (System/exit 1))
     (do
-      (display/print-info "Starting TUI dashboard...")
+      (display/print-info "Starting TUI monitor...")
+      (display/print-info "Watching ~/.miniforge/events/ for workflow activity")
       (display/print-info "Press 'q' to quit, '?' for help")
       (println)
       (try
-        (require 'ai.miniforge.event-stream.interface)
-        (require 'ai.miniforge.tui-views.interface)
-        (let [create-stream (resolve 'ai.miniforge.event-stream.interface/create-event-stream)
-              start-tui!    (resolve 'ai.miniforge.tui-views.interface/start-tui!)
-              event-stream  (create-stream)]
-          ;; Start TUI (blocks until quit)
-          (start-tui! event-stream))
+        (let [start-standalone! (requiring-resolve 'ai.miniforge.tui-views.interface/start-standalone-tui!)]
+          ;; Start standalone TUI (blocks until quit)
+          (start-standalone! opts))
         (catch Exception e
           (display/print-error (str "Failed to start TUI: " (.getMessage e)))
-          (when (clojure.string/includes? (str e) "terminal")
+          (when (str/includes? (str e) "terminal")
             (println)
             (println "Note: The TUI requires a proper terminal environment.")
             (println "Try running from Terminal.app or iTerm2, not from an IDE.")))))))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/tui.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/tui.clj
@@ -1,0 +1,34 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.main.commands.tui
+  "TUI command — launch standalone TUI monitor."
+  (:require
+   [ai.miniforge.cli.main.display :as display]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; TUI command
+
+(defn tui-cmd
+  "Launch standalone TUI that monitors workflow event files.
+   Tail-follows ~/.miniforge/events/*.edn for live workflow state."
+  [opts]
+  (display/print-info "Starting TUI monitor...")
+  (display/print-info "Watching ~/.miniforge/events/ for workflow activity")
+  (let [start-tui! (requiring-resolve 'ai.miniforge.tui-views.interface/start-standalone-tui!)]
+    (start-tui! opts)))

--- a/components/tui-views/src/ai/miniforge/tui_views/file_subscription.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/file_subscription.clj
@@ -1,0 +1,182 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.file-subscription
+  "File-based event subscription for standalone TUI mode.
+
+   Tail-follows ~/.miniforge/events/*.edn files and dispatches parsed
+   events to the TUI dispatch-fn. Enables the TUI to monitor running
+   workflows without an in-memory event stream — cross-process via
+   the filesystem protocol used by event-stream file-sink."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [ai.miniforge.tui-views.subscription :as subscription]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Directory and file helpers
+
+(defn- events-dir
+  "Returns ~/.miniforge/events/ as a java.io.File."
+  []
+  (io/file (System/getProperty "user.home") ".miniforge" "events"))
+
+(defn- scan-event-files
+  "Find *.edn files in dir, returns sorted list of java.io.File."
+  [^java.io.File dir]
+  (if (and dir (.exists dir) (.isDirectory dir))
+    (->> (.listFiles dir)
+         (filter #(.endsWith (.getName ^java.io.File %) ".edn"))
+         (sort-by #(.getName ^java.io.File %))
+         vec)
+    []))
+
+(defn- read-new-lines
+  "Read lines added since last position using RandomAccessFile.
+   Updates position-atom with new file length. Returns vector of line strings."
+  [^java.io.File file position-atom]
+  (try
+    (let [current-length (.length file)]
+      (if (<= current-length @position-atom)
+        []
+        (with-open [raf (java.io.RandomAccessFile. file "r")]
+          (.seek raf @position-atom)
+          (let [lines (loop [acc []]
+                        (if-let [line (.readLine raf)]
+                          (recur (conj acc line))
+                          acc))]
+            (reset! position-atom (.getFilePointer raf))
+            lines))))
+    (catch Exception _
+      [])))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Parse and dispatch
+
+(defn- parse-and-dispatch!
+  "Parse each line as EDN, translate via subscription/translate-event,
+   dispatch non-nil results to dispatch-fn."
+  [lines dispatch-fn]
+  (doseq [line lines]
+    (when (seq line)
+      (try
+        (let [event (edn/read-string line)]
+          (when-let [msg (subscription/translate-event event)]
+            (dispatch-fn msg)))
+        (catch Exception _
+          ;; Malformed EDN line — skip silently
+          nil)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Command sending
+
+(defn send-command!
+  "Send a command to a running workflow via filesystem protocol.
+   Writes a .edn command file that the workflow runner's command poller picks up."
+  [workflow-id command]
+  (let [commands-dir (io/file (System/getProperty "user.home")
+                              ".miniforge" "commands" (str workflow-id))
+        cmd-file (io/file commands-dir (str (System/currentTimeMillis) ".edn"))]
+    (.mkdirs commands-dir)
+    (spit cmd-file (pr-str {:command command :timestamp (java.util.Date.)}))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Main subscription entry point
+
+(defn subscribe-to-files!
+  "Subscribe to workflow event files via tail-following.
+
+   Scans ~/.miniforge/events/ for existing .edn files, hydrates initial
+   state from all existing lines, then polls for new lines and new files
+   on a background daemon thread.
+
+   Arguments:
+   - dispatch-fn - (fn [msg]) to send TUI messages into the Elm loop
+   - opts        - {:poll-ms 500, :scan-ms 2000} polling intervals
+
+   Returns: cleanup function (fn [] ...) to call on shutdown."
+  [dispatch-fn & [opts]]
+  (let [poll-ms   (get opts :poll-ms 500)
+        scan-ms   (get opts :scan-ms 2000)
+        dir       (events-dir)
+        ;; Map of file-path -> position-atom for tracked files
+        tracked   (atom {})
+        running?  (atom true)
+
+        ;; Track a file: read all existing lines (hydrate), store position
+        track-file!
+        (fn [^java.io.File f]
+          (let [path (.getAbsolutePath f)
+                pos  (atom 0)]
+            (swap! tracked assoc path {:file f :position pos})
+            ;; Hydrate: read all existing lines
+            (let [lines (read-new-lines f pos)]
+              (parse-and-dispatch! lines dispatch-fn))))
+
+        ;; Initial scan — hydrate all existing files
+        _  (doseq [f (scan-event-files dir)]
+             (track-file! f))
+
+        ;; Background polling thread
+        thread
+        (Thread.
+         (fn []
+           (try
+             (let [scan-counter (atom 0)]
+               (while @running?
+                 (Thread/sleep poll-ms)
+                 (when @running?
+                   ;; Poll tracked files for new lines
+                   (doseq [[_path {:keys [file position]}] @tracked]
+                     (let [lines (read-new-lines file position)]
+                       (when (seq lines)
+                         (parse-and-dispatch! lines dispatch-fn))))
+
+                   ;; Periodically scan for new files
+                   (swap! scan-counter + poll-ms)
+                   (when (>= @scan-counter scan-ms)
+                     (reset! scan-counter 0)
+                     (let [current-files (scan-event-files dir)
+                           tracked-paths (set (keys @tracked))]
+                       (doseq [^java.io.File f current-files]
+                         (when-not (tracked-paths (.getAbsolutePath f))
+                           (track-file! f))))))))
+             (catch InterruptedException _)
+             (catch Exception _))))]
+    (.setDaemon thread true)
+    (.setName thread "tui-file-subscription")
+    (.start thread)
+    ;; Return cleanup function
+    (fn []
+      (reset! running? false)
+      (.interrupt thread))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Test file subscription
+  (def messages (atom []))
+  (def cleanup (subscribe-to-files! (fn [msg] (swap! messages conj msg))))
+
+  @messages
+
+  ;; Send a test command
+  (send-command! "test-workflow-id" :pause)
+
+  (cleanup)
+
+  :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/file_subscription.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/file_subscription.clj
@@ -96,6 +96,59 @@
     (spit cmd-file (pr-str {:command command :timestamp (java.util.Date.)}))))
 
 ;------------------------------------------------------------------------------ Layer 3
+;; File tracking and polling
+
+(defn- track-file!
+  "Track a new event file: register it in tracked map and hydrate
+   all existing lines through dispatch-fn."
+  [tracked dispatch-fn ^java.io.File f]
+  (let [path (.getAbsolutePath f)
+        pos  (atom 0)]
+    (swap! tracked assoc path {:file f :position pos})
+    (let [lines (read-new-lines f pos)]
+      (parse-and-dispatch! lines dispatch-fn))))
+
+(defn- poll-tracked-files!
+  "Read new lines from all tracked files and dispatch them."
+  [tracked dispatch-fn]
+  (doseq [[_path {:keys [file position]}] @tracked]
+    (let [lines (read-new-lines file position)]
+      (when (seq lines)
+        (parse-and-dispatch! lines dispatch-fn)))))
+
+(defn- scan-for-new-files!
+  "Check for new .edn files in dir and start tracking them."
+  [dir tracked dispatch-fn]
+  (let [current-files (scan-event-files dir)
+        tracked-paths (set (keys @tracked))]
+    (doseq [^java.io.File f current-files]
+      (when-not (tracked-paths (.getAbsolutePath f))
+        (track-file! tracked dispatch-fn f)))))
+
+(defn- poll-loop
+  "Polling loop body for the file-subscription daemon thread.
+   Polls tracked files every poll-ms, scans for new files every scan-ms."
+  [running? tracked dispatch-fn dir poll-ms scan-ms]
+  (try
+    (let [scan-counter (atom 0)]
+      (while @running?
+        (Thread/sleep poll-ms)
+        (when @running?
+          (poll-tracked-files! tracked dispatch-fn)
+          (swap! scan-counter + poll-ms)
+          (when (>= @scan-counter scan-ms)
+            (reset! scan-counter 0)
+            (scan-for-new-files! dir tracked dispatch-fn)))))
+    (catch InterruptedException _)
+    (catch Exception _)))
+
+(defn- stop-subscription!
+  "Stop the file-subscription polling thread."
+  [running? ^Thread thread]
+  (reset! running? false)
+  (.interrupt thread))
+
+;------------------------------------------------------------------------------ Layer 4
 ;; Main subscription entry point
 
 (defn subscribe-to-files!
@@ -114,57 +167,15 @@
   (let [poll-ms   (get opts :poll-ms 500)
         scan-ms   (get opts :scan-ms 2000)
         dir       (events-dir)
-        ;; Map of file-path -> position-atom for tracked files
         tracked   (atom {})
         running?  (atom true)
-
-        ;; Track a file: read all existing lines (hydrate), store position
-        track-file!
-        (fn [^java.io.File f]
-          (let [path (.getAbsolutePath f)
-                pos  (atom 0)]
-            (swap! tracked assoc path {:file f :position pos})
-            ;; Hydrate: read all existing lines
-            (let [lines (read-new-lines f pos)]
-              (parse-and-dispatch! lines dispatch-fn))))
-
-        ;; Initial scan — hydrate all existing files
-        _  (doseq [f (scan-event-files dir)]
-             (track-file! f))
-
-        ;; Background polling thread
-        thread
-        (Thread.
-         (fn []
-           (try
-             (let [scan-counter (atom 0)]
-               (while @running?
-                 (Thread/sleep poll-ms)
-                 (when @running?
-                   ;; Poll tracked files for new lines
-                   (doseq [[_path {:keys [file position]}] @tracked]
-                     (let [lines (read-new-lines file position)]
-                       (when (seq lines)
-                         (parse-and-dispatch! lines dispatch-fn))))
-
-                   ;; Periodically scan for new files
-                   (swap! scan-counter + poll-ms)
-                   (when (>= @scan-counter scan-ms)
-                     (reset! scan-counter 0)
-                     (let [current-files (scan-event-files dir)
-                           tracked-paths (set (keys @tracked))]
-                       (doseq [^java.io.File f current-files]
-                         (when-not (tracked-paths (.getAbsolutePath f))
-                           (track-file! f))))))))
-             (catch InterruptedException _)
-             (catch Exception _))))]
-    (.setDaemon thread true)
-    (.setName thread "tui-file-subscription")
-    (.start thread)
-    ;; Return cleanup function
-    (fn []
-      (reset! running? false)
-      (.interrupt thread))))
+        _         (doseq [f (scan-event-files dir)]
+                    (track-file! tracked dispatch-fn f))
+        thread    (doto (Thread. #(poll-loop running? tracked dispatch-fn dir poll-ms scan-ms))
+                    (.setDaemon true)
+                    (.setName "tui-file-subscription")
+                    (.start))]
+    (partial stop-subscription! running? thread)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -30,6 +30,7 @@
    [ai.miniforge.tui-views.update :as update]
    [ai.miniforge.tui-views.view :as view]
    [ai.miniforge.tui-views.subscription :as subscription]
+   [ai.miniforge.tui-views.file-subscription :as file-subscription]
    [ai.miniforge.tui-views.persistence :as persistence]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.policy-pack.interface :as policy-pack]
@@ -289,6 +290,35 @@
    Safe to call multiple times."
   [app]
   (tui/stop! app))
+
+(defn start-standalone-tui!
+  "Start the TUI in standalone monitoring mode.
+   Discovers and tail-follows workflow event files from ~/.miniforge/events/.
+   Does not require an in-memory event stream."
+  [& [opts]]
+  (let [train-mgr (pr-train/create-manager)
+        app (tui/create-app
+             {:init   (fn []
+                        (persistence/load-all-into-model
+                         (model/init-model)
+                         {:limit (:load-limit opts 100)}))
+              :update update/update-model
+              :view   view/root-view
+              :screen (:screen opts)
+              :effect-handler (partial dispatch-effect train-mgr)
+              :subscriptions
+              (fn [dispatch-fn]
+                (file-subscription/subscribe-to-files!
+                 dispatch-fn
+                 {:poll-ms (:poll-ms opts 500)
+                  :scan-ms (:scan-ms opts 2000)}))})]
+    (tui/start! app)
+    (try
+      (while (not (:quit? (tui/get-model app)))
+        (Thread/sleep 100))
+      (finally
+        (tui/stop! app)))
+    app))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
@@ -29,7 +29,7 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event -> TUI message translation
 
-(defn- translate-event
+(defn translate-event
   "Translate a single event-stream event to a TUI message vector.
    Returns nil for events that should be ignored."
   [event]

--- a/docs/pull-requests/2026-02-25-feat-tui-file-watcher.md
+++ b/docs/pull-requests/2026-02-25-feat-tui-file-watcher.md
@@ -1,0 +1,55 @@
+# feat(tui): Add file-watcher subscription for standalone `mf tui` command
+
+**Branch**: `feat/tui-file-watcher`
+**Date**: 2026-02-25
+**Status**: Open
+
+## Overview
+
+Add a file-based event subscription that tail-follows `~/.miniforge/events/*.edn` files, enabling the TUI to run as a standalone process monitoring running workflows without an in-memory event stream.
+
+## Motivation
+
+The existing TUI (`start-tui!`) requires an in-memory event stream, meaning it must run in the same process as the workflow executor. This limits the TUI to embedded mode only. With file-based subscription, `mf tui` can launch independently and discover/monitor any running workflows via the filesystem protocol already used by `event-stream/file-sink`.
+
+## Changes in Detail
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `components/tui-views/src/ai/miniforge/tui_views/file_subscription.clj` | File-based event subscription: tail-follows event files, parses EDN, dispatches to TUI |
+| `bases/cli/src/ai/miniforge/cli/main/commands/tui.clj` | Standalone `tui-cmd` using `requiring-resolve` for cross-component call |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `components/tui-views/src/ai/miniforge/tui_views/subscription.clj` | Made `translate-event` public (was `defn-`) for reuse by file subscription |
+| `components/tui-views/src/ai/miniforge/tui_views/interface.clj` | Added `start-standalone-tui!` entry point, added `file-subscription` require |
+| `bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj` | Updated `tui-cmd` to use `start-standalone-tui!` via `requiring-resolve` |
+
+## Architecture
+
+```
+mf tui  -->  monitoring/tui-cmd  -->  interface/start-standalone-tui!
+                                          |
+                                          v
+                                  file-subscription/subscribe-to-files!
+                                          |
+                                          v
+                              ~/.miniforge/events/*.edn  <-- file-sink (from mf run)
+```
+
+- **Events out**: `mf run` writes to `~/.miniforge/events/<workflow-id>.edn` via file sink
+- **Events in**: `file-subscription` uses `RandomAccessFile` with position tracking to tail-follow
+- **Commands out**: `send-command!` writes `.edn` to `~/.miniforge/commands/<workflow-id>/`
+- Polling: 500ms for new lines, 2s for new files (configurable)
+
+## Key Design Decisions
+
+1. **RandomAccessFile for tail-following**: Efficient seek-based reading avoids re-reading entire files
+2. **Position tracking via atoms**: Each tracked file has its own position atom for independent progress
+3. **Reuse `translate-event`**: Made public so both in-memory and file-based subscriptions share the same event-to-message translation
+4. **Daemon thread**: Background poller is a daemon thread that dies with the JVM
+5. **Hydration on startup**: Existing file content is read in full to reconstruct current state


### PR DESCRIPTION
## Summary
- Add `file_subscription.clj` that tail-follows `~/.miniforge/events/*.edn` files using `RandomAccessFile` with position tracking, enabling cross-process TUI monitoring
- Add `start-standalone-tui!` entry point in `interface.clj` wired to file-based subscription instead of in-memory event stream
- Update `monitoring/tui-cmd` and add dedicated `tui.clj` CLI command to launch standalone TUI via `requiring-resolve`
- Make `translate-event` public in `subscription.clj` for reuse by both in-memory and file-based subscription paths
- Fix pre-existing unresolved `clojure.string` namespace in `monitoring.clj`

## Test plan
- [ ] Verify `mf tui` launches and displays the TUI interface
- [ ] Run a workflow with `mf run`, confirm TUI picks up events from `~/.miniforge/events/`
- [ ] Start TUI before any workflow runs, confirm it discovers new event files when a workflow starts
- [ ] Test `send-command!` writes correct `.edn` to `~/.miniforge/commands/<id>/`
- [ ] Verify cleanup function stops the polling thread
- [ ] Confirm existing `start-tui!` (in-memory mode) still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)