### PR TITLE
Strip :release phase from DAG sub-task pipelines

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -169,10 +169,11 @@
   [task-def context]
   (let [parent-workflow (:execution/workflow context)
         parent-pipeline (or (:workflow/pipeline parent-workflow) [])
-        ;; Keep phases after plan (implement, verify, review, release, done)
-        ;; Drop explore and plan — the task description IS the plan
+        ;; Keep phases after plan (implement, verify, review, done)
+        ;; Drop explore/plan (task description IS the plan) and release
+        ;; (parent workflow handles release with collected artifacts)
         sub-phases (->> parent-pipeline
-                        (remove #(#{:explore :plan} (:phase %)))
+                        (remove #(#{:explore :plan :release} (:phase %)))
                         vec)
         ;; If no implement phase found, use a minimal pipeline
         sub-pipeline (if (seq sub-phases)

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_test.clj
@@ -488,3 +488,29 @@
           (is (= 3 (:tasks-failed result)))
           (is (= total accounted)
               "Every task must be accounted for — no silent drops"))))))
+
+(deftest test-sub-workflow-strips-release-phase
+  (testing "sub-workflow pipeline excludes :explore, :plan, and :release phases"
+    (let [task-def {:task/id (random-uuid)
+                    :task/description "Test task"}
+          context {:execution/workflow
+                   {:workflow/pipeline
+                    [{:phase :explore}
+                     {:phase :plan}
+                     {:phase :implement}
+                     {:phase :verify}
+                     {:phase :review}
+                     {:phase :release}
+                     {:phase :done}]}}
+          sub-wf (dag-orch/task-sub-workflow task-def context)
+          phase-names (mapv :phase (:workflow/pipeline sub-wf))]
+      (is (= [:implement :verify :review :done] phase-names)
+          "Sub-workflow should strip :explore, :plan, and :release")))
+
+  (testing "sub-workflow with no parent pipeline falls back to minimal"
+    (let [task-def {:task/id (random-uuid)
+                    :task/description "Test task"}
+          context {:execution/workflow {:workflow/pipeline []}}
+          sub-wf (dag-orch/task-sub-workflow task-def context)
+          phase-names (mapv :phase (:workflow/pipeline sub-wf))]
+      (is (= [:implement :done] phase-names)))))


### PR DESCRIPTION
## Summary

- DAG sub-tasks were including the `:release` phase in their pipeline, causing every sub-task to fail at release (missing worktree path, no git context). This made the DAG report task failures despite successful implementation.
- Fix: add `:release` to the stripped phases set in `task-sub-workflow` alongside `:explore` and `:plan`. The parent workflow handles release with collected artifacts.

Found during Run 8 dogfood — sub-task `668ec231` completed implement → verify → review successfully but failed at release with 311ms duration.

## Test plan

- [x] `test-sub-workflow-strips-release-phase` — verifies `:release` excluded from sub-workflow pipeline
- [x] All 197 workflow tests pass (1 new test, 2 new assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)