### PR TITLE
test: align CLI assertions with resource config

### DIFF
--- a/bases/cli/test/ai/miniforge/cli/app_config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/app_config_test.clj
@@ -6,13 +6,16 @@
 
 (deftest default-app-profile-test
   (let [profile (app-config/app-profile)]
-    (testing "base CLI defaults to the flagship profile"
-      (is (= "miniforge" (:name profile)))
-      (is (= ".miniforge" (:home-dir-name profile)))
-      (is (= "miniforge-tui" (:tui-package profile))))
+    (testing "base CLI exposes a resource-backed profile"
+      (is (= (:name profile) (app-config/binary-name)))
+      (is (= (:display-name profile) (app-config/display-name)))
+      (is (= (:description profile) (app-config/description)))
+      (is (= (:tui-package profile) (app-config/tui-package))))
     (testing "derived paths use the configured home dir"
-      (is (.endsWith (app-config/config-path) "/.miniforge/config.edn"))
-      (is (.endsWith (app-config/events-dir) "/.miniforge/events")))))
+      (is (.endsWith (app-config/config-path)
+                     (str "/" (:home-dir-name profile) "/config.edn")))
+      (is (.endsWith (app-config/events-dir)
+                     (str "/" (:home-dir-name profile) "/events"))))))
 
 (deftest app-profile-loads-resource-backed-config-test
   (testing "app profile delegates to the resource-backed config loader"

--- a/bases/cli/test/ai/miniforge/cli/main_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main_test.clj
@@ -7,13 +7,13 @@
 
 (deftest help-cmd-uses-generic-workflow-examples-test
   (testing "CLI help shows generic workflow examples instead of SDLC-specific ones"
-    (let [output (with-out-str (sut/help-cmd {}))]
-      (is (.contains output "miniforge - AI-powered software development workflows"))
-      (is (.contains output "miniforge workflow run :simple-v2"))
-      (is (.contains output "miniforge workflow run :financial-etl -i input.edn"))
-      (is (.contains output "miniforge chain list"))
-      (is (not (.contains output "canonical-sdlc-v1")))
-      (is (not (.contains output "Build feature"))))))
+    (let [output (with-out-str (sut/help-cmd {}))
+          title (messages/t :help/title {:binary (app-config/binary-name)
+                                         :description (app-config/description)})]
+      (is (.contains output title))
+      (doseq [example (app-config/help-examples)]
+        (is (.contains output (app-config/command-string example))))
+      (is (not (.contains output "canonical-sdlc-v1"))))))
 
 (deftest help-cmd-reads-copy-from-message-catalog-test
   (testing "help output is assembled from message resources rather than hardcoded strings"

--- a/bases/cli/test/ai/miniforge/cli/messages_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/messages_test.clj
@@ -1,17 +1,22 @@
 (ns ai.miniforge.cli.messages-test
   (:require
+   [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.messages :as messages]))
 
 (deftest message-catalog-renders-placeholders-test
-  (testing "messages are loaded from EDN resources and rendered with parameters"
-    (is (= "Usage: miniforge <command> [options]"
-           (messages/t :help/usage {:binary "miniforge"})))
-    (is (= "Run 'miniforge help' for more information."
-           (messages/t :main/run-help {:command "miniforge help"})))))
+  (let [english-catalog (messages/catalog "en")
+        usage-template (:help/usage english-catalog)
+        help-template (:main/run-help english-catalog)]
+    (testing "messages are loaded from resources and interpolate placeholders"
+      (is (= (str/replace usage-template "{binary}" "miniforge")
+             (messages/t :help/usage {:binary "miniforge"})))
+      (is (= (str/replace help-template "{command}" "miniforge help")
+             (messages/t :main/run-help {:command "miniforge help"}))))))
 
 (deftest message-catalog-falls-back-to-english-test
   (testing "unknown locales fall back to the English catalog"
-    (with-redefs [messages/active-locale (constantly :fr)]
-      (is (= "Usage: moteur <command> [options]"
-             (messages/t :help/usage {:binary "moteur"}))))))
+    (let [english-usage (messages/t :help/usage {:binary "moteur"})]
+      (with-redefs [messages/active-locale (constantly :fr)]
+        (is (= english-usage
+               (messages/t :help/usage {:binary "moteur"})))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_recommendation_config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_recommendation_config_test.clj
@@ -1,14 +1,25 @@
 (ns ai.miniforge.cli.workflow-recommendation-config-test
   (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.workflow-recommendation-config :as cfg]))
 
+(defn- recommendation-prompt-resource
+  []
+  (-> "config/workflow/recommendation-prompt.edn"
+      io/resource
+      slurp
+      edn/read-string
+      :workflow-recommendation/prompt))
+
 (deftest recommendation-prompt-config-test
   (testing "software-factory prompt config loads from resources"
-    (let [config (cfg/recommendation-prompt-config)]
-      (is (= "Task type (feature, bugfix, refactor, test)"
+    (let [config (cfg/recommendation-prompt-config)
+          prompt-resource (recommendation-prompt-resource)]
+      (is (= (last (:analysis-dimensions prompt-resource))
              (last (:analysis-dimensions config))))
-      (is (= "Includes code review"
+      (is (= (get-in prompt-resource [:summary-labels :has-review])
              (get-in config [:summary-labels :has-review])))
-      (is (= "Includes testing"
+      (is (= (get-in prompt-resource [:summary-labels :has-testing])
              (get-in config [:summary-labels :has-testing]))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
@@ -10,37 +10,38 @@
                              {:workflow/id :canonical-sdlc-v1
                               :workflow/task-types [:feature :refactoring]}]]
     (testing "configured prompt vocabulary is reflected in the assembled prompt"
-      (with-redefs [cfg/recommendation-prompt-config
-                    (fn []
-                      {:analysis-dimensions
-                       ["Task complexity (simple, medium, complex)"
-                        "Task type (feature, bugfix, refactor, test)"]
-                       :summary-labels
-                       {:has-review "Includes code review"
-                        :has-testing "Includes testing"}})
-                    recommender/build-workflow-summaries
-                    (fn [_workflows]
-                      "- workflow\n  Includes code review\n  Includes testing")]
-        (let [prompt (recommender/build-recommendation-prompt
-                      {:spec/title "Fix flaky test"}
-                      available-workflows)]
-          (is (.contains prompt "Task type (feature, bugfix, refactor, test)"))
-          (is (.contains prompt "Includes code review"))
-          (is (.contains prompt "Includes testing")))))
+      (let [prompt-config (cfg/recommendation-prompt-config)]
+        (with-redefs [cfg/recommendation-prompt-config
+                      (fn []
+                        prompt-config)
+                      recommender/build-workflow-summaries
+                      (fn [_workflows]
+                        (str "- workflow\n  "
+                             (get-in prompt-config [:summary-labels :has-review]) "\n  "
+                             (get-in prompt-config [:summary-labels :has-testing])))]
+          (let [prompt (recommender/build-recommendation-prompt
+                        {:spec/title "Fix flaky test"}
+                        available-workflows)]
+            (is (.contains prompt (last (:analysis-dimensions prompt-config))))
+            (is (.contains prompt (get-in prompt-config [:summary-labels :has-review])))
+            (is (.contains prompt (get-in prompt-config [:summary-labels :has-testing])))))))
 
     (testing "generic fallback vocabulary is available when no app config is present"
-      (with-redefs [cfg/recommendation-prompt-config
-                    (fn []
-                      cfg/default-prompt-config)
-                    recommender/build-workflow-summaries
-                    (fn [_workflows]
-                      "- workflow\n  Includes review checkpoints\n  Includes verification/testing")]
-        (let [prompt (recommender/build-recommendation-prompt
-                      {:spec/title "Run analytical workflow"}
-                      available-workflows)]
-          (is (.contains prompt "Work category and expected outputs"))
-          (is (.contains prompt "Includes review checkpoints"))
-          (is (.contains prompt "Includes verification/testing")))))))
+      (let [prompt-config cfg/default-prompt-config]
+        (with-redefs [cfg/recommendation-prompt-config
+                      (fn []
+                        prompt-config)
+                      recommender/build-workflow-summaries
+                      (fn [_workflows]
+                        (str "- workflow\n  "
+                             (get-in prompt-config [:summary-labels :has-review]) "\n  "
+                             (get-in prompt-config [:summary-labels :has-testing])))]
+          (let [prompt (recommender/build-recommendation-prompt
+                        {:spec/title "Run analytical workflow"}
+                        available-workflows)]
+            (is (.contains prompt (last (:analysis-dimensions prompt-config))))
+            (is (.contains prompt (get-in prompt-config [:summary-labels :has-review])))
+            (is (.contains prompt (get-in prompt-config [:summary-labels :has-testing])))))))))
 
 (deftest recommend-by-task-type-test
   (let [available-workflows [{:workflow/id :lean-sdlc-v1

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/display_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/display_test.clj
@@ -9,9 +9,15 @@
   (testing "workflow runner header uses the active app display name"
     (with-redefs [app-config/display-name (constantly "Workflow Kernel")]
       (let [output (with-out-str (sut/print-workflow-header :simple-v2 "latest" false))]
-        (is (.contains output "Workflow Kernel Workflow Runner"))
-        (is (.contains output "Workflow: "))
-        (is (.contains output "simple-v2"))))))
+        (is (.contains output
+                       (messages/t :workflow-runner/header
+                                   {:display-name (app-config/display-name)})))
+        (is (.contains output
+                       (messages/t :workflow-runner/workflow
+                                   {:workflow-id "simple-v2"})))
+        (is (.contains output
+                       (messages/t :workflow-runner/version
+                                   {:version "latest"})))))))
 
 (deftest workflow-runner-event-lines-use-message-catalog-test
   (testing "event formatting reads labels from the message catalog"

--- a/docs/pull-requests/2026-03-12-codex-test-catalog-followup.md
+++ b/docs/pull-requests/2026-03-12-codex-test-catalog-followup.md
@@ -1,0 +1,43 @@
+# Test Catalog Follow-Up
+
+## Layer
+
+Testing
+
+## Depends on
+
+- #308 (`codex/messages-catalog-split`) — merged
+
+## What this adds
+
+- removes duplicated resource-owned CLI copy/config values from tests that were still asserting against hardcoded
+  English literals
+- updates CLI tests to read expected help/title/example output through `app-config` and `messages`
+- updates recommendation prompt tests to read expected prompt vocabulary from the same resource-backed config the
+  runtime
+  uses
+- updates the kernel CLI integration test to assert against the active project-owned app profile instead of duplicating
+  kernel-specific copy in test literals
+
+## Strata affected
+
+- `bases/cli` tests — app profile, messages, help output, workflow-runner output, and recommendation prompt coverage
+- `projects/workflow-kernel` tests — kernel help/config assertions now read from the active app profile and message
+  catalog
+
+## Why
+
+- after the message-catalog split, a number of tests still carried their own copies of user-facing strings
+- that made the tests a second source of truth for English copy instead of consumers of the resource seam
+- if locale support expands later, these tests need to be catalog/config-driven rather than pinned to inline literals
+
+## Verification
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.app-config-test 'ai.miniforge.cli.messages-test
+  'ai.miniforge.cli.main-test 'ai.miniforge.cli.workflow-runner.display-test
+  'ai.miniforge.cli.workflow-recommendation-config-test 'ai.miniforge.cli.workflow-recommender-test)
+  (clojure.test/run-tests 'ai.miniforge.cli.app-config-test 'ai.miniforge.cli.messages-test
+  'ai.miniforge.cli.main-test 'ai.miniforge.cli.workflow-runner.display-test
+  'ai.miniforge.cli.workflow-recommendation-config-test 'ai.miniforge.cli.workflow-recommender-test)"`
+- `clojure -M -e "(require 'ai.miniforge.workflow.kernel-loader-integration-test)
+  (clojure.test/run-tests 'ai.miniforge.workflow.kernel-loader-integration-test)"` from `projects/workflow-kernel`

--- a/projects/workflow-kernel/test/ai/miniforge/workflow/kernel_loader_integration_test.clj
+++ b/projects/workflow-kernel/test/ai/miniforge/workflow/kernel_loader_integration_test.clj
@@ -2,6 +2,7 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.main :as main]
    [ai.miniforge.workflow.interface :as workflow]))
 
@@ -17,11 +18,17 @@
       (is (not (contains? workflow-ids :financial-etl))))))
 
 (deftest kernel-project-overrides-cli-identity
-  (testing "kernel project uses its own app profile"
-    (is (= "workflow-kernel" (app-config/binary-name)))
-    (is (.endsWith (app-config/config-path) "/.workflow-kernel/config.edn")))
-  (testing "kernel help uses kernel-specific copy"
-    (let [output (with-out-str (main/help-cmd {}))]
-      (is (.contains output "workflow-kernel - Local governed workflow engine"))
-      (is (.contains output "workflow-kernel workflow list"))
-      (is (not (.contains output "workflow-kernel workflow run :financial-etl -i input.edn"))))))
+  (let [profile (app-config/app-profile)]
+    (testing "kernel project uses its own app profile"
+      (is (= (:name profile) (app-config/binary-name)))
+      (is (.endsWith (app-config/config-path)
+                     (str "/" (:home-dir-name profile) "/config.edn"))))
+    (testing "kernel help uses kernel-specific copy"
+      (let [output (with-out-str (main/help-cmd {}))
+            title (messages/t :help/title {:binary (app-config/binary-name)
+                                           :description (app-config/description)})]
+        (is (.contains output title))
+        (doseq [example (app-config/help-examples)]
+          (is (.contains output (app-config/command-string example))))
+        (is (not (.contains output (app-config/command-string
+                                    "workflow run :financial-etl -i input.edn"))))))))


