### PR TITLE
refactor: externalize workflow recommendation prompt

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_recommendation_config.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommendation_config.clj
@@ -1,0 +1,43 @@
+(ns ai.miniforge.cli.workflow-recommendation-config
+  "Resource-driven workflow recommendation prompt configuration."
+  (:require
+   [clojure.edn :as edn]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Resource loading
+
+(def recommendation-config-resource
+  "Classpath resource path for workflow recommendation prompt config."
+  "config/workflow/recommendation-prompt.edn")
+
+(def default-prompt-config
+  {:analysis-dimensions
+   ["Task complexity (simple, medium, complex)"
+    "Risk level (low, medium, high)"
+    "Review requirements (minimal, standard, comprehensive)"
+    "Time constraints (quick, normal, extensive)"
+    "Work category and expected outputs"]
+   :summary-labels
+   {:has-review "Includes review checkpoints"
+    :has-testing "Includes verification/testing"}})
+
+(defn- read-recommendation-config
+  "Read a single recommendation prompt config resource."
+  [resource]
+  (let [config (-> resource slurp edn/read-string)]
+    (or (:workflow-recommendation/prompt config) {})))
+
+(defn- merge-prompt-config
+  "Merge prompt config maps, preserving nested summary labels."
+  [base override]
+  (-> base
+      (merge override)
+      (update :summary-labels #(merge (:summary-labels base) %))))
+
+(defn recommendation-prompt-config
+  "Resolve the active workflow recommendation prompt config from the classpath."
+  []
+  (->> (enumeration-seq (.getResources (clojure.lang.RT/baseLoader)
+                                       recommendation-config-resource))
+       (map read-recommendation-config)
+       (reduce merge-prompt-config default-prompt-config)))

--- a/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommender.clj
@@ -9,6 +9,7 @@
   (:require
    [clojure.string :as str]
    [cheshire.core :as json]
+   [ai.miniforge.cli.workflow-recommendation-config :as recommendation-config]
    [ai.miniforge.cli.workflow-selection-config :as selection-config]
    [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.response.interface :as response]))
@@ -24,14 +25,18 @@
 
    Returns: String summary"
   [workflow]
-  (let [chars (workflow/workflow-characteristics workflow)]
+  (let [chars (workflow/workflow-characteristics workflow)
+        summary-labels (:summary-labels
+                        (recommendation-config/recommendation-prompt-config))]
     (str "- " (name (:id chars)) " (v" (:version chars) ")"
          "\n  " (:name chars)
          "\n  Complexity: " (name (:complexity chars))
          "\n  Phases: " (:phases chars)
          "\n  Task types: " (str/join ", " (map name (:task-types chars)))
-         (when (:has-review chars) "\n  Includes code review")
-         (when (:has-testing chars) "\n  Includes testing"))))
+         (when (:has-review chars)
+           (str "\n  " (:has-review summary-labels)))
+         (when (:has-testing chars)
+           (str "\n  " (:has-testing summary-labels))))))
 
 (defn build-workflow-summaries
   "Build summaries for all available workflows.
@@ -71,28 +76,30 @@
 
    Returns: String prompt"
   [spec workflows]
-  (str "You are a workflow recommendation system for Miniforge, a governed autonomous workflow platform.\n\n"
-       "Your task is to analyze a task specification and recommend the most appropriate workflow.\n\n"
-       "Available workflows:\n\n"
-       (build-workflow-summaries workflows)
-       "\n\n"
-       "Task specification:\n\n"
-       (extract-spec-summary spec)
-       "\n\n"
-       "Analyze the task based on:\n"
-       "1. Task complexity (simple, medium, complex)\n"
-       "2. Risk level (low, medium, high)\n"
-       "3. Review requirements (minimal, standard, comprehensive)\n"
-       "4. Time constraints (quick, normal, extensive)\n"
-       "5. Task type (feature, bugfix, refactor, test)\n\n"
-       "Provide your recommendation as a JSON object with this exact structure:\n"
-       "{\n"
-       "  \"workflow\": \"workflow-id\",\n"
-       "  \"confidence\": 0.85,\n"
-       "  \"reasoning\": \"Brief explanation of why this workflow is recommended\",\n"
-       "  \"characteristics\": [\"multi-phase\", \"has-review\", \"comprehensive\"]\n"
-       "}\n\n"
-       "Respond ONLY with the JSON object, no additional text."))
+  (let [analysis-dimensions (:analysis-dimensions
+                             (recommendation-config/recommendation-prompt-config))]
+    (str "You are a workflow recommendation system for Miniforge, a governed autonomous workflow platform.\n\n"
+         "Your task is to analyze a task specification and recommend the most appropriate workflow.\n\n"
+         "Available workflows:\n\n"
+         (build-workflow-summaries workflows)
+         "\n\n"
+         "Task specification:\n\n"
+         (extract-spec-summary spec)
+         "\n\n"
+         "Analyze the task based on:\n"
+         (->> analysis-dimensions
+              (map-indexed (fn [idx dimension]
+                             (str (inc idx) ". " dimension)))
+              (str/join "\n"))
+         "\n\n"
+         "Provide your recommendation as a JSON object with this exact structure:\n"
+         "{\n"
+         "  \"workflow\": \"workflow-id\",\n"
+         "  \"confidence\": 0.85,\n"
+         "  \"reasoning\": \"Brief explanation of why this workflow is recommended\",\n"
+         "  \"characteristics\": [\"multi-phase\", \"has-review\", \"comprehensive\"]\n"
+         "}\n\n"
+         "Respond ONLY with the JSON object, no additional text.")))
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; LLM interaction

