### PR TITLE
fix: 8 bugs from YC MVP validation run

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -46,15 +46,42 @@
     (.mkdirs events-dir)
     (.getPath (io/file events-dir workflow-file))))
 
+(defn cleanup-stale-events!
+  "Delete event files older than TTL from the events directory.
+
+   Arguments:
+     opts - Map with optional:
+       :ttl-ms - Max age in milliseconds (default: 7 days)
+
+   Returns: Number of files deleted"
+  [& [opts]]
+  (let [ttl-ms (or (:ttl-ms opts) (* 7 24 60 60 1000))
+        home (System/getProperty "user.home")
+        events-dir (io/file home ".miniforge" "events")
+        cutoff (- (System/currentTimeMillis) ttl-ms)]
+    (if (.isDirectory events-dir)
+      (let [stale-files (->> (.listFiles events-dir)
+                             (filter #(and (.isFile %)
+                                           (str/ends-with? (.getName %) ".edn")
+                                           (< (.lastModified %) cutoff))))]
+        (doseq [f stale-files] (.delete f))
+        (count stale-files))
+      0)))
+
 (defn file-sink
   "Create a file sink that writes events to per-workflow files.
+
+   Performs lazy cleanup of stale event files (older than 7 days) on creation.
 
    Arguments:
      opts - Map with optional:
        :base-dir - Base directory (default: ~/.miniforge/events)
+       :ttl-ms   - Max event file age in ms (default: 7 days)
 
    Returns: Sink function (fn [event] -> nil)"
-  [& [_opts]]
+  [& [opts]]
+  ;; Non-blocking cleanup on sink creation
+  (future (try (cleanup-stale-events! opts) (catch Exception _ nil)))
   (fn [event]
     (when-let [workflow-id (:workflow/id event)]
       (try

--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -157,12 +157,19 @@
         duration-ms (- end-time start-time)
         result (get-in ctx [:phase :result])
         agent-status (:status result)
+        iterations (get-in ctx [:phase :iterations] 1)
+        max-iterations (get-in ctx [:phase :budget :iterations]
+                               (get-in default-config [:budget :iterations]))
         phase-status (cond
+                       ;; Error with retry budget remaining — retry
+                       (and (= :error agent-status)
+                            (< iterations max-iterations))
+                       :retrying
+                       ;; Error with budget exhausted — fail
                        (= :error agent-status) :failed
                        (= :already-implemented agent-status) :already-implemented
                        :else :completed)
         metrics (get result :metrics {:tokens 0 :duration-ms duration-ms})
-        iterations (get-in ctx [:phase :iterations] 1)
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)
                         (assoc-in [:phase :duration-ms] duration-ms)
@@ -180,8 +187,15 @@
       (println "WARNING: implement phase result has no :output — artifact may be nil"))
     ;; Emit phase completed event
     (emit-phase-completed! updated-ctx :implement result)
-    ;; Add skip metadata when work was already implemented
+    ;; Handle retrying: increment iteration counter and record last error
     (cond-> updated-ctx
+      (= :retrying phase-status)
+      (-> (update-in [:phase :iterations] (fnil inc 1))
+          (assoc-in [:phase :last-error]
+                    (or (get-in result [:error :message])
+                        (get-in result [:output :error])
+                        "Agent returned error status")))
+
       (= :already-implemented agent-status)
       (assoc-in [:phase :skipped-reason] :already-implemented))))
 

--- a/components/phase/src/ai/miniforge/phase/release.clj
+++ b/components/phase/src/ai/miniforge/phase/release.clj
@@ -188,12 +188,23 @@
         release-data (when (= :success (:status result)) (:output result))
         release-metrics (or (:release/metrics release-data) {})
         metrics (merge {:tokens 0 :duration-ms duration-ms} release-metrics)
+        agent-status (:status result)
         iterations (get-in ctx [:phase :iterations] 1)
