### PR TITLE
refactor(repo): decompose large interfaces

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -1,825 +1,138 @@
 (ns ai.miniforge.agent.interface
-  "Public API for the agent component.
-   Provides agent creation, execution, memory management, and inter-agent messaging.
-
-   Agents are pure functions: (context, task) -> (artifacts, decisions, signals)"
+  "Canonical public boundary for the agent component.
+   Public API groups are decomposed into ai.miniforge.agent.interface.* namespaces,
+   while this namespace remains the Polylith entrypoint."
   (:require
-   [ai.miniforge.agent.core :as core]
-   [ai.miniforge.agent.interface.protocols.agent :as agent-proto]
-   [ai.miniforge.agent.interface.protocols.memory :as mem-proto]
-   [ai.miniforge.agent.interface.protocols.messaging :as msg-proto]
-   [ai.miniforge.agent.protocols.records.memory :as mem-records]
-   [ai.miniforge.agent.protocols.records.specialized :as specialized-records]
-   [ai.miniforge.agent.protocols.records.messaging :as msg-records]
-   [ai.miniforge.agent.protocols.impl.memory :as mem-impl]
-   [ai.miniforge.agent.protocols.impl.messaging :as msg-impl]
-   [ai.miniforge.agent.planner :as planner]
-   [ai.miniforge.agent.implementer :as implementer]
-   [ai.miniforge.agent.tester :as tester]
-   [ai.miniforge.agent.reviewer :as reviewer]
-   [ai.miniforge.agent.releaser :as releaser]
-   [ai.miniforge.agent.meta-coordinator :as meta-coord]
-   [ai.miniforge.agent.meta.progress-monitor :as progress-monitor]
-   [ai.miniforge.agent.task-classifier :as classifier]))
+   [ai.miniforge.agent.interface.classification :as classification]
+   [ai.miniforge.agent.interface.llm :as llm]
+   [ai.miniforge.agent.interface.memory :as memory]
+   [ai.miniforge.agent.interface.messaging :as messaging]
+   [ai.miniforge.agent.interface.meta :as meta]
+   [ai.miniforge.agent.interface.protocols :as protocols]
+   [ai.miniforge.agent.interface.runtime :as runtime]
+   [ai.miniforge.agent.interface.specialized :as specialized]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Protocol re-exports (allow other components to reference protocols)
+;; Protocols and configuration
 
-(def Agent agent-proto/Agent)
-(def AgentLifecycle agent-proto/AgentLifecycle)
-(def AgentExecutor agent-proto/AgentExecutor)
-(def LLMBackend agent-proto/LLMBackend)
-(def Memory mem-proto/Memory)
-(def MemoryStore mem-proto/MemoryStore)
-(def InterAgentMessaging msg-proto/InterAgentMessaging)
-(def MessageRouter msg-proto/MessageRouter)
-(def MessageValidator msg-proto/MessageValidator)
-
-;; Configuration re-exports
-(def default-role-configs core/default-role-configs)
-(def role-capabilities core/role-capabilities)
-(def role-system-prompts core/role-system-prompts)
+(def Agent protocols/Agent)
+(def AgentLifecycle protocols/AgentLifecycle)
+(def AgentExecutor protocols/AgentExecutor)
+(def LLMBackend protocols/LLMBackend)
+(def Memory protocols/Memory)
+(def MemoryStore protocols/MemoryStore)
+(def InterAgentMessaging protocols/InterAgentMessaging)
+(def MessageRouter protocols/MessageRouter)
+(def MessageValidator protocols/MessageValidator)
+(def default-role-configs protocols/default-role-configs)
+(def role-capabilities protocols/role-capabilities)
+(def role-system-prompts protocols/role-system-prompts)
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Agent creation
+;; Runtime and memory API
 
