### PR TITLE
feat(cli): chain CLI command + spec-to-pr chain for dogfooding

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -168,6 +168,24 @@
 
 (defn workflow-list-cmd [_m] (workflow-runner/list-workflows!))
 
+;; Chain commands
+(defn chain-run-cmd
+  [m]
+  (let [{:keys [chain-id version spec input-json quiet]} (get-opts m)]
+    (if-not chain-id
+      (display/print-error "Usage: miniforge chain run <chain-id> [options]")
+      (try
+        (workflow-runner/run-chain!
+         (keyword (str/replace chain-id #"^:" ""))
+         {:version (or version "latest")
+          :spec spec
+          :input-json input-json
+          :quiet (boolean quiet)})
+        (catch Exception e
+          (display/print-error (str "Chain execution failed: " (ex-message e))))))))
+
+(defn chain-list-cmd [_m] (workflow-runner/list-chains!))
+
 ;; Observability commands
 (defn logs-tail-cmd [m] (observability/handle-logs (assoc (get-opts m) :subcommand "tail")))
 (defn logs-list-cmd [_m] (observability/handle-logs {:subcommand "list"}))
@@ -217,6 +235,14 @@ Commands:
       -o, --output    Output format: pretty, json, edn (default: pretty)
       -q, --quiet     Suppress progress output
     list              List available workflows
+
+  chain <subcommand>  Chain execution (multi-workflow)
+    run <id>          Execute a chain by ID
+      -v, --version   Chain version (default: latest)
+      -s, --spec      Input spec file (EDN)
+      --input-json    Inline JSON input
+      -q, --quiet     Suppress progress output
+    list              List available chains
 
   fleet <subcommand>  Multi-repo management
     start             Start fleet daemon
@@ -310,6 +336,18 @@ Examples:
 
    {:cmds ["workflow" "list"]
     :fn workflow-list-cmd}
+
+   ;; Chain commands
+   {:cmds ["chain" "run"]
+    :fn chain-run-cmd
+    :args->opts [:chain-id]
+    :spec {:version {:coerce :string :alias :v :default "latest"}
+           :spec {:alias :s}
+           :input-json {}
+           :quiet {:coerce :boolean :alias :q}}}
+
+   {:cmds ["chain" "list"]
+    :fn chain-list-cmd}
 
    ;; Config subcommands
    {:cmds ["config"] :fn help-cmd}

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -317,3 +317,105 @@
       (when-not quiet
         (println (display/colorize :red (str "\n❌ Workflow execution failed: " (ex-message e)))))
       (throw e))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Chain-driven execution
+
+(defn- resolve-chain-input
+  "Resolve chain input from a spec file path or inline JSON."
+  [opts]
+  (let [spec-path (:spec opts)
+        inline-json (:input-json opts)]
+    (cond
+      inline-json (json/parse-string inline-json true)
+      spec-path (let [parsed (edn/read-string (slurp spec-path))
+                      enriched (context/decorate-spec-with-runtime-context parsed {})]
+                  (context/spec->workflow-input enriched))
+      :else {})))
+
+(defn- print-chain-header
+  "Print chain execution banner."
+  [chain-id chain-def quiet]
+  (when-not quiet
+    (println)
+    (println (display/colorize :cyan (str "⛓  Chain: " (name chain-id))))
+    (println (display/colorize :cyan (str "   " (:chain/description chain-def))))
+    (println (display/colorize :cyan (str "   Steps: " (count (:chain/steps chain-def)))))
+    (println (display/colorize :cyan (apply str (repeat 60 "─"))))))
+
+(defn- print-chain-result
+  "Print chain execution result summary."
+  [result quiet]
+  (when-not quiet
+    (let [status (:chain/status result)
+          steps (:chain/step-results result)
+          duration (:chain/duration-ms result)]
+      (println)
+      (println (display/colorize :cyan (apply str (repeat 60 "─"))))
+      (if (= :completed status)
+        (println (display/colorize :green (str "✓ Chain completed — "
+                                                (count steps) " steps in "
+                                                duration "ms")))
+        (let [failed-step (some #(when (= :failed (:step/status %)) (:step/id %)) steps)]
+          (println (display/colorize :red (str "✗ Chain failed at step: "
+                                                (when failed-step (name failed-step))))))))))
+
+(defn run-chain!
+  "Execute a chain of workflows.
+
+   Arguments:
+   - chain-id: Chain identifier keyword (e.g. :spec-to-pr)
+   - opts: {:version \"latest\" :spec \"spec.edn\" :input-json \"{...}\" :quiet false}"
+  [chain-id opts]
+  (let [quiet (or (:quiet opts) false)
+        version (or (:version opts) "latest")]
+    (try
+      (let [load-chain-fn (requiring-resolve 'ai.miniforge.workflow.interface/load-chain)
+            run-chain-fn (requiring-resolve 'ai.miniforge.workflow.interface/run-chain)
+            chain-result (load-chain-fn chain-id version)
+            chain-def (:chain chain-result)
+            chain-input (resolve-chain-input opts)
+            event-stream (es/create-event-stream)
+            llm-client (context/create-llm-client nil nil quiet)
+            callbacks (create-phase-callbacks quiet)
+            context (context/create-workflow-context {:callbacks callbacks
+                                                      :event-stream event-stream
+                                                      :llm-client llm-client
+                                                      :quiet quiet
+                                                      :workflow-id (random-uuid)
+                                                      :workflow-type chain-id
+                                                      :workflow-version version
+                                                      :spec-title (str "Chain: " (name chain-id))
+                                                      :control-state (es/create-control-state)})]
+        (print-chain-header chain-id chain-def quiet)
+        (dashboard/print-dashboard-status! quiet)
+        (let [result (run-chain-fn chain-def chain-input context)]
+          (print-chain-result result quiet)
+          result))
+      (catch Exception e
+        (when-not quiet
+          (println (display/colorize :red (str "\n❌ Chain execution failed: " (ex-message e)))))
+        (throw e)))))
+
+(defn list-chains!
+  "List all available chain definitions."
+  []
+  (try
+    (let [list-chains-fn (requiring-resolve 'ai.miniforge.workflow.interface/list-chains)
+          chains (list-chains-fn)]
+      (if (empty? chains)
+        (println "No chains found.")
+        (do
+          (println (display/colorize :cyan "\nAvailable Chains:"))
+          (println (display/colorize :cyan (apply str (repeat 60 "─"))))
+          (doseq [{:keys [id version description steps]} chains]
+            (println (str (display/colorize :bold (str "  " (name id)))
+                          " (v" version ")"
+                          "  " steps " step(s)"))
+            (when description
+              (println (str "    " description)))
+            (println))
+          (println (display/colorize :cyan (apply str (repeat 60 "─")))))))
+    (catch Exception e
+      (println (display/colorize :red (str "Failed to list chains: " (ex-message e))))
+      (throw e))))

--- a/components/workflow/resources/chains/spec-to-pr-v1.0.0.edn
+++ b/components/workflow/resources/chains/spec-to-pr-v1.0.0.edn
@@ -1,0 +1,23 @@
+;; Spec-to-PR Chain v1.0.0
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Reference chain: Takes a spec file and produces a pull request.
+;; Uses the lean-sdlc workflow for each step with different input bindings.
+;;
+;; This is the dogfooding chain — Miniforge building itself.
+
+{:chain/id :spec-to-pr
+ :chain/version "1.0.0"
+ :chain/description
+ "End-to-end spec to pull request. Runs a lean SDLC workflow that plans,
+  implements, tests, reviews, and releases the change as a PR."
+
+ :chain/steps
+ [{:step/id :execute
+   :step/workflow-id :lean-sdlc-v1
+   :step/input-bindings {:title       :chain/input.title
+                         :description :chain/input.description
+                         :intent      :chain/input.intent
+                         :constraints :chain/input.constraints
+                         :context     :chain/input.context
+                         :metadata    :chain/input.metadata}}]}

--- a/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.chain-loader
+  "Chain definition loading from classpath resources.
+   Loads chain EDN files from resources/chains/ directory."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.edn :as edn]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Resource loading
+
+(defn- find-latest-chain-resource
+  "Scan classpath for the highest versioned chain file matching chain-id.
+   Looks for chains/<chain-id>-v*.edn files."
+  [chain-id]
+  (when-let [chains-dir (io/resource "chains")]
+    (let [prefix (str (name chain-id) "-v")
+          dir-file (io/file (.getPath chains-dir))]
+      (when (.isDirectory dir-file)
+        (->> (.listFiles dir-file)
+             (filter #(.isFile %))
+             (filter #(let [n (.getName %)]
+                        (and (.startsWith n prefix) (.endsWith n ".edn"))))
+             (sort-by #(.getName %) (comp - compare))
+             first
+             (#(when % (str "chains/" (.getName %)))))))))
+
+(defn- load-chain-resource
+  "Load a chain EDN file from classpath."
+  [resource-path]
+  (when-let [resource (io/resource resource-path)]
+    (edn/read-string (slurp resource))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Public API
+
+(defn load-chain
+  "Load a chain definition from classpath resources.
+
+   Arguments:
+   - chain-id: Chain identifier (keyword, e.g. :spec-to-pr)
+   - version: Version string (e.g. \"1.0.0\" or \"latest\")
+
+   Returns chain definition map or throws if not found."
+  [chain-id version]
+  (let [versioned-path (str "chains/" (name chain-id) "-v" version ".edn")
+        base-path (str "chains/" (name chain-id) ".edn")
+        resource-path (or (when (and version (not= version "latest"))
+                            (when (io/resource versioned-path)
+                              versioned-path))
+                          (when (io/resource base-path) base-path)
+                          (find-latest-chain-resource chain-id))
+        chain-def (when resource-path (load-chain-resource resource-path))]
+    (if chain-def
+      {:chain chain-def :source :resource :path resource-path}
+      (throw (ex-info (str "Chain '" (name chain-id) "' not found. "
+                           "Looked for: " versioned-path ", " base-path)
+                      {:chain-id chain-id :version version})))))
+
+(defn list-chains
+  "List all available chain definitions from classpath."
+  []
+  (when-let [chains-dir (io/resource "chains")]
+    (let [dir-file (io/file (.getPath chains-dir))]
+      (when (.isDirectory dir-file)
+        (->> (.listFiles dir-file)
+             (filter #(and (.isFile %) (.endsWith (.getName %) ".edn")))
+             (keep (fn [f]
+                     (try
+                       (let [content (edn/read-string (slurp f))]
+                         {:id (:chain/id content)
+                          :version (:chain/version content)
+                          :description (:chain/description content)
+                          :steps (count (:chain/steps content))})
+                       (catch Exception _ nil))))
+             vec)))))

--- a/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
@@ -59,16 +59,18 @@
 ;; Resource loading
 
 (defn- find-latest-chain-resource
-  "Find the highest-versioned chain EDN resource path for chain-id."
+  "Find the highest-versioned chain EDN resource path for chain-id.
+   Returns a resource path string like \"chains/spec-to-pr-v1.0.0.edn\"."
   [chain-id]
-  (let [prefix (str (name chain-id) "-v")]
-    (some->> (resource-dir-files "chains")
-             (filter edn-file?)
-             (filter (partial matches-prefix? prefix))
-             (sort-by #(.getName %) (comp - compare))
-             first
-             (.getName)
-             (str "chains/"))))
+  (let [prefix (str (name chain-id) "-v")
+        candidates (->> (resource-dir-files "chains")
+                        (filter edn-file?)
+                        (filter (partial matches-prefix? prefix))
+                        (map #(.getName %))
+                        sort
+                        reverse)]
+    (when-let [filename (first candidates)]
+      (str "chains/" filename))))
 
 (defn- load-chain-resource
   "Load a chain EDN file from classpath."

--- a/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
@@ -24,23 +24,51 @@
    [clojure.edn :as edn]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; File helpers
+
+(defn- edn-file?
+  "True when file is an existing .edn file."
+  [^java.io.File f]
+  (and (.isFile f) (.endsWith (.getName f) ".edn")))
+
+(defn- matches-prefix?
+  "True when filename starts with prefix."
+  [prefix ^java.io.File f]
+  (.startsWith (.getName f) prefix))
+
+(defn- resource-dir-files
+  "List files in a classpath resource directory, or nil."
+  [dir-name]
+  (when-let [dir-url (io/resource dir-name)]
+    (let [dir-file (io/file (.getPath dir-url))]
+      (when (.isDirectory dir-file)
+        (vec (.listFiles dir-file))))))
+
+(defn- parse-chain-file
+  "Parse a chain EDN file into a summary map, or nil on failure."
+  [^java.io.File f]
+  (try
+    (let [content (edn/read-string (slurp f))]
+      {:id (:chain/id content)
+       :version (:chain/version content)
+       :description (:chain/description content)
+       :steps (count (:chain/steps content))})
+    (catch Exception _ nil)))
+
+;------------------------------------------------------------------------------ Layer 1
 ;; Resource loading
 
 (defn- find-latest-chain-resource
-  "Scan classpath for the highest versioned chain file matching chain-id.
-   Looks for chains/<chain-id>-v*.edn files."
+  "Find the highest-versioned chain EDN resource path for chain-id."
   [chain-id]
-  (when-let [chains-dir (io/resource "chains")]
-    (let [prefix (str (name chain-id) "-v")
-          dir-file (io/file (.getPath chains-dir))]
-      (when (.isDirectory dir-file)
-        (->> (.listFiles dir-file)
-             (filter #(.isFile %))
-             (filter #(let [n (.getName %)]
-                        (and (.startsWith n prefix) (.endsWith n ".edn"))))
+  (let [prefix (str (name chain-id) "-v")]
+    (some->> (resource-dir-files "chains")
+             (filter edn-file?)
+             (filter (partial matches-prefix? prefix))
              (sort-by #(.getName %) (comp - compare))
              first
-             (#(when % (str "chains/" (.getName %)))))))))
+             (.getName)
+             (str "chains/"))))
 
 (defn- load-chain-resource
   "Load a chain EDN file from classpath."
@@ -48,7 +76,7 @@
   (when-let [resource (io/resource resource-path)]
     (edn/read-string (slurp resource))))
 
-;------------------------------------------------------------------------------ Layer 1
+;------------------------------------------------------------------------------ Layer 2
 ;; Public API
 
 (defn load-chain
@@ -77,17 +105,7 @@
 (defn list-chains
   "List all available chain definitions from classpath."
   []
-  (when-let [chains-dir (io/resource "chains")]
-    (let [dir-file (io/file (.getPath chains-dir))]
-      (when (.isDirectory dir-file)
-        (->> (.listFiles dir-file)
-             (filter #(and (.isFile %) (.endsWith (.getName %) ".edn")))
-             (keep (fn [f]
-                     (try
-                       (let [content (edn/read-string (slurp f))]
-                         {:id (:chain/id content)
-                          :version (:chain/version content)
-                          :description (:chain/description content)
-                          :steps (count (:chain/steps content))})
-                       (catch Exception _ nil))))
-             vec)))))
+  (some->> (resource-dir-files "chains")
+           (filter edn-file?)
+           (keep parse-chain-file)
+           vec))

--- a/components/workflow/src/ai/miniforge/workflow/interface.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface.clj
@@ -238,6 +238,18 @@
   ((requiring-resolve 'ai.miniforge.workflow.chain/run-chain)
    chain-def chain-input opts))
 
+(defn load-chain
+  "Load a chain definition by ID and version from classpath resources.
+   Returns {:chain chain-def :source :resource :path resource-path}."
+  [chain-id version]
+  ((requiring-resolve 'ai.miniforge.workflow.chain-loader/load-chain)
+   chain-id version))
+
+(defn list-chains
+  "List all available chain definitions from classpath."
+  []
+  ((requiring-resolve 'ai.miniforge.workflow.chain-loader/list-chains)))
+
 ;------------------------------------------------------------------------------ Layer 6
 ;; Configurable workflow API (Legacy)
 

--- a/components/workflow/test/ai/miniforge/workflow/chain_loader_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_loader_test.clj
@@ -1,0 +1,33 @@
+(ns ai.miniforge.workflow.chain-loader-test
+  "Tests for chain definition loading."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.workflow.chain-loader :as chain-loader]))
+
+(deftest load-chain-versioned-test
+  (testing "loads chain by ID and version from resources"
+    (let [{:keys [chain source]} (chain-loader/load-chain :spec-to-pr "1.0.0")]
+      (is (= :spec-to-pr (:chain/id chain)))
+      (is (= "1.0.0" (:chain/version chain)))
+      (is (= :resource source))
+      (is (seq (:chain/steps chain))))))
+
+(deftest load-chain-latest-test
+  (testing "loads latest version when version is 'latest'"
+    (let [{:keys [chain]} (chain-loader/load-chain :spec-to-pr "latest")]
+      (is (= :spec-to-pr (:chain/id chain)))
+      (is (some? (:chain/version chain))))))
+
+(deftest load-chain-not-found-test
+  (testing "throws when chain not found"
+    (is (thrown-with-msg? Exception #"not found"
+          (chain-loader/load-chain :nonexistent-chain "1.0.0")))))
+
+(deftest list-chains-test
+  (testing "lists available chains"
+    (let [chains (chain-loader/list-chains)]
+      (is (seq chains))
+      (is (some #(= :spec-to-pr (:id %)) chains))
+      (let [spec-to-pr (first (filter #(= :spec-to-pr (:id %)) chains))]
+        (is (= "1.0.0" (:version spec-to-pr)))
+        (is (pos? (:steps spec-to-pr)))))))


### PR DESCRIPTION
## Summary
- Add `mf chain run <id>` and `mf chain list` CLI commands
- Add chain loader (`chain_loader.clj`) — loads chain EDN from `resources/chains/`
- Add reference `spec-to-pr-v1.0.0.edn` chain definition — runs lean-sdlc with full input passthrough
- Wire LLM client, event stream, and control state through chain context to `run-chain`
- Expose `load-chain` and `list-chains` on workflow interface

## Usage
```bash
# List available chains
mf chain list

# Run a chain with a spec file
mf chain run :spec-to-pr -s feature.spec.edn

# Run with inline JSON input
mf chain run :spec-to-pr --input-json '{"title": "Add feature X", "description": "..."}'
```

## Test plan
- [x] 4 chain loader tests pass (11 assertions)
- [x] Full `bb test` passes (0 failures)
- [x] Pre-commit hooks pass (lint, format, test, GraalVM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)