--- a/bases/cli/test/ai/miniforge/cli/workflow_recommendation_config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_recommendation_config_test.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.cli.workflow-recommendation-config-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.workflow-recommendation-config :as cfg]))
+
+(deftest recommendation-prompt-config-test
+  (testing "software-factory prompt config loads from resources"
+    (let [config (cfg/recommendation-prompt-config)]
+      (is (= "Task type (feature, bugfix, refactor, test)"
+             (last (:analysis-dimensions config))))
+      (is (= "Includes code review"
+             (get-in config [:summary-labels :has-review])))
+      (is (= "Includes testing"
+             (get-in config [:summary-labels :has-testing]))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
@@ -1,7 +1,46 @@
 (ns ai.miniforge.cli.workflow-recommender-test
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.workflow-recommendation-config :as cfg]
    [ai.miniforge.cli.workflow-recommender :as recommender]))
+
+(deftest build-recommendation-prompt-test
+  (let [available-workflows [{:workflow/id :lean-sdlc-v1
+                              :workflow/task-types [:bugfix :docs]}
+                             {:workflow/id :canonical-sdlc-v1
+                              :workflow/task-types [:feature :refactoring]}]]
+    (testing "configured prompt vocabulary is reflected in the assembled prompt"
+      (with-redefs [cfg/recommendation-prompt-config
+                    (fn []
+                      {:analysis-dimensions
+                       ["Task complexity (simple, medium, complex)"
+                        "Task type (feature, bugfix, refactor, test)"]
+                       :summary-labels
+                       {:has-review "Includes code review"
+                        :has-testing "Includes testing"}})
+                    recommender/build-workflow-summaries
+                    (fn [_workflows]
+                      "- workflow\n  Includes code review\n  Includes testing")]
+        (let [prompt (recommender/build-recommendation-prompt
+                      {:spec/title "Fix flaky test"}
+                      available-workflows)]
+          (is (.contains prompt "Task type (feature, bugfix, refactor, test)"))
+          (is (.contains prompt "Includes code review"))
+          (is (.contains prompt "Includes testing")))))
+
+    (testing "generic fallback vocabulary is available when no app config is present"
+      (with-redefs [cfg/recommendation-prompt-config
+                    (fn []
+                      cfg/default-prompt-config)
+                    recommender/build-workflow-summaries
+                    (fn [_workflows]
+                      "- workflow\n  Includes review checkpoints\n  Includes verification/testing")]
+        (let [prompt (recommender/build-recommendation-prompt
+                      {:spec/title "Run analytical workflow"}
+                      available-workflows)]
+          (is (.contains prompt "Work category and expected outputs"))
+          (is (.contains prompt "Includes review checkpoints"))
+          (is (.contains prompt "Includes verification/testing")))))))
 
 (deftest recommend-by-task-type-test
   (let [available-workflows [{:workflow/id :lean-sdlc-v1

--- a/components/workflow-software-factory/resources/config/workflow/recommendation-prompt.edn
+++ b/components/workflow-software-factory/resources/config/workflow/recommendation-prompt.edn
@@ -1,0 +1,10 @@
+{:workflow-recommendation/prompt
+ {:analysis-dimensions
+  ["Task complexity (simple, medium, complex)"
+   "Risk level (low, medium, high)"
+   "Review requirements (minimal, standard, comprehensive)"
+   "Time constraints (quick, normal, extensive)"
+   "Task type (feature, bugfix, refactor, test)"]
+  :summary-labels
+  {:has-review "Includes code review"
+   :has-testing "Includes testing"}}}

--- a/docs/pull-requests/2026-03-11-codex-recommendation-config-split.md
+++ b/docs/pull-requests/2026-03-11-codex-recommendation-config-split.md
@@ -1,0 +1,56 @@
+# PR: Move workflow recommendation prompt vocabulary into app config
+
+## Summary
+
+This PR moves software-factory-specific workflow recommendation prompt
+vocabulary out of shared CLI code and into app-owned resources.
+
+The recommender still assembles prompts generically, but the active classpath
+now provides the workflow-summary labels and analysis dimensions.
+
+## Changes
+
+- Added `ai.miniforge.cli.workflow-recommendation-config`
+- Added app-owned prompt config at:
+  - `components/workflow-software-factory/resources/config/workflow/recommendation-prompt.edn`
+- Updated `ai.miniforge.cli.workflow-recommender` to read:
+  - workflow summary labels from config
+  - analysis dimensions from config
+
+## Why
+
+After removing workflow defaults and chain resources from shared code, the next
+remaining software-factory leak was the recommendation prompt itself.
+
+Shared CLI code still hardcoded software-delivery task vocabulary such as
+`feature`, `bugfix`, `refactor`, and `test`, plus software-factory summary
+labels like `Includes code review`.
+
+This keeps recommendation assembly generic while letting each composed app
+define its own prompt vocabulary.
+
+## Test coverage
+
+New coverage in:
+
+- `ai.miniforge.cli.workflow-recommendation-config-test`
+  - software-factory prompt config loads from resources
+- `ai.miniforge.cli.workflow-recommender-test`
+  - configured prompt vocabulary appears in assembled prompts
+  - generic fallback vocabulary is used when no app config is present
+
+## Verification
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-recommendation-config-test
+  'ai.miniforge.cli.workflow-recommender-test) ..."`
+- `bb test`
+- `bb test:integration`
+- `bb build:cli`
+- `bb build:tui`
+- `bb pre-commit`
+
+## Follow-up
+
+The next seam on this track is the remaining software-factory naming and help
+copy in shared CLI and workflow-facing docs, not the recommendation prompt
+contract itself.


### PR DESCRIPTION
# PR: Move workflow recommendation prompt vocabulary into app config

## Summary

This PR moves software-factory-specific workflow recommendation prompt
vocabulary out of shared CLI code and into app-owned resources.

The recommender still assembles prompts generically, but the active classpath
now provides the workflow-summary labels and analysis dimensions.

## Changes

- Added `ai.miniforge.cli.workflow-recommendation-config`
- Added app-owned prompt config at:
  - `components/workflow-software-factory/resources/config/workflow/recommendation-prompt.edn`
- Updated `ai.miniforge.cli.workflow-recommender` to read:
  - workflow summary labels from config
  - analysis dimensions from config

## Why

After removing workflow defaults and chain resources from shared code, the next
remaining software-factory leak was the recommendation prompt itself.

Shared CLI code still hardcoded software-delivery task vocabulary such as
`feature`, `bugfix`, `refactor`, and `test`, plus software-factory summary
labels like `Includes code review`.

This keeps recommendation assembly generic while letting each composed app
define its own prompt vocabulary.

## Test coverage

New coverage in:

- `ai.miniforge.cli.workflow-recommendation-config-test`
  - software-factory prompt config loads from resources
- `ai.miniforge.cli.workflow-recommender-test`
  - configured prompt vocabulary appears in assembled prompts
  - generic fallback vocabulary is used when no app config is present

## Verification

- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-recommendation-config-test
  'ai.miniforge.cli.workflow-recommender-test) ..."`
- `bb test`
- `bb test:integration`
- `bb build:cli`
- `bb build:tui`
- `bb pre-commit`

## Follow-up

The next seam on this track is the remaining software-factory naming and help
copy in shared CLI and workflow-facing docs, not the recommendation prompt
contract itself.
