### PR TITLE
fix: prevent DAG child phantom rows + harden input thread

### DIFF
--- a/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
@@ -216,19 +216,23 @@
 ;; Input polling thread
 
 (defn start-input-thread!
-  "Start a daemon thread that polls for keyboard input and dispatches messages."
+  "Start a daemon thread that polls for keyboard input and dispatches messages.
+   Catches exceptions per-keystroke so a single dispatch failure doesn't kill
+   the input thread (which would freeze the TUI)."
   [app]
   (let [thread (Thread.
                 (fn []
                   (try
                     (while (:running? @app)
-                      (let [screen (:screen @app)
-                            key (input/poll-key screen)]
-                        (if key
-                          (dispatch! app [:input key])
-                          (Thread/sleep 16)))) ; ~60Hz polling
-                    (catch InterruptedException _)
-                    (catch Exception _))))]
+                      (try
+                        (let [screen (:screen @app)
+                              key (input/poll-key screen)]
+                          (if key
+                            (dispatch! app [:input key])
+                            (Thread/sleep 16))) ; ~60Hz polling
+                        (catch InterruptedException e (throw e))
+                        (catch Exception _)))
+                    (catch InterruptedException _))))]
     (.setDaemon thread true)
     (.setName thread "tui-input-poll")
     (.start thread)

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -225,7 +225,7 @@
         (apply-gate-result idx workflow-id gate passed? payload)
         with-timestamp)))
 
-(defn handle-gate-started [model {:keys [workflow-id gate]}]
+(defn handle-gate-started [model {:keys [gate]}]
   (-> model
       (assoc :flash-message (str "Gate running: " (if gate (name gate) "unknown")))
       with-timestamp))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -131,8 +131,7 @@
         with-timestamp)))
 
 (defn handle-phase-changed [model {:keys [workflow-id phase]}]
-  (let [model (ensure-workflow model workflow-id)
-        idx (find-workflow-idx (:workflows model) workflow-id)]
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
         (apply-phase-change idx workflow-id phase)
         with-timestamp)))
@@ -164,8 +163,7 @@
       model)))
 
 (defn handle-phase-done [model {:keys [workflow-id phase outcome artifacts duration-ms]}]
-  (let [model (ensure-workflow model workflow-id)
-        idx (find-workflow-idx (:workflows model) workflow-id)
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)
         phase-status (case outcome :success :success :failed :failed :success)]
     (-> model
         (update-workflow-at idx #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))
@@ -174,8 +172,7 @@
         with-timestamp)))
 
 (defn handle-agent-status [model {:keys [workflow-id agent status message]}]
-  (let [model (ensure-workflow model workflow-id)
-        idx (find-workflow-idx (:workflows model) workflow-id)]
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
         (apply-agent-status-update idx workflow-id agent status message)
         with-timestamp)))
