### PR TITLE
Elevate hidden DAG in pr-lifecycle create-pr!

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -96,7 +96,92 @@
   nil)
 
 ;------------------------------------------------------------------------------ Layer 1
-;; PR creation
+;; PR creation steps
+
+(defn fail-controller!
+  "Mark controller as failed and return a DAG error."
+  [controller error-key error-msg]
+  (update-status! controller :failed)
+  (dag/err error-key error-msg))
+
+(defn create-and-checkout-branch!
+  "Create and checkout a new branch for the task.
+   Returns the branch result or a DAG error."
+  [controller worktree-path branch-name]
+  (let [branch-result (release/create-branch! worktree-path branch-name)]
+    (if (:success? branch-result)
+      branch-result
+      (do
+        (add-history! controller :pr-creation-failed {:error (:error branch-result)})
+        (fail-controller! controller :branch-creation-failed (:error branch-result))))))
+
+(defn apply-code-to-files!
+  "Apply the code artifact to the worktree.
+   Returns the apply result or a DAG error."
+  [controller worktree-path code-artifact logger]
+  (let [apply-result (fix/apply-fix-to-worktree worktree-path code-artifact logger)]
+    (if (dag/err? apply-result)
+      (fail-controller! controller :artifact-apply-failed (:error apply-result))
+      apply-result)))
+
+(defn commit-changes!
+  "Stage and commit all changes with the given task info.
+   Returns the commit result or a DAG error."
+  [controller worktree-path task task-id]
+  (let [commit-msg (str "feat: " (or (:task/title task) "implement task")
+                        "\n\nTask: " task-id)
+        commit-result (release/commit-changes! worktree-path commit-msg)]
+    (if (:success? commit-result)
+      commit-result
+      (fail-controller! controller :commit-failed (:error commit-result)))))
+
+(defn push-and-create-pr!
+  "Push the branch and open a GitHub PR.
+   Returns the PR info map or a DAG error."
+  [controller worktree-path branch-name base-branch task task-id commit-result]
+  (let [push-result (release/push-branch! worktree-path branch-name)]
+    (if-not (:success? push-result)
+      (fail-controller! controller :push-failed (:error push-result))
+      (let [pr-title (or (:task/title task) (str "Task " (subs (str task-id) 0 8)))
+            pr-body  (str "## Task\n\n"
+                          (or (:task/description task) "Automated task implementation")
+                          "\n\n"
+                          "## Acceptance Criteria\n\n"
+                          (when-let [criteria (:task/acceptance-criteria task)]
+                            (str/join "\n" (map #(str "- " %) criteria))))
+            pr-result (release/create-pr! worktree-path
+                                          {:title pr-title
+                                           :body pr-body
+                                           :base-branch base-branch})]
+        (if-not (:success? pr-result)
+          (fail-controller! controller :pr-creation-failed (:error pr-result))
+          {:pr/id       (:pr-number pr-result)
+           :pr/url      (:pr-url pr-result)
+           :pr/branch   branch-name
+           :pr/base-sha nil
+           :pr/head-sha (:commit-sha commit-result)})))))
+
+(defn finalize-pr-creation!
+  "Record PR info on the controller, publish the event, and log success."
+  [controller pr-info dag-id run-id task-id event-bus logger]
+  (swap! controller assoc :pr pr-info)
+  (add-history! controller :pr-created pr-info)
+  (when event-bus
+    (events/publish! event-bus
+                     (events/pr-opened dag-id run-id task-id
+                                       (:pr/id pr-info)
+                                       (:pr/url pr-info)
+                                       (:pr/branch pr-info)
+                                       (:pr/head-sha pr-info))
+                     logger))
+  (when logger
+    (log/info logger :pr-lifecycle :controller/pr-created
+              {:message "PR created successfully"
+               :data {:pr-url (:pr/url pr-info)}}))
+  (dag/ok pr-info))
+
+;------------------------------------------------------------------------------ Layer 1
+;; PR creation orchestrator
 
 (defn create-pr!
   "Create a PR for the task.
@@ -120,78 +205,23 @@
                 {:message "Creating PR for task"
                  :data {:task-id task-id :branch branch-name}}))
 
-    ;; Create branch
-    (let [branch-result (release/create-branch! worktree-path branch-name)]
-      (if-not (:success? branch-result)
-        (do
-          (update-status! controller :failed)
-          (add-history! controller :pr-creation-failed {:error (:error branch-result)})
-          (dag/err :branch-creation-failed (:error branch-result)))
-
-        ;; Apply code artifact
-        (let [apply-result (fix/apply-fix-to-worktree worktree-path code-artifact logger)]
+    (let [branch-result (create-and-checkout-branch! controller worktree-path branch-name)]
+      (if (dag/err? branch-result)
+        branch-result
+        (let [apply-result (apply-code-to-files! controller worktree-path code-artifact logger)]
           (if (dag/err? apply-result)
-            (do
-              (update-status! controller :failed)
-              (dag/err :artifact-apply-failed (:error apply-result)))
-
-            ;; Stage and commit
-            (let [commit-msg (str "feat: " (or (:task/title task) "implement task")
-                                  "\n\nTask: " task-id)
-                  commit-result (release/commit-changes! worktree-path commit-msg)]
-              (if-not (:success? commit-result)
-                (do
-                  (update-status! controller :failed)
-                  (dag/err :commit-failed (:error commit-result)))
-
-                ;; Push and create PR
-                (let [push-result (release/push-branch! worktree-path branch-name)]
-                  (if-not (:success? push-result)
-                    (do
-                      (update-status! controller :failed)
-                      (dag/err :push-failed (:error push-result)))
-
-                    (let [pr-title (or (:task/title task) (str "Task " (subs (str task-id) 0 8)))
-                          pr-body (str "## Task\n\n"
-                                       (or (:task/description task) "Automated task implementation")
-                                       "\n\n"
-                                       "## Acceptance Criteria\n\n"
-                                       (when-let [criteria (:task/acceptance-criteria task)]
-                                         (str/join "\n" (map #(str "- " %) criteria))))
-                          pr-result (release/create-pr! worktree-path
-                                                        {:title pr-title
-                                                         :body pr-body
-                                                         :base-branch (:base-branch branch-result)})]
-                      (if-not (:success? pr-result)
-                        (do
-                          (update-status! controller :failed)
-                          (dag/err :pr-creation-failed (:error pr-result)))
-
-                        ;; Success!
-                        (let [pr-info {:pr/id (:pr-number pr-result)
-                                       :pr/url (:pr-url pr-result)
-                                       :pr/branch branch-name
-                                       :pr/base-sha nil
-                                       :pr/head-sha (:commit-sha commit-result)}]
-                          (swap! controller assoc :pr pr-info)
-                          (add-history! controller :pr-created pr-info)
-
-                          ;; Publish event
-                          (when event-bus
-                            (events/publish! event-bus
-                                             (events/pr-opened dag-id run-id task-id
-                                                               (:pr/id pr-info)
-                                                               (:pr/url pr-info)
-                                                               branch-name
-                                                               (:pr/head-sha pr-info))
-                                             logger))
-
-                          (when logger
-                            (log/info logger :pr-lifecycle :controller/pr-created
-                                      {:message "PR created successfully"
-                                       :data {:pr-url (:pr/url pr-info)}}))
-
-                          (dag/ok pr-info))))))))))))))
+            apply-result
+            (let [commit-result (commit-changes! controller worktree-path task task-id)]
+              (if (dag/err? commit-result)
+                commit-result
+                (let [pr-info (push-and-create-pr! controller worktree-path branch-name
+                                                   (:base-branch branch-result)
+                                                   task task-id commit-result)]
+                  (if (dag/err? pr-info)
+                    pr-info
+                    (finalize-pr-creation! controller pr-info
+                                           dag-id run-id task-id
+                                           event-bus logger)))))))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Monitoring

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
@@ -2,12 +2,16 @@
   "Unit tests for the PR lifecycle controller state machine.
 
    Tests controller creation, state initialization, configuration,
-   fix iteration enforcement, and history tracking.
-   Does NOT test functions that call external services."
+   fix iteration enforcement, history tracking, and the extracted
+   PR creation step functions."
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.pr-lifecycle.controller :as controller]
-   [ai.miniforge.pr-lifecycle.merge :as merge]))
+   [ai.miniforge.pr-lifecycle.merge :as merge]
+   [ai.miniforge.pr-lifecycle.events :as events]
+   [ai.miniforge.pr-lifecycle.fix-loop :as fix]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.release-executor.interface :as release]))
 
 ;------------------------------------------------------------------------------ Test Data
 
