### PR TITLE
refactor: move state profiles into resources

### DIFF
--- a/components/dag-executor/resources/config/dag-executor/state-profiles/kernel.edn
+++ b/components/dag-executor/resources/config/dag-executor/state-profiles/kernel.edn
@@ -1,0 +1,15 @@
+{:profile/id :kernel
+ :task-statuses [:pending :ready :running :completed :failed :skipped]
+ :terminal-statuses [:completed :failed :skipped]
+ :success-terminal-statuses [:completed]
+ :valid-transitions
+ {:pending [:ready :skipped]
+  :ready [:running :skipped]
+  :running [:completed :failed]
+  :completed []
+  :failed []
+  :skipped []}
+ :event-mappings
+ {:started {:type :transition :to :running}
+  :completed {:type :complete :to :completed}
+  :failed {:type :fail :reason :failed}}}

--- a/components/dag-executor/resources/config/dag-executor/state-profiles/registry.edn
+++ b/components/dag-executor/resources/config/dag-executor/state-profiles/registry.edn
@@ -1,0 +1,2 @@
+{:default-profile :kernel
+ :profiles {:kernel "config/dag-executor/state-profiles/kernel.edn"}}

--- a/components/dag-executor/src/ai/miniforge/dag_executor/interface.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/interface.clj
@@ -54,17 +54,13 @@
   "Build a custom state profile map."
   state-profile/build-profile)
 
-(def software-factory-profile
-  "Software-factory task lifecycle profile."
-  state-profile/software-factory-profile)
+(def resolve-state-profile
+  "Resolve a state profile keyword or inline map via the active resource registry."
+  state-profile/resolve-profile)
 
-(def kernel-profile
-  "Domain-neutral task lifecycle profile."
-  state-profile/kernel-profile)
-
-(def etl-profile
-  "Example ETL task lifecycle profile."
-  state-profile/etl-profile)
+(def available-state-profile-ids
+  "List the state profile ids exposed by the active resource registry."
+  state-profile/available-profile-ids)
 
 (def task-statuses
   "Valid task workflow statuses: :pending :ready :implementing :pr-opening

--- a/components/dag-executor/src/ai/miniforge/dag_executor/state.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/state.clj
@@ -17,11 +17,11 @@
 (def task-statuses
   "Valid task workflow statuses.
    Defaults to the software-factory profile."
-  (:task-statuses profiles/default-profile))
+  (:task-statuses (profiles/default-profile)))
 
 (def terminal-statuses
   "Terminal statuses (no further transitions)."
-  (:terminal-statuses profiles/default-profile))
+  (:terminal-statuses (profiles/default-profile)))
 
 (def run-statuses
   "Valid DAG run statuses."
@@ -34,7 +34,7 @@
 
 (def valid-transitions
   "Valid state transitions for the default task workflow profile."
-  (:valid-transitions profiles/default-profile))
+  (:valid-transitions (profiles/default-profile)))
 
 (defn resolve-task-profile
   [task-state]
@@ -168,7 +168,7 @@
 (defn valid-transition?
   "Check if a state transition is valid."
   ([from-status to-status]
-   (valid-transition? profiles/default-profile from-status to-status))
+   (valid-transition? (profiles/default-profile) from-status to-status))
   ([profile from-status to-status]
    (contains? (get (:valid-transitions (profiles/resolve-profile profile)) from-status #{})
               to-status)))
@@ -176,7 +176,7 @@
 (defn terminal?
   "Check if a status is terminal (no further transitions)."
   ([status]
-   (terminal? profiles/default-profile status))
+   (terminal? (profiles/default-profile) status))
   ([profile status]
    (contains? (:terminal-statuses (profiles/resolve-profile profile)) status)))
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/state_profile.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/state_profile.clj
@@ -1,9 +1,13 @@
 (ns ai.miniforge.dag-executor.state-profile
   "State profiles for DAG task workflows.
 
-   Profiles let the DAG executor support domain-neutral task lifecycles while
-   preserving the existing software-factory semantics as the default."
+   The kernel owns only the profile schema, normalization, and resource-backed
+   resolution. Concrete profile data lives in classpath resources so project
+   layers can override the loaded registry without embedding configuration in
+   kernel code."
   (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.set :as set]))
 
 (defn build-profile
@@ -18,106 +22,55 @@
            :task-statuses (set task-statuses)
            :terminal-statuses terminal-statuses
            :success-terminal-statuses success-terminal-statuses
-           :valid-transitions valid-transitions
+           :valid-transitions (into {}
+                                    (map (fn [[from-status targets]]
+                                           [from-status (set targets)]))
+                                    valid-transitions)
            :event-mappings event-mappings
            :failure-terminal-statuses (set/difference terminal-statuses
                                                      success-terminal-statuses))))
 
