### PR TITLE
Enforce cross-component interface discipline

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/plan_executor.clj
@@ -5,7 +5,7 @@
    [ai.miniforge.cli.workflow-runner.context :as context]
    [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
    [ai.miniforge.event-stream.interface :as es]
-   [ai.miniforge.phase.registry :as phase-reg])
+   [ai.miniforge.phase.interface :as phase])
   (:import
    [java.util UUID]))
 
@@ -116,8 +116,8 @@
       (let [execute-dag (requiring-resolve 'ai.miniforge.workflow.dag-orchestrator/execute-plan-as-dag)
             result (execute-dag plan ctx)]
         (when-not quiet
-          (let [completed (count (filter phase-reg/succeeded? (vals result)))
-                failed (count (filter phase-reg/failed? (vals result)))]
+          (let [completed (count (filter phase/succeeded? (vals result)))
+                failed (count (filter phase/failed? (vals result)))]
             (display/print-info (str "Plan execution complete: "
                                      completed " completed, " failed " failed"))))
         result)

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -13,7 +13,7 @@
    [ai.miniforge.cli.workflow-runner.context :as context]
    [ai.miniforge.cli.workflow-runner.sandbox :as sandbox]
    [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
-   [ai.miniforge.phase.registry :as phase-reg]))
+   [ai.miniforge.phase.interface :as phase]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Workflow interface resolution and pipeline helpers
@@ -114,7 +114,7 @@
       (->> (run-pipeline workflow input))))
 
 (defn publish-completion-event [event-stream workflow-id result]
-  (let [status (if (phase-reg/succeeded? result) :success :failure)
+  (let [status (if (phase/succeeded? result) :success :failure)
         duration-ms (get-in result [:execution/metrics :duration-ms])]
     (es/publish! event-stream
                  (if (= status :success)
@@ -352,11 +352,11 @@
           duration (:chain/duration-ms result)]
       (println)
       (println (display/colorize :cyan (apply str (repeat 60 "─"))))
-      (if (phase-reg/succeeded? result)
+      (if (phase/succeeded? result)
         (println (display/colorize :green (str "✓ Chain completed — "
                                                 (count steps) " steps in "
                                                 duration "ms")))
-        (let [failed-step (some #(when (phase-reg/failed? %) (:step/id %)) steps)]
+        (let [failed-step (some #(when (phase/failed? %) (:step/id %)) steps)]
           (println (display/colorize :red (str "✗ Chain failed at step: "
                                                 (when failed-step (name failed-step))))))))))
 

--- a/components/evidence-bundle/src/ai/miniforge/evidence_bundle/chain_evidence.clj
+++ b/components/evidence-bundle/src/ai/miniforge/evidence_bundle/chain_evidence.clj
@@ -3,7 +3,7 @@
 
    Aggregates per-step evidence bundles into a chain-level bundle,
    including chain definition, step results, total timing, and metrics."
-  (:require [ai.miniforge.phase.registry :as phase-reg]))
+  (:require [ai.miniforge.phase.interface :as phase]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Step Summarization
@@ -44,8 +44,8 @@
    - :steps-with-output"
   [step-results]
   (let [total (count step-results)
-        completed (count (filter phase-reg/succeeded? step-results))
-        failed (count (filter phase-reg/failed? step-results))
+        completed (count (filter phase/succeeded? step-results))
+        failed (count (filter phase/failed? step-results))
         with-output (count (filter #(some? (:step/output %)) step-results))]
     {:total-steps total
      :completed-steps completed
@@ -58,7 +58,7 @@
 (defn derive-chain-status
   "Derive chain evidence status from the chain result."
   [chain-result]
-  (if (phase-reg/succeeded? chain-result)
+  (if (phase/succeeded? chain-result)
     :completed
     :failed))
 

--- a/components/llm/test/ai/miniforge/llm/model_selection_integration_test.clj
+++ b/components/llm/test/ai/miniforge/llm/model_selection_integration_test.clj
@@ -3,7 +3,7 @@
    Tests the full flow: task -> classification -> model selection -> execution."
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.agent.task-classifier :as classifier]
+   [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.llm.model-registry :as registry]
    [ai.miniforge.llm.model-selector :as selector]))
 
@@ -16,7 +16,7 @@
                 :title "Architecture Design"}
 
           ;; Step 2: Classify task
-          classification (classifier/classify-task task)
+          classification (agent/classify-task task)
 
           ;; Step 3: Select model
           selection (selector/select-model classification)]
@@ -43,7 +43,7 @@
                 :description "Implement user authentication service"
                 :title "Implement Auth"}
 
-          classification (classifier/classify-task task)
+          classification (agent/classify-task task)
           selection (selector/select-model classification)]
 
       ;; Verify classification
@@ -63,7 +63,7 @@
                 :description "Validate syntax and formatting"
                 :title "Quick Validation"}
 
-          classification (classifier/classify-task task)
+          classification (agent/classify-task task)
           selection (selector/select-model classification)]
 
       ;; Verify classification
@@ -83,7 +83,7 @@
                 :privacy-required true
                 :description "Implement banking feature"}
 
-          classification (classifier/classify-task task)
+          classification (agent/classify-task task)
           selection (selector/select-model classification
                                            {}
                                            {:require-local true})]
@@ -102,7 +102,7 @@
                 :context-tokens 500000
                 :description "Refactor entire codebase"}
 
-          classification (classifier/classify-task task)
+          classification (agent/classify-task task)
           selection (selector/select-model classification
                                            {}
                                            {:context-size 500000})]
@@ -122,7 +122,7 @@
                 :agent-type :implementer-agent
                 :description "Standard implementation task"}
 
