### PR TITLE
feat(tui): chain lifecycle event handlers

### DIFF
--- a/components/tui-views/src/ai/miniforge/tui_views/model.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/model.clj
@@ -50,6 +50,7 @@
     :selected-ids    set          ; Set of selected item IDs (UUIDs or composite keys)
     :visual-anchor   int-or-nil   ; Index where visual mode started (nil = not active)
     :confirm         map-or-nil   ; Confirmation prompt {:action :label :ids} or nil
+    :active-chain    map-or-nil   ; Active chain {:chain-id :step-count :current-step :status} or nil
     :search-matches  vec          ; Vector of {:line-idx N} match descriptors (find-in-page)
     :search-match-idx int-or-nil} ; Current match index into search-matches (nil = none)"
   []
@@ -86,6 +87,8 @@
    :confirm         nil
    :search-matches  []
    :search-match-idx nil
+   ;; Active chain tracking
+   :active-chain nil
    ;; PR filter state (:open, :closed, :merged, :all)
    :pr-filter-state :open
    ;; Train state

--- a/components/tui-views/src/ai/miniforge/tui_views/msg.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/msg.clj
@@ -95,3 +95,29 @@
 
 (defn gate-result [wf-id gate passed?]
   [:msg/gate-result {:workflow-id wf-id :gate gate :passed? passed?}])
+
+;------------------------------------------------------------------------------ Layer 0c
+;; Chain event messages (from subscription.clj)
+
+(defn chain-started [chain-id step-count]
+  [:msg/chain-started {:chain-id chain-id :step-count step-count}])
+
+(defn chain-step-started [chain-id step-id step-index workflow-id]
+  [:msg/chain-step-started {:chain-id chain-id :step-id step-id
+                            :step-index step-index :workflow-id workflow-id}])
+
+(defn chain-step-completed [chain-id step-id step-index]
+  [:msg/chain-step-completed {:chain-id chain-id :step-id step-id
+                              :step-index step-index}])
+
+(defn chain-step-failed [chain-id step-id step-index error]
+  [:msg/chain-step-failed {:chain-id chain-id :step-id step-id
+                           :step-index step-index :error error}])
+
+(defn chain-completed [chain-id duration-ms step-count]
+  [:msg/chain-completed {:chain-id chain-id :duration-ms duration-ms
+                         :step-count step-count}])
+
+(defn chain-failed [chain-id failed-step error]
+  [:msg/chain-failed {:chain-id chain-id :failed-step failed-step
+                      :error error}])

--- a/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
@@ -67,6 +67,30 @@
     :gate/failed
     (msg/gate-result (:workflow/id event) (:gate event) false)
 
+    ;; Chain lifecycle events
+    :chain/started
+    (msg/chain-started (:chain/id event) (:chain/step-count event))
+
+    :chain/step-started
+    (msg/chain-step-started (:chain/id event) (:step/id event)
+                            (:step/index event) (:step/workflow-id event))
+
+    :chain/step-completed
+    (msg/chain-step-completed (:chain/id event) (:step/id event)
+                              (:step/index event))
+
+    :chain/step-failed
+    (msg/chain-step-failed (:chain/id event) (:step/id event)
+                           (:step/index event) (:chain/error event))
+
+    :chain/completed
+    (msg/chain-completed (:chain/id event) (:chain/duration-ms event)
+                         (:chain/step-count event))
+
+    :chain/failed
+    (msg/chain-failed (:chain/id event) (:chain/failed-step event)
+                      (:chain/error event))
+
     ;; Unknown event types are ignored
     nil))
 

--- a/components/tui-views/src/ai/miniforge/tui_views/update.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update.clj
@@ -537,6 +537,14 @@
       :msg/workflow-failed  (events/handle-workflow-failed model payload)
       :msg/gate-result      (events/handle-gate-result model payload)
 
+      ;; Chain lifecycle messages
+      :msg/chain-started         (events/handle-chain-started model payload)
+      :msg/chain-step-started    (events/handle-chain-step-started model payload)
+      :msg/chain-step-completed  (events/handle-chain-step-completed model payload)
+      :msg/chain-step-failed     (events/handle-chain-step-failed model payload)
+      :msg/chain-completed       (events/handle-chain-completed model payload)
+      :msg/chain-failed          (events/handle-chain-failed model payload)
+
       ;; PR fleet messages
       :msg/policy-evaluated (events/handle-policy-evaluated model payload)
       :msg/prs-synced       (events/handle-prs-synced model payload)

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -140,6 +140,73 @@
         (apply-gate-result idx workflow-id gate passed? payload)
         with-timestamp)))
 
