### PR TITLE
Fix PersistentArrayMap cannot be cast to CharSequence

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -126,7 +126,8 @@
                  (if (= status :success)
                    (es/workflow-completed event-stream workflow-id status duration-ms)
                    (es/workflow-failed event-stream workflow-id
-                                       {:message (str (first (:execution/errors result)))
+                                       {:message (let [err (first (:execution/errors result))]
+                                              (if (map? err) (:message err (pr-str err)) (str err)))
                                         :errors (:execution/errors result)})))))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -139,7 +140,8 @@
       (if-let [sandbox-error (:sandbox-error context)]
         (let [result {:success? false
                       :errors [{:type :sandbox-setup-failed
-                                :message (str (:error sandbox-error))}]}]
+                                :message (let [err (:error sandbox-error)]
+                                  (if (map? err) (:message err (pr-str err)) (str err)))}]}]
           (publish-completion-event event-stream workflow-id result)
           (reset! completed? true)
           (display/print-result result opts)

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
@@ -64,7 +64,7 @@
     (when (seq errors)
       (println (colorize :red "\nErrors:"))
       (doseq [err errors]
-        (println (str "  • " err))))))
+        (println (str "  • " (if (map? err) (:message err (pr-str err)) err)))))))
 
 (defn- print-pretty-result [result]
   (println (colorize :cyan (str "\n" (apply str (repeat 65 "━")))))

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -38,7 +38,7 @@
 
 (defn- workflow-failure [error metrics]
   {:success? false
-   :error error
+   :error (if (map? error) (:message error (pr-str error)) (str error))
    :metrics (or metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0})})
 
 (defn- dag-execution-result [completed failed artifacts metrics-agg]


### PR DESCRIPTION
## Summary
- Error maps were being passed where strings were expected in the workflow error pipeline, causing `PersistentArrayMap cannot be cast to CharSequence` crash during YC MVP spec run
- Root cause: `workflow-failure` in dag_orchestrator stored raw error maps from `execution/errors`, which flowed to `dag/err` as the `message` param and ultimately to `re-find` in `rate-limit-error?` which requires `CharSequence`
- Fixed all four sites: `workflow-failure`, `publish-completion-event`, `print-workflow-summary`, and sandbox error handling — all now extract `:message` from error maps

## Test plan
- [x] All 197 affected tests pass (0 failures, 0 errors)
- [ ] Rerun `finish-yc-mvp.spec.edn` to confirm no more cast crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)