### PR TITLE
fix(tui-views,gate,verify): wire PR decomposition and error handling

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -296,9 +296,13 @@
             ;; Use the real LLM with artifact session for MCP tool support
             (let [{:keys [llm-result artifact]}
                   (artifact-session/with-artifact-session [session]
-                    (let [mcp-opts {:mcp-config (:mcp-config-path session)
+                    (let [budget-usd (or (get-in opts [:config :budget :cost-usd])
+                                        (get-in context [:budget :cost-usd])
+                                        2.50)
+                          mcp-opts {:mcp-config (:mcp-config-path session)
                                     :mcp-allowed-tools (:mcp-allowed-tools session)
-                                    :supervision (:supervision session)}]
+                                    :supervision (:supervision session)
+                                    :budget-usd budget-usd}]
                       (if on-chunk
                         (llm/chat-stream llm-client user-prompt on-chunk
                                          (merge {:system effective-system-prompt} mcp-opts))

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -306,9 +306,13 @@
             ;; Use the real LLM with artifact session for MCP tool support
             (let [{:keys [llm-result artifact]}
                   (artifact-session/with-artifact-session [session]
-                    (let [mcp-opts {:mcp-config (:mcp-config-path session)
+                    (let [budget-usd (or (get-in opts [:config :budget :cost-usd])
+                                        (get-in context [:budget :cost-usd])
+                                        5.00)
+                          mcp-opts {:mcp-config (:mcp-config-path session)
                                     :mcp-allowed-tools (:mcp-allowed-tools session)
-                                    :supervision (:supervision session)}]
+                                    :supervision (:supervision session)
+                                    :budget-usd budget-usd}]
                       (if on-chunk
                         (llm/chat-stream llm-client user-prompt on-chunk
                                          (merge {:system @planner-system-prompt} mcp-opts))

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -208,9 +208,13 @@
             ;; Use the real LLM with artifact session for MCP tool support
             (let [{:keys [llm-result artifact]}
                   (artifact-session/with-artifact-session [session]
-                    (let [mcp-opts {:mcp-config (:mcp-config-path session)
+                    (let [budget-usd (or (get-in opts [:config :budget :cost-usd])
+                                        (get-in context [:budget :cost-usd])
+                                        1.00)
+                          mcp-opts {:mcp-config (:mcp-config-path session)
                                     :mcp-allowed-tools (:mcp-allowed-tools session)
-                                    :supervision (:supervision session)}]
+                                    :supervision (:supervision session)
+                                    :budget-usd budget-usd}]
                       (if on-chunk
                         (llm/chat-stream llm-client user-prompt on-chunk
                                          (merge {:system @releaser-system-prompt} mcp-opts))

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -16,6 +16,11 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Tester-specific schemas
 
+(def ^:private default-tester-budget-usd
+  "Fallback budget cap for tester LLM calls when no budget is supplied
+   through opts or agent context."
+  2.00)
+
 (def TestFile
   "Schema for a test file."
   [:map
@@ -265,8 +270,8 @@
             (let [{:keys [llm-result artifact]}
                   (artifact-session/with-artifact-session [session]
                     (let [budget-usd (or (get-in opts [:config :budget :cost-usd])
-                                        (get-in context [:budget :cost-usd])
-                                        2.00)
+                                         (get-in context [:budget :cost-usd])
+                                         default-tester-budget-usd)
                           mcp-opts {:mcp-config (:mcp-config-path session)
                                     :mcp-allowed-tools (:mcp-allowed-tools session)
                                     :supervision (:supervision session)

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -264,9 +264,13 @@
             ;; Use the real LLM with artifact session for MCP tool support
             (let [{:keys [llm-result artifact]}
                   (artifact-session/with-artifact-session [session]
-                    (let [mcp-opts {:mcp-config (:mcp-config-path session)
+                    (let [budget-usd (or (get-in opts [:config :budget :cost-usd])
+                                        (get-in context [:budget :cost-usd])
+                                        2.00)
+                          mcp-opts {:mcp-config (:mcp-config-path session)
                                     :mcp-allowed-tools (:mcp-allowed-tools session)
-                                    :supervision (:supervision session)}]
+                                    :supervision (:supervision session)
+                                    :budget-usd budget-usd}]
                       (if on-chunk
                         (llm/chat-stream llm-client user-prompt on-chunk
                                          (merge {:system @tester-system-prompt} mcp-opts))

--- a/components/gate/src/ai/miniforge/gate/policy.clj
+++ b/components/gate/src/ai/miniforge/gate/policy.clj
@@ -87,7 +87,10 @@
 (defn check-review-approved
   "Check if review is approved."
   [artifact _ctx]
-  (let [approved? (or (get-in artifact [:metadata :approved])
+  (let [decision (get artifact :review/decision)
+        approved? (or (= :approved decision)
+                      (= :conditionally-approved decision)
+                      (get-in artifact [:metadata :approved])
                       (get-in artifact [:artifact/metadata :approved])
                       (get-in artifact [:review :approved]))]
     (if approved?

--- a/components/gate/test/ai/miniforge/gate/interface_test.clj
+++ b/components/gate/test/ai/miniforge/gate/interface_test.clj
@@ -206,3 +206,50 @@
     (let [result (gate/check-gate :syntax {:content "(+ 1 2)"} {})]
       (is (:passed? result))
       (is (= :syntax (:gate result))))))
+
+;; ============================================================================
+;; Review-approved gate tests (PR #288)
+;; ============================================================================
+
+(deftest check-gate-review-approved-via-decision-test
+  (testing "review-approved gate passes when :review/decision is :approved"
+    (let [result (gate/check-gate :review-approved
+                                   {:review/decision :approved}
+                                   {})]
+      (is (:passed? result))))
+
+  (testing "review-approved gate passes when :review/decision is :conditionally-approved"
+    (let [result (gate/check-gate :review-approved
+                                   {:review/decision :conditionally-approved}
+                                   {})]
+      (is (:passed? result))))
+
+  (testing "review-approved gate fails when :review/decision is :rejected"
+    (let [result (gate/check-gate :review-approved
+                                   {:review/decision :rejected}
+                                   {})]
+      (is (not (:passed? result)))
+      (is (= :not-approved (get-in (first (:errors result)) [:type]))))))
+
+(deftest check-gate-review-approved-fallback-paths-test
+  (testing "review-approved gate passes via :metadata :approved fallback"
+    (let [result (gate/check-gate :review-approved
+                                   {:metadata {:approved true}}
+                                   {})]
+      (is (:passed? result))))
+
+  (testing "review-approved gate passes via :artifact/metadata :approved fallback"
+    (let [result (gate/check-gate :review-approved
+                                   {:artifact/metadata {:approved true}}
+                                   {})]
+      (is (:passed? result))))
+
+  (testing "review-approved gate passes via :review :approved fallback"
+    (let [result (gate/check-gate :review-approved
+                                   {:review {:approved true}}
+                                   {})]
+      (is (:passed? result))))
+
+  (testing "review-approved gate fails when no approval signal present"
+    (let [result (gate/check-gate :review-approved {} {})]
+      (is (not (:passed? result))))))

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -166,16 +166,17 @@
             :requires-cli? true
             :api-key-var "ANTHROPIC_API_KEY"
             :stream-parser parse-claude-stream-line
-            :args-fn (fn [{:keys [prompt system max-tokens streaming? mcp-config mcp-allowed-tools supervision]}]
-                       (cond-> ["-p"]
-                         streaming?                   (conj "--output-format" "stream-json")
-                         streaming?                   (conj "--verbose")
-                         mcp-config                   (into ["--mcp-config" mcp-config])
-                         (seq mcp-allowed-tools)      (into ["--allowedTools" (str/join "," mcp-allowed-tools)])
-                         (:settings-path supervision) (into ["--settings" (:settings-path supervision)])
-                         system                       (into ["--system-prompt" system])
-                         max-tokens                   (into ["--max-budget-usd" "0.10"])
-                         true                         (conj prompt)))}
+            :args-fn (fn [{:keys [prompt system max-tokens streaming? mcp-config mcp-allowed-tools supervision budget-usd]}]
+                       (let [budget (or budget-usd (when max-tokens "0.10"))]
+                         (cond-> ["-p"]
+                           streaming?                   (conj "--output-format" "stream-json")
+                           streaming?                   (conj "--verbose")
+                           mcp-config                   (into ["--mcp-config" mcp-config])
+                           (seq mcp-allowed-tools)      (into ["--allowedTools" (str/join "," mcp-allowed-tools)])
+                           (:settings-path supervision) (into ["--settings" (:settings-path supervision)])
+                           system                       (into ["--system-prompt" system])
+                           budget                       (into ["--max-budget-usd" (str budget)])
+                           true                         (conj prompt))))}
 
    :codex {:cmd "codex"
            :streaming? true

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -21,6 +21,11 @@
 ;; These builders ensure consistent construction across all backends
 ;; (CLI, HTTP/OpenAI, HTTP/Ollama, streaming, non-streaming).
 
+(def ^:private default-claude-cli-budget-usd
+  "Default CLI budget cap used when a request is token-bounded but does not
+   supply an explicit dollar budget."
+  "0.10")
+
 (defn llm-success
   "Build a successful LLM response."
   ([content]
@@ -167,7 +172,8 @@
             :api-key-var "ANTHROPIC_API_KEY"
             :stream-parser parse-claude-stream-line
             :args-fn (fn [{:keys [prompt system max-tokens streaming? mcp-config mcp-allowed-tools supervision budget-usd]}]
-                       (let [budget (or budget-usd (when max-tokens "0.10"))]
+                       (let [budget (or budget-usd
+                                        (when max-tokens default-claude-cli-budget-usd))]
                          (cond-> ["-p"]
                            streaming?                   (conj "--output-format" "stream-json")
                            streaming?                   (conj "--verbose")

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -286,6 +286,37 @@
     (let [resp (impl/streaming-success-response "(defn foo [] 42)" 0 nil nil)]
       (is (:success resp)))))
 
+;------------------------------------------------------------------------------ Layer 4
+;; Claude backend args-fn budget tests (PR #288)
+
+(deftest claude-args-fn-budget-usd-test
+  (let [args-fn (:args-fn (get impl/backends :claude))]
+
+    (testing "budget-usd from request is used as --max-budget-usd value"
+      (let [args (args-fn {:prompt "test" :budget-usd 2.50})]
+        (is (some #{"--max-budget-usd"} args))
+        (is (some #{"2.5"} args))))
+
+    (testing "falls back to 0.10 when max-tokens set but no budget-usd"
+      (let [args (args-fn {:prompt "test" :max-tokens 8000})]
+        (is (some #{"--max-budget-usd"} args))
+        (is (some #{"0.10"} args))))
+
+    (testing "budget-usd takes priority over max-tokens fallback"
+      (let [args (args-fn {:prompt "test" :max-tokens 8000 :budget-usd 5.0})]
+        (is (some #{"5.0"} args))
+        (is (not (some #{"0.10"} args)))))
+
+    (testing "no budget flag when neither budget-usd nor max-tokens"
+      (let [args (args-fn {:prompt "test"})]
+        (is (not (some #{"--max-budget-usd"} args)))))
+
+    (testing "mcp-config flag is included when provided"
+      (let [args (args-fn {:prompt "test" :mcp-config "/tmp/mcp.json"
+                           :budget-usd 2.50})]
+        (is (some #{"--mcp-config"} args))
+        (is (some #{"/tmp/mcp.json"} args))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (test/run-tests 'ai.miniforge.llm.interface-test)

--- a/components/phase/src/ai/miniforge/phase/verify.clj
+++ b/components/phase/src/ai/miniforge/phase/verify.clj
@@ -190,6 +190,12 @@
         result (get-in ctx [:phase :result])
         agent-status (:status result)
         gate-failed? (= :failed (:phase/status (get-in ctx [:phase])))
+        timeout? (and (= :error agent-status)
+                      (some-> (get-in result [:error :message])
+                              (str/includes? "timed out")))
+        rate-limited? (and (= :error agent-status)
+                           (let [msg (str (get-in result [:error :message]))]
+                             (re-find #"(?i)rate.?limit|429|you've hit your limit|quota.?exceeded" msg)))
         phase-status (cond
                        gate-failed?                :failed
                        (= :error agent-status)     :failed
@@ -210,8 +216,10 @@
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
     ;; When verify failed and on-fail is configured, redirect to target phase
-    ;; and attach verify failure details for the implement agent to use
-    (if (and (= :failed phase-status) on-fail)
+    ;; UNLESS the failure was a timeout or rate limit — those aren't code quality
+    ;; issues and retrying implement won't help.
+    (if (and (= :failed phase-status) on-fail
+             (not timeout?) (not rate-limited?))
       (-> updated-ctx
           (assoc-in [:phase :redirect-to] on-fail)
           (assoc-in [:phase :error]
@@ -220,7 +228,16 @@
                                   "Verification failed")
                      :agent-status agent-status
                      :gate-failed? gate-failed?}))
-      updated-ctx)))
+      (cond-> updated-ctx
+        (= :failed phase-status)
+        (assoc-in [:phase :error]
+                  {:message (or (not-empty (get-in result [:error :message]))
+                                (when gate-failed? "Gate validation failed")
+                                "Verification failed")
+                   :agent-status agent-status
+                   :timeout? timeout?
+                   :rate-limited? rate-limited?
+                   :gate-failed? gate-failed?})))))
 
 (defn error-verify
   "Handle verification phase errors.

--- a/components/phase/src/ai/miniforge/phase/verify.clj
+++ b/components/phase/src/ai/miniforge/phase/verify.clj
@@ -42,6 +42,14 @@
    ;; Verification can use fast validation - hint at Haiku
    :model-hint :haiku-4.5})
 
+(def ^:private timeout-message-fragment
+  "Substring that marks a non-actionable verify timeout."
+  "timed out")
+
+(def ^:private verify-rate-limit-pattern
+  "Pattern for non-actionable verify failures caused by provider throttling."
+  #"(?i)rate.?limit|429|you've hit your limit|quota.?exceeded")
+
 ;; Register defaults on load
 (registry/register-phase-defaults! :verify default-config)
 
@@ -192,10 +200,10 @@
         gate-failed? (= :failed (:phase/status (get-in ctx [:phase])))
         timeout? (and (= :error agent-status)
                       (some-> (get-in result [:error :message])
-                              (str/includes? "timed out")))
+                              (str/includes? timeout-message-fragment)))
         rate-limited? (and (= :error agent-status)
                            (let [msg (str (get-in result [:error :message]))]
-                             (re-find #"(?i)rate.?limit|429|you've hit your limit|quota.?exceeded" msg)))
+                             (re-find verify-rate-limit-pattern msg)))
         phase-status (cond
                        gate-failed?                :failed
                        (= :error agent-status)     :failed

--- a/components/phase/test/ai/miniforge/phase/verify_failure_modes_test.clj
+++ b/components/phase/test/ai/miniforge/phase/verify_failure_modes_test.clj
@@ -1,11 +1,11 @@
 (ns ai.miniforge.phase.verify-failure-modes-test
   "Additional tests for verify phase failure modes and artifact validation.
-  
+
   Extends the existing verify_test.clj with comprehensive failure mode testing."
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.phase.registry :as registry]
-   [ai.miniforge.phase.verify] ;; registers :verify defmethod
+   [ai.miniforge.phase.verify :as verify] ;; registers :verify defmethod
    [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.response.interface :as response]))
 
@@ -150,6 +150,65 @@
               "Test result should indicate failure")
           (is (seq (:test/failures test-result))
               "Failures should be captured"))))))
+
+;------------------------------------------------------------------------------ Leave-verify redirect suppression tests (PR #288)
+
+(defn make-leave-ctx
+  "Build a minimal context suitable for leave-verify.
+   `result` is the phase result map (agent output).
+   `on-fail` is the redirect target (e.g. :implement) or nil."
+  [result on-fail]
+  (cond-> {:phase {:started-at (- (System/currentTimeMillis) 1000)
+                   :result result
+                   :iterations 1}
+           :execution {:phases-completed []}
+           :execution/metrics {:tokens 0 :duration-ms 0}}
+    on-fail (assoc :phase-config {:on-fail on-fail})))
+
+(deftest leave-verify-redirects-on-normal-failure-test
+  (testing "normal verify failure with :on-fail configured sets :redirect-to"
+    (let [ctx (make-leave-ctx {:status :error
+                               :error {:message "Tests failed: 3 assertions"}}
+                              :implement)
+          result (verify/leave-verify ctx)]
+      (is (= :implement (get-in result [:phase :redirect-to])))
+      (is (= :failed (get-in result [:phase :status]))))))
+
+(deftest leave-verify-no-redirect-on-timeout-test
+  (testing "timeout error does NOT redirect even with :on-fail configured"
+    (let [ctx (make-leave-ctx {:status :error
+                               :error {:message "Agent timed out after 600000ms"}}
+                              :implement)
+          result (verify/leave-verify ctx)]
+      (is (nil? (get-in result [:phase :redirect-to])))
+      (is (= :failed (get-in result [:phase :status])))
+      (is (true? (get-in result [:phase :error :timeout?]))))))
+
+(deftest leave-verify-no-redirect-on-rate-limit-test
+  (testing "rate-limit error does NOT redirect even with :on-fail configured"
+    (let [ctx (make-leave-ctx {:status :error
+                               :error {:message "429 rate limit exceeded"}}
+                              :implement)
+          result (verify/leave-verify ctx)]
+      (is (nil? (get-in result [:phase :redirect-to])))
+      (is (= :failed (get-in result [:phase :status])))
+      (is (some? (get-in result [:phase :error :rate-limited?])))))
+
+  (testing "rate-limit variant: you've hit your limit"
+    (let [ctx (make-leave-ctx {:status :error
+                               :error {:message "You've hit your limit · resets 7pm"}}
+                              :implement)
+          result (verify/leave-verify ctx)]
+      (is (nil? (get-in result [:phase :redirect-to]))))))
+
+(deftest leave-verify-no-redirect-without-on-fail-test
+  (testing "normal failure without :on-fail does not set :redirect-to"
+    (let [ctx (make-leave-ctx {:status :error
+                               :error {:message "Tests failed"}}
+                              nil)
+          result (verify/leave-verify ctx)]
+      (is (nil? (get-in result [:phase :redirect-to])))
+      (is (= :failed (get-in result [:phase :status]))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -39,6 +39,7 @@
    [ai.miniforge.policy-pack.interface :as policy-pack]
    [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.llm.interface :as llm]
+   [ai.miniforge.tui-views.persistence.github :as github]
    [ai.miniforge.tui-views.prompts :as prompts]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -147,10 +148,63 @@
   (let [fixable (count (filter #(seq (get-in % [:pr/policy :evaluation/violations])) prs))]
     (msg/remediation-completed 0 fixable "Remediation via pr-lifecycle not yet wired")))
 
-(defn handle-decompose-pr [{:keys [pr]}]
-  (msg/decomposition-started [(:pr/repo pr) (:pr/number pr)]
-                             {:sub-prs []
-                              :message "Decomposition analysis not yet wired"}))
+(defonce ^:private decompose-llm-client (delay (llm/create-client)))
+
+(defn handle-decompose-pr
+  "Decompose a large PR into sub-PRs.
+   Entire body is wrapped in try/catch — no exceptions leak."
+  [{:keys [pr]}]
+  (let [pr-id [(:pr/repo pr) (:pr/number pr)]]
+    (try
+      (let [{:keys [diff detail]} (github/fetch-pr-diff-and-detail
+                                   (:pr/repo pr) (:pr/number pr))
+            changed-files (mapv :path (:files detail []))
+            decompose-fn (try (requiring-resolve
+                               'ai.miniforge.pr-decompose.interface/decompose)
+                              (catch Throwable _ nil))]
+        (cond
+          ;; Both fetches failed
+          (and (nil? diff) (nil? detail))
+          (msg/decomposition-started pr-id
+                                     {:sub-prs []
+                                      :message "Failed to fetch PR diff and details"})
+
+          ;; Decompose component not available
+          (nil? decompose-fn)
+          (msg/decomposition-started pr-id
+                                     {:sub-prs []
+                                      :message "Decomposition component not available"})
+
+          :else
+          (let [llm-fn (fn [req] (llm/complete @decompose-llm-client req))
+                result (decompose-fn pr (or diff "") changed-files llm-fn)]
+            (if (:ok? result)
+              (let [plan (get-in result [:data :plan])]
+                (msg/decomposition-started pr-id
+                                           {:sub-prs (:sub-prs plan [])
+                                            :strategy (:strategy plan)
+                                            :original-size (:original-size plan)
+                                            :coverage (:coverage plan)}))
+              (msg/decomposition-started pr-id
+                                         {:sub-prs []
+                                          :message (or (get-in result [:error :message])
+                                                       "Decomposition failed")})))))
+      (catch Throwable e
+        (msg/decomposition-started pr-id
+                                   {:sub-prs []
+                                    :message (.getMessage e)})))))
+
+(defn handle-fetch-pr-diff
+  "Fetch PR diff and detail from GitHub CLI."
+  [{:keys [repo number]}]
+  (try
+    (let [n (long (if (string? number) (Long/parseLong number) number))
+          {:keys [diff detail]} (github/fetch-pr-diff-and-detail repo n)]
+      (if (and (nil? diff) (nil? detail))
+        (msg/pr-diff-fetched [repo n] nil nil "Failed to fetch PR diff and details")
+        (msg/pr-diff-fetched [repo n] diff detail nil)))
+    (catch Throwable e
+      (msg/pr-diff-fetched [repo number] nil nil (.getMessage e)))))
 
 (defn handle-cache-policy-result [{:keys [pr-id result prs]}]
   (pr-cache/persist-policy-result! pr-id result prs)
@@ -178,38 +232,47 @@
   [{:keys [action context]}]
   (try
     (let [action-type (:action action)]
-      (case action-type
-        :review
-        (if-let [pr (:pr context)]
-          (handle-review-prs {:prs [pr]})
-          (msg/chat-action-result {:success? false :message "No PR in context for review"}))
+      (let [result (case action-type
+                     :review
+                     (if-let [pr (:pr context)]
+                       (handle-review-prs {:prs [pr]})
+                       (msg/chat-action-result {:success? false :message "No PR in context for review"}))
 
-        :evaluate
-        (if-let [pr (:pr context)]
-          (handle-evaluate-policy {:pr pr :pr-id [(:pr/repo pr) (:pr/number pr)]})
-          (msg/chat-action-result {:success? false :message "No PR in context for evaluation"}))
+                     :evaluate
+                     (if-let [pr (:pr context)]
+                       (handle-evaluate-policy {:pr pr :pr-id [(:pr/repo pr) (:pr/number pr)]})
+                       (msg/chat-action-result {:success? false :message "No PR in context for evaluation"}))
 
-        :sync
-        (handle-sync-prs {})
+                     :sync
+                     (handle-sync-prs {})
 
-        :open
-        (if-let [url (get-in context [:pr :pr/url])]
-          (do (handle-open-url {:url url})
-              (msg/chat-action-result {:success? true :message (str "Opened " url)}))
-          (msg/chat-action-result {:success? false :message "No PR URL available"}))
+                     :open
+                     (if-let [url (get-in context [:pr :pr/url])]
+                       (do (handle-open-url {:url url})
+                           (msg/chat-action-result {:success? true :message (str "Opened " url)}))
+                       (msg/chat-action-result {:success? false :message "No PR URL available"}))
 
-        :remediate
-        (if-let [pr (:pr context)]
-          (handle-remediate-prs {:prs [pr]})
-          (msg/chat-action-result {:success? false :message "No PR in context"}))
+                     :remediate
+                     (if-let [pr (:pr context)]
+                       (handle-remediate-prs {:prs [pr]})
+                       (msg/chat-action-result {:success? false :message "No PR in context"}))
 
-        :decompose
-        (if-let [pr (:pr context)]
-          (handle-decompose-pr {:pr pr})
-          (msg/chat-action-result {:success? false :message "No PR in context"}))
+                     :decompose
+                     (if-let [pr (:pr context)]
+                       (handle-decompose-pr {:pr pr})
+                       (msg/chat-action-result {:success? false :message "No PR in context"}))
 
-        (msg/chat-action-result {:success? false
-                                 :message (str "Unknown action: " (name (or action-type :none)))})))
+                     (msg/chat-action-result
+                      {:success? false
+                       :message (str "Unknown action: " (name (or action-type :none)))}))]
+        (if (= :msg/side-effect-error (first result))
+          (let [payload (second result)
+                message (or (get-in payload [:error :message])
+                            (:message payload)
+                            (:error payload)
+                            "Action failed")]
+            (msg/chat-action-result {:success? false :message message}))
+          result)))
     (catch Exception e
       (msg/chat-action-result {:success? false :message (.getMessage e)}))))
 
@@ -428,6 +491,7 @@
     :cache-policy-result (handle-cache-policy-result effect)
     :cache-risk-triage   (handle-cache-risk-triage effect)
     :decompose-pr      (handle-decompose-pr effect)
+    :fetch-pr-diff     (handle-fetch-pr-diff effect)
     :control-action    (handle-control-action effect)
     :archive-workflows (handle-archive-workflows effect)
     :chat-send         (handle-chat-send effect)

--- a/components/tui-views/src/ai/miniforge/tui_views/msg.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/msg.clj
@@ -66,7 +66,14 @@
   [:msg/remediation-completed {:fixed fixed :failed failed :message message}])
 
 (defn decomposition-started [pr-id plan]
-  [:msg/decomposition-started {:pr-id pr-id :plan plan}])
+  [:msg/decomposition-started (merge {:pr-id pr-id} plan)])
+
+(defn pr-diff-fetched
+  "Build a :msg/pr-diff-fetched message.
+   Omits :error key when error is nil."
+  [pr-id diff detail error]
+  [:msg/pr-diff-fetched (cond-> {:pr-id pr-id :diff diff :detail detail}
+                          error (assoc :error error))])
 
 (defn chat-response [content actions]
   [:msg/chat-response {:content content :actions actions}])

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence/github.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence/github.clj
@@ -1,0 +1,84 @@
+(ns ai.miniforge.tui-views.persistence.github
+  "GitHub CLI wrappers for fetching PR diffs and details.
+
+   Uses `gh pr diff` and `gh pr view` via babashka.process/shell.
+   All functions return nil on failure (non-zero exit, exception, parse error)."
+  (:require
+   [clojure.string :as str]
+   [cheshire.core :as json]
+   [babashka.process :as process]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Validation and CLI helpers
+
+(def ^:private shell-opts
+  {:out :string :err :string})
+
+(def ^:private detail-fields
+  "title,body,labels,files")
+
+(defn- assert-request! [repo number]
+  (assert (string? repo) "repo must be a string")
+  (assert (some? number) "number must be present"))
+
+(defn- assert-composite-request! [repo number]
+  (assert-request! repo number)
+  (assert (or (integer? number) (string? number))
+          "number must be an integer or string"))
+
+(defn- coerce-number [number]
+  (long (if (string? number) (Long/parseLong number) number)))
+
+(defn- run-gh [& args]
+  (apply process/shell shell-opts args))
+
+(defn- successful-output [result]
+  (when (zero? (:exit result))
+    (or (:out result) "")))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Individual fetchers
+
+(defn fetch-pr-diff
+  "Fetch the diff for a PR via `gh pr diff`.
+
+   Returns the trimmed diff string on success, nil on failure."
+  [repo number]
+  (assert-request! repo number)
+  (try
+    (some-> (run-gh "gh" "pr" "diff" (str number) "--repo" repo)
+            successful-output
+            str/trim)
+    (catch Exception _
+      nil)))
+
+(defn fetch-pr-detail
+  "Fetch PR detail (title, body, labels, files) via `gh pr view --json`.
+
+   Returns a parsed map with keyword keys on success, nil on failure."
+  [repo number]
+  (assert-request! repo number)
+  (try
+    (some-> (run-gh "gh" "pr" "view" (str number) "--repo" repo
+                    "--json" detail-fields)
+            successful-output
+            (json/parse-string true))
+    (catch Exception _
+      nil)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Composite fetcher
+
+(defn fetch-pr-diff-and-detail
+  "Fetch both diff and detail for a PR. Coerces number to long.
+
+   Returns {:diff string-or-nil, :detail map-or-nil, :repo string, :number long}."
+  [repo number]
+  (assert-composite-request! repo number)
+  (let [n (coerce-number number)
+        diff-future (future (try (fetch-pr-diff repo n) (catch Throwable _ nil)))
+        detail-future (future (try (fetch-pr-detail repo n) (catch Throwable _ nil)))]
+    {:diff   @diff-future
+     :detail @detail-future
+     :repo   repo
+     :number n}))

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -623,10 +623,11 @@
 
 (defn handle-decomposition-started
   "Handle result of :decompose-pr side effect."
-  [model {:keys [pr-id plan]}]
+  [model {:keys [pr-id sub-prs message] :as _payload}]
   (-> model
-      (assoc :flash-message (str "Decomposition plan for #" (second pr-id) ": "
-                                 (count (:sub-prs plan [])) " sub-PRs proposed"))
+      (assoc :flash-message (or message
+                                (str "Decomposition plan for #" (second pr-id) ": "
+                                     (count (or sub-prs [])) " sub-PRs proposed")))
       with-timestamp))
 
 (defn handle-repos-discovered

--- a/components/tui-views/test/ai/miniforge/tui_views/decompose_pr_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/decompose_pr_test.clj
@@ -1,0 +1,422 @@
+(ns ai.miniforge.tui-views.decompose-pr-test
+  "Comprehensive tests for handle-decompose-pr in interface.clj.
+
+   Acceptance criteria verified:
+   1. Fetches diff and metadata for the selected PR via GitHub CLI
+   2. Calls pr-decomposer/decompose (via requiring-resolve) with assembled context
+   3. Returns msg/decomposition-started with real sub-PR proposals on success
+   4. Returns msg/decomposition-started with error message on any failure (no exceptions leak)
+   5. Uses requiring-resolve for pr-decomposer dependency (Babashka compat)"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.interface :as iface]
+   [ai.miniforge.tui-views.msg :as msg]
+   [ai.miniforge.tui-views.persistence.github :as github]))
+
+;; ---------------------------------------------------------------------------- Helpers
+
+(defn msg-type [m] (first m))
+(defn msg-payload [m] (second m))
+
+(def ^:private sample-pr
+  {:pr/repo "acme/app"
+   :pr/number 42
+   :pr/title "Add auth and dashboard"
+   :pr/body "Adds JWT auth and admin panel."
+   :pr/labels ["feature"]
+   :pr/additions 650
+   :pr/deletions 30
+   :pr/head-sha "abc123"
+   :pr/status :open
+   :pr/ci-status :passing})
+
+(def ^:private sample-detail
+  {:title "Add auth and dashboard"
+   :body "Adds JWT auth and admin panel."
+   :labels [{:name "feature"}]
+   :files [{:path "src/auth.clj" :additions 300 :deletions 10}
+           {:path "src/dashboard.clj" :additions 350 :deletions 20}]})
+
+(def ^:private sample-diff
+  "diff --git a/src/auth.clj b/src/auth.clj\n+auth code\ndiff --git a/src/dashboard.clj b/src/dashboard.clj\n+dashboard code")
+
+(def ^:private sample-plan
+  {:sub-prs [{:title "Add auth module"
+              :description "JWT and session management."
+              :files ["src/auth.clj"]
+              :dependency-order 0
+              :estimated-size {:additions 300 :deletions 10}}
+             {:title "Add dashboard"
+              :description "Admin dashboard views."
+              :files ["src/dashboard.clj"]
+              :dependency-order 1
+              :estimated-size {:additions 350 :deletions 20}}]
+   :strategy "Split auth (foundation) from dashboard (consumer)."
+   :original-size {:additions 650 :deletions 30}
+   :coverage 1.0})
+
+(defn- mock-decompose-success
+  "Returns a mock decompose fn that succeeds with sample-plan."
+  []
+  (fn [_pr _diff _files _llm-fn]
+    {:ok? true
+     :data {:plan sample-plan
+            :coverage {:covered? true}
+            :warnings []}}))
+
+(defn- mock-github-success
+  "Returns a mock fetch fn that returns diff + detail."
+  []
+  (fn [_ _]
+    {:diff sample-diff :detail sample-detail
+     :repo "acme/app" :number 42}))
+
+(defn- mock-requiring-resolve
+  "Returns a mock requiring-resolve that returns the given fn for decompose symbol."
+  [decompose-fn]
+  (fn [sym]
+    (when (= sym 'ai.miniforge.pr-decompose.interface/decompose)
+      decompose-fn)))
+
+;; ---------------------------------------------------------------------------- AC1: Fetches diff and metadata
+
+(deftest handle-decompose-pr-fetches-diff-and-detail-test
+  (testing "calls fetch-pr-diff-and-detail with correct repo and number"
+    (let [fetched-args (atom nil)]
+      (with-redefs [github/fetch-pr-diff-and-detail
+                    (fn [repo number]
+                      (reset! fetched-args {:repo repo :number number})
+                      {:diff sample-diff :detail sample-detail
+                       :repo repo :number number})
+                    requiring-resolve (mock-requiring-resolve (mock-decompose-success))]
+        (iface/handle-decompose-pr {:pr sample-pr})
+        (is (= "acme/app" (:repo @fetched-args)))
+        (is (= 42 (:number @fetched-args)))))))
+
+(deftest handle-decompose-pr-extracts-changed-files-from-detail-test
+  (testing "extracts file paths from the detail response and passes to decompose"
+    (let [captured-files (atom nil)]
+      (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                    requiring-resolve
+                    (mock-requiring-resolve
+                     (fn [_pr diff files _llm-fn]
+                       (reset! captured-files files)
+                       {:ok? true
+                        :data {:plan sample-plan
+                               :coverage {:covered? true}
+                               :warnings []}}))]
+        (iface/handle-decompose-pr {:pr sample-pr})
+        (is (= ["src/auth.clj" "src/dashboard.clj"] @captured-files))))))
+
+;; ---------------------------------------------------------------------------- AC2: Calls decompose with assembled context
+
+(deftest handle-decompose-pr-calls-decompose-with-pr-and-diff-test
+  (testing "passes the PR map and diff text to the decompose function"
+    (let [captured (atom nil)]
+      (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                    requiring-resolve
+                    (mock-requiring-resolve
+                     (fn [pr diff files llm-fn]
+                       (reset! captured {:pr pr :diff diff :files files
+                                         :llm-fn-present? (fn? llm-fn)})
+                       {:ok? true
+                        :data {:plan sample-plan
+                               :coverage {:covered? true}
+                               :warnings []}}))]
+        (iface/handle-decompose-pr {:pr sample-pr})
+        (is (= sample-pr (:pr @captured)))
+        (is (= sample-diff (:diff @captured)))
+        (is (= ["src/auth.clj" "src/dashboard.clj"] (:files @captured)))
+        (is (true? (:llm-fn-present? @captured)))))))
+
+;; ---------------------------------------------------------------------------- AC3: Returns decomposition-started with real plan on success
+
+(deftest handle-decompose-pr-success-returns-plan-test
+  (testing "returns :msg/decomposition-started with the real plan on success"
+    (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                  requiring-resolve (mock-requiring-resolve (mock-decompose-success))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))
+        (is (= ["acme/app" 42] (:pr-id (msg-payload m))))))))
+
+(deftest handle-decompose-pr-success-has-sub-prs-test
+  (testing "successful decomposition includes sub-PR proposals"
+    (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                  requiring-resolve (mock-requiring-resolve (mock-decompose-success))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})
+            payload (msg-payload m)]
+        (is (= :msg/decomposition-started (msg-type m)))
+        (is (some? (:sub-prs payload)))
+        (is (= 2 (count (:sub-prs payload))))))))
+
+(deftest handle-decompose-pr-success-plan-has-expected-fields-test
+  (testing "plan payload includes strategy, sub-prs, original-size, coverage"
+    (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                  requiring-resolve (mock-requiring-resolve (mock-decompose-success))]
+      (let [payload (msg-payload (iface/handle-decompose-pr {:pr sample-pr}))]
+        ;; The plan is merged into the payload
+        (is (= 2 (count (:sub-prs payload))))
+        (let [first-sub (first (:sub-prs payload))]
+          (is (= "Add auth module" (:title first-sub)))
+          (is (= ["src/auth.clj"] (:files first-sub))))))))
+
+(deftest handle-decompose-pr-no-longer-returns-stub-message-test
+  (testing "does NOT return 'Decomposition analysis not yet wired'"
+    (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                  requiring-resolve (mock-requiring-resolve (mock-decompose-success))]
+      (let [payload (msg-payload (iface/handle-decompose-pr {:pr sample-pr}))]
+        (is (not= "Decomposition analysis not yet wired"
+                  (:message payload)))))))
+
+;; ---------------------------------------------------------------------------- AC4: Returns error on failures, no exceptions leak
+
+(deftest handle-decompose-pr-both-fetches-nil-test
+  (testing "returns error message when both diff and detail are nil"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail nil :repo "acme/app" :number 42})]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))
+        (is (= ["acme/app" 42] (:pr-id (msg-payload m))))
+        (is (= [] (:sub-prs (msg-payload m))))
+        (is (string? (:message (msg-payload m))))
+        (is (str/includes? (:message (msg-payload m)) "Failed"))))))
+
+(deftest handle-decompose-pr-diff-nil-detail-present-test
+  (testing "proceeds with empty diff when only detail is available"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail sample-detail :repo "acme/app" :number 42})
+                  requiring-resolve
+                  (mock-requiring-resolve
+                   (fn [_pr diff _files _llm-fn]
+                     ;; diff should be empty string, not nil
+                     (is (= "" diff))
+                     {:ok? true
+                      :data {:plan sample-plan
+                             :coverage {:covered? true}
+                             :warnings []}}))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))))))
+
+(deftest handle-decompose-pr-detail-nil-diff-present-test
+  (testing "proceeds with empty changed-files when only diff is available"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff sample-diff :detail nil :repo "acme/app" :number 42})
+                  requiring-resolve
+                  (mock-requiring-resolve
+                   (fn [_pr _diff files _llm-fn]
+                     ;; changed-files should be empty when detail is nil
+                     (is (= [] files))
+                     {:ok? true
+                      :data {:plan sample-plan
+                             :coverage {:covered? true}
+                             :warnings []}}))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))))))
+
+(deftest handle-decompose-pr-decompose-fn-not-found-test
+  (testing "returns error when requiring-resolve returns nil (component not on classpath)"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff sample-diff :detail sample-detail
+                             :repo "acme/app" :number 42})
+                  requiring-resolve (fn [_] nil)]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))
+        (is (= ["acme/app" 42] (:pr-id (msg-payload m))))
+        (is (= [] (:sub-prs (msg-payload m))))
+        (is (str/includes? (:message (msg-payload m)) "not available"))))))
+
+(deftest handle-decompose-pr-decompose-returns-error-test
+  (testing "returns error message when decompose pipeline returns {:ok? false}"
+    (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                  requiring-resolve
+                  (mock-requiring-resolve
+                   (fn [_pr _diff _files _llm-fn]
+                     {:ok? false
+                      :error {:code :llm-error
+                              :message "Rate limited by provider"}}))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))
+        (is (= ["acme/app" 42] (:pr-id (msg-payload m))))
+        (is (= [] (:sub-prs (msg-payload m))))
+        (is (str/includes? (:message (msg-payload m)) "Rate limited"))))))
+
+(deftest handle-decompose-pr-decompose-returns-parse-error-test
+  (testing "returns error message when LLM response fails to parse"
+    (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                  requiring-resolve
+                  (mock-requiring-resolve
+                   (fn [_pr _diff _files _llm-fn]
+                     {:ok? false
+                      :error {:code :parse-error
+                              :message "Could not parse EDN from LLM response"}}))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))
+        (is (= [] (:sub-prs (msg-payload m))))
+        (is (str/includes? (:message (msg-payload m)) "parse"))))))
+
+(deftest handle-decompose-pr-exception-in-github-fetch-test
+  (testing "catches exception from GitHub fetch and returns error msg"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] (throw (Exception. "gh CLI not found")))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))
+        (is (= ["acme/app" 42] (:pr-id (msg-payload m))))
+        (is (= [] (:sub-prs (msg-payload m))))
+        (is (str/includes? (:message (msg-payload m)) "gh CLI not found"))))))
+
+(deftest handle-decompose-pr-exception-in-decompose-fn-test
+  (testing "catches exception from decompose function and returns error msg"
+    (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                  requiring-resolve
+                  (mock-requiring-resolve
+                   (fn [_pr _diff _files _llm-fn]
+                     (throw (RuntimeException. "LLM connection timeout"))))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))
+        (is (= [] (:sub-prs (msg-payload m))))
+        (is (str/includes? (:message (msg-payload m)) "LLM connection timeout"))))))
+
+(deftest handle-decompose-pr-exception-in-requiring-resolve-test
+  (testing "catches exception from requiring-resolve itself"
+    (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                  requiring-resolve
+                  (fn [_] (throw (Exception. "Class not found")))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))
+        (is (= [] (:sub-prs (msg-payload m))))
+        (is (string? (:message (msg-payload m))))))))
+
+(deftest handle-decompose-pr-no-exception-leaks-test
+  (testing "no scenario leaks exceptions — all return decomposition-started messages"
+    (let [scenarios
+          [{:name "github throws"
+            :redefs {#'github/fetch-pr-diff-and-detail
+                     (fn [_ _] (throw (Exception. "boom")))}}
+           {:name "both nil"
+            :redefs {#'github/fetch-pr-diff-and-detail
+                     (fn [_ _] {:diff nil :detail nil :repo "r" :number 1})}}
+           {:name "decompose fn nil"
+            :redefs {#'github/fetch-pr-diff-and-detail
+                     (fn [_ _] {:diff "d" :detail {:files []} :repo "r" :number 1})
+                     #'clojure.core/requiring-resolve (fn [_] nil)}}
+           {:name "decompose throws"
+            :redefs {#'github/fetch-pr-diff-and-detail
+                     (fn [_ _] {:diff "d" :detail {:files []} :repo "r" :number 1})
+                     #'clojure.core/requiring-resolve
+                     (fn [_] (fn [& _] (throw (Error. "OOM"))))}}]]
+      (doseq [{:keys [name redefs]} scenarios]
+        (testing (str "scenario: " name)
+          (with-redefs-fn redefs
+            (fn []
+              (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+                (is (= :msg/decomposition-started (msg-type m))
+                    (str "Expected decomposition-started for: " name))))))))))
+
+;; ---------------------------------------------------------------------------- AC5: Uses requiring-resolve (Babashka compat)
+
+(deftest handle-decompose-pr-uses-requiring-resolve-test
+  (testing "uses requiring-resolve to load pr-decompose.interface/decompose"
+    (let [resolved-sym (atom nil)]
+      (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                    requiring-resolve
+                    (fn [sym]
+                      (reset! resolved-sym sym)
+                      ;; Return a mock decompose fn
+                      (mock-decompose-success))]
+        (iface/handle-decompose-pr {:pr sample-pr})
+        (is (= 'ai.miniforge.pr-decompose.interface/decompose @resolved-sym))))))
+
+;; ---------------------------------------------------------------------------- PR-ID construction
+
+(deftest handle-decompose-pr-id-is-repo-number-tuple-test
+  (testing "pr-id in the result message is [repo number]"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail nil :repo "org/repo" :number 99})]
+      (let [m (iface/handle-decompose-pr {:pr {:pr/repo "org/repo" :pr/number 99}})]
+        (is (= ["org/repo" 99] (:pr-id (msg-payload m))))))))
+
+;; ---------------------------------------------------------------------------- Edge: detail with no files key
+
+(deftest handle-decompose-pr-detail-with-no-files-key-test
+  (testing "handles detail map that has no :files key gracefully"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff sample-diff :detail {:title "T"}
+                             :repo "acme/app" :number 42})
+                  requiring-resolve
+                  (mock-requiring-resolve
+                   (fn [_pr _diff files _llm-fn]
+                     (is (= [] files))
+                     {:ok? true
+                      :data {:plan sample-plan
+                             :coverage {:covered? true}
+                             :warnings []}}))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))))))
+
+;; ---------------------------------------------------------------------------- Edge: decompose result has no :error :message
+
+(deftest handle-decompose-pr-error-without-message-test
+  (testing "uses fallback message when :error has no :message key"
+    (with-redefs [github/fetch-pr-diff-and-detail (mock-github-success)
+                  requiring-resolve
+                  (mock-requiring-resolve
+                   (fn [_pr _diff _files _llm-fn]
+                     {:ok? false
+                      :error {:code :unknown-error}}))]
+      (let [m (iface/handle-decompose-pr {:pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))
+        (is (= [] (:sub-prs (msg-payload m))))
+        ;; Should have the fallback message
+        (is (string? (:message (msg-payload m))))
+        (is (str/includes? (:message (msg-payload m)) "failed"))))))
+
+;; ---------------------------------------------------------------------------- dispatch-effect routing for :decompose-pr
+
+(deftest dispatch-effect-routes-decompose-pr-test
+  (testing ":decompose-pr effect type routes to handle-decompose-pr"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail nil :repo "r" :number 1})]
+      (let [m (iface/dispatch-effect nil {:type :decompose-pr :pr sample-pr})]
+        (is (= :msg/decomposition-started (msg-type m)))))))
+
+;; ---------------------------------------------------------------------------- handle-fetch-pr-diff (related)
+
+(deftest handle-fetch-pr-diff-success-test
+  (testing "returns :msg/pr-diff-fetched with diff and detail"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [repo number]
+                    {:diff sample-diff :detail sample-detail
+                     :repo repo :number number})]
+      (let [m (iface/handle-fetch-pr-diff {:repo "acme/app" :number 42})]
+        (is (= :msg/pr-diff-fetched (msg-type m)))
+        (is (= ["acme/app" 42] (:pr-id (msg-payload m))))
+        (is (= sample-diff (:diff (msg-payload m))))
+        (is (= sample-detail (:detail (msg-payload m))))
+        (is (nil? (:error (msg-payload m))))))))
+
+(deftest handle-fetch-pr-diff-both-nil-test
+  (testing "returns error when both diff and detail are nil"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail nil :repo "r" :number 1})]
+      (let [m (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (= :msg/pr-diff-fetched (msg-type m)))
+        (is (string? (:error (msg-payload m))))))))
+
+(deftest handle-fetch-pr-diff-exception-test
+  (testing "returns error when fetch throws"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] (throw (Exception. "network error")))]
+      (let [m (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (= :msg/pr-diff-fetched (msg-type m)))
+        (is (nil? (:diff (msg-payload m))))
+        (is (str/includes? (:error (msg-payload m)) "network error"))))))
+
+(deftest handle-fetch-pr-diff-string-number-coercion-test
+  (testing "coerces string number to long"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ number]
+                    (is (= 42 number))
+                    {:diff "d" :detail {:title "T"} :repo "r" :number number})]
+      (let [m (iface/handle-fetch-pr-diff {:repo "r" :number "42"})]
+        (is (= :msg/pr-diff-fetched (msg-type m)))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/events_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/events_test.clj
@@ -333,7 +333,7 @@
 
 (deftest handle-decomposition-started-test
   (let [m (events/handle-decomposition-started (fresh)
-            {:pr-id [:repo 42] :plan {:sub-prs [1 2 3]}})]
+            {:pr-id [:repo 42] :sub-prs [1 2 3]})]
     (is (str/includes? (:flash-message m) "3 sub-PRs"))))
 
 ;; ---------------------------------------------------------------------------- Repos events

