### PR TITLE
Fix TUI stability issues: enhance workflow detail hydration, improve …

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/monitoring.clj
@@ -116,7 +116,11 @@
       (try
         (let [start-standalone! (requiring-resolve 'ai.miniforge.tui-views.interface/start-standalone-tui!)]
           ;; Start standalone TUI (blocks until quit)
-          (start-standalone! opts))
+          (start-standalone! opts)
+          ;; Force immediate JVM exit — Clojure's agent thread pool
+          ;; keeps the process alive for ~60s otherwise
+          (shutdown-agents)
+          (System/exit 0))
         (catch Exception e
           (display/print-error (str "Failed to start TUI: " (.getMessage e)))
           (when (str/includes? (str e) "terminal")

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -185,7 +185,9 @@
           (:duration-ms result) (assoc :phase/duration-ms (:duration-ms result))
           (:artifacts result) (assoc :phase/artifacts (:artifacts result))
           (:error result) (assoc :phase/error (:error result))
-          (:redirect-to result) (assoc :phase/redirect-to (:redirect-to result))))))
+          (:redirect-to result) (assoc :phase/redirect-to (:redirect-to result))
+          (:tokens result) (assoc :phase/tokens (:tokens result))
+          (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))))))
 
 (defn agent-chunk [stream workflow-id agent-id delta & [done?]]
   (-> (create-envelope stream :agent/chunk workflow-id
@@ -199,11 +201,13 @@
       (assoc :agent/id agent-id
              :status/type status-type)))
 
-(defn workflow-completed [stream workflow-id status & [duration-ms]]
+(defn workflow-completed [stream workflow-id status & [duration-ms opts]]
   (-> (create-envelope stream :workflow/completed workflow-id
                        (str "Workflow " (name status)))
       (assoc :workflow/status status)
-      (cond-> duration-ms (assoc :workflow/duration-ms duration-ms))))
+      (cond-> duration-ms (assoc :workflow/duration-ms duration-ms)
+              (:tokens opts) (assoc :workflow/tokens (:tokens opts))
+              (:cost-usd opts) (assoc :workflow/cost-usd (:cost-usd opts)))))
 
 (defn workflow-failed [stream workflow-id error]
   (let [;; Handle anomaly maps, Throwables, and plain error maps

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -295,11 +295,13 @@
    - workflow-id: UUID of the workflow
    - status: Keyword status (:success, :failure, :cancelled)
    - duration-ms: Optional total workflow duration in milliseconds
+   - opts: Optional map with :tokens and :cost-usd
 
    Example:
-     (workflow-completed stream wf-id :success 120000)"
-  [stream workflow-id status & [duration-ms]]
-  (core/workflow-completed stream workflow-id status duration-ms))
+     (workflow-completed stream wf-id :success 120000)
+     (workflow-completed stream wf-id :success 120000 {:tokens 5000 :cost-usd 0.15})"
+  [stream workflow-id status & [duration-ms opts]]
+  (core/workflow-completed stream workflow-id status duration-ms opts))
 
 (defn workflow-failed
   "Create a workflow/failed event.

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -82,6 +82,8 @@
    [:phase/duration-ms {:optional true} int?]
    [:phase/outcome {:optional true} [:enum :success :failure :skipped]]
    [:phase/artifacts {:optional true} [:vector uuid?]]
+   [:phase/tokens {:optional true} int?]
+   [:phase/cost-usd {:optional true} number?]
    [:message string?]])
 
 (def WorkflowCompleted
@@ -96,6 +98,8 @@
    [:workflow/status [:enum :success :failure :cancelled]]
    [:workflow/duration-ms {:optional true} int?]
    [:workflow/evidence-bundle-id {:optional true} uuid?]
+   [:workflow/tokens {:optional true} int?]
+   [:workflow/cost-usd {:optional true} number?]
    [:message string?]])
 
 (def WorkflowFailed

--- a/components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/interface_test.clj
@@ -138,6 +138,23 @@
       (is (= :success (:workflow/status event)))
       (is (= 120000 (:workflow/duration-ms event)))))
 
+  (testing "phase-completed includes tokens and cost"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/phase-completed stream wf-id :implement
+                                     {:outcome :success :duration-ms 8000
+                                      :tokens 2500 :cost-usd 0.08})]
+      (is (= 2500 (:phase/tokens event)))
+      (is (= 0.08 (:phase/cost-usd event)))))
+
+  (testing "workflow-completed includes tokens and cost via opts"
+    (let [stream (es/create-event-stream)
+          wf-id (random-uuid)
+          event (es/workflow-completed stream wf-id :success 120000
+                                        {:tokens 5000 :cost-usd 0.25})]
+      (is (= 5000 (:workflow/tokens event)))
+      (is (= 0.25 (:workflow/cost-usd event)))))
+
   (testing "workflow-failed captures error details"
     (let [stream (es/create-event-stream)
           wf-id (random-uuid)

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -244,11 +244,24 @@
       (update result :prs (fn [prs] (vec (remove #(#{:closed :merged} (:pr/status %)) prs))))
       result)))
 
-(defn fetch-open-gitlab-mrs
-  [repo]
-  (let [repo* (provider-repo-slug repo)
+(defn gitlab-state-param
+  "Map canonical state keyword to GitLab API state parameter."
+  [state]
+  (case state
+    :open   "opened"
+    :closed "closed"
+    :merged "merged"
+    :all    "all"
+    "opened"))
+
+(defn fetch-gitlab-mrs-by-state
+  "Fetch GitLab merge requests by state (:open, :closed, :merged, :all)."
+  [repo state]
+  (let [repo*    (provider-repo-slug repo)
+        gl-state (gitlab-state-param state)
         endpoint (str "projects/" (url-encode repo*)
-                      "/merge_requests?state=opened&per_page=100&with_merge_status_recheck=true")
+                      "/merge_requests?state=" gl-state
+                      "&per_page=100&with_merge_status_recheck=true")
         {:keys [success? out err]} (run-glab "api" endpoint)]
     (if-not success?
       (result-failure (gh-error-message out err) {:repo repo :provider :gitlab})
@@ -259,12 +272,18 @@
             :provider :gitlab
             :prs (->> rows
                       (map #(status/gitlab-mr->train-pr % repo))
-                      (remove #(= :closed (:pr/status %)))
                       (sort-by :pr/number)
                       vec)}))
         (catch Exception e
           (result-failure (str "Failed to parse merge request list for " repo ".")
                           {:repo repo :provider :gitlab :error (.getMessage e)}))))))
+
+(defn fetch-open-gitlab-mrs
+  [repo]
+  (let [result (fetch-gitlab-mrs-by-state repo :open)]
+    (if (succeeded? result)
+      (update result :prs (fn [prs] (vec (remove #(#{:closed :merged} (:pr/status %)) prs))))
+      result)))
 
 (defn fetch-open-prs
   "Fetch open PR/MR items for a single configured repository.
@@ -280,7 +299,7 @@
    Returns {:success? bool :repo str :prs [TrainPR ...]}."
   [repo state]
   (case (repo-provider repo)
-    :gitlab (fetch-open-gitlab-mrs repo) ;; GitLab API only supports opened for now
+    :gitlab (fetch-gitlab-mrs-by-state repo state)
     (fetch-github-prs repo state)))
 
 (defn fetch-all-fleet-prs

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -221,7 +221,7 @@
         {:keys [success? out err]} (run-gh "pr" "list"
                                            "--repo" repo*
                                            "--state" gh-state
-                                           "--json" "number,title,url,state,headRefName,isDraft,reviewDecision,statusCheckRollup,mergeStateStatus")]
+                                           "--json" "number,title,url,state,mergedAt,headRefName,isDraft,reviewDecision,statusCheckRollup,mergeStateStatus")]
     (if-not success?
       (result-failure (gh-error-message out err) {:repo repo :provider :github})
       (try

--- a/components/pr-sync/src/ai/miniforge/pr_sync/status.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/status.clj
@@ -130,6 +130,7 @@
         merge-status (some-> (:merge_status mr) str str/lower-case)
         conflicts? (true? (:has_conflicts mr))]
     (cond
+      (= "merged" state) :merged
       (not= "opened" state) :closed
       draft? :draft
       conflicts? :changes-requested

--- a/components/pr-sync/src/ai/miniforge/pr_sync/status.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/status.clj
@@ -49,8 +49,10 @@
   [pr]
   (let [state (some-> (:state pr) str str/upper-case)
         draft? (boolean (:isDraft pr))
+        merged? (boolean (or (:mergedAt pr) (= "MERGED" state)))
         decision (some-> (:reviewDecision pr) str str/upper-case)]
     (cond
+      merged? :merged
       (and state (not= "OPEN" state)) :closed
       draft? :draft
       (= "APPROVED" decision) :approved
@@ -109,6 +111,7 @@
               :pr/url           (:url pr)
               :pr/branch        (:headRefName pr)
               :pr/status        (pr-status-from-provider pr)
+              :pr/merged-at     (:mergedAt pr)
               :pr/ci-status     (check-rollup->ci-status (:statusCheckRollup pr))
               :pr/ci-checks     (check-rollup->ci-checks (:statusCheckRollup pr))
               :pr/merge-state   (some-> merge-state str str/upper-case)

--- a/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
@@ -130,6 +130,32 @@
         (is (not (:removed? result)))))))
 
 ;; ─────────────────────────────────────────────────────────────────────────────
+;; GitLab state parameter mapping
+
+(deftest gitlab-state-param-test
+  (testing "Maps canonical state keywords to GitLab API parameters"
+    (is (= "opened" (core/gitlab-state-param :open)))
+    (is (= "closed" (core/gitlab-state-param :closed)))
+    (is (= "merged" (core/gitlab-state-param :merged)))
+    (is (= "all"    (core/gitlab-state-param :all)))
+    (is (= "opened" (core/gitlab-state-param :unknown)))))
+
+(deftest fetch-prs-by-state-routes-gitlab-test
+  (testing "GitLab repos use state-aware fetch instead of hardcoded opened"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (if (and (= "glab" (first args))
+                             (some #(and (string? %) (.contains ^String % "state=merged")) args))
+                      {:exit 0
+                       :out "[{\"iid\":5,\"title\":\"Merged MR\",\"web_url\":\"https://gl.com/g/p/-/merge_requests/5\",\"source_branch\":\"done\",\"state\":\"merged\",\"draft\":false}]"
+                       :err ""}
+                      {:exit 1 :out "" :err "unexpected call"}))]
+      (let [result (core/fetch-prs-by-state "gitlab:g/p" :merged)]
+        (is (:success? result))
+        (is (= 1 (count (:prs result))))
+        (is (= :merged (:pr/status (first (:prs result)))))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
 ;; Integration tests (PR fetching with mocked shell)
 
 (deftest fetch-all-fleet-prs-multi-provider-test

--- a/components/pr-sync/test/ai/miniforge/pr_sync/status_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/status_test.clj
@@ -169,4 +169,18 @@
                                               :draft true :source_branch "wip"
                                               :web_url "https://gl.com/x/y/-/merge_requests/1"}
                                              "gitlab:x/y")]
-      (is (= :draft (:pr/status result))))))
+      (is (= :draft (:pr/status result)))))
+
+  (testing "Merged MR maps to :merged not :closed"
+    (let [result (status/gitlab-mr->train-pr {:iid 10 :title "Done MR" :state "merged"
+                                              :source_branch "feat"
+                                              :web_url "https://gl.com/x/y/-/merge_requests/10"}
+                                             "gitlab:x/y")]
+      (is (= :merged (:pr/status result)))))
+
+  (testing "Closed MR remains :closed"
+    (let [result (status/gitlab-mr->train-pr {:iid 11 :title "Closed MR" :state "closed"
+                                              :source_branch "old"
+                                              :web_url "https://gl.com/x/y/-/merge_requests/11"}
+                                             "gitlab:x/y")]
+      (is (= :closed (:pr/status result))))))

--- a/components/pr-sync/test/ai/miniforge/pr_sync/status_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/status_test.clj
@@ -45,9 +45,14 @@
     (is (= :reviewing (status/pr-status-from-provider
                         {:state "OPEN" :isDraft false :reviewDecision "REVIEW_REQUIRED"}))))
 