@@ -231,3 +235,174 @@
                  :worktree-path "/tmp")]
       (is (nil? (:ci-monitor @ctrl)))
       (is (nil? (:review-monitor @ctrl))))))
+
+;------------------------------------------------------------------------------ Extracted PR creation steps
+
+(defn make-controller
+  "Create a test controller with minimal config."
+  ([] (make-controller {}))
+  ([overrides]
+   (let [ctrl (controller/create-controller
+                "dag-1" "run-1" "task-00000001" test-task
+                :worktree-path "/tmp/repo")]
+     (when (seq overrides)
+       (swap! ctrl merge overrides))
+     ctrl)))
+
+;; fail-controller!
+
+(deftest fail-controller-sets-status-and-returns-err
+  (testing "fail-controller! sets :failed status and returns a DAG error"
+    (let [ctrl (make-controller)]
+      (is (= :pending (:status @ctrl)))
+      (let [result (controller/fail-controller! ctrl :some-error "boom")]
+        (is (= :failed (:status @ctrl)))
+        (is (dag/err? result))
+        (is (= :some-error (get-in result [:error :code])))))))
+
+;; create-and-checkout-branch!
+
+(deftest create-and-checkout-branch-success
+  (testing "Returns branch result on success"
+    (let [ctrl (make-controller)]
+      (with-redefs [release/create-branch! (fn [_path _name]
+                                              {:success? true :base-branch "main"})]
+        (let [result (controller/create-and-checkout-branch! ctrl "/tmp" "feat/x")]
+          (is (:success? result))
+          (is (= "main" (:base-branch result))))))))
+
+(deftest create-and-checkout-branch-failure
+  (testing "Returns DAG error on failure and adds history"
+    (let [ctrl (make-controller)]
+      (with-redefs [release/create-branch! (fn [_path _name]
+                                              {:success? false :error "git error"})]
+        (let [result (controller/create-and-checkout-branch! ctrl "/tmp" "feat/x")]
+          (is (dag/err? result))
+          (is (= :failed (:status @ctrl)))
+          (is (some #(= :pr-creation-failed (:type %)) (:history @ctrl))))))))
+
+;; apply-code-to-files!
+
+(deftest apply-code-to-files-success
+  (testing "Returns apply result on success"
+    (let [ctrl (make-controller)]
+      (with-redefs [fix/apply-fix-to-worktree (fn [_path _artifact _logger]
+                                                 {:applied true})]
+        (let [result (controller/apply-code-to-files! ctrl "/tmp" {:code/files []} nil)]
+          (is (= {:applied true} result)))))))
+
+(deftest apply-code-to-files-failure
+  (testing "Returns DAG error when fix/apply returns error"
+    (let [ctrl (make-controller)]
+      (with-redefs [fix/apply-fix-to-worktree (fn [_path _artifact _logger]
+                                                 (dag/err :apply-failed "bad artifact"))]
+        (let [result (controller/apply-code-to-files! ctrl "/tmp" {:code/files []} nil)]
+          (is (dag/err? result))
+          (is (= :failed (:status @ctrl))))))))
+
+;; commit-changes!
+
+(deftest commit-changes-success
+  (testing "Returns commit result on success"
+    (let [ctrl (make-controller)
+          task-id "task-00000001"]
+      (with-redefs [release/commit-changes! (fn [_path _msg]
+                                               {:success? true :commit-sha "abc123"})]
+        (let [result (controller/commit-changes! ctrl "/tmp" test-task task-id)]
+          (is (:success? result))
+          (is (= "abc123" (:commit-sha result))))))))
+
+(deftest commit-changes-failure
+  (testing "Returns DAG error on commit failure"
+    (let [ctrl (make-controller)]
+      (with-redefs [release/commit-changes! (fn [_path _msg]
+                                               {:success? false :error "nothing to commit"})]
+        (let [result (controller/commit-changes! ctrl "/tmp" test-task "t-1")]
+          (is (dag/err? result))
+          (is (= :failed (:status @ctrl))))))))
+
+(deftest commit-changes-uses-task-title-in-message
+  (testing "Commit message includes task title"
+    (let [ctrl (make-controller)
+          captured-msg (atom nil)]
+      (with-redefs [release/commit-changes! (fn [_path msg]
+                                               (reset! captured-msg msg)
+                                               {:success? true :commit-sha "x"})]
+        (controller/commit-changes! ctrl "/tmp" test-task "t-1")
+        (is (.contains @captured-msg "Implement feature X"))))))
+
+;; push-and-create-pr!
+
+(deftest push-and-create-pr-success
+  (testing "Returns PR info map on success"
+    (let [ctrl (make-controller)]
+      (with-redefs [release/push-branch! (fn [_path _branch]
+                                            {:success? true})
+                    release/create-pr! (fn [_path opts]
+                                         {:success? true
+                                          :pr-number 42
+                                          :pr-url "https://github.com/org/repo/pull/42"})]
+        (let [commit {:commit-sha "abc123"}
+              result (controller/push-and-create-pr! ctrl "/tmp" "feat/x" "main"
+                                                      test-task "t-1" commit)]
+          (is (map? result))
+          (is (not (dag/err? result)))
+          (is (= 42 (:pr/id result)))
+          (is (= "feat/x" (:pr/branch result)))
+          (is (= "abc123" (:pr/head-sha result))))))))
+
+(deftest push-and-create-pr-push-failure
+  (testing "Returns DAG error when push fails"
+    (let [ctrl (make-controller)]
+      (with-redefs [release/push-branch! (fn [_path _branch]
+                                            {:success? false :error "remote rejected"})]
+        (let [result (controller/push-and-create-pr! ctrl "/tmp" "feat/x" "main"
+                                                      test-task "t-1" {:commit-sha "x"})]
+          (is (dag/err? result))
+          (is (= :failed (:status @ctrl))))))))
+
+(deftest push-and-create-pr-pr-creation-failure
+  (testing "Returns DAG error when PR creation fails"
+    (let [ctrl (make-controller)]
+      (with-redefs [release/push-branch! (fn [_path _branch]
+                                            {:success? true})
+                    release/create-pr! (fn [_path _opts]
+                                         {:success? false :error "repo not found"})]
+        (let [result (controller/push-and-create-pr! ctrl "/tmp" "feat/x" "main"
+                                                      test-task "t-1" {:commit-sha "x"})]
+          (is (dag/err? result)))))))
+
+(deftest push-and-create-pr-includes-acceptance-criteria
+  (testing "PR body includes acceptance criteria from task"
+    (let [ctrl (make-controller)
+          captured-opts (atom nil)]
+      (with-redefs [release/push-branch! (fn [_path _branch] {:success? true})
+                    release/create-pr! (fn [_path opts]
+                                         (reset! captured-opts opts)
+                                         {:success? true :pr-number 1 :pr-url "url"})]
+        (controller/push-and-create-pr! ctrl "/tmp" "feat/x" "main"
+                                         test-task "t-1" {:commit-sha "x"})
+        (is (.contains (:body @captured-opts) "Tests pass"))
+        (is (.contains (:body @captured-opts) "No lint errors"))))))
+
+;; finalize-pr-creation!
+
+(deftest finalize-pr-creation-records-pr-and-returns-ok
+  (testing "Stores PR on controller, adds history, returns dag/ok"
+    (let [ctrl (make-controller)
+          pr-info {:pr/id 42 :pr/url "url" :pr/branch "feat/x" :pr/head-sha "abc"}
+          result (controller/finalize-pr-creation! ctrl pr-info "dag" "run" "task" nil nil)]
+      (is (dag/ok? result))
+      (is (= 42 (get-in @ctrl [:pr :pr/id])))
+      (is (some #(= :pr-created (:type %)) (:history @ctrl))))))
+
+(deftest finalize-pr-creation-publishes-event
+  (testing "Publishes pr-opened event when event-bus is present"
+    (let [ctrl (make-controller)
+          published (atom [])
+          mock-bus (reify Object)
+          pr-info {:pr/id 42 :pr/url "url" :pr/branch "feat/x" :pr/head-sha "abc"}]
+      (with-redefs [events/publish! (fn [_bus event _logger]
+                                       (swap! published conj event))]
+        (controller/finalize-pr-creation! ctrl pr-info "dag" "run" "task" mock-bus nil)
+        (is (= 1 (count @published)))))))


### PR DESCRIPTION
## Summary

- Decompose `create-pr!` from ~93 lines with 4-level nested let-if chains into 6 named step functions
- Each step has a single responsibility: branch creation, code application, commit, push, PR creation, finalization
- `create-pr!` is now a thin orchestrator calling steps in sequence

## Functions extracted

| Function | Responsibility |
|----------|---------------|
| `fail-controller!` | Shared error: mark failed + return DAG error |
| `create-and-checkout-branch!` | Git branch creation |
| `apply-code-to-files!` | Apply code artifact to worktree |
| `commit-changes!` | Stage and commit with message |
| `push-and-create-pr!` | Push branch, open GitHub PR |
| `finalize-pr-creation!` | Record PR info, publish event, log |

## Test plan

- [x] All 137 changed-brick tests pass
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)