-          classification (classifier/classify-task task)
+          classification (agent/classify-task task)
 
           ;; Default automatic selection
           selection-auto (selector/select-model classification
@@ -145,7 +145,7 @@
     (let [task {:phase :plan
                 :description "Architecture planning"}
 
-          classification (classifier/classify-task task)
+          classification (agent/classify-task task)
           selection (selector/select-model classification)
           explanation (selector/explain-selection selection)]
 
@@ -171,7 +171,7 @@
 
           ;; Classify and select for each
           selections (map (fn [task]
-                            (let [classification (classifier/classify-task task)]
+                            (let [classification (agent/classify-task task)]
                               {:task task
                                :classification classification
                                :selection (selector/select-model classification)}))
@@ -203,7 +203,7 @@
     (let [;; Minimal task with no clear signals
           task {:description "Generic task"}
 
-          classification (classifier/classify-task task)
+          classification (agent/classify-task task)
           selection (selector/select-model classification)]
 
       ;; Should default to execution-focused
@@ -222,7 +222,7 @@
                  {:phase :implement :privacy-required true :title "Private code"}]
 
           selections (map (fn [task]
-                            (let [classification (classifier/classify-task task)
+                            (let [classification (agent/classify-task task)
                                   selection (selector/select-model
                                              classification
                                              {}
@@ -250,7 +250,7 @@
     ;; In actual agent creation, passing :model explicitly
     ;; should skip automatic selection
     (let [task {:phase :validate :title "Validation"}
-          classification (classifier/classify-task task)
+          classification (agent/classify-task task)
 
           ;; Normal selection would pick Haiku
           auto-selection (selector/select-model classification)]
@@ -273,8 +273,8 @@
           ;; Low-confidence task (ambiguous)
           low-conf-task {:description "Do something"}
 
-          high-classification (classifier/classify-task high-conf-task)
-          low-classification (classifier/classify-task low-conf-task)
+          high-classification (agent/classify-task high-conf-task)
+          low-classification (agent/classify-task low-conf-task)
 
           high-selection (selector/select-model high-classification)
           low-selection (selector/select-model low-classification)]
@@ -311,7 +311,7 @@
                 :description "Code implementation"
                 :context-tokens 50000}
 
-          classification (classifier/classify-task task)
+          classification (agent/classify-task task)
           selection (selector/select-model classification
                                            {:strategy :automatic}
                                            {:context-size 50000})]

--- a/components/observer/src/ai/miniforge/observer/core.clj
+++ b/components/observer/src/ai/miniforge/observer/core.clj
@@ -5,7 +5,7 @@
    collects metrics, and generates performance reports."
   (:require
    [ai.miniforge.observer.protocol :as proto]
-   [ai.miniforge.phase.registry :as phase-reg]
+   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.workflow.interface :as wf]
    [clojure.string :as str]))
 
@@ -322,7 +322,7 @@
   [observer opts]
   (let [limit (get opts :limit 100)
         metrics (proto/get-all-metrics observer {:limit limit})
-        failed (filter phase-reg/failed? metrics)
+        failed (filter phase/failed? metrics)
 
         ;; Analyze which phases fail most often
         failed-phases (reduce

--- a/components/phase/src/ai/miniforge/phase/interface.clj
+++ b/components/phase/src/ai/miniforge/phase/interface.clj
@@ -72,6 +72,34 @@
      Default config map or nil if unknown"
   registry/phase-defaults)
 
+(def merge-with-defaults
+  "Merge user config with phase defaults."
+  registry/merge-with-defaults)
+
+(def extract-status
+  "Extract a status keyword from a map by trying known status keys."
+  registry/extract-status)
+
+(def succeeded?
+  "Check if a result map indicates success."
+  registry/succeeded?)
+
+(def failed?
+  "Check if a result map indicates failure."
+  registry/failed?)
+
+(def already-done?
+  "Check if a result map indicates work was already complete (neutral outcome)."
+  registry/already-done?)
+
+(def succeeded-or-done?
+  "Check if a result map indicates success or already-done (neutral)."
+  registry/succeeded-or-done?)
+
+(def retrying?
+  "Check if a result map indicates retry."
+  registry/retrying?)
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Pipeline construction
 

--- a/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
@@ -5,11 +5,10 @@
    operations when :executor and :environment-id are present in context,
    and falls back to git operations when they are absent."
   (:require
-   [ai.miniforge.dag-executor.protocols.executor]
+   [ai.miniforge.dag-executor.interface :as dag]
    [clojure.string]
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.release-executor.core :as core]
-   [ai.miniforge.dag-executor.result :as dag-result]))
+   [ai.miniforge.release-executor.core :as core]))
 
 ;; ============================================================================
 ;; Mock executor (same pattern as sandbox_test.clj)
@@ -22,10 +21,10 @@
            default-response {:exit-code 0 :stdout "" :stderr ""}}}]
   (let [commands (atom [])]
     [(reify
-       ai.miniforge.dag-executor.protocols.executor/TaskExecutor
+       dag/TaskExecutor
        (executor-type [_] :mock)
-       (available? [_] (dag-result/ok {:available? true}))
-       (acquire-environment! [_ _ _] (dag-result/ok {:environment-id "mock-env"}))
+       (available? [_] (dag/ok {:available? true}))
+       (acquire-environment! [_ _ _] (dag/ok {:environment-id "mock-env"}))
        (execute! [_ _env-id command _opts]
          (swap! commands conj command)
          (let [response (or (some (fn [[substr resp]]
@@ -33,11 +32,11 @@
                                       resp))
                                   responses)
                             default-response)]
-           (dag-result/ok response)))
-       (copy-to! [_ _ _ _] (dag-result/ok {}))
-       (copy-from! [_ _ _ _] (dag-result/ok {}))
-       (release-environment! [_ _] (dag-result/ok {:released? true}))
-       (environment-status [_ _] (dag-result/ok {:status :running})))
+           (dag/ok response)))
+       (copy-to! [_ _ _ _] (dag/ok {}))
+       (copy-from! [_ _ _ _] (dag/ok {}))
+       (release-environment! [_ _] (dag/ok {:released? true}))
+       (environment-status [_ _] (dag/ok {:status :running})))
      commands]))
 
 ;; ============================================================================

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -4,11 +4,10 @@
    Uses a mock executor to verify correct command generation
    without requiring Docker."
   (:require
-   [ai.miniforge.dag-executor.protocols.executor]
+   [ai.miniforge.dag-executor.interface :as dag]
    [clojure.string]
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.release-executor.sandbox :as sandbox]
-   [ai.miniforge.dag-executor.result :as dag-result]))
+   [ai.miniforge.release-executor.sandbox :as sandbox]))
 
 ;; ============================================================================
 ;; Mock executor