-  (testing "Closed/merged PR"
-    (is (= :closed (status/pr-status-from-provider
+  (testing "Merged PR"
+    (is (= :merged (status/pr-status-from-provider
                      {:state "MERGED" :isDraft false :reviewDecision nil})))
+    (is (= :merged (status/pr-status-from-provider
+                     {:state "CLOSED" :mergedAt "2026-03-06T00:00:00Z"
+                      :isDraft false :reviewDecision nil}))))
+
+  (testing "Closed PR"
     (is (= :closed (status/pr-status-from-provider
                      {:state "CLOSED" :isDraft false :reviewDecision nil})))))
 
@@ -104,6 +109,7 @@
               :url "https://github.com/owner/repo/pull/42"
               :headRefName "fix-auth"
               :state "OPEN"
+              :mergedAt nil
               :isDraft false
               :reviewDecision "APPROVED"
               :statusCheckRollup [{:name "lint" :conclusion "SUCCESS"}]
@@ -121,6 +127,15 @@
       (is (= "lint" (:name (first (:pr/ci-checks result)))))
       (is (= "CLEAN" (:pr/merge-state result)))
       (is (false? (:pr/behind-main? result)))))
+
+  (testing "Merged PR retains merged state"
+    (let [result (status/provider-pr->train-pr
+                  {:number 7
+                   :title "Done"
+                   :state "CLOSED"
+                   :mergedAt "2026-03-06T00:00:00Z"})]
+      (is (= :merged (:pr/status result)))
+      (is (= "2026-03-06T00:00:00Z" (:pr/merged-at result)))))
 
   (testing "Behind main PR"
     (let [result (status/provider-pr->train-pr

--- a/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
@@ -238,6 +238,31 @@
     (.start thread)
     thread))
 
+(defn start-resize-thread!
+  "Start a daemon thread that checks for terminal size changes and forces
+   a re-render when the size changes. Checks every 250ms."
+  [app]
+  (let [last-size (atom nil)
+        thread (Thread.
+                (fn []
+                  (try
+                    (while (:running? @app)
+                      (try
+                        (Thread/sleep 250)
+                        (let [screen (:screen @app)
+                              size (screen/get-size screen)]
+                          (when (and size (not= size @last-size))
+                            (reset! last-size size)
+                            ;; Force re-render by dispatching a no-op tick
+                            (do-render! @app @(:model-ref @app))))
+                        (catch InterruptedException e (throw e))
+                        (catch Exception _)))
+                    (catch InterruptedException _))))]
+    (.setDaemon thread true)
+    (.setName thread "tui-resize-check")
+    (.start thread)
+    thread))
+
 ;------------------------------------------------------------------------------ Layer 6
 ;; Application lifecycle
 
@@ -261,6 +286,9 @@
     ;; Start input thread
     (let [thread (start-input-thread! app)]
       (swap! app assoc :input-thread thread))
+    ;; Start resize detection thread
+    (let [thread (start-resize-thread! app)]
+      (swap! app assoc :resize-thread thread))
     ;; Register subscriptions
     (when-let [sub-fn (:subscriptions @app)]
       (let [unsub (sub-fn (fn [msg] (dispatch! app msg)))]
@@ -293,6 +321,9 @@
     ;; Stop input thread
     (when-let [thread (:input-thread @app)]
       (.interrupt thread))
+    ;; Stop resize thread
+    (when-let [thread (:resize-thread @app)]
+      (.interrupt thread))
     ;; Interrupt all in-flight side-effect threads
     (when-let [threads-atom (:effect-threads @app)]
       (doseq [^Thread t @threads-atom]
@@ -302,7 +333,7 @@
     (try
       (screen/stop-screen! (:screen @app))
       (catch Exception _))
-    (swap! app assoc :unsub-fn nil :input-thread nil)))
+    (swap! app assoc :unsub-fn nil :input-thread nil :resize-thread nil)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tui-engine/src/ai/miniforge/tui_engine/layout/table.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/layout/table.clj
@@ -115,24 +115,29 @@
    - :columns - vector of {:key kw, :header str, :width int (opt), :align :left/:right/:center}
    - :rows    - vector of maps keyed by column :key
    - :selected-row - index of highlighted row (nil for none)
+   - :offset - number of rows to skip from the top of data (default 0)
    - :header-fg, :header-bg - Header style
    - :row-fg, :row-bg - Default row style
    - :selected-fg, :selected-bg - Selected row style
    - :separator-fg - Separator line color (defaults to header-fg)"
-  [[cols rows] & [{:keys [columns data selected-row
+  [[cols rows] & [{:keys [columns data selected-row offset
                            header-fg header-bg row-fg row-bg
                            selected-fg selected-bg separator-fg]
                     :or {header-fg :cyan header-bg :default
                          row-fg :default row-bg :default
-                         selected-fg :white selected-bg :blue}}]]
+                         selected-fg :white selected-bg :blue
+                         offset 0}}]]
   (let [col-widths (compute-col-widths columns cols)
         buffer (buf/make-buffer [cols rows])
         buffer (render-header-row buffer columns col-widths header-fg header-bg)
         buffer (render-separator buffer cols rows (or separator-fg header-fg))
-        visible-rows (take (max 0 (- rows 2)) (or data []))]
+        off (or offset 0)
+        visible-rows (take (max 0 (- rows 2)) (drop off (or data [])))
+        ;; Adjust selected-row to be relative to the visible window
+        adj-selected (when selected-row (- selected-row off))]
     (reduce (fn [b [row-idx row-data]]
               (render-data-row b row-idx row-data columns col-widths rows
-                               selected-row row-fg row-bg selected-fg selected-bg))
+                               adj-selected row-fg row-bg selected-fg selected-bg))
             buffer
             (map-indexed vector visible-rows))))
 

--- a/components/tui-views/src/ai/miniforge/tui_views/file_subscription.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/file_subscription.clj
@@ -101,12 +101,13 @@
 (defn track-file!
   "Track a new event file: register it in tracked map and hydrate
    all existing lines through dispatch-fn."
-  [tracked dispatch-fn ^java.io.File f]
+  [tracked dispatch-fn ^java.io.File f & [{:keys [hydrate?] :or {hydrate? true}}]]
   (let [path (.getAbsolutePath f)
-        pos  (atom 0)]
+        pos  (atom (if hydrate? 0 (.length f)))]
     (swap! tracked assoc path {:file f :position pos})
-    (let [lines (read-new-lines f pos)]
-      (parse-and-dispatch! lines dispatch-fn))))
+    (when hydrate?
+      (let [lines (read-new-lines f pos)]
+        (parse-and-dispatch! lines dispatch-fn)))))
 
 (defn poll-tracked-files!
   "Read new lines from all tracked files and dispatch them."
@@ -123,7 +124,7 @@
         tracked-paths (set (keys @tracked))]
     (doseq [^java.io.File f current-files]
       (when-not (tracked-paths (.getAbsolutePath f))
-        (track-file! tracked dispatch-fn f)))))
+        (track-file! tracked dispatch-fn f {:hydrate? true})))))
 
 (defn poll-loop
   "Polling loop body for the file-subscription daemon thread.
@@ -166,11 +167,12 @@
   [dispatch-fn & [opts]]
   (let [poll-ms   (get opts :poll-ms 500)
         scan-ms   (get opts :scan-ms 2000)
+        hydrate-existing? (get opts :hydrate-existing? true)
         dir       (events-dir)
         tracked   (atom {})
         running?  (atom true)
         _         (doseq [f (scan-event-files dir)]
-                    (track-file! tracked dispatch-fn f))
+                    (track-file! tracked dispatch-fn f {:hydrate? hydrate-existing?}))
         thread    (doto (Thread. #(poll-loop running? tracked dispatch-fn dir poll-ms scan-ms))
                     (.setDaemon true)
                     (.setName "tui-file-subscription")

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -287,10 +287,16 @@
                    event-stream dispatch-fn
                    {:throttle-ms throttle-ms})))})]
     (tui/start! app)
+    ;; Install SIGINT handler so Ctrl+C triggers graceful quit
+    (let [quit-fn #(dosync (alter (:model-ref @app) assoc :quit? true))]
+      (try
+        (.addShutdownHook (Runtime/getRuntime)
+                          (Thread. ^Runnable quit-fn))
+        (catch Exception _)))
     ;; Block until quit
     (try
       (while (not (:quit? (tui/get-model app)))
-        (Thread/sleep 100))
+        (Thread/sleep 50))
       (finally
         (tui/stop! app)))
     app))
@@ -324,9 +330,15 @@
                   :scan-ms (:scan-ms opts 2000)
                   :hydrate-existing? false}))})]
     (tui/start! app)
+    ;; Install SIGINT handler so Ctrl+C triggers graceful quit
+    (let [quit-fn #(dosync (alter (:model-ref @app) assoc :quit? true))]
+      (try
+        (.addShutdownHook (Runtime/getRuntime)
+                          (Thread. ^Runnable quit-fn))
+        (catch Exception _)))
     (try
       (while (not (:quit? (tui/get-model app)))
-        (Thread/sleep 100))
+        (Thread/sleep 50))
       (finally
         (tui/stop! app)))
     app))

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -321,7 +321,8 @@
                 (file-subscription/subscribe-to-files!
                  dispatch-fn
                  {:poll-ms (:poll-ms opts 500)
-                  :scan-ms (:scan-ms opts 2000)}))})]
+                  :scan-ms (:scan-ms opts 2000)
+                  :hydrate-existing? false}))})]
     (tui/start! app)
     (try
       (while (not (:quit? (tui/get-model app)))

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
@@ -46,13 +46,16 @@
    :workflow/id workflow-id
    :workflow/phase phase})
 
-(defn phase-completed-event [workflow-id phase outcome artifacts duration-ms]
-  {:event/type :workflow/phase-completed
-   :workflow/id workflow-id
-   :workflow/phase phase
-   :phase/outcome outcome
-   :phase/artifacts artifacts
-   :phase/duration-ms duration-ms})
+(defn phase-completed-event [workflow-id phase outcome artifacts duration-ms
+                             & [{:keys [tokens cost-usd]}]]
+  (cond-> {:event/type :workflow/phase-completed
+           :workflow/id workflow-id
+           :workflow/phase phase
+           :phase/outcome outcome
+           :phase/artifacts artifacts
+           :phase/duration-ms duration-ms}
+    tokens (assoc :phase/tokens tokens)
+    cost-usd (assoc :phase/cost-usd cost-usd)))
 
 (defn agent-status-event [workflow-id agent-id status message]
   {:event/type :agent/status
@@ -66,12 +69,15 @@
    :workflow/id workflow-id
    :chunk/delta delta})
 
