### PR TITLE
fix(workflow): resolve namespaced :chain/input.KEY bindings

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -52,10 +52,11 @@
     ;; String literal — pass through
     (string? binding) binding
 
-    ;; Keyword starting with :chain/input. — read from chain input
+    ;; Namespaced keyword :chain/input.KEY — read from chain input
     (and (keyword? binding)
-         (.startsWith (name binding) "chain/input."))
-    (let [input-key (keyword (subs (name binding) (count "chain/input.")))]
+         (= "chain" (namespace binding))
+         (.startsWith (name binding) "input."))
+    (let [input-key (keyword (subs (name binding) (count "input.")))]
       (get chain-input input-key))
 
     ;; Vector path — navigate into prev-output

--- a/components/workflow/test/ai/miniforge/workflow/chain_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_test.clj
@@ -102,7 +102,7 @@
               (is (= :test-chain (:chain/id result)))
               (is (= :completed (:chain/status result)))
               (is (= 2 (count (:chain/step-results result))))
-              (is (pos? (:chain/duration-ms result)))
+              (is (nat-int? (:chain/duration-ms result)))
 
               ;; Verify step 1 received chain input
               (is (= {:task "build-login"} (first @call-log)))
@@ -153,4 +153,4 @@
               (is (= 1 (count (:chain/step-results result))))
               (is (= 1 @call-count) "step 2 should never execute")
               (is (= :failed (get-in result [:chain/step-results 0 :step/status])))
-              (is (pos? (:chain/duration-ms result))))))))))
+              (is (nat-int? (:chain/duration-ms result))))))))))


### PR DESCRIPTION
## Summary
- Fix `resolve-binding` to correctly handle Clojure namespaced keywords: `(name :chain/input.task)` returns `"input.task"`, not `"chain/input.task"`, so the `.startsWith` check was always false
- Check `(namespace binding)` == `"chain"` separately, then `.startsWith` on the name for `"input."` prefix
- Relax `duration-ms` test assertions from `pos?` to `nat-int?` since mock workflows complete in 0ms

## Test plan
- [x] All 9 previously-failing `chain_test.clj` assertions now pass
- [x] Full poly test suite green (0 failures, 0 errors)
- [x] GraalVM compatibility verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)