### PR TITLE
Fix duplicate events, missing error details, and verify redirect

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -183,7 +183,9 @@
                :phase/outcome outcome)
         (cond->
           (:duration-ms result) (assoc :phase/duration-ms (:duration-ms result))
-          (:artifacts result) (assoc :phase/artifacts (:artifacts result))))))
+          (:artifacts result) (assoc :phase/artifacts (:artifacts result))
+          (:error result) (assoc :phase/error (:error result))
+          (:redirect-to result) (assoc :phase/redirect-to (:redirect-to result))))))
 
 (defn agent-chunk [stream workflow-id agent-id delta & [done?]]
   (-> (create-envelope stream :agent/chunk workflow-id

--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -29,30 +29,6 @@
             [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Event stream helpers (optional dependency)
-
-(defn emit-phase-started!
-  "Emit phase-started event if event-stream is available in context."
-  [ctx phase]
-  (when-let [event-stream (:event-stream ctx)]
-    (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (when-let [phase-started (requiring-resolve 'ai.miniforge.event-stream.interface/phase-started)]
-        (let [workflow-id (:execution/id ctx)]
-          (publish! event-stream (phase-started event-stream workflow-id phase)))))))
-
-(defn emit-phase-completed!
-  "Emit phase-completed event if event-stream is available in context."
-  [ctx phase _result]
-  (when-let [event-stream (:event-stream ctx)]
-    (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (when-let [phase-completed (requiring-resolve 'ai.miniforge.event-stream.interface/phase-completed)]
-        (let [workflow-id (:execution/id ctx)
-              outcome (if (registry/succeeded-or-done? (:phase ctx)) :success :failure)
-              duration-ms (get-in ctx [:phase :duration-ms])]
-          (publish! event-stream (phase-completed event-stream workflow-id phase
-                                                   {:outcome outcome :duration-ms duration-ms})))))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Defaults
 
 (def default-config
@@ -127,7 +103,6 @@
    Reads plan from context, invokes implementer agent,
    runs through inner loop with syntax/lint gates."
   [ctx]
-  (emit-phase-started! ctx :implement)
   (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
         {:keys [gates budget]} config
         start-time (System/currentTimeMillis)
@@ -189,9 +164,7 @@
     (when (and (not= :already-implemented agent-status)
                (nil? (:output result)))
       (println "WARNING: implement phase result has no :output — artifact may be nil"))
-    ;; Emit phase completed event
-    (emit-phase-completed! updated-ctx :implement result)
-    ;; Handle retrying: increment iteration counter and record last error
+    ;; Handle retrying, failure, or already-implemented outcomes
     (cond-> updated-ctx
       (registry/retrying? (:phase updated-ctx))
       (-> (update-in [:phase :iterations] (fnil inc 1))
@@ -199,6 +172,14 @@
                     (or (get-in result [:error :message])
                         (get-in result [:output :error])
                         "Agent returned error status")))
+
+      (= :failed phase-status)
+      (assoc-in [:phase :error]
+                {:message (or (get-in result [:error :message])
+                              (get-in result [:output :error])
+                              "Implementation failed after exhausting retry budget")
+                 :agent-status agent-status
+                 :iterations iterations})
 
       (= :already-implemented agent-status)
       (assoc-in [:phase :skipped-reason] :already-implemented))))

--- a/components/phase/src/ai/miniforge/phase/plan.clj
+++ b/components/phase/src/ai/miniforge/phase/plan.clj
@@ -27,30 +27,6 @@
             [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Event stream helpers (optional dependency)
-
-(defn emit-phase-started!
-  "Emit phase-started event if event-stream is available in context."
-  [ctx phase]
-  (when-let [event-stream (:event-stream ctx)]
-    (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (when-let [phase-started (requiring-resolve 'ai.miniforge.event-stream.interface/phase-started)]
-        (let [workflow-id (:execution/id ctx)]
-          (publish! event-stream (phase-started event-stream workflow-id phase)))))))
-
-(defn emit-phase-completed!
-  "Emit phase-completed event if event-stream is available in context."
-  [ctx phase _result]
-  (when-let [event-stream (:event-stream ctx)]
-    (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (when-let [phase-completed (requiring-resolve 'ai.miniforge.event-stream.interface/phase-completed)]
-        (let [workflow-id (:execution/id ctx)
-              outcome (if (registry/succeeded-or-done? (:phase ctx)) :success :failure)
-              duration-ms (get-in ctx [:phase :duration-ms])]
-          (publish! event-stream (phase-completed event-stream workflow-id phase
-                                                   {:outcome outcome :duration-ms duration-ms})))))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Defaults
 
 (def default-config
@@ -145,7 +121,6 @@
    When the spec provides :plan/tasks directly, builds the plan from those
    tasks and skips the LLM call entirely."
   [ctx]
-  (emit-phase-started! ctx :plan)
   (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
         {:keys [gates budget]} config
         start-time (System/currentTimeMillis)
@@ -175,8 +150,6 @@
                         ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
-    ;; Emit phase completed event
-    (emit-phase-completed! updated-ctx :plan result)
     ;; Handle :already-satisfied — signal pipeline to skip to :done
     (if (= :already-satisfied (:status result))
       (assoc-in updated-ctx [:phase :status] :already-satisfied)

--- a/components/phase/src/ai/miniforge/phase/release.clj
+++ b/components/phase/src/ai/miniforge/phase/release.clj
@@ -27,30 +27,6 @@
             [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Event stream helpers (optional dependency)
-
-(defn emit-phase-started!
-  "Emit phase-started event if event-stream is available in context."
-  [ctx phase]
-  (when-let [event-stream (:event-stream ctx)]
-    (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (when-let [phase-started (requiring-resolve 'ai.miniforge.event-stream.interface/phase-started)]
-        (let [workflow-id (:execution/id ctx)]
-          (publish! event-stream (phase-started event-stream workflow-id phase)))))))
-
-(defn emit-phase-completed!
-  "Emit phase-completed event if event-stream is available in context."
-  [ctx phase _result]
-  (when-let [event-stream (:event-stream ctx)]
-    (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (when-let [phase-completed (requiring-resolve 'ai.miniforge.event-stream.interface/phase-completed)]
-        (let [workflow-id (:execution/id ctx)
-              outcome (if (registry/succeeded-or-done? (:phase ctx)) :success :failure)
-              duration-ms (get-in ctx [:phase :duration-ms])]
-          (publish! event-stream (phase-completed event-stream workflow-id phase
-                                                   {:outcome outcome :duration-ms duration-ms})))))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Defaults
 
 (def default-config
@@ -124,8 +100,6 @@
    - Commit changes
    - Push branch and create PR (if enabled)"
   [ctx]
-  ;; Emit phase started event
-  (emit-phase-started! ctx :release)
   (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
         {:keys [gates budget]} config
         start-time (System/currentTimeMillis)
@@ -209,8 +183,6 @@
                         ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
-    ;; Emit phase completed event
-    (emit-phase-completed! updated-ctx :release result)
     ;; Handle retrying: increment iteration counter
     (cond-> updated-ctx
       (registry/retrying? (:phase updated-ctx))

--- a/components/phase/src/ai/miniforge/phase/review.clj
+++ b/components/phase/src/ai/miniforge/phase/review.clj
@@ -27,30 +27,6 @@
             [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Event stream helpers (optional dependency)
-
-(defn emit-phase-started!
-  "Emit phase-started event if event-stream is available in context."
-  [ctx phase]
-  (when-let [event-stream (:event-stream ctx)]
-    (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (when-let [phase-started (requiring-resolve 'ai.miniforge.event-stream.interface/phase-started)]
-        (let [workflow-id (:execution/id ctx)]
-          (publish! event-stream (phase-started event-stream workflow-id phase)))))))
-
-(defn emit-phase-completed!
-  "Emit phase-completed event if event-stream is available in context."
-  [ctx phase _result]
-  (when-let [event-stream (:event-stream ctx)]
-    (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (when-let [phase-completed (requiring-resolve 'ai.miniforge.event-stream.interface/phase-completed)]
-        (let [workflow-id (:execution/id ctx)
-              outcome (if (registry/succeeded-or-done? (:phase ctx)) :success :failure)
-              duration-ms (get-in ctx [:phase :duration-ms])]
-          (publish! event-stream (phase-completed event-stream workflow-id phase
-                                                   {:outcome outcome :duration-ms duration-ms})))))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Defaults
 
 (def default-config
@@ -73,8 +49,6 @@
 
    Runs code review, quality checks, and policy validation."
   [ctx]
-  ;; Emit phase started event
-  (emit-phase-started! ctx :review)
   (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
         {:keys [gates budget]} config
         start-time (System/currentTimeMillis)
@@ -157,8 +131,6 @@
                         ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
-    ;; Emit phase completed event
-    (emit-phase-completed! updated-ctx :review result)
     ;; Handle changes-requested: redirect to implement with review feedback
     (if (and (= :changes-requested review-decision)
              (< iterations max-iterations))

--- a/components/phase/src/ai/miniforge/phase/verify.clj
+++ b/components/phase/src/ai/miniforge/phase/verify.clj
@@ -31,30 +31,6 @@
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Event stream helpers (optional dependency)
-
-(defn emit-phase-started!
-  "Emit phase-started event if event-stream is available in context."
-  [ctx phase]
-  (when-let [event-stream (:event-stream ctx)]
-    (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (when-let [phase-started (requiring-resolve 'ai.miniforge.event-stream.interface/phase-started)]
-        (let [workflow-id (:execution/id ctx)]
-          (publish! event-stream (phase-started event-stream workflow-id phase)))))))
-
-(defn emit-phase-completed!
-  "Emit phase-completed event if event-stream is available in context."
-  [ctx phase _result]
-  (when-let [event-stream (:event-stream ctx)]
-    (when-let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-      (when-let [phase-completed (requiring-resolve 'ai.miniforge.event-stream.interface/phase-completed)]
-        (let [workflow-id (:execution/id ctx)
-              outcome (if (registry/succeeded-or-done? (:phase ctx)) :success :failure)
-              duration-ms (get-in ctx [:phase :duration-ms])]
-          (publish! event-stream (phase-completed event-stream workflow-id phase
-                                                   {:outcome outcome :duration-ms duration-ms})))))))
-
-;------------------------------------------------------------------------------ Layer 0
 ;; Defaults
 
 (def default-config
@@ -138,8 +114,6 @@
    Generates tests for code artifacts, runs them,
    checks coverage thresholds."
   [ctx]
-  ;; Emit phase started event
-  (emit-phase-started! ctx :verify)
   (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
         {:keys [gates budget]} config
         start-time (System/currentTimeMillis)
@@ -206,7 +180,9 @@
 (defn leave-verify
   "Post-processing for verification phase.
 
-   Records test metrics: count, pass rate, coverage."
+   Records test metrics: count, pass rate, coverage.
+   When verification fails and :on-fail is configured, sets :redirect-to
+   so the execution engine jumps to the target phase (typically :implement)."
   [ctx]
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
@@ -220,6 +196,7 @@
                        :else                       :completed)
         metrics (get result :metrics {:tokens 0 :duration-ms duration-ms})
         iterations (get-in ctx [:phase :iterations] 1)
+        on-fail (get-in ctx [:phase-config :on-fail])
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)
                         (assoc-in [:phase :duration-ms] duration-ms)
@@ -231,9 +208,18 @@
                         ;; Merge agent metrics into execution metrics
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
-    ;; Emit phase completed event
-    (emit-phase-completed! updated-ctx :verify result)
-    updated-ctx))
+    ;; When verify failed and on-fail is configured, redirect to target phase
+    ;; and attach verify failure details for the implement agent to use
+    (if (and (= :failed phase-status) on-fail)
+      (-> updated-ctx
+          (assoc-in [:phase :redirect-to] on-fail)
+          (assoc-in [:phase :error]
+                    {:message (or (get-in result [:error :message])
+                                  (when gate-failed? "Gate validation failed")
+                                  "Verification failed")
+                     :agent-status agent-status
+                     :gate-failed? gate-failed?}))
+      updated-ctx)))
 
 (defn error-verify
   "Handle verification phase errors.

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -126,23 +126,35 @@
   "Publish phase completed event."
   [event-stream context phase-name result]
   (when event-stream
-    (try
-      (when-let [constructor (requiring-resolve 'ai.miniforge.event-stream.interface/phase-completed)]
-        (publish-event! event-stream
-                        (constructor event-stream (:execution/id context) phase-name
-                                     {:outcome (if (or (:success? result)
-                                                       (phase/succeeded-or-done? result))
-                                                 :success
-                                                 :failure)
-                                      :duration-ms (or (get-in result [:phase/metrics :duration-ms])
-                                                       (get-in result [:metrics :duration-ms]))})))
-      (catch Exception _
-        (publish-event! event-stream
-                        {:event/type :workflow/phase-completed
-                         :workflow/id (:execution/id context)
-                         :workflow/phase phase-name
-                         :phase/outcome (if (:success? result) :success :failure)
-                         :event/timestamp (java.time.Instant/now)})))))
+    (let [succeeded? (or (:success? result)
+                         (phase/succeeded-or-done? result))
+          outcome (if succeeded? :success :failure)
+          duration-ms (or (get-in result [:phase/metrics :duration-ms])
+                          (get-in result [:metrics :duration-ms])
+                          (:duration-ms result))
+          error-info (when-not succeeded?
+                       (or (:error result)
+                           (when-let [msg (get-in result [:phase/gate-errors])]
+                             {:message "Gate validation failed" :details msg})
+                           (when-let [msg (:message result)]
+                             {:message msg})))
+          redirect-to (:redirect-to result)
+          event-data (cond-> {:outcome outcome :duration-ms duration-ms}
+                       error-info (assoc :error error-info)
+                       redirect-to (assoc :redirect-to redirect-to))]
+      (try
+        (when-let [constructor (requiring-resolve 'ai.miniforge.event-stream.interface/phase-completed)]
+          (publish-event! event-stream
+                          (constructor event-stream (:execution/id context) phase-name
+                                       event-data)))
+        (catch Exception _
+          (publish-event! event-stream
+                          {:event/type :workflow/phase-completed
+                           :workflow/id (:execution/id context)
+                           :workflow/phase phase-name
+                           :phase/outcome outcome
+                           :phase/error error-info
+                           :event/timestamp (java.time.Instant/now)}))))))
 
 (defn check-backend-health-at-boundary!
   "Check backend health at phase boundary. Returns switch-result or nil."


### PR DESCRIPTION
## Summary
- Remove `emit-phase-started!`/`emit-phase-completed!` from all 5 phase files (plan, implement, verify, review, release) — runner callbacks already publish these events, causing every phase event to appear twice in the event stream
- `leave-verify` now checks `:on-fail` config and sets `:redirect-to` when verification fails (previously only `error-verify` did this, so normal failures never redirected)
- `leave-implement` attaches `:phase :error` with agent-status and iteration count when phase fails (was silently swallowing failure details)
- `publish-phase-completed!` in runner.clj now includes error info and redirect-to in the event payload
- `phase-completed` event constructor passes through `:error` and `:redirect-to`

Net -102 lines.

## Root cause
Phase files emitted events in enter/leave AND runner emitted via callbacks — a classic callback + internal emission duplication pattern. Additionally, `leave-verify` only set `:failed` status without checking the `:on-fail` pipeline config, while `error-verify` (exception handler) correctly used it — inconsistency between normal failure path and exception path.

## Test plan
- [x] All 458 tests pass, 0 failures
- [x] Lint clean (1 existing warning: unused `clojure.string` require in verify.clj)
- [ ] Dogfood a spec and verify single events per phase transition in `~/.miniforge/events/`
- [ ] Verify failed verify phase redirects to implement when `:on-fail :implement` is configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)