### PR TITLE
TUI fidelity: caching, group-select, batch commands, light theme

### DIFF
--- a/components/tui-engine/resources/config/tui/key-tokens.edn
+++ b/components/tui-engine/resources/config/tui/key-tokens.edn
@@ -34,6 +34,7 @@
   "e"     :key/e
   "f"     :key/f
   "o"     :key/o
+  "O"     :key/O
   "x"     :key/x
   "a"     :key/a
   "v"     :key/v
@@ -56,5 +57,7 @@
   :arrow-left :key/left
   :arrow-right :key/right
   :tab        :key/tab
-  :reverse-tab :key/shift-tab
-  :eof        :key/eof}}
+  :reverse-tab      :key/shift-tab
+  :shift-arrow-up   :key/shift-up
+  :shift-arrow-down :key/shift-down
+  :eof              :key/eof}}

--- a/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/screen/lanterna.clj
@@ -101,7 +101,8 @@
 
   (poll-input [_]
     (when-let [key (.pollInput screen)]
-      (let [kind (.getKeyType key)]
+      (let [kind (.getKeyType key)
+            shift? (.isShiftDown key)]
         (cond
           (= kind com.googlecode.lanterna.input.KeyType/Character)
           {:type :character :char (.getCharacter key)}
@@ -116,10 +117,10 @@
           {:type :backspace}
 
           (= kind com.googlecode.lanterna.input.KeyType/ArrowUp)
-          {:type :arrow-up}
+          {:type (if shift? :shift-arrow-up :arrow-up)}
 
           (= kind com.googlecode.lanterna.input.KeyType/ArrowDown)
-          {:type :arrow-down}
+          {:type (if shift? :shift-arrow-down :arrow-down)}
 
           (= kind com.googlecode.lanterna.input.KeyType/ArrowLeft)
           {:type :arrow-left}

--- a/components/tui-views/resources/config/tui/keybindings.edn
+++ b/components/tui-views/resources/config/tui/keybindings.edn
@@ -40,11 +40,12 @@
 
   ;; Selection
   :key/space     :action/toggle-or-expand
+  :key/shift-up  :action/select-up
+  :key/shift-down :action/select-down
   :key/v         :action/enter-visual-mode
   :key/a         :action/add-or-select-all
   :key/d         :action/delete-or-noop
-  :key/c         :action/chat-or-clear
-  :key/C         :action/clear-selection
+  :key/c         :action/chat
 
   ;; Filter + Train
   :key/p         :action/enter-filter-mode

--- a/components/tui-views/resources/config/tui/prompts.edn
+++ b/components/tui-views/resources/config/tui/prompts.edn
@@ -45,16 +45,31 @@ Active filter: {{active-filter}}
 {{selected-summary}}"
 
  :fleet-triage/system
- "You are a PR fleet risk analyst. You will receive a list of PRs with their mechanical risk data.
-For EACH PR, provide a risk assessment with:
+ "You are a PR fleet risk analyst. Assess the MERGE RISK of each PR — the likelihood that merging it causes problems (regressions, outages, tech debt, review burden).
+
+For EACH PR, provide a risk assessment:
 - level: low, medium, high, or critical
 - reason: one sentence explaining your assessment
 
-Consider: change size, CI status, whether it's behind main, mechanical risk score, and how PRs interact (e.g., large PRs blocking others = higher fleet risk).
+Risk factors to evaluate (weight heavily):
+- CHANGE SIZE: >500 LOC is large, >1000 LOC is very large. Large PRs are inherently harder to review correctly.
+- FILE SPREAD: Many files across modules = higher architectural risk. Cross-cutting changes are error-prone.
+- TEST COVERAGE: If a large PR adds implementation without proportional test additions, risk is HIGH. New code paths without tests are blind spots.
+- CI STATUS: Failing CI = high risk. Behind main = merge conflict risk.
+- REVIEW STATE: Changes requested = known issues. No reviews yet on a large PR = unvalidated risk.
+- FLEET INTERACTION: PRs blocking others, touching shared code, or conflicting with other open PRs.
+
+Calibration guide:
+- low: <200 LOC, few files, passing CI, has tests, reviewed
+- medium: 200-500 LOC or moderate file spread, but CI passing and reviewed
+- high: >500 LOC, or many files, or missing tests for new code, or CI failing
+- critical: >1000 LOC with missing tests, or CI failing + changes requested, or blocks other PRs
+
+Err on the side of caution. A large PR with passing CI but no new tests is still HIGH risk — CI passing doesn't mean the change is safe, it means existing tests didn't catch problems.
 
 Respond ONLY with one line per PR in this exact format:
 RISK: repo#number | level | reason
 
 Example:
-RISK: owner/repo#42 | high | Large change with failing CI blocks 3 dependent PRs
-RISK: owner/repo#43 | low | Small fix with passing CI, no dependencies"}
+RISK: owner/repo#42 | high | 800 LOC across 21 files with no new test coverage — review blind spots likely
+RISK: owner/repo#43 | low | 50 LOC bugfix with tests, passing CI, already reviewed"}

--- a/components/tui-views/resources/config/tui/screens.edn
+++ b/components/tui-views/resources/config/tui/screens.edn
@@ -37,8 +37,8 @@
      :selection-col? true}
     {:type :node/footer
      :segments
-     {:normal "j/k:nav  Enter:detail  Space:select  v:visual  1-0:views  /:search  ::cmd  q:quit"
-      :selected "{n} selected │ Space:toggle  v:visual  a:all  c:clear  :archive :delete :cancel"
+     {:normal "j/k:nav  Enter:detail  Space:select  Shift+↑↓:range  1-0:views  /:search  ::cmd  q:quit"
+      :selected "{n} selected │ Space:toggle  Shift+↑↓:range  v:visual  a:all  Esc:clear  :archive :delete :cancel"
       :visual "VISUAL │ j/k:extend  Space:toggle  Esc:exit  a:all"
       :filtered "FILTER [{n}] │ Space:select  a:all  v:visual  Esc:clear filter"}}]}}
 
@@ -53,8 +53,7 @@
      :columns [{:key :repo      :header "Repo"      :width 30}
                {:key :number   :header "PR"        :width 6}
                {:key :title    :header "Title"     :width :flex}
-               {:key :state    :header "State"     :width 7}
-               {:key :status   :header "Status"    :width 12}
+               {:key :status   :header "State"     :width 14}
                {:key :ready    :header "Readiness" :width 15}
                {:key :risk     :header "Risk"      :width 6}
                {:key :policy   :header "Policy"    :width 6}
@@ -63,8 +62,8 @@
      :selection-col? true}
     {:type :node/footer
      :segments
-     {:normal "j/k:nav  Enter:detail  O:open  Space:select  p:filter  c:chat  r:sync  /:search  ::cmd  Tab:views  q:quit"
-      :selected "{n} selected │ Space:toggle  v:visual  a:all  c:chat  C:clear  :review :remediate :decompose"
+     {:normal "j/k:nav  Enter:detail  O:open  Shift+↑↓:select  p:filter  c:chat  r:sync  /:search  ::cmd  Tab:views  q:quit"
+      :selected "{n} selected │ Shift+↑↓:range  v:visual  a:all  c:chat  Esc:clear  :approve :merge :review :reject :decompose"
       :visual "VISUAL │ j/k:extend  Space:toggle  Esc:exit  a:all"
       :filtered "FILTER [{n}] │ Space:select  a:all  v:visual  Esc:clear filter"}}]}}
 
@@ -82,7 +81,7 @@
        :children
        [{:type :node/box
          :title "Summary"
-         :child {:type :widget/tree :data-fn :project/pr-summary}}
+         :child {:type :widget/tree :data-fn :project/pr-summary :pane-id 0}}
         {:type :node/split-h
          :ratio 0.5
          :children
@@ -91,16 +90,16 @@
            :children
            [{:type :node/box
              :title "Readiness"
-             :child {:type :widget/tree :data-fn :project/readiness-tree}}
+             :child {:type :widget/tree :data-fn :project/readiness-tree :pane-id 1}}
             {:type :node/box
              :title "Risk"
-             :child {:type :widget/tree :data-fn :project/risk-tree}}]}
+             :child {:type :widget/tree :data-fn :project/risk-tree :pane-id 2}}]}
           {:type :node/box
            :title "Checks & Policy"
-           :child {:type :widget/tree :data-fn :project/gate-list}}]}]}
+           :child {:type :widget/tree :data-fn :project/gate-list :pane-id 3}}]}]}
       {:type :node/box
        :title "Agent"
-       :child {:type :widget/tree :data-fn :project/chat-messages}}]}
+       :child {:type :widget/tree :data-fn :project/chat-messages :pane-id 4}}]}
     {:type :node/footer
      :segments
      {:normal "Esc:back  O:open  c:chat  ←/→:prev/next  Tab:pane  q:quit"}}]}}
@@ -156,8 +155,8 @@
              :selection-col? true}}
     {:type :node/footer
      :segments
-     {:normal "j/k:navigate  Space:select  /:search  Tab:cycle  Esc:back  q:quit"
-      :selected "{n} selected │ Space:toggle  v:visual  a:all  c:clear"
+     {:normal "j/k:navigate  Space:select  Shift+↑↓:range  /:search  Tab:cycle  Esc:back  q:quit"
+      :selected "{n} selected │ Shift+↑↓:range  v:visual  a:all  Esc:clear"
       :visual "VISUAL │ j/k:extend  Space:toggle  Esc:exit  a:all"}}]}}
 
  :dag-kanban
@@ -208,6 +207,6 @@
      :selection-col? true}
     {:type :node/footer
      :segments
-     {:normal "j/k:nav  a:add  d:delete  Space:select  b:browse  f:fleet  r:sync  /:search  Tab:views  q:quit"
-      :selected "{n} selected │ d:delete  Space:toggle  v:visual  C:clear"
+     {:normal "j/k:nav  a:add  d:delete  Space:select  Shift+↑↓:range  b:browse  f:fleet  r:sync  /:search  Tab:views  q:quit"
+      :selected "{n} selected │ d:delete  Shift+↑↓:range  v:visual  Esc:clear"
       :visual "VISUAL │ j/k:extend  Space:toggle  Esc:exit"}}]}}}

--- a/components/tui-views/resources/config/tui/screens.edn
+++ b/components/tui-views/resources/config/tui/screens.edn
@@ -54,7 +54,7 @@
                {:key :number   :header "PR"        :width 6}
                {:key :title    :header "Title"     :width :flex}
                {:key :status   :header "State"     :width 14}
-               {:key :ready    :header "Needs"     :width 15}
+               {:key :ready    :header "Size"      :width 15}
                {:key :risk     :header "Risk"      :width 6}
                {:key :policy   :header "Policy"    :width 6}
                {:key :recommend :header "Recommend" :width 14}]

--- a/components/tui-views/resources/config/tui/screens.edn
+++ b/components/tui-views/resources/config/tui/screens.edn
@@ -54,7 +54,7 @@
                {:key :number   :header "PR"        :width 6}
                {:key :title    :header "Title"     :width :flex}
                {:key :status   :header "State"     :width 14}
-               {:key :ready    :header "Readiness" :width 15}
+               {:key :ready    :header "Needs"     :width 15}
                {:key :risk     :header "Risk"      :width 6}
                {:key :policy   :header "Policy"    :width 6}
                {:key :recommend :header "Recommend" :width 14}]

--- a/components/tui-views/resources/config/tui/screens.edn
+++ b/components/tui-views/resources/config/tui/screens.edn
@@ -63,7 +63,7 @@
     {:type :node/footer
      :segments
      {:normal "j/k:nav  Enter:detail  O:open  Shift+↑↓:select  p:filter  c:chat  r:sync  /:search  ::cmd  Tab:views  q:quit"
-      :selected "{n} selected │ Shift+↑↓:range  v:visual  a:all  c:chat  Esc:clear  :approve :merge :review :reject :decompose"
+      :selected "{n} selected │ Shift+↑↓:range  v:visual  a:all  c:chat  Esc:clear  :review :remediate :decompose"
       :visual "VISUAL │ j/k:extend  Space:toggle  Esc:exit  a:all"
       :filtered "FILTER [{n}] │ Space:select  a:all  v:visual  Esc:clear filter"}}]}}
 

--- a/components/tui-views/src/ai/miniforge/tui_views/effect.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/effect.clj
@@ -89,21 +89,6 @@
   [pr]
   {:type :decompose-pr :pr pr})
 
-(defn approve-prs
-  "Approve a set of PRs (post approval review on GitHub)."
-  [prs]
-  {:type :approve-prs :prs prs})
-
-(defn merge-prs
-  "Merge a set of PRs on GitHub."
-  [prs]
-  {:type :merge-prs :prs prs})
-
-(defn reject-prs
-  "Request changes on a set of PRs (post review with 'changes requested')."
-  [prs]
-  {:type :reject-prs :prs prs})
-
 (defn control-action
   "Create a control action effect to pause/resume/cancel a workflow.
    The effect handler writes a command file to ~/.miniforge/commands/<workflow-id>/."
@@ -127,3 +112,13 @@
   "Persistently archive workflows by moving their event files to archive/."
   [workflow-ids]
   {:type :archive-workflows :workflow-ids workflow-ids})
+
+(defn cache-policy-result
+  "Persist a single PR's policy evaluation result to the disk cache."
+  [pr-id result prs]
+  {:type :cache-policy-result :pr-id pr-id :result result :prs prs})
+
+(defn cache-risk-triage
+  "Persist fleet risk triage results to the disk cache."
+  [risk-map prs]
+  {:type :cache-risk-triage :risk-map risk-map :prs prs})

--- a/components/tui-views/src/ai/miniforge/tui_views/effect.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/effect.clj
@@ -54,6 +54,11 @@
   [pr-id pr]
   {:type :evaluate-policy :pr-id pr-id :pr pr})
 
+(defn batch-evaluate-policy
+  "Evaluate policy for multiple PRs that don't have evaluation results."
+  [prs]
+  {:type :batch-evaluate-policy :prs prs})
+
 (defn create-train
   "Create a new merge train with the given name."
   [train-name]
@@ -83,6 +88,21 @@
   "Analyze a PR for decomposition into sub-PRs."
   [pr]
   {:type :decompose-pr :pr pr})
+
+(defn approve-prs
+  "Approve a set of PRs (post approval review on GitHub)."
+  [prs]
+  {:type :approve-prs :prs prs})
+
+(defn merge-prs
+  "Merge a set of PRs on GitHub."
+  [prs]
+  {:type :merge-prs :prs prs})
+
+(defn reject-prs
+  "Request changes on a set of PRs (post review with 'changes requested')."
+  [prs]
+  {:type :reject-prs :prs prs})
 
 (defn control-action
   "Create a control action effect to pause/resume/cancel a workflow.

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -34,6 +34,7 @@
    [ai.miniforge.tui-views.file-subscription :as file-subscription]
    [ai.miniforge.tui-views.persistence :as persistence]
    [ai.miniforge.tui-views.persistence.pr :as persistence-pr]
+   [ai.miniforge.tui-views.persistence.pr-cache :as pr-cache]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.policy-pack.interface :as policy-pack]
    [ai.miniforge.pr-train.interface :as pr-train]
@@ -44,8 +45,11 @@
 ;; Side-effect handlers — each returns [msg-type payload] or nil
 
 (defn handle-sync-prs [{:keys [state]}]
-  (let [{:keys [prs error]} (persistence-pr/load-pr-items (when state {:state state}))]
-    (msg/prs-synced (or prs []) error)))
+  (let [{:keys [prs error]} (persistence-pr/load-pr-items (when state {:state state}))
+        cache (pr-cache/read-cache)
+        prs-with-cache (pr-cache/apply-cached-policy (or prs []) cache)
+        cached-risk (pr-cache/apply-cached-agent-risk (or prs []) cache)]
+    (msg/prs-synced-with-cache prs-with-cache cached-risk error)))
 
 (defn handle-discover-repos [{:keys [owner]}]
   (msg/repos-discovered (persistence-pr/discover-repos owner)))
@@ -148,23 +152,13 @@
                              {:sub-prs []
                               :message "Decomposition analysis not yet wired"}))
 
-(defn handle-approve-prs [{:keys [prs]}]
-  ;; TODO: Wire to pr-lifecycle/approve-pr (GitHub API)
-  (msg/chat-action-result
-   {:success? false
-    :message (str "Approve " (count prs) " PR(s): not yet wired to GitHub API")}))
+(defn handle-cache-policy-result [{:keys [pr-id result prs]}]
+  (pr-cache/persist-policy-result! pr-id result prs)
+  nil)
 
-(defn handle-merge-prs [{:keys [prs]}]
-  ;; TODO: Wire to pr-lifecycle/merge-pr (GitHub API)
-  (msg/chat-action-result
-   {:success? false
-    :message (str "Merge " (count prs) " PR(s): not yet wired to GitHub API")}))
-
-(defn handle-reject-prs [{:keys [prs]}]
-  ;; TODO: Wire to pr-lifecycle/request-changes (GitHub API)
-  (msg/chat-action-result
-   {:success? false
-    :message (str "Reject " (count prs) " PR(s): not yet wired to GitHub API")}))
+(defn handle-cache-risk-triage [{:keys [risk-map prs]}]
+  (pr-cache/persist-risk-triage! risk-map prs)
+  nil)
 
 (defn handle-control-action [{:keys [action workflow-id]}]
   (let [commands-dir (io/file (System/getProperty "user.home")
@@ -423,11 +417,10 @@
     :create-train      (handle-create-train train-mgr effect)
     :add-to-train      (handle-add-to-train train-mgr effect)
     :merge-next        (handle-merge-next train-mgr effect)
-    :approve-prs       (handle-approve-prs effect)
-    :merge-prs         (handle-merge-prs effect)
     :review-prs        (handle-review-prs effect)
-    :reject-prs        (handle-reject-prs effect)
     :remediate-prs     (handle-remediate-prs effect)
+    :cache-policy-result (handle-cache-policy-result effect)
+    :cache-risk-triage   (handle-cache-risk-triage effect)
     :decompose-pr      (handle-decompose-pr effect)
     :control-action    (handle-control-action effect)
     :archive-workflows (handle-archive-workflows effect)

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -69,6 +69,25 @@
                             {:evaluation/passed? nil
                              :evaluation/error (.getMessage e)}))))
 
