### PR TITLE
test: add profile extraction regression coverage

### DIFF
--- a/components/dag-executor/test/ai/miniforge/dag_executor/state_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/state_test.clj
@@ -110,6 +110,44 @@
     (is (contains? (set (profiles/available-profile-ids)) :software-factory))
     (is (contains? (set (profiles/available-profile-ids)) :etl))))
 
+(deftest profile-resolution-falls-back-to-kernel-test
+  (testing "unknown profiles fall back to the configured default profile"
+    (let [kernel-definition {:profile/id :kernel
+                             :task-statuses [:pending :ready :running :completed :failed :skipped]
+                             :terminal-statuses [:completed :failed :skipped]
+                             :success-terminal-statuses [:completed]
+                             :valid-transitions {:pending [:ready :skipped]
+                                                 :ready [:running :skipped]
+                                                 :running [:completed :failed]
+                                                 :completed []
+                                                 :failed []
+                                                 :skipped []}
+                             :event-mappings {:completed {:type :complete :to :completed}}}]
+      (with-redefs [profiles/load-profile-registry (fn []
+                                                     {:default-profile :kernel
+                                                      :profiles {:kernel "kernel.edn"}})
+                    profiles/load-profile-definition (fn [profile-id]
+                                                       (when (= profile-id :kernel)
+                                                         kernel-definition))]
+        (is (= :kernel (profiles/default-profile-id)))
+        (is (= (profiles/build-profile kernel-definition)
+               (profiles/resolve-profile :missing-profile)))))))
+
+(deftest build-profile-normalizes-transition-targets-test
+  (testing "resource-shaped profile data is normalized into set-based transitions"
+    (let [profile (profiles/build-profile
+                   {:profile/id :vector-backed
+                    :task-statuses [:pending :ready :completed]
+                    :terminal-statuses [:completed]
+                    :success-terminal-statuses [:completed]
+                    :valid-transitions {:pending [:ready]
+                                        :ready [:completed]
+                                        :completed []}
+                    :event-mappings {}})]
+      (is (= #{:ready} (get-in profile [:valid-transitions :pending])))
+      (is (state/valid-transition? profile :pending :ready))
+      (is (not (state/valid-transition? profile :pending :completed))))))
+
 (deftest kernel-profile-completion-test
   (testing "generic kernel profile reaches :completed without merge semantics"
     (let [task-id (random-uuid)

--- a/docs/pull-requests/2026-03-11-codex-test-coverage-followup.md
+++ b/docs/pull-requests/2026-03-11-codex-test-coverage-followup.md
@@ -1,0 +1,38 @@
+# test: harden state profile extraction coverage
+
+## Overview
+
+Adds targeted regression tests around the recent state-profile extraction so the fallback and normalization paths are
+explicitly covered.
+
+## Motivation
+
+The resource-backed profile move is correct, but the first pass exposed an easy-to-miss bug: transition targets loaded
+from EDN arrived as vectors, which broke membership checks until they were normalized to sets. This PR locks down those
+seams so later extraction work has tighter safety rails.
+
+## Changes in Detail
+
+- Added a test that proves unknown profiles fall back to the configured default profile.
+- Added a test that proves EDN-shaped transition targets are normalized before the DAG state machine uses them.
+- Kept the existing classpath-overlay coverage that verifies the software-factory registry remains active on the
+  flagship app classpath.
+
+## Testing Plan
+
+- `bb pre-commit`
+
+## Deployment Plan
+
+Merge normally. Test-only change.
+
+## Related Issues/PRs
+
+- Follow-up to PR #292
+
+## Checklist
+
+- [x] Cover fallback profile resolution
+- [x] Cover resource/EDN normalization path
+- [x] Keep classpath overlay coverage intact
+- [x] Re-run pre-commit


### PR DESCRIPTION
# test: harden state profile extraction coverage

## Overview

Adds targeted regression tests around the recent state-profile extraction so the fallback and normalization paths are
explicitly covered.

## Motivation

The resource-backed profile move is correct, but the first pass exposed an easy-to-miss bug: transition targets loaded
from EDN arrived as vectors, which broke membership checks until they were normalized to sets. This PR locks down those
seams so later extraction work has tighter safety rails.

## Changes in Detail

- Added a test that proves unknown profiles fall back to the configured default profile.
- Added a test that proves EDN-shaped transition targets are normalized before the DAG state machine uses them.
- Kept the existing classpath-overlay coverage that verifies the software-factory registry remains active on the
  flagship app classpath.

## Testing Plan

- `bb pre-commit`

## Deployment Plan

Merge normally. Test-only change.

## Related Issues/PRs

- Follow-up to PR #292

## Checklist

- [x] Cover fallback profile resolution
- [x] Cover resource/EDN normalization path
- [x] Keep classpath overlay coverage intact
- [x] Re-run pre-commit