@@ -195,7 +192,7 @@
         (assoc :flash-message (str "Agent " (name agent-kw) " failed")))))
 
 (defn handle-agent-output [model {:keys [workflow-id delta]}]
-  (-> (ensure-workflow model workflow-id)
+  (-> model
       (update-detail-if-active workflow-id
         #(update-in % [:detail :agent-output] str delta))
       with-timestamp))
@@ -208,8 +205,7 @@
     duration-ms        (assoc-in [:detail :duration-ms] duration-ms)))
 
 (defn handle-workflow-done [model {:keys [workflow-id status duration-ms evidence-bundle-id]}]
-  (let [model (ensure-workflow model workflow-id)
-        idx (find-workflow-idx (:workflows model) workflow-id)]
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
         (update-workflow-at idx #(assoc % :status (or status :success) :progress 100
                                           :duration-ms duration-ms))
@@ -218,36 +214,31 @@
         with-timestamp)))
 
 (defn handle-workflow-failed [model {:keys [workflow-id error]}]
-  (let [model (ensure-workflow model workflow-id)
-        idx (find-workflow-idx (:workflows model) workflow-id)]
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
         (update-workflow-at idx #(assoc % :status :failed :error error))
         with-timestamp)))
 
 (defn handle-gate-result [model {:keys [workflow-id gate passed?] :as payload}]
-  (let [model (ensure-workflow model workflow-id)
-        idx (find-workflow-idx (:workflows model) workflow-id)]
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
         (apply-gate-result idx workflow-id gate passed? payload)
         with-timestamp)))
 
 (defn handle-gate-started [model {:keys [workflow-id gate]}]
-  (let [model (ensure-workflow model workflow-id)]
-    (-> model
-        (assoc :flash-message (str "Gate running: " (if gate (name gate) "unknown")))
-        with-timestamp)))
+  (-> model
+      (assoc :flash-message (str "Gate running: " (if gate (name gate) "unknown")))
+      with-timestamp))
 
 (defn handle-tool-invoked [model {:keys [workflow-id agent tool]}]
-  (let [model (ensure-workflow model workflow-id)
-        idx (find-workflow-idx (:workflows model) workflow-id)
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)
         status-message (str "Tool " (if tool (name tool) "unknown") " invoked")]
     (-> model
         (apply-agent-status-update idx workflow-id (or agent :agent) :tool-running status-message)
         with-timestamp)))
 
 (defn handle-tool-completed [model {:keys [workflow-id agent tool]}]
-  (let [model (ensure-workflow model workflow-id)
-        idx (find-workflow-idx (:workflows model) workflow-id)
+  (let [idx (find-workflow-idx (:workflows model) workflow-id)
         status-message (str "Tool " (if tool (name tool) "unknown") " completed")]
     (-> model
         (apply-agent-status-update idx workflow-id (or agent :agent) :tool-completed status-message)

--- a/components/tui-views/test/ai/miniforge/tui_views/events_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/events_test.clj
@@ -41,11 +41,10 @@
                 (events/handle-phase-changed {:workflow-id wf-id :phase :implement}))]
       (is (= :implement (get-in m [:workflows 0 :phase])))))
 
-  (testing "creates workflow row if missing (late event)"
+  (testing "ignores phase event for unknown workflow (DAG child)"
     (let [wf-id (random-uuid)
           m (events/handle-phase-changed (fresh) {:workflow-id wf-id :phase :plan})]
-      (is (= 1 (count (:workflows m))))
-      (is (= :plan (get-in m [:workflows 0 :phase]))))))
+      (is (= 0 (count (:workflows m)))))))
 
 (deftest handle-phase-changed-updates-detail-test
   (testing "updates detail phases when workflow is active in detail"
@@ -400,23 +399,21 @@
     (let [m (events/handle-chat-action-result (fresh) {:success? false})]
       (is (= "Action failed" (:flash-message m))))))
 
-;; ---------------------------------------------------------------------------- ensure-workflow helper
+;; ---------------------------------------------------------------------------- Unknown workflow-id handling
 
-(deftest ensure-workflow-creates-row-for-unknown-id-test
-  (testing "events for unknown workflow-ids auto-create a row"
+(deftest unknown-workflow-id-is-noop-test
+  (testing "events for unknown workflow-ids are no-ops (DAG children)"
     (let [wf-id (random-uuid)
           m (events/handle-agent-status (fresh)
               {:workflow-id wf-id :agent :planner :status :thinking :message "hi"})]
-      (is (= 1 (count (:workflows m))))
-      (is (= wf-id (get-in m [:workflows 0 :id]))))))
+      (is (= 0 (count (:workflows m)))))))
 
-(deftest ensure-workflow-does-not-duplicate-test
-  (testing "ensure-workflow doesn't add duplicates"
+(deftest known-workflow-not-duplicated-test
+  (testing "multiple events for same known workflow don't add duplicates"
     (let [wf-id (random-uuid)
           m (-> (fresh)
                 (with-workflow wf-id)
                 (events/handle-agent-status {:workflow-id wf-id :agent :a :status :ok :message ""}))
-          ;; Apply another event to same workflow
           m2 (events/handle-phase-changed m {:workflow-id wf-id :phase :plan})]
       (is (= 1 (count (:workflows m2)))))))
 


### PR DESCRIPTION
## Summary
- Remove `ensure-workflow` from all event handlers — DAG sub-workflows that skip lifecycle events no longer create phantom top-level entries like `workflow-f19c1492`
- Events for unknown workflow IDs are silently ignored (legitimate workflows always emit `:workflow/started` first)
- Harden input thread to catch exceptions per-keystroke instead of per-thread, preventing a single dispatch failure from freezing the TUI (likely root cause of `q`/`:quit` breaking)
- Remove unused `workflow-id` binding in `handle-gate-started`
- Update tests to match new behavior

## Test plan
- [x] All 263 tests pass (tui-engine + tui-views)
- [x] GraalVM compatibility tests pass
- [ ] Verify `q` key works to quit TUI
- [ ] Verify DAG sub-workflows no longer appear as top-level list items

🤖 Generated with [Claude Code](https://claude.com/claude-code)