### PR TITLE
feat: wire tester agent to MCP artifact submission

### DIFF
--- a/components/agent/resources/prompts/tester.edn
+++ b/components/agent/resources/prompts/tester.edn
@@ -112,5 +112,19 @@ You must output a structured test artifact as a Clojure map:
     - No shared mutable state between tests
     - Use fixtures for setup/teardown
 
+## Preferred Output Method
+
+If the `submit_test_artifact` MCP tool is available, you MUST use it to submit your tests.
+Call `submit_test_artifact` with:
+- `files`: array of objects with `path` and `content`
+- `summary`: description of test coverage
+- `type`: \"unit\", \"integration\", \"property\", \"e2e\", or \"acceptance\" (optional)
+- `framework`: testing framework used, e.g. \"clojure.test\" (optional)
+- `coverage`: object with `lines`, `branches`, `functions` percentages (optional)
+
+Do NOT output raw EDN text when the MCP tool is available.
+
+If the tool is NOT available, fall back to the EDN output format described above.
+
 Remember: Good tests are documentation. They show how the code is intended to be used
 and what behavior is expected. Make tests readable and maintainable."}

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -2,6 +2,7 @@
   "Tester agent implementation.
    Generates tests for code artifacts and validates coverage."
   (:require
+   [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
@@ -294,20 +295,29 @@
                                "\n\nOutput your tests as a Clojure map following the format in your system prompt. "
                                "Include complete test code, not placeholders.")]
           (if llm-client
-            ;; Use the real LLM with streaming if callback provided
-            (let [response (if on-chunk
-                             (llm/chat-stream llm-client user-prompt on-chunk
-                                              {:system @tester-system-prompt})
-                             (llm/chat llm-client user-prompt
-                                       {:system @tester-system-prompt}))
+            ;; Use the real LLM with artifact session for MCP tool support
+            (let [{:keys [llm-result artifact]}
+                  (artifact-session/with-artifact-session [session]
+                    (let [mcp-opts {:mcp-config (:mcp-config-path session)}]
+                      (if on-chunk
+                        (llm/chat-stream llm-client user-prompt on-chunk
+                                         (merge {:system @tester-system-prompt} mcp-opts))
+                        (llm/chat llm-client user-prompt
+                                  (merge {:system @tester-system-prompt} mcp-opts)))))
+                  response llm-result
                   tokens (or (:tokens response) 0)]
               (log/info logger :tester :tester/llm-called
                         {:data {:success (llm/success? response)
                                 :tokens tokens
-                                :streaming? (boolean on-chunk)}})
+                                :streaming? (boolean on-chunk)
+                                :mcp-artifact? (boolean artifact)}})
               (if (llm/success? response)
+                ;; Check for MCP artifact first, then fall back to text parsing
                 (let [content (llm/get-content response)
-                      parsed (parse-test-response content)
+                      parsed (or artifact (parse-test-response content))
+                      _ (when artifact
+                          (log/info logger :tester :tester/mcp-artifact-received
+                                    {:data {:file-count (count (:test/files artifact))}}))
                       ;; Try multiple parsing strategies
                       tests (or parsed
                                 (when-let [files (extract-test-code-blocks content)]

--- a/docs/pull-requests/2026-02-28-feat-tester-mcp-integration.md
+++ b/docs/pull-requests/2026-02-28-feat-tester-mcp-integration.md
@@ -1,0 +1,62 @@
+# feat: Tester agent MCP integration
+
+**Branch:** `feat/tester-mcp-integration`
+**Date:** 2026-02-28
+**Dependencies:** `refactor/data-driven-mcp-artifact-server` (PR1)
+
+## Overview
+
+Wires the tester agent to use the `submit_test_artifact` MCP tool, with fallback to text parsing for backward compatibility.
+
+## Motivation
+
+The tester agent previously relied on parsing raw EDN or extracting code
+blocks from the LLM's text output. This is fragile and inconsistent with
+the implementer and planner agents, which already use MCP artifact sessions.
+Adding MCP support gives the tester the same structured submission path.
+
+## Changes in Detail
+
+### `components/agent/src/ai/miniforge/agent/tester.clj`
+
+- Added require: `[ai.miniforge.agent.artifact-session :as artifact-session]`
+- Wrapped the LLM call in `artifact-session/with-artifact-session`,
+  following the exact same pattern as `implementer.clj` and `planner.clj`:
+  - Passes `{:mcp-config (:mcp-config-path session)}` into LLM opts
+  - After LLM call: if `artifact` is non-nil, uses it; else falls through
+    to `parse-test-response` -> `extract-test-code-blocks` ->
+    `make-fallback-tests`
+- Added `:tester/mcp-artifact-received` log event when artifact found
+- No changes to the no-LLM-client fallback path (backward compat for testing)
+
+### `components/agent/resources/prompts/tester.edn`
+
+- Added "Preferred Output Method" section before the closing `Remember:` paragraph
+- Instructs LLM to use `submit_test_artifact` when available with params: `files`, `summary`, `type`, `framework`, `coverage`
+- Falls back to EDN output if tool unavailable
+
+## Testing Plan
+
+- Invoke tester with no LLM backend (`:echo` or nil) -> falls through to fallback tests (backward compat)
+- With `:claude` backend and MCP config -> should use MCP tool, artifact returned via session
+- Verify test artifact has proper UUID and timestamp after MCP round-trip
+- Verify assertion/case counts are populated from MCP artifact
+
+## Deployment Plan
+
+Merge after PR1 (data-driven MCP server). Independent of PR3 (releaser).
+
+## Related Issues/PRs
+
+- **Depends on:** PR1 (data-driven MCP artifact server)
+- **Parallel with:** PR3 (releaser MCP integration)
+- **Pattern from:** implementer.clj, planner.clj MCP integration
+
+## Checklist
+
+- [x] `artifact-session` require added to tester.clj
+- [x] LLM call wrapped with `with-artifact-session`
+- [x] MCP artifact preferred over text parsing
+- [x] Fallback to text parsing preserved
+- [x] `:tester/mcp-artifact-received` log event added
+- [x] Prompt updated with MCP tool instructions


### PR DESCRIPTION
## Summary

- Add `artifact-session` integration to tester agent
- LLM call wrapped with `with-artifact-session` for MCP tool support
- Prefer MCP artifact over text parsing, fall back gracefully
- Add `:tester/mcp-artifact-received` log event
- Update tester prompt with "Preferred Output Method" section

**Depends on:** #224

## Test plan

- [x] All existing tests pass (lint, unit, graalvm)
- [ ] Tester with no LLM backend falls through to fallback (backward compat)
- [ ] Tester with Claude backend uses MCP tool when available
- [ ] Test artifact has proper UUID and timestamp after MCP round-trip

See `docs/pull-requests/2026-02-28-feat-tester-mcp-integration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)