@@ -27,10 +26,10 @@
            default-response {:exit-code 0 :stdout "" :stderr ""}}}]
   (let [commands (atom [])]
     [(reify
-       ai.miniforge.dag-executor.protocols.executor/TaskExecutor
+       dag/TaskExecutor
        (executor-type [_] :mock)
-       (available? [_] (dag-result/ok {:available? true}))
-       (acquire-environment! [_ _ _] (dag-result/ok {:environment-id "mock-env"}))
+       (available? [_] (dag/ok {:available? true}))
+       (acquire-environment! [_ _ _] (dag/ok {:environment-id "mock-env"}))
        (execute! [_ _env-id command _opts]
          (swap! commands conj command)
          (let [response (or (some (fn [[substr resp]]
@@ -38,11 +37,11 @@
                                       resp))
                                   responses)
                             default-response)]
-           (dag-result/ok response)))
-       (copy-to! [_ _ _ _] (dag-result/ok {}))
-       (copy-from! [_ _ _ _] (dag-result/ok {}))
-       (release-environment! [_ _] (dag-result/ok {:released? true}))
-       (environment-status [_ _] (dag-result/ok {:status :running})))
+           (dag/ok response)))
+       (copy-to! [_ _ _ _] (dag/ok {}))
+       (copy-from! [_ _ _ _] (dag/ok {}))
+       (release-environment! [_ _] (dag/ok {:released? true}))
+       (environment-status [_ _] (dag/ok {:status :running})))
      commands]))
 
 ;; ============================================================================

