### PR TITLE
feat(evidence): add chain-level evidence metadata and aggregation

### DIFF
--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/chain_evidence.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/chain_evidence.clj
@@ -1,0 +1,98 @@
+(ns ai.miniforge.evidence-bundle.chain-evidence
+  "Chain-level evidence aggregation.
+
+   Aggregates per-step evidence bundles into a chain-level bundle,
+   including chain definition, step results, total timing, and metrics.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Step Summarization
+
+(defn summarize-step
+  "Create a summary of a single chain step for inclusion in chain evidence.
+
+   Arguments:
+   - step-result: Map with :step/id, :step/workflow-id, :step/status, :step/output
+   - step-index: Zero-based index of this step in the chain
+
+   Returns: Step summary map with:
+   - :step/id
+   - :step/workflow-id
+   - :step/index
+   - :step/status
+   - :step/has-output? (boolean)"
+  [step-result step-index]
+  {:step/id (:step/id step-result)
+   :step/workflow-id (:step/workflow-id step-result)
+   :step/index step-index
+   :step/status (:step/status step-result)
+   :step/has-output? (some? (:step/output step-result))})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Metrics Aggregation
+
+(defn aggregate-metrics
+  "Aggregate timing and count metrics across chain steps.
+
+   Arguments:
+   - step-results: Vector of step result maps
+
+   Returns: Metrics map with:
+   - :total-steps
+   - :completed-steps
+   - :failed-steps
+   - :steps-with-output"
+  [step-results]
+  (let [total (count step-results)
+        completed (count (filter #(= :completed (:step/status %)) step-results))
+        failed (count (filter #(= :failed (:step/status %)) step-results))
+        with-output (count (filter #(some? (:step/output %)) step-results))]
+    {:total-steps total
+     :completed-steps completed
+     :failed-steps failed
+     :steps-with-output with-output}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Chain Evidence Creation
+
+(defn- derive-chain-status
+  "Derive chain evidence status from the chain result."
+  [chain-result]
+  (if (= :completed (:chain/status chain-result))
+    :completed
+    :failed))
+
+(defn- build-step-summaries
+  "Build step summaries from chain step results."
+  [step-results]
+  (vec (map-indexed (fn [idx sr] (summarize-step sr idx)) step-results)))
+
+(defn create-chain-evidence
+  "Create a chain-level evidence record from chain execution results.
+
+   Arguments:
+   - chain-def: Chain definition map with :chain/id, :chain/steps, etc.
+   - chain-result: Result map from run-chain with :chain/step-results, :chain/duration-ms
+   - opts: Optional map with :step-bundles (vector of per-step evidence bundle IDs)
+
+   Returns: Chain evidence map with:
+   - :chain-evidence/id (random UUID)
+   - :chain-evidence/chain-id
+   - :chain-evidence/chain-version
+   - :chain-evidence/step-count
+   - :chain-evidence/status (:completed or :failed)
+   - :chain-evidence/duration-ms
+   - :chain-evidence/step-summaries (vector of per-step summaries)
+   - :chain-evidence/created-at"
+  [chain-def chain-result & [opts]]
+  (let [step-results (:chain/step-results chain-result)]
+    (cond-> {:chain-evidence/id (random-uuid)
+             :chain-evidence/chain-id (:chain/id chain-def)
+             :chain-evidence/chain-version (:chain/version chain-def)
+             :chain-evidence/step-count (count step-results)
+             :chain-evidence/status (derive-chain-status chain-result)
+             :chain-evidence/duration-ms (:chain/duration-ms chain-result)
+             :chain-evidence/step-summaries (build-step-summaries step-results)
+             :chain-evidence/metrics (aggregate-metrics step-results)
+             :chain-evidence/created-at (java.time.Instant/now)}
+      (:step-bundles opts)
+      (assoc :chain-evidence/step-bundles (:step-bundles opts)))))

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj
@@ -2,6 +2,7 @@
   "Public API for the evidence-bundle component.
    Handles evidence collection, storage, and provenance tracing per N6 spec."
   (:require
+   [ai.miniforge.evidence-bundle.chain-evidence :as chain-evidence]
    [ai.miniforge.evidence-bundle.collector :as collector]
    [ai.miniforge.evidence-bundle.extraction :as extraction]
    [ai.miniforge.evidence-bundle.hash :as hash]
@@ -264,6 +265,24 @@
      ;; => \"a3f2b7c9...\" (64-char hex string)"
   [content]
   (hash/content-hash content))
+
+;------------------------------------------------------------------------------ Layer 7b
+;; Chain Evidence
+
+(defn create-chain-evidence
+  "Create a chain-level evidence record from chain results."
+  [chain-def chain-result & [opts]]
+  (chain-evidence/create-chain-evidence chain-def chain-result opts))
+
+(defn summarize-step
+  "Create a summary of a single chain step."
+  [step-result step-index]
+  (chain-evidence/summarize-step step-result step-index))
+
+(defn aggregate-metrics
+  "Aggregate metrics across chain step results."
+  [step-results]
+  (chain-evidence/aggregate-metrics step-results))
 
 ;------------------------------------------------------------------------------ Layer 7
 ;; Schema Exports

--- a/components/evidence-bundle/test/ai/miniforge/evidence_bundle/chain_evidence_test.clj
+++ b/components/evidence-bundle/test/ai/miniforge/evidence_bundle/chain_evidence_test.clj
@@ -1,0 +1,104 @@
+(ns ai.miniforge.evidence-bundle.chain-evidence-test
+  "Tests for chain-level evidence aggregation."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.evidence-bundle.interface :as evidence]))
+
+;------------------------------------------------------------------------------ Test Data
+
+(def test-chain-def
+  {:chain/id :test-chain
+   :chain/version "1.0.0"
+   :chain/steps [{:step/id :plan :step/workflow-id :planning}
+                 {:step/id :implement :step/workflow-id :implementation}]})
+
+(def test-chain-result
+  {:chain/id :test-chain
+   :chain/status :completed
+   :chain/duration-ms 5000
+   :chain/step-results [{:step/id :plan
+                         :step/workflow-id :planning
+                         :step/status :completed
+                         :step/output {:phase-results {:plan {:result "ok"}}}}
+                        {:step/id :implement
+                         :step/workflow-id :implementation
+                         :step/status :completed
+                         :step/output nil}]})
+
+(def test-failed-chain-result
+  {:chain/id :test-chain
+   :chain/status :failed
+   :chain/duration-ms 2000
+   :chain/step-results [{:step/id :plan
+                         :step/workflow-id :planning
+                         :step/status :completed
+                         :step/output {:phase-results {:plan {:result "ok"}}}}
+                        {:step/id :implement
+                         :step/workflow-id :implementation
+                         :step/status :failed
+                         :step/output nil}]})
+
+;------------------------------------------------------------------------------ create-chain-evidence Tests
+
+(deftest create-chain-evidence-success-test
+  (testing "Creates evidence with all required fields for successful chain"
+    (let [ev (evidence/create-chain-evidence test-chain-def test-chain-result)]
+      (is (uuid? (:chain-evidence/id ev)))
+      (is (= :test-chain (:chain-evidence/chain-id ev)))
+      (is (= "1.0.0" (:chain-evidence/chain-version ev)))
+      (is (= 2 (:chain-evidence/step-count ev)))
+      (is (= :completed (:chain-evidence/status ev)))
+      (is (= 5000 (:chain-evidence/duration-ms ev)))
+      (is (= 2 (count (:chain-evidence/step-summaries ev))))
+      (is (inst? (:chain-evidence/created-at ev))))))
+
+(deftest create-chain-evidence-failed-test
+  (testing "Creates evidence with :failed status for failed chain"
+    (let [ev (evidence/create-chain-evidence test-chain-def test-failed-chain-result)]
+      (is (= :failed (:chain-evidence/status ev)))
+      (is (= 2000 (:chain-evidence/duration-ms ev))))))
+
+(deftest create-chain-evidence-step-bundles-test
+  (testing "Includes step-bundles when provided in opts"
+    (let [bundle-ids [#uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+                      #uuid "11111111-2222-3333-4444-555555555555"]
+          ev (evidence/create-chain-evidence test-chain-def test-chain-result
+                                             {:step-bundles bundle-ids})]
+      (is (= bundle-ids (:chain-evidence/step-bundles ev))))))
+
+;------------------------------------------------------------------------------ summarize-step Tests
+
+(deftest summarize-step-with-output-test
+  (testing "Step with output has :step/has-output? true"
+    (let [step-result {:step/id :plan
+                       :step/workflow-id :planning
+                       :step/status :completed
+                       :step/output {:result "ok"}}
+          summary (evidence/summarize-step step-result 0)]
+      (is (= :plan (:step/id summary)))
+      (is (= :planning (:step/workflow-id summary)))
+      (is (= 0 (:step/index summary)))
+      (is (= :completed (:step/status summary)))
+      (is (true? (:step/has-output? summary))))))
+
+(deftest summarize-step-without-output-test
+  (testing "Step without output has :step/has-output? false"
+    (let [step-result {:step/id :implement
+                       :step/workflow-id :implementation
+                       :step/status :completed
+                       :step/output nil}
+          summary (evidence/summarize-step step-result 1)]
+      (is (false? (:step/has-output? summary))))))
+
+;------------------------------------------------------------------------------ aggregate-metrics Tests
+
+(deftest aggregate-metrics-mixed-test
+  (testing "Correctly counts completed, failed, and output steps"
+    (let [step-results [{:step/id :a :step/status :completed :step/output {:x 1}}
+                        {:step/id :b :step/status :completed :step/output nil}
+                        {:step/id :c :step/status :failed :step/output nil}]
+          metrics (evidence/aggregate-metrics step-results)]
+      (is (= 3 (:total-steps metrics)))
+      (is (= 2 (:completed-steps metrics)))
+      (is (= 1 (:failed-steps metrics)))
+      (is (= 1 (:steps-with-output metrics))))))

--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -104,12 +104,14 @@
         load-workflow (requiring-resolve 'ai.miniforge.workflow.interface/load-workflow)]
     (loop [remaining steps
            prev-output nil
-           step-results []]
+           step-results []
+           idx 0]
       (if (empty? remaining)
         ;; All steps completed successfully
         {:chain/id (:chain/id chain-def)
          :chain/status :completed
          :chain/step-results step-results
+         :chain/step-count (count steps)
          :chain/duration-ms (- (System/currentTimeMillis) start-time)}
 
         ;; Execute next step
@@ -123,19 +125,23 @@
               step-result {:step/id (:step/id step)
                            :step/workflow-id (:step/workflow-id step)
                            :step/status (:execution/status result)
-                           :step/output output}
+                           :step/output output
+                           :step/chain-id (:chain/id chain-def)
+                           :step/chain-index idx}
               updated-results (conj step-results step-result)]
           (if (= :failed (:execution/status result))
             ;; Step failed — stop the chain immediately
             {:chain/id (:chain/id chain-def)
              :chain/status :failed
              :chain/step-results updated-results
+             :chain/step-count (count steps)
              :chain/duration-ms (- (System/currentTimeMillis) start-time)}
 
             ;; Step succeeded — continue with next step
             (recur (rest remaining)
                    output
-                   updated-results)))))))
+                   updated-results
+                   (inc idx))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-02-25-feat-chain-evidence.md
+++ b/docs/pull-requests/2026-02-25-feat-chain-evidence.md
@@ -1,0 +1,55 @@
+# feat/chain-evidence — PR6a
+
+## Layer
+
+Domain (Evidence Bundle, Workflow)
+
+## Depends on
+
+- PR1b: Chain schema and executor (for chain.clj modifications)
+
+## Overview
+
+Adds chain-level evidence metadata so that when a chain of workflows runs, the
+evidence bundle knows which chain and step each workflow belongs to, and can
+aggregate per-step evidence into a chain-level bundle.
+
+## Motivation
+
+When workflows execute as part of a chain, the individual evidence bundles lack
+context about their position in the chain. This makes it impossible to
+reconstruct the full chain execution from evidence alone. Chain evidence
+metadata fills this gap by tagging each step result with its chain ID and index,
+and providing aggregation functions to build a chain-level evidence record.
+
+## Changes In Detail
+
+| File | What changed |
+|------|-------------|
+| `components/evidence-bundle/src/ai/miniforge/evidence_bundle/chain_evidence.clj` | New file — `create-chain-evidence`, `summarize-step`, `aggregate-metrics` |
+| `components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj` | Layer 7b — chain evidence interface wrappers + require |
+| `components/workflow/src/ai/miniforge/workflow/chain.clj` | Added `:step/chain-id`, `:step/chain-index`, `:chain/step-count` to results |
+| `components/evidence-bundle/test/ai/miniforge/evidence_bundle/chain_evidence_test.clj` | 6 tests covering success, failure, step-bundles, summarization, and metrics |
+| `docs/pull-requests/2026-02-25-feat-chain-evidence.md` | This PR doc |
+
+## Testing Plan
+
+- [x] 6 unit tests for chain evidence functions
+- [ ] Integration verification with full chain execution
+
+## Deployment Plan
+
+Additive only — new functions and metadata fields on existing maps.
+No breaking changes. Ships with next release.
+
+## Related Issues / PRs
+
+- PR1b: Chain schema and executor (prerequisite)
+- PR6b: Evidence content hashing (sibling)
+
+## Checklist
+
+- [x] Tests written and passing
+- [x] No breaking changes to existing interfaces
+- [x] Polylith interface boundaries respected
+- [x] Babashka / GraalVM compatible


### PR DESCRIPTION
## Summary

- Add `chain_evidence.clj` with `create-chain-evidence`, `summarize-step`, and `aggregate-metrics` functions for chain-level evidence aggregation
- Modify `chain.clj` to include `:step/chain-id`, `:step/chain-index`, and `:chain/step-count` in chain execution results
- Export chain evidence functions via evidence-bundle interface (Layer 7b)

## Changes

| File | What changed |
|------|-------------|
| `components/evidence-bundle/src/ai/miniforge/evidence_bundle/chain_evidence.clj` | New — chain evidence aggregation functions |
| `components/evidence-bundle/src/ai/miniforge/evidence_bundle/interface.clj` | Layer 7b wrappers + require |
| `components/workflow/src/ai/miniforge/workflow/chain.clj` | Chain metadata in step results |
| `components/evidence-bundle/test/ai/miniforge/evidence_bundle/chain_evidence_test.clj` | 6 tests, 21 assertions |
| `docs/pull-requests/2026-02-25-feat-chain-evidence.md` | PR documentation |

## Test plan

- [x] 6 unit tests covering success/failure chains, step summarization, metrics aggregation, and step-bundle opts
- [ ] Integration verification with full chain execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)