+(defn handle-batch-evaluate-policy
+  "Evaluate policy for multiple PRs in batch.
+   Returns a single :msg/review-completed message with all results,
+   reusing the existing review-completed handler to merge policy data."
+  [{:keys [prs]}]
+  (try
+    (let [packs (persistence-pr/load-policy-packs)]
+      (msg/review-completed
+       (mapv (fn [pr]
+               {:pr-id  [(:pr/repo pr) (:pr/number pr)]
+                :result (try
+                          (policy-pack/evaluate-external-pr packs pr)
+                          (catch Exception e
+                            {:evaluation/passed? nil
+                             :evaluation/error (.getMessage e)}))})
+             prs)))
+    (catch Exception e
+      (msg/review-completed []))))
+
 (defn handle-create-train [train-mgr {:keys [name description]
                                        :or {description ""}}]
   (try
@@ -128,6 +147,24 @@
   (msg/decomposition-started [(:pr/repo pr) (:pr/number pr)]
                              {:sub-prs []
                               :message "Decomposition analysis not yet wired"}))
+
+(defn handle-approve-prs [{:keys [prs]}]
+  ;; TODO: Wire to pr-lifecycle/approve-pr (GitHub API)
+  (msg/chat-action-result
+   {:success? false
+    :message (str "Approve " (count prs) " PR(s): not yet wired to GitHub API")}))
+
+(defn handle-merge-prs [{:keys [prs]}]
+  ;; TODO: Wire to pr-lifecycle/merge-pr (GitHub API)
+  (msg/chat-action-result
+   {:success? false
+    :message (str "Merge " (count prs) " PR(s): not yet wired to GitHub API")}))
+
+(defn handle-reject-prs [{:keys [prs]}]
+  ;; TODO: Wire to pr-lifecycle/request-changes (GitHub API)
+  (msg/chat-action-result
+   {:success? false
+    :message (str "Reject " (count prs) " PR(s): not yet wired to GitHub API")}))
 
 (defn handle-control-action [{:keys [action workflow-id]}]
   (let [commands-dir (io/file (System/getProperty "user.home")
@@ -382,10 +419,14 @@
     :browse-repos      (handle-browse-repos effect)
     :open-url          (handle-open-url effect)
     :evaluate-policy   (handle-evaluate-policy effect)
+    :batch-evaluate-policy (handle-batch-evaluate-policy effect)
     :create-train      (handle-create-train train-mgr effect)
     :add-to-train      (handle-add-to-train train-mgr effect)
     :merge-next        (handle-merge-next train-mgr effect)
+    :approve-prs       (handle-approve-prs effect)
+    :merge-prs         (handle-merge-prs effect)
     :review-prs        (handle-review-prs effect)
+    :reject-prs        (handle-reject-prs effect)
     :remediate-prs     (handle-remediate-prs effect)
     :decompose-pr      (handle-decompose-pr effect)
     :control-action    (handle-control-action effect)

--- a/components/tui-views/src/ai/miniforge/tui_views/msg.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/msg.clj
@@ -33,6 +33,14 @@
   ([pr-items error] [:msg/prs-synced (cond-> {:pr-items pr-items}
                                        error (assoc :error error))]))
 
+(defn prs-synced-with-cache
+  "Like prs-synced but includes pre-loaded cache data so the reducer
+   doesn't need to perform filesystem IO."
+  [pr-items cached-risk error]
+  [:msg/prs-synced (cond-> {:pr-items pr-items
+                            :cached-risk cached-risk}
+                     error (assoc :error error))])
+
 (defn repos-discovered [result]
   [:msg/repos-discovered result])
 

--- a/components/tui-views/src/ai/miniforge/tui_views/palette.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/palette.clj
@@ -1,0 +1,35 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.palette
+  "Shared RGB color palette for TUI views.
+
+   Fixed status colors with good contrast on both light and dark terminal
+   backgrounds. ANSI keywords are terminal-dependent, so these use explicit
+   RGB triples to guarantee consistent appearance.
+
+   All view namespaces that need status or accent colors should reference
+   these defs rather than inlining RGB literals.")
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Semantic status colors — fixed RGB values
+
+(def status-pass    [0 180 80])      ;; medium green
+(def status-fail    [220 50 40])     ;; medium red
+(def status-warning [200 160 0])     ;; darker yellow/gold
+(def status-info    [0 150 180])     ;; teal/darker cyan

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence/pr.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence/pr.clj
@@ -29,6 +29,7 @@
    [clojure.java.io :as io]
    [ai.miniforge.tui-views.model :as model]
    [ai.miniforge.tui-views.persistence :as persistence]
+   [ai.miniforge.tui-views.persistence.pr-cache :as pr-cache]
    [ai.miniforge.pr-sync.interface :as pr-sync]
    [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.policy-pack.interface :as policy-pack]))
@@ -125,6 +126,8 @@
 
 (defn load-pr-items-into-model
   "Load PRs from configured repos and merge into model.
+   Applies cached policy and risk analysis results to avoid re-running
+   expensive evaluations on startup.
 
    Arguments:
    - model - The TUI model
@@ -132,14 +135,23 @@
 
    Returns: Updated model with :pr-items populated."
   [model & [opts]]
-  (let [{:keys [prs error]} (load-pr-items opts)]
+  (let [{:keys [prs error]} (load-pr-items opts)
+        cache (pr-cache/read-cache)]
     (cond
       (seq prs)
-      (-> model
-          (assoc :pr-items (vec prs))
-          (assoc :last-updated (java.util.Date.))
-          (assoc :flash-message (str "Loaded " (count prs) " PRs from "
-                                     (count (distinct (map :pr/repo prs))) " repo(s)")))
+      (let [prs-with-cache (pr-cache/apply-cached-policy prs cache)
+            cached-risk (pr-cache/apply-cached-agent-risk prs cache)
+            cache-hits (count (filter :pr/policy prs-with-cache))
+            fresh (- (count prs-with-cache) cache-hits)]
+        (-> model
+            (assoc :pr-items (vec prs-with-cache))
+            (cond-> (seq cached-risk) (assoc :agent-risk cached-risk))
+            (assoc :last-updated (java.util.Date.))
+            (assoc :flash-message
+                   (str "Loaded " (count prs) " PRs from "
+                        (count (distinct (map :pr/repo prs))) " repo(s)"
+                        (when (pos? cache-hits)
+                          (str " (" cache-hits " cached, " fresh " need eval)"))))))
 
       error
       (assoc model :flash-message (str "PR sync failed: " error))

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence/pr_cache.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence/pr_cache.clj
@@ -1,0 +1,181 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.persistence.pr-cache
+  "Disk-backed cache for PR analysis results (risk triage, policy evaluation).
+
+   Avoids re-running expensive LLM-based risk triage and policy gate checks
+   on every TUI session. Results are cached per-PR, keyed by [repo, pr-number],
+   and invalidated when the PR's fingerprint (additions, deletions, status,
+   ci-status, head-sha) changes.
+
+   Cache file: ~/.miniforge/cache/pr-analysis.edn
+
+   Layer 0: Fingerprint + cache entry helpers
+   Layer 1: Read/write cache file
+   Layer 2: Apply cache to model, persist from model"
+  (:require
+   [clojure.java.io :as io]
+   [clojure.edn :as edn]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Fingerprint + cache entry helpers
+
+(defn pr-fingerprint
+  "Compute a fingerprint for a PR that determines cache validity.
+   When any of these fields change, cached analysis is stale."
+  [pr]
+  {:additions  (get pr :pr/additions 0)
+   :deletions  (get pr :pr/deletions 0)
+   :status     (get pr :pr/status)
+   :ci-status  (get pr :pr/ci-status)
+   :head-sha   (get pr :pr/head-sha)})
+
+(defn pr-cache-key
+  "Canonical cache key for a PR: [repo-string, pr-number]."
+  [pr]
+  [(:pr/repo pr) (:pr/number pr)])
+
+(defn cache-entry
+  "Build a cache entry for a PR with its current analysis results."
+  [pr & [{:keys [agent-risk]}]]
+  (let [fp (pr-fingerprint pr)]
+    (cond-> {:fingerprint fp
+             :cached-at   (System/currentTimeMillis)}
+      (:pr/policy pr)
+      (assoc :policy (:pr/policy pr))
+      agent-risk
+      (assoc :agent-risk agent-risk))))
+
+(defn entry-valid?
+  "True when a cache entry's fingerprint matches the current PR."
+  [entry pr]
+  (= (:fingerprint entry) (pr-fingerprint pr)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Read/write cache file
+
+(def ^:private cache-dir-path
+  "Default cache directory."
+  (delay (io/file (System/getProperty "user.home") ".miniforge" "cache")))
+
+(defn cache-file
+  "Returns the cache file path."
+  [& [{:keys [dir]}]]
+  (io/file (or dir @cache-dir-path) "pr-analysis.edn"))
+
+(defn read-cache
+  "Read the PR analysis cache from disk. Returns map of {[repo num] -> entry}."
+  [& [opts]]
+  (let [f (cache-file opts)]
+    (if (.exists f)
+      (try
+        (let [data (edn/read-string (slurp f))]
+          (if (map? data) data {}))
+        (catch Exception _ {}))
+      {})))
+
+(defn write-cache!
+  "Write the PR analysis cache to disk. Runs in a future to avoid blocking."
+  [entries & [opts]]
+  (future
+    (try
+      (let [f (cache-file opts)]
+        (.mkdirs (.getParentFile f))
+        (spit f (pr-str entries)))
+      (catch Exception _ nil)))
+  nil)
+
+;------------------------------------------------------------------------------ Layer 2
+;; Apply cache to model, persist from model
+
+(defn apply-cached-policy
+  "Apply cached policy results to PRs that haven't been evaluated yet.
+   Only applies when the cache entry's fingerprint matches the current PR."
+  [prs cache]
+  (mapv (fn [pr]
+          (if (:pr/policy pr)
+            pr ;; already evaluated, don't override
+            (let [k (pr-cache-key pr)
+                  entry (get cache k)]
+              (if (and entry (entry-valid? entry pr) (:policy entry))
+                (assoc pr :pr/policy (:policy entry))
+                pr))))
+        prs))
+
+(defn apply-cached-agent-risk
+  "Extract cached agent-risk entries into a {[repo num] -> risk-map} map.
+   Only includes entries whose fingerprint matches a current PR."
+  [prs cache]
+  (reduce (fn [acc pr]
+            (let [k (pr-cache-key pr)
+                  entry (get cache k)]
+              (if (and entry (entry-valid? entry pr) (:agent-risk entry))
+                (assoc acc k (:agent-risk entry))
+                acc)))
+          {}
+          prs))
+
+(defn persist-analysis!
+  "Persist current PR analysis results to the cache file.
+   Merges with existing cache to preserve entries for PRs not currently loaded."
+  [prs agent-risk & [opts]]
+  (let [existing (read-cache opts)
+        updated (reduce (fn [cache pr]
+                          (let [k (pr-cache-key pr)
+                                risk (get agent-risk k)]
+                            (if (or (:pr/policy pr) risk)
+                              (assoc cache k (cache-entry pr {:agent-risk risk}))
+                              cache)))
+                        existing
+                        prs)]
+    (write-cache! updated opts)))
+
+(defn persist-policy-result!
+  "Persist a single PR's policy evaluation result to the cache."
+  [pr-id policy-result prs & [opts]]
+  (let [[repo number] pr-id
+        pr (some #(when (and (= (:pr/repo %) repo)
+                             (= (:pr/number %) number))
+                    %)
+                 prs)]
+    (when pr
+      (let [existing (read-cache opts)
+            k pr-id
+            entry (-> (or (get existing k) {})
+                      (assoc :fingerprint (pr-fingerprint pr)
+                             :cached-at (System/currentTimeMillis)
+                             :policy policy-result))]
+        (write-cache! (assoc existing k entry) opts)))))
+
+(defn persist-risk-triage!
+  "Persist fleet risk triage results to the cache."
+  [assessments prs & [opts]]
+  (let [existing (read-cache opts)
+        pr-by-key (into {} (map (fn [pr] [(pr-cache-key pr) pr]) prs))
+        updated (reduce (fn [cache [k risk]]
+                          (if-let [pr (get pr-by-key k)]
+                            (let [entry (-> (or (get cache k) {})
+                                           (assoc :fingerprint (pr-fingerprint pr)
+                                                  :cached-at (System/currentTimeMillis)
+                                                  :agent-risk risk))]
+                              (assoc cache k entry))
+                            cache))
+                        existing
+                        assessments)]
+    (write-cache! updated opts)))

--- a/components/tui-views/src/ai/miniforge/tui_views/schema.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/schema.clj
@@ -28,7 +28,7 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Risk levels used by both mechanical and agent risk
 
-(def risk-levels [:enum :low :medium :high :critical :unknown])
+(def risk-levels [:enum :low :medium :high :critical :unknown :unevaluated])
 
 ;------------------------------------------------------------------------------ Layer 0a
 ;; Agent risk assessment (from fleet-level LLM triage)

--- a/components/tui-views/src/ai/miniforge/tui_views/update.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update.clj
@@ -209,10 +209,10 @@
     (sel/toggle-selection model)
     (nav/toggle-expand model)))
 
-(defn handle-chat-or-clear [model]
+(defn handle-chat [model]
   (if (#{:pr-fleet :pr-detail} (:view model))
     (chat/enter model)
-    (sel/clear-selection model)))
+    model))
 
 (defn handle-train-view [model]
   (if (:active-train-id model)
@@ -325,7 +325,8 @@
    :action/enter-filter-mode  mode/enter-filter-mode
    :action/next-search-match  nav/next-search-match
    :action/prev-search-match  nav/prev-search-match
-   :action/clear-selection    sel/clear-selection
+   :action/select-up          sel/select-up
+   :action/select-down        sel/select-down
    :action/evidence-view      nav-to-evidence
    :action/toggle-help        nav/toggle-help
    :action/quit               handle-quit})
@@ -335,7 +336,7 @@
   {:action/enter-or-confirm   handle-enter-or-confirm
    :action/escape-cascade     handle-escape-cascade
    :action/toggle-or-expand   handle-toggle-or-expand
-   :action/chat-or-clear      handle-chat-or-clear
+   :action/chat               handle-chat
    :action/train-view         handle-train-view
    :action/refresh-or-sync    handle-refresh-or-sync
    :action/sync               handle-sync
@@ -539,13 +540,14 @@
       ;; User input
       :input
       (if (:confirm model)
-        ;; Confirmation prompt active -- only y/n/escape accepted
+        ;; Confirmation prompt active -- Y(es) / C(ancel) / Esc
         (let [k (extract-key payload)]
           (case k
             :key/y     (-> model
                            (command/execute-confirmed-action)
                            (assoc :confirm nil))
             :key/n     (assoc model :confirm nil :flash-message "Cancelled")
+            :key/c     (assoc model :confirm nil :flash-message "Cancelled")
             :key/escape (assoc model :confirm nil :flash-message "Cancelled")
             model))
         ;; Normal input routing by mode

--- a/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
@@ -390,10 +390,7 @@
                                         #(= :running (:status %)))
       :remove-repos (confirm-remove-repos model ids)
       ;; Batch PR actions
-      :approve   (batch-pr-action model ids "Approving" effect/approve-prs)
-      :merge     (batch-pr-action model ids "Merging" effect/merge-prs)
       :review    (batch-pr-action model ids "Reviewing" effect/review-prs)
-      :reject    (batch-pr-action model ids "Rejecting" effect/reject-prs)
       :remediate (batch-pr-action model ids "Remediating" effect/remediate-prs)
       :decompose (let [pr (first (selected-prs model ids))]
                    (if pr
@@ -474,14 +471,8 @@
    "merge-next"    {:handler cmd-merge-next    :help "Merge next ready PR in active train"}
    "train"         {:handler cmd-train         :help "Switch to train view"}
    ;; Batch actions
-   "approve"       {:handler (fn [m _] (request-confirmation m :approve "Approve"))
-                    :help "Approve selected PRs on GitHub"}
-   "merge"         {:handler (fn [m _] (request-confirmation m :merge "Merge"))
-                    :help "Merge selected PRs on GitHub"}
    "review"        {:handler (fn [m _] (request-confirmation m :review "Review"))
                     :help "Evaluate policy and post review for selected PRs"}
-   "reject"        {:handler (fn [m _] (request-confirmation m :reject "Reject"))
-                    :help "Request changes on selected PRs"}
    "remediate"     {:handler (fn [m _] (request-confirmation m :remediate "Remediate"))
                     :help "Auto-fix policy violations for selected PRs"}
    "decompose"     {:handler (fn [m _]

--- a/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/command.clj
@@ -390,7 +390,10 @@
                                         #(= :running (:status %)))
       :remove-repos (confirm-remove-repos model ids)
       ;; Batch PR actions
+      :approve   (batch-pr-action model ids "Approving" effect/approve-prs)
+      :merge     (batch-pr-action model ids "Merging" effect/merge-prs)
       :review    (batch-pr-action model ids "Reviewing" effect/review-prs)
+      :reject    (batch-pr-action model ids "Rejecting" effect/reject-prs)
       :remediate (batch-pr-action model ids "Remediating" effect/remediate-prs)
       :decompose (let [pr (first (selected-prs model ids))]
                    (if pr
@@ -471,8 +474,14 @@
    "merge-next"    {:handler cmd-merge-next    :help "Merge next ready PR in active train"}
    "train"         {:handler cmd-train         :help "Switch to train view"}
    ;; Batch actions
+   "approve"       {:handler (fn [m _] (request-confirmation m :approve "Approve"))
+                    :help "Approve selected PRs on GitHub"}
+   "merge"         {:handler (fn [m _] (request-confirmation m :merge "Merge"))
+                    :help "Merge selected PRs on GitHub"}
    "review"        {:handler (fn [m _] (request-confirmation m :review "Review"))
-                    :help "Evaluate policy for selected PRs"}
+                    :help "Evaluate policy and post review for selected PRs"}
+   "reject"        {:handler (fn [m _] (request-confirmation m :reject "Reject"))
+                    :help "Request changes on selected PRs"}
    "remediate"     {:handler (fn [m _] (request-confirmation m :remediate "Remediate"))
                     :help "Auto-fix policy violations for selected PRs"}
    "decompose"     {:handler (fn [m _]

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.tui-views.effect :as effect]
    [ai.miniforge.tui-views.model :as model]
    [ai.miniforge.tui-views.persistence :as persistence]
+   [ai.miniforge.tui-views.persistence.pr-cache :as pr-cache]
    [ai.miniforge.tui-views.update.filter :as filter]))
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -436,8 +437,10 @@
    Preserves the current selection position, clamping to new bounds."
   [model {:keys [pr-items error]}]
   (let [wf-pr-idx (get model :workflow-pr-index {})
-        prs (mapv (partial annotate-pr-with-workflow wf-pr-idx)
-                  (or pr-items []))
+        cache (pr-cache/read-cache)
+        raw-prs (mapv (partial annotate-pr-with-workflow wf-pr-idx)
+                      (or pr-items []))
+        prs (pr-cache/apply-cached-policy raw-prs cache)
         active-pr (get-in model [:detail :selected-pr])
         refreshed-pr (when active-pr
                        (some #(when (pr-match? (:pr/repo active-pr)
@@ -468,14 +471,24 @@
                              :else
                              "No PRs found in fleet repos"))
                     with-timestamp)
+        ;; Apply cached agent-risk if model doesn't have any yet
+        cached-risk (when (empty? (:agent-risk model))
+                      (pr-cache/apply-cached-agent-risk prs cache))
+        updated (cond-> updated
+                  (seq cached-risk) (assoc :agent-risk cached-risk))
         pr-hash (hash (mapv #(select-keys % [:pr/repo :pr/number :pr/additions
                                               :pr/deletions :pr/status :pr/ci-status])
                             prs))]
-    (if (and (seq prs) (not= pr-hash (:agent-risk-hash model)))
-      (-> updated
-          (assoc :agent-risk-hash pr-hash)
-          (assoc :side-effect (effect/fleet-risk-triage (mapv pr-triage-summary prs))))
-      updated)))
+    (let [risk-changed? (and (seq prs) (not= pr-hash (:agent-risk-hash model)))
+          unevaluated-prs (filterv #(nil? (:pr/policy %)) prs)
+          effects (cond-> []
+                    risk-changed?
+                    (conj (effect/fleet-risk-triage (mapv pr-triage-summary prs)))
+                    (seq unevaluated-prs)
+                    (conj (effect/batch-evaluate-policy unevaluated-prs)))]
+      (cond-> updated
+        risk-changed?    (assoc :agent-risk-hash pr-hash)
+        (seq effects)    (assoc :side-effects effects)))))
 
 (defn merge-matching-pr
   "Merge updated fields into the PR matching [repo, number]; pass others through."
@@ -524,6 +537,8 @@
                        (= (:pr/number active-pr) number))
                 (assoc-in model [:detail :selected-pr :pr/policy] result)
                 model)]
+    ;; Persist to disk cache (async, non-blocking)
+    (pr-cache/persist-policy-result! pr-id result (:pr-items model))
     (-> model
         (assoc :flash-message
                (if (:evaluation/passed? result)
@@ -581,6 +596,9 @@
                           (:pr-items model []))
         passed (count (filter #(get-in % [:result :evaluation/passed?]) results))
         failed (- (count results) passed)]
+    ;; Persist all policy results to disk cache (async)
+    (doseq [{:keys [pr-id result]} results]
+      (pr-cache/persist-policy-result! pr-id result updated-prs))
     (-> model
         (assoc :pr-items updated-prs)
         (assoc :flash-message (str "Review complete: " passed " passed, " failed " with violations"))
@@ -705,6 +723,9 @@
     (-> model
         (assoc :flash-message (str "Risk triage: " error))
         with-timestamp)
-    (-> model
-        (assoc :agent-risk (assessments->risk-map assessments))
-        with-timestamp)))
+    (let [risk-map (assessments->risk-map assessments)]
+      ;; Persist to disk cache (async, non-blocking)
+      (pr-cache/persist-risk-triage! risk-map (:pr-items model))
+      (-> model
+          (assoc :agent-risk risk-map)
+          with-timestamp))))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -22,11 +22,12 @@
    Pure functions that handle workflow events from the event stream.
    Layer 2."
   (:require
+   [clojure.string]
    [ai.miniforge.tui-views.effect :as effect]
    [ai.miniforge.tui-views.model :as model]
    [ai.miniforge.tui-views.persistence :as persistence]
-   [ai.miniforge.tui-views.persistence.pr-cache :as pr-cache]
-   [ai.miniforge.tui-views.update.filter :as filter]))
+   [ai.miniforge.tui-views.update.filter :as filter]
+   [ai.miniforge.tui-views.view.project.helpers :as helpers]))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Event stream message handlers
@@ -410,19 +411,29 @@
 ;; PR event handlers
 
 (defn build-pr-summary-for-triage
-  "Build a compact text summary of a PR for fleet-level risk triage."
+  "Build a compact text summary of a PR for fleet-level risk triage.
+   Always includes the mechanical risk assessment so the triage agent
+   can use it as one input signal."
   [pr]
-  (let [risk (:pr/risk pr)
-        adds (get pr :pr/additions 0)
-        dels (get pr :pr/deletions 0)]
+  (let [risk  (or (:pr/risk pr)
+                  (helpers/derive-risk pr))
+        adds  (get pr :pr/additions 0)
+        dels  (get pr :pr/deletions 0)
+        total (+ adds dels)
+        files (get pr :pr/changed-files-count 0)
+        behind? (:pr/behind-main? pr false)
+        factors (mapv :factor (:risk/factors risk []))]
     (cond-> (str (:pr/repo pr) "#" (:pr/number pr)
                  " \"" (:pr/title pr) "\""
                  " | " (name (get pr :pr/status :unknown))
                  " | ci:" (name (get pr :pr/ci-status :unknown))
-                 " | +" adds "/-" dels
-                 (when risk
-                   (str " | risk:" (name (get risk :risk/level :unknown))
-                        " (" (format "%.0f" (* 100.0 (get risk :risk/score 0))) "%)")))
+                 " | +" adds "/-" dels " (" total " LOC)"
+                 " | " files " files"
+                 (when behind? " | behind-main")
+                 " | mech-risk:" (name (get risk :risk/level :unknown))
+                 " (score " (format "%.2f" (double (get risk :risk/score 0))) ")"
+                 (when (seq factors)
+                   (str " [" (clojure.string/join ", " (map name factors)) "]")))
       (:pr/workflow-id pr) (str " | miniforge-sourced"))))
 
 (defn pr-triage-summary
@@ -434,13 +445,13 @@
 (defn handle-prs-synced
   "Handle result of a :sync-prs side effect.
    Replaces :pr-items with freshly fetched data.
-   Preserves the current selection position, clamping to new bounds."
-  [model {:keys [pr-items error]}]
+   Preserves the current selection position, clamping to new bounds.
+   Cache data (policy and risk) is pre-loaded by the effect handler
+   and passed in via the :cached-risk key in the payload."
+  [model {:keys [pr-items cached-risk error]}]
   (let [wf-pr-idx (get model :workflow-pr-index {})
-        cache (pr-cache/read-cache)
-        raw-prs (mapv (partial annotate-pr-with-workflow wf-pr-idx)
-                      (or pr-items []))
-        prs (pr-cache/apply-cached-policy raw-prs cache)
+        prs (mapv (partial annotate-pr-with-workflow wf-pr-idx)
+                  (or pr-items []))
         active-pr (get-in model [:detail :selected-pr])
         refreshed-pr (when active-pr
                        (some #(when (pr-match? (:pr/repo active-pr)
@@ -471,11 +482,10 @@
                              :else
                              "No PRs found in fleet repos"))
                     with-timestamp)
-        ;; Apply cached agent-risk if model doesn't have any yet
-        cached-risk (when (empty? (:agent-risk model))
-                      (pr-cache/apply-cached-agent-risk prs cache))
+        ;; Apply pre-loaded cached agent-risk if model doesn't have any yet
         updated (cond-> updated
-                  (seq cached-risk) (assoc :agent-risk cached-risk))
+                  (and (empty? (:agent-risk model)) (seq cached-risk))
+                  (assoc :agent-risk cached-risk))
         pr-hash (hash (mapv #(select-keys % [:pr/repo :pr/number :pr/additions
                                               :pr/deletions :pr/status :pr/ci-status])
                             prs))]