--- a/components/tui-views/test/ai/miniforge/tui_views/github_acceptance_criteria_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/github_acceptance_criteria_test.clj
@@ -1,0 +1,230 @@
+(ns ai.miniforge.tui-views.github-acceptance-criteria-test
+  "Acceptance criteria verification tests that validate all stated requirements
+   for the GitHub persistence layer in a single consolidated test file.
+
+   Acceptance criteria:
+   AC-1: ai.miniforge.tui-views.persistence.github namespace exists with fetch-pr-diff-and-detail
+   AC-2: Calls gh pr diff and gh pr view --json for the given repo/number
+   AC-3: Returns {:diff :detail :repo :number} map; nil diff/detail on CLI failure (no exceptions)
+   AC-4: Existing github_test.clj and github_msg_contract_test.clj pass (verified by test runner)"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.persistence.github :as github]
+   [ai.miniforge.tui-views.interface :as iface]
+   [ai.miniforge.tui-views.msg :as msg]
+   [babashka.process :as process]))
+
+;; ---------------------------------------------------------------------------- Helpers
+
+(defn mock-sh-success [out]
+  {:exit 0 :out out :err ""})
+
+(defn mock-sh-failure [exit err]
+  {:exit exit :out "" :err err})
+
+(def sample-detail-json
+  "{\"title\":\"Fix\\nbugs\",\"body\":\"desc\",\"labels\":[{\"name\":\"bug\"}],\"files\":[{\"path\":\"a.clj\",\"additions\":3,\"deletions\":1}]}")
+
+;; ---------------------------------------------------------------------------- AC-1: Namespace and function existence
+
+(deftest ac1-namespace-exists-test
+  (testing "the github namespace is loadable"
+    (is (some? (find-ns 'ai.miniforge.tui-views.persistence.github)))))
+
+(deftest ac1-fetch-pr-diff-and-detail-is-public-test
+  (testing "fetch-pr-diff-and-detail is a public var"
+    (is (some? (resolve 'ai.miniforge.tui-views.persistence.github/fetch-pr-diff-and-detail)))))
+
+(deftest ac1-fetch-pr-diff-is-public-test
+  (testing "fetch-pr-diff is a public var"
+    (is (some? (resolve 'ai.miniforge.tui-views.persistence.github/fetch-pr-diff)))))
+
+(deftest ac1-fetch-pr-detail-is-public-test
+  (testing "fetch-pr-detail is a public var"
+    (is (some? (resolve 'ai.miniforge.tui-views.persistence.github/fetch-pr-detail)))))
+
+(deftest ac1-functions-are-fns-test
+  (testing "all three are actual functions"
+    (is (fn? github/fetch-pr-diff))
+    (is (fn? github/fetch-pr-detail))
+    (is (fn? github/fetch-pr-diff-and-detail))))
+
+;; ---------------------------------------------------------------------------- AC-2: CLI commands invoked
+
+(deftest ac2-fetch-pr-diff-calls-gh-pr-diff-test
+  (testing "fetch-pr-diff invokes `gh pr diff <number> --repo <repo>`"
+    (let [captured (atom nil)]
+      (with-redefs [process/shell (fn [_opts & args]
+                                 (reset! captured (vec args))
+                                 (mock-sh-success "patch"))]
+        (github/fetch-pr-diff "owner/repo" 42)
+        (is (= ["gh" "pr" "diff" "42" "--repo" "owner/repo"] @captured))))))
+
+(deftest ac2-fetch-pr-detail-calls-gh-pr-view-json-test
+  (testing "fetch-pr-detail invokes `gh pr view <number> --repo <repo> --json title,body,labels,files`"
+    (let [captured (atom nil)]
+      (with-redefs [process/shell (fn [_opts & args]
+                                 (reset! captured (vec args))
+                                 (mock-sh-success sample-detail-json))]
+        (github/fetch-pr-detail "owner/repo" 42)
+        (let [args @captured]
+          (is (= "gh" (nth args 0)))
+          (is (= "pr" (nth args 1)))
+          (is (= "view" (nth args 2)))
+          (is (= "42" (nth args 3)))
+          (is (= "--repo" (nth args 4)))
+          (is (= "owner/repo" (nth args 5)))
+          (is (= "--json" (nth args 6)))
+          (is (= "title,body,labels,files" (nth args 7))))))))
+
+(deftest ac2-composite-calls-both-test
+  (testing "fetch-pr-diff-and-detail calls both fetch-pr-diff and fetch-pr-detail"
+    (let [diff-called (atom false)
+          detail-called (atom false)]
+      (with-redefs [github/fetch-pr-diff   (fn [r n] (reset! diff-called true) "d")
+                    github/fetch-pr-detail (fn [r n] (reset! detail-called true) {:t 1})]
+        (github/fetch-pr-diff-and-detail "r" 1)
+        (is (true? @diff-called))
+        (is (true? @detail-called))))))
+
+;; ---------------------------------------------------------------------------- AC-3: Return shape and nil on failure
+
+(deftest ac3-return-map-has-four-keys-test
+  (testing "returns a map with exactly :diff :detail :repo :number"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] "d")
+                  github/fetch-pr-detail (fn [_ _] {:title "T"})]
+      (let [result (github/fetch-pr-diff-and-detail "org/repo" 99)]
+        (is (map? result))
+        (is (= #{:diff :detail :repo :number} (set (keys result))))
+        (is (= 4 (count (keys result))))))))
+
+(deftest ac3-diff-is-string-on-success-test
+  (testing ":diff is a string when gh pr diff succeeds"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] "diff content")
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (is (string? (:diff (github/fetch-pr-diff-and-detail "r" 1)))))))
+
+(deftest ac3-detail-is-map-on-success-test
+  (testing ":detail is a map when gh pr view --json succeeds"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] {:title "T" :body "B"})]
+      (is (map? (:detail (github/fetch-pr-diff-and-detail "r" 1)))))))
+
+(deftest ac3-diff-nil-on-failure-test
+  (testing ":diff is nil when gh pr diff fails (non-zero exit)"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-failure 1 "err"))]
+      (is (nil? (github/fetch-pr-diff "r" 1))))))
+
+(deftest ac3-detail-nil-on-failure-test
+  (testing ":detail is nil when gh pr view --json fails"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-failure 128 "auth"))]
+      (is (nil? (github/fetch-pr-detail "r" 1))))))
+
+(deftest ac3-detail-nil-on-malformed-json-test
+  (testing ":detail is nil when JSON parsing fails"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success "NOT JSON"))]
+      (is (nil? (github/fetch-pr-detail "r" 1))))))
+
+(deftest ac3-no-exceptions-on-failure-test
+  (testing "never throws exceptions to caller on CLI failure"
+    ;; fetch-pr-diff: exception in process/shell
+    (with-redefs [process/shell (fn [_opts & _] (throw (Exception. "gh not found")))]
+      (is (nil? (github/fetch-pr-diff "r" 1))))
+    ;; fetch-pr-detail: exception in process/shell
+    (with-redefs [process/shell (fn [_opts & _] (throw (java.io.IOException. "broken pipe")))]
+      (is (nil? (github/fetch-pr-detail "r" 1))))
+    ;; composite: both fail via process/shell
+    (with-redefs [process/shell (fn [_opts & _] (throw (RuntimeException. "timeout")))]
+      (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+        (is (nil? (:diff result)))
+        (is (nil? (:detail result)))
+        (is (= "r" (:repo result)))
+        (is (= 1 (:number result)))))))
+
+(deftest ac3-repo-passthrough-test
+  (testing ":repo is the exact input string"
+    (with-redefs [github/fetch-pr-diff (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (is (= "my-org/my-repo" (:repo (github/fetch-pr-diff-and-detail "my-org/my-repo" 1)))))))
+
+(deftest ac3-number-is-long-test
+  (testing ":number is always a long, coerced from string or integer"
+    (with-redefs [github/fetch-pr-diff (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      ;; Integer input
+      (is (= 42 (:number (github/fetch-pr-diff-and-detail "r" 42))))
+      (is (instance? Long (:number (github/fetch-pr-diff-and-detail "r" 42))))
+      ;; String input
+      (is (= 99 (:number (github/fetch-pr-diff-and-detail "r" "99"))))
+      (is (instance? Long (:number (github/fetch-pr-diff-and-detail "r" "99")))))))
+
+(deftest ac3-partial-failure-preserves-success-test
+  (testing "diff failure does not affect detail success"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] {:title "T"})]
+      (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+        (is (nil? (:diff result)))
+        (is (= {:title "T"} (:detail result))))))
+
+  (testing "detail failure does not affect diff success"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] "patch")
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+        (is (= "patch" (:diff result)))
+        (is (nil? (:detail result)))))))
+
+;; ---------------------------------------------------------------------------- AC-4: Integration with msg and interface
+
+(deftest ac4-handle-fetch-pr-diff-wires-to-msg-test
+  (testing "handle-fetch-pr-diff produces :msg/pr-diff-fetched"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [r n] {:diff "d" :detail {:title "T"} :repo r :number n})]
+      (let [[msg-type payload] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (= :msg/pr-diff-fetched msg-type))
+        (is (= ["r" 1] (:pr-id payload)))
+        (is (= "d" (:diff payload)))
+        (is (= {:title "T"} (:detail payload)))
+        (is (nil? (:error payload)))))))
+
+(deftest ac4-handle-fetch-pr-diff-total-failure-sets-error-test
+  (testing "both nil diff and detail triggers error message"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail nil :repo "r" :number 1})]
+      (let [[_ payload] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (string? (:error payload)))))))
+
+(deftest ac4-handle-fetch-pr-diff-exception-caught-test
+  (testing "exception is caught and wrapped in error"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] (throw (Exception. "network error")))]
+      (let [[msg-type payload] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (= :msg/pr-diff-fetched msg-type))
+        (is (nil? (:diff payload)))
+        (is (nil? (:detail payload)))
+        (is (str/includes? (:error payload) "network error"))))))
+
+(deftest ac4-dispatch-effect-routes-to-handler-test
+  (testing "dispatch-effect :fetch-pr-diff reaches handle-fetch-pr-diff"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [r n] {:diff "patch" :detail {:title "X"} :repo r :number n})]
+      (let [[msg-type payload] (iface/dispatch-effect nil {:type :fetch-pr-diff
+                                                           :repo "org/lib"
+                                                           :number 55})]
+        (is (= :msg/pr-diff-fetched msg-type))
+        (is (= ["org/lib" 55] (:pr-id payload)))))))
+
+(deftest ac4-msg-pr-diff-fetched-contract-test
+  (testing "msg/pr-diff-fetched produces correct shape"
+    ;; No error
+    (let [[t p] (msg/pr-diff-fetched ["r" 1] "d" {:t 1} nil)]
+      (is (= :msg/pr-diff-fetched t))
+      (is (contains? p :pr-id))
+      (is (contains? p :diff))
+      (is (contains? p :detail))
+      (is (not (contains? p :error))))
+    ;; With error
+    (let [[t p] (msg/pr-diff-fetched ["r" 1] nil nil "err")]
+      (is (= :msg/pr-diff-fetched t))
+      (is (contains? p :error))
+      (is (= "err" (:error p))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/interface_context_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/interface_context_test.clj
@@ -1,0 +1,370 @@
+(ns ai.miniforge.tui-views.interface-context-test
+  "Tests for pure helper functions in interface.clj:
+   - build-pr-context-str (comprehensive PR context rendering)
+   - format-check-context
+   - build-context-section
+   - build-chat-system-prompt
+   - handle-chat-execute-action routing
+   - dispatch-effect routing"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.interface :as iface]
+   [ai.miniforge.tui-views.msg :as msg]
+   [ai.miniforge.tui-views.persistence.github :as github]
+   [ai.miniforge.tui-views.persistence.pr :as persistence-pr]
+   [ai.miniforge.tui-views.persistence.pr-cache :as pr-cache]
+   [ai.miniforge.policy-pack.interface :as policy-pack]
+   [ai.miniforge.tui-views.prompts :as prompts]))
+
+;; ---------------------------------------------------------------------------- format-check-context
+
+(deftest format-check-context-test
+  (testing "formats single check"
+    (let [result (iface/format-check-context [{:name "lint" :conclusion :success}])]
+      (is (= "lint=success" result))))
+
+  (testing "formats multiple checks comma-separated"
+    (let [result (iface/format-check-context [{:name "lint" :conclusion :success}
+                                              {:name "test" :conclusion :failure}])]
+      (is (= "lint=success, test=failure" result))))
+
+  (testing "uses :unknown when conclusion is missing"
+    (let [result (iface/format-check-context [{:name "build"}])]
+      (is (= "build=unknown" result))))
+
+  (testing "empty checks returns empty string"
+    (is (= "" (iface/format-check-context [])))))
+
+;; ---------------------------------------------------------------------------- build-pr-context-str
+
+(defn make-full-pr
+  "Build a PR map with all fields populated."
+  []
+  {:pr/repo "acme/app"
+   :pr/number 42
+   :pr/title "Fix critical bug"
+   :pr/branch "fix/critical-bug"
+   :pr/author "alice"
+   :pr/status :open
+   :pr/ci-status :passed
+   :pr/behind-main? true
+   :pr/additions 50
+   :pr/deletions 20
+   :pr/changed-files-count 5
+   :pr/ci-checks [{:name "lint" :conclusion :success}
+                  {:name "test" :conclusion :success}]
+   :pr/readiness {:readiness/score 85 :readiness/ready? true}
+   :pr/risk {:risk/level :high
+             :risk/score 0.85
+             :risk/factors [{:explanation "Large change touching core module"}]}
+   :pr/policy {:evaluation/passed? true
+               :evaluation/packs-applied ["security" "style"]}})
+
+(deftest build-pr-context-str-full-pr-test
+  (testing "renders all fields for a fully-populated PR"
+    (let [ctx (iface/build-pr-context-str (make-full-pr))]
+      (is (string? ctx))
+      (is (str/includes? ctx "acme/app#42"))
+      (is (str/includes? ctx "Fix critical bug"))
+      (is (str/includes? ctx "fix/critical-bug"))
+      (is (str/includes? ctx "alice"))
+      (is (str/includes? ctx "open"))
+      (is (str/includes? ctx "Behind main: yes"))
+      (is (str/includes? ctx "lint=success"))
+      (is (str/includes? ctx "test=success"))
+      (is (str/includes? ctx "+50/-20"))
+      (is (str/includes? ctx "70 total lines"))
+      (is (str/includes? ctx "5 files"))
+      (is (str/includes? ctx "Readiness score: 85"))
+      (is (str/includes? ctx "(ready)"))
+      (is (str/includes? ctx "Risk level: high"))
+      (is (str/includes? ctx "0.85"))
+      (is (str/includes? ctx "Large change touching core module"))
+      (is (str/includes? ctx "Policy: passed"))
+      (is (str/includes? ctx "security"))
+      (is (str/includes? ctx "style"))
+      (is (str/includes? ctx "GitHub")))))
+
+(deftest build-pr-context-str-minimal-pr-test
+  (testing "renders minimal PR without optional fields"
+    (let [pr {:pr/repo "acme/app" :pr/number 1 :pr/title "Small"
+              :pr/branch "main" :pr/status :open}
+          ctx (iface/build-pr-context-str pr)]
+      (is (string? ctx))
+      (is (str/includes? ctx "acme/app#1"))
+      (is (str/includes? ctx "Small"))
+      ;; No CI checks -> falls back to ci-status default
+      (is (str/includes? ctx "CI status: unknown"))
+      ;; No readiness
+      (is (not (str/includes? ctx "Readiness score")))
+      ;; No risk
+      (is (not (str/includes? ctx "Risk level")))
+      ;; No policy
+      (is (not (str/includes? ctx "Policy"))))))
+
+(deftest build-pr-context-str-nil-test
+  (testing "returns nil for nil input"
+    (is (nil? (iface/build-pr-context-str nil)))))
+
+(deftest build-pr-context-str-behind-main-false-test
+  (testing "shows 'no' when not behind main"
+    (let [pr {:pr/repo "r" :pr/number 1 :pr/title "T"
+              :pr/branch "b" :pr/behind-main? false :pr/status :open}
+          ctx (iface/build-pr-context-str pr)]
+      (is (str/includes? ctx "Behind main: no")))))
+
+(deftest build-pr-context-str-failed-policy-test
+  (testing "shows FAILED when policy did not pass"
+    (let [pr {:pr/repo "r" :pr/number 1 :pr/title "T"
+              :pr/branch "b" :pr/status :open
+              :pr/policy {:evaluation/passed? false}}
+          ctx (iface/build-pr-context-str pr)]
+      (is (str/includes? ctx "Policy: FAILED")))))
+
+(deftest build-pr-context-str-gitlab-provider-test
+  (testing "detects GitLab provider from repo prefix"
+    (let [pr {:pr/repo "gitlab:group/project" :pr/number 1 :pr/title "T"
+              :pr/branch "b" :pr/status :open}
+          ctx (iface/build-pr-context-str pr)]
+      (is (str/includes? ctx "GitLab")))))
+
+(deftest build-pr-context-str-zero-additions-test
+  (testing "omits change size when additions and deletions are zero"
+    (let [pr {:pr/repo "r" :pr/number 1 :pr/title "T"
+              :pr/branch "b" :pr/status :open
+              :pr/additions 0 :pr/deletions 0}
+          ctx (iface/build-pr-context-str pr)]
+      (is (not (str/includes? ctx "Change size"))))))
+
+(deftest build-pr-context-str-no-author-test
+  (testing "shows 'unknown' when author is nil"
+    (let [pr {:pr/repo "r" :pr/number 1 :pr/title "T"
+              :pr/branch "b" :pr/status :open}
+          ctx (iface/build-pr-context-str pr)]
+      (is (str/includes? ctx "Author: unknown")))))
+
+(deftest build-pr-context-str-risk-without-score-test
+  (testing "risk level without score omits score parenthetical"
+    (let [pr {:pr/repo "r" :pr/number 1 :pr/title "T"
+              :pr/branch "b" :pr/status :open
+              :pr/risk {:risk/level :medium}}
+          ctx (iface/build-pr-context-str pr)]
+      (is (str/includes? ctx "Risk level: medium"))
+      (is (not (str/includes? ctx "score:"))))))
+
+;; ---------------------------------------------------------------------------- build-context-section
+
+(deftest build-context-section-pr-detail-test
+  (testing "renders PR detail context via prompts"
+    (let [pr {:pr/repo "r" :pr/number 1 :pr/title "T" :pr/branch "b" :pr/status :open}
+          result (#'iface/build-context-section {:type :pr-detail :pr pr})]
+      (is (string? result))
+      ;; Should contain the PR info rendered by build-pr-context-str
+      (is (str/includes? result "r#1")))))
+
+(deftest build-context-section-pr-fleet-test
+  (testing "renders fleet context with selected PRs"
+    (let [prs [{:pr/repo "a/b" :pr/number 1 :pr/title "First"}
+               {:pr/repo "c/d" :pr/number 2 :pr/title "Second"}]
+          result (#'iface/build-context-section
+                  {:type :pr-fleet
+                   :selected-prs prs
+                   :total-prs 10
+                   :active-filter :open})]
+      (is (string? result))
+      (is (str/includes? result "2 PR(s) selected"))))
+
+  (testing "renders fleet context with no selected PRs"
+    (let [result (#'iface/build-context-section
+                  {:type :pr-fleet
+                   :selected-prs []
+                   :total-prs 5
+                   :active-filter :all})]
+      (is (str/includes? result "No PRs currently selected")))))
+
+(deftest build-context-section-unknown-type-test
+  (testing "returns unknown context for unrecognized type"
+    (is (= "Unknown context."
+           (#'iface/build-context-section {:type :unknown})))))
+
+;; ---------------------------------------------------------------------------- build-chat-system-prompt
+
+(deftest build-chat-system-prompt-test
+  (testing "produces a non-empty string with context"
+    (let [prompt (iface/build-chat-system-prompt
+                  {:type :pr-detail
+                   :pr {:pr/repo "r" :pr/number 1 :pr/title "T"
+                        :pr/branch "b" :pr/status :open}
+                   :max-line-width 80})]
+      (is (string? prompt))
+      (is (pos? (count prompt)))
+      ;; Should reference max line width from template
+      (is (str/includes? prompt "80")))))
+
+;; ---------------------------------------------------------------------------- handle-chat-execute-action routing
+
+(deftest handle-chat-execute-action-sync-test
+  (testing ":sync action triggers sync-prs"
+    (with-redefs [persistence-pr/load-pr-items (fn [_] {:prs [] :error nil})
+                  pr-cache/read-cache          (fn [] {})
+                  pr-cache/apply-cached-policy  (fn [prs _] prs)
+                  pr-cache/apply-cached-agent-risk (fn [_ _] {})]
+      (let [m (iface/handle-chat-execute-action {:action {:action :sync} :context {}})]
+        (is (= :msg/prs-synced (first m)))))))
+
+(deftest handle-chat-execute-action-review-with-pr-test
+  (testing ":review action with PR in context"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] [])
+                  policy-pack/evaluate-external-pr (fn [_ _] {:evaluation/passed? true})]
+      (let [pr {:pr/repo "r" :pr/number 1}
+            m (iface/handle-chat-execute-action
+                {:action {:action :review}
+                 :context {:pr pr}})]
+        (is (= :msg/review-completed (first m)))))))
+
+(deftest handle-chat-execute-action-review-no-pr-test
+  (testing ":review action without PR returns failure"
+    (let [m (iface/handle-chat-execute-action
+              {:action {:action :review}
+               :context {}})]
+      (is (= :msg/chat-action-result (first m)))
+      (is (false? (:success? (second m)))))))
+
+(deftest handle-chat-execute-action-open-with-url-test
+  (testing ":open action with URL in context"
+    (let [opened (atom nil)]
+      (with-redefs [clojure.java.browse/browse-url (fn [url] (reset! opened url))]
+        (let [m (iface/handle-chat-execute-action
+                  {:action {:action :open}
+                   :context {:pr {:pr/url "https://github.com/r/r/pull/1"}}})]
+          (is (= :msg/chat-action-result (first m)))
+          (is (true? (:success? (second m)))))))))
+
+(deftest handle-chat-execute-action-open-no-url-test
+  (testing ":open action without URL returns failure"
+    (let [m (iface/handle-chat-execute-action
+              {:action {:action :open}
+               :context {:pr {}}})]
+      (is (= :msg/chat-action-result (first m)))
+      (is (false? (:success? (second m)))))))
+
+(deftest handle-chat-execute-action-unknown-test
+  (testing "unknown action type returns failure"
+    (let [m (iface/handle-chat-execute-action
+              {:action {:action :foobar}
+               :context {}})]
+      (is (= :msg/chat-action-result (first m)))
+      (is (false? (:success? (second m))))
+      (is (str/includes? (:message (second m)) "Unknown action")))))
+
+(deftest handle-chat-execute-action-exception-test
+  (testing "exception is caught and returned as chat-action-result"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] (throw (Exception. "boom")))]
+      (let [m (iface/handle-chat-execute-action
+                {:action {:action :review}
+                 :context {:pr {:pr/repo "r" :pr/number 1}}})]
+        (is (= :msg/chat-action-result (first m)))
+        (is (false? (:success? (second m))))
+        (is (str/includes? (:message (second m)) "boom"))))))
+
+(deftest handle-chat-execute-action-decompose-test
+  (testing ":decompose action returns decomposition-started"
+    (let [pr {:pr/repo "r" :pr/number 1}
+          m (iface/handle-chat-execute-action
+              {:action {:action :decompose}
+               :context {:pr pr}})]
+      (is (= :msg/decomposition-started (first m))))))
+
+(deftest handle-chat-execute-action-evaluate-test
+  (testing ":evaluate action with PR triggers policy evaluation"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] [])
+                  policy-pack/evaluate-external-pr (fn [_ _] {:evaluation/passed? true})]
+      (let [pr {:pr/repo "r" :pr/number 1}
+            m (iface/handle-chat-execute-action
+                {:action {:action :evaluate}
+                 :context {:pr pr}})]
+        (is (= :msg/policy-evaluated (first m)))))))
+
+;; ---------------------------------------------------------------------------- dispatch-effect routing
+
+(deftest dispatch-effect-routes-fetch-pr-diff-test
+  (testing ":fetch-pr-diff routes to handle-fetch-pr-diff"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [repo number]
+                    {:diff "d" :detail {:title "T"} :repo repo :number number})]
+      (let [m (iface/dispatch-effect nil {:type :fetch-pr-diff :repo "r" :number 1})]
+        (is (= :msg/pr-diff-fetched (first m)))))))
+
+(deftest dispatch-effect-routes-sync-prs-test
+  (testing ":sync-prs routes to handle-sync-prs"
+    (with-redefs [persistence-pr/load-pr-items (fn [_] {:prs [] :error nil})
+                  pr-cache/read-cache          (fn [] {})
+                  pr-cache/apply-cached-policy  (fn [prs _] prs)
+                  pr-cache/apply-cached-agent-risk (fn [_ _] {})]
+      (let [m (iface/dispatch-effect nil {:type :sync-prs})]
+        (is (= :msg/prs-synced (first m)))))))
+
+(deftest dispatch-effect-unknown-type-test
+  (testing "unknown effect type returns nil"
+    (is (nil? (iface/dispatch-effect nil {:type :unknown-effect})))))
+
+(deftest dispatch-effect-open-url-test
+  (testing ":open-url with nil url returns nil"
+    (is (nil? (iface/dispatch-effect nil {:type :open-url :url nil})))))
+
+;; ---------------------------------------------------------------------------- parse-actions edge cases
+
+(deftest parse-actions-multiple-test
+  (testing "extracts multiple actions from text"
+    (let [text (str "Analysis complete.\n"
+                    "[ACTION: review | Review PR | Run policy packs]\n"
+                    "Also consider:\n"
+                    "[ACTION: remediate | Fix issues | Auto-fix violations]")
+          [clean actions] (iface/parse-actions text)]
+      (is (= 2 (count actions)))
+      (is (= :review (:action (first actions))))
+      (is (= :remediate (:action (second actions))))
+      (is (not (str/includes? clean "[ACTION:"))))))
+
+(deftest parse-actions-preserves-surrounding-text-test
+  (testing "clean content preserves non-action text"
+    (let [[clean _] (iface/parse-actions "Before.\n[ACTION: x | Y | Z]\nAfter.")]
+      (is (str/includes? clean "Before."))
+      (is (str/includes? clean "After.")))))
+
+;; ---------------------------------------------------------------------------- parse-risk-line edge cases
+
+(deftest parse-risk-line-level-case-insensitive-test
+  (testing "level is lowercased"
+    (let [r (iface/parse-risk-line "RISK: owner/repo#1 | HIGH | reason")]
+      (is (= "high" (:level r)))))
+
+  (testing "mixed case level"
+    (let [r (iface/parse-risk-line "RISK: owner/repo#1 | Medium | reason")]
+      (is (= "medium" (:level r))))))
+
+(deftest parse-risk-line-non-numeric-pr-number-test
+  (testing "returns nil when PR number is not numeric"
+    (is (nil? (iface/parse-risk-line "RISK: owner/repo#abc | high | reason")))))
+
+(deftest parse-risk-line-repo-with-org-slashes-test
+  (testing "handles repo slug with owner/repo format"
+    (let [r (iface/parse-risk-line "RISK: my-org/my-repo#100 | low | trivial")]
+      (is (= ["my-org/my-repo" 100] (:id r))))))
+
+;; ---------------------------------------------------------------------------- format-pr-summary-line edge cases
+
+(deftest format-pr-summary-line-with-special-chars-test
+  (testing "handles title with special characters"
+    (let [pr {:pr/repo "r" :pr/number 1 :pr/title "Fix: handle [brackets] & 'quotes'"}
+          result (iface/format-pr-summary-line pr)]
+      (is (= "- r#1 Fix: handle [brackets] & 'quotes'" result)))))
+
+;; ---------------------------------------------------------------------------- chat-msg->llm-msg
+
+(deftest chat-msg->llm-msg-assistant-test
+  (testing "converts assistant role"
+    (let [result (iface/chat-msg->llm-msg {:role :assistant :content "hi"})]
+      (is (= "assistant" (:role result)))
+      (is (= "hi" (:content result))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/interface_handlers_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/interface_handlers_test.clj
@@ -1,0 +1,525 @@
+(ns ai.miniforge.tui-views.interface-handlers-test
+  "Tests for side-effect handlers in interface.clj that lack dedicated coverage.
+
+   Covers:
+   - handle-batch-evaluate-policy (batch policy evaluation)
+   - handle-remediate-prs (remediation stub)
+   - handle-decompose-pr (decomposition stub)
+   - handle-cache-policy-result / handle-cache-risk-triage (caching side-effects)
+   - handle-control-action (filesystem command writing)
+   - handle-archive-workflows (workflow archival)
+   - handle-fleet-risk-triage (LLM-based fleet risk triage)
+   - handle-reload-workflow-detail (workflow detail reload)
+   - dispatch-effect routing for all effect types
+   - parse-risk-triage-response / parse-risk-line / action-match->action"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.interface :as iface]
+   [ai.miniforge.tui-views.msg :as msg]
+   [ai.miniforge.tui-views.persistence :as persistence]
+   [ai.miniforge.tui-views.persistence.pr :as persistence-pr]
+   [ai.miniforge.tui-views.persistence.pr-cache :as pr-cache]
+   [ai.miniforge.tui-views.persistence.github :as github]
+   [ai.miniforge.policy-pack.interface :as policy-pack]
+   [ai.miniforge.pr-train.interface :as pr-train]
+   [ai.miniforge.llm.interface :as llm]
+   [ai.miniforge.response.interface :as response]))
+
+;; ---------------------------------------------------------------------------- Helpers
+
+(defn msg-type [m] (first m))
+(defn msg-payload [m] (second m))
+
+(defn make-pr
+  "Build a minimal PR map for testing."
+  [repo number & {:keys [title policy violations]
+                  :or {title "Test PR"}}]
+  (cond-> {:pr/repo repo :pr/number number :pr/title title}
+    policy     (assoc :pr/policy policy)
+    violations (assoc-in [:pr/policy :evaluation/violations] violations)))
+
+;; ---------------------------------------------------------------------------- handle-batch-evaluate-policy
+
+(deftest handle-batch-evaluate-policy-success-test
+  (testing "evaluates policy for multiple PRs and returns review-completed"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] [{:pack/name "security"}])
+                  policy-pack/evaluate-external-pr
+                  (fn [packs pr]
+                    (is (= 1 (count packs)))
+                    {:evaluation/passed? true})]
+      (let [prs [(make-pr "a/b" 1) (make-pr "c/d" 2)]
+            m (iface/handle-batch-evaluate-policy {:prs prs})]
+        (is (= :msg/review-completed (msg-type m)))
+        (is (= 2 (count (:results (msg-payload m)))))
+        (is (every? #(true? (get-in % [:result :evaluation/passed?]))
+                    (:results (msg-payload m))))))))
+
+(deftest handle-batch-evaluate-policy-pr-ids-test
+  (testing "each result contains correct pr-id"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] [])
+                  policy-pack/evaluate-external-pr (fn [_ _] {:evaluation/passed? true})]
+      (let [prs [(make-pr "a/b" 1) (make-pr "c/d" 2)]
+            results (:results (msg-payload (iface/handle-batch-evaluate-policy {:prs prs})))]
+        (is (= ["a/b" 1] (:pr-id (first results))))
+        (is (= ["c/d" 2] (:pr-id (second results))))))))
+
+(deftest handle-batch-evaluate-policy-individual-exception-test
+  (testing "individual PR evaluation exception is caught per-PR"
+    (let [call-count (atom 0)]
+      (with-redefs [persistence-pr/load-policy-packs (fn [] [])
+                    policy-pack/evaluate-external-pr
+                    (fn [_ pr]
+                      (swap! call-count inc)
+                      (if (= 1 (:pr/number pr))
+                        (throw (Exception. "bad PR"))
+                        {:evaluation/passed? true}))]
+        (let [prs [(make-pr "a/b" 1) (make-pr "c/d" 2)]
+              results (:results (msg-payload (iface/handle-batch-evaluate-policy {:prs prs})))]
+          (is (= 2 (count results)))
+          ;; First PR has error
+          (is (nil? (get-in (first results) [:result :evaluation/passed?])))
+          (is (= "bad PR" (get-in (first results) [:result :evaluation/error])))
+          ;; Second PR succeeds
+          (is (true? (get-in (second results) [:result :evaluation/passed?]))))))))
+
+(deftest handle-batch-evaluate-policy-load-packs-exception-test
+  (testing "exception loading packs returns empty results"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] (throw (Exception. "no packs")))]
+      (let [m (iface/handle-batch-evaluate-policy {:prs [(make-pr "r" 1)]})]
+        (is (= :msg/review-completed (msg-type m)))
+        (is (= [] (:results (msg-payload m))))))))
+
+(deftest handle-batch-evaluate-policy-empty-prs-test
+  (testing "empty PR list returns empty results"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] [])]
+      (let [m (iface/handle-batch-evaluate-policy {:prs []})]
+        (is (= :msg/review-completed (msg-type m)))
+        (is (= [] (:results (msg-payload m))))))))
+
+;; ---------------------------------------------------------------------------- handle-remediate-prs
+
+(deftest handle-remediate-prs-stub-test
+  (testing "returns remediation-completed with zero fixed"
+    (let [m (iface/handle-remediate-prs {:prs [(make-pr "r" 1)]})]
+      (is (= :msg/remediation-completed (msg-type m)))
+      (is (= 0 (:fixed (msg-payload m))))
+      (is (string? (:message (msg-payload m)))))))
+
+(deftest handle-remediate-prs-counts-fixable-test
+  (testing "counts PRs with violations as fixable"
+    (let [prs [(make-pr "r" 1 :violations [{:rule "no-large-pr"}])
+               (make-pr "r" 2 :violations [{:rule "require-tests"}])
+               (make-pr "r" 3)]  ;; no violations
+          m (iface/handle-remediate-prs {:prs prs})]
+      (is (= 2 (:failed (msg-payload m)))))))
+
+(deftest handle-remediate-prs-empty-list-test
+  (testing "empty PR list returns zero counts"
+    (let [m (iface/handle-remediate-prs {:prs []})]
+      (is (= 0 (:fixed (msg-payload m))))
+      (is (= 0 (:failed (msg-payload m)))))))
+
+;; ---------------------------------------------------------------------------- handle-decompose-pr
+
+(deftest handle-decompose-pr-returns-started-msg-test
+  (testing "returns decomposition-started with pr-id"
+    (let [pr (make-pr "acme/app" 42)
+          m (iface/handle-decompose-pr {:pr pr})]
+      (is (= :msg/decomposition-started (msg-type m)))
+      (is (= ["acme/app" 42] (:pr-id (msg-payload m)))))))
+
+(deftest handle-decompose-pr-plan-shape-test
+  (testing "payload has expected structure with sub-prs and message"
+    (let [m (iface/handle-decompose-pr {:pr (make-pr "r" 1)})
+          payload (msg-payload m)]
+      (is (map? payload))
+      (is (contains? payload :sub-prs))
+      (is (contains? payload :message)))))
+
+;; ---------------------------------------------------------------------------- handle-cache-policy-result
+
+(deftest handle-cache-policy-result-calls-persist-test
+  (testing "calls pr-cache/persist-policy-result! and returns nil"
+    (let [persisted (atom nil)]
+      (with-redefs [pr-cache/persist-policy-result!
+                    (fn [pr-id result prs] (reset! persisted {:pr-id pr-id :result result :prs prs}))]
+        (let [result (iface/handle-cache-policy-result
+                       {:pr-id ["r" 1] :result {:passed? true} :prs [{:pr/repo "r"}]})]
+          (is (nil? result))
+          (is (= ["r" 1] (:pr-id @persisted)))
+          (is (= {:passed? true} (:result @persisted))))))))
+
+;; ---------------------------------------------------------------------------- handle-cache-risk-triage
+
+(deftest handle-cache-risk-triage-calls-persist-test
+  (testing "calls pr-cache/persist-risk-triage! and returns nil"
+    (let [persisted (atom nil)]
+      (with-redefs [pr-cache/persist-risk-triage!
+                    (fn [risk-map prs] (reset! persisted {:risk-map risk-map :prs prs}))]
+        (let [result (iface/handle-cache-risk-triage
+                       {:risk-map {["r" 1] {:level :high}} :prs [{:pr/repo "r"}]})]
+          (is (nil? result))
+          (is (= {["r" 1] {:level :high}} (:risk-map @persisted))))))))
+
+;; ---------------------------------------------------------------------------- handle-control-action
+
+(deftest handle-control-action-returns-nil-test
+  (testing "returns nil (fire-and-forget side-effect)"
+    (let [wf-id (random-uuid)]
+      ;; We can't easily test file writing without temp dirs, but we can
+      ;; verify the function doesn't throw and returns nil.
+      ;; Using a temp dir via system property override.
+      (let [tmp-dir (System/getProperty "java.io.tmpdir")
+            original-home (System/getProperty "user.home")]
+        (try
+          (System/setProperty "user.home" tmp-dir)
+          (let [result (iface/handle-control-action {:action :pause :workflow-id wf-id})]
+            (is (nil? result)))
+          (finally
+            (System/setProperty "user.home" original-home)))))))
+
+;; ---------------------------------------------------------------------------- handle-archive-workflows
+
+(deftest handle-archive-workflows-success-test
+  (testing "returns workflows-archived message"
+    (with-redefs [persistence/archive-workflows!
+                  (fn [ids] {:archived (count ids) :failed 0})]
+      (let [m (iface/handle-archive-workflows {:workflow-ids [:w1 :w2 :w3]})]
+        (is (= :msg/workflows-archived (msg-type m)))
+        (is (= 3 (:archived (msg-payload m))))
+        (is (= 0 (:failed (msg-payload m))))))))
+
+(deftest handle-archive-workflows-empty-ids-test
+  (testing "empty workflow list returns zero archived"
+    (with-redefs [persistence/archive-workflows!
+                  (fn [ids] {:archived 0 :failed 0})]
+      (let [m (iface/handle-archive-workflows {:workflow-ids []})]
+        (is (= 0 (:archived (msg-payload m))))))))
+
+;; ---------------------------------------------------------------------------- handle-fleet-risk-triage
+
+(defn mock-llm-success [content]
+  (reify
+    Object
+    (toString [_] "mock-result")))
+
+(deftest handle-fleet-risk-triage-success-test
+  (testing "parses LLM response into risk assessments"
+    (let [llm-response "RISK: acme/app#42 | high | Large change\nRISK: other/lib#7 | low | Trivial fix"]
+      (with-redefs [llm/complete   (fn [_ _] ::result)
+                    llm/success?   (fn [r] (= ::result r))
+                    llm/get-content (fn [_] llm-response)
+                    iface/fleet-triage-system-prompt (fn [] "system prompt")]
+        (let [m (iface/handle-fleet-risk-triage
+                  {:pr-summaries [{:id ["acme/app" 42] :summary "s1"}
+                                  {:id ["other/lib" 7] :summary "s2"}]})]
+          (is (= :msg/fleet-risk-triaged (msg-type m)))
+          (let [assessments (:assessments (msg-payload m))]
+            (is (= 2 (count assessments)))
+            (is (= ["acme/app" 42] (:id (first assessments))))
+            (is (= "high" (:level (first assessments))))
+            (is (= ["other/lib" 7] (:id (second assessments))))
+            (is (= "low" (:level (second assessments))))))))))
+
+(deftest handle-fleet-risk-triage-llm-failure-test
+  (testing "LLM failure returns error message"
+    (with-redefs [llm/complete   (fn [_ _] ::fail)
+                  llm/success?   (fn [_] false)
+                  iface/fleet-triage-system-prompt (fn [] "prompt")]
+      (let [m (iface/handle-fleet-risk-triage {:pr-summaries [{:id ["r" 1] :summary "s"}]})]
+        (is (= :msg/fleet-risk-triaged (msg-type m)))
+        (is (= "LLM request failed" (:error (msg-payload m))))))))
+
+(deftest handle-fleet-risk-triage-exception-test
+  (testing "exception returns error message"
+    (with-redefs [llm/complete (fn [_ _] (throw (Exception. "network error")))
+                  iface/fleet-triage-system-prompt (fn [] "prompt")]
+      (let [m (iface/handle-fleet-risk-triage {:pr-summaries [{:id ["r" 1] :summary "s"}]})]
+        (is (= :msg/fleet-risk-triaged (msg-type m)))
+        (is (str/includes? (:error (msg-payload m)) "network error"))))))
+
+(deftest handle-fleet-risk-triage-no-parseable-lines-test
+  (testing "unparseable LLM response falls back to medium for all PRs"
+    (with-redefs [llm/complete    (fn [_ _] ::result)
+                  llm/success?    (fn [_] true)
+                  llm/get-content (fn [_] "I can't assess risk for these PRs.")
+                  iface/fleet-triage-system-prompt (fn [] "prompt")]
+      (let [ids [["a/b" 1] ["c/d" 2]]
+            m (iface/handle-fleet-risk-triage
+                {:pr-summaries [{:id ["a/b" 1] :summary "s1"}
+                                {:id ["c/d" 2] :summary "s2"}]})]
+        (is (= :msg/fleet-risk-triaged (msg-type m)))
+        (let [assessments (:assessments (msg-payload m))]
+          (is (= 2 (count assessments)))
+          (is (every? #(= "medium" (:level %)) assessments)))))))
+
+;; ---------------------------------------------------------------------------- handle-reload-workflow-detail
+
+(deftest handle-reload-workflow-detail-found-test
+  (testing "returns workflow-detail-loaded when detail exists"
+    (let [wf-id (random-uuid)
+          detail {:phases [:plan :implement]}]
+      (with-redefs [persistence/load-workflow-detail (fn [id] (when (= id wf-id) detail))]
+        (let [m (iface/handle-reload-workflow-detail {:workflow-id wf-id})]
+          (is (= :msg/workflow-detail-loaded (msg-type m)))
+          (is (= wf-id (:workflow-id (msg-payload m))))
+          (is (= detail (:detail (msg-payload m)))))))))
+
+(deftest handle-reload-workflow-detail-not-found-test
+  (testing "returns nil when no detail on disk"
+    (with-redefs [persistence/load-workflow-detail (fn [_] nil)]
+      (is (nil? (iface/handle-reload-workflow-detail {:workflow-id (random-uuid)}))))))
+
+;; ---------------------------------------------------------------------------- parse-risk-triage-response
+
+(deftest parse-risk-triage-response-multiple-lines-test
+  (testing "parses multiple RISK: lines"
+    (let [content "RISK: org/repo#10 | high | Security issue\nRISK: org/repo#20 | low | Docs only\nSome other text"]
+      (let [result (iface/parse-risk-triage-response content)]
+        (is (= 2 (count result)))
+        (is (= ["org/repo" 10] (:id (first result))))
+        (is (= "high" (:level (first result))))
+        (is (= "Security issue" (:reason (first result))))
+        (is (= ["org/repo" 20] (:id (second result))))))))
+
+(deftest parse-risk-triage-response-empty-test
+  (testing "returns empty vector for no RISK: lines"
+    (is (= [] (iface/parse-risk-triage-response "no risk lines here")))))
+
+(deftest parse-risk-triage-response-mixed-content-test
+  (testing "skips non-RISK lines"
+    (let [content "Header\nRISK: r#1 | medium | reason\nFooter\nRISK: r#2 | high | big"]
+      (is (= 2 (count (iface/parse-risk-triage-response content)))))))
+
+;; ---------------------------------------------------------------------------- parse-risk-line
+
+(deftest parse-risk-line-valid-test
+  (testing "parses valid RISK: line"
+    (let [r (iface/parse-risk-line "RISK: owner/repo#42 | HIGH | Large change touching core")]
+      (is (= ["owner/repo" 42] (:id r)))
+      (is (= "high" (:level r)))
+      (is (= "Large change touching core" (:reason r))))))
+
+(deftest parse-risk-line-invalid-format-test
+  (testing "returns nil for non-matching lines"
+    (is (nil? (iface/parse-risk-line "not a risk line")))
+    (is (nil? (iface/parse-risk-line "RISK: missing pipes")))))
+
+(deftest parse-risk-line-non-numeric-number-test
+  (testing "returns nil when PR number is not numeric"
+    (is (nil? (iface/parse-risk-line "RISK: owner/repo#abc | high | reason")))))
+
+(deftest parse-risk-line-trims-whitespace-test
+  (testing "trims level and reason whitespace"
+    (let [r (iface/parse-risk-line "RISK: r#1 |  medium  |  some reason  ")]
+      (is (= "medium" (:level r)))
+      (is (= "some reason" (:reason r))))))
+
+;; ---------------------------------------------------------------------------- action-match->action
+
+(deftest action-match->action-test
+  (testing "converts regex match to ChatAction map"
+    (let [match ["[ACTION: review | Review PR | Run policy]" "review" "Review PR" "Run policy"]
+          result (iface/action-match->action match)]
+      (is (= :review (:action result)))
+      (is (= "Review PR" (:label result)))
+      (is (= "Run policy" (:description result))))))
+
+(deftest action-match->action-trims-test
+  (testing "trims label and description"
+    (let [match ["_" "sync" "  Sync  " "  Refresh PRs  "]
+          result (iface/action-match->action match)]
+      (is (= "Sync" (:label result)))
+      (is (= "Refresh PRs" (:description result))))))
+
+;; ---------------------------------------------------------------------------- parse-actions
+
+(deftest parse-actions-no-actions-test
+  (testing "returns clean content and empty actions when no ACTION markers"
+    (let [[clean actions] (iface/parse-actions "Just normal text.")]
+      (is (= "Just normal text." clean))
+      (is (= [] actions)))))
+
+(deftest parse-actions-single-action-test
+  (testing "extracts single action and cleans content"
+    (let [text "Here is my analysis.\n[ACTION: review | Review | Run review]\nDone."
+          [clean actions] (iface/parse-actions text)]
+      (is (= 1 (count actions)))
+      (is (= :review (:action (first actions))))
+      (is (not (str/includes? clean "[ACTION:")))
+      (is (str/includes? clean "Here is my analysis."))
+      (is (str/includes? clean "Done.")))))
+
+(deftest parse-actions-empty-string-test
+  (testing "empty string returns empty clean and no actions"
+    (let [[clean actions] (iface/parse-actions "")]
+      (is (= "" clean))
+      (is (= [] actions)))))
+
+;; ---------------------------------------------------------------------------- chat-msg->llm-msg
+
+(deftest chat-msg->llm-msg-user-test
+  (testing "converts user role"
+    (let [result (iface/chat-msg->llm-msg {:role :user :content "hello"})]
+      (is (= "user" (:role result)))
+      (is (= "hello" (:content result))))))
+
+(deftest chat-msg->llm-msg-system-test
+  (testing "converts system role"
+    (let [result (iface/chat-msg->llm-msg {:role :system :content "sys"})]
+      (is (= "system" (:role result))))))
+
+;; ---------------------------------------------------------------------------- dispatch-effect comprehensive routing
+
+(deftest dispatch-effect-routes-sync-prs-test
+  (testing ":sync-prs routes correctly"
+    (with-redefs [persistence-pr/load-pr-items (fn [_] {:prs [] :error nil})
+                  pr-cache/read-cache          (fn [] {})
+                  pr-cache/apply-cached-policy  (fn [prs _] prs)
+                  pr-cache/apply-cached-agent-risk (fn [_ _] {})]
+      (let [m (iface/dispatch-effect nil {:type :sync-prs})]
+        (is (= :msg/prs-synced (msg-type m)))))))
+
+(deftest dispatch-effect-routes-discover-repos-test
+  (testing ":discover-repos routes correctly"
+    (with-redefs [persistence-pr/discover-repos (fn [owner] {:repos []})]
+      (let [m (iface/dispatch-effect nil {:type :discover-repos :owner "acme"})]
+        (is (= :msg/repos-discovered (msg-type m)))))))
+
+(deftest dispatch-effect-routes-browse-repos-test
+  (testing ":browse-repos routes correctly"
+    (with-redefs [persistence-pr/browse-repos (fn [opts] {:repos []})]
+      (let [m (iface/dispatch-effect nil {:type :browse-repos :owner "acme"
+                                           :provider :github :limit 10 :source :browse})]
+        (is (= :msg/repos-browsed (msg-type m)))))))
+
+(deftest dispatch-effect-routes-open-url-nil-test
+  (testing ":open-url with nil returns nil"
+    (is (nil? (iface/dispatch-effect nil {:type :open-url :url nil})))))
+
+(deftest dispatch-effect-routes-evaluate-policy-test
+  (testing ":evaluate-policy routes correctly"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] [])
+                  policy-pack/evaluate-external-pr (fn [_ _] {:evaluation/passed? true})]
+      (let [m (iface/dispatch-effect nil {:type :evaluate-policy
+                                           :pr (make-pr "r" 1)
+                                           :pr-id ["r" 1]})]
+        (is (= :msg/policy-evaluated (msg-type m)))))))
+
+(deftest dispatch-effect-routes-batch-evaluate-policy-test
+  (testing ":batch-evaluate-policy routes correctly"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] [])
+                  policy-pack/evaluate-external-pr (fn [_ _] {:evaluation/passed? true})]
+      (let [m (iface/dispatch-effect nil {:type :batch-evaluate-policy
+                                           :prs [(make-pr "r" 1)]})]
+        (is (= :msg/review-completed (msg-type m)))))))
+
+(deftest dispatch-effect-routes-review-prs-test
+  (testing ":review-prs routes correctly"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] [])
+                  policy-pack/evaluate-external-pr (fn [_ _] {:evaluation/passed? true})]
+      (let [m (iface/dispatch-effect nil {:type :review-prs :prs [(make-pr "r" 1)]})]
+        (is (= :msg/review-completed (msg-type m)))))))
+
+(deftest dispatch-effect-routes-remediate-prs-test
+  (testing ":remediate-prs routes correctly"
+    (let [m (iface/dispatch-effect nil {:type :remediate-prs :prs [(make-pr "r" 1)]})]
+      (is (= :msg/remediation-completed (msg-type m))))))
+
+(deftest dispatch-effect-routes-decompose-pr-test
+  (testing ":decompose-pr routes correctly"
+    (let [m (iface/dispatch-effect nil {:type :decompose-pr :pr (make-pr "r" 1)})]
+      (is (= :msg/decomposition-started (msg-type m))))))
+
+(deftest dispatch-effect-routes-cache-policy-result-test
+  (testing ":cache-policy-result routes correctly and returns nil"
+    (with-redefs [pr-cache/persist-policy-result! (fn [_ _ _] nil)]
+      (is (nil? (iface/dispatch-effect nil {:type :cache-policy-result
+                                             :pr-id ["r" 1]
+                                             :result {:passed? true}
+                                             :prs []}))))))
+
+(deftest dispatch-effect-routes-cache-risk-triage-test
+  (testing ":cache-risk-triage routes correctly and returns nil"
+    (with-redefs [pr-cache/persist-risk-triage! (fn [_ _] nil)]
+      (is (nil? (iface/dispatch-effect nil {:type :cache-risk-triage
+                                             :risk-map {}
+                                             :prs []}))))))
+
+(deftest dispatch-effect-routes-archive-workflows-test
+  (testing ":archive-workflows routes correctly"
+    (with-redefs [persistence/archive-workflows! (fn [ids] {:archived (count ids)})]
+      (let [m (iface/dispatch-effect nil {:type :archive-workflows :workflow-ids [:w1]})]
+        (is (= :msg/workflows-archived (msg-type m)))))))
+
+(deftest dispatch-effect-routes-reload-workflow-detail-test
+  (testing ":reload-workflow-detail routes correctly"
+    (let [wf-id (random-uuid)]
+      (with-redefs [persistence/load-workflow-detail (fn [id] {:phases [:plan]})]
+        (let [m (iface/dispatch-effect nil {:type :reload-workflow-detail :workflow-id wf-id})]
+          (is (= :msg/workflow-detail-loaded (msg-type m))))))))
+
+(deftest dispatch-effect-routes-fetch-pr-diff-test
+  (testing ":fetch-pr-diff routes correctly"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [r n] {:diff "d" :detail {:title "T"} :repo r :number n})]
+      (let [m (iface/dispatch-effect nil {:type :fetch-pr-diff :repo "r" :number 1})]
+        (is (= :msg/pr-diff-fetched (msg-type m)))))))
+
+(deftest dispatch-effect-unknown-returns-nil-test
+  (testing "unknown effect type returns nil"
+    (is (nil? (iface/dispatch-effect nil {:type :nonexistent-effect})))))
+
+;; ---------------------------------------------------------------------------- handle-review-prs
+
+(deftest handle-review-prs-success-test
+  (testing "evaluates policy for each PR"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] [{:pack/name "p1"}])
+                  policy-pack/evaluate-external-pr
+                  (fn [_ pr] {:evaluation/passed? (= 1 (:pr/number pr))})]
+      (let [m (iface/handle-review-prs {:prs [(make-pr "r" 1) (make-pr "r" 2)]})]
+        (is (= :msg/review-completed (msg-type m)))
+        (let [results (:results (msg-payload m))]
+          (is (= 2 (count results)))
+          (is (true? (get-in (first results) [:result :evaluation/passed?])))
+          (is (false? (get-in (second results) [:result :evaluation/passed?]))))))))
+
+(deftest handle-review-prs-exception-test
+  (testing "exception returns side-effect-error"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] (throw (Exception. "boom")))]
+      (let [m (iface/handle-review-prs {:prs [(make-pr "r" 1)]})]
+        (is (= :msg/side-effect-error (msg-type m)))))))
+
+;; ---------------------------------------------------------------------------- handle-evaluate-policy
+
+(deftest handle-evaluate-policy-success-test
+  (testing "returns policy-evaluated on success"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] [])
+                  policy-pack/evaluate-external-pr
+                  (fn [_ _] {:evaluation/passed? true})]
+      (let [m (iface/handle-evaluate-policy {:pr (make-pr "r" 1) :pr-id ["r" 1]})]
+        (is (= :msg/policy-evaluated (msg-type m)))
+        (is (= ["r" 1] (:pr-id (msg-payload m))))
+        (is (true? (get-in (msg-payload m) [:result :evaluation/passed?])))))))
+
+(deftest handle-evaluate-policy-exception-test
+  (testing "exception returns policy-evaluated with error"
+    (with-redefs [persistence-pr/load-policy-packs (fn [] (throw (Exception. "no packs")))]
+      (let [m (iface/handle-evaluate-policy {:pr (make-pr "r" 1) :pr-id ["r" 1]})]
+        (is (= :msg/policy-evaluated (msg-type m)))
+        (is (nil? (get-in (msg-payload m) [:result :evaluation/passed?])))
+        (is (= "no packs" (get-in (msg-payload m) [:result :evaluation/error])))))))
+
+;; ---------------------------------------------------------------------------- format-pr-summary-line
+
+(deftest format-pr-summary-line-test
+  (testing "formats as dash-prefixed line"
+    (let [pr {:pr/repo "acme/app" :pr/number 42 :pr/title "Fix bug"}
+          result (iface/format-pr-summary-line pr)]
+      (is (= "- acme/app#42 Fix bug" result)))))
+
+(deftest format-pr-summary-line-empty-title-test
+  (testing "handles empty title"
+    (let [result (iface/format-pr-summary-line {:pr/repo "r" :pr/number 1 :pr/title ""})]
+      (is (= "- r#1 " result)))))

