### PR TITLE
Fix metrics tracking: token counts, cost, and duration

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -228,8 +228,8 @@
            :content (get-in body [:choices 0 :message :content] "")
            :usage {:input-tokens (get-in body [:usage :prompt_tokens])
                    :output-tokens (get-in body [:usage :completion_tokens])}
-           :tokens (+ (or (get-in body [:usage :prompt_tokens]) 0)
-                      (or (get-in body [:usage :completion_tokens]) 0))}
+           :tokens (+ (get-in body [:usage :prompt_tokens] 0)
+                      (get-in body [:usage :completion_tokens] 0))}
           {:success false
            :anomaly (response/make-anomaly
                      :anomalies/unavailable

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -26,10 +26,12 @@
   ([content]
    (llm-success content nil))
   ([content {:keys [usage exit-code]}]
-   (cond-> {:success true
-            :content content
-            :usage (or usage {:input-tokens nil :output-tokens nil})}
-     (some? exit-code) (assoc :exit-code exit-code))))
+   (let [usage (or usage {:input-tokens nil :output-tokens nil})]
+     (cond-> {:success true
+              :content content
+              :usage usage
+              :tokens (+ (or (:input-tokens usage) 0) (or (:output-tokens usage) 0))}
+       (some? exit-code) (assoc :exit-code exit-code)))))
 
 (defn- llm-error
   "Build a failed LLM response with anomaly."
@@ -487,8 +489,8 @@
       (log/debug logger :system :agent/streaming-complete
                  {:data {:response-length content-length}}))))
 
-(defn- streaming-success-response [content exit-code]
-  (llm-success content {:exit-code exit-code}))
+(defn- streaming-success-response [content exit-code usage]
+  (llm-success content {:exit-code exit-code :usage usage}))
 
 (defn- streaming-error-response [content exit-code err-result timeout-info]
   (let [error-message (or err-result

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -46,7 +46,13 @@
           (when-let [delta-text (get-in data [:event :delta :text])]
             {:delta delta-text :done? false})
 
-          ;; Ignore system, result, rate_limit_event
+          "result"
+          (let [usage (get-in data [:result :usage])]
+            {:delta "" :done? true
+             :usage {:input-tokens (:input_tokens usage)
+                     :output-tokens (:output_tokens usage)}})
+
+          ;; Ignore system, rate_limit_event
           nil)))
     (catch Exception _e
       nil)))
@@ -221,7 +227,9 @@
           {:success true
            :content (get-in body [:choices 0 :message :content] "")
            :usage {:input-tokens (get-in body [:usage :prompt_tokens])
-                   :output-tokens (get-in body [:usage :completion_tokens])}}
+                   :output-tokens (get-in body [:usage :completion_tokens])}
+           :tokens (+ (or (get-in body [:usage :prompt_tokens]) 0)
+                      (or (get-in body [:usage :completion_tokens]) 0))}
           {:success false
            :anomaly (response/make-anomaly
                      :anomalies/unavailable
@@ -330,6 +338,7 @@
   {:success true
    :content (str/trim output)
    :usage {:input-tokens nil :output-tokens nil}
+   :tokens 0
    :exit-code exit-code})
 
 (defn- error-response [output exit-code stderr]
@@ -477,9 +486,11 @@
                  :content (:content result)}))
     result))
 
-(defn- stream-with-parser [stream-parser on-chunk accumulated-content]
+(defn- stream-with-parser [stream-parser on-chunk accumulated-content accumulated-usage]
   (fn [line]
     (when-let [parsed (stream-parser line)]
+      (when-let [usage (:usage parsed)]
+        (reset! accumulated-usage usage))
       (when-let [delta (:delta parsed)]
         (swap! accumulated-content str delta)
         (on-chunk (assoc parsed :content @accumulated-content))))))
@@ -495,11 +506,13 @@
       (log/debug logger :system :agent/streaming-complete
                  {:data {:response-length content-length}}))))
 
-(defn- streaming-success-response [content exit-code]
-  {:success true
-   :content content
-   :usage {:input-tokens nil :output-tokens nil}
-   :exit-code exit-code})
+(defn- streaming-success-response [content exit-code usage]
+  (let [usage (or usage {:input-tokens nil :output-tokens nil})]
+    {:success true
+     :content content
+     :usage usage
+     :tokens (+ (or (:input-tokens usage) 0) (or (:output-tokens usage) 0))
+     :exit-code exit-code}))
 
 (defn- streaming-error-response [content exit-code err-result timeout-info]
   (let [error-message (or err-result
@@ -525,14 +538,15 @@
         prompt (build-request-prompt request)
         args (args-fn (assoc request :prompt prompt :streaming? true))
         full-cmd (into [cmd] args)
-        accumulated-content (atom "")]
+        accumulated-content (atom "")
+        accumulated-usage (atom nil)]
     (when logger
       (log/debug logger :system :agent/streaming-prompt-sent
                  {:data {:backend backend
                          :prompt-length (count prompt)}}))
     (let [result (stream-exec-fn
                   full-cmd
-                  (stream-with-parser stream-parser on-chunk accumulated-content)
+                  (stream-with-parser stream-parser on-chunk accumulated-content accumulated-usage)
                   {:progress-monitor progress-monitor})
           exit-code (:exit result)
           timeout-info (:timeout result)
@@ -543,7 +557,7 @@
                  :timeout timeout-info})
       (log-streaming-result logger timeout-info (count final-content))
       (if (zero? exit-code)
-        (streaming-success-response final-content exit-code)
+        (streaming-success-response final-content exit-code @accumulated-usage)
         (streaming-error-response final-content exit-code (:err result) timeout-info)))))
 
 (defn complete-stream-impl [client request on-chunk]

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :as test :refer [deftest testing is]]
             [ai.miniforge.llm.interface :as llm]
             [ai.miniforge.llm.protocols.records.llm-client]
