### PR TITLE
Wire TUI detail panes with live data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ projects/**/pom.xml
 artifacts
 dist/
 
+# Tool config (local)
+.codex/
+.cursor/
+
 # Checkpoints (local development snapshots)
 docs/checkpoints/
 

--- a/components/tui-views/src/ai/miniforge/tui_views/msg.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/msg.clj
@@ -76,8 +76,8 @@
 (defn phase-changed [wf-id phase]
   [:msg/phase-changed {:workflow-id wf-id :phase phase}])
 
-(defn phase-done [wf-id phase outcome]
-  [:msg/phase-done {:workflow-id wf-id :phase phase :outcome outcome}])
+(defn phase-done [wf-id phase outcome & [extras]]
+  [:msg/phase-done (merge {:workflow-id wf-id :phase phase :outcome outcome} extras)])
 
 (defn agent-status [wf-id agent-id status-type message]
   [:msg/agent-status {:workflow-id wf-id :agent agent-id
@@ -96,8 +96,8 @@
 (defn agent-failed [wf-id agent-id error]
   [:msg/agent-failed {:workflow-id wf-id :agent agent-id :error error}])
 
-(defn workflow-done [wf-id status]
-  [:msg/workflow-done {:workflow-id wf-id :status status}])
+(defn workflow-done [wf-id status & [extras]]
+  [:msg/workflow-done (merge {:workflow-id wf-id :status status} extras)])
 
 (defn workflow-failed [wf-id error]
   [:msg/workflow-failed {:workflow-id wf-id :error error}])

--- a/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
@@ -75,7 +75,11 @@
     (msg/phase-done (workflow-id event)
                     (workflow-phase event)
                     (or (:phase/outcome event)
-                        (get-in event [:result :outcome])))
+                        (get-in event [:result :outcome]))
+                    (cond-> {}
+                      (:phase/artifacts event) (assoc :artifacts (:phase/artifacts event))
+                      (:phase/duration-ms event) (assoc :duration-ms (:phase/duration-ms event))
+                      (:phase/error event) (assoc :error (:phase/error event))))
 
     :agent/started
     (msg/agent-started (workflow-id event) (agent-id event)
@@ -99,7 +103,10 @@
 
     :workflow/completed
     (msg/workflow-done (workflow-id event)
-                       (or (:workflow/status event) (:status event)))
+                       (or (:workflow/status event) (:status event))
+                       (cond-> {}
+                         (:workflow/duration-ms event) (assoc :duration-ms (:workflow/duration-ms event))
+                         (:workflow/evidence-bundle-id event) (assoc :evidence-bundle-id (:workflow/evidence-bundle-id event))))
 
     :workflow/failed
     (msg/workflow-failed (workflow-id event)

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -118,6 +118,14 @@
     (-> model
         (update :workflows conj wf)
         (link-chain-instance workflow-id)
+        ;; Populate evidence intent from spec when detail is active
+        (update-detail-if-active workflow-id
+          (fn [m]
+            (if spec
+              (assoc-in m [:detail :evidence :intent]
+                        {:description (or (:name spec) name)
+                         :spec spec})
+              m)))
         with-timestamp)))
 
 (defn handle-phase-changed [model {:keys [workflow-id phase]}]
@@ -127,11 +135,31 @@
         (apply-phase-change idx workflow-id phase)
         with-timestamp)))
 
-(defn handle-phase-done [model {:keys [workflow-id]}]
+(defn handle-phase-done [model {:keys [workflow-id phase outcome artifacts duration-ms]}]
   (let [model (ensure-workflow model workflow-id)
-        idx (find-workflow-idx (:workflows model) workflow-id)]
+        idx (find-workflow-idx (:workflows model) workflow-id)
+        phase-status (case outcome :success :success :failed :failed :success)]
     (-> model
         (update-workflow-at idx #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))
+        ;; Update phase status in detail
+        (update-detail-if-active workflow-id
+          (fn [m]
+            (let [m (update-in m [:detail :phases]
+                      (fn [phases]
+                        (mapv (fn [p]
+                                (if (= (:phase p) phase)
+                                  (assoc p :status phase-status
+                                           :duration-ms duration-ms)
+                                  p))
+                              phases)))]
+              ;; Append artifacts from this phase
+              (if (seq artifacts)
+                (update-in m [:detail :artifacts] into
+                  (mapv (fn [a]
+                          (if (map? a) (assoc a :phase phase)
+                            {:id a :phase phase :type :unknown :name (str a)}))
+                        artifacts))
+                m))))
         with-timestamp)))
 
 (defn handle-agent-status [model {:keys [workflow-id agent status message]}]
@@ -161,11 +189,19 @@
         #(update-in % [:detail :agent-output] str delta))
       with-timestamp))
 
