### PR TITLE
feat: DAG rate limit resilience — failover, graceful pause, and resume

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj
@@ -107,7 +107,8 @@
                                              :skip-lifecycle-events false})
         ;; Enrich context with workflow definition for sub-workflow construction
         ctx (assoc ctx :execution/workflow workflow
-                       :workflow-id workflow-id)]
+                       :workflow-id workflow-id
+                       :pre-completed-ids (get opts :pre-completed-dag-tasks #{}))]
     (when-not quiet
       (display/print-info (str "Executing plan: " plan-id " (" task-count " tasks)"))
       (display/print-info (str "Format: " (name format-type))))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -30,6 +30,23 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Context reconstruction
 
+(defn- extract-completed-dag-tasks
+  "Extract task IDs that completed successfully from :dag/task-completed events."
+  [events]
+  (->> events
+       (filter #(= :dag/task-completed (:event/type %)))
+       (map :dag/task-id)
+       set))
+
+(defn- extract-dag-pause-info
+  "Find last :dag/paused event and extract completed task IDs and reason."
+  [events]
+  (when-let [pause-event (->> events
+                               (filter #(= :dag/paused (:event/type %)))
+                               last)]
+    {:completed-task-ids (set (:dag/completed-task-ids pause-event))
+     :pause-reason (:dag/pause-reason pause-event)}))
+
 (defn- extract-completed-phases
   "Extract phase names that completed successfully from events."
   [events]
@@ -68,14 +85,21 @@
         workflow-spec (find-workflow-spec events)
         started-event (first (get by-type :workflow/started))
         completed? (boolean (seq (get by-type :workflow/completed)))
-        failed? (boolean (seq (get by-type :workflow/failed)))]
+        failed? (boolean (seq (get by-type :workflow/failed)))
+        completed-dag-tasks (extract-completed-dag-tasks events)
+        dag-pause-info (extract-dag-pause-info events)]
     {:phase-results phase-results
      :completed-phases completed-phases
      :workflow-spec workflow-spec
      :workflow-id (or (:workflow/id started-event) workflow-id)
      :completed? completed?
      :failed? failed?
-     :event-count (count events)}))
+     :event-count (count events)
+     :completed-dag-tasks (or (not-empty completed-dag-tasks)
+                              (:completed-task-ids dag-pause-info)
+                              #{})
+     :dag-paused? (boolean dag-pause-info)
+     :dag-pause-reason (:pause-reason dag-pause-info)}))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public API
@@ -146,6 +170,7 @@
                                       :event-stream event-stream
                                       :control-state control-state
                                       :skip-lifecycle-events false
+                                      :pre-completed-dag-tasks (:completed-dag-tasks reconstructed)
                                       :on-phase-start (fn [_ctx interceptor]
                                                         (when-not quiet
                                                           (display/print-info

--- a/components/agent-runtime/resources/error-patterns/external.edn
+++ b/components/agent-runtime/resources/error-patterns/external.edn
@@ -7,7 +7,8 @@
   {:regex "Network error"
    :description "Network connectivity issue"}
   {:regex "API rate limit exceeded"
-   :description "API rate limit hit"}
+   :description "API rate limit hit"
+   :rate-limit? true}
   {:regex "API service unavailable"
    :description "API temporarily unavailable"}
   {:regex "Request timeout"
@@ -23,4 +24,19 @@
   {:regex "permission denied|Permission denied|EACCES"
    :description "File permission error"}
   {:regex "Codex cannot access session files"
-   :description "Codex session directory permission issue"}]}
+   :description "Codex session directory permission issue"}
+  {:regex "(?i)you've hit your limit"
+   :description "Claude CLI rate limit reached"
+   :rate-limit? true}
+  {:regex "(?i)rate.?limit"
+   :description "Generic rate limit"
+   :rate-limit? true}
+  {:regex "(?i)quota.?exceeded"
+   :description "API quota exceeded"
+   :rate-limit? true}
+  {:regex "429|Too Many Requests"
+   :description "HTTP 429 Too Many Requests"
+   :rate-limit? true}
+  {:regex "resets \\d+[ap]m|resets in \\d+"
+   :description "Rate limit with reset time indicator"
+   :rate-limit? true}]}

--- a/components/workflow/src/ai/miniforge/workflow/configurable.clj
+++ b/components/workflow/src/ai/miniforge/workflow/configurable.clj
@@ -178,6 +178,8 @@
                                                                      {:phase/id :dag-task
                                                                       :task-id task-id}
                                                                      result)))})
+        dag-context (assoc dag-context :pre-completed-ids
+                          (get-in context [:pre-completed-dag-tasks] #{}))
         dag-result (dag-orch/execute-plan-as-dag plan dag-context)]
 
     ;; Merge DAG results into execution state

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -307,6 +307,28 @@
         propagated
         (recur (into propagated newly-failed))))))
 
