### PR TITLE
Fix dogfood Run 6 bugs: empty errors, rate limits, stale redirects

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -361,8 +361,20 @@
         (llm-error :anomalies/fault "stream_error"
                    (str "Streaming failed: " (.getMessage e)))))))
 
+(defn rate-limited?
+  "Detect Claude CLI rate limit messages in content.
+   Claude CLI returns exit 0 but emits a rate limit message as content."
+  [content]
+  (and (string? content)
+       (re-find #"(?i)you've hit your limit|rate limit|resets \d+[ap]m" content)))
+
 (defn success-response [output exit-code]
-  (llm-success (str/trim output) {:exit-code exit-code}))
+  (let [trimmed (str/trim output)]
+    (if (rate-limited? trimmed)
+      (llm-error :anomalies.agent/rate-limited "rate_limit"
+                 (str "Claude CLI rate limited: " trimmed)
+                 {:exit-code exit-code :stdout output})
+      (llm-success trimmed {:exit-code exit-code}))))
 
 (defn error-response [output exit-code stderr]
   (let [error-message (if (and stderr (str/blank? output)) stderr output)]
@@ -527,8 +539,12 @@
                  {:data {:response-length content-length}}))))
 
 (defn streaming-success-response [content exit-code usage cost-usd]
-  (cond-> (llm-success content {:exit-code exit-code :usage usage})
-    cost-usd (assoc :cost-usd cost-usd)))
+  (if (rate-limited? content)
+    (llm-error :anomalies.agent/rate-limited "rate_limit"
+               (str "Claude CLI rate limited: " (str/trim content))
+               {:exit-code exit-code :stdout content})
+    (cond-> (llm-success content {:exit-code exit-code :usage usage})
+      cost-usd (assoc :cost-usd cost-usd))))
 
 (defn streaming-error-response [content exit-code err-result timeout-info]
   (let [error-message (or err-result

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -195,6 +195,45 @@
       (is (= {:input-tokens 100 :output-tokens 50} @usage))
       (is (= 0.0045 @cost)))))
 
+;------------------------------------------------------------------------------ Layer 3
+;; Rate limit detection tests
+
+(deftest rate-limited?-test
+  (testing "detects Claude CLI rate limit message"
+    (is (impl/rate-limited? "You've hit your limit · resets 7pm (America/Los_Angeles)"))
+    (is (impl/rate-limited? "You've hit your limit · resets 3am (UTC)")))
+
+  (testing "detects generic rate limit phrasing"
+    (is (impl/rate-limited? "rate limit exceeded")))
+
+  (testing "does not flag normal content"
+    (is (not (impl/rate-limited? "(ns example.core)\n(defn hello [] \"world\")")))
+    (is (not (impl/rate-limited? "Here is the implementation...")))
+    (is (not (impl/rate-limited? nil)))))
+
+(deftest rate-limited-success-response-test
+  (testing "rate limit content in success-response returns error"
+    (let [resp (impl/success-response
+                 "You've hit your limit · resets 7pm (America/Los_Angeles)" 0)]
+      (is (not (:success resp)))
+      (is (some? (:error resp)))
+      (is (re-find #"rate limited" (:message (:error resp))))))
+
+  (testing "normal content in success-response returns success"
+    (let [resp (impl/success-response "(defn hello [] \"world\")" 0)]
+      (is (:success resp)))))
+
+(deftest rate-limited-streaming-success-response-test
+  (testing "rate limit content in streaming-success-response returns error"
+    (let [resp (impl/streaming-success-response
+                 "You've hit your limit · resets 7pm (America/Los_Angeles)" 0 nil nil)]
+      (is (not (:success resp)))
+      (is (some? (:error resp)))))
+
+  (testing "normal content in streaming-success-response returns success"
+    (let [resp (impl/streaming-success-response "(defn foo [] 42)" 0 nil nil)]
+      (is (:success resp)))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.llm.interface-test)

--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -169,14 +169,14 @@
       (registry/retrying? (:phase updated-ctx))
       (-> (update-in [:phase :iterations] (fnil inc 1))
           (assoc-in [:phase :last-error]
-                    (or (get-in result [:error :message])
-                        (get-in result [:output :error])
+                    (or (not-empty (get-in result [:error :message]))
+                        (not-empty (get-in result [:output :error]))
                         "Agent returned error status")))
 
       (= :failed phase-status)
       (assoc-in [:phase :error]
-                {:message (or (get-in result [:error :message])
-                              (get-in result [:output :error])
+                {:message (or (not-empty (get-in result [:error :message]))
+                              (not-empty (get-in result [:output :error]))
                               "Implementation failed after exhausting retry budget")
                  :agent-status agent-status
                  :iterations iterations})

--- a/components/phase/src/ai/miniforge/phase/verify.clj
+++ b/components/phase/src/ai/miniforge/phase/verify.clj
@@ -214,7 +214,7 @@
       (-> updated-ctx
           (assoc-in [:phase :redirect-to] on-fail)
           (assoc-in [:phase :error]
-                    {:message (or (get-in result [:error :message])
+                    {:message (or (not-empty (get-in result [:error :message]))
                                   (when gate-failed? "Gate validation failed")
                                   "Verification failed")
                      :agent-status agent-status

--- a/components/response/src/ai/miniforge/response/builder.clj
+++ b/components/response/src/ai/miniforge/response/builder.clj
@@ -2,7 +2,8 @@
   "Canonical builders for common response patterns.
 
    Eliminates scattered inline map constructions by providing
-   standard builders for success/error responses with metrics.")
+   standard builders for success/error responses with metrics."
+  (:require [clojure.string]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Success responses
@@ -54,9 +55,16 @@
   ([message]
    (error-details message nil))
   ([message data]
-   (let [msg (if (instance? Exception message)
-              (.getMessage ^Exception message)
-              (str message))
+   (let [raw-msg (if (instance? Exception message)
+                   (.getMessage ^Exception message)
+                   (str message))
+         ;; Ensure message is never nil or empty — downstream (or msg fallback)
+         ;; treats "" as truthy, masking useful defaults
+         msg (if (or (nil? raw-msg) (clojure.string/blank? raw-msg))
+               (if (instance? Exception message)
+                 (str (class message))
+                 "Unknown error")
+               raw-msg)
          err-data (if (instance? Exception message)
                    (or data (ex-data message) {})
                    (or data {}))]

--- a/components/response/test/ai/miniforge/response/interface_test.clj
+++ b/components/response/test/ai/miniforge/response/interface_test.clj
@@ -386,6 +386,35 @@
       (is (= "claude-sonnet-4" (:anomaly.llm/model anom))))))
 
 ;; ============================================================================
+;; Builder error-details tests (empty message fix)
+;; ============================================================================
+
+(deftest error-details-never-empty-test
+  (testing "exception with nil message produces non-empty error message"
+    (let [ex (NullPointerException.)
+          resp (r/error ex)]
+      (is (some? (get-in resp [:error :message])))
+      (is (pos? (count (get-in resp [:error :message]))))))
+
+  (testing "exception with empty message produces non-empty error message"
+    (let [ex (Exception. "")
+          resp (r/error ex)]
+      (is (pos? (count (get-in resp [:error :message]))))))
+
+  (testing "nil message argument produces non-empty error message"
+    (let [resp (r/error nil)]
+      (is (pos? (count (get-in resp [:error :message]))))))
+
+  (testing "normal exception message preserved"
+    (let [resp (r/error (Exception. "Timeout in verify phase"))]
+      (is (= "Timeout in verify phase" (get-in resp [:error :message])))))
+
+  (testing "failure with nil-message exception produces non-empty error"
+    (let [resp (r/failure (NullPointerException.))]
+      (is (some? (get-in resp [:error :message])))
+      (is (pos? (count (get-in resp [:error :message])))))))
+
+;; ============================================================================
 ;; Boundary translator tests
 ;; ============================================================================
 

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -169,7 +169,10 @@
 
    Returns [ctx phase-result]."
   [interceptor ctx]
-  (let [ctx-entered (execute-enter interceptor ctx)
+  ;; Clear :phase map before each phase to prevent stale state (e.g. :redirect-to)
+  ;; from leaking across phase boundaries
+  (let [ctx-clean (dissoc ctx :phase)
+        ctx-entered (execute-enter interceptor ctx-clean)
         phase-result (extract-phase-result ctx-entered)
         phase-result-gated (apply-gate-validation interceptor phase-result ctx-entered)
         ctx-left (execute-leave interceptor (assoc ctx-entered :phase phase-result-gated))]

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -341,25 +341,33 @@
        (publish-workflow-started! event-stream initial-ctx))
 
      (let [final-ctx
-           (if (empty? pipeline)
-             (handle-empty-pipeline initial-ctx)
+           (try
+             (if (empty? pipeline)
+               (handle-empty-pipeline initial-ctx)
 
-             ;; Execute pipeline loop
-             (loop [context initial-ctx
-                    iteration 0]
-               (cond
-                 ;; Terminal state reached
-                 (terminal-state? context)
-                 context
+               ;; Execute pipeline loop
+               (loop [context initial-ctx
+                      iteration 0]
+                 (cond
+                   ;; Terminal state reached
+                   (terminal-state? context)
+                   context
 
-                 ;; Max iterations exceeded
-                 (>= iteration max-phases)
-                 (handle-max-phases-exceeded context max-phases)
+                   ;; Max iterations exceeded
+                   (>= iteration max-phases)
+                   (handle-max-phases-exceeded context max-phases)
 
-                 ;; Execute next iteration: health check -> phase -> cleanup
-                 :else
-                 (recur (execute-single-iteration pipeline context callbacks iteration control-state)
-                        (inc iteration)))))
+                   ;; Execute next iteration: health check -> phase -> cleanup
+                   :else
+                   (recur (execute-single-iteration pipeline context callbacks iteration control-state)
+                          (inc iteration)))))
+             (catch Exception e
+               (-> initial-ctx
+                   (update :execution/errors conj
+                           {:type :pipeline-exception
+                            :message (ex-message e)
+                            :data (ex-data e)})
+                   (assoc :execution/status :failed))))
 
            ;; Validate completed workflows produced results
            final-ctx (if (and (phase/succeeded? final-ctx)


### PR DESCRIPTION
## Summary

Fixes 4 bugs discovered during dogfooding Run 6 of the YC MVP spec:

- **Empty error messages**: `error-details` in `response/builder` now guarantees non-empty `:message` — previously `""` was truthy in `(or ...)` chains, masking useful fallback messages like "Verification failed"
- **Rate limit detection**: LLM client detects Claude CLI rate limit messages (`"You've hit your limit"`) even with exit code 0, returning a proper `rate_limit` error instead of treating it as valid LLM output that fails downstream parsing
- **Stale redirect-to leaking across phases**: `execute-phase-lifecycle` now clears the `:phase` map before each phase, preventing `:redirect-to :implement` from verify's leave function from persisting into the implement phase (caused verify→implement→implement→... infinite redirect loop)
- **Missing terminal event**: `run-pipeline` wraps the execution loop in try-catch, ensuring `publish-workflow-completed!` always fires even if the loop throws

## Files changed

| Component | File | Change |
|-----------|------|--------|
| response | `builder.clj` | `error-details` never produces nil/empty message |
| llm | `llm_client.clj` | `rate-limited?` detection + wired into `success-response` and `streaming-success-response` |
| phase | `implement.clj`, `verify.clj` | `not-empty` guards on error message extraction |
| workflow | `execution.clj` | Clear `:phase` map between phases |
| workflow | `runner.clj` | try-catch around pipeline loop |

## Test plan

- [x] `bb test` — 330 tests, 1464 assertions, 0 failures
- [x] New: `rate-limited?-test` — detects rate limit strings, ignores normal content
- [x] New: `rate-limited-success-response-test` — non-streaming path returns error on rate limit
- [x] New: `rate-limited-streaming-success-response-test` — streaming path returns error on rate limit
- [x] New: `error-details-never-empty-test` — nil message exception, empty message exception, nil argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)