### PR TITLE
Fix review feedback lost during phase clearing

### DIFF
--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -58,7 +58,9 @@
         existing-files (file-ctx/load-files-in-scope worktree-path files-in-scope)
         behavior-addendum (agent-beh/load-and-filter-behaviors
                             :implement {:task {:task/intent (:intent input)}})
-        review-feedback (get-in ctx [:phase :review-feedback])
+        ;; Read review feedback from phase results (survives :phase clearing between phases)
+        review-feedback (or (get-in ctx [:execution/phase-results :review :result :output :review/feedback])
+                            (get-in ctx [:execution/phase-results :review :result :output :review/issues]))
         base-task {:task/id (random-uuid)
                    :task/type :implement
                    :task/description (:description input)

--- a/components/phase/test/ai/miniforge/phase/review_repair_loop_test.clj
+++ b/components/phase/test/ai/miniforge/phase/review_repair_loop_test.clj
@@ -117,13 +117,14 @@
 
 (deftest implement-task-includes-review-feedback-from-context
   (testing "build-implement-task passes review-feedback through to task"
-    ;; The implement phase reads :phase :review-feedback from context
-    ;; and includes it in the task map as :task/review-feedback
+    ;; The implement phase reads review feedback from execution/phase-results
+    ;; (survives :phase clearing between phases) and includes it as :task/review-feedback
     (let [build-implement-task #'ai.miniforge.phase.implement/build-implement-task
-          ctx {:phase {:review-feedback [{:severity :blocking
-                                          :description "Missing require"}]}
-               :execution/input {:description "Build widget"}
-               :execution/phase-results {:plan {:result {:output nil}}}}
+          ctx {:execution/input {:description "Build widget"}
+               :execution/phase-results {:plan {:result {:output nil}}
+                                         :review {:result {:output {:review/decision :changes-requested
+                                                                     :review/feedback [{:severity :blocking
+                                                                                         :description "Missing require"}]}}}}}
           task (build-implement-task ctx)]
       (is (= [{:severity :blocking :description "Missing require"}]
              (:task/review-feedback task))

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -258,7 +258,7 @@
 
 (def max-redirects
   "Maximum number of phase redirects before failing to prevent infinite loops."
-  3)
+  5)
 
 (defn apply-phase-transition
   "Apply phase transition based on next-index.

--- a/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
@@ -1,8 +1,10 @@
 (ns ai.miniforge.workflow.run7-regression-test
-  "Regression tests for Run 7 bugs:
+  "Regression tests for Run 7+ bugs:
    1. Duration-ms always 0 — agent metrics fallback shadows real wall-clock time
    2. Terminal event silently dropped — requiring-resolve nil causes when-let short-circuit
-   3. Phase leave functions must override agent duration-ms with wall-clock time"
+   3. Phase leave functions must override agent duration-ms with wall-clock time
+   4. Stale :phase map cleared between phases
+   5. Review feedback lost during phase clearing (Run 9)"
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.workflow.runner :as runner]
@@ -140,3 +142,46 @@
       ;; The stale :redirect-to should NOT be present
       (is (not= :implement (get-in ctx-after [:phase :redirect-to]))
           "Stale :redirect-to from previous phase must not leak"))))
+
+;; ============================================================================
+;; Fix 5: Review feedback survives :phase clearing (Run 9 bug)
+;;
+;; Root cause: review stored feedback at [:phase :review-feedback], but
+;; execute-phase-lifecycle clears :phase before entering next phase.
+;; Implement now reads from [:execution/phase-results :review] instead.
+;; ============================================================================
+
+(deftest review-feedback-survives-phase-clearing-test
+  (testing "implement reads review feedback from phase-results, not :phase"
+    ;; Simulate context after review phase: :phase cleared, but phase-results has review output
+    (let [review-feedback [{:type :blocking :message "Missing error handling for nil input"}]
+          ctx {:execution/input {:description "test task" :title "test"}
+               :execution/phase-results {:review {:result {:output {:review/decision :changes-requested
+                                                                     :review/feedback review-feedback}}}}
+               :execution/errors []
+               :execution/response-chain {:operation :test :succeeded? true}
+               :execution/artifacts []
+               :execution/files-written []
+               :execution/metrics {:tokens 0 :duration-ms 0}}
+          ;; build-implement-task should find the feedback from phase-results
+          ;; Test the extraction path directly (build-implement-task needs worktree files)
+          feedback (or (get-in ctx [:execution/phase-results :review :result :output :review/feedback])
+                       (get-in ctx [:execution/phase-results :review :result :output :review/issues]))]
+      (is (= review-feedback feedback)
+          "Review feedback extraction path should find feedback in phase-results")
+      ;; Verify the OLD path ([:phase :review-feedback]) would return nil after clearing
+      (is (nil? (get-in ctx [:phase :review-feedback]))
+          "Cleared :phase should not have review-feedback")))
+
+  (testing "review feedback from :review/issues path also works"
+    (let [issues [{:severity :warning :message "Consider using protocols"}]
+          ctx {:execution/phase-results {:review {:result {:output {:review/decision :changes-requested
+                                                                     :review/issues issues}}}}}
+          feedback (or (get-in ctx [:execution/phase-results :review :result :output :review/feedback])
+                       (get-in ctx [:execution/phase-results :review :result :output :review/issues]))]
+      (is (= issues feedback)
+          "Should fall back to :review/issues when :review/feedback absent")))
+
+  (testing "max-redirects is now 5"
+    (is (= 5 exec/max-redirects)
+        "Should allow 5 redirects for complex repair cycles")))


### PR DESCRIPTION
## Summary

- **Bug**: Review feedback was stored at `[:phase :review-feedback]`, but `execute-phase-lifecycle` clears the entire `:phase` map before entering the next phase. The implementer always read `nil` — flying blind on every repair cycle.
- **Fix**: Implement now reads review feedback from `[:execution/phase-results :review :result :output :review/feedback]`, which persists across phase boundaries.
- **Bump `max-redirects` from 3 → 5** to give complex repair cycles more room to converge now that feedback actually flows.

## Root cause trace

```
leave-review sets [:phase :review-feedback]
  → execute-phase-lifecycle clears :phase (dissoc ctx :phase)
    → enter-implement reads (get-in ctx [:phase :review-feedback]) → nil
      → implementer has no idea what reviewer complained about
        → produces code with new issues → exhausts redirect budget
```

## Test plan

- [x] Updated `review_repair_loop_test.clj` — test now verifies feedback comes from phase-results path
- [x] Added regression tests in `run7_regression_test.clj`:
  - Review feedback extraction from phase-results (both `:review/feedback` and `:review/issues` paths)
  - Old `[:phase :review-feedback]` path returns nil after clearing
  - `max-redirects` is 5
- [x] 254 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)