@@ -537,8 +547,6 @@
                        (= (:pr/number active-pr) number))
                 (assoc-in model [:detail :selected-pr :pr/policy] result)
                 model)]
-    ;; Persist to disk cache (async, non-blocking)
-    (pr-cache/persist-policy-result! pr-id result (:pr-items model))
     (-> model
         (assoc :flash-message
                (if (:evaluation/passed? result)
@@ -549,6 +557,7 @@
                         (str "FAILED ("
                              (count (:evaluation/violations result))
                              " violation(s))")))))
+        (assoc :side-effect (effect/cache-policy-result pr-id result (:pr-items model)))
         with-timestamp)))
 
 ;------------------------------------------------------------------------------ Layer 3b
@@ -596,12 +605,13 @@
                           (:pr-items model []))
         passed (count (filter #(get-in % [:result :evaluation/passed?]) results))
         failed (- (count results) passed)]
-    ;; Persist all policy results to disk cache (async)
-    (doseq [{:keys [pr-id result]} results]
-      (pr-cache/persist-policy-result! pr-id result updated-prs))
     (-> model
         (assoc :pr-items updated-prs)
         (assoc :flash-message (str "Review complete: " passed " passed, " failed " with violations"))
+        (assoc :side-effects
+               (mapv (fn [{:keys [pr-id result]}]
+                       (effect/cache-policy-result pr-id result updated-prs))
+                     results))
         with-timestamp)))
 
 (defn handle-remediation-completed
@@ -724,8 +734,7 @@
         (assoc :flash-message (str "Risk triage: " error))
         with-timestamp)
     (let [risk-map (assessments->risk-map assessments)]
-      ;; Persist to disk cache (async, non-blocking)
-      (pr-cache/persist-risk-triage! risk-map (:pr-items model))
       (-> model
           (assoc :agent-risk risk-map)
+          (assoc :side-effect (effect/cache-risk-triage risk-map (:pr-items model)))
           with-timestamp))))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
@@ -308,6 +308,46 @@
   (some (fn [[i wf]] (when (= (:id wf) wf-id) i))
         (map-indexed vector workflows)))
 
+(defn- switch-pr-detail
+  "Switch the PR detail view to a different PR.
+   Resets pane state, expanded nodes, and loads the correct chat thread.
+   Triggers auto-analysis if the PR has no existing chat thread."
+  [model pr]
+  (let [pr-id  [(:pr/repo pr) (:pr/number pr)]
+        base   (-> model
+                   (assoc-in [:detail :selected-pr] pr)
+                   (assoc-in [:detail :expanded-nodes] #{0})
+                   (pane/init-pane-state)
+                   (assoc :selected-idx 0))
+        tk     (chat/chat-thread-key base)
+        thread (get-in base [:chat-threads tk])
+        fresh? (or (nil? thread) (empty? (:messages thread)))
+        ;; Load existing thread into active :chat, or set up for auto-analysis
+        base   (if fresh?
+                 (-> base
+                     (assoc-in [:chat :messages]
+                               [{:role :user
+                                 :content "Briefly analyze this PR: risk, readiness, and key concerns. Suggest 2-3 actions."
+                                 :timestamp (java.util.Date.)}])
+                     (assoc-in [:chat :pending?] true)
+                     (assoc-in [:chat :pending-since] (System/currentTimeMillis))
+                     (assoc-in [:chat :context] (chat/pr-detail-context base))
+                     (assoc :chat-active-key tk))
+                 (-> base
+                     (assoc :chat (assoc thread :pending? false))
+                     (assoc :chat-active-key tk)))
+        effects (cond-> []
+                  (nil? (:pr/policy pr))
+                  (conj (effect/evaluate-policy pr-id pr))
+                  fresh?
+                  (conj (let [context (chat/pr-detail-context base)
+                              auto-msg "Briefly analyze this PR: risk, readiness, and key concerns. Suggest 2-3 actions."
+                              user-msg {:role :user :content auto-msg :timestamp (java.util.Date.)}]
+                          (effect/chat-send context auto-msg [user-msg]))))]
+    (cond-> base
+      (seq effects)
+      (assoc :side-effects effects))))
+
 (defn navigate-prev-item
   "Navigate to the previous item's detail view.
    In workflow detail/evidence/artifact-browser: show previous workflow.
@@ -335,10 +375,7 @@
                             (map-indexed vector prs))
           prev-idx (when current-idx (dec current-idx))]
       (if (and prev-idx (>= prev-idx 0))
-        (let [pr (get prs prev-idx)]
-          (-> model
-              (assoc-in [:detail :selected-pr] pr)
-              (assoc :selected-idx 0)))
+        (switch-pr-detail model (get prs prev-idx))
         model))
 
     ;; Non-detail views: no-op
@@ -371,10 +408,7 @@
                             (map-indexed vector prs))
           next-idx (when current-idx (inc current-idx))]
       (if (and next-idx (< next-idx (count prs)))
-        (let [pr (get prs next-idx)]
-          (-> model
-              (assoc-in [:detail :selected-pr] pr)
-              (assoc :selected-idx 0)))
+        (switch-pr-detail model (get prs next-idx))
         model))
 
     ;; Non-detail views: no-op

--- a/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
@@ -57,24 +57,51 @@
   [view]
   (= :workflow-detail view))
 