-(def software-factory-profile
-  (build-profile
-   {:profile/id :software-factory
-    :task-statuses #{:pending :ready :implementing :pr-opening :ci-running
-                     :review-pending :responding :ready-to-merge :merging
-                     :merged :failed :skipped}
-    :terminal-statuses #{:merged :failed :skipped}
-    :success-terminal-statuses #{:merged}
-    :valid-transitions
-    {:pending #{:ready :skipped}
-     :ready #{:implementing :skipped}
-     :implementing #{:pr-opening :failed}
-     :pr-opening #{:ci-running :failed}
-     :ci-running #{:review-pending :responding :failed}
-     :review-pending #{:ready-to-merge :responding}
-     :responding #{:ci-running :failed}
-     :ready-to-merge #{:merging :responding}
-     :merging #{:merged :failed}
-     :merged #{}
-     :failed #{}
-     :skipped #{}}
-    :event-mappings
-    {:pr-opened {:type :transition :to :ci-running}
-     :ci-passed {:type :transition :to :review-pending}
-     :ci-failed {:type :retry-or-fail
-                 :retry-limit-predicate :max-ci-retries-exceeded?
-                 :retry-update-fn :increment-ci-retries
-                 :retry-transition :responding
-                 :failure-reason :ci-failed-max-retries}
-     :review-approved {:type :transition :to :ready-to-merge}
-     :review-changes-requested {:type :retry-or-fail
-                                :retry-limit-predicate :max-fix-iterations-exceeded?
-                                :retry-update-fn :increment-fix-iterations
-                                :retry-transition :responding
-                                :failure-reason :review-failed-max-iterations}
-     :fix-pushed {:type :transition :to :ci-running}
-     :merge-ready {:type :transition :to :merging}
-     :merged {:type :complete :to :merged}
-     :merge-failed {:type :fail :reason :merge-failed}}}))
+(def registry-resource
+  "Classpath resource that identifies which profiles are available."
+  "config/dag-executor/state-profiles/registry.edn")
 
-(def kernel-profile
-  (build-profile
-   {:profile/id :kernel
-    :task-statuses #{:pending :ready :running :completed :failed :skipped}
-    :terminal-statuses #{:completed :failed :skipped}
-    :success-terminal-statuses #{:completed}
-    :valid-transitions
-    {:pending #{:ready :skipped}
-     :ready #{:running :skipped}
-     :running #{:completed :failed}
-     :completed #{}
-     :failed #{}
-     :skipped #{}}
-    :event-mappings
-    {:started {:type :transition :to :running}
-     :completed {:type :complete :to :completed}
-     :failed {:type :fail :reason :failed}}}))
+(defn read-edn-resource
+  [resource-path]
+  (when-let [resource (io/resource resource-path)]
+    (-> resource slurp edn/read-string)))
 
-(def etl-profile
-  (build-profile
-   {:profile/id :etl
-    :task-statuses #{:pending :ready :acquiring :extracting :canonicalizing
-                     :evaluating :publishing :completed :failed :skipped}
-    :terminal-statuses #{:completed :failed :skipped}
-    :success-terminal-statuses #{:completed}
-    :valid-transitions
-    {:pending #{:ready :skipped}
-     :ready #{:acquiring :skipped}
-     :acquiring #{:extracting :failed}
-     :extracting #{:canonicalizing :failed}
-     :canonicalizing #{:evaluating :failed}
-     :evaluating #{:publishing :failed}
-     :publishing #{:completed :failed}
-     :completed #{}
-     :failed #{}
-     :skipped #{}}
-    :event-mappings
-    {:acquired {:type :transition :to :extracting}
-     :extracted {:type :transition :to :canonicalizing}
-     :canonicalized {:type :transition :to :evaluating}
-     :evaluated {:type :transition :to :publishing}
-     :published {:type :complete :to :completed}
-     :failed {:type :fail :reason :failed}}}))
+(defn load-profile-registry
+  []
+  (or (read-edn-resource registry-resource)
+      {:default-profile :kernel
+       :profiles {:kernel "config/dag-executor/state-profiles/kernel.edn"}}))
 
-(def known-profiles
-  {:software-factory software-factory-profile
-   :kernel kernel-profile
-   :etl etl-profile})
+(defn available-profile-ids
+  []
+  (keys (:profiles (load-profile-registry))))
 
-(def default-profile software-factory-profile)
+(defn load-profile-definition
+  [profile-id]
+  (let [registry (load-profile-registry)
+        resource-path (get-in registry [:profiles profile-id])]
+    (when resource-path
+      (read-edn-resource resource-path))))
+
+(defn default-profile-id
+  []
+  (or (:default-profile (load-profile-registry)) :kernel))
 
 (defn resolve-profile
   [profile]
-  (cond
-    (nil? profile) default-profile
-    (keyword? profile) (get known-profiles profile default-profile)
-    (map? profile) (build-profile profile)
-    :else default-profile))
+  (let [fallback-id (default-profile-id)
+        fallback-profile (some-> (load-profile-definition fallback-id) build-profile)]
+    (cond
+      (nil? profile) fallback-profile
+      (keyword? profile) (or (some-> (load-profile-definition profile) build-profile)
+                             fallback-profile)
+      (map? profile) (build-profile profile)
+      :else fallback-profile)))
+
+(defn default-profile
+  []
+  (resolve-profile nil))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/state_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/state_test.clj
@@ -103,13 +103,20 @@
     (is (not (state/terminal? :pending)))
     (is (not (state/terminal? :implementing)))))
 
