### PR TITLE
Remove silent fallback stubs from all agents

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -5,6 +5,7 @@
    [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.specialized :as specialized]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
@@ -170,21 +171,8 @@
                            :action :create}))
            vec))))
 
-(defn- make-fallback-code
-  "Create a fallback code artifact when LLM response cannot be parsed."
-  [task-text]
-  {:code/id (random-uuid)
-   :code/files [{:path "generated/impl.clj"
-                 :content (str "(ns generated.impl\n"
-                               "  \"Generated implementation — fallback stub.\")\n\n"
-                               ";; Task: " (subs task-text 0 (min 60 (count task-text))) "\n\n"
-                               "(defn execute [input]\n"
-                               "  {:status :not-implemented :input input})\n")
-                 :action :create}]
-   :code/tests-needed? true
-   :code/language "clojure"
-   :code/summary "Fallback stub implementation"
-   :code/created-at (java.util.Date.)})
+;; make-fallback-code removed — silent fallback masks real failures,
+;; prevents retry/repair from working, and short-circuits checkpoint resume.
 
 (defn- repair-code-artifact
   "Attempt to repair a code artifact based on validation errors."
@@ -322,47 +310,33 @@
                                :files-created 0
                                :skipped-reason :already-implemented}}
                     ;; Normal code artifact parsing
-                    (let [code (or parsed
-                                   (when-let [files (extract-code-blocks content)]
-                                     {:code/id (random-uuid)
-                                      :code/files files
-                                      :code/tests-needed? true
-                                      :code/summary "Implementation from code blocks"
-                                      :code/created-at (java.util.Date.)})
-                                   (make-fallback-code task-text))
-                          ;; Ensure proper ID and language
-                          code-with-meta (-> code
-                                             (update :code/id #(or % (random-uuid)))
-                                             (assoc :code/language (extract-language (:code/files code) context))
-                                             (assoc :code/created-at (java.util.Date.)))
-                          lang (:code/language code-with-meta)]
-                      {:status :success
-                       :output code-with-meta
-                       :artifact code-with-meta
-                       :tokens tokens
-                       :metrics {:files-created (count (filter #(= :create (:action %)) (:code/files code-with-meta)))
-                                 :files-modified (count (filter #(= :modify (:action %)) (:code/files code-with-meta)))
-                                 :files-deleted (count (filter #(= :delete (:action %)) (:code/files code-with-meta)))
-                                 :language lang
-                                 :tokens tokens}})))
-                ;; LLM call failed
-                (let [fallback (make-fallback-code task-text)]
-                  {:status :error
-                   :error (llm/get-error response)
-                   :output fallback
-                   :artifact fallback
-                   :metrics {:tokens 0}})))
-            ;; No LLM client - use fallback (for testing)
-            (do
-              (log/warn logger :implementer :implementer/no-llm-backend
-                        {:message "No LLM backend provided, using fallback code"})
-              (let [code (make-fallback-code task-text)
-                    lang (extract-language (:code/files code) context)]
-                {:status :success
-                 :output (assoc code :code/language lang)
-                 :artifact (assoc code :code/language lang)
-                 :metrics {:files-created 1
-                           :language lang}})))))
+                    (if-let [code (or parsed
+                                      (when-let [files (extract-code-blocks content)]
+                                        {:code/id (random-uuid)
+                                         :code/files files
+                                         :code/tests-needed? true
+                                         :code/summary "Implementation from code blocks"
+                                         :code/created-at (java.util.Date.)}))]
+                      (let [code-with-meta (-> code
+                                               (update :code/id #(or % (random-uuid)))
+                                               (assoc :code/language (extract-language (:code/files code) context))
+                                               (assoc :code/created-at (java.util.Date.)))
+                            lang (:code/language code-with-meta)]
+                        (response/success code-with-meta
+                                          {:tokens tokens
+                                           :metrics {:files-created (count (filter #(= :create (:action %)) (:code/files code-with-meta)))
+                                                     :files-modified (count (filter #(= :modify (:action %)) (:code/files code-with-meta)))
+                                                     :files-deleted (count (filter #(= :delete (:action %)) (:code/files code-with-meta)))
+                                                     :language lang
+                                                     :tokens tokens}}))
+                      ;; LLM returned content but no parseable code — fail explicitly
+                      (response/error "LLM response could not be parsed as code artifact"
+                                      {:tokens tokens}))))
+                ;; LLM call failed — propagate error, no fallback
+                (response/error (or (:message (llm/get-error response))
+                                    "LLM call failed"))))
+            ;; No LLM client — fail explicitly
+            (response/error "No LLM backend provided"))))
 
       :validate-fn validate-code-artifact
 

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -139,29 +139,8 @@
                  (str/replace #"^-|-$" ""))]
     (subs slug 0 (min 40 (count slug)))))
 
