### PR TITLE
fix(resilience): rate limit propagation, backoff, and reset-time waiting

### DIFF
--- a/components/phase/src/ai/miniforge/phase/implement.clj
+++ b/components/phase/src/ai/miniforge/phase/implement.clj
@@ -128,6 +128,20 @@
         (assoc-in [:phase :status] :running)
         (assoc-in [:phase :result] result))))
 
+(def ^:private rate-limit-pattern
+  "Lightweight rate limit detection for the phase level.
+   Avoids a dependency on workflow/dag-resilience."
+  #"(?i)you've hit your limit|rate.?limit|429|quota.?exceeded|resets \d+[ap]m")
+
+(defn- rate-limit-in-result?
+  "Check if an agent result contains rate limit indicators.
+   Scans both error message and output text."
+  [result]
+  (some (fn [text]
+          (and (string? text) (re-find rate-limit-pattern text)))
+        [(get-in result [:error :message])
+         (when (string? (:output result)) (:output result))]))
+
 (defn leave-implement
   "Post-processing for implementation phase.
 
@@ -138,11 +152,14 @@
         duration-ms (- end-time start-time)
         result (get-in ctx [:phase :result])
         agent-status (:status result)
+        rate-limited? (and (= :error agent-status) (rate-limit-in-result? result))
         iterations (get-in ctx [:phase :iterations] 1)
         max-iterations (get-in ctx [:phase :budget :iterations]
                                (get-in default-config [:budget :iterations]))
         phase-status (cond
                        (= :already-implemented agent-status) :already-implemented
+                       ;; Rate limit: fail immediately, don't burn retry budget
+                       rate-limited? :failed
                        :else (registry/determine-phase-status
                                agent-status iterations max-iterations))
         metrics (get result :metrics {:tokens 0 :duration-ms duration-ms})
@@ -179,8 +196,11 @@
       (assoc-in [:phase :error]
                 {:message (or (not-empty (get-in result [:error :message]))
                               (not-empty (get-in result [:output :error]))
+                              (when (string? (:output result))
+                                (not-empty (:output result)))
                               "Implementation failed after exhausting retry budget")
                  :agent-status agent-status
+                 :rate-limited? (boolean rate-limited?)
                  :iterations iterations})
 
       (= :already-implemented agent-status)

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -223,6 +223,19 @@
 
 ;--- Layer 1: Mini-Workflow Execution
 
+(defn extract-sub-workflow-error
+  "Extract the most informative error message from a failed sub-workflow result.
+   Digs into phase results to find rate limit messages and other details
+   that may not appear in the top-level execution errors."
+  [result]
+  (or (-> result :execution/errors first :message)
+      ;; Check phase result error messages (where rate limit text lives)
+      (->> (vals (:execution/phase-results result))
+           (keep #(get-in % [:error :message]))
+           (filter not-empty)
+           first)
+      "Sub-workflow failed"))
+
 (defn run-mini-workflow
   "Execute a full sub-workflow pipeline for a single DAG task.
 
@@ -239,9 +252,7 @@
         metrics (:execution/metrics result)]
     (if (phase/succeeded? result)
       (workflow-success (first artifacts) metrics)
-      (workflow-failure (or (-> result :execution/errors first :message)
-                            "Sub-workflow failed")
-                        metrics))))
+      (workflow-failure (extract-sub-workflow-error result) metrics))))
 
 (defn workflow-result->dag-result [task-id description wf-result]
   (if (:success? wf-result)
@@ -340,11 +351,12 @@
 (defn handle-rate-limit-in-batch
   "Handle rate-limited tasks in a batch. Returns either:
    - {:action :continue :new-backend X} to re-queue tasks
+   - {:action :continue :waited-ms N} to retry after waiting for reset
    - {:action :pause :result <paused-map>} to stop execution"
-  [context rate-limited-ids new-completed failed-ids all-results
+  [context rate-limited-ids new-completed failed-ids all-results batch-results
    event-stream workflow-id logger]
   (let [decision (resilience/handle-rate-limited-batch
-                  context rate-limited-ids new-completed logger)]
+                  context rate-limited-ids new-completed logger batch-results)]
     (if (= :continue (:action decision))
       decision
       (let [{:keys [artifacts]} (aggregate-results all-results)]
@@ -430,7 +442,7 @@
             (if (seq rate-limited-ids)
               (let [decision (handle-rate-limit-in-batch
                               context rate-limited-ids new-completed failed-ids
-                              all-results event-stream workflow-id logger)]
+                              all-results results event-stream workflow-id logger)]
                 (if (= :continue (:action decision))
                   (recur new-completed
                          failed-ids

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -51,6 +51,79 @@
 (def rate-limit-patterns
   (delay (load-rate-limit-patterns)))
 
+(defn rate-limit-in-text?
+  "Check if arbitrary text contains rate limit patterns.
+   Useful for scanning agent output, error messages, or phase results."
+  [text]
+  (when (and (string? text) (seq text))
+    (boolean (some #(re-find % text) @rate-limit-patterns))))
+
+(def ^:private reset-time-pattern
+  "Matches 'resets 2pm', 'resets 2:30pm', 'resets 2pm (America/Los_Angeles)'"
+  #"resets\s+(\d{1,2}(?::\d{2})?\s*[ap]m)(?:\s*\(([^)]+)\))?")
+
+(def ^:private reset-duration-pattern
+  "Matches 'resets in 30 minutes', 'resets in 2 hours'"
+  #"resets\s+in\s+(\d+)\s*(minutes?|hours?|seconds?)")
+
+(defn parse-reset-instant
+  "Parse rate limit reset time from message text.
+   Returns java.time.Instant or nil.
+
+   Handles:
+   - 'resets 2pm' — assumes local timezone
+   - 'resets 2pm (America/Los_Angeles)' — uses specified timezone
+   - 'resets in 30 minutes' — relative duration"
+  [text]
+  (when (string? text)
+    (or
+     ;; Absolute time: "resets 2pm (America/Los_Angeles)"
+     (when-let [m (re-find reset-time-pattern text)]
+       (try
+         (let [time-str (nth m 1)
+               tz-str (nth m 2)
+               zone (if tz-str
+                      (java.time.ZoneId/of tz-str)
+                      (java.time.ZoneId/systemDefault))
+               ;; Parse "2pm" or "2:30pm" — case-insensitive for am/pm
+               pattern (if (re-find #":" time-str) "h:mma" "ha")
+               formatter (-> (java.time.format.DateTimeFormatterBuilder.)
+                             (.parseCaseInsensitive)
+                             (.appendPattern pattern)
+                             (.toFormatter))
+               local-time (java.time.LocalTime/parse
+                           (.trim time-str)
+                           formatter)
+               now (java.time.ZonedDateTime/now zone)
+               reset-today (.with now local-time)
+               ;; If reset time is in the past, it means tomorrow
+               reset (if (.isBefore reset-today now)
+                       (.plusDays reset-today 1)
+                       reset-today)]
+           (.toInstant reset))
+         (catch Exception _ nil)))
+
+     ;; Relative time: "resets in 30 minutes"
+     (when-let [m (re-find reset-duration-pattern text)]
+       (try
+         (let [amount (Long/parseLong (nth m 1))
+               unit (nth m 2)
+               duration (cond
+                          (re-find #"second" unit) (java.time.Duration/ofSeconds amount)
+                          (re-find #"minute" unit) (java.time.Duration/ofMinutes amount)
+                          (re-find #"hour" unit) (java.time.Duration/ofHours amount))]
+           (.plus (java.time.Instant/now) duration))
+         (catch Exception _ nil))))))
+
+(def ^:private max-rate-limit-wait-ms
+  "Maximum time to wait for a rate limit reset (30 minutes)."
+  (* 30 60 1000))
+
+(defn millis-until-reset
+  "Calculate milliseconds until a reset instant. Returns 0 if already past."
+  [reset-instant]
+  (max 0 (- (.toEpochMilli reset-instant) (System/currentTimeMillis))))
+
 (defn rate-limit-error?
   "Check if a DAG result indicates a rate limit error."
   [result]
@@ -59,7 +132,7 @@
                   (get-in result [:error :data :message])
                   (str result))
           msg (if (string? raw) raw (str raw))]
-      (boolean (some #(re-find % msg) @rate-limit-patterns)))))
+      (rate-limit-in-text? msg))))
 
 (defn find-healthy-backend
   "Find a healthy backend from the allowed list, excluding the current one.
@@ -159,11 +232,59 @@
           {:completed-ids #{} :rate-limited-ids #{} :other-failed-ids #{}}
           results))
 
-(defn handle-rate-limited-batch
-  "Orchestrate the failover decision for a rate-limited batch.
+(defn extract-rate-limit-messages
+  "Extract error messages from rate-limited DAG results."
+  [results rate-limited-ids]
+  (->> rate-limited-ids
+       (map #(get results %))
+       (keep #(or (get-in % [:error :message])
+                  (get-in % [:error :data :message])))
+       (filter string?)))
 
-   Returns {:action :continue :new-backend X} or {:action :pause :reason \"...\"}."
-  [context rate-limited-ids completed-ids logger]
+(defn find-reset-instant
+  "Scan rate limit error messages for a reset time. Returns Instant or nil."
+  [messages]
+  (some parse-reset-instant messages))
+
+(defn wait-for-reset!
+  "Sleep until rate limit resets, if the wait is within the cap.
+   Returns {:waited? true :wait-ms N} or {:waited? false :reason ...}."
+  [reset-instant logger]
+  (let [wait-ms (millis-until-reset reset-instant)]
+    (cond
+      (<= wait-ms 0)
+      {:waited? true :wait-ms 0}
+
+      (<= wait-ms max-rate-limit-wait-ms)
+      (do (log/info logger :dag-resilience :rate-limit/waiting
+                    {:data {:reset-at (str reset-instant)
+                            :wait-ms wait-ms
+                            :wait-minutes (/ wait-ms 60000.0)}})
+          (Thread/sleep wait-ms)
+          {:waited? true :wait-ms wait-ms})
+
+      :else
+      {:waited? false
+       :reason (str "Reset time too far away: "
+                    (long (/ wait-ms 60000)) " minutes (max "
+                    (long (/ max-rate-limit-wait-ms 60000)) ")")})))
+
+(defn- try-wait-for-reset
+  "Strategy 1: Wait for a known reset time.
+   Returns {:action :continue ...} on success, nil to fall through."
+  [results rate-limited-ids logger]
+  (when results
+    (let [msgs (extract-rate-limit-messages results rate-limited-ids)
+          reset-instant (find-reset-instant msgs)]
+      (when reset-instant
+        (let [{:keys [waited?] :as wait-result} (wait-for-reset! reset-instant logger)]
+          (when waited?
+            {:action :continue :waited-ms (:wait-ms wait-result)}))))))
+
+(defn- try-backend-failover
+  "Strategy 2: Switch to an alternative backend.
+   Returns {:action :continue ...} on success, nil to fall through."
+  [context logger]
   (let [self-healing (or (get-in context [:execution/opts :self-healing])
                          (get-in context [:user-config :self-healing])
                          {})
@@ -173,19 +294,45 @@
         accumulated-cost (get-in context [:execution/metrics :cost-usd] 0.0)
         current-backend (or (get-in context [:llm-backend :backend-type])
                             (get context :current-backend :claude))]
-    (log/info logger :dag-resilience :rate-limit/detected
-              {:data {:rate-limited-count (count rate-limited-ids)
-                      :completed-count (count completed-ids)
-                      :auto-switch? auto-switch?
-                      :allowed-backends allowed}})
-    (if (and auto-switch? (seq allowed))
+    (when (and auto-switch? (seq allowed))
       (let [switch-result (attempt-backend-switch
                            current-backend allowed cost-ceiling accumulated-cost logger)]
-        (if (:switched? switch-result)
-          {:action :continue :new-backend (:new-backend switch-result)}
-          {:action :pause
-           :reason (str "Rate limited. Failover failed: " (name (or (:reason switch-result) :unknown)))}))
-      {:action :pause
-       :reason (if (not auto-switch?)
-                 "Rate limited. Backend auto-switch is disabled."
-                 "Rate limited. No failover backends configured (set :allowed-failover-backends).")})))
+        (when (:switched? switch-result)
+          {:action :continue :new-backend (:new-backend switch-result)})))))
+
+(defn- pause-with-reason
+  "Strategy 3 (terminal): Pause with an explanatory reason."
+  [context]
+  (let [self-healing (or (get-in context [:execution/opts :self-healing])
+                         (get-in context [:user-config :self-healing])
+                         {})
+        auto-switch? (get self-healing :backend-auto-switch true)]
+    {:action :pause
+     :reason (cond
+               (not auto-switch?)
+               "Rate limited. Backend auto-switch is disabled."
+
+               (empty? (get self-healing :allowed-failover-backends []))
+               "Rate limited. No failover backends configured (set :allowed-failover-backends)."
+
+               :else
+               "Rate limited. All recovery strategies exhausted.")}))
+
+(defn handle-rate-limited-batch
+  "Orchestrate the failover decision for a rate-limited batch.
+
+   Runs a strategy chain:
+   1. Wait for known reset time (if within 30 minutes)
+   2. Switch to an alternative backend (if configured)
+   3. Pause with reason
+
+   Returns {:action :continue ...} or {:action :pause :reason \"...\"}."
+  ([context rate-limited-ids completed-ids logger]
+   (handle-rate-limited-batch context rate-limited-ids completed-ids logger nil))
+  ([context rate-limited-ids completed-ids logger results]
+   (log/info logger :dag-resilience :rate-limit/detected
+             {:data {:rate-limited-count (count rate-limited-ids)
+                     :completed-count (count completed-ids)}})
+   (or (try-wait-for-reset results rate-limited-ids logger)
+       (try-backend-failover context logger)
+       (pause-with-reason context))))

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -266,11 +266,18 @@
                                                    ctx/transition-to-completed
                                                    ctx/transition-to-failed)
                           (monitoring/clear-transient-state))
-            event-stream (get-in phase-ctx [:execution/opts :event-stream])
-            switch-result (check-backend-health-at-boundary! event-stream phase-ctx)]
-        (if switch-result
-          (assoc phase-ctx :self-healing/backend-switch switch-result)
-          phase-ctx)))))
+            ;; Exponential backoff when phase is retrying
+            retrying? (= (:execution/phase-index phase-ctx)
+                         (:execution/phase-index context))
+            retry-count (get-in phase-ctx [:phase :iterations] 1)]
+        (when (and retrying? (> retry-count 1))
+          (let [backoff-ms (min 30000 (long (* 1000 (Math/pow 2 (dec retry-count)))))]
+            (Thread/sleep backoff-ms)))
+        (let [event-stream (get-in phase-ctx [:execution/opts :event-stream])
+              switch-result (check-backend-health-at-boundary! event-stream phase-ctx)]
+          (if switch-result
+            (assoc phase-ctx :self-healing/backend-switch switch-result)
+            phase-ctx))))))
 
 ;------------------------------------------------------------------------------ Layer 1.5: Output extraction
 

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_test.clj
@@ -5,7 +5,8 @@
    [ai.miniforge.workflow.dag-resilience :as resilience]
    [ai.miniforge.workflow.dag-orchestrator :as dag-orch]
    [ai.miniforge.dag-executor.interface :as dag]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log])
+  (:import [java.time Instant ZonedDateTime ZoneId]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures
@@ -514,3 +515,102 @@
           sub-wf (dag-orch/task-sub-workflow task-def context)
           phase-names (mapv :phase (:workflow/pipeline sub-wf))]
       (is (= [:implement :done] phase-names)))))
+
+;------------------------------------------------------------------------------ Layer 6
+;; rate-limit-in-text? tests
+
+(deftest test-rate-limit-in-text-detects-patterns
+  (testing "detects rate limit patterns in arbitrary text"
+    (are [text] (resilience/rate-limit-in-text? text)
+      "You've hit your limit · resets 2pm"
+      "Claude CLI rate limited: You've hit your limit · resets 2pm (America/Los_Angeles)"
+      "API rate limit exceeded"
+      "429 Too Many Requests"
+      "Quota exceeded for this billing period"
+      "resets 3pm (US/Pacific)")))
+
+(deftest test-rate-limit-in-text-rejects-normal-text
+  (testing "does not flag normal text"
+    (are [text] (not (resilience/rate-limit-in-text? text))
+      "Syntax error in foo.clj"
+      "Connection refused"
+      nil
+      "")))
+
+;------------------------------------------------------------------------------ Layer 7
+;; parse-reset-instant tests
+
+(deftest test-parse-reset-instant-absolute-time
+  (testing "parses 'resets 2pm' as an instant"
+    (let [text "You've hit your limit · resets 2pm"
+          result (resilience/parse-reset-instant text)]
+      (is (instance? Instant result))
+      (is (.isAfter result (Instant/now)))))
+
+  (testing "parses 'resets 2pm (America/Los_Angeles)' with timezone"
+    (let [text "You've hit your limit · resets 2pm (America/Los_Angeles)"
+          result (resilience/parse-reset-instant text)]
+      (is (instance? Instant result))))
+
+  (testing "parses 'resets 2:30pm' with minutes"
+    (let [text "resets 2:30pm"
+          result (resilience/parse-reset-instant text)]
+      (is (instance? Instant result)))))
+
+(deftest test-parse-reset-instant-relative-time
+  (testing "parses 'resets in 30 minutes' as relative duration"
+    (let [before (Instant/now)
+          result (resilience/parse-reset-instant "resets in 30 minutes")
+          after (Instant/now)]
+      (is (instance? Instant result))
+      ;; Should be approximately 30 minutes from now
+      (is (> (.toEpochMilli result) (+ (.toEpochMilli before) 1790000)))
+      (is (< (.toEpochMilli result) (+ (.toEpochMilli after) 1810000))))))
+
+(deftest test-parse-reset-instant-no-match
+  (testing "returns nil for non-reset text"
+    (is (nil? (resilience/parse-reset-instant "Syntax error")))
+    (is (nil? (resilience/parse-reset-instant nil)))))
+
+;------------------------------------------------------------------------------ Layer 8
+;; handle-rate-limited-batch with reset time waiting
+
+(deftest test-handle-rate-limited-batch-waits-for-reset
+  (testing "waits for reset when reset time is imminent (relative)"
+    (let [[logger _] (log/collecting-logger)
+          rate-limit-msg "You've hit your limit · resets in 1 seconds"
+          results {:b (dag/err :task-execution-failed rate-limit-msg {:task-id :b})}
+          decision (resilience/handle-rate-limited-batch
+                    {} #{:b} #{:a} logger results)]
+      ;; Should have waited and returned :continue
+      (is (= :continue (:action decision)))
+      (is (number? (:waited-ms decision))))))
+
+(deftest test-handle-rate-limited-batch-pauses-without-results
+  (testing "pauses when no results provided (backward compat)"
+    (let [[logger _] (log/collecting-logger)
+          decision (resilience/handle-rate-limited-batch
+                    {} #{:b} #{:a} logger)]
+      (is (= :pause (:action decision))))))
+
+;------------------------------------------------------------------------------ Layer 9
+;; extract-sub-workflow-error tests
+
+(deftest test-extract-sub-workflow-error-from-phase-results
+  (testing "extracts error from phase results when execution errors empty"
+    (let [result {:execution/errors []
+                  :execution/phase-results
+                  {:implement {:error {:message "Claude CLI rate limited: You've hit your limit"}}}}]
+      (is (= "Claude CLI rate limited: You've hit your limit"
+             (dag-orch/extract-sub-workflow-error result)))))
+
+  (testing "prefers execution errors when available"
+    (let [result {:execution/errors [{:message "Exceeded 5 redirects"}]
+                  :execution/phase-results
+                  {:implement {:error {:message "some phase error"}}}}]
+      (is (= "Exceeded 5 redirects"
+             (dag-orch/extract-sub-workflow-error result)))))
+
+  (testing "falls back to default message"
+    (is (= "Sub-workflow failed"
+           (dag-orch/extract-sub-workflow-error {})))))


### PR DESCRIPTION
## Summary

- **Phase-level rate limit detection**: implement phase now detects rate limit errors in agent results and fails immediately instead of burning through the 8-iteration retry budget in ~16 seconds
- **Error message propagation**: sub-workflow errors now dig into phase results to extract rate limit text, so `rate-limit-error?` at the DAG level can match it
- **Reset-time waiting**: parses "resets 2pm (America/Los_Angeles)" and "resets in 30 minutes" from Claude CLI rate limit messages, sleeps until reset (capped at 30 min), then retries automatically
- **Exponential backoff**: all phase retries now have 2^n second backoff (max 30s), preventing tight loops for any transient error
- **Strategy chain refactor**: `handle-rate-limited-batch` decomposed from nested if/let tree into composable `or` chain: `try-wait-for-reset → try-backend-failover → pause-with-reason`

## Bug context

During dogfooding of `tui-decomposition-workflow.spec.edn`, two DAG tasks hit Claude CLI rate limit. The system:
1. Retried implement 6+ times in rapid succession (~2s per attempt, $0.00 each)
2. Exhausted the redirect budget without any backoff
3. Reported generic "Sub-workflow failed" — `rate-limit-error?` never triggered
4. DAG reported 5/11 completed, 6 failed (all rate-limited)

The rate limit text was present in agent chunks/output but never reached the DAG result's error message path.

## Files changed

| File | Change |
|------|--------|
| `implement.clj` | `rate-limit-in-result?` → skip retry, fail immediately with rate limit message |
| `dag_orchestrator.clj` | `extract-sub-workflow-error` digs into phase results for error details |
| `dag_resilience.clj` | `rate-limit-in-text?`, `parse-reset-instant`, `wait-for-reset!`, strategy chain refactor |
| `runner.clj` | Exponential backoff in `execute-single-iteration` when phase retries |
| `dag_resilience_test.clj` | 8 new tests for text detection, time parsing, waiting, error extraction |

## Test plan

- [x] All 290 existing tests pass (0 failures)
- [x] 5 GraalVM compatibility tests pass
- [x] New tests cover: rate-limit-in-text? detection/rejection, parse-reset-instant absolute/relative, handle-rate-limited-batch with waiting, extract-sub-workflow-error from phase results
- [ ] Re-run `tui-decomposition-workflow.spec.edn` after rate limit resets to verify end-to-end fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)