--- a/components/tui-views/test/ai/miniforge/tui_views/interface_pr_context_acceptance_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/interface_pr_context_acceptance_test.clj
@@ -1,0 +1,172 @@
+(ns ai.miniforge.tui-views.interface-pr-context-acceptance-test
+  "Acceptance tests for PR context rendering and action parsing
+   in the TUI interface layer.
+
+   Verifies:
+   - build-pr-context-str produces correct text for various PR shapes
+   - parse-actions round-trips with action-match->action
+   - parse-risk-line handles edge cases in LLM output
+   - handle-fetch-pr-diff correctly wires number coercion"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.interface :as iface]
+   [ai.miniforge.tui-views.persistence.github :as github]))
+
+;; ---------------------------------------------------------------------------- build-pr-context-str acceptance
+
+(deftest pr-context-str-includes-provider-detection-test
+  (testing "GitHub provider detected for standard repo slug"
+    (let [ctx (iface/build-pr-context-str
+                {:pr/repo "acme/app" :pr/number 1 :pr/title "T"
+                 :pr/branch "b" :pr/status :open})]
+      (is (str/includes? ctx "GitHub"))))
+
+  (testing "GitLab provider detected for gitlab: prefix"
+    (let [ctx (iface/build-pr-context-str
+                {:pr/repo "gitlab:group/project" :pr/number 1 :pr/title "T"
+                 :pr/branch "b" :pr/status :open})]
+      (is (str/includes? ctx "GitLab"))))
+
+  (testing "GitHub is default for non-gitlab repos"
+    (let [ctx (iface/build-pr-context-str
+                {:pr/repo "bitbucket:org/repo" :pr/number 1 :pr/title "T"
+                 :pr/branch "b" :pr/status :open})]
+      (is (str/includes? ctx "GitHub")))))
+
+(deftest pr-context-str-risk-factors-rendering-test
+  (testing "multiple risk factors are each rendered on a separate line"
+    (let [ctx (iface/build-pr-context-str
+                {:pr/repo "r" :pr/number 1 :pr/title "T"
+                 :pr/branch "b" :pr/status :open
+                 :pr/risk {:risk/level :high
+                           :risk/score 0.9
+                           :risk/factors [{:explanation "Large PR"}
+                                          {:explanation "No tests"}
+                                          {:explanation "Core module"}]}})]
+      (is (str/includes? ctx "Large PR"))
+      (is (str/includes? ctx "No tests"))
+      (is (str/includes? ctx "Core module"))))
+
+  (testing "no risk factors section when factors list is empty"
+    (let [ctx (iface/build-pr-context-str
+                {:pr/repo "r" :pr/number 1 :pr/title "T"
+                 :pr/branch "b" :pr/status :open
+                 :pr/risk {:risk/level :low :risk/factors []}})]
+      (is (not (str/includes? ctx "Risk factors"))))))
+
+(deftest pr-context-str-readiness-rendering-test
+  (testing "readiness without ready? flag omits (ready) suffix"
+    (let [ctx (iface/build-pr-context-str
+                {:pr/repo "r" :pr/number 1 :pr/title "T"
+                 :pr/branch "b" :pr/status :open
+                 :pr/readiness {:readiness/score 50 :readiness/ready? false}})]
+      (is (str/includes? ctx "Readiness score: 50"))
+      (is (not (str/includes? ctx "(ready)"))))))
+
+(deftest pr-context-str-change-size-with-files-count-test
+  (testing "includes file count when changed-files-count is positive"
+    (let [ctx (iface/build-pr-context-str
+                {:pr/repo "r" :pr/number 1 :pr/title "T"
+                 :pr/branch "b" :pr/status :open
+                 :pr/additions 100 :pr/deletions 20
+                 :pr/changed-files-count 8})]
+      (is (str/includes? ctx "+100/-20"))
+      (is (str/includes? ctx "120 total lines"))
+      (is (str/includes? ctx "8 files"))))
+
+  (testing "omits file count when changed-files-count is zero"
+    (let [ctx (iface/build-pr-context-str
+                {:pr/repo "r" :pr/number 1 :pr/title "T"
+                 :pr/branch "b" :pr/status :open
+                 :pr/additions 5 :pr/deletions 3
+                 :pr/changed-files-count 0})]
+      (is (str/includes? ctx "+5/-3"))
+      (is (not (str/includes? ctx "files"))))))
+
+(deftest pr-context-str-policy-packs-rendering-test
+  (testing "shows pack names when packs-applied is present"
+    (let [ctx (iface/build-pr-context-str
+                {:pr/repo "r" :pr/number 1 :pr/title "T"
+                 :pr/branch "b" :pr/status :open
+                 :pr/policy {:evaluation/passed? true
+                             :evaluation/packs-applied ["security" "performance"]}})]
+      (is (str/includes? ctx "security"))
+      (is (str/includes? ctx "performance"))))
+
+  (testing "omits pack names when packs-applied is nil"
+    (let [ctx (iface/build-pr-context-str
+                {:pr/repo "r" :pr/number 1 :pr/title "T"
+                 :pr/branch "b" :pr/status :open
+                 :pr/policy {:evaluation/passed? false}})]
+      (is (str/includes? ctx "Policy: FAILED"))
+      (is (not (str/includes? ctx "packs:"))))))
+
+;; ---------------------------------------------------------------------------- parse-actions round-trip
+
+(deftest parse-actions-round-trip-test
+  (testing "parse-actions → action-match->action produces correct action maps"
+    (let [text (str "I analyzed the PR.\n"
+                    "[ACTION: review | Run Policy | Evaluate against security pack]\n"
+                    "[ACTION: open | View in Browser | Open PR URL in browser]\n"
+                    "Let me know if you need more.")
+          [clean actions] (iface/parse-actions text)]
+      ;; Clean text
+      (is (str/includes? clean "I analyzed the PR."))
+      (is (str/includes? clean "Let me know"))
+      (is (not (str/includes? clean "[ACTION:")))
+      ;; Actions
+      (is (= 2 (count actions)))
+      (is (= :review (:action (first actions))))
+      (is (= "Run Policy" (:label (first actions))))
+      (is (= "Evaluate against security pack" (:description (first actions))))
+      (is (= :open (:action (second actions)))))))
+
+(deftest parse-actions-trims-whitespace-test
+  (testing "labels and descriptions are trimmed"
+    (let [[_ actions] (iface/parse-actions
+                        "[ACTION: sync |  Refresh PRs  |  Reload from disk  ]")]
+      (is (= 1 (count actions)))
+      (is (= "Refresh PRs" (:label (first actions))))
+      (is (= "Reload from disk" (:description (first actions)))))))
+
+(deftest parse-actions-empty-input-test
+  (testing "empty string returns empty clean and no actions"
+    (let [[clean actions] (iface/parse-actions "")]
+      (is (= "" clean))
+      (is (empty? actions)))))
+
+;; ---------------------------------------------------------------------------- parse-risk-line edge cases
+
+(deftest parse-risk-line-whitespace-in-level-test
+  (testing "trims whitespace from level"
+    (let [r (iface/parse-risk-line "RISK: org/repo#10 |  high  | reason here")]
+      (is (= "high" (:level r))))))
+
+(deftest parse-risk-line-with-hash-in-repo-name-test
+  (testing "handles repo names with org containing hyphens"
+    (let [r (iface/parse-risk-line "RISK: my-org/my-repo#999 | critical | big change")]
+      (is (= ["my-org/my-repo" 999] (:id r))))))
+
+(deftest parse-risk-line-zero-pr-number-test
+  (testing "handles PR number 0"
+    (let [r (iface/parse-risk-line "RISK: r/r#0 | low | trivial")]
+      (is (= ["r/r" 0] (:id r))))))
+
+;; ---------------------------------------------------------------------------- handle-fetch-pr-diff number coercion
+
+(deftest handle-fetch-pr-diff-large-number-test
+  (testing "handles large PR numbers correctly"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [repo number]
+                    {:diff "d" :detail {:title "T"} :repo repo :number number})]
+      (let [[_ payload] (iface/handle-fetch-pr-diff {:repo "r" :number 999999})]
+        (is (= ["r" 999999] (:pr-id payload)))))))
+
+(deftest handle-fetch-pr-diff-string-zero-test
+  (testing "handles string '0' as PR number"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [repo number]
+                    {:diff nil :detail nil :repo repo :number number})]
+      (let [[_ payload] (iface/handle-fetch-pr-diff {:repo "r" :number "0"})]
+        (is (= ["r" 0] (:pr-id payload)))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/msg_contract_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/msg_contract_test.clj
@@ -1,0 +1,152 @@
+(ns ai.miniforge.tui-views.msg-contract-test
+  "Contract tests for msg.clj — verifies structural invariants
+   that all message constructors must satisfy.
+
+   These tests complement the existing msg_test.clj and msg_extended_test.clj
+   by testing cross-cutting invariants rather than individual constructors."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.tui-views.msg :as msg]))
+
+;; ---------------------------------------------------------------------------- Helpers
+
+(defn msg-type [m] (first m))
+(defn msg-payload [m] (second m))
+
+;; ---------------------------------------------------------------------------- pr-diff-fetched contract
+
+(deftest pr-diff-fetched-contract-test
+  (testing "pr-diff-fetched always has :pr-id :diff :detail in payload"
+    (doseq [[label args] [["all present" [["r" 1] "diff" {:title "T"} nil]]
+                           ["all nil"     [["r" 1] nil nil nil]]
+                           ["error"       [["r" 1] nil nil "err"]]
+                           ["diff only"   [["r" 1] "d" nil nil]]
+                           ["detail only" [["r" 1] nil {:t 1} nil]]]]
+      (testing label
+        (let [m (apply msg/pr-diff-fetched args)
+              p (msg-payload m)]
+          (is (= :msg/pr-diff-fetched (msg-type m)))
+          (is (contains? p :pr-id))
+          (is (contains? p :diff))
+          (is (contains? p :detail)))))))
+
+(deftest pr-diff-fetched-error-omission-test
+  (testing ":error key is absent when error arg is nil"
+    (let [p (msg-payload (msg/pr-diff-fetched ["r" 1] "d" {:t 1} nil))]
+      (is (not (contains? p :error)))))
+
+  (testing ":error key is present when error arg is non-nil"
+    (let [p (msg-payload (msg/pr-diff-fetched ["r" 1] nil nil "boom"))]
+      (is (contains? p :error))
+      (is (= "boom" (:error p))))))
+
+;; ---------------------------------------------------------------------------- prs-synced arity contract
+
+(deftest prs-synced-arity-contract-test
+  (testing "1-arity always has :pr-items, never :error"
+    (let [p (msg-payload (msg/prs-synced [{:id 1}]))]
+      (is (contains? p :pr-items))
+      (is (not (contains? p :error)))))
+
+  (testing "2-arity with error has both :pr-items and :error"
+    (let [p (msg-payload (msg/prs-synced [{:id 1}] "timeout"))]
+      (is (contains? p :pr-items))
+      (is (= "timeout" (:error p)))))
+
+  (testing "2-arity with nil error omits :error (same as 1-arity)"
+    (let [p (msg-payload (msg/prs-synced [{:id 1}] nil))]
+      (is (not (contains? p :error))))))
+
+;; ---------------------------------------------------------------------------- prs-synced-with-cache contract
+
+(deftest prs-synced-with-cache-contract-test
+  (testing "always includes :pr-items and :cached-risk"
+    (let [p (msg-payload (msg/prs-synced-with-cache [] {} nil))]
+      (is (contains? p :pr-items))
+      (is (contains? p :cached-risk))))
+
+  (testing "omits :error when nil, includes when present"
+    (is (not (contains? (msg-payload (msg/prs-synced-with-cache [] {} nil)) :error)))
+    (is (= "e" (:error (msg-payload (msg/prs-synced-with-cache [] {} "e")))))))
+
+;; ---------------------------------------------------------------------------- Message type namespace
+
+(deftest all-msg-types-use-msg-namespace-test
+  (testing "all message types use :msg/ namespace prefix"
+    (let [messages [(msg/prs-synced [])
+                    (msg/repos-discovered {})
+                    (msg/repos-browsed {})
+                    (msg/policy-evaluated :id {})
+                    (msg/pr-diff-fetched :id nil nil nil)
+                    (msg/train-created :id "n")
+                    (msg/prs-added-to-train {} 0)
+                    (msg/merge-started 1 {})
+                    (msg/review-completed [])
+                    (msg/remediation-completed 0 0 "m")
+                    (msg/decomposition-started :id {})
+                    (msg/chat-response "" [])
+                    (msg/chat-action-result {})
+                    (msg/fleet-risk-triaged [])
+                    (msg/fleet-risk-triaged-error "e")
+                    (msg/side-effect-error {})
+                    (msg/workflows-archived {})
+                    (msg/workflow-detail-loaded :id {})
+                    (msg/workflow-added :w "n" {})
+                    (msg/phase-changed :w :p)
+                    (msg/phase-done :w :p :o)
+                    (msg/agent-status :w :a :s "m")
+                    (msg/agent-output :w :a "d" false)
+                    (msg/agent-started :w :a {})
+                    (msg/agent-completed :w :a {})
+                    (msg/agent-failed :w :a {})
+                    (msg/workflow-done :w :s)
+                    (msg/workflow-failed :w "e")
+                    (msg/gate-result :w :g true)
+                    (msg/gate-started :w :g)
+                    (msg/tool-invoked :w :a :t)
+                    (msg/tool-completed :w :a :t)
+                    (msg/chain-started :c 3)
+                    (msg/chain-step-started :c :s 0 :w)
+                    (msg/chain-step-completed :c :s 0)
+                    (msg/chain-step-failed :c :s 0 "e")
+                    (msg/chain-completed :c 100 3)
+                    (msg/chain-failed :c :s "e")]]
+      (doseq [m messages]
+        (is (= "msg" (namespace (msg-type m)))
+            (str "Expected :msg/ namespace for " (msg-type m)))))))
+
+;; ---------------------------------------------------------------------------- Chain messages contract
+
+(deftest chain-messages-always-include-chain-id-test
+  (testing "all chain messages include :chain-id in payload"
+    (let [chain-msgs [(msg/chain-started :c 3)
+                      (msg/chain-step-started :c :s 0 :w)
+                      (msg/chain-step-completed :c :s 0)
+                      (msg/chain-step-failed :c :s 0 "e")
+                      (msg/chain-completed :c 100 3)
+                      (msg/chain-failed :c :s "e")]]
+      (doseq [m chain-msgs]
+        (is (= :c (:chain-id (msg-payload m)))
+            (str "Expected :chain-id = :c for " (msg-type m)))))))
+
+;; ---------------------------------------------------------------------------- Workflow messages contract
+
+(deftest workflow-event-messages-always-include-workflow-id-test
+  (testing "all workflow/agent/gate/tool messages include :workflow-id"
+    (let [wf-msgs [(msg/workflow-added :wf "n" {})
+                   (msg/phase-changed :wf :p)
+                   (msg/phase-done :wf :p :o)
+                   (msg/agent-status :wf :a :s "m")
+                   (msg/agent-output :wf :a "d" false)
+                   (msg/agent-started :wf :a {})
+                   (msg/agent-completed :wf :a {})
+                   (msg/agent-failed :wf :a {})
+                   (msg/workflow-done :wf :s)
+                   (msg/workflow-failed :wf "e")
+                   (msg/gate-result :wf :g true)
+                   (msg/gate-started :wf :g)
+                   (msg/tool-invoked :wf :a :t)
+                   (msg/tool-completed :wf :a :t)]]
+      (doseq [m wf-msgs]
+        (is (= :wf (:workflow-id (msg-payload m)))
+            (str "Expected :workflow-id = :wf for " (msg-type m)))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/msg_extended_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/msg_extended_test.clj
@@ -1,0 +1,186 @@
+(ns ai.miniforge.tui-views.msg-extended-test
+  "Extended tests for msg.clj covering constructors missed by msg_test.clj:
+   - prs-synced 2-arity (with error)
+   - prs-synced-with-cache
+   - fleet-risk-triaged / fleet-risk-triaged-error
+   - workflows-archived
+   - workflow-detail-loaded
+   - pr-diff-fetched (error vs no-error)
+   - phase-done with extras
+   - workflow-done with extras"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.tui-views.msg :as msg]))
+
+;; ---------------------------------------------------------------------------- Helpers
+
+(defn msg-type [m] (first m))
+(defn msg-payload [m] (second m))
+
+;; ---------------------------------------------------------------------------- prs-synced arity variants
+
+(deftest prs-synced-with-error-test
+  (testing "2-arity includes error in payload"
+    (let [m (msg/prs-synced [{:id 1}] "network timeout")]
+      (is (= :msg/prs-synced (msg-type m)))
+      (is (= [{:id 1}] (:pr-items (msg-payload m))))
+      (is (= "network timeout" (:error (msg-payload m))))))
+
+  (testing "2-arity with nil error omits :error key"
+    (let [m (msg/prs-synced [{:id 1}] nil)]
+      (is (not (contains? (msg-payload m) :error))))))
+
+(deftest prs-synced-empty-items-test
+  (testing "empty pr-items list is valid"
+    (let [m (msg/prs-synced [])]
+      (is (= :msg/prs-synced (msg-type m)))
+      (is (= [] (:pr-items (msg-payload m)))))))
+
+;; ---------------------------------------------------------------------------- prs-synced-with-cache
+
+(deftest prs-synced-with-cache-test
+  (testing "includes cached-risk in payload"
+    (let [m (msg/prs-synced-with-cache [{:id 1}] {:risk-data true} nil)]
+      (is (= :msg/prs-synced (msg-type m)))
+      (is (= [{:id 1}] (:pr-items (msg-payload m))))
+      (is (= {:risk-data true} (:cached-risk (msg-payload m))))
+      (is (not (contains? (msg-payload m) :error)))))
+
+  (testing "includes error when present"
+    (let [m (msg/prs-synced-with-cache [] nil "fail")]
+      (is (= "fail" (:error (msg-payload m))))))
+
+  (testing "nil cached-risk is stored as nil"
+    (let [p (msg-payload (msg/prs-synced-with-cache [] nil nil))]
+      (is (nil? (:cached-risk p))))))
+
+;; ---------------------------------------------------------------------------- fleet-risk-triaged
+
+(deftest fleet-risk-triaged-test
+  (testing "wraps assessments"
+    (let [assessments [{:id ["r" 1] :level "high" :reason "Big"}]
+          m (msg/fleet-risk-triaged assessments)]
+      (is (= :msg/fleet-risk-triaged (msg-type m)))
+      (is (= assessments (:assessments (msg-payload m))))
+      (is (not (contains? (msg-payload m) :error))))))
+
+(deftest fleet-risk-triaged-error-test
+  (testing "wraps error string"
+    (let [m (msg/fleet-risk-triaged-error "LLM timeout")]
+      (is (= :msg/fleet-risk-triaged (msg-type m)))
+      (is (= "LLM timeout" (:error (msg-payload m)))))))
+
+;; ---------------------------------------------------------------------------- workflows-archived
+
+(deftest workflows-archived-test
+  (let [result {:archived 3 :failed 0}
+        m (msg/workflows-archived result)]
+    (is (= :msg/workflows-archived (msg-type m)))
+    (is (= result (msg-payload m)))))
+
+;; ---------------------------------------------------------------------------- workflow-detail-loaded
+
+(deftest workflow-detail-loaded-test
+  (let [wf-id (random-uuid)
+        detail {:phases [{:name :plan}]}
+        m (msg/workflow-detail-loaded wf-id detail)]
+    (is (= :msg/workflow-detail-loaded (msg-type m)))
+    (is (= wf-id (:workflow-id (msg-payload m))))
+    (is (= detail (:detail (msg-payload m))))))
+
+;; ---------------------------------------------------------------------------- pr-diff-fetched
+
+(deftest pr-diff-fetched-test
+  (testing "without error omits :error key"
+    (let [m (msg/pr-diff-fetched ["r" 1] "diff" {:title "T"} nil)]
+      (is (= :msg/pr-diff-fetched (msg-type m)))
+      (is (= ["r" 1] (:pr-id (msg-payload m))))
+      (is (= "diff" (:diff (msg-payload m))))
+      (is (= {:title "T"} (:detail (msg-payload m))))
+      (is (not (contains? (msg-payload m) :error)))))
+
+  (testing "with error includes :error key"
+    (let [m (msg/pr-diff-fetched ["r" 1] nil nil "gh not found")]
+      (is (= "gh not found" (:error (msg-payload m))))
+      (is (nil? (:diff (msg-payload m))))))
+
+  (testing "nil diff and detail but no error"
+    (let [p (msg-payload (msg/pr-diff-fetched ["r" 1] nil nil nil))]
+      (is (nil? (:diff p)))
+      (is (nil? (:detail p)))
+      (is (not (contains? p :error))))))
+
+;; ---------------------------------------------------------------------------- phase-done with extras
+
+(deftest phase-done-with-extras-test
+  (testing "extras are merged into payload"
+    (let [m (msg/phase-done :wf1 :plan :success {:duration-ms 500})]
+      (is (= :msg/phase-done (msg-type m)))
+      (is (= :success (:outcome (msg-payload m))))
+      (is (= 500 (:duration-ms (msg-payload m))))))
+
+  (testing "without extras works normally"
+    (let [m (msg/phase-done :wf1 :plan :failure)]
+      (is (= :failure (:outcome (msg-payload m)))))))
+
+;; ---------------------------------------------------------------------------- workflow-done with extras
+
+(deftest workflow-done-with-extras-test
+  (testing "extras are merged into payload"
+    (let [m (msg/workflow-done :wf1 :success {:pr-info {:number 42}})]
+      (is (= :msg/workflow-done (msg-type m)))
+      (is (= :success (:status (msg-payload m))))
+      (is (= {:number 42} (:pr-info (msg-payload m))))))
+
+  (testing "without extras works normally"
+    (let [m (msg/workflow-done :wf1 :failure)]
+      (is (= :failure (:status (msg-payload m)))))))
+
+;; ---------------------------------------------------------------------------- All messages are 2-element vectors
+
+(deftest all-messages-are-vectors-test
+  (testing "every constructor returns [keyword map-or-value]"
+    (let [messages [(msg/prs-synced [])
+                    (msg/prs-synced [] "err")
+                    (msg/prs-synced-with-cache [] nil nil)
+                    (msg/repos-discovered {})
+                    (msg/repos-browsed {})
+                    (msg/policy-evaluated :id {})
+                    (msg/train-created :id "name")
+                    (msg/prs-added-to-train {} 0)
+                    (msg/merge-started 1 {})
+                    (msg/review-completed [])
+                    (msg/remediation-completed 0 0 "msg")
+                    (msg/decomposition-started :id {})
+                    (msg/chat-response "" [])
+                    (msg/chat-action-result {})
+                    (msg/fleet-risk-triaged [])
+                    (msg/fleet-risk-triaged-error "e")
+                    (msg/side-effect-error {})
+                    (msg/workflows-archived {})
+                    (msg/workflow-detail-loaded :id {})
+                    (msg/pr-diff-fetched :id nil nil nil)
+                    (msg/workflow-added :w "n" {})
+                    (msg/phase-changed :w :p)
+                    (msg/phase-done :w :p :o)
+                    (msg/agent-status :w :a :s "m")
+                    (msg/agent-output :w :a "d" false)
+                    (msg/agent-started :w :a {})
+                    (msg/agent-completed :w :a {})
+                    (msg/agent-failed :w :a {})
+                    (msg/workflow-done :w :s)
+                    (msg/workflow-failed :w "e")
+                    (msg/gate-result :w :g true)
+                    (msg/gate-started :w :g)
+                    (msg/tool-invoked :w :a :t)
+                    (msg/tool-completed :w :a :t)
+                    (msg/chain-started :c 3)
+                    (msg/chain-step-started :c :s 0 :w)
+                    (msg/chain-step-completed :c :s 0)
+                    (msg/chain-step-failed :c :s 0 "e")
+                    (msg/chain-completed :c 100 3)
+                    (msg/chain-failed :c :s "e")]]
+      (doseq [m messages]
+        (is (vector? m) (str "Expected vector, got: " (type m)))
+        (is (= 2 (count m)) (str "Expected 2 elements in " (first m)))
+        (is (keyword? (first m)) (str "Expected keyword msg-type, got: " (first m)))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/msg_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/msg_test.clj
@@ -14,11 +14,29 @@
 ;; ---------------------------------------------------------------------------- Layer 0: Side-effect result messages
 
 (deftest prs-synced-test
-  (testing "prs-synced produces correct message"
+  (testing "prs-synced produces correct message with items only"
     (let [items [{:pr/id 1} {:pr/id 2}]
           m (msg/prs-synced items)]
       (is (= :msg/prs-synced (msg-type m)))
-      (is (= items (:pr-items (msg-payload m)))))))
+      (is (= items (:pr-items (msg-payload m))))))
+
+  (testing "prs-synced with error includes error key"
+    (let [m (msg/prs-synced [] "timeout")]
+      (is (= :msg/prs-synced (msg-type m)))
+      (is (= "timeout" (:error (msg-payload m))))))
+
+  (testing "prs-synced with nil error omits error key"
+    (let [[_ payload] (msg/prs-synced [] nil)]
+      (is (not (contains? payload :error))))))
+
+(deftest prs-synced-with-cache-test
+  (testing "prs-synced-with-cache includes cached-risk and error"
+    (let [m (msg/prs-synced-with-cache [{:pr/id 1}] {:risk :high} nil)]
+      (is (= :msg/prs-synced (msg-type m)))
+      (is (= [{:pr/id 1}] (:pr-items (msg-payload m))))
+      (is (= {:risk :high} (:cached-risk (msg-payload m)))))
+    (let [m (msg/prs-synced-with-cache [] {} "err")]
+      (is (= "err" (:error (msg-payload m)))))))
 
 (deftest repos-discovered-test
   (testing "repos-discovered wraps result"
@@ -71,9 +89,31 @@
     (is (= "Done" (:message (msg-payload m))))))
 
 (deftest decomposition-started-test
-  (let [m (msg/decomposition-started :pr-1 {:sub-prs [1 2]})]
-    (is (= :msg/decomposition-started (msg-type m)))
-    (is (= :pr-1 (:pr-id (msg-payload m))))))
+  (testing "decomposition-started merges pr-id into plan payload"
+    (let [m (msg/decomposition-started :pr-1 {:sub-prs [1 2]})]
+      (is (= :msg/decomposition-started (msg-type m)))
+      (is (= :pr-1 (:pr-id (msg-payload m))))
+      (is (= [1 2] (:sub-prs (msg-payload m))))))
+
+  (testing "decomposition-started with error message"
+    (let [m (msg/decomposition-started ["r" 1] {:sub-prs [] :message "Failed"})]
+      (is (= :msg/decomposition-started (msg-type m)))
+      (is (= ["r" 1] (:pr-id (msg-payload m))))
+      (is (= [] (:sub-prs (msg-payload m))))
+      (is (= "Failed" (:message (msg-payload m)))))))
+
+(deftest pr-diff-fetched-test
+  (testing "pr-diff-fetched with all fields"
+    (let [m (msg/pr-diff-fetched ["r" 42] "diff" {:title "T"} nil)]
+      (is (= :msg/pr-diff-fetched (msg-type m)))
+      (is (= ["r" 42] (:pr-id (msg-payload m))))
+      (is (= "diff" (:diff (msg-payload m))))
+      (is (= {:title "T"} (:detail (msg-payload m))))
+      (is (not (contains? (msg-payload m) :error)))))
+
+  (testing "pr-diff-fetched with error"
+    (let [m (msg/pr-diff-fetched ["r" 1] nil nil "boom")]
+      (is (= "boom" (:error (msg-payload m)))))))
 
 (deftest chat-response-test
   (let [m (msg/chat-response "Hello" [{:action :create-pr}])]
@@ -86,10 +126,32 @@
     (is (= :msg/chat-action-result (msg-type m)))
     (is (= {:success? true} (msg-payload m)))))
 
+(deftest fleet-risk-triaged-test
+  (testing "fleet-risk-triaged wraps assessments"
+    (let [m (msg/fleet-risk-triaged [{:id ["r" 1] :level "high"}])]
+      (is (= :msg/fleet-risk-triaged (msg-type m)))
+      (is (= [{:id ["r" 1] :level "high"}] (:assessments (msg-payload m))))))
+
+  (testing "fleet-risk-triaged-error wraps error string"
+    (let [m (msg/fleet-risk-triaged-error "LLM failed")]
+      (is (= :msg/fleet-risk-triaged (msg-type m)))
+      (is (= "LLM failed" (:error (msg-payload m)))))))
+
 (deftest side-effect-error-test
   (let [m (msg/side-effect-error {:type :sync-prs :error "timeout"})]
     (is (= :msg/side-effect-error (msg-type m)))
     (is (= :sync-prs (:type (msg-payload m))))))
+
+(deftest workflows-archived-test
+  (let [m (msg/workflows-archived {:archived 3})]
+    (is (= :msg/workflows-archived (msg-type m)))
+    (is (= {:archived 3} (msg-payload m)))))
+
+(deftest workflow-detail-loaded-test
+  (let [m (msg/workflow-detail-loaded :wf-1 {:phases [:plan]})]
+    (is (= :msg/workflow-detail-loaded (msg-type m)))
+    (is (= :wf-1 (:workflow-id (msg-payload m))))
+    (is (= {:phases [:plan]} (:detail (msg-payload m))))))
 
 ;; ---------------------------------------------------------------------------- Layer 0b: Event stream translation messages
 
@@ -107,9 +169,14 @@
     (is (= :implement (:phase (msg-payload m))))))
 
 (deftest phase-done-msg-test
-  (let [m (msg/phase-done :wf1 :plan :success)]
-    (is (= :msg/phase-done (msg-type m)))
-    (is (= :success (:outcome (msg-payload m))))))
+  (testing "without extras"
+    (let [m (msg/phase-done :wf1 :plan :success)]
+      (is (= :msg/phase-done (msg-type m)))
+      (is (= :success (:outcome (msg-payload m))))))
+
+  (testing "with extras merged in"
+    (let [m (msg/phase-done :wf1 :plan :success {:duration-ms 500})]
+      (is (= 500 (:duration-ms (msg-payload m)))))))
 
 (deftest agent-status-msg-test
   (let [m (msg/agent-status :wf1 :planner :thinking "Analyzing")]
@@ -124,10 +191,31 @@
     (is (= "chunk text" (:delta (msg-payload m))))
     (is (false? (:done? (msg-payload m))))))
 
+(deftest agent-started-msg-test
+  (let [m (msg/agent-started :wf1 :planner {:phase :plan})]
+    (is (= :msg/agent-started (msg-type m)))
+    (is (= :planner (:agent (msg-payload m))))
+    (is (= {:phase :plan} (:context (msg-payload m))))))
+
+(deftest agent-completed-msg-test
+  (let [m (msg/agent-completed :wf1 :planner {:outcome :success})]
+    (is (= :msg/agent-completed (msg-type m)))
+    (is (= {:outcome :success} (:result (msg-payload m))))))
+
+(deftest agent-failed-msg-test
+  (let [m (msg/agent-failed :wf1 :planner {:message "timeout"})]
+    (is (= :msg/agent-failed (msg-type m)))
+    (is (= {:message "timeout"} (:error (msg-payload m))))))
+
 (deftest workflow-done-msg-test
-  (let [m (msg/workflow-done :wf1 :success)]
-    (is (= :msg/workflow-done (msg-type m)))
-    (is (= :success (:status (msg-payload m))))))
+  (testing "without extras"
+    (let [m (msg/workflow-done :wf1 :success)]
+      (is (= :msg/workflow-done (msg-type m)))
+      (is (= :success (:status (msg-payload m))))))
+
+  (testing "with extras merged in"
+    (let [m (msg/workflow-done :wf1 :success {:duration-ms 1000})]
+      (is (= 1000 (:duration-ms (msg-payload m)))))))
 
 (deftest workflow-failed-msg-test
   (let [m (msg/workflow-failed :wf1 "error details")]
@@ -154,24 +242,6 @@
   (let [m (msg/tool-completed :wf1 :planner :tools/write-file)]
     (is (= :msg/tool-completed (msg-type m)))
     (is (= :tools/write-file (:tool (msg-payload m))))))
-
-;; ---------------------------------------------------------------------------- Layer 0b2: Agent lifecycle messages
-
-(deftest agent-started-msg-test
-  (let [m (msg/agent-started :wf1 :planner {:phase :plan})]
-    (is (= :msg/agent-started (msg-type m)))
-    (is (= :planner (:agent (msg-payload m))))
-    (is (= {:phase :plan} (:context (msg-payload m))))))
-
-(deftest agent-completed-msg-test
-  (let [m (msg/agent-completed :wf1 :planner {:outcome :success})]
-    (is (= :msg/agent-completed (msg-type m)))
-    (is (= {:outcome :success} (:result (msg-payload m))))))
-
-(deftest agent-failed-msg-test
-  (let [m (msg/agent-failed :wf1 :planner {:message "timeout"})]
-    (is (= :msg/agent-failed (msg-type m)))
-    (is (= {:message "timeout"} (:error (msg-payload m))))))
 
 ;; ---------------------------------------------------------------------------- Layer 0c: Chain event messages
 
@@ -209,3 +279,52 @@
     (is (= :msg/chain-failed (msg-type m)))
     (is (= :plan (:failed-step (msg-payload m))))
     (is (= "error" (:error (msg-payload m))))))
+
+;; ---------------------------------------------------------------------------- Invariant: all messages are [keyword map] vectors
+
+(deftest all-messages-are-keyword-map-vectors-test
+  (testing "every constructor returns [keyword map-or-value]"
+    (let [msgs [(msg/prs-synced [])
+                (msg/prs-synced [] "err")
+                (msg/prs-synced-with-cache [] {} nil)
+                (msg/repos-discovered {:ok true})
+                (msg/repos-browsed {:ok true})
+                (msg/policy-evaluated :id {})
+                (msg/train-created :id "name")
+                (msg/prs-added-to-train {} 1)
+                (msg/merge-started 1 {})
+                (msg/review-completed [])
+                (msg/remediation-completed 0 0 "")
+                (msg/decomposition-started :id {})
+                (msg/pr-diff-fetched :id nil nil nil)
+                (msg/chat-response "" [])
+                (msg/chat-action-result {})
+                (msg/fleet-risk-triaged [])
+                (msg/fleet-risk-triaged-error "e")
+                (msg/side-effect-error {})
+                (msg/workflows-archived {})
+                (msg/workflow-detail-loaded :id {})
+                (msg/workflow-added :id "n" {})
+                (msg/phase-changed :id :p)
+                (msg/phase-done :id :p :o)
+                (msg/agent-status :wf :a :s "m")
+                (msg/agent-output :wf :a "d" false)
+                (msg/agent-started :wf :a {})
+                (msg/agent-completed :wf :a {})
+                (msg/agent-failed :wf :a {})
+                (msg/workflow-done :wf :s)
+                (msg/workflow-failed :wf "e")
+                (msg/gate-result :wf :g true)
+                (msg/gate-started :wf :g)
+                (msg/tool-invoked :wf :a :t)
+                (msg/tool-completed :wf :a :t)
+                (msg/chain-started :c 1)
+                (msg/chain-step-started :c :s 0 :wf)
+                (msg/chain-step-completed :c :s 0)
+                (msg/chain-step-failed :c :s 0 "e")
+                (msg/chain-completed :c 100 1)
+                (msg/chain-failed :c :s "e")]]
+      (doseq [m msgs]
+        (is (vector? m) (str "Expected vector for " (first m)))
+        (is (= 2 (count m)) (str "Expected 2-element vector for " (first m)))
+        (is (keyword? (first m)) (str "Expected keyword type for " m))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/persistence/github_acceptance_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/persistence/github_acceptance_test.clj
@@ -1,0 +1,385 @@
+(ns ai.miniforge.tui-views.persistence.github-acceptance-test
+  "Acceptance tests for the GitHub PR diff/detail fetch pipeline.
+
+   Acceptance criteria verified:
+   AC1: Function accepts repo string and PR number, returns
+        {:diff <string> :detail <map> :repo <string> :number <int>}
+   AC2: Diff is the unified diff text (GitHub API format)
+   AC3: Detail includes at minimum :title, :body, :labels, :files
+        (files contain per-file :path, :additions, :deletions)
+   AC4: Function handles API errors gracefully — returns nil fields,
+        never throws exceptions to the caller
+
+   Note: The implementation returns nil on failure (not result/err).
+   These tests document the actual graceful-degradation contract."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.persistence.github :as github]
+   [ai.miniforge.tui-views.interface :as iface]
+   [babashka.process :as process]))
+
+;; ---------------------------------------------------------------------------- Test data
+
+(def ^:private realistic-diff
+  "A realistic unified diff in GitHub format."
+  (str "diff --git a/src/auth/core.clj b/src/auth/core.clj\n"
+       "index abc1234..def5678 100644\n"
+       "--- a/src/auth/core.clj\n"
+       "+++ b/src/auth/core.clj\n"
+       "@@ -1,5 +1,8 @@\n"
+       " (ns src.auth.core)\n"
+       " \n"
+       "-(defn authenticate [user pass]\n"
+       "-  (= pass \"secret\"))\n"
+       "+(defn authenticate\n"
+       "+  \"Authenticate user against credential store.\"\n"
+       "+  [user pass]\n"
+       "+  (let [stored (lookup-credential user)]\n"
+       "+    (crypto/verify stored pass)))\n"
+       " \n"
+       " (defn logout [session]\n"
+       "diff --git a/test/auth/core_test.clj b/test/auth/core_test.clj\n"
+       "new file mode 100644\n"
+       "index 0000000..1234567\n"
+       "--- /dev/null\n"
+       "+++ b/test/auth/core_test.clj\n"
+       "@@ -0,0 +1,10 @@\n"
+       "+(ns auth.core-test\n"
+       "+  (:require [clojure.test :refer [deftest is]]\n"
+       "+            [src.auth.core :as sut]))\n"
+       "+\n"
+       "+(deftest authenticate-test\n"
+       "+  (is (true? (sut/authenticate \"admin\" \"correct\"))))\n"))
+
+(def ^:private realistic-detail-json
+  "Realistic JSON from `gh pr view --json body,title,labels,files`."
+  (str "{\"title\":\"Improve authentication with bcrypt\","
+       "\"body\":\"## Summary\\nReplaces plaintext comparison with bcrypt.\\n\\n## Test plan\\n- Unit tests added\","
+       "\"labels\":[{\"name\":\"security\"},{\"name\":\"enhancement\"}],"
+       "\"files\":[{\"path\":\"src/auth/core.clj\",\"additions\":5,\"deletions\":2},"
+       "{\"path\":\"test/auth/core_test.clj\",\"additions\":10,\"deletions\":0}]}"))
+
+(defn- mock-sh-success [out]
+  {:exit 0 :out out :err ""})
+
+(defn- mock-sh-failure [exit err]
+  {:exit exit :out "" :err err})
+
+;; ---------------------------------------------------------------------------- AC1: Return shape contract
+
+(deftest ac1-return-shape-has-exactly-four-keys-test
+  (testing "fetch-pr-diff-and-detail returns map with :diff :detail :repo :number"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] "d")
+                  github/fetch-pr-detail (fn [_ _] {:title "T"})]
+      (let [result (github/fetch-pr-diff-and-detail "owner/repo" 42)]
+        (is (map? result))
+        (is (= #{:diff :detail :repo :number} (set (keys result))))
+        (is (= 4 (count (keys result))))))))
+
+(deftest ac1-repo-is-string-test
+  (testing ":repo value is always a string matching the input"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (let [result (github/fetch-pr-diff-and-detail "my-org/my-repo" 1)]
+        (is (string? (:repo result)))
+        (is (= "my-org/my-repo" (:repo result)))))))
+
+(deftest ac1-number-is-long-from-integer-input-test
+  (testing ":number is a long when given an integer"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" 42)]
+        (is (integer? (:number result)))
+        (is (= 42 (:number result)))))))
+
+(deftest ac1-number-is-long-from-string-input-test
+  (testing ":number is coerced to long when given a string"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" "123")]
+        (is (integer? (:number result)))
+        (is (= 123 (:number result)))))))
+
+(deftest ac1-diff-is-string-or-nil-test
+  (testing ":diff is a string on success"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] "patch")
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (is (string? (:diff (github/fetch-pr-diff-and-detail "r" 1))))))
+
+  (testing ":diff is nil on failure"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (is (nil? (:diff (github/fetch-pr-diff-and-detail "r" 1)))))))
+
+(deftest ac1-detail-is-map-or-nil-test
+  (testing ":detail is a map on success"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] {:title "T"})]
+      (is (map? (:detail (github/fetch-pr-diff-and-detail "r" 1))))))
+
+  (testing ":detail is nil on failure"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (is (nil? (:detail (github/fetch-pr-diff-and-detail "r" 1)))))))
+
+;; ---------------------------------------------------------------------------- AC2: Unified diff format
+
+(deftest ac2-diff-is-unified-diff-text-test
+  (testing "diff output preserves the full unified diff from gh CLI"
+    (with-redefs [process/shell (fn [_opts & args]
+                               (let [a (vec args)]
+                                 (if (= "diff" (nth a 2))
+                                   (mock-sh-success realistic-diff)
+                                   (mock-sh-success realistic-detail-json))))]
+      (let [diff (github/fetch-pr-diff "owner/repo" 42)]
+        (is (string? diff))
+        (is (str/starts-with? diff "diff --git"))
+        (is (str/includes? diff "---"))
+        (is (str/includes? diff "+++"))
+        (is (str/includes? diff "@@"))))))
+
+(deftest ac2-diff-preserves-multiple-file-hunks-test
+  (testing "diff with multiple files is returned intact"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success realistic-diff))]
+      (let [diff (github/fetch-pr-diff "r" 1)
+            file-diffs (re-seq #"diff --git" diff)]
+        (is (= 2 (count file-diffs))
+            "Should contain two file diff headers")))))
+
+(deftest ac2-diff-preserves-new-file-mode-test
+  (testing "diff includes new file mode markers"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success realistic-diff))]
+      (let [diff (github/fetch-pr-diff "r" 1)]
+        (is (str/includes? diff "new file mode"))))))
+
+;; ---------------------------------------------------------------------------- AC3: Detail metadata fields
+
+(deftest ac3-detail-has-title-test
+  (testing "detail includes :title as a string"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success realistic-detail-json))]
+      (let [detail (github/fetch-pr-detail "r" 1)]
+        (is (contains? detail :title))
+        (is (string? (:title detail)))
+        (is (= "Improve authentication with bcrypt" (:title detail)))))))
+
+(deftest ac3-detail-has-body-test
+  (testing "detail includes :body (description) as a string"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success realistic-detail-json))]
+      (let [detail (github/fetch-pr-detail "r" 1)]
+        (is (contains? detail :body))
+        (is (string? (:body detail)))
+        (is (str/includes? (:body detail) "Summary"))))))
+
+(deftest ac3-detail-has-labels-test
+  (testing "detail includes :labels as a vector of maps with :name"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success realistic-detail-json))]
+      (let [detail (github/fetch-pr-detail "r" 1)]
+        (is (contains? detail :labels))
+        (is (sequential? (:labels detail)))
+        (is (= 2 (count (:labels detail))))
+        (is (= #{"security" "enhancement"}
+               (set (map :name (:labels detail)))))))))
+
+(deftest ac3-detail-has-files-with-path-additions-deletions-test
+  (testing "detail includes :files, each with :path :additions :deletions"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success realistic-detail-json))]
+      (let [detail (github/fetch-pr-detail "r" 1)
+            files  (:files detail)]
+        (is (contains? detail :files))
+        (is (sequential? files))
+        (is (= 2 (count files)))
+        ;; First file
+        (let [f1 (first files)]
+          (is (= "src/auth/core.clj" (:path f1)))
+          (is (= 5 (:additions f1)))
+          (is (= 2 (:deletions f1))))
+        ;; Second file (new file)
+        (let [f2 (second files)]
+          (is (= "test/auth/core_test.clj" (:path f2)))
+          (is (= 10 (:additions f2)))
+          (is (= 0 (:deletions f2))))))))
+
+(deftest ac3-detail-computed-totals-test
+  (testing "total additions/deletions/changed-files can be derived from :files"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success realistic-detail-json))]
+      (let [detail (github/fetch-pr-detail "r" 1)
+            files  (:files detail)
+            total-additions (reduce + (map :additions files))
+            total-deletions (reduce + (map :deletions files))
+            changed-files   (count files)]
+        (is (= 15 total-additions))
+        (is (= 2 total-deletions))
+        (is (= 2 changed-files))))))
+
+(deftest ac3-json-query-includes-required-fields-test
+  (testing "the --json argument requests body, title, labels, and files"
+    (let [captured (atom nil)]
+      (with-redefs [process/shell (fn [_opts & args]
+                                 (reset! captured (vec args))
+                                 (mock-sh-success "{\"title\":\"T\",\"body\":\"\",\"labels\":[],\"files\":[]}"))]
+        (github/fetch-pr-detail "r" 1)
+        (let [json-arg (last @captured)]
+          (is (str/includes? json-arg "title"))
+          (is (str/includes? json-arg "body"))
+          (is (str/includes? json-arg "labels"))
+          (is (str/includes? json-arg "files")))))))
+
+;; ---------------------------------------------------------------------------- AC4: Graceful error handling
+
+(deftest ac4-fetch-pr-diff-returns-nil-on-nonzero-exit-test
+  (testing "returns nil (graceful degradation) when gh exits non-zero"
+    (doseq [exit-code [1 2 127 128 255]]
+      (with-redefs [process/shell (fn [_opts & _] (mock-sh-failure exit-code "error"))]
+        (is (nil? (github/fetch-pr-diff "r" 1))
+            (str "Expected nil for exit code " exit-code))))))
+
+(deftest ac4-fetch-pr-diff-returns-nil-on-exception-test
+  (testing "returns nil when process/sh throws any exception"
+    (doseq [ex [(Exception. "gh not found")
+                (RuntimeException. "IO error")
+                (java.io.IOException. "broken pipe")]]
+      (with-redefs [process/shell (fn [_opts & _] (throw ex))]
+        (is (nil? (github/fetch-pr-diff "r" 1))
+            (str "Expected nil for " (type ex)))))))
+
+(deftest ac4-fetch-pr-detail-returns-nil-on-nonzero-exit-test
+  (testing "returns nil when gh exits non-zero"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-failure 1 "not found"))]
+      (is (nil? (github/fetch-pr-detail "r" 1))))))
+
+(deftest ac4-fetch-pr-detail-returns-nil-on-malformed-json-test
+  (testing "returns nil when response is not valid JSON"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success "<html>404</html>"))]
+      (is (nil? (github/fetch-pr-detail "r" 1))))))
+
+(deftest ac4-fetch-pr-detail-returns-nil-on-partial-json-test
+  (testing "returns nil when JSON is truncated"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success "{\"title\":"))]
+      (is (nil? (github/fetch-pr-detail "r" 1))))))
+
+(deftest ac4-composite-never-throws-test
+  (testing "fetch-pr-diff-and-detail never throws, returns nil fields on failure"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] (throw (Exception. "diff boom")))
+                  github/fetch-pr-detail (fn [_ _] (throw (Exception. "detail boom")))]
+      ;; The futures catch exceptions — they return nil via the individual fn try/catch
+      ;; But the futures themselves will propagate the exception on deref.
+      ;; Since fetch-pr-diff and fetch-pr-detail have internal try/catch,
+      ;; the redefs bypass that. Let's test with process/sh redefs instead.
+      true))
+
+  (testing "fetch-pr-diff-and-detail with process/sh failure returns nil fields"
+    (with-redefs [process/shell (fn [_opts & _] (throw (Exception. "all broken")))]
+      ;; Both individual fns catch Exception, so composite gets nil for both
+      (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+        (is (nil? (:diff result)))
+        (is (nil? (:detail result)))
+        (is (= "r" (:repo result)))
+        (is (= 1 (:number result)))))))
+
+(deftest ac4-composite-partial-failure-preserves-success-test
+  (testing "when diff fails but detail succeeds, detail is preserved"
+    (let [call-count (atom 0)]
+      (with-redefs [process/shell (fn [_opts & args]
+                                 (let [cmd (nth (vec args) 2)]
+                                   (if (= "diff" cmd)
+                                     (mock-sh-failure 1 "err")
+                                     (mock-sh-success realistic-detail-json))))]
+        (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+          (is (nil? (:diff result)))
+          (is (map? (:detail result)))
+          (is (= "Improve authentication with bcrypt" (:title (:detail result))))))))
+
+  (testing "when detail fails but diff succeeds, diff is preserved"
+    (with-redefs [process/shell (fn [_opts & args]
+                               (let [cmd (nth (vec args) 2)]
+                                 (if (= "view" cmd)
+                                   (mock-sh-failure 1 "err")
+                                   (mock-sh-success realistic-diff))))]
+      (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+        (is (string? (:diff result)))
+        (is (str/starts-with? (:diff result) "diff --git"))
+        (is (nil? (:detail result)))))))
+
+;; ---------------------------------------------------------------------------- AC4 via interface handler
+
+(deftest ac4-handle-fetch-pr-diff-graceful-on-total-failure-test
+  (testing "interface handler returns error message when both fetches fail"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail nil :repo "r" :number 1})]
+      (let [[msg-type payload] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (= :msg/pr-diff-fetched msg-type))
+        (is (string? (:error payload)))
+        (is (str/includes? (:error payload) "Failed"))))))
+
+(deftest ac4-handle-fetch-pr-diff-graceful-on-exception-test
+  (testing "interface handler catches exceptions and wraps in error message"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] (throw (java.net.ConnectException. "Connection refused")))]
+      (let [[msg-type payload] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (= :msg/pr-diff-fetched msg-type))
+        (is (= ["r" 1] (:pr-id payload)))
+        (is (nil? (:diff payload)))
+        (is (nil? (:detail payload)))
+        (is (str/includes? (:error payload) "Connection refused"))))))
+
+(deftest ac4-handle-fetch-pr-diff-no-error-on-partial-success-test
+  (testing "no error when at least one of diff or detail succeeds"
+    ;; diff ok, detail nil
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff "patch" :detail nil :repo "r" :number 1})]
+      (let [[_ payload] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (nil? (:error payload)))))
+
+    ;; diff nil, detail ok
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail {:title "X"} :repo "r" :number 1})]
+      (let [[_ payload] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (nil? (:error payload)))))))
+
+;; ---------------------------------------------------------------------------- Precondition validation
+
+(deftest precondition-repo-must-be-string-test
+  (testing "all three functions reject non-string repo"
+    (is (thrown? AssertionError (github/fetch-pr-diff nil 1)))
+    (is (thrown? AssertionError (github/fetch-pr-diff 123 1)))
+    (is (thrown? AssertionError (github/fetch-pr-detail nil 1)))
+    (is (thrown? AssertionError (github/fetch-pr-detail :repo 1)))
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail nil 1)))
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail 42 1)))))
+
+(deftest precondition-number-must-not-be-nil-test
+  (testing "all three functions reject nil number"
+    (is (thrown? AssertionError (github/fetch-pr-diff "r" nil)))
+    (is (thrown? AssertionError (github/fetch-pr-detail "r" nil)))
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail "r" nil)))))
+
+(deftest precondition-composite-rejects-invalid-number-types-test
+  (testing "composite rejects keyword, float, vector as number"
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail "r" :k)))
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail "r" 3.14)))
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail "r" [1])))))
+
+;; ---------------------------------------------------------------------------- End-to-end via dispatch-effect
+
+(deftest dispatch-effect-fetch-pr-diff-end-to-end-test
+  (testing "dispatch-effect :fetch-pr-diff wires through to pr-diff-fetched message"
+    (with-redefs [process/shell (fn [_opts & args]
+                               (let [cmd (nth (vec args) 2)]
+                                 (case cmd
+                                   "diff" (mock-sh-success realistic-diff)
+                                   "view" (mock-sh-success realistic-detail-json))))]
+      (let [[msg-type payload] (iface/dispatch-effect nil {:type :fetch-pr-diff
+                                                           :repo "acme/app"
+                                                           :number 42})]
+        (is (= :msg/pr-diff-fetched msg-type))
+        (is (= ["acme/app" 42] (:pr-id payload)))
+        ;; diff present
+        (is (string? (:diff payload)))
+        (is (str/starts-with? (:diff payload) "diff --git"))
+        ;; detail present with expected fields
+        (is (map? (:detail payload)))
+        (is (= "Improve authentication with bcrypt" (:title (:detail payload))))
+        (is (= 2 (count (:files (:detail payload)))))
+        ;; no error
+        (is (nil? (:error payload)))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/persistence/github_extended_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/persistence/github_extended_test.clj
@@ -1,0 +1,302 @@
+(ns ai.miniforge.tui-views.persistence.github-extended-test
+  "Extended tests for persistence/github.clj covering:
+   - Precondition assertions (invalid inputs)
+   - coerce-number edge cases via composite function
+   - Concurrency behavior of fetch-pr-diff-and-detail
+   - Empty/whitespace diff handling
+   - Large PR number handling
+   - No cli-base dependency verification
+   - CLI argument correctness
+   - files field inclusion in --json query"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.tui-views.persistence.github :as github]
+   [babashka.process :as process]))
+
+;; ---------------------------------------------------------------------------- Helpers
+
+(defn mock-sh-success [out]
+  {:exit 0 :out out :err ""})
+
+(defn mock-sh-failure [exit err]
+  {:exit exit :out "" :err err})
+
+;; ---------------------------------------------------------------------------- Precondition tests
+
+(deftest fetch-pr-diff-precondition-test
+  (testing "throws AssertionError when repo is not a string"
+    (is (thrown? AssertionError (github/fetch-pr-diff nil 42)))
+    (is (thrown? AssertionError (github/fetch-pr-diff 123 42))))
+
+  (testing "throws AssertionError when number is nil"
+    (is (thrown? AssertionError (github/fetch-pr-diff "owner/repo" nil)))))
+
+(deftest fetch-pr-detail-precondition-test
+  (testing "throws AssertionError when repo is not a string"
+    (is (thrown? AssertionError (github/fetch-pr-detail nil 42)))
+    (is (thrown? AssertionError (github/fetch-pr-detail :keyword 42))))
+
+  (testing "throws AssertionError when number is nil"
+    (is (thrown? AssertionError (github/fetch-pr-detail "owner/repo" nil)))))
+
+(deftest fetch-pr-diff-and-detail-precondition-test
+  (testing "throws AssertionError when repo is not a string"
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail nil 42))))
+
+  (testing "throws AssertionError when number is nil"
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail "r" nil))))
+
+  (testing "throws AssertionError when number is not string or integer"
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail "r" :keyword)))
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail "r" 3.14)))
+    (is (thrown? AssertionError (github/fetch-pr-diff-and-detail "r" [42])))))
+
+;; ---------------------------------------------------------------------------- coerce-number edge cases
+
+(deftest coerce-number-via-composite-test
+  (testing "large PR number as string is coerced correctly"
+    (with-redefs [github/fetch-pr-diff   (fn [_ n] (is (= 999999 n)) "d")
+                  github/fetch-pr-detail (fn [_ n] (is (= 999999 n)) {:title "X"})]
+      (let [result (github/fetch-pr-diff-and-detail "r" "999999")]
+        (is (= 999999 (:number result))))))
+
+  (testing "zero as string"
+    (with-redefs [github/fetch-pr-diff   (fn [_ n] (is (= 0 n)) nil)
+                  github/fetch-pr-detail (fn [_ n] (is (= 0 n)) nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" "0")]
+        (is (= 0 (:number result))))))
+
+  (testing "zero as integer"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" 0)]
+        (is (= 0 (:number result))))))
+
+  (testing "negative number passes through as long"
+    (with-redefs [github/fetch-pr-diff   (fn [_ n] (is (= -1 n)) nil)
+                  github/fetch-pr-detail (fn [_ n] (is (= -1 n)) nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" -1)]
+        (is (= -1 (:number result))))))
+
+  (testing "string number with leading zeros parses correctly"
+    (with-redefs [github/fetch-pr-diff   (fn [_ n] (is (= 7 n)) nil)
+                  github/fetch-pr-detail (fn [_ n] (is (= 7 n)) nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" "007")]
+        (is (= 7 (:number result)))))))
+
+(deftest coerce-number-invalid-string-test
+  (testing "non-numeric string throws NumberFormatException from Long/parseLong"
+    (is (thrown? NumberFormatException
+          (github/fetch-pr-diff-and-detail "r" "abc")))))
+
+;; ---------------------------------------------------------------------------- Whitespace / multiline diff
+
+(deftest fetch-pr-diff-whitespace-test
+  (testing "trims whitespace-only diff output"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success "   \n  "))]
+      (is (= "" (github/fetch-pr-diff "r" 1)))))
+
+  (testing "returns multiline diff intact"
+    (let [diff "diff --git a/x b/x\n--- a/x\n+++ b/x\n@@ -1 +1 @@\n-old\n+new\n"]
+      (with-redefs [process/shell (fn [_opts & _] (mock-sh-success diff))]
+        (is (= (clojure.string/trim diff) (github/fetch-pr-diff "r" 1)))))))
+
+;; ---------------------------------------------------------------------------- fetch-pr-detail nested JSON
+
+(deftest fetch-pr-detail-nested-labels-test
+  (testing "handles multiple labels"
+    (let [json "{\"title\":\"T\",\"body\":\"B\",\"labels\":[{\"name\":\"bug\"},{\"name\":\"urgent\"}],\"files\":[]}"]
+      (with-redefs [process/shell (fn [_opts & _] (mock-sh-success json))]
+        (let [result (github/fetch-pr-detail "r" 1)]
+          (is (= 2 (count (:labels result))))
+          (is (= "bug" (:name (first (:labels result)))))
+          (is (= "urgent" (:name (second (:labels result))))))))))
+
+(deftest fetch-pr-detail-empty-body-test
+  (testing "handles PR with empty body and no labels/files"
+    (let [json "{\"title\":\"Tiny\",\"body\":\"\",\"labels\":[],\"files\":[]}"]
+      (with-redefs [process/shell (fn [_opts & _] (mock-sh-success json))]
+        (let [result (github/fetch-pr-detail "r" 1)]
+          (is (= "Tiny" (:title result)))
+          (is (= "" (:body result)))
+          (is (empty? (:labels result)))
+          (is (empty? (:files result))))))))
+
+(deftest fetch-pr-detail-files-field-present-test
+  (testing "files field is included in the --json query for TUI file-level views"
+    (let [captured-args (atom nil)]
+      (with-redefs [process/shell (fn [_opts & args]
+                                 (reset! captured-args (vec args))
+                                 (mock-sh-success "{\"title\":\"T\",\"body\":\"\",\"labels\":[],\"files\":[]}"))]
+        (github/fetch-pr-detail "r" 1)
+        (let [json-field (last @captured-args)]
+          (is (clojure.string/includes? json-field "files")
+              "--json query must include 'files' for TUI file-level detail")
+          (is (clojure.string/includes? json-field "body"))
+          (is (clojure.string/includes? json-field "title"))
+          (is (clojure.string/includes? json-field "labels")))))))
+
+(deftest fetch-pr-detail-multiple-files-test
+  (testing "handles PR with multiple changed files including additions/deletions"
+    (let [json "{\"title\":\"Big PR\",\"body\":\"Many changes\",\"labels\":[],\"files\":[{\"path\":\"src/a.clj\",\"additions\":10,\"deletions\":3},{\"path\":\"src/b.clj\",\"additions\":0,\"deletions\":20},{\"path\":\"test/c_test.clj\",\"additions\":50,\"deletions\":0}]}"]
+      (with-redefs [process/shell (fn [_opts & _] (mock-sh-success json))]
+        (let [result (github/fetch-pr-detail "r" 1)
+              files (:files result)]
+          (is (= 3 (count files)))
+          (is (= "src/a.clj" (:path (first files))))
+          (is (= 10 (:additions (first files))))
+          (is (= 20 (:deletions (second files))))
+          (is (= 50 (:additions (nth files 2)))))))))
+
+;; ---------------------------------------------------------------------------- Concurrency
+
+(deftest fetch-pr-diff-and-detail-concurrency-test
+  (testing "both fetches run concurrently (neither blocks the other)"
+    (let [diff-called (promise)
+          detail-called (promise)]
+      (with-redefs [github/fetch-pr-diff
+                    (fn [_ _]
+                      (deliver diff-called true)
+                      ;; Wait briefly for detail to also start
+                      (deref detail-called 500 false)
+                      "diff")
+                    github/fetch-pr-detail
+                    (fn [_ _]
+                      (deliver detail-called true)
+                      (deref diff-called 500 false)
+                      {:title "T"})]
+        (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+          (is (= "diff" (:diff result)))
+          (is (= {:title "T"} (:detail result)))
+          ;; Both should have been called
+          (is (true? (deref diff-called 0 false)))
+          (is (true? (deref detail-called 0 false))))))))
+
+(deftest fetch-pr-diff-and-detail-one-slow-does-not-block-other-test
+  (testing "slow diff does not prevent detail from completing"
+    (let [detail-done (promise)]
+      (with-redefs [github/fetch-pr-diff
+                    (fn [_ _]
+                      ;; Simulate slow diff
+                      (Thread/sleep 100)
+                      "slow-diff")
+                    github/fetch-pr-detail
+                    (fn [_ _]
+                      (let [result {:title "Fast"}]
+                        (deliver detail-done true)
+                        result))]
+        (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+          (is (= "slow-diff" (:diff result)))
+          (is (= {:title "Fast"} (:detail result)))
+          (is (true? (deref detail-done 0 false))))))))
+
+;; ---------------------------------------------------------------------------- Various exit codes
+
+(deftest fetch-pr-diff-various-exit-codes-test
+  (testing "exit code 1 returns nil"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-failure 1 "err"))]
+      (is (nil? (github/fetch-pr-diff "r" 1)))))
+
+  (testing "exit code 127 (command not found) returns nil"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-failure 127 "gh: command not found"))]
+      (is (nil? (github/fetch-pr-diff "r" 1)))))
+
+  (testing "exit code 128 returns nil"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-failure 128 "auth"))]
+      (is (nil? (github/fetch-pr-diff "r" 1))))))
+
+(deftest fetch-pr-detail-various-exit-codes-test
+  (testing "exit code 127 returns nil"
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-failure 127 "not found"))]
+      (is (nil? (github/fetch-pr-detail "r" 1))))))
+
+;; ---------------------------------------------------------------------------- CLI argument structure
+
+(deftest fetch-pr-diff-cli-args-test
+  (testing "passes correct arguments to gh pr diff"
+    (let [captured (atom nil)]
+      (with-redefs [process/shell (fn [_opts & args]
+                                 (reset! captured (vec args))
+                                 (mock-sh-success "patch"))]
+        (github/fetch-pr-diff "octocat/hello-world" 123)
+        (is (= ["gh" "pr" "diff" "123" "--repo" "octocat/hello-world"]
+               @captured)))))
+
+  (testing "number is stringified via str for CLI arg"
+    (let [captured (atom nil)]
+      (with-redefs [process/shell (fn [_opts & args]
+                                 (reset! captured (vec args))
+                                 (mock-sh-success ""))]
+        (github/fetch-pr-diff "r" 0)
+        (is (= "0" (nth @captured 3)))))))
+
+(deftest fetch-pr-detail-cli-args-test
+  (testing "passes correct arguments to gh pr view --json"
+    (let [captured (atom nil)]
+      (with-redefs [process/shell (fn [_opts & args]
+                                 (reset! captured (vec args))
+                                 (mock-sh-success "{\"title\":\"T\",\"body\":\"\",\"labels\":[],\"files\":[]}"))]
+        (github/fetch-pr-detail "octocat/hello-world" 456)
+        (is (= ["gh" "pr" "view" "456"
+                "--repo" "octocat/hello-world"
+                "--json" "title,body,labels,files"]
+               @captured))))))
+
+;; ---------------------------------------------------------------------------- No cli-base dependency
+
+(deftest no-cli-base-dependency-test
+  (testing "namespace requires babashka.process directly, not cli base"
+    (let [ns-obj (find-ns 'ai.miniforge.tui-views.persistence.github)
+          requires (set (map first (ns-aliases ns-obj)))]
+      (is (contains? requires 'process)
+          "Should alias babashka.process as 'process'")
+      (is (contains? requires 'json)
+          "Should alias cheshire.core as 'json'")
+      ;; Must NOT depend on CLI base namespaces
+      (is (not (some #(clojure.string/starts-with? (str %) "ai.miniforge.cli")
+                     (map (comp str second) (ns-aliases ns-obj))))
+          "Must not depend on any ai.miniforge.cli namespace"))))
+
+;; ---------------------------------------------------------------------------- Return type invariants
+
+(deftest fetch-pr-diff-return-type-test
+  (testing "always returns string or nil, never other types"
+    ;; Success: string
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success "data"))]
+      (let [result (github/fetch-pr-diff "r" 1)]
+        (is (or (string? result) (nil? result)))))
+    ;; Failure: nil
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-failure 1 "err"))]
+      (let [result (github/fetch-pr-diff "r" 1)]
+        (is (or (string? result) (nil? result)))))
+    ;; Exception: nil
+    (with-redefs [process/shell (fn [_opts & _] (throw (Exception. "boom")))]
+      (let [result (github/fetch-pr-diff "r" 1)]
+        (is (or (string? result) (nil? result)))))))
+
+(deftest fetch-pr-detail-return-type-test
+  (testing "always returns map or nil, never other types"
+    ;; Success: map
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success "{\"title\":\"T\",\"body\":\"\",\"labels\":[],\"files\":[]}"))]
+      (let [result (github/fetch-pr-detail "r" 1)]
+        (is (or (map? result) (nil? result)))))
+    ;; Failure: nil
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-failure 1 "err"))]
+      (let [result (github/fetch-pr-detail "r" 1)]
+        (is (or (map? result) (nil? result)))))
+    ;; Bad JSON: nil
+    (with-redefs [process/shell (fn [_opts & _] (mock-sh-success "broken"))]
+      (let [result (github/fetch-pr-detail "r" 1)]
+        (is (or (map? result) (nil? result)))))))
+
+(deftest fetch-pr-diff-and-detail-return-shape-test
+  (testing "always returns a map with :diff :detail :repo :number keys"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+        (is (contains? result :diff))
+        (is (contains? result :detail))
+        (is (contains? result :repo))
+        (is (contains? result :number))
+        (is (= 4 (count (keys result)))
+            "Result map should have exactly 4 keys")))))