-(defn- make-fallback-artifact
-  "Create a fallback release artifact when LLM response cannot be parsed."
-  [input]
-  (let [code-artifact (:code-artifact input)
-        task-description (get input :task-description "implement changes")
-        files (:code/files code-artifact)
-        slug (slugify task-description)
-        file-summary (when files (summarize-files files))]
-    {:release/id (random-uuid)
-     :release/branch-name (str "feature/" slug)
-     :release/commit-message (str "feat: " task-description "\n\n"
-                                  (when file-summary (str file-summary "\n")))
-     :release/pr-title (str "feat: " (subs task-description 0 (min 60 (count task-description))))
-     :release/pr-description (str "## Summary\n"
-                                  task-description "\n\n"
-                                  "## Changes\n"
-                                  (if files
-                                    (str/join "\n" (map #(str "- " (name (:action %)) " `" (:path %) "`") files))
-                                    "- See commits for details")
-                                  "\n\n## Testing\n"
-                                  "- [ ] Manual verification")
-     :release/files-summary (or file-summary "no file changes")
-     :release/created-at (java.util.Date.)}))
+;; make-fallback-artifact removed — silent fallback masks real failures,
+;; prevents retry/repair from working, and short-circuits checkpoint resume.
 
 (defn- repair-release-artifact
   "Attempt to repair a release artifact based on validation errors."
@@ -249,23 +228,21 @@
                       parsed (or artifact (parse-release-response content))
                       _ (when artifact
                           (log/info logger :releaser :releaser/mcp-artifact-received
-                                    {:data {:branch (:release/branch-name artifact)}}))
-                      release (or parsed (make-fallback-artifact input))
-                      ;; Ensure proper ID and timestamp
-                      release-with-meta (-> release
-                                            (update :release/id #(or % (random-uuid)))
-                                            (assoc :release/created-at (java.util.Date.)))]
-                  (response/success release-with-meta {:tokens tokens}))
-                ;; LLM call failed
-                (let [fallback (make-fallback-artifact input)
-                      error-msg (or (:message (llm/get-error llm-response))
+                                    {:data {:branch (:release/branch-name artifact)}}))]
+                  (if parsed
+                    (let [release-with-meta (-> parsed
+                                                (update :release/id #(or % (random-uuid)))
+                                                (assoc :release/created-at (java.util.Date.)))]
+                      (response/success release-with-meta {:tokens tokens}))
+                    ;; LLM returned content but no parseable release artifact — fail explicitly
+                    (response/error "LLM response could not be parsed as release artifact"
+                                    {:tokens tokens})))
+                ;; LLM call failed — propagate error, no fallback
+                (let [error-msg (or (:message (llm/get-error llm-response))
                                     "LLM call failed")]
-                  (response/error error-msg {:output fallback}))))
-            ;; No LLM client - use fallback (for testing)
-            (do
-              (log/warn logger :releaser :releaser/no-llm-backend
-                        {:message "No LLM backend provided, using fallback release metadata"})
-              (response/success (make-fallback-artifact input))))))
+                  (response/error error-msg))))
+            ;; No LLM client — fail explicitly
+            (response/error "No LLM backend provided"))))
 
       :validate-fn validate-release-artifact
 

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -5,6 +5,7 @@
    [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.specialized :as specialized]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.llm.interface :as llm]
@@ -148,43 +149,8 @@
                              :content (str/trim content)})))
            vec))))
 
