### PR TITLE
Fix workflow default to standard-sdlc

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
@@ -200,9 +200,9 @@
        :confidence 0.5
        :reasoning (str "Fallback: Selected based on task type " task-type)
        :source :fallback}
-      {:workflow :simple-test-v1
+      {:workflow :standard-sdlc
        :confidence 0.3
-       :reasoning "Fallback: Default to simple workflow"
+       :reasoning "Fallback: Default to standard SDLC workflow"
        :source :fallback})))
 
 (defn recommend-workflow-with-fallback

--- a/work/tui-decomposition-workflow.spec.edn
+++ b/work/tui-decomposition-workflow.spec.edn
@@ -15,7 +15,7 @@
   with a real workflow that mirrors the Autodev decomposition pattern."
 
  :spec/intent
- {:type :workflow-integration
+ {:type :feature
   :scope ["PR decomposition analysis via miniforge workflow"
           "Spec generation from PR metadata + diff"
           "Sub-PR creation proposals"


### PR DESCRIPTION
## Summary
- Change fallback workflow from `simple-test-v1` to `standard-sdlc` so specs get the full pipeline (explore → plan → implement → verify → review → release)
- Fix `tui-decomposition-workflow.spec.edn` type from `:workflow-integration` (invalid) to `:feature`

## Test plan
- [x] Pre-commit tests pass (28 tests, 0 failures)
- [ ] Run `bb miniforge run work/tui-decomposition-workflow.spec.edn` and verify it uses standard-sdlc

🤖 Generated with [Claude Code](https://claude.com/claude-code)