--- a/components/tui-views/test/ai/miniforge/tui_views/persistence/github_integration_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/persistence/github_integration_test.clj
@@ -1,0 +1,256 @@
+(ns ai.miniforge.tui-views.persistence.github-integration-test
+  "Integration tests for the GitHub PR fetch pipeline.
+
+   Verifies the full path from dispatch-effect through handle-fetch-pr-diff
+   to github/fetch-pr-diff-and-detail and msg/pr-diff-fetched construction.
+
+   Covers acceptance criteria:
+   AC1: Function accepts repo string + PR number, returns
+        {:diff <string> :detail <map> :repo <string> :number <int>}
+   AC2: Diff is unified diff text (GitHub API format)
+   AC3: Detail includes :title, :body, :labels, :files
+        (files have :path, :additions, :deletions)
+   AC4: Graceful error handling — nil fields, never throws
+
+   Also covers msg/pr-diff-fetched constructor and
+   handle-fetch-pr-diff number coercion edge cases."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.string :as str]
+   [ai.miniforge.tui-views.persistence.github :as github]
+   [ai.miniforge.tui-views.interface :as iface]
+   [ai.miniforge.tui-views.msg :as msg]
+   [babashka.process :as process]))
+
+;; ---------------------------------------------------------------------------- Test data
+
+(def ^:private multi-file-diff
+  "A realistic multi-file unified diff with additions, deletions, renames."
+  (str "diff --git a/src/core.clj b/src/core.clj\n"
+       "index 1234567..abcdef0 100644\n"
+       "--- a/src/core.clj\n"
+       "+++ b/src/core.clj\n"
+       "@@ -10,7 +10,12 @@\n"
+       " (ns src.core)\n"
+       " \n"
+       "-(defn process [x] x)\n"
+       "+(defn process\n"
+       "+  \"Process input with validation.\"\n"
+       "+  [x]\n"
+       "+  {:pre [(some? x)]}\n"
+       "+  (transform x))\n"
+       " \n"
+       "diff --git a/src/util.clj b/src/util.clj\n"
+       "index 0000000..fedcba9\n"
+       "--- a/src/util.clj\n"
+       "+++ b/src/util.clj\n"
+       "@@ -1,3 +1,5 @@\n"
+       " (ns src.util)\n"
+       "+(defn transform [x]\n"
+       "+  (str x))\n"
+       "diff --git a/test/core_test.clj b/test/core_test.clj\n"
+       "new file mode 100644\n"
+       "index 0000000..9876543\n"
+       "--- /dev/null\n"
+       "+++ b/test/core_test.clj\n"
+       "@@ -0,0 +1,8 @@\n"
+       "+(ns core-test\n"
+       "+  (:require [clojure.test :refer [deftest is]]\n"
+       "+            [src.core :as sut]))\n"
+       "+\n"
+       "+(deftest process-test\n"
+       "+  (is (= \"42\" (sut/process 42))))\n"))
+
+(def ^:private detail-with-all-fields
+  "JSON with title, body, labels, and files — comprehensive."
+  (str "{\"title\":\"Add input validation to process fn\","
+       "\"body\":\"## Summary\\nAdds precondition checks and transforms.\\n\\n"
+       "## Test plan\\n- Unit tests for process fn\","
+       "\"labels\":[{\"name\":\"enhancement\"},{\"name\":\"needs-review\"}],"
+       "\"files\":["
+       "{\"path\":\"src/core.clj\",\"additions\":5,\"deletions\":1},"
+       "{\"path\":\"src/util.clj\",\"additions\":2,\"deletions\":0},"
+       "{\"path\":\"test/core_test.clj\",\"additions\":8,\"deletions\":0}"
+       "]}"))
+
+(def ^:private empty-pr-json
+  "{\"title\":\"Empty PR\",\"body\":\"\",\"labels\":[],\"files\":[]}")
+
+(defn- mock-shell-success [out]
+  {:exit 0 :out out :err ""})
+
+(defn- mock-shell-failure [exit err]
+  {:exit exit :out "" :err err})
+
+(defn- route-gh-command
+  "Create a mock process/shell that routes based on gh subcommand.
+   diff-response and detail-response are [exit-code output] pairs."
+  [diff-response detail-response]
+  (fn [_opts & args]
+    (let [a (vec args)
+          cmd (nth a 2)]
+      (case cmd
+        "diff" (if (zero? (first diff-response))
+                 (mock-shell-success (second diff-response))
+                 (mock-shell-failure (first diff-response) (second diff-response)))
+        "view" (if (zero? (first detail-response))
+                 (mock-shell-success (second detail-response))
+                 (mock-shell-failure (first detail-response) (second detail-response)))))))
+
+;; ---------------------------------------------------------------------------- msg/pr-diff-fetched unit tests
+
+(deftest pr-diff-fetched-msg-structure-test
+  (testing "produces :msg/pr-diff-fetched with pr-id, diff, detail"
+    (let [m (msg/pr-diff-fetched ["r" 1] "patch" {:title "T"} nil)]
+      (is (= :msg/pr-diff-fetched (first m)))
+      (is (= ["r" 1] (:pr-id (second m))))
+      (is (= "patch" (:diff (second m))))
+      (is (= {:title "T"} (:detail (second m))))))
+
+  (testing "omits :error key when error is nil"
+    (let [[_ payload] (msg/pr-diff-fetched ["r" 1] "d" {} nil)]
+      (is (not (contains? payload :error)))))
+
+  (testing "includes :error key when error is truthy"
+    (let [[_ payload] (msg/pr-diff-fetched ["r" 1] nil nil "fetch failed")]
+      (is (contains? payload :error))
+      (is (= "fetch failed" (:error payload)))))
+
+  (testing "diff and detail can both be nil"
+    (let [[_ payload] (msg/pr-diff-fetched ["r" 1] nil nil "err")]
+      (is (nil? (:diff payload)))
+      (is (nil? (:detail payload))))))
+
+(deftest pr-diff-fetched-msg-always-vector-test
+  (testing "always returns a two-element vector"
+    (doseq [args [[["r" 1] "d" {:title "T"} nil]
+                  [["r" 1] nil nil "err"]
+                  [["r" 1] "" {} nil]
+                  [["r" 1] nil {:title "X"} nil]]]
+      (let [m (apply msg/pr-diff-fetched args)]
+        (is (vector? m))
+        (is (= 2 (count m)))
+        (is (= :msg/pr-diff-fetched (first m)))
+        (is (map? (second m)))))))
+
+;; ---------------------------------------------------------------------------- Integration: handle-fetch-pr-diff
+
+(deftest handle-fetch-pr-diff-full-success-pipeline-test
+  (testing "full pipeline: dispatch → handle → github → msg, all fields present"
+    (with-redefs [process/shell (route-gh-command [0 multi-file-diff]
+                                                   [0 detail-with-all-fields])]
+      (let [[msg-type payload] (iface/handle-fetch-pr-diff
+                                {:repo "acme/app" :number 99})]
+        ;; AC1: correct message type
+        (is (= :msg/pr-diff-fetched msg-type))
+        ;; AC1: pr-id is [repo, coerced-number]
+        (is (= ["acme/app" 99] (:pr-id payload)))
+
+        ;; AC2: diff is unified diff text
+        (is (string? (:diff payload)))
+        (is (str/starts-with? (:diff payload) "diff --git"))
+        (is (str/includes? (:diff payload) "@@"))
+
+        ;; AC3: detail has minimum required fields
+        (let [detail (:detail payload)]
+          (is (map? detail))
+          (is (= "Add input validation to process fn" (:title detail)))
+          (is (string? (:body detail)))
+          (is (sequential? (:labels detail)))
+          (is (= #{"enhancement" "needs-review"}
+                 (set (map :name (:labels detail)))))
+          (is (= 3 (count (:files detail))))
+          (is (every? #(contains? % :path) (:files detail))))
+
+        ;; AC4: no error on success
+        (is (nil? (:error payload)))))))
+
+(deftest handle-fetch-pr-diff-string-number-coercion-test
+  (testing "string PR number is coerced to long in pr-id"
+    (with-redefs [process/shell (route-gh-command [0 "patch"] [0 empty-pr-json])]
+      (let [[_ payload] (iface/handle-fetch-pr-diff
+                         {:repo "org/repo" :number "456"})]
+        (is (= ["org/repo" 456] (:pr-id payload)))
+        (is (integer? (second (:pr-id payload))))))))
+
+;; ---------------------------------------------------------------------------- Integration: partial failures
+
+(deftest handle-fetch-pr-diff-diff-fails-detail-ok-test
+  (testing "diff failure + detail success → no error, detail preserved"
+    (with-redefs [process/shell (route-gh-command [1 "not found"]
+                                                   [0 detail-with-all-fields])]
+      (let [[msg-type payload] (iface/handle-fetch-pr-diff
+                                {:repo "r" :number 1})]
+        (is (= :msg/pr-diff-fetched msg-type))
+        (is (nil? (:diff payload)))
+        (is (map? (:detail payload)))
+        (is (nil? (:error payload)))))))
+
+(deftest handle-fetch-pr-diff-detail-fails-diff-ok-test
+  (testing "detail failure + diff success → no error, diff preserved"
+    (with-redefs [process/shell (route-gh-command [0 multi-file-diff]
+                                                   [128 "auth failed"])]
+      (let [[_ payload] (iface/handle-fetch-pr-diff
+                         {:repo "r" :number 1})]
+        (is (string? (:diff payload)))
+        (is (str/starts-with? (:diff payload) "diff --git"))
+        (is (nil? (:detail payload)))
+        (is (nil? (:error payload)))))))
+
+(deftest handle-fetch-pr-diff-both-fail-sets-error-test
+  (testing "both diff and detail fail → error message set"
+    (with-redefs [process/shell (fn [_opts & _] (mock-shell-failure 1 "nope"))]
+      (let [[_ payload] (iface/handle-fetch-pr-diff
+                         {:repo "r" :number 1})]
+        (is (nil? (:diff payload)))
+        (is (nil? (:detail payload)))
+        (is (string? (:error payload)))))))
+
+(deftest handle-fetch-pr-diff-exception-wraps-error-test
+  (testing "exception from github layer is caught and wrapped"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] (throw (java.net.SocketTimeoutException. "Read timed out")))]
+      (let [[msg-type payload] (iface/handle-fetch-pr-diff
+                                {:repo "r" :number 5})]
+        (is (= :msg/pr-diff-fetched msg-type))
+        (is (= ["r" 5] (:pr-id payload)))
+        (is (nil? (:diff payload)))
+        (is (str/includes? (:error payload) "Read timed out"))))))
+
+;; ---------------------------------------------------------------------------- Integration: dispatch-effect routing
+
+(deftest dispatch-effect-routes-fetch-pr-diff-test
+  (testing ":fetch-pr-diff effect type routes to handle-fetch-pr-diff"
+    (with-redefs [process/shell (route-gh-command [0 "simple diff"]
+                                                   [0 empty-pr-json])]
+      (let [[msg-type payload] (iface/dispatch-effect nil {:type :fetch-pr-diff
+                                                           :repo "org/lib"
+                                                           :number 77})]
+        (is (= :msg/pr-diff-fetched msg-type))
+        (is (= ["org/lib" 77] (:pr-id payload)))
+        (is (= "simple diff" (:diff payload)))
+        (is (map? (:detail payload)))))))
+
+(deftest dispatch-effect-fetch-pr-diff-total-failure-test
+  (testing "dispatch-effect with total failure returns error in payload"
+    (with-redefs [process/shell (fn [_opts & _] (mock-shell-failure 127 "gh: command not found"))]
+      (let [[msg-type payload] (iface/dispatch-effect nil {:type :fetch-pr-diff
+                                                           :repo "r"
+                                                           :number 1})]
+        (is (= :msg/pr-diff-fetched msg-type))
+        (is (string? (:error payload)))))))
+
+;; ---------------------------------------------------------------------------- Edge cases: diff content
+
+(deftest diff-with-binary-file-markers-test
+  (testing "diff containing binary file markers is returned intact"
+    (let [diff "diff --git a/img.png b/img.png\nBinary files differ"]
+      (with-redefs [process/shell (fn [_opts & _] (mock-shell-success diff))]
+        (is (= diff (github/fetch-pr-diff "r" 1)))))))
+
+(deftest diff-with-unicode-content-test
+  (testing "diff with unicode characters is preserved"
+    (let [diff "diff --git a/i18n.clj b/i18n.clj\n+;; 日本語テスト — émojis: 🎉"]
+      (with-redefs [process/shell (fn [_opts & _] (mock-shell-success diff))]
+        (is (= diff (github/fetch-pr-diff "r" 1)))
+        (is (str/includes? (github/fetch-pr-diff "r" 1) "🎉"))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/persistence/github_msg_contract_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/persistence/github_msg_contract_test.clj
@@ -1,0 +1,117 @@
+(ns ai.miniforge.tui-views.persistence.github-msg-contract-test
+  "Contract tests verifying the msg/pr-diff-fetched constructor
+   and handle-fetch-pr-diff produce messages that conform to the
+   expected shape for downstream update/reducer consumption.
+
+   These tests ensure the contract between the persistence layer
+   and the Elm update loop is maintained."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.tui-views.msg :as msg]
+   [ai.miniforge.tui-views.interface :as iface]
+   [ai.miniforge.tui-views.persistence.github :as github]
+   [babashka.process :as process]))
+
+;; ---------------------------------------------------------------------------- msg/pr-diff-fetched contract
+
+(deftest pr-diff-fetched-is-two-element-vector-test
+  (testing "all arities produce [keyword map]"
+    ;; success case
+    (let [m (msg/pr-diff-fetched ["r" 1] "diff" {:title "T"} nil)]
+      (is (vector? m))
+      (is (= 2 (count m)))
+      (is (keyword? (first m)))
+      (is (map? (second m))))
+    ;; error case
+    (let [m (msg/pr-diff-fetched ["r" 1] nil nil "err")]
+      (is (vector? m))
+      (is (= 2 (count m)))
+      (is (keyword? (first m)))
+      (is (map? (second m))))))
+
+(deftest pr-diff-fetched-payload-keys-contract-test
+  (testing "payload always has :pr-id, :diff, :detail; :error only when present"
+    ;; No error
+    (let [[_ p] (msg/pr-diff-fetched ["r" 1] "d" {:t 1} nil)]
+      (is (contains? p :pr-id))
+      (is (contains? p :diff))
+      (is (contains? p :detail))
+      (is (not (contains? p :error))))
+    ;; With error
+    (let [[_ p] (msg/pr-diff-fetched ["r" 1] nil nil "bad")]
+      (is (contains? p :pr-id))
+      (is (contains? p :diff))
+      (is (contains? p :detail))
+      (is (contains? p :error)))))
+
+(deftest pr-diff-fetched-error-false-string-test
+  (testing "empty string error is truthy, so :error key IS included"
+    ;; Note: empty string is truthy in Clojure (only nil and false are falsy)
+    (let [[_ p] (msg/pr-diff-fetched ["r" 1] nil nil "")]
+      (is (contains? p :error))
+      (is (= "" (:error p))))))
+
+(deftest pr-diff-fetched-error-false-value-test
+  (testing "false as error is falsy, so :error key is omitted"
+    (let [[_ p] (msg/pr-diff-fetched ["r" 1] nil nil false)]
+      (is (not (contains? p :error))))))
+
+;; ---------------------------------------------------------------------------- handle-fetch-pr-diff output contract
+
+(deftest handle-fetch-pr-diff-output-is-msg-vector-test
+  (testing "handle-fetch-pr-diff always returns [msg-type payload] vector"
+    ;; Success
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff "d" :detail {:t 1} :repo "r" :number 1})]
+      (let [result (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (vector? result))
+        (is (= 2 (count result)))
+        (is (= :msg/pr-diff-fetched (first result)))))
+    ;; Exception
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] (throw (Exception. "boom")))]
+      (let [result (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (vector? result))
+        (is (= 2 (count result)))
+        (is (= :msg/pr-diff-fetched (first result)))))))
+
+(deftest handle-fetch-pr-diff-pr-id-is-vector-pair-test
+  (testing ":pr-id is always [repo-string number-long]"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail nil :repo "org/lib" :number 99})]
+      (let [[_ payload] (iface/handle-fetch-pr-diff {:repo "org/lib" :number 99})]
+        (is (vector? (:pr-id payload)))
+        (is (= 2 (count (:pr-id payload))))
+        (is (string? (first (:pr-id payload))))
+        (is (integer? (second (:pr-id payload))))))))
+
+(deftest handle-fetch-pr-diff-pr-id-from-string-number-test
+  (testing ":pr-id number component is long even when input is string"
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail nil :repo "r" :number 42})]
+      (let [[_ payload] (iface/handle-fetch-pr-diff {:repo "r" :number "42"})]
+        (is (= ["r" 42] (:pr-id payload)))
+        (is (integer? (second (:pr-id payload))))))))
+
+(deftest handle-fetch-pr-diff-error-only-on-total-failure-test
+  (testing "error is set only when BOTH diff and detail are nil"
+    ;; Both nil → error
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail nil :repo "r" :number 1})]
+      (let [[_ p] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (some? (:error p)))))
+    ;; Diff present → no error
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff "x" :detail nil :repo "r" :number 1})]
+      (let [[_ p] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (nil? (:error p)))))
+    ;; Detail present → no error
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff nil :detail {:t 1} :repo "r" :number 1})]
+      (let [[_ p] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (nil? (:error p)))))
+    ;; Both present → no error
+    (with-redefs [github/fetch-pr-diff-and-detail
+                  (fn [_ _] {:diff "d" :detail {:t 1} :repo "r" :number 1})]
+      (let [[_ p] (iface/handle-fetch-pr-diff {:repo "r" :number 1})]
+        (is (nil? (:error p)))))))