-(defn- make-fallback-tests
-  "Create a fallback test artifact when LLM response cannot be parsed."
-  [code-artifact spec]
-  (let [code-files (or (:code/files code-artifact) [])
-        source-file (first (filter #(= :create (:action %)) code-files))
-        source-path (get source-file :path "src/unknown.clj")
-        test-path (-> source-path
-                      (str/replace #"^src/" "test/")
-                      (str/replace #"\.clj$" "_test.clj"))
-        source-ns (-> source-path
-                      (str/replace #"^src/" "")
-                      (str/replace #"\.clj$" "")
-                      (str/replace "/" ".")
-                      (str/replace "_" "-"))
-        test-ns (str source-ns "-test")
-        acceptance-criteria (or (:task/acceptance-criteria spec)
-                                (:acceptance-criteria spec)
-                                ["Functionality works as expected"])]
-    {:test/id (random-uuid)
-     :test/files [{:path test-path
-                   :content (str "(ns " test-ns "\n"
-                                 "  \"Tests for " source-ns ".\"\n"
-                                 "  (:require\n"
-                                 "   [clojure.test :as test :refer [deftest testing is]]\n"
-                                 "   [" source-ns " :as sut]))\n\n"
-                                 ";; Acceptance criteria:\n"
-                                 (str/join "\n" (map #(str ";; - " %) acceptance-criteria))
-                                 "\n\n"
-                                 "(deftest basic-test\n"
-                                 "  (testing \"placeholder test - LLM response could not be parsed\"\n"
-                                 "    (is true)))\n")}]
-     :test/type :unit
-     :test/framework "clojure.test"
-     :test/assertions-count 1
-     :test/cases-count 1
-     :test/summary "Fallback test placeholder"
-     :test/created-at (java.util.Date.)}))
+;; make-fallback-tests removed — silent fallback masks real failures,
+;; prevents retry/repair from working, and short-circuits checkpoint resume.
 
 (defn- repair-test-artifact
   "Attempt to repair a test artifact based on validation errors."
@@ -320,17 +286,16 @@
                       _ (when artifact
                           (log/info logger :tester :tester/mcp-artifact-received
                                     {:data {:file-count (count (:test/files artifact))}}))
-                      ;; Try multiple parsing strategies
+                      ;; Try multiple parsing strategies (no fallback — fail explicitly)
                       tests (or parsed
                                 (when-let [files (extract-test-code-blocks content)]
                                   {:test/id (random-uuid)
                                    :test/files files
                                    :test/type :unit
                                    :test/summary "Tests from code blocks"
-                                   :test/created-at (java.util.Date.)})
-                                (make-fallback-tests code-artifact spec))
-                      ;; Ensure proper ID and calculate metrics
-                      tests-with-meta (-> tests
+                                   :test/created-at (java.util.Date.)}))]
+                  (if tests
+                    (let [tests-with-meta (-> tests
                                           (update :test/id #(or % (random-uuid)))
                                           (assoc :test/framework (extract-test-framework (:test/files tests) context))
                                           (assoc :test/assertions-count
@@ -346,35 +311,21 @@
                                                           (map count-test-cases)
                                                           (reduce +))))
                                           (assoc :test/created-at (java.util.Date.)))]
-                  {:status :success
-                   :output tests-with-meta
-                   :artifact tests-with-meta
-                   :tokens tokens
-                   :metrics {:test-files (count (:test/files tests-with-meta))
-                             :test-type (:test/type tests-with-meta)
-                             :assertions (:test/assertions-count tests-with-meta)
-                             :cases (:test/cases-count tests-with-meta)
-                             :tokens tokens}})
-                ;; LLM call failed
-                (let [fallback (make-fallback-tests code-artifact spec)]
-                  {:status :error
-                   :error (llm/get-error response)
-                   :output fallback
-                   :artifact fallback
-                   :metrics {:tokens 0}})))
-            ;; No LLM client - use fallback (for testing)
-            (do
-              (log/warn logger :tester :tester/no-llm-backend
-                        {:message "No LLM backend provided, using fallback tests"})
-              (let [tests (make-fallback-tests code-artifact spec)
-                    framework (extract-test-framework (:test/files tests) context)]
-                {:status :success
-                 :output (assoc tests :test/framework framework)
-                 :artifact (assoc tests :test/framework framework)
-                 :metrics {:test-files (count (:test/files tests))
-                           :test-type (:test/type tests)
-                           :assertions 1
-                           :cases 1}})))))
+                  (response/success tests-with-meta
+                                    {:tokens tokens
+                                     :metrics {:test-files (count (:test/files tests-with-meta))
+                                               :test-type (:test/type tests-with-meta)
+                                               :assertions (:test/assertions-count tests-with-meta)
+                                               :cases (:test/cases-count tests-with-meta)
+                                               :tokens tokens}}))
+                    ;; LLM returned content but no parseable tests — fail explicitly
+                    (response/error "LLM response could not be parsed as test artifact"
+                                    {:tokens tokens})))
+                ;; LLM call failed — propagate error, no fallback
+                (response/error (or (:message (llm/get-error response))
+                                    "LLM call failed"))))
+            ;; No LLM client — fail explicitly
+            (response/error "No LLM backend provided"))))
 
       :validate-fn validate-test-artifact
 

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -48,30 +48,14 @@
 ;; Invoke tests
 
 (deftest implementer-invoke-test
-  (testing "generates code from task"
+  (testing "fails explicitly without LLM backend (no silent fallback)"
     (let [agent (implementer/create-implementer)
           result (core/invoke agent
                               {:suggested-path "src/auth/login.clj"}
                               {:task/description "Implement user login"
                                :task/type :implement})]
-      (is (= :success (:status result)))
-      (is (uuid? (get-in result [:output :code/id])))
-      (is (vector? (get-in result [:output :code/files])))
-      (is (= :create (get-in result [:output :code/files 0 :action])))))
-
-  (testing "includes metrics in result"
-    (let [agent (implementer/create-implementer)
-          result (core/invoke agent {} {:description "Simple task"})]
-      (is (number? (get-in result [:metrics :files-created])))
-      (is (string? (get-in result [:metrics :language])))))
-
-  (testing "detects language from file extension"
-    (let [agent (implementer/create-implementer)
-          result (core/invoke agent
-                              {:suggested-path "src/app.py"}
-                              {:description "Python task"})]
-      ;; Note: actual language detection happens during generation
-      (is (= :success (:status result))))))
+      (is (= :error (:status result)))
+      (is (some? (:error result))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests
@@ -179,12 +163,11 @@
 ;; Full cycle tests
 
 (deftest implementer-cycle-test
-  (testing "full invoke-validate cycle succeeds"
+  (testing "full invoke-validate cycle fails without LLM (no silent fallback)"
     (let [agent (implementer/create-implementer)
           result (core/cycle-agent agent {} {:task/description "Create a helper function"
                                               :task/type :implement})]
-      (is (= :success (:status result)))
-      (is (uuid? (get-in result [:output :code/id]))))))
+      (is (= :error (:status result))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/test/ai/miniforge/agent/releaser_test.clj
+++ b/components/agent/test/ai/miniforge/agent/releaser_test.clj
@@ -58,27 +58,11 @@
 ;; Invoke tests
 
 (deftest releaser-invoke-test
-  (testing "generates release metadata from code artifact"
+  (testing "fails explicitly without LLM backend (no silent fallback)"
     (let [agent (releaser/create-releaser)
           result (core/invoke agent {} code-artifact-input)]
-      (is (= :success (:status result)))
-      (is (uuid? (get-in result [:output :release/id])))
-      (is (string? (get-in result [:output :release/branch-name])))
-      (is (string? (get-in result [:output :release/commit-message])))
-      (is (string? (get-in result [:output :release/pr-title])))
-      (is (string? (get-in result [:output :release/pr-description])))))
-
-  (testing "generates branch name with proper prefix"
-    (let [agent (releaser/create-releaser)
-          result (core/invoke agent {} code-artifact-input)
-          branch-name (get-in result [:output :release/branch-name])]
-      (is (re-matches #"(feature|fix|refactor|docs|chore)/.*" branch-name))))
-
-  (testing "handles minimal input"
-    (let [agent (releaser/create-releaser)
-          result (core/invoke agent {} {:task-description "simple change"})]
-      (is (= :success (:status result)))
-      (is (string? (get-in result [:output :release/branch-name]))))))
+      (is (= :error (:status result)))
+      (is (some? (:error result))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests
@@ -153,12 +137,10 @@
 ;; Full cycle tests
 
 (deftest releaser-cycle-test
-  (testing "full invoke-validate cycle succeeds"
+  (testing "full invoke-validate cycle fails without LLM (no silent fallback)"
     (let [agent (releaser/create-releaser)
           result (core/cycle-agent agent {} code-artifact-input)]
-      (is (= :success (:status result)))
-      (is (uuid? (get-in result [:output :release/id])))
-      (is (string? (get-in result [:output :release/branch-name]))))))
+      (is (= :error (:status result))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/test/ai/miniforge/agent/tester_test.clj
+++ b/components/agent/test/ai/miniforge/agent/tester_test.clj
@@ -55,31 +55,11 @@
 ;; Invoke tests
 
 (deftest tester-invoke-test
-  (testing "generates tests from code artifact"
+  (testing "fails explicitly without LLM backend (no silent fallback)"
     (let [agent (tester/create-tester)
           result (core/invoke agent {} {:code sample-code-artifact})]
-      (is (= :success (:status result)))
-      (is (uuid? (get-in result [:output :test/id])))
-      (is (vector? (get-in result [:output :test/files])))
-      (is (keyword? (get-in result [:output :test/type])))))
-
-  (testing "includes metrics in result"
-    (let [agent (tester/create-tester)
-          result (core/invoke agent {} {:code sample-code-artifact})]
-      (is (number? (get-in result [:metrics :test-files])))
-      (is (keyword? (get-in result [:metrics :test-type])))
-      (is (number? (get-in result [:metrics :assertions])))))
-
-  (testing "generates tests with acceptance criteria"
-    (let [agent (tester/create-tester)
-          result (core/invoke agent {}
-                              {:code sample-code-artifact
-                               :spec {:acceptance-criteria ["User can log in"
-                                                            "Error shown for invalid credentials"]}})]
-      (is (= :success (:status result)))
-      ;; Check that test content references criteria
-      (let [content (get-in result [:output :test/files 0 :content])]
-        (is (re-find #"Acceptance criteria" content))))))
+      (is (= :error (:status result)))
+      (is (some? (:error result))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests
@@ -193,11 +173,10 @@
 ;; Full cycle tests
 
 (deftest tester-cycle-test
-  (testing "full invoke-validate cycle succeeds"
+  (testing "full invoke-validate cycle fails without LLM (no silent fallback)"
     (let [agent (tester/create-tester)
           result (core/cycle-agent agent {} {:code sample-code-artifact})]
-      (is (= :success (:status result)))
-      (is (uuid? (get-in result [:output :test/id]))))))
+      (is (= :error (:status result))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -82,10 +82,15 @@
 (defn- step-generate-metadata [state]
   (if (failed? state)
     state
-    (let [{:keys [releaser code-artifacts task-description context logger]} state
-          release-meta (metadata/generate-release-metadata
-                        releaser code-artifacts task-description context logger)]
-      (assoc state :release-meta release-meta))))
+    (if (:release-meta state)
+      state ;; Already provided (e.g. by caller or test)
+      (let [{:keys [releaser code-artifacts task-description context logger]} state
+            release-meta (metadata/generate-release-metadata
+                          releaser code-artifacts task-description context logger)]
+        (if release-meta
+          (assoc state :release-meta release-meta)
+          (fail state :metadata-generation-failed
+                "Releaser agent failed to generate release metadata"))))))
 
 (defn- step-create-branch [state]
   (if (failed? state)
@@ -248,17 +253,18 @@
         executor (:executor context)
         environment-id (:environment-id context)
         sandbox? (boolean (and executor environment-id))
-        initial-state {:logger logger
-                       :worktree-path (:worktree-path context)
-                       :artifact-store (:artifact-store context)
-                       :context context
-                       :create-pr? (get context :create-pr? true)
-                       :releaser (:releaser opts)
-                       :task-description (get-in workflow-state [:workflow/spec :spec/description])
-                       :code-artifacts (extract-code-artifacts (:workflow/artifacts workflow-state))
-                       :executor executor
-                       :environment-id environment-id
-                       :sandbox? sandbox?}]
+        initial-state (cond-> {:logger logger
+                               :worktree-path (:worktree-path context)
+                               :artifact-store (:artifact-store context)
+                               :context context
+                               :create-pr? (get context :create-pr? true)
+                               :releaser (:releaser opts)
+                               :task-description (get-in workflow-state [:workflow/spec :spec/description])
+                               :code-artifacts (extract-code-artifacts (:workflow/artifacts workflow-state))
+                               :executor executor
+                               :environment-id environment-id
+                               :sandbox? sandbox?}
+                       (:release-meta opts) (assoc :release-meta (:release-meta opts)))]
 
     (when logger
       (log/info logger :release-executor :phase-started

--- a/components/release-executor/src/ai/miniforge/release_executor/metadata.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/metadata.clj
@@ -66,28 +66,11 @@
           nil))
       nil)))
 
-(defn make-fallback-release-metadata
-  "Generate fallback release metadata when releaser agent is unavailable."
-  [code-artifacts task-description]
-  (let [first-artifact (first code-artifacts)
-        files (:code/files first-artifact)
-        summary (or (:code/summary first-artifact) "code changes")
-        task-desc (or task-description summary)
-        slug (slugify task-desc)]
-    {:release/id (random-uuid)
-     :release/branch-name (str "feature/" slug)
-     :release/commit-message (str "feat: " task-desc)
-     :release/pr-title (str "feat: " (subs task-desc 0 (min 60 (count task-desc))))
-     :release/pr-description (str "## Summary\n" task-desc "\n\n"
-                                  "## Changes\n"
-                                  (if files
-                                    (str/join "\n" (map #(str "- " (name (:action %)) " `" (:path %) "`") files))
-                                    "See commits for details"))
-     :release/created-at (java.util.Date.)}))
+;; make-fallback-release-metadata removed — silent fallback masks real failures,
+;; prevents retry/repair from working, and short-circuits checkpoint resume.
 
 (defn generate-release-metadata
-  "Generate release metadata using releaser agent or fallback.
-   Returns release metadata map."
+  "Generate release metadata using releaser agent.
+   Returns release metadata map, or nil if releaser fails (caller must handle)."
   [releaser code-artifacts task-description context logger]
-  (or (invoke-releaser releaser code-artifacts task-description context logger)
-      (make-fallback-release-metadata code-artifacts task-description)))
+  (invoke-releaser releaser code-artifacts task-description context logger))

--- a/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
@@ -52,6 +52,15 @@
                                            :code/files files}}]
    :workflow/spec {:spec/description "test task"}})
 
+(def test-release-meta
+  "Pre-built release metadata so tests don't need an LLM backend."
+  {:release/id (random-uuid)
+   :release/branch-name "feature/test-change"
+   :release/commit-message "feat: test change"
+   :release/pr-title "feat: test change"
+   :release/pr-description "## Summary\nTest change"
+   :release/created-at (java.util.Date.)})
+
 ;; ============================================================================
 ;; Sandbox mode detection tests
 ;; ============================================================================
@@ -72,7 +81,8 @@
           context {:executor exec
                    :environment-id "mock-env"
                    :create-pr? false}  ;; skip PR creation for simplicity
-          result (core/execute-release-phase workflow-state context {})]
+          result (core/execute-release-phase workflow-state context
+                                             {:release-meta test-release-meta})]
       ;; Should succeed via sandbox path
       (is (:success? result))
       ;; Commands should have been sent to the mock executor
@@ -108,7 +118,8 @@
           context {:executor exec
                    :environment-id "mock-env"
                    :create-pr? false}
-          result (core/execute-release-phase workflow-state context {})]
+          result (core/execute-release-phase workflow-state context
+                                             {:release-meta test-release-meta})]
       (is (:success? result)))))
 
 (deftest sandbox-no-code-artifacts-still-fails


### PR DESCRIPTION
## Summary
- Remove `make-fallback-*` functions from implementer, releaser, tester, and release-executor metadata
- All agents now fail explicitly with `:status :error` when LLM is unavailable or response parsing fails
- Fallback stubs were masking real failures, preventing retry/repair from working, and short-circuiting checkpoint resume
- Add `:release-meta` opts support in `execute-release-phase` so tests (and callers with pre-computed metadata) can bypass the releaser agent

## Test plan
- [x] All 484 core tests pass (0 failures, 0 errors)
- [x] Agent invoke/cycle tests updated to expect `:error` without LLM backend
- [x] Sandbox tests updated with pre-built release metadata
- [ ] Verify dogfood run fails explicitly instead of creating stub PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)