+(defn- pane-detail-view?
+  "Views where j/k should navigate per-pane selection."
+  [view]
+  (= :pr-detail view))
+
 (defn navigate-up [model]
-  (if (scrollable-view? (:view model))
+  (cond
+    (scrollable-view? (:view model))
     (update model :scroll-offset #(max 0 (dec (or % 0))))
+
+    (pane-detail-view? (:view model))
+    (let [pane (get-in model [:detail :focused-pane] 0)]
+      (update-in model [:detail :pane-selections pane] #(max 0 (dec (or % 0)))))
+
+    :else
     (update model :selected-idx #(max 0 (dec %)))))
 
 (defn navigate-down [model]
-  (if (scrollable-view? (:view model))
+  (cond
+    (scrollable-view? (:view model))
     ;; scroll-offset upper bound is clamped at render time
     (update model :scroll-offset #(inc (or % 0)))
+
+    (pane-detail-view? (:view model))
+    (let [pane (get-in model [:detail :focused-pane] 0)]
+      (update-in model [:detail :pane-selections pane] #(inc (or % 0))))
+
+    :else
     (let [max-idx (max 0 (dec (list-count model)))]
       (update model :selected-idx #(min max-idx (inc %))))))
 
 (defn navigate-top [model]
-  (assoc model :selected-idx 0 :scroll-offset 0))
+  (if (pane-detail-view? (:view model))
+    (let [pane (get-in model [:detail :focused-pane] 0)]
+      (assoc-in model [:detail :pane-selections pane] 0))
+    (assoc model :selected-idx 0 :scroll-offset 0)))
 
 (defn navigate-bottom [model]
-  (let [max-idx (max 0 (dec (list-count model)))]
-    (assoc model :selected-idx max-idx)))
+  (if (pane-detail-view? (:view model))
+    ;; In detail views we don't know the exact item count per pane,
+    ;; so set a high value; the tree renderer clamps naturally.
+    (let [pane (get-in model [:detail :focused-pane] 0)]
+      (update-in model [:detail :pane-selections pane] (constantly 999)))
+    (let [max-idx (max 0 (dec (list-count model)))]
+      (assoc model :selected-idx max-idx))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; View navigation
@@ -148,6 +175,9 @@
           detail (-> model
                      (assoc :view :pr-detail)
                      (assoc-in [:detail :selected-pr] pr)
+                     (assoc-in [:detail :expanded-nodes] #{0})
+                     (assoc-in [:detail :focused-pane] 0)
+                     (assoc-in [:detail :pane-selections] {0 0, 1 0, 2 0, 3 0})
                      (assoc :selected-idx 0 :selected-ids #{} :visual-anchor nil))
           ;; Check if this PR already has a chat thread
           tk      (chat/chat-thread-key detail)
@@ -183,6 +213,9 @@
       (-> model
           (assoc :view :pr-detail)
           (assoc-in [:detail :selected-pr] pr)
+          (assoc-in [:detail :expanded-nodes] #{0})
+          (assoc-in [:detail :focused-pane] 0)
+          (assoc-in [:detail :pane-selections] {0 0, 1 0, 2 0, 3 0})
           (assoc :selected-idx 0 :selected-ids #{} :visual-anchor nil))
       model)))
 
@@ -244,16 +277,17 @@
 (defn cycle-pane
   "Cycle Tab focus between panes in multi-pane views.
    Views with multiple columns/panes define their pane count;
-   single-pane views are a no-op."
+   single-pane views are a no-op.
+   Saves the current pane's selected-idx and restores the next pane's."
   [model]
   (let [pane-count (case (:view model)
                      :workflow-detail 2   ;; phases | agent output
-                     :pr-detail       3   ;; readiness | risk | gates
+                     :pr-detail       5   ;; summary | readiness | risk | gates | chat
                      :dag-kanban      6   ;; 6 kanban columns
                      1)
-        current (get-in model [:detail :focused-pane] 0)]
-    (assoc-in model [:detail :focused-pane]
-              (mod (inc current) pane-count))))
+        current (get-in model [:detail :focused-pane] 0)
+        next-pane (mod (inc current) pane-count)]
+    (assoc-in model [:detail :focused-pane] next-pane)))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Detail screen navigation — sibling items + sub-view cycling
@@ -467,7 +501,7 @@
   [model]
   (let [pane-count (case (:view model)
                      :workflow-detail 2
-                     :pr-detail       3
+                     :pr-detail       5
                      :dag-kanban      6
                      1)
         current (get-in model [:detail :focused-pane] 0)]

--- a/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj
@@ -20,12 +20,14 @@
   "Navigation helpers and view transitions.
 
    Pure functions for list navigation and view switching.
-   Layers 0-1."
+   Pane focus/selection logic lives in `update.pane`.
+   Layers 0-2."
   (:require
    [ai.miniforge.tui-views.effect :as effect]
    [ai.miniforge.tui-views.model :as model]
    [ai.miniforge.tui-views.transition :as transition]
-   [ai.miniforge.tui-views.update.chat :as chat]))
+   [ai.miniforge.tui-views.update.chat :as chat]
+   [ai.miniforge.tui-views.update.pane :as pane]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Navigation helpers
@@ -57,19 +59,13 @@
   [view]
   (= :workflow-detail view))
 
-(defn- pane-detail-view?
-  "Views where j/k should navigate per-pane selection."
-  [view]
-  (= :pr-detail view))
-
 (defn navigate-up [model]
   (cond
     (scrollable-view? (:view model))
     (update model :scroll-offset #(max 0 (dec (or % 0))))
 
-    (pane-detail-view? (:view model))
-    (let [pane (get-in model [:detail :focused-pane] 0)]
-      (update-in model [:detail :pane-selections pane] #(max 0 (dec (or % 0)))))
+    (pane/pane-detail-view? (:view model))
+    (pane/pane-navigate-up model)
 
     :else
     (update model :selected-idx #(max 0 (dec %)))))
@@ -80,26 +76,21 @@
     ;; scroll-offset upper bound is clamped at render time
     (update model :scroll-offset #(inc (or % 0)))
 
-    (pane-detail-view? (:view model))
-    (let [pane (get-in model [:detail :focused-pane] 0)]
-      (update-in model [:detail :pane-selections pane] #(inc (or % 0))))
+    (pane/pane-detail-view? (:view model))
+    (pane/pane-navigate-down model)
 
     :else
     (let [max-idx (max 0 (dec (list-count model)))]
       (update model :selected-idx #(min max-idx (inc %))))))
 
 (defn navigate-top [model]
-  (if (pane-detail-view? (:view model))
-    (let [pane (get-in model [:detail :focused-pane] 0)]
-      (assoc-in model [:detail :pane-selections pane] 0))
+  (if (pane/pane-detail-view? (:view model))
+    (pane/pane-navigate-top model)
     (assoc model :selected-idx 0 :scroll-offset 0)))
 
 (defn navigate-bottom [model]
-  (if (pane-detail-view? (:view model))
-    ;; In detail views we don't know the exact item count per pane,
-    ;; so set a high value; the tree renderer clamps naturally.
-    (let [pane (get-in model [:detail :focused-pane] 0)]
-      (update-in model [:detail :pane-selections pane] (constantly 999)))
+  (if (pane/pane-detail-view? (:view model))
+    (pane/pane-navigate-bottom model)
     (let [max-idx (max 0 (dec (list-count model)))]
       (assoc model :selected-idx max-idx))))
 
@@ -176,8 +167,7 @@
                      (assoc :view :pr-detail)
                      (assoc-in [:detail :selected-pr] pr)
                      (assoc-in [:detail :expanded-nodes] #{0})
-                     (assoc-in [:detail :focused-pane] 0)
-                     (assoc-in [:detail :pane-selections] {0 0, 1 0, 2 0, 3 0})
+                     (pane/init-pane-state)
                      (assoc :selected-idx 0 :selected-ids #{} :visual-anchor nil))
           ;; Check if this PR already has a chat thread
           tk      (chat/chat-thread-key detail)
@@ -214,8 +204,7 @@
           (assoc :view :pr-detail)
           (assoc-in [:detail :selected-pr] pr)
           (assoc-in [:detail :expanded-nodes] #{0})
-          (assoc-in [:detail :focused-pane] 0)
-          (assoc-in [:detail :pane-selections] {0 0, 1 0, 2 0, 3 0})
+          (pane/init-pane-state)
           (assoc :selected-idx 0 :selected-ids #{} :visual-anchor nil))
       model)))
 
@@ -275,21 +264,10 @@
                      (conj nodes idx)))))))
 
 (defn cycle-pane
-  "Cycle Tab focus between panes in multi-pane views.
-   Views with multiple columns/panes define their pane count;
-   single-pane views are a no-op.
-   Saves the current pane's selected-idx and restores the next pane's."
+  "Cycle Tab focus between panes in multi-pane views. Delegates to pane ns."
   [model]
-  (let [pane-count (case (:view model)
-                     :workflow-detail 2   ;; phases | agent output
-                     :pr-detail       5   ;; summary | readiness | risk | gates | chat
-                     :dag-kanban      6   ;; 6 kanban columns
-                     1)
-        current (get-in model [:detail :focused-pane] 0)
-        next-pane (mod (inc current) pane-count)]
-    (assoc-in model [:detail :focused-pane] next-pane)))
+  (pane/cycle-pane model))
 
-;------------------------------------------------------------------------------ Layer 3
 ;; Detail screen navigation — sibling items + sub-view cycling
 
 (def workflow-subviews
@@ -402,7 +380,6 @@
     ;; Non-detail views: no-op
     model))
 
-;------------------------------------------------------------------------------ Layer 4
 ;; Search match navigation
 
 (defn next-search-match
@@ -497,13 +474,6 @@
     (transition/switch-view model prev-view)))
 
 (defn cycle-pane-reverse
-  "Cycle Shift+Tab focus between panes in reverse."
+  "Cycle Shift+Tab focus between panes in reverse. Delegates to pane ns."
   [model]
-  (let [pane-count (case (:view model)
-                     :workflow-detail 2
-                     :pr-detail       5
-                     :dag-kanban      6
-                     1)
-        current (get-in model [:detail :focused-pane] 0)]
-    (assoc-in model [:detail :focused-pane]
-              (mod (+ current (dec pane-count)) pane-count))))
+  (pane/cycle-pane-reverse model))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/pane.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/pane.clj
@@ -1,0 +1,100 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.update.pane
+  "Pane focus, selection, and cycling for multi-pane detail views.
+
+   Pure functions for PR-detail (and other multi-pane) pane navigation.
+   Layers 0-1.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pane predicates and per-pane selection helpers
+
+(defn pane-detail-view?
+  "Views where j/k should navigate per-pane selection."
+  [view]
+  (= :pr-detail view))
+
+(defn pane-count
+  "Return the number of panes for the given view, or 1 for single-pane views."
+  [view]
+  (case view
+    :workflow-detail 2   ;; phases | agent output
+    :pr-detail       5   ;; summary | readiness | risk | gates | chat
+    :dag-kanban      6   ;; 6 kanban columns
+    1))
+
+(defn focused-pane
+  "Return the currently focused pane index (default 0)."
+  [model]
+  (get-in model [:detail :focused-pane] 0))
+
+(defn pane-navigate-up
+  "Move the per-pane selection cursor up in the focused pane."
+  [model]
+  (let [pane (focused-pane model)]
+    (update-in model [:detail :pane-selections pane] #(max 0 (dec (or % 0))))))
+
+(defn pane-navigate-down
+  "Move the per-pane selection cursor down in the focused pane."
+  [model]
+  (let [pane (focused-pane model)]
+    (update-in model [:detail :pane-selections pane] #(inc (or % 0)))))
+
+(defn pane-navigate-top
+  "Jump the per-pane selection cursor to the top of the focused pane."
+  [model]
+  (let [pane (focused-pane model)]
+    (assoc-in model [:detail :pane-selections pane] 0)))
+
+(defn pane-navigate-bottom
+  "Jump the per-pane selection cursor to the bottom of the focused pane.
+   Sets a high value; the tree renderer clamps naturally."
+  [model]
+  (let [pane (focused-pane model)]
+    (update-in model [:detail :pane-selections pane] (constantly 999))))
+
+(defn init-pane-state
+  "Initialize pane focus and per-pane selections on a model entering a
+   multi-pane detail view (e.g. pr-detail)."
+  [model]
+  (-> model
+      (assoc-in [:detail :focused-pane] 0)
+      (assoc-in [:detail :pane-selections] {0 0, 1 0, 2 0, 3 0})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pane cycling
+
+(defn cycle-pane
+  "Cycle Tab focus between panes in multi-pane views.
+   Views with multiple columns/panes define their pane count;
+   single-pane views are a no-op.
+   Saves the current pane's selected-idx and restores the next pane's."
+  [model]
+  (let [n       (pane-count (:view model))
+        current (focused-pane model)
+        next-p  (mod (inc current) n)]
+    (assoc-in model [:detail :focused-pane] next-p)))
+
+(defn cycle-pane-reverse
+  "Cycle Shift+Tab focus between panes in reverse."
+  [model]
+  (let [n       (pane-count (:view model))
+        current (focused-pane model)]
+    (assoc-in model [:detail :focused-pane]
+              (mod (+ current (dec n)) n))))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/selection.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/selection.clj
@@ -103,6 +103,26 @@
         (nav/navigate-down))
     model))
 
+(defn select-down
+  "Select the item at cursor and move down. Shift+Arrow-Down behavior:
+   extends selection by one item downward (word-processor style)."
+  [model]
+  (if-let [id (current-item-id model)]
+    (-> model
+        (update :selected-ids (fnil conj #{}) id)
+        (nav/navigate-down))
+    model))
+
+(defn select-up
+  "Select the item at cursor and move up. Shift+Arrow-Up behavior:
+   extends selection by one item upward (word-processor style)."
+  [model]
+  (if-let [id (current-item-id model)]
+    (-> model
+        (update :selected-ids (fnil conj #{}) id)
+        (nav/navigate-up))
+    model))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Visual mode
 

--- a/components/tui-views/src/ai/miniforge/tui_views/view.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view.clj
@@ -98,27 +98,56 @@
       (layout/blit buf overlay x y))
     buf))
 
+(defn- confirm-item-label
+  "Format a confirmation item ID for display."
+  [id]
+  (cond
+    (and (vector? id) (= 2 (count id)))
+    (let [[repo num] id]
+      (str "  " repo " #" num))
+    (string? id) (str "  " id)
+    :else (str "  " id)))
+
 (defn overlay-confirm
-  "Add confirmation dialog centered on screen when confirming."
+  "Add confirmation dialog centered on screen showing affected items."
   [buf model _theme [cols rows]]
   (if-let [{:keys [action label ids]} (:confirm model)]
-    (let [msg (str label " " (count ids) " item(s)?")
-          hint "(y)es / (n)o"
-          box-w (min (+ (max (count msg) (count hint)) 4) (- cols 4))
-          box-h 5
+    (let [id-list (sort (map confirm-item-label ids))
+          max-show (min (count id-list) (- rows 8))
+          shown (take max-show id-list)
+          truncated? (> (count id-list) max-show)
+          header (str label " " (count ids) " item(s)?")
+          hint "  (Y)es  /  (C)ancel"
+          max-label-w (reduce max 0 (map count (cons header (cons hint shown))))
+          box-w (min (+ max-label-w 4) (- cols 4))
+          ;; 2 border + 1 header + items + 1 blank + 1 hint
+          box-h (+ 4 (count shown) (if truncated? 1 0))
           x-off (max 0 (quot (- cols box-w) 2))
           y-off (max 0 (quot (- rows box-h) 2))
+          content-h (- box-h 2) ;; inside borders
           overlay (layout/box [box-w box-h]
                     {:title (str " " (name action) " ")
                      :border :single
-                     :fg :yellow
+                     :fg [200 160 0]
                      :content-fn
                      (fn [[ic _ir]]
-                       (-> (layout/make-buffer [ic 2])
-                           (layout/buf-put-string 1 0 msg
-                             {:fg :white :bg :default :bold? true})
-                           (layout/buf-put-string 1 1 hint
-                             {:fg :default :bg :default :bold? false})))})]
+                       (let [cbuf (layout/make-buffer [ic content-h])
+                             cbuf (layout/buf-put-string cbuf 1 0 header
+                                    {:fg :default :bg :default :bold? true})
+                             cbuf (reduce (fn [b [i lbl]]
+                                            (layout/buf-put-string b 1 (inc i) lbl
+                                              {:fg :default :bg :default :bold? false}))
+                                          cbuf
+                                          (map-indexed vector shown))
+                             trunc-row (inc (count shown))
+                             cbuf (if truncated?
+                                    (layout/buf-put-string cbuf 1 trunc-row
+                                      (str "  ... and " (- (count id-list) max-show) " more")
+                                      {:fg :default :bg :default :bold? false})
+                                    cbuf)
+                             hint-row (dec content-h)]
+                         (layout/buf-put-string cbuf 1 hint-row hint
+                           {:fg :default :bg :default :bold? false})))})]
       (layout/blit buf overlay x-off y-off))
     buf))
 
@@ -149,7 +178,7 @@
    model -> [cols rows] -> cell-buffer"
   [model [cols rows]]
   (if (< rows 4)
-    (layout/text [cols rows] "Terminal too small" {:fg :red})
+    (layout/text [cols rows] "Terminal too small" {:fg [220 50 40]})
     (let [theme (engine/get-theme (:theme model))
           model (assoc model :resolved-theme theme)
           cmd-active? (not= :normal (:mode model))

--- a/components/tui-views/src/ai/miniforge/tui_views/view.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view.clj
@@ -25,8 +25,9 @@
   (:require
    [ai.miniforge.tui-engine.interface :as engine]
    [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.palette :as palette]
    [ai.miniforge.tui-views.view.interpret :as interpret]
-   [ai.miniforge.tui-views.views.help :as help]))
+   [ai.miniforge.tui-views.view.overlays :as overlays]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; View dispatch — data-driven via screen specs
@@ -39,119 +40,6 @@
     (layout/text size "Unknown view")))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Overlay pipeline — each overlay is (buf, model, theme, [cols rows]) -> buf
-
-(defn overlay-command-bar
-  "Add command/search bar at the bottom when in command/search mode."
-  [buf model theme [cols rows]]
-  (if (not= :normal (:mode model))
-    (let [cmd-bar (layout/text [cols 1] (:command-buf model)
-                    {:fg (get theme :command-fg :white)
-                     :bg (get theme :command-bg :default)
-                     :bold? true})]
-      (layout/blit buf cmd-bar 0 (dec rows)))
-    buf))
-
-(defn overlay-completions
-  "Add tab-completion popup above the command bar when completing."
-  [buf model theme [cols rows]]
-  (if (and (:completing? model) (seq (:completions model)))
-    (let [completions (:completions model)
-          idx (:completion-idx model)
-          max-visible 8
-          visible (vec (take max-visible completions))
-          longest (apply max 1 (map count visible))
-          popup-w (min (+ longest 4) (- cols 4))
-          popup-h (+ 2 (count visible))
-          y-off (max 0 (- rows 1 popup-h))
-          popup (layout/box [popup-w popup-h]
-                  {:border :single
-                   :fg (get theme :border-focus (get theme :border :default))
-                   :content-fn
-                   (fn [[ic ir]]
-                     (reduce
-                       (fn [b [i item]]
-                         (let [selected? (= i idx)
-                               label (subs item 0 (min (count item) ic))]
-                           (layout/buf-put-string b 1 i label
-                             {:fg (if selected?
-                                    (get theme :selected-fg :white)
-                                    (get theme :fg :default))
-                              :bg (if selected?
-                                    (get theme :selected-bg :blue)
-                                    :default)
-                              :bold? selected?})))
-                       (layout/make-buffer [ic ir])
-                       (map-indexed vector visible)))})]
-      (layout/blit buf popup 0 y-off))
-    buf))
-
-(defn overlay-help
-  "Add help overlay centered on screen when help is visible."
-  [buf model _theme [cols rows]]
-  (if (:help-visible? model)
-    (let [overlay (help/render-overlay [cols rows])
-          ov-cols (count (first overlay))
-          ov-rows (count overlay)
-          x (max 0 (quot (- cols ov-cols) 2))
-          y (max 0 (quot (- rows ov-rows) 2))]
-      (layout/blit buf overlay x y))
-    buf))
-
-(defn- confirm-item-label
-  "Format a confirmation item ID for display."
-  [id]
-  (cond
-    (and (vector? id) (= 2 (count id)))
-    (let [[repo num] id]
-      (str "  " repo " #" num))
-    (string? id) (str "  " id)
-    :else (str "  " id)))
-
-(defn overlay-confirm
-  "Add confirmation dialog centered on screen showing affected items."
-  [buf model _theme [cols rows]]
-  (if-let [{:keys [action label ids]} (:confirm model)]
-    (let [id-list (sort (map confirm-item-label ids))
-          max-show (min (count id-list) (- rows 8))
-          shown (take max-show id-list)
-          truncated? (> (count id-list) max-show)
-          header (str label " " (count ids) " item(s)?")
-          hint "  (Y)es  /  (C)ancel"
-          max-label-w (reduce max 0 (map count (cons header (cons hint shown))))
-          box-w (min (+ max-label-w 4) (- cols 4))
-          ;; 2 border + 1 header + items + 1 blank + 1 hint
-          box-h (+ 4 (count shown) (if truncated? 1 0))
-          x-off (max 0 (quot (- cols box-w) 2))
-          y-off (max 0 (quot (- rows box-h) 2))
-          content-h (- box-h 2) ;; inside borders
-          overlay (layout/box [box-w box-h]
-                    {:title (str " " (name action) " ")
-                     :border :single
-                     :fg [200 160 0]
-                     :content-fn
-                     (fn [[ic _ir]]
-                       (let [cbuf (layout/make-buffer [ic content-h])
-                             cbuf (layout/buf-put-string cbuf 1 0 header
-                                    {:fg :default :bg :default :bold? true})
-                             cbuf (reduce (fn [b [i lbl]]
-                                            (layout/buf-put-string b 1 (inc i) lbl
-                                              {:fg :default :bg :default :bold? false}))
-                                          cbuf
-                                          (map-indexed vector shown))
-                             trunc-row (inc (count shown))
-                             cbuf (if truncated?
-                                    (layout/buf-put-string cbuf 1 trunc-row
-                                      (str "  ... and " (- (count id-list) max-show) " more")
-                                      {:fg :default :bg :default :bold? false})
-                                    cbuf)
-                             hint-row (dec content-h)]
-                         (layout/buf-put-string cbuf 1 hint-row hint
-                           {:fg :default :bg :default :bold? false})))})]
-      (layout/blit buf overlay x-off y-off))
-    buf))
-
-;------------------------------------------------------------------------------ Layer 2
 ;; Theme post-processing
 
 (defn apply-theme-bg
@@ -168,7 +56,7 @@
                     row))
             buffer))))
 
-;------------------------------------------------------------------------------ Layer 3
+;------------------------------------------------------------------------------ Layer 2
 ;; Root view function
 
 (defn root-view
@@ -178,7 +66,7 @@
    model -> [cols rows] -> cell-buffer"
   [model [cols rows]]
   (if (< rows 4)
-    (layout/text [cols rows] "Terminal too small" {:fg [220 50 40]})
+    (layout/text [cols rows] "Terminal too small" {:fg palette/status-fail})
     (let [theme (engine/get-theme (:theme model))
           model (assoc model :resolved-theme theme)
           cmd-active? (not= :normal (:mode model))
@@ -191,10 +79,10 @@
                  content)]
       ;; Overlay pipeline: each step gets the buffer and can modify it
       (-> base
-          (overlay-command-bar model theme [cols rows])
-          (overlay-completions model theme [cols rows])
-          (overlay-help model theme [cols rows])
-          (overlay-confirm model theme [cols rows])
+          (overlays/overlay-command-bar model theme [cols rows])
+          (overlays/overlay-completions model theme [cols rows])
+          (overlays/overlay-help model theme [cols rows])
+          (overlays/overlay-confirm model theme [cols rows])
           (apply-theme-bg theme)))))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/tui-views/src/ai/miniforge/tui_views/view/interpret.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/interpret.clj
@@ -137,15 +137,17 @@
           {:columns resolved-cols :data data
            :selected-row (when selectable? selected)
            :offset offset
-           :header-fg (get theme :header :cyan)
+           :header-fg (get theme :header [0 150 180])
            :row-fg (get theme :row-fg :default)
            :row-bg (get theme :row-bg :default)
            :selected-fg (get theme :selected-fg :white)
            :selected-bg (get theme :selected-bg :blue)})))))
 
 (defn render-tree-widget
-  "Render a tree widget from spec."
-  [model _theme [cols rows] {:keys [data-fn]}]
+  "Render a tree widget from spec.
+   When a :pane-id is present in the widget config, selection highlight is
+   shown only when this pane is the focused pane (per-pane selection)."
+  [model _theme [cols rows] {:keys [data-fn pane-id]}]
   (let [project-fn (project/get-projection data-fn)
         nodes (project-fn (assoc model :_panel-cols cols))
         expanded (or (get-in model [:detail :expanded-nodes]) #{0})
@@ -158,11 +160,19 @@
                    (if (nil? user-offset)
                      max-scroll   ;; pinned to bottom
                      (min user-offset max-scroll)))
-                 0)]
+                 0)
+        ;; Per-pane selection: only show highlight on the focused pane
+        focused-pane (get-in model [:detail :focused-pane] 0)
+        focused? (or (nil? pane-id) (= pane-id focused-pane))
+        pane-sel (when pane-id
+                   (get-in model [:detail :pane-selections pane-id] 0))
+        selected (if focused?
+                   (or pane-sel (:selected-idx model))
+                   -1)]
     (widget/tree [cols rows]
       {:nodes nodes
        :expanded expanded
-       :selected (:selected-idx model)
+       :selected selected
        :scroll-offset scroll})))
 
 (defn render-kanban-widget
@@ -251,7 +261,7 @@
                          (ctx-fn model))
                        "MINIFORGE")]
             (layout/text [c r] text
-              {:fg (get theme :header :cyan) :bold? true}))
+              {:fg (get theme :header [0 150 180]) :bold? true}))
 
           :else
           (tab-bar/render model nil [c r])))

--- a/components/tui-views/src/ai/miniforge/tui_views/view/interpret.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/interpret.clj
@@ -33,6 +33,7 @@
    [clojure.string :as str]
    [ai.miniforge.tui-engine.interface.layout :as layout]
    [ai.miniforge.tui-engine.interface.widget :as widget]
+   [ai.miniforge.tui-views.palette :as palette]
    [ai.miniforge.tui-views.view.project :as project]
    [ai.miniforge.tui-views.views.tab-bar :as tab-bar]))
 
@@ -137,7 +138,7 @@
           {:columns resolved-cols :data data
            :selected-row (when selectable? selected)
            :offset offset
-           :header-fg (get theme :header [0 150 180])
+           :header-fg (get theme :header palette/status-info)
            :row-fg (get theme :row-fg :default)
            :row-bg (get theme :row-bg :default)
            :selected-fg (get theme :selected-fg :white)
@@ -261,7 +262,7 @@
                          (ctx-fn model))
                        "MINIFORGE")]
             (layout/text [c r] text
-              {:fg (get theme :header [0 150 180]) :bold? true}))
+              {:fg (get theme :header palette/status-info) :bold? true}))
 
           :else
           (tab-bar/render model nil [c r])))

--- a/components/tui-views/src/ai/miniforge/tui_views/view/overlays.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/overlays.clj
@@ -1,0 +1,146 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.view.overlays
+  "Overlay pipeline for TUI views.
+
+   Each overlay is a function (buf, model, theme, [cols rows]) -> buf that
+   conditionally composites UI chrome on top of the main content buffer.
+
+   Overlays:
+   - Command bar: shown when in command/search mode
+   - Completions: tab-completion popup above command bar
+   - Help: centered keybinding reference overlay
+   - Confirm: confirmation dialog for batch actions"
+  (:require
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.palette :as palette]
+   [ai.miniforge.tui-views.views.help :as help]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Overlay functions
+
+(defn overlay-command-bar
+  "Add command/search bar at the bottom when in command/search mode."
+  [buf model theme [cols rows]]
+  (if (not= :normal (:mode model))
+    (let [cmd-bar (layout/text [cols 1] (:command-buf model)
+                    {:fg (get theme :command-fg :white)
+                     :bg (get theme :command-bg :default)
+                     :bold? true})]
+      (layout/blit buf cmd-bar 0 (dec rows)))
+    buf))
+
+(defn overlay-completions
+  "Add tab-completion popup above the command bar when completing."
+  [buf model theme [cols rows]]
+  (if (and (:completing? model) (seq (:completions model)))
+    (let [completions (:completions model)
+          idx (:completion-idx model)
+          max-visible 8
+          visible (vec (take max-visible completions))
+          longest (apply max 1 (map count visible))
+          popup-w (min (+ longest 4) (- cols 4))
+          popup-h (+ 2 (count visible))
+          y-off (max 0 (- rows 1 popup-h))
+          popup (layout/box [popup-w popup-h]
+                  {:border :single
+                   :fg (get theme :border-focus (get theme :border :default))
+                   :content-fn
+                   (fn [[ic ir]]
+                     (reduce
+                       (fn [b [i item]]
+                         (let [selected? (= i idx)
+                               label (subs item 0 (min (count item) ic))]
+                           (layout/buf-put-string b 1 i label
+                             {:fg (if selected?
+                                    (get theme :selected-fg :white)
+                                    (get theme :fg :default))
+                              :bg (if selected?
+                                    (get theme :selected-bg :blue)
+                                    :default)
+                              :bold? selected?})))
+                       (layout/make-buffer [ic ir])
+                       (map-indexed vector visible)))})]
+      (layout/blit buf popup 0 y-off))
+    buf))
+
+(defn overlay-help
+  "Add help overlay centered on screen when help is visible."
+  [buf model _theme [cols rows]]
+  (if (:help-visible? model)
+    (let [overlay (help/render-overlay [cols rows])
+          ov-cols (count (first overlay))
+          ov-rows (count overlay)
+          x (max 0 (quot (- cols ov-cols) 2))
+          y (max 0 (quot (- rows ov-rows) 2))]
+      (layout/blit buf overlay x y))
+    buf))
+
+(defn- confirm-item-label
+  "Format a confirmation item ID for display."
+  [id]
+  (cond
+    (and (vector? id) (= 2 (count id)))
+    (let [[repo num] id]
+      (str "  " repo " #" num))
+    (string? id) (str "  " id)
+    :else (str "  " id)))
+
+(defn overlay-confirm
+  "Add confirmation dialog centered on screen showing affected items."
+  [buf model _theme [cols rows]]
+  (if-let [{:keys [action label ids]} (:confirm model)]
+    (let [id-list (sort (map confirm-item-label ids))
+          max-show (min (count id-list) (- rows 8))
+          shown (take max-show id-list)
+          truncated? (> (count id-list) max-show)
+          header (str label " " (count ids) " item(s)?")
+          hint "  (Y)es  /  (C)ancel"
+          max-label-w (reduce max 0 (map count (cons header (cons hint shown))))
+          box-w (min (+ max-label-w 4) (- cols 4))
+          ;; 2 border + 1 header + items + 1 blank + 1 hint
+          box-h (+ 4 (count shown) (if truncated? 1 0))
+          x-off (max 0 (quot (- cols box-w) 2))
+          y-off (max 0 (quot (- rows box-h) 2))
+          content-h (- box-h 2) ;; inside borders
+          overlay (layout/box [box-w box-h]
+                    {:title (str " " (name action) " ")
+                     :border :single
+                     :fg palette/status-warning
+                     :content-fn
+                     (fn [[ic _ir]]
+                       (let [cbuf (layout/make-buffer [ic content-h])
+                             cbuf (layout/buf-put-string cbuf 1 0 header
+                                    {:fg :default :bg :default :bold? true})
+                             cbuf (reduce (fn [b [i lbl]]
+                                            (layout/buf-put-string b 1 (inc i) lbl
+                                              {:fg :default :bg :default :bold? false}))
+                                          cbuf
+                                          (map-indexed vector shown))
+                             trunc-row (inc (count shown))
+                             cbuf (if truncated?
+                                    (layout/buf-put-string cbuf 1 trunc-row
+                                      (str "  ... and " (- (count id-list) max-show) " more")
+                                      {:fg :default :bg :default :bold? false})
+                                    cbuf)
+                             hint-row (dec content-h)]
+                         (layout/buf-put-string cbuf 1 hint-row hint
+                           {:fg :default :bg :default :bold? false})))})]
+      (layout/blit buf overlay x-off y-off))
+    buf))

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -179,7 +179,11 @@
        :title (get pr :pr/title "")
        :status      status-str
        :status-fg   (trees/readiness-state-color r-state)
