### PR TITLE
docs: generalize shared workflow docs

### DIFF
--- a/components/phase-software-factory/README.md
+++ b/components/phase-software-factory/README.md
@@ -1,0 +1,43 @@
+# Software Factory Phase Set
+
+This component owns the shipped phase implementations for the flagship
+software-factory application.
+
+The shared `phase` component now owns only the registry and generic loading
+surface. The actual SDLC phase implementations live here.
+
+## Registered Phase Namespaces
+
+Loaded from `resources/config/phase/namespaces.edn`:
+
+```clojure
+[ai.miniforge.phase.explore
+ ai.miniforge.phase.plan
+ ai.miniforge.phase.implement
+ ai.miniforge.phase.verify
+ ai.miniforge.phase.review
+ ai.miniforge.phase.release]
+```
+
+## What This Component Owns
+
+- software-factory phase implementations
+- shipped SDLC phase registration
+- review, verify, release, and implementation behavior specific to the flagship
+  app
+
+## Relationship to the Shared Phase Component
+
+The shared `phase` component owns:
+
+- registry helpers
+- generic status helpers
+- resource-driven namespace loading
+
+This component supplies the concrete flagship phase set used by the loaded
+software-factory workflows.
+
+## Related Components
+
+- `components/workflow-software-factory/`
+- `components/workflow-chain-software-factory/`

--- a/components/workflow-chain-software-factory/README.md
+++ b/components/workflow-chain-software-factory/README.md
@@ -1,0 +1,31 @@
+# Software Factory Workflow Chains
+
+This component owns chain definitions for the flagship software-factory
+application.
+
+Chains are higher-level compositions that bind application inputs to one or
+more workflow executions. They are app assets, not shared-kernel assets.
+
+## Shipped Chains
+
+| Chain ID | Version | Purpose |
+|----------|---------|---------|
+| `spec-to-pr` | 1.0.0 | Run the flagship spec-to-pull-request flow |
+
+`spec-to-pr` currently delegates to the `standard-sdlc` workflow and binds
+spec-style inputs into the workflow execution.
+
+## What This Component Owns
+
+- chain resources under `resources/chains/`
+- software-factory chain semantics such as spec-to-PR orchestration
+
+## Relationship to the Shared Workflow Component
+
+The shared `workflow` component owns generic chain loading and listing.
+This component owns the actual flagship chain resources.
+
+## Related Components
+
+- `components/workflow-software-factory/`
+- `docs/architecture/live-workflow-configuration.md`

--- a/components/workflow-software-factory/README.md
+++ b/components/workflow-software-factory/README.md
@@ -1,0 +1,59 @@
+# Software Factory Workflow Families
+
+This component owns the flagship software-factory workflow definitions.
+
+These workflows are intentionally outside the shared `workflow` component. They
+are application-owned resources composed onto the classpath by projects such as
+the CLI app.
+
+## What This Component Owns
+
+- SDLC workflow family definitions under `resources/workflows/`
+- software-factory workflow selection mappings under
+  `resources/config/workflow/selection-profiles.edn`
+- software-factory recommendation prompt vocabulary under
+  `resources/config/workflow/recommendation-prompt.edn`
+
+## Shipped Workflow Families
+
+| Workflow ID | Version | Purpose |
+|-------------|---------|---------|
+| `standard-sdlc` | 2.0.0 | Main interceptor-based SDLC flow |
+| `quick-fix` | 2.0.0 | Fast path for small bug fixes |
+| `nimble-sdlc` | 1.0.0 | Explore-first SDLC variant |
+| `canonical-sdlc-v1` | 1.0.0 | Legacy comprehensive SDLC flow |
+| `lean-sdlc-v1` | 1.0.0 | Legacy fast-path SDLC flow |
+
+Unversioned aliases such as `canonical-sdlc.edn` are present for compatibility
+with existing references inside the flagship app.
+
+## Selection Profiles
+
+The software-factory app currently maps logical workflow profiles as follows:
+
+```clojure
+{:comprehensive :canonical-sdlc-v1
+ :fast :lean-sdlc-v1
+ :default :lean-sdlc-v1}
+```
+
+Those mappings are app-owned. The shared workflow selector only understands
+logical profiles such as `:fast` and `:comprehensive`.
+
+## Relationship to the Shared Workflow Component
+
+The shared `workflow` component owns:
+
+- workflow loading
+- registry and discovery
+- validation
+- generic execution
+- generic publication and event-trigger seams
+
+This component owns the flagship app's workflow data and prompt/config assets.
+
+## Related Components
+
+- `components/phase-software-factory/`
+- `components/workflow-chain-software-factory/`
+- `docs/architecture/workflow-component.md`