-(defn handle-workflow-done [model {:keys [workflow-id status]}]
+(defn handle-workflow-done [model {:keys [workflow-id status duration-ms evidence-bundle-id]}]
   (let [model (ensure-workflow model workflow-id)
         idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
-        (update-workflow-at idx #(assoc % :status (or status :success) :progress 100))
+        (update-workflow-at idx #(assoc % :status (or status :success) :progress 100
+                                          :duration-ms duration-ms))
+        (update-detail-if-active workflow-id
+          (fn [m]
+            (cond-> m
+              evidence-bundle-id
+              (assoc-in [:detail :evidence :bundle-id] evidence-bundle-id)
+              duration-ms
+              (assoc-in [:detail :duration-ms] duration-ms))))
         with-timestamp)))
 
 (defn handle-workflow-failed [model {:keys [workflow-id error]}]

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -111,6 +111,14 @@
     (assoc-in model [:active-chain :current-step :instance-id] workflow-id)
     model))
 
+(defn apply-evidence-intent
+  "Seed evidence intent from workflow spec."
+  [model spec name]
+  (if spec
+    (assoc-in model [:detail :evidence :intent]
+              {:description (or (:name spec) name) :spec spec})
+    model))
+
 (defn handle-workflow-added [model {:keys [workflow-id name spec]}]
   (let [wf (model/make-workflow {:id workflow-id
                                   :name (or name (:name spec))
@@ -118,14 +126,8 @@
     (-> model
         (update :workflows conj wf)
         (link-chain-instance workflow-id)
-        ;; Populate evidence intent from spec when detail is active
         (update-detail-if-active workflow-id
-          (fn [m]
-            (if spec
-              (assoc-in m [:detail :evidence :intent]
-                        {:description (or (:name spec) name)
-                         :spec spec})
-              m)))
+          #(apply-evidence-intent % spec name))
         with-timestamp)))
 
 (defn handle-phase-changed [model {:keys [workflow-id phase]}]
@@ -135,31 +137,40 @@
         (apply-phase-change idx workflow-id phase)
         with-timestamp)))
 
+(defn update-phase-status
+  "Update a phase entry's status and duration in the phases vector."
+  [phases phase phase-status duration-ms]
+  (mapv (fn [p]
+          (if (= (:phase p) phase)
+            (assoc p :status phase-status :duration-ms duration-ms)
+            p))
+        phases))
+
+(defn normalize-artifact
+  "Normalize an artifact entry, ensuring it has phase and required keys."
+  [artifact phase]
+  (if (map? artifact)
+    (assoc artifact :phase phase)
+    {:id artifact :phase phase :type :unknown :name (str artifact)}))
+
+(defn apply-phase-completion
+  "Update detail model with phase completion data: status and artifacts."
+  [model phase phase-status duration-ms artifacts]
+  (let [model (update-in model [:detail :phases]
+                          update-phase-status phase phase-status duration-ms)]
+    (if (seq artifacts)
+      (update-in model [:detail :artifacts] into
+                 (mapv #(normalize-artifact % phase) artifacts))
+      model)))
+
 (defn handle-phase-done [model {:keys [workflow-id phase outcome artifacts duration-ms]}]
   (let [model (ensure-workflow model workflow-id)
         idx (find-workflow-idx (:workflows model) workflow-id)
         phase-status (case outcome :success :success :failed :failed :success)]
     (-> model
         (update-workflow-at idx #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))
-        ;; Update phase status in detail
         (update-detail-if-active workflow-id
-          (fn [m]
-            (let [m (update-in m [:detail :phases]
-                      (fn [phases]
-                        (mapv (fn [p]
-                                (if (= (:phase p) phase)
-                                  (assoc p :status phase-status
-                                           :duration-ms duration-ms)
-                                  p))
-                              phases)))]
-              ;; Append artifacts from this phase
-              (if (seq artifacts)
-                (update-in m [:detail :artifacts] into
-                  (mapv (fn [a]
-                          (if (map? a) (assoc a :phase phase)
-                            {:id a :phase phase :type :unknown :name (str a)}))
-                        artifacts))
-                m))))
+          #(apply-phase-completion % phase phase-status duration-ms artifacts))
         with-timestamp)))
 
 (defn handle-agent-status [model {:keys [workflow-id agent status message]}]
@@ -189,6 +200,13 @@
         #(update-in % [:detail :agent-output] str delta))
       with-timestamp))
 
+(defn apply-workflow-completion
+  "Update detail model with workflow completion data."
+  [model evidence-bundle-id duration-ms]
+  (cond-> model
+    evidence-bundle-id (assoc-in [:detail :evidence :bundle-id] evidence-bundle-id)
+    duration-ms        (assoc-in [:detail :duration-ms] duration-ms)))
+
 (defn handle-workflow-done [model {:keys [workflow-id status duration-ms evidence-bundle-id]}]
   (let [model (ensure-workflow model workflow-id)
         idx (find-workflow-idx (:workflows model) workflow-id)]
@@ -196,12 +214,7 @@
         (update-workflow-at idx #(assoc % :status (or status :success) :progress 100
                                           :duration-ms duration-ms))
         (update-detail-if-active workflow-id
-          (fn [m]
-            (cond-> m
-              evidence-bundle-id
-              (assoc-in [:detail :evidence :bundle-id] evidence-bundle-id)
-              duration-ms
-              (assoc-in [:detail :duration-ms] duration-ms))))
+          #(apply-workflow-completion % evidence-bundle-id duration-ms))
         with-timestamp)))
 
 (defn handle-workflow-failed [model {:keys [workflow-id error]}]

--- a/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
@@ -91,19 +91,25 @@
     (if-let [wf (when raw-idx (get (:workflows model) raw-idx))]
       (-> model
           (assoc :view :workflow-detail)
-          ;; Reset all detail fields to prevent stale data from previous workflow
+          ;; Reset detail, seeding from existing workflow row data
           (assoc :detail {:workflow-id    (:id wf)
-                          :phases         []
-                          :current-agent  nil
+                          :phases         (if-let [p (:phase wf)]
+                                            [{:phase p :status (if (= :failed (:status wf))
+                                                                 :failed :running)}]
+                                            [])
+                          :current-agent  (when-let [[agent-kw entry] (first (:agents wf))]
+                                            (assoc entry :agent agent-kw))
                           :agent-output   ""
-                          :evidence       nil
+                          :evidence       (when (seq (:gate-results wf))
+                                            {:validation {:results (:gate-results wf)}})
                           :artifacts      []
                           :expanded-nodes #{}
                           :focused-pane   0
                           :selected-pr    nil
                           :pr-readiness   nil
                           :pr-risk        nil
-                          :selected-train nil})
+                          :selected-train nil
+                          :duration-ms    (:duration-ms wf)})
           (assoc :selected-idx 0 :selected-ids #{} :visual-anchor nil
                  :scroll-offset nil :search-matches [] :search-match-idx nil))
       model)))

