### PR TITLE
Fix nil metrics NPE and TUI data wiring

### DIFF
--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -241,7 +241,7 @@
   [repo]
   (let [result (fetch-github-prs repo :open)]
     (if (succeeded? result)
-      (update result :prs (fn [prs] (vec (remove #(= :closed (:pr/status %)) prs))))
+      (update result :prs (fn [prs] (vec (remove #(#{:closed :merged} (:pr/status %)) prs))))
       result)))
 
 (defn- fetch-open-gitlab-mrs

--- a/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
@@ -91,7 +91,19 @@
     (if-let [wf (when raw-idx (get (:workflows model) raw-idx))]
       (-> model
           (assoc :view :workflow-detail)
-          (assoc-in [:detail :workflow-id] (:id wf))
+          ;; Reset all detail fields to prevent stale data from previous workflow
+          (assoc :detail {:workflow-id    (:id wf)
+                          :phases         []
+                          :current-agent  nil
+                          :agent-output   ""
+                          :evidence       nil
+                          :artifacts      []
+                          :expanded-nodes #{}
+                          :focused-pane   0
+                          :selected-pr    nil
+                          :pr-readiness   nil
+                          :pr-risk        nil
+                          :selected-train nil})
           (assoc :selected-idx 0 :selected-ids #{} :visual-anchor nil
                  :scroll-offset nil :search-matches [] :search-match-idx nil))
       model)))

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -73,9 +73,11 @@
                        :on-chunk :event-stream :worktree-path]))))
 
 (defn merge-metrics
-  "Merge phase metrics into execution metrics."
+  "Merge phase metrics into execution metrics.
+   Nil-safe: treats nil values as 0 to prevent NPE from merge-with +."
   [exec-metrics phase-metrics]
-  (merge-with + exec-metrics
+  (merge-with (fn [a b] (+ (or a 0) (or b 0)))
+              exec-metrics
               (select-keys phase-metrics [:tokens :cost-usd :duration-ms])))
 
 (defn transition-to-completed


### PR DESCRIPTION
## Summary
- **NPE in merge-metrics**: `(merge-with +)` crashes when phase metrics contain nil values (e.g., `:cost-usd nil` from review/verify agents). This caused ALL DAG sub-workflow tasks to fail with NullPointerException. Fixed with nil-safe merge function.
- **TUI stale workflow detail**: Entering a workflow detail view didn't reset phase/agent/artifact data, causing previous workflow's data to leak through. Now resets all detail fields on entry.
- **Merged PRs in open list**: `fetch-open-github-prs` only filtered `:closed` status, not `:merged`. Old merged PRs persisted in the TUI PR list.

## Test plan
- [x] 192 workflow tests pass (0 failures)
- [x] 188 TUI + pr-sync tests pass (0 failures)
- [x] GraalVM compatibility: 0 failures
- [x] Lint: 0 errors, 0 warnings
- [ ] Rerun YC MVP dogfood spec — expect tasks 2+ to succeed now

🤖 Generated with [Claude Code](https://claude.com/claude-code)