### PR TITLE
refactor: move state profiles to project providers

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/interface.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/interface.clj
@@ -5,11 +5,11 @@
    - Dependency ordering and parallelism
    - Task workflow state machine
    - Budget and checkpoint management
-   - Integration with PR lifecycle events
+   - Integration with domain-specific lifecycle events
    - Pluggable execution backends (K8s, Docker, worktree)
 
    A DAG node is not 'generate code once' - it's a task workflow that runs
-   until it reaches a terminal integration state (:merged)."
+   until it reaches a profile-defined terminal success state."
   (:require
    [ai.miniforge.dag-executor.result :as result]
    [ai.miniforge.dag-executor.state-profile :as state-profile]
@@ -54,22 +54,31 @@
   "Build a custom state profile map."
   state-profile/build-profile)
 
-(def resolve-state-profile
-  "Resolve a state profile keyword or inline map via the active resource registry."
-  state-profile/resolve-profile)
+(def build-state-profile-provider
+  "Build a state-profile provider from profile definitions or resource-path entries."
+  state-profile/build-provider)
 
-(def available-state-profile-ids
-  "List the state profile ids exposed by the active resource registry."
-  state-profile/available-profile-ids)
+(defn resolve-state-profile
+  "Resolve a state profile keyword or inline map.
+
+   With one argument, resolves against the kernel provider.
+   With two arguments, resolves against the supplied provider."
+  ([profile]
+   (state-profile/resolve-profile profile))
+  ([provider profile]
+   (state-profile/resolve-profile provider profile)))
+
+(defn available-state-profile-ids
+  "List the state profile ids exposed by the kernel provider or a supplied provider."
+  ([] (state-profile/available-profile-ids))
+  ([provider] (state-profile/available-profile-ids provider)))
 
 (def task-statuses
-  "Valid task workflow statuses: :pending :ready :implementing :pr-opening
-   :ci-running :review-pending :responding :ready-to-merge :merging
-   :merged :failed :skipped"
+  "Valid task workflow statuses for the kernel default profile."
   state/task-statuses)
 
 (def terminal-statuses
-  "Terminal statuses: :merged :failed :skipped"
+  "Terminal statuses for the kernel default profile."
   state/terminal-statuses)
 
 (def run-statuses
@@ -86,6 +95,7 @@
    Options:
    - :max-fix-iterations - Max fix attempts (default 5)
    - :max-ci-retries - Max CI retry attempts (default 3)
+   - :state-profile-provider - Provider map for keyword profile lookup
 
    Example:
      (create-task-state (random-uuid) #{parent-task-id}
@@ -102,6 +112,7 @@
 
    Options:
    - :budget - Budget constraints map with :max-tokens :max-cost-usd :max-duration-ms
+   - :state-profile-provider - Provider map for keyword profile lookup
 
    Example:
      (create-run-state dag-id
@@ -453,6 +464,7 @@
    Options:
    - :budget - Budget constraints
    - :state-profile - Task lifecycle profile keyword or map
+   - :state-profile-provider - Provider map for keyword profile lookup
    - :max-fix-iterations - Default max fix iterations
    - :max-ci-retries - Default max CI retries
 
@@ -463,7 +475,8 @@
         {:task/id b-id :task/deps #{a-id}}
         {:task/id c-id :task/deps #{a-id}}]
        :budget {:max-tokens 500000})"
-  [dag-id task-defs & {:keys [budget state-profile max-fix-iterations max-ci-retries]
+  [dag-id task-defs & {:keys [budget state-profile state-profile-provider
+                              max-fix-iterations max-ci-retries]
                        :or {max-fix-iterations 5 max-ci-retries 3}}]
   (let [tasks (->> task-defs
                    (map (fn [def]
@@ -472,10 +485,14 @@
                             (:task/id def)
                             (or (:task/deps def) #{})
                             :state-profile state-profile
+                            :state-profile-provider state-profile-provider
                             :max-fix-iterations max-fix-iterations
                             :max-ci-retries max-ci-retries)]))
                    (into {}))]
-    (create-run-state dag-id tasks :budget budget :state-profile state-profile)))
+    (create-run-state dag-id tasks
+                      :budget budget
+                      :state-profile state-profile
+                      :state-profile-provider state-profile-provider)))
 
 (defn execute-dag
   "Execute a DAG to completion.

--- a/components/dag-executor/src/ai/miniforge/dag_executor/scheduler.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/scheduler.clj
@@ -42,7 +42,7 @@
   "Compute tasks that are ready to execute.
    A task is ready when:
    - Status is :pending
-   - All dependencies are in :run/merged"
+   - All dependencies have reached a profile-defined success state"
   [run-state]
   (state/ready-tasks run-state))
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/state.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/state.clj
@@ -16,7 +16,7 @@
 
 (def task-statuses
   "Valid task workflow statuses.
-   Defaults to the software-factory profile."
+   Defaults to the kernel profile."
   (:task-statuses (profiles/default-profile)))
 
 (def terminal-statuses
@@ -108,12 +108,14 @@
    Options:
    - :max-fix-iterations - Max fix attempts (default 5)
    - :max-ci-retries - Max CI retry attempts (default 3)
-   - :state-profile - Task lifecycle profile keyword or map"
-  [task-id deps & {:keys [max-fix-iterations max-ci-retries state-profile]
+   - :state-profile - Task lifecycle profile keyword or map
+   - :state-profile-provider - Provider map used to resolve keyword profiles"
+  [task-id deps & {:keys [max-fix-iterations max-ci-retries
+                          state-profile state-profile-provider]
                    :or {max-fix-iterations 5 max-ci-retries 3}}]
   {:task/id task-id
    :task/status :pending
-   :task/state-profile (profiles/resolve-profile state-profile)
+   :task/state-profile (profiles/resolve-profile state-profile-provider state-profile)
    :task/deps (set deps)
    :task/pr nil
    :task/attempts []
@@ -136,9 +138,10 @@
 
    Options:
    - :budget - Budget constraints map with :max-tokens :max-cost-usd :max-duration-ms
-   - :state-profile - Run/task lifecycle profile keyword or map"
-  [dag-id tasks & {:keys [budget state-profile]}]
-  (let [resolved-profile (profiles/resolve-profile state-profile)
+   - :state-profile - Run/task lifecycle profile keyword or map
+   - :state-profile-provider - Provider map used to resolve keyword profiles"
+  [dag-id tasks & {:keys [budget state-profile state-profile-provider]}]
+  (let [resolved-profile (profiles/resolve-profile state-profile-provider state-profile)
         normalized-tasks (into {}
                                (map (fn [[task-id task]]
                                       [task-id (assoc task :task/state-profile
@@ -337,7 +340,8 @@
     (->> tasks
          (filter (fn [[_id task]]
                    (and (not= :pending (:task/status task))
-                        (not (terminal? (:task/status task))))))
+                        (not (terminal? (resolve-task-profile task)
+                                        (:task/status task))))))
          (map first)
          set)))
 
@@ -346,13 +350,18 @@
    Returns map of task-id -> set of blocking task IDs."
   [run-state]
   (let [tasks (:run/tasks run-state)
-        merged (:run/merged run-state)]
+        profile (resolve-run-profile run-state)
+        completed-task-ids (->> tasks
+                                (filter (fn [[_id task]]
+                                          (success-terminal-status? profile (:task/status task))))
+                                (map first)
+                                set)]
     (->> tasks
          (filter (fn [[_id task]]
                    (and (= :pending (:task/status task))
-                        (not (every? merged (:task/deps task))))))
+                        (not (every? completed-task-ids (:task/deps task))))))
          (map (fn [[id task]]
-                [id (set/difference (:task/deps task) merged)]))
+                [id (set/difference (:task/deps task) completed-task-ids)]))
          (into {}))))
 
 (defn all-terminal?

--- a/components/dag-executor/src/ai/miniforge/dag_executor/state_profile.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/state_profile.clj
@@ -1,10 +1,9 @@
 (ns ai.miniforge.dag-executor.state-profile
   "State profiles for DAG task workflows.
 
-   The kernel owns only the profile schema, normalization, and resource-backed
-   resolution. Concrete profile data lives in classpath resources so project
-   layers can override the loaded registry without embedding configuration in
-   kernel code."
+   The kernel owns only the profile schema, normalization, and profile
+   resolution. Application layers own profile-provider configuration and pass it
+   into DAG construction explicitly."
   (:require
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -30,8 +29,8 @@
            :failure-terminal-statuses (set/difference terminal-statuses
                                                      success-terminal-statuses))))
 
-(def registry-resource
-  "Classpath resource that identifies which profiles are available."
+(def kernel-registry-resource
+  "Classpath resource for the kernel-owned default provider."
   "config/dag-executor/state-profiles/registry.edn")
 
 (defn read-edn-resource
@@ -39,37 +38,76 @@
   (when-let [resource (io/resource resource-path)]
     (-> resource slurp edn/read-string)))
 
-(defn load-profile-registry
+(defn build-provider
+  [{:keys [default-profile profiles] :as provider}]
+  (let [normalized-profiles
+        (into {}
+              (keep (fn [[profile-id profile-definition]]
+                      (let [normalized-profile
+                            (cond
+                              (string? profile-definition)
+                              (some-> profile-definition read-edn-resource build-profile)
+
+                              (map? profile-definition)
+                              (build-profile (assoc profile-definition
+                                                    :profile/id (or (:profile/id profile-definition)
+                                                                    profile-id)))
+
+                              :else nil)]
+                        (when normalized-profile
+                          [profile-id normalized-profile]))))
+              profiles)
+        fallback-profile-id (or default-profile
+                                (first (keys normalized-profiles))
+                                :kernel)]
+    (assoc provider
+           :default-profile fallback-profile-id
+           :profiles normalized-profiles)))
+
+(defn load-provider
   []
-  (or (read-edn-resource registry-resource)
-      {:default-profile :kernel
-       :profiles {:kernel "config/dag-executor/state-profiles/kernel.edn"}}))
+  (build-provider
+   (or (read-edn-resource kernel-registry-resource)
+       {:default-profile :kernel
+        :profiles {:kernel "config/dag-executor/state-profiles/kernel.edn"}})))
+
+(def ^:private kernel-provider
+  (delay (load-provider)))
+
+(defn default-provider
+  []
+  @kernel-provider)
 
 (defn available-profile-ids
-  []
-  (keys (:profiles (load-profile-registry))))
-
-(defn load-profile-definition
-  [profile-id]
-  (let [registry (load-profile-registry)
-        resource-path (get-in registry [:profiles profile-id])]
-    (when resource-path
-      (read-edn-resource resource-path))))
+  ([] (available-profile-ids (default-provider)))
+  ([provider]
+   (keys (:profiles (if provider
+                      (build-provider provider)
+                      (default-provider))))))
 
 (defn default-profile-id
-  []
-  (or (:default-profile (load-profile-registry)) :kernel))
+  ([] (default-profile-id (default-provider)))
+  ([provider]
+   (or (:default-profile (if provider
+                          (build-provider provider)
+                          (default-provider)))
+       :kernel)))
 
 (defn resolve-profile
-  [profile]
-  (let [fallback-id (default-profile-id)
-        fallback-profile (some-> (load-profile-definition fallback-id) build-profile)]
-    (cond
-      (nil? profile) fallback-profile
-      (keyword? profile) (or (some-> (load-profile-definition profile) build-profile)
-                             fallback-profile)
-      (map? profile) (build-profile profile)
-      :else fallback-profile)))
+  ([profile]
+   (resolve-profile (default-provider) profile))
+  ([provider profile]
+   (let [resolved-provider (if provider
+                             (build-provider provider)
+                             (default-provider))
+         fallback-id (default-profile-id resolved-provider)
+         fallback-profile (get-in resolved-provider [:profiles fallback-id])]
+     (cond
+       (nil? profile) fallback-profile
+       (keyword? profile) (or (get-in resolved-provider [:profiles profile])
+                              fallback-profile)
+       (map? profile) (build-profile profile)
+       :else fallback-profile))))
 
 (defn default-profile
   []

--- a/components/dag-executor/src/ai/miniforge/dag_executor/state_profile.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/state_profile.clj
@@ -38,24 +38,28 @@
   (when-let [resource (io/resource resource-path)]
     (-> resource slurp edn/read-string)))
 
+(defn resolve-provider-profile
+  [profile-id profile-definition]
+  (let [normalized-profile
+        (cond
+          (string? profile-definition)
+          (some-> profile-definition read-edn-resource build-profile)
+
+          (map? profile-definition)
+          (build-profile (assoc profile-definition
+                                :profile/id (or (:profile/id profile-definition)
+                                                profile-id)))
+
+          :else nil)]
+    (when normalized-profile
+      [profile-id normalized-profile])))
+
 (defn build-provider
   [{:keys [default-profile profiles] :as provider}]
   (let [normalized-profiles
         (into {}
               (keep (fn [[profile-id profile-definition]]
-                      (let [normalized-profile
-                            (cond
-                              (string? profile-definition)
-                              (some-> profile-definition read-edn-resource build-profile)
-
-                              (map? profile-definition)
-                              (build-profile (assoc profile-definition
-                                                    :profile/id (or (:profile/id profile-definition)
-                                                                    profile-id)))
-
-                              :else nil)]
-                        (when normalized-profile
-                          [profile-id normalized-profile]))))
+                      (resolve-provider-profile profile-id profile-definition)))
               profiles)
         fallback-profile-id (or default-profile
                                 (first (keys normalized-profiles))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/state_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/state_test.clj
@@ -247,6 +247,25 @@
       (is (state/valid-transition? profile :pending :ready))
       (is (not (state/valid-transition? profile :pending :completed))))))
 
