### PR TITLE
refactor: externalize workflow selector mappings

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
@@ -9,6 +9,7 @@
   (:require
    [clojure.string :as str]
    [cheshire.core :as json]
+   [ai.miniforge.cli.workflow-selection-config :as selection-config]
    [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.response.interface :as response]))
 
@@ -70,7 +71,7 @@
 
    Returns: String prompt"
   [spec workflows]
-  (str "You are a workflow recommendation system for Miniforge, an agentic SDLC platform.\n\n"
+  (str "You are a workflow recommendation system for Miniforge, a governed autonomous workflow platform.\n\n"
        "Your task is to analyze a task specification and recommend the most appropriate workflow.\n\n"
        "Available workflows:\n\n"
        (build-workflow-summaries workflows)
@@ -200,9 +201,9 @@
        :confidence 0.5
        :reasoning (str "Fallback: Selected based on task type " task-type)
        :source :fallback}
-      {:workflow :standard-sdlc
+      {:workflow (selection-config/resolve-selection-profile :default available-workflows)
        :confidence 0.3
-       :reasoning "Fallback: Default to standard SDLC workflow"
+       :reasoning "Fallback: Default to app-configured workflow profile"
        :source :fallback})))
 
 (defn recommend-workflow-with-fallback

--- a/bases/cli/src/ai/miniforge/cli/workflow_selection_config.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selection_config.clj
@@ -1,0 +1,84 @@
+(ns ai.miniforge.cli.workflow-selection-config
+  "Resource-driven workflow selection profile resolution."
+  (:require
+   [clojure.edn :as edn]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Resource loading
+
+(def selection-profiles-resource
+  "Classpath resource path for workflow selection profile mappings."
+  "config/workflow/selection-profiles.edn")
+
+(defn- read-selection-profile-config
+  "Read a single selection profile config resource."
+  [resource]
+  (let [config (-> resource slurp edn/read-string)]
+    (or (:workflow-selection/profiles config) {})))
+
+(defn configured-selection-profiles
+  "Merge workflow selection profile mappings from all matching classpath resources."
+  []
+  (->> (enumeration-seq (.getResources (clojure.lang.RT/baseLoader)
+                                       selection-profiles-resource))
+       (map read-selection-profile-config)
+       (apply merge {})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Generic fallback resolution
+
+(defn- workflow-characteristics
+  "Resolve workflow characteristics through the workflow interface."
+  [workflow]
+  (when-let [characteristics-fn (requiring-resolve
+                                  'ai.miniforge.workflow.interface/workflow-characteristics)]
+    (characteristics-fn workflow)))
+
+(defn- simplest-workflow-id
+  "Choose the simplest available workflow by phase count and max iterations."
+  [available-workflows]
+  (->> available-workflows
+       (sort-by (fn [workflow]
+                  (let [{:keys [phases max-iterations]} (workflow-characteristics workflow)]
+                    [phases max-iterations])))
+       first
+       :workflow/id))
+
+(defn- most-comprehensive-workflow-id
+  "Choose the most comprehensive available workflow by phase count."
+  [available-workflows]
+  (->> available-workflows
+       (sort-by (fn [workflow]
+                  (let [{:keys [phases max-iterations]} (workflow-characteristics workflow)]
+                    [(- phases) (- max-iterations)])))
+       first
+       :workflow/id))
+
+(defn- resolve-profile-fallback
+  "Resolve a profile via generic workflow characteristics when no config is present."
+  [profile available-workflows]
+  (case profile
+    :comprehensive (most-comprehensive-workflow-id available-workflows)
+    :fast (simplest-workflow-id available-workflows)
+    :default (or (resolve-profile-fallback :fast available-workflows)
+                 (most-comprehensive-workflow-id available-workflows))
+    nil))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Public API
+
+(defn resolve-selection-profile
+  "Resolve a logical selection profile to a concrete workflow id.
+
+   Profiles are app-owned configuration. If a configured profile points at a
+   workflow not present on the active classpath, fall back to generic workflow
+   characteristics."
+  ([profile]
+   (let [available-workflows ((requiring-resolve 'ai.miniforge.workflow.interface/list-workflows))]
+     (resolve-selection-profile profile available-workflows)))
+  ([profile available-workflows]
+   (let [configured-id (get (configured-selection-profiles) profile)
+         available-ids (set (map :workflow/id available-workflows))]
+     (cond
+       (contains? available-ids configured-id) configured-id
+       :else (resolve-profile-fallback profile available-workflows)))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_selector.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_selector.clj
@@ -20,13 +20,14 @@
   "Intelligent workflow selection based on spec characteristics.
 
    Analyzes workflow specs and automatically selects the appropriate workflow
-   type (canonical-sdlc-v1, lean-sdlc-v1, or simple-test-v1).
+   profile, then resolves that profile to the active app's workflow id.
 
    Layer 0: Spec analysis - extract features from spec
    Layer 1: Rule matching - apply selection rules
    Layer 2: Workflow selection with reasoning"
   (:require
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [ai.miniforge.cli.workflow-selection-config :as selection-config]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Spec feature extraction
@@ -150,65 +151,73 @@
      :size size
      :constraint-mentions (extract-constraints-mentions spec)}))
 
+(defn selection-result
+  "Build a selection result from a logical profile."
+  [profile confidence reason]
+  {:selection-profile profile
+   :workflow-type (selection-config/resolve-selection-profile profile)
+   :confidence confidence
+   :reason reason})
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Rule matching
 
 (defn match-multi-phase-rule
-  "Multi-phase implementation → canonical-sdlc-v1"
+  "Multi-phase implementation → comprehensive profile"
   [features]
   (when (and (:pr-count features)
              (>= (:pr-count features) 4))
-    {:workflow-type :canonical-sdlc-v1
-     :confidence :high
-     :reason (str "Multi-phase implementation with "
-                  (:pr-count features)
-                  " PRs requires comprehensive review")}))
+    (selection-result :comprehensive
+                      :high
+                      (str "Multi-phase implementation with "
+                           (:pr-count features)
+                           " PRs requires comprehensive review"))))
 
 (defn match-refactoring-stratification-rule
-  "Refactoring with stratification → canonical-sdlc-v1"
+  "Refactoring with stratification → comprehensive profile"
   [features]
   (when (and (or (= (:type features) :refactoring)
                  (contains? (:keywords features) :refactoring))
              (or (contains? (:keywords features) :stratified-design)
                  (contains? (:constraint-mentions features) :rule-210)))
-    {:workflow-type :canonical-sdlc-v1
-     :confidence :high
-     :reason "Refactoring with stratification requires comprehensive design review"}))
+    (selection-result :comprehensive
+                      :high
+                      "Refactoring with stratification requires comprehensive design review")))
 
 (defn match-large-feature-rule
-  "Large feature → canonical-sdlc-v1"
+  "Large feature → comprehensive profile"
   [features]
   (when (and (= (:size features) :large)
              (not (contains? (:keywords features) :bugfix))
              (not (contains? (:keywords features) :docs-only)))
-    {:workflow-type :canonical-sdlc-v1
-     :confidence :medium
-     :reason "Large feature requires comprehensive SDLC phases"}))
+    (selection-result :comprehensive
+                      :medium
+                      "Large feature requires comprehensive workflow phases")))
 
 (defn match-bugfix-rule
-  "Bug fix → lean-sdlc-v1"
+  "Bug fix → fast profile"
   [features]
   (when (or (= (:type features) :bugfix)
             (contains? (:keywords features) :bugfix))
-    {:workflow-type :lean-sdlc-v1
-     :confidence :high
-     :reason "Bug fix is well-suited for lean workflow"}))
+    (selection-result :fast
+                      :high
+                      "Bug fix is well-suited for a fast workflow")))
 
 (defn match-docs-only-rule
-  "Docs only → lean-sdlc-v1"
+  "Docs only → fast profile"
   [features]
   (when (or (= (:type features) :docs)
             (contains? (:keywords features) :docs-only))
-    {:workflow-type :lean-sdlc-v1
-     :confidence :high
-     :reason "Documentation changes use lean workflow"}))
+    (selection-result :fast
+                      :high
+                      "Documentation changes use a fast workflow")))
 
 (defn match-unknown-rule
-  "Unknown/ambiguous → lean-sdlc-v1 (safer default than simple)"
+  "Unknown/ambiguous → default profile"
   [_features]
-  {:workflow-type :lean-sdlc-v1
-   :confidence :low
-   :reason "Unknown task type defaults to lean workflow (safer than simple)"})
+  (selection-result :default
+                    :low
+                    "Unknown task type defaults to the app's default workflow"))
 
 (def selection-rules
   "Ordered list of selection rules. First matching rule wins."
@@ -223,12 +232,12 @@
   "Apply selection rules to features and return first match.
 
    Rules are applied in order:
-   1. Multi-phase implementation → canonical-sdlc-v1
-   2. Refactoring with stratification → canonical-sdlc-v1
-   3. Large feature → canonical-sdlc-v1
-   4. Bug fix → lean-sdlc-v1
-   5. Docs only → lean-sdlc-v1
-   6. Unknown → lean-sdlc-v1 (default)
+   1. Multi-phase implementation → comprehensive profile
+   2. Refactoring with stratification → comprehensive profile
+   3. Large feature → comprehensive profile
+   4. Bug fix → fast profile
+   5. Docs only → fast profile
+   6. Unknown → default profile
 
    Returns map with:
    - :workflow-type - Selected workflow keyword
@@ -252,6 +261,7 @@
    Example:
      (select-workflow spec)
      => {:workflow-type :canonical-sdlc-v1
+         :selection-profile :comprehensive
          :confidence :high
          :reason \"Multi-phase implementation with 6 PRs requires comprehensive review\"
          :features {...}}"
@@ -297,7 +307,9 @@
      :spec/constraints ["Follow stratified design" "≤400 lines per file"]})
 
   (select-workflow emojui-spec)
