### PR TITLE
feat(mcp): integrate artifact server as `miniforge mcp-serve` CLI subcommand

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -209,6 +209,16 @@
 (defn pr-respond-cmd [m] (cmd-pr/pr-respond-cmd (get-opts m)))
 (defn pr-merge-cmd [m] (cmd-pr/pr-merge-cmd (get-opts m)))
 
+(defn mcp-serve-cmd
+  "Run the MCP artifact server (stdin/stdout JSON-RPC)."
+  [m]
+  (let [{:keys [artifact-dir]} (get-opts m)]
+    (when-not artifact-dir
+      (display/print-error "--artifact-dir is required")
+      (System/exit 1))
+    (let [run-server (requiring-resolve 'ai.miniforge.mcp-artifact-server.interface/start-server)]
+      (run-server artifact-dir))))
+
 (defn help-cmd
   [_m]
   (println "
@@ -301,6 +311,11 @@ Examples:
    {:cmds ["doctor"]  :fn doctor-cmd}
    {:cmds ["help"]    :fn help-cmd}
    {:cmds []          :fn help-cmd}  ; default
+
+   ;; MCP artifact server
+   {:cmds ["mcp-serve"]
+    :fn mcp-serve-cmd
+    :spec {:artifact-dir {:alias :d}}}
 
    ;; Run command
    {:cmds ["run"]

--- a/bb.edn
+++ b/bb.edn
@@ -452,7 +452,9 @@
                  "components/policy-pack/src"
                  "components/policy-pack/resources"
                  "components/web-dashboard/src"
-                 "components/web-dashboard/resources"]
+                 "components/web-dashboard/resources"
+                 "components/mcp-artifact-server/src"
+                 "components/mcp-artifact-server/resources"]
    :extra-deps {metosin/malli {:mvn/version "0.16.1"}
                 clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}
                 aero/aero        {:mvn/version "1.1.6"}

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -81,13 +81,28 @@
                                   "scripts/mcp-artifact-server.bb"
                                   "MINIFORGE_HOME"]})))))
 
+(defn- resolve-server-classpath
+  "Build the full classpath for the MCP artifact server.
+
+   Includes both the src directory (for code) and the resources directory
+   (for tool-registry.edn). Falls back to src-only if resources doesn't exist."
+  [server-path]
+  (let [;; server-path ends with /src — derive /resources from the parent
+        parent (.getParent (io/file server-path))
+        resources-dir (io/file parent "resources")]
+    (if (.exists resources-dir)
+      (str server-path java.io.File/pathSeparator (.getAbsolutePath resources-dir))
+      server-path)))
+
 (defn- server-command
   "Build the command vector for starting the MCP server process."
   [server-path artifact-dir]
   (if (str/ends-with? server-path "/src")
     ;; Component mode: use bb -cp with main class
-    ["bb" "-cp" server-path "-m" "ai.miniforge.mcp-artifact-server.main"
-     "--artifact-dir" artifact-dir]
+    ;; Include resources dir on classpath for tool-registry.edn
+    (let [classpath (resolve-server-classpath server-path)]
+      ["bb" "-cp" classpath "-m" "ai.miniforge.mcp-artifact-server.main"
+       "--artifact-dir" artifact-dir])
     ;; Legacy script mode
     ["bb" server-path "--artifact-dir" artifact-dir]))
 

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -39,72 +39,41 @@
     {:valid? false
      :errors (m/explain Session session)}))
 