--- a/components/tui-views/test/ai/miniforge/tui_views/events_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/events_test.clj
@@ -420,6 +420,76 @@
           m2 (events/handle-phase-changed m {:workflow-id wf-id :phase :plan})]
       (is (= 1 (count (:workflows m2)))))))
 
+;; ---------------------------------------------------------------------------- Extracted helper functions
+
+(deftest update-phase-status-test
+  (testing "updates matching phase status and duration"
+    (let [phases [{:phase :plan :status :running}
+                  {:phase :implement :status :running}]
+          result (events/update-phase-status phases :plan :success 1200)]
+      (is (= :success (:status (first result))))
+      (is (= 1200 (:duration-ms (first result))))
+      (is (= :running (:status (second result))))))
+
+  (testing "leaves phases unchanged when no match"
+    (let [phases [{:phase :plan :status :running}]
+          result (events/update-phase-status phases :review :success 500)]
+      (is (= :running (:status (first result))))
+      (is (nil? (:duration-ms (first result)))))))
+
+(deftest normalize-artifact-test
+  (testing "map artifact gets phase key added"
+    (let [a (events/normalize-artifact {:id "a1" :type :file :name "foo.clj"} :implement)]
+      (is (= :implement (:phase a)))
+      (is (= "a1" (:id a)))))
+
+  (testing "non-map artifact gets wrapped with defaults"
+    (let [a (events/normalize-artifact "some-id" :plan)]
+      (is (= "some-id" (:id a)))
+      (is (= :plan (:phase a)))
+      (is (= :unknown (:type a)))
+      (is (= "some-id" (:name a))))))
+
+(deftest apply-phase-completion-test
+  (testing "updates phase status and appends artifacts"
+    (let [model {:detail {:phases [{:phase :plan :status :running}]
+                          :artifacts []}}
+          result (events/apply-phase-completion model :plan :success 800
+                   [{:id "a1" :type :file :name "f.clj"}])]
+      (is (= :success (get-in result [:detail :phases 0 :status])))
+      (is (= 800 (get-in result [:detail :phases 0 :duration-ms])))
+      (is (= 1 (count (get-in result [:detail :artifacts]))))))
+
+  (testing "no artifacts leaves artifacts unchanged"
+    (let [model {:detail {:phases [{:phase :plan :status :running}]
+                          :artifacts [{:id "existing"}]}}
+          result (events/apply-phase-completion model :plan :success 500 nil)]
+      (is (= 1 (count (get-in result [:detail :artifacts])))))))
+
+(deftest apply-workflow-completion-test
+  (testing "sets evidence bundle-id and duration"
+    (let [result (events/apply-workflow-completion {} "bundle-123" 5000)]
+      (is (= "bundle-123" (get-in result [:detail :evidence :bundle-id])))
+      (is (= 5000 (get-in result [:detail :duration-ms])))))
+
+  (testing "nil values are not assoc'd"
+    (let [result (events/apply-workflow-completion {} nil nil)]
+      (is (nil? (get-in result [:detail :evidence :bundle-id])))
+      (is (nil? (get-in result [:detail :duration-ms]))))))
+
+(deftest apply-evidence-intent-test
+  (testing "sets evidence intent from spec"
+    (let [result (events/apply-evidence-intent {} {:name "My Spec"} "fallback")]
+      (is (= "My Spec" (get-in result [:detail :evidence :intent :description])))))
+
+  (testing "uses name fallback when spec has no :name"
+    (let [result (events/apply-evidence-intent {} {:tasks []} "fallback")]
+      (is (= "fallback" (get-in result [:detail :evidence :intent :description])))))
+
+  (testing "nil spec is a no-op"
+    (let [result (events/apply-evidence-intent {:existing :data} nil "name")]
+      (is (= {:existing :data} result)))))
+
 ;; ---------------------------------------------------------------------------- PR update/remove
 
 (deftest handle-pr-updated-test

--- a/work/configurable-spec-types.spec.edn
+++ b/work/configurable-spec-types.spec.edn
@@ -1,0 +1,25 @@
+{:spec/title "Configurable Spec Type Taxonomy via Policy Pack"
+ :version "1.0.0"
+ :type :feature
+ :priority :medium
+
+ :spec/description
+ "The spec validator currently hardcodes allowed :type values (:feature, :bugfix,
+  :refactor, :test, :docs). PMs want control over naming — 'enhancement' vs 'feature',
+  etc. Move the allowed types into a policy pack so different teams can define their
+  own taxonomy. The spec validator should check against the policy pack's allowed-types
+  set instead of a hardcoded enum."
+
+ :current-state
+ {:validator "Hardcoded enum in spec validator rejects :enhancement, :error-handling-improvement, etc."
+  :problem "Every non-standard type requires a code change to the validator"}
+
+ :spec/acceptance-criteria
+ [{:criterion "Allowed spec types defined in a policy pack, not hardcoded"
+   :verification "Policy pack edn file contains :allowed-types set"}
+  {:criterion "Spec validator reads allowed types from policy pack"
+   :verification "Validator passes with custom types when policy pack includes them"}
+  {:criterion "Default policy pack includes standard types"
+   :verification "Out-of-box experience unchanged — :feature, :bugfix, :refactor, :test, :docs all work"}
+  {:criterion "Teams can extend types without code changes"
+   :verification "Adding :enhancement to policy pack allows specs with :type :enhancement"}]}

