### PR TITLE
Fix ClassCastException: error map passed as CharSequence to re-find

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -238,7 +238,7 @@
         metrics (:execution/metrics result)]
     (if (phase-reg/succeeded? result)
       (workflow-success (first artifacts) metrics)
-      (workflow-failure (or (first (:execution/errors result))
+      (workflow-failure (or (-> result :execution/errors first :message)
                             "Sub-workflow failed")
                         metrics))))
 

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -55,9 +55,10 @@
   "Check if a DAG result indicates a rate limit error."
   [result]
   (when-not (dag/ok? result)
-    (let [msg (or (get-in result [:error :message])
+    (let [raw (or (get-in result [:error :message])
                   (get-in result [:error :data :message])
-                  (str result))]
+                  (str result))
+          msg (if (string? raw) raw (str raw))]
       (boolean (some #(re-find % msg) @rate-limit-patterns)))))
 
 (defn- find-healthy-backend

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_test.clj
@@ -51,6 +51,15 @@
   (testing "returns nil/false for successful results"
     (is (not (resilience/rate-limit-error? (ok-result :a))))))
 
+(deftest test-rate-limit-error-handles-map-message
+  (testing "handles non-string :message (error map) without throwing ClassCastException"
+    (let [result (dag/err :task-execution-failed
+                          {:type :phase-error :phase :implement
+                           :message "Sub-workflow failed"
+                           :data {:some "context"}}
+                          {:task-id :test})]
+      (is (not (resilience/rate-limit-error? result))))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; analyze-batch-for-rate-limits tests
 


### PR DESCRIPTION
## Summary

- Fix crash when DAG sub-workflow fails: `PersistentArrayMap cannot be cast to java.lang.CharSequence`
- Root cause: `run-mini-workflow` passed the entire error map from `:execution/errors` to `workflow-failure` instead of extracting the `:message` string
- The map flowed through to `rate-limit-error?` which called `re-find` on it — `re-find` requires a CharSequence, not a map
- Also added defensive `str` coercion in `rate-limit-error?` for belt-and-suspenders safety

## Error chain
```
run-mini-workflow: (first (:execution/errors result)) → error MAP
  → workflow-failure → dag/err (stores map as :message)
    → rate-limit-error? → (re-find pattern map) → ClassCastException
```

## Test plan
- [x] New test: `rate-limit-error?` handles non-string `:message` without throwing
- [x] All 174 workflow tests pass (0 failures, 0 errors)
- [ ] Rerun `finish-yc-mvp.spec.edn` — should no longer crash on sub-workflow failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)