### PR TITLE
Fix observability blind spot during tool-heavy agent phases

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -627,14 +627,28 @@
      (agent/invoke planner task (assoc ctx :on-chunk on-chunk))"
   [stream workflow-id agent-id & [opts]]
   (let [{:keys [print? quiet?]} opts]
-    (fn [{:keys [delta done?]}]
-      ;; Print to console if requested
-      (when (and print? (not quiet?) delta (not (empty? delta)))
-        (print delta)
-        (flush))
-      ;; Always publish to event stream
-      (when stream
-        (publish! stream (agent-chunk stream workflow-id agent-id (or delta "") done?))))))
+    (fn [{:keys [delta done? tool-use heartbeat]}]
+      (cond
+        ;; Tool-use events — publish an agent-status event (no console print)
+        tool-use
+        (when stream
+          (publish! stream (agent-status stream workflow-id agent-id
+                                         :tool-calling "Agent calling tool")))
+
+        ;; Heartbeat events — no-op but counts as activity (keeps stream alive)
+        heartbeat
+        nil
+
+        ;; Normal text deltas
+        :else
+        (do
+          ;; Print to console if requested
+          (when (and print? (not quiet?) delta (not (empty? delta)))
+            (print delta)
+            (flush))
+          ;; Always publish to event stream
+          (when stream
+            (publish! stream (agent-chunk stream workflow-id agent-id (or delta "") done?))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -90,8 +90,17 @@
                      :output-tokens (:output_tokens usage)}
              :cost-usd (:total_cost_usd data)})
 
-          ;; Ignore system, rate_limit_event
-          nil)))
+          ;; Tool use events — signal activity without text content
+          "tool_use"
+          {:delta "" :done? false :tool-use true}
+
+          ;; System and rate_limit_event are known no-ops
+          ("system" "rate_limit_event")
+          nil
+
+          ;; Any other unrecognised event type — emit a heartbeat so the
+          ;; stream stays alive during tool-heavy phases
+          {:delta "" :done? false :heartbeat true})))
     (catch Exception _e
       nil)))
 
@@ -498,9 +507,13 @@
         (swap! accumulated-usage (fn [prev] (merge prev usage))))
       (when-let [cost (:cost-usd parsed)]
         (reset! accumulated-cost cost))
-      (when-let [delta (:delta parsed)]
-        (swap! accumulated-content str delta)
-        (on-chunk (assoc parsed :content @accumulated-content))))))
+      (if (or (:tool-use parsed) (:heartbeat parsed))
+        ;; Tool-use and heartbeat events: fire on-chunk without accumulating text
+        (on-chunk (assoc parsed :content @accumulated-content))
+        ;; Normal text deltas
+        (when-let [delta (:delta parsed)]
+          (swap! accumulated-content str delta)
+          (on-chunk (assoc parsed :content @accumulated-content)))))))
 
 (defn log-streaming-result [logger timeout-info content-length]
   (when logger


### PR DESCRIPTION
## Summary
- `parse-claude-stream-line`: handle `"tool_use"` events (return `{:tool-use true}`) and unrecognized event types (return `{:heartbeat true}`) instead of nil
- `stream-with-parser`: fire `on-chunk` for tool-use/heartbeat events even when delta is empty
- `create-streaming-callback`: publish `agent-status` `:tool-calling` events for tool-use signals; heartbeat events count as activity without publishing

## Root cause
The event stream went dark for 10+ minutes when agents made tool calls because `parse-claude-stream-line` silently discarded all non-assistant/result event types (returning nil), so `on-chunk` never fired.

## Test plan
- [x] All tests pass
- [ ] Dogfood a spec with tool-heavy phases and verify event stream shows activity during tool calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)