--- a/components/reporting/test/ai/miniforge/reporting/interface_test.clj
+++ b/components/reporting/test/ai/miniforge/reporting/interface_test.clj
@@ -4,7 +4,7 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.reporting.interface :as reporting]
    [ai.miniforge.logging.interface :as log]
-   [ai.miniforge.workflow.protocol :as workflow-proto]))
+   [ai.miniforge.workflow.interface :as workflow]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures
@@ -28,7 +28,7 @@
                           :workflow/created-at (System/currentTimeMillis)
                           :workflow/metrics {:tokens 200 :cost-usd 0.01}}])]
     (reify
-      workflow-proto/Workflow
+      workflow/Workflow
       (get-state [_this workflow-id]
         (if (= workflow-id :all)
           @workflows

--- a/components/workflow/src/ai/miniforge/workflow/chain.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain.clj
@@ -37,7 +37,7 @@
    - [:prev/last-phase-result ...] — navigates into previous step's last phase result
    - keyword                 — reads from chain input"
   (:require
-   [ai.miniforge.phase.registry :as phase-reg]
+   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.workflow.runner :as runner]))
 
 ;------------------------------------------------------------------------------ Layer 0: Binding resolution
@@ -153,7 +153,7 @@
                            :step/chain-id chain-id
                            :step/chain-index idx}
               updated-results (conj step-results step-result)]
-          (if (phase-reg/failed? result)
+          (if (phase/failed? result)
             ;; Step failed — emit failure events and stop
             (let [error (or (:execution/error result) "Step execution failed")]
               (emit! opts 'ai.miniforge.event-stream.interface/chain-step-failed

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -26,7 +26,7 @@
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
-   [ai.miniforge.phase.registry :as phase-reg]
+   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.workflow.dag-resilience :as resilience]))
 
 ;--- Layer 0: Result Constructors
@@ -236,7 +236,7 @@
         result (run-pipeline sub-workflow sub-input sub-opts)
         artifacts (:execution/artifacts result)
         metrics (:execution/metrics result)]