-(defn workflow-completed-event [workflow-id status duration-ms evidence-bundle-id]
-  {:event/type :workflow/completed
-   :workflow/id workflow-id
-   :workflow/status status
-   :workflow/duration-ms duration-ms
-   :workflow/evidence-bundle-id evidence-bundle-id})
+(defn workflow-completed-event [workflow-id status duration-ms evidence-bundle-id
+                                & [{:keys [tokens cost-usd]}]]
+  (cond-> {:event/type :workflow/completed
+           :workflow/id workflow-id
+           :workflow/status status
+           :workflow/duration-ms duration-ms
+           :workflow/evidence-bundle-id evidence-bundle-id}
+    tokens (assoc :workflow/tokens tokens)
+    cost-usd (assoc :workflow/cost-usd cost-usd)))
 
 (defn workflow-failed-event [workflow-id error]
   {:event/type :workflow/failed
@@ -145,9 +151,11 @@
     :running))
 
 (defn update-phase-entry
-  [phases phase status duration-ms]
+  [phases phase status duration-ms & [{:keys [tokens cost-usd]}]]
   (let [entry (cond-> {:phase phase :status status}
-                duration-ms (assoc :duration-ms duration-ms))
+                duration-ms (assoc :duration-ms duration-ms)
+                tokens (assoc :tokens tokens)
+                cost-usd (assoc :cost-usd cost-usd))
         idx (first (keep-indexed (fn [i p] (when (= phase (:phase p)) i)) phases))]
     (if idx
       (assoc phases idx (merge (get phases idx) entry))
@@ -208,6 +216,8 @@
    :pr-risk nil
    :selected-train nil
    :duration-ms nil
+   :tokens 0
+   :cost-usd 0.0
    :error nil})
 
 (defn ensure-evidence-intent
@@ -250,11 +260,17 @@
     (let [phase (event-phase event)
           outcome (:phase/outcome event)
           duration-ms (:phase/duration-ms event)
-          artifacts (:phase/artifacts event)]
+          artifacts (:phase/artifacts event)
+          tokens (:phase/tokens event)
+          cost-usd (:phase/cost-usd event)]
       (-> detail
           (assoc :current-phase phase)
-          (update :phases update-phase-entry phase (phase-status outcome) duration-ms)
-          (append-artifacts phase artifacts)))
+          (update :phases update-phase-entry phase (phase-status outcome) duration-ms
+                  {:tokens tokens :cost-usd cost-usd})
+          (append-artifacts phase artifacts)
+          (cond->
+            tokens (update :tokens + tokens)
+            cost-usd (update :cost-usd + cost-usd))))
 
     :agent/started
     (let [agent (:agent/id event)
@@ -300,6 +316,9 @@
     :workflow/completed
     (-> detail
         (assoc :duration-ms (:workflow/duration-ms event))
+        (cond->
+          (:workflow/tokens event) (assoc :tokens (:workflow/tokens event))
+          (:workflow/cost-usd event) (assoc :cost-usd (:workflow/cost-usd event)))
         (append-artifacts (or (:current-phase detail) :done) (nested-dag-artifacts event)))
 
     :workflow/failed

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
@@ -36,6 +36,9 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; EDN line reading
 
+(def lifecycle-event-types
+  #{:workflow/started :workflow/completed :workflow/failed})
+
 (defn safe-read-edn
   "Read a single EDN value from a string, returning nil on parse errors.
    Uses default EDN readers which already handle #uuid and #inst."
@@ -44,72 +47,266 @@
     (edn/read-string s)
     (catch Exception _ nil)))
 
-(defn read-first-and-last
-  "Read the first and last EDN events from a workflow file.
-   Returns [first-event last-event] or nil on error."
+(defn read-events
+  "Read all valid EDN events from a workflow file in file order."
   [file]
   (try
     (with-open [rdr (io/reader file)]
-      (let [lines (vec (line-seq rdr))]
-        (when (seq lines)
-          [(safe-read-edn (first lines))
-           (safe-read-edn (peek lines))])))
-    (catch Exception _ nil)))
+      (->> (line-seq rdr)
+           (keep safe-read-edn)
+           vec))
+    (catch Exception _
+      [])))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Workflow reconstruction
+;; Workflow reconstruction helpers
+
+(defn workflow-start-event
+  [events]
+  (first (filter #(= :workflow/started (:event/type %)) events)))
+
+(defn workflow-terminal-event
+  [events]
+  (last (filter #(contains? lifecycle-event-types (:event/type %)) events)))
+
+(defn workflow-id-from-events
+  [events]
+  (some :workflow/id events))
+
+(defn top-level-workflow-events?
+  "True when the file contains lifecycle events for a real workflow.
+   Phase-only files are typically DAG child traces and should not appear in the
+   top-level workflow list."
+  [events]
+  (boolean (some #(contains? lifecycle-event-types (:event/type %)) events)))
+
+(defn event-phase
+  [event]
+  (or (:workflow/phase event) (:phase event)))
+
+(defn phase-status
+  [outcome]
+  (case outcome
+    :failure :failed
+    :failed  :failed
+    :skipped :skipped
+    :success :success
+    :running))
+
+(defn update-phase-entry
+  [phases phase status duration-ms]
+  (let [entry (cond-> {:phase phase :status status}
+                duration-ms (assoc :duration-ms duration-ms))
+        idx (first (keep-indexed (fn [i p] (when (= phase (:phase p)) i)) phases))]
+    (if idx
+      (assoc phases idx (merge (get phases idx) entry))
+      (conj (vec phases) entry))))
+
+(defn normalize-artifact
+  [artifact phase]
+  (if (map? artifact)
+    (assoc artifact :phase phase)
+    {:id artifact :phase phase :type :unknown :name (str artifact)}))
+
+(defn nested-dag-artifacts
+  "Extract artifacts persisted inside DAG terminal errors/results."
+  [event]
+  (or (get-in event [:workflow/error-details :dag-result :artifacts])
+      (mapcat #(get-in % [:dag-result :artifacts] [])
+              (get-in event [:workflow/error-details :errors] []))
+      []))
+
+(defn empty-detail
+  [workflow-id]
+  {:workflow-id workflow-id
+   :phases []
+   :current-phase nil
+   :current-agent nil
+   :agent-output ""
+   :agents {}
+   :evidence nil
+   :artifacts []
+   :expanded-nodes #{}
+   :focused-pane 0
+   :selected-pr nil
+   :pr-readiness nil
+   :pr-risk nil
+   :selected-train nil
+   :duration-ms nil
+   :error nil})
+
+(defn ensure-evidence-intent
+  [detail event]
+  (if-let [spec (:workflow/spec event)]
+    (assoc-in detail [:evidence :intent]
+              {:description (or (:name spec)
+                                (:workflow/name spec))
+               :spec spec})
+    detail))
+
+(defn append-artifacts
+  [detail phase artifacts]
+  (if (seq artifacts)
+    (update detail :artifacts into (map #(normalize-artifact % phase) artifacts))
+    detail))
+
+(defn append-validation-result
+  [detail event passed?]
+  (update-in detail [:evidence :validation :results]
+             (fnil conj [])
+             {:gate (:gate/id event)
+              :passed? passed?
+              :event/type (:event/type event)
+              :event/timestamp (:event/timestamp event)}))
+
+(defn apply-detail-event
+  [detail event]
+  (case (:event/type event)
+    :workflow/started
+    (ensure-evidence-intent detail event)
+
+    :workflow/phase-started
+    (let [phase (event-phase event)]
+      (-> detail
+          (assoc :current-phase phase)
+          (update :phases update-phase-entry phase :running nil)))
+
+    :workflow/phase-completed
+    (let [phase (event-phase event)
+          outcome (:phase/outcome event)
+          duration-ms (:phase/duration-ms event)
+          artifacts (:phase/artifacts event)]
+      (-> detail
+          (assoc :current-phase phase)
+          (update :phases update-phase-entry phase (phase-status outcome) duration-ms)
+          (append-artifacts phase artifacts)))
+
+    :agent/started
+    (let [agent (:agent/id event)
+          entry {:status :started :message (:message event)}]
+      (-> detail
+          (assoc :current-agent (assoc entry :agent agent))
+          (assoc-in [:agents agent] entry)))
+
+    :agent/completed
+    (let [agent (:agent/id event)
+          entry {:status :completed :message (:message event)}]
+      (-> detail
+          (assoc :current-agent (assoc entry :agent agent))
+          (assoc-in [:agents agent] entry)))
+
+    :agent/failed
+    (let [agent (:agent/id event)
+          entry {:status :failed :message (:message event)}]
+      (-> detail
+          (assoc :current-agent (assoc entry :agent agent))
+          (assoc :error (or (:agent/error event) (:message event)))
+          (assoc-in [:agents agent] entry)))
+
+    :agent/status
+    (let [agent (:agent/id event)
+          entry {:status (:status/type event) :message (:message event)}]
+      (-> detail
+          (assoc :current-agent (assoc entry :agent agent))
+          (assoc-in [:agents agent] entry)))
+
+    :agent/chunk
+    (update detail :agent-output str (or (:chunk/delta event) ""))
+
+    :gate/started
+    detail
+
+    :gate/passed
+    (append-validation-result detail event true)
+
+    :gate/failed
+    (append-validation-result detail event false)
+
+    :workflow/completed
+    (-> detail
+        (assoc :duration-ms (:workflow/duration-ms event))
+        (append-artifacts (or (:current-phase detail) :done) (nested-dag-artifacts event)))
+
+    :workflow/failed
+    (-> detail
+        (assoc :error (or (:workflow/failure-reason event)
+                          (get-in event [:workflow/error-details :message])))
+        (append-artifacts (or (:current-phase detail) :failed) (nested-dag-artifacts event)))
+
+    detail))
+
+(defn detail-from-events
+  [workflow-id events]
+  (reduce apply-detail-event (empty-detail workflow-id) events))
+
+(defn workflow-name
+  [workflow-id events]
+  (or (get-in (workflow-start-event events) [:workflow/spec :name])
+      (get-in (workflow-start-event events) [:workflow/spec :workflow/name])
+      (str "workflow-" (subs (str workflow-id) 0 8))))
 
 (defn derive-status
-  "Derive workflow status from the last event in the file."
-  [last-event]
-  (case (:event/type last-event)
-    :workflow/completed (or (:workflow/status last-event) :success)
-    :workflow/failed    :failed
-    ;; Still in progress (no terminal event yet) — default clause
-    :running))
+  "Derive workflow status from the event sequence."
+  [events]
+  (let [terminal (workflow-terminal-event events)
+        last-event (last events)]
+    (case (:event/type terminal)
+      :workflow/completed (or (:workflow/status terminal) :success)
+      :workflow/failed    :failed
+      (case (:event/type last-event)
+        :workflow/phase-completed :running
+        :workflow/phase-started   :running
+        :agent/chunk              :running
+        :agent/status             :running
+        :workflow/started         :running
+        :running))))
 
 (defn derive-phase
   "Derive current/last phase from events."
-  [last-event]
-  (when-let [phase (:workflow/phase last-event)]
-    phase))
+  [events]
+  (some->> events reverse (keep event-phase) first))
 
 (defn derive-progress
-  "Estimate progress from the last event."
-  [last-event]
-  (case (:event/type last-event)
-    :workflow/completed 100
-    :workflow/failed    100
-    ;; Rough estimate based on event type
-    :workflow/phase-completed 60
-    :workflow/phase-started   40
-    :agent/chunk              50
-    :agent/status             50
-    :workflow/started         10
-    0))
+  "Estimate progress from the full event sequence."
+  [events]
+  (let [status (derive-status events)
+        phase-completions (count (filter #(= :workflow/phase-completed (:event/type %)) events))
+        last-event (last events)]
+    (cond
+      (#{:success :failed :cancelled :completed} status) 100
+      (pos? phase-completions) (min 95 (* 20 phase-completions))
+      (= :workflow/phase-started (:event/type last-event)) 40
+      (#{:agent/chunk :agent/status} (:event/type last-event)) 50
+      (= :workflow/started (:event/type last-event)) 10
+      :else 0)))
 
 (defn event-file->workflow
   "Convert a single event file into a workflow summary map for the model.
    Returns nil if the file cannot be read or parsed."
   [file]
   (try
-    (when-let [[first-event last-event] (read-first-and-last file)]
-      (when (and first-event (:workflow/id first-event))
-        (let [workflow-id (:workflow/id first-event)
-              name        (or (get-in first-event [:workflow/spec :name])
-                             (str "workflow-" (subs (str workflow-id) 0 8)))
-              status      (derive-status last-event)
-              phase       (or (derive-phase last-event)
-                             (derive-phase first-event))
-              progress    (derive-progress last-event)
-              started-at  (:event/timestamp first-event)]
-          (model/make-workflow
-           {:id         workflow-id
-            :name       name
-            :status     status
-            :phase      phase
-            :progress   progress
-            :started-at started-at}))))
+    (let [events (read-events file)
+          workflow-id (workflow-id-from-events events)]
+      (when (and workflow-id
+                 (seq events)
+                 (top-level-workflow-events? events))
+        (let [detail     (detail-from-events workflow-id events)
+              start      (workflow-start-event events)
+              started-at (or (:event/timestamp start)
+                             (:event/timestamp (first events)))
+              workflow   (model/make-workflow
+                          {:id         workflow-id
+                           :name       (workflow-name workflow-id events)
+                           :status     (derive-status events)
+                           :phase      (derive-phase events)
+                           :progress   (derive-progress events)
+                           :started-at started-at})]
+          (assoc workflow
+                 :agents (:agents detail)
+                 :gate-results (get-in detail [:evidence :validation :results] [])
+                 :duration-ms (:duration-ms detail)
+                 :error (:error detail)
+                 :detail-snapshot detail))))
     (catch Exception _ nil)))
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -119,6 +316,11 @@
   "Get the events directory path. Returns a java.io.File."
   []
   (io/file (System/getProperty "user.home") ".miniforge" "events"))
+
+(defn workflow-events-file
+  "Resolve the persisted event file for a workflow UUID."
+  [workflow-id & [{:keys [dir]}]]
+  (io/file (or dir (events-dir)) (str workflow-id ".edn")))
 
 (defn load-workflows
   "Scan the events directory and load workflow summaries.
@@ -143,6 +345,15 @@
              (sort-by :started-at #(compare %2 %1))
              vec))
       [])))
+
+(defn load-workflow-detail
+  "Load the reconstructed detail snapshot for a single workflow from disk."
+  [workflow-id & [{:keys [dir]}]]
+  (let [file (workflow-events-file workflow-id {:dir dir})]
+    (when (.exists file)
+      (let [events (read-events file)]
+        (when (seq events)
+          (detail-from-events workflow-id events))))))
 
 (defn load-workflows-into-model
   "Load persisted workflows and merge them into the given model.

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
@@ -131,11 +131,14 @@
   (some :workflow/id events))
 
 (defn top-level-workflow-events?
-  "True when the file contains lifecycle events for a real workflow.
-   Phase-only files are typically DAG child traces and should not appear in the
-   top-level workflow list."
+  "True when the file contains lifecycle events for a real, named workflow.
+   Excludes:
+   - Phase-only files (DAG child traces without lifecycle events)
+   - Anonymous workflows (no spec name — typically test artifacts or sub-workflows)"
   [events]
-  (boolean (some #(contains? lifecycle-event-types (:event/type %)) events)))
+  (when-let [start (first (filter #(= :workflow/started (:event/type %)) events))]
+    (boolean (or (get-in start [:workflow/spec :name])
+                 (get-in start [:workflow/spec :workflow/name])))))
 
 (defn event-phase
   [event]

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
@@ -102,10 +102,34 @@
       (assoc phases idx (merge (get phases idx) entry))
       (conj (vec phases) entry))))
 
+(defn infer-artifact-type
+  "Infer artifact type from map keys when :type is not set."
+  [artifact]
+  (cond
+    (:type artifact)         (:type artifact)
+    (:code/files artifact)   :code
+    (:plan/tasks artifact)   :plan
+    (:test/files artifact)   :test
+    (:review/id artifact)    :review
+    (:evidence/id artifact)  :evidence
+    :else                    :unknown))
+
+(defn infer-artifact-name
+  "Derive a display name from artifact data."
+  [artifact type]
+  (or (:name artifact)
+      (:code/summary artifact)
+      (:plan/name artifact)
+      (str (name type) " artifact")))
+
 (defn normalize-artifact
   [artifact phase]
   (if (map? artifact)
-    (assoc artifact :phase phase)
+    (let [type (infer-artifact-type artifact)]
+      (assoc artifact
+             :phase phase
+             :type type
+             :name (infer-artifact-name artifact type)))
     {:id artifact :phase phase :type :unknown :name (str artifact)}))
 
 (defn nested-dag-artifacts
@@ -245,21 +269,27 @@
       (get-in (workflow-start-event events) [:workflow/spec :workflow/name])
       (str "workflow-" (subs (str workflow-id) 0 8))))
 
+(def ^:private stale-threshold-ms
+  "Workflows without a terminal event and no activity for this long are :stale."
+  (* 60 60 1000)) ;; 1 hour
+
 (defn derive-status
-  "Derive workflow status from the event sequence."
-  [events]
-  (let [terminal (workflow-terminal-event events)
-        last-event (last events)]
-    (case (:event/type terminal)
-      :workflow/completed (or (:workflow/status terminal) :success)
-      :workflow/failed    :failed
-      (case (:event/type last-event)
-        :workflow/phase-completed :running
-        :workflow/phase-started   :running
-        :agent/chunk              :running
-        :agent/status             :running
-        :workflow/started         :running
-        :running))))
+  "Derive workflow status from the event sequence.
+   Accepts an optional file for age-based stale detection."
+  ([events] (derive-status events nil))
+  ([events file]
+   (let [terminal (workflow-terminal-event events)
+         last-event (last events)]
+     (case (:event/type terminal)
+       :workflow/completed (or (:workflow/status terminal) :success)
+       :workflow/failed    :failed
+       (let [active? (contains? #{:workflow/phase-completed :workflow/phase-started
+                                   :agent/chunk :agent/status :workflow/started}
+                                (:event/type last-event))
+             stale?  (when (and active? file (.exists ^java.io.File file))
+                       (> (- (System/currentTimeMillis) (.lastModified ^java.io.File file))
+                          stale-threshold-ms))]
+         (if stale? :stale :running))))))
 
 (defn derive-phase
   "Derive current/last phase from events."
@@ -297,7 +327,7 @@
               workflow   (model/make-workflow
                           {:id         workflow-id
                            :name       (workflow-name workflow-id events)
-                           :status     (derive-status events)
+                           :status     (derive-status events file)
                            :phase      (derive-phase events)
                            :progress   (derive-progress events)
                            :started-at started-at})]

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
@@ -34,6 +34,57 @@
    [ai.miniforge.policy-pack.interface :as policy-pack]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Event constructors — canonical shapes consumed by apply-detail-event
+
+(defn workflow-started-event [workflow-id spec]
+  {:event/type :workflow/started
+   :workflow/id workflow-id
+   :workflow/spec spec})
+
+(defn phase-started-event [workflow-id phase]
+  {:event/type :workflow/phase-started
+   :workflow/id workflow-id
+   :workflow/phase phase})
+
+(defn phase-completed-event [workflow-id phase outcome artifacts duration-ms]
+  {:event/type :workflow/phase-completed
+   :workflow/id workflow-id
+   :workflow/phase phase
+   :phase/outcome outcome
+   :phase/artifacts artifacts
+   :phase/duration-ms duration-ms})
+
+(defn agent-status-event [workflow-id agent-id status message]
+  {:event/type :agent/status
+   :workflow/id workflow-id
+   :agent/id agent-id
+   :status/type status
+   :message message})
+
+(defn agent-chunk-event [workflow-id delta]
+  {:event/type :agent/chunk
+   :workflow/id workflow-id
+   :chunk/delta delta})
+
+(defn workflow-completed-event [workflow-id status duration-ms evidence-bundle-id]
+  {:event/type :workflow/completed
+   :workflow/id workflow-id
+   :workflow/status status
+   :workflow/duration-ms duration-ms
+   :workflow/evidence-bundle-id evidence-bundle-id})
+
+(defn workflow-failed-event [workflow-id error]
+  {:event/type :workflow/failed
+   :workflow/id workflow-id
+   :workflow/failure-reason error
+   :workflow/error-details {:message error}})
+
+(defn gate-event [workflow-id gate passed? timestamp]
+  {:event/type (if passed? :gate/passed :gate/failed)
+   :workflow/id workflow-id
+   :gate/id gate
+   :event/timestamp timestamp})
+
 ;; EDN line reading
 
 (def lifecycle-event-types

--- a/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/subscription.clj
@@ -79,7 +79,9 @@
                     (cond-> {}
                       (:phase/artifacts event) (assoc :artifacts (:phase/artifacts event))
                       (:phase/duration-ms event) (assoc :duration-ms (:phase/duration-ms event))
-                      (:phase/error event) (assoc :error (:phase/error event))))
+                      (:phase/error event) (assoc :error (:phase/error event))
+                      (:phase/tokens event) (assoc :tokens (:phase/tokens event))
+                      (:phase/cost-usd event) (assoc :cost-usd (:phase/cost-usd event))))
 
     :agent/started
     (msg/agent-started (workflow-id event) (agent-id event)
@@ -106,7 +108,9 @@
                        (or (:workflow/status event) (:status event))
                        (cond-> {}
                          (:workflow/duration-ms event) (assoc :duration-ms (:workflow/duration-ms event))
-                         (:workflow/evidence-bundle-id event) (assoc :evidence-bundle-id (:workflow/evidence-bundle-id event))))
+                         (:workflow/evidence-bundle-id event) (assoc :evidence-bundle-id (:workflow/evidence-bundle-id event))
+                         (:workflow/tokens event) (assoc :tokens (:workflow/tokens event))
+                         (:workflow/cost-usd event) (assoc :cost-usd (:workflow/cost-usd event))))
 
     :workflow/failed
     (msg/workflow-failed (workflow-id event)

--- a/components/tui-views/src/ai/miniforge/tui_views/update.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update.clj
@@ -531,11 +531,17 @@
       :msg/workflow-added   (events/handle-workflow-added model payload)
       :msg/phase-changed    (events/handle-phase-changed model payload)
       :msg/phase-done       (events/handle-phase-done model payload)
+      :msg/agent-started    (events/handle-agent-started model payload)
+      :msg/agent-completed  (events/handle-agent-completed model payload)
+      :msg/agent-failed     (events/handle-agent-failed model payload)
       :msg/agent-status     (events/handle-agent-status model payload)
       :msg/agent-output     (events/handle-agent-output model payload)
       :msg/workflow-done    (events/handle-workflow-done model payload)
       :msg/workflow-failed  (events/handle-workflow-failed model payload)
+      :msg/gate-started     (events/handle-gate-started model payload)
       :msg/gate-result      (events/handle-gate-result model payload)
+      :msg/tool-invoked     (events/handle-tool-invoked model payload)
+      :msg/tool-completed   (events/handle-tool-completed model payload)
 
       ;; Chain lifecycle messages
       :msg/chain-started         (events/handle-chain-started model payload)

--- a/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
@@ -97,9 +97,11 @@
     (let [result (pr-sync/add-repo! (str/trim args))]
       (if (pr-sync/succeeded? result)
         (-> (with-fleet-repos model (:repos result))
+            (cond-> (:added? result)
+              (assoc :side-effect (effect/sync-prs)))
             (assoc :flash-message
                    (if (:added? result)
-                     (str "Added " (:repo result) " to fleet")
+                     (str "Added " (:repo result) " to fleet. Syncing PRs...")
                      (str (:repo result) " already in fleet"))))
         (assoc model :flash-message (str "Error: " (:error result)))))))
 
@@ -109,9 +111,11 @@
     (let [result (pr-sync/remove-repo! (str/trim args))]
       (if (pr-sync/succeeded? result)
         (-> (with-fleet-repos model (:repos result))
+            (cond-> (:removed? result)
+              (assoc :side-effect (effect/sync-prs)))
             (assoc :flash-message
                    (if (:removed? result)
-                     (str "Removed " (:repo result) " from fleet")
+                     (str "Removed " (:repo result) " from fleet. Syncing PRs...")
                      (str (:repo result) " not in fleet"))))
         (assoc model :flash-message (str "Error: " (:error result)))))))
 
@@ -323,21 +327,22 @@
                        sel/clear-selection)
         removed (:removed result)
         failures (count (:errors result))]
