### PR TITLE
docs: clean up shared workflow copy

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -306,8 +306,9 @@ Examples:
   miniforge tui                        # Start terminal UI (requires miniforge-tui)
   miniforge workflow list
   miniforge workflow run :simple-v2
-  miniforge workflow run :canonical-sdlc-v1 -i input.edn
-  miniforge workflow run :workflow-id --input-json '{\"task\": \"Build feature\"}'
+  miniforge workflow run :financial-etl -i input.edn
+  miniforge workflow run :workflow-id --input-json '{\"task\": \"Prepare report\"}'
+  miniforge chain list
   miniforge fleet add myorg/myrepo
   miniforge pr review https://github.com/org/repo/pull/123
 "))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -381,7 +381,7 @@
   "Execute a chain of workflows.
 
    Arguments:
-   - chain-id: Chain identifier keyword (e.g. :spec-to-pr)
+   - chain-id: Chain identifier keyword (e.g. :reporting-chain)
    - opts: {:version \"latest\" :spec \"spec.edn\" :input-json \"{...}\" :quiet false}"
   [chain-id opts]
   (let [quiet (or (:quiet opts) false)

--- a/bases/cli/test/ai/miniforge/cli/main_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main_test.clj
@@ -1,0 +1,13 @@
+(ns ai.miniforge.cli.main-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.main :as sut]))
+
+(deftest help-cmd-uses-generic-workflow-examples-test
+  (testing "CLI help shows generic workflow examples instead of SDLC-specific ones"
+    (let [output (with-out-str (sut/help-cmd {}))]
+      (is (.contains output "miniforge workflow run :simple-v2"))
+      (is (.contains output "miniforge workflow run :financial-etl -i input.edn"))
+      (is (.contains output "miniforge chain list"))
+      (is (not (.contains output "canonical-sdlc-v1")))
+      (is (not (.contains output "Build feature"))))))

--- a/components/workflow/resources/workflows/README.md
+++ b/components/workflow/resources/workflows/README.md
@@ -1,299 +1,40 @@
 # Workflow Catalog
 
-This directory contains configurable workflow definitions in EDN format. Each workflow represents a complete SDLC flow that can be executed by the configurable workflow engine.
+This directory contains the workflow definitions that ship with the shared
+`workflow` component.
+
+These workflows are intended to be domain-neutral examples, local validation
+flows, and reference implementations for the generic workflow runtime.
+
+Software-factory workflow families such as the SDLC flows now live in
+`components/workflow-software-factory/resources/workflows/`.
 
 ## Workflow Index
 
-### Production Workflows
-
-| Workflow ID | Version | Purpose | Phases | Complexity |
-|-------------|---------|---------|--------|------------|
-| `canonical-sdlc-v1` | 1.0.0 | Complete SDLC with all phases | 10 | High |
-| `lean-sdlc-v1` | 1.0.0 | Fast iteration for small changes | 6 | Medium |
-
-### Test Workflows
-
-| Workflow ID | Version | Purpose | Phases | Complexity |
-|-------------|---------|---------|--------|------------|
-| `simple-test-v1` | 1.0.0 | Integration testing & demos | 3 | Low |
-| `minimal-test-v1` | 1.0.0 | Unit testing workflow basics | 1 | Minimal |
-
----
-
-## Production Workflows
-
-### canonical-sdlc-v1.0.0
-
-**Purpose**: Complete, production-grade SDLC workflow with comprehensive review loops.
-
-**Phases**:
-
-1. PM Spec → PM Review
-2. Dev Spec → Dev Review
-3. Test Plan → Multi-reviewer Review
-4. Test Implementation
-5. Dev Implementation → Test Loop
-6. PR Monitoring → PR Comment Loop
-7. Ready for Merge
-8. Meta Loop
-9. Observe
-
-**Characteristics**:
-
-- **Max iterations**: 100
-- **Max time**: 2 hours
-- **Max tokens**: 200,000
-- **Gates**: Comprehensive (syntax, lint, tests, policy, reviews)
-- **Review loops**: Multiple reviewers at each phase
-- **Best for**: Large features, critical changes, team collaboration
-
-**Task types**: `:feature`, `:major-refactor`, `:architecture-change`
-
----
-
-### lean-sdlc-v1.0.0
-
-**Purpose**: Streamlined workflow optimized for speed and rapid iteration.
-
-**Phases**:
-
-1. Input Validation
-2. Planning & Design (combined)
-3. TDD Implementation (tests + code combined)
-4. Quick Review
-5. Release
-6. Observe
-
-**Characteristics**:
-
-- **Max iterations**: 50
-- **Max time**: 1 hour
-- **Max tokens**: 100,000
-- **Gates**: Essential only (syntax, lint, tests)
-- **Review loops**: Single reviewer, fewer rounds
-- **Best for**: Small features, bug fixes, documentation
-
-**Task types**: `:small-feature`, `:bugfix`, `:docs`
-
----
-
-## Test Workflows
-
-### simple-test-v1.0.0
-
-**Purpose**: Minimal workflow for integration testing and demonstrations.
-
-**Phases**:
-
-1. **Plan**: Create implementation plan
-2. **Implement**: Generate code from plan
-3. **Done**: Terminal phase (no agent)
-
-**Characteristics**:
-
-- **Max iterations**: 20
-- **Max time**: 5 minutes
-- **Max tokens**: 20,000
-- **Gates**: Syntax only (on implement phase)
-- **Review loops**: None
-- **Best for**: Testing workflow execution, demos, tutorials
-
-**Task types**: `:test`, `:demo`, `:tutorial`
-
-**Use cases**:
-
-- Integration testing the configurable workflow engine
-- Demonstrating workflow execution flow
-- Tutorial examples for new users
-- Fast iteration during development
-
-**Phase details**:
-
-```clojure
-;; Plan phase
-{:phase/id :plan
- :phase/agent :planner
- :phase/inner-loop {:max-iterations 3}
- :phase/gates []
- :phase/next [{:target :implement}]}
-
-;; Implement phase
-{:phase/id :implement
- :phase/agent :implementer
- :phase/inner-loop {:max-iterations 5}
- :phase/gates [:syntax-valid]
- :phase/next [{:target :done}]}
-
-;; Done phase
-{:phase/id :done
- :phase/agent :none
- :phase/next []}
-```
-
----
-
-### minimal-test-v1.0.0
-
-**Purpose**: Absolute minimal workflow for unit testing workflow basics.
-
-**Phases**:
-
-1. **Plan**: Single phase that creates a plan and terminates
-
-**Characteristics**:
-
-- **Max iterations**: 5
-- **Max time**: 1 minute
-- **Max tokens**: 5,000
-- **Gates**: None
-- **Review loops**: None
-- **Best for**: Unit testing, fastest possible execution
-
-**Task types**: `:test`, `:unit-test`
-
-**Use cases**:
-
-- Unit testing workflow state management
-- Testing phase execution in isolation
-- Validating workflow configuration loading
-- Performance testing (minimal overhead)
-- CI/CD smoke tests
-
-**Phase details**:
-
-```clojure
-;; Plan phase (terminal)
-{:phase/id :plan
- :phase/agent :planner
- :phase/inner-loop {:max-iterations 2}
- :phase/gates []
- :phase/next []}  ; No transitions - terminal
-```
-
----
-
-## Workflow Selection Guide
-
-### When to use each workflow
-
-**canonical-sdlc-v1**:
-
-- ✅ Large features requiring multiple phases
-- ✅ Critical changes needing thorough review
-- ✅ Team collaboration with multiple reviewers
-- ✅ Complex architectures
-- ❌ Time-sensitive small fixes
-- ❌ Solo development iterations
-
-**lean-sdlc-v1**:
-
-- ✅ Small, isolated features
-- ✅ Bug fixes
-- ✅ Documentation updates
-- ✅ Low-risk changes
-- ✅ Rapid prototyping
-- ❌ Complex multi-component changes
-- ❌ Architecture decisions
-
-**simple-test-v1**:
-
-- ✅ Integration testing workflows
-- ✅ Demos and tutorials
-- ✅ Development/debugging workflow engine
-- ✅ Learning the system
-- ❌ Production use
-
-**minimal-test-v1**:
-
-- ✅ Unit testing
-- ✅ CI smoke tests
-- ✅ Performance benchmarking
-- ✅ Configuration validation
-- ❌ Any real work
-
----
-
-## Workflow File Structure
-
-All workflow files follow this structure:
-
-```clojure
-{:workflow/id keyword          ; Unique identifier
- :workflow/version string       ; Semantic version
- :workflow/name string          ; Human-readable name
- :workflow/description string   ; Purpose and details
- :workflow/created-at inst      ; Creation timestamp
- :workflow/task-types [keyword] ; Suitable task types
- :workflow/entry keyword        ; Entry phase ID
-
- :workflow/phases
- [{:phase/id keyword           ; Unique phase identifier
-   :phase/name string          ; Human-readable name
-   :phase/description string   ; Phase purpose
-   :phase/agent keyword        ; Agent type (:planner, :implementer, etc.)
-   :phase/actions [keyword]    ; Actions performed
-   :phase/inner-loop map       ; Inner loop configuration
-   :phase/gates [keyword]      ; Validation gates
-   :phase/budget map           ; Resource limits
-   :phase/next [map]           ; Phase transitions
-   :phase/metrics [keyword]}]  ; Metrics to collect
-
- :workflow/config
- {:parallel-phases [keyword]          ; Phases that can run in parallel
-  :failure-strategy keyword           ; :retry, :fail-fast, :rollback
-  :max-total-iterations int           ; Global iteration limit
-  :max-total-time-seconds int         ; Global time limit
-  :max-total-tokens int}              ; Global token budget
-
- :workflow/metrics map}               ; Metrics tracking
-```
-
----
-
-## Adding New Workflows
-
-To add a new workflow:
-
-1. **Create EDN file**: `components/workflow/resources/workflows/your-workflow-v1.0.0.edn`
-
-2. **Follow naming convention**: `{workflow-id}-v{version}.edn`
-
-3. **Include all required fields**: See structure above
-
-4. **Validate structure**: Run tests to ensure proper format
-
-5. **Document here**: Add entry to this README
-
-6. **Test execution**: Create integration test in `test/` directory
-
----
-
-## Version History
-
-| Workflow | Versions | Latest | Notes |
-|----------|----------|--------|-------|
-| canonical-sdlc | 1.0.0 | 1.0.0 | Initial release |
-| lean-sdlc | 1.0.0 | 1.0.0 | Initial release |
-| simple-test | 1.0.0 | 1.0.0 | Initial release |
-| minimal-test | 1.0.0 | 1.0.0 | Initial release |
-
----
-
-## Meta Loop Integration
-
-All workflows feed metrics into the Meta Loop for optimization:
-
-- **Success rate**: Percentage of workflows completing successfully
-- **Avg iterations**: Mean iterations per phase
-- **Avg time**: Mean execution time
-- **Avg tokens**: Mean token usage
-- **Repair cycles**: Mean repair attempts per phase
-
-The Meta Loop uses these metrics to:
-
-1. Compare workflow effectiveness
-2. Suggest optimizations
-3. Generate new workflow variants
-4. Evolve SDLC processes over time
-
-See `docs/research/workflow-optimization-theory.md` for details on workflow evolution and optimization strategies.
+| Workflow ID | Version | Purpose | Notes |
+|-------------|---------|---------|-------|
+| `financial-etl` | 1.0.0 | Reference analytical workflow for staged ETL and evaluation | Exercises non-software vertical seams |
+| `simple-v2` | 2.0.0 | Lightweight general workflow for local execution | Good default example for demos |
+| `simple-test-v1` | 1.0.0 | Integration testing and tutorial flow | Minimal multi-phase example |
+| `minimal-test-v1` | 1.0.0 | Unit and smoke testing flow | Single-phase baseline |
+
+## What Belongs Here
+
+- Domain-neutral workflow examples
+- Test and validation workflows used by the shared runtime
+- Reference vertical demos that prove the kernel is not software-only
+
+## What Does Not Belong Here
+
+- Software-factory workflow families
+- App-specific workflow defaults or selection policy
+- Premium or marketplace workflow packs
+
+## Notes
+
+- Workflows are discovered from every `workflows/` directory on the active
+  classpath.
+- The final visible catalog depends on which components are loaded by the
+  current project or base.
+- For flagship software-factory workflows, inspect the
+  `workflow-software-factory` component instead of this directory.

--- a/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
@@ -83,7 +83,7 @@
 
 (defn find-latest-chain-resource
   "Find the highest-versioned chain EDN resource path for chain-id.
-   Returns a resource path string like \"chains/spec-to-pr-v1.0.0.edn\"."
+   Returns a resource path string like \"chains/reporting-chain-v1.0.0.edn\"."
   [chain-id]
   (let [prefix (str (name chain-id) "-v")
         candidates (->> (list-resource-names "chains")
@@ -107,7 +107,7 @@
   "Load a chain definition from classpath resources.
 
    Arguments:
-   - chain-id: Chain identifier (keyword, e.g. :spec-to-pr)
+   - chain-id: Chain identifier (keyword, e.g. :reporting-chain)
    - version: Version string (e.g. \"1.0.0\" or \"latest\")
 
    Returns chain definition map or throws if not found."

--- a/docs/pull-requests/2026-03-11-codex-public-copy-cleanup.md
+++ b/docs/pull-requests/2026-03-11-codex-public-copy-cleanup.md
@@ -1,0 +1,51 @@
+# PR: Clean up public workflow copy in shared surfaces
+
+## Summary
+
+This PR removes software-factory-specific workflow examples from the live shared
+CLI help and kernel workflow catalog copy.
+
+The goal is not to rename the whole product in one pass. It is to stop the
+shared public surfaces from implying that SDLC workflows are the only first
+class workflows.
+
+## Changes
+
+- Updated CLI help examples in `ai.miniforge.cli.main`
+- Updated generic chain docstrings in:
+  - `ai.miniforge.cli.workflow-runner`
+  - `ai.miniforge.workflow.chain-loader`
+- Rewrote `components/workflow/resources/workflows/README.md` so it describes
+  the workflows that actually ship in the shared workflow component today
+- Added a regression test for CLI help output
+
+## Why
+
+After moving workflow families, phase implementations, chains, defaults, and
+recommendation prompt vocabulary behind app composition, the remaining leak on
+the public path was copy.
+
+The live help output and kernel workflow catalog still pointed users at
+software-factory examples that no longer belong to the shared workflow
+component.
+
+## Test coverage
+
+New coverage in:
+
+- `ai.miniforge.cli.main-test`
+  - generic workflow examples appear in help output
+  - software-factory workflow ids are not shown in shared help output
+
+## Verification
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main-test) ..."`
+- `bb test`
+- `bb build:cli`
+- `bb pre-commit`
+
+## Follow-up
+
+The next seam after this is the deeper software-factory terminology embedded in
+internal workflow component docstrings and older architecture docs, which is a
+larger documentation pass rather than a live-surface cleanup.


### PR DESCRIPTION
# PR: Clean up public workflow copy in shared surfaces

## Summary

This PR removes software-factory-specific workflow examples from the live shared
CLI help and kernel workflow catalog copy.

The goal is not to rename the whole product in one pass. It is to stop the
shared public surfaces from implying that SDLC workflows are the only first
class workflows.

## Changes

- Updated CLI help examples in `ai.miniforge.cli.main`
- Updated generic chain docstrings in:
  - `ai.miniforge.cli.workflow-runner`
  - `ai.miniforge.workflow.chain-loader`
- Rewrote `components/workflow/resources/workflows/README.md` so it describes
  the workflows that actually ship in the shared workflow component today
- Added a regression test for CLI help output

## Why

After moving workflow families, phase implementations, chains, defaults, and
recommendation prompt vocabulary behind app composition, the remaining leak on
the public path was copy.

The live help output and kernel workflow catalog still pointed users at
software-factory examples that no longer belong to the shared workflow
component.

## Test coverage

New coverage in:

- `ai.miniforge.cli.main-test`
  - generic workflow examples appear in help output
  - software-factory workflow ids are not shown in shared help output

## Verification

- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.main-test) ..."`
- `bb test`
- `bb build:cli`
- `bb pre-commit`

## Follow-up

The next seam after this is the deeper software-factory terminology embedded in
internal workflow component docstrings and older architecture docs, which is a
larger documentation pass rather than a live-surface cleanup.
