### PR TITLE
feat: wire releaser agent to MCP artifact submission

### DIFF
--- a/components/agent/resources/prompts/releaser.edn
+++ b/components/agent/resources/prompts/releaser.edn
@@ -83,5 +83,19 @@ How this was tested.\"
    - Brief count of files affected
    - Example: \"2 files created, 1 modified, 1 deleted\"
 
+## Preferred Output Method
+
+If the `submit_release_artifact` MCP tool is available, you MUST use it to submit your release metadata.
+Call `submit_release_artifact` with:
+- `branch_name`: git branch name (e.g. \"feature/add-auth\")
+- `commit_message`: git commit message in conventional commits format
+- `pr_title`: pull request title (max 70 characters)
+- `pr_description`: pull request description in markdown
+- `files_summary`: brief summary of files changed (optional)
+
+Do NOT output raw EDN text when the MCP tool is available.
+
+If the tool is NOT available, fall back to the EDN output format described above.
+
 Remember: Your release metadata will be used for git commits and GitHub PRs.
 Write messages that help reviewers understand the changes at a glance."}

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -3,6 +3,7 @@
    Generates branch names, commit messages, PR titles and descriptions
    for the release phase."
   (:require
+   [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
@@ -225,20 +226,28 @@
               on-chunk (:on-chunk context)
               user-prompt (input->text input context)]
           (if llm-client
-            ;; Use the real LLM with streaming if callback provided
-            (let [llm-response (if on-chunk
-                                 (llm/chat-stream llm-client user-prompt on-chunk
-                                                  {:system @releaser-system-prompt})
-                                 (llm/chat llm-client user-prompt
-                                           {:system @releaser-system-prompt}))
+            ;; Use the real LLM with artifact session for MCP tool support
+            (let [{:keys [llm-result artifact]}
+                  (artifact-session/with-artifact-session [session]
+                    (let [mcp-opts {:mcp-config (:mcp-config-path session)}]
+                      (if on-chunk
+                        (llm/chat-stream llm-client user-prompt on-chunk
+                                         (merge {:system @releaser-system-prompt} mcp-opts))
+                        (llm/chat llm-client user-prompt
+                                  (merge {:system @releaser-system-prompt} mcp-opts)))))
+                  llm-response llm-result
                   tokens (or (:tokens llm-response) 0)]
               (log/info logger :releaser :releaser/llm-called
                         {:data {:success (llm/success? llm-response)
                                 :tokens tokens
-                                :streaming? (boolean on-chunk)}})
+                                :streaming? (boolean on-chunk)
+                                :mcp-artifact? (boolean artifact)}})
               (if (llm/success? llm-response)
                 (let [content (llm/get-content llm-response)
-                      parsed (parse-release-response content)
+                      parsed (or artifact (parse-release-response content))
+                      _ (when artifact
+                          (log/info logger :releaser :releaser/mcp-artifact-received
+                                    {:data {:branch (:release/branch-name artifact)}}))
                       release (or parsed (make-fallback-artifact input))
                       ;; Ensure proper ID and timestamp
                       release-with-meta (-> release

--- a/docs/pull-requests/2026-02-28-feat-releaser-mcp-integration.md
+++ b/docs/pull-requests/2026-02-28-feat-releaser-mcp-integration.md
@@ -1,0 +1,64 @@
+# feat: Releaser agent MCP integration
+
+**Branch:** `feat/releaser-mcp-integration`
+**Date:** 2026-02-28
+**Dependencies:** `refactor/data-driven-mcp-artifact-server` (PR1)
+
+## Overview
+
+Wires the releaser agent to use the `submit_release_artifact` MCP tool, with fallback to text parsing for backward compatibility.
+
+## Motivation
+
+The releaser agent previously relied on parsing raw EDN from the LLM's
+text output. This is fragile and inconsistent with the implementer and
+planner agents, which already use MCP artifact sessions. Adding MCP
+support gives the releaser the same structured submission path.
+
+## Changes in Detail
+
+### `components/agent/src/ai/miniforge/agent/releaser.clj`
+
+- Added require: `[ai.miniforge.agent.artifact-session :as artifact-session]`
+- Wrapped the LLM call in `artifact-session/with-artifact-session`,
+  following the exact same pattern as `implementer.clj` and `planner.clj`:
+  - Passes `{:mcp-config (:mcp-config-path session)}` into LLM opts
+  - After LLM call: if `artifact` is non-nil, uses it; else falls through to `parse-release-response` -> `make-fallback-artifact`
+- Added `:releaser/mcp-artifact-received` log event when artifact found
+- Preserves `response/success` and `response/error` return convention (unlike tester/implementer which return raw maps)
+- No changes to the no-LLM-client fallback path (backward compat for testing)
+
+### `components/agent/resources/prompts/releaser.edn`
+
+- Added "Preferred Output Method" section before the closing `Remember:` paragraph
+- Instructs LLM to use `submit_release_artifact` when available with
+  params: `branch_name`, `commit_message`, `pr_title`, `pr_description`,
+  `files_summary`
+- Falls back to EDN output if tool unavailable
+
+## Testing Plan
+
+- Invoke releaser with no LLM backend -> falls through to fallback artifact (backward compat)
+- With `:claude` backend and MCP config -> should use MCP tool, artifact returned via session
+- Verify release artifact has proper UUID and timestamp after MCP round-trip
+- Verify `response/success` wrapping is preserved
+
+## Deployment Plan
+
+Merge after PR1 (data-driven MCP server). Independent of PR2 (tester).
+
+## Related Issues/PRs
+
+- **Depends on:** PR1 (data-driven MCP artifact server)
+- **Parallel with:** PR2 (tester MCP integration)
+- **Pattern from:** implementer.clj, planner.clj MCP integration
+
+## Checklist
+
+- [x] `artifact-session` require added to releaser.clj
+- [x] LLM call wrapped with `with-artifact-session`
+- [x] MCP artifact preferred over text parsing
+- [x] Fallback to text parsing preserved
+- [x] `response/success` / `response/error` convention preserved
+- [x] `:releaser/mcp-artifact-received` log event added
+- [x] Prompt updated with MCP tool instructions


### PR DESCRIPTION
## Summary

- Add `artifact-session` integration to releaser agent
- LLM call wrapped with `with-artifact-session` for MCP tool support
- Prefer MCP artifact over text parsing, fall back gracefully
- Preserve `response/success` and `response/error` return convention
- Add `:releaser/mcp-artifact-received` log event
- Update releaser prompt with "Preferred Output Method" section

**Depends on:** #224

## Test plan

- [x] All existing tests pass (lint, unit, graalvm)
- [ ] Releaser with no LLM backend falls through to fallback (backward compat)
- [ ] Releaser with Claude backend uses MCP tool when available
- [ ] Release artifact has proper UUID and timestamp after MCP round-trip

See `docs/pull-requests/2026-02-28-feat-releaser-mcp-integration.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)