+(defn- handle-rate-limit-in-batch
+  "Handle rate-limited tasks in a batch. Returns either:
+   - {:action :continue :new-backend X} to re-queue tasks
+   - {:action :pause :result <paused-map>} to stop execution"
+  [context rate-limited-ids new-completed failed-ids all-results
+   event-stream workflow-id logger]
+  (let [decision (resilience/handle-rate-limited-batch
+                  context rate-limited-ids new-completed logger)]
+    (if (= :continue (:action decision))
+      decision
+      (let [{:keys [artifacts]} (aggregate-results all-results)]
+        (resilience/emit-dag-paused! event-stream workflow-id new-completed (:reason decision))
+        {:action :pause
+         :result (dag-execution-paused (count new-completed) (count failed-ids)
+                                       artifacts (:reason decision))}))))
+
+(defn- emit-completed-checkpoints!
+  "Emit task-completed events for checkpointing."
+  [completed-task-ids results event-stream workflow-id]
+  (doseq [tid completed-task-ids]
+    (resilience/emit-dag-task-completed! event-stream workflow-id tid (get results tid))))
+
 (defn- execute-dag-loop [tasks-map context logger]
   (let [{:keys [on-task-start on-task-complete]} context
         max-parallel (get context :max-parallel 4)
@@ -347,26 +369,21 @@
                 {:keys [rate-limited-ids]} (resilience/analyze-batch-for-rate-limits results)
                 new-completed (into completed-ids completed)]
 
-            ;; Emit task-completed events for checkpointing
-            (doseq [tid completed]
-              (resilience/emit-dag-task-completed! event-stream workflow-id tid (get results tid)))
+            (emit-completed-checkpoints! completed results event-stream workflow-id)
 
             (if (seq rate-limited-ids)
               ;; Handle rate-limited batch
-              (let [decision (resilience/handle-rate-limited-batch
-                              context rate-limited-ids new-completed logger)]
+              (let [decision (handle-rate-limit-in-batch
+                              context rate-limited-ids new-completed failed-ids
+                              all-results event-stream workflow-id logger)]
                 (if (= :continue (:action decision))
-                  ;; Re-queue rate-limited tasks with new backend, don't mark as failed
                   (recur new-completed
                          failed-ids
                          (merge all-results (select-keys results completed))
                          (into sub-workflow-ids batch-sub-ids)
                          (:new-backend decision)
                          (inc iteration))
-                  ;; Pause — emit event and return paused result
-                  (let [{:keys [artifacts]} (aggregate-results all-results)]
-                    (resilience/emit-dag-paused! event-stream workflow-id new-completed (:reason decision))
-                    (dag-execution-paused (count new-completed) (count failed-ids) artifacts (:reason decision)))))
+                  (:result decision)))
 
               ;; Normal path — no rate limits
               (recur new-completed

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -26,7 +26,8 @@
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
-   [ai.miniforge.phase.registry :as phase-reg]))
+   [ai.miniforge.phase.registry :as phase-reg]
+   [ai.miniforge.workflow.dag-resilience :as resilience]))
 
 ;--- Layer 0: Result Constructors
 
@@ -54,6 +55,15 @@
    :artifacts []
    :metrics {}
    :error error})
+
+(defn- dag-execution-paused [completed failed artifacts reason]
+  {:success? false
+   :paused? true
+   :tasks-completed completed
+   :tasks-failed failed
+   :artifacts (vec artifacts)
+   :pause-reason reason
+   :metrics {}})
 
 ;--- Layer 0: Level Traversal
 