--- a/work/repo-context-implementation-plan.md
+++ b/work/repo-context-implementation-plan.md
@@ -1,0 +1,322 @@
+# Repository Intelligence & Context Assembly — Implementation Plan
+
+**Date:** 2026-03-04
+**Spec:** N1 §2.27–§2.30, §11 (PR #247)
+**Style:** Waterfall phases, DAG within each phase
+
+---
+
+## Phase 0: Observe (1 week)
+
+**Goal:** Calibrate budgets empirically before enforcing them.
+
+```text
+0.1 Instrument existing agent calls
+     ├── Add retrieval logging to orchestrator (repo-id, path, lines, tokens)
+     ├── Emit context-retrieval events to event-stream (N3)
+     └── Wire to evidence-bundle for persistence (N6)
+0.2 Run observe-only for ≥5 real workflows
+     ├── Collect: files opened, lines read, tokens consumed, dedup opportunities
+     └── Output: baseline-metrics.edn (actual usage per phase)
+0.3 Calibrate default budgets
+     └── Adjust §2.30.5 defaults based on observed P50/P95 per phase
+```
+
+**Deliverables:**
+
+| ID | Artifact | Type |
+|----|----------|------|
+| 0.1 | Retrieval logging in orchestrator | Code (modify `orchestrator`) |
+| 0.2 | Context retrieval event schema | Schema (amend N3) |
+| 0.3 | baseline-metrics.edn | Data artifact |
+
+**Exit gate:** Baseline metrics collected for ≥5 workflows across plan/implement/test.
+
+---
+
+## Phase 1: Core Index + Map + Search (3 weeks)
+
+**Goal:** Ship `repo.map` + `repo.search-lex` + `repo.open` with budget enforcement
+and audit logging. This is the minimum viable context assembly.
+
+### DAG
+
+```text
+1.1 repo-index component (Polylith)
+     ├── 1.1.1 schema.clj — Malli schemas for RepoIndex, FileRecord, Range, Coverage
+     ├── 1.1.2 scanner.clj — Walk git tree, compute blob-sha, detect is-generated?
+     ├── 1.1.3 incremental.clj — Diff tree-sha, index only changed blobs
+     ├── 1.1.4 repo-map.clj — Build token-budgeted repo map (file summaries)
+     ├── 1.1.5 search-lex.clj — BM25 index (tantivy-clj or custom postings)
+     ├── 1.1.6 storage.clj — Persist index manifest + heavyweight artifacts behind refs
+     └── 1.1.7 interface.clj — Layer 0-3 public API
+
+1.2 context-pack component (Polylith)                        [depends: 1.1]
+     ├── 1.2.1 schema.clj — Malli schemas for ContextPack, ConstraintEnvelope,
+     │                       PolicyEnvelope, Citation, WhyRecord
+     ├── 1.2.2 builder.clj — Assemble ContextPack from RepoIndex + query
+     ├── 1.2.3 budget.clj — Enforce limits, track usage, handle exhaustion
+     ├── 1.2.4 dedup.clj — Deduplicate snippets by (blob-sha, range) across agents
+     ├── 1.2.5 audit.clj — Log retrieval ops, link to N6 evidence bundles
+     └── 1.2.6 interface.clj — Layer 0-3 public API
+
+1.3 Tool registration                                        [depends: 1.1, 1.2]
+     ├── 1.3.1 Register repo.index-status, repo.map, repo.search-lex, repo.open
+     │         in tool-registry (resources/tools/*.edn)
+     ├── 1.3.2 Implement tool handlers in repo-index + context-pack
+     └── 1.3.3 Add budget accounting to each tool handler (§2.30.4)
+
+1.4 Orchestrator integration                                 [depends: 1.3]
+     ├── 1.4.1 context.build — Assemble initial ContextPack for agent invocation
+     ├── 1.4.2 context.extend — Handle agent requests for additional context
+     ├── 1.4.3 context.audit — Expose budget + source trace query
+     ├── 1.4.4 Wire ContextPack into agent invocation protocol (N1 §6.1)
+     └── 1.4.5 Enforce agent MUST NOT call orchestrator-only tools
+
+1.5 Agent protocol changes                                   [depends: 1.4]
+     ├── 1.5.1 Modify agent context handoff to include ContextPack (§6.3)
+     ├── 1.5.2 Add repo.map + repo.search-lex to agent tool allowlist
+     ├── 1.5.3 Block direct repo reads (enforce N1.CP.2)
+     └── 1.5.4 Update LLM system prompts to use search-before-open protocol
+
+1.6 Audit integration                                        [depends: 1.2.5]
+     ├── 1.6.1 Emit context-pack-built event (N3)
+     ├── 1.6.2 Emit context-extended event (N3)
+     ├── 1.6.3 Link audit traces to evidence bundles (N6 §3.2)
+     └── 1.6.4 Add context audit to workflow evidence bundle
+```
+
+**Component dependency graph:**
+
+```text
+repo-index ──► context-pack ──► orchestrator
+     │              │                │
+     ▼              ▼                ▼
+tool-registry  event-stream    agent (modified)
+                    │
+                    ▼
+             evidence-bundle
+```
+
+**Deliverables:**
+
+| ID | Artifact | Type | Polylith Component |
+|----|----------|------|--------------------|
+| 1.1 | Repo Index | New component | `components/repo-index/` |
+| 1.2 | Context Pack | New component | `components/context-pack/` |
+| 1.3 | Tool registrations | Config + handlers | `tool-registry` resources |
+| 1.4 | Orchestrator wiring | Modify existing | `components/orchestrator/` |
+| 1.5 | Agent protocol | Modify existing | `components/agent/` |
+| 1.6 | Audit events | Schema + emitters | `event-stream`, `evidence-bundle` |
+
+**Exit gate:** End-to-end workflow runs with ContextPack-only context; repo.open
+blocked without prior search; budget enforcement logged; audit trace queryable.
+
+---
+
+## Phase 2: Symbols + Tree-sitter (2 weeks)
+
+**Goal:** Add symbol extraction via Tree-sitter for all target languages.
+Enables `repo.symbol` tool and signature-first context retrieval.
+
+### DAG
+
+```text
+2.1 Tree-sitter integration                                  [depends: Phase 1]
+     ├── 2.1.1 Evaluate JNI/subprocess approach for tree-sitter from JVM
+     │         (tree-sitter CLI → JSON AST, or java-tree-sitter bindings)
+     ├── 2.1.2 Language grammars: Clojure, TypeScript, Python, Go, Rust
+     └── 2.1.3 AST → Symbol extraction (kind, name, fqname, ranges, visibility)
+
+2.2 Symbol table                                             [depends: 2.1]
+     ├── 2.2.1 symbol-id generation (deterministic hash scheme per §2.27.3)
+     ├── 2.2.2 symbol-key generation (cross-commit logical identity)
+     ├── 2.2.3 Container hierarchy (class → method, namespace → function)
+     ├── 2.2.4 Edge extraction: imports (file-level), member-of (symbol-level)
+     └── 2.2.5 Incremental symbol update (only re-parse changed blobs)
+
+2.3 repo.symbol tool                                         [depends: 2.2]
+     ├── 2.3.1 Register in tool-registry
+     ├── 2.3.2 Implement handler (signature/doc by default; body opt-in)
+     ├── 2.3.3 Budget accounting (body counts against snippet tokens)
+     └── 2.3.4 Update agent prompts: prefer symbol-id over repo.open
+
+2.4 Context Pack symbol integration                          [depends: 2.2, 2.3]
+     ├── 2.4.1 context.build uses symbols for relevant matches
+     ├── 2.4.2 ContextPack :context/symbols populated from search results
+     └── 2.4.3 Citation generation uses symbol ranges
+```
+
+**Language-specific notes:**
+
+| Language | Symbol Kinds | Special Handling |
+|----------|-------------|------------------|
+| Clojure | defn, defmulti, defmethod, defprotocol, ns, def | Macro-generated code → `is-generated?` |
+| TypeScript | class, function, method, interface, type, const | JSX/TSX files need tsx grammar |
+| Python | class, function, method, variable | Decorators as modifiers |
+| Go | func, type, struct, interface, const, var | Generated protobuf stubs → `is-generated?` |
+| Rust | fn, struct, enum, trait, impl, const, mod | `#[derive]` → generated impls |
+
+**Exit gate:** Symbol extraction works for all 5 languages; `repo.symbol` returns
+signature/doc for any indexed symbol; agents use symbol-id before repo.open.
+
+---
+
+## Phase 3: SCIP/LSIF Precision Navigation (2 weeks)
+
+**Goal:** Add precise def/refs/impls/calls from SCIP or LSIF output.
+Enables `nav.*` tools for languages with SCIP coverage.
+
+### DAG
+
+```text
+3.1 SCIP ingestion                                           [depends: Phase 2]
+     ├── 3.1.1 Parse SCIP index protobuf (scip.proto → Clojure records)
+     ├── 3.1.2 Map SCIP symbols to repo-index symbol-ids
+     ├── 3.1.3 Extract edges: def, ref, call, implements, inherits
+     ├── 3.1.4 Update coverage record (:scip? true, :refs? :precise, etc.)
+     └── 3.1.5 Incremental: re-ingest only when SCIP index changes
+
+3.2 LSIF fallback                                            [depends: 3.1]
+     ├── 3.2.1 Parse LSIF JSON-lines format
+     ├── 3.2.2 Map LSIF vertices/edges to repo-index model
+     └── 3.2.3 Update coverage record
+
+3.3 Graph navigation tools                                   [depends: 3.1]
+     ├── 3.3.1 Register nav.def, nav.refs, nav.impls, nav.calls
+     ├── 3.3.2 Implement handlers with coverage gating (error when :none)
+     ├── 3.3.3 Budget accounting for nav calls
+     └── 3.3.4 Update agent prompts for graph-aware navigation
+
+3.4 SCIP generation pipeline                                 [depends: 3.1]
+     ├── 3.4.1 TypeScript: scip-typescript (npm package)
+     ├── 3.4.2 Go: scip-go
+     ├── 3.4.3 Python: scip-python
+     ├── 3.4.4 Rust: rust-analyzer SCIP export
+     └── 3.4.5 Clojure: evaluate clj-kondo → SCIP bridge or custom emitter
+```
+
+**SCIP availability by language:**
+
+| Language | SCIP Indexer | Maturity | Notes |
+|----------|-------------|----------|-------|
+| TypeScript | scip-typescript | Stable | Best coverage |
+| Go | scip-go | Stable | |
+| Python | scip-python | Beta | Some edge cases |
+| Rust | rust-analyzer | Stable | Via `--emit scip` |
+| Clojure | None | N/A | Needs custom bridge from clj-kondo analysis |
+
+**Exit gate:** `nav.def` + `nav.refs` work for ≥1 SCIP-covered language; coverage
+gating returns proper errors for uncovered languages.
+
+---
+
+## Phase 4: Staleness + Semantic Search (2 weeks)
+
+**Goal:** Handle concurrent edits and add vector search.
+
+### DAG
+
+```text
+4.1 Staleness detection                                      [depends: Phase 1]
+     ├── 4.1.1 Track blob-sha → agent mapping in context-pack
+     ├── 4.1.2 Detect tree changes during agent execution
+     ├── 4.1.3 Implement invalidate-and-rebuild (default)
+     └── 4.1.4 Implement fail-on-staleness (when rebuild budget exhausted)
+
+4.2 Semantic search                                          [depends: Phase 2]
+     ├── 4.2.1 Evaluate embedding options (local model vs API)
+     ├── 4.2.2 Embed symbol signatures + docstrings
+     ├── 4.2.3 Embed file summaries from repo map
+     ├── 4.2.4 Vector store (hnswlib-clj or similar)
+     ├── 4.2.5 Register repo.search-sem tool
+     └── 4.2.6 Budget accounting for semantic search calls
+
+4.3 Merge support (optional, stretch)                        [depends: 4.1]
+     ├── 4.3.1 Compute delta between old and new tree
+     ├── 4.3.2 Patch ContextPack for non-overlapping changes
+     └── 4.3.3 Fail when overlap detected
+```
+
+**Exit gate:** Staleness detected and handled for concurrent agent scenarios;
+semantic search returns relevant symbols for natural language queries.
+
+---
+
+## Full DAG (cross-phase dependencies)
+
+```text
+Phase 0: Observe
+  0.1 → 0.2 → 0.3
+                 │
+Phase 1: Core    ▼
+  1.1 ──────────────► 1.2 ──────► 1.4 ──► 1.5
+   │                   │           │
+   └──► 1.3 ◄─────────┘           │
+         │                         │
+         └─────────────────────────┘
+                                   │
+  1.6 ◄───────────────────────────┘
+   │
+Phase 2: Symbols ▼
+  2.1 ──► 2.2 ──► 2.3 ──► 2.4
+                            │
+Phase 3: SCIP/LSIF          ▼
+  3.1 ──► 3.3               │
+   │                         │
+  3.2 ──┘                   │
+   │                         │
+  3.4 (parallel, per-lang)  │
+                             │
+Phase 4: Staleness + Vectors ▼
+  4.1 (from Phase 1)
+  4.2 (from Phase 2) ──► 4.2.5
+  4.3 (from 4.1, stretch)
+```
+
+---
+
+## PR Layering Strategy
+
+Per project convention (rule 720: <400 lines, independently mergeable):
+
+| PR | Phase | Scope | ~Lines | Depends On |
+|----|-------|-------|--------|------------|
+| #247 | — | Spec additions (this PR) | 809 | — |
+| P1-A | 0 | Retrieval instrumentation + observe metrics | ~250 | #247 |
+| P1-B | 1.1 | repo-index component (scanner + incremental + storage) | ~400 | P1-A |
+| P1-C | 1.1 | repo-map + search-lex | ~350 | P1-B |
+| P1-D | 1.2 | context-pack component (builder + budget + dedup) | ~400 | P1-C |
+| P1-E | 1.3–1.4 | Tool registration + orchestrator wiring | ~350 | P1-D |
+| P1-F | 1.5–1.6 | Agent protocol + audit integration | ~300 | P1-E |
+| P2-A | 2.1 | Tree-sitter integration + AST extraction | ~400 | P1-F |
+| P2-B | 2.2–2.4 | Symbol table + repo.symbol tool + context integration | ~400 | P2-A |
+| P3-A | 3.1 | SCIP ingestion + edge extraction | ~400 | P2-B |
+| P3-B | 3.2–3.3 | LSIF fallback + nav tools | ~350 | P3-A |
+| P3-C | 3.4 | SCIP generation pipelines (per-language) | ~300 | P3-A |
+| P4-A | 4.1 | Staleness detection + invalidate-and-rebuild | ~300 | P1-F |
+| P4-B | 4.2 | Semantic search (embeddings + vector store) | ~400 | P2-B |
+
+---
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Tree-sitter JVM integration is brittle | Medium | High | Fallback: subprocess + JSON AST; evaluate java-tree-sitter early |
+| Clojure has no SCIP indexer | Certain | Medium | Phase 3: build clj-kondo → symbol bridge; defer precise nav |
+| Budget defaults too tight for large repos | Medium | Medium | Phase 0 observe-only calibration; per-repo overrides |
+| Staleness rebuilds too expensive | Low | Medium | Defer merge support to Phase 4.3; most workflows are single-agent |
+| BM25 index too slow for large repos | Low | Low | Use tantivy (Rust) via JNI; proven at scale |
+
+---
+
+## Success Metrics
+
+| Metric | Baseline (Phase 0) | Target (Phase 1) | Target (Phase 4) |
+|--------|-------------------|-------------------|-------------------|
+| Tokens per agent call (context) | Measure | -40% | -60% |
+| Duplicate snippets across agents | Measure | 0 (dedup) | 0 (dedup) |
+| Context retrieval audit coverage | 0% | 100% | 100% |
+| Symbol-first retrievals (vs raw open) | 0% | N/A | >70% |
+| Cache hit rate (cross-commit symbol-key) | N/A | N/A | >50% |

--- a/work/wire-self-repair-chain.spec.edn
+++ b/work/wire-self-repair-chain.spec.edn
@@ -1,0 +1,147 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+{:spec/title "Wire Self-Repair Chain Into Workflow Execution"
+ :spec/description
+ "Connect the existing self-repair components (inner loop, agent repair,
+  workaround detector, error handlers) into the workflow phase execution
+  pipeline. Currently these components are implemented but disconnected:
+
+  1. Phase interceptors define :error handlers (error-implement, error-release,
+     etc.) with retry/redirect logic, but execution.clj never invokes them
+     on phase failure.
+  2. The workaround detector (self-healing/workaround_detector.clj) is loaded
+     but never triggered when phases fail — it should match error patterns
+     to known workarounds before propagating failure.
+  3. DAG sub-workflows (dag_orchestrator.clj task-sub-opts) don't forward
+     repair context, so sub-task failures can't self-repair.
+  4. The inner loop state machine (loop/inner.clj) runs within agents but
+     the outer generate→validate→repair cycle isn't connected to the
+     phase-level execution in workflow/execution.clj.
+
+  The goal is a connected chain:
+    phase fails → error handler retries (if budget allows) →
+    workaround detector matches known patterns →
+    self-healing applies fix → retry →
+    if exhausted, escalate cleanly with context"
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/workflow/src/ai/miniforge/workflow/execution.clj"
+          "components/workflow/src/ai/miniforge/workflow/runner.clj"
+          "components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj"
+          "components/self-healing/src/ai/miniforge/self_healing"
+          "components/loop/src/ai/miniforge/loop"
+          "components/phase/src/ai/miniforge/phase"]}
+
+ :spec/constraints
+ ["Do not change phase interceptor signatures — :enter/:leave/:error contract is stable"
+  "Preserve existing agent-level repair (specialized.clj cycle-agent-impl) unchanged"
+  "Keep backward compatibility — workflows without repair config must still work"
+  "Self-repair budget must be bounded (max retries per phase, max total across workflow)"
+  "DAG sub-workflow repair must not cause cascading retries across tasks"
+  "Add tests for each connection point — no silent regressions"
+  "Prefer additive changes over rewrites of existing components"]
+
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :plan/tasks
+ [{:task/id :invoke-phase-error-handlers
+   :task/description
+   "Wire phase interceptor :error handlers into workflow/execution.clj.
+
+    Currently execute-enter catches exceptions and records errors but never
+    calls the interceptor's :error function. The :error handler has retry
+    logic (e.g. error-implement sets :status :retrying when within budget).
+
+    Changes needed in execution.clj:
+    - In execute-enter's catch block, call (:error interceptor) before
+      falling through to the default error recording
+    - In execute-leave's catch block, same pattern
+    - Respect the :retrying status returned by error handlers — if the
+      phase wants to retry, determine-next-index already handles it
+      (returns current-index for :retrying status)
+
+    Add tests verifying:
+    - Phase error handler is called on exception
+    - Retry budget is respected (retries N times then fails)
+    - on-fail redirect works when budget exhausted"
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :trigger-workaround-detector-on-phase-failure
+   :task/description
+   "Call the workaround detector when a phase fails, before propagating
+    the failure up the chain.
+
+    The workaround detector (self_healing/workaround_detector.clj) has
+    pattern matching for known error types. It should be called:
+    - After a phase's :error handler has been invoked
+    - Before the workflow records the phase as :failed
+    - Only if the error handler didn't already resolve the issue
+
+    Integration point: workflow/runner.clj between-phase boundary or
+    execution.clj phase-result processing.
+
+    Add tests verifying:
+    - Known error pattern triggers workaround
+    - Unknown error pattern passes through unchanged
+    - Workaround application is logged/evented"
+   :task/type :implement
+   :task/dependencies [:invoke-phase-error-handlers]}
+
+  {:task/id :forward-repair-context-to-dag-sub-workflows
+   :task/description
+   "Update dag_orchestrator.clj task-sub-opts to forward repair-relevant
+    context to sub-workflows so they can self-repair.
+
+    Currently task-sub-opts forwards: llm-backend, event-stream, executor,
+    environment-id, sandbox-workdir, worktree-path. Missing: any repair
+    config, workaround registry, error budget.
+
+    Add to forwarded context:
+    - :repair-budget (subset of parent budget for sub-tasks)
+    - :workaround-registry (if present in parent context)
+    - :self-healing-enabled? flag
+
+    Add tests verifying:
+    - Repair context is forwarded when present
+    - Missing repair context doesn't break sub-workflow execution
+    - Sub-task repair budget is bounded independently of parent"
+   :task/type :implement
+   :task/dependencies [:invoke-phase-error-handlers]}
+
+  {:task/id :add-self-repair-chain-integration-tests
+   :task/description
+   "Add end-to-end tests for the full self-repair chain:
+    phase fails → error handler → workaround detector → retry → succeed
+    or exhaust budget → clean failure with context.
+
+    Test scenarios:
+    - Transient error: phase fails once, error handler retries, succeeds
+    - Known workaround: phase fails, detector matches, applies fix, retries
+    - Budget exhausted: phase fails N times, each retry fails, clean failure
+    - DAG sub-task: sub-workflow phase fails, repairs within sub-budget
+    - No repair config: workflow runs without repair, fails normally (backward compat)
+
+    These should use with-redefs to mock agent/phase behavior, not real
+    LLM calls."
+   :task/type :test
+   :task/dependencies [:trigger-workaround-detector-on-phase-failure
+                       :forward-repair-context-to-dag-sub-workflows]}]}