+(deftest resource-backed-profile-registry-test
+  (testing "active profile registry is loaded from classpath resources"
+    (is (= :software-factory (profiles/default-profile-id)))
+    (is (contains? (set (profiles/available-profile-ids)) :kernel))
+    (is (contains? (set (profiles/available-profile-ids)) :software-factory))
+    (is (contains? (set (profiles/available-profile-ids)) :etl))))
+
 (deftest kernel-profile-completion-test
   (testing "generic kernel profile reaches :completed without merge semantics"
     (let [task-id (random-uuid)
           task (state/create-task-state task-id #{} :state-profile :kernel)
           run (state/create-run-state (random-uuid) {task-id task} :state-profile :kernel)
           run-atom (state/create-run-atom run)]
-      (is (= profiles/kernel-profile (get-in @run-atom [:run/config :state-profile])))
+      (is (= (profiles/resolve-profile :kernel) (get-in @run-atom [:run/config :state-profile])))
       (is (result/ok? (state/transition-task! run-atom task-id :ready nil)))
       (is (result/ok? (state/transition-task! run-atom task-id :running nil)))
       (is (result/ok? (state/mark-completed! run-atom task-id nil)))

--- a/components/workflow/resources/config/dag-executor/state-profiles/registry.edn
+++ b/components/workflow/resources/config/dag-executor/state-profiles/registry.edn
@@ -1,0 +1,5 @@
+{:default-profile :software-factory
+ :profiles
+ {:kernel "config/dag-executor/state-profiles/kernel.edn"
+  :software-factory "config/workflow/state-profiles/software-factory.edn"
+  :etl "config/workflow/state-profiles/etl.edn"}}

--- a/components/workflow/resources/config/workflow/state-profiles/etl.edn
+++ b/components/workflow/resources/config/workflow/state-profiles/etl.edn
@@ -1,0 +1,23 @@
+{:profile/id :etl
+ :task-statuses [:pending :ready :acquiring :extracting :canonicalizing
+                 :evaluating :publishing :completed :failed :skipped]
+ :terminal-statuses [:completed :failed :skipped]
+ :success-terminal-statuses [:completed]
+ :valid-transitions
+ {:pending [:ready :skipped]
+  :ready [:acquiring :skipped]
+  :acquiring [:extracting :failed]
+  :extracting [:canonicalizing :failed]
+  :canonicalizing [:evaluating :failed]
+  :evaluating [:publishing :failed]
+  :publishing [:completed :failed]
+  :completed []
+  :failed []
+  :skipped []}
+ :event-mappings
+ {:acquired {:type :transition :to :extracting}
+  :extracted {:type :transition :to :canonicalizing}
+  :canonicalized {:type :transition :to :evaluating}
+  :evaluated {:type :transition :to :publishing}
+  :published {:type :complete :to :completed}
+  :failed {:type :fail :reason :failed}}}

--- a/components/workflow/resources/config/workflow/state-profiles/software-factory.edn
+++ b/components/workflow/resources/config/workflow/state-profiles/software-factory.edn
@@ -1,0 +1,37 @@
+{:profile/id :software-factory
+ :task-statuses [:pending :ready :implementing :pr-opening :ci-running
+                 :review-pending :responding :ready-to-merge :merging
+                 :merged :failed :skipped]
+ :terminal-statuses [:merged :failed :skipped]
+ :success-terminal-statuses [:merged]
+ :valid-transitions
+ {:pending [:ready :skipped]
+  :ready [:implementing :skipped]
+  :implementing [:pr-opening :failed]
+  :pr-opening [:ci-running :failed]
+  :ci-running [:review-pending :responding :failed]
+  :review-pending [:ready-to-merge :responding]
+  :responding [:ci-running :failed]
+  :ready-to-merge [:merging :responding]
+  :merging [:merged :failed]
+  :merged []
+  :failed []
+  :skipped []}
+ :event-mappings
+ {:pr-opened {:type :transition :to :ci-running}
+  :ci-passed {:type :transition :to :review-pending}
+  :ci-failed {:type :retry-or-fail
+              :retry-limit-predicate :max-ci-retries-exceeded?
+              :retry-update-fn :increment-ci-retries
+              :retry-transition :responding
+              :failure-reason :ci-failed-max-retries}
+  :review-approved {:type :transition :to :ready-to-merge}
+  :review-changes-requested {:type :retry-or-fail
+                             :retry-limit-predicate :max-fix-iterations-exceeded?
+                             :retry-update-fn :increment-fix-iterations
+                             :retry-transition :responding
+                             :failure-reason :review-failed-max-iterations}
+  :fix-pushed {:type :transition :to :ci-running}
+  :merge-ready {:type :transition :to :merging}
+  :merged {:type :complete :to :merged}
+  :merge-failed {:type :fail :reason :merge-failed}}}

--- a/docs/pull-requests/2026-03-11-codex-profile-config-followup.md
+++ b/docs/pull-requests/2026-03-11-codex-profile-config-followup.md
@@ -1,0 +1,43 @@
+# refactor: extract state profiles to resource-backed registries
+
+## Overview
+
+Moves DAG task lifecycle profiles out of kernel code and into classpath resources, while keeping the kernel responsible
+only for profile schema, normalization, and resolution.
+
+## Motivation
+
+The previous extraction left `software-factory` and `etl` profile data embedded in the `dag-executor` kernel. That kept
+project-specific configuration in code and made the kernel own app-layer semantics it should only consume.
+
+## Changes in Detail
+
+- Replaced hardcoded profile literals in `state_profile.clj` with a resource-backed registry loader.
+- Added a kernel fallback registry that exposes only the generic `:kernel` profile.
+- Added a workflow-layer registry overlay that provides `:software-factory` and `:etl` profile resources and sets the
+  active default profile for the flagship app.
+- Removed direct profile constant exports from the public DAG executor interface and replaced them with resource-backed
+  resolver APIs.
+- Added regression coverage to prove the active profile registry comes from classpath resources and still supports
+  explicit `:kernel` runs.
+
+## Testing Plan
+
+- `bb test`
+- `bb test:integration`
+
+## Deployment Plan
+
+Merge normally. This is an internal configuration-boundary refactor with no data migration.
+
+## Related Issues/PRs
+
+- Follow-up to PR #291
+
+## Checklist
+
+- [x] Move project-specific profile data out of kernel code
+- [x] Keep kernel profile resolution generic
+- [x] Preserve software-factory default behavior through app-layer resources
+- [x] Keep ETL profile available without reintroducing kernel literals
+- [x] Verify unit and integration coverage


### PR DESCRIPTION
# refactor: extract state profiles to resource-backed registries

## Overview

Moves DAG task lifecycle profiles out of kernel code and into classpath resources, while keeping the kernel responsible
only for profile schema, normalization, and resolution.

## Motivation

The previous extraction left `software-factory` and `etl` profile data embedded in the `dag-executor` kernel. That kept
project-specific configuration in code and made the kernel own app-layer semantics it should only consume.

## Changes in Detail

- Replaced hardcoded profile literals in `state_profile.clj` with a resource-backed registry loader.
- Added a kernel fallback registry that exposes only the generic `:kernel` profile.
- Added a workflow-layer registry overlay that provides `:software-factory` and `:etl` profile resources and sets the
  active default profile for the flagship app.
- Removed direct profile constant exports from the public DAG executor interface and replaced them with resource-backed
  resolver APIs.
- Added regression coverage to prove the active profile registry comes from classpath resources and still supports
  explicit `:kernel` runs.

## Testing Plan

- `bb test`
- `bb test:integration`

## Deployment Plan

Merge normally. This is an internal configuration-boundary refactor with no data migration.

## Related Issues/PRs

- Follow-up to PR #291

## Checklist

- [x] Move project-specific profile data out of kernel code
- [x] Keep kernel profile resolution generic
- [x] Preserve software-factory default behavior through app-layer resources
- [x] Keep ETL profile available without reintroducing kernel literals
- [x] Verify unit and integration coverage
