### PR TITLE
fix(event-stream+workflow): flush event sinks and wire phase retry recovery

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -61,7 +61,8 @@
         (let [file-path (event-file-path workflow-id)]
           (with-open [writer (io/writer file-path :append true)]
             (.write writer (pr-str event))
-            (.write writer "\n")))
+            (.write writer "\n")
+            (.flush writer)))
         (catch Exception _e
           ;; Silently fail - don't break event stream
           nil)))))
@@ -91,7 +92,8 @@
                        :json (let [gen-str (requiring-resolve 'cheshire.core/generate-string)]
                                (str (gen-str event {:pretty (not compact?)})))
                        (pr-str event))]
-          (println output))
+          (println output)
+          (flush))
         (catch Exception _e
           nil)))))
 

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -188,8 +188,13 @@
   [pipeline current-index phase-config phase-result]
   (let [status (or (:status phase-result) (:phase/status phase-result))
         on-fail (:on-fail phase-config)
-        on-success (:on-success phase-config)]
+        on-success (:on-success phase-config)
+        redirect-to (:redirect-to phase-result)]
     (cond
+      ;; Phase requested retry — re-run current phase
+      (= :retrying status)
+      current-index
+
       ;; Phase completed successfully
       (= :completed status)
       (if on-success
@@ -204,6 +209,14 @@
           (if (< next-idx (count pipeline))
             next-idx
             :done)))
+
+      ;; Phase failed with redirect — jump to target phase
+      (and (= :failed status) redirect-to)
+      (let [target-index (->> pipeline
+                              (map-indexed vector)
+                              (filter #(= redirect-to (get-in (second %) [:config :phase])))
+                              (first))]
+        (if target-index (first target-index) :error))
 
       ;; Phase failed
       (= :failed status)


### PR DESCRIPTION
## Summary
- Event file sink was not calling `.flush()` after writes, causing events to sit in `BufferedWriter` memory instead of reaching disk. TUI and web dashboard depend on the file stream for live monitoring — this caused the monitoring views to stall mid-workflow.
- Pipeline executor did not handle `:retrying` status from phase error handlers, causing test/pre-commit failures to skip to the next phase instead of re-running the current one. Also wires `:redirect-to` for failed phases to jump back to earlier phases (e.g., verify failure -> implement).

## Test plan
- [x] Full poly test suite passes (0 failures, 0 errors)
- [x] GraalVM compatibility tests pass
- [ ] Manually verify event file updates in real-time during `mf run`
- [ ] Trigger a verify phase failure and confirm retry behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)