-       :ready       (helpers/readiness-blockers-summary readiness)
+       :ready       (let [adds (get pr :pr/additions 0)
+                          dels (get pr :pr/deletions 0)]
+                      (if (and (zero? adds) (zero? dels))
+                        "—"
+                        (str "+" adds "/-" dels)))
        :risk        (helpers/risk-label display-risk)
        :risk-fg     (trees/risk-level-color display-risk)
        :policy      (helpers/policy-label policy)

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -178,7 +178,7 @@
        :title (get pr :pr/title "")
        :status      status-str
        :status-fg   (trees/readiness-state-color r-state)
-       :ready       (helpers/readiness-bar (get readiness :readiness/score 0) 15)
+       :ready       (helpers/readiness-blockers-summary readiness)
        :risk        (helpers/risk-label display-risk)
        :risk-fg     (trees/risk-level-color display-risk)
        :policy      (helpers/policy-label policy)

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -48,6 +48,7 @@
 (def status-char             helpers/status-char)
 (def format-progress-bar     helpers/format-progress-bar)
 (def readiness-bar           helpers/readiness-bar)
+(def readiness-blockers-summary helpers/readiness-blockers-summary)
 (def risk-label              helpers/risk-label)
 (def readiness-state         helpers/readiness-state)
 (def readiness-blockers      helpers/readiness-blockers)

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -184,6 +184,12 @@
                       (if (and (zero? adds) (zero? dels))
                         "—"
                         (str "+" adds "/-" dels)))
+       :ready-fg    (let [total (+ (get pr :pr/additions 0) (get pr :pr/deletions 0))]
+                      (cond
+                        (> total 1000) palette/status-fail
+                        (> total 500)  palette/status-warning
+                        (> total 200)  nil
+                        :else          palette/status-pass))
        :risk        (helpers/risk-label display-risk)
        :risk-fg     (trees/risk-level-color display-risk)
        :policy      (helpers/policy-label policy)

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -154,27 +154,36 @@
   [pr agent-risk-map]
   (let [{:keys [readiness risk policy recommend]} (helpers/resolve-enrichment pr)
         r-state   (get readiness :readiness/state :unknown)
-        risk-lvl  (get risk :risk/level :low)
+        risk-lvl  (get risk :risk/level :unevaluated)
         pol-pass? (:evaluation/passed? policy)
         pr-id     [(:pr/repo pr) (:pr/number pr)]
         agent-r   (get agent-risk-map pr-id)
         ;; Use agent risk when available, fall back to mechanical
         display-risk (if agent-r (:level agent-r) risk-lvl)]
-    {:_id pr-id
-     :repo (str (get pr :pr/repo "")
-                (when (:pr/workflow-id pr) " [mf]"))
-     :number (str "#" (:pr/number pr))
-     :title (get pr :pr/title "")
-     :state (helpers/pr-state-label (:pr/status pr))
-     :status      (helpers/readiness-indicator r-state)
-     :status-fg   (trees/readiness-state-color r-state)
-     :ready       (helpers/readiness-bar (get readiness :readiness/score 0) 15)
-     :risk        (helpers/risk-label display-risk)
-     :risk-fg     (trees/risk-level-color display-risk)
-     :policy      (helpers/policy-label policy)
-     :policy-fg   (case pol-pass? true trees/status-pass false trees/status-fail nil)
-     :recommend   (:label recommend)
-     :recommend-fg (trees/recommend-action-color (:action recommend))}))
+    (let [;; Fold GitHub PR state into the readiness indicator when it adds info.
+          ;; The readiness indicator already covers: merged, closed, draft, ci-failing,
+          ;; merge-ready, needs-review, changes-requested, behind-main, conflicts, policy-fail.
+          ;; GitHub states that add new info: :approved, :reviewing.
+          pr-status (:pr/status pr)
+          status-str (str (helpers/readiness-indicator r-state)
+                          (case pr-status
+                            :approved  " ✓"
+                            :reviewing " ⊙"
+                            ""))]
+      {:_id pr-id
+       :repo (str (get pr :pr/repo "")
+                  (when (:pr/workflow-id pr) " [mf]"))
+       :number (str "#" (:pr/number pr))
+       :title (get pr :pr/title "")
+       :status      status-str
+       :status-fg   (trees/readiness-state-color r-state)
+       :ready       (helpers/readiness-bar (get readiness :readiness/score 0) 15)
+       :risk        (helpers/risk-label display-risk)
+       :risk-fg     (trees/risk-level-color display-risk)
+       :policy      (helpers/policy-label policy)
+       :policy-fg   (case pol-pass? true trees/status-pass false trees/status-fail nil)
+       :recommend   (:label recommend)
+       :recommend-fg (trees/recommend-action-color (:action recommend))})))
 
 (defn project-pr-items
   "Project PR items for the fleet table widget.
@@ -225,17 +234,17 @@
         in-review (filterv #(#{:ci-running :review-pending} (:status %)) all-wfs)
         merging   (filterv #(#{:ready-to-merge :merging} (:status %)) all-wfs)
         done      (filterv #(#{:merged :success :completed :failed :skipped} (:status %)) all-wfs)]
-    [{:title "BLOCKED" :color :red
+    [{:title "BLOCKED" :color [220 50 40]
       :cards (mapv (fn [wf] {:label (:name wf) :status :blocked}) blocked)}
-     {:title "READY" :color :yellow
+     {:title "READY" :color [200 160 0]
       :cards (mapv (fn [wf] {:label (:name wf) :status :ready}) ready)}
-     {:title "ACTIVE" :color :cyan
+     {:title "ACTIVE" :color [0 150 180]
       :cards (mapv (fn [wf] {:label (:name wf) :status :running}) active)}
      {:title "IN REVIEW" :color :magenta
       :cards (mapv (fn [wf] {:label (:name wf) :status :review}) in-review)}
      {:title "MERGING" :color :blue
       :cards (mapv (fn [wf] {:label (:name wf) :status :merging}) merging)}
-     {:title "DONE" :color :green
+     {:title "DONE" :color [0 180 80]
       :cards (mapv (fn [wf] {:label (:name wf) :status (get wf :status :success)}) done)}]))
 
 (defn project-agent-output

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -35,6 +35,7 @@
   (:require
    [clojure.string :as str]
    [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.palette :as palette]
    [ai.miniforge.tui-views.view.project.helpers :as helpers]
    [ai.miniforge.tui-views.view.project.trees :as trees]))
 
@@ -234,17 +235,17 @@
         in-review (filterv #(#{:ci-running :review-pending} (:status %)) all-wfs)
         merging   (filterv #(#{:ready-to-merge :merging} (:status %)) all-wfs)
         done      (filterv #(#{:merged :success :completed :failed :skipped} (:status %)) all-wfs)]
-    [{:title "BLOCKED" :color [220 50 40]
+    [{:title "BLOCKED" :color palette/status-fail
       :cards (mapv (fn [wf] {:label (:name wf) :status :blocked}) blocked)}
-     {:title "READY" :color [200 160 0]
+     {:title "READY" :color palette/status-warning
       :cards (mapv (fn [wf] {:label (:name wf) :status :ready}) ready)}
-     {:title "ACTIVE" :color [0 150 180]
+     {:title "ACTIVE" :color palette/status-info
       :cards (mapv (fn [wf] {:label (:name wf) :status :running}) active)}
      {:title "IN REVIEW" :color :magenta
       :cards (mapv (fn [wf] {:label (:name wf) :status :review}) in-review)}
      {:title "MERGING" :color :blue
       :cards (mapv (fn [wf] {:label (:name wf) :status :merging}) merging)}
-     {:title "DONE" :color [0 180 80]
+     {:title "DONE" :color palette/status-pass
       :cards (mapv (fn [wf] {:label (:name wf) :status (get wf :status :success)}) done)}]))
 
 (defn project-agent-output

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
@@ -405,14 +405,17 @@
 
 (defn extract-pr-signals
   "Extract enriched signals from a PR for recommendation.
-   Returns a flat map of booleans/keywords for predicate use."
+   Returns a flat map of booleans/keywords for predicate use.
+   Merges derived state into enriched readiness (explain-readiness lacks :readiness/state)."
   [pr]
-  (let [readiness   (or (:pr/readiness pr) (derive-readiness pr))
-        risk        (or (:pr/risk pr) (derive-risk pr))
-        policy      (:pr/policy pr)
-        violations  (:evaluation/violations policy)
-        changes     (+ (get-in pr [:change-size :additions] 0)
-                       (get-in pr [:change-size :deletions] 0))]
+  (let [derived    (derive-readiness pr)
+        enriched   (:pr/readiness pr)
+        readiness  (if enriched (merge derived enriched) derived)
+        risk       (or (:pr/risk pr) (derive-risk pr))
+        policy     (:pr/policy pr)
+        violations (:evaluation/violations policy)
+        changes    (+ (get pr :pr/additions 0)
+                      (get pr :pr/deletions 0))]
     {:ready?          (:readiness/ready? readiness)
      :state           (get readiness :readiness/state :unknown)
      :risk-level      (get risk :risk/level :unevaluated)

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
@@ -86,6 +86,23 @@
          (apply str (repeat (- bar-w filled) \u2591))
          (format " %3d%%" pct))))
 
+(defn readiness-blockers-summary
+  "Compact blocker summary for fleet table. Shows what's needed for merge."
+  [readiness]
+  (let [blockers (:readiness/blockers readiness [])
+        types    (set (map :blocker/type blockers))]
+    (if (empty? blockers)
+      "ready"
+      (str/join ", "
+        (cond-> []
+          (:ci types)           (conj "CI")
+          (:review types)       (conj "review")
+          (:behind-main types)  (conj "rebase")
+          (:changes types)      (conj "changes")
+          (:draft types)        (conj "draft")
+          (:conflicts types)    (conj "conflicts")
+          (:policy types)       (conj "policy"))))))
+
 (defn risk-label [level]
   (case level :critical "CRIT" :high "high" :medium "med" :low "low" :unevaluated "?" "?"))
 
@@ -108,10 +125,10 @@
     (and (#{:merge-ready :approved} status) ci-ok? behind?)
     [:behind-main 0.85]
 
-    (and (= :approved status) ci-fail?)
+    (and (#{:merge-ready :approved} status) ci-fail?)
     [:ci-failing 0.5]
 
-    (and (= :approved status) (not ci-ok?))
+    (and (#{:merge-ready :approved} status) (not ci-ok?))
     [:needs-review 0.7]
 
     (= :changes-requested status)

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
@@ -86,7 +86,7 @@
          (format " %3d%%" pct))))
 
 (defn risk-label [level]
-  (case level :critical "CRIT" :high "high" :medium "med" :low "low" "?"))
+  (case level :critical "CRIT" :high "high" :medium "med" :low "low" :unevaluated "?" "?"))
 
 ;------------------------------------------------------------------------------ Layer 0c
 ;; Readiness + risk derivation (pure, from provider signals)
@@ -330,7 +330,7 @@
               header {:_header? true
                       :status-char ""
                       :name (str "── " (get bucket-labels bucket) " (" (count wfs) ") ")
-                      :name-fg :cyan
+                      :name-fg [0 150 180]
                       :phase ""
                       :time ""
                       :progress-str ""
@@ -410,7 +410,7 @@
                        (get-in pr [:change-size :deletions] 0))]
     {:ready?          (:readiness/ready? readiness)
      :state           (get readiness :readiness/state :unknown)
-     :risk-level      (get risk :risk/level :low)
+     :risk-level      (get risk :risk/level :unevaluated)
      :policy-pass?    (:evaluation/passed? policy)
      :policy-unknown? (nil? policy)
      :has-violations? (boolean (seq violations))
@@ -477,6 +477,9 @@
       (recommend-action :review "Awaiting review")
 
       ;; Ready — risk-gated merge
+      (and ready? (= :unevaluated risk-level))
+      (recommend-action :evaluate "Risk not yet assessed")
+
       (and ready? (#{:medium :high :critical} risk-level))
       (recommend-action :approve (str "Ready but " (name risk-level) " risk"))
 
@@ -539,11 +542,15 @@
   "Map normalized PR status keyword to human-readable GitHub-level state."
   [status]
   (case status
-    :closed  "closed"
-    :draft   "draft"
-    :merged  "merged"
-    (:approved :reviewing :changes-requested :open :merge-ready) "open"
-    "open"))
+    :closed             "closed"
+    :draft              "draft"
+    :merged             "merged"
+    :open               "open"
+    :approved           "approved"
+    :reviewing          "in review"
+    :changes-requested  "changes req"
+    :merge-ready        "merge ready"
+    (if (nil? status) "—" "open")))
 
 (defn wrap-text
   "Word-wrap a string to fit within max-width characters.

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
@@ -23,7 +23,8 @@
 
    Layer 0: Pure functions with no model dependency."
   (:require
-   [clojure.string :as str])
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.palette :as palette])
   (:import
    [java.text SimpleDateFormat]
    [java.time LocalDate ZoneId]
@@ -209,8 +210,10 @@
      :readiness/factors  factors}))
 
 (defn derive-risk
-  "Derive N9 risk assessment from provider signals and change size.
-   Returns {:risk/level kw :risk/score float :risk/factors [{:factor kw :explanation str :value any} ...]}"
+  "Derive mechanical risk assessment from provider signals and change size.
+   Returns {:risk/level kw :risk/score float :risk/factors [{:factor kw :explanation str :value any} ...]}
+   Uses max-of-factors scoring (not averaging) so a single high-risk signal
+   isn't diluted by low-risk ones."
   [pr]
   (let [status    (:pr/status pr)
         ci        (:pr/ci-status pr)
@@ -220,38 +223,40 @@
         deletions (get pr :pr/deletions 0)
         total     (+ additions deletions)
         changed-files (get pr :pr/changed-files-count 0)
-        size-risk (cond (> total 1000) :high (> total 500) :medium (> total 200) :low :else :minimal)
         factors   (cond-> []
                     (pos? total)
                     (conj {:factor :change-size
                            :explanation (str total " lines changed (+" additions "/-" deletions ")")
                            :value {:additions additions :deletions deletions :total total}
-                           :score (cond (> total 1000) 1.0 (> total 500) 0.75 (> total 200) 0.5 :else 0.25)})
+                           :score (cond (> total 1000) 1.0 (> total 500) 0.75 (> total 200) 0.5 :else 0.2)})
                     (pos? changed-files)
                     (conj {:factor :files-changed
                            :explanation (str changed-files " files modified")
                            :value changed-files
-                           :score (cond (> changed-files 50) 1.0 (> changed-files 20) 0.7 (> changed-files 10) 0.4 :else 0.2)})
+                           :score (cond (> changed-files 50) 1.0 (> changed-files 20) 0.75 (> changed-files 10) 0.5 :else 0.2)})
                     ci-fail?
                     (conj {:factor :ci-health
                            :explanation "CI checks are failing"
-                           :score 0.8})
+                           :score 0.9})
                     changes?
                     (conj {:factor :review-concerns
                            :explanation "Reviewer requested changes"
-                           :score 0.6})
+                           :score 0.8})
                     (and (not ci-fail?) (not changes?) (zero? total))
                     (conj {:factor :signal-check
                            :explanation "All available signals nominal"
                            :score 0.0}))
+        ;; Use max-of-factors, not average — one high signal shouldn't be diluted
         score     (if (seq factors)
-                    (/ (reduce + 0.0 (map #(get % :score 0.0) factors)) (count factors))
+                    (reduce max 0.0 (map #(get % :score 0.0) factors))
                     0.0)
         level     (cond
-                    (or ci-fail? changes? (= size-risk :high)) :medium
-                    (> score 0.6) :medium
-                    (> score 0.3) :low
-                    :else :low)]
+                    (and ci-fail? changes?)          :critical
+                    (or ci-fail? changes?)            :high
+                    (>= score 0.9)                    :high
+                    (>= score 0.65)                   :medium
+                    (>= score 0.4)                    :low
+                    :else                             :low)]
     {:risk/level   level
      :risk/score   score
      :risk/factors factors}))
@@ -330,7 +335,7 @@
               header {:_header? true
                       :status-char ""
                       :name (str "── " (get bucket-labels bucket) " (" (count wfs) ") ")
-                      :name-fg [0 150 180]
+                      :name-fg palette/status-info
                       :phase ""
                       :time ""
                       :progress-str ""

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
@@ -24,6 +24,7 @@
    Layer 1: Composite tree builders that assemble node sequences."
   (:require
    [clojure.string :as str]
+   [ai.miniforge.tui-views.palette :as palette]
    [ai.miniforge.tui-views.view.project.helpers :as helpers]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -36,12 +37,11 @@
   ([label depth expandable?] {:label label :depth depth :expandable? expandable?})
   ([label depth expandable? fg] {:label label :depth depth :expandable? expandable? :fg fg}))
 
-;; Semantic status colors — fixed RGB values with good contrast on both
-;; light and dark terminal backgrounds (ANSI keywords are terminal-dependent)
-(def status-pass    [0 180 80])      ;; medium green
-(def status-fail    [220 50 40])     ;; medium red
-(def status-warning [200 160 0])     ;; darker yellow/gold
-(def status-info    [0 150 180])     ;; teal/darker cyan
+;; Re-export palette colors for backward compatibility (tests reference sut/status-pass etc.)
+(def status-pass    palette/status-pass)
+(def status-fail    palette/status-fail)
+(def status-warning palette/status-warning)
+(def status-info    palette/status-info)
 
 (defn readiness-state-color
   "Map readiness state to fixed status color."

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
@@ -36,11 +36,12 @@
   ([label depth expandable?] {:label label :depth depth :expandable? expandable?})
   ([label depth expandable? fg] {:label label :depth depth :expandable? expandable? :fg fg}))
 
-;; Semantic status colors — fixed across all themes
-(def status-pass    :green)
-(def status-fail    :red)
-(def status-warning :yellow)
-(def status-info    :cyan)
+;; Semantic status colors — fixed RGB values with good contrast on both
+;; light and dark terminal backgrounds (ANSI keywords are terminal-dependent)
+(def status-pass    [0 180 80])      ;; medium green
+(def status-fail    [220 50 40])     ;; medium red
+(def status-warning [200 160 0])     ;; darker yellow/gold
+(def status-info    [0 150 180])     ;; teal/darker cyan
 
 (defn readiness-state-color
   "Map readiness state to fixed status color."
@@ -66,6 +67,7 @@
     :medium   status-warning
     :high     status-fail
     :critical status-fail
+    :unevaluated nil
     nil))
 
 (defn recommend-action-color
@@ -199,12 +201,29 @@
 (defn severity-color [severity]
   (case severity :critical status-fail :major status-fail :minor status-warning :info status-info nil))
 
+(defn pack-detail-nodes
+  "Build detail child nodes for a pack at depth 3.
+   Packs may be strings (name only) or maps with :name, :version, :description."
+  [pack]
+  (if (map? pack)
+    (cond-> []
+      (:version pack)     (conj (tree-node (str "  Version: " (:version pack)) 3))
+      (:description pack) (conj (tree-node (str "  " (:description pack)) 3)))
+    []))
+
 (defn packs-applied-nodes
-  "Build tree nodes for policy packs applied."
+  "Build tree nodes for policy packs applied.
+   Each pack is expandable if it has version or description detail."
   [packs]
   (when (seq packs)
     (into [(tree-node (str "Packs applied (" (count packs) "):") 1 true)]
-          (mapv #(tree-node (str "  " %) 2) packs))))
+          (mapcat (fn [pack]
+                    (let [pack-name (if (map? pack) (or (:name pack) (str pack)) (str pack))
+                          details   (pack-detail-nodes pack)
+                          expandable? (seq details)]
+                      (into [(tree-node (str "  " pack-name) 2 (boolean expandable?))]
+                            details)))
+                  packs))))
 
 (defn severity-summary-nodes
   "Build a summary node listing violation counts by severity."
@@ -218,17 +237,40 @@
       (when (seq parts)
         [(tree-node (str "Summary: " (str/join ", " parts)) 1)]))))
 
+(defn violation-detail-nodes
+  "Build detail child nodes for a single violation at depth 3."
+  [v]
+  (let [artifact  (:artifact-path v)
+        rule-id   (:rule-id v)
+        det-type  (:detection-type v)
+        matches   (:matches v [])]
+    (cond-> []
+      artifact (conj (tree-node (str "  File: " artifact) 3))
+      rule-id  (conj (tree-node (str "  Rule: " (if (keyword? rule-id) (str rule-id) (str rule-id))) 3))
+      det-type (conj (tree-node (str "  Type: " (name det-type)) 3))
+      (seq matches)
+      (into (mapv (fn [m]
+                    (tree-node (str "  L" (:line m "?") ":" (:column m "?")
+                                    " " (or (:context m) (:text m) ""))
+                               3))
+                  matches)))))
+
 (defn violation-nodes
-  "Build tree nodes for individual policy violations."
+  "Build tree nodes for individual policy violations.
+   Each violation is expandable with detail children showing artifact path,
+   rule ID, detection type, and match locations."
   [violations]
   (when (seq violations)
     (into [(tree-node (str "Violations (" (count violations) "):") 1 true)]
-          (mapv (fn [v]
-                  (tree-node (str (severity-prefix (:severity v))
-                                  (or (:message v) (name (get v :rule-id "")))
-                                  (when (:auto-fixable? v) " [auto-fix]"))
-                             2 false (severity-color (:severity v))))
-                violations))))
+          (mapcat (fn [v]
+                    (let [details (violation-detail-nodes v)
+                          expandable? (seq details)]
+                      (into [(tree-node (str (severity-prefix (:severity v))
+                                             (or (:message v) (name (get v :rule-id "")))
+                                             (when (:auto-fixable? v) " [auto-fix]"))
+                                        2 (boolean expandable?) (severity-color (:severity v)))]
+                            details)))
+                  violations))))
 
 (defn policy-tree [policy]
   (let [summary    (:evaluation/summary policy)
@@ -245,9 +287,20 @@
            (violation-nodes violations)))))
 
 (defn gates-tree [gates]
-  (mapv #(tree-node (str (if (:gate/passed? %) "pass " "FAIL ") (name (:gate/id %)))
-                    0 false (if (:gate/passed? %) status-pass status-fail))
-        gates))
+  (let [passed (count (filter :gate/passed? gates))
+        total  (count gates)
+        all?   (= passed total)]
+    (into [(tree-node (str "Gates (" passed "/" total " passed):")
+                      0 true (if all? status-pass status-warning))]
+          (mapcat (fn [g]
+                    (let [has-msg? (seq (:gate/message g))]
+                      (into [(tree-node (str (if (:gate/passed? g) "\u2713 " "\u2718 ")
+                                             (name (:gate/id g)))
+                                        1 (boolean has-msg?)
+                                        (if (:gate/passed? g) status-pass status-fail))]
+                            (when has-msg?
+                              [(tree-node (str "  " (:gate/message g)) 2)]))))
+                  gates))))
 
 (defn intent-nodes
   "Build intent section nodes for evidence tree."
@@ -335,13 +388,13 @@
         pr-id   (when pr [(:pr/repo pr) (:pr/number pr)])
         agent-r (when pr-id (get-in model [:agent-risk pr-id]))
         wf-id   (:pr/workflow-id pr)
-        level   (get risk :risk/level :unknown)
+        level   (get risk :risk/level :unevaluated)
         score   (:risk/score risk)
         factors (:risk/factors risk [])]
     (concat
       ;; Provenance indicator
       (when wf-id
-        [(tree-node "Miniforge-sourced PR" 0 false :cyan)])
+        [(tree-node "Miniforge-sourced PR" 0 false status-info)])
       ;; Agent risk assessment (if available)
       (when agent-r
         [(tree-node (str "Agent risk: " (name (:level agent-r)))
@@ -369,7 +422,7 @@
   [model]
   (let [{:keys [pr readiness risk]} (resolve-detail-enrichment model)
         r-state  (get readiness :readiness/state :unknown)
-        risk-lvl (get risk :risk/level :unknown)
+        risk-lvl (get risk :risk/level :unevaluated)
         recommend (when pr (helpers/derive-recommendation pr))
         ;; Find linked workflow: direct lookup via workflow-id, fallback to branch name match
         wf-id    (:pr/workflow-id pr)
@@ -458,7 +511,7 @@
       (let [msg-nodes (mapcat
                         (fn [{:keys [role content]}]
                           (let [prefix (if (= :user role) "You" "Agent")
-                                fg     (if (= :user role) :cyan :green)
+                                fg     (if (= :user role) status-info status-pass)
                                 lines  (str/split-lines (or content ""))]
                             (into [(tree-node (str prefix ":") 0 false fg)]
                                   (mapcat (fn [line]
@@ -468,13 +521,13 @@
                         messages)
             action-nodes (when (and (seq actions) (not pending?))
                            (into [(tree-node "" 0)
-                                  (tree-node "Actions (press number to run):" 0 false :yellow)]
+                                  (tree-node "Actions (press number to run):" 0 false status-warning)]
                                  (mapcat
                                    (fn [i {:keys [label description]}]
                                      (let [text (str (inc i) ") " label
                                                      (when description
                                                        (str " — " description)))]
-                                       (mapv #(tree-node (str "  " %) 1 false :cyan)
+                                       (mapv #(tree-node (str "  " %) 1 false status-info)
                                              (helpers/wrap-text text wrap-width))))
                                    (range) actions)))]
         (let [nodes (cond-> (vec msg-nodes)
@@ -487,7 +540,7 @@
                   spinner (get ["⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏"]
                                (mod elapsed 10))
                   label   (str spinner " Agent thinking... (" elapsed "s)")]
-              (conj nodes (tree-node label 0 false :yellow)))
+              (conj nodes (tree-node label 0 false status-warning)))
             nodes))))))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/tui-views/src/ai/miniforge/tui_views/views/artifact_browser.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/artifact_browser.clj
@@ -41,7 +41,7 @@
       ;; Title bar
       (fn [[c r]]
         (layout/text [c r] " MINIFORGE │ Artifact Browser"
-                     {:fg :cyan :bold? true}))
+                     {:fg [0 150 180] :bold? true}))
       ;; Content + footer
       (fn [[c r]]
         (layout/split-v [c r] (/ (- r 2.0) r)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/artifact_browser.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/artifact_browser.clj
@@ -25,7 +25,8 @@
    - Size
    - Status"
   (:require
-   [ai.miniforge.tui-engine.interface.layout :as layout]))
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.palette :as palette]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Rendering
@@ -41,7 +42,7 @@
       ;; Title bar
       (fn [[c r]]
         (layout/text [c r] " MINIFORGE │ Artifact Browser"
-                     {:fg [0 150 180] :bold? true}))
+                     {:fg palette/status-info :bold? true}))
       ;; Content + footer
       (fn [[c r]]
         (layout/split-v [c r] (/ (- r 2.0) r)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/dag_kanban.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/dag_kanban.clj
@@ -59,16 +59,16 @@
         pending-cards (mapv (fn [wf] {:label (:name wf) :status :pending}) pending)
         running-cards (mapv (fn [wf] {:label (:name wf) :status :running}) running)]
     [{:title (column-title "BLOCKED" blocked-cards)
-      :color :red
+      :color [220 50 40]
       :cards blocked-cards}
      {:title (column-title "PENDING" pending-cards)
-      :color :yellow
+      :color [200 160 0]
       :cards pending-cards}
      {:title (column-title "RUNNING" running-cards)
-      :color :cyan
+      :color [0 150 180]
       :cards running-cards}
      {:title (column-title "DONE" done-cards)
-      :color :green
+      :color [0 180 80]
       :cards done-cards}]))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -84,7 +84,7 @@
       ;; Title bar
       (fn [[c r]]
         (layout/text [c r] " MINIFORGE │ DAG Kanban"
-                     {:fg :cyan :bold? true}))
+                     {:fg [0 150 180] :bold? true}))
       ;; Content + footer
       (fn [[c r]]
         (layout/split-v [c r] (/ (- r 2.0) r)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/dag_kanban.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/dag_kanban.clj
@@ -29,7 +29,8 @@
    assigned agent, and dependency status."
   (:require
    [ai.miniforge.tui-engine.interface.layout :as layout]
-   [ai.miniforge.tui-engine.interface.widget :as widget]))
+   [ai.miniforge.tui-engine.interface.widget :as widget]
+   [ai.miniforge.tui-views.palette :as palette]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Task grouping
@@ -59,16 +60,16 @@
         pending-cards (mapv (fn [wf] {:label (:name wf) :status :pending}) pending)
         running-cards (mapv (fn [wf] {:label (:name wf) :status :running}) running)]
     [{:title (column-title "BLOCKED" blocked-cards)
-      :color [220 50 40]
+      :color palette/status-fail
       :cards blocked-cards}
      {:title (column-title "PENDING" pending-cards)
-      :color [200 160 0]
+      :color palette/status-warning
       :cards pending-cards}
      {:title (column-title "RUNNING" running-cards)
-      :color [0 150 180]
+      :color palette/status-info
       :cards running-cards}
      {:title (column-title "DONE" done-cards)
-      :color [0 180 80]
+      :color palette/status-pass
       :cards done-cards}]))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -84,7 +85,7 @@
       ;; Title bar
       (fn [[c r]]
         (layout/text [c r] " MINIFORGE │ DAG Kanban"
-                     {:fg [0 150 180] :bold? true}))
+                     {:fg palette/status-info :bold? true}))
       ;; Content + footer
       (fn [[c r]]
         (layout/split-v [c r] (/ (- r 2.0) r)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/evidence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/evidence.clj
@@ -27,7 +27,8 @@
    - Policy (policy check results)"
   (:require
    [ai.miniforge.tui-engine.interface.layout :as layout]
-   [ai.miniforge.tui-engine.interface.widget :as widget]))
+   [ai.miniforge.tui-engine.interface.widget :as widget]
+   [ai.miniforge.tui-views.palette :as palette]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Evidence tree construction
@@ -83,7 +84,7 @@
       ;; Title bar
       (fn [[c r]]
         (layout/text [c r] " MINIFORGE │ Evidence Bundle"
-                     {:fg [0 150 180] :bold? true}))
+                     {:fg palette/status-info :bold? true}))
       ;; Content + footer
       (fn [[c r]]
         (layout/split-v [c r] (/ (- r 2.0) r)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/evidence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/evidence.clj
@@ -83,7 +83,7 @@
       ;; Title bar
       (fn [[c r]]
         (layout/text [c r] " MINIFORGE │ Evidence Bundle"
-                     {:fg :cyan :bold? true}))
+                     {:fg [0 150 180] :bold? true}))
       ;; Content + footer
       (fn [[c r]]
         (layout/split-v [c r] (/ (- r 2.0) r)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/help.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/help.clj
@@ -23,7 +23,8 @@
    Displayed when :help-visible? is true in model."
   (:require
    [clojure.string :as str]
-   [ai.miniforge.tui-engine.interface.layout :as layout]))
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.palette :as palette]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Help content
@@ -83,7 +84,7 @@
         box-h (min (- rows 2) (+ (count lines) 2))]
     (layout/box [box-w box-h]
       {:title "Help — Key Bindings" :border :single
-       :fg [0 150 180]
+       :fg palette/status-info
        :content-fn
        (fn [[ic ir]]
          (layout/text [ic ir]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/help.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/help.clj
@@ -83,9 +83,9 @@
         box-h (min (- rows 2) (+ (count lines) 2))]
     (layout/box [box-w box-h]
       {:title "Help — Key Bindings" :border :single
-       :fg :cyan
+       :fg [0 150 180]
        :content-fn
        (fn [[ic ir]]
          (layout/text [ic ir]
            (str/join "\n" (take ir lines))
-           {:fg :white}))})))
+           {:fg :default}))})))

