### PR TITLE
fix: rewrite codex stream parser for actual JSONL format

### DIFF
--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -107,11 +107,12 @@
 (defn parse-codex-stream-line
   "Parse a line from Codex CLI streaming output.
 
-   Codex uses Anthropic API streaming format:
-   - message_start: initial message with input token count
-   - content_block_delta: content chunks
-   - message_delta: final delta with output token usage
-   - message_stop: end of message
+   Codex emits JSONL events:
+   - thread.started: session began
+   - turn.started: turn began
+   - item.completed: reasoning, agent_message, mcp_tool_call, etc.
+   - turn.completed: carries usage data
+   - turn.failed / error: failure events
 
    Arguments:
      line - String line from stream
@@ -121,32 +122,37 @@
   (try
     (when-not (str/blank? line)
       (let [data (json/parse-string line true)]
-        (cond
-          ;; message_start carries input token count
-          (= "message_start" (:type data))
-          (let [usage (get-in data [:message :usage])]
-            {:delta "" :done? false
-             :usage {:input-tokens (:input_tokens usage)}})
+        (case (:type data)
+          ;; Agent message — the actual text output
+          "item.completed"
+          (let [item (:item data)
+                item-type (:type item)]
+            (case item-type
+              "agent_message"
+              {:delta (str (:text item) "\n") :done? false}
 
-          ;; Extract content from content_block_delta events
-          (= "content_block_delta" (:type data))
-          (when-let [delta-text (get-in data [:delta :text])]
-            {:delta delta-text :done? false})
+              "mcp_tool_call"
+              {:delta "" :done? false}
 
-          ;; message_delta carries output token usage
-          (= "message_delta" (:type data))
-          (let [delta-text (get-in data [:delta :text])
-                usage (get-in data [:usage])]
-            (cond-> {:done? false}
-              delta-text (assoc :delta delta-text)
-              usage (assoc :usage {:output-tokens (:output_tokens usage)})))
+              ;; reasoning, tool_call, etc. — ignore content
+              nil))
 
-          ;; message_stop signals end
-          (= "message_stop" (:type data))
-          {:delta "" :done? true}
+          ;; Turn completed carries usage
+          "turn.completed"
+          (let [usage (:usage data)]
+            {:delta "" :done? true
+             :usage {:input-tokens (:input_tokens usage)
+                     :output-tokens (:output_tokens usage)}})
 
-          ;; Ignore other event types
-          :else nil)))
+          ;; Turn failed
+          "turn.failed"
+          {:delta (str "\nError: " (get-in data [:error :message] "unknown")) :done? true}
+
+          "error"
+          {:delta (str "\nError: " (:message data "unknown")) :done? true}
+
+          ;; thread.started, turn.started, item.started — ignore
+          nil)))
     (catch Exception _e
       nil)))
 

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -1,5 +1,6 @@
 (ns ai.miniforge.llm.interface-test
   (:require [clojure.test :as test :refer [deftest testing is]]
+            [clojure.string :as str]
             [ai.miniforge.llm.interface :as llm]
             [ai.miniforge.llm.protocols.records.llm-client]
             [ai.miniforge.llm.protocols.impl.llm-client :as impl]
@@ -139,6 +140,57 @@
           parsed (impl/parse-claude-stream-line line)]
       (is (true? (:done? parsed)))
       (is (nil? (get-in parsed [:usage :input-tokens]))))))
+
+(deftest parse-codex-stream-line-test
+  (testing "agent_message item extracts text delta"
+    (let [line (json/generate-string
+                 {:type "item.completed"
+                  :item {:id "item_1" :type "agent_message"
+                         :text "Hello world"}})
+          parsed (impl/parse-codex-stream-line line)]
+      (is (= "Hello world\n" (:delta parsed)))
+      (is (false? (:done? parsed)))))
+
+  (testing "turn.completed extracts usage and signals done"
+    (let [line (json/generate-string
+                 {:type "turn.completed"
+                  :usage {:input_tokens 9971
+                          :output_tokens 206}})
+          parsed (impl/parse-codex-stream-line line)]
+      (is (true? (:done? parsed)))
+      (is (= 9971 (get-in parsed [:usage :input-tokens])))
+      (is (= 206 (get-in parsed [:usage :output-tokens])))))
+
+  (testing "mcp_tool_call item returns empty delta"
+    (let [line (json/generate-string
+                 {:type "item.completed"
+                  :item {:id "item_2" :type "mcp_tool_call"
+                         :server "artifact" :tool "submit_code_artifact"
+                         :status "completed"}})
+          parsed (impl/parse-codex-stream-line line)]
+      (is (= "" (:delta parsed)))
+      (is (false? (:done? parsed)))))
+
+  (testing "reasoning item is ignored"
+    (let [line (json/generate-string
+                 {:type "item.completed"
+                  :item {:id "item_0" :type "reasoning"
+                         :text "Thinking..."}})
+          parsed (impl/parse-codex-stream-line line)]
+      (is (nil? parsed))))
+
+  (testing "turn.failed returns error and done"
+    (let [line (json/generate-string
+                 {:type "turn.failed"
+                  :error {:message "Rate limited"}})
+          parsed (impl/parse-codex-stream-line line)]
+      (is (true? (:done? parsed)))
+      (is (str/includes? (:delta parsed) "Rate limited"))))
+
+  (testing "thread.started is ignored"
+    (let [line (json/generate-string {:type "thread.started" :thread_id "abc"})
+          parsed (impl/parse-codex-stream-line line)]
+      (is (nil? parsed)))))
 
 (deftest parse-cli-output-includes-metrics-test
   (testing "success response includes :tokens and :usage keys"


### PR DESCRIPTION
## Summary
- Rewrites `parse-codex-stream-line` to handle actual codex CLI JSONL format (`item.completed`, `turn.completed`, `turn.failed`, `error`) instead of the Anthropic streaming format it was incorrectly parsing
- Root cause of "artifact file not found" errors during codex backend runs — parser couldn't read output so content/MCP tool calls were never captured
- Adds rate-limit detection and cost tracking to the Claude CLI `result` event parser
- Adds 6 tests for the codex parser covering all event types

## Test plan
- [x] All 50 llm brick tests pass (including 6 new codex parser tests)
- [x] GraalVM compatibility tests pass
- [ ] Re-run YC MVP spec with `--backend codex` to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)