-            [ai.miniforge.llm.protocols.impl.llm-client]))
+            [ai.miniforge.llm.protocols.impl.llm-client :as impl]
+            [cheshire.core :as json]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures
@@ -117,6 +118,78 @@
 
 ;; Streaming tests removed - they call actual CLIs via p/process and can't be
 ;; properly mocked in brick tests. Move to integration tests.
+
+;------------------------------------------------------------------------------ Layer 2
+;; Metrics tracking tests (PR #248)
+
+(deftest parse-claude-stream-result-event-test
+  (testing "result event extracts usage tokens"
+    (let [line (json/generate-string
+                 {:type "result"
+                  :result {:usage {:input_tokens 1234
+                                   :output_tokens 567}}})
+          parsed (#'impl/parse-claude-stream-line line)]
+      (is (= "" (:delta parsed)))
+      (is (true? (:done? parsed)))
+      (is (= 1234 (get-in parsed [:usage :input-tokens])))
+      (is (= 567 (get-in parsed [:usage :output-tokens])))))
+
+  (testing "result event with no usage returns nil tokens"
+    (let [line (json/generate-string {:type "result" :result {}})
+          parsed (#'impl/parse-claude-stream-line line)]
+      (is (true? (:done? parsed)))
+      (is (nil? (get-in parsed [:usage :input-tokens]))))))
+
+(deftest parse-cli-output-includes-metrics-test
+  (testing "success response includes :tokens and :usage keys"
+    (let [resp (impl/parse-cli-output "hello world" 0)]
+      (is (:success resp))
+      (is (= "hello world" (:content resp)))
+      (is (contains? resp :tokens))
+      (is (contains? resp :usage))
+      (is (= 0 (:tokens resp)))))
+
+  (testing "error response includes :anomaly key"
+    (let [resp (impl/parse-cli-output "bad" 1 "stderr")]
+      (is (not (:success resp)))
+      (is (some? (:error resp)))
+      (is (some? (:anomaly resp))))))
+
+(deftest mock-client-response-includes-metrics-test
+  (testing "mock client success response has :tokens and :usage"
+    (let [client (llm/mock-client {:output "ok"})
+          resp (llm/complete client {:prompt "test"})]
+      (is (contains? resp :tokens))
+      (is (contains? resp :usage))
+      (is (number? (:tokens resp)))))
+
+  (testing "mock client failure response has :anomaly"
+    (let [client (llm/mock-client {:output "err" :exit 1})
+          resp (llm/complete client {:prompt "test"})]
+      (is (some? (:anomaly resp))))))
+
+(deftest stream-parser-accumulates-usage-test
+  (testing "stream-with-parser stores usage from parsed events"
+    (let [content (atom "")
+          usage (atom nil)
+          chunks (atom [])
+          handler (#'impl/stream-with-parser
+                    #'impl/parse-claude-stream-line
+                    (fn [chunk] (swap! chunks conj chunk))
+                    content
+                    usage)]
+      ;; Feed an assistant event
+      (handler (json/generate-string
+                 {:type "assistant"
+                  :message {:content [{:type "text" :text "Hello"}]}}))
+      (is (= "Hello" @content))
+      (is (nil? @usage))
+      ;; Feed a result event with usage
+      (handler (json/generate-string
+                 {:type "result"
+                  :result {:usage {:input_tokens 100
+                                   :output_tokens 50}}}))
+      (is (= {:input-tokens 100 :output-tokens 50} @usage)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -166,6 +166,8 @@
                        :else (registry/determine-phase-status
                                agent-status iterations max-iterations))
         metrics (get result :metrics {:tokens 0 :duration-ms duration-ms})
+        cost-usd (* (:tokens metrics 0) 0.000015)
+        metrics (assoc metrics :cost-usd cost-usd)
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)
                         (assoc-in [:phase :duration-ms] duration-ms)
@@ -176,6 +178,7 @@
                         (update-in [:execution :phases-completed] (fnil conj []) :implement)
                         ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
+                        (update-in [:execution/metrics :cost-usd] (fnil + 0.0) cost-usd)
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
     ;; Warn if result has no output and isn't already-implemented
     (when (and (not= :already-implemented agent-status)

--- a/components/phase/test/ai/miniforge/phase/implement_test.clj
+++ b/components/phase/test/ai/miniforge/phase/implement_test.clj
@@ -198,7 +198,13 @@
         
         (is (= 1500 (get-in final-result [:phase :metrics :tokens]))
             "Token metrics should be recorded")
-        
+
+        (is (= (* 1500 0.000015) (get-in final-result [:phase :metrics :cost-usd]))
+            "Cost-usd should be estimated from token count")
+
+        (is (= (* 1500 0.000015) (get-in final-result [:execution/metrics :cost-usd]))
+            "Cost-usd should be merged into execution metrics")
+
         (is (= :implement (first (get-in final-result [:execution :phases-completed])))
             "Implement should be added to phases-completed")))))
 

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -40,12 +40,14 @@
    :error error
    :metrics (or metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0})})
 
-(defn- dag-execution-result [completed failed artifacts total-tokens]
+(defn- dag-execution-result [completed failed artifacts metrics-agg]
   {:success? (zero? failed)
    :tasks-completed completed
    :tasks-failed failed
    :artifacts (vec artifacts)
-   :metrics {:tokens total-tokens}})
+   :metrics {:tokens (:total-tokens metrics-agg 0)
+             :cost-usd (:total-cost metrics-agg 0.0)
+             :duration-ms (:total-duration metrics-agg 0)}})
 
 (defn- dag-execution-error [completed failed error]
   {:success? false
@@ -268,9 +270,12 @@
     {:completed ok-results :failed err-results}))
 
 (defn- aggregate-results [all-results]
-  (let [artifacts (->> (vals all-results) (mapcat #(get-in % [:data :artifacts] [])))
-        total-tokens (->> (vals all-results) (map #(get-in % [:data :metrics :tokens] 0)) (reduce + 0))]
-    {:artifacts artifacts :total-tokens total-tokens}))
+  (let [results (vals all-results)
+        artifacts (->> results (mapcat #(get-in % [:data :artifacts] [])))
+        total-tokens (->> results (map #(get-in % [:data :metrics :tokens] 0)) (reduce + 0))
+        total-cost (->> results (map #(get-in % [:data :metrics :cost-usd] 0.0)) (reduce + 0.0))
+        total-duration (->> results (map #(get-in % [:data :metrics :duration-ms] 0)) (reduce + 0))]
+    {:artifacts artifacts :total-tokens total-tokens :total-cost total-cost :total-duration total-duration}))
 
 (defn- has-failed-dependency?
   "Check if a task depends on any task in the failed set."
@@ -302,12 +307,12 @@
             ready-tasks (compute-ready-tasks tasks-map completed-ids all-failed)]
         (cond
           (empty? ready-tasks)
-          (let [{:keys [artifacts total-tokens]} (aggregate-results all-results)]
+          (let [metrics-agg (aggregate-results all-results)]
             (log/info logger :dag-orchestrator :dag/completed
                       {:data {:completed (count completed-ids)
                               :failed (count all-failed)
                               :iterations iteration}})
-            (assoc (dag-execution-result (count completed-ids) (count all-failed) artifacts total-tokens)
+            (assoc (dag-execution-result (count completed-ids) (count all-failed) (:artifacts metrics-agg) metrics-agg)
                    :sub-workflow-ids (vec sub-workflow-ids)))
 
           (> iteration 100)


### PR DESCRIPTION
## Summary

- **Parse Claude CLI `"result"` event** for token usage — was previously ignored (returned `nil`), causing all metrics to propagate as zeros through the pipeline
- **Thread usage data through streaming pipeline** via `accumulated-usage` atom in `stream-with-parser` → `handle-streaming` → `streaming-success-response`
- **Add `:tokens` key** to all success response paths (streaming, non-streaming CLI, OpenAI HTTP) for consistent downstream access
- **Estimate `cost-usd`** at the implement phase level using a blended rate ($15/1M tokens)
- **Aggregate `cost-usd` + `duration-ms`** alongside tokens in DAG orchestrator's `aggregate-results` and `dag-execution-result`

## Root cause

Claude CLI's `--output-format stream-json` emits usage in a final `{"type": "result", "result": {"usage": {...}}}` event. `parse-claude-stream-line` had a catch-all `nil` for `"result"` type (line 49), so usage was never captured. This propagated zeros through: `streaming-success-response` → `implement.clj` metrics → `dag_orchestrator` aggregation → display output showing `"Tokens: 0 | Cost: $0.0000 | Duration: 0ms"`.

## Files changed

| File | What |
|------|------|
| `components/llm/.../llm_client.clj` | Parse `"result"` event, thread `accumulated-usage` atom through streaming, add `:tokens` to all response paths |
| `components/phase/.../implement.clj` | Compute `cost-usd` from token count, merge into execution metrics |
| `components/workflow/.../dag_orchestrator.clj` | Aggregate `cost-usd` + `duration-ms`, pass full metrics map to result constructor |

## Test plan

- [x] All 601 existing tests pass (0 failures, 0 errors)
- [x] GraalVM/Babashka compatibility tests pass
- [ ] Run a dogfood spec and verify non-zero tokens/cost/duration in output
- [ ] Verify OpenAI HTTP path still reports tokens (existing tests cover this)

🤖 Generated with [Claude Code](https://claude.com/claude-code)