--- a/components/tui-views/src/ai/miniforge/tui_views/views/pr_detail.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/pr_detail.clj
@@ -23,7 +23,8 @@
    and review information."
   (:require
    [clojure.string :as str]
-   [ai.miniforge.tui-engine.interface.layout :as layout]))
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.palette :as palette]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Rendering helpers
@@ -32,7 +33,7 @@
   (layout/text [cols rows]
     (str " MINIFORGE │ "
          (or (:pr/title pr) "PR Detail"))
-    {:fg [0 150 180] :bold? true}))
+    {:fg palette/status-info :bold? true}))
 
 (defn render-info-panel [pr [cols rows]]
   (layout/box [cols rows]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/pr_detail.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/pr_detail.clj
@@ -32,7 +32,7 @@
   (layout/text [cols rows]
     (str " MINIFORGE │ "
          (or (:pr/title pr) "PR Detail"))
-    {:fg :cyan :bold? true}))
+    {:fg [0 150 180] :bold? true}))
 
 (defn render-info-panel [pr [cols rows]]
   (layout/box [cols rows]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
@@ -32,7 +32,8 @@
   (case risk
     :low    "LOW"
     :medium "MED"
-    :high   "HIGH"
+    :high        "HIGH"
+    :unevaluated "?"
     "---"))
 
 (defn readiness-bar [readiness cols]
@@ -51,7 +52,7 @@
 
 (defn render-title-bar [[cols rows]]
   (layout/text [cols rows] " MINIFORGE │ PR Fleet"
-               {:fg :cyan :bold? true}))
+               {:fg [0 150 180] :bold? true}))
 
 (defn auto-scroll-offset
   "Compute scroll offset so selected-idx is always visible within visible-count rows."

--- a/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/pr_fleet.clj
@@ -23,6 +23,7 @@
    CI status, and repo information."
   (:require
    [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.palette :as palette]
    [ai.miniforge.tui-views.update.navigation :as nav]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -52,7 +53,7 @@
 
 (defn render-title-bar [[cols rows]]
   (layout/text [cols rows] " MINIFORGE │ PR Fleet"
-               {:fg [0 150 180] :bold? true}))
+               {:fg palette/status-info :bold? true}))
 
 (defn auto-scroll-offset
   "Compute scroll offset so selected-idx is always visible within visible-count rows."

--- a/components/tui-views/src/ai/miniforge/tui_views/views/repo_manager.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/repo_manager.clj
@@ -23,7 +23,8 @@
    Supports selection for batch add/remove operations."
   (:require
    [ai.miniforge.tui-engine.interface.layout :as layout]
-   [ai.miniforge.tui-views.model :as model]))
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.palette :as palette]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Rendering helpers
@@ -51,7 +52,7 @@
                    (source-label model) " — "
                    (count items) " repo(s)")]
     (layout/text [cols rows] label
-                 {:fg [0 150 180] :bold? true})))
+                 {:fg palette/status-info :bold? true})))
 
 (defn auto-scroll-offset
   "Compute scroll offset so selected-idx is always visible within visible-count rows."

--- a/components/tui-views/src/ai/miniforge/tui_views/views/repo_manager.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/repo_manager.clj
@@ -51,7 +51,7 @@
                    (source-label model) " — "
                    (count items) " repo(s)")]
     (layout/text [cols rows] label
-                 {:fg :cyan :bold? true})))
+                 {:fg [0 150 180] :bold? true})))
 
 (defn auto-scroll-offset
   "Compute scroll offset so selected-idx is always visible within visible-count rows."

--- a/components/tui-views/src/ai/miniforge/tui_views/views/tab_bar.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/tab_bar.clj
@@ -37,4 +37,4 @@
         label (get model/view-labels active-view "MINIFORGE")
         text (str " MINIFORGE │ " label
                   (when (seq context) (str " │ " context)))]
-    (layout/text [cols rows] text {:fg :cyan :bold? true})))
+    (layout/text [cols rows] text {:fg [0 150 180] :bold? true})))

--- a/components/tui-views/src/ai/miniforge/tui_views/views/tab_bar.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/tab_bar.clj
@@ -25,7 +25,8 @@
    Layer 0: Pure rendering, depends only on layout and model data."
   (:require
    [ai.miniforge.tui-engine.interface.layout :as layout]
-   [ai.miniforge.tui-views.model :as model]))
+   [ai.miniforge.tui-views.model :as model]
+   [ai.miniforge.tui-views.palette :as palette]))
 
 (defn render
   "Render the tab bar header.
@@ -37,4 +38,4 @@
         label (get model/view-labels active-view "MINIFORGE")
         text (str " MINIFORGE │ " label
                   (when (seq context) (str " │ " context)))]
-    (layout/text [cols rows] text {:fg [0 150 180] :bold? true})))
+    (layout/text [cols rows] text {:fg palette/status-info :bold? true})))

