### PR TITLE
refactor: remove resume workflow default

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -5,6 +5,7 @@
    [clojure.edn :as edn]
    [clojure.string :as str]
    [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.workflow-selection-config :as selection-config]
    [ai.miniforge.cli.workflow-runner.context :as context]
    [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
    [ai.miniforge.event-stream.interface :as es]))
@@ -104,6 +105,23 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public API
 
+(defn resolve-resume-workflow
+  "Resolve the workflow identity for a resumed run.
+
+   Uses the recorded workflow spec when present. Otherwise falls back to the
+   app-owned default selection profile."
+  [reconstructed]
+  (let [workflow-spec (:workflow-spec reconstructed)
+        workflow-type (or (some-> workflow-spec :name keyword)
+                          (selection-config/resolve-selection-profile :default))
+        workflow-version (or (:version workflow-spec) "latest")]
+    (when-not workflow-type
+      (throw (ex-info "Could not resolve a default workflow for resume"
+                      {:operation :resume-workflow
+                       :selection-profile :default})))
+    {:workflow-type workflow-type
+     :workflow-version workflow-version}))
+
 (defn resume-workflow
   "Resume a workflow from its last checkpoint.
 
@@ -130,11 +148,9 @@
             load-workflow (requiring-resolve 'ai.miniforge.workflow.interface/load-workflow)
             run-pipeline (requiring-resolve 'ai.miniforge.workflow.interface/run-pipeline)
 
-            ;; Determine workflow type from event spec, fall back to lean-sdlc
-            workflow-spec (:workflow-spec reconstructed)
-            workflow-type (or (when workflow-spec (keyword (:name workflow-spec)))
-                             :lean-sdlc)
-            workflow-version (or (when workflow-spec (:version workflow-spec)) "latest")
+            ;; Determine workflow identity from event spec or app-owned default profile
+            {:keys [workflow-type workflow-version]}
+            (resolve-resume-workflow reconstructed)
 
             ;; Load the workflow definition
             {:keys [workflow]} (load-workflow workflow-type workflow-version {})

--- a/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
@@ -1,0 +1,33 @@
+(ns ai.miniforge.cli.main.commands.resume-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.main.commands.resume :as sut]
+   [ai.miniforge.cli.workflow-selection-config :as selection-config]))
+
+(deftest resolve-resume-workflow-test
+  (testing "recorded workflow spec wins over configured fallback"
+    (with-redefs [selection-config/resolve-selection-profile
+                  (fn [_profile]
+                    (throw (ex-info "should not be called" {})))]
+      (is (= {:workflow-type :financial-etl
+              :workflow-version "1.2.3"}
+             (sut/resolve-resume-workflow
+              {:workflow-spec {:name "financial-etl"
+                               :version "1.2.3"}})))))
+
+  (testing "missing workflow spec falls back to app-configured default profile"
+    (with-redefs [selection-config/resolve-selection-profile
+                  (fn [profile]
+                    (is (= :default profile))
+                    :lean-sdlc-v1)]
+      (is (= {:workflow-type :lean-sdlc-v1
+              :workflow-version "latest"}
+             (sut/resolve-resume-workflow {})))))
+
+  (testing "missing configured fallback raises a clear error"
+    (with-redefs [selection-config/resolve-selection-profile
+                  (fn [_profile] nil)]
+      (is (thrown-with-msg?
+           clojure.lang.ExceptionInfo
+           #"Could not resolve a default workflow for resume"
+           (sut/resolve-resume-workflow {}))))))

--- a/docs/pull-requests/2026-03-11-codex-chain-helper-split.md
+++ b/docs/pull-requests/2026-03-11-codex-chain-helper-split.md
@@ -1,0 +1,49 @@
+# PR: Remove hardcoded workflow default from resume
+
+## Summary
+
+This PR removes the hardcoded `:lean-sdlc` fallback from the CLI resume path.
+
+Resumed runs now resolve their fallback workflow through the same app-owned
+selection-profile seam used by workflow selection and recommendation.
+
+## Changes
+
+- Added `ai.miniforge.cli.main.commands.resume/resolve-resume-workflow`
+- `resume-workflow` now prefers the recorded workflow spec and otherwise
+  resolves the `:default` selection profile through
+  `ai.miniforge.cli.workflow-selection-config`
+- Added direct unit coverage for the resolver
+
+## Why
+
+After moving workflow selector defaults and chain resources behind app
+composition, the resume path still carried a software-factory-specific fallback
+workflow id in shared CLI code.
+
+This keeps resume generic and lets each composed app decide its own default
+workflow for reconstructed runs.
+
+## Test coverage
+
+New coverage in:
+
+- `ai.miniforge.cli.main.commands.resume-test`
+  - recorded workflow spec wins
+  - app-configured default fallback is used when no spec is present
+  - missing fallback produces a clear error
+
+## Verification
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main.commands.resume-test) ..."`
+- `bb test`
+- `bb test:integration`
+- `bb build:cli`
+- `bb build:tui`
+- `bb pre-commit`
+
+## Follow-up
+
+The next seam on this track is the remaining software-factory language and
+heuristics in workflow recommendation prompts and adjacent CLI helper copy, not
+the default workflow binding itself.


### PR DESCRIPTION
# PR: Remove hardcoded workflow default from resume

## Summary

This PR removes the hardcoded `:lean-sdlc` fallback from the CLI resume path.

Resumed runs now resolve their fallback workflow through the same app-owned
selection-profile seam used by workflow selection and recommendation.

## Changes

- Added `ai.miniforge.cli.main.commands.resume/resolve-resume-workflow`
- `resume-workflow` now prefers the recorded workflow spec and otherwise
  resolves the `:default` selection profile through
  `ai.miniforge.cli.workflow-selection-config`
- Added direct unit coverage for the resolver

## Why

After moving workflow selector defaults and chain resources behind app
composition, the resume path still carried a software-factory-specific fallback
workflow id in shared CLI code.

This keeps resume generic and lets each composed app decide its own default
workflow for reconstructed runs.

## Test coverage

New coverage in:

- `ai.miniforge.cli.main.commands.resume-test`
  - recorded workflow spec wins
  - app-configured default fallback is used when no spec is present
  - missing fallback produces a clear error

## Verification

- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main.commands.resume-test) ..."`
- `bb test`
- `bb test:integration`
- `bb build:cli`
- `bb build:tui`
- `bb pre-commit`

## Follow-up

The next seam on this track is the remaining software-factory language and
heuristics in workflow recommendation prompts and adjacent CLI helper copy, not
the default workflow binding itself.