--- a/components/tui-views/test/ai/miniforge/tui_views/persistence/github_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/persistence/github_test.clj
@@ -1,0 +1,208 @@
+(ns ai.miniforge.tui-views.persistence.github-test
+  "Tests for the GitHub CLI wrapper (persistence/github.clj).
+
+   All tests mock babashka.process/shell to avoid real CLI calls.
+   Verifies:
+   - fetch-pr-diff returns diff string on success, nil on failure
+   - fetch-pr-detail returns parsed JSON map on success, nil on failure
+   - fetch-pr-diff-and-detail composes both + coerces number
+   - Graceful handling of non-zero exit, empty output, and exceptions"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.tui-views.persistence.github :as github]
+   [babashka.process :as process]))
+
+;; ---------------------------------------------------------------------------- Helpers
+
+(defn mock-shell-success
+  "Return a mock shell result that looks like a successful process."
+  [out]
+  {:exit 0 :out out :err ""})
+
+(defn mock-shell-failure
+  "Return a mock shell result with non-zero exit code."
+  ([exit err] {:exit exit :out "" :err err})
+  ([exit] (mock-shell-failure exit "something went wrong")))
+
+;; ---------------------------------------------------------------------------- fetch-pr-diff
+
+(deftest fetch-pr-diff-success-test
+  (testing "returns trimmed diff string when gh exits 0"
+    (let [diff-text "diff --git a/foo.clj b/foo.clj\n+new line"]
+      (with-redefs [process/shell (fn [_opts & args]
+                                    (is (= ["gh" "pr" "diff" "42" "--repo" "owner/repo"]
+                                           (vec args)))
+                                    (mock-shell-success (str diff-text "\n")))]
+        (is (= diff-text (github/fetch-pr-diff "owner/repo" 42)))))))
+
+(deftest fetch-pr-diff-string-number-test
+  (testing "coerces number to string in CLI args via (str number)"
+    (with-redefs [process/shell (fn [_opts & args]
+                                  (is (= "99" (nth (vec args) 3)))
+                                  (mock-shell-success "patch"))]
+      (is (= "patch" (github/fetch-pr-diff "owner/repo" 99))))))
+
+(deftest fetch-pr-diff-failure-exit-code-test
+  (testing "returns nil when gh exits non-zero"
+    (with-redefs [process/shell (fn [_opts & _] (mock-shell-failure 1 "not found"))]
+      (is (nil? (github/fetch-pr-diff "owner/repo" 42))))))
+
+(deftest fetch-pr-diff-exception-test
+  (testing "returns nil when process/shell throws"
+    (with-redefs [process/shell (fn [_opts & _] (throw (Exception. "gh not installed")))]
+      (is (nil? (github/fetch-pr-diff "owner/repo" 42))))))
+
+(deftest fetch-pr-diff-empty-output-test
+  (testing "returns empty string when diff is empty but exit 0"
+    (with-redefs [process/shell (fn [_opts & _] (mock-shell-success ""))]
+      (is (= "" (github/fetch-pr-diff "owner/repo" 1))))))
+
+(deftest fetch-pr-diff-whitespace-trimming-test
+  (testing "trims leading/trailing whitespace from output"
+    (with-redefs [process/shell (fn [_opts & _] (mock-shell-success "  diff text  "))]
+      (is (= "diff text" (github/fetch-pr-diff "r" 1))))))
+
+(deftest fetch-pr-diff-nil-out-test
+  (testing "handles nil :out gracefully via (get result :out \"\")"
+    (with-redefs [process/shell (fn [_opts & _] {:exit 0 :out nil :err ""})]
+      ;; str/trim on (:out result "") → trims empty string
+      (is (= "" (github/fetch-pr-diff "r" 1))))))
+
+;; ---------------------------------------------------------------------------- fetch-pr-detail
+
+(def sample-detail-json
+  "{\"title\":\"Fix bug\",\"body\":\"Description\",\"labels\":[{\"name\":\"bugfix\"}],\"files\":[{\"path\":\"src/a.clj\",\"additions\":5,\"deletions\":2}]}")
+
+(deftest fetch-pr-detail-success-test
+  (testing "returns parsed map with keyword keys on success"
+    (with-redefs [process/shell (fn [_opts & args]
+                                  (let [a (vec args)]
+                                    (is (= "gh" (first a)))
+                                    (is (= "pr" (second a)))
+                                    (is (= "view" (nth a 2)))
+                                    (is (= "7" (nth a 3)))
+                                    (mock-shell-success sample-detail-json)))]
+      (let [result (github/fetch-pr-detail "acme/lib" 7)]
+        (is (map? result))
+        (is (= "Fix bug" (:title result)))
+        (is (= "Description" (:body result)))
+        (is (= 1 (count (:labels result))))
+        (is (= "bugfix" (:name (first (:labels result)))))
+        (is (= 1 (count (:files result))))
+        (is (= "src/a.clj" (:path (first (:files result)))))))))
+
+(deftest fetch-pr-detail-failure-exit-code-test
+  (testing "returns nil when gh exits non-zero"
+    (with-redefs [process/shell (fn [_opts & _] (mock-shell-failure 128 "auth error"))]
+      (is (nil? (github/fetch-pr-detail "owner/repo" 1))))))
+
+(deftest fetch-pr-detail-exception-test
+  (testing "returns nil when process/shell throws"
+    (with-redefs [process/shell (fn [_opts & _] (throw (RuntimeException. "timeout")))]
+      (is (nil? (github/fetch-pr-detail "owner/repo" 5))))))
+
+(deftest fetch-pr-detail-malformed-json-test
+  (testing "returns nil when JSON parsing fails (exception caught)"
+    (with-redefs [process/shell (fn [_opts & _] (mock-shell-success "NOT JSON"))]
+      ;; cheshire will throw — caught by the outer try/catch
+      (is (nil? (github/fetch-pr-detail "owner/repo" 1))))))
+
+(deftest fetch-pr-detail-empty-json-object-test
+  (testing "returns empty-ish map for minimal JSON"
+    (with-redefs [process/shell (fn [_opts & _] (mock-shell-success "{}"))]
+      (let [result (github/fetch-pr-detail "r" 1)]
+        (is (map? result))
+        (is (nil? (:title result)))))))
+
+(deftest fetch-pr-detail-passes-json-fields-arg-test
+  (testing "passes --json title,body,labels,files to gh CLI"
+    (let [captured-args (atom nil)]
+      (with-redefs [process/shell (fn [_opts & args]
+                                    (reset! captured-args (vec args))
+                                    (mock-shell-success "{}"))]
+        (github/fetch-pr-detail "r" 1)
+        (let [args @captured-args
+              json-idx (.indexOf args "--json")]
+          (is (pos? json-idx))
+          (is (= "title,body,labels,files" (nth args (inc json-idx)))))))))
+
+;; ---------------------------------------------------------------------------- fetch-pr-diff-and-detail
+
+(deftest fetch-pr-diff-and-detail-success-test
+  (testing "returns combined map when both succeed"
+    (with-redefs [github/fetch-pr-diff   (fn [r n] (is (= "o/r" r)) (is (= 10 n)) "diff-text")
+                  github/fetch-pr-detail (fn [r n] (is (= "o/r" r)) (is (= 10 n)) {:title "T"})]
+      (let [result (github/fetch-pr-diff-and-detail "o/r" 10)]
+        (is (= "diff-text" (:diff result)))
+        (is (= {:title "T"} (:detail result)))
+        (is (= "o/r" (:repo result)))
+        (is (= 10 (:number result)))))))
+
+(deftest fetch-pr-diff-and-detail-string-number-coercion-test
+  (testing "coerces string number to long"
+    (with-redefs [github/fetch-pr-diff   (fn [_ n] (is (= 42 n)) "d")
+                  github/fetch-pr-detail (fn [_ n] (is (= 42 n)) {:title "X"})]
+      (let [result (github/fetch-pr-diff-and-detail "r" "42")]
+        (is (= 42 (:number result)))))))
+
+(deftest fetch-pr-diff-and-detail-int-number-test
+  (testing "passes integer number through unchanged"
+    (with-redefs [github/fetch-pr-diff   (fn [_ n] (is (= 7 n)) nil)
+                  github/fetch-pr-detail (fn [_ n] (is (= 7 n)) nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" 7)]
+        (is (= 7 (:number result)))))))
+
+(deftest fetch-pr-diff-and-detail-partial-failure-test
+  (testing "diff nil but detail ok"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] {:title "T"})]
+      (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+        (is (nil? (:diff result)))
+        (is (= {:title "T"} (:detail result))))))
+
+  (testing "diff ok but detail nil"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] "patch")
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+        (is (= "patch" (:diff result)))
+        (is (nil? (:detail result)))))))
+
+(deftest fetch-pr-diff-and-detail-both-fail-test
+  (testing "both nil when gh is unavailable"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+        (is (nil? (:diff result)))
+        (is (nil? (:detail result)))
+        (is (= "r" (:repo result)))
+        (is (= 1 (:number result)))))))
+
+(deftest fetch-pr-diff-and-detail-return-shape-invariant-test
+  (testing "always returns exactly 4 keys: :diff :detail :repo :number"
+    (doseq [[label mock-diff mock-detail]
+            [["both ok"    (fn [_ _] "d")  (fn [_ _] {:title "T"})]
+             ["diff nil"   (fn [_ _] nil)  (fn [_ _] {:title "T"})]
+             ["detail nil" (fn [_ _] "d") (fn [_ _] nil)]
+             ["both nil"   (fn [_ _] nil)  (fn [_ _] nil)]]]
+      (with-redefs [github/fetch-pr-diff   mock-diff
+                    github/fetch-pr-detail mock-detail]
+        (let [result (github/fetch-pr-diff-and-detail "r" 1)]
+          (is (= #{:diff :detail :repo :number} (set (keys result)))
+              (str "Keys invariant failed for: " label)))))))
+
+(deftest fetch-pr-diff-and-detail-number-type-invariant-test
+  (testing ":number is always a long regardless of input type"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (is (instance? Long (:number (github/fetch-pr-diff-and-detail "r" 42))))
+      (is (instance? Long (:number (github/fetch-pr-diff-and-detail "r" "42"))))
+      (is (instance? Long (:number (github/fetch-pr-diff-and-detail "r" 0)))))))
+
+(deftest fetch-pr-diff-and-detail-repo-passthrough-invariant-test
+  (testing ":repo is always the exact input string"
+    (with-redefs [github/fetch-pr-diff   (fn [_ _] nil)
+                  github/fetch-pr-detail (fn [_ _] nil)]
+      (doseq [repo ["owner/repo" "my-org/my-repo" "gitlab:group/project"
+                    "org/repo-with-dashes" "ORG/REPO"]]
+        (is (= repo (:repo (github/fetch-pr-diff-and-detail repo 1)))
+            (str "Repo passthrough failed for: " repo))))))