-  ;; => {:workflow-type :canonical-sdlc-v1, :confidence :high, ...}
+  ;; => {:workflow-type :canonical-sdlc-v1
+  ;;     :selection-profile :comprehensive
+  ;;     :confidence :high, ...}
 
   ;; Test with bug fix spec
   (def bugfix-spec
@@ -306,7 +318,9 @@
      :spec/intent {:type :bugfix}})
 
   (select-workflow bugfix-spec)
-  ;; => {:workflow-type :lean-sdlc-v1, :confidence :high, ...}
+  ;; => {:workflow-type :lean-sdlc-v1
+  ;;     :selection-profile :fast
+  ;;     :confidence :high, ...}
 
   ;; Test with explicit override
   (def override-spec

--- a/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
@@ -1,0 +1,24 @@
+(ns ai.miniforge.cli.workflow-recommender-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.workflow-recommender :as recommender]))
+
+(deftest recommend-by-task-type-test
+  (let [available-workflows [{:workflow/id :lean-sdlc-v1
+                              :workflow/task-types [:bugfix :docs]}
+                             {:workflow/id :canonical-sdlc-v1
+                              :workflow/task-types [:feature :refactoring]}]]
+    (testing "matching task types win before profile fallback"
+      (let [result (recommender/recommend-by-task-type
+                    {:spec/workflow-type :bugfix}
+                    available-workflows)]
+        (is (= :lean-sdlc-v1 (:workflow result)))
+        (is (= :fallback (:source result)))))
+
+    (testing "missing task types fall back to the app-configured default workflow"
+      (let [result (recommender/recommend-by-task-type
+                    {:spec/workflow-type :unmapped-task}
+                    available-workflows)]
+        (is (= :lean-sdlc-v1 (:workflow result)))
+        (is (= :fallback (:source result)))
+        (is (= 0.3 (:confidence result)))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_selection_config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_selection_config_test.clj
@@ -1,0 +1,36 @@
+(ns ai.miniforge.cli.workflow-selection-config-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.workflow-selection-config :as cfg]))
+
+(deftest configured-selection-profiles-test
+  (testing "software-factory workflow selection profiles load from resources"
+    (let [profiles (cfg/configured-selection-profiles)]
+      (is (= :canonical-sdlc-v1 (:comprehensive profiles)))
+      (is (= :lean-sdlc-v1 (:fast profiles)))
+      (is (= :lean-sdlc-v1 (:default profiles))))))
+
+(deftest resolve-selection-profile-test
+  (testing "configured profiles resolve to available workflows"
+    (let [available-workflows [{:workflow/id :canonical-sdlc-v1
+                                :workflow/phases [{:phase/id :explore}
+                                                  {:phase/id :plan}
+                                                  {:phase/id :implement}
+                                                  {:phase/id :verify}
+                                                  {:phase/id :review}
+                                                  {:phase/id :release}
+                                                  {:phase/id :done}]
+                                :workflow/config {:max-total-iterations 50}}
+                               {:workflow/id :lean-sdlc-v1
+                                :workflow/phases [{:phase/id :plan-design}
+                                                  {:phase/id :implement-tdd}
+                                                  {:phase/id :review}
+                                                  {:phase/id :release}
+                                                  {:phase/id :observe}]
+                                :workflow/config {:max-total-iterations 20}}]]
+      (is (= :canonical-sdlc-v1
+             (cfg/resolve-selection-profile :comprehensive available-workflows)))
+      (is (= :lean-sdlc-v1
+             (cfg/resolve-selection-profile :fast available-workflows)))
+      (is (= :lean-sdlc-v1
+             (cfg/resolve-selection-profile :default available-workflows))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_selector_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_selector_test.clj
@@ -107,6 +107,7 @@
     (let [features (ws/analyze-spec multi-phase-refactor-spec)
           result (ws/match-rule features)]
       (is (= :canonical-sdlc-v1 (:workflow-type result)))
+      (is (= :comprehensive (:selection-profile result)))
       (is (= :high (:confidence result)))
       (is (string? (:reason result)))))
 
@@ -114,30 +115,35 @@
     (let [features (ws/analyze-spec refactor-with-rule-210-spec)
           result (ws/match-rule features)]
       (is (= :canonical-sdlc-v1 (:workflow-type result)))
+      (is (= :comprehensive (:selection-profile result)))
       (is (= :high (:confidence result)))))
 
   (testing "Bug fix rule matches"
     (let [features (ws/analyze-spec bugfix-spec)
           result (ws/match-rule features)]
       (is (= :lean-sdlc-v1 (:workflow-type result)))
+      (is (= :fast (:selection-profile result)))
       (is (= :high (:confidence result)))))
 
   (testing "Docs only rule matches"
     (let [features (ws/analyze-spec docs-spec)
           result (ws/match-rule features)]
       (is (= :lean-sdlc-v1 (:workflow-type result)))
+      (is (= :fast (:selection-profile result)))
       (is (= :high (:confidence result)))))
 
   (testing "Large feature rule matches"
     (let [features (ws/analyze-spec large-feature-spec)
           result (ws/match-rule features)]
       (is (= :canonical-sdlc-v1 (:workflow-type result)))
+      (is (= :comprehensive (:selection-profile result)))
       (is (= :medium (:confidence result)))))
 
   (testing "Unknown defaults to lean-sdlc-v1"
     (let [features (ws/analyze-spec unknown-spec)
           result (ws/match-rule features)]
       (is (= :lean-sdlc-v1 (:workflow-type result)))
+      (is (= :default (:selection-profile result)))
       (is (= :low (:confidence result))))))
 
 ;------------------------------------------------------------------------------ Layer 2 Tests
@@ -147,6 +153,7 @@
   (testing "select-workflow returns complete result for multi-phase refactor"
     (let [result (ws/select-workflow multi-phase-refactor-spec)]
       (is (= :canonical-sdlc-v1 (:workflow-type result)))
+      (is (= :comprehensive (:selection-profile result)))
       (is (= :high (:confidence result)))
       (is (string? (:reason result)))
       (is (map? (:features result)))
@@ -155,21 +162,25 @@
   (testing "select-workflow handles bugfix"
     (let [result (ws/select-workflow bugfix-spec)]
       (is (= :lean-sdlc-v1 (:workflow-type result)))
+      (is (= :fast (:selection-profile result)))
       (is (= :high (:confidence result)))))
 
   (testing "select-workflow handles docs-only"
     (let [result (ws/select-workflow docs-spec)]
       (is (= :lean-sdlc-v1 (:workflow-type result)))
+      (is (= :fast (:selection-profile result)))
       (is (= :high (:confidence result)))))
 
   (testing "select-workflow handles large feature"
     (let [result (ws/select-workflow large-feature-spec)]
       (is (= :canonical-sdlc-v1 (:workflow-type result)))
+      (is (= :comprehensive (:selection-profile result)))
       (is (= :medium (:confidence result)))))
 
   (testing "select-workflow handles unknown with safe default"
     (let [result (ws/select-workflow unknown-spec)]
       (is (= :lean-sdlc-v1 (:workflow-type result)))
+      (is (= :default (:selection-profile result)))
       (is (= :low (:confidence result))))))
 
 (deftest explain-selection-test

--- a/components/workflow-software-factory/resources/config/workflow/selection-profiles.edn
+++ b/components/workflow-software-factory/resources/config/workflow/selection-profiles.edn
@@ -1,0 +1,4 @@
+{:workflow-selection/profiles
+ {:comprehensive :canonical-sdlc-v1
+  :fast :lean-sdlc-v1
+  :default :lean-sdlc-v1}}

--- a/docs/pull-requests/2026-03-11-codex-workflow-selector-split.md
+++ b/docs/pull-requests/2026-03-11-codex-workflow-selector-split.md
@@ -1,0 +1,82 @@
+# PR: Move workflow selector mappings into app-owned resources
+
+## Summary
+
+This PR removes hardcoded software-factory workflow ids from the shared CLI
+workflow selector and recommender fallback path.
+
+The selector heuristics still live in the CLI, but they now produce logical
+selection profiles:
+
+- `:comprehensive`
+- `:fast`
+- `:default`
+
+Those profiles are resolved to concrete workflow ids through app-owned classpath
+resources provided by `workflow-software-factory`.
+
+## Changes
+
+### New config seam
+
+- Added `ai.miniforge.cli.workflow-selection-config`
+- Added resource config at:
+  - `components/workflow-software-factory/resources/config/workflow/selection-profiles.edn`
+
+Current software-factory mapping is:
+
+- `:comprehensive -> :canonical-sdlc-v1`
+- `:fast -> :lean-sdlc-v1`
+- `:default -> :lean-sdlc-v1`
+
+### Selector refactor
+
+- `ai.miniforge.cli.workflow-selector` no longer hardcodes SDLC workflow ids
+- Rule logic now selects logical profiles, then resolves them through config
+- Selection results now include `:selection-profile` alongside `:workflow-type`
+
+### Recommender fallback
+
+- `ai.miniforge.cli.workflow-recommender` no longer hardcodes `:standard-sdlc`
+- Fallback now resolves the `:default` selection profile against available
+  workflows
+- Prompt copy was generalized from "agentic SDLC platform" to
+  "governed autonomous workflow platform"
+
+## Why
+
+After splitting workflow families and phase implementations into app-owned
+components, the next remaining leak was the selector path in the CLI.
+
+This keeps the heuristic engine reusable while moving the app-specific workflow
+identity into resource configuration, which matches the project’s config-in-code
+pattern better than hardcoded ids.
+
+## Test coverage
+
+Existing selector behavior coverage remains in:
+
+- `ai.miniforge.cli.workflow-selector-test`
+
+New seam-specific coverage was added in:
+
+- `ai.miniforge.cli.workflow-selection-config-test`
+  - resource-driven profile mapping
+  - profile resolution against available workflows
+- `ai.miniforge.cli.workflow-recommender-test`
+  - task-type match path
+  - default-profile fallback path
+
+## Verification
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-selector-test
+  'ai.miniforge.cli.workflow-selection-config-test 'ai.miniforge.cli.workflow-recommender-test) ..."`
+- `bb test`
+- `bb build:cli`
+- `bb build:tui`
+- `bb pre-commit`
+
+## Follow-up
+
+The next seam on this track is the remaining software-factory assumptions in
+shared chain/recommendation helpers, not the selector mapping itself.


### PR DESCRIPTION
# PR: Move workflow selector mappings into app-owned resources

## Summary

This PR removes hardcoded software-factory workflow ids from the shared CLI
workflow selector and recommender fallback path.

The selector heuristics still live in the CLI, but they now produce logical
selection profiles:

- `:comprehensive`
- `:fast`
- `:default`

Those profiles are resolved to concrete workflow ids through app-owned classpath
resources provided by `workflow-software-factory`.

## Changes

### New config seam

- Added `ai.miniforge.cli.workflow-selection-config`
- Added resource config at:
  - `components/workflow-software-factory/resources/config/workflow/selection-profiles.edn`

Current software-factory mapping is:

- `:comprehensive -> :canonical-sdlc-v1`
- `:fast -> :lean-sdlc-v1`
- `:default -> :lean-sdlc-v1`

### Selector refactor

- `ai.miniforge.cli.workflow-selector` no longer hardcodes SDLC workflow ids
- Rule logic now selects logical profiles, then resolves them through config
- Selection results now include `:selection-profile` alongside `:workflow-type`

### Recommender fallback

- `ai.miniforge.cli.workflow-recommender` no longer hardcodes `:standard-sdlc`
- Fallback now resolves the `:default` selection profile against available
  workflows
- Prompt copy was generalized from "agentic SDLC platform" to
  "governed autonomous workflow platform"

## Why

After splitting workflow families and phase implementations into app-owned
components, the next remaining leak was the selector path in the CLI.

This keeps the heuristic engine reusable while moving the app-specific workflow
identity into resource configuration, which matches the project’s config-in-code
pattern better than hardcoded ids.

## Test coverage

Existing selector behavior coverage remains in:

- `ai.miniforge.cli.workflow-selector-test`

New seam-specific coverage was added in:

- `ai.miniforge.cli.workflow-selection-config-test`
  - resource-driven profile mapping
  - profile resolution against available workflows
- `ai.miniforge.cli.workflow-recommender-test`
  - task-type match path
  - default-profile fallback path

## Verification

- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-selector-test
  'ai.miniforge.cli.workflow-selection-config-test 'ai.miniforge.cli.workflow-recommender-test) ..."`
- `bb test`
- `bb build:cli`
- `bb build:tui`
- `bb pre-commit`

## Follow-up

The next seam on this track is the remaining software-factory assumptions in
shared chain/recommendation helpers, not the selector mapping itself.