+;------------------------------------------------------------------------------ Layer 2b
+;; Chain event handlers
+
+(defn handle-chain-started
+  "Set active chain in model when a chain begins execution."
+  [model {:keys [chain-id step-count]}]
+  (-> model
+      (assoc :active-chain {:chain-id chain-id
+                            :step-count step-count
+                            :current-step nil
+                            :status :running})
+      (assoc :flash-message (str "Chain " (name chain-id)
+                                 " started (" step-count " steps)"))
+      with-timestamp))
+
+(defn handle-chain-step-started
+  "Update active chain with current step info."
+  [model {:keys [chain-id step-id step-index workflow-id]}]
+  (-> model
+      (assoc-in [:active-chain :current-step]
+                {:step-id step-id
+                 :step-index step-index
+                 :workflow-id workflow-id})
+      (assoc :flash-message (str "Chain " (name chain-id)
+                                 " step " (inc step-index) "/"
+                                 (get-in model [:active-chain :step-count])
+                                 ": " (name step-id)))
+      with-timestamp))
+
+(defn handle-chain-step-completed
+  "Mark current chain step as completed."
+  [model {:keys [chain-id step-index]}]
+  (-> model
+      (assoc :flash-message (str "Chain " (name chain-id)
+                                 " step " (inc step-index) " completed"))
+      with-timestamp))
+
+(defn handle-chain-step-failed
+  "Mark current chain step as failed, update chain status."
+  [model {:keys [chain-id step-index error]}]
+  (-> model
+      (assoc-in [:active-chain :status] :failed)
+      (assoc :flash-message (str "Chain " (name chain-id)
+                                 " step " (inc step-index)
+                                 " FAILED: " error))
+      with-timestamp))
+
+(defn handle-chain-completed
+  "Mark chain as completed and clear active chain."
+  [model {:keys [chain-id duration-ms step-count]}]
+  (-> model
+      (assoc :active-chain nil)
+      (assoc :flash-message (str "Chain " (name chain-id)
+                                 " completed — " step-count " steps in "
+                                 duration-ms "ms"))
+      with-timestamp))
+
+(defn handle-chain-failed
+  "Mark chain as failed and record error."
+  [model {:keys [chain-id failed-step error]}]
+  (-> model
+      (assoc-in [:active-chain :status] :failed)
+      (assoc :flash-message (str "Chain " (name chain-id)
+                                 " FAILED at " (when failed-step (name failed-step))
+                                 ": " error))
+      with-timestamp))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; PR event handlers
 

