### PR TITLE
fix(workflow): chain loader JAR compatibility + test gap specs

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
@@ -18,41 +18,61 @@
 
 (ns ai.miniforge.workflow.chain-loader
   "Chain definition loading from classpath resources.
-   Loads chain EDN files from resources/chains/ directory."
+   Loads chain EDN files from resources/chains/ directory.
+   Works both on filesystem (dev) and inside uberjars."
   (:require
    [clojure.java.io :as io]
-   [clojure.edn :as edn]))
+   [clojure.edn :as edn]
+   [clojure.string :as str])
+  (:import
+   [java.util.jar JarFile]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; File helpers
+;; Resource enumeration
 
-(defn- edn-file?
-  "True when file is an existing .edn file."
-  [^java.io.File f]
-  (and (.isFile f) (.endsWith (.getName f) ".edn")))
+(defn- jar-entry-names
+  "List entry names under dir-prefix inside a JAR file."
+  [^java.net.URL jar-url dir-prefix]
+  (let [jar-path (-> (.getPath jar-url)
+                     (str/replace #"^file:" "")
+                     (str/replace #"!.*$" ""))]
+    (with-open [jf (JarFile. jar-path)]
+      (->> (enumeration-seq (.entries jf))
+           (map #(.getName %))
+           (filter #(str/starts-with? % dir-prefix))
+           (remove #(= % dir-prefix))
+           vec))))
 
-(defn- matches-prefix?
-  "True when filename starts with prefix."
-  [prefix ^java.io.File f]
-  (.startsWith (.getName f) prefix))
-
-(defn- resource-dir-files
-  "List files in a classpath resource directory, or nil."
+(defn- list-resource-names
+  "List resource names under a classpath directory.
+   Works for both filesystem directories and JAR entries."
   [dir-name]
   (when-let [dir-url (io/resource dir-name)]
-    (let [dir-file (io/file (.getPath dir-url))]
-      (when (.isDirectory dir-file)
-        (vec (.listFiles dir-file))))))
+    (let [protocol (.getProtocol dir-url)
+          prefix (if (str/ends-with? dir-name "/") dir-name (str dir-name "/"))]
+      (case protocol
+        "file" (let [dir-file (io/file (.getPath dir-url))]
+                 (when (.isDirectory dir-file)
+                   (->> (.listFiles dir-file)
+                        (filter #(.isFile ^java.io.File %))
+                        (map #(.getName ^java.io.File %))
+                        vec)))
+        "jar"  (->> (jar-entry-names dir-url prefix)
+                    (map #(str/replace-first % prefix ""))
+                    (remove #(str/includes? % "/"))
+                    vec)
+        nil))))
 
-(defn- parse-chain-file
-  "Parse a chain EDN file into a summary map, or nil on failure."
-  [^java.io.File f]
+(defn- parse-chain-resource
+  "Parse a chain resource path into a summary map, or nil on failure."
+  [resource-path]
   (try
-    (let [content (edn/read-string (slurp f))]
-      {:id (:chain/id content)
-       :version (:chain/version content)
-       :description (:chain/description content)
-       :steps (count (:chain/steps content))})
+    (when-let [url (io/resource resource-path)]
+      (let [content (edn/read-string (slurp url))]
+        {:id (:chain/id content)
+         :version (:chain/version content)
+         :description (:chain/description content)
+         :steps (count (:chain/steps content))}))
     (catch Exception _ nil)))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -63,10 +83,9 @@
    Returns a resource path string like \"chains/spec-to-pr-v1.0.0.edn\"."
   [chain-id]
   (let [prefix (str (name chain-id) "-v")
-        candidates (->> (resource-dir-files "chains")
-                        (filter edn-file?)
-                        (filter (partial matches-prefix? prefix))
-                        (map #(.getName %))
+        candidates (->> (list-resource-names "chains")
+                        (filter #(str/ends-with? % ".edn"))
+                        (filter #(str/starts-with? % prefix))
                         sort
                         reverse)]
     (when-let [filename (first candidates)]
@@ -107,7 +126,8 @@
 (defn list-chains
   "List all available chain definitions from classpath."
   []
-  (some->> (resource-dir-files "chains")
-           (filter edn-file?)
-           (keep parse-chain-file)
+  (some->> (list-resource-names "chains")
+           (filter #(str/ends-with? % ".edn"))
+           (map #(str "chains/" %))
+           (keep parse-chain-resource)
            vec))

--- a/work/algorithms-tests.spec.edn
+++ b/work/algorithms-tests.spec.edn
@@ -1,0 +1,79 @@
+{:spec/title "Add Comprehensive algorithms Component Tests"
+ :spec/description
+ "The algorithms component has 2 source files (graph.clj, interface.clj) with 0 tests.
+  Add thorough unit tests for DFS traversal, cycle detection, graph validation,
+  and collection. All functions are pure with well-documented behavior."
+
+ :spec/intent
+ {:type :test
+  :scope ["components/algorithms/src/ai/miniforge/algorithms/"
+          "components/algorithms/test/ai/miniforge/algorithms/"]}
+
+ :spec/constraints
+ ["Test all public API functions from interface.clj"
+  "Cover edge cases: empty graph, single node, disconnected components"
+  "Test cycle detection with various cycle shapes"
+  "All tests must pass with bb test"
+  "Pre-commit hooks must pass"]
+
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :plan/tasks
+ [{:task/id :test-dfs-traversal
+   :task/description
+   "Create algorithms/graph_test.clj with tests for:
+    - Basic DFS traversal visits all reachable nodes
+    - Correct visiting order (depth-first, not breadth-first)
+    - Traversal terminates on all graph shapes
+    - Pre-visit and post-visit hooks fire correctly
+    - Custom :neighbors-fn works
+    Read source: components/algorithms/src/ai/miniforge/algorithms/graph.clj"
+   :task/type :test
+   :task/dependencies []}
+
+  {:task/id :test-dfs-find
+   :task/description
+   "Add tests for dfs-find:
+    - Finds node matching predicate
+    - Returns nil when no match
+    - Stops early on first match
+    - Works with complex predicates
+    Read source: components/algorithms/src/ai/miniforge/algorithms/interface.clj"
+   :task/type :test
+   :task/dependencies []}
+
+  {:task/id :test-dfs-validate-graph
+   :task/description
+   "Add tests for dfs-validate-graph:
+    - Validates graph with no cycles passes
+    - Validates graph with cycles detects them
+    - Missing node references detected
+    - Custom validation hooks fire correctly
+    Read source: components/algorithms/src/ai/miniforge/algorithms/graph.clj"
+   :task/type :test
+   :task/dependencies []}
+
+  {:task/id :test-dfs-collect
+   :task/description
+   "Add tests for dfs-collect:
+    - Collects nodes matching criteria
+    - Different :collect-on modes work (:pre, :post)
+    - Accumulation with custom reduce function
+    - Empty graph returns empty collection
+    Read source: components/algorithms/src/ai/miniforge/algorithms/graph.clj"
+   :task/type :test
+   :task/dependencies []}
+
+  {:task/id :test-edge-cases
+   :task/description
+   "Add edge case tests:
+    - Empty graph (no nodes)
+    - Single node, no edges
+    - Disconnected components (only reachable nodes visited)
+    - Self-loops
+    - Diamond dependency patterns
+    - Very deep graphs (stack behavior)
+    Read source: components/algorithms/src/ai/miniforge/algorithms/graph.clj"
+   :task/type :test
+   :task/dependencies []}]}

--- a/work/pr-lifecycle-tests.spec.edn
+++ b/work/pr-lifecycle-tests.spec.edn
@@ -1,0 +1,89 @@
+{:spec/title "Add Comprehensive pr-lifecycle Tests"
+ :spec/description
+ "The pr-lifecycle component has 9 source files but only 1 integration test file.
+  Add focused unit tests for each submodule: controller state machine, CI monitoring,
+  review monitoring, comment triage, merge operations, and fix loop enforcement.
+  This is critical test coverage needed before YC MVP demo."
+
+ :spec/intent
+ {:type :test
+  :scope ["components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/"
+          "components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/"]}
+
+ :spec/constraints
+ ["Test each source file independently with mocked dependencies"
+  "Use with-redefs for shell command mocking (gh CLI calls)"
+  "No real GitHub API calls - all mocked"
+  "Follow existing test patterns (see pr-train tests for examples)"
+  "All tests must pass with bb test"
+  "Pre-commit hooks must pass"]
+
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :plan/tasks
+ [{:task/id :test-controller
+   :task/description
+   "Create pr_lifecycle/controller_test.clj with tests for:
+    - Controller creation with valid config
+    - State machine transitions (open -> ci-pending -> ci-passed -> review -> approved -> merging -> merged)
+    - Invalid state transition rejection
+    - Controller config validation
+    Read source: components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj"
+   :task/type :test
+   :task/dependencies []}
+
+  {:task/id :test-ci-monitor
+   :task/description
+   "Create pr_lifecycle/ci_monitor_test.clj with tests for:
+    - CI status check parsing (success, failure, pending, no checks)
+    - Retry logic on transient failures
+    - Timeout handling
+    - Status change detection
+    Mock: (sh \"gh\" \"pr\" \"checks\" ...) calls
+    Read source: components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/ci_monitor.clj"
+   :task/type :test
+   :task/dependencies []}
+
+  {:task/id :test-review-monitor
+   :task/description
+   "Create pr_lifecycle/review_monitor_test.clj with tests for:
+    - Review status parsing (approved, changes-requested, pending)
+    - Multiple reviewer handling
+    - Review state transitions
+    Mock: (sh \"gh\" \"pr\" \"view\" ...) calls
+    Read source: components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/review_monitor.clj"
+   :task/type :test
+   :task/dependencies []}
+
+  {:task/id :test-triage
+   :task/description
+   "Create pr_lifecycle/triage_test.clj with tests for:
+    - Comment classification (actionable vs informational)
+    - Review comment parsing
+    - Priority assignment
+    Read source: components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/triage.clj"
+   :task/type :test
+   :task/dependencies []}
+
+  {:task/id :test-merge
+   :task/description
+   "Create pr_lifecycle/merge_test.clj with tests for:
+    - Merge execution (squash, rebase, merge commit)
+    - Conflict detection and handling
+    - Auto-merge enable/disable
+    - Post-merge cleanup
+    Mock: (sh \"gh\" \"pr\" \"merge\" ...) calls
+    Read source: components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/merge.clj"
+   :task/type :test
+   :task/dependencies []}
+
+  {:task/id :test-fix-loop
+   :task/description
+   "Create pr_lifecycle/fix_loop_test.clj with tests for:
+    - Fix iteration counting
+    - Max iteration enforcement
+    - Fix loop state management
+    Read source: components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fix_loop.clj"
+   :task/type :test
+   :task/dependencies []}]}


### PR DESCRIPTION
## Summary
- Fixed `chain_loader.clj` to work inside uberjars — `resource-dir-files` used `io/file` + `.isDirectory` which fails for `jar:` URLs. Replaced with `list-resource-names` that handles both filesystem (dev) and JAR resource enumeration via `java.util.jar.JarFile`.
- Added two new work specs for test gap filling: `pr-lifecycle-tests.spec.edn` and `algorithms-tests.spec.edn`

## Test plan
- [x] `bb test` passes (all existing chain-loader tests still green)
- [x] `bb --jar dist/miniforge.jar chain list` now shows chains from inside the JAR
- [x] `bb --jar dist/miniforge.jar chain run spec-to-pr` resolves the chain correctly

Generated with [Claude Code](https://claude.com/claude-code)