### PR TITLE
feat: add workflow-kernel project composition

### DIFF
--- a/bases/cli/deps.edn
+++ b/bases/cli/deps.edn
@@ -20,20 +20,4 @@
         ;; Web server dependencies (BB-compatible)
         ;; http-kit and hiccup are bundled with Babashka
         http-kit/http-kit {:mvn/version "2.8.0"}
-        hiccup/hiccup     {:mvn/version "2.0.0-RC3"}
-
-        ;; Flagship app workflow families
-        ai.miniforge/workflow-chain-software-factory
-        {:local/root "../../components/workflow-chain-software-factory"}
-
-        ;; Flagship app chain resources
-        ai.miniforge/workflow-software-factory
-        {:local/root "../../components/workflow-software-factory"}
-
-        ;; Financial ETL product resources
-        ai.miniforge/workflow-financial-etl
-        {:local/root "../../components/workflow-financial-etl"}
-
-        ;; Flagship app phase implementations
-        ai.miniforge/phase-software-factory
-        {:local/root "../../components/phase-software-factory"}}}
+        hiccup/hiccup     {:mvn/version "2.0.0-RC3"}}}

--- a/bb.edn
+++ b/bb.edn
@@ -143,6 +143,11 @@
    :requires ([build])
    :task (build/cli)}
 
+  build:kernel
+  {:doc  "Build workflow-kernel CLI as distributable uberjar"
+   :requires ([build])
+   :task (build/kernel)}
+
   build:jar
   {:doc  "Build JVM uberjar for a project"
    :task (let [[project] *command-line-args*]

--- a/docs/pull-requests/2026-03-12-codex-kernel-project-split.md
+++ b/docs/pull-requests/2026-03-12-codex-kernel-project-split.md
@@ -1,0 +1,30 @@
+# Kernel Project Split
+
+## Layer
+
+Infrastructure
+
+## Depends on
+
+- #305 (`codex/etl-runtime-split`) — merged
+
+## What this adds
+
+- removes product-owned workflow resources from the shared CLI base
+- adds a kernel-only `workflow-kernel` project composition
+- adds integration coverage proving the kernel project classpath only ships kernel workflows
+
+## Strata affected
+
+- `bases/cli` — base no longer depends on software-factory or ETL components
+- `projects/workflow-kernel` — new kernel/local-runtime project composition
+- `tasks/build.clj`, `bb.edn`, `tasks/test_runner.clj` — build and integration tooling for the new project
+
+## Verification
+
+- `bb test`
+- `bb test:integration`
+- `bb build:kernel`
+- `bb build:cli`
+- `bb build:tui`
+- `bb pre-commit`

--- a/projects/workflow-kernel/deps.edn
+++ b/projects/workflow-kernel/deps.edn
@@ -1,0 +1,37 @@
+{:paths ["test"]
+
+ :deps {ai.miniforge/cli {:local/root "../../bases/cli"}
+        ai.miniforge/workflow {:local/root "../../components/workflow"}
+        ai.miniforge/schema {:local/root "../../components/schema"}
+        ai.miniforge/config {:local/root "../../components/config"}
+        ai.miniforge/algorithms {:local/root "../../components/algorithms"}
+        ai.miniforge/logging {:local/root "../../components/logging"}
+        ai.miniforge/llm {:local/root "../../components/llm"}
+        ai.miniforge/tool {:local/root "../../components/tool"}
+        ai.miniforge/artifact {:local/root "../../components/artifact"}
+        ai.miniforge/agent {:local/root "../../components/agent"}
+        ai.miniforge/agent-runtime {:local/root "../../components/agent-runtime"}
+        ai.miniforge/task {:local/root "../../components/task"}
+        ai.miniforge/loop {:local/root "../../components/loop"}
+        ai.miniforge/observer {:local/root "../../components/observer"}
+        ai.miniforge/knowledge {:local/root "../../components/knowledge"}
+        ai.miniforge/spec-parser {:local/root "../../components/spec-parser"}
+        ai.miniforge/policy {:local/root "../../components/policy"}
+        ai.miniforge/heuristic {:local/root "../../components/heuristic"}
+        ai.miniforge/response {:local/root "../../components/response"}
+        ai.miniforge/fsm {:local/root "../../components/fsm"}
+        ai.miniforge/phase {:local/root "../../components/phase"}
+        ai.miniforge/gate {:local/root "../../components/gate"}
+        ai.miniforge/evidence-bundle {:local/root "../../components/evidence-bundle"}
+        ai.miniforge/dag-executor {:local/root "../../components/dag-executor"}
+        ai.miniforge/policy-pack {:local/root "../../components/policy-pack"}
+        ai.miniforge/tool-registry {:local/root "../../components/tool-registry"}
+        ai.miniforge/operator {:local/root "../../components/operator"}
+        ai.miniforge/orchestrator {:local/root "../../components/orchestrator"}
+        ai.miniforge/event-stream {:local/root "../../components/event-stream"}
+        ai.miniforge/self-healing {:local/root "../../components/self-healing"}
+        ai.miniforge/mcp-artifact-server {:local/root "../../components/mcp-artifact-server"}}
+
+ :aliases
+ {:uberjar
+  {:main ai.miniforge.cli.main}}}

--- a/projects/workflow-kernel/test/ai/miniforge/workflow/kernel_loader_integration_test.clj
+++ b/projects/workflow-kernel/test/ai/miniforge/workflow/kernel_loader_integration_test.clj
@@ -1,0 +1,15 @@
+(ns ai.miniforge.workflow.kernel-loader-integration-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.workflow.interface :as workflow]))
+
+(deftest kernel-project-loads-only-kernel-workflows
+  (let [workflow-ids (->> (workflow/list-workflows)
+                          (map :workflow/id)
+                          set)]
+    (testing "kernel project loads generic workflows"
+      (is (contains? workflow-ids :simple-test-v1))
+      (is (contains? workflow-ids :minimal-test-v1)))
+    (testing "kernel project does not ship product workflows"
+      (is (not (contains? workflow-ids :canonical-sdlc-v1)))
+      (is (not (contains? workflow-ids :financial-etl))))))