--- a/components/tui-views/test/ai/miniforge/tui_views/chain_events_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/chain_events_test.clj
@@ -1,0 +1,153 @@
+(ns ai.miniforge.tui-views.chain-events-test
+  "Tests for chain event translation and TUI model handlers."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.tui-views.subscription :as sub]
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.update.events :as events]
+   [ai.miniforge.tui-views.msg :as msg]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; translate-event tests
+
+(deftest translate-chain-started-test
+  (testing "chain/started event translates to msg/chain-started"
+    (let [event {:event/type :chain/started
+                 :chain/id :plan-then-implement
+                 :chain/step-count 3}
+          [msg-type payload] (sub/translate-event event)]
+      (is (= :msg/chain-started msg-type))
+      (is (= :plan-then-implement (:chain-id payload)))
+      (is (= 3 (:step-count payload))))))
+
+(deftest translate-chain-step-started-test
+  (testing "chain/step-started event translates correctly"
+    (let [event {:event/type :chain/step-started
+                 :chain/id :my-chain
+                 :step/id :plan
+                 :step/index 0
+                 :step/workflow-id :planning-v1}
+          [msg-type payload] (sub/translate-event event)]
+      (is (= :msg/chain-step-started msg-type))
+      (is (= :my-chain (:chain-id payload)))
+      (is (= :plan (:step-id payload)))
+      (is (= 0 (:step-index payload)))
+      (is (= :planning-v1 (:workflow-id payload))))))
+
+(deftest translate-chain-step-completed-test
+  (testing "chain/step-completed event translates correctly"
+    (let [event {:event/type :chain/step-completed
+                 :chain/id :my-chain
+                 :step/id :plan
+                 :step/index 0}
+          [msg-type payload] (sub/translate-event event)]
+      (is (= :msg/chain-step-completed msg-type))
+      (is (= :plan (:step-id payload)))
+      (is (= 0 (:step-index payload))))))
+
+(deftest translate-chain-step-failed-test
+  (testing "chain/step-failed event translates correctly"
+    (let [event {:event/type :chain/step-failed
+                 :chain/id :my-chain
+                 :step/id :implement
+                 :step/index 1
+                 :chain/error "LLM timeout"}
+          [msg-type payload] (sub/translate-event event)]
+      (is (= :msg/chain-step-failed msg-type))
+      (is (= :implement (:step-id payload)))
+      (is (= "LLM timeout" (:error payload))))))
+
+(deftest translate-chain-completed-test
+  (testing "chain/completed event translates correctly"
+    (let [event {:event/type :chain/completed
+                 :chain/id :my-chain
+                 :chain/duration-ms 5000
+                 :chain/step-count 3}
+          [msg-type payload] (sub/translate-event event)]
+      (is (= :msg/chain-completed msg-type))
+      (is (= 5000 (:duration-ms payload)))
+      (is (= 3 (:step-count payload))))))
+
+(deftest translate-chain-failed-test
+  (testing "chain/failed event translates correctly"
+    (let [event {:event/type :chain/failed
+                 :chain/id :my-chain
+                 :chain/failed-step :implement
+                 :chain/error "Step execution failed"}
+          [msg-type payload] (sub/translate-event event)]
+      (is (= :msg/chain-failed msg-type))
+      (is (= :implement (:failed-step payload)))
+      (is (= "Step execution failed" (:error payload))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Event handler tests
+
+(deftest handle-chain-started-test
+  (testing "chain-started sets active-chain in model"
+    (let [model (model/init-model)
+          result (events/handle-chain-started model
+                   {:chain-id :plan-then-implement :step-count 3})]
+      (is (= :plan-then-implement (get-in result [:active-chain :chain-id])))
+      (is (= 3 (get-in result [:active-chain :step-count])))
+      (is (= :running (get-in result [:active-chain :status])))
+      (is (nil? (get-in result [:active-chain :current-step])))
+      (is (some? (:last-updated result))))))
+
+(deftest handle-chain-step-started-test
+  (testing "chain-step-started updates current step"
+    (let [model (-> (model/init-model)
+                    (assoc :active-chain {:chain-id :my-chain
+                                         :step-count 2
+                                         :current-step nil
+                                         :status :running}))
+          result (events/handle-chain-step-started model
+                   {:chain-id :my-chain :step-id :plan
+                    :step-index 0 :workflow-id :planning-v1})]
+      (is (= :plan (get-in result [:active-chain :current-step :step-id])))
+      (is (= 0 (get-in result [:active-chain :current-step :step-index])))
+      (is (= :planning-v1 (get-in result [:active-chain :current-step :workflow-id]))))))
+
+(deftest handle-chain-step-failed-test
+  (testing "chain-step-failed marks chain as failed"
+    (let [model (-> (model/init-model)
+                    (assoc :active-chain {:chain-id :my-chain
+                                         :step-count 2
+                                         :current-step {:step-id :plan :step-index 0}
+                                         :status :running}))
+          result (events/handle-chain-step-failed model
+                   {:chain-id :my-chain :step-index 0 :error "boom"})]
+      (is (= :failed (get-in result [:active-chain :status])))
+      (is (clojure.string/includes? (:flash-message result) "FAILED")))))
+
+(deftest handle-chain-completed-test
+  (testing "chain-completed clears active-chain"
+    (let [model (-> (model/init-model)
+                    (assoc :active-chain {:chain-id :my-chain
+                                         :step-count 2
+                                         :status :running}))
+          result (events/handle-chain-completed model
+                   {:chain-id :my-chain :duration-ms 5000 :step-count 2})]
+      (is (nil? (:active-chain result)))
+      (is (clojure.string/includes? (:flash-message result) "completed")))))
+
+(deftest handle-chain-failed-test
+  (testing "chain-failed marks chain as failed with error"
+    (let [model (-> (model/init-model)
+                    (assoc :active-chain {:chain-id :my-chain
+                                         :step-count 2
+                                         :status :running}))
+          result (events/handle-chain-failed model
+                   {:chain-id :my-chain :failed-step :implement
+                    :error "LLM timeout"})]
+      (is (= :failed (get-in result [:active-chain :status])))
+      (is (clojure.string/includes? (:flash-message result) "FAILED"))
+      (is (clojure.string/includes? (:flash-message result) "LLM timeout")))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Model initialization test
+
+(deftest init-model-has-active-chain-test
+  (testing "init-model includes :active-chain nil"
+    (let [model (model/init-model)]
+      (is (contains? model :active-chain))
+      (is (nil? (:active-chain model))))))


### PR DESCRIPTION
## Summary
- Wire all 6 chain events (`:chain/started`, `step-started`, `step-completed`, `step-failed`, `completed`, `failed`) through the full TUI event pipeline
- Add message constructors (`msg.clj`), event translation (`subscription.clj`), model state tracking (`model.clj`), update handlers (`events.clj`), and root dispatch (`update.clj`)
- Track active chain with step progress via `:active-chain` in model — set on chain start, updated on step transitions, cleared on completion
- 12 tests covering translation and handler model state transitions

## Test plan
- [x] All 12 chain event tests pass (37 assertions)
- [x] Full `bb test :tui-views` passes (0 failures)
- [x] Pre-commit hooks pass (lint, format, test, GraalVM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)