### PR DESCRIPTION
# Test Catalog Follow-Up

## Layer

Testing

## Depends on

- #308 (`codex/messages-catalog-split`) — merged

## What this adds

- removes duplicated resource-owned CLI copy/config values from tests that were still asserting against hardcoded
  English literals
- updates CLI tests to read expected help/title/example output through `app-config` and `messages`
- updates recommendation prompt tests to read expected prompt vocabulary from the same resource-backed config the
  runtime
  uses
- updates the kernel CLI integration test to assert against the active project-owned app profile instead of duplicating
  kernel-specific copy in test literals

## Strata affected

- `bases/cli` tests — app profile, messages, help output, workflow-runner output, and recommendation prompt coverage
- `projects/workflow-kernel` tests — kernel help/config assertions now read from the active app profile and message
  catalog

## Why

- after the message-catalog split, a number of tests still carried their own copies of user-facing strings
- that made the tests a second source of truth for English copy instead of consumers of the resource seam
- if locale support expands later, these tests need to be catalog/config-driven rather than pinned to inline literals

## Verification

- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.app-config-test 'ai.miniforge.cli.messages-test
  'ai.miniforge.cli.main-test 'ai.miniforge.cli.workflow-runner.display-test
  'ai.miniforge.cli.workflow-recommendation-config-test 'ai.miniforge.cli.workflow-recommender-test)
  (clojure.test/run-tests 'ai.miniforge.cli.app-config-test 'ai.miniforge.cli.messages-test
  'ai.miniforge.cli.main-test 'ai.miniforge.cli.workflow-runner.display-test
  'ai.miniforge.cli.workflow-recommendation-config-test 'ai.miniforge.cli.workflow-recommender-test)"`
- `clojure -M -e "(require 'ai.miniforge.workflow.kernel-loader-integration-test)
  (clojure.test/run-tests 'ai.miniforge.workflow.kernel-loader-integration-test)"` from `projects/workflow-kernel`