-(defn- resolve-server-script
-  "Find the MCP artifact server entry point.
+(defn- command-on-path?
+  "Check if a command exists on PATH."
+  [cmd]
+  (try
+    (let [proc (.exec (Runtime/getRuntime) (into-array String ["which" cmd]))]
+      (zero? (.waitFor proc)))
+    (catch Exception _ false)))
+
+(defn- resolve-miniforge-command
+  "Resolve the miniforge command to use for spawning subprocesses.
 
    Resolution order:
-   1. Component main class via bb -cp (preferred)
-   2. Legacy script at scripts/mcp-artifact-server.bb
-   3. MINIFORGE_HOME env var fallback
-
-   Throws if no candidate is found."
+   1. MINIFORGE_CMD env var (explicit override, e.g. \"/usr/local/bin/mf\")
+   2. \"miniforge\" on PATH (installed binary)
+   3. [\"bb\" \"miniforge\"] (dev mode — bb.edn task, requires CWD at project root)"
   []
-  (let [;; Prefer the component source directory
-        component-src (io/file "components/mcp-artifact-server/src")
-        ;; Legacy script
-        legacy-script (io/file "scripts/mcp-artifact-server.bb")
-        ;; MINIFORGE_HOME fallback
-        home-script (when-let [home (System/getenv "MINIFORGE_HOME")]
-                      (io/file home "components/mcp-artifact-server/src"))
-        home-legacy (when-let [home (System/getenv "MINIFORGE_HOME")]
-                      (io/file home "scripts/mcp-artifact-server.bb"))]
-    (cond
-      ;; Component exists — use bb -m with classpath
-      (and component-src (.exists component-src))
-      (.getAbsolutePath ^java.io.File component-src)
+  (cond
+    ;; 1. Explicit override
+    (System/getenv "MINIFORGE_CMD")
+    [(System/getenv "MINIFORGE_CMD")]
 
-      ;; Legacy script
-      (.exists legacy-script)
-      (.getAbsolutePath ^java.io.File legacy-script)
+    ;; 2. Installed binary on PATH
+    (command-on-path? "miniforge")
+    ["miniforge"]
 
-      ;; MINIFORGE_HOME component
-      (and home-script (.exists ^java.io.File home-script))
-      (.getAbsolutePath ^java.io.File home-script)
-
-      ;; MINIFORGE_HOME legacy
-      (and home-legacy (.exists ^java.io.File home-legacy))
-      (.getAbsolutePath ^java.io.File home-legacy)
-
-      :else
-      (throw (ex-info "Cannot resolve MCP artifact server: no component or script found"
-                       {:checked ["components/mcp-artifact-server/src"
-                                  "scripts/mcp-artifact-server.bb"
-                                  "MINIFORGE_HOME"]})))))
-
-(defn- resolve-server-classpath
-  "Build the full classpath for the MCP artifact server.
-
-   Includes both the src directory (for code) and the resources directory
-   (for tool-registry.edn). Falls back to src-only if resources doesn't exist."
-  [server-path]
-  (let [;; server-path ends with /src — derive /resources from the parent
-        parent (.getParent (io/file server-path))
-        resources-dir (io/file parent "resources")]
-    (if (.exists resources-dir)
-      (str server-path java.io.File/pathSeparator (.getAbsolutePath resources-dir))
-      server-path)))
+    ;; 3. Dev mode fallback (bb.edn task)
+    :else
+    ["bb" "miniforge"]))
 
 (defn- server-command
-  "Build the command vector for starting the MCP server process."
-  [server-path artifact-dir]
-  (if (str/ends-with? server-path "/src")
-    ;; Component mode: use bb -cp with main class
-    ;; Include resources dir on classpath for tool-registry.edn
-    (let [classpath (resolve-server-classpath server-path)]
-      ["bb" "-cp" classpath "-m" "ai.miniforge.mcp-artifact-server.main"
-       "--artifact-dir" artifact-dir])
-    ;; Legacy script mode
-    ["bb" server-path "--artifact-dir" artifact-dir]))
+  "Build the MCP config command map for starting the artifact server."
+  [artifact-dir]
+  (let [[cmd & args] (resolve-miniforge-command)]
+    {:command cmd
+     :args (vec (concat args ["mcp-serve" "--artifact-dir" artifact-dir]))}))
 
 (defn create-session!
   "Create a new artifact session with a temporary directory.
@@ -132,12 +101,11 @@
 
    Returns: session (for threading)"
   [session]
-  (let [server-path (resolve-server-script)
-        cmd-vec (server-command server-path (:dir session))
+  (let [{:keys [command args]} (server-command (:dir session))
         config {"mcpServers"
                 {"artifact"
-                 {"command" (first cmd-vec)
-                  "args" (vec (rest cmd-vec))}}}]
+                 {"command" command
+                  "args" args}}}]
     (spit (:mcp-config-path session) (json/generate-string config))
     session))
 

--- a/docs/pull-requests/2026-03-02-feat-integrate-mcp-artifact-server-cli.md
+++ b/docs/pull-requests/2026-03-02-feat-integrate-mcp-artifact-server-cli.md
@@ -1,0 +1,73 @@
+# feat: Integrate MCP artifact server into miniforge CLI
+
+## Overview
+
+Adds `miniforge mcp-serve` as a CLI subcommand so the MCP artifact server runs
+as part of miniforge itself, eliminating fragile CWD-relative path resolution
+and manual classpath construction.
+
+## Motivation
+
+The MCP artifact server previously ran as a separate Babashka subprocess spawned
+via `bb -cp components/mcp-artifact-server/src -m ...`. This required:
+
+- CWD to be the project root (broke when invoked from elsewhere)
+- Manual classpath assembly (src + resources directories)
+- Multiple fallback resolution strategies (component path, legacy script, MINIFORGE_HOME)
+
+By putting the MCP server on the CLI's classpath and exposing it as a command,
+`artifact_session.clj` can generate MCP configs that simply point back to
+`miniforge mcp-serve`, regardless of where the process is running.
+
+## Changes in Detail
+
+### 1. `bb.edn` — Add MCP component to CLI classpath
+
+Added `components/mcp-artifact-server/src` and `resources` to the `miniforge`
+task's `:extra-paths`.
+
+### 2. `bases/cli/src/ai/miniforge/cli/main.clj` — New `mcp-serve` command
+
+- `mcp-serve-cmd` handler using `requiring-resolve` for lazy loading
+- Dispatch table entry with `--artifact-dir` / `-d` spec
+
+### 3. `components/agent/src/.../artifact_session.clj` — Simplified config generation
+
+Replaced `resolve-server-script`, `resolve-server-classpath`, and the old
+`server-command` (60+ lines of path resolution) with:
+
+- `resolve-miniforge-command` — 3-tier resolution:
+  1. `MINIFORGE_CMD` env var (explicit override)
+  2. `miniforge` on PATH (installed binary)
+  3. `["bb" "miniforge"]` (dev mode fallback)
+- `server-command` — returns `{:command ... :args [...]}` for MCP config
+
+### 4. `scripts/test-mcp-artifact-server.bb` — Simplified test server startup
+
+Replaced manual classpath construction with `bb miniforge mcp-serve --artifact-dir`.
+
+## Testing Plan
+
+- [x] `bb miniforge mcp-serve` without `--artifact-dir` prints error and exits 1
+- [x] `bb test:mcp` — all 50 MCP integration tests pass
+- [ ] `bb test:all` — no regressions
+- [ ] `bb miniforge run work/<spec>` — workflows produce artifacts end-to-end
+
+## Deployment Plan
+
+Merge to main. No breaking changes — the MCP server interface is internal.
+
+## Related Issues/PRs
+
+- PR #233 (this branch: `fix/mcp-artifact-persistence`)
+- Prior: `2026-02-28-refactor-data-driven-mcp-artifact-server.md`
+- Prior: `2026-02-28-test-mcp-artifact-server.md`
+
+## Checklist
+
+- [x] MCP component on CLI classpath
+- [x] `mcp-serve` CLI subcommand wired up
+- [x] `artifact_session.clj` uses `miniforge mcp-serve`
+- [x] Test script uses `bb miniforge mcp-serve`
+- [x] 50/50 MCP tests passing
+- [ ] Full test suite passes