--- a/docs/pull-requests/2026-03-10-fix-review-gate-and-verify-timeout.md
+++ b/docs/pull-requests/2026-03-10-fix-review-gate-and-verify-timeout.md
@@ -1,0 +1,104 @@
+# fix: Review Gate, Verify Timeout, and TUI PR Decomposition Wiring
+
+**Branch:** `fix/review-gate-and-verify-timeout`
+**Base:** `main`
+**Date:** 2026-03-10
+**Layer:** Application / TUI integration
+**Depends On:** None
+
+## Overview
+
+Updates the existing review-gate / verify-timeout PR branch with the missing
+`tui-views` GitHub persistence and PR decomposition wiring that had stalled in
+the implement loop.
+
+The branch now contains:
+
+- the original gate fix so approved reviews satisfy the review gate
+- the verify fix so timeout/rate-limit failures do not loop back into implement
+- the `tui-views` follow-up that fetches PR diffs/details through `gh` and wires
+  `handle-decompose-pr` and `:fetch-pr-diff` into the Elm-style update loop
+
+## Motivation
+
+The TUI had stubbed or incomplete behavior around PR decomposition:
+
+- there was no concrete GitHub persistence namespace for `gh pr diff` and
+  `gh pr view --json`
+- `handle-decompose-pr` was not wired to fetch real PR context and invoke the
+  decomposition component
+- the message/update contract for decomposition and PR diff fetching was not
+  consistent across handlers and tests
+- chat-triggered actions could surface `:msg/side-effect-error` directly
+  instead of a chat-friendly result when a delegated handler failed
+
+This left the decomposition flow unreviewable and broke a large portion of the
+generated `tui-views` acceptance coverage.
+
+## Changes In Detail
+
+### TUI GitHub persistence
+
+- Added `components/tui-views/src/ai/miniforge/tui_views/persistence/github.clj`
+- Wrapped `gh pr diff` and `gh pr view --json` with precondition checks
+- Standardized on `babashka.process/shell`
+- Added number coercion helper and concurrent diff/detail fetches
+- Gracefully return `nil` fields on CLI failure, parse failure, or exception
+
+### TUI handler wiring
+
+- Replaced the `handle-decompose-pr` stub with a real implementation
+- Fetches diff/detail, derives changed file paths, resolves
+  `ai.miniforge.pr-decompose.interface/decompose` via `requiring-resolve`, and
+  emits `:msg/decomposition-started`
+- Added `handle-fetch-pr-diff`
+- Routed `:fetch-pr-diff` in `dispatch-effect`
+- Normalized `handle-chat-execute-action` so delegated handler failures become
+  `:msg/chat-action-result` for chat consumers
+
+### Message and reducer contracts
+
+- Flattened `decomposition-started` payloads so plan fields live at the top
+  level beside `:pr-id`
+- Added `pr-diff-fetched` constructor with `[pr-id diff detail error]`
+- Updated decomposition reducer expectations to consume the flattened payload
+
+### Test coverage
+
+- Added and aligned `tui-views` acceptance, integration, contract, and handler
+  tests around:
+  - GitHub persistence wrappers
+  - PR diff fetch effect routing
+  - decomposition flow behavior
+  - chat action error handling
+  - message contract shape
+
+## Testing Plan
+
+- [x] Targeted `tui-views` namespaces covering GitHub persistence, decomposition,
+      events, and interface context pass
+- [x] `bb scripts/test-changed-bricks.bb` passes with `888` tests and `0`
+      failures / `0` errors
+- [ ] Manual TUI smoke test against a real PR
+
+## Deployment Plan
+
+No special deployment steps.
+
+This is application/TUI logic plus tests. It ships with the normal deploy path.
+
+## Related Issues/PRs
+
+- Existing PR: #288
+- Related branch work already present in this PR:
+  - review gate uses `:review/decision`
+  - verify timeout/rate-limit avoids implement-loop redirects
+
+## Checklist
+
+- [x] PR doc added
+- [x] GitHub persistence namespace added
+- [x] decomposition handler wired
+- [x] PR diff fetch effect wired
+- [x] message/update contract aligned
+- [x] tests passing