+(deftest resolve-provider-profile-test
+  (testing "map-backed provider entries inherit the map key as profile id"
+    (let [[profile-id profile]
+          (profiles/resolve-provider-profile
+           :software-factory
+           {:task-statuses [:pending :ready :merged]
+            :terminal-statuses [:merged]
+            :success-terminal-statuses [:merged]
+            :valid-transitions {:pending [:ready]
+                                :ready [:merged]
+                                :merged []}
+            :event-mappings {:merged {:type :complete :to :merged}}})]
+      (is (= :software-factory profile-id))
+      (is (= :software-factory (:profile/id profile)))
+      (is (= #{:ready} (get-in profile [:valid-transitions :pending])))))
+
+  (testing "unsupported provider entries are ignored"
+    (is (nil? (profiles/resolve-provider-profile :bogus 42)))))
+
 (deftest kernel-profile-completion-test
   (testing "generic kernel profile reaches :completed without merge semantics"
     (let [task-id (random-uuid)

--- a/components/dag-executor/test/ai/miniforge/dag_executor/state_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/state_test.clj
@@ -83,32 +83,134 @@
   (testing "finds tasks with all deps satisfied"
     (let [task-a-id (random-uuid)
           task-b-id (random-uuid)
-          task-a (state/create-task-state task-a-id #{})
-          task-b (state/create-task-state task-b-id #{task-a-id})
-          run (state/create-run-state (random-uuid) {task-a-id task-a
-                                                      task-b-id task-b})]
+          task-a (state/create-task-state task-a-id #{} :state-profile :kernel)
+          task-b (state/create-task-state task-b-id #{task-a-id} :state-profile :kernel)
+          run (state/create-run-state (random-uuid)
+                                      {task-a-id task-a
+                                       task-b-id task-b}
+                                      :state-profile :kernel)]
       ;; Only task-a is ready (no deps)
       (is (= #{task-a-id} (state/ready-tasks run)))
-      ;; After marking task-a merged, task-b becomes ready
+      ;; After marking task-a completed, task-b becomes ready
       (let [run' (-> run
-                     (assoc-in [:run/tasks task-a-id :task/status] :merged)
-                     (state/mark-task-merged task-a-id))]
+                     (assoc-in [:run/tasks task-a-id :task/status] :completed)
+                     (state/mark-task-completed task-a-id))]
         (is (contains? (state/ready-tasks run') task-b-id))))))
+
+(deftest blocked-tasks-test
+  (testing "blocked tasks use profile success states instead of merge-only bookkeeping"
+    (let [task-a-id (random-uuid)
+          task-b-id (random-uuid)
+          task-a (state/create-task-state task-a-id #{} :state-profile :kernel)
+          task-b (state/create-task-state task-b-id #{task-a-id} :state-profile :kernel)
+          run (state/create-run-state (random-uuid)
+                                      {task-a-id task-a
+                                       task-b-id task-b}
+                                      :state-profile :kernel)
+          run' (-> run
+                   (assoc-in [:run/tasks task-a-id :task/status] :completed)
+                   (state/mark-task-completed task-a-id))]
+      (is (= {task-b-id #{task-a-id}}
+             (state/blocked-tasks run)))
+      (is (= {}
+             (state/blocked-tasks run'))))))
+
+(deftest running-tasks-test
+  (testing "running tasks respect the task profile rather than the kernel default"
+    (let [provider (profiles/build-provider
+                    {:default-profile :software-factory
+                     :profiles
+                     {:software-factory
+                      {:profile/id :software-factory
+                       :task-statuses [:pending :ready :implementing :merged :failed :skipped]
+                       :terminal-statuses [:merged :failed :skipped]
+                       :success-terminal-statuses [:merged]
+                       :valid-transitions {:pending [:ready]
+                                           :ready [:implementing]
+                                           :implementing [:merged :failed]
+                                           :merged []
+                                           :failed []
+                                           :skipped []}
+                       :event-mappings {}}}})
+          task-id (random-uuid)
+          task (state/create-task-state task-id #{}
+                                        :state-profile :software-factory
+                                        :state-profile-provider provider)
+          run (-> (state/create-run-state (random-uuid) {task-id task}
+                                          :state-profile :software-factory
+                                          :state-profile-provider provider)
+                  (assoc-in [:run/tasks task-id :task/status] :merged))]
+      (is (= #{} (state/running-tasks run))))))
 
 (deftest terminal?-test
   (testing "terminal statuses"
-    (is (state/terminal? :merged))
+    (is (state/terminal? :completed))
     (is (state/terminal? :failed))
     (is (state/terminal? :skipped))
     (is (not (state/terminal? :pending)))
-    (is (not (state/terminal? :implementing)))))
+    (is (not (state/terminal? :running))))
+
+  (testing "terminal? respects explicit non-kernel profiles"
+    (let [software-factory-provider
+          (profiles/build-provider
+           {:default-profile :software-factory
+            :profiles
+            {:software-factory
+             {:profile/id :software-factory
+              :task-statuses [:pending :ready :implementing :merged :failed :skipped]
+              :terminal-statuses [:merged :failed :skipped]
+              :success-terminal-statuses [:merged]
+              :valid-transitions {:pending [:ready]
+                                  :ready [:implementing]
+                                  :implementing [:merged :failed]
+                                  :merged []
+                                  :failed []
+                                  :skipped []}
+              :event-mappings {}}}})]
+      (is (state/terminal? (profiles/resolve-profile software-factory-provider :software-factory)
+                           :merged)))))
 
 (deftest resource-backed-profile-registry-test
-  (testing "active profile registry is loaded from classpath resources"
-    (is (= :software-factory (profiles/default-profile-id)))
-    (is (contains? (set (profiles/available-profile-ids)) :kernel))
-    (is (contains? (set (profiles/available-profile-ids)) :software-factory))
-    (is (contains? (set (profiles/available-profile-ids)) :etl))))
+  (testing "kernel profile registry is loaded from kernel resources"
+    (is (= :kernel (profiles/default-profile-id)))
+    (is (= [:kernel] (vec (profiles/available-profile-ids))))))
+
+(deftest explicit-provider-resolution-test
+  (testing "explicit providers resolve project-specific profiles without classpath overrides"
+    (let [provider (profiles/build-provider
+                    {:default-profile :software-factory
+                     :profiles
+                     {:software-factory
+                      {:profile/id :software-factory
+                       :task-statuses [:pending :ready :implementing :merged :failed :skipped]
+                       :terminal-statuses [:merged :failed :skipped]
+                       :success-terminal-statuses [:merged]
+                       :valid-transitions {:pending [:ready]
+                                           :ready [:implementing]
+                                           :implementing [:merged :failed]
+                                           :merged []
+                                           :failed []
+                                           :skipped []}
+                       :event-mappings {:merged {:type :complete :to :merged}}}
+                      :etl
+                      {:profile/id :etl
+                       :task-statuses [:pending :ready :running :completed :failed :skipped]
+                       :terminal-statuses [:completed :failed :skipped]
+                       :success-terminal-statuses [:completed]
+                       :valid-transitions {:pending [:ready]
+                                           :ready [:running]
+                                           :running [:completed :failed]
+                                           :completed []
+                                           :failed []
+                                           :skipped []}
+                       :event-mappings {:completed {:type :complete :to :completed}}}}})]
+      (is (= #{:software-factory :etl}
+             (set (profiles/available-profile-ids provider))))
+      (is (= :software-factory (profiles/default-profile-id provider)))
+      (is (= :merged
+             (-> (profiles/resolve-profile provider :software-factory)
+                 :success-terminal-statuses
+                 first))))))
 
 (deftest profile-resolution-falls-back-to-kernel-test
   (testing "unknown profiles fall back to the configured default profile"
@@ -122,16 +224,13 @@
                                                  :completed []
                                                  :failed []
                                                  :skipped []}
-                             :event-mappings {:completed {:type :complete :to :completed}}}]
-      (with-redefs [profiles/load-profile-registry (fn []
-                                                     {:default-profile :kernel
-                                                      :profiles {:kernel "kernel.edn"}})
-                    profiles/load-profile-definition (fn [profile-id]
-                                                       (when (= profile-id :kernel)
-                                                         kernel-definition))]
-        (is (= :kernel (profiles/default-profile-id)))
-        (is (= (profiles/build-profile kernel-definition)
-               (profiles/resolve-profile :missing-profile)))))))
+                             :event-mappings {:completed {:type :complete :to :completed}}}
+          provider (profiles/build-provider
+                    {:default-profile :kernel
+                     :profiles {:kernel kernel-definition}})]
+      (is (= :kernel (profiles/default-profile-id provider)))
+      (is (= (profiles/build-profile kernel-definition)
+             (profiles/resolve-profile provider :missing-profile))))))
 
 (deftest build-profile-normalizes-transition-targets-test
   (testing "resource-shaped profile data is normalized into set-based transitions"
@@ -160,4 +259,37 @@
       (is (result/ok? (state/mark-completed! run-atom task-id nil)))
       (is (= :completed (get-in @run-atom [:run/tasks task-id :task/status])))
       (is (contains? (:run/completed @run-atom) task-id))
+      (is (= :completed (state/compute-run-status @run-atom))))))
+
+(deftest explicit-provider-construction-test
+  (testing "run construction uses the supplied provider for keyword profiles"
+    (let [provider (profiles/build-provider
+                    {:default-profile :software-factory
+                     :profiles
+                     {:software-factory
+                      {:profile/id :software-factory
+                       :task-statuses [:pending :ready :implementing :merged :failed :skipped]
+                       :terminal-statuses [:merged :failed :skipped]
+                       :success-terminal-statuses [:merged]
+                       :valid-transitions {:pending [:ready]
+                                           :ready [:implementing]
+                                           :implementing [:merged :failed]
+                                           :merged []
+                                           :failed []
+                                           :skipped []}
+                       :event-mappings {:merged {:type :complete :to :merged}}}}})
+          task-id (random-uuid)
+          task (state/create-task-state task-id #{}
+                                        :state-profile :software-factory
+                                        :state-profile-provider provider)
+          run (state/create-run-state (random-uuid) {task-id task}
+                                      :state-profile :software-factory
+                                      :state-profile-provider provider)
+          run-atom (state/create-run-atom run)]
+      (is (= :software-factory (get-in task [:task/state-profile :profile/id])))
+      (is (= :software-factory (get-in run [:run/config :state-profile :profile/id])))
+      (is (result/ok? (state/transition-task! run-atom task-id :ready nil)))
+      (is (result/ok? (state/transition-task! run-atom task-id :implementing nil)))
+      (is (result/ok? (state/mark-merged! run-atom task-id nil)))
+      (is (= :merged (get-in @run-atom [:run/tasks task-id :task/status])))
       (is (= :completed (state/compute-run-status @run-atom))))))

--- a/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/orchestrator.clj
@@ -182,9 +182,12 @@
                    :logger my-logger
                    :max-parallel 4})"
   [dag-id task-defs config]
-  (let [{:keys [logger budget]} config
+  (let [{:keys [logger budget state-profile state-profile-provider]} config
         ;; Initialize DAG using dag-executor's function
-        run-state (dag/create-dag-from-tasks dag-id task-defs :budget budget)
+        run-state (dag/create-dag-from-tasks dag-id task-defs
+                                             :budget budget
+                                             :state-profile state-profile
+                                             :state-profile-provider state-profile-provider)
         run-atom (dag/create-run-atom run-state)
 
         ;; Create orchestrated context

--- a/components/task-executor/test/ai/miniforge/task_executor/orchestrator_test.clj
+++ b/components/task-executor/test/ai/miniforge/task_executor/orchestrator_test.clj
@@ -4,6 +4,8 @@
   Tests that multiple tasks execute in parallel respecting dependencies,
   resource limits, and budget constraints. Uses diamond DAG pattern."
   (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.task-executor.orchestrator :as orchestrator]
    [clojure.test :refer [deftest testing is]]))
 
 ;------------------------------------------------------------------------------ Mock Data
@@ -465,3 +467,37 @@
 
       (is (= :completed (:status @run-atom))
           "Run should transition to :completed"))))
+
+(deftest execute-dag-passes-state-profile-config-test
+  (testing "execute-dag! forwards state profile configuration into DAG construction"
+    (let [captured (atom nil)
+          run-state {:run/status :completed
+                     :run/tasks {}}
+          run-atom (atom run-state)
+          provider {:default-profile :software-factory
+                    :profiles {:software-factory {:profile/id :software-factory}}}
+          scheduler-value {:status :completed
+                           :pending #{}
+                           :running #{}
+                           :completed #{}}]
+      (with-redefs [dag/create-dag-from-tasks
+                    (fn [dag-id task-defs & opts]
+                      (reset! captured {:dag-id dag-id
+                                        :task-defs task-defs
+                                        :opts (apply hash-map opts)})
+                      run-state)
+                    dag/create-run-atom (fn [_] run-atom)
+                    dag/schedule-iteration (fn [_ _]
+                                             {:ok? true
+                                              :value scheduler-value})
+                    orchestrator/create-orchestrated-scheduler-context
+                    (fn [_ _] {:execute-task-fn (fn [& _] nil)})
+                    orchestrator/log-event (fn [& _] nil)]
+        (let [final-state (orchestrator/execute-dag!
+                           "dag-123"
+                           [{:task/id "task-1" :task/deps #{}}]
+                           {:state-profile :software-factory
+                            :state-profile-provider provider})]
+          (is (= run-state final-state))
+          (is (= :software-factory (get-in @captured [:opts :state-profile])))
+          (is (= provider (get-in @captured [:opts :state-profile-provider]))))))))

--- a/components/workflow/resources/config/dag-executor/state-profiles/registry.edn
+++ b/components/workflow/resources/config/dag-executor/state-profiles/registry.edn
@@ -1,5 +1,0 @@
-{:default-profile :software-factory
- :profiles
- {:kernel "config/dag-executor/state-profiles/kernel.edn"
-  :software-factory "config/workflow/state-profiles/software-factory.edn"
-  :etl "config/workflow/state-profiles/etl.edn"}}

--- a/components/workflow/resources/config/workflow/state-profiles/registry.edn
+++ b/components/workflow/resources/config/workflow/state-profiles/registry.edn
@@ -1,0 +1,4 @@
+{:default-profile :software-factory
+ :profiles
+ {:software-factory "config/workflow/state-profiles/software-factory.edn"
+  :etl "config/workflow/state-profiles/etl.edn"}}

--- a/components/workflow/src/ai/miniforge/workflow/interface.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface.clj
@@ -5,6 +5,7 @@
   (:require
    [ai.miniforge.workflow.interface.configurable :as configurable]
    [ai.miniforge.workflow.interface.pipeline :as pipeline]
+   [ai.miniforge.workflow.interface.profiles :as profiles]
    [ai.miniforge.workflow.interface.protocols :as protocols]
    [ai.miniforge.workflow.interface.registry :as registry]
    [ai.miniforge.workflow.interface.runtime :as runtime]))
@@ -62,6 +63,11 @@
 (def create-event-trigger configurable/create-event-trigger)
 (def create-merge-trigger configurable/create-merge-trigger)
 (def stop-trigger! configurable/stop-trigger!)
+
+(def load-state-profile-provider profiles/load-state-profile-provider)
+(def available-state-profile-ids profiles/available-state-profile-ids)
+(def default-state-profile-id profiles/default-state-profile-id)
+(def resolve-state-profile profiles/resolve-state-profile)
 
 (def register-workflow! registry/register-workflow!)
 (def get-workflow registry/get-workflow)

--- a/components/workflow/src/ai/miniforge/workflow/interface/profiles.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/profiles.clj
@@ -1,0 +1,18 @@
+(ns ai.miniforge.workflow.interface.profiles
+  "Workflow-owned state-profile provider helpers.")
+
+(defn load-state-profile-provider
+  []
+  ((requiring-resolve 'ai.miniforge.workflow.state-profile/load-state-profile-provider)))
+
+(defn available-state-profile-ids
+  []
+  ((requiring-resolve 'ai.miniforge.workflow.state-profile/available-state-profile-ids)))
+
+(defn default-state-profile-id
+  []
+  ((requiring-resolve 'ai.miniforge.workflow.state-profile/default-state-profile-id)))
+
+(defn resolve-state-profile
+  [profile]
+  ((requiring-resolve 'ai.miniforge.workflow.state-profile/resolve-state-profile) profile))

--- a/components/workflow/src/ai/miniforge/workflow/state_profile.clj
+++ b/components/workflow/src/ai/miniforge/workflow/state_profile.clj
@@ -1,0 +1,33 @@
+(ns ai.miniforge.workflow.state-profile
+  "Workflow-owned state-profile provider configuration."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+(def registry-resource
+  "Classpath resource for workflow-owned state-profile configuration."
+  "config/workflow/state-profiles/registry.edn")
+
+(defn read-edn-resource
+  [resource-path]
+  (when-let [resource (io/resource resource-path)]
+    (-> resource slurp edn/read-string)))
+
+(defn load-state-profile-provider
+  []
+  (some-> registry-resource
+          read-edn-resource
+          dag/build-state-profile-provider))
+
+(defn available-state-profile-ids
+  []
+  (dag/available-state-profile-ids (load-state-profile-provider)))
+
+(defn default-state-profile-id
+  []
+  (:default-profile (load-state-profile-provider)))
+
+(defn resolve-state-profile
+  [profile]
+  (dag/resolve-state-profile (load-state-profile-provider) profile))

--- a/components/workflow/test/ai/miniforge/workflow/state_profile_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/state_profile_test.clj
@@ -1,0 +1,23 @@
+(ns ai.miniforge.workflow.state-profile-test
+  (:require
+   [ai.miniforge.workflow.interface :as workflow]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest workflow-state-profile-provider-test
+  (testing "workflow component loads its own state-profile provider from resources"
+    (let [provider (workflow/load-state-profile-provider)]
+      (is (= :software-factory (workflow/default-state-profile-id)))
+      (is (= #{:software-factory :etl}
+             (set (workflow/available-state-profile-ids))))
+      (is (= :software-factory
+             (get-in provider [:profiles :software-factory :profile/id])))
+      (is (= :etl
+             (-> (workflow/resolve-state-profile :etl)
+                 :profile/id)))))
+
+  (testing "workflow provider exposes ETL completion semantics explicitly"
+    (let [etl-profile (workflow/resolve-state-profile :etl)]
+      (is (= #{:completed}
+             (:success-terminal-statuses etl-profile)))
+      (is (= :completed
+             (get-in etl-profile [:event-mappings :published :to]))))))

--- a/docs/pull-requests/2026-03-11-codex-profile-provider-followup.md
+++ b/docs/pull-requests/2026-03-11-codex-profile-provider-followup.md
@@ -1,0 +1,59 @@
+# refactor: move state profile ownership to project-side providers
+
+## Overview
+
+Moves DAG state-profile ownership out of implicit kernel classpath overlays and onto explicit project-side providers.
+The kernel now owns profile normalization and consumption; the workflow app layer owns the software-factory and ETL
+profile resources and loads them intentionally.
+
+## Motivation
+
+The previous pass removed hardcoded profile literals from the kernel, but the resolution path still depended on
+resource overlays on the active classpath. That kept project-specific configuration coupled to the kernel and blurred
+the intended Polylith seam. This follow-up makes profile selection explicit at DAG construction time and fixes the last
+few merge-centric assumptions that surfaced once the kernel default reverted to `:kernel`.
+
+## Changes in Detail
+
+- Added provider-aware profile resolution in `dag-executor`, with explicit provider injection on task/run/DAG creation.
+- Kept the kernel default provider limited to the kernel-owned `:kernel` profile.
+- Moved workflow-owned profile registry data under `components/workflow/resources/config/workflow/state-profiles/`.
+- Added workflow-side provider loader helpers and exported them through the workflow interface.
+- Threaded `:state-profile` and `:state-profile-provider` through `task-executor` so app code can choose profiles
+  without pulling workflow internals into the kernel.
+- Fixed generic DAG queries that still assumed `:merged` was the universal success state:
+  `running-tasks` now respects each task profile, and `blocked-tasks` now keys off success-terminal states instead of
+  `:run/merged`.
+- Added regression coverage for:
+  - explicit provider resolution
+  - provider-backed DAG construction
+  - workflow provider loading from resources
+  - task-executor forwarding provider config
+  - generic blocked/running task behavior after the kernel default changed
+
+## Testing Plan
+
+- `bb pre-commit`
+- `clojure -M:dev:test -e "(require '[clojure.test :as t] 'ai.miniforge.dag-executor.state-test
+  'ai.miniforge.workflow.state-profile-test 'ai.miniforge.task-executor.orchestrator-test) ..."`
+- Attempted `bb test:integration`, but the repo-wide integration runner stalled idle without producing output or a
+  failure signal during this pass
+
+## Deployment Plan
+
+Merge normally. This is an internal refactor plus test coverage.
+
+## Related Issues/PRs
+
+- Follow-up to PR #291
+- Follow-up to PR #292
+- Follow-up to PR #293
+
+## Checklist
+
+- [x] Keep kernel default profile ownership in the kernel only
+- [x] Move workflow-owned profiles to workflow resources
+- [x] Make profile selection explicit at DAG construction time
+- [x] Remove remaining merge-only assumptions from generic DAG queries
+- [x] Add regression coverage for the new provider seam
+- [x] Re-run `bb pre-commit`

--- a/docs/pull-requests/2026-03-11-codex-profile-provider-followup.md
+++ b/docs/pull-requests/2026-03-11-codex-profile-provider-followup.md
@@ -30,14 +30,21 @@ few merge-centric assumptions that surfaced once the kernel default reverted to 
   - workflow provider loading from resources
   - task-executor forwarding provider config
   - generic blocked/running task behavior after the kernel default changed
+- Fixed the repo integration runner so `bb test:integration` streams child test output instead of buffering until the
+  end of the full suite. This makes slow namespaces visible and avoids the appearance of a hang.
+- Fixed a real integration-test cleanup race in `artifact.interface-integration-test` by closing tracked stores before
+  temp-dir cleanup and retrying directory deletion when async persistence has not fully settled yet.
 
 ## Testing Plan
 
 - `bb pre-commit`
+- `bb test:integration`
 - `clojure -M:dev:test -e "(require '[clojure.test :as t] 'ai.miniforge.dag-executor.state-test
   'ai.miniforge.workflow.state-profile-test 'ai.miniforge.task-executor.orchestrator-test) ..."`
-- Attempted `bb test:integration`, but the repo-wide integration runner stalled idle without producing output or a
-  failure signal during this pass
+- `bb test:integration` now completes green: 293 tests, 1015 assertions, 0 failures, 0 errors
+
+Note: the integration run still emits noisy `babashka.process/destroy_tree` `sysctl failed` warnings in this local
+sandbox when child processes are cleaned up. They do not fail the suite and were pre-existing.
 
 ## Deployment Plan
 
@@ -57,3 +64,4 @@ Merge normally. This is an internal refactor plus test coverage.
 - [x] Remove remaining merge-only assumptions from generic DAG queries
 - [x] Add regression coverage for the new provider seam
 - [x] Re-run `bb pre-commit`
+- [x] Re-run `bb test:integration` and confirm the suite completes

--- a/projects/miniforge/test/ai/miniforge/artifact/interface_integration_test.clj
+++ b/projects/miniforge/test/ai/miniforge/artifact/interface_integration_test.clj
@@ -7,6 +7,7 @@
 ;; Test fixtures
 
 (def test-dirs (atom #{}))
+(def test-stores (atom #{}))
 (def test-store-root (System/getenv "MINIFORGE_ARTIFACT_TEST_DIR"))
 (def test-backend (or (System/getenv "MINIFORGE_ARTIFACT_TEST_BACKEND") "transit"))
 
@@ -27,24 +28,47 @@
       (try
         (let [store (artifact/create-store datalevin-opts)]
           (swap! test-dirs conj dir)
+          (swap! test-stores conj store)
           store)
         (catch Throwable _e
           (let [fallback-dir (create-temp-test-dir (str prefix "transit-"))
                 store (artifact/create-transit-store (assoc opts :dir fallback-dir))]
             (swap! test-dirs conj dir)
             (swap! test-dirs conj fallback-dir)
+            (swap! test-stores conj store)
             store)))
       (let [store (artifact/create-transit-store (assoc opts :dir dir))]
         (swap! test-dirs conj dir)
+        (swap! test-stores conj store)
         store))))
 
+(defn delete-tree-with-retries!
+  [dir]
+  (loop [attempt 0]
+    (let [result (try
+                   (fs/delete-tree dir)
+                   :deleted
+                   (catch java.nio.file.DirectoryNotEmptyException e
+                     (if (< attempt 4)
+                       e
+                       (throw e))))]
+      (when (instance? java.nio.file.DirectoryNotEmptyException result)
+        (Thread/sleep 50)
+        (recur (inc attempt))))))
+
 (defn cleanup-stores [f]
-  (f)
-  ;; Clean up temp directories after tests
-  (doseq [dir @test-dirs]
-    (when (fs/exists? dir)
-      (fs/delete-tree dir)))
-  (reset! test-dirs #{}))
+  (try
+    (f)
+    (finally
+      ;; Close stores first so async persistence can settle before filesystem cleanup.
+      (doseq [store @test-stores]
+        (artifact/close-store store))
+      (reset! test-stores #{})
+      ;; Clean up temp directories after tests.
+      (doseq [dir @test-dirs]
+        (when (fs/exists? dir)
+          (delete-tree-with-retries! dir)))
+      (reset! test-dirs #{}))))
 
 (use-fixtures :each cleanup-stores)
 

--- a/tasks/test_runner.clj
+++ b/tasks/test_runner.clj
@@ -4,7 +4,11 @@
    [clojure.string :as str]))
 
 (defn run-stream! [& args]
-  (let [{:keys [exit]} (deref (apply p/process {:out :inherit :err :inherit} args))]
+  (let [[opts cmd-args] (if (map? (first args))
+                          [(merge {:out :inherit :err :inherit} (first args))
+                           (rest args)]
+                          [{:out :inherit :err :inherit} args])
+        {:keys [exit]} (deref (apply p/process opts cmd-args))]
     exit))
 
 (defn integration []
@@ -46,11 +50,8 @@
         expr (str "(require 'clojure.test" require-expr ") "
                   "(let [r (clojure.test/run-tests" run-expr ")] "
                   "  (System/exit (if (zero? (+ (:fail r 0) (:error r 0))) 0 1)))")
-        {:keys [exit out err]}
-        (p/sh {:out :string :err :string :dir "projects/miniforge"}
-              "clojure" "-Sdeps" deps "-M" "-e" expr)]
-    (when-not (str/blank? out) (println out))
-    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+        exit (run-stream! {:dir "projects/miniforge"}
+                          "clojure" "-Sdeps" deps "-M" "-e" expr)]
     (when-not (zero? exit)
       (println "❌ Integration tests failed with exit code:" exit)
       (System/exit exit))))


### PR DESCRIPTION
# refactor: move state profile ownership to project-side providers

## Overview

Moves DAG state-profile ownership out of implicit kernel classpath overlays and onto explicit project-side providers.
The kernel now owns profile normalization and consumption; the workflow app layer owns the software-factory and ETL
profile resources and loads them intentionally.

## Motivation

The previous pass removed hardcoded profile literals from the kernel, but the resolution path still depended on
resource overlays on the active classpath. That kept project-specific configuration coupled to the kernel and blurred
the intended Polylith seam. This follow-up makes profile selection explicit at DAG construction time and fixes the last
few merge-centric assumptions that surfaced once the kernel default reverted to `:kernel`.

## Changes in Detail

- Added provider-aware profile resolution in `dag-executor`, with explicit provider injection on task/run/DAG creation.
- Kept the kernel default provider limited to the kernel-owned `:kernel` profile.
- Moved workflow-owned profile registry data under `components/workflow/resources/config/workflow/state-profiles/`.
- Added workflow-side provider loader helpers and exported them through the workflow interface.
- Threaded `:state-profile` and `:state-profile-provider` through `task-executor` so app code can choose profiles
  without pulling workflow internals into the kernel.
- Fixed generic DAG queries that still assumed `:merged` was the universal success state:
  `running-tasks` now respects each task profile, and `blocked-tasks` now keys off success-terminal states instead of
  `:run/merged`.
- Added regression coverage for:
  - explicit provider resolution
  - provider-backed DAG construction
  - workflow provider loading from resources
  - task-executor forwarding provider config
  - generic blocked/running task behavior after the kernel default changed

## Testing Plan

- `bb pre-commit`
- `clojure -M:dev:test -e "(require '[clojure.test :as t] 'ai.miniforge.dag-executor.state-test
  'ai.miniforge.workflow.state-profile-test 'ai.miniforge.task-executor.orchestrator-test) ..."`
- Attempted `bb test:integration`, but the repo-wide integration runner stalled idle without producing output or a
  failure signal during this pass

## Deployment Plan

Merge normally. This is an internal refactor plus test coverage.

## Related Issues/PRs

- Follow-up to PR #291
- Follow-up to PR #292
- Follow-up to PR #293

## Checklist

- [x] Keep kernel default profile ownership in the kernel only
- [x] Move workflow-owned profiles to workflow resources
- [x] Make profile selection explicit at DAG construction time
- [x] Remove remaining merge-only assumptions from generic DAG queries
- [x] Add regression coverage for the new provider seam
- [x] Re-run `bb pre-commit`
