### PR TITLE
Fix false positive backend health switch from stale data

### DIFF
--- a/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/backend_health.clj
@@ -92,13 +92,50 @@
 ;;------------------------------------------------------------------------------ Layer 2
 ;; Backend health operations
 
+(def ^:private decay-threshold-ms
+  "Maximum age of health data before counters are reset (24 hours)."
+  86400000)
+
+(defn- maybe-decay-health
+  "Reset backend counters if all recorded last-failure timestamps are older than
+   24 hours. Prevents accumulation of stale metrics over weeks of use.
+
+   Backends with no last-failure (nil) are healthy and never trigger decay.
+   Decay only fires when at least one backend has a last-failure, and ALL
+   last-failure timestamps are older than the threshold.
+
+   Arguments:
+     health-data - Map with :backends etc.
+
+   Returns: health-data unchanged, or with backends reset if stale"
+  [health-data]
+  (let [backends (:backends health-data)
+        now (java.time.Instant/now)
+        failure-timestamps (->> backends
+                                vals
+                                (keep :last-failure))
+        has-failures? (seq failure-timestamps)
+        all-failures-stale? (and has-failures?
+                                 (every?
+                                  (fn [lf]
+                                    (let [age-ms (.until (java.time.Instant/parse lf)
+                                                         now
+                                                         java.time.temporal.ChronoUnit/MILLIS)]
+                                      (> age-ms decay-threshold-ms)))
+                                  failure-timestamps))]
+    (if all-failures-stale?
+      (assoc health-data :backends {})
+      health-data)))
+
 (defn load-health
   "Load backend health data from persistent storage.
+   Applies decay: if all backend metrics are older than 24 hours, resets counters.
 
    Returns: Map with :backends, :switch-cooldowns, :default-backend, :fallback-order"
   []
-  (or (safe-read-edn (backend-health-path) nil)
-      (default-health-data)))
+  (let [raw (or (safe-read-edn (backend-health-path) nil)
+                (default-health-data))]
+    (maybe-decay-health raw)))
 
 (defn save-health!
   "Save backend health data to persistent storage.
@@ -109,6 +146,16 @@
    Returns: nil"
   [health-data]
   (atomic-write-edn (backend-health-path) health-data))
+
+(defn reset-backend-health!
+  "Reset all backend health data to defaults.
+   Useful for clearing stale accumulated metrics.
+
+   Returns: Default health data map"
+  []
+  (let [defaults (default-health-data)]
+    (save-health! defaults)
+    defaults))
 
 (defn record-backend-call!
   "Record a backend API call and its result.
@@ -156,8 +203,30 @@
         stats (get-in health [:backends backend-key])]
     (:success-rate stats)))
 
+(defn- recent-failure?
+  "Check if the last failure for a backend is within the recency window.
+
+   Arguments:
+     backend - Keyword backend name
+     recency-ms - Recency window in milliseconds (default 300000 = 5 min)
+
+   Returns: Boolean true if last failure is recent (or nil if no failure recorded)"
+  ([backend]
+   (recent-failure? backend 300000))
+  ([backend recency-ms]
+   (let [health (load-health)
+         backend-key (keyword backend)
+         last-failure (get-in health [:backends backend-key :last-failure])]
+     (when last-failure
+       (let [failure-instant (java.time.Instant/parse last-failure)
+             now (java.time.Instant/now)
+             age-ms (.until failure-instant now java.time.temporal.ChronoUnit/MILLIS)]
+         (< age-ms recency-ms))))))
+
 (defn should-switch-backend?
   "Check if backend should be switched due to low success rate.
+   Only triggers if the last failure is recent (within 5 minutes),
+   preventing false positives from stale accumulated health data.
 
    Arguments:
      backend - Keyword backend name
@@ -168,7 +237,8 @@
    (should-switch-backend? backend 0.90))
   ([backend threshold]
    (if-let [success-rate (get-backend-success-rate backend)]
-     (< success-rate threshold)
+     (and (recent-failure? backend)
+          (< success-rate threshold))
      false)))
 
 (defn in-cooldown?

--- a/components/self-healing/src/ai/miniforge/self_healing/interface.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/interface.clj
@@ -111,6 +111,10 @@
   "Check current backend health and switch if necessary."
   health/check-and-switch-if-needed)
 
+(def reset-backend-health!
+  "Reset all backend health data to defaults, clearing stale metrics."
+  health/reset-backend-health!)
+
 ;;------------------------------------------------------------------------------ Integration
 
 (def execute-with-health-tracking

--- a/projects/miniforge/test/ai/miniforge/self_healing/backend_health_test.clj
+++ b/projects/miniforge/test/ai/miniforge/self_healing/backend_health_test.clj
@@ -262,3 +262,43 @@
           backend-stats (get-in health-data [:backends :anthropic])]
       (is (some? (:last-failure backend-stats)))
       (is (string? (:last-failure backend-stats))))))
+
+(deftest test-should-not-switch-stale-failure
+  (testing "Should not switch when last failure is stale (older than 5 minutes)"
+    ;; Manually write health data with an old last-failure timestamp
+    (let [old-instant (.minus (java.time.Instant/now) 10 java.time.temporal.ChronoUnit/MINUTES)
+          stale-data {:backends {:anthropic {:total-calls 100
+                                              :successful-calls 75
+                                              :success-rate 0.75
+                                              :last-failure (str old-instant)}}
+                      :switch-cooldowns {}
+                      :default-backend :anthropic
+                      :fallback-order [:anthropic :openai :codex :ollama :google]}]
+      (health/save-health! stale-data)
+      ;; 75% success rate is below 90% threshold, but failure is stale
+      (is (not (health/should-switch-backend? :anthropic 0.90))))))
+
+(deftest test-should-switch-recent-failure
+  (testing "Should switch when last failure is recent and rate is below threshold"
+    ;; Record calls so last failure is "now"
+    (dotimes [_ 85]
+      (health/record-backend-call! :anthropic true))
+    (dotimes [_ 15]
+      (health/record-backend-call! :anthropic false))
+    ;; Last failure is very recent, rate is 85% < 90%
+    (is (health/should-switch-backend? :anthropic 0.90))))
+
+(deftest test-reset-backend-health
+  (testing "Reset clears all health data"
+    ;; Record some data
+    (dotimes [_ 10]
+      (health/record-backend-call! :anthropic true))
+    (health/record-backend-call! :anthropic false)
+    (is (some? (health/get-backend-success-rate :anthropic)))
+
+    ;; Reset
+    (health/reset-backend-health!)
+    (is (nil? (health/get-backend-success-rate :anthropic)))
+    (let [health-data (health/load-health)]
+      (is (= {} (:backends health-data)))
+      (is (= :anthropic (:default-backend health-data))))))


### PR DESCRIPTION
## Summary
- Add 5-minute recency check to `should-switch-backend?` so stale failure data from previous runs no longer triggers unnecessary switches
- Add `reset-backend-health!` for clearing accumulated metrics between runs
- Add 24-hour decay on load to prevent unbounded metric accumulation in `~/.miniforge/backend_health.edn`
- 3 new tests for stale/recent/reset scenarios

## Root cause
`~/.miniforge/backend_health.edn` persists cumulative call/failure counts with no TTL. After enough runs, the 75% failure rate threshold always triggers a backend switch even when recent calls are healthy.

## Test plan
- [x] All tests pass (3 new tests)
- [ ] Verify that after 24h, stale health data decays and doesn't trigger switches

🤖 Generated with [Claude Code](https://claude.com/claude-code)