### PR DESCRIPTION
# fix: Review Gate, Verify Timeout, and TUI PR Decomposition Wiring

**Branch:** `fix/review-gate-and-verify-timeout`
**Base:** `main`
**Date:** 2026-03-10
**Layer:** Application / TUI integration
**Depends On:** None

## Overview

Updates the existing review-gate / verify-timeout PR branch with the missing
`tui-views` GitHub persistence and PR decomposition wiring that had stalled in
the implement loop.

The branch now contains:

- the original gate fix so approved reviews satisfy the review gate
- the verify fix so timeout/rate-limit failures do not loop back into implement
- the `tui-views` follow-up that fetches PR diffs/details through `gh` and wires
  `handle-decompose-pr` and `:fetch-pr-diff` into the Elm-style update loop

## Motivation

The TUI had stubbed or incomplete behavior around PR decomposition:

- there was no concrete GitHub persistence namespace for `gh pr diff` and
  `gh pr view --json`
- `handle-decompose-pr` was not wired to fetch real PR context and invoke the
  decomposition component
- the message/update contract for decomposition and PR diff fetching was not
  consistent across handlers and tests
- chat-triggered actions could surface `:msg/side-effect-error` directly
  instead of a chat-friendly result when a delegated handler failed

This left the decomposition flow unreviewable and broke a large portion of the
generated `tui-views` acceptance coverage.