--- a/components/workflow/src/ai/miniforge/workflow/interface/protocols/workflow.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/protocols/workflow.clj
@@ -1,10 +1,10 @@
 (ns ai.miniforge.workflow.interface.protocols.workflow
-  "Public protocol for SDLC workflow execution.
+  "Public protocol for governed workflow execution.
    This is the main extensibility point for custom workflow implementations.")
 
 (defprotocol Workflow
-  "Protocol for SDLC workflow execution.
-   Manages state transitions through phases."
+  "Protocol for governed workflow execution.
+   Manages state transitions through workflow phases."
 
   (start [this spec context]
     "Start a new workflow from a specification.

--- a/components/workflow/src/ai/miniforge/workflow/loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/loader.clj
@@ -271,7 +271,7 @@
 (comment
   ;; Load workflow from resource
   (def workflow-result
-    (load-workflow :canonical-sdlc-v1 "1.0.0" {}))
+    (load-workflow :financial-etl "1.0.0" {}))
 
   (:source workflow-result)
   (:workflow workflow-result)
@@ -284,13 +284,13 @@
   (clear-cache!)
 
   ;; Test cache behavior
-  (def result1 (load-workflow :canonical-sdlc-v1 "1.0.0" {}))
-  (def result2 (load-workflow :canonical-sdlc-v1 "1.0.0" {}))
+  (def result1 (load-workflow :simple-v2 "2.0.0" {}))
+  (def result2 (load-workflow :simple-v2 "2.0.0" {}))
   (= :resource (:source result1))
   (= :cache (:source result2))
 
   ;; Skip cache
-  (def result3 (load-workflow :canonical-sdlc-v1 "1.0.0" {:skip-cache? true}))
+  (def result3 (load-workflow :simple-v2 "2.0.0" {:skip-cache? true}))
   (= :resource (:source result3))
 
   :end)

--- a/docs/architecture/live-workflow-configuration.md
+++ b/docs/architecture/live-workflow-configuration.md
@@ -1,368 +1,153 @@
 # Live Workflow Configuration Architecture
 
-This document explains how workflow EDN configs become live, executable configuration
-that the Meta loop can self-update at runtime.
+This document explains how workflow configuration becomes live at runtime in the
+current classpath-composed model.
+
+The important change is that the shared runtime no longer owns a single
+software-factory catalog. Workflow families, chains, selection profiles, and
+state profiles are composed by the active project.
+
+For the parts of workflow configuration that are concretely implemented today,
+including `active.edn`, heuristic-backed workflow saving/loading, and logical
+selection-profile resolution, see
+`docs/architecture/workflow-persistence-and-selection.md`.
 
 ## Configuration Flow
 
 ```text
-┌─────────────────────────────────────────────────────────────────────┐
-│ WORKFLOW CONFIGURATION LIFECYCLE                                     │
-└─────────────────────────────────────────────────────────────────────┘
+1. RESOURCES ON CLASSPATH
+   - shared workflow resources
+   - app-specific workflow resources
+   - app-specific chain resources
+   - app-specific config/workflow/*.edn resources
+   - app-specific config/dag-executor/*.edn resources
 
-1. DESIGN TIME (Human/Meta Loop creates configs)
-   ↓
-   ┌──────────────────────────────────────────────────────────────────┐
-   │ EDN Config Files                                                  │
-   │ components/workflow/resources/workflows/                          │
-   │                                                                   │
-   │ - canonical-sdlc-v1.0.0.edn   (baseline)                         │
-   │ - lean-sdlc-v1.0.0.edn        (alternative)                      │
-   │ - proposed-v1.1.0.edn         (Meta loop generated)              │
-   └──────────────────────────────────────────────────────────────────┘
-   ↓
-2. VALIDATION (Schema + DAG correctness)
-   ↓
-   ┌──────────────────────────────────────────────────────────────────┐
-   │ Malli Schema Validation                                           │
-   │ components/workflow/resources/schemas/workflow.edn                │
-   │                                                                   │
-   │ - Type checking (keyword?, string?, int?)                        │
-   │ - Structure validation (required fields present)                 │
-   │ - DAG validation (no cycles, reachable nodes)                    │
-   └──────────────────────────────────────────────────────────────────┘
-   ↓
-3. STORAGE (Versioned in Heuristic component)
-   ↓
-   ┌──────────────────────────────────────────────────────────────────┐
-   │ Heuristic Storage                                                 │
-   │ ~/.miniforge/heuristics/                                          │
-   │                                                                   │
-   │ workflow-config/1.0.0.edn                                         │
-   │ workflow-config/1.1.0.edn                                         │
-   │ workflow-config/_active → "1.0.0"                                 │
-   └──────────────────────────────────────────────────────────────────┘
-   ↓
-4. ACTIVATION (Set active workflow per task type)
-   ↓
-   ┌──────────────────────────────────────────────────────────────────┐
-   │ Active Workflow Mapping                                           │
-   │ ~/.miniforge/workflows/active.edn                                 │
-   │                                                                   │
-   │ {:feature :canonical-sdlc-v1                                      │
-   │  :bugfix :lean-sdlc-v1                                            │
-   │  :refactor :canonical-sdlc-v1                                     │
-   │  :component :canonical-sdlc-v1}                                   │
-   └──────────────────────────────────────────────────────────────────┘
-   ↓
-5. RUNTIME (Load and execute)
-   ↓
-   ┌──────────────────────────────────────────────────────────────────┐
-   │ Workflow Executor                                                 │
-   │                                                                   │
-   │ (workflow/execute-workflow                                        │
-   │   (workflow/get-active-workflow :feature)                         │
-   │   user-spec)                                                      │
-   └──────────────────────────────────────────────────────────────────┘
+2. DISCOVERY
+   - workflow registry scans every workflows/ root
+   - chain loader scans every chains/ root
+   - selection config merges matching config resources
+   - state profile provider resolves matching profile resources
+
+3. RESOLUTION
+   - caller selects a workflow id directly, or
+   - app config maps a logical selection profile to a workflow id, or
+   - fallback logic derives a workflow from generic characteristics
+
+4. EXECUTION
+   - workflow runtime loads the workflow definition
+   - phase handlers come from execution context
+   - publication and triggers use generic interfaces with app-owned adapters
 ```
 
-## Live Configuration Mechanism
+## Shared vs App-Owned Resources
 
-### Hot-Reload Support
+### Shared resources
 
-Workflows can be updated without restarting miniforge:
+The shared `workflow` component contributes:
 
-```clojure
-;; Current execution
-(let [workflow (load-workflow :canonical-sdlc-v1 "1.0.0")]
-  (execute-workflow workflow spec))
+- workflow schema
+- reference workflows such as `financial-etl` and `simple-v2`
+- generic runtime code
 
-;; Meta loop updates config
-(save-workflow new-workflow-v1.1.0)
-(set-active-workflow :feature :canonical-sdlc-v1 "1.1.0")
+### App-owned resources
 
-;; Next execution (different task)
-(let [workflow (load-workflow :canonical-sdlc-v1 "1.1.0")]
-  (execute-workflow workflow spec))  ; Uses new config!
-```
+Applications contribute:
 
-**Key insight:** Each execution loads the workflow config at start time. Updating the
-active pointer affects new executions, not in-flight ones.
+- additional workflow families
+- chain definitions
+- workflow selection profile config
+- DAG state profile config
+- phase implementations and workflow helpers
 
-### Active Workflow Resolution
+For example, the CLI app can load software-factory workflows without making the
+kernel itself software-factory-specific.
 
-```clojure
-(defn get-active-workflow [task-type]
-  ;; 1. Read active.edn mapping
-  (let [active-map (read-active-config)
-        workflow-id (get active-map task-type)]
+## Workflow Discovery
 
-    ;; 2. Load workflow from heuristic store
-    (heuristic/get-active-heuristic workflow-id)))
-```
+Workflow discovery is driven by all `workflows/*.edn` resources on the active
+classpath.
 
-## Meta Loop Self-Update
+That means:
 
-The Meta loop can update workflows at runtime:
+- a minimal project may only see shared reference workflows
+- the flagship app may see both shared workflows and software-factory workflows
+- a future analytical app can add its own workflows without modifying the
+  shared runtime
+
+## Selection Profile Resolution
+
+Workflow selection now has two layers:
+
+1. Logical profiles such as `:fast`, `:comprehensive`, and `:default`
+2. App-owned mapping from those logical profiles to concrete workflow ids
+
+The mapping comes from:
 
 ```text
-┌─────────────────────────────────────────────────────────────────────┐
-│ META LOOP WORKFLOW UPDATE CYCLE                                      │
-└─────────────────────────────────────────────────────────────────────┘
-
-1. OBSERVE
-   Collect metrics from recent executions:
-   - canonical-sdlc-v1: 80% success, 45min avg, 50k tokens
-   - Review phase: 40% of total time (bottleneck!)
-
-2. ANALYZE
-   Identify optimization opportunities:
-   - Review max-rounds: 3 → could reduce to 2
-   - Hypothesis: Save time without hurting quality
-
-3. PROPOSE
-   Generate new workflow config:
-
-   {:workflow/id :canonical-sdlc-v1
-    :workflow/version "1.1.0"  ; Incremented
-    :workflow/phases
-    [{:phase/id :review
-      :phase/review-loop
-      {:max-rounds 2}}]}  ; Changed from 3
-
-4. VALIDATE
-   Check correctness:
-   (validate-workflow proposed-config)
-   ;; - Schema valid?
-   ;; - DAG valid?
-   ;; - Budgets reasonable?
-
-5. SAVE
-   Version in heuristic store:
-   (heuristic/save-heuristic
-     :workflow-config
-     "1.1.0"
-     proposed-config)
-
-6. EXPERIMENT (A/B Test)
-   Route 50% of tasks to new version:
-   - 10 tasks on v1.0.0
-   - 10 tasks on v1.1.0
-   - Collect metrics
-
-7. MEASURE
-   Compare outcomes:
-   - v1.0.0: 80% success, 45min, 50k tokens
-   - v1.1.0: 79% success, 35min, 48k tokens
-   - Result: Faster with similar quality!
-
-8. DECIDE
-   If better, promote:
-   (set-active-workflow :feature :canonical-sdlc-v1 "1.1.0")
-
-   Update active.edn:
-   {:feature :canonical-sdlc-v1  ; Now uses v1.1.0
-    ...}
-
-9. MONITOR
-   Track v1.1.0 in production:
-   - Continue collecting metrics
-   - Ready to rollback if issues
-   - Iterate again (v1.2.0?)
+config/workflow/selection-profiles.edn
 ```
 
-## Integration with Existing Components
+If no app-specific mapping is present, fallback selection uses generic workflow
+characteristics such as phase count and max iterations.
 
-### Policy Component (Phase 1)
+This keeps the selection seam generic even when the loaded app happens to be
+the software factory.
 
-Gates are evaluated at phase boundaries:
+## DAG State Profile Resolution
 
-```clojure
-;; From workflow config
-{:phase/id :implement-code
- :phase/gates [:syntax-valid :lint-clean :tests-pass]}
+Workflow execution lifecycle semantics are also resource-driven.
 
-;; At runtime
-(defn advance-to-next-phase? [phase artifact]
-  (let [gates (:phase/gates phase)
-        result (policy/evaluate artifact
-                               (:phase/id phase)
-                               gates)]
-    (:passed? result)))
-```
+- the kernel owns profile normalization and consumption
+- profile definitions come from provider-backed resources
+- projects can swap in different lifecycle semantics without editing kernel code
 
-**Already built!** Just wire in the phase transitions.
+This is the seam that allows the same runtime to support both software-factory
+flows and analytical flows such as financial ETL.
 
-### Heuristic Component (Phase 1)
+## Publication and Triggering
 
-Workflows are stored as versioned heuristics:
+The runtime exposes generic seams for:
 
-```clojure
-;; Save workflow
-(heuristic/save-heuristic
-  :workflow-config
-  "1.0.0"
-  {:workflow/id :canonical-sdlc-v1
-   :workflow/phases [...]})
+- event-triggered workflow starts
+- output publication
 
-;; Retrieve workflow
-(heuristic/get-heuristic :workflow-config "1.0.0")
+The shared runtime ships with generic implementations such as directory
+publication. App layers can add git, worktree, or PR-specific publication
+without moving those assumptions back into the kernel.
 
-;; Get active version
-(heuristic/get-active-heuristic :workflow-config)
-```
+## Why This Matters
 
-**Already built!** Workflows are just another heuristic type.
+This composition model supports the open-core boundary directly:
 
-### Loop Component (Future)
+- OSS kernel owns the generic runtime and SDK seams
+- flagship apps own their workflow families and app-specific defaults
+- additional verticals can compose new resources onto the same runtime
 
-Inner loops execute within phases:
+## Practical Examples
 
-```clojure
-;; From workflow config
-{:phase/id :implement-code
- :phase/inner-loop
- {:max-iterations 15
-  :validation-steps [:tests-pass :lint-clean]
-  :repair-strategy :fix-code-errors}}
+### Shared-only project
 
-;; At runtime
-(defn execute-phase-inner-loop [phase artifact agent]
-  (loop-engine/execute
-    {:max-iterations (get-in phase [:phase/inner-loop :max-iterations])
-     :generate-fn (partial agent/generate agent)
-     :validate-fn (partial validate-steps (get-in phase [:phase/inner-loop :validation-steps]))
-     :repair-fn (partial repair-artifact agent (get-in phase [:phase/inner-loop :repair-strategy]))
-     :artifact artifact}))
-```
+- visible workflows: `financial-etl`, `simple-v2`, test/demo workflows
+- publication: directory publisher
+- selection fallback: based on generic workflow characteristics
 
-**To be built in Phase 2.**
+### Flagship software-factory project
 
-## Safety and Rollback
+- visible workflows: shared workflows plus SDLC workflow families
+- selection mapping: app config points `:fast` and `:comprehensive` at
+  software-factory workflows
+- publication: app can layer git or PR-specific publishing on top
 
-### Version Control
+### Analytical vertical project
 
-All workflow configs are versioned:
+- visible workflows: shared workflows plus analytical packs or demos
+- state profile: app-specific lifecycle resource
+- publication: local directories, reports, exports, or domain-specific sinks
 
-```text
-~/.miniforge/heuristics/
-  workflow-config/
-    1.0.0.edn  (stable baseline)
-    1.1.0.edn  (proposed by Meta loop)
-    1.2.0.edn  (experimental)
-    _active → "1.0.0"
-```
+## See Also
 
-### Rollback
-
-If a new workflow causes issues:
-
-```clojure
-;; Quick rollback
-(set-active-workflow :feature :canonical-sdlc-v1 "1.0.0")
-
-;; Or system-wide
-(reset-all-active-workflows "1.0.0")
-```
-
-### Audit Log
-
-All workflow changes are logged:
-
-```clojure
-{:timestamp #inst "2026-01-21T12:00:00"
- :event :workflow-activated
- :workflow-id :canonical-sdlc-v1
- :version "1.1.0"
- :previous-version "1.0.0"
- :reason "Meta loop: Review bottleneck optimization"
- :approver :meta-loop}
-```
-
-## Configuration Precedence
-
-```text
-1. Task-specific override (highest priority)
-   (execute-workflow explicit-workflow spec)
-
-2. Task type mapping
-   (get-active-workflow :bugfix) → :lean-sdlc-v1
-
-3. Default fallback
-   (get-active-workflow :unknown) → :canonical-sdlc-v1
-
-4. System default (lowest priority)
-   :canonical-sdlc-v1
-```
-
-## Performance Considerations
-
-### Caching
-
-Workflow configs are cached in memory:
-
-```clojure
-(def workflow-cache
-  (atom {}))
-
-(defn load-workflow [workflow-id version]
-  (if-let [cached (get @workflow-cache [workflow-id version])]
-    cached
-    (let [loaded (heuristic/get-heuristic workflow-id version)]
-      (swap! workflow-cache assoc [workflow-id version] loaded)
-      loaded)))
-```
-
-### Cache Invalidation
-
-When Meta loop updates a workflow:
-
-```clojure
-(defn set-active-workflow [task-type workflow-id version]
-  ;; 1. Update active.edn
-  (update-active-config task-type workflow-id)
-
-  ;; 2. Invalidate cache
-  (swap! workflow-cache dissoc [workflow-id :active])
-
-  ;; 3. Broadcast to other instances (if distributed)
-  (broadcast-config-change workflow-id version))
-```
-
-## Example: Gradual Rollout
-
-Meta loop can gradually roll out new workflows:
-
-```clojure
-;; Week 1: A/B test (10% traffic)
-(set-rollout-percentage :canonical-sdlc-v1.1 0.1)
-
-;; Week 2: Expand (50% traffic)
-(set-rollout-percentage :canonical-sdlc-v1.1 0.5)
-
-;; Week 3: Full rollout (100% traffic)
-(set-active-workflow :feature :canonical-sdlc-v1 "1.1.0")
-```
-
-## Summary
-
-**Live Configuration Enabled:**
-
-- ✅ Workflows load from EDN at runtime
-- ✅ Validated before activation
-- ✅ Stored as versioned heuristics
-- ✅ Hot-reload without restart
-- ✅ Meta loop can self-update
-- ✅ Gradual rollout supported
-- ✅ Rollback capability
-- ✅ Audit logging
-
-**Integration:**
-
-- ✅ Policy component (gates) - Phase 1
-- ✅ Heuristic component (storage) - Phase 1
-- ⏳ Loop component (inner loops) - Phase 2
-- ⏳ Meta loop (proposals) - Phase 3
-
-The configuration is **truly live** - the Meta loop can experiment with and deploy new
-SDLC workflows without code changes or restarts.
+- `docs/architecture/workflow-component.md`
+- `docs/architecture/workflow-persistence-and-selection.md`
+- `components/workflow/resources/workflows/README.md`
+- `components/workflow-software-factory/README.md`
+- `components/workflow-chain-software-factory/README.md`

--- a/docs/architecture/workflow-component.md
+++ b/docs/architecture/workflow-component.md
@@ -1,214 +1,154 @@
 # Workflow Component Architecture
 
-This document describes the architecture of the Workflow component, which makes EDN workflow
-configurations live and executable at runtime.
+This document describes the current architecture of the shared `workflow`
+component.
+
+The component is the generic runtime for loading, validating, and executing
+workflow definitions. It is not the home of every shipped workflow family.
+Application-specific workflows are composed onto the classpath by whichever
+project or base loads them.
 
 ## Overview
 
-The Workflow component is the execution engine for configurable SDLC flows.
+The shared `workflow` component provides the domain-neutral execution layer for
+governed workflows.
 
 **Key responsibilities:**
 
-- Load workflow configs from EDN files
-- Validate configs against Malli schema
-- Execute workflows by interpreting the DAG
-- Track state during execution (current phase, budgets, metrics)
-- Integrate with Policy component for gate evaluation
-- Store/retrieve workflows via Heuristic component
-- Enable Meta loop to propose and activate new workflows
-
-This is the "interpreter" that makes workflow configs executable.
+- Discover workflow definitions from classpath resources
+- Validate workflow EDN against schema and DAG rules
+- Execute workflow phases through the generic runtime
+- Expose registry, loading, replay, event-trigger, and publication APIs
+- Support app-owned composition for workflows, chains, and state profiles
 
 ## Component Structure
 
 ```text
 components/workflow/
 ├── src/ai/miniforge/workflow/
-│   ├── interface.clj       # Public API
-│   ├── core.clj            # Component orchestration
-│   ├── loader.clj          # Load & validate configs
-│   ├── executor.clj        # Execute workflow DAG
-│   ├── state.clj           # Execution state management
-│   └── validator.clj       # Schema & DAG validation
+│   ├── interface.clj       # Public Polylith boundary
+│   ├── configurable.clj    # Config-driven workflow execution
+│   ├── loader.clj          # Workflow loading and caching
+│   ├── registry.clj        # Classpath discovery and registry
+│   ├── trigger.clj         # Generic event-trigger entrypoints
+│   ├── publish.clj         # Generic publication helpers
+│   └── validator.clj       # Schema and DAG validation
 ├── resources/
 │   ├── schemas/
-│   │   └── workflow.edn    # Malli schema
+│   │   └── workflow.edn
+│   ├── config/
+│   │   └── workflow/
+│   │       └── state-profiles/
 │   └── workflows/
-│       ├── canonical-sdlc-v1.0.0.edn
-│       └── lean-sdlc-v1.0.0.edn
+│       ├── financial-etl-v1.0.0.edn
+│       ├── simple-v2.0.0.edn
+│       └── test/demo workflows
 └── test/
 ```
 
-**Runtime configuration:**
+App-specific workflow families live in separate components such as:
+
+- `components/workflow-software-factory/resources/workflows/`
+- `components/workflow-chain-software-factory/resources/chains/`
+- app-owned `config/workflow/*.edn` resources
+
+## Runtime Composition
+
+The current model is classpath composition, not a single kernel-owned workflow
+catalog.
 
 ```text
-~/.miniforge/workflows/
-└── active.edn              # Active workflow per task type
+shared workflow component
+  + shared reference workflows
+  + app-specific workflow resources
+  + app-specific chain resources
+  + app-specific selection profile config
+  + app-specific state profile config
+  = runtime-visible workflow surface
 ```
 
-## Dependencies
+In practice:
 
-- **policy**: Gate evaluation at phase boundaries
-- **heuristic**: Workflow storage and versioning
-- **schema**: Malli validation of configs
-- **llm**: Agent invocation during phase execution
+- the shared `workflow` component contributes reference workflows such as
+  `financial-etl` and `simple-v2`
+- an application component may add software-factory workflows such as
+  `canonical-sdlc-v1`
+- the active project decides what exists by deciding which components are on
+  the classpath
 
-## Live Configuration
+## Discovery and Registry
 
-### Active Workflow Mapping
+Workflow discovery is resource-driven.
 
-File: `~/.miniforge/workflows/active.edn`
+- `workflow.registry/discover-workflows-from-resources` scans every
+  `workflows/` resource root on the active classpath
+- `workflow.loader/list-available-workflows` extracts metadata from those
+  resources
+- `workflow.registry/initialize-registry!` registers the discovered workflows
 
-```clojure
-{:feature :canonical-sdlc-v1
- :bugfix :lean-sdlc-v1
- :refactor :canonical-sdlc-v1
- :component :canonical-sdlc-v1}
-```
+This is the seam that allows the kernel to stay generic while apps own their
+workflow families.
 
-Maps task types to active workflow IDs.
+## Execution Model
 
-### Hot-Reload Mechanism
+The shared runtime executes whichever workflow definition it is given.
 
-Workflows can be updated without restarting miniforge:
+- `workflow.configurable` interprets the workflow DAG
+- phase behavior can be provided through `:phase-handlers`
+- DAG execution can delegate to the `dag-executor` seam when a plan produces
+  parallelizable work
+- publication happens through generic publishers such as the directory
+  publisher, while app layers can wrap git or PR-specific publication
 
-1. Meta loop proposes new workflow config
-2. Saves to `~/.miniforge/workflows/proposed-v1.1.0.edn`
-3. Validates config (schema + DAG)
-4. Updates `active.edn` to point to new version
-5. Next task uses new workflow
-6. Old executions continue with their original workflow
+The runtime should not assume software delivery as the only domain.
 
-### Meta Loop Self-Update Cycle
+## Related App-Owned Configuration
 
-The Meta loop can self-update workflow configs through a 9-step cycle:
+The workflow runtime now expects several important choices to come from the app
+layer.
 
-1. **Observe**: Collect metrics from recent workflow executions
-2. **Analyze**: Identify bottleneck phases (e.g., review takes 40% of time)
-3. **Propose**: Generate new workflow config (e.g., reduce review rounds)
-4. **Validate**: Check schema + DAG correctness
-5. **Save**: Write to heuristic store with new version
-6. **Experiment**: A/B test by routing 50% of tasks to new version
-7. **Measure**: Compare metrics (success rate, time, cost)
-8. **Decide**: If better, update active.edn to make it default
-9. **Version**: Increment version (1.0.0 → 1.1.0)
+### Workflow selection profiles
 
-**Example mutation:**
-
-```clojure
-;; Before (v1.0.0)
-{:phase/id :review
- :phase/review-loop {:max-rounds 3}}
-
-;; After (v1.1.0)
-{:phase/id :review
- :phase/review-loop {:max-rounds 2}}  ; Reduced to save time
-```
-
-**Safety mechanisms:**
-
-- Always validate before activating
-- Keep old versions available for rollback
-- Log all config changes for audit
-- Gradual rollout (A/B test before full deployment)
-
-## Integration with Existing System
-
-### Release Executor
-
-**File**: `components/release/src/ai/miniforge/release/executor.clj`
-
-**Current**: Hardcodes the SDLC flow
-
-**Integration**:
-
-```clojure
-(defn execute [spec]
-  (let [workflow (workflow/get-active-workflow (:task-type spec))]
-    (workflow/execute-workflow workflow spec)))
-```
-
-**Benefit**: Makes the entire flow configurable
-
-### LLM Agents
-
-**Files**: `components/llm/src/ai/miniforge/llm/agent.clj`
-
-**Integration**: Agents are invoked by phases in the workflow config. Phase configs specify
-which agent handles each phase.
-
-### Policy Gates
-
-**Files**: `components/policy/src/ai/miniforge/policy/gates.clj`
-
-**Status**: Already built in Phase 1!
-
-**Integration**: Wire into phase transitions:
-
-```clojure
-(defn advance-phase? [phase artifact]
-  (policy/evaluate-gates artifact
-                         (:phase/id phase)
-                         (:phase/gates phase)))
-```
-
-### Heuristic Storage
-
-**Files**: `components/heuristic/src/ai/miniforge/heuristic/core.clj`
-
-**Status**: Already built in Phase 1!
-
-**Integration**: Workflows are stored as versioned heuristics:
-
-```clojure
-(heuristic/save-heuristic :workflow-config "1.0.0" workflow-edn)
-(heuristic/get-heuristic :workflow-config "1.0.0")
-```
-
-## Configuration Lifecycle
+Logical selection profiles such as `:fast` and `:comprehensive` are resolved
+through classpath resources like:
 
 ```text
-┌─────────────────────────────────────────────────────────────────────┐
-│ WORKFLOW CONFIGURATION LIFECYCLE                                     │
-└─────────────────────────────────────────────────────────────────────┘
-
-1. DESIGN TIME (Human/Meta Loop creates configs)
-   ↓
-   [EDN Config Files]
-   - canonical-sdlc-v1.0.0.edn
-   - lean-sdlc-v1.0.0.edn
-   - proposed-v1.1.0.edn (Meta loop generated)
-   ↓
-2. VALIDATION (Schema + DAG correctness)
-   ↓
-   [Malli Schema Validation]
-   - Type checking
-   - Structure validation
-   - DAG validation (no cycles, reachable nodes)
-   ↓
-3. STORAGE (Versioned in Heuristic component)
-   ↓
-   [Heuristic Storage: ~/.miniforge/heuristics/]
-   - workflow-config/1.0.0.edn
-   - workflow-config/1.1.0.edn
-   ↓
-4. ACTIVATION (Set active workflow per task type)
-   ↓
-   [Active Workflow Mapping: ~/.miniforge/workflows/active.edn]
-   {:feature :canonical-sdlc-v1
-    :bugfix :lean-sdlc-v1}
-   ↓
-5. RUNTIME (Load and execute)
-   ↓
-   [Workflow Executor]
-   (workflow/execute-workflow
-     (workflow/get-active-workflow :feature)
-     user-spec)
+config/workflow/selection-profiles.edn
 ```
+
+If an app does not provide config, shared fallback logic uses generic workflow
+characteristics rather than hardcoded software-factory workflow ids.
+
+### DAG state profiles
+
+Execution lifecycle profiles are loaded through provider-backed resources rather
+than hardcoded kernel literals.
+
+### Chains and workflow families
+
+Chains and workflow families are discovered from every matching classpath
+resource root, so the kernel does not need to know which app owns which
+workflow family.
+
+## What Belongs in the Shared Component
+
+- Workflow loading, validation, execution, replay, and registry APIs
+- Generic publication and event-trigger seams
+- Shared reference workflows and test workflows
+- Generic schemas and runtime helpers
+
+## What Does Not Belong in the Shared Component
+
+- Software-factory workflow families
+- PR-specific chains and release flows
+- App-specific workflow defaults or recommendation vocabulary
+- Enterprise/Fleet control-plane behavior
 
 ## See Also
 
-- `docs/specs/workflow-api.spec.edn` - Public API specification
-- `docs/guides/workflow-implementation.md` - Implementation guide
-- `docs/architecture/live-workflow-configuration.md` - Detailed configuration lifecycle
-- `docs/specs/workflow-configuration.spec.edn` - Workflow EDN format spec
+- `docs/architecture/live-workflow-configuration.md`
+- `docs/architecture/workflow-persistence-and-selection.md`
+- `docs/guides/workflow-implementation.md`
+- `components/workflow/resources/workflows/README.md`
+- `components/workflow-software-factory/README.md`
+- `components/phase-software-factory/README.md`

--- a/docs/architecture/workflow-persistence-and-selection.md
+++ b/docs/architecture/workflow-persistence-and-selection.md
@@ -1,0 +1,193 @@
+# Workflow Persistence and Selection
+
+This document describes the workflow configuration mechanics that are actually
+implemented today.
+
+It intentionally covers the concrete runtime path, not the older aspirational
+story around rollout percentages, A/B promotion, or full meta-loop-driven
+workflow optimization.
+
+## What Exists Today
+
+The current system supports four real configuration paths:
+
+1. Classpath workflow resources
+2. Heuristic-store workflow persistence
+3. Local active-workflow selection in `~/.miniforge/workflows/active.edn`
+4. App-owned logical selection profiles via `config/workflow/selection-profiles.edn`
+
+These paths are implemented across:
+
+- `components/workflow/src/ai/miniforge/workflow/loader.clj`
+- `components/workflow/src/ai/miniforge/workflow/persistence.clj`
+- `components/workflow/src/ai/miniforge/workflow/comparison.clj`
+- `bases/cli/src/ai/miniforge/cli/workflow_selection_config.clj`
+
+## Workflow Loading
+
+Workflow loading is resource-first, store-second.
+
+`workflow.loader/load-workflow` resolves a workflow in this order:
+
+1. in-memory cache
+2. classpath resources under `workflows/`
+3. heuristic store via `ai.miniforge.heuristic.interface/get-heuristic`
+
+That means:
+
+- shipped workflows come from whichever components contribute `workflows/*.edn`
+  to the active classpath
+- dynamically saved workflows can still be loaded from the heuristic store
+- cache can be bypassed with `:skip-cache?`
+- validation can be bypassed with `:skip-validation?`
+
+## Active Workflow Persistence
+
+The active workflow mapping is still implemented as a local file:
+
+```text
+~/.miniforge/workflows/active.edn
+```
+
+The current on-disk shape is:
+
+```clojure
+{:feature {:workflow-id :standard-sdlc
+           :version "2.0.0"}
+ :bugfix  {:workflow-id :quick-fix
+           :version "2.0.0"}}
+```
+
+The API surface is:
+
+- `workflow.persistence/get-active-workflow-id`
+- `workflow.persistence/set-active-workflow`
+
+Those functions are re-exported through the public workflow interface.
+
+This is real, implemented local configuration. It is not the same thing as the
+app-owned logical selection-profile mapping described below.
+
+## Event Log Persistence
+
+Workflow event logs are persisted locally under:
+
+```text
+~/.miniforge/workflows/events/<workflow-id>.edn
+```
+
+The implemented helpers are:
+
+- `workflow.persistence/append-event`
+- `workflow.persistence/load-event-log`
+
+These support replay and determinism checks through the shared workflow
+interface.
+
+## Saving Workflows to the Heuristic Store
+
+Workflow configurations can be saved into the heuristic store with:
+
+- `workflow.comparison/save-workflow`
+- public alias: `workflow.interface/save-workflow`
+
+The saved heuristic key is derived from the workflow id:
+
+```clojure
+(keyword "workflow" (name (:workflow/id workflow)))
+```
+
+This is implemented today and is useful for:
+
+- persisting generated or revised workflow definitions
+- loading saved workflows later through the normal loader path
+
+What is not implemented here is the larger lifecycle implied by older docs:
+
+- no rollout percentage system
+- no automated promotion logic
+- no built-in experiment coordinator
+
+## Comparing Workflow Executions
+
+Execution comparison is also implemented today.
+
+- `workflow.comparison/compare-workflows`
+- public alias: `workflow.interface/compare-workflows`
+
+It currently produces:
+
+- per-execution summaries
+- aggregate counts
+- average tokens
+- average cost
+- average duration
+
+This is a lightweight comparison utility, not a full experimentation framework.
+
+## Logical Selection Profiles
+
+Logical workflow selection profiles are resolved in the CLI layer through:
+
+```text
+config/workflow/selection-profiles.edn
+```
+
+The implemented behavior is:
+
+1. merge all matching classpath resources
+2. resolve a logical profile such as `:fast` or `:comprehensive`
+3. if the configured workflow id is not present, fall back to generic workflow
+   characteristics
+
+That fallback uses:
+
+- phase count
+- max iterations
+
+So the system currently supports both:
+
+- explicit app-owned mapping
+- generic fallback when no mapping is available
+
+## Important Boundary Distinction
+
+There are two different selection layers:
+
+### Local active workflow mapping
+
+Stored in `~/.miniforge/workflows/active.edn`
+
+- local mutable runtime state
+- keyed by task type
+- stores concrete `{:workflow-id :version}` values
+
+### App-owned logical selection profiles
+
+Loaded from `config/workflow/selection-profiles.edn`
+
+- classpath configuration
+- keyed by logical profile such as `:fast`
+- maps to concrete workflow ids
+
+The older documentation tended to blend these together. They are separate
+mechanisms.
+
+## What the Older Docs Overstated
+
+Older workflow-configuration docs also described behavior that is not present as
+a complete system today:
+
+- rollout percentages
+- A/B traffic routing
+- automatic promotion of a proposed workflow version
+- a complete meta-loop workflow optimization cycle
+
+Those ideas may still be useful design direction, but they should not be
+documented as current runtime behavior.
+
+## See Also
+
+- `docs/architecture/workflow-component.md`
+- `docs/architecture/live-workflow-configuration.md`
+- `components/workflow-software-factory/README.md`

--- a/docs/guides/workflow-implementation.md
+++ b/docs/guides/workflow-implementation.md
@@ -1,263 +1,149 @@
 # Workflow Component Implementation Guide
 
-This guide provides implementation details for building the Workflow component.
+This guide summarizes the current implementation shape of the shared
+`workflow` component.
+
+The goal of the component is to provide a generic workflow runtime that can be
+composed into different applications. Workflow families, phase handlers, and
+selection defaults are expected to come from app-owned components.
 
 ## Core Namespaces
 
-### Loader (`workflow.loader`)
+### `workflow.loader`
 
-**Purpose**: Load and validate workflow configs
+Loads workflow definitions from classpath resources and caches resolved
+definitions.
 
-**Functions:**
+Use it when you need to:
 
-```clojure
-(defn load-from-file [path]
-  (-> path slurp edn/read-string validate-workflow))
+- load a workflow by id and version
+- inspect available workflow metadata
+- validate that a workflow resource can be resolved in the active project
 
-(defn load-from-heuristic [workflow-id version]
-  (heuristic/get-heuristic workflow-id version))
+### `workflow.registry`
 
-(defn validate-workflow [config]
-  (let [schema (load-schema)]
-    (if (m/validate schema config)
-      config
-      (throw (ex-info "Invalid workflow config"
-                      {:errors (m/explain schema config)})))))
-```
+Discovers workflows from every `workflows/` root on the active classpath and
+maintains the runtime registry.
 
-### Executor (`workflow.executor`)
+Use it when you need to:
 
-**Purpose**: Execute workflow DAG with state management
+- initialize workflow availability for a project
+- inspect visible workflow ids
+- reason about workflow characteristics for fallback selection
 
-**Functions:**
+### `workflow.configurable`
 
-```clojure
-(defn execute [workflow input opts]
-  (let [state (init-state workflow input)]
-    (loop [current-phase (first-phase workflow)
-           state state]
-      (if (terminal-phase? current-phase)
-        (finalize-execution state)
-        (let [result (execute-phase current-phase state)
-              next-phase (select-next-phase result)]
-          (recur next-phase (update-state state result)))))))
+Executes workflow definitions through the generic runtime.
 
-(defn execute-phase [phase state]
-  ;; 1. Check budget
-  ;; 2. Run inner loop (generate → validate → repair)
-  ;; 3. Run review loop (if configured)
-  ;; 4. Evaluate gates
-  ;; 5. Collect metrics
-  ;; 6. Return result
-  {:phase/id (:phase/id phase)
-   :phase/status :passed
-   :phase/iterations 3
-   :phase/metrics {...}})
+Important traits:
 
-(defn select-next-phase [result]
-  ;; Interpret phase/next transitions
-  ;; Support conditional branching
-  ;; Handle parallel phases (future)
-  (first (filter #(gates-pass? % result)
-                 (:phase/next result))))
-```
+- phase behavior can be provided through `:phase-handlers`
+- plan execution can delegate to the DAG orchestrator seam
+- the runtime interprets workflow data rather than hardcoding one domain flow
 
-### State Manager (`workflow.state`)
+### `workflow.trigger`
 
-**Purpose**: Manage workflow execution state
+Provides generic event-trigger entrypoints.
 
-**Functions:**
+Application layers can keep convenience aliases for domain-specific events, but
+the shared interface should remain event-oriented rather than PR-oriented.
 
-```clojure
-(defn init-state [workflow input]
-  {:execution/id (random-uuid)
-   :execution/workflow-id (:workflow/id workflow)
-   :execution/start-time (Instant/now)
-   :execution/current-phase nil
-   :execution/phases []
-   :execution/artifact input
-   :execution/budget-used {:tokens 0 :time 0 :iterations 0}
-   :execution/metrics []})
+### `workflow.publish`
 
-(defn update-state [state phase-result]
-  (-> state
-      (update :execution/phases conj phase-result)
-      (update :execution/budget-used merge-budgets (:budget-used phase-result))
-      (update :execution/metrics conj (:metrics phase-result))
-      (assoc :execution/artifact (:artifact phase-result))))
+Provides generic publication helpers.
 
-(defn finalize-execution [state]
-  (assoc state
-         :execution/end-time (Instant/now)
-         :execution/status :completed
-         :execution/total-time (calculate-duration state)
-         :execution/summary (summarize-metrics state)))
-```
+The shared runtime should prefer neutral sinks such as directories, while app
+layers can wrap git, worktree, or PR-specific behavior outside the kernel.
 
-### Validator (`workflow.validator`)
+## Implementation Principles
 
-**Purpose**: Validate workflow configs and DAG correctness
+### Keep workflow families out of the kernel
 
-**Functions:**
+The shared component should own:
 
-```clojure
-(defn validate-dag [workflow]
-  ;; Check for cycles
-  ;; Verify all phase/next targets exist
-  ;; Ensure single start node
-  ;; Ensure reachability of all phases
-  (when-let [errors (check-dag-structure workflow)]
-    (throw (ex-info "Invalid DAG" {:errors errors}))))
+- schemas
+- loaders
+- registry helpers
+- execution runtime
+- generic triggers and publishers
 
-(defn validate-gates [phase]
-  ;; Ensure all gate types are known
-  ;; Verify gate configs are valid
-  (policy/validate-gate-configs (:phase/gates phase)))
+It should not own:
 
-(defn validate-budgets [workflow]
-  ;; Check phase budgets sum <= total budget
-  ;; Ensure all budgets are positive
-  (when (> (sum-phase-budgets workflow)
-          (get-in workflow [:workflow/config :max-total-tokens]))
-    (throw (ex-info "Budget overflow" {...}))))
-```
+- software-factory workflow families
+- app-specific workflow selection mappings
+- PR-specific publication assumptions
 
-## Integration Examples
+### Treat workflow composition as classpath composition
 
-### Policy Component
+A project becomes “the software factory,” “financial ETL,” or another vertical
+by choosing which components and resources to load.
 
-Evaluate gates at phase boundaries:
+That means implementation work should prefer:
 
-```clojure
-(defn evaluate-phase-gates [phase artifact]
-  (policy/evaluate artifact
-                   (:phase/id phase)
-                   (:phase/gates phase)))
-```
+- resource-backed configuration
+- provider-backed runtime seams
+- generic fallback behavior
 
-### Heuristic Component
+over hardcoded workflow ids in shared code.
 
-Store/retrieve workflows as versioned heuristics:
+### Pass app behavior in through context
 
-```clojure
-(defn save-workflow-as-heuristic [workflow]
-  (heuristic/save-heuristic
-    (:workflow/id workflow)
-    (:workflow/version workflow)
-    workflow))
-```
+When the runtime needs domain behavior, prefer inputs such as:
 
-### Loop Component
+- `:phase-handlers`
+- profile providers
+- selection profile resources
+- publisher implementations
 
-Execute inner loops within phases:
-
-```clojure
-(defn run-inner-loop [phase artifact agent]
-  (loop-engine/execute
-    {:max-iterations (get-in phase [:phase/inner-loop :max-iterations])
-     :validator (get-validator phase)
-     :repairer (get-repairer phase agent)
-     :artifact artifact}))
-```
-
-### LLM Component
-
-Invoke agents for phase actions:
-
-```clojure
-(defn invoke-agent [agent action artifact context]
-  (llm/chat agent
-            (build-prompt action artifact)
-            {:context context}))
-```
+This keeps the shared runtime stable while apps vary around it.
 
 ## Testing Strategy
 
-### Unit Tests
+### Shared runtime tests
 
-- Test workflow loading from EDN
-- Test schema validation (valid and invalid configs)
-- Test DAG validation (cycles, unreachable nodes)
-- Test phase execution (with mocked agents)
-- Test gate evaluation integration
-- Test budget tracking
-- Test state transitions
+Cover:
 
-### Integration Tests
+- workflow loading and validation
+- DAG correctness checks
+- registry discovery across multiple classpath roots
+- generic publication and event-trigger behavior
+- state profile resolution and execution semantics
 
-- Test full workflow execution with real Policy component
-- Test workflow storage/retrieval via Heuristic component
-- Test hot-reload of workflow configs
-- Test Meta loop updating active workflow
+### App-composition tests
 
-### End-to-End Tests
+Cover:
 
-- Execute canonical-sdlc-v1 on a simple spec
-- Execute lean-sdlc-v1 on same spec
-- Compare metrics between executions
-- Verify Meta loop can propose and activate new workflow
+- app-owned workflow resources appearing in the shared registry
+- app-owned selection profile mappings resolving to loaded workflows
+- app-owned state profiles loading through provider seams
+- app-specific publishers or phase handlers working through the shared runtime
 
-## Implementation Plan
+### End-to-end proofs
 
-### Phase 1: Loader and Validator
+At minimum, keep proof workflows for:
 
-**Tasks:**
+- a simple shared workflow such as `simple-v2`
+- a non-software vertical workflow such as `financial-etl`
+- the flagship app workflow family through app composition
 
-1. Create `components/workflow/deps.edn`
-2. Implement `workflow.loader` (load from file/heuristic)
-3. Implement `workflow.validator` (schema + DAG validation)
-4. Add tests for loading and validation
-5. Wire into heuristic component for storage
+The point is to prove the kernel works across more than one domain without
+adding domain branches back into the kernel.
 
-### Phase 2: Executor Core
+## Practical Checklist for New Work
 
-**Tasks:**
+When adding a new workflow capability:
 
-1. Implement `workflow.state` (execution state management)
-2. Implement `workflow.executor` (DAG interpretation)
-3. Implement phase execution (stub agents initially)
-4. Add tests for execution flow
-5. Track budgets and metrics
+1. Decide whether it is kernel behavior or app behavior.
+2. If it is app behavior, put the data or implementation in an app-owned
+   component.
+3. Feed that behavior into the shared runtime through an existing seam.
+4. Add regression coverage for the seam you touched.
+5. Avoid reintroducing workflow ids or domain terms into shared code unless the
+   feature is intentionally app-specific.
 
-### Phase 3: Integration
+## Related Files
 
-**Tasks:**
-
-1. Wire executor to Policy component (gate evaluation)
-2. Wire executor to LLM component (agent invocation)
-3. Wire executor to Loop component (inner loops)
-4. Create `active.edn` config file
-5. Implement `get-active-workflow` / `set-active-workflow`
-
-### Phase 4: Meta Loop Integration
-
-**Tasks:**
-
-1. Enable Meta loop to propose new workflow configs
-2. Implement A/B testing framework
-3. Implement comparison and promotion logic
-4. Add hot-reload support
-5. Test self-updating workflows
-
-## Success Criteria
-
-- ✓ Can load workflow configs from EDN files
-- ✓ Validates configs against Malli schema
-- ✓ Detects invalid DAGs (cycles, unreachable nodes)
-- ✓ Executes workflows by interpreting the DAG
-- ✓ Tracks execution state (phases, budgets, metrics)
-- ✓ Integrates with Policy component for gates
-- ✓ Stores workflows via Heuristic component
-- ✓ Supports active workflow per task type
-- ✓ Meta loop can propose and activate new workflows
-- ✓ Hot-reload works without restart
-- ✓ Can compare workflow executions
-- ✓ All tests pass
-- ✓ Dogfood: Use workflow component to execute Phase 3 tasks
-
-## See Also
-
-- `docs/specs/workflow-api.spec.edn` - Public API specification
-- `docs/architecture/workflow-component.md` - Component architecture
-- `docs/specs/workflow-configuration.spec.edn` - Workflow EDN format
-- `components/workflow/resources/schemas/workflow.edn` - Malli schema
+- `components/workflow/src/ai/miniforge/workflow/interface.clj`
+- `components/workflow/src/ai/miniforge/workflow/registry.clj`
+- `components/workflow/src/ai/miniforge/workflow/configurable.clj`
+- `components/workflow/resources/workflows/README.md`

--- a/docs/pull-requests/2026-03-11-codex-shared-doc-copy-followup.md
+++ b/docs/pull-requests/2026-03-11-codex-shared-doc-copy-followup.md
@@ -1,0 +1,58 @@
+# PR: Generalize shared workflow docs and source comments
+
+## Summary
+
+This PR cleans up the remaining shared workflow documentation that still
+described software-factory workflows as if they were owned by the kernel.
+
+It does not change runtime behavior. It updates the shared architecture docs,
+implementation guide, and shared source comments so they match the current
+classpath-composed model, and it adds replacement software-factory-owned docs
+next to the app components.
+
+## Changes
+
+- Generalized the shared workflow protocol docstrings
+- Replaced stale loader examples with shared workflow examples
+- Rewrote `docs/architecture/workflow-component.md` to describe the shared
+  workflow component as a generic runtime
+- Rewrote `docs/architecture/live-workflow-configuration.md` to describe the
+  current resource-driven composition model
+- Added `docs/architecture/workflow-persistence-and-selection.md` to preserve
+  the implemented workflow configuration mechanics that still exist today
+- Rewrote `docs/guides/workflow-implementation.md` around the current kernel vs
+  app-owned seam
+- Added software-factory-owned READMEs for:
+  - `components/workflow-software-factory/`
+  - `components/phase-software-factory/`
+  - `components/workflow-chain-software-factory/`
+
+## Why
+
+Earlier extraction PRs moved workflow families, chains, selection config, and
+state profiles behind app composition.
+
+The remaining mismatch was in shared documentation:
+
+- the shared protocol still said "SDLC workflow"
+- shared loader examples still pointed at software-factory workflow ids
+- architecture docs still described `canonical-sdlc` and `lean-sdlc` as if they
+  shipped in the shared `workflow` component
+
+That documentation was now teaching the wrong boundary.
+
+This PR keeps the boundary cleanup, but it no longer drops the flagship
+documentation on the floor. The SDLC-specific guidance is restored in
+software-factory-owned docs next to the components that now own that behavior.
+
+It also restores the genuinely implemented workflow configuration mechanics in
+their own shared architecture doc, instead of losing them during the cleanup.
+
+## Verification
+
+- `bb pre-commit`
+
+## Follow-up
+
+The next likely docs seam is app-side documentation and older historical docs
+that still assume the flagship software-factory view is the whole platform.


### PR DESCRIPTION
# PR: Generalize shared workflow docs and source comments

## Summary

This PR cleans up the remaining shared workflow documentation that still
described software-factory workflows as if they were owned by the kernel.

It does not change runtime behavior. It updates the shared architecture docs,
implementation guide, and shared source comments so they match the current
classpath-composed model.

## Changes

- Generalized the shared workflow protocol docstrings
- Replaced stale loader examples with shared workflow examples
- Rewrote `docs/architecture/workflow-component.md` to describe the shared
  workflow component as a generic runtime
- Rewrote `docs/architecture/live-workflow-configuration.md` to describe the
  current resource-driven composition model
- Rewrote `docs/guides/workflow-implementation.md` around the current kernel vs
  app-owned seam

## Why

Earlier extraction PRs moved workflow families, chains, selection config, and
state profiles behind app composition.

The remaining mismatch was in shared documentation:

- the shared protocol still said "SDLC workflow"
- shared loader examples still pointed at software-factory workflow ids
- architecture docs still described `canonical-sdlc` and `lean-sdlc` as if they
  shipped in the shared `workflow` component

That documentation was now teaching the wrong boundary.

## Verification

- `bb pre-commit`

## Follow-up

The next likely docs seam is app-side documentation and older historical docs
that still assume the flagship software-factory view is the whole platform.