--- a/components/tui-views/src/ai/miniforge/tui_views/views/train_view.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/train_view.clj
@@ -36,7 +36,7 @@
   (layout/text [cols rows]
     (str " MINIFORGE │ Train: "
          (or (:train/name train) "Release Train"))
-    {:fg :cyan :bold? true}))
+    {:fg [0 150 180] :bold? true}))
 
 (defn render-table [prs selected [cols rows]]
   (if (empty? prs)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/train_view.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/train_view.clj
@@ -22,7 +22,8 @@
    Displays the train name and a table of PRs in merge order
    with readiness and status."
   (:require
-   [ai.miniforge.tui-engine.interface.layout :as layout]))
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.palette :as palette]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Rendering helpers
@@ -36,7 +37,7 @@
   (layout/text [cols rows]
     (str " MINIFORGE │ Train: "
          (or (:train/name train) "Release Train"))
-    {:fg [0 150 180] :bold? true}))
+    {:fg palette/status-info :bold? true}))
 
 (defn render-table [prs selected [cols rows]]
   (if (empty? prs)

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
@@ -74,7 +74,7 @@
                       (when-let [phase (:phase wf)]
                         (str " │ " (name phase)))
                       metrics-str)
-                 {:fg :cyan :bold? true})))
+                 {:fg [0 150 180] :bold? true})))
 
 (defn render-phase-list [phases [cols rows]]
   (layout/box [cols rows]
@@ -102,7 +102,7 @@
          (widget/scrollable [ic ir]
            {:lines lines
             :offset offset
-            :fg :white})))}))
+            :fg :default})))}))
 
 (defn render-footer [[cols rows]]
   (layout/text [cols rows]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_detail.clj
@@ -26,7 +26,8 @@
   (:require
    [clojure.string :as str]
    [ai.miniforge.tui-engine.interface.layout :as layout]
-   [ai.miniforge.tui-engine.interface.widget :as widget]))
+   [ai.miniforge.tui-engine.interface.widget :as widget]
+   [ai.miniforge.tui-views.palette :as palette]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Helpers
@@ -74,7 +75,7 @@
                       (when-let [phase (:phase wf)]
                         (str " │ " (name phase)))
                       metrics-str)
-                 {:fg [0 150 180] :bold? true})))
+                 {:fg palette/status-info :bold? true})))
 
 (defn render-phase-list [phases [cols rows]]
   (layout/box [cols rows]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
@@ -27,7 +27,8 @@
    - Agent status
    - Temporal grouping (Today, This Week, Older)"
   (:require
-   [ai.miniforge.tui-engine.interface.layout :as layout])
+   [ai.miniforge.tui-engine.interface.layout :as layout]
+   [ai.miniforge.tui-views.palette :as palette])
   (:import
    [java.time LocalDate ZoneId]
    [java.time.temporal ChronoUnit]))
@@ -115,7 +116,7 @@
 
 (defn render-title-bar [[cols rows]]
   (layout/text [cols rows] " MINIFORGE │ Workflows"
-               {:fg [0 150 180] :bold? true}))
+               {:fg palette/status-info :bold? true}))
 
 (defn auto-scroll-offset
   "Compute scroll offset so selected-idx is always visible within visible-count rows."
@@ -132,7 +133,7 @@
     ;; Section header — spans full width with dimmed color
     {:status-char ""
      :name (:label entry)
-     :name-fg [0 150 180]
+     :name-fg palette/status-info
      :phase ""
      :progress-str ""
      :agent-msg ""
@@ -202,7 +203,7 @@
             (layout/text [tc tr]
               (str " MINIFORGE │ Workflows"
                    (when search-active? (str " [" (count workflows) " matches]")))
-              {:fg [0 150 180] :bold? true}))
+              {:fg palette/status-info :bold? true}))
 
           render-content-area
           (fn [[c r]]

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
@@ -115,7 +115,7 @@
 
 (defn render-title-bar [[cols rows]]
   (layout/text [cols rows] " MINIFORGE │ Workflows"
-               {:fg :cyan :bold? true}))
+               {:fg [0 150 180] :bold? true}))
 
 (defn auto-scroll-offset
   "Compute scroll offset so selected-idx is always visible within visible-count rows."
@@ -132,7 +132,7 @@
     ;; Section header — spans full width with dimmed color
     {:status-char ""
      :name (:label entry)
-     :name-fg :cyan
+     :name-fg [0 150 180]
      :phase ""
      :progress-str ""
      :agent-msg ""
@@ -202,7 +202,7 @@
             (layout/text [tc tr]
               (str " MINIFORGE │ Workflows"
                    (when search-active? (str " [" (count workflows) " matches]")))
-              {:fg :cyan :bold? true}))
+              {:fg [0 150 180] :bold? true}))
 
           render-content-area
           (fn [[c r]]

--- a/components/tui-views/test/ai/miniforge/tui_views/pane_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/pane_test.clj
@@ -1,0 +1,208 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-views.pane-test
+  "Tests for PR-detail pane cycling, per-pane cursor positions,
+   and g/G/j/k behavior in pane mode."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.test-util :as util]
+   [ai.miniforge.tui-views.update :as update]
+   [ai.miniforge.tui-views.update.pane :as pane]))
+
+;; ---------------------------------------------------------------------------
+;; Helpers
+;; ---------------------------------------------------------------------------
+
+(defn pr-detail-model
+  "Create a model in :pr-detail view with pane state initialized.
+   Optionally accepts a focused-pane and pane-selections override."
+  ([]
+   (pr-detail-model 0 {0 0, 1 0, 2 0, 3 0}))
+  ([focused-pane pane-selections]
+   (-> (util/fresh-model)
+       (assoc :view :pr-detail)
+       (assoc-in [:detail :focused-pane] focused-pane)
+       (assoc-in [:detail :pane-selections] pane-selections)
+       (assoc-in [:detail :selected-pr] {:pr/id 1 :pr/title "Test PR"
+                                          :pr/repo "acme/repo" :pr/number 42}))))
+
+;; ---------------------------------------------------------------------------
+;; cycle-pane tests
+;; ---------------------------------------------------------------------------
+
+(deftest cycle-pane-test
+  (testing "cycle-pane increments focused-pane from 0 to 1"
+    (let [m (pane/cycle-pane (pr-detail-model))]
+      (is (= 1 (get-in m [:detail :focused-pane])))))
+
+  (testing "cycle-pane increments through all 5 panes"
+    (let [m (-> (pr-detail-model)
+                pane/cycle-pane   ;; 0 -> 1
+                pane/cycle-pane   ;; 1 -> 2
+                pane/cycle-pane   ;; 2 -> 3
+                pane/cycle-pane)] ;; 3 -> 4
+      (is (= 4 (get-in m [:detail :focused-pane])))))
+
+  (testing "cycle-pane wraps from last pane (4) back to 0"
+    (let [m (pane/cycle-pane (pr-detail-model 4 {0 0, 1 0, 2 0, 3 0}))]
+      (is (= 0 (get-in m [:detail :focused-pane])))))
+
+  (testing "cycle-pane on workflow-detail wraps at 2 panes"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-detail)
+                (assoc-in [:detail :focused-pane] 1)
+                pane/cycle-pane)]
+      (is (= 0 (get-in m [:detail :focused-pane])))))
+
+  (testing "cycle-pane on single-pane view stays at 0"
+    (let [m (-> (util/fresh-model)
+                (assoc :view :workflow-list)
+                (assoc-in [:detail :focused-pane] 0)
+                pane/cycle-pane)]
+      (is (= 0 (get-in m [:detail :focused-pane]))))))
+
+;; ---------------------------------------------------------------------------
+;; cycle-pane-reverse tests
+;; ---------------------------------------------------------------------------
+
+(deftest cycle-pane-reverse-test
+  (testing "cycle-pane-reverse decrements focused-pane from 2 to 1"
+    (let [m (pane/cycle-pane-reverse (pr-detail-model 2 {0 0, 1 0, 2 0, 3 0}))]
+      (is (= 1 (get-in m [:detail :focused-pane])))))
+
+  (testing "cycle-pane-reverse wraps from 0 to last pane (4)"
+    (let [m (pane/cycle-pane-reverse (pr-detail-model))]
+      (is (= 4 (get-in m [:detail :focused-pane])))))
+
+  (testing "cycle-pane and cycle-pane-reverse are inverses"
+    (let [m (-> (pr-detail-model 2 {0 0, 1 0, 2 0, 3 0})
+                pane/cycle-pane
+                pane/cycle-pane-reverse)]
+      (is (= 2 (get-in m [:detail :focused-pane]))))))
+
+;; ---------------------------------------------------------------------------
+;; Per-pane selection: j/k navigate the correct pane's cursor
+;; ---------------------------------------------------------------------------
+
+(deftest pane-navigate-down-test
+  (testing "j in pr-detail increments the focused pane's selection"
+    (let [m (pane/pane-navigate-down (pr-detail-model))]
+      (is (= 1 (get-in m [:detail :pane-selections 0])))))
+
+  (testing "j increments selection in the focused pane only, not others"
+    (let [m (-> (pr-detail-model 1 {0 5, 1 0, 2 0, 3 0})
+                pane/pane-navigate-down)]
+      ;; Pane 1 should have moved; pane 0 stays at 5
+      (is (= 1 (get-in m [:detail :pane-selections 1])))
+      (is (= 5 (get-in m [:detail :pane-selections 0]))))))
+
+(deftest pane-navigate-up-test
+  (testing "k in pr-detail decrements the focused pane's selection"
+    (let [m (pane/pane-navigate-up (pr-detail-model 0 {0 3, 1 0, 2 0, 3 0}))]
+      (is (= 2 (get-in m [:detail :pane-selections 0])))))
+
+  (testing "k at selection 0 stays at 0"
+    (let [m (pane/pane-navigate-up (pr-detail-model))]
+      (is (= 0 (get-in m [:detail :pane-selections 0]))))))
+
+(deftest pane-navigate-top-test
+  (testing "g in pr-detail resets focused pane selection to 0"
+    (let [m (pane/pane-navigate-top (pr-detail-model 0 {0 7, 1 3, 2 0, 3 0}))]
+      (is (= 0 (get-in m [:detail :pane-selections 0])))
+      ;; Other panes untouched
+      (is (= 3 (get-in m [:detail :pane-selections 1]))))))
+
+(deftest pane-navigate-bottom-test
+  (testing "G in pr-detail sets focused pane selection to a high value"
+    (let [m (pane/pane-navigate-bottom (pr-detail-model))]
+      (is (= 999 (get-in m [:detail :pane-selections 0]))))))
+
+;; ---------------------------------------------------------------------------
+;; Integration: j/k/g/G through update-model in pr-detail view
+;; ---------------------------------------------------------------------------
+
+(deftest pane-navigation-integration-test
+  (testing "j in pr-detail view updates pane selection via update-model"
+    (let [m (update/update-model (pr-detail-model) [:input {:key :key/j :char \j}])]
+      (is (= 1 (get-in m [:detail :pane-selections 0])))))
+
+  (testing "k in pr-detail view updates pane selection via update-model"
+    (let [m (-> (pr-detail-model 0 {0 3, 1 0, 2 0, 3 0})
+                (update/update-model [:input {:key :key/k :char \k}]))]
+      (is (= 2 (get-in m [:detail :pane-selections 0])))))
+
+  (testing "g in pr-detail view jumps to top of focused pane"
+    (let [m (-> (pr-detail-model 0 {0 5, 1 0, 2 0, 3 0})
+                (update/update-model [:input {:key :key/g :char \g}]))]
+      (is (= 0 (get-in m [:detail :pane-selections 0])))))
+
+  (testing "G in pr-detail view jumps to bottom of focused pane"
+    (let [m (update/update-model (pr-detail-model) [:input {:key :key/G :char \G}])]
+      (is (= 999 (get-in m [:detail :pane-selections 0]))))))
+
+;; ---------------------------------------------------------------------------
+;; Entering PR detail initializes pane state
+;; ---------------------------------------------------------------------------
+
+(deftest enter-pr-detail-pane-init-test
+  (testing "Entering PR detail from pr-fleet initializes focused-pane to 0"
+    (let [pr-item {:pr/id 1 :pr/title "Test" :pr/repo "r" :pr/number 1}
+          m (-> (util/fresh-model)
+                (assoc :view :pr-fleet :pr-items [pr-item])
+                (update/update-model [:input :key/enter]))]
+      (is (= 0 (get-in m [:detail :focused-pane])))))
+
+  (testing "Entering PR detail from pr-fleet initializes pane-selections map"
+    (let [pr-item {:pr/id 1 :pr/title "Test" :pr/repo "r" :pr/number 1}
+          m (-> (util/fresh-model)
+                (assoc :view :pr-fleet :pr-items [pr-item])
+                (update/update-model [:input :key/enter]))]
+      (is (= {0 0, 1 0, 2 0, 3 0} (get-in m [:detail :pane-selections])))))
+
+  (testing "Entering PR detail from train-view initializes pane state"
+    (let [pr-item {:pr/id 99 :pr/title "Train PR" :pr/repo "r" :pr/number 2}
+          m (-> (util/fresh-model)
+                (assoc :view :train-view)
+                (assoc-in [:detail :selected-train :train/prs] [pr-item])
+                (update/update-model [:input :key/enter]))]
+      (is (= 0 (get-in m [:detail :focused-pane])))
+      (is (= {0 0, 1 0, 2 0, 3 0} (get-in m [:detail :pane-selections]))))))
+
+;; ---------------------------------------------------------------------------
+;; Tab/Shift-Tab cycles panes in pr-detail via update-model
+;; ---------------------------------------------------------------------------
+
+(deftest tab-pane-cycling-integration-test
+  (testing "Tab in pr-detail cycles focused-pane forward"
+    (let [m (update/update-model (pr-detail-model) [:input :key/tab])]
+      (is (= 1 (get-in m [:detail :focused-pane])))))
+
+  (testing "Shift-Tab in pr-detail cycles focused-pane backward"
+    (let [m (update/update-model (pr-detail-model 2 {0 0, 1 0, 2 0, 3 0})
+                                  [:input :key/shift-tab])]
+      (is (= 1 (get-in m [:detail :focused-pane])))))
+
+  (testing "Tab wraps pane in pr-detail after cycling through all 5"
+    (let [m (-> (pr-detail-model)
+                (update/update-model [:input :key/tab])       ;; 0->1
+                (update/update-model [:input :key/tab])       ;; 1->2
+                (update/update-model [:input :key/tab])       ;; 2->3
+                (update/update-model [:input :key/tab])       ;; 3->4
+                (update/update-model [:input :key/tab]))]     ;; 4->0
+      (is (= 0 (get-in m [:detail :focused-pane]))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/persistence/pr_cache_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/persistence/pr_cache_test.clj
@@ -1,0 +1,192 @@
+(ns ai.miniforge.tui-views.persistence.pr-cache-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.tui-views.persistence.pr-cache :as cache])
+  (:import
+   [java.io File]))
+
+;; ---------------------------------------------------------------------------
+;; Test data
+;; ---------------------------------------------------------------------------
+
+(def pr-1
+  {:pr/repo "acme/api" :pr/number 42
+   :pr/additions 10 :pr/deletions 5
+   :pr/status :open :pr/ci-status :success
+   :pr/head-sha "abc123"})
+
+(def pr-2
+  {:pr/repo "acme/web" :pr/number 7
+   :pr/additions 20 :pr/deletions 3
+   :pr/status :open :pr/ci-status :pending
+   :pr/head-sha "def456"})
+
+(def pr-1-modified
+  "Same repo/number as pr-1, but different fingerprint fields."
+  (assoc pr-1 :pr/additions 99 :pr/head-sha "changed"))
+
+;; ---------------------------------------------------------------------------
+;; Temp directory helper
+;; ---------------------------------------------------------------------------
+
+(defn make-temp-dir
+  "Create a temp directory for cache tests."
+  []
+  (let [f (File/createTempFile "pr-cache-test" ".d")]
+    (.delete f)
+    (.mkdirs f)
+    f))
+
+(defn cleanup-temp-dir
+  "Recursively delete a temp directory."
+  [^File dir]
+  (doseq [f (reverse (file-seq dir))]
+    (.delete f)))
+
+;; ---------------------------------------------------------------------------
+;; Layer 0: Fingerprint + entry helpers
+;; ---------------------------------------------------------------------------
+
+(deftest pr-fingerprint-test
+  (testing "pr-fingerprint returns expected keys"
+    (let [fp (cache/pr-fingerprint pr-1)]
+      (is (= #{:additions :deletions :status :ci-status :head-sha}
+             (set (keys fp))))
+      (is (= 10 (:additions fp)))
+      (is (= 5 (:deletions fp)))
+      (is (= :open (:status fp)))
+      (is (= :success (:ci-status fp)))
+      (is (= "abc123" (:head-sha fp))))))
+
+(deftest entry-valid?-test
+  (testing "returns true when fingerprints match"
+    (let [entry (cache/cache-entry pr-1)]
+      (is (cache/entry-valid? entry pr-1))))
+
+  (testing "returns false when fingerprints differ"
+    (let [entry (cache/cache-entry pr-1)]
+      (is (not (cache/entry-valid? entry pr-1-modified))))))
+
+;; ---------------------------------------------------------------------------
+;; Layer 2: apply-cached-policy
+;; ---------------------------------------------------------------------------
+
+(deftest apply-cached-policy-test
+  (testing "applies cached policy to PRs without :pr/policy"
+    (let [entry (assoc (cache/cache-entry pr-1)
+                       :policy {:gate :pass :reason "all good"})
+          the-cache {(cache/pr-cache-key pr-1) entry}
+          result (cache/apply-cached-policy [pr-1] the-cache)]
+      (is (= {:gate :pass :reason "all good"}
+             (:pr/policy (first result))))))
+
+  (testing "skips PRs that already have :pr/policy"
+    (let [pr-with-policy (assoc pr-1 :pr/policy {:gate :fail :reason "nope"})
+          entry (assoc (cache/cache-entry pr-1)
+                       :policy {:gate :pass :reason "cached"})
+          the-cache {(cache/pr-cache-key pr-1) entry}
+          result (cache/apply-cached-policy [pr-with-policy] the-cache)]
+      (is (= {:gate :fail :reason "nope"}
+             (:pr/policy (first result))))))
+
+  (testing "skips entries with mismatched fingerprints"
+    (let [entry (assoc (cache/cache-entry pr-1)
+                       :policy {:gate :pass :reason "stale"})
+          the-cache {(cache/pr-cache-key pr-1-modified) entry}
+          result (cache/apply-cached-policy [pr-1-modified] the-cache)]
+      (is (nil? (:pr/policy (first result)))))))
+
+;; ---------------------------------------------------------------------------
+;; Layer 2: apply-cached-agent-risk
+;; ---------------------------------------------------------------------------
+
+(deftest apply-cached-agent-risk-test
+  (testing "extracts risk from matching cache entries"
+    (let [risk {:level :high :summary "danger"}
+          entry (assoc (cache/cache-entry pr-1)
+                       :agent-risk risk)
+          the-cache {(cache/pr-cache-key pr-1) entry}
+          result (cache/apply-cached-agent-risk [pr-1] the-cache)]
+      (is (= {(cache/pr-cache-key pr-1) risk} result))))
+
+  (testing "skips entries with mismatched fingerprints"
+    (let [risk {:level :low :summary "fine"}
+          entry (assoc (cache/cache-entry pr-1)
+                       :agent-risk risk)
+          the-cache {(cache/pr-cache-key pr-1-modified) entry}
+          result (cache/apply-cached-agent-risk [pr-1-modified] the-cache)]
+      (is (= {} result)))))
+
+;; ---------------------------------------------------------------------------
+;; Layer 1: read-cache / write-cache! roundtrip
+;; ---------------------------------------------------------------------------
+
+(deftest read-cache-nonexistent-test
+  (testing "read-cache returns {} for non-existent file"
+    (let [dir (make-temp-dir)]
+      (try
+        (is (= {} (cache/read-cache {:dir dir})))
+        (finally
+          (cleanup-temp-dir dir))))))
+
+(deftest write-read-roundtrip-test
+  (testing "write-cache! + read-cache roundtrip preserves data"
+    (let [dir (make-temp-dir)
+          entries {["acme/api" 42] {:fingerprint {:additions 10}
+                                    :cached-at   12345
+                                    :policy      {:gate :pass}}}]
+      (try
+        (cache/write-cache! entries {:dir dir})
+        ;; write-cache! runs in a future; deref to ensure completion
+        (Thread/sleep 100)
+        (is (= entries (cache/read-cache {:dir dir})))
+        (finally
+          (cleanup-temp-dir dir))))))
+
+;; ---------------------------------------------------------------------------
+;; Layer 2: persist-policy-result!
+;; ---------------------------------------------------------------------------
+
+(deftest persist-policy-result!-test
+  (testing "updates cache for a specific PR"
+    (let [dir (make-temp-dir)
+          prs [pr-1 pr-2]
+          policy-result {:gate :pass :reason "lgtm"}]
+      (try
+        (cache/persist-policy-result!
+         (cache/pr-cache-key pr-1) policy-result prs {:dir dir})
+        (Thread/sleep 100)
+        (let [c (cache/read-cache {:dir dir})
+              entry (get c (cache/pr-cache-key pr-1))]
+          (is (some? entry))
+          (is (= policy-result (:policy entry)))
+          (is (= (cache/pr-fingerprint pr-1) (:fingerprint entry)))
+          ;; pr-2 should not be in cache
+          (is (nil? (get c (cache/pr-cache-key pr-2)))))
+        (finally
+          (cleanup-temp-dir dir))))))
+
+;; ---------------------------------------------------------------------------
+;; Layer 2: persist-risk-triage!
+;; ---------------------------------------------------------------------------
+
+(deftest persist-risk-triage!-test
+  (testing "updates cache for risk entries"
+    (let [dir (make-temp-dir)
+          prs [pr-1 pr-2]
+          assessments {(cache/pr-cache-key pr-1) {:level :high :summary "risky"}
+                       (cache/pr-cache-key pr-2) {:level :low :summary "safe"}}]
+      (try
+        (cache/persist-risk-triage! assessments prs {:dir dir})
+        (Thread/sleep 100)
+        (let [c (cache/read-cache {:dir dir})
+              e1 (get c (cache/pr-cache-key pr-1))
+              e2 (get c (cache/pr-cache-key pr-2))]
+          (is (some? e1))
+          (is (= {:level :high :summary "risky"} (:agent-risk e1)))
+          (is (= (cache/pr-fingerprint pr-1) (:fingerprint e1)))
+          (is (some? e2))
+          (is (= {:level :low :summary "safe"} (:agent-risk e2)))
+          (is (= (cache/pr-fingerprint pr-2) (:fingerprint e2))))
+        (finally
+          (cleanup-temp-dir dir))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/selection_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/selection_test.clj
@@ -112,11 +112,11 @@
                [:input {:key :key/a :char \a}]])]
       (is (util/selection-count-is? m 3))))
 
-  (testing "c clears all selections"
+  (testing "Esc clears all selections"
     (let [m (util/apply-updates (three-workflows)
               [[:input {:key :key/space :char \space}]
                [:input {:key :key/a :char \a}]
-               [:input {:key :key/c :char \c}]])]
+               [:input :key/escape]])]
       (is (util/selection-count-is? m 0)))))
 
 ;; ---------------------------------------------------------------------------

