### PR TITLE
Fix DAG task ID normalization for keyword IDs

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -115,12 +115,16 @@
 
 ;--- Layer 1: Plan to DAG Conversion
 
-(defn- ensure-uuid [x]
+(defn- normalize-task-id
+  "Normalize a task ID to a UUID. Handles UUIDs, UUID strings, keywords, and
+   other values by generating a deterministic UUID from the value's string form."
+  [x]
   (cond
     (uuid? x) x
     (string? x) (or (parse-uuid x)
-                     (throw (ex-info (str "Invalid UUID string: " x) {:value x})))
-    :else (throw (ex-info (str "Cannot convert to UUID: " (pr-str x)) {:value x :type (type x)}))))
+                     (java.util.UUID/nameUUIDFromBytes (.getBytes (str x))))
+    (keyword? x) (java.util.UUID/nameUUIDFromBytes (.getBytes (name x)))
+    :else (java.util.UUID/nameUUIDFromBytes (.getBytes (pr-str x)))))
 
 (defn- validate-deps
   "Filter deps to only those referencing actual task IDs. Warns on phantoms."
@@ -136,20 +140,21 @@
 (defn- plan-task->dag-task
   "Convert a single plan task to a DAG task with validated deps."
   [t valid-task-ids plan-id workflow-id context]
-  {:task/id (:task/id t)
-   :task/deps (validate-deps (:task/id t)
-                             (map ensure-uuid (:task/dependencies t []))
+  (let [task-id (normalize-task-id (:task/id t))]
+  {:task/id task-id
+   :task/deps (validate-deps task-id
+                             (map normalize-task-id (:task/dependencies t []))
                              valid-task-ids)
    :task/description (:task/description t)
    :task/type (:task/type t :implement)
    :task/acceptance-criteria (:task/acceptance-criteria t [])
    :task/context (merge {:parent-plan-id plan-id
                          :parent-workflow-id workflow-id}
-                        (select-keys context [:llm-backend :artifact-store]))})
+                        (select-keys context [:llm-backend :artifact-store]))}))
 
 (defn plan->dag-tasks [plan context]
   (let [tasks (:plan/tasks plan [])
-        valid-task-ids (set (map :task/id tasks))]
+        valid-task-ids (set (map (comp normalize-task-id :task/id) tasks))]
     (mapv #(plan-task->dag-task % valid-task-ids (:plan/id plan) (:workflow-id context) context)
           tasks)))
 

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_test.clj
@@ -292,6 +292,77 @@
           task-c-dag (first (filter #(= task-c (:task/id %)) dag-tasks))]
       (is (= #{task-a task-b} (:task/deps task-c-dag))))))
 
+(deftest test-plan->dag-tasks-keyword-task-ids
+  (testing "keyword task IDs are normalized to deterministic UUIDs"
+    (let [plan {:plan/id (random-uuid)
+                :plan/tasks [{:task/id :task-a
+                              :task/description "A" :task/type :implement
+                              :task/dependencies []}
+                             {:task/id :task-b
+                              :task/description "B" :task/type :implement
+                              :task/dependencies [:task-a]}]}
+          dag-tasks (dag-orch/plan->dag-tasks plan {})
+          id-a (:task/id (first dag-tasks))
+          id-b (:task/id (second dag-tasks))]
+      ;; IDs are UUIDs, not keywords
+      (is (uuid? id-a))
+      (is (uuid? id-b))
+      ;; Same keyword produces same UUID (deterministic)
+      (is (= id-a (java.util.UUID/nameUUIDFromBytes (.getBytes "task-a"))))
+      ;; Dependency resolved correctly
+      (is (= #{id-a} (:task/deps (second dag-tasks)))))))
+
+(deftest test-plan->dag-tasks-keyword-deps-resolve
+  (testing "keyword dependencies resolve to the correct normalized task IDs"
+    (let [plan {:plan/id (random-uuid)
+                :plan/tasks [{:task/id :alpha
+                              :task/description "Alpha" :task/type :implement
+                              :task/dependencies []}
+                             {:task/id :beta
+                              :task/description "Beta" :task/type :implement
+                              :task/dependencies []}
+                             {:task/id :gamma
+                              :task/description "Gamma" :task/type :implement
+                              :task/dependencies [:alpha :beta]}]}
+          dag-tasks (dag-orch/plan->dag-tasks plan {})
+          ids (into {} (map (juxt :task/description :task/id) dag-tasks))
+          gamma-task (first (filter #(= "Gamma" (:task/description %)) dag-tasks))]
+      (is (= #{(ids "Alpha") (ids "Beta")} (:task/deps gamma-task))))))
+
+(deftest test-plan->dag-tasks-mixed-id-types
+  (testing "plan with mixed UUID and keyword IDs normalizes consistently"
+    (let [uuid-id (random-uuid)
+          plan {:plan/id (random-uuid)
+                :plan/tasks [{:task/id uuid-id
+                              :task/description "UUID task" :task/type :implement
+                              :task/dependencies []}
+                             {:task/id :keyword-task
+                              :task/description "Keyword task" :task/type :implement
+                              :task/dependencies [uuid-id]}]}
+          dag-tasks (dag-orch/plan->dag-tasks plan {})]
+      ;; UUID task ID preserved as-is
+      (is (= uuid-id (:task/id (first dag-tasks))))
+      ;; Keyword task ID converted to UUID
+      (is (uuid? (:task/id (second dag-tasks))))
+      ;; Dependency on UUID task resolves
+      (is (= #{uuid-id} (:task/deps (second dag-tasks)))))))
+
+(deftest test-plan->dag-tasks-string-non-uuid-ids
+  (testing "non-UUID string task IDs are normalized to deterministic UUIDs"
+    (let [plan {:plan/id (random-uuid)
+                :plan/tasks [{:task/id "build-fixtures"
+                              :task/description "Build" :task/type :implement
+                              :task/dependencies []}
+                             {:task/id "run-tests"
+                              :task/description "Test" :task/type :test
+                              :task/dependencies ["build-fixtures"]}]}
+          dag-tasks (dag-orch/plan->dag-tasks plan {})
+          id-build (:task/id (first dag-tasks))
+          id-test (:task/id (second dag-tasks))]
+      (is (uuid? id-build))
+      (is (uuid? id-test))
+      (is (= #{id-build} (:task/deps (second dag-tasks)))))))
+
 (deftest test-phantom-deps-caused-stuck-tasks-before-fix
   (testing "regression: phantom deps no longer cause silently stuck tasks"
     (let [[logger _] (log/collecting-logger)


### PR DESCRIPTION
## Summary
- Specs with keyword task IDs (e.g. `:build-deterministic-demo-fixtures`) crashed with `Cannot convert to UUID` because `ensure-uuid` only handled UUIDs and UUID strings
- Replaced `ensure-uuid` with `normalize-task-id` using `UUID/nameUUIDFromBytes` for deterministic conversion of keywords, arbitrary strings, and UUIDs
- Both task IDs and dependency references are normalized consistently so deps resolve correctly

## Test plan
- [x] All 169 workflow tests pass
- [x] `finish-yc-mvp.spec.edn` DAG starts successfully with 8 keyword-ID tasks (previously crashed immediately)

🤖 Generated with [Claude Code](https://claude.com/claude-code)