### PR TITLE
feat(tui): chain progress indicator on workflow list rows

### DIFF
--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -90,12 +90,23 @@
 
 ;; Event handlers
 
+(defn- link-chain-instance
+  "When a chain step is active, record the workflow instance UUID so
+   the view layer can show the chain indicator on the correct row."
+  [model workflow-id]
+  (if (and (:active-chain model)
+           (get-in model [:active-chain :current-step])
+           (nil? (get-in model [:active-chain :current-step :instance-id])))
+    (assoc-in model [:active-chain :current-step :instance-id] workflow-id)
+    model))
+
 (defn handle-workflow-added [model {:keys [workflow-id name spec]}]
   (let [wf (model/make-workflow {:id workflow-id
                                   :name (or name (:name spec))
                                   :status :running})]
     (-> model
         (update :workflows conj wf)
+        (link-chain-instance workflow-id)
         with-timestamp)))
 
 (defn handle-phase-changed [model {:keys [workflow-id phase]}]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
@@ -39,22 +39,34 @@
     :blocked "◐"
     "○"))
 
+(defn- chain-prefix
+  "Build a chain progress prefix like '[plan-impl 2/4] ' when this workflow
+   is the active chain step. Returns empty string otherwise."
+  [wf active-chain]
+  (when-let [{:keys [chain-id current-step step-count]} active-chain]
+    (when (and current-step
+               (= (:id wf) (:instance-id current-step)))
+      (str "[" (name chain-id) " "
+           (inc (:step-index current-step)) "/" step-count "] "))))
+
 (defn- format-workflow-row
-  "Transform workflow data into table row format."
-  [wf]
-  {:status-char (status-char (:status wf))
-   :name (:name wf)
-   :phase (some-> (:phase wf) name)
-   :progress-str (str (:progress wf 0) "%")
-   :agent-msg (when-let [agent (first (vals (:agents wf)))]
-                (when-let [msg (:message agent)]
-                  (subs msg 0 (min 16 (count msg)))))})
+  "Transform workflow data into table row format.
+   active-chain is the :active-chain map from the model (or nil)."
+  [wf active-chain]
+  (let [prefix (or (chain-prefix wf active-chain) "")]
+    {:status-char (status-char (:status wf))
+     :name (str prefix (:name wf))
+     :phase (some-> (:phase wf) name)
+     :progress-str (str (:progress wf 0) "%")
+     :agent-msg (when-let [agent (first (vals (:agents wf)))]
+                  (when-let [msg (:message agent)]
+                    (subs msg 0 (min 16 (count msg)))))}))
 
 (defn- render-title-bar [[cols rows]]
   (layout/text [cols rows] " MINIFORGE │ Workflows"
                {:fg :cyan :bold? true}))
 
-(defn- render-table [workflows selected [cols rows]]
+(defn- render-table [workflows selected active-chain [cols rows]]
   (if (empty? workflows)
     (layout/text [cols rows] "  No active workflows. Waiting for events..."
                  {:fg :default})
@@ -64,7 +76,7 @@
                  {:key :phase :header "Phase" :width 12}
                  {:key :progress-str :header "Progress" :width 20}
                  {:key :agent-msg :header "Agent" :width 16}]
-       :data (mapv format-workflow-row workflows)
+       :data (mapv #(format-workflow-row % active-chain) workflows)
        :selected-row selected})))
 
 (defn- render-footer [flash-message [cols rows]]
@@ -80,12 +92,13 @@
   [model [cols rows]]
   (let [workflows (:workflows model)
         selected (:selected-idx model)
+        active-chain (:active-chain model)
         flash (:flash-message model)]
     (layout/split-v [cols rows] (/ 2.0 rows)
       (fn [size] (render-title-bar size))
       (fn [[c r]]
         (layout/split-v [c r] (/ (- r 2.0) r)
-          (fn [size] (render-table workflows selected size))
+          (fn [size] (render-table workflows selected active-chain size))
           (fn [size] (render-footer flash size)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/tui-views/test/ai/miniforge/tui_views/chain_events_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/chain_events_test.clj
@@ -1,11 +1,11 @@
 (ns ai.miniforge.tui-views.chain-events-test
   "Tests for chain event translation and TUI model handlers."
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.tui-views.subscription :as sub]
    [ai.miniforge.tui-views.model :as model]
-   [ai.miniforge.tui-views.update.events :as events]
-   [ai.miniforge.tui-views.msg :as msg]))
+   [ai.miniforge.tui-views.update.events :as events]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; translate-event tests
@@ -117,7 +117,7 @@
           result (events/handle-chain-step-failed model
                    {:chain-id :my-chain :step-index 0 :error "boom"})]
       (is (= :failed (get-in result [:active-chain :status])))
-      (is (clojure.string/includes? (:flash-message result) "FAILED")))))
+      (is (str/includes? (:flash-message result) "FAILED")))))
 
 (deftest handle-chain-completed-test
   (testing "chain-completed clears active-chain"
@@ -128,7 +128,7 @@
           result (events/handle-chain-completed model
                    {:chain-id :my-chain :duration-ms 5000 :step-count 2})]
       (is (nil? (:active-chain result)))
-      (is (clojure.string/includes? (:flash-message result) "completed")))))
+      (is (str/includes? (:flash-message result) "completed")))))
 
 (deftest handle-chain-failed-test
   (testing "chain-failed marks chain as failed with error"
@@ -140,8 +140,8 @@
                    {:chain-id :my-chain :failed-step :implement
                     :error "LLM timeout"})]
       (is (= :failed (get-in result [:active-chain :status])))
