### PR TITLE
Fix verify failure details not reaching implementer agent

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -136,7 +136,18 @@
                               (conj (str "\n\n## Review Feedback (MUST FIX)\n\n"
                                          "The previous implementation was reviewed and changes were requested. "
                                          "You MUST address ALL of the following issues:\n\n"
-                                         (if (string? review-feedback) review-feedback (pr-str review-feedback)))))]
+                                         (if (string? review-feedback) review-feedback (pr-str review-feedback)))))
+                      verify-failures (:task/verify-failures task)
+                      parts (cond-> parts
+                              verify-failures
+                              (conj (str "\n\n## Test Failures (MUST FIX)\n\n"
+                                         "The previous implementation failed verification. "
+                                         "You MUST fix these failing tests:\n\n"
+                                         (if-let [test-results (:test-results verify-failures)]
+                                           (str "Test results:\n" (pr-str test-results))
+                                           (str "Verify failure details:\n" (pr-str verify-failures)))
+                                         (when-let [test-output (:test-output verify-failures)]
+                                           (str "\n\nTest output:\n" test-output)))))]
                   (if (seq parts)
                     (str/join "" parts)
                     (pr-str task)))

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -2,6 +2,7 @@
   "Tests for the Implementer agent."
   (:require
    [clojure.test :as test :refer [deftest testing is]]
+   [clojure.string :as str]
    [ai.miniforge.agent.core :as core]
    [ai.miniforge.agent.implementer :as implementer]
    [ai.miniforge.logging.interface :as log]))
@@ -137,6 +138,83 @@
       (is (= 2 lines)))))
 
 ;------------------------------------------------------------------------------ Layer 5
+;; task->text tests
+
+(deftest task->text-basic-test
+  (testing "string task passes through"
+    (is (= "hello" (implementer/task->text "hello"))))
+
+  (testing "map task uses :task/description"
+    (is (= "Implement login"
+           (implementer/task->text {:task/description "Implement login"}))))
+
+  (testing "includes plan when present"
+    (let [text (implementer/task->text {:task/description "Do thing"
+                                        :task/plan "Step 1: foo\nStep 2: bar"})]
+      (is (str/includes? text "Do thing"))
+      (is (str/includes? text "## Plan"))
+      (is (str/includes? text "Step 1: foo"))))
+
+  (testing "includes intent when present"
+    (let [text (implementer/task->text {:task/description "Do thing"
+                                        :task/intent {:scope ["src/core.clj"]}})]
+      (is (str/includes? text "## Intent"))
+      (is (str/includes? text "src/core.clj")))))
+
+(deftest task->text-review-feedback-test
+  (testing "includes review feedback as string"
+    (let [text (implementer/task->text {:task/description "Fix it"
+                                        :task/review-feedback "Missing error handling in login"})]
+      (is (str/includes? text "## Review Feedback (MUST FIX)"))
+      (is (str/includes? text "Missing error handling in login"))))
+
+  (testing "includes review feedback as map"
+    (let [text (implementer/task->text {:task/description "Fix it"
+                                        :task/review-feedback {:issues ["no validation" "no tests"]}})]
+      (is (str/includes? text "## Review Feedback (MUST FIX)"))
+      (is (str/includes? text "no validation")))))
+
+(deftest task->text-verify-failures-test
+  (testing "includes verify failures with test-results"
+    (let [text (implementer/task->text
+                 {:task/description "Fix failing tests"
+                  :task/verify-failures
+                  {:test-results {:all-passed? false
+                                  :test-count 5
+                                  :fail-count 2
+                                  :error-count 0}
+                   :test-output "FAIL in (login-test)\nexpected: 200\n  actual: 401"}})]
+      (is (str/includes? text "## Test Failures (MUST FIX)"))
+      (is (str/includes? text "Test results:"))
+      (is (str/includes? text ":fail-count 2"))
+      (is (str/includes? text "FAIL in (login-test)"))
+      (is (str/includes? text "expected: 200"))))
+
+  (testing "includes verify failures without test-results"
+    (let [text (implementer/task->text
+                 {:task/description "Fix it"
+                  :task/verify-failures
+                  {:error "Verification timed out"}})]
+      (is (str/includes? text "## Test Failures (MUST FIX)"))
+      (is (str/includes? text "Verify failure details:"))
+      (is (str/includes? text "Verification timed out"))))
+
+  (testing "includes both review feedback and verify failures"
+    (let [text (implementer/task->text
+                 {:task/description "Fix everything"
+                  :task/review-feedback "Add input validation"
+                  :task/verify-failures
+                  {:test-results {:all-passed? false :fail-count 1}}})]
+      (is (str/includes? text "## Review Feedback (MUST FIX)"))
+      (is (str/includes? text "Add input validation"))
+      (is (str/includes? text "## Test Failures (MUST FIX)"))
+      (is (str/includes? text ":fail-count 1"))))
+
+  (testing "no verify section when verify-failures is nil"
+    (let [text (implementer/task->text {:task/description "Normal task"})]
+      (is (not (str/includes? text "Test Failures"))))))
+
+;------------------------------------------------------------------------------ Layer 6
 ;; Repair tests
 
 (deftest implementer-repair-test


### PR DESCRIPTION
## Summary
- Add "Test Failures (MUST FIX)" section to implementer's `task->text`, processing `:task/verify-failures` analogous to how `:task/review-feedback` is handled
- The implementer now sees both test-results and test-output from the failed verify phase on retry

## Root cause
`build-implement-task` correctly extracts verify failure data into `:task/verify-failures`, but `task->text` in implementer.clj never processed that key. The implementer agent was completely blind to what tests failed when retrying after verification failure.

## Test plan
- [x] All tests pass
- [ ] Dogfood a spec where verify fails and confirm implementer prompt includes test failure details

🤖 Generated with [Claude Code](https://claude.com/claude-code)