@@ -299,11 +309,15 @@
 
 (defn- execute-dag-loop [tasks-map context logger]
   (let [{:keys [on-task-start on-task-complete]} context
-        max-parallel (get context :max-parallel 4)]
-    (loop [completed-ids #{}
+        max-parallel (get context :max-parallel 4)
+        event-stream (or (:event-stream context)
+                         (get-in context [:execution/opts :event-stream]))
+        workflow-id (:workflow-id context)]
+    (loop [completed-ids (get context :pre-completed-ids #{})
            failed-ids #{}
            all-results {}
            sub-workflow-ids []
+           current-backend (get context :current-backend)
            iteration 0]
       (let [all-failed (propagate-failures tasks-map failed-ids)
             ready-tasks (compute-ready-tasks tasks-map completed-ids all-failed)]
@@ -323,23 +337,57 @@
           :else
           (let [batch (take max-parallel ready-tasks)
                 _ (notify-batch-start batch on-task-start)
-                results (execute-tasks-batch batch execute-single-task context)
+                ctx (cond-> context
+                      current-backend (assoc :current-backend current-backend))
+                results (execute-tasks-batch batch execute-single-task ctx)
                 _ (notify-batch-complete results on-task-complete)
                 {:keys [completed failed]} (partition-results results)
-                batch-sub-ids (map (fn [[tid _]] (keyword (str "dag-task-" tid))) batch)]
-            (recur (into completed-ids completed)
-                   (into failed-ids failed)
-                   (merge all-results results)
-                   (into sub-workflow-ids batch-sub-ids)
-                   (inc iteration))))))))
+                batch-sub-ids (map (fn [[tid _]] (keyword (str "dag-task-" tid))) batch)
+                ;; Analyze for rate limits
+                {:keys [rate-limited-ids]} (resilience/analyze-batch-for-rate-limits results)
+                new-completed (into completed-ids completed)]
+
+            ;; Emit task-completed events for checkpointing
+            (doseq [tid completed]
+              (resilience/emit-dag-task-completed! event-stream workflow-id tid (get results tid)))
+
+            (if (seq rate-limited-ids)
+              ;; Handle rate-limited batch
+              (let [decision (resilience/handle-rate-limited-batch
+                              context rate-limited-ids new-completed logger)]
+                (if (= :continue (:action decision))
+                  ;; Re-queue rate-limited tasks with new backend, don't mark as failed
+                  (recur new-completed
+                         failed-ids
+                         (merge all-results (select-keys results completed))
+                         (into sub-workflow-ids batch-sub-ids)
+                         (:new-backend decision)
+                         (inc iteration))
+                  ;; Pause — emit event and return paused result
+                  (let [{:keys [artifacts]} (aggregate-results all-results)]
+                    (resilience/emit-dag-paused! event-stream workflow-id new-completed (:reason decision))
+                    (dag-execution-paused (count new-completed) (count failed-ids) artifacts (:reason decision)))))
+
+              ;; Normal path — no rate limits
+              (recur new-completed
+                     (into failed-ids failed)
+                     (merge all-results results)
+                     (into sub-workflow-ids batch-sub-ids)
+                     current-backend
+                     (inc iteration)))))))))
 
 (defn execute-plan-as-dag [plan context]
   (let [logger (or (:logger context) (log/create-logger {:min-level :info}))
         task-defs (plan->dag-tasks plan context)
-        tasks-map (->> task-defs (map (fn [t] [(:task/id t) t])) (into {}))]
+        tasks-map (->> task-defs (map (fn [t] [(:task/id t) t])) (into {}))
+        pre-completed (get context :pre-completed-ids #{})
+        ctx (cond-> context
+              (seq pre-completed) (assoc :pre-completed-ids pre-completed))]
     (log/info logger :dag-orchestrator :dag/starting
-              {:data {:plan-id (:plan/id plan) :task-count (count task-defs)}})
-    (execute-dag-loop tasks-map context logger)))
+              {:data {:plan-id (:plan/id plan)
+                      :task-count (count task-defs)
+                      :pre-completed (count pre-completed)}})
+    (execute-dag-loop tasks-map ctx logger)))
 
 ;--- Layer 3: Workflow Integration
 

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -60,6 +60,20 @@
                   (str result))]
       (boolean (some #(re-find % msg) @rate-limit-patterns)))))
 
+(defn- find-healthy-backend
+  "Find a healthy backend from the allowed list, excluding the current one.
+   Records the current backend's failure, then returns the first candidate."
+  [current-backend allowed-backends]
+  (try
+    (let [record-call! (requiring-resolve 'ai.miniforge.self-healing.backend-health/record-backend-call!)]
+      (record-call! current-backend false)
+      (first (filter #(not= % (keyword current-backend))
+                     (map keyword allowed-backends))))
+    (catch Exception _
+      ;; If backend-health isn't available, still pick from allowed list
+      (first (filter #(not= % (keyword current-backend))
+                     (map keyword allowed-backends))))))
+
 ;--- Layer 1: Backend Failover + Event Emission
 
 (defn attempt-backend-switch
@@ -82,25 +96,21 @@
 
     ;; Try to find a healthy backend from the allowed list
     :else
-    (try
-      (let [record-call! (requiring-resolve 'ai.miniforge.self-healing.backend-health/record-backend-call!)
-            trigger-switch! (requiring-resolve 'ai.miniforge.self-healing.backend-health/trigger-backend-switch!)
-            _ (record-call! current-backend false)
-            ;; Pick first allowed backend that isn't the current one
-            candidate (first (filter #(not= % (keyword current-backend))
-                                     (map keyword allowed-backends)))]
-        (if candidate
-          (let [result (trigger-switch! current-backend candidate)]
+    (let [candidate (find-healthy-backend current-backend allowed-backends)]
+      (if candidate
+        (try
+          (let [trigger-switch! (requiring-resolve 'ai.miniforge.self-healing.backend-health/trigger-backend-switch!)
+                result (trigger-switch! current-backend candidate)]
             (log/info logger :dag-resilience :failover/switched
                       {:data {:from current-backend :to candidate}})
             {:switched? true :new-backend candidate :switch-result result})
-          (do (log/info logger :dag-resilience :failover/exhausted
-                        {:data {:allowed allowed-backends}})
-              {:switched? false :exhausted? true :reason :all-allowed-exhausted})))
-      (catch Exception e
-        (log/info logger :dag-resilience :failover/error
-                  {:data {:error (.getMessage e)}})
-        {:switched? false :reason :failover-error :error (.getMessage e)}))))
+          (catch Exception e
+            (log/info logger :dag-resilience :failover/error
+                      {:data {:error (.getMessage e)}})
+            {:switched? false :reason :failover-error :error (.getMessage e)}))
+        (do (log/info logger :dag-resilience :failover/exhausted
+                      {:data {:allowed allowed-backends}})
+            {:switched? false :exhausted? true :reason :all-allowed-exhausted})))))
 
 (defn emit-dag-task-completed!
   "Publish :dag/task-completed event for checkpointing."

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -1,0 +1,180 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.dag-resilience
+  "Rate limit detection, backend failover, and DAG pause/resume support.
+
+   Keeps the DAG orchestrator under 400 lines by extracting resilience
+   concerns into this module. Three layers:
+   - Layer 0: Rate limit detection from error patterns
+   - Layer 1: Backend failover + event emission
+   - Layer 2: Batch analysis + rate limit handling"
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]))
+
+;--- Layer 0: Rate Limit Detection
+
+(defn- load-rate-limit-patterns
+  "Load and compile rate-limit patterns from external error patterns.
+   Returns a seq of compiled regex patterns."
+  []
+  (try
+    (let [load-fn (requiring-resolve 'ai.miniforge.agent-runtime.error-classifier.patterns/external-patterns)]
+      (->> @load-fn
+           (filter :rate-limit?)
+           (map :regex)))
+    (catch Exception _
+      ;; Fallback patterns if error-classifier not available
+      (map re-pattern
+           ["(?i)you've hit your limit"
+            "(?i)rate.?limit"
+            "(?i)quota.?exceeded"
+            "429|Too Many Requests"
+            "resets \\d+[ap]m|resets in \\d+"]))))
+
+(def ^:private rate-limit-patterns
+  (delay (load-rate-limit-patterns)))
+
+(defn rate-limit-error?
+  "Check if a DAG result indicates a rate limit error."
+  [result]
+  (when-not (dag/ok? result)
+    (let [msg (or (:message result)
+                  (get-in result [:data :message])
+                  (str result))]
+      (boolean (some #(re-find % msg) @rate-limit-patterns)))))
+
+;--- Layer 1: Backend Failover + Event Emission
+
+(defn attempt-backend-switch
+  "Attempt to switch to an alternative backend after rate limiting.
+
+   Returns {:switched? true :new-backend :openai} or
+           {:switched? false :reason ...}"
+  [current-backend allowed-backends cost-ceiling accumulated-cost logger]
+  (cond
+    ;; Cost ceiling exceeded
+    (and cost-ceiling (> accumulated-cost cost-ceiling))
+    (do (log/info logger :dag-resilience :failover/cost-ceiling-exceeded
+                  {:data {:ceiling cost-ceiling :accumulated accumulated-cost}})
+        {:switched? false :reason :cost-ceiling})
+
+    ;; No allowed backends configured (user didn't opt in)
+    (empty? allowed-backends)
+    (do (log/info logger :dag-resilience :failover/no-allowed-backends {})
+        {:switched? false :reason :no-allowed-backends})
+
+    ;; Try to find a healthy backend from the allowed list
+    :else
+    (try
+      (let [record-call! (requiring-resolve 'ai.miniforge.self-healing.backend-health/record-backend-call!)
+            trigger-switch! (requiring-resolve 'ai.miniforge.self-healing.backend-health/trigger-backend-switch!)
+            _ (record-call! current-backend false)
+            ;; Pick first allowed backend that isn't the current one
+            candidate (first (filter #(not= % (keyword current-backend))
+                                     (map keyword allowed-backends)))]
+        (if candidate
+          (let [result (trigger-switch! current-backend candidate)]
+            (log/info logger :dag-resilience :failover/switched
+                      {:data {:from current-backend :to candidate}})
+            {:switched? true :new-backend candidate :switch-result result})
+          (do (log/info logger :dag-resilience :failover/exhausted
+                        {:data {:allowed allowed-backends}})
+              {:switched? false :exhausted? true :reason :all-allowed-exhausted})))
+      (catch Exception e
+        (log/info logger :dag-resilience :failover/error
+                  {:data {:error (.getMessage e)}})
+        {:switched? false :reason :failover-error :error (.getMessage e)}))))
+
+(defn emit-dag-task-completed!
+  "Publish :dag/task-completed event for checkpointing."
+  [event-stream workflow-id task-id result]
+  (when event-stream
+    (try
+      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
+        (publish! event-stream
+                  {:event/type :dag/task-completed
+                   :event/timestamp (str (java.time.Instant/now))
+                   :workflow/id workflow-id
+                   :dag/task-id task-id
+                   :dag/result (select-keys result [:data :status])}))
+      (catch Exception _ nil))))
+
+(defn emit-dag-paused!
+  "Publish :dag/paused event with completed task IDs for resume."
+  [event-stream workflow-id completed-ids reason]
+  (when event-stream
+    (try
+      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
+        (publish! event-stream
+                  {:event/type :dag/paused
+                   :event/timestamp (str (java.time.Instant/now))
+                   :workflow/id workflow-id
+                   :dag/completed-task-ids (vec completed-ids)
+                   :dag/pause-reason reason}))
+      (catch Exception _ nil))))
+
+;--- Layer 2: Batch Analysis + Rate Limit Handling
+
+(defn analyze-batch-for-rate-limits
+  "Categorize batch results into completed, rate-limited, and other-failed."
+  [results]
+  (reduce (fn [acc [task-id result]]
+            (cond
+              (dag/ok? result)
+              (update acc :completed-ids conj task-id)
+
+              (rate-limit-error? result)
+              (update acc :rate-limited-ids conj task-id)
+
+              :else
+              (update acc :other-failed-ids conj task-id)))
+          {:completed-ids #{} :rate-limited-ids #{} :other-failed-ids #{}}
+          results))
+
+(defn handle-rate-limited-batch
+  "Orchestrate the failover decision for a rate-limited batch.
+
+   Returns {:action :continue :new-backend X} or {:action :pause :reason \"...\"}."
+  [context rate-limited-ids completed-ids logger]
+  (let [self-healing (or (get-in context [:execution/opts :self-healing])
+                         (get-in context [:user-config :self-healing])
+                         {})
+        auto-switch? (get self-healing :backend-auto-switch true)
+        allowed (get self-healing :allowed-failover-backends [])
+        cost-ceiling (get self-healing :max-cost-per-workflow)
+        accumulated-cost (get-in context [:execution/metrics :cost-usd] 0.0)
+        current-backend (or (get-in context [:llm-backend :backend-type])
+                            (get context :current-backend :claude))]
+    (log/info logger :dag-resilience :rate-limit/detected
+              {:data {:rate-limited-count (count rate-limited-ids)
+                      :completed-count (count completed-ids)
+                      :auto-switch? auto-switch?
+                      :allowed-backends allowed}})
+    (if (and auto-switch? (seq allowed))
+      (let [switch-result (attempt-backend-switch
+                           current-backend allowed cost-ceiling accumulated-cost logger)]
+        (if (:switched? switch-result)
+          {:action :continue :new-backend (:new-backend switch-result)}
+          {:action :pause
+           :reason (str "Rate limited. Failover failed: " (name (or (:reason switch-result) :unknown)))}))
+      {:action :pause
+       :reason (if (not auto-switch?)
+                 "Rate limited. Backend auto-switch is disabled."
+                 "Rate limited. No failover backends configured (set :allowed-failover-backends).")})))

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -55,8 +55,8 @@
   "Check if a DAG result indicates a rate limit error."
   [result]
   (when-not (dag/ok? result)
-    (let [msg (or (:message result)
-                  (get-in result [:data :message])
+    (let [msg (or (get-in result [:error :message])
+                  (get-in result [:error :data :message])
                   (str result))]
       (boolean (some #(re-find % msg) @rate-limit-patterns)))))
 

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -363,7 +363,9 @@
   [ctx phase-name phase-result pipeline
    transition-to-completed-fn transition-to-failed-fn]
   (when-let [plan (dag-applicable? phase-name phase-result ctx)]
-    (let [dag-result (dag-orch/execute-plan-as-dag plan ctx)]
+    (let [ctx-with-resume (assoc ctx :pre-completed-ids
+                                 (get-in ctx [:execution/opts :pre-completed-dag-tasks] #{}))
+          dag-result (dag-orch/execute-plan-as-dag plan ctx-with-resume)]
       (if (:success? dag-result)
         (apply-dag-success ctx dag-result pipeline transition-to-completed-fn)
         (apply-dag-failure ctx dag-result transition-to-failed-fn)))))

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_test.clj
@@ -1,0 +1,226 @@
+(ns ai.miniforge.workflow.dag-resilience-test
+  "Tests for DAG rate limit detection, batch analysis, and failover handling."
+  (:require
+   [clojure.test :refer [deftest testing is are]]
+   [ai.miniforge.workflow.dag-resilience :as resilience]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures
+
+(defn- ok-result [task-id]
+  (dag/ok {:task-id task-id :status :implemented}))
+
+(defn- rate-limit-err [message]
+  (dag/err :task-execution-failed message {:task-id :test}))
+
+(defn- generic-err [message]
+  (dag/err :task-execution-failed message {:task-id :test}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; rate-limit-error? tests
+
+(deftest test-rate-limit-error-detects-claude-cli
+  (testing "detects Claude CLI rate limit message"
+    (is (resilience/rate-limit-error?
+         (rate-limit-err "You've hit your limit · resets 2pm")))))
+
+(deftest test-rate-limit-error-detects-generic
+  (testing "detects generic rate limit messages"
+    (are [msg] (resilience/rate-limit-error? (rate-limit-err msg))
+      "API rate limit exceeded"
+      "Rate limit reached for model"
+      "rate-limit error on request"
+      "Quota exceeded for this billing period"
+      "429 Too Many Requests"
+      "Too Many Requests"
+      "resets 2pm"
+      "resets in 30 minutes")))
+
+(deftest test-rate-limit-error-rejects-non-rate-limit
+  (testing "does not flag non-rate-limit errors"
+    (are [msg] (not (resilience/rate-limit-error? (generic-err msg)))
+      "Syntax error in foo.clj"
+      "Connection refused"
+      "Task failed: compilation error"
+      "File not found")))
+
+(deftest test-rate-limit-error-returns-false-for-ok
+  (testing "returns nil/false for successful results"
+    (is (not (resilience/rate-limit-error? (ok-result :a))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; analyze-batch-for-rate-limits tests
+
+(deftest test-analyze-batch-all-ok
+  (testing "all successful results"
+    (let [results {:a (ok-result :a)
+                   :b (ok-result :b)
+                   :c (ok-result :c)}
+          analysis (resilience/analyze-batch-for-rate-limits results)]
+      (is (= #{:a :b :c} (:completed-ids analysis)))
+      (is (empty? (:rate-limited-ids analysis)))
+      (is (empty? (:other-failed-ids analysis))))))
+
+(deftest test-analyze-batch-with-rate-limits
+  (testing "mix of successful and rate-limited results"
+    (let [results {:a (ok-result :a)
+                   :b (rate-limit-err "You've hit your limit")
+                   :c (rate-limit-err "429 Too Many Requests")}
+          analysis (resilience/analyze-batch-for-rate-limits results)]
+      (is (= #{:a} (:completed-ids analysis)))
+      (is (= #{:b :c} (:rate-limited-ids analysis)))
+      (is (empty? (:other-failed-ids analysis))))))
+
+(deftest test-analyze-batch-mixed-failures
+  (testing "mix of rate-limited and other failures"
+    (let [results {:a (ok-result :a)
+                   :b (rate-limit-err "Rate limit reached")
+                   :c (generic-err "Syntax error in foo.clj")}
+          analysis (resilience/analyze-batch-for-rate-limits results)]
+      (is (= #{:a} (:completed-ids analysis)))
+      (is (= #{:b} (:rate-limited-ids analysis)))
+      (is (= #{:c} (:other-failed-ids analysis))))))
+
+(deftest test-analyze-batch-empty
+  (testing "empty results"
+    (let [analysis (resilience/analyze-batch-for-rate-limits {})]
+      (is (empty? (:completed-ids analysis)))
+      (is (empty? (:rate-limited-ids analysis)))
+      (is (empty? (:other-failed-ids analysis))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; handle-rate-limited-batch tests
+
+(deftest test-handle-rate-limited-no-failover-configured
+  (testing "pauses when no allowed-failover-backends configured"
+    (let [[logger _] (log/collecting-logger)
+          context {}
+          decision (resilience/handle-rate-limited-batch
+                    context #{:b :c} #{:a} logger)]
+      (is (= :pause (:action decision)))
+      (is (string? (:reason decision))))))
+
+(deftest test-handle-rate-limited-auto-switch-disabled
+  (testing "pauses when backend-auto-switch is false"
+    (let [[logger _] (log/collecting-logger)
+          context {:execution/opts
+                   {:self-healing {:backend-auto-switch false
+                                   :allowed-failover-backends [:openai]}}}
+          decision (resilience/handle-rate-limited-batch
+                    context #{:b} #{:a} logger)]
+      (is (= :pause (:action decision)))
+      (is (clojure.string/includes? (:reason decision) "disabled")))))
+
+(deftest test-handle-rate-limited-with-allowed-backends
+  (testing "attempts failover when allowed backends are configured"
+    (let [[logger _] (log/collecting-logger)
+          context {:execution/opts
+                   {:self-healing {:backend-auto-switch true
+                                   :allowed-failover-backends [:openai]}}}
+          decision (resilience/handle-rate-limited-batch
+                    context #{:b} #{:a} logger)]
+      ;; Should attempt failover — result depends on backend health state
+      ;; Either continues with new backend or pauses if failover fails
+      (is (contains? #{:continue :pause} (:action decision))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; DAG orchestrator integration — pause on rate limit
+
+(deftest test-dag-execution-pauses-on-rate-limit
+  (testing "DAG execution returns paused result when all tasks hit rate limits"
+    (let [[logger _] (log/collecting-logger)
+          ;; Use real UUIDs as task IDs since plan->dag-tasks expects them
+          task-a (random-uuid)
+          task-b (random-uuid)
+          plan {:plan/id (random-uuid)
+                :plan/name "test-plan"
+                :plan/tasks [{:task/id task-a
+                              :task/description "Task A"
+                              :task/type :implement
+                              :task/dependencies []}
+                             {:task/id task-b
+                              :task/description "Task B"
+                              :task/type :implement
+                              :task/dependencies []}]}
+          ;; Mock execute-single-task to return rate limit errors
+          original-fn @(resolve 'ai.miniforge.workflow.dag-orchestrator/execute-single-task)]
+      (with-redefs [ai.miniforge.workflow.dag-orchestrator/execute-single-task
+                    (fn [_task-def _context]
+                      (dag/err :task-execution-failed
+                               "You've hit your limit · resets 2pm"
+                               {}))]
+        (let [result (ai.miniforge.workflow.dag-orchestrator/execute-plan-as-dag
+                      plan {:logger logger})]
+          (is (not (:success? result)))
+          (is (true? (:paused? result)))
+          (is (string? (:pause-reason result))))))))
+
+(deftest test-dag-execution-partial-rate-limit
+  (testing "DAG pauses when some tasks succeed and others hit rate limits"
+    (let [[logger _] (log/collecting-logger)
+          task-a (random-uuid)
+          task-b (random-uuid)
+          call-count (atom 0)
+          plan {:plan/id (random-uuid)
+                :plan/name "test-plan"
+                :plan/tasks [{:task/id task-a
+                              :task/description "Task A"
+                              :task/type :implement
+                              :task/dependencies []}
+                             {:task/id task-b
+                              :task/description "Task B"
+                              :task/type :implement
+                              :task/dependencies []}]}]
+      (with-redefs [ai.miniforge.workflow.dag-orchestrator/execute-single-task
+                    (fn [task-def _context]
+                      (let [n (swap! call-count inc)]
+                        (if (= n 1)
+                          ;; First task succeeds
+                          (dag/ok {:task-id (:task/id task-def)
+                                   :status :implemented
+                                   :artifacts []
+                                   :metrics {:tokens 0 :cost-usd 0.0}})
+                          ;; Second task hits rate limit
+                          (dag/err :task-execution-failed
+                                   "429 Too Many Requests"
+                                   {}))))]
+        (let [result (ai.miniforge.workflow.dag-orchestrator/execute-plan-as-dag
+                      plan {:logger logger})]
+          (is (not (:success? result)))
+          (is (true? (:paused? result)))
+          ;; One task completed, one rate-limited
+          (is (= 1 (:tasks-completed result))))))))
+
+(deftest test-dag-execution-pre-completed-ids
+  (testing "DAG skips tasks in pre-completed-ids set"
+    (let [[logger _] (log/collecting-logger)
+          task-a (random-uuid)
+          task-b (random-uuid)
+          executed-tasks (atom #{})
+          plan {:plan/id (random-uuid)
+                :plan/name "test-plan"
+                :plan/tasks [{:task/id task-a
+                              :task/description "Task A"
+                              :task/type :implement
+                              :task/dependencies []}
+                             {:task/id task-b
+                              :task/description "Task B"
+                              :task/type :implement
+                              :task/dependencies []}]}]
+      (with-redefs [ai.miniforge.workflow.dag-orchestrator/execute-single-task
+                    (fn [task-def _context]
+                      (swap! executed-tasks conj (:task/id task-def))
+                      (dag/ok {:task-id (:task/id task-def)
+                               :status :implemented
+                               :artifacts []
+                               :metrics {:tokens 0 :cost-usd 0.0}}))]
+        (let [result (ai.miniforge.workflow.dag-orchestrator/execute-plan-as-dag
+                      plan {:logger logger
+                            :pre-completed-ids #{task-a}})]
+          (is (:success? result))
+          ;; Only task-b should have been executed
+          (is (= #{task-b} @executed-tasks))
+          ;; Both count as completed (1 pre-completed + 1 executed)
+          (is (= 2 (:tasks-completed result))))))))

--- a/docs/pull-requests/2026-03-04-feat-dag-rate-limit-resilience.md
+++ b/docs/pull-requests/2026-03-04-feat-dag-rate-limit-resilience.md
@@ -1,0 +1,128 @@
+# feat: DAG rate limit resilience — failover + graceful pause + resume
+
+**Branch:** `feat/dag-rate-limit-resilience`
+**Base:** `refactor/phase-status-and-neutral-result`
+**Date:** 2026-03-04
+
+## Overview
+
+When Claude CLI hits rate limits mid-DAG execution, the orchestrator now detects the
+rate limit, attempts backend failover (if configured), or gracefully pauses and emits
+checkpoint events so the workflow can be resumed later without losing completed work.
+
+## Motivation
+
+Dogfooding `dashboard-production-ready.spec.edn` produced a 15-task DAG. 7 tasks
+succeeded, then Claude CLI hit rate limits. The remaining 8 tasks all failed because:
+
+1. Rate limit messages (`"You've hit your limit · resets 2pm"`) weren't detected —
+   error patterns in `external.edn` didn't match Claude CLI's actual format
+2. The implement phase retried 5 times with zero delay, burning all iterations in ~10s
+3. No backend failover was attempted despite `backend_health.clj` having full logic
+4. No way to resume — completed work was lost
+5. Dependent tasks transitively failed immediately
+
+## Changes
+
+### 1. Failover policy in user config (`default-user-config.edn`)
+
+Added two new keys to `:self-healing`:
+
+- `:allowed-failover-backends []` — empty by default (pause, don't failover). User opts
+  in by listing backends like `[:openai :ollama]`
+- `:max-cost-per-workflow nil` — cost ceiling; pauses even if failover backends available
+
+### 2. Rate limit error patterns (`external.edn`)
+
+- Added 5 new patterns matching actual LLM CLI rate limit messages
+- Added `:rate-limit? true` metadata to each, plus the existing `"API rate limit exceeded"` pattern
+- Patterns: `you've hit your limit`, `rate?limit`, `quota?exceeded`, `429|Too Many Requests`,
+  `resets \d+[ap]m`
+
+### 3. New module: `dag_resilience.clj` (~140 lines)
+
+Three-layer module extracted to keep `dag_orchestrator.clj` under 400 lines:
+
+- **Layer 0** — `rate-limit-error?`: checks DAG error results against rate-limit patterns
+- **Layer 1** — `attempt-backend-switch`: failover with cost ceiling + allowed-backends filter;
+  `emit-dag-task-completed!` / `emit-dag-paused!`: event emission for checkpointing
+- **Layer 2** — `analyze-batch-for-rate-limits`: categorizes batch results;
+  `handle-rate-limited-batch`: orchestrates the failover-or-pause decision
+
+Uses `requiring-resolve` for self-healing and event-stream dependencies (matching existing pattern).
+
+### 4. DAG orchestrator loop changes (`dag_orchestrator.clj`)
+
+- Added `dag-execution-paused` result constructor (`:paused? true`, `:pause-reason`)
+- `execute-dag-loop` now:
+  - Seeds `completed-ids` from `:pre-completed-ids` (resume support)
+  - Tracks `current-backend` through the loop
+  - After each batch, calls `resilience/analyze-batch-for-rate-limits`
+  - On rate limit: calls `handle-rate-limited-batch` → continue (failover) or pause
+  - Emits `dag/task-completed` events per completed task for checkpointing
+- `execute-plan-as-dag` accepts `:pre-completed-ids` from context
+
+### 5. DAG resume in `resume.clj`
+
+- `extract-completed-dag-tasks`: collects task IDs from `:dag/task-completed` events
+- `extract-dag-pause-info`: finds last `:dag/paused` event
+- `reconstruct-context` now returns `:completed-dag-tasks`, `:dag-paused?`, `:dag-pause-reason`
+- `resume-workflow` threads `:pre-completed-dag-tasks` into pipeline opts
+
+### 6. Threading pre-completed-ids at call sites
+
+- `execution.clj` (`try-dag-execution`): passes `pre-completed-dag-tasks` from execution opts
+- `configurable.clj` (`execute-dag-for-plan`): passes from context
+- `plan_executor.clj` (`execute-plan`): passes from opts
+
+## Files Changed
+
+| File | Type | Description |
+|------|------|-------------|
+| `resources/config/default-user-config.edn` | Modified | Add failover config keys |
+| `components/agent-runtime/resources/error-patterns/external.edn` | Modified | Add 5 rate-limit patterns |
+| `components/workflow/src/.../dag_resilience.clj` | **New** | Rate limit detection, failover, events |
+| `components/workflow/src/.../dag_orchestrator.clj` | Modified | Wire resilience into loop, paused result, pre-completed-ids |
+| `bases/cli/src/.../commands/resume.clj` | Modified | DAG checkpoint extraction, thread pre-completed-ids |
+| `components/workflow/src/.../execution.clj` | Modified | Thread pre-completed-ids (1 line) |
+| `components/workflow/src/.../configurable.clj` | Modified | Thread pre-completed-ids (1 line) |
+| `bases/cli/src/.../commands/plan_executor.clj` | Modified | Thread pre-completed-ids (1 line) |
+
+## Flow
+
+```text
+Task fails → "You've hit your limit · resets 2pm"
+  ↓
+execute-dag-loop: resilience/analyze-batch-for-rate-limits → detects rate limit
+  ↓
+resilience/handle-rate-limited-batch
+  ↓
+  ├─ allowed-failover-backends includes :openai → switch, re-queue, continue
+  ├─ max-cost-per-workflow exceeded → pause
+  ├─ allowed-failover-backends is empty → pause (default)
+  └─ All allowed backends exhausted → emit :dag/paused, return {:paused? true}
+                      ↓
+                    User runs: miniforge run --resume <workflow-id>
+                      ↓
+                    resume.clj reads :dag/task-completed events
+                      ↓
+                    Passes pre-completed-ids into re-run
+                      ↓
+                    execute-dag-loop starts with pre-populated completed-ids
+                      ↓
+                    Skips already-completed tasks, runs only remaining
+```
+
+## Testing Plan
+
+- [x] `bb test` — 277 tests, 1132 assertions, 0 failures
+- [ ] Add test in `dag_resilience_test.clj` for `rate-limit-error?` and `analyze-batch-for-rate-limits`
+- [ ] Add test in `dag_orchestrator_test.clj` for rate-limit-triggered pause
+- [ ] Manual: run spec that triggers rate limits, verify failover or graceful pause
+- [ ] Manual: `miniforge run --resume <paused-workflow-id>` resumes remaining tasks
+
+## Related Issues/PRs
+
+- Depends on: `refactor/phase-status-and-neutral-result` (base branch)
+- Related: PR #233 (MCP artifact server integration)
+- Future: per-backend cost/spend limits, provider-level rate limit increase options

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -22,7 +22,9 @@
                  :workaround-auto-apply true
                  :backend-auto-switch true
                  :backend-health-threshold 0.90
-                 :backend-switch-cooldown-ms 1800000}
+                 :backend-switch-cooldown-ms 1800000
+                 :allowed-failover-backends []
+                 :max-cost-per-workflow nil}
   :governance {:readiness {}
                :risk {}
                :tiers {}


### PR DESCRIPTION
## Summary

- Detect rate limit errors (Claude CLI, HTTP 429, quota exceeded) during DAG execution via new error patterns
- Attempt backend failover when rate-limited (opt-in via `:allowed-failover-backends` config)
- Gracefully pause DAG and emit checkpoint events when failover unavailable
- Resume paused workflows with `miniforge run --resume <id>`, skipping already-completed tasks

## Changes

| File | Description |
|------|-------------|
| `resources/config/default-user-config.edn` | Add `:allowed-failover-backends` + `:max-cost-per-workflow` |
| `external.edn` | Add 5 rate-limit patterns with `:rate-limit? true` |
| `dag_resilience.clj` | **NEW** — rate limit detection, failover, event emission (~140 lines) |
| `dag_orchestrator.clj` | Wire resilience into loop, paused result, pre-completed-ids |
| `resume.clj` | Extract DAG checkpoints, thread pre-completed-ids |
| `execution.clj` | Thread pre-completed-ids (1 line) |
| `configurable.clj` | Thread pre-completed-ids (1 line) |
| `plan_executor.clj` | Thread pre-completed-ids (1 line) |

## Test plan

- [x] `bb test` — 277 tests, 1132 assertions, 0 failures
- [x] Pre-commit hooks pass (lint, format, test, graalvm)
- [ ] Add unit tests for `rate-limit-error?` and `analyze-batch-for-rate-limits`
- [ ] Manual: trigger rate limits during DAG, verify pause
- [ ] Manual: resume paused workflow, verify only remaining tasks run

See `docs/pull-requests/2026-03-04-feat-dag-rate-limit-resilience.md` for full details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)