### PR TITLE
feat(workflow): add chain lifecycle event emission

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -387,6 +387,54 @@
       (cond-> content (assoc :annotation/content content))))
 
 ;------------------------------------------------------------------------------ Layer 4
+;; Chain lifecycle events
+;; Chains are not workflow-scoped, so workflow-id is nil.
+;; Message is derived from the event-type keyword.
+
+(defn- chain-envelope
+  "Create an envelope for chain events. Chains are not workflow-scoped,
+   so workflow-id is nil. Message is derived from the event-type keyword."
+  [stream event-type]
+  (create-envelope stream event-type nil (name event-type)))
+
+(defn chain-started [stream chain-id step-count]
+  (-> (chain-envelope stream :chain/started)
+      (assoc :chain/id chain-id
+             :chain/step-count step-count)))
+
+(defn chain-step-started [stream chain-id step-id step-index workflow-id]
+  (-> (chain-envelope stream :chain/step-started)
+      (assoc :chain/id chain-id
+             :step/id step-id
+             :step/index step-index
+             :step/workflow-id workflow-id)))
+
+(defn chain-step-completed [stream chain-id step-id step-index]
+  (-> (chain-envelope stream :chain/step-completed)
+      (assoc :chain/id chain-id
+             :step/id step-id
+             :step/index step-index)))
+
+(defn chain-step-failed [stream chain-id step-id step-index error]
+  (-> (chain-envelope stream :chain/step-failed)
+      (assoc :chain/id chain-id
+             :step/id step-id
+             :step/index step-index
+             :chain/error error)))
+
+(defn chain-completed [stream chain-id duration-ms step-count]
+  (-> (chain-envelope stream :chain/completed)
+      (assoc :chain/id chain-id
+             :chain/duration-ms duration-ms
+             :chain/step-count step-count)))
+
+(defn chain-failed [stream chain-id step-id error]
+  (-> (chain-envelope stream :chain/failed)
+      (assoc :chain/id chain-id
+             :chain/failed-step step-id
+             :chain/error error)))
+
+;------------------------------------------------------------------------------ Layer 4
 ;; Control action events (N8)
 
 (defn control-action-requested [stream workflow-id action-id action-type & [requester]]

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -467,6 +467,39 @@
   [stream workflow-id action-id & [result]]
   (core/control-action-executed stream workflow-id action-id result))
 
+;------------------------------------------------------------------------------ Layer 2j
+;; Chain lifecycle event constructors
+
+(defn chain-started
+  "Create a chain/started event."
+  [stream chain-id step-count]
+  (core/chain-started stream chain-id step-count))
+
+(defn chain-step-started
+  "Create a chain/step-started event."
+  [stream chain-id step-id step-index workflow-id]
+  (core/chain-step-started stream chain-id step-id step-index workflow-id))
+
+(defn chain-step-completed
+  "Create a chain/step-completed event."
+  [stream chain-id step-id step-index]
+  (core/chain-step-completed stream chain-id step-id step-index))
+
+(defn chain-step-failed
+  "Create a chain/step-failed event."
+  [stream chain-id step-id step-index error]
+  (core/chain-step-failed stream chain-id step-id step-index error))
+
+(defn chain-completed
+  "Create a chain/completed event."
+  [stream chain-id duration-ms step-count]
+  (core/chain-completed stream chain-id duration-ms step-count))
+
+(defn chain-failed
+  "Create a chain/failed event."
+  [stream chain-id step-id error]
+  (core/chain-failed stream chain-id step-id error))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Listener management API (N8)
 

--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -83,7 +83,17 @@
     {}
     input-bindings))
 