-    (if (phase-reg/succeeded? result)
+    (if (phase/succeeded? result)
       (workflow-success (first artifacts) metrics)
       (workflow-failure (or (-> result :execution/errors first :message)
                             "Sub-workflow failed")

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -22,7 +22,7 @@
    Handles execution of individual phase steps through the enter -> gates -> leave lifecycle.
    Processes results, tracks metrics/files/artifacts, and determines phase transitions."
   (:require [ai.miniforge.gate.interface :as gate]
-            [ai.miniforge.phase.registry :as phase-reg]
+            [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.workflow.dag-orchestrator :as dag-orch]))
 
@@ -89,8 +89,8 @@
 (defn already-done?
   "Check if phase result indicates work was already done."
   [phase-result]
-  (or (phase-reg/already-done? phase-result)
-      (phase-reg/already-done? (:result phase-result))))
+  (or (phase/already-done? phase-result)
+      (phase/already-done? (:result phase-result))))
 
 (defn apply-gate-validation
   "Apply gate validation to phase result.
@@ -116,7 +116,7 @@
 (defn phase-succeeded?
   "Check if phase completed successfully or work was already done."
   [phase-result]
-  (or (phase-reg/succeeded-or-done? phase-result)
+  (or (phase/succeeded-or-done? phase-result)
       (already-done? phase-result)))
 
 (defn update-response-chain
@@ -203,11 +203,11 @@
         redirect-to (:redirect-to phase-result)]
     (cond
       ;; Phase retrying (transient error, stay at current index)
-      (phase-reg/retrying? phase-result)
+      (phase/retrying? phase-result)
       current-index
 
       ;; Phase already done — skip to done
-      (phase-reg/already-done? phase-result)
+      (phase/already-done? phase-result)
       (let [done-index (->> pipeline
                             (map-indexed vector)
                             (filter #(= :done (get-in (second %) [:config :phase])))
@@ -215,7 +215,7 @@
         (if done-index (first done-index) :done))
 
       ;; Phase completed successfully
-      (phase-reg/succeeded? phase-result)
+      (phase/succeeded? phase-result)
       (if on-success
         ;; Find target phase by name
         (let [target-index (->> pipeline
@@ -230,7 +230,7 @@
             :done)))
 
       ;; Phase failed with redirect — jump to target phase
-      (and (phase-reg/failed? phase-result) redirect-to)
+      (and (phase/failed? phase-result) redirect-to)
       (let [target-index (->> pipeline
                               (map-indexed vector)
                               (filter #(= redirect-to (get-in (second %) [:config :phase])))
@@ -238,7 +238,7 @@
         (if target-index (first target-index) :error))
 
       ;; Phase failed
-      (phase-reg/failed? phase-result)
+      (phase/failed? phase-result)
       (if on-fail
         ;; Find target phase by name
         (let [target-index (->> pipeline

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -26,7 +26,6 @@
 
    Provides the main run-pipeline entry point."
   (:require [ai.miniforge.phase.interface :as phase]
-            [ai.miniforge.phase.registry :as phase-reg]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.workflow.context :as ctx]
             [ai.miniforge.workflow.execution :as exec]
@@ -132,7 +131,7 @@
         (publish-event! event-stream
                         (constructor event-stream (:execution/id context) phase-name
                                      {:outcome (if (or (:success? result)
-                                                       (phase-reg/succeeded-or-done? result))
+                                                       (phase/succeeded-or-done? result))
                                                  :success
                                                  :failure)
                                       :duration-ms (or (get-in result [:phase/metrics :duration-ms])
@@ -351,7 +350,7 @@
                         (inc iteration)))))
 
            ;; Validate completed workflows produced results
-           final-ctx (if (and (phase-reg/succeeded? final-ctx)
+           final-ctx (if (and (phase/succeeded? final-ctx)
                               (empty? (:execution/artifacts final-ctx))
                               (empty? (:execution/phase-results final-ctx)))
                        (-> final-ctx
@@ -369,7 +368,7 @@
        (try
          (when-let [operator (:operator opts)]
            (let [observe-fn (requiring-resolve 'ai.miniforge.operator.interface/observe-signal)
-                 signal-type (if (phase-reg/succeeded? output-ctx)
+                 signal-type (if (phase/succeeded? output-ctx)
                                :workflow-complete
                                :workflow-failed)]
              (observe-fn operator

--- a/components/workflow/src/ai/miniforge/workflow/state.clj
+++ b/components/workflow/src/ai/miniforge/workflow/state.clj
@@ -22,7 +22,7 @@
    Uses a formal FSM (see fsm.clj) for state transitions.
    Tracks runtime state separately from workflow configuration."
   (:require
-   [ai.miniforge.phase.registry :as phase-reg]
+   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.workflow.fsm :as fsm]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -209,12 +209,12 @@
 (defn completed?
   "Check if execution is completed."
   [state]
-  (phase-reg/succeeded? state))
+  (phase/succeeded? state))
 
 (defn failed?
   "Check if execution has failed."
   [state]
-  (phase-reg/failed? state))
+  (phase/failed? state))
 
 (defn running?
   "Check if execution is running."

--- a/components/workflow/test/ai/miniforge/workflow/chain_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/chain_events_test.clj
@@ -4,14 +4,14 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.workflow.chain :as chain]
    [ai.miniforge.workflow.runner :as runner]
-   [ai.miniforge.event-stream.core :as es-core]))
+   [ai.miniforge.event-stream.interface :as event-stream]))
 
 ;------------------------------------------------------------------------------ Helpers
 
 (defn create-test-stream
   "Create a minimal event stream with no sinks for testing."
   []
-  (es-core/create-event-stream {:sinks []}))
+  (event-stream/create-event-stream {:sinks []}))
 
 (defn event-types
   "Extract ordered event types from a stream."

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]
-   [ai.miniforge.phase.release]))
+   [ai.miniforge.phase.interface]))
 
 ;; ---------------------------------------------------------------------------- extract-output
 

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -6,8 +6,7 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]
-   ;; :done is registered by release.clj
-   [ai.miniforge.phase.release]))
+   [ai.miniforge.phase.interface]))
 
 ;; ============================================================================
 ;; Context creation tests

--- a/projects/miniforge/test/ai/miniforge/phase/handoff_test.clj
+++ b/projects/miniforge/test/ai/miniforge/phase/handoff_test.clj
@@ -7,16 +7,7 @@
   Mocks all agent invocations to focus purely on the handoff plumbing."
   (:require
    [clojure.test :refer [deftest testing is]]
-   ;; Required for defmethod side effects (register phase handlers)
-   #_{:clj-kondo/ignore [:unused-namespace]}
-   [ai.miniforge.phase.plan]
-   #_{:clj-kondo/ignore [:unused-namespace]}
-   [ai.miniforge.phase.implement]
-   #_{:clj-kondo/ignore [:unused-namespace]}
-   [ai.miniforge.phase.verify]
-   #_{:clj-kondo/ignore [:unused-namespace]}
-   [ai.miniforge.phase.release]
-   [ai.miniforge.phase.registry :as registry]
+   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.release-executor.interface :as release-executor]
@@ -123,7 +114,7 @@
 
   Simulates the workflow runner's phase execution."
   [phase-name ctx]
-  (let [interceptor (registry/get-phase-interceptor {:phase phase-name})
+  (let [interceptor (phase/get-phase-interceptor {:phase phase-name})
         enter-fn (:enter interceptor)]
     (enter-fn ctx)))
 
@@ -132,7 +123,7 @@
 
   Simulates the workflow runner's phase completion and result storage."
   [phase-name ctx]
-  (let [interceptor (registry/get-phase-interceptor {:phase phase-name})
+  (let [interceptor (phase/get-phase-interceptor {:phase phase-name})
         leave-fn (:leave interceptor)
         updated-ctx (leave-fn ctx)]
     ;; Store entire phase map in execution context (mimics workflow runner)

--- a/projects/miniforge/test/ai/miniforge/workflow/artifact_persistence_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/artifact_persistence_test.clj
@@ -20,7 +20,7 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [babashka.fs :as fs]
-   [ai.miniforge.phase.registry :as registry]
+   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.release-executor.interface :as release-executor]
@@ -130,7 +130,7 @@
                   :execution/metrics {:tokens 0 :duration-ms 0}
                   :execution/phase-results {}}
         
-        plan-interceptor (registry/get-phase-interceptor {:phase :plan})
+        plan-interceptor (phase/get-phase-interceptor {:phase :plan})
         plan-result-ctx (-> plan-ctx
                            (assoc :phase-config {:phase :plan})
                            ((:enter plan-interceptor))
@@ -143,7 +143,7 @@
         
         ;; Execute implement phase
         impl-ctx (assoc plan-result-ctx :phase-config {:phase :implement})
-        impl-interceptor (registry/get-phase-interceptor {:phase :implement})
+        impl-interceptor (phase/get-phase-interceptor {:phase :implement})
         impl-result-ctx (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                                       agent/invoke (or implement-agent-fn
                                                       (fn [_ _ _]
@@ -161,7 +161,7 @@
         ;; Execute verify phase (optional)
         verify-result-ctx (when verify-agent-fn
                            (let [verify-ctx (assoc impl-result-ctx :phase-config {:phase :verify})
-                                 verify-interceptor (registry/get-phase-interceptor {:phase :verify})]
+                                 verify-interceptor (phase/get-phase-interceptor {:phase :verify})]
                              (with-redefs [agent/create-tester (fn [_] {:type :mock-tester})
                                           agent/invoke verify-agent-fn]
                                (-> verify-ctx
@@ -173,7 +173,7 @@
         release-ctx (assoc release-ctx 
                           :phase-config {:phase :release}
                           :worktree-path *test-worktree-path*)
-        release-interceptor (registry/get-phase-interceptor {:phase :release})]
+        release-interceptor (phase/get-phase-interceptor {:phase :release})]
     
     (if release-opts
       ;; Custom release executor for testing
@@ -286,7 +286,7 @@
                :execution/phase-results {}
                :phase-config {:phase :verify}}
 
-          verify-interceptor (registry/get-phase-interceptor {:phase :verify})]
+          verify-interceptor (phase/get-phase-interceptor {:phase :verify})]
 
       (with-redefs [agent/create-tester (fn [_] {:type :mock-tester})
                     agent/invoke (fn [_agent _task _ctx]


### PR DESCRIPTION
## Summary

- Expose phase status predicates (`succeeded?`, `failed?`, `already-done?`, `succeeded-or-done?`, `retrying?`) through `phase.interface`
- Fix 16 cross-component violations across 19 files — all deps now route through `.interface` namespaces
- Applies to both src and test code equally

### Violations fixed

| Pattern | Count | Fix |
|---------|-------|-----|
| `phase.registry` imported from outside phase | 9 files | → `phase.interface` |
| `agent.task-classifier` from llm test | 1 file | → `agent.interface` |
| `dag-executor.protocols.executor` + `dag-executor.result` from release-executor tests | 2 files | → `dag-executor.interface` |
| `workflow.protocol` from reporting test | 1 file | → `workflow.interface` |
| `event-stream.core` from workflow test | 1 file | → `event-stream.interface` |
| `phase.release` side-effect imports | 2 files | → `phase.interface` (loads all phases) |
| `phase.verify`/`phase.release`/etc scattered side-effect imports | 1 file | → single `phase.interface` |

## Test plan

- [x] All 425 brick tests pass (0 failures, 0 errors)
- [x] Pre-commit hook passes (lint + test + graalvm)
- [x] No remaining cross-component `.registry`/`.core`/`.protocol` imports outside their own component

🤖 Generated with [Claude Code](https://claude.com/claude-code)