+        max-iterations (get-in ctx [:phase :budget :iterations]
+                               (get-in default-config [:budget :iterations]))
+        phase-status (cond
+                       (= :success agent-status) :completed
+                       (and (= :error agent-status)
+                            (< iterations max-iterations)) :retrying
+                       (= :error agent-status) :failed
+                       ;; Fallback: if no explicit success, treat as failed
+                       (not= :success agent-status) :failed
+                       :else :completed)
         pr-info (get-in ctx [:workflow/pr-info])
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)
                         (assoc-in [:phase :duration-ms] duration-ms)
-                        (assoc-in [:phase :status] :completed)
+                        (assoc-in [:phase :status] phase-status)
                         (assoc-in [:phase :metrics] metrics)
                         (assoc-in [:metrics :release :duration-ms] duration-ms)
                         (assoc-in [:metrics :release :repair-cycles] (dec iterations))
@@ -206,7 +217,13 @@
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
     ;; Emit phase completed event
     (emit-phase-completed! updated-ctx :release result)
-    updated-ctx))
+    ;; Handle retrying: increment iteration counter
+    (cond-> updated-ctx
+      (= :retrying phase-status)
+      (-> (update-in [:phase :iterations] (fnil inc 1))
+          (assoc-in [:phase :last-error]
+                    (or (get-in result [:error :message])
+                        "Release phase failed"))))))
 
 (defn- error-release
   "Handle release phase errors."

--- a/components/phase/src/ai/miniforge/phase/review.clj
+++ b/components/phase/src/ai/miniforge/phase/review.clj
@@ -125,18 +125,32 @@
 (defn- leave-review
   "Post-processing for review phase.
 
-   Records review metrics: issues found, approval status."
+   Records review metrics: issues found, approval status.
+   When review decision is :changes-requested, sets status to :retrying
+   and stores review feedback for the implement phase to consume."
   [ctx]
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
         duration-ms (- end-time start-time)
         result (get-in ctx [:phase :result])
+        review-decision (get-in result [:output :review/decision])
         metrics (get result :metrics {:tokens 0 :duration-ms duration-ms})
         iterations (get-in ctx [:phase :iterations] 1)
+        max-iterations (get-in ctx [:phase :budget :iterations]
+                               (get-in default-config [:budget :iterations]))
+        phase-status (cond
+                       ;; Reviewer requested changes and we have retry budget
+                       (and (= :changes-requested review-decision)
+                            (< iterations max-iterations))
+                       :retrying
+                       ;; Reviewer requested changes but budget exhausted
+                       (= :changes-requested review-decision) :failed
+                       ;; Default: approved / completed
+                       :else :completed)
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)
                         (assoc-in [:phase :duration-ms] duration-ms)
-                        (assoc-in [:phase :status] :completed)
+                        (assoc-in [:phase :status] phase-status)
                         (assoc-in [:phase :metrics] metrics)
                         (assoc-in [:metrics :review :duration-ms] duration-ms)
                         (assoc-in [:metrics :review :repair-cycles] (dec iterations))
@@ -146,7 +160,13 @@
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
     ;; Emit phase completed event
     (emit-phase-completed! updated-ctx :review result)
-    updated-ctx))
+    ;; Handle retrying: store review feedback for implement phase
+    (cond-> updated-ctx
+      (= :retrying phase-status)
+      (-> (update-in [:phase :iterations] (fnil inc 1))
+          (assoc-in [:phase :review-feedback]
+                    (get-in result [:output :review/feedback]))
+          (assoc-in [:phase :redirect-to] :implement)))))
 
 (defn- error-review
   "Handle review phase errors.

--- a/components/phase/test/ai/miniforge/phase/artifact_persistence_test.clj
+++ b/components/phase/test/ai/miniforge/phase/artifact_persistence_test.clj
@@ -165,7 +165,7 @@
             "Source file content should match artifact")))))
 
 (deftest test-implement-fails-on-agent-error
-  (testing "leave-implement sets phase status to :failed when agent returns :error"
+  (testing "leave-implement retries when agent returns :error and within budget"
     (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                   agent/invoke (fn [_ _ _]
                                  ;; Simulate agent returning error status
@@ -173,9 +173,22 @@
       (let [ctx (create-base-context)
             ctx-entered (execute-phase-enter :implement ctx)
             ctx-left (execute-phase-leave :implement ctx-entered)]
-        ;; Agent returned :error status, so leave-implement should set :failed
+        ;; Agent returned :error status within retry budget — should retry
+        (is (= :retrying (get-in ctx-left [:phase :status]))
+            "Phase status should be :retrying when agent returns error within budget")
+        (is (= :retrying (get-in ctx-left [:execution/phase-results :implement :status]))
+            "Stored phase result should also show :retrying"))))
+
+  (testing "leave-implement fails when agent returns :error and budget exhausted"
+    (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
+                  agent/invoke (fn [_ _ _]
+                                 (response/error "LLM timeout" {:tokens 0 :duration-ms 5000}))]
+      (let [ctx (-> (create-base-context)
+                    (assoc-in [:phase :iterations] 5)) ;; At max budget
+            ctx-entered (execute-phase-enter :implement ctx)
+            ctx-left (execute-phase-leave :implement ctx-entered)]
         (is (= :failed (get-in ctx-left [:phase :status]))
-            "Phase status should be :failed when agent returns error")
+            "Phase status should be :failed when budget exhausted")
         (is (= :failed (get-in ctx-left [:execution/phase-results :implement :status]))
             "Stored phase result should also show :failed")))))
 

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -160,17 +160,21 @@
 (defn- task-sub-opts
   "Build execution opts for a DAG task's sub-workflow.
 
-   Carries forward LLM backend and event stream from parent context,
-   disables DAG execution to prevent recursion, and skips lifecycle
-   events (parent workflow owns those)."
+   Carries forward LLM backend, event stream, and sandbox/isolation config
+   from parent context. Disables DAG execution to prevent recursion and
+   skips lifecycle events (parent workflow owns those)."
   [context]
   (cond-> {:disable-dag-execution true
            :skip-lifecycle-events true
            :quiet true}
-    (:llm-backend context) (assoc :llm-backend (:llm-backend context))
-    (:event-stream context) (assoc :event-stream (:event-stream context))
+    (:llm-backend context)      (assoc :llm-backend (:llm-backend context))
+    (:event-stream context)     (assoc :event-stream (:event-stream context))
     (get-in context [:execution/opts :event-stream])
-    (assoc :event-stream (get-in context [:execution/opts :event-stream]))))
+    (assoc :event-stream (get-in context [:execution/opts :event-stream]))
+    (:executor context)         (assoc :executor (:executor context))
+    (:environment-id context)   (assoc :environment-id (:environment-id context))
+    (:sandbox-workdir context)  (assoc :sandbox-workdir (:sandbox-workdir context))
+    (:worktree-path context)    (assoc :worktree-path (:worktree-path context))))
 
 ;--- Layer 1: Mini-Workflow Execution
 