### PR DESCRIPTION
## Summary

TUI detail panes (artifacts, evidence, phase status, workflow duration) showed no data because the event subscription layer dropped key fields and the event handlers never populated the detail model.

**Root cause**: `translate-event` for `:workflow/phase-completed` only passed `phase` and `outcome` — dropping artifacts, duration, and error data. Similarly, workflow completion events dropped duration and evidence bundle IDs. The `enter-workflow-detail` action reset all detail fields to empty without seeding from existing workflow row data.

## Changes

- **msg.clj**: `phase-done` and `workflow-done` accept optional extras map
- **subscription.clj**: Phase-completed now passes artifacts, duration-ms, error; workflow-completed passes duration-ms, evidence-bundle-id
- **events.clj**: 
  - `handle-phase-done` populates `[:detail :artifacts]` and updates phase status/duration
  - `handle-workflow-done` stores duration-ms and evidence-bundle-id
  - `handle-workflow-added` seeds evidence intent from workflow spec
- **navigation.clj**: `enter-workflow-detail` seeds detail from workflow row (phase, agent, gate results)

## Test plan

- [x] 226 TUI tests pass, 0 failures
- [ ] Manual: launch TUI during a workflow run, verify phase status updates, artifacts appear, evidence shows gate results

🤖 Generated with [Claude Code](https://claude.com/claude-code)