### PR TITLE
Fix inline already-implemented detection in codex responses

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -155,15 +155,20 @@
 
 (defn parse-code-response
   "Parse the LLM response to extract code artifact.
-   Handles both EDN in code blocks and plain EDN.
-   Returns nil if the parsed result is not a map."
+   Handles EDN in code blocks, plain EDN, and inline EDN maps
+   embedded in reasoning text (e.g. {:status :already-implemented ...}).
+   Returns nil if no parseable map is found."
   [response-content]
   (try
     (let [parsed (if-let [match (re-find #"```(?:clojure|edn)?\s*\n([\s\S]*?)\n```" response-content)]
                    (edn/read-string (second match))
                    ;; Try to parse the whole response as EDN
-                   (edn/read-string response-content))]
-      ;; Validate that the parsed result is a map (code artifact should be a map)
+                   (or (try (let [r (edn/read-string response-content)]
+                              (when (map? r) r))
+                            (catch Exception _ nil))
+                       ;; Scan for inline EDN map (e.g. {:status :already-implemented ...})
+                       (when-let [match (re-find #"\{:status\s+:already-implemented[^}]*\}" response-content)]
+                         (edn/read-string match))))]
       (when (map? parsed)
         parsed))
     (catch Exception _

--- a/components/agent/test/ai/miniforge/agent/parser_validation_test.clj
+++ b/components/agent/test/ai/miniforge/agent/parser_validation_test.clj
@@ -62,4 +62,13 @@
     
     (testing "returns map from code block"
       (let [response "```edn\n{:code/id #uuid \"123e4567-e89b-12d3-a456-426614174000\" :code/files []}\n```"]
-        (is (map? (implementer/parse-code-response response)))))))
+        (is (map? (implementer/parse-code-response response)))))
+
+    (testing "extracts inline {:status :already-implemented} from reasoning text"
+      (let [response "Looking at the existing files, this feature is already fully implemented.\n\n{:status :already-implemented :summary \"The login module already exists with email verification.\"}"]
+        (is (= :already-implemented (:status (implementer/parse-code-response response))))
+        (is (string? (:summary (implementer/parse-code-response response))))))
+
+    (testing "returns nil for reasoning text without EDN map"
+      (let [response "I've analyzed the codebase and the feature looks good. No changes needed."]
+        (is (nil? (implementer/parse-code-response response)))))))


### PR DESCRIPTION
## Summary
- Fix `parse-code-response` to detect `{:status :already-implemented}` when embedded inline in reasoning text (codex backend outputs this without code fences)
- Root cause: `edn/read-string` on mixed text returns a Symbol for the first word rather than throwing, so the `catch`-based fallback regex scan never ran
- Changed from `catch`-based fallback to `or`-based: regex scan runs whenever full-text parse doesn't yield a map

## Test plan
- [x] Added tests for inline already-implemented detection and plain reasoning text
- [x] All 744 tests pass (0 failures)
- [ ] Re-run YC MVP spec with codex backend to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)