-      (is (clojure.string/includes? (:flash-message result) "FAILED"))
-      (is (clojure.string/includes? (:flash-message result) "LLM timeout")))))
+      (is (str/includes? (:flash-message result) "FAILED"))
+      (is (str/includes? (:flash-message result) "LLM timeout")))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Model initialization test

--- a/components/tui-views/test/ai/miniforge/tui_views/chain_events_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/chain_events_test.clj
@@ -151,3 +151,47 @@
     (let [model (model/init-model)]
       (is (contains? model :active-chain))
       (is (nil? (:active-chain model))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Chain instance linking and view indicator tests
+
+(deftest workflow-added-links-chain-instance-test
+  (testing "workflow-added during active chain step links instance-id"
+    (let [wf-id (random-uuid)
+          model (-> (model/init-model)
+                    (assoc :active-chain {:chain-id :my-chain
+                                         :step-count 2
+                                         :current-step {:step-id :plan
+                                                        :step-index 0
+                                                        :workflow-id :planning-v1}
+                                         :status :running}))
+          result (events/handle-workflow-added model
+                   {:workflow-id wf-id :name "plan-wf" :spec nil})]
+      (is (= wf-id (get-in result [:active-chain :current-step :instance-id])))
+      (is (= 1 (count (:workflows result)))))))
+
+(deftest workflow-added-no-chain-leaves-model-unchanged-test
+  (testing "workflow-added without active chain does not add chain info"
+    (let [wf-id (random-uuid)
+          model (model/init-model)
+          result (events/handle-workflow-added model
+                   {:workflow-id wf-id :name "solo-wf" :spec nil})]
+      (is (nil? (:active-chain result)))
+      (is (= 1 (count (:workflows result)))))))
+
+(deftest workflow-added-does-not-overwrite-instance-id-test
+  (testing "second workflow-added does not overwrite existing instance-id"
+    (let [wf-id-1 (random-uuid)
+          wf-id-2 (random-uuid)
+          model (-> (model/init-model)
+                    (assoc :active-chain {:chain-id :my-chain
+                                         :step-count 2
+                                         :current-step {:step-id :plan
+                                                        :step-index 0
+                                                        :workflow-id :planning-v1
+                                                        :instance-id wf-id-1}
+                                         :status :running}))
+          result (events/handle-workflow-added model
+                   {:workflow-id wf-id-2 :name "other-wf" :spec nil})]
+      (is (= wf-id-1 (get-in result [:active-chain :current-step :instance-id]))
+          "instance-id should not be overwritten"))))


### PR DESCRIPTION
## Summary
- Prefix workflow names with `[chain-name step/total]` (e.g. `[plan-impl 2/4]`) when the workflow belongs to the active chain step
- Link chain step to workflow instance UUID via `handle-workflow-added` so the view can identify the correct row
- 3 new tests for instance linking (link on add, no-op without chain, no overwrite)

## Test plan
- [x] 15 chain event tests pass (42 assertions)
- [x] Full `bb test :tui-views` passes (0 failures)
- [x] Pre-commit hooks pass (lint, format, test, GraalVM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)