-(defn create-agent
-  "Create an agent by role with optional config overrides.
+(def create-agent runtime/create-agent)
+(def create-agent-map runtime/create-agent-map)
+(def create-executor runtime/create-executor)
+(def execute runtime/execute)
+(def invoke runtime/invoke)
+(def validate runtime/validate)
+(def repair runtime/repair)
+(def init runtime/init)
+(def agent-status runtime/agent-status)
+(def shutdown runtime/shutdown)
 
-   Arguments:
-   - role    - Agent role keyword (:planner, :implementer, :tester, etc.)
-   - opts    - Optional config overrides
-
-   Options:
-   - :model       - LLM model to use (default: configured agent model)
-   - :temperature - Sampling temperature (0.0-1.0)
-   - :max-tokens  - Max tokens per response
-   - :budget      - Token/cost budget {:tokens int :cost-usd double}
-   - :memory-id   - Existing memory ID to use
-
-   Example:
-     (create-agent :implementer)
-     (create-agent :implementer {:model \"claude-opus-4-6\" :max-tokens 16000})"
-  ([role] (core/create-agent role))
-  ([role opts] (core/create-agent role opts)))
-
-(defn create-agent-map
-  "Create an agent and return as a map conforming to Agent schema.
-   Useful for serialization and storage.
-
-   Example:
-     (create-agent-map :implementer {:max-tokens 8000})
-     ;; => {:agent/id #uuid \"...\" :agent/role :implementer ...}"
-  ([role] (core/create-agent-map role))
-  ([role opts] (core/create-agent-map role opts)))
+(def create-memory memory/create-memory)
+(def add-to-memory memory/add-to-memory)
+(def add-system-message memory/add-system-message)
+(def add-user-message memory/add-user-message)
+(def add-assistant-message memory/add-assistant-message)
+(def get-messages memory/get-messages)
+(def get-memory-window memory/get-memory-window)
+(def clear-memory memory/clear-memory)
+(def memory-metadata memory/memory-metadata)
+(def create-memory-store memory/create-memory-store)
+(def get-memory memory/get-memory)
+(def save-memory memory/save-memory)
+(def delete-memory memory/delete-memory)
+(def list-memories memory/list-memories)
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Agent execution
-
-(defn execute
-  "Execute an agent on a task with given context.
-   Handles full lifecycle: init -> invoke -> validate -> repair -> complete/fail
-
-   Arguments:
-   - executor - Agent executor instance
-   - agent    - Agent instance or agent map
-   - task     - Task map with :task/id, :task/type, :task/status, etc.
-   - context  - Execution context with :llm-backend, etc.
-
-   Returns:
-     {:success bool
-      :outputs [artifact...]
-      :decisions [keyword...]
-      :signals [keyword...]
-      :metrics {:tokens-input int :tokens-output int :duration-ms int ...}
-      :error (optional string)}
-
-   Example:
-     (execute executor agent task {:llm-backend llm})"
-  [executor agent task context]
-  (agent-proto/execute executor agent task context))
-
-(defn create-executor
-  "Create an agent executor.
-
-   Options:
-   - :logger       - Logger instance for structured logging
-   - :memory-store - Memory store for persistence
-
-   Example:
-     (create-executor)
-     (create-executor {:memory-store (create-memory-store)})"
-  ([] (core/create-executor))
-  ([opts] (core/create-executor opts)))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Agent protocol operations
-
-(defn invoke
-  "Execute the agent's main logic on a task.
-   Lower-level than execute - does not handle full lifecycle.
-
-   Returns {:success bool :outputs [...] :decisions [...] :signals [...] :metrics {...}}"
-  [agent task context]
-  (agent-proto/invoke agent task context))
-
-(defn validate
-  "Check if agent output meets requirements.
-
-   Returns {:valid? bool :errors [...] :warnings [...]}"
-  [agent output context]
-  (agent-proto/validate agent output context))
-
-(defn repair
-  "Attempt to fix validation failures in agent output.
-
-   Returns {:repaired output :changes [...] :success bool}"
-  [agent output errors context]
-  (agent-proto/repair agent output errors context))
-
-(defn init
-  "Initialize agent with configuration.
-
-   Returns initialized agent instance."
-  [agent config]
-  (agent-proto/init agent config))
-
-(defn agent-status
-  "Return current agent status.
-
-   Returns {:state keyword :metrics {...} :last-activity inst}"
-  [agent]
-  (agent-proto/status agent))
-
-(defn shutdown
-  "Clean up agent resources.
-
-   Returns {:success bool}"
-  [agent]
-  (agent-proto/shutdown agent))
-
-;------------------------------------------------------------------------------ Layer 4
-;; Memory operations
-
-(defn create-memory
-  "Create a new memory instance.
-
-   Options:
-   - :scope     - Memory scope (:agent, :task, :workflow)
-   - :scope-id  - ID of the scope (agent-id, task-id, or workflow-id)
-   - :metadata  - Additional metadata map
-
-   Example:
-     (create-memory)
-     (create-memory {:scope :task :scope-id task-id})"
-  ([] (mem-records/create-memory))
-  ([opts] (mem-records/create-memory opts)))
-
-(defn add-to-memory
-  "Add a message to memory.
-
-   Arguments:
-   - memory  - Memory instance
-   - role    - Message role (:system, :user, :assistant)
-   - content - Message content string
-
-   Returns updated memory."
-  [memory role content]
-  (mem-proto/add-message memory role content {}))
-
-(defn add-system-message
-  "Add a system message to memory. Convenience function."
-  [memory content]
-  (mem-records/add-system-message memory content))
-
-(defn add-user-message
-  "Add a user message to memory. Convenience function."
-  [memory content]
-  (mem-records/add-user-message memory content))
-
-(defn add-assistant-message
-  "Add an assistant message to memory. Convenience function."
-  [memory content]
-  (mem-records/add-assistant-message memory content))
-
-(defn get-messages
-  "Get all messages from memory in chronological order."
-  [memory]
-  (mem-proto/get-messages memory))
-
-(defn get-memory-window
-  "Get messages that fit within token limit, prioritizing recent.
-
-   Returns {:messages [...] :total-tokens int :trimmed-count int}"
-  [memory token-limit]
-  (mem-proto/get-window memory token-limit))
-
-(defn clear-memory
-  "Clear all messages from memory. Returns empty memory."
-  [memory]
-  (mem-proto/clear-messages memory))
-
-(defn memory-metadata
-  "Get memory metadata (scope, created-at, etc.)."
-  [memory]
-  (mem-proto/get-metadata memory))
-
-;------------------------------------------------------------------------------ Layer 5
-;; Memory store operations
-
-(defn create-memory-store
-  "Create an in-memory store for agent memories."
-  []
-  (mem-records/create-memory-store))
-
-(defn get-memory
-  "Retrieve a memory by ID from store."
-  [store memory-id]
-  (mem-proto/get-memory store memory-id))
-
-(defn save-memory
-  "Save/update a memory in store. Returns the memory."
-  [store memory]
-  (mem-proto/save-memory store memory))
-
-(defn delete-memory
-  "Delete a memory by ID from store."
-  [store memory-id]
-  (mem-proto/delete-memory store memory-id))
-
-(defn list-memories
-  "List all memories for a given scope."
-  [store scope scope-id]
-  (mem-proto/list-memories store scope scope-id))
-
-;------------------------------------------------------------------------------ Layer 6
-;; Inter-Agent Messaging
-
-(defn create-message-router
-  "Create a message router for inter-agent communication.
-
-   The router maintains message queues and handles delivery.
-
-   Example:
-     (create-message-router)"
-  []
-  (msg-records/create-message-router))
-
-(defn create-agent-messaging
-  "Create messaging capability for an agent.
-
-   Required:
-   - agent-id    - Agent role keyword (:planner, :implementer, etc.)
-   - instance-id - Agent instance UUID
-   - workflow-id - Workflow UUID
-   - router      - MessageRouter instance
-
-   Example:
-     (create-agent-messaging :implementer instance-id workflow-id router)"
-  [agent-id instance-id workflow-id router]
-  (msg-records/create-agent-messaging agent-id instance-id workflow-id router))
-
-(defn send-message
-  "Send a message from one agent to another.
-
-   Arguments:
-   - agent-messaging - AgentMessaging instance
-   - message-data    - Map with :type, :to-agent, :content
-
-   Returns:
-     {:message message-map :event event-map}
-
-   Example:
-     (send-message messaging
-                   {:type :clarification-request
-                    :to-agent :planner
-                    :content \"Should we create new security group?\"})"
-  [agent-messaging message-data]
-  (msg-proto/send-message agent-messaging message-data))
-
-(defn receive-messages
-  "Get all messages received by an agent.
-
-   Returns sequence of message maps."
-  [agent-messaging]
-  (msg-proto/receive-messages agent-messaging))
-
-(defn respond-to-message
-  "Send a response to a received message.
-
-   Arguments:
-   - agent-messaging  - AgentMessaging instance
-   - original-message - The message being responded to
-   - response-content - Response content string
-
-   Example:
-     (respond-to-message messaging original-msg \"Yes, create new sg.\")"
-  [agent-messaging original-message response-content]
-  (msg-proto/respond-to-message agent-messaging original-message response-content))
-
-;; Convenience functions for specific message types
-
-(defn send-clarification-request
-  "Send a clarification request to another agent.
-
-   Example:
-     (send-clarification-request messaging :planner \"Clarify X?\")"
-  [agent-messaging to-agent content]
-  (msg-records/send-clarification-request agent-messaging to-agent content))
-
-(defn send-concern
-  "Send a concern to another agent.
-
-   Example:
-     (send-concern messaging :implementer \"Security concern: ...\")"
-  [agent-messaging to-agent content]
-  (msg-records/send-concern agent-messaging to-agent content))
-
-(defn send-suggestion
-  "Send a suggestion to another agent.
-
-   Example:
-     (send-suggestion messaging :tester \"Consider adding edge case test\")"
-  [agent-messaging to-agent content]
-  (msg-records/send-suggestion agent-messaging to-agent content))
-
-(defn get-clarification-requests
-  "Get all clarification requests received by agent."
-  [agent-messaging]
-  (msg-records/get-clarification-requests agent-messaging))
-
-(defn get-concerns
-  "Get all concerns received by agent."
-  [agent-messaging]
-  (msg-records/get-concerns agent-messaging))
-
-(defn get-suggestions
-  "Get all suggestions received by agent."
-  [agent-messaging]
-  (msg-records/get-suggestions agent-messaging))
-
-;; Router operations
-
-(defn route-message
-  "Route a message to its recipient (internal use).
-
-   Returns the routed message with delivery metadata."
-  [router message]
-  (msg-proto/route-message router message))
-
-(defn get-messages-for-agent
-  "Get all messages for a specific agent in a workflow.
-
-   Example:
-     (get-messages-for-agent router :implementer workflow-id)"
-  [router agent-id workflow-id]
-  (msg-proto/get-messages-for-agent router agent-id workflow-id))
-
-(defn get-messages-by-workflow
-  "Get all messages in a workflow, ordered by timestamp.
-
-   Example:
-     (get-messages-by-workflow router workflow-id)"
-  [router workflow-id]
-  (msg-proto/get-messages-by-workflow router workflow-id))
-
-(defn clear-workflow-messages
-  "Clear all messages for a workflow.
-
-   Example:
-     (clear-workflow-messages router workflow-id)"
-  [router workflow-id]
-  (msg-proto/clear-messages router workflow-id))
-
-;; Message validation and schemas
-
-(defn validate-message
-  "Validate a message against the schema.
-
-   Returns {:valid? boolean :errors [...]}"
-  [message]
-  (msg-impl/validate-message-impl message))
-
-(def Message
-  "Message schema for validation.
-   See ai.miniforge.agent.protocols.impl.messaging/Message"
-  msg-impl/Message)
-
-(def MessageType
-  "Valid message types: :clarification-request, :clarification-response, :concern, :suggestion"
-  msg-impl/MessageType)
-
-;------------------------------------------------------------------------------ Layer 7
-;; Utility functions
-
-(defn estimate-tokens
-  "Estimate token count for content.
-   Uses rough heuristic: ~4 chars per token."
-  [content]
-  (mem-impl/estimate-tokens content))
-
-(defn estimate-cost
-  "Estimate cost in USD for tokens used.
-   Uses approximate Claude pricing."
-  [input-tokens output-tokens model]
-  (core/estimate-cost input-tokens output-tokens model))
-
-(defn create-mock-llm
-  "Create a mock LLM backend for testing.
-
-   Arguments:
-   - responses - Single response map or sequence of responses
-
-   Response format:
-     {:content string
-      :usage {:input-tokens int :output-tokens int}
-      :model string}
-
-   Example:
-     (create-mock-llm {:content \"Hello\" :usage {:input-tokens 10 :output-tokens 5}})"
-  ([] (core/create-mock-llm))
-  ([responses] (core/create-mock-llm responses)))
-
-;------------------------------------------------------------------------------ Layer 8
-;; Specialized agent support
-
-(defn create-base-agent
-  "Create a base agent with the given configuration.
-   Used by specialized agents (planner, implementer, tester).
-
-   Required options:
-   - :role          - Agent role keyword (:planner, :implementer, :tester, etc.)
-   - :system-prompt - System prompt for the agent
-   - :invoke-fn     - Function (fn [context input] -> result)
-   - :validate-fn   - Function (fn [output] -> {:valid? bool, :errors [...]})
-   - :repair-fn     - Function (fn [output errors context] -> repaired-result)
-
-   Optional:
-   - :config - Agent configuration map (model, temperature, etc.)
-   - :logger - Logger instance (defaults to silent logger)"
-  [opts]
-  (specialized-records/create-base-agent opts))
-
-(defn make-validator
-  "Create a validation function from a Malli schema."
-  [malli-schema]
-  (specialized-records/make-validator malli-schema))
-
-(defn cycle-agent
-  "Execute a full invoke-validate-repair cycle on a specialized agent.
-   Returns the final result after up to max-iterations of repair attempts.
-
-   Options:
-   - :max-iterations - Maximum repair attempts (default 3)"
-  [agent context input & {:keys [max-iterations] :or {max-iterations 3}}]
-  (specialized-records/cycle-agent agent context input :max-iterations max-iterations))
-
-;------------------------------------------------------------------------------ Layer 9
-;; Specialized agent creation
-
-(def create-planner
-  "Create a Planner agent with optional configuration overrides.
-   The Planner analyzes specifications and creates detailed implementation plans."
-  planner/create-planner)
-
-(def create-implementer
-  "Create an Implementer agent with optional configuration overrides.
-   The Implementer generates code from plans and task descriptions."
-  implementer/create-implementer)
-
-(def create-tester
-  "Create a Tester agent with optional configuration overrides.
-   The Tester generates tests for code artifacts and validates coverage."
-  tester/create-tester)
-
-(def create-reviewer
-  "Create a Reviewer agent with optional configuration overrides.
-   The Reviewer performs LLM-backed semantic code review plus deterministic
-   gate validation. Falls back to gate-only review when no LLM backend
-   is available."
-  reviewer/create-reviewer)
-
-(def create-releaser
-  "Create a Releaser agent with optional configuration overrides.
-   The Releaser generates branch names, commit messages, PR titles and descriptions."
-  releaser/create-releaser)
-
-;------------------------------------------------------------------------------ Layer 10
-;; Specialized agent schemas
-
-;; Planner schemas
-(def Plan planner/Plan)
-(def PlanTask planner/PlanTask)
-
-;; Implementer schemas
-(def CodeArtifact implementer/CodeArtifact)
-(def CodeFile implementer/CodeFile)
-
-;; Tester schemas
-(def TestArtifact tester/TestArtifact)
-(def TestFile tester/TestFile)
-(def Coverage tester/Coverage)
-
-;; Reviewer schemas
-(def ReviewArtifact reviewer/ReviewArtifact)
-(def ReviewIssue reviewer/ReviewIssue)
-(def GateFeedback reviewer/GateFeedback)
-
-;; Releaser schemas
-(def ReleaseArtifact releaser/ReleaseArtifact)
-
-;------------------------------------------------------------------------------ Layer 11
-;; Specialized agent utilities
-
-;; Planner utilities
-(def plan-summary
-  "Get a summary of a plan for logging/display."
-  planner/plan-summary)
-
-(def task-dependency-order
-  "Return tasks in dependency order (topological sort)."
-  planner/task-dependency-order)
-
-(def validate-plan
-  "Validate a plan against the Plan schema and check for structural issues."
-  planner/validate-plan)
-
-;; Implementer utilities
-(def code-summary
-  "Get a summary of a code artifact for logging/display."
-  implementer/code-summary)
-
-(def files-by-action
-  "Group files by their action type (:create, :modify, :delete)."
-  implementer/files-by-action)
-
-(def total-lines
-  "Count total lines of code in the artifact."
-  implementer/total-lines)
-
-(def validate-code-artifact
-  "Validate a code artifact against the schema and check for issues."
-  implementer/validate-code-artifact)
-
-;; Tester utilities
-(def test-summary
-  "Get a summary of a test artifact for logging/display."
-  tester/test-summary)
-
-(def coverage-meets-threshold?
-  "Check if coverage meets the specified thresholds."
-  tester/coverage-meets-threshold?)
-
-(def tests-by-path
-  "Get a map of test file paths to their content."
-  tester/tests-by-path)
-
-(def validate-test-artifact
-  "Validate a test artifact against the schema and check for issues."
-  tester/validate-test-artifact)
-
-;; Reviewer utilities
-(def review-summary
-  "Get a summary of a review artifact for logging/display."
-  reviewer/review-summary)
-
-(def approved?
-  "Check if a review artifact represents approval."
-  reviewer/approved?)
-
-(def rejected?
-  "Check if a review artifact represents rejection."
-  reviewer/rejected?)
-
-(def conditionally-approved?
-  "Check if a review artifact is conditionally approved."
-  reviewer/conditionally-approved?)
-
-(def get-blocking-issues
-  "Extract blocking issues from review artifact."
-  reviewer/get-blocking-issues)
-
-(def get-review-warnings
-  "Extract warnings from review artifact."
-  reviewer/get-warnings)
-
-(def get-recommendations
-  "Extract recommendations from review artifact."
-  reviewer/get-recommendations)
-
-(def changes-requested?
-  "Check if a review artifact has changes requested."
-  reviewer/changes-requested?)
-
-(def get-review-issues
-  "Extract LLM review issues from review artifact."
-  reviewer/get-issues)
-
-(def get-review-strengths
-  "Extract strengths noted by the LLM from review artifact."
-  reviewer/get-strengths)
-
-(def validate-review-artifact
-  "Validate a review artifact against the schema."
-  reviewer/validate-review-artifact)
-
-;; Releaser utilities
-(def release-summary
-  "Get a summary of a release artifact for logging/display."
-  releaser/release-summary)
-
-(def validate-release-artifact
-  "Validate a release artifact against the schema."
-  releaser/validate-release-artifact)
-
-;------------------------------------------------------------------------------ Layer 12
-;; Meta-agent operations
-
-(def create-progress-monitor-agent
-  "Create a Progress Monitor meta-agent for workflow health monitoring."
-  progress-monitor/create-progress-monitor-agent)
-
-(def create-meta-coordinator
-  "Create a meta-agent coordinator for managing multiple meta-agents."
-  meta-coord/create-coordinator)
-
-(def check-all-meta-agents
-  "Check health of all meta-agents in the coordinator."
-  meta-coord/check-all-agents)
-
-(def reset-all-meta-agents!
-  "Reset state of all meta-agents in the coordinator."
-  meta-coord/reset-all-agents!)
-
-(def get-meta-check-history
-  "Get health check history from the coordinator."
-  meta-coord/get-check-history)
-
-(def get-meta-agent-stats
-  "Get statistics for all meta-agents."
-  meta-coord/get-agent-stats)
-
-;------------------------------------------------------------------------------ Rich Comment
-(comment
-  ;; Create agents by role
-  (def planner (create-agent :planner))
-  (def implementer (create-agent :implementer {:model "claude-opus-4-6"}))
-
-  ;; Create agent as map (for storage/validation)
-  (create-agent-map :tester {:max-tokens 4000})
-  ;; => {:agent/id #uuid "..." :agent/role :tester ...}
-
-  ;; Memory operations
-  (def mem (create-memory {:scope :task :scope-id (random-uuid)}))
-
-  (def mem2
-    (-> mem
-        (add-system-message "You are a helpful assistant.")
-        (add-user-message "Write a factorial function")
-        (add-assistant-message "(defn factorial [n] ...)")))
-
-  (get-messages mem2)
-  (get-memory-window mem2 100)
-  (memory-metadata mem2)
-
-  ;; Execute agent on task
-  (def executor (create-executor))
-  (def mock-llm (create-mock-llm {:content "(defn hello [] \"world\")"
-                                   :usage {:input-tokens 200 :output-tokens 100}
-                                   :model "mock"}))
-
-  (def task {:task/id (random-uuid)
-             :task/type :implement
-             :task/status :pending
-             :task/inputs []})
-
-  (execute executor implementer task {:llm-backend mock-llm})
-  ;; => {:success true :outputs [...] :metrics {...}}
-
-  ;; Cost estimation
-  (estimate-cost 1000 500 "claude-sonnet-4-6")
-  ;; => 0.0105 USD
-
-  ;; Role configurations
-  default-role-configs
-  role-capabilities
-  role-system-prompts
-
-  ;; Inter-Agent Messaging
-  ;; ---------------------
-
-  ;; 1. Create message router and agent messaging capabilities
-  (def router (create-message-router))
-  (def workflow-id (random-uuid))
-  (def planner-id (random-uuid))
-  (def implementer-id (random-uuid))
-
-  (def planner-messaging
-    (create-agent-messaging :planner planner-id workflow-id router))
-
-  (def implementer-messaging
-    (create-agent-messaging :implementer implementer-id workflow-id router))
-
-  ;; 2. Send clarification request from implementer to planner
-  (def {:keys [message event]}
-    (send-clarification-request
-     implementer-messaging
-     :planner
-     "Should we create a new security group or reuse sg-prod-rds?"))
-
-  ;; The event can be emitted to the event stream
-  ;; event => {:event/type :agent/message-sent
-  ;;          :from-agent/id :implementer
-  ;;          :to-agent/id :planner
-  ;;          :message-type :clarification-request
-  ;;          ...}
-
-  ;; 3. Planner receives messages
-  (def planner-inbox (receive-messages planner-messaging))
-  ;; => [{:message/id #uuid "..."
-  ;;      :message/type :clarification-request
-  ;;      :message/from-agent :implementer
-  ;;      :message/to-agent :planner
-  ;;      :message/content "Should we create..."
-  ;;      ...}]
-
-  ;; 4. Get specific types of messages
-  (def clarifications (get-clarification-requests planner-messaging))
-
-  ;; 5. Planner responds to the clarification request
-  (def {:keys [message event]}
-    (respond-to-message
-     planner-messaging
-     (first planner-inbox)
-     "Reuse the existing security group sg-prod-rds to maintain consistency."))
-
-  ;; 6. Implementer checks for responses
-  (def implementer-inbox (receive-messages implementer-messaging))
-  ;; Will contain the response from planner
-
-  ;; 7. Send concern from reviewer to implementer
-  (def reviewer-messaging
-    (create-agent-messaging :reviewer (random-uuid) workflow-id router))
-
-  (send-concern
-   reviewer-messaging
-   :implementer
-   "Policy violation: Missing required tags on S3 bucket resource.")
-
-  ;; 8. Send suggestion from tester to implementer
-  (def tester-messaging
-    (create-agent-messaging :tester (random-uuid) workflow-id router))
-
-  (send-suggestion
-   tester-messaging
-   :implementer
-   "Consider adding error handling for network timeout scenarios.")
-
-  ;; 9. Query all messages in workflow
-  (def all-workflow-messages (get-messages-by-workflow router workflow-id))
-  ;; Returns all messages ordered by timestamp
-
-  ;; 10. Validate message structure
-  (def example-message {:type :clarification-request :to-agent :planner :content "..."})
-  (validate-message example-message)
-  ;; => {:valid? true :errors []}
-
-  ;; 11. Filter messages by type
-  (def concerns (get-concerns implementer-messaging))
-  (def suggestions (get-suggestions implementer-messaging))
-
-  ;; 12. Clean up workflow messages
-  (clear-workflow-messages router workflow-id)
-
-  :leave-this-here)
-
-;------------------------------------------------------------------------------ Layer 9
-;; Task Classification (for intelligent model selection)
-
-(defn classify-task
-  "Classify a task to determine optimal model type.
-
-   Arguments:
-   - task - Map with :phase, :agent-type, :description, :title, etc.
-
-   Returns:
-   - {:type :thinking-heavy|:execution-focused|:simple-validation|...
-      :confidence 0.0-1.0
-      :reason \"...\"
-      :alternative-types [...]
-      :all-reasons [...]}
-
-   Example:
-     (classify-task {:phase :plan
-                     :agent-type :planner-agent
-                     :description \"Design architecture\"})"
-  [task]
-  (classifier/classify-task task))
-
-(defn get-task-characteristics
-  "Extract task characteristics for debugging/transparency.
-
-   Example:
-     (get-task-characteristics task)"
-  [task]
-  (classifier/get-task-characteristics task))
+;; Messaging, utilities, specialized agents, and meta-operations
+
+(def create-message-router messaging/create-message-router)
+(def create-agent-messaging messaging/create-agent-messaging)
+(def send-message messaging/send-message)
+(def receive-messages messaging/receive-messages)
+(def respond-to-message messaging/respond-to-message)
+(def send-clarification-request messaging/send-clarification-request)
+(def send-concern messaging/send-concern)
+(def send-suggestion messaging/send-suggestion)
+(def get-clarification-requests messaging/get-clarification-requests)
+(def get-concerns messaging/get-concerns)
+(def get-suggestions messaging/get-suggestions)
+(def route-message messaging/route-message)
+(def get-messages-for-agent messaging/get-messages-for-agent)
+(def get-messages-by-workflow messaging/get-messages-by-workflow)
+(def clear-workflow-messages messaging/clear-workflow-messages)
+(def validate-message messaging/validate-message)
+(def Message messaging/Message)
+(def MessageType messaging/MessageType)
+
+(def estimate-tokens llm/estimate-tokens)
+(def estimate-cost llm/estimate-cost)
+(def create-mock-llm llm/create-mock-llm)
+
+(def create-base-agent specialized/create-base-agent)
+(def make-validator specialized/make-validator)
+(def cycle-agent specialized/cycle-agent)
+(def create-planner specialized/create-planner)
+(def create-implementer specialized/create-implementer)
+(def create-tester specialized/create-tester)
+(def create-reviewer specialized/create-reviewer)
+(def create-releaser specialized/create-releaser)
+(def Plan specialized/Plan)
+(def PlanTask specialized/PlanTask)
+(def CodeArtifact specialized/CodeArtifact)
+(def CodeFile specialized/CodeFile)
+(def TestArtifact specialized/TestArtifact)
+(def TestFile specialized/TestFile)
+(def Coverage specialized/Coverage)
+(def ReviewArtifact specialized/ReviewArtifact)
+(def ReviewIssue specialized/ReviewIssue)
+(def GateFeedback specialized/GateFeedback)
+(def ReleaseArtifact specialized/ReleaseArtifact)
+(def plan-summary specialized/plan-summary)
+(def task-dependency-order specialized/task-dependency-order)
+(def validate-plan specialized/validate-plan)
+(def code-summary specialized/code-summary)
+(def files-by-action specialized/files-by-action)
+(def total-lines specialized/total-lines)
+(def validate-code-artifact specialized/validate-code-artifact)
+(def test-summary specialized/test-summary)
+(def coverage-meets-threshold? specialized/coverage-meets-threshold?)
+(def tests-by-path specialized/tests-by-path)
+(def validate-test-artifact specialized/validate-test-artifact)
+(def review-summary specialized/review-summary)
+(def approved? specialized/approved?)
+(def rejected? specialized/rejected?)
+(def conditionally-approved? specialized/conditionally-approved?)
+(def get-blocking-issues specialized/get-blocking-issues)
+(def get-review-warnings specialized/get-review-warnings)
+(def get-recommendations specialized/get-recommendations)
+(def changes-requested? specialized/changes-requested?)
+(def get-review-issues specialized/get-review-issues)
+(def get-review-strengths specialized/get-review-strengths)
+(def validate-review-artifact specialized/validate-review-artifact)
+(def release-summary specialized/release-summary)
+(def validate-release-artifact specialized/validate-release-artifact)
+
+(def create-progress-monitor-agent meta/create-progress-monitor-agent)
+(def create-meta-coordinator meta/create-meta-coordinator)
+(def check-all-meta-agents meta/check-all-meta-agents)
+(def reset-all-meta-agents! meta/reset-all-meta-agents!)
+(def get-meta-check-history meta/get-meta-check-history)
+(def get-meta-agent-stats meta/get-meta-agent-stats)
+
+(def classify-task classification/classify-task)
+(def get-task-characteristics classification/get-task-characteristics)

--- a/components/agent/src/ai/miniforge/agent/interface/classification.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/classification.clj
@@ -1,0 +1,10 @@
+(ns ai.miniforge.agent.interface.classification
+  "Task-classification helpers for intelligent model selection."
+  (:require
+   [ai.miniforge.agent.task-classifier :as classifier]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Task classification
+
+(def classify-task classifier/classify-task)
+(def get-task-characteristics classifier/get-task-characteristics)

--- a/components/agent/src/ai/miniforge/agent/interface/llm.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/llm.clj
@@ -1,0 +1,12 @@
+(ns ai.miniforge.agent.interface.llm
+  "LLM-facing utility helpers for the agent public API."
+  (:require
+   [ai.miniforge.agent.core :as core]
+   [ai.miniforge.agent.protocols.impl.memory :as mem-impl]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Utility helpers
+
+(def estimate-tokens mem-impl/estimate-tokens)
+(def estimate-cost core/estimate-cost)
+(def create-mock-llm core/create-mock-llm)

--- a/components/agent/src/ai/miniforge/agent/interface/memory.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/memory.clj
@@ -1,0 +1,50 @@
+(ns ai.miniforge.agent.interface.memory
+  "Agent memory and memory-store operations."
+  (:require
+   [ai.miniforge.agent.interface.protocols.memory :as mem-proto]
+   [ai.miniforge.agent.protocols.records.memory :as mem-records]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Memory operations
+
+(def create-memory mem-records/create-memory)
+(def add-system-message mem-records/add-system-message)
+(def add-user-message mem-records/add-user-message)
+(def add-assistant-message mem-records/add-assistant-message)
+(def create-memory-store mem-records/create-memory-store)
+
+(defn add-to-memory
+  [memory role content]
+  (mem-proto/add-message memory role content {}))
+
+(defn get-messages
+  [memory]
+  (mem-proto/get-messages memory))
+
+(defn get-memory-window
+  [memory token-limit]
+  (mem-proto/get-window memory token-limit))
+
+(defn clear-memory
+  [memory]
+  (mem-proto/clear-messages memory))
+
+(defn memory-metadata
+  [memory]
+  (mem-proto/get-metadata memory))
+
+(defn get-memory
+  [store memory-id]
+  (mem-proto/get-memory store memory-id))
+
+(defn save-memory
+  [store memory]
+  (mem-proto/save-memory store memory))
+
+(defn delete-memory
+  [store memory-id]
+  (mem-proto/delete-memory store memory-id))
+
+(defn list-memories
+  [store scope scope-id]
+  (mem-proto/list-memories store scope scope-id))

--- a/components/agent/src/ai/miniforge/agent/interface/messaging.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/messaging.clj
@@ -1,0 +1,52 @@
+(ns ai.miniforge.agent.interface.messaging
+  "Inter-agent messaging public API."
+  (:require
+   [ai.miniforge.agent.interface.protocols.messaging :as msg-proto]
+   [ai.miniforge.agent.protocols.impl.messaging :as msg-impl]
+   [ai.miniforge.agent.protocols.records.messaging :as msg-records]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Messaging operations
+
+(def create-message-router msg-records/create-message-router)
+(def create-agent-messaging msg-records/create-agent-messaging)
+(def send-clarification-request msg-records/send-clarification-request)
+(def send-concern msg-records/send-concern)
+(def send-suggestion msg-records/send-suggestion)
+(def get-clarification-requests msg-records/get-clarification-requests)
+(def get-concerns msg-records/get-concerns)
+(def get-suggestions msg-records/get-suggestions)
+(def Message msg-impl/Message)
+(def MessageType msg-impl/MessageType)
+
+(defn send-message
+  [agent-messaging message-data]
+  (msg-proto/send-message agent-messaging message-data))
+
+(defn receive-messages
+  [agent-messaging]
+  (msg-proto/receive-messages agent-messaging))
+
+(defn respond-to-message
+  [agent-messaging original-message response-content]
+  (msg-proto/respond-to-message agent-messaging original-message response-content))
+
+(defn route-message
+  [router message]
+  (msg-proto/route-message router message))
+
+(defn get-messages-for-agent
+  [router agent-id workflow-id]
+  (msg-proto/get-messages-for-agent router agent-id workflow-id))
+
+(defn get-messages-by-workflow
+  [router workflow-id]
+  (msg-proto/get-messages-by-workflow router workflow-id))
+
+(defn clear-workflow-messages
+  [router workflow-id]
+  (msg-proto/clear-messages router workflow-id))
+
+(defn validate-message
+  [message]
+  (msg-impl/validate-message-impl message))

--- a/components/agent/src/ai/miniforge/agent/interface/meta.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/meta.clj
@@ -1,0 +1,15 @@
+(ns ai.miniforge.agent.interface.meta
+  "Meta-agent orchestration API."
+  (:require
+   [ai.miniforge.agent.meta-coordinator :as meta-coord]
+   [ai.miniforge.agent.meta.progress-monitor :as progress-monitor]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Meta-agent operations
+
+(def create-progress-monitor-agent progress-monitor/create-progress-monitor-agent)
+(def create-meta-coordinator meta-coord/create-coordinator)
+(def check-all-meta-agents meta-coord/check-all-agents)
+(def reset-all-meta-agents! meta-coord/reset-all-agents!)
+(def get-meta-check-history meta-coord/get-check-history)
+(def get-meta-agent-stats meta-coord/get-agent-stats)

--- a/components/agent/src/ai/miniforge/agent/interface/protocols.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/protocols.clj
@@ -1,0 +1,24 @@
+(ns ai.miniforge.agent.interface.protocols
+  "Protocol and configuration re-exports for the agent public API."
+  (:require
+   [ai.miniforge.agent.core :as core]
+   [ai.miniforge.agent.interface.protocols.agent :as agent-proto]
+   [ai.miniforge.agent.interface.protocols.memory :as mem-proto]
+   [ai.miniforge.agent.interface.protocols.messaging :as msg-proto]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Protocol and configuration re-exports
+
+(def Agent agent-proto/Agent)
+(def AgentLifecycle agent-proto/AgentLifecycle)
+(def AgentExecutor agent-proto/AgentExecutor)
+(def LLMBackend agent-proto/LLMBackend)
+(def Memory mem-proto/Memory)
+(def MemoryStore mem-proto/MemoryStore)
+(def InterAgentMessaging msg-proto/InterAgentMessaging)
+(def MessageRouter msg-proto/MessageRouter)
+(def MessageValidator msg-proto/MessageValidator)
+
+(def default-role-configs core/default-role-configs)
+(def role-capabilities core/role-capabilities)
+(def role-system-prompts core/role-system-prompts)

--- a/components/agent/src/ai/miniforge/agent/interface/runtime.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/runtime.clj
@@ -1,0 +1,40 @@
+(ns ai.miniforge.agent.interface.runtime
+  "Agent creation, execution, and lifecycle operations."
+  (:require
+   [ai.miniforge.agent.core :as core]
+   [ai.miniforge.agent.interface.protocols.agent :as agent-proto]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Agent creation and execution
+
+(def create-agent core/create-agent)
+(def create-agent-map core/create-agent-map)
+(def create-executor core/create-executor)
+
+(defn execute
+  [executor agent task context]
+  (agent-proto/execute executor agent task context))
+
+(defn invoke
+  [agent task context]
+  (agent-proto/invoke agent task context))
+
+(defn validate
+  [agent output context]
+  (agent-proto/validate agent output context))
+
+(defn repair
+  [agent output errors context]
+  (agent-proto/repair agent output errors context))
+
+(defn init
+  [agent config]
+  (agent-proto/init agent config))
+
+(defn agent-status
+  [agent]
+  (agent-proto/status agent))
+
+(defn shutdown
+  [agent]
+  (agent-proto/shutdown agent))

--- a/components/agent/src/ai/miniforge/agent/interface/specialized.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/specialized.clj
@@ -1,0 +1,59 @@
+(ns ai.miniforge.agent.interface.specialized
+  "Specialized agent constructors, schemas, and helper utilities."
+  (:require
+   [ai.miniforge.agent.implementer :as implementer]
+   [ai.miniforge.agent.planner :as planner]
+   [ai.miniforge.agent.releaser :as releaser]
+   [ai.miniforge.agent.reviewer :as reviewer]
+   [ai.miniforge.agent.tester :as tester]
+   [ai.miniforge.agent.protocols.records.specialized :as specialized-records]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Specialized agent support
+
+(def create-base-agent specialized-records/create-base-agent)
+(def make-validator specialized-records/make-validator)
+(def cycle-agent specialized-records/cycle-agent)
+
+(def create-planner planner/create-planner)
+(def create-implementer implementer/create-implementer)
+(def create-tester tester/create-tester)
+(def create-reviewer reviewer/create-reviewer)
+(def create-releaser releaser/create-releaser)
+
+(def Plan planner/Plan)
+(def PlanTask planner/PlanTask)
+(def CodeArtifact implementer/CodeArtifact)
+(def CodeFile implementer/CodeFile)
+(def TestArtifact tester/TestArtifact)
+(def TestFile tester/TestFile)
+(def Coverage tester/Coverage)
+(def ReviewArtifact reviewer/ReviewArtifact)
+(def ReviewIssue reviewer/ReviewIssue)
+(def GateFeedback reviewer/GateFeedback)
+(def ReleaseArtifact releaser/ReleaseArtifact)
+
+(def plan-summary planner/plan-summary)
+(def task-dependency-order planner/task-dependency-order)
+(def validate-plan planner/validate-plan)
+(def code-summary implementer/code-summary)
+(def files-by-action implementer/files-by-action)
+(def total-lines implementer/total-lines)
+(def validate-code-artifact implementer/validate-code-artifact)
+(def test-summary tester/test-summary)
+(def coverage-meets-threshold? tester/coverage-meets-threshold?)
+(def tests-by-path tester/tests-by-path)
+(def validate-test-artifact tester/validate-test-artifact)
+(def review-summary reviewer/review-summary)
+(def approved? reviewer/approved?)
+(def rejected? reviewer/rejected?)
+(def conditionally-approved? reviewer/conditionally-approved?)
+(def get-blocking-issues reviewer/get-blocking-issues)
+(def get-review-warnings reviewer/get-warnings)
+(def get-recommendations reviewer/get-recommendations)
+(def changes-requested? reviewer/changes-requested?)
+(def get-review-issues reviewer/get-issues)
+(def get-review-strengths reviewer/get-strengths)
+(def validate-review-artifact reviewer/validate-review-artifact)
+(def release-summary releaser/release-summary)
+(def validate-release-artifact releaser/validate-release-artifact)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -1,684 +1,95 @@
-;; Title: Miniforge.ai
-;; Subtitle: An agentic SDLC / fleet-control platform
-;; Author: Christopher Lester
-;; Line: Founder, Miniforge.ai (project)
-;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
-;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software
-;; distributed under the License is distributed on an "AS IS" BASIS,
-;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and
-;; limitations under the License.
-
 (ns ai.miniforge.event-stream.interface
-  "Public API for workflow event streaming and observability.
-
-   This component provides real-time visibility into workflow execution:
-   - Pub/sub event bus for workflow lifecycle events
-   - N3-compliant event schemas (see specs/normative/N3-event-stream.md)
-   - Streaming callbacks for agent output
-   - Per-workflow event sequencing
-
-   Key use cases:
-   - CLI: Real-time console output during workflow execution
-   - Web: Server-Sent Events (SSE) for live dashboard updates
-   - Debugging: Complete event replay for workflow analysis
-   - Analytics: Token usage, timing, and cost tracking
-
-   Example:
-     ;; Create event stream
-     (def stream (create-event-stream))
-
-     ;; Subscribe to all events
-     (subscribe! stream :my-listener
-       (fn [event]
-         (println (:event/type event) \"-\" (:message event))))
-
-     ;; Publish workflow events
-     (publish! stream (workflow-started stream workflow-id spec))
-     (publish! stream (phase-started stream workflow-id :plan))
-     (publish! stream (agent-chunk stream workflow-id :planner \"Output...\"))
-     (publish! stream (phase-completed stream workflow-id :plan {:outcome :success}))
-     (publish! stream (workflow-completed stream workflow-id :success))"
+  "Canonical public boundary for the event-stream component.
+   Public API groups live under ai.miniforge.event-stream.interface.* namespaces,
+   while this namespace remains the Polylith entrypoint."
   (:require
-   [ai.miniforge.event-stream.core :as core]
-   [ai.miniforge.event-stream.listeners :as listeners]
-   [ai.miniforge.event-stream.control :as control]
-   [ai.miniforge.event-stream.approval :as approval]))
+   [ai.miniforge.event-stream.interface.approval :as approval]
+   [ai.miniforge.event-stream.interface.callbacks :as callbacks]
+   [ai.miniforge.event-stream.interface.control :as control]
+   [ai.miniforge.event-stream.interface.control-state :as control-state]
+   [ai.miniforge.event-stream.interface.events :as events]
+   [ai.miniforge.event-stream.interface.listeners :as listeners]
+   [ai.miniforge.event-stream.interface.stream :as stream]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Control state primitives
+;; Stream lifecycle and control state
 
-(def create-control-state
-  "Create a canonical control-state atom for workflow execution.
-   Used by both CLI dashboard poller and TUI to drive pause/resume/cancel."
-  control/create-control-state)
+(def create-control-state control-state/create-control-state)
+(def pause! control-state/pause!)
+(def resume! control-state/resume!)
+(def cancel! control-state/cancel!)
+(def paused? control-state/paused?)
+(def cancelled? control-state/cancelled?)
 
-(def pause!
-  "Pause workflow execution."
-  control/pause!)
-
-(def resume!
-  "Resume paused workflow execution."
-  control/resume!)
-
-(def cancel!
-  "Cancel workflow execution."
-  control/cancel!)
-
-(def paused?
-  "Check if workflow is paused."
-  control/paused?)
-
-(def cancelled?
-  "Check if workflow is cancelled."
-  control/cancelled?)
-
-;------------------------------------------------------------------------------ Layer 0b
-;; Event stream lifecycle
-
-(defn create-event-stream
-  "Create an event stream for publishing and subscribing to workflow events.
-
-   Options:
-   - :logger - Optional logger instance for debugging
-   - :sinks - Vector of sink functions (default: file sink)
-   - :config - User config map to create sinks from
-
-   Returns: Event stream atom that manages subscribers and event log.
-
-   Sinks control where events are written (files, stdout, fleet, etc).
-   See ai.miniforge.event-stream.sinks for sink options.
-
-   Examples:
-     ;; Default file sink
-     (create-event-stream)
-
-     ;; With custom sinks
-     (require '[ai.miniforge.event-stream.sinks :as sinks])
-     (create-event-stream {:sinks [(sinks/file-sink) (sinks/stdout-sink)]})
-
-     ;; From user config
-     (create-event-stream {:config user-config})"
-  [& [opts]]
-  (core/create-event-stream opts))
-
-(defn publish!
-  "Publish an event to the event stream.
-
-   Arguments:
-   - stream: Event stream atom from create-event-stream
-   - event: Event map created by one of the event constructors
-
-   Notifies all subscribers whose filters match the event.
-   Events are appended to the stream's event log (append-only).
-
-   Returns: The event that was published.
-
-   Example:
-     (publish! stream (workflow-started stream wf-id spec))"
-  [stream event]
-  (core/publish! stream event))
-
-(defn subscribe!
-  "Subscribe to events on the event stream.
-
-   Arguments:
-   - stream: Event stream atom
-   - subscriber-id: Unique identifier for this subscriber (keyword or string)
-   - callback: Function (fn [event] ...) called for matching events
-   - filter-fn: Optional predicate (fn [event] bool) to filter events
-
-   Returns: subscriber-id (for use with unsubscribe!)
-
-   Example:
-     ;; Subscribe to all events
-     (subscribe! stream :my-sub (fn [e] (println e)))
-
-     ;; Subscribe to phase events only
-     (subscribe! stream :phase-watcher
-       (fn [e] (println (:workflow/phase e)))
-       (fn [e] (#{:workflow/phase-started :workflow/phase-completed}
-                (:event/type e))))"
-  ([stream subscriber-id callback]
-   (core/subscribe! stream subscriber-id callback))
-  ([stream subscriber-id callback filter-fn]
-   (core/subscribe! stream subscriber-id callback filter-fn)))
-
-(defn unsubscribe!
-  "Unsubscribe from events on the event stream.
-
-   Arguments:
-   - stream: Event stream atom
-   - subscriber-id: The subscriber ID returned from subscribe!
-
-   Example:
-     (unsubscribe! stream :my-sub)"
-  [stream subscriber-id]
-  (core/unsubscribe! stream subscriber-id))
+(def create-event-stream stream/create-event-stream)
+(def publish! stream/publish!)
+(def subscribe! stream/subscribe!)
+(def unsubscribe! stream/unsubscribe!)
+(def get-events stream/get-events)
+(def get-latest-status stream/get-latest-status)
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Query API
+;; Event constructors
 
-(defn get-events
-  "Get events from the stream, optionally filtered.
-
-   Arguments:
-   - stream: Event stream atom
-   - opts: Options map with:
-     - :workflow-id - Filter by workflow UUID
-     - :event-type - Filter by event type keyword
-     - :offset - Skip first N events
-     - :limit - Return at most N events
-
-   Returns: Vector of events.
-
-   Example:
-     (get-events stream)
-     (get-events stream {:workflow-id wf-id})
-     (get-events stream {:event-type :workflow/phase-started :limit 10})"
-  [stream & [opts]]
-  (core/get-events stream opts))
-
-(defn get-latest-status
-  "Get the most recent agent/status event for a workflow.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - agent-id: Optional keyword agent ID to filter by
-
-   Returns: Most recent status event or nil.
-
-   Example:
-     (get-latest-status stream wf-id)
-     (get-latest-status stream wf-id :planner)"
-  [stream workflow-id & [agent-id]]
-  (core/get-latest-status stream workflow-id agent-id))
+(def workflow-started events/workflow-started)
+(def phase-started events/phase-started)
+(def phase-completed events/phase-completed)
+(def agent-chunk events/agent-chunk)
+(def agent-status events/agent-status)
+(def workflow-completed events/workflow-completed)
+(def workflow-failed events/workflow-failed)
+(def llm-request events/llm-request)
+(def llm-response events/llm-response)
+(def agent-started events/agent-started)
+(def agent-completed events/agent-completed)
+(def agent-failed events/agent-failed)
+(def gate-started events/gate-started)
+(def gate-passed events/gate-passed)
+(def gate-failed events/gate-failed)
+(def tool-invoked events/tool-invoked)
+(def tool-completed events/tool-completed)
+(def milestone-reached events/milestone-reached)
+(def task-state-changed events/task-state-changed)
+(def task-frontier-entered events/task-frontier-entered)
+(def task-skip-propagated events/task-skip-propagated)
+(def inter-agent-message-sent events/inter-agent-message-sent)
+(def inter-agent-message-received events/inter-agent-message-received)
+(def listener-attached events/listener-attached)
+(def listener-detached events/listener-detached)
+(def annotation-created events/annotation-created)
+(def control-action-requested events/control-action-requested)
+(def control-action-executed events/control-action-executed)
+(def chain-started events/chain-started)
+(def chain-step-started events/chain-step-started)
+(def chain-step-completed events/chain-step-completed)
+(def chain-step-failed events/chain-step-failed)
+(def chain-completed events/chain-completed)
+(def chain-failed events/chain-failed)
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Event constructors (N3 compliant)
-
-(defn workflow-started
-  "Create a workflow/started event.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - spec: Optional workflow specification map
-
-   Example:
-     (workflow-started stream wf-id)
-     (workflow-started stream wf-id {:name \"quick-fix\" :version \"2.0.0\"})"
-  [stream workflow-id & [spec]]
-  (core/workflow-started stream workflow-id spec))
-
-(defn phase-started
-  "Create a workflow/phase-started event.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - phase: Keyword phase name (:plan, :implement, :verify, :review, etc.)
-   - context: Optional phase context map
-
-   Example:
-     (phase-started stream wf-id :plan)
-     (phase-started stream wf-id :implement {:budget {:tokens 30000}})"
-  [stream workflow-id phase & [context]]
-  (core/phase-started stream workflow-id phase context))
-
-(defn phase-completed
-  "Create a workflow/phase-completed event.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - phase: Keyword phase name
-   - result: Optional result map with:
-     - :outcome - :success, :failure, or :skipped
-     - :duration-ms - Phase duration in milliseconds
-     - :artifacts - Vector of artifact UUIDs
-
-   Example:
-     (phase-completed stream wf-id :plan)
-     (phase-completed stream wf-id :implement {:outcome :success :duration-ms 45000})"
-  [stream workflow-id phase & [result]]
-  (core/phase-completed stream workflow-id phase result))
-
-(defn agent-chunk
-  "Create an agent/chunk event for streaming agent output.
-
-   This is the key event for real-time observability - it streams
-   LLM output tokens as they're generated.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - agent-id: Keyword agent ID (:planner, :implementer, etc.)
-   - delta: String chunk of output text
-   - done?: Optional boolean indicating stream completion
-
-   Example:
-     (agent-chunk stream wf-id :planner \"Analyzing the spec...\")
-     (agent-chunk stream wf-id :planner \"\" true) ; Stream complete"
-  [stream workflow-id agent-id delta & [done?]]
-  (core/agent-chunk stream workflow-id agent-id delta done?))
-
-(defn agent-status
-  "Create an agent/status event for real-time progress updates.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - agent-id: Keyword agent ID
-   - status-type: One of :reading, :thinking, :generating, :validating,
-                  :repairing, :running, :waiting, :communicating
-   - message: Human-readable status message
-
-   Example:
-     (agent-status stream wf-id :implementer :generating \"Writing Terraform config\")"
-  [stream workflow-id agent-id status-type message]
-  (core/agent-status stream workflow-id agent-id status-type message))
-
-(defn workflow-completed
-  "Create a workflow/completed event.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - status: Keyword status (:success, :failure, :cancelled)
-   - duration-ms: Optional total workflow duration in milliseconds
-   - opts: Optional map with :tokens and :cost-usd
-
-   Example:
-     (workflow-completed stream wf-id :success 120000)
-     (workflow-completed stream wf-id :success 120000 {:tokens 5000 :cost-usd 0.15})"
-  [stream workflow-id status & [duration-ms opts]]
-  (core/workflow-completed stream workflow-id status duration-ms opts))
-
-(defn workflow-failed
-  "Create a workflow/failed event.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - error: Error map with :message key, or Throwable
-
-   Example:
-     (workflow-failed stream wf-id {:message \"LLM timeout\" :type :timeout})
-     (workflow-failed stream wf-id (ex-info \"Out of tokens\" {:tokens 0}))"
-  [stream workflow-id error]
-  (core/workflow-failed stream workflow-id error))
-
-(defn llm-request
-  "Create an llm/request event.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - agent-id: Keyword agent ID
-   - model: String model name (e.g., \"claude-sonnet-4\")
-   - prompt-tokens: Optional input token count
-
-   Example:
-     (llm-request stream wf-id :planner \"claude-sonnet-4\" 2400)"
-  [stream workflow-id agent-id model & [prompt-tokens]]
-  (core/llm-request stream workflow-id agent-id model prompt-tokens))
-
-(defn llm-response
-  "Create an llm/response event.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - agent-id: Keyword agent ID
-   - model: String model name
-   - request-id: UUID of the original llm/request event
-   - metrics: Optional map with :completion-tokens, :total-tokens,
-              :duration-ms, :cost-usd
-
-   Example:
-     (llm-response stream wf-id :planner \"claude-sonnet-4\" req-id
-                   {:completion-tokens 850 :duration-ms 3200})"
-  [stream workflow-id agent-id model request-id & [metrics]]
-  (core/llm-response stream workflow-id agent-id model request-id metrics))
-
-;------------------------------------------------------------------------------ Layer 2b
-;; Agent lifecycle event constructors
-
-(defn agent-started
-  "Create an agent/started event."
-  [stream workflow-id agent-id & [context]]
-  (core/agent-started stream workflow-id agent-id context))
-
-(defn agent-completed
-  "Create an agent/completed event."
-  [stream workflow-id agent-id & [result]]
-  (core/agent-completed stream workflow-id agent-id result))
-
-(defn agent-failed
-  "Create an agent/failed event."
-  [stream workflow-id agent-id & [error]]
-  (core/agent-failed stream workflow-id agent-id error))
-
-;------------------------------------------------------------------------------ Layer 2c
-;; Gate lifecycle event constructors
-
-(defn gate-started
-  "Create a gate/started event."
-  [stream workflow-id gate-id & [artifact-summary]]
-  (core/gate-started stream workflow-id gate-id artifact-summary))
-
-(defn gate-passed
-  "Create a gate/passed event."
-  [stream workflow-id gate-id & [duration-ms]]
-  (core/gate-passed stream workflow-id gate-id duration-ms))
-
-(defn gate-failed
-  "Create a gate/failed event."
-  [stream workflow-id gate-id & [violations]]
-  (core/gate-failed stream workflow-id gate-id violations))
-
-;------------------------------------------------------------------------------ Layer 2d
-;; Tool lifecycle event constructors
-
-(defn tool-invoked
-  "Create a tool/invoked event."
-  [stream workflow-id agent-id tool-id & [params-summary]]
-  (core/tool-invoked stream workflow-id agent-id tool-id params-summary))
-
-(defn tool-completed
-  "Create a tool/completed event."
-  [stream workflow-id agent-id tool-id & [result-summary]]
-  (core/tool-completed stream workflow-id agent-id tool-id result-summary))
-
-;------------------------------------------------------------------------------ Layer 2e
-;; Milestone event constructor
-
-(defn milestone-reached
-  "Create a workflow/milestone-reached event."
-  [stream workflow-id milestone-id & [description]]
-  (core/milestone-reached stream workflow-id milestone-id description))
-
-;------------------------------------------------------------------------------ Layer 2f
-;; Task lifecycle (DAG) event constructors
-
-(defn task-state-changed
-  "Create a task/state-changed event."
-  [stream workflow-id dag-id task-id from-state to-state & [context]]
-  (core/task-state-changed stream workflow-id dag-id task-id from-state to-state context))
-
-(defn task-frontier-entered
-  "Create a task/frontier-entered event."
-  [stream workflow-id dag-id task-id & [frontier-size]]
-  (core/task-frontier-entered stream workflow-id dag-id task-id frontier-size))
-
-(defn task-skip-propagated
-  "Create a task/skip-propagated event."
-  [stream workflow-id dag-id task-id & [cause-task]]
-  (core/task-skip-propagated stream workflow-id dag-id task-id cause-task))
-
-;------------------------------------------------------------------------------ Layer 2g
-;; Inter-agent messaging event constructors
-
-(defn inter-agent-message-sent
-  "Create an agent/message-sent event."
-  [stream workflow-id from-agent to-agent & [message-type]]
-  (core/inter-agent-message-sent stream workflow-id from-agent to-agent message-type))
-
-(defn inter-agent-message-received
-  "Create an agent/message-received event."
-  [stream workflow-id from-agent to-agent & [message-type]]
-  (core/inter-agent-message-received stream workflow-id from-agent to-agent message-type))
-
-;------------------------------------------------------------------------------ Layer 2h
-;; Listener lifecycle event constructors (N8)
-
-(defn listener-attached
-  "Create a listener/attached event."
-  [stream workflow-id listener-id & [listener-type capability]]
-  (core/listener-attached stream workflow-id listener-id listener-type capability))
-
-(defn listener-detached
-  "Create a listener/detached event."
-  [stream workflow-id listener-id & [reason]]
-  (core/listener-detached stream workflow-id listener-id reason))
-
-(defn annotation-created
-  "Create an annotation/created event."
-  [stream workflow-id listener-id annotation-type & [content]]
-  (core/annotation-created stream workflow-id listener-id annotation-type content))
-
-;------------------------------------------------------------------------------ Layer 2i
-;; Control action event constructors (N8)
-
-(defn control-action-requested
-  "Create a control-action/requested event."
-  [stream workflow-id action-id action-type & [requester]]
-  (core/control-action-requested stream workflow-id action-id action-type requester))
-
-(defn control-action-executed
-  "Create a control-action/executed event."
-  [stream workflow-id action-id & [result]]
-  (core/control-action-executed stream workflow-id action-id result))
-
-;------------------------------------------------------------------------------ Layer 2j
-;; Chain lifecycle event constructors
-
-(defn chain-started
-  "Create a chain/started event."
-  [stream chain-id step-count]
-  (core/chain-started stream chain-id step-count))
-
-(defn chain-step-started
-  "Create a chain/step-started event."
-  [stream chain-id step-id step-index workflow-id]
-  (core/chain-step-started stream chain-id step-id step-index workflow-id))
-
-(defn chain-step-completed
-  "Create a chain/step-completed event."
-  [stream chain-id step-id step-index]
-  (core/chain-step-completed stream chain-id step-id step-index))
-
-(defn chain-step-failed
-  "Create a chain/step-failed event."
-  [stream chain-id step-id step-index error]
-  (core/chain-step-failed stream chain-id step-id step-index error))
-
-(defn chain-completed
-  "Create a chain/completed event."
-  [stream chain-id duration-ms step-count]
-  (core/chain-completed stream chain-id duration-ms step-count))
-
-(defn chain-failed
-  "Create a chain/failed event."
-  [stream chain-id step-id error]
-  (core/chain-failed stream chain-id step-id error))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Listener management API (N8)
-
-(defn register-listener!
-  "Register a listener with capability level.
-   See ai.miniforge.event-stream.listeners for full docs."
-  [stream listener-spec]
-  (listeners/register-listener! stream listener-spec))
-
-(defn deregister-listener!
-  "Deregister a listener and remove its subscription."
-  [stream listener-id & [reason]]
-  (listeners/deregister-listener! stream listener-id reason))
-
-(defn list-listeners
-  "List all registered listeners."
-  [stream]
-  (listeners/list-listeners stream))
-
-(defn submit-annotation!
-  "Submit an advisory annotation (requires :advise or :control capability)."
-  [stream listener-id annotation]
-  (listeners/submit-annotation! stream listener-id annotation))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Control action API (N8)
-
-(defn create-control-action
-  "Create a structured control action."
-  [action-type target requester & [opts]]
-  (control/create-control-action action-type target requester opts))
-
-(defn authorize-action
-  "Check RBAC authorization for a control action."
-  [roles action requester]
-  (control/authorize-action roles action requester))
-
-(defn execute-control-action!
-  "Execute an authorized control action with event emission."
-  [stream action execution-fn]
-  (control/execute-control-action! stream action execution-fn))
-
-(def requires-approval?
-  "Check if a control action type requires multi-party approval."
-  control/requires-approval?)
-
-(defn execute-control-action-with-approval!
-  "Execute a control action, creating an approval request if required."
-  [stream action execution-fn & [approval-opts]]
-  (control/execute-control-action-with-approval! stream action execution-fn approval-opts))
-
-;------------------------------------------------------------------------------ Layer 3b
-;; Multi-party approval API (N8)
-
-(def approval-succeeded?
-  "Check if an approval builder response succeeded."
-  approval/succeeded?)
-
-(def approval-failed?
-  "Check if an approval builder response failed."
-  approval/failed?)
-
-(def create-approval-request
-  "Create a new approval request.
-   Arguments: action-id, required-signers, quorum, [opts]"
-  approval/create-approval-request)
-
-(defn submit-approval
-  "Submit an approval or rejection for a request."
-  [approval-request signer decision & [opts]]
-  (approval/submit-approval approval-request signer decision opts))
-
-(def check-approval-status
-  "Check the current status of an approval request."
-  approval/check-approval-status)
-
-(defn cancel-approval
-  "Cancel a pending approval request."
-  [approval-request canceller reason]
-  (approval/cancel-approval approval-request canceller reason))
-
-(def create-approval-manager
-  "Create an atom-backed approval manager."
-  approval/create-approval-manager)
-
-(def store-approval!
-  "Store an approval request in the manager."
-  approval/store-approval!)
-
-(def get-approval
-  "Get an approval request by ID."
-  approval/get-approval)
-
-(def update-approval!
-  "Update an approval request in the manager."
-  approval/update-approval!)
-
-(def list-approvals
-  "List all approval requests."
-  approval/list-approvals)
-
-;------------------------------------------------------------------------------ Layer 4
-;; Convenience functions
-
-(defn create-streaming-callback
-  "Create an on-chunk callback that publishes to an event stream and optionally prints.
-
-   This is the primary integration point for wiring streaming into workflows.
-   The callback conforms to the signature expected by agents and LLM clients.
-
-   Arguments:
-   - stream: Event stream atom
-   - workflow-id: UUID of the workflow
-   - agent-id: Keyword agent ID for the current agent
-   - opts: Options map with:
-     - :print? - If true, print chunks to stdout (default: false)
-     - :quiet? - If true, suppress all console output (default: false)
-
-   Returns: Callback function (fn [{:keys [delta done? content]}])
-
-   Example:
-     (def on-chunk (create-streaming-callback stream wf-id :planner {:print? true}))
-
-     ;; Use in agent context
-     (agent/invoke planner task (assoc ctx :on-chunk on-chunk))"
-  [stream workflow-id agent-id & [opts]]
-  (let [{:keys [print? quiet?]} opts]
-    (fn [{:keys [delta done? tool-use heartbeat]}]
-      (cond
-        ;; Tool-use events — publish an agent-status event (no console print)
-        tool-use
-        (when stream
-          (publish! stream (agent-status stream workflow-id agent-id
-                                         :tool-calling "Agent calling tool")))
-
-        ;; Heartbeat events — no-op but counts as activity (keeps stream alive)
-        heartbeat
-        nil
-
-        ;; Normal text deltas
-        :else
-        (do
-          ;; Print to console if requested
-          (when (and print? (not quiet?) delta (not (empty? delta)))
-            (print delta)
-            (flush))
-          ;; Always publish to event stream
-          (when stream
-            (publish! stream (agent-chunk stream workflow-id agent-id (or delta "") done?))))))))
-
-;------------------------------------------------------------------------------ Rich Comment
-(comment
-  ;; Full workflow example
-  (def stream (create-event-stream))
-  (def wf-id (random-uuid))
-
-  ;; Subscribe to see events
-  (subscribe! stream :console
-              (fn [e] (println (:event/type e) "-" (:message e))))
-
-  ;; Run through workflow
-  (publish! stream (workflow-started stream wf-id {:name "test"}))
-  (publish! stream (phase-started stream wf-id :plan))
-
-  ;; Create streaming callback
-  (def on-chunk (create-streaming-callback stream wf-id :planner {:print? true}))
-  (on-chunk {:delta "Planning..." :done? false})
-  (on-chunk {:delta " step 1..." :done? false})
-  (on-chunk {:delta " done!" :done? true})
-
-  (publish! stream (phase-completed stream wf-id :plan {:outcome :success}))
-  (publish! stream (workflow-completed stream wf-id :success 10000))
-
-  ;; Query events
-  (count (get-events stream))
-  (get-events stream {:event-type :agent/chunk})
-
-  (unsubscribe! stream :console)
-
-  :leave-this-here)
+;; Listener, control, approval, and callback APIs
+
+(def register-listener! listeners/register-listener!)
+(def deregister-listener! listeners/deregister-listener!)
+(def list-listeners listeners/list-listeners)
+(def submit-annotation! listeners/submit-annotation!)
+
+(def create-control-action control/create-control-action)
+(def authorize-action control/authorize-action)
+(def execute-control-action! control/execute-control-action!)
+(def requires-approval? control/requires-approval?)
+(def execute-control-action-with-approval! control/execute-control-action-with-approval!)
+
+(def approval-succeeded? approval/approval-succeeded?)
+(def approval-failed? approval/approval-failed?)
+(def create-approval-request approval/create-approval-request)
+(def submit-approval approval/submit-approval)
+(def check-approval-status approval/check-approval-status)
+(def cancel-approval approval/cancel-approval)
+(def create-approval-manager approval/create-approval-manager)
+(def store-approval! approval/store-approval!)
+(def get-approval approval/get-approval)
+(def update-approval! approval/update-approval!)
+(def list-approvals approval/list-approvals)
+
+(def create-streaming-callback callbacks/create-streaming-callback)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/approval.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/approval.clj
@@ -1,0 +1,19 @@
+(ns ai.miniforge.event-stream.interface.approval
+  "Multi-party approval API for the event stream."
+  (:require
+   [ai.miniforge.event-stream.approval :as approval]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Approval management
+
+(def approval-succeeded? approval/succeeded?)
+(def approval-failed? approval/failed?)
+(def create-approval-request approval/create-approval-request)
+(def submit-approval approval/submit-approval)
+(def check-approval-status approval/check-approval-status)
+(def cancel-approval approval/cancel-approval)
+(def create-approval-manager approval/create-approval-manager)
+(def store-approval! approval/store-approval!)
+(def get-approval approval/get-approval)
+(def update-approval! approval/update-approval!)
+(def list-approvals approval/list-approvals)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
@@ -1,0 +1,32 @@
+(ns ai.miniforge.event-stream.interface.callbacks
+  "Streaming callback helpers for the event-stream public API."
+  (:require
+   [ai.miniforge.event-stream.interface.events :as events]
+   [ai.miniforge.event-stream.interface.stream :as stream]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Convenience callbacks
+
+(defn create-streaming-callback
+  [stream-atom workflow-id agent-id & [opts]]
+  (let [{:keys [print? quiet?]} opts]
+    (fn [{:keys [delta done? tool-use heartbeat]}]
+      (cond
+        tool-use
+        (when stream-atom
+          (stream/publish! stream-atom
+                           (events/agent-status stream-atom workflow-id agent-id
+                                                :tool-calling "Agent calling tool")))
+
+        heartbeat
+        nil
+
+        :else
+        (do
+          (when (and print? (not quiet?) delta (not (empty? delta)))
+            (print delta)
+            (flush))
+          (when stream-atom
+            (stream/publish! stream-atom
+                             (events/agent-chunk stream-atom workflow-id agent-id
+                                                 (or delta "") done?))))))))

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/control.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/control.clj
@@ -1,0 +1,13 @@
+(ns ai.miniforge.event-stream.interface.control
+  "Control-action API for the event stream."
+  (:require
+   [ai.miniforge.event-stream.control :as control]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Control actions
+
+(def create-control-action control/create-control-action)
+(def authorize-action control/authorize-action)
+(def execute-control-action! control/execute-control-action!)
+(def requires-approval? control/requires-approval?)
+(def execute-control-action-with-approval! control/execute-control-action-with-approval!)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/control_state.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/control_state.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.event-stream.interface.control-state
+  "Control-state helpers for the event-stream public API."
+  (:require
+   [ai.miniforge.event-stream.control :as control]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Control state primitives
+
+(def create-control-state control/create-control-state)
+(def pause! control/pause!)
+(def resume! control/resume!)
+(def cancel! control/cancel!)
+(def paused? control/paused?)
+(def cancelled? control/cancelled?)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -1,0 +1,42 @@
+(ns ai.miniforge.event-stream.interface.events
+  "Workflow, agent, gate, task, listener, control, and chain event constructors."
+  (:require
+   [ai.miniforge.event-stream.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Event constructors
+
+(def workflow-started core/workflow-started)
+(def phase-started core/phase-started)
+(def phase-completed core/phase-completed)
+(def agent-chunk core/agent-chunk)
+(def agent-status core/agent-status)
+(def workflow-completed core/workflow-completed)
+(def workflow-failed core/workflow-failed)
+(def llm-request core/llm-request)
+(def llm-response core/llm-response)
+(def agent-started core/agent-started)
+(def agent-completed core/agent-completed)
+(def agent-failed core/agent-failed)
+(def gate-started core/gate-started)
+(def gate-passed core/gate-passed)
+(def gate-failed core/gate-failed)
+(def tool-invoked core/tool-invoked)
+(def tool-completed core/tool-completed)
+(def milestone-reached core/milestone-reached)
+(def task-state-changed core/task-state-changed)
+(def task-frontier-entered core/task-frontier-entered)
+(def task-skip-propagated core/task-skip-propagated)
+(def inter-agent-message-sent core/inter-agent-message-sent)
+(def inter-agent-message-received core/inter-agent-message-received)
+(def listener-attached core/listener-attached)
+(def listener-detached core/listener-detached)
+(def annotation-created core/annotation-created)
+(def control-action-requested core/control-action-requested)
+(def control-action-executed core/control-action-executed)
+(def chain-started core/chain-started)
+(def chain-step-started core/chain-step-started)
+(def chain-step-completed core/chain-step-completed)
+(def chain-step-failed core/chain-step-failed)
+(def chain-completed core/chain-completed)
+(def chain-failed core/chain-failed)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/listeners.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/listeners.clj
@@ -1,0 +1,12 @@
+(ns ai.miniforge.event-stream.interface.listeners
+  "Listener management API for the event stream."
+  (:require
+   [ai.miniforge.event-stream.listeners :as listeners]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Listener management
+
+(def register-listener! listeners/register-listener!)
+(def deregister-listener! listeners/deregister-listener!)
+(def list-listeners listeners/list-listeners)
+(def submit-annotation! listeners/submit-annotation!)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/stream.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/stream.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.event-stream.interface.stream
+  "Event-stream lifecycle and query API."
+  (:require
+   [ai.miniforge.event-stream.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Event stream lifecycle and queries
+
+(def create-event-stream core/create-event-stream)
+(def publish! core/publish!)
+(def subscribe! core/subscribe!)
+(def unsubscribe! core/unsubscribe!)
+(def get-events core/get-events)
+(def get-latest-status core/get-latest-status)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -1,606 +1,78 @@
-;; Title: Miniforge.ai
-;; Subtitle: An agentic SDLC / fleet-control platform
-;; Author: Christopher Lester
-;; Line: Founder, Miniforge.ai (project)
-;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
-;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software
-;; distributed under the License is distributed on an "AS IS" BASIS,
-;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and
-;; limitations under the License.
-
 (ns ai.miniforge.policy-pack.interface
-  "Public API for the policy-pack component.
-
-   Provides policy-as-code functionality:
-   - Pack and rule schemas
-   - Pack registry for CRUD and composition
-   - Pack loading from EDN files and directories
-   - Rule violation detection
-   - Artifact checking against packs
-
-   Layer 0: Schema re-exports
-   Layer 1: Registry operations
-   Layer 2: Loading operations
-   Layer 3: Detection and checking
-   Layer 4: Rule and pack builders"
+  "Canonical public boundary for the policy-pack component.
+   Public API groups live under ai.miniforge.policy-pack.interface.* namespaces,
+   while this namespace remains the Polylith entrypoint."
   (:require
-   [ai.miniforge.policy-pack.schema :as schema]
-   [ai.miniforge.policy-pack.registry :as registry]
-   [ai.miniforge.policy-pack.loader :as loader]
-   [ai.miniforge.policy-pack.detection :as detection]
-   [ai.miniforge.policy-pack.core :as core]
-   [ai.miniforge.policy-pack.external :as external]))
+   [ai.miniforge.policy-pack.interface.builders :as builders]
+   [ai.miniforge.policy-pack.interface.checking :as checking]
+   [ai.miniforge.policy-pack.interface.loading :as loading]
+   [ai.miniforge.policy-pack.interface.registry :as registry]
+   [ai.miniforge.policy-pack.interface.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema re-exports
+;; Schema and registry API
 
-(def Rule
-  "Malli schema for a policy rule."
-  schema/Rule)
+(def Rule schema/Rule)
+(def PackManifest schema/PackManifest)
+(def RuleSeverity schema/RuleSeverity)
+(def RuleEnforcement schema/RuleEnforcement)
+(def RuleApplicability schema/RuleApplicability)
+(def RuleDetection schema/RuleDetection)
+(def rule-severities schema/rule-severities)
+(def enforcement-actions schema/enforcement-actions)
+(def detection-types schema/detection-types)
+(def valid-rule? schema/valid-rule?)
+(def validate-rule schema/validate-rule)
+(def valid-pack? schema/valid-pack?)
+(def validate-pack schema/validate-pack)
 
-(def PackManifest
-  "Malli schema for a policy pack manifest."
-  schema/PackManifest)
-
-(def RuleSeverity
-  "Malli schema for rule severity enum."
-  schema/RuleSeverity)
-
-(def RuleEnforcement
-  "Malli schema for enforcement action enum."
-  schema/RuleEnforcement)
-
-(def RuleApplicability
-  "Malli schema for rule applicability config."
-  schema/RuleApplicability)
-
-(def RuleDetection
-  "Malli schema for rule detection config."
-  schema/RuleDetection)
-
-;; Enum values for programmatic access
-(def rule-severities
-  "Rule severity levels: [:critical :major :minor :info]"
-  schema/rule-severities)
-
-(def enforcement-actions
-  "Enforcement actions: [:hard-halt :require-approval :warn :audit]"
-  schema/enforcement-actions)
-
-(def detection-types
-  "Detection types: [:plan-output :diff-analysis :state-comparison :content-scan :ast-analysis :custom]"
-  schema/detection-types)
-
-;------------------------------------------------------------------------------ Layer 0
-;; Validation functions
-
-(def valid-rule?
-  "Check if value is a valid Rule.
-   Returns boolean."
-  schema/valid-rule?)
-
-(def validate-rule
-  "Validate a rule against the schema.
-   Returns {:valid? bool :errors map-or-nil}."
-  schema/validate-rule)
-
-(def valid-pack?
-  "Check if value is a valid PackManifest.
-   Returns boolean."
-  schema/valid-pack?)
-
-(def validate-pack
-  "Validate a pack manifest against the schema.
-   Returns {:valid? bool :errors map-or-nil}."
-  schema/validate-pack)
+(def PolicyPackRegistry registry/PolicyPackRegistry)
+(def create-registry registry/create-registry)
+(def register-pack registry/register-pack)
+(def get-pack registry/get-pack)
+(def get-pack-version registry/get-pack-version)
+(def list-packs registry/list-packs)
+(def delete-pack registry/delete-pack)
+(def resolve-pack registry/resolve-pack)
+(def get-rules-for-context registry/get-rules-for-context)
+(def glob-matches? registry/glob-matches?)
+(def compare-versions registry/compare-versions)
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Registry protocol re-export
+;; Loading and checking API
 
-(def PolicyPackRegistry
-  "Protocol for managing policy packs.
+(def load-pack loading/load-pack)
+(def load-pack-from-file loading/load-pack-from-file)
+(def load-pack-from-directory loading/load-pack-from-directory)
+(def discover-packs loading/discover-packs)
+(def load-all-packs loading/load-all-packs)
+(def write-pack-to-file loading/write-pack-to-file)
 
-   Methods:
-   - register-pack [this pack]
-   - get-pack [this pack-id]
-   - get-pack-version [this pack-id version]
-   - list-packs [this criteria]
-   - delete-pack [this pack-id version]
-   - import-pack [this source]
-   - export-pack [this pack-id version format]
-   - validate-pack [this pack]
-   - verify-signature [this pack]
-   - resolve-pack [this pack-id]
-   - get-rules-for-context [this pack-ids context]"
-  registry/PolicyPackRegistry)
-
-(def create-registry
-  "Create an in-memory policy pack registry.
-
-   Options:
-   - :logger - Logger instance for structured logging
-
-   Example:
-     (create-registry)
-     (create-registry {:logger my-logger})"
-  registry/create-registry)
-
-;; Registry operations delegated
-(defn register-pack
-  "Register a pack in the registry.
-   Returns the registered pack."
-  [registry pack]
-  (registry/register-pack registry pack))
-
-(defn get-pack
-  "Get latest version of a pack by ID.
-   Returns pack or nil."
-  [registry pack-id]
-  (registry/get-pack registry pack-id))
-
-(defn get-pack-version
-  "Get specific version of a pack.
-   Returns pack or nil."
-  [registry pack-id version]
-  (registry/get-pack-version registry pack-id version))
-
-(defn list-packs
-  "List packs matching criteria.
-   Criteria: {:category :author :search}"
-  [registry criteria]
-  (registry/list-packs registry criteria))
-
-(defn delete-pack
-  "Delete a pack version from registry.
-   Returns true if deleted."
-  [registry pack-id version]
-  (registry/delete-pack registry pack-id version))
-
-(defn resolve-pack
-  "Resolve a pack with all extensions merged.
-   Returns fully resolved pack."
-  [registry pack-id]
-  (registry/resolve-pack registry pack-id))
-
-(defn get-rules-for-context
-  "Get applicable rules for pack IDs and context.
-   Returns vector of applicable rules."
-  [registry pack-ids context]
-  (registry/get-rules-for-context registry pack-ids context))
+(def detect-violation checking/detect-violation)
+(def check-rules checking/check-rules)
+(def check-artifact checking/check-artifact)
+(def check-artifacts checking/check-artifacts)
+(def blocking-violations checking/blocking-violations)
+(def approval-required-violations checking/approval-required-violations)
+(def warning-violations checking/warning-violations)
+(def violation->error checking/violation->error)
+(def violation->warning checking/violation->warning)
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Loading operations
-
-(def load-pack
-  "Load a policy pack, auto-detecting format.
-
-   Supports:
-   - Single EDN file (pack.edn or *.pack.edn)
-   - Directory with pack.edn manifest
-
-   Arguments:
-   - path - File or directory path
-
-   Returns:
-   - {:success? bool :pack PackManifest :errors [...]}
-
-   Example:
-     (load-pack \"terraform-safety.pack.edn\")
-     (load-pack \"./packs/terraform-safety/\")"
-  loader/load-pack)
-
-(def load-pack-from-file
-  "Load a policy pack from a single EDN file.
-
-   Arguments:
-   - file-path - Path to the .pack.edn file
-
-   Returns:
-   - {:success? bool :pack PackManifest :errors [...]}
-
-   Example:
-     (load-pack-from-file \"terraform-safety.pack.edn\")"
-  loader/load-pack-from-file)
-
-(def load-pack-from-directory
-  "Load a policy pack from a directory structure.
-
-   Expected structure:
-   ```
-   my-pack/
-   ├── pack.edn           # Pack manifest
-   └── rules/             # Optional separate rule files
-       └── ...
-   ```
-
-   Arguments:
-   - dir-path - Path to the pack directory
-
-   Returns:
-   - {:success? bool :pack PackManifest :errors [...]}
-
-   Example:
-     (load-pack-from-directory \"./packs/terraform-safety\")"
-  loader/load-pack-from-directory)
-
-(def discover-packs
-  "Discover all packs in a directory.
-
-   Arguments:
-   - packs-dir - Directory containing packs
-
-   Returns:
-   - Vector of {:path string :type :file|:directory}"
-  loader/discover-packs)
-
-(def load-all-packs
-  "Load all packs from a packs directory.
-
-   Arguments:
-   - packs-dir - Directory containing packs
-
-   Returns:
-   - {:loaded [PackManifest...] :failed [{:path :errors}...]}
-
-   Example:
-     (load-all-packs \".miniforge/packs\")"
-  loader/load-all-packs)
-
-(def write-pack-to-file
-  "Write a pack manifest to a single EDN file.
-
-   Arguments:
-   - pack - PackManifest
-   - file-path - Output file path
-
-   Returns:
-   - {:success? bool :error string}"
-  loader/write-pack-to-file)
-
-;------------------------------------------------------------------------------ Layer 3
-;; Detection and checking
-
-(def detect-violation
-  "Detect violations for a rule against an artifact.
-
-   Dispatches to the appropriate detection implementation based on
-   the rule's :rule/detection :type.
-
-   Arguments:
-   - rule - Rule with :rule/detection
-   - artifact - Artifact being validated
-   - context - Execution context map
-
-   Returns:
-   - Violation map if detected, nil otherwise."
-  detection/detect-violation)
-
-(def check-rules
-  "Check multiple rules against an artifact.
-
-   Arguments:
-   - rules - Vector of rules to check
-   - artifact - Artifact being validated
-   - context - Execution context
-
-   Returns:
-   - Vector of violation maps"
-  detection/check-rules)
-
-(def check-artifact
-  "Check an artifact against all applicable rules from pack(s).
-
-   Arguments:
-   - pack - PackManifest (or vector of packs)
-   - artifact - Artifact to check
-   - context - Execution context
-
-   Returns:
-   - {:passed? bool
-      :violations [...]
-      :blocking [...]
-      :require-approval [...]
-      :warnings [...]
-      :audits [...]}
-
-   Example:
-     (check-artifact pack
-                     {:artifact/content \"...\" :artifact/path \"main.tf\"}
-                     {:phase :implement})"
-  core/check-artifact)
-
-(def check-artifacts
-  "Check multiple artifacts against pack rules.
-
-   Arguments:
-   - pack - PackManifest (or vector of packs)
-   - artifacts - Vector of artifacts
-   - context - Execution context
-
-   Returns:
-   - Vector of check results, one per artifact"
-  core/check-artifacts)
-
-;; Violation classification helpers
-(def blocking-violations
-  "Filter violations that block progress (:hard-halt)."
-  detection/blocking-violations)
-
-(def approval-required-violations
-  "Filter violations requiring approval."
-  detection/approval-required-violations)
-
-(def warning-violations
-  "Filter warning-only violations."
-  detection/warning-violations)
-
-(def violation->error
-  "Convert violation to gate error map."
-  detection/violation->error)
-
-(def violation->warning
-  "Convert violation to gate warning map."
-  detection/violation->warning)
-
-;------------------------------------------------------------------------------ Layer 4
-;; Rule and pack builders
-
-(def create-pack
-  "Create a new policy pack with default values.
-
-   Arguments:
-   - id - Pack ID string
-   - name - Human-readable name
-   - description - Pack description
-   - author - Author string
-
-   Options:
-   - :version - DateVer string (default: today's date)
-   - :license - License string
-   - :rules - Vector of rules
-
-   Returns:
-   - PackManifest
-
-   Example:
-     (create-pack \"my-pack\" \"My Pack\" \"Description\" \"author\"
-                  :license \"Apache-2.0\"
-                  :rules [rule1 rule2])"
-  core/create-pack)
-
-(def create-rule
-  "Create a new rule with required fields.
-
-   Arguments:
-   - id - Rule ID keyword
-   - title - Short title
-   - description - Full description
-   - severity - :critical, :major, :minor, or :info
-   - category - Dewey category string
-   - detection - Detection config map
-   - enforcement - Enforcement config map
-
-   Options:
-   - :applies-to - Applicability config
-   - :agent-behavior - Agent guidance string
-   - :examples - Vector of example maps
-
-   Returns:
-   - Rule map
-
-   Example:
-     (create-rule :no-todos
-                  \"No TODOs\"
-                  \"Forbid TODO comments in production code\"
-                  :minor \"800\"
-                  (content-scan-detection \"TODO\")
-                  (warn-enforcement \"Found TODO comment\"))"
-  core/create-rule)
-
-(def add-rule-to-pack
-  "Add a rule to a pack. Returns updated pack."
-  core/add-rule-to-pack)
-
-(def remove-rule-from-pack
-  "Remove a rule from a pack by ID. Returns updated pack."
-  core/remove-rule-from-pack)
-
-(def update-pack-categories
-  "Regenerate pack categories from rules."
-  core/update-pack-categories)
-
-;; Detection config builders
-(def content-scan-detection
-  "Create a content-scan detection config.
-
-   Arguments:
-   - pattern - Regex pattern
-   - opts - Optional {:context-lines n}
-
-   Example:
-     (content-scan-detection \"TODO\")
-     (content-scan-detection \"FIXME\" {:context-lines 5})"
-  core/content-scan-detection)
-
-(def diff-analysis-detection
-  "Create a diff-analysis detection config.
-
-   Arguments:
-   - pattern - Regex pattern for diff content
-   - opts - Optional {:context-lines n}
-
-   Example:
-     (diff-analysis-detection \"^-\\\\s*import\\\\s*\\\\{\")"
-  core/diff-analysis-detection)
-
-(def plan-output-detection
-  "Create a plan-output detection config.
-
-   Arguments:
-   - patterns - Vector of regex patterns
-
-   Example:
-     (plan-output-detection [\"-/\\\\+.*aws_route\"])"
-  core/plan-output-detection)
-
-;; Enforcement config builders
-(def warn-enforcement
-  "Create a warn-only enforcement config.
-
-   Arguments:
-   - message - Violation message
-
-   Example:
-     (warn-enforcement \"Found TODO comment\")"
-  core/warn-enforcement)
-
-(def halt-enforcement
-  "Create a hard-halt enforcement config.
-
-   Arguments:
-   - message - Violation message
-   - opts - Optional {:remediation string}
-
-   Example:
-     (halt-enforcement \"Critical violation\"
-                       {:remediation \"Revert the change\"})"
-  core/halt-enforcement)
-
-(def approval-enforcement
-  "Create a require-approval enforcement config.
-
-   Arguments:
-   - message - Violation message
-   - approvers - Vector of approver types [:human :senior-engineer :security]
-
-   Example:
-     (approval-enforcement \"Network change detected\"
-                           [:human :senior-engineer])"
-  core/approval-enforcement)
-
-;------------------------------------------------------------------------------ Layer 4
-;; Rule resolution
-
-(def resolve-rules
-  "Resolve rules from multiple packs.
-
-   Resolution:
-   - Group by ID
-   - Merge with severity/enforcement escalation
-
-   Arguments:
-   - rules - Sequence of rules
-
-   Returns:
-   - Vector of resolved rules"
-  core/resolve-rules)
-
-(def merge-rules
-  "Merge two rules with the same ID.
-
-   Resolution:
-   - Override with escalation for severity and enforcement
-
-   Arguments:
-   - base - Original rule
-   - override - Overriding rule
-
-   Returns:
-   - Merged rule"
-  core/merge-rules)
-
-;------------------------------------------------------------------------------ Layer 4
-;; Utility functions
-
-(def glob-matches?
-  "Check if a glob pattern matches a path.
-
-   Arguments:
-   - pattern - Glob pattern (supports * and **)
-   - path - File path to match
-
-   Returns:
-   - boolean
-
-   Example:
-     (glob-matches? \"**/*.tf\" \"modules/vpc/main.tf\") ;; => true"
-  registry/glob-matches?)
-
-(def compare-versions
-  "Compare two DateVer version strings.
-
-   Returns negative if a < b, 0 if equal, positive if a > b.
-
-   Example:
-     (compare-versions \"2026.01.22\" \"2026.01.15\") ;; => 7"
-  registry/compare-versions)
-
-;------------------------------------------------------------------------------ Layer 5
-;; External PR evaluation (N4/N9)
-
-(def evaluate-external-pr
-  "Evaluate an external PR against policy packs in read-only mode.
-
-   Arguments:
-   - packs - Vector of PackManifest maps (or single pack)
-   - pr-data - Map with :diff, :repo, :pr-number, :labels, :changed-files
-
-   Returns:
-   {:evaluation/passed? bool
-    :evaluation/violations [...]
-    :evaluation/summary {:critical N :major N :minor N :info N :total N}
-    :evaluation/artifacts-checked int
-    :evaluation/packs-applied [string]}"
-  external/evaluate-external-pr)
-
-(def parse-pr-diff
-  "Parse a unified diff into artifact maps."
-  external/parse-pr-diff)
-
-;------------------------------------------------------------------------------ Rich Comment
-(comment
-  ;; Create a registry and add packs
-  (def reg (create-registry))
-
-  ;; Create a simple pack
-  (def my-pack
-    (create-pack "my-rules" "My Rules" "Custom rules" "me"
-                 :rules
-                 [(create-rule :no-todos
-                               "No TODOs"
-                               "Forbid TODO comments"
-                               :minor "800"
-                               (content-scan-detection "TODO")
-                               (warn-enforcement "Found TODO"))
-                  (create-rule :no-fixmes
-                               "No FIXMEs"
-                               "Forbid FIXME comments"
-                               :minor "800"
-                               (content-scan-detection "FIXME")
-                               (warn-enforcement "Found FIXME"))]))
-
-  ;; Register it
-  (register-pack reg my-pack)
-
-  ;; Check an artifact
-  (check-artifact my-pack
-                  {:artifact/content "# TODO: implement this\ndef foo(): pass"
-                   :artifact/path "main.py"}
-                  {:phase :implement})
-
-  ;; Load packs from disk
-  (load-pack "terraform-safety.pack.edn")
-  (load-all-packs ".miniforge/packs")
-
-  ;; Validate a pack
-  (validate-pack my-pack)
-
-  :leave-this-here)
+;; Builders, resolution, and external evaluation
+
+(def create-pack builders/create-pack)
+(def create-rule builders/create-rule)
+(def add-rule-to-pack builders/add-rule-to-pack)
+(def remove-rule-from-pack builders/remove-rule-from-pack)
+(def update-pack-categories builders/update-pack-categories)
+(def content-scan-detection builders/content-scan-detection)
+(def diff-analysis-detection builders/diff-analysis-detection)
+(def plan-output-detection builders/plan-output-detection)
+(def warn-enforcement builders/warn-enforcement)
+(def halt-enforcement builders/halt-enforcement)
+(def approval-enforcement builders/approval-enforcement)
+(def resolve-rules builders/resolve-rules)
+(def merge-rules builders/merge-rules)
+(def evaluate-external-pr builders/evaluate-external-pr)
+(def parse-pr-diff builders/parse-pr-diff)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/builders.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/builders.clj
@@ -1,0 +1,24 @@
+(ns ai.miniforge.policy-pack.interface.builders
+  "Policy-pack builders, rule resolution, and external-PR evaluation."
+  (:require
+   [ai.miniforge.policy-pack.core :as core]
+   [ai.miniforge.policy-pack.external :as external]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Builders and resolution helpers
+
+(def create-pack core/create-pack)
+(def create-rule core/create-rule)
+(def add-rule-to-pack core/add-rule-to-pack)
+(def remove-rule-from-pack core/remove-rule-from-pack)
+(def update-pack-categories core/update-pack-categories)
+(def content-scan-detection core/content-scan-detection)
+(def diff-analysis-detection core/diff-analysis-detection)
+(def plan-output-detection core/plan-output-detection)
+(def warn-enforcement core/warn-enforcement)
+(def halt-enforcement core/halt-enforcement)
+(def approval-enforcement core/approval-enforcement)
+(def resolve-rules core/resolve-rules)
+(def merge-rules core/merge-rules)
+(def evaluate-external-pr external/evaluate-external-pr)
+(def parse-pr-diff external/parse-pr-diff)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/checking.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/checking.clj
@@ -1,0 +1,18 @@
+(ns ai.miniforge.policy-pack.interface.checking
+  "Detection and artifact-checking helpers."
+  (:require
+   [ai.miniforge.policy-pack.core :as core]
+   [ai.miniforge.policy-pack.detection :as detection]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Detection and checking
+
+(def detect-violation detection/detect-violation)
+(def check-rules detection/check-rules)
+(def check-artifact core/check-artifact)
+(def check-artifacts core/check-artifacts)
+(def blocking-violations detection/blocking-violations)
+(def approval-required-violations detection/approval-required-violations)
+(def warning-violations detection/warning-violations)
+(def violation->error detection/violation->error)
+(def violation->warning detection/violation->warning)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/loading.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/loading.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.policy-pack.interface.loading
+  "Pack loading and serialization helpers."
+  (:require
+   [ai.miniforge.policy-pack.loader :as loader]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Loading operations
+
+(def load-pack loader/load-pack)
+(def load-pack-from-file loader/load-pack-from-file)
+(def load-pack-from-directory loader/load-pack-from-directory)
+(def discover-packs loader/discover-packs)
+(def load-all-packs loader/load-all-packs)
+(def write-pack-to-file loader/write-pack-to-file)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/registry.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/registry.clj
@@ -1,0 +1,19 @@
+(ns ai.miniforge.policy-pack.interface.registry
+  "Registry-facing policy-pack API."
+  (:require
+   [ai.miniforge.policy-pack.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Registry protocol and helpers
+
+(def PolicyPackRegistry registry/PolicyPackRegistry)
+(def create-registry registry/create-registry)
+(def register-pack registry/register-pack)
+(def get-pack registry/get-pack)
+(def get-pack-version registry/get-pack-version)
+(def list-packs registry/list-packs)
+(def delete-pack registry/delete-pack)
+(def resolve-pack registry/resolve-pack)
+(def get-rules-for-context registry/get-rules-for-context)
+(def glob-matches? registry/glob-matches?)
+(def compare-versions registry/compare-versions)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/schema.clj
@@ -1,0 +1,21 @@
+(ns ai.miniforge.policy-pack.interface.schema
+  "Schema and validation helpers for the policy-pack public API."
+  (:require
+   [ai.miniforge.policy-pack.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema and validation re-exports
+
+(def Rule schema/Rule)
+(def PackManifest schema/PackManifest)
+(def RuleSeverity schema/RuleSeverity)
+(def RuleEnforcement schema/RuleEnforcement)
+(def RuleApplicability schema/RuleApplicability)
+(def RuleDetection schema/RuleDetection)
+(def rule-severities schema/rule-severities)
+(def enforcement-actions schema/enforcement-actions)
+(def detection-types schema/detection-types)
+(def valid-rule? schema/valid-rule?)
+(def validate-rule schema/validate-rule)
+(def valid-pack? schema/valid-pack?)
+(def validate-pack schema/validate-pack)

--- a/components/response/src/ai/miniforge/response/translate.clj
+++ b/components/response/src/ai/miniforge/response/translate.clj
@@ -189,7 +189,7 @@
   (let [category (:anomaly/category anomaly-map)]
     {:message (:anomaly/message anomaly-map)
      :anomaly-code category
-     :retryable? (boolean (anomaly/retryable? category))
+     :retryable? (anomaly/retryable? category)
      :phase (:anomaly/phase anomaly-map)}))
 
 ;------------------------------------------------------------------------------ Layer 4

--- a/components/self-healing/src/ai/miniforge/self_healing/integration.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/integration.clj
@@ -187,7 +187,7 @@
    :workflow/id (or (:workflow/id context) (java.util.UUID/randomUUID))
    :from (:from switch-result)
    :to (:to switch-result)
-   :reason (str "Backend health below threshold")
+   :reason "Backend health below threshold"
    :cooldown-until (:cooldown-until switch-result)
    :message (str "Switched backend from " (name (:from switch-result))
                 " to " (name (:to switch-result))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
@@ -180,7 +180,7 @@
   (def sample-app
     (create-app
      {:init   (fn [] {:count 0})
-      :update (fn [model msg] model)
+      :update (fn [model _msg] model)
       :view   (fn [model [cols rows]]
                 (layout/text [cols rows]
                              (str "Count: " (:count model))))}))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/runtime.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/runtime.clj
@@ -231,6 +231,8 @@
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
+  (require '[ai.miniforge.tui-engine.layout :as layout])
+
   ;; Minimal app example
   (def my-app
     (core/create-app
@@ -244,7 +246,7 @@
                              model))
                   model))
       :view   (fn [model [cols rows]]
-                (ai.miniforge.tui-engine.layout/text [cols rows]
+                (layout/text [cols rows]
                              (str "Count: " (:count model))))}))
 
   (start! my-app)

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -90,7 +90,7 @@
                             {:evaluation/passed? nil
                              :evaluation/error (.getMessage e)}))})
              prs)))
-    (catch Exception e
+    (catch Exception _e
       (msg/review-completed []))))
 
 (defn handle-create-train [train-mgr {:keys [name description]
@@ -231,40 +231,40 @@
    based on the action type keyword."
   [{:keys [action context]}]
   (try
-    (let [action-type (:action action)]
-      (let [result (case action-type
-                     :review
-                     (if-let [pr (:pr context)]
-                       (handle-review-prs {:prs [pr]})
-                       (msg/chat-action-result {:success? false :message "No PR in context for review"}))
+    (let [action-type (:action action)
+          result (case action-type
+                   :review
+                   (if-let [pr (:pr context)]
+                     (handle-review-prs {:prs [pr]})
+                     (msg/chat-action-result {:success? false :message "No PR in context for review"}))
 
-                     :evaluate
-                     (if-let [pr (:pr context)]
-                       (handle-evaluate-policy {:pr pr :pr-id [(:pr/repo pr) (:pr/number pr)]})
-                       (msg/chat-action-result {:success? false :message "No PR in context for evaluation"}))
+                   :evaluate
+                   (if-let [pr (:pr context)]
+                     (handle-evaluate-policy {:pr pr :pr-id [(:pr/repo pr) (:pr/number pr)]})
+                     (msg/chat-action-result {:success? false :message "No PR in context for evaluation"}))
 
-                     :sync
-                     (handle-sync-prs {})
+                   :sync
+                   (handle-sync-prs {})
 
-                     :open
-                     (if-let [url (get-in context [:pr :pr/url])]
-                       (do (handle-open-url {:url url})
-                           (msg/chat-action-result {:success? true :message (str "Opened " url)}))
-                       (msg/chat-action-result {:success? false :message "No PR URL available"}))
+                   :open
+                   (if-let [url (get-in context [:pr :pr/url])]
+                     (do (handle-open-url {:url url})
+                         (msg/chat-action-result {:success? true :message (str "Opened " url)}))
+                     (msg/chat-action-result {:success? false :message "No PR URL available"}))
 
-                     :remediate
-                     (if-let [pr (:pr context)]
-                       (handle-remediate-prs {:prs [pr]})
-                       (msg/chat-action-result {:success? false :message "No PR in context"}))
+                   :remediate
+                   (if-let [pr (:pr context)]
+                     (handle-remediate-prs {:prs [pr]})
+                     (msg/chat-action-result {:success? false :message "No PR in context"}))
 
-                     :decompose
-                     (if-let [pr (:pr context)]
-                       (handle-decompose-pr {:pr pr})
-                       (msg/chat-action-result {:success? false :message "No PR in context"}))
+                   :decompose
+                   (if-let [pr (:pr context)]
+                     (handle-decompose-pr {:pr pr})
+                     (msg/chat-action-result {:success? false :message "No PR in context"}))
 
-                     (msg/chat-action-result
-                      {:success? false
-                       :message (str "Unknown action: " (name (or action-type :none)))}))]
+                   (msg/chat-action-result
+                    {:success? false
+                     :message (str "Unknown action: " (name (or action-type :none)))}))]
         (if (= :msg/side-effect-error (first result))
           (let [payload (second result)
                 message (or (get-in payload [:error :message])
@@ -272,7 +272,7 @@
                             (:error payload)
                             "Action failed")]
             (msg/chat-action-result {:success? false :message message}))
-          result)))
+          result))
     (catch Exception e
       (msg/chat-action-result {:success? false :message (.getMessage e)}))))
 

--- a/components/tui-views/src/ai/miniforge/tui_views/update.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update.clj
@@ -31,7 +31,6 @@
   (:require
    [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [clojure.set :as set]
    [clojure.string :as str]
    [ai.miniforge.tui-views.effect :as effect]
    [ai.miniforge.tui-views.model :as model]

--- a/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/events.clj
@@ -488,17 +488,17 @@
                   (assoc :agent-risk cached-risk))
         pr-hash (hash (mapv #(select-keys % [:pr/repo :pr/number :pr/additions
                                               :pr/deletions :pr/status :pr/ci-status])
-                            prs))]
-    (let [risk-changed? (and (seq prs) (not= pr-hash (:agent-risk-hash model)))
-          unevaluated-prs (filterv #(nil? (:pr/policy %)) prs)
-          effects (cond-> []
-                    risk-changed?
-                    (conj (effect/fleet-risk-triage (mapv pr-triage-summary prs)))
-                    (seq unevaluated-prs)
-                    (conj (effect/batch-evaluate-policy unevaluated-prs)))]
-      (cond-> updated
-        risk-changed?    (assoc :agent-risk-hash pr-hash)
-        (seq effects)    (assoc :side-effects effects)))))
+                            prs))
+        risk-changed? (and (seq prs) (not= pr-hash (:agent-risk-hash model)))
+        unevaluated-prs (filterv #(nil? (:pr/policy %)) prs)
+        effects (cond-> []
+                  risk-changed?
+                  (conj (effect/fleet-risk-triage (mapv pr-triage-summary prs)))
+                  (seq unevaluated-prs)
+                  (conj (effect/batch-evaluate-policy unevaluated-prs)))]
+    (cond-> updated
+      risk-changed? (assoc :agent-risk-hash pr-hash)
+      (seq effects) (assoc :side-effects effects))))
 
 (defn merge-matching-pr
   "Merge updated fields into the PR matching [repo, number]; pass others through."
@@ -707,16 +707,16 @@
                        :content (or content "No response")
                        :timestamp (java.util.Date.)
                        :actions actions-vec
-                       :workflow-id workflow-id}]
-    (let [updated (-> model
-                      (update-in [:chat :messages] conj assistant-msg)
-                      (assoc-in [:chat :pending?] false)
-                      (assoc-in [:chat :suggested-actions] actions-vec)
-                      (assoc-in [:chat :scroll-offset] nil) ;; pin to bottom on new message
-                      with-timestamp)
-          tk (get updated :chat-active-key)]
-      (cond-> updated
-        tk (assoc-in [:chat-threads tk] (:chat updated))))))
+                       :workflow-id workflow-id}
+        updated (-> model
+                    (update-in [:chat :messages] conj assistant-msg)
+                    (assoc-in [:chat :pending?] false)
+                    (assoc-in [:chat :suggested-actions] actions-vec)
+                    (assoc-in [:chat :scroll-offset] nil) ;; pin to bottom on new message
+                    with-timestamp)
+        tk (:chat-active-key updated)]
+    (cond-> updated
+      tk (assoc-in [:chat-threads tk] (:chat updated)))))
 
 (defn handle-chat-action-result
   "Handle result of a :chat-execute-action side effect.

--- a/components/tui-views/src/ai/miniforge/tui_views/view.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view.clj
@@ -87,6 +87,8 @@
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
-  (def m (ai.miniforge.tui-views.model/init-model))
+  (require '[ai.miniforge.tui-views.model :as model])
+
+  (def m (model/init-model))
   (layout/buf->strings (root-view m [80 24]))
   :leave-this-here)

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -169,42 +169,42 @@
         pr-id     [(:pr/repo pr) (:pr/number pr)]
         agent-r   (get agent-risk-map pr-id)
         ;; Use agent risk when available, fall back to mechanical
-        display-risk (if agent-r (:level agent-r) risk-lvl)]
-    (let [;; Fold GitHub PR state into the readiness indicator when it adds info.
-          ;; The readiness indicator already covers: merged, closed, draft, ci-failing,
-          ;; merge-ready, needs-review, changes-requested, behind-main, conflicts, policy-fail.
-          ;; GitHub states that add new info: :approved, :reviewing.
-          pr-status (:pr/status pr)
-          status-str (str (helpers/readiness-indicator r-state)
-                          (case pr-status
-                            :approved  " ✓"
-                            :reviewing " ⊙"
-                            ""))]
-      {:_id pr-id
-       :repo (str (get pr :pr/repo "")
-                  (when (:pr/workflow-id pr) " [mf]"))
-       :number (str "#" (:pr/number pr))
-       :title (get pr :pr/title "")
-       :status      status-str
-       :status-fg   (trees/readiness-state-color r-state)
-       :ready       (let [adds (get pr :pr/additions 0)
-                          dels (get pr :pr/deletions 0)]
-                      (if (and (zero? adds) (zero? dels))
-                        "—"
-                        (str "+" adds "/-" dels)))
-       :ready-fg    (let [total (+ (get pr :pr/additions 0) (get pr :pr/deletions 0))
-                          {:keys [red yellow green]} size-display-config]
-                      (cond
-                        (> total red)    palette/status-fail
-                        (> total yellow) palette/status-warning
-                        (> total green)  nil
-                        :else            palette/status-pass))
-       :risk        (helpers/risk-label display-risk)
-       :risk-fg     (trees/risk-level-color display-risk)
-       :policy      (helpers/policy-label policy)
-       :policy-fg   (case pol-pass? true trees/status-pass false trees/status-fail nil)
-       :recommend   (:label recommend)
-       :recommend-fg (trees/recommend-action-color (:action recommend))})))
+        display-risk (if agent-r (:level agent-r) risk-lvl)
+        ;; Fold GitHub PR state into the readiness indicator when it adds info.
+        ;; The readiness indicator already covers: merged, closed, draft, ci-failing,
+        ;; merge-ready, needs-review, changes-requested, behind-main, conflicts, policy-fail.
+        ;; GitHub states that add new info: :approved, :reviewing.
+        pr-status (:pr/status pr)
+        status-str (str (helpers/readiness-indicator r-state)
+                        (case pr-status
+                          :approved  " ✓"
+                          :reviewing " ⊙"
+                          ""))]
+    {:_id pr-id
+     :repo (str (get pr :pr/repo "")
+                (when (:pr/workflow-id pr) " [mf]"))
+     :number (str "#" (:pr/number pr))
+     :title (get pr :pr/title "")
+     :status status-str
+     :status-fg (trees/readiness-state-color r-state)
+     :ready (let [adds (get pr :pr/additions 0)
+                  dels (get pr :pr/deletions 0)]
+              (if (and (zero? adds) (zero? dels))
+                "—"
+                (str "+" adds "/-" dels)))
+     :ready-fg (let [total (+ (get pr :pr/additions 0) (get pr :pr/deletions 0))
+                     {:keys [red yellow green]} size-display-config]
+                 (cond
+                   (> total red)    palette/status-fail
+                   (> total yellow) palette/status-warning
+                   (> total green)  nil
+                   :else            palette/status-pass))
+     :risk (helpers/risk-label display-risk)
+     :risk-fg (trees/risk-level-color display-risk)
+     :policy (helpers/policy-label policy)
+     :policy-fg (case pol-pass? true trees/status-pass false trees/status-fail nil)
+     :recommend (:label recommend)
+     :recommend-fg (trees/recommend-action-color (:action recommend))}))
 
 (defn project-pr-items
   "Project PR items for the fleet table widget.

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
@@ -428,36 +428,36 @@
         wf-id    (:pr/workflow-id pr)
         branch   (:pr/branch pr)
         wfs      (get model :workflows [])
-        linked-wf (helpers/find-linked-workflow wfs wf-id branch)]
-    (let [additions (get pr :pr/additions 0)
-          deletions (get pr :pr/deletions 0)
-          total     (+ additions deletions)
-          files     (get pr :pr/changed-files-count 0)]
-      (cond-> [(tree-node (str (:pr/repo pr "") " #" (:pr/number pr "?"))
-                          0 false status-info)
-               (tree-node (str "  " (:pr/title pr "")) 0)
-               (tree-node (str "Branch: " (or branch "?")
-                               (when-let [author (:pr/author pr)]
-                                 (when (seq author) (str " by " author))))
-                          0)
-               (tree-node (str "State: " (helpers/pr-state-label (:pr/status pr))
-                               " │ Status: " (helpers/readiness-indicator r-state))
-                          0 false (readiness-state-color r-state))
-               (tree-node (str "Risk: " (name risk-lvl)
-                               " │ Score: " (int (* 100 (get readiness :readiness/score 0))) "%"
-                               (when (pos? total)
-                                 (str " │ +" additions "/-" deletions
-                                      (when (pos? files) (str " " files " files")))))
-                          0 false (risk-level-color risk-lvl))]
-        recommend
-        (conj (tree-node (str "Action: " (:label recommend) " — " (:reason recommend))
-                         0 false (recommend-action-color (:action recommend))))
-        linked-wf
-        (conj (tree-node (str "Workflow: " (:name linked-wf)
-                              " (" (name (get linked-wf :status :unknown)) ")")
-                         0 false status-info))
-        (not linked-wf)
-        (conj (tree-node "Workflow: not linked" 0))))))
+        linked-wf (helpers/find-linked-workflow wfs wf-id branch)
+        additions (get pr :pr/additions 0)
+        deletions (get pr :pr/deletions 0)
+        total     (+ additions deletions)
+        files     (get pr :pr/changed-files-count 0)]
+    (cond-> [(tree-node (str (:pr/repo pr "") " #" (:pr/number pr "?"))
+                        0 false status-info)
+             (tree-node (str "  " (:pr/title pr "")) 0)
+             (tree-node (str "Branch: " (or branch "?")
+                             (when-let [author (:pr/author pr)]
+                               (when (seq author) (str " by " author))))
+                        0)
+             (tree-node (str "State: " (helpers/pr-state-label (:pr/status pr))
+                             " │ Status: " (helpers/readiness-indicator r-state))
+                        0 false (readiness-state-color r-state))
+             (tree-node (str "Risk: " (name risk-lvl)
+                             " │ Score: " (int (* 100 (get readiness :readiness/score 0))) "%"
+                             (when (pos? total)
+                               (str " │ +" additions "/-" deletions
+                                    (when (pos? files) (str " " files " files")))))
+                        0 false (risk-level-color risk-lvl))]
+      recommend
+      (conj (tree-node (str "Action: " (:label recommend) " — " (:reason recommend))
+                       0 false (recommend-action-color (:action recommend))))
+      linked-wf
+      (conj (tree-node (str "Workflow: " (:name linked-wf)
+                            " (" (name (get linked-wf :status :unknown)) ")")
+                       0 false status-info))
+      (not linked-wf)
+      (conj (tree-node "Workflow: not linked" 0)))))
 
 (defn project-evidence-tree
   "Build evidence tree nodes."
@@ -529,19 +529,19 @@
                                                        (str " — " description)))]
                                        (mapv #(tree-node (str "  " %) 1 false status-info)
                                              (helpers/wrap-text text wrap-width))))
-                                   (range) actions)))]
-        (let [nodes (cond-> (vec msg-nodes)
-                      (seq action-nodes) (into action-nodes))]
-          (if pending?
-            (let [since   (get-in model [:chat :pending-since])
-                  elapsed (if since
-                            (quot (- (System/currentTimeMillis) since) 1000)
-                            0)
-                  spinner (get ["⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏"]
-                               (mod elapsed 10))
-                  label   (str spinner " Agent thinking... (" elapsed "s)")]
-              (conj nodes (tree-node label 0 false status-warning)))
-            nodes))))))
+                                   (range) actions)))
+            nodes (cond-> (vec msg-nodes)
+                    (seq action-nodes) (into action-nodes))
+            since (get-in model [:chat :pending-since])
+            elapsed (if since
+                      (quot (- (System/currentTimeMillis) since) 1000)
+                      0)
+            spinner (get ["⠋" "⠙" "⠹" "⠸" "⠼" "⠴" "⠦" "⠧" "⠇" "⠏"]
+                         (mod elapsed 10))
+            label   (str spinner " Agent thinking... (" elapsed "s)")]
+        (if pending?
+          (conj nodes (tree-node label 0 false status-warning))
+          nodes)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/views/workflow_list.clj
@@ -197,22 +197,21 @@
         selected (:selected-idx model)
         active-chain (:active-chain model)
         flash (:flash-message model)
-        search-active? (and (:filtered-indices model) (= :search (:mode model)))]
-    (let [render-header-bar
-          (fn [[tc tr]]
-            (layout/text [tc tr]
-              (str " MINIFORGE │ Workflows"
-                   (when search-active? (str " [" (count workflows) " matches]")))
-              {:fg palette/status-info :bold? true}))
-
-          render-content-area
-          (fn [[c r]]
-            (layout/split-v [c r] (/ (- r 2.0) r)
-              (fn [size] (render-table workflows selected active-chain size))
-              (fn [size] (render-footer flash size))))]
-      (layout/split-v [cols rows] (/ 2.0 rows)
+        search-active? (and (:filtered-indices model) (= :search (:mode model)))
         render-header-bar
-        render-content-area))))
+        (fn [[tc tr]]
+          (layout/text [tc tr]
+            (str " MINIFORGE │ Workflows"
+                 (when search-active? (str " [" (count workflows) " matches]")))
+            {:fg palette/status-info :bold? true}))
+        render-content-area
+        (fn [[c r]]
+          (layout/split-v [c r] (/ (- r 2.0) r)
+            (fn [size] (render-table workflows selected active-chain size))
+            (fn [size] (render-footer flash size))))]
+    (layout/split-v [cols rows] (/ 2.0 rows)
+      render-header-bar
+      render-content-area)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/src/ai/miniforge/workflow/interface.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface.clj
@@ -1,585 +1,70 @@
 (ns ai.miniforge.workflow.interface
-  "Public API for the workflow component.
-   Handles SDLC phase execution: Plan → Design → Implement → Verify → Review → Release → Observe"
+  "Canonical public boundary for the workflow component.
+   Public API groups live under ai.miniforge.workflow.interface.* namespaces,
+   while this namespace remains the Polylith entrypoint."
   (:require
-   [ai.miniforge.workflow.core :as core]
-   [ai.miniforge.workflow.persistence :as persist]
-   [ai.miniforge.workflow.replay :as replay]
-   [ai.miniforge.workflow.registry :as registry]
-   [ai.miniforge.workflow.schemas :as schemas]
-   [ai.miniforge.workflow.interface.protocols.workflow :as workflow-proto]
-   [ai.miniforge.workflow.interface.protocols.phase-executor :as executor-proto]
-   [ai.miniforge.workflow.interface.protocols.workflow-observer :as observer-proto]
-   [ai.miniforge.workflow.protocols.impl.workflow :as workflow-impl]))
+   [ai.miniforge.workflow.interface.configurable :as configurable]
+   [ai.miniforge.workflow.interface.pipeline :as pipeline]
+   [ai.miniforge.workflow.interface.protocols :as protocols]
+   [ai.miniforge.workflow.interface.registry :as registry]
+   [ai.miniforge.workflow.interface.runtime :as runtime]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Protocol re-exports
+;; Protocols and workflow topology
 
-(def Workflow workflow-proto/Workflow)
-(def PhaseExecutor executor-proto/PhaseExecutor)
-(def WorkflowObserver observer-proto/WorkflowObserver)
-
-;; Phase definitions
-(def phases workflow-impl/phases)
-(def phase-transitions workflow-impl/phase-transitions)
+(def Workflow protocols/Workflow)
+(def PhaseExecutor protocols/PhaseExecutor)
+(def WorkflowObserver protocols/WorkflowObserver)
+(def phases protocols/phases)
+(def phase-transitions protocols/phase-transitions)
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Workflow creation
+;; Workflow lifecycle and execution
 
-(def create-workflow
-  "Create a workflow manager.
-
-   Options:
-   - :max-iterations-per-phase - Max inner loop iterations per phase (default 5)
-   - :max-rollbacks - Max rollbacks before failure (default 3)
-   - :timeout-per-phase-ms - Timeout per phase in ms (default 10 minutes)
-
-   Example:
-     (create-workflow)
-     (create-workflow {:max-rollbacks 5})"
-  core/create-workflow)
-
-(def add-observer
-  "Add a workflow observer for meta-loop integration.
-   Observers receive callbacks on phase transitions and completions."
-  core/add-observer)
-
-(def remove-observer
-  "Remove a workflow observer."
-  core/remove-observer)
+(def create-workflow runtime/create-workflow)
+(def add-observer runtime/add-observer)
+(def remove-observer runtime/remove-observer)
+(def start runtime/start)
+(def get-state runtime/get-state)
+(def advance runtime/advance)
+(def rollback runtime/rollback)
+(def complete runtime/complete)
+(def fail runtime/fail)
+(def create-phase-executor runtime/create-phase-executor)
+(def execute-phase runtime/execute-phase)
+(def can-execute? runtime/can-execute?)
+(def get-phase-requirements runtime/get-phase-requirements)
+(def run-workflow runtime/run-workflow)
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Workflow operations
-
-(defn start
-  "Start a new workflow from a specification.
-
-   Arguments:
-   - workflow - Workflow instance
-   - spec - Map with :title and :description
-   - context - Execution context
-
-   Returns workflow-id."
-  [workflow spec context]
-  (workflow-proto/start workflow spec context))
-
-(defn get-state
-  "Get current workflow state.
-
-   Returns:
-     {:workflow/id uuid
-      :workflow/phase keyword
-      :workflow/status keyword (:pending :running :completed :failed)
-      :workflow/artifacts []
-      :workflow/errors []
-      :workflow/metrics {:tokens :cost-usd :duration-ms}
-      :workflow/history []}"
-  [workflow workflow-id]
-  (workflow-proto/get-state workflow workflow-id))
-
-(defn advance
-  "Advance workflow based on phase execution result.
-
-   phase-result:
-     {:success? bool
-      :artifacts []
-      :errors []
-      :metrics {}}
-
-   Returns updated workflow state."
-  [workflow workflow-id phase-result]
-  (workflow-proto/advance workflow workflow-id phase-result))
-
-(defn rollback
-  "Rollback workflow to a previous phase.
-
-   Arguments:
-   - workflow - Workflow instance
-   - workflow-id - Workflow identifier
-   - target-phase - Phase to rollback to
-   - reason - Reason for rollback
-
-   Returns updated workflow state."
-  [workflow workflow-id target-phase reason]
-  (workflow-proto/rollback workflow workflow-id target-phase reason))
-
-(defn complete
-  "Mark workflow as complete.
-   Returns final workflow state."
-  [workflow workflow-id]
-  (workflow-proto/complete workflow workflow-id))
-
-(defn fail
-  "Mark workflow as failed.
-   Returns final workflow state."
-  [workflow workflow-id error]
-  (workflow-proto/fail workflow workflow-id error))
-
-;------------------------------------------------------------------------------ Layer 3
-;; Phase execution
-
-(def create-phase-executor
-  "Create a phase executor for a specific phase.
-
-   Arguments:
-   - phase - Phase keyword (:plan :implement :verify etc.)
-   - llm-backend - LLM backend for agent execution
-
-   Returns PhaseExecutor or nil if phase not supported."
-  core/create-phase-executor)
-
-(defn execute-phase
-  "Execute a phase using an executor.
-
-   Returns:
-     {:success? bool
-      :artifacts []
-      :errors []
-      :metrics {}}"
-  [executor workflow-state context]
-  (executor-proto/execute-phase executor workflow-state context))
-
-(defn can-execute?
-  "Check if an executor can handle a phase."
-  [executor phase]
-  (executor-proto/can-execute? executor phase))
-
-(defn get-phase-requirements
-  "Get required inputs for a phase."
-  [executor phase]
-  (executor-proto/get-phase-requirements executor phase))
-
-;------------------------------------------------------------------------------ Layer 4
-;; Workflow runner
-
-(def run-workflow
-  "Run a complete workflow from spec to completion.
-
-   Arguments:
-   - workflow - Workflow instance
-   - spec - Specification map {:title :description}
-   - context - Execution context {:llm-backend :budget :tags}
-
-   Returns final workflow state.
-
-   Example:
-     (def wf (create-workflow))
-     (run-workflow wf
-                   {:title \"Create greeting function\"
-                    :description \"A function that says hello\"}
-                   {:llm-backend llm-client})"
-  core/run-workflow)
-
-;------------------------------------------------------------------------------ Layer 5
-;; Interceptor-based workflow API (Simplified)
-
-(defn run-pipeline
-  "Execute a workflow using interceptor pipeline.
-
-   This is the new simplified API using phase and gate interceptors.
-   Workflows are defined as vectors of phase configurations.
-
-   Arguments:
-   - workflow: Workflow configuration with :workflow/pipeline
-   - input: Input data for the workflow
-   - opts: Execution options
-     - :max-phases - Max phases to execute (default 50)
-     - :on-phase-start - Callback fn [ctx interceptor]
-     - :on-phase-complete - Callback fn [ctx interceptor result]
-
-   Returns execution context with:
-   - :execution/status - :completed or :failed
-   - :execution/phase-results - Results per phase
-   - :execution/artifacts - All artifacts produced
-   - :execution/metrics - Accumulated metrics
-
-   Example:
-     (def workflow
-       {:workflow/id :simple
-        :workflow/version \"2.0.0\"
-        :workflow/pipeline
-        [{:phase :plan}
-         {:phase :implement}
-         {:phase :done}]})
-     (run-pipeline workflow {:task \"Build feature\"} {})"
-  ([workflow input]
-   (run-pipeline workflow input {}))
-  ([workflow input opts]
-   ((requiring-resolve 'ai.miniforge.workflow.runner/run-pipeline)
-    workflow input opts)))
-
-(defn build-pipeline
-  "Build interceptor pipeline from workflow config.
-
-   Arguments:
-   - workflow: Workflow configuration with :workflow/pipeline
-
-   Returns vector of interceptor maps.
-
-   Example:
-     (build-pipeline {:workflow/pipeline [{:phase :plan} {:phase :implement}]})"
-  [workflow]
-  ((requiring-resolve 'ai.miniforge.workflow.runner/build-pipeline) workflow))
-
-(defn validate-pipeline
-  "Validate a workflow pipeline configuration.
-
-   Arguments:
-   - workflow: Workflow configuration with :workflow/pipeline
-
-   Returns {:valid? bool :errors []}"
-  [workflow]
-  ((requiring-resolve 'ai.miniforge.workflow.runner/validate-pipeline) workflow))
-
-(defn run-chain
-  "Execute a chain of workflows sequentially.
-   See workflow.chain for details."
-  [chain-def chain-input opts]
-  ((requiring-resolve 'ai.miniforge.workflow.chain/run-chain)
-   chain-def chain-input opts))
-
-(defn load-chain
-  "Load a chain definition by ID and version from classpath resources.
-   Returns {:chain chain-def :source :resource :path resource-path}."
-  [chain-id version]
-  ((requiring-resolve 'ai.miniforge.workflow.chain-loader/load-chain)
-   chain-id version))
-
-(defn list-chains
-  "List all available chain definitions from classpath."
-  []
-  ((requiring-resolve 'ai.miniforge.workflow.chain-loader/list-chains)))
-
-;------------------------------------------------------------------------------ Layer 6
-;; Configurable workflow API (Legacy)
-
-(defn load-workflow
-  "Load a workflow configuration by ID and version.
-   Loads from resources or heuristic store with caching and validation.
-
-   Arguments:
-   - workflow-id: Workflow identifier (keyword)
-   - version: Version string or :latest
-   - opts: Options map
-     - :store - Optional heuristic store
-     - :skip-cache? - Skip cache lookup
-     - :skip-validation? - Skip validation
-
-   Returns:
-   {:workflow workflow-config
-    :source :resource | :store | :cache
-    :validation {:valid? boolean :errors []}}
-
-   Example:
-     (load-workflow :canonical-sdlc-v1 \"1.0.0\" {})
-     (load-workflow :custom-workflow \"2.0.0\" {:store my-store})"
-  ([workflow-id version]
-   (load-workflow workflow-id version {}))
-  ([workflow-id version opts]
-   ((requiring-resolve 'ai.miniforge.workflow.loader/load-workflow)
-    workflow-id version opts)))
-
-(defn execute-workflow
-  "Execute a configurable workflow.
-
-   Arguments:
-   - workflow: Workflow configuration (from load-workflow)
-   - input: Input data for the workflow
-   - opts: Execution options
-     - :max-phases - Max phases to execute (default 50)
-     - :on-phase-start - Callback fn [exec-state phase]
-     - :on-phase-complete - Callback fn [exec-state phase result]
-
-   Returns execution state with:
-   - :execution/status - :completed or :failed
-   - :execution/phase-results - Results per phase
-   - :execution/artifacts - All artifacts produced
-   - :execution/metrics - Accumulated metrics
-
-   Example:
-     (def workflow-result (load-workflow :canonical-sdlc-v1 \"1.0.0\" {}))
-     (execute-workflow (:workflow workflow-result)
-                       {:task \"Build feature\"}
-                       {})"
-  ([workflow input]
-   (execute-workflow workflow input {}))
-  ([workflow input opts]
-   ((requiring-resolve 'ai.miniforge.workflow.configurable/run-configurable-workflow)
-    workflow input opts)))
-
-(defn get-active-workflow
-  "Get the active workflow configuration for a task type.
-
-   Arguments:
-   - task-type: Task type keyword (e.g., :feature, :bugfix)
-
-   Returns map {:workflow-id :version} or nil if not set.
-
-   Example:
-     (get-active-workflow :feature)
-     ;; => {:workflow-id :canonical-sdlc-v1 :version \"1.0.0\"}"
-  [task-type]
-  (persist/get-active-workflow-id task-type))
-
-(defn set-active-workflow
-  "Set the active workflow for a task type.
-
-   Arguments:
-   - task-type: Task type keyword (e.g., :feature, :bugfix)
-   - workflow-id: Workflow identifier
-   - version: Workflow version
-
-   Returns true on success, false on error.
-
-   Example:
-     (set-active-workflow :feature :canonical-sdlc-v1 \"1.0.0\")
-     (set-active-workflow :bugfix :simple-test-v1 \"1.0.0\")"
-  [task-type workflow-id version]
-  (persist/set-active-workflow task-type workflow-id version))
-
-;; Event log persistence
-
-(defn append-event
-  "Append an event to a workflow's event log.
-   Events are stored in ~/.miniforge/workflows/events/<workflow-id>.edn
-   
-   Arguments:
-   - workflow-id - Workflow UUID
-   - event - Log event map
-   
-   Returns true on success."
-  [workflow-id event]
-  (persist/append-event workflow-id event))
-
-(defn load-event-log
-  "Load all events for a workflow.
-   
-   Arguments:
-   - workflow-id - Workflow UUID
-   
-   Returns vector of events, or empty vector if no log exists."
-  [workflow-id]
-  (persist/load-event-log workflow-id))
-
-;; Event stream replay
-
-(defn replay-workflow
-  "Reconstruct workflow state from event stream.
-   
-   Arguments:
-   - events - All events for this workflow
-   - opts   - Options map:
-     :workflow-id - Filter to specific workflow (optional)
-     :until       - Replay only up to this timestamp (optional)
-   
-   Returns:
-   {:state workflow-state
-    :events-applied int
-    :final-status keyword}
-   
-   Example:
-     (replay-workflow (load-event-log wf-id) :workflow-id wf-id)"
-  [events & {:keys [workflow-id until] :as _opts}]
-  (replay/replay-workflow events :workflow-id workflow-id :until until))
-
-(defn verify-determinism
-  "Verify that replaying events produces the expected state.
-   
-   Arguments:
-   - events - Event stream
-   - expected-state - Expected final state
-   - & opts - Keyword options for replay
-   
-   Returns:
-   {:deterministic? boolean
-    :differences [...]
-    :replayed-state map}
-   
-   Example:
-     (verify-determinism events final-state :workflow-id wf-id)"
-  [events expected-state & {:keys [workflow-id until] :as _opts}]
-  (replay/verify-determinism events expected-state :workflow-id workflow-id :until until))
-
-(defn save-workflow
-  "Save a workflow configuration to the heuristic store.
-
-   Arguments:
-   - workflow: Workflow configuration map
-   - opts: Optional map with :store
-
-   Returns UUID of saved workflow.
-
-   Example:
-     (def my-workflow {...})
-     (save-workflow my-workflow {})"
-  ([workflow]
-   (save-workflow workflow {}))
-  ([workflow opts]
-   ((requiring-resolve 'ai.miniforge.workflow.comparison/save-workflow)
-    workflow opts)))
-
-(defn list-workflows
-  "List available workflow configurations.
-
-   Returns vector of workflow metadata maps:
-   [{:workflow/id keyword
-     :workflow/version string
-     :workflow/type keyword
-     :workflow/description string}]
-
-   Example:
-     (list-workflows)
-     ;; => [{:workflow/id :canonical-sdlc-v1
-     ;;      :workflow/version \"1.0.0\"
-     ;;      :workflow/type :feature
-     ;;      :workflow/description \"...\"}]"
-  []
-  ((requiring-resolve 'ai.miniforge.workflow.loader/list-available-workflows)))
-
-(defn compare-workflows
-  "Compare execution results from multiple workflow runs.
-
-   Arguments:
-   - execution-states: Vector of execution states to compare
-
-   Returns comparison map with:
-   - :executions - Vector of execution summaries
-   - :comparison - Side-by-side metrics comparison
-
-   Example:
-     (def exec1 (execute-workflow workflow1 input {}))
-     (def exec2 (execute-workflow workflow2 input {}))
-     (compare-workflows [exec1 exec2])"
-  [execution-states]
-  ((requiring-resolve 'ai.miniforge.workflow.comparison/compare-workflows)
-   execution-states))
-
-;------------------------------------------------------------------------------ Layer 6b
-;; Event-driven triggers
-
-(defn create-merge-trigger
-  "Create a merge trigger that subscribes to an event stream.
-
-   Arguments:
-   - event-stream: Event stream to subscribe to
-   - trigger-config: {:triggers [{:on :pr/merged :repo ... :run {...}}]}
-   - opts: Options map, passed to workflow execution
-
-   Returns {:subscriber-id keyword, :stop-fn (fn [])}
-
-   Example:
-     (def trigger (create-merge-trigger stream
-                    {:triggers [{:on :pr/merged
-                                 :repo \"my-org/my-repo\"
-                                 :run {:workflow-id :deploy-v1
-                                       :version \"1.0.0\"
-                                       :input-from-event {:branch :pr/branch}}}]}
-                    {}))
-     ;; Later:
-     (stop-trigger! trigger)"
-  [event-stream trigger-config opts]
-  ((requiring-resolve 'ai.miniforge.workflow.trigger/create-merge-trigger)
-   event-stream trigger-config opts))
-
-(defn stop-trigger!
-  "Stop a merge trigger. Unsubscribes and cancels pending work."
-  [trigger]
-  ((requiring-resolve 'ai.miniforge.workflow.trigger/stop-trigger!) trigger))
-
-;------------------------------------------------------------------------------ Layer 7
-;; Workflow registry
-
-(def register-workflow!
-  "Register a workflow in the registry.
-   See workflow.registry for details."
-  registry/register-workflow!)
-
-(def get-workflow
-  "Get a workflow by ID from the registry.
-   See workflow.registry for details."
-  registry/get-workflow)
-
-(def list-workflow-ids
-  "List all registered workflow IDs.
-   See workflow.registry for details."
-  registry/list-workflow-ids)
-
-(def workflow-exists?
-  "Check if a workflow is registered.
-   See workflow.registry for details."
-  registry/workflow-exists?)
-
-(def workflow-characteristics
-  "Extract characteristics from workflow for selection.
-   See workflow.registry for details."
-  registry/workflow-characteristics)
-
-(def ensure-initialized!
-  "Ensure the registry is initialized (idempotent).
-   See workflow.registry for details."
-  registry/ensure-initialized!)
-
-;------------------------------------------------------------------------------ Layer 8
-;; Workflow schemas
-
-(def valid-recommendation?
-  "Check if a value is a valid workflow recommendation.
-   See workflow.schemas for details."
-  schemas/valid-recommendation?)
-
-(def explain-recommendation
-  "Get human-readable explanation of validation errors for recommendation.
-   See workflow.schemas for details."
-  schemas/explain-recommendation)
-
-;------------------------------------------------------------------------------ Rich Comment
-(comment
-  (require '[ai.miniforge.llm.interface :as llm])
-
-  ;; Create workflow
-  (def wf (create-workflow))
-
-  ;; Mock LLM
-  (def llm-client (llm/mock-client {:output "Mock response"}))
-
-  ;; Start workflow
-  (def wf-id (start wf {:title "Test" :description "Test workflow"} {}))
-
-  ;; Get state
-  (get-state wf wf-id)
-
-  ;; Run full workflow
-  (run-workflow wf
-                {:title "Create greeting function"
-                 :description "A function that says hello"}
-                {:llm-backend llm-client})
-
-  ;; Layer 2 API - Configurable workflows
-
-  ;; List available workflows
-  (list-workflows)
-
-  ;; Load workflow
-  (def workflow-result (load-workflow :canonical-sdlc-v1 "1.0.0" {}))
-  (:source workflow-result)
-  (:workflow workflow-result)
-
-  ;; Execute workflow
-  (def exec-state
-    (execute-workflow (:workflow workflow-result)
-                      {:task "Build feature"}
-                      {}))
-
-  (:execution/status exec-state)
-  (:execution/metrics exec-state)
-
-  ;; Active workflow management
-  (set-active-workflow :feature :canonical-sdlc-v1 "1.0.0")
-  (get-active-workflow :feature)
-
-  ;; Compare workflows
-  (def exec1 (execute-workflow (:workflow workflow-result) {:task "Test 1"} {}))
-  (def exec2 (execute-workflow (:workflow workflow-result) {:task "Test 2"} {}))
-  (compare-workflows [exec1 exec2])
-
-  :end)
+;; Pipeline, configurable workflows, persistence, and registry helpers
+
+(def run-pipeline pipeline/run-pipeline)
+(def build-pipeline pipeline/build-pipeline)
+(def validate-pipeline pipeline/validate-pipeline)
+(def run-chain pipeline/run-chain)
+(def load-chain pipeline/load-chain)
+(def list-chains pipeline/list-chains)
+
+(def load-workflow configurable/load-workflow)
+(def execute-workflow configurable/execute-workflow)
+(def get-active-workflow configurable/get-active-workflow)
+(def set-active-workflow configurable/set-active-workflow)
+(def append-event configurable/append-event)
+(def load-event-log configurable/load-event-log)
+(def replay-workflow configurable/replay-workflow)
+(def verify-determinism configurable/verify-determinism)
+(def save-workflow configurable/save-workflow)
+(def list-workflows configurable/list-workflows)
+(def compare-workflows configurable/compare-workflows)
+(def create-merge-trigger configurable/create-merge-trigger)
+(def stop-trigger! configurable/stop-trigger!)
+
+(def register-workflow! registry/register-workflow!)
+(def get-workflow registry/get-workflow)
+(def list-workflow-ids registry/list-workflow-ids)
+(def workflow-exists? registry/workflow-exists?)
+(def workflow-characteristics registry/workflow-characteristics)
+(def ensure-initialized! registry/ensure-initialized!)
+(def valid-recommendation? registry/valid-recommendation?)
+(def explain-recommendation registry/explain-recommendation)

--- a/components/workflow/src/ai/miniforge/workflow/interface/configurable.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/configurable.clj
@@ -1,0 +1,60 @@
+(ns ai.miniforge.workflow.interface.configurable
+  "Configurable workflow loading, execution, persistence, and triggers."
+  (:require
+   [ai.miniforge.workflow.persistence :as persist]
+   [ai.miniforge.workflow.replay :as replay]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Configurable workflows and persistence
+
+(defn load-workflow
+  ([workflow-id version]
+   (load-workflow workflow-id version {}))
+  ([workflow-id version opts]
+   ((requiring-resolve 'ai.miniforge.workflow.loader/load-workflow)
+    workflow-id version opts)))
+
+(defn execute-workflow
+  ([workflow input]
+   (execute-workflow workflow input {}))
+  ([workflow input opts]
+   ((requiring-resolve 'ai.miniforge.workflow.configurable/run-configurable-workflow)
+    workflow input opts)))
+
+(def get-active-workflow persist/get-active-workflow-id)
+(def set-active-workflow persist/set-active-workflow)
+(def append-event persist/append-event)
+(def load-event-log persist/load-event-log)
+
+(defn replay-workflow
+  [events & {:keys [workflow-id until] :as _opts}]
+  (replay/replay-workflow events :workflow-id workflow-id :until until))
+
+(defn verify-determinism
+  [events expected-state & {:keys [workflow-id until] :as _opts}]
+  (replay/verify-determinism events expected-state :workflow-id workflow-id :until until))
+
+(defn save-workflow
+  ([workflow]
+   (save-workflow workflow {}))
+  ([workflow opts]
+   ((requiring-resolve 'ai.miniforge.workflow.comparison/save-workflow)
+    workflow opts)))
+
+(defn list-workflows
+  []
+  ((requiring-resolve 'ai.miniforge.workflow.loader/list-available-workflows)))
+
+(defn compare-workflows
+  [execution-states]
+  ((requiring-resolve 'ai.miniforge.workflow.comparison/compare-workflows)
+   execution-states))
+
+(defn create-merge-trigger
+  [event-stream trigger-config opts]
+  ((requiring-resolve 'ai.miniforge.workflow.trigger/create-merge-trigger)
+   event-stream trigger-config opts))
+
+(defn stop-trigger!
+  [trigger]
+  ((requiring-resolve 'ai.miniforge.workflow.trigger/stop-trigger!) trigger))

--- a/components/workflow/src/ai/miniforge/workflow/interface/pipeline.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/pipeline.clj
@@ -1,0 +1,25 @@
+(ns ai.miniforge.workflow.interface.pipeline
+  "Interceptor-pipeline workflow APIs."
+  (:require
+   [ai.miniforge.workflow.runner :as runner]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pipeline API
+
+(def run-pipeline runner/run-pipeline)
+(def build-pipeline runner/build-pipeline)
+(def validate-pipeline runner/validate-pipeline)
+
+(defn run-chain
+  [chain-def chain-input opts]
+  ((requiring-resolve 'ai.miniforge.workflow.chain/run-chain)
+   chain-def chain-input opts))
+
+(defn load-chain
+  [chain-id version]
+  ((requiring-resolve 'ai.miniforge.workflow.chain-loader/load-chain)
+   chain-id version))
+
+(defn list-chains
+  []
+  ((requiring-resolve 'ai.miniforge.workflow.chain-loader/list-chains)))

--- a/components/workflow/src/ai/miniforge/workflow/interface/protocols.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/protocols.clj
@@ -1,0 +1,16 @@
+(ns ai.miniforge.workflow.interface.protocols
+  "Workflow protocol and schema-adjacent re-exports."
+  (:require
+   [ai.miniforge.workflow.interface.protocols.phase-executor :as executor-proto]
+   [ai.miniforge.workflow.interface.protocols.workflow :as workflow-proto]
+   [ai.miniforge.workflow.interface.protocols.workflow-observer :as observer-proto]
+   [ai.miniforge.workflow.protocols.impl.workflow :as workflow-impl]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Protocol re-exports
+
+(def Workflow workflow-proto/Workflow)
+(def PhaseExecutor executor-proto/PhaseExecutor)
+(def WorkflowObserver observer-proto/WorkflowObserver)
+(def phases workflow-impl/phases)
+(def phase-transitions workflow-impl/phase-transitions)

--- a/components/workflow/src/ai/miniforge/workflow/interface/registry.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/registry.clj
@@ -1,0 +1,17 @@
+(ns ai.miniforge.workflow.interface.registry
+  "Workflow registry and schema-adjacent helpers."
+  (:require
+   [ai.miniforge.workflow.registry :as registry]
+   [ai.miniforge.workflow.schemas :as schemas]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Registry and schema helpers
+
+(def register-workflow! registry/register-workflow!)
+(def get-workflow registry/get-workflow)
+(def list-workflow-ids registry/list-workflow-ids)
+(def workflow-exists? registry/workflow-exists?)
+(def workflow-characteristics registry/workflow-characteristics)
+(def ensure-initialized! registry/ensure-initialized!)
+(def valid-recommendation? schemas/valid-recommendation?)
+(def explain-recommendation schemas/explain-recommendation)

--- a/components/workflow/src/ai/miniforge/workflow/interface/runtime.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/runtime.clj
@@ -1,0 +1,51 @@
+(ns ai.miniforge.workflow.interface.runtime
+  "Workflow creation, lifecycle, and phase execution API."
+  (:require
+   [ai.miniforge.workflow.core :as core]
+   [ai.miniforge.workflow.interface.protocols.phase-executor :as executor-proto]
+   [ai.miniforge.workflow.interface.protocols.workflow :as workflow-proto]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Workflow lifecycle
+
+(def create-workflow core/create-workflow)
+(def add-observer core/add-observer)
+(def remove-observer core/remove-observer)
+(def create-phase-executor core/create-phase-executor)
+(def run-workflow core/run-workflow)
+
+(defn start
+  [workflow spec context]
+  (workflow-proto/start workflow spec context))
+
+(defn get-state
+  [workflow workflow-id]
+  (workflow-proto/get-state workflow workflow-id))
+
+(defn advance
+  [workflow workflow-id phase-result]
+  (workflow-proto/advance workflow workflow-id phase-result))
+
+(defn rollback
+  [workflow workflow-id target-phase reason]
+  (workflow-proto/rollback workflow workflow-id target-phase reason))
+
+(defn complete
+  [workflow workflow-id]
+  (workflow-proto/complete workflow workflow-id))
+
+(defn fail
+  [workflow workflow-id error]
+  (workflow-proto/fail workflow workflow-id error))
+
+(defn execute-phase
+  [executor workflow-state context]
+  (executor-proto/execute-phase executor workflow-state context))
+
+(defn can-execute?
+  [executor phase]
+  (executor-proto/can-execute? executor phase))
+
+(defn get-phase-requirements
+  [executor phase]
+  (executor-proto/get-phase-requirements executor phase))

--- a/docs/pull-requests/2026-03-10-codex-repo-health-scan.md
+++ b/docs/pull-requests/2026-03-10-codex-repo-health-scan.md
@@ -1,0 +1,55 @@
+# refactor: Repo Health Scan Cleanup
+
+**Branch:** `codex/repo-health-scan`
+**Base:** `main`
+**Date:** 2026-03-10
+**Layer:** Application / Adapter cleanup
+
+## Overview
+
+Reduces accumulated repo-health drift by cleaning current source lint warnings
+and decomposing oversized interface namespaces while preserving each
+`interface.clj` file as the canonical Polylith component boundary.
+
+## Motivation
+
+The audit surfaced two concrete classes of problems:
+
+- source namespaces with active lint warnings
+- very large `interface.clj` namespaces that have drifted into "god interface"
+  territory, making the public boundary harder to reason about and maintain
+
+This work keeps the public API stable but restructures the implementation
+surface underneath it so the interface remains the boundary rather than the
+place where all public logic accumulates.
+
+## Changes In Detail
+
+- fix source lint warnings in the currently affected `response`,
+  `self-healing`, `tui-engine`, and `tui-views` namespaces
+- split oversized `agent`, `event-stream`, `workflow`, and `policy-pack`
+  interface namespaces into focused `...interface.*` subnamespaces
+- keep `interface.clj` as the canonical public entrypoint with thin forwarding
+  and composition
+- preserve behavior while reducing namespace size and layer sprawl
+
+## Testing Plan
+
+- [x] `clj-kondo --lint ...` for affected sources
+- [x] `bb scripts/test-changed-bricks.bb`
+- [x] spot-check public interface entrypoints through component test suites
+
+## Deployment Plan
+
+No special deployment steps.
+
+## Related Issues/PRs
+
+- follow-up to the merged agent/model default cleanup work
+
+## Checklist
+
+- [x] PR doc added
+- [x] source lint warnings cleaned up
+- [x] oversized interface namespaces decomposed
+- [x] verification passing


### PR DESCRIPTION
# refactor: Repo Health Scan Cleanup

**Branch:** `codex/repo-health-scan`
**Base:** `main`
**Date:** 2026-03-10
**Layer:** Application / Adapter cleanup

## Overview

Reduces accumulated repo-health drift by cleaning current source lint warnings
and decomposing oversized interface namespaces while preserving each
`interface.clj` file as the canonical Polylith component boundary.

## Motivation

The audit surfaced two concrete classes of problems:

- source namespaces with active lint warnings
- very large `interface.clj` namespaces that have drifted into "god interface"
  territory, making the public boundary harder to reason about and maintain

This work keeps the public API stable but restructures the implementation
surface underneath it so the interface remains the boundary rather than the
place where all public logic accumulates.

## Changes In Detail

- fix source lint warnings in the currently affected `response`,
  `self-healing`, `tui-engine`, and `tui-views` namespaces
- split oversized `agent`, `event-stream`, `workflow`, and `policy-pack`
  interface namespaces into focused `...interface.*` subnamespaces
- keep `interface.clj` as the canonical public entrypoint with thin forwarding
  and composition
- preserve behavior while reducing namespace size and layer sprawl

## Testing Plan

- [x] `clj-kondo --lint ...` for affected sources
- [x] `bb scripts/test-changed-bricks.bb`
- [x] spot-check public interface entrypoints through component test suites

## Deployment Plan

No special deployment steps.

## Related Issues/PRs

- follow-up to the merged agent/model default cleanup work

## Checklist

- [x] PR doc added
- [x] source lint warnings cleaned up
- [x] oversized interface namespaces decomposed
- [x] verification passing
