### PR TITLE
Add work specs for PR comment monitoring and TUI decomposition

### DIFF
--- a/work/pr-comment-monitoring.spec.edn
+++ b/work/pr-comment-monitoring.spec.edn
@@ -1,0 +1,210 @@
+;; PR Comment Monitoring Workflow — Autonomous PR Lifecycle Management
+
+{:spec/title "PR Comment Monitoring — Autonomous Fix/Resolve Workflow"
+ :version "1.0.0"
+ :type :feature
+ :priority :high
+
+ :spec/description
+ "Background workflow that monitors PR comments (review comments, CI bot comments,
+  Sentry alerts, other AI bot comments), autonomously fixes issues, pushes fixes,
+  and resolves comments with reasoning. A meta-agent layer verifies resolutions
+  aren't incorrect (e.g., resolving because it couldn't access the code rather
+  than actually fixing the issue).
+
+  This is the miniforge equivalent of Autodev's PR monitoring pattern: push PR →
+  monitor → fix → push fix → resolve comments → meta-agent verification loop.
+
+  Can run as a background daemon per-PR or as a batch action on selected PRs."
+
+ :spec/intent
+ {:type :feature
+  :scope ["PR comment monitoring and triage"
+          "Automated fix generation and push"
+          "Comment resolution with reasoning"
+          "Meta-agent verification of resolutions"
+          "Integration with Sentry, CI bots, and review comments"]
+
+  :context
+  {:autodev-pattern
+   ["Autodev pushes PR → starts monitoring workflow"
+    "Monitoring workflow polls for new comments"
+    "When comment found: analyze → fix → push fix → resolve comment"
+    "Resolution includes reasoning (why this fix addresses the comment)"
+    "Meta-agent reviews resolutions for correctness"
+    "Meta-agent catches false resolutions (couldn't access, so resolved anyway)"
+    "Loop continues until no new comments for N minutes"]
+
+   :current-state
+   ["TUI has batch policy evaluation running in background"
+    "TUI has risk triage running in background"
+    "No comment monitoring exists"
+    "No automated fix-and-push workflow"
+    "No meta-agent verification layer"
+    "PR analysis caching exists (can store monitoring state)"]
+
+   :desired-state
+   ["Background monitoring per-PR or per-fleet"
+    "Automatic response to review comments, CI failures, bot alerts"
+    "Fix → push → resolve cycle with reasoning"
+    "Meta-agent prevents false/lazy resolutions"
+    "Status visible in TUI (monitoring active, comments pending, fixes pushed)"
+    "User can start/stop monitoring per-PR or batch"]}}
+
+ :requirements
+ [{:id "R1"
+   :requirement "Comment polling and triage"
+   :details "Poll GitHub PR comments (review comments, issue comments, check
+             annotations) on a configurable interval. Triage each comment:
+             - Actionable (needs fix): code review feedback, linting errors, test failures
+             - Informational (resolve with ack): bot status updates, CI summaries
+             - External (escalate): Sentry alerts, security findings
+             - Noise (ignore): duplicate bot comments, stale notifications"
+   :comment-sources
+   ["GitHub PR review comments" "GitHub PR issue comments"
+    "Check run annotations" "Status check details"
+    "Sentry issue links" "Dependabot/Renovate comments"]}
+
+  {:id "R2"
+   :requirement "Automated fix generation"
+   :details "For actionable comments, generate a fix by:
+             1. Analyze the comment + referenced code
+             2. Generate a fix using miniforge workflow (explore → plan → implement → verify)
+             3. Run tests/linting to verify fix
+             4. Commit and push to the PR branch"
+   :workflow-phases
+   [{:phase :analyze :description "Understand the comment and its context"}
+    {:phase :plan :description "Plan the fix (may involve multiple files)"}
+    {:phase :implement :description "Generate code changes"}
+    {:phase :verify :description "Run tests, lint, gate checks"}
+    {:phase :push :description "Commit and push to PR branch"}]}
+
+  {:id "R3"
+   :requirement "Comment resolution with reasoning"
+   :details "After pushing a fix, resolve the comment on GitHub with a reply
+             explaining what was changed and why it addresses the feedback.
+             Include: files changed, approach taken, test results."
+   :resolution-format
+   "Fixed in commit abc1234:
+    - Changed `src/foo.clj:42` to use safe null-check
+    - Added test case for nil input in `foo_test.clj`
+    - All 288 tests pass, lint clean
+
+    Reasoning: The reviewer noted that `(.getField obj)` could NPE when obj
+    is nil. Added a `when-let` guard and a test covering the nil case."}
+
+  {:id "R4"
+   :requirement "Meta-agent verification"
+   :details "A meta-agent reviews each resolution before it's posted. Catches:
+             - False resolutions (comment resolved but code not actually changed)
+             - Lazy resolutions ('could not reproduce' when code wasn't checked)
+             - Scope creep (fix introduces unrelated changes)
+             - Incomplete fixes (only partially addresses the comment)"
+   :verification-checks
+   ["Did the fix actually change code related to the comment?"
+    "Do the test results support the fix claim?"
+    "Is the resolution reasoning accurate and specific?"
+    "Does the fix introduce any regressions?"
+    "Is the fix minimal and focused on the comment?"]
+   :actions-on-failure
+   ["Block resolution posting" "Flag for human review"
+    "Retry with more specific instructions" "Escalate to user"]}
+
+  {:id "R5"
+   :requirement "TUI integration"
+   :details "Show monitoring status in TUI:
+             - PR fleet: monitoring icon/column showing active/paused/idle
+             - PR detail: list of pending/resolved/failed comments
+             - Batch action: :monitor to start monitoring selected PRs
+             - Background flash messages for significant events"
+   :ui-elements
+   ["Monitoring status column or icon in PR fleet"
+    "Comment feed in PR detail pane"
+    ":monitor / :stop-monitor commands"
+    "Flash messages: 'Fixed review comment on #42', 'Meta-agent flagged resolution on #55'"]}
+
+  {:id "R6"
+   :requirement "Daemon lifecycle"
+   :details "Monitoring runs as a background process that survives across
+             TUI screens but stops when the TUI exits. Configurable poll
+             interval (default 60s). Can be started per-PR or for all PRs."
+   :lifecycle
+   ["Start: :monitor command or automatic on PR push"
+    "Run: Poll → triage → fix → resolve → verify loop"
+    "Pause: :pause-monitor (stop polling, keep state)"
+    "Stop: :stop-monitor or TUI exit"
+    "Resume: :resume-monitor (continue from where paused)"]}]
+
+ :architecture
+ {:layers
+  [{:layer "Comment Poller"
+    :responsibility "Fetch new comments from GitHub API on interval"
+    :component "components/pr-lifecycle or new components/pr-monitor"}
+   {:layer "Comment Triage"
+    :responsibility "Classify comments as actionable/informational/external/noise"
+    :component "Could reuse LLM or rule-based classifier"}
+   {:layer "Fix Workflow"
+    :responsibility "Generate, verify, and push fixes for actionable comments"
+    :component "Miniforge workflow invocation (spec generation → run)"}
+   {:layer "Resolution Engine"
+    :responsibility "Post resolution comments with reasoning on GitHub"
+    :component "GitHub API via pr-lifecycle component"}
+   {:layer "Meta-Agent"
+    :responsibility "Verify resolutions are correct before posting"
+    :component "LLM-based verification pass"}
+   {:layer "TUI Integration"
+    :responsibility "Display status, accept commands, show results"
+    :component "tui-views effects/events/projections"}]
+
+  :data-flow
+  "PR push → start monitor → poll comments → triage →
+   [actionable] → generate fix → verify → push → draft resolution →
+   meta-agent verify → [pass] → post resolution → poll again
+                       [fail] → flag for human → notify user"}
+
+ :implementation
+ {:phases
+  [{:phase 1
+    :title "Comment polling and triage"
+    :deliverables ["GitHub comment fetching" "Comment classification"
+                   "TUI status display" ":monitor command"]}
+   {:phase 2
+    :title "Fix generation and push"
+    :deliverables ["Spec generation from comment context" "Miniforge workflow invocation"
+                   "Commit and push to PR branch"]}
+   {:phase 3
+    :title "Resolution posting and meta-agent"
+    :deliverables ["Resolution comment generation" "Meta-agent verification"
+                   "False resolution detection" "Human escalation"]}]
+
+  :estimated-complexity "Large — spans 3-4 components, requires GitHub API work,
+                         LLM integration for triage/meta-agent, workflow orchestration"}
+
+ :spec/acceptance-criteria
+ [{:criterion "Monitor detects new PR comments within poll interval"
+   :verification "Post a review comment, see it appear in TUI within 60s"}
+  {:criterion "Actionable comments trigger fix workflow"
+   :verification "Post 'this function can NPE', see fix generated and pushed"}
+  {:criterion "Resolutions include accurate reasoning"
+   :verification "Resolution comment references specific code changes and test results"}
+  {:criterion "Meta-agent catches false resolutions"
+   :verification "Simulate a lazy resolution, verify meta-agent blocks it"}
+  {:criterion "TUI shows monitoring status and comment feed"
+   :verification "See active monitoring indicator, pending/resolved comment counts"}]
+
+ :risks
+ [{:risk "GitHub API rate limiting with frequent polling"
+   :mitigation "Configurable poll interval, conditional requests (If-Modified-Since)"}
+  {:risk "Fix workflow generates incorrect code"
+   :mitigation "Verify phase (tests + lint), meta-agent review, human escalation"}
+  {:risk "Meta-agent itself makes mistakes"
+   :mitigation "Conservative default (block on uncertainty), human override"}
+  {:risk "Cost from LLM calls for triage + fix + meta-agent"
+   :mitigation "Cache triage results, batch similar comments, skip noise early"}]
+
+ :notes
+ ["Pattern proven in Autodev — this is the miniforge port"
+  "Meta-agent is critical — without it, the system resolves comments incorrectly"
+  "Start with review comments only, expand to CI/Sentry/bots in phase 2"
+  "Consider making this a miniforge 'daemon spec' — a long-running spec type"
+  "PR analysis cache can store comment monitoring state for persistence"]}

--- a/work/tui-decomposition-workflow.spec.edn
+++ b/work/tui-decomposition-workflow.spec.edn
@@ -1,0 +1,112 @@
+;; TUI PR Decomposition Workflow
+
+{:spec/title "PR Decomposition Workflow — TUI-Driven Sub-PR Generation"
+ :version "1.0.0"
+ :type :feature
+ :priority :medium
+
+ :spec/description
+ "Wire the TUI decompose command to generate a decomposition spec and hand it
+  to miniforge for execution. When a user selects a large PR and runs :decompose,
+  the system should analyze the PR's diff, propose a decomposition plan with
+  logical sub-PRs, and optionally execute the plan to create the sub-PRs.
+
+  This replaces the current stub that returns 'Decomposition analysis not yet wired'
+  with a real workflow that mirrors the Autodev decomposition pattern."
+
+ :spec/intent
+ {:type :workflow-integration
+  :scope ["PR decomposition analysis via miniforge workflow"
+          "Spec generation from PR metadata + diff"
+          "Sub-PR creation proposals"
+          "MCP integration for decomposition commands"]
+
+  :context
+  {:current-state
+   ["TUI has :decompose command with confirmation dialog"
+    "effect/decompose-pr effect constructor exists"
+    "handle-decompose-pr in interface.clj is a stub returning empty sub-prs"
+    "Recommendation engine already suggests :decompose for PRs > 500 lines"
+    "Autodev has a working decomposition pattern"]
+
+   :desired-state
+   ["User selects large PR → :decompose → confirmation dialog"
+    "System generates decomposition spec from PR metadata + diff"
+    "Spec handed to miniforge workflow for analysis"
+    "Workflow returns proposed sub-PRs with titles, file groupings, dependency order"
+    "User reviews proposals, optionally creates the sub-PRs"
+    "Results cached in PR analysis cache for future reference"]}}
+
+ :requirements
+ [{:id "R1"
+   :requirement "Generate decomposition spec from PR"
+   :details "Create a .spec.edn with PR metadata, file list, diff summary, and
+             decomposition constraints (max sub-PR size, logical grouping rules)"
+   :inputs ["PR repo/number" "PR diff (additions/deletions by file)"
+            "PR description/intent" "File dependency graph"]
+   :output "EDN spec suitable for miniforge run"}
+
+  {:id "R2"
+   :requirement "Execute decomposition workflow"
+   :details "Hand the generated spec to miniforge for analysis. The workflow
+             should analyze the diff, identify logical boundaries, and propose
+             sub-PRs with titles, file groupings, and merge order."
+   :options ["Direct miniforge invocation (shell subprocess)"
+             "MCP command (miniforge as MCP server)"
+             "In-process workflow execution"]}
+
+  {:id "R3"
+   :requirement "Present decomposition results in TUI"
+   :details "Show proposed sub-PRs in a review pane: title, files, size estimate,
+             dependency order. User can accept/reject/modify before creation."
+   :ui-elements ["Sub-PR list with file groupings"
+                  "Size estimates per sub-PR"
+                  "Dependency arrows between sub-PRs"
+                  "Accept/Reject/Modify actions"]}
+
+  {:id "R4"
+   :requirement "Cache decomposition results"
+   :details "Store decomposition proposals in PR analysis cache so they persist
+             across sessions. Invalidate when PR diff changes."
+   :cache-key "[repo, number]"
+   :invalidation "PR fingerprint change (additions/deletions/head-sha)"}
+
+  {:id "R5"
+   :requirement "Create sub-PRs from accepted proposal"
+   :details "When user accepts, create actual sub-PRs on GitHub via cherry-pick
+             or branch-per-file-group strategy. Each sub-PR references the parent."
+   :stretch? true}]
+
+ :implementation
+ {:approach "spec-generation"
+  :description "Generate a decomposition .spec.edn and invoke miniforge"
+
+  :new-files
+  [{:path "components/tui-views/src/ai/miniforge/tui_views/decompose.clj"
+    :purpose "Spec generation from PR metadata, result parsing"
+    :functions
+    [{:name "generate-decompose-spec"
+      :signature "(generate-decompose-spec pr diff-data)"
+      :returns "EDN spec map"}
+     {:name "parse-decompose-result"
+      :signature "(parse-decompose-result workflow-output)"
+      :returns "{:sub-prs [{:title :files :size :depends-on}]}"}]}]
+
+  :modified-files
+  [{:path "components/tui-views/src/ai/miniforge/tui_views/interface.clj"
+    :change "Replace handle-decompose-pr stub with real implementation"
+    :handler "Generate spec → invoke miniforge → parse result → return msg"}
+   {:path "components/tui-views/src/ai/miniforge/tui_views/update/events.clj"
+    :change "Enhance handle-decomposition-started to display sub-PR proposals"}
+   {:path "components/tui-views/resources/config/tui/screens.edn"
+    :change "Add decomposition review pane or modal"}]}
+
+ :spec/acceptance-criteria
+ [{:criterion "Decompose command produces sub-PR proposals for large PRs"
+   :verification "Select a 500+ line PR, run :decompose, see proposed sub-PRs"}
+  {:criterion "Proposals include file groupings and size estimates"
+   :verification "Each sub-PR shows which files it contains and line count"}
+  {:criterion "Results persist across sessions via cache"
+   :verification "Run :decompose, exit TUI, re-enter, proposals still visible"}
+  {:criterion "Stub replaced with real workflow invocation"
+   :verification "handle-decompose-pr no longer returns 'not yet wired'"}]}


### PR DESCRIPTION
## Summary
- Adds `work/pr-comment-monitoring.spec.edn` — autonomous PR comment triage, fix generation, resolution posting with meta-agent verification
- Adds `work/tui-decomposition-workflow.spec.edn` — wire TUI `:decompose` command to generate sub-PR proposals via miniforge workflow

## Test plan
- [x] EDN files lint clean
- [x] No code changes, specs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)