-    (assoc next-model
-           :flash-message
-           (cond
-             (zero? (count targets))
-             "No repositories selected for removal."
+    (cond-> (assoc next-model
+                    :flash-message
+                    (cond
+                      (zero? (count targets))
+                      "No repositories selected for removal."
 
-             (and (pos? removed) (zero? failures))
-             (str "Removed " removed " repo(s) from fleet")
+                      (and (pos? removed) (zero? failures))
+                      (str "Removed " removed " repo(s) from fleet. Syncing PRs...")
 
-             (and (zero? removed) (pos? failures))
-             (str "Failed to remove selected repos: "
-                  (str/join "; " (:errors result)))
+                      (and (zero? removed) (pos? failures))
+                      (str "Failed to remove selected repos: "
+                           (str/join "; " (:errors result)))
 
-             :else
-             (str "Removed " removed " repo(s), " failures " failed")))))
+                      :else
+                      (str "Removed " removed " repo(s), " failures " failed. Syncing PRs...")))
+      (pos? removed) (assoc :side-effect (effect/sync-prs)))))
 
 (defn execute-confirmed-action
   "Execute the action stored in :confirm after user presses 'y'.

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -175,9 +175,7 @@
 (defn normalize-artifact
   "Normalize an artifact entry, ensuring it has phase and required keys."
   [artifact phase]
-  (if (map? artifact)
-    (assoc artifact :phase phase)
-    {:id artifact :phase phase :type :unknown :name (str artifact)}))
+  (persistence/normalize-artifact artifact phase))
 
 (defn apply-phase-completion
   "Update detail model with phase completion data: status and artifacts."

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -23,7 +23,9 @@
    Layer 2."
   (:require
    [ai.miniforge.tui-views.effect :as effect]
-   [ai.miniforge.tui-views.model :as model]))
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.persistence :as persistence]
+   [ai.miniforge.tui-views.update.filter :as filter]))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Event stream message handlers
@@ -42,6 +44,22 @@
   (if idx
     (update-in model [:workflows idx] update-fn)
     model))
