### PR TITLE
fix(tui): filter archived workflows from views and add status-char

### DIFF
--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -42,7 +42,7 @@
 
 (defn- status-char [status]
   (case status
-    :running "●" :success "✓" :failed "✗" :blocked "◐" "○"))
+    :running "●" :success "✓" :failed "✗" :blocked "◐" :archived "⊘" "○"))
 
 (defn- format-progress-bar [pct width]
   (let [pct (or pct 0)
@@ -183,7 +183,7 @@
 (defn- project-workflows
   "Project workflow list for the table widget."
   [model]
-  (let [wfs (:workflows model)
+  (let [wfs (vec (remove #(= :archived (:status %)) (:workflows model)))
         filtered (if-let [fi (:filtered-indices model)]
                    (vec (keep-indexed (fn [i wf] (when (contains? fi i) wf)) wfs))
                    wfs)]
@@ -721,7 +721,7 @@
 (defn- project-kanban-columns
   "Project workflows into kanban columns."
   [model]
-  (let [all-wfs (or (:workflows model) [])
+  (let [all-wfs (vec (remove #(= :archived (:status %)) (or (:workflows model) [])))
         blocked   (filterv #(= :blocked (:status %)) all-wfs)
         ready     (filterv #(#{:ready :pending} (:status %)) all-wfs)
         active    (filterv #(#{:running :implementing :pr-opening :responding} (:status %)) all-wfs)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
@@ -33,10 +33,11 @@
 
 (defn- status-char [status]
   (case status
-    :running "●"
-    :success "✓"
-    :failed  "✗"
-    :blocked "◐"
+    :running  "●"
+    :success  "✓"
+    :failed   "✗"
+    :blocked  "◐"
+    :archived "⊘"
     "○"))
 
 (defn- chain-prefix
@@ -90,7 +91,7 @@
    model: full app model
    [cols rows]: available screen area"
   [model [cols rows]]
-  (let [workflows (:workflows model)
+  (let [workflows (vec (remove #(= :archived (:status %)) (:workflows model)))
         selected (:selected-idx model)
         active-chain (:active-chain model)
         flash (:flash-message model)]


### PR DESCRIPTION
## Summary
- Add `:archived` case (`⊘`) to `status-char` in both `workflow_list.clj` and `project.clj`
- Filter out archived workflows in `workflow_list/render` so they disappear from the list view
- Filter out archived workflows in `project-workflows` and `project-kanban-columns` projections so they don't appear in the spec-driven views either

## Problem
The `:archive` command set workflow status to `:archived` but:
1. Views never filtered out archived workflows, so they remained visible
2. `status-char` didn't handle `:archived`, falling through to the default `○` indicator

## Test plan
- [x] `bb test :tui-views` passes (all existing tests green)
- [x] Pre-commit hooks pass (lint + format + test + graalvm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)