--- a/tasks/build.clj
+++ b/tasks/build.clj
@@ -15,6 +15,17 @@
       (println "❌ Build failed with exit code:" exit)
       (System/exit exit))))
 
+(defn kernel []
+  (println "🔨 Building workflow-kernel CLI uberjar...")
+  (println "Command: clojure -T:build bb-uberjar :project workflow-kernel")
+  (let [{:keys [exit out err]} (p/sh {:out :string :err :string}
+                                     "clojure" "-T:build" "bb-uberjar" ":project" "workflow-kernel")]
+    (when-not (str/blank? out) (println out))
+    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+    (when-not (zero? exit)
+      (println "❌ Build failed with exit code:" exit)
+      (System/exit exit))))
+
 (defn tui []
   (let [jar-file   "dist/miniforge-tui.jar"
         jlink-dir  "dist/miniforge-tui-runtime"

--- a/tasks/test_runner.clj
+++ b/tasks/test_runner.clj
@@ -11,50 +11,59 @@
         {:keys [exit]} (deref (apply p/process opts cmd-args))]
     exit))
 
-(defn integration []
-  (println "🧪 Running project integration tests...")
-  (let [deps (slurp "projects/miniforge/deps.edn")
-        test-nses ["ai.miniforge.workflow.release-integration-test"
-                   "ai.miniforge.workflow.loader-integration-test"
-                   "ai.miniforge.workflow.configurable-integration-test"
-                   "ai.miniforge.workflow.runner-integration-test"
-                   "ai.miniforge.workflow.financial-etl-test"
-                   "ai.miniforge.workflow.dag-orchestrator-test"
-                   "ai.miniforge.workflow.artifact-persistence-test"
-                   "ai.miniforge.dag-executor.executor-test"
-                   "ai.miniforge.orchestrator.interface-test"
-                   "ai.miniforge.llm.progress-monitor-test"
-                   "ai.miniforge.phase.handoff-test"
-                   "ai.miniforge.tool-registry.integration-test"
-                   "ai.miniforge.self-healing.backend-health-test"
-                   "ai.miniforge.tui-views.subscription-test"
-                   "ai.miniforge.tui-engine.core-test"
-                   "ai.miniforge.web-dashboard.interface-test"
-                   "ai.miniforge.tui-views.pr-views-test"
-                   "ai.miniforge.tui-views.view-test"
-                   "ai.miniforge.tui-views.persistence-test"
-                   "ai.miniforge.knowledge.interface-test"
-                   "ai.miniforge.gate.pipeline-test"
-                   "ai.miniforge.evidence-bundle.interface-test"
-                   "ai.miniforge.artifact.interface-integration-test"
-                   "ai.miniforge.loop.interface-integration-test"
-                   "ai.miniforge.observer.interface-integration-test"
-                   "ai.miniforge.task.interface-integration-test"
-                   "ai.miniforge.release-executor.artifact-validation-integration-test"
-                   "ai.miniforge.web-dashboard.fleet-onboarding-integration-test"
-                   "ai.miniforge.self-healing.integration-test"
-                   "ai.miniforge.governance.e2e-test"
-                   "ai.miniforge.mcp.artifact-server-integration-test"]
+(defn- run-project-tests!
+  [project test-nses]
+  (let [deps (slurp (str "projects/" project "/deps.edn"))
         require-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
         run-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
         expr (str "(require 'clojure.test" require-expr ") "
                   "(let [r (clojure.test/run-tests" run-expr ")] "
-                  "  (System/exit (if (zero? (+ (:fail r 0) (:error r 0))) 0 1)))")
-        exit (run-stream! {:dir "projects/miniforge"}
-                          "clojure" "-Sdeps" deps "-M" "-e" expr)]
-    (when-not (zero? exit)
-      (println "❌ Integration tests failed with exit code:" exit)
-      (System/exit exit))))
+                  "  (System/exit (if (zero? (+ (:fail r 0) (:error r 0))) 0 1)))")]
+    (run-stream! {:dir (str "projects/" project)}
+                 "clojure" "-Sdeps" deps "-M" "-e" expr)))
+
+(defn integration []
+  (println "🧪 Running project integration tests...")
+  (let [miniforge-tests ["ai.miniforge.workflow.release-integration-test"
+                         "ai.miniforge.workflow.loader-integration-test"
+                         "ai.miniforge.workflow.configurable-integration-test"
+                         "ai.miniforge.workflow.runner-integration-test"
+                         "ai.miniforge.workflow.financial-etl-test"
+                         "ai.miniforge.workflow.dag-orchestrator-test"
+                         "ai.miniforge.workflow.artifact-persistence-test"
+                         "ai.miniforge.dag-executor.executor-test"
+                         "ai.miniforge.orchestrator.interface-test"
+                         "ai.miniforge.llm.progress-monitor-test"
+                         "ai.miniforge.phase.handoff-test"
+                         "ai.miniforge.tool-registry.integration-test"
+                         "ai.miniforge.self-healing.backend-health-test"
+                         "ai.miniforge.tui-views.subscription-test"
+                         "ai.miniforge.tui-engine.core-test"
+                         "ai.miniforge.web-dashboard.interface-test"
+                         "ai.miniforge.tui-views.pr-views-test"
+                         "ai.miniforge.tui-views.view-test"
+                         "ai.miniforge.tui-views.persistence-test"
+                         "ai.miniforge.knowledge.interface-test"
+                         "ai.miniforge.gate.pipeline-test"
+                         "ai.miniforge.evidence-bundle.interface-test"
+                         "ai.miniforge.artifact.interface-integration-test"
+                         "ai.miniforge.loop.interface-integration-test"
+                         "ai.miniforge.observer.interface-integration-test"
+                         "ai.miniforge.task.interface-integration-test"
+                         "ai.miniforge.release-executor.artifact-validation-integration-test"
+                         "ai.miniforge.web-dashboard.fleet-onboarding-integration-test"
+                         "ai.miniforge.self-healing.integration-test"
+                         "ai.miniforge.governance.e2e-test"
+                         "ai.miniforge.mcp.artifact-server-integration-test"]
+        kernel-tests ["ai.miniforge.workflow.kernel-loader-integration-test"]
+        miniforge-exit (run-project-tests! "miniforge" miniforge-tests)]
+    (when-not (zero? miniforge-exit)
+      (println "❌ Integration tests failed in project: miniforge")
+      (System/exit miniforge-exit))
+    (let [kernel-exit (run-project-tests! "workflow-kernel" kernel-tests)]
+      (when-not (zero? kernel-exit)
+        (println "❌ Integration tests failed in project: workflow-kernel")
+        (System/exit kernel-exit)))))
 
 (defn conformance []
   (println "🧪 Running N1 conformance tests...")

--- a/workspace.edn
+++ b/workspace.edn
@@ -7,5 +7,6 @@
  :tag-patterns {:stable "stable/*"
                 :release "v[0-9]*"}
  :projects {"development"    {:alias "dev"}
+            "workflow-kernel" {:alias "kernel"}
             "miniforge"      {:alias "cli"}
             "miniforge-tui"  {:alias "tui"}}}


### PR DESCRIPTION
# Kernel Project Split

## Layer

Infrastructure

## Depends on

- #305 (`codex/etl-runtime-split`) — merged

## What this adds

- removes product-owned workflow resources from the shared CLI base
- adds a kernel-only `workflow-kernel` project composition
- adds integration coverage proving the kernel project classpath only ships kernel workflows

## Strata affected

- `bases/cli` — base no longer depends on software-factory or ETL components
- `projects/workflow-kernel` — new kernel/local-runtime project composition
- `tasks/build.clj`, `bb.edn`, `tasks/test_runner.clj` — build and integration tooling for the new project

## Verification

- `bb test`
- `bb test:integration`
- `bb build:kernel`
- `bb build:cli`
- `bb build:tui`
- `bb pre-commit`