+
+(defn update-workflow-snapshot
+  "Apply a persisted-detail event reducer to the workflow row snapshot."
+  [model idx workflow-id event]
+  (if idx
+    (update-in model [:workflows idx :detail-snapshot]
+               #(persistence/apply-detail-event (or % (persistence/empty-detail workflow-id))
+                                                event))
+    model))
+
+(defn upsert-workflow
+  "Insert a workflow row or merge it into the existing row with the same id."
+  [model workflow]
+  (if-let [idx (find-workflow-idx (:workflows model) (:id workflow))]
+    (assoc-in model [:workflows idx] (merge (get-in model [:workflows idx]) workflow))
+    (update model :workflows conj workflow)))
 
 (defn update-detail-if-active
   "Apply update-fn to detail if workflow-id matches active detail."
@@ -120,11 +138,17 @@
     model))
 
 (defn handle-workflow-added [model {:keys [workflow-id name spec]}]
-  (let [wf (model/make-workflow {:id workflow-id
-                                  :name (or name (:name spec))
-                                  :status :running})]
+  (let [event {:event/type :workflow/started
+               :workflow/id workflow-id
+               :workflow/spec spec}
+        wf (assoc (model/make-workflow {:id workflow-id
+                                        :name (or name (:name spec))
+                                        :status :running})
+                  :detail-snapshot (persistence/apply-detail-event
+                                    (persistence/empty-detail workflow-id)
+                                    event))]
     (-> model
-        (update :workflows conj wf)
+        (upsert-workflow wf)
         (link-chain-instance workflow-id)
         (update-detail-if-active workflow-id
           #(apply-evidence-intent % spec name))
@@ -133,6 +157,9 @@
 (defn handle-phase-changed [model {:keys [workflow-id phase]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
+        (update-workflow-snapshot idx workflow-id {:event/type :workflow/phase-started
+                                                   :workflow/id workflow-id
+                                                   :workflow/phase phase})
         (apply-phase-change idx workflow-id phase)
         with-timestamp)))
 
@@ -166,6 +193,12 @@
   (let [idx (find-workflow-idx (:workflows model) workflow-id)
         phase-status (case outcome :success :success :failed :failed :success)]
     (-> model
+        (update-workflow-snapshot idx workflow-id {:event/type :workflow/phase-completed
+                                                   :workflow/id workflow-id
+                                                   :workflow/phase phase
+                                                   :phase/outcome outcome
+                                                   :phase/artifacts artifacts
+                                                   :phase/duration-ms duration-ms})
         (update-workflow-at idx #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))
         (update-detail-if-active workflow-id
           #(apply-phase-completion % phase phase-status duration-ms artifacts))
@@ -174,6 +207,11 @@
 (defn handle-agent-status [model {:keys [workflow-id agent status message]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
+        (update-workflow-snapshot idx workflow-id {:event/type :agent/status
+                                                   :workflow/id workflow-id
+                                                   :agent/id agent
+                                                   :status/type status
+                                                   :message message})
         (apply-agent-status-update idx workflow-id agent status message)
         with-timestamp)))
 
@@ -193,6 +231,11 @@
 
 (defn handle-agent-output [model {:keys [workflow-id delta]}]
   (-> model
+      (update-workflow-snapshot (find-workflow-idx (:workflows model) workflow-id)
+                                workflow-id
+                                {:event/type :agent/chunk
+                                 :workflow/id workflow-id
+                                 :chunk/delta delta})
       (update-detail-if-active workflow-id
         #(update-in % [:detail :agent-output] str delta))
       with-timestamp))
@@ -207,6 +250,11 @@
 (defn handle-workflow-done [model {:keys [workflow-id status duration-ms evidence-bundle-id]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
+        (update-workflow-snapshot idx workflow-id {:event/type :workflow/completed
+                                                   :workflow/id workflow-id
+                                                   :workflow/status status
+                                                   :workflow/duration-ms duration-ms
+                                                   :workflow/evidence-bundle-id evidence-bundle-id})
         (update-workflow-at idx #(assoc % :status (or status :success) :progress 100
                                           :duration-ms duration-ms))
         (update-detail-if-active workflow-id
@@ -216,12 +264,21 @@
 (defn handle-workflow-failed [model {:keys [workflow-id error]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
+        (update-workflow-snapshot idx workflow-id {:event/type :workflow/failed
+                                                   :workflow/id workflow-id
+                                                   :workflow/failure-reason error
+                                                   :workflow/error-details {:message error}})
         (update-workflow-at idx #(assoc % :status :failed :error error))
         with-timestamp)))
 
 (defn handle-gate-result [model {:keys [workflow-id gate passed?] :as payload}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
+        (update-workflow-snapshot idx workflow-id
+                                  {:event/type (if passed? :gate/passed :gate/failed)
+                                   :workflow/id workflow-id
+                                   :gate/id gate
+                                   :event/timestamp (:event/timestamp payload)})
         (apply-gate-result idx workflow-id gate passed? payload)
         with-timestamp)))
 
@@ -234,6 +291,11 @@
   (let [idx (find-workflow-idx (:workflows model) workflow-id)
         status-message (str "Tool " (if tool (name tool) "unknown") " invoked")]
     (-> model
+        (update-workflow-snapshot idx workflow-id {:event/type :agent/status
+                                                   :workflow/id workflow-id
+                                                   :agent/id (or agent :agent)
+                                                   :status/type :tool-running
+                                                   :message status-message})
         (apply-agent-status-update idx workflow-id (or agent :agent) :tool-running status-message)
         with-timestamp)))
 
@@ -241,6 +303,11 @@
   (let [idx (find-workflow-idx (:workflows model) workflow-id)
         status-message (str "Tool " (if tool (name tool) "unknown") " completed")]
     (-> model
+        (update-workflow-snapshot idx workflow-id {:event/type :agent/status
+                                                   :workflow/id workflow-id
+                                                   :agent/id (or agent :agent)
+                                                   :status/type :tool-completed
+                                                   :message status-message})
         (apply-agent-status-update idx workflow-id (or agent :agent) :tool-completed status-message)
         with-timestamp)))
 
@@ -318,9 +385,21 @@
   "Handle result of a :sync-prs side effect.
    Replaces :pr-items with freshly fetched data."
   [model {:keys [pr-items]}]
-  (let [prs (or pr-items [])]
+  (let [prs (vec (or pr-items []))
+        active-pr (get-in model [:detail :selected-pr])
+        refreshed-pr (when active-pr
+                       (some #(when (and (= (:pr/repo %) (:pr/repo active-pr))
+                                         (= (:pr/number %) (:pr/number active-pr)))
+                                %)
+                             prs))
+        filtered-indices (when-let [query (:active-filter model)]
+                           (filter/compute-filter-indices prs query))]
     (-> model
-        (assoc :pr-items (vec prs))
+        (assoc :pr-items prs
+               :filtered-indices filtered-indices
+               :selected-idx 0)
+        (cond-> refreshed-pr
+          (assoc-in [:detail :selected-pr] refreshed-pr))
         (assoc :flash-message (str "Synced " (count prs) " PRs from "
                                    (count (distinct (map :pr/repo prs))) " repo(s)"))
         with-timestamp)))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -184,13 +184,16 @@
                  (mapv #(normalize-artifact % phase) artifacts))
       model)))
 
-(defn handle-phase-done [model {:keys [workflow-id phase outcome artifacts duration-ms]}]
+(defn handle-phase-done [model {:keys [workflow-id phase outcome artifacts duration-ms
+                                       tokens cost-usd]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)
         phase-status (case outcome :success :success :failed :failed :success)]
     (-> model
         (update-workflow-snapshot idx workflow-id
                                   (persistence/phase-completed-event workflow-id phase outcome
-                                                                     artifacts duration-ms))
+                                                                     artifacts duration-ms
+                                                                     {:tokens tokens
+                                                                      :cost-usd cost-usd}))
         (update-workflow-at idx #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))
         (update-detail-if-active workflow-id
           #(apply-phase-completion % phase phase-status duration-ms artifacts))
@@ -234,12 +237,15 @@
     evidence-bundle-id (assoc-in [:detail :evidence :bundle-id] evidence-bundle-id)
     duration-ms        (assoc-in [:detail :duration-ms] duration-ms)))
 
-(defn handle-workflow-done [model {:keys [workflow-id status duration-ms evidence-bundle-id]}]
+(defn handle-workflow-done [model {:keys [workflow-id status duration-ms evidence-bundle-id
+                                          tokens cost-usd]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
         (update-workflow-snapshot idx workflow-id
                                   (persistence/workflow-completed-event workflow-id status
-                                                                       duration-ms evidence-bundle-id))
+                                                                       duration-ms evidence-bundle-id
+                                                                       {:tokens tokens
+                                                                        :cost-usd cost-usd}))
         (update-workflow-at idx #(assoc % :status (or status :success) :progress 100
                                           :duration-ms duration-ms))
         (update-detail-if-active workflow-id

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -138,9 +138,7 @@
     model))
 
 (defn handle-workflow-added [model {:keys [workflow-id name spec]}]
-  (let [event {:event/type :workflow/started
-               :workflow/id workflow-id
-               :workflow/spec spec}
+  (let [event (persistence/workflow-started-event workflow-id spec)
         wf (assoc (model/make-workflow {:id workflow-id
                                         :name (or name (:name spec))
                                         :status :running})
@@ -157,9 +155,8 @@
 (defn handle-phase-changed [model {:keys [workflow-id phase]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
-        (update-workflow-snapshot idx workflow-id {:event/type :workflow/phase-started
-                                                   :workflow/id workflow-id
-                                                   :workflow/phase phase})
+        (update-workflow-snapshot idx workflow-id
+                                  (persistence/phase-started-event workflow-id phase))
         (apply-phase-change idx workflow-id phase)
         with-timestamp)))
 
@@ -191,12 +188,9 @@
   (let [idx (find-workflow-idx (:workflows model) workflow-id)
         phase-status (case outcome :success :success :failed :failed :success)]
     (-> model
-        (update-workflow-snapshot idx workflow-id {:event/type :workflow/phase-completed
-                                                   :workflow/id workflow-id
-                                                   :workflow/phase phase
-                                                   :phase/outcome outcome
-                                                   :phase/artifacts artifacts
-                                                   :phase/duration-ms duration-ms})
+        (update-workflow-snapshot idx workflow-id
+                                  (persistence/phase-completed-event workflow-id phase outcome
+                                                                     artifacts duration-ms))
         (update-workflow-at idx #(update % :progress (fn [p] (min 100 (+ (or p 0) 20)))))
         (update-detail-if-active workflow-id
           #(apply-phase-completion % phase phase-status duration-ms artifacts))
@@ -205,11 +199,8 @@
 (defn handle-agent-status [model {:keys [workflow-id agent status message]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
-        (update-workflow-snapshot idx workflow-id {:event/type :agent/status
-                                                   :workflow/id workflow-id
-                                                   :agent/id agent
-                                                   :status/type status
-                                                   :message message})
+        (update-workflow-snapshot idx workflow-id
+                                  (persistence/agent-status-event workflow-id agent status message))
         (apply-agent-status-update idx workflow-id agent status message)
         with-timestamp)))
 
@@ -231,9 +222,7 @@
   (-> model
       (update-workflow-snapshot (find-workflow-idx (:workflows model) workflow-id)
                                 workflow-id
-                                {:event/type :agent/chunk
-                                 :workflow/id workflow-id
-                                 :chunk/delta delta})
+                                (persistence/agent-chunk-event workflow-id delta))
       (update-detail-if-active workflow-id
         #(update-in % [:detail :agent-output] str delta))
       with-timestamp))
@@ -248,11 +237,9 @@
 (defn handle-workflow-done [model {:keys [workflow-id status duration-ms evidence-bundle-id]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
-        (update-workflow-snapshot idx workflow-id {:event/type :workflow/completed
-                                                   :workflow/id workflow-id
-                                                   :workflow/status status
-                                                   :workflow/duration-ms duration-ms
-                                                   :workflow/evidence-bundle-id evidence-bundle-id})
+        (update-workflow-snapshot idx workflow-id
+                                  (persistence/workflow-completed-event workflow-id status
+                                                                       duration-ms evidence-bundle-id))
         (update-workflow-at idx #(assoc % :status (or status :success) :progress 100
                                           :duration-ms duration-ms))
         (update-detail-if-active workflow-id
@@ -262,10 +249,8 @@
 (defn handle-workflow-failed [model {:keys [workflow-id error]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
-        (update-workflow-snapshot idx workflow-id {:event/type :workflow/failed
-                                                   :workflow/id workflow-id
-                                                   :workflow/failure-reason error
-                                                   :workflow/error-details {:message error}})
+        (update-workflow-snapshot idx workflow-id
+                                  (persistence/workflow-failed-event workflow-id error))
         (update-workflow-at idx #(assoc % :status :failed :error error))
         with-timestamp)))
 
@@ -273,10 +258,8 @@
   (let [idx (find-workflow-idx (:workflows model) workflow-id)]
     (-> model
         (update-workflow-snapshot idx workflow-id
-                                  {:event/type (if passed? :gate/passed :gate/failed)
-                                   :workflow/id workflow-id
-                                   :gate/id gate
-                                   :event/timestamp (:event/timestamp payload)})
+                                  (persistence/gate-event workflow-id gate passed?
+                                                          (:event/timestamp payload)))
         (apply-gate-result idx workflow-id gate passed? payload)
         with-timestamp)))
 
@@ -287,26 +270,24 @@
 
 (defn handle-tool-invoked [model {:keys [workflow-id agent tool]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)
+        agent-id (or agent :agent)
         status-message (str "Tool " (if tool (name tool) "unknown") " invoked")]
     (-> model
-        (update-workflow-snapshot idx workflow-id {:event/type :agent/status
-                                                   :workflow/id workflow-id
-                                                   :agent/id (or agent :agent)
-                                                   :status/type :tool-running
-                                                   :message status-message})
-        (apply-agent-status-update idx workflow-id (or agent :agent) :tool-running status-message)
+        (update-workflow-snapshot idx workflow-id
+                                  (persistence/agent-status-event workflow-id agent-id
+                                                                  :tool-running status-message))
+        (apply-agent-status-update idx workflow-id agent-id :tool-running status-message)
         with-timestamp)))
 
 (defn handle-tool-completed [model {:keys [workflow-id agent tool]}]
   (let [idx (find-workflow-idx (:workflows model) workflow-id)
+        agent-id (or agent :agent)
         status-message (str "Tool " (if tool (name tool) "unknown") " completed")]
     (-> model
-        (update-workflow-snapshot idx workflow-id {:event/type :agent/status
-                                                   :workflow/id workflow-id
-                                                   :agent/id (or agent :agent)
-                                                   :status/type :tool-completed
-                                                   :message status-message})
-        (apply-agent-status-update idx workflow-id (or agent :agent) :tool-completed status-message)
+        (update-workflow-snapshot idx workflow-id
+                                  (persistence/agent-status-event workflow-id agent-id
+                                                                  :tool-completed status-message))
+        (apply-agent-status-update idx workflow-id agent-id :tool-completed status-message)
         with-timestamp)))
 
 ;------------------------------------------------------------------------------ Layer 2b

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -368,7 +368,8 @@
 
 (defn handle-prs-synced
   "Handle result of a :sync-prs side effect.
-   Replaces :pr-items with freshly fetched data."
+   Replaces :pr-items with freshly fetched data.
+   Preserves the current selection position, clamping to new bounds."
   [model {:keys [pr-items]}]
   (let [prs (vec (or pr-items []))
         active-pr (get-in model [:detail :selected-pr])
@@ -378,11 +379,15 @@
                                 %)
                              prs))
         filtered-indices (when-let [query (:active-filter model)]
-                           (filter/compute-filter-indices prs query))]
+                           (filter/compute-filter-indices prs query))
+        max-idx (max 0 (dec (if filtered-indices
+                              (count filtered-indices)
+                              (count prs))))
+        clamped-idx (min (or (:selected-idx model) 0) max-idx)]
     (-> model
         (assoc :pr-items prs
                :filtered-indices filtered-indices
-               :selected-idx 0)
+               :selected-idx clamped-idx)
         (cond-> refreshed-pr
           (assoc-in [:detail :selected-pr] refreshed-pr))
         (assoc :flash-message (str "Synced " (count prs) " PRs from "

--- a/components/tui-views/src/ai/miniforge/tui_views/update/filter.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/filter.clj
@@ -28,7 +28,7 @@
      neg-field   = '-' field-name ':' value
      field       = field-name ':' value
      free-text   = word (anything not field-qualified)
-     field-name  = 'repo' | 'author' | 'readiness' | 'risk' | 'policy' | 'recommend'
+     field-name  = 'repo' | 'author' | 'readiness' | 'risk' | 'policy' | 'recommend' | 'state' | 'status'
 
    Examples:
      'repo:miniforge risk:high dark mode'
@@ -45,7 +45,7 @@
 
 (def field-names
   "Recognized field qualifiers."
-  #{"repo" "author" "readiness" "risk" "policy" "recommend"})
+  #{"repo" "author" "readiness" "risk" "policy" "recommend" "state" "status"})
 
 (defn parse-token
   "Parse a single whitespace-delimited token.
@@ -135,6 +135,8 @@
                   true "pass"
                   false "fail"
                   "unknown")
+    (:state :status)
+    (name (or (:pr/status pr) :unknown))
     :recommend  (name (resolve-or :wait
                         #(:action (project/derive-recommendation pr))))
     ""))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
@@ -86,30 +86,57 @@
       (into [] (keep-indexed #(when (contains? fi %1) %2)) prs)
       prs)))
 
+(defn empty-workflow-detail
+  [workflow-id]
+  {:workflow-id workflow-id
+   :phases []
+   :current-phase nil
+   :current-agent nil
+   :agent-output ""
+   :evidence nil
+   :artifacts []
+   :expanded-nodes #{}
+   :focused-pane 0
+   :selected-pr nil
+   :pr-readiness nil
+   :pr-risk nil
+   :selected-train nil
+   :duration-ms nil
+   :error nil})
+
+(defn workflow-row->detail
+  [wf]
+  (merge (empty-workflow-detail (:id wf))
+         {:current-phase (:phase wf)
+          :phases (if-let [phase (:phase wf)]
+                    [{:phase phase
+                      :status (case (:status wf)
+                                :failed :failed
+                                :success :success
+                                :completed :success
+                                :running)}]
+                    [])
+          :current-agent (when-let [[agent entry] (first (:agents wf))]
+                           (assoc entry :agent agent))
+          :evidence (when (seq (:gate-results wf))
+                      {:validation {:results (:gate-results wf)}})
+          :duration-ms (:duration-ms wf)
+          :error (:error wf)}))
+
+(defn workflow-detail-context
+  "Build detail context from the workflow row and any snapshot data already
+   stored on the row."
+  [wf]
+  (merge (workflow-row->detail wf)
+         (or (:detail-snapshot wf) {})
+         {:workflow-id (:id wf)}))
+
 (defn enter-workflow-detail [model]
   (let [raw-idx (raw-workflow-index model (:selected-idx model))]
     (if-let [wf (when raw-idx (get (:workflows model) raw-idx))]
       (-> model
           (assoc :view :workflow-detail)
-          ;; Reset detail, seeding from existing workflow row data
-          (assoc :detail {:workflow-id    (:id wf)
-                          :phases         (if-let [p (:phase wf)]
-                                            [{:phase p :status (if (= :failed (:status wf))
-                                                                 :failed :running)}]
-                                            [])
-                          :current-agent  (when-let [[agent-kw entry] (first (:agents wf))]
-                                            (assoc entry :agent agent-kw))
-                          :agent-output   ""
-                          :evidence       (when (seq (:gate-results wf))
-                                            {:validation {:results (:gate-results wf)}})
-                          :artifacts      []
-                          :expanded-nodes #{}
-                          :focused-pane   0
-                          :selected-pr    nil
-                          :pr-readiness   nil
-                          :pr-risk        nil
-                          :selected-train nil
-                          :duration-ms    (:duration-ms wf)})
+          (assoc :detail (workflow-detail-context wf))
           (assoc :selected-idx 0 :selected-ids #{} :visual-anchor nil
                  :scroll-offset nil :search-matches [] :search-match-idx nil))
       model)))
@@ -259,7 +286,7 @@
       (if (and prev-idx (>= prev-idx 0))
         (let [wf (get workflows prev-idx)]
           (-> model
-              (assoc-in [:detail :workflow-id] (:id wf))
+              (assoc :detail (workflow-detail-context wf))
               (assoc :selected-idx 0)
               (assoc-in [:detail :expanded-nodes] #{})))
         model))
@@ -295,7 +322,7 @@
       (if (and next-idx (< next-idx (count workflows)))
         (let [wf (get workflows next-idx)]
           (-> model
-              (assoc-in [:detail :workflow-id] (:id wf))
+              (assoc :detail (workflow-detail-context wf))
               (assoc :selected-idx 0)
               (assoc-in [:detail :expanded-nodes] #{})))
         model))

--- a/components/tui-views/src/ai/miniforge/tui_views/view/interpret.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/interpret.clj
@@ -125,14 +125,19 @@
     (if (empty? data)
       (layout/text [cols rows] "  No data available."
                    {:fg (get theme :fg :default)})
-      (layout/table [cols rows]
-        {:columns resolved-cols :data data
-         :selected-row (when selectable? selected)
-         :header-fg (get theme :header :cyan)
-         :row-fg (get theme :row-fg :default)
-         :row-bg (get theme :row-bg :default)
-         :selected-fg (get theme :selected-fg :white)
-         :selected-bg (get theme :selected-bg :blue)}))))
+      (let [visible-count (max 0 (- rows 2))
+            sel (or selected 0)
+            offset (if (<= (inc sel) visible-count) 0
+                       (inc (- sel visible-count)))]
+        (layout/table [cols rows]
+          {:columns resolved-cols :data data
+           :selected-row (when selectable? selected)
+           :offset offset
+           :header-fg (get theme :header :cyan)
+           :row-fg (get theme :row-fg :default)
+           :row-bg (get theme :row-bg :default)
+           :selected-fg (get theme :selected-fg :white)
+           :selected-bg (get theme :selected-bg :blue)})))))
 
 (defn render-tree-widget
   "Render a tree widget from spec."

--- a/components/tui-views/src/ai/miniforge/tui_views/views/artifact_browser.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/artifact_browser.clj
@@ -59,18 +59,23 @@
                  :border :single :fg :default
                  :content-fn
                  (fn [[ic ir]]
-                   (layout/table [ic ir]
-                     {:columns [{:key :type :header "Type" :width 10}
-                                {:key :name :header "Name" :width (max 10 (- ic 35))}
-                                {:key :size :header "Size" :width 8}
-                                {:key :status :header "Status" :width 8}]
-                      :data (mapv (fn [a]
-                                    {:type (some-> (:type a) name)
-                                     :name (or (:name a) (:path a) "unnamed")
-                                     :size (get a :size "-")
-                                     :status (some-> (:status a) name)})
-                                  artifacts)
-                      :selected-row selected}))})))
+                   (let [visible-count (max 0 (- ir 2))
+                         offset (let [sel (or selected 0)]
+                                  (if (<= (inc sel) visible-count) 0
+                                      (inc (- sel visible-count))))]
+                     (layout/table [ic ir]
+                       {:columns [{:key :type :header "Type" :width 10}
+                                  {:key :name :header "Name" :width (max 10 (- ic 35))}
+                                  {:key :size :header "Size" :width 8}
+                                  {:key :status :header "Status" :width 8}]
+                        :data (mapv (fn [a]
+                                      {:type (some-> (:type a) name)
+                                       :name (or (:name a) (:path a) "unnamed")
+                                       :size (get a :size "-")
+                                       :status (some-> (:status a) name)})
+                                    artifacts)
+                        :selected-row selected
+                        :offset offset})))})))
           ;; Footer
           (fn [[fc fr]]
             (layout/text [fc fr]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/dag_kanban.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/dag_kanban.clj
@@ -34,6 +34,13 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Task grouping
 
+(defn column-title
+  "Column title with item count."
+  [label cards]
+  (if (seq cards)
+    (str label " (" (count cards) ")")
+    label))
+
 (defn group-tasks-by-status
   "Group workflow tasks into kanban columns."
   [workflows]
@@ -41,22 +48,28 @@
         blocked (filterv #(= :blocked (:status %)) all-wfs)
         pending (filterv #(= :pending (:status %)) all-wfs)
         running (filterv #(= :running (:status %)) all-wfs)
-        done (filterv #(#{:success :completed} (:status %)) all-wfs)
-        failed (filterv #(= :failed (:status %)) all-wfs)]
-    [{:title "BLOCKED"
+        stale   (filterv #(= :stale (:status %)) all-wfs)
+        done    (filterv #(#{:success :completed} (:status %)) all-wfs)
+        failed  (filterv #(= :failed (:status %)) all-wfs)
+        done-cards (vec (concat
+                         (mapv (fn [wf] {:label (:name wf) :status :success}) done)
+                         (mapv (fn [wf] {:label (:name wf) :status :failed}) failed)
+                         (mapv (fn [wf] {:label (:name wf) :status :stale}) stale)))
+        blocked-cards (mapv (fn [wf] {:label (:name wf) :status :blocked}) blocked)
+        pending-cards (mapv (fn [wf] {:label (:name wf) :status :pending}) pending)
+        running-cards (mapv (fn [wf] {:label (:name wf) :status :running}) running)]
+    [{:title (column-title "BLOCKED" blocked-cards)
       :color :red
-      :cards (mapv (fn [wf] {:label (:name wf) :status :blocked}) blocked)}
-     {:title "PENDING"
+      :cards blocked-cards}
+     {:title (column-title "PENDING" pending-cards)
       :color :yellow
-      :cards (mapv (fn [wf] {:label (:name wf) :status :pending}) pending)}
-     {:title "RUNNING"
+      :cards pending-cards}
+     {:title (column-title "RUNNING" running-cards)
       :color :cyan
-      :cards (mapv (fn [wf] {:label (:name wf) :status :running}) running)}
-     {:title "DONE"
+      :cards running-cards}
+     {:title (column-title "DONE" done-cards)
       :color :green
-      :cards (concat
-              (mapv (fn [wf] {:label (:name wf) :status :success}) done)
-              (mapv (fn [wf] {:label (:name wf) :status :failed}) failed))}]))
+      :cards done-cards}]))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Rendering

--- a/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
@@ -53,18 +53,29 @@
   (layout/text [cols rows] " MINIFORGE │ PR Fleet"
                {:fg :cyan :bold? true}))
 
+(defn auto-scroll-offset
+  "Compute scroll offset so selected-idx is always visible within visible-count rows."
+  [selected-idx visible-count]
+  (let [sel (or selected-idx 0)]
+    (if (<= (inc sel) visible-count)
+      0
+      (inc (- sel visible-count)))))
+
 (defn render-table [pr-items selected [cols rows]]
   (if (empty? pr-items)
     (layout/text [cols rows] "  No PRs tracked. Use :add-repo to add repositories."
                  {:fg :default})
-    (let [title-width (max 10 (- cols 60))]
+    (let [title-width (max 10 (- cols 60))
+          visible-count (max 0 (- rows 2))
+          offset (auto-scroll-offset selected visible-count)]
       (layout/table [cols rows]
         {:columns [{:key :title :header "PR Title" :width title-width}
                    {:key :repo :header "Repository" :width 25}
                    {:key :readiness :header "Readiness" :width 18}
                    {:key :risk :header "Risk" :width 6}]
          :data (mapv #(format-pr-row % cols) pr-items)
-         :selected-row selected}))))
+         :selected-row selected
+         :offset offset}))))
 
 (defn render-footer [flash-message [cols rows]]
   (layout/text [cols rows]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
@@ -22,7 +22,8 @@
    Displays a table of PRs with title, readiness score, risk level,
    CI status, and repo information."
   (:require
-   [ai.miniforge.tui-engine.interface.layout :as layout]))
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.update.navigation :as nav]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Rendering helpers
@@ -76,7 +77,7 @@
    model: full app model
    [cols rows]: available screen area"
   [model [cols rows]]
-  (let [pr-items (:pr-items model)
+  (let [pr-items (nav/visible-prs model)
         selected (:selected-idx model)
         flash (:flash-message model)]
     (layout/split-v [cols rows] (/ 2.0 rows)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/repo_manager.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/repo_manager.clj
@@ -53,15 +53,26 @@
     (layout/text [cols rows] label
                  {:fg :cyan :bold? true})))
 
+(defn auto-scroll-offset
+  "Compute scroll offset so selected-idx is always visible within visible-count rows."
+  [selected-idx visible-count]
+  (let [sel (or selected-idx 0)]
+    (if (<= (inc sel) visible-count)
+      0
+      (inc (- sel visible-count)))))
+
 (defn render-table [items selected selected-ids [cols rows]]
   (if (empty? items)
     (layout/text [cols rows] "  No repositories configured. Use :add-repo or b to browse."
                  {:fg :default})
-    (layout/table [cols rows]
-      {:columns [{:key :marker :header " " :width 2}
-                 {:key :repo :header "Repository" :width (max 10 (- cols 8))}]
-       :data (mapv #(format-repo-row % selected-ids) items)
-       :selected-row selected})))
+    (let [visible-count (max 0 (- rows 2))
+          offset (auto-scroll-offset selected visible-count)]
+      (layout/table [cols rows]
+        {:columns [{:key :marker :header " " :width 2}
+                   {:key :repo :header "Repository" :width (max 10 (- cols 8))}]
+         :data (mapv #(format-repo-row % selected-ids) items)
+         :selected-row selected
+         :offset offset}))))
 
 (defn render-footer [model [cols rows]]
   (let [source (if (= :browse (:repo-manager-source model)) :browse :fleet)]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/train_view.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/train_view.clj
@@ -42,13 +42,18 @@
   (if (empty? prs)
     (layout/text [cols rows] "  No PRs in this train."
                  {:fg :default})
-    (layout/table [cols rows]
-      {:columns [{:key :order :header "#" :width 4}
-                 {:key :title :header "PR Title" :width (max 10 (- cols 30))}
-                 {:key :readiness :header "Ready" :width 8}]
-       :data (mapv format-pr-row
-               (sort-by :pr/merge-order prs))
-       :selected-row selected})))
+    (let [visible-count (max 0 (- rows 2))
+          offset (let [sel (or selected 0)]
+                   (if (<= (inc sel) visible-count) 0
+                       (inc (- sel visible-count))))]
+      (layout/table [cols rows]
+        {:columns [{:key :order :header "#" :width 4}
+                   {:key :title :header "PR Title" :width (max 10 (- cols 30))}
+                   {:key :readiness :header "Ready" :width 8}]
+         :data (mapv format-pr-row
+                 (sort-by :pr/merge-order prs))
+         :selected-row selected
+         :offset offset}))))
 
 (defn render-footer [[cols rows]]
   (layout/text [cols rows]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
@@ -42,18 +42,39 @@
     :failed   " ✗"
     ""))
 
-(defn format-phase-node [{:keys [phase status]}]
-  {:label (str (name phase) (status-suffix status))
-   :depth 0
-   :expandable? false})
+(defn format-cost [cost-usd]
+  (when (and cost-usd (pos? cost-usd))
+    (format "$%.4f" (double cost-usd))))
 
-(defn render-title-bar [wf [cols rows]]
-  (layout/text [cols rows]
-               (str " MINIFORGE │ "
-                    (get wf :name "Workflow Detail")
-                    (when-let [phase (:phase wf)]
-                      (str " │ " (name phase))))
-               {:fg :cyan :bold? true}))
+(defn format-tokens [tokens]
+  (when (and tokens (pos? tokens))
+    (if (>= tokens 1000)
+      (format "%.1fk" (/ (double tokens) 1000.0))
+      (str tokens))))
+
+(defn format-phase-node [{:keys [phase status tokens cost-usd]}]
+  (let [suffix (status-suffix status)
+        metrics (str/join " " (keep identity
+                                     [(format-tokens tokens)
+                                      (format-cost cost-usd)]))]
+    {:label (str (name phase) suffix
+                 (when (seq metrics) (str "  " metrics)))
+     :depth 0
+     :expandable? false}))
+
+(defn render-title-bar [wf detail [cols rows]]
+  (let [metrics-parts (keep identity
+                             [(format-tokens (:tokens detail))
+                              (format-cost (:cost-usd detail))])
+        metrics-str (when (seq metrics-parts)
+                      (str " │ " (str/join " " metrics-parts)))]
+    (layout/text [cols rows]
+                 (str " MINIFORGE │ "
+                      (get wf :name "Workflow Detail")
+                      (when-let [phase (:phase wf)]
+                        (str " │ " (name phase)))
+                      metrics-str)
+                 {:fg :cyan :bold? true})))
 
 (defn render-phase-list [phases [cols rows]]
   (layout/box [cols rows]
@@ -99,7 +120,7 @@
         agent (:current-agent detail)
         output (:agent-output detail)]
     (layout/split-v [cols rows] (/ 2.0 rows)
-      (fn [size] (render-title-bar wf size))
+      (fn [size] (render-title-bar wf detail size))
       (fn [[c r]]
         (layout/split-v [c r] (/ (- r 2.0) r)
           (fn [[mc mr]]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
@@ -67,18 +67,29 @@
   (layout/text [cols rows] " MINIFORGE │ Workflows"
                {:fg :cyan :bold? true}))
 
+(defn auto-scroll-offset
+  "Compute scroll offset so selected-idx is always visible within visible-count rows."
+  [selected-idx visible-count]
+  (let [sel (or selected-idx 0)]
+    (if (<= (inc sel) visible-count)
+      0
+      (inc (- sel visible-count)))))
+
 (defn render-table [workflows selected active-chain [cols rows]]
   (if (empty? workflows)
     (layout/text [cols rows] "  No active workflows. Waiting for events..."
                  {:fg :default})
-    (layout/table [cols rows]
-      {:columns [{:key :status-char :header "  " :width 2}
-                 {:key :name :header "Workflow" :width (max 10 (- cols 50))}
-                 {:key :phase :header "Phase" :width 12}
-                 {:key :progress-str :header "Progress" :width 20}
-                 {:key :agent-msg :header "Agent" :width 16}]
-       :data (mapv #(format-workflow-row % active-chain) workflows)
-       :selected-row selected})))
+    (let [visible-count (max 0 (- rows 2))
+          offset (auto-scroll-offset selected visible-count)]
+      (layout/table [cols rows]
+        {:columns [{:key :status-char :header "  " :width 2}
+                   {:key :name :header "Workflow" :width (max 10 (- cols 50))}
+                   {:key :phase :header "Phase" :width 12}
+                   {:key :progress-str :header "Progress" :width 20}
+                   {:key :agent-msg :header "Agent" :width 16}]
+         :data (mapv #(format-workflow-row % active-chain) workflows)
+         :selected-row selected
+         :offset offset}))))
 
 (defn render-footer [flash-message [cols rows]]
   (layout/text [cols rows]

--- a/components/tui-views/test/ai/miniforge/tui_views/events_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/events_test.clj
@@ -27,6 +27,15 @@
       (is (= :running (:status (first (:workflows m)))))
       (is (some? (:last-updated m))))))
 
+(deftest handle-workflow-added-upserts-existing-row-test
+  (testing "workflow-added updates an existing row instead of duplicating it"
+    (let [wf-id (random-uuid)
+          m (-> (fresh)
+                (with-workflow wf-id :name "old-name")
+                (events/handle-workflow-added {:workflow-id wf-id :name "new-name" :spec nil}))]
+      (is (= 1 (count (:workflows m))))
+      (is (= "new-name" (get-in m [:workflows 0 :name]))))))
+
 (deftest handle-workflow-added-uses-spec-name-test
   (testing "uses spec name when name is nil"
     (let [m (events/handle-workflow-added (fresh)
@@ -221,6 +230,18 @@
           m (events/handle-prs-synced (fresh) {:pr-items prs})]
       (is (= 2 (count (:pr-items m))))
       (is (str/includes? (:flash-message m) "2 PRs")))))
+
+(deftest handle-prs-synced-refreshes-active-detail-and-filter-test
+  (testing "sync updates the active PR detail and recomputes an active filter"
+    (let [old-pr {:pr/repo "r1" :pr/number 1 :pr/title "Old"}
+          new-pr {:pr/repo "r1" :pr/number 1 :pr/title "New" :pr/status :merged}
+          other-pr {:pr/repo "r2" :pr/number 2 :pr/title "Other" :pr/status :open}
+          m (-> (fresh)
+                (assoc :active-filter "status:merged")
+                (assoc-in [:detail :selected-pr] old-pr)
+                (events/handle-prs-synced {:pr-items [new-pr other-pr]}))]
+      (is (= "New" (get-in m [:detail :selected-pr :pr/title])))
+      (is (= #{0} (:filtered-indices m))))))
 
 (deftest handle-prs-synced-empty-test
   (testing "empty sync clears items"

--- a/components/tui-views/test/ai/miniforge/tui_views/file_subscription_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/file_subscription_test.clj
@@ -1,0 +1,57 @@
+(ns ai.miniforge.tui-views.file-subscription-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.file-subscription :as file-sub]))
+
+(defn temp-dir
+  []
+  (doto (io/file (System/getProperty "java.io.tmpdir")
+                 (str "miniforge-file-sub-test-" (System/nanoTime)))
+    .mkdirs))
+
+(defn cleanup!
+  [dir]
+  (doseq [f (.listFiles dir)]
+    (.delete f))
+  (.delete dir))
+
+(defn write-event-file!
+  [dir file-name events]
+  (let [file (io/file dir file-name)]
+    (with-open [w (io/writer file)]
+      (doseq [event events]
+        (.write w (pr-str event))
+        (.write w "\n")))
+    file))
+
+(deftest track-file-hydrate-flag-test
+  (testing "hydrate? false tracks the file from EOF without replaying history"
+    (let [dir (temp-dir)
+          file (write-event-file! dir "wf.edn"
+                                  [{:event/type :workflow/started
+                                    :workflow/id (random-uuid)
+                                    :workflow/spec {:name "test"}}])
+          tracked (atom {})
+          dispatched (atom [])]
+      (try
+        (file-sub/track-file! tracked #(swap! dispatched conj %) file {:hydrate? false})
+        (is (empty? @dispatched))
+        (is (= (.length file)
+               @(get-in @tracked [(.getAbsolutePath file) :position])))
+        (finally
+          (cleanup! dir)))))
+
+  (testing "hydrate? true replays existing events immediately"
+    (let [dir (temp-dir)
+          file (write-event-file! dir "wf.edn"
+                                  [{:event/type :workflow/started
+                                    :workflow/id (random-uuid)
+                                    :workflow/spec {:name "test"}}])
+          tracked (atom {})
+          dispatched (atom [])]
+      (try
+        (file-sub/track-file! tracked #(swap! dispatched conj %) file {:hydrate? true})
+        (is (= 1 (count @dispatched)))
+        (finally
+          (cleanup! dir))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/update_test.clj
@@ -76,6 +76,18 @@
       (is (util/view-is? m :workflow-detail))
       (is (= wf-id-1 (get-in m [:detail :workflow-id])))))
 
+  (testing "Workflow detail entry uses the row detail snapshot when present"
+    (let [m (-> (two-workflows)
+                (assoc-in [:workflows 0 :detail-snapshot]
+                          {:workflow-id wf-id-1
+                           :phases [{:phase :plan :status :success}
+                                    {:phase :implement :status :running}]
+                           :agent-output "streamed output"})
+                (assoc :view :workflow-list)
+                (update/update-model [:input :key/enter]))]
+      (is (= 2 (count (get-in m [:detail :phases]))))
+      (is (= "streamed output" (get-in m [:detail :agent-output])))))
+
   (testing "Escape from workflow-detail returns to workflow-list"
     (let [m (util/apply-updates
               (assoc (two-workflows) :view :workflow-list)
@@ -117,6 +129,12 @@
                [:msg/workflow-done {:workflow-id wf-id-1 :status :success}]])]
       (is (util/workflow-has-status? m 0 :success))
       (is (= 100 (get-in m [:workflows 0 :progress]))))))
+
+  (testing "Agent started message is routed through the root update"
+    (let [m (util/apply-updates (util/fresh-model)
+              [[:msg/workflow-added {:workflow-id wf-id-1 :name "test"}]
+               [:msg/agent-started {:workflow-id wf-id-1 :agent :planner}]])]
+      (is (= :started (get-in m [:workflows 0 :agents :planner :status])))))
 
 (deftest mode-switching-test
   (testing "Colon enters command mode"

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -81,7 +81,13 @@
     (try
       (let [status (:execution/status context)
             wf-id (:execution/id context)
-            duration-ms (get-in context [:execution/metrics :duration-ms])
+            metrics (:execution/metrics context)
+            duration-ms (:duration-ms metrics)
+            tokens (:tokens metrics)
+            cost-usd (:cost-usd metrics)
+            metrics-opts (cond-> {}
+                           tokens (assoc :tokens tokens)
+                           cost-usd (assoc :cost-usd cost-usd))
             workflow-failed (requiring-resolve 'ai.miniforge.event-stream.interface/workflow-failed)
             workflow-completed (requiring-resolve 'ai.miniforge.event-stream.interface/workflow-completed)]
         (if (= status :failed)
@@ -90,7 +96,8 @@
                                           {:message "Workflow failed"
                                            :errors (:execution/errors context)}))
           (publish-event! event-stream
-                          (workflow-completed event-stream wf-id status duration-ms))))
+                          (workflow-completed event-stream wf-id status duration-ms
+                                              (when (seq metrics-opts) metrics-opts)))))
       (catch Exception e
         (println "Warning: Failed to publish workflow-completed event:" (ex-message e))))))
 
@@ -123,9 +130,15 @@
                            (when-let [msg (:message result)]
                              {:message msg})))
           redirect-to (:redirect-to result)
+          tokens (or (get-in result [:metrics :tokens])
+                     (get-in result [:phase/metrics :tokens]))
+          cost-usd (or (get-in result [:metrics :cost-usd])
+                       (get-in result [:phase/metrics :cost-usd]))
           event-data (cond-> {:outcome outcome :duration-ms duration-ms}
                        error-info (assoc :error error-info)
-                       redirect-to (assoc :redirect-to redirect-to))]
+                       redirect-to (assoc :redirect-to redirect-to)
+                       tokens (assoc :tokens tokens)
+                       cost-usd (assoc :cost-usd cost-usd))]
       (try
         (let [phase-completed (requiring-resolve 'ai.miniforge.event-stream.interface/phase-completed)]
           (publish-event! event-stream

--- a/docs/pull-requests/2026-03-07-codex-tui-stability-fixes.md
+++ b/docs/pull-requests/2026-03-07-codex-tui-stability-fixes.md
@@ -1,0 +1,106 @@
+# PR: TUI stability fixes for exit, PR freshness, and workflow detail hydration
+
+**Branch:** `codex/tui-stability-fixes`  
+**Base Branch:** `main`  
+**Date:** 2026-03-07
+
+## Summary
+
+Fixes a cluster of TUI regressions around:
+
+- standalone startup replaying the full historical event store,
+  which made the app sluggish and effectively non-exitable while booting,
+- stale PR detail state after refresh/sync,
+- PR filter queries being unable to target merged vs closed state,
+- workflow list hydration admitting partial event files that behave like DAG child traces,
+- workflow detail panes lacking reconstructed phase / agent / artifact / gate data for persisted runs.
+
+## Root Causes
+
+1. **Standalone file subscription replayed all existing event files on startup**
+   - The app already loads startup state from persistence.
+   - Replaying every historical event file again created a massive dispatch
+     backlog, duplicated workflow rows, and delayed responsiveness.
+
+2. **Workflow startup persistence only used first/last events**
+   - That was enough for a row summary, but not enough for detail panes.
+   - Phase-only files were also treated as top-level workflows, which let DAG child traces leak into the flat workflow list.
+
+3. **PR sync replaced list data without refreshing dependent UI state**
+   - `:detail.selected-pr` stayed stale after sync.
+   - Active PR filters were not recomputed after list replacement.
+
+4. **GitHub merged PRs were normalized as `:closed`**
+   - This made merged/closed filtering inaccurate even when the provider returned the correct merged information.
+
+5. **Root update dispatch missed several translated runtime messages**
+   - Agent started/completed/failed and tool/gate lifecycle messages had
+     handlers but were not wired at the top-level update switch.
+
+## Changes
+
+### Workflow persistence and detail reconstruction
+
+- Reworked persisted workflow loading to read full event files instead of only first/last events.
+- Added detail reconstruction for:
+  - phases,
+  - current phase,
+  - current agent,
+  - streamed agent output,
+  - gate validation results,
+  - artifacts,
+  - duration and error state.
+- Excluded phase-only event files from the top-level workflow list so DAG child traces do not appear as standalone workflows.
+- Added `load-workflow-detail` helper for direct persisted detail reconstruction.
+
+### Workflow row and detail state
+
+- Workflow rows now keep a `:detail-snapshot`.
+- Live event handlers update that snapshot so detail views remain useful without replaying full history.
+- Entering workflow detail now uses the row snapshot instead of a shallow placeholder.
+- Workflow-added is now an upsert instead of blindly appending duplicate rows.
+
+### Standalone file subscription
+
+- Added `:hydrate-existing?` behavior to file tracking.
+- Standalone TUI now tracks existing files from EOF instead of replaying all historical events at startup.
+- Newly discovered files still hydrate from the beginning, so active runs remain observable.
+
+### PR sync and filtering
+
+- PR sync now refreshes the active PR detail row when the selected PR still exists in the newly synced data.
+- Active PR filters are recomputed after sync.
+- Added `state:` / `status:` filter qualifiers for the PR filter palette.
+
+### Provider status normalization
+
+- GitHub PR fetch now requests `mergedAt`.
+- Normalization now maps merged PRs to `:merged` instead of collapsing them into `:closed`.
+
+### Update wiring
+
+- Added root update dispatch for:
+  - `:msg/agent-started`
+  - `:msg/agent-completed`
+  - `:msg/agent-failed`
+  - `:msg/gate-started`
+  - `:msg/tool-invoked`
+  - `:msg/tool-completed`
+
+## Testing
+
+- Focused component tests:
+  - `XDG_CONFIG_HOME=/tmp/clj-config clojure -M:test -e "(require ...)"`
+  - Result: `98 tests, 521 assertions, 0 failures, 0 errors`
+- Project persistence tests:
+  - `XDG_CONFIG_HOME=/tmp/clj-config clojure -e "(require 'ai.miniforge.tui-views.persistence-test) ..."`
+  - Result: `14 tests, 39 assertions, 0 failures, 0 errors`
+- Packaging:
+  - `bb build:tui`
+  - Result: built `dist/miniforge-tui` successfully
+
+## Notes
+
+- This change intentionally avoids replaying the entire historical event store during standalone startup.
+- Persisted workflow detail is reconstructed from disk on load, and live
+  event handlers now keep row snapshots current during active sessions.

--- a/projects/miniforge/test/ai/miniforge/tui_views/persistence_test.clj
+++ b/projects/miniforge/test/ai/miniforge/tui_views/persistence_test.clj
@@ -372,3 +372,66 @@
           ;; Should return empty — corrupted file silently skipped
           (is (= 0 (count wfs))))
         (finally (cleanup-dir! dir))))))
+
+(deftest stale-workflow-detection-test
+  (testing "Non-terminal workflow with old file is marked :stale"
+    (let [dir (temp-events-dir)
+          wf-id (java.util.UUID/randomUUID)
+          ts (java.util.Date.)]
+      (try
+        (let [file (write-event-file! dir wf-id
+                     [{:event/type :workflow/started
+                       :event/id (java.util.UUID/randomUUID)
+                       :event/timestamp ts
+                       :event/version "1.0.0"
+                       :event/sequence-number 0
+                       :workflow/id wf-id
+                       :workflow/spec {:name "stale-test"}}])]
+          ;; Set file modification time to 2 hours ago
+          (.setLastModified file (- (System/currentTimeMillis) (* 2 60 60 1000)))
+          (let [wfs (persistence/load-workflows {:dir dir})]
+            (is (= 1 (count wfs)))
+            (is (= :stale (:status (first wfs))))))
+        (finally (cleanup-dir! dir)))))
+
+  (testing "Non-terminal workflow with recent file stays :running"
+    (let [dir (temp-events-dir)
+          wf-id (java.util.UUID/randomUUID)
+          ts (java.util.Date.)]
+      (try
+        (write-event-file! dir wf-id
+          [{:event/type :workflow/started
+            :event/id (java.util.UUID/randomUUID)
+            :event/timestamp ts
+            :event/version "1.0.0"
+            :event/sequence-number 0
+            :workflow/id wf-id
+            :workflow/spec {:name "fresh-test"}}])
+        (let [wfs (persistence/load-workflows {:dir dir})]
+          (is (= 1 (count wfs)))
+          (is (= :running (:status (first wfs)))))
+        (finally (cleanup-dir! dir))))))
+
+(deftest normalize-artifact-type-inference-test
+  (testing "Infers :code type from :code/files key"
+    (let [a (persistence/normalize-artifact {:code/files ["src/foo.clj"]} :implement)]
+      (is (= :code (:type a)))
+      (is (= :implement (:phase a)))
+      (is (string? (:name a)))))
+
+  (testing "Infers :plan type from :plan/tasks key"
+    (let [a (persistence/normalize-artifact {:plan/tasks [{:id :t1}]} :plan)]
+      (is (= :plan (:type a)))))
+
+  (testing "Infers :review type from :review/id key"
+    (let [a (persistence/normalize-artifact {:review/id :r1} :review)]
+      (is (= :review (:type a)))))
+
+  (testing "Preserves explicit :type when set"
+    (let [a (persistence/normalize-artifact {:type :custom :name "my-art"} :build)]
+      (is (= :custom (:type a)))
+      (is (= "my-art" (:name a)))))
+
+  (testing "Non-map artifact gets :unknown type"
+    (let [a (persistence/normalize-artifact (java.util.UUID/randomUUID) :implement)]
+      (is (= :unknown (:type a))))))

--- a/projects/miniforge/test/ai/miniforge/tui_views/persistence_test.clj
+++ b/projects/miniforge/test/ai/miniforge/tui_views/persistence_test.clj
@@ -435,3 +435,46 @@
   (testing "Non-map artifact gets :unknown type"
     (let [a (persistence/normalize-artifact (java.util.UUID/randomUUID) :implement)]
       (is (= :unknown (:type a))))))
+
+;; ──────────────────────────────────────────────────────────────────────────────
+;; Token and cost tracking
+
+(deftest metrics-accumulation-test
+  (testing "Phase-completed events accumulate tokens and cost"
+    (let [wf-id (random-uuid)
+          events [(persistence/workflow-started-event wf-id {:name "test"})
+                  (persistence/phase-started-event wf-id :plan)
+                  (persistence/phase-completed-event wf-id :plan :success nil 5000
+                                                      {:tokens 1200 :cost-usd 0.05})
+                  (persistence/phase-started-event wf-id :implement)
+                  (persistence/phase-completed-event wf-id :implement :success nil 10000
+                                                      {:tokens 3800 :cost-usd 0.12})]
+          detail (persistence/detail-from-events wf-id events)]
+      (is (= 5000 (:tokens detail)))
+      (is (< (abs (- 0.17 (:cost-usd detail))) 0.001))
+      ;; Per-phase metrics
+      (let [plan-phase (first (filter #(= :plan (:phase %)) (:phases detail)))
+            impl-phase (first (filter #(= :implement (:phase %)) (:phases detail)))]
+        (is (= 1200 (:tokens plan-phase)))
+        (is (= 0.05 (:cost-usd plan-phase)))
+        (is (= 3800 (:tokens impl-phase)))
+        (is (= 0.12 (:cost-usd impl-phase))))))
+
+  (testing "Workflow-completed overrides totals when present"
+    (let [wf-id (random-uuid)
+          events [(persistence/workflow-started-event wf-id {:name "test"})
+                  (persistence/phase-completed-event wf-id :plan :success nil 5000
+                                                      {:tokens 1200 :cost-usd 0.05})
+                  (persistence/workflow-completed-event wf-id :success 15000 nil
+                                                         {:tokens 5000 :cost-usd 0.20})]
+          detail (persistence/detail-from-events wf-id events)]
+      (is (= 5000 (:tokens detail)))
+      (is (= 0.20 (:cost-usd detail)))))
+
+  (testing "Zero defaults when no metrics present"
+    (let [wf-id (random-uuid)
+          events [(persistence/workflow-started-event wf-id {:name "test"})
+                  (persistence/phase-completed-event wf-id :plan :success nil 5000)]
+          detail (persistence/detail-from-events wf-id events)]
+      (is (= 0 (:tokens detail)))
+      (is (= 0.0 (:cost-usd detail))))))

--- a/projects/miniforge/test/ai/miniforge/tui_views/persistence_test.clj
+++ b/projects/miniforge/test/ai/miniforge/tui_views/persistence_test.clj
@@ -276,6 +276,92 @@
           (is (= 100 (:progress (first wfs)))))
         (finally (cleanup-dir! dir))))))
 
+(deftest load-workflows-ignores-phase-only-files-test
+  (testing "Phase-only event files are ignored in the top-level workflow list"
+    (let [dir (temp-events-dir)
+          wf-id (java.util.UUID/randomUUID)]
+      (try
+        (write-event-file! dir wf-id
+          [{:event/type :workflow/phase-started
+            :event/id (java.util.UUID/randomUUID)
+            :event/timestamp (java.util.Date.)
+            :event/version "1.0.0"
+            :event/sequence-number 0
+            :workflow/id wf-id
+            :workflow/phase :implement
+            :message "implement phase started"}])
+        (is (= [] (persistence/load-workflows {:dir dir})))
+        (finally (cleanup-dir! dir))))))
+
+(deftest load-workflow-detail-test
+  (testing "Reconstructs phases, agent output, validation, and artifacts from the event file"
+    (let [dir (temp-events-dir)
+          wf-id (java.util.UUID/randomUUID)
+          artifact-id (java.util.UUID/randomUUID)]
+      (try
+        (write-event-file! dir wf-id
+          [{:event/type :workflow/started
+            :event/id (java.util.UUID/randomUUID)
+            :event/timestamp (java.util.Date.)
+            :event/version "1.0.0"
+            :event/sequence-number 0
+            :workflow/id wf-id
+            :workflow/spec {:name "detail-test"}
+            :message "Workflow started"}
+           {:event/type :workflow/phase-started
+            :event/id (java.util.UUID/randomUUID)
+            :event/timestamp (java.util.Date.)
+            :event/version "1.0.0"
+            :event/sequence-number 1
+            :workflow/id wf-id
+            :workflow/phase :implement
+            :message "implement phase started"}
+           {:event/type :agent/status
+            :event/id (java.util.UUID/randomUUID)
+            :event/timestamp (java.util.Date.)
+            :event/version "1.0.0"
+            :event/sequence-number 2
+            :workflow/id wf-id
+            :agent/id :implement
+            :status/type :thinking
+            :message "Thinking"}
+           {:event/type :agent/chunk
+            :event/id (java.util.UUID/randomUUID)
+            :event/timestamp (java.util.Date.)
+            :event/version "1.0.0"
+            :event/sequence-number 3
+            :workflow/id wf-id
+            :agent/id :implement
+            :chunk/delta "hello"}
+           {:event/type :gate/failed
+            :event/id (java.util.UUID/randomUUID)
+            :event/timestamp (java.util.Date.)
+            :event/version "1.0.0"
+            :event/sequence-number 4
+            :workflow/id wf-id
+            :gate/id :lint
+            :message "lint failed"}
+           {:event/type :workflow/phase-completed
+            :event/id (java.util.UUID/randomUUID)
+            :event/timestamp (java.util.Date.)
+            :event/version "1.0.0"
+            :event/sequence-number 5
+            :workflow/id wf-id
+            :workflow/phase :implement
+            :phase/outcome :success
+            :phase/duration-ms 123
+            :phase/artifacts [artifact-id]
+            :message "implement phase success"}])
+        (let [detail (persistence/load-workflow-detail wf-id {:dir dir})]
+          (is (= wf-id (:workflow-id detail)))
+          (is (= :implement (:current-phase detail)))
+          (is (= "hello" (:agent-output detail)))
+          (is (= :thinking (get-in detail [:current-agent :status])))
+          (is (= 1 (count (:phases detail))))
+          (is (= 1 (count (get-in detail [:evidence :validation :results]))))
+          (is (= artifact-id (:id (first (:artifacts detail))))))
+        (finally (cleanup-dir! dir))))))
+
 (deftest load-corrupted-file-test
   (testing "Gracefully handles corrupted event files"
     (let [dir (temp-events-dir)


### PR DESCRIPTION
## Summary

### Commit 1: Stability fixes (workflow detail hydration, PR sync, file subscription)
- Reworked persisted workflow loading to read full event files (not just first/last), reconstructing phases, artifacts, agent output, gates, and duration for detail views
- Excluded DAG child trace files from top-level workflow list (no more phantom "in progress" rows)
- Standalone TUI tracks existing files from EOF instead of replaying all historical events at startup (fixes sluggish boot / non-exitable state)
- PR sync now refreshes active detail row and recomputes filters after sync
- GitHub PR fetch requests `mergedAt`, normalizes merged PRs to `:merged` (not `:closed`)
- Added root update dispatch for agent/gate/tool lifecycle messages

### Commit 2: GitLab state filtering, artifact type inference, stale detection
- GitLab `fetch-prs-by-state` now uses proper state param mapping (`open`/`closed`/`merged`/`all`) instead of hardcoding `state=opened`
- GitLab status mapping distinguishes `:merged` from `:closed`
- `normalize-artifact` infers type from map keys (`:code/files` -> `:code`, `:plan/tasks` -> `:plan`, etc.)
- `derive-status` marks non-terminal workflows as `:stale` when event file is >1hr old
- Kanban groups stale workflows into DONE column and shows counts per column

## Test plan

- [x] 248 brick tests, 858 assertions, 0 failures
- [x] 16 persistence tests (including stale detection, artifact normalization)
- [x] 14 pr-sync tests (including GitLab merged status, state param routing)
- [x] 5 GraalVM compatibility tests, 169 assertions
- [x] `bb build:tui` packages successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)