## Changes In Detail

### TUI GitHub persistence

- Added `components/tui-views/src/ai/miniforge/tui_views/persistence/github.clj`
- Wrapped `gh pr diff` and `gh pr view --json` with precondition checks
- Standardized on `babashka.process/shell`
- Added number coercion helper and concurrent diff/detail fetches
- Gracefully return `nil` fields on CLI failure, parse failure, or exception

### TUI handler wiring

- Replaced the `handle-decompose-pr` stub with a real implementation
- Fetches diff/detail, derives changed file paths, resolves
  `ai.miniforge.pr-decompose.interface/decompose` via `requiring-resolve`, and
  emits `:msg/decomposition-started`
- Added `handle-fetch-pr-diff`
- Routed `:fetch-pr-diff` in `dispatch-effect`
- Normalized `handle-chat-execute-action` so delegated handler failures become
  `:msg/chat-action-result` for chat consumers

### Message and reducer contracts

- Flattened `decomposition-started` payloads so plan fields live at the top
  level beside `:pr-id`
- Added `pr-diff-fetched` constructor with `[pr-id diff detail error]`
- Updated decomposition reducer expectations to consume the flattened payload

### Test coverage

- Added and aligned `tui-views` acceptance, integration, contract, and handler
  tests around:
  - GitHub persistence wrappers
  - PR diff fetch effect routing
  - decomposition flow behavior
  - chat action error handling
  - message contract shape

## Testing Plan

- [x] Targeted `tui-views` namespaces covering GitHub persistence, decomposition,
      events, and interface context pass
- [x] `bb scripts/test-changed-bricks.bb` passes with `888` tests and `0`
      failures / `0` errors
- [ ] Manual TUI smoke test against a real PR

## Deployment Plan

No special deployment steps.

This is application/TUI logic plus tests. It ships with the normal deploy path.

## Related Issues/PRs

- Existing PR: #288
- Related branch work already present in this PR:
  - review gate uses `:review/decision`
  - verify timeout/rate-limit avoids implement-loop redirects

## Checklist

- [x] PR doc added
- [x] GitHub persistence namespace added
- [x] decomposition handler wired
- [x] PR diff fetch effect wired
- [x] message/update contract aligned
- [x] tests passing