--- a/scripts/test-mcp-artifact-server.bb
+++ b/scripts/test-mcp-artifact-server.bb
@@ -57,18 +57,9 @@
 ;; --------------------------------------------------------------------------- Server process management
 
 (defn start-server [artifact-dir]
-  (let [;; Prefer component over legacy script
-        component-src (str (fs/absolutize "components/mcp-artifact-server/src"))
-        component-resources (str (fs/absolutize "components/mcp-artifact-server/resources"))
-        legacy-script (str (fs/absolutize "scripts/mcp-artifact-server.bb"))
-        proc (if (fs/exists? component-src)
-               (let [classpath (str component-src java.io.File/pathSeparator component-resources)]
-                 (p/process {:in :pipe :out :pipe :err :pipe}
-                            "bb" "-cp" classpath
-                            "-m" "ai.miniforge.mcp-artifact-server.main"
-                            "--artifact-dir" artifact-dir))
-               (p/process {:in :pipe :out :pipe :err :pipe}
-                          "bb" legacy-script "--artifact-dir" artifact-dir))]
+  (let [proc (p/process {:in :pipe :out :pipe :err :pipe}
+                        "bb" "miniforge" "mcp-serve"
+                        "--artifact-dir" artifact-dir)]
     ;; Give server a moment to start
     (Thread/sleep 200)
     proc))

--- a/scripts/test-mcp-artifact-server.bb
+++ b/scripts/test-mcp-artifact-server.bb
@@ -59,12 +59,14 @@
 (defn start-server [artifact-dir]
   (let [;; Prefer component over legacy script
         component-src (str (fs/absolutize "components/mcp-artifact-server/src"))
+        component-resources (str (fs/absolutize "components/mcp-artifact-server/resources"))
         legacy-script (str (fs/absolutize "scripts/mcp-artifact-server.bb"))
         proc (if (fs/exists? component-src)
-               (p/process {:in :pipe :out :pipe :err :pipe}
-                          "bb" "-cp" component-src
-                          "-m" "ai.miniforge.mcp-artifact-server.main"
-                          "--artifact-dir" artifact-dir)
+               (let [classpath (str component-src java.io.File/pathSeparator component-resources)]
+                 (p/process {:in :pipe :out :pipe :err :pipe}
+                            "bb" "-cp" classpath
+                            "-m" "ai.miniforge.mcp-artifact-server.main"
+                            "--artifact-dir" artifact-dir))
                (p/process {:in :pipe :out :pipe :err :pipe}
                           "bb" legacy-script "--artifact-dir" artifact-dir))]
     ;; Give server a moment to start


### PR DESCRIPTION
## Summary

- Adds `miniforge mcp-serve` CLI subcommand so the MCP artifact server runs as part of miniforge itself
- Eliminates fragile CWD-relative path resolution and manual classpath construction in `artifact_session.clj`
- Simplifies MCP config generation to point back to `miniforge mcp-serve --artifact-dir <dir>`
- 3-tier command resolution: `MINIFORGE_CMD` env var → `miniforge` on PATH → `bb miniforge` (dev fallback)

## Test plan

- [x] `bb miniforge mcp-serve` without `--artifact-dir` prints error and exits 1
- [x] `bb test:mcp` — 50/50 MCP integration tests pass
- [x] Pre-commit hooks pass (307 tests, 1523 assertions, 0 failures)

See `docs/pull-requests/2026-03-02-feat-integrate-mcp-artifact-server-cli.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)