-;------------------------------------------------------------------------------ Layer 1: Chain execution
+;------------------------------------------------------------------------------ Layer 1: Event emission
+
+(defn- emit!
+  "Emit a chain event if event-stream is present in opts."
+  [opts constructor-sym & args]
+  (when-let [stream (:event-stream opts)]
+    (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)
+          constructor (requiring-resolve constructor-sym)]
+      (publish! stream (apply constructor stream args)))))
+
+;------------------------------------------------------------------------------ Layer 2: Chain execution
 
 (defn run-chain
   "Execute a chain of workflows sequentially.
@@ -93,56 +103,76 @@
    - chain-input: Initial input map for the chain
    - opts: Execution options passed to each run-pipeline call
      Must include everything run-pipeline needs (e.g. :llm-backend)
+     Optional :event-stream for chain lifecycle events.
 
    Returns:
    {:chain/id keyword
     :chain/status :completed | :failed
     :chain/step-results [step-result...]
+    :chain/step-count int
     :chain/duration-ms long}"
   [chain-def chain-input opts]
   (let [start-time (System/currentTimeMillis)
+        chain-id (:chain/id chain-def)
         steps (:chain/steps chain-def)
         load-workflow (requiring-resolve 'ai.miniforge.workflow.interface/load-workflow)]
+    (emit! opts 'ai.miniforge.event-stream.interface/chain-started
+           chain-id (count steps))
     (loop [remaining steps
            prev-output nil
            step-results []
            idx 0]
       (if (empty? remaining)
         ;; All steps completed successfully
-        {:chain/id (:chain/id chain-def)
-         :chain/status :completed
-         :chain/step-results step-results
-         :chain/step-count (count steps)
-         :chain/duration-ms (- (System/currentTimeMillis) start-time)}
+        (let [duration-ms (- (System/currentTimeMillis) start-time)]
+          (emit! opts 'ai.miniforge.event-stream.interface/chain-completed
+                 chain-id duration-ms (count steps))
+          {:chain/id chain-id
+           :chain/status :completed
+           :chain/step-results step-results
+           :chain/step-count (count steps)
+           :chain/duration-ms duration-ms})
 
         ;; Execute next step
         (let [step (first remaining)
+              step-id (:step/id step)
+              workflow-id (:step/workflow-id step)
+              _ (emit! opts 'ai.miniforge.event-stream.interface/chain-step-started
+                       chain-id step-id idx workflow-id)
               input-bindings (:step/input-bindings step)
               resolved-input (resolve-bindings input-bindings prev-output chain-input)
-              workflow-result (load-workflow (:step/workflow-id step) :latest {})
+              workflow-result (load-workflow workflow-id :latest {})
               workflow (:workflow workflow-result)
               result (runner/run-pipeline workflow resolved-input opts)
               output (:execution/output result)
-              step-result {:step/id (:step/id step)
-                           :step/workflow-id (:step/workflow-id step)
+              step-result {:step/id step-id
+                           :step/workflow-id workflow-id
                            :step/status (:execution/status result)
                            :step/output output
-                           :step/chain-id (:chain/id chain-def)
+                           :step/chain-id chain-id
                            :step/chain-index idx}
               updated-results (conj step-results step-result)]
           (if (= :failed (:execution/status result))
-            ;; Step failed — stop the chain immediately
-            {:chain/id (:chain/id chain-def)
-             :chain/status :failed
-             :chain/step-results updated-results
-             :chain/step-count (count steps)
-             :chain/duration-ms (- (System/currentTimeMillis) start-time)}
+            ;; Step failed — emit failure events and stop
+            (let [error (or (:execution/error result) "Step execution failed")]
+              (emit! opts 'ai.miniforge.event-stream.interface/chain-step-failed
+                     chain-id step-id idx error)
+              (emit! opts 'ai.miniforge.event-stream.interface/chain-failed
+                     chain-id step-id error)
+              {:chain/id chain-id
+               :chain/status :failed
+               :chain/step-results updated-results
+               :chain/step-count (count steps)
+               :chain/duration-ms (- (System/currentTimeMillis) start-time)})
 
-            ;; Step succeeded — continue with next step
-            (recur (rest remaining)
-                   output
-                   updated-results
-                   (inc idx))))))))
+            ;; Step succeeded — emit completion and continue
+            (do
+              (emit! opts 'ai.miniforge.event-stream.interface/chain-step-completed
+                     chain-id step-id idx)
+              (recur (rest remaining)
+                     output
+                     updated-results
+                     (inc idx)))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/test/ai/miniforge/workflow/chain_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_events_test.clj
@@ -1,0 +1,165 @@
+(ns ai.miniforge.workflow.chain-events-test
+  "Tests for chain lifecycle event emission."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.workflow.chain :as chain]
+   [ai.miniforge.workflow.runner :as runner]
+   [ai.miniforge.event-stream.core :as es-core]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- create-test-stream
+  "Create a minimal event stream with no sinks for testing."
+  []
+  (es-core/create-event-stream {:sinks []}))
+
+(defn- event-types
+  "Extract ordered event types from a stream."
+  [stream]
+  (mapv :event/type (:events @stream)))
+
+(defn- mock-load-workflow
+  "Mock load-workflow that returns a stub workflow."
+  [_wf-id _version _opts]
+  {:workflow {:workflow/id :mock
+              :workflow/pipeline [{:phase :plan}]}
+   :source :mock})
+
+(defn- mock-pipeline-success
+  "Mock run-pipeline that always succeeds."
+  [_workflow _input _opts]
+  {:execution/status :completed
+   :execution/output {:artifacts []
+                      :phase-results {}
+                      :last-phase-result {:plan "the-plan"}
+                      :status :completed}})
+
+(defn- mock-pipeline-failure
+  "Mock run-pipeline that always fails."
+  [_workflow _input _opts]
+  {:execution/status :failed
+   :execution/output {:artifacts []
+                      :phase-results {}
+                      :last-phase-result {:success? false}
+                      :status :failed}
+   :execution/error "LLM timeout"})
+
+(defmacro with-chain-mocks
+  "Run body with load-workflow and run-pipeline mocked.
+   Uses alter-var-root to avoid corrupting requiring-resolve for other tests."
+  [pipeline-fn & body]
+  `(with-redefs [runner/run-pipeline ~pipeline-fn]
+     ;; Temporarily install mock load-workflow via the emit-safe requiring-resolve
+     ;; We avoid with-redefs on requiring-resolve to prevent cross-test pollution
+     (let [saved-rr# @#'clojure.core/requiring-resolve]
+       (try
+         (alter-var-root #'clojure.core/requiring-resolve
+                         (fn [orig#]
+                           (fn [sym#]
+                             (if (= sym# 'ai.miniforge.workflow.interface/load-workflow)
+                               mock-load-workflow
+                               (orig# sym#)))))
+         ~@body
+         (finally
+           (alter-var-root #'clojure.core/requiring-resolve (constantly saved-rr#)))))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Success path event emission
+
+(deftest chain-events-success-test
+  (testing "successful 2-step chain emits correct event sequence"
+    (let [stream (create-test-stream)
+          chain-def {:chain/id :test-chain
+                     :chain/version "1.0.0"
+                     :chain/description "Test chain"
+                     :chain/steps
+                     [{:step/id :step-1
+                       :step/workflow-id :workflow-a
+                       :step/input-bindings {:task :task}}
+                      {:step/id :step-2
+                       :step/workflow-id :workflow-b
+                       :step/input-bindings {:plan [:prev/last-phase-result :plan]}}]}
+          opts {:event-stream stream}]
+      (with-chain-mocks mock-pipeline-success
+        (let [result (chain/run-chain chain-def {:task "build"} opts)]
+          (is (= :completed (:chain/status result)))
+
+          ;; Verify event sequence
+          (is (= [:chain/started
+                   :chain/step-started
+                   :chain/step-completed
+                   :chain/step-started
+                   :chain/step-completed
+                   :chain/completed]
+                 (event-types stream)))
+
+          ;; Verify chain-started event fields
+          (let [started (first (:events @stream))]
+            (is (= :test-chain (:chain/id started)))
+            (is (= 2 (:chain/step-count started))))
+
+          ;; Verify step-started has workflow-id
+          (let [step-started (second (:events @stream))]
+            (is (= :step-1 (:step/id step-started)))
+            (is (= 0 (:step/index step-started)))
+            (is (= :workflow-a (:step/workflow-id step-started))))
+
+          ;; Verify chain-completed has duration and step count
+          (let [completed (last (:events @stream))]
+            (is (= :test-chain (:chain/id completed)))
+            (is (= 2 (:chain/step-count completed)))
+            (is (nat-int? (:chain/duration-ms completed)))))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Failure path event emission
+
+(deftest chain-events-failure-test
+  (testing "failed step emits step-failed and chain-failed events"
+    (let [stream (create-test-stream)
+          chain-def {:chain/id :fail-chain
+                     :chain/version "1.0.0"
+                     :chain/description "Failing chain"
+                     :chain/steps
+                     [{:step/id :step-1
+                       :step/workflow-id :workflow-a
+                       :step/input-bindings {:task :task}}
+                      {:step/id :step-2
+                       :step/workflow-id :workflow-b
+                       :step/input-bindings {:task :task}}]}
+          opts {:event-stream stream}]
+      (with-chain-mocks mock-pipeline-failure
+        (let [result (chain/run-chain chain-def {:task "doomed"} opts)]
+          (is (= :failed (:chain/status result)))
+
+          ;; Verify event sequence: started, step-started, step-failed, chain-failed
+          (is (= [:chain/started
+                   :chain/step-started
+                   :chain/step-failed
+                   :chain/failed]
+                 (event-types stream)))
+
+          ;; Verify step-failed has error info
+          (let [step-failed (nth (:events @stream) 2)]
+            (is (= :step-1 (:step/id step-failed)))
+            (is (= 0 (:step/index step-failed)))
+            (is (= "LLM timeout" (:chain/error step-failed))))
+
+          ;; Verify chain-failed has failed step reference
+          (let [chain-failed (last (:events @stream))]
+            (is (= :step-1 (:chain/failed-step chain-failed)))
+            (is (= "LLM timeout" (:chain/error chain-failed)))))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; No event-stream — silent execution
+
+(deftest chain-no-event-stream-test
+  (testing "chain runs silently when no event-stream in opts"
+    (with-chain-mocks mock-pipeline-success
+      (let [result (chain/run-chain
+                     {:chain/id :quiet-chain
+                      :chain/steps [{:step/id :s1
+                                     :step/workflow-id :wf-a
+                                     :step/input-bindings {}}]}
+                     {}
+                     {})]
+        (is (= :completed (:chain/status result)))))))

--- a/docs/pull-requests/2026-02-25-feat-chain-events.md
+++ b/docs/pull-requests/2026-02-25-feat-chain-events.md
@@ -1,0 +1,56 @@
+# feat(workflow): Add chain lifecycle event emission
+
+**Branch**: `feat/chain-events`
+**Date**: 2026-02-25
+**Status**: Open
+
+## Overview
+
+Add chain lifecycle event emission to `run-chain` so the TUI and other subscribers can observe chain execution progress in real time. This builds on PR1b's chain executor and the existing event-stream infrastructure.
+
+## Motivation
+
+The chain executor currently runs silently with no observability. For the TUI to display chain progress (which step is running, success/failure status), the chain needs to emit events through the event-stream. This follows the same pattern used by workflow, agent, gate, and tool lifecycle events.
+
+## Changes in Detail
+
+### New Files
+
+| File | Purpose |
+|------|---------|
+| `components/workflow/test/ai/miniforge/workflow/chain_events_test.clj` | Tests for chain event emission in success, failure, and no-stream cases |
+
+### Modified Files
+
+| File | Changes |
+|------|---------|
+| `components/event-stream/src/ai/miniforge/event_stream/core.clj` | Added 6 chain event constructors (Layer 4) |
+| `components/event-stream/src/ai/miniforge/event_stream/interface.clj` | Added Layer 2j with delegating wrappers for chain events |
+| `components/workflow/src/ai/miniforge/workflow/chain.clj` | Added `emit!` helper and event emission throughout `run-chain` |
+
+## Architecture
+
+### Event Types
+
+| Event | When Emitted |
+|-------|-------------|
+| `:chain/started` | Before the execution loop begins |
+| `:chain/step-started` | Before each step executes |
+| `:chain/step-completed` | After a step succeeds |
+| `:chain/step-failed` | When a step fails |
+| `:chain/completed` | After all steps complete successfully |
+| `:chain/failed` | When the chain stops due to a step failure |
+
+### Cross-Component Resolution
+
+The `emit!` helper uses `requiring-resolve` to call event-stream functions from the workflow component, consistent with the codebase pattern for cross-component calls under Babashka compatibility constraints.
+
+### Backward Compatibility
+
+When no `:event-stream` key is present in `opts`, `emit!` is a no-op. Existing callers of `run-chain` are unaffected.
+
+## Testing
+
+- Success path: 2-step chain emits `started, step-started, step-completed, step-started, step-completed, completed`
+- Failure path: failing step emits `started, step-started, step-failed, failed`
+- No event-stream: chain runs silently without errors


### PR DESCRIPTION
## Summary

- Add 6 chain event constructors to `event-stream` component (`chain-started`, `chain-step-started`, `chain-step-completed`, `chain-step-failed`, `chain-completed`, `chain-failed`)
- Add `emit!` helper to `chain.clj` using `requiring-resolve` for cross-component calls
- Modify `run-chain` to emit lifecycle events at each stage (start, step start/complete/fail, chain complete/fail)
- Events are conditional on `:event-stream` presence in opts — backward compatible

## Test plan

- [x] Success path: 2-step chain emits `started, step-started, step-completed, step-started, step-completed, completed`
- [x] Failure path: failing step emits `started, step-started, step-failed, failed`
- [x] No event-stream: chain runs silently without errors
- [ ] Note: pre-existing `chain_test.clj` failures exist on main (`:chain/input.task` keyword namespace parsing issue) — unrelated to this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)