@@ -236,10 +240,11 @@
 
 ;--- Layer 2: Synchronous DAG Execution
 
-(defn- compute-ready-tasks [tasks-map completed-ids]
+(defn- compute-ready-tasks [tasks-map completed-ids failed-ids]
   (->> tasks-map
        (filter (fn [[task-id task]]
                  (and (not (contains? completed-ids task-id))
+                      (not (contains? failed-ids task-id))
                       (every? #(contains? completed-ids %) (:task/deps task #{})))))))
 
 (defn- execute-tasks-batch [tasks execute-fn context]
@@ -267,35 +272,54 @@
         total-tokens (->> (vals all-results) (map #(get-in % [:data :metrics :tokens] 0)) (reduce + 0))]
     {:artifacts artifacts :total-tokens total-tokens}))
 
+(defn- propagate-failures
+  "Mark tasks whose deps include any failed task as transitively failed."
+  [tasks-map failed-ids]
+  (loop [propagated failed-ids]
+    (let [newly-failed (->> tasks-map
+                            (filter (fn [[tid task]]
+                                      (and (not (contains? propagated tid))
+                                           (some propagated (:task/deps task #{})))))
+                            (map first)
+                            set)]
+      (if (empty? newly-failed)
+        propagated
+        (recur (into propagated newly-failed))))))
+
 (defn- execute-dag-loop [tasks-map context logger]
   (let [{:keys [on-task-start on-task-complete]} context
         max-parallel (or (:max-parallel context) 4)]
     (loop [completed-ids #{}
            failed-ids #{}
            all-results {}
+           sub-workflow-ids []
            iteration 0]
-      (let [ready-tasks (compute-ready-tasks tasks-map completed-ids)]
+      (let [all-failed (propagate-failures tasks-map failed-ids)
+            ready-tasks (compute-ready-tasks tasks-map completed-ids all-failed)]
         (cond
           (empty? ready-tasks)
           (let [{:keys [artifacts total-tokens]} (aggregate-results all-results)]
             (log/info logger :dag-orchestrator :dag/completed
                       {:data {:completed (count completed-ids)
-                              :failed (count failed-ids)
+                              :failed (count all-failed)
                               :iterations iteration}})
-            (dag-execution-result (count completed-ids) (count failed-ids) artifacts total-tokens))
+            (assoc (dag-execution-result (count completed-ids) (count all-failed) artifacts total-tokens)
+                   :sub-workflow-ids (vec sub-workflow-ids)))
 
           (> iteration 100)
-          (dag-execution-error (count completed-ids) (count failed-ids) "Max iterations exceeded")
+          (dag-execution-error (count completed-ids) (count all-failed) "Max iterations exceeded")
 
           :else
           (let [batch (take max-parallel ready-tasks)
                 _ (notify-batch-start batch on-task-start)
                 results (execute-tasks-batch batch execute-single-task context)
                 _ (notify-batch-complete results on-task-complete)
-                {:keys [completed failed]} (partition-results results)]
+                {:keys [completed failed]} (partition-results results)
+                batch-sub-ids (map (fn [[tid _]] (keyword (str "dag-task-" tid))) batch)]
             (recur (into completed-ids completed)
                    (into failed-ids failed)
                    (merge all-results results)
+                   (into sub-workflow-ids batch-sub-ids)
                    (inc iteration))))))))
 
 (defn execute-plan-as-dag [plan context]

--- a/docs/pull-requests/2026-03-03-fix-yc-mvp-validation-bugs.md
+++ b/docs/pull-requests/2026-03-03-fix-yc-mvp-validation-bugs.md
@@ -1,0 +1,57 @@
+# Fix 8 Bugs Found During YC MVP Validation Run
+
+**Branch:** `fix/yc-mvp-validation-bugs`
+**Base:** `feat/meta-agent-supervision`
+**Date:** 2026-03-03
+
+## Summary
+
+Fixes 8 bugs discovered by running `bb miniforge run work/finish-yc-mvp.spec.edn`
+(8 DAG tasks) as a validation exercise. Result before fixes: 7 tasks completed,
+2 failed, "Max iterations exceeded" from an infinite-loop failure cascade.
+
+## Bugs Fixed
+
+### Commit 1: DAG failure cascade + context forwarding
+
+| Bug | Problem | Fix |
+|-----|---------|-----|
+| **4** — DAG infinite loop on failure | `compute-ready-tasks` only checks `completed-ids`, ignoring `failed-ids`. Tasks depending on failed tasks are perpetually "ready", causing the loop to hit iteration 100. | Added `failed-ids` parameter and `propagate-failures` for transitive failure marking. Tasks blocked by failures are skipped. |
+| **3** — Sandbox context keys dropped | `task-sub-opts` drops `:executor`, `:environment-id`, `:sandbox-workdir`, `:worktree-path` from parent context. Sub-workflows can't use sandbox. | Forward all 4 keys from parent context. |
+| **7** — Sub-workflow events orphaned | Each sub-workflow creates its own event files but parent DAG never tracks them. | Track sub-workflow IDs in `execute-dag-loop` and include `:sub-workflow-ids` in DAG result map. |
+
+### Commit 2: Soft-failure retry (pre-existing)
+
+| Bug | Problem | Fix |
+|-----|---------|-----|
+| **1** — No retry on soft agent failure | `leave-implement` mapped all `:error` agent status to `:failed` without checking retry budget. | Error + budget remaining → `:retrying`, error + budget exhausted → `:failed`. |
+
+### Commit 3: Release + review phase repairs
+
+| Bug | Problem | Fix |
+|-----|---------|-----|
+| **5** — Release phase 0ms no-op | `leave-release` always sets status to `:completed` regardless of result. | Check agent result `:status` flag. `:success` → `:completed`, `:error` → `:failed`/`:retrying`. |
+| **6** — Review can't trigger repair loop | `leave-review` ignores `:review/decision` from agent output. `:changes-requested` silently marked `:completed`. | Check `[:output :review/decision]`. If `:changes-requested`, set `:retrying` with `:redirect-to :implement` and store review feedback. |
+
+### Commit 4: Event file cleanup
+
+| Bug | Problem | Fix |
+|-----|---------|-----|
+| **8** — Stale event file accumulation | `file-sink` creates per-workflow `.edn` files with no cleanup. | Added `cleanup-stale-events!` (configurable TTL, default 7 days). Called non-blocking on file-sink creation. |
+| **2** — Broken generated test | `fleet_pure_test.clj` references non-existent var. | Already removed from repo (was untracked). |
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `components/workflow/src/.../dag_orchestrator.clj` | Failure propagation, context forwarding, sub-workflow tracking |
+| `components/phase/src/.../implement.clj` | Soft-failure retry logic |
+| `components/phase/test/.../artifact_persistence_test.clj` | Test for retry behavior |
+| `components/phase/src/.../release.clj` | Status-aware leave-release |
+| `components/phase/src/.../review.clj` | Review decision → repair loop |
+| `components/event-stream/src/.../sinks.clj` | Stale file cleanup |
+
+## Verification
+
+- `bb test` — 650 tests, 3181 assertions, 0 failures, 0 errors
+- All pre-commit hooks pass (lint, format, test)


### PR DESCRIPTION
## Summary

- **DAG infinite loop on failure**: `compute-ready-tasks` now skips tasks blocked by failed dependencies, with transitive failure propagation
- **Sandbox context keys dropped**: Sub-workflows inherit `:executor`, `:environment-id`, `:sandbox-workdir`, `:worktree-path`
- **Soft-failure retry**: `leave-implement` checks retry budget before failing
- **Release phase 0ms no-op**: `leave-release` checks result `:status` instead of unconditional `:completed`
- **Review can't trigger repair loop**: `leave-review` inspects `:review/decision`, redirects to implement on `:changes-requested`
- **Sub-workflow tracking**: DAG result includes `:sub-workflow-ids`
- **Stale event file cleanup**: `file-sink` runs `cleanup-stale-events!` on creation (7-day TTL)
- **Broken generated test**: Already removed (was untracked)

## Test plan

- [x] `bb test` — 650 tests, 3181 assertions, 0 failures
- [ ] Manual: DAG with a failing task exits cleanly instead of looping to iteration 100
- [ ] Manual: Review `:changes-requested` triggers re-entry to implement
- [ ] Manual: Event files older than TTL cleaned up on sink creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)