--- a/components/tui-views/test/ai/miniforge/tui_views/selection_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/selection_test.clj
@@ -201,6 +201,50 @@
       (is (contains? (:selected-ids m) "acme/api")))))
 
 ;; ---------------------------------------------------------------------------
+;; Shift+Arrow selection (select-down / select-up)
+;; ---------------------------------------------------------------------------
+
+(deftest select-down-test
+  (testing "Shift+Down selects current item and moves cursor down"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/shift-down}]])]
+      (is (util/selection-count-is? m 1))
+      (is (contains? (:selected-ids m) wf-id-1))
+      (is (= 1 (:selected-idx m))))))
+
+(deftest select-up-test
+  (testing "Shift+Up selects current item and moves cursor up"
+    ;; Start at bottom item (idx 2) so we can move up
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/j :char \j}]          ;; cursor -> 1
+               [:input {:key :key/j :char \j}]          ;; cursor -> 2
+               [:input {:key :key/shift-up}]])]
+      (is (util/selection-count-is? m 1))
+      (is (contains? (:selected-ids m) wf-id-3))
+      (is (= 1 (:selected-idx m))))))
+
+(deftest select-range-test
+  (testing "Multiple Shift+Down creates a range selection"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/shift-down}]           ;; select wf-1, cursor -> 1
+               [:input {:key :key/shift-down}]])]        ;; select wf-2, cursor -> 2
+      (is (util/selection-count-is? m 2))
+      (is (contains? (:selected-ids m) wf-id-1))
+      (is (contains? (:selected-ids m) wf-id-2))
+      (is (not (contains? (:selected-ids m) wf-id-3)))
+      (is (= 2 (:selected-idx m)))))
+
+  (testing "Shift+Down through entire list selects all items"
+    (let [m (util/apply-updates (three-workflows)
+              [[:input {:key :key/shift-down}]           ;; select wf-1, cursor -> 1
+               [:input {:key :key/shift-down}]           ;; select wf-2, cursor -> 2
+               [:input {:key :key/shift-down}]])]        ;; select wf-3, cursor stays 2
+      (is (util/selection-count-is? m 3))
+      (is (contains? (:selected-ids m) wf-id-1))
+      (is (contains? (:selected-ids m) wf-id-2))
+      (is (contains? (:selected-ids m) wf-id-3)))))
+
+;; ---------------------------------------------------------------------------
 ;; Search + select (filter-aware selection)
 ;; ---------------------------------------------------------------------------
 

--- a/components/tui-views/test/ai/miniforge/tui_views/view/project_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/view/project_test.clj
@@ -441,3 +441,107 @@
     (let [signals (sut/extract-pr-signals {:pr/status :open :pr/ci-status :passed
                                            :pr/additions 400 :pr/deletions 200})]
       (is (true? (:large? signals)) "600 LOC should be large"))))
+
+;; ============================================================================
+;; readiness-state — :merge-ready status (GitLab PRs)
+;; ============================================================================
+
+(deftest readiness-state-merge-ready-ci-passed
+  (testing "merge-ready + CI passed + not behind → merge-ready"
+    (is (= [:merge-ready 1.0]
+           (sut/readiness-state :merge-ready true false false)))))
+
+(deftest readiness-state-merge-ready-behind
+  (testing "merge-ready + CI passed + behind → behind-main"
+    (is (= [:behind-main 0.85]
+           (sut/readiness-state :merge-ready true false true)))))
+
+(deftest readiness-state-merge-ready-ci-failing
+  (testing "merge-ready + CI failing → ci-failing (regression: was :unknown)"
+    (is (= [:ci-failing 0.5]
+           (sut/readiness-state :merge-ready false true false)))))
+
+(deftest readiness-state-merge-ready-ci-pending
+  (testing "merge-ready + CI pending → needs-review (regression: was :unknown)"
+    (is (= [:needs-review 0.7]
+           (sut/readiness-state :merge-ready false false false)))))
+
+;; ============================================================================
+;; readiness-blockers-summary
+;; ============================================================================
+
+(deftest blockers-summary-ready
+  (testing "No blockers → ready"
+    (is (= "ready"
+           (sut/readiness-blockers-summary {:readiness/blockers []})))))
+
+(deftest blockers-summary-nil-blockers
+  (testing "Nil blockers → ready"
+    (is (= "ready"
+           (sut/readiness-blockers-summary {})))))
+
+(deftest blockers-summary-review
+  (testing "Review blocker → review"
+    (is (= "review"
+           (sut/readiness-blockers-summary
+             {:readiness/blockers [{:blocker/type :review :blocker/message "Needs review"}]})))))
+
+(deftest blockers-summary-ci
+  (testing "CI blocker → CI"
+    (is (= "CI"
+           (sut/readiness-blockers-summary
+             {:readiness/blockers [{:blocker/type :ci :blocker/message "CI failing"}]})))))
+
+(deftest blockers-summary-multiple
+  (testing "Multiple blockers joined with comma"
+    (let [summary (sut/readiness-blockers-summary
+                    {:readiness/blockers [{:blocker/type :ci :blocker/message "CI failing"}
+                                          {:blocker/type :review :blocker/message "Needs review"}
+                                          {:blocker/type :behind-main :blocker/message "Behind"}]})]
+      (is (.contains summary "CI"))
+      (is (.contains summary "review"))
+      (is (.contains summary "rebase")))))
+
+(deftest blockers-summary-draft
+  (testing "Draft blocker → draft"
+    (is (= "draft"
+           (sut/readiness-blockers-summary
+             {:readiness/blockers [{:blocker/type :draft :blocker/message "Draft PR"}]})))))
+
+;; ============================================================================
+;; derive-risk — scoring changes
+;; ============================================================================
+
+(deftest derive-risk-ci-fail-is-high
+  (testing "CI failing → high risk"
+    (let [risk (sut/derive-risk {:pr/status :open :pr/ci-status :failed
+                                 :pr/additions 100 :pr/deletions 50})]
+      (is (= :high (:risk/level risk))))))
+
+(deftest derive-risk-ci-fail-plus-changes-requested-is-critical
+  (testing "CI failing + changes requested → critical"
+    (let [risk (sut/derive-risk {:pr/status :changes-requested :pr/ci-status :failed
+                                 :pr/additions 100 :pr/deletions 50})]
+      (is (= :critical (:risk/level risk))))))
+
+(deftest derive-risk-large-pr-is-medium
+  (testing ">500 LOC → medium risk"
+    (let [risk (sut/derive-risk {:pr/status :open :pr/ci-status :passed
+                                 :pr/additions 400 :pr/deletions 200})]
+      (is (= :medium (:risk/level risk))))))
+
+(deftest derive-risk-small-pr-is-low
+  (testing "<200 LOC → low risk"
+    (let [risk (sut/derive-risk {:pr/status :open :pr/ci-status :passed
+                                 :pr/additions 50 :pr/deletions 20})]
+      (is (= :low (:risk/level risk))))))
+
+(deftest derive-risk-uses-max-not-average
+  (testing "Max-of-factors scoring: one high signal isn't diluted"
+    (let [risk (sut/derive-risk {:pr/status :open :pr/ci-status :passed
+                                 :pr/additions 600 :pr/deletions 100
+                                 :pr/changed-files-count 2})]
+      ;; 700 LOC = score 0.75, 2 files = score 0.2
+      ;; Max = 0.75 (not average 0.475), so level = :medium
+      (is (= :medium (:risk/level risk)))
+      (is (>= (:risk/score risk) 0.7)))))

--- a/components/tui-views/test/ai/miniforge/tui_views/view/project_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/view/project_test.clj
@@ -154,13 +154,13 @@
   (testing "Passed CI produces green header"
     (let [nodes (sut/ci-section-nodes :passed [])]
       (is (= 1 (count nodes)))
-      (is (= :green (:fg (first nodes))))
+      (is (= sut/status-pass (:fg (first nodes))))
       (is (.contains (:label (first nodes)) "passed")))))
 
 (deftest ci-section-nodes-failed
   (testing "Failed CI produces red header"
     (let [nodes (sut/ci-section-nodes :failed [])]
-      (is (= :red (:fg (first nodes)))))))
+      (is (= sut/status-fail (:fg (first nodes)))))))
 
 (deftest ci-section-nodes-with-checks
   (testing "Individual checks are appended as child nodes"
@@ -179,13 +179,13 @@
     (let [node (sut/behind-main-node true "DIRTY")]
       (is (.contains (:label node) "yes"))
       (is (.contains (:label node) "DIRTY"))
-      (is (= :red (:fg node))))))
+      (is (= sut/status-fail (:fg node))))))
 
 (deftest behind-main-node-not-behind
   (testing "Not behind → green node"
     (let [node (sut/behind-main-node false nil)]
       (is (.contains (:label node) "no"))
-      (is (= :green (:fg node))))))
+      (is (= sut/status-pass (:fg node))))))
 
 ;; ============================================================================
 ;; review-node
@@ -195,19 +195,19 @@
   (testing "Approved → green node"
     (let [node (sut/review-node :approved)]
       (is (.contains (:label node) "approved"))
-      (is (= :green (:fg node))))))
+      (is (= sut/status-pass (:fg node))))))
 
 (deftest review-node-changes-requested
   (testing "Changes requested → red node"
     (let [node (sut/review-node :changes-requested)]
       (is (.contains (:label node) "changes requested"))
-      (is (= :red (:fg node))))))
+      (is (= sut/status-fail (:fg node))))))
 
 (deftest review-node-reviewing
   (testing "Reviewing → yellow node"
     (let [node (sut/review-node :reviewing)]
       (is (.contains (:label node) "review required"))
-      (is (= :yellow (:fg node))))))
+      (is (= sut/status-warning (:fg node))))))
 
 (deftest review-node-draft
   (testing "Draft → no color"
@@ -219,7 +219,7 @@
   (testing "Unknown status → pending with yellow"
     (let [node (sut/review-node :unknown)]
       (is (.contains (:label node) "pending"))
-      (is (= :yellow (:fg node))))))
+      (is (= sut/status-warning (:fg node))))))
 
 ;; ============================================================================
 ;; gates-section-nodes
@@ -237,7 +237,7 @@
                  {:gate/id :test :gate/passed? true}]
           nodes (sut/gates-section-nodes gates)]
       (is (= 3 (count nodes)))
-      (is (= :green (:fg (first nodes))))
+      (is (= sut/status-pass (:fg (first nodes))))
       (is (.contains (:label (first nodes)) "2/2 passed")))))
 
 (deftest gates-section-nodes-some-failed
@@ -246,10 +246,10 @@
                  {:gate/id :test :gate/passed? false}]
           nodes (sut/gates-section-nodes gates)]
       (is (= 3 (count nodes)))
-      (is (= :yellow (:fg (first nodes))))
+      (is (= sut/status-warning (:fg (first nodes))))
       (is (.contains (:label (first nodes)) "1/2 passed"))
-      (is (= :green (:fg (second nodes))))
-      (is (= :red (:fg (nth nodes 2)))))))
+      (is (= sut/status-pass (:fg (second nodes))))
+      (is (= sut/status-fail (:fg (nth nodes 2)))))))
 
 ;; ============================================================================
 ;; packs-applied-nodes
@@ -302,7 +302,7 @@
           nodes (sut/violation-nodes violations)]
       (is (= 3 (count nodes)))
       (is (.contains (:label (first nodes)) "2"))
-      (is (= :red (:fg (second nodes))))
+      (is (= sut/status-fail (:fg (second nodes))))
       (is (.contains (:label (nth nodes 2)) "[auto-fix]")))))
 
 ;; ============================================================================

--- a/components/tui-views/test/ai/miniforge/tui_views/view/project_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/view/project_test.clj
@@ -369,3 +369,75 @@
   (testing "Non-compliant policy → violations label"
     (let [nodes (sut/policy-evidence-nodes {:policy {:compliant? false}})]
       (is (.contains (:label (second nodes)) "violations detected")))))
+
+;; ============================================================================
+;; derive-recommendation — regression: readiness state resolution
+;; ============================================================================
+
+(deftest recommend-not-wait-when-enriched
+  (testing "PR with pr-train enrichment (no :readiness/state) produces actionable recommendation, not :wait"
+    ;; Regression: explain-readiness returns {:readiness/score :readiness/ready? :readiness/factors}
+    ;; but NOT :readiness/state. extract-pr-signals must derive the state from PR status/CI.
+    (let [pr {:pr/status :open :pr/ci-status :passed
+              :pr/additions 100 :pr/deletions 50
+              :pr/readiness {:readiness/score 0.4
+                             :readiness/ready? false
+                             :readiness/factors []}}
+          rec (sut/derive-recommendation pr)]
+      (is (not= :wait (:action rec))
+          "Should not be :wait — :open + ci:passed should derive :needs-review state")
+      (is (= :review (:action rec))))))
+
+(deftest recommend-merge-when-all-green
+  (testing "Approved PR with passing CI, low risk, policy pass → merge"
+    (let [pr {:pr/status :approved :pr/ci-status :passed
+              :pr/additions 50 :pr/deletions 10
+              :pr/policy {:evaluation/passed? true}
+              :pr/readiness {:readiness/score 1.0
+                             :readiness/ready? true
+                             :readiness/factors []}}
+          rec (sut/derive-recommendation pr)]
+      (is (= :merge (:action rec))))))
+
+(deftest recommend-do-not-merge-ci-failing
+  (testing "Open PR with failing CI → do-not-merge"
+    (let [pr {:pr/status :open :pr/ci-status :failed
+              :pr/additions 100 :pr/deletions 50}
+          rec (sut/derive-recommendation pr)]
+      (is (= :do-not-merge (:action rec))))))
+
+(deftest recommend-evaluate-when-ready-no-policy
+  (testing "Ready PR without policy evaluation → evaluate"
+    (let [pr {:pr/status :approved :pr/ci-status :passed
+              :pr/additions 50 :pr/deletions 10
+              :pr/readiness {:readiness/score 1.0
+                             :readiness/ready? true
+                             :readiness/factors []}}
+          rec (sut/derive-recommendation pr)]
+      (is (= :evaluate (:action rec))))))
+
+(deftest recommend-decompose-large-pr
+  (testing "Large open PR with policy evaluated → decompose"
+    (let [pr {:pr/status :open :pr/ci-status :passed
+              :pr/additions 400 :pr/deletions 200
+              :pr/policy {:evaluation/passed? true}}
+          rec (sut/derive-recommendation pr)]
+      (is (= :decompose (:action rec))))))
+
+(deftest recommend-approve-elevated-risk
+  (testing "Ready PR with medium risk → approve (human sign-off)"
+    (let [pr {:pr/status :approved :pr/ci-status :passed
+              :pr/additions 50 :pr/deletions 10
+              :pr/policy {:evaluation/passed? true}
+              :pr/risk {:risk/level :medium :risk/score 0.6}
+              :pr/readiness {:readiness/score 1.0
+                             :readiness/ready? true
+                             :readiness/factors []}}
+          rec (sut/derive-recommendation pr)]
+      (is (= :approve (:action rec))))))
+
+(deftest extract-pr-signals-uses-pr-additions
+  (testing "extract-pr-signals reads :pr/additions not [:change-size :additions]"
+    (let [signals (sut/extract-pr-signals {:pr/status :open :pr/ci-status :passed
+                                           :pr/additions 400 :pr/deletions 200})]
+      (is (true? (:large? signals)) "600 LOC should be large"))))


### PR DESCRIPTION
## Summary

- **PR analysis caching** — Disk-backed cache at `~/.miniforge/cache/pr-analysis.edn` persists risk triage and policy evaluation results across TUI sessions. Fingerprint-based invalidation ensures stale results are re-evaluated when PR data changes (additions, deletions, status, CI, head SHA). Eliminates redundant LLM calls on restart.
- **Shift+Arrow group select** — Shift+Up/Down extends selection one row at a time on fleet/aggregate screens, matching word-processor conventions. Replaces the old `c`/`C` clear-selection keybindings that conflicted with chat.
- **Batch PR commands** — `:approve`, `:merge`, `:review`, `:reject`, `:decompose` commands with enhanced confirmation dialog that lists each affected PR by repo and number (Yes/Cancel). Effect handlers for approve/merge/reject are stubbed pending GitHub API wiring.
- **Light theme contrast** — All ANSI keyword colors (`:green`, `:red`, `:yellow`, `:cyan`, `:white`) replaced with RGB vectors across 13 view files for theme-independent contrast.
- **Per-pane focus** — PR detail view tracks selection per-pane with Tab cycling. Only the focused pane shows a highlight.
- **State/Status column merge** — Single "State" column with meaningful labels (approved, in review, changes req, merge ready). Risk defaults to `:unevaluated` ("?") instead of "medium".
- **Policy/gate tree expansion** — Detail pane shows expandable gate check results, violation details (file, rule, match locations), pack info. Batch policy evaluation triggers automatically on PR sync for unevaluated PRs.

## Changed components

- `tui-engine` — Shift+Arrow key detection in Lanterna adapter, key token additions
- `tui-views` — All changes across persistence, update, view, and config layers

## Test plan

- [x] 288 tests pass (0 failures, 0 errors)
- [x] Selection test updated for Esc-clears-selection (was `c`)
- [x] Color assertion tests updated for RGB vectors
- [ ] Manual: verify Shift+Up/Down selects on PR fleet screen
- [ ] Manual: verify `:approve` / `:merge` / `:review` / `:reject` show confirmation with PR list
- [ ] Manual: verify light theme text is visible across all screens
- [ ] Manual: verify cache persists across TUI restarts (risk/policy not re-evaluated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)