### PR TITLE
refactor: externalize recommendation fallback config

### DIFF
--- a/bases/cli/resources/config/workflow/recommendation-prompt-default.edn
+++ b/bases/cli/resources/config/workflow/recommendation-prompt-default.edn
@@ -1,0 +1,10 @@
+{:workflow-recommendation/prompt
+ {:analysis-dimensions
+  ["Task complexity (simple, medium, complex)"
+   "Risk level (low, medium, high)"
+   "Review requirements (minimal, standard, comprehensive)"
+   "Time constraints (quick, normal, extensive)"
+   "Work category and expected outputs"]
+  :summary-labels
+  {:has-review "Includes review checkpoints"
+   :has-testing "Includes verification/testing"}}}

--- a/bases/cli/src/ai/miniforge/cli/workflow_recommendation_config.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_recommendation_config.clj
@@ -1,7 +1,7 @@
 (ns ai.miniforge.cli.workflow-recommendation-config
   "Resource-driven workflow recommendation prompt configuration."
   (:require
-   [clojure.edn :as edn]))
+   [ai.miniforge.cli.resource-config :as resource-config]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Resource loading
@@ -10,22 +10,16 @@
   "Classpath resource path for workflow recommendation prompt config."
   "config/workflow/recommendation-prompt.edn")
 
-(def default-prompt-config
-  {:analysis-dimensions
-   ["Task complexity (simple, medium, complex)"
-    "Risk level (low, medium, high)"
-    "Review requirements (minimal, standard, comprehensive)"
-    "Time constraints (quick, normal, extensive)"
-    "Work category and expected outputs"]
-   :summary-labels
-   {:has-review "Includes review checkpoints"
-    :has-testing "Includes verification/testing"}})
+(def default-recommendation-config-resource
+  "Classpath resource path for base workflow recommendation prompt config."
+  "config/workflow/recommendation-prompt-default.edn")
 
-(defn- read-recommendation-config
-  "Read a single recommendation prompt config resource."
-  [resource]
-  (let [config (-> resource slurp edn/read-string)]
-    (or (:workflow-recommendation/prompt config) {})))
+(defn default-prompt-config
+  "Load the base workflow recommendation prompt config from resources."
+  []
+  (resource-config/merged-resource-config default-recommendation-config-resource
+                                          :workflow-recommendation/prompt
+                                          {}))
 
 (defn- merge-prompt-config
   "Merge prompt config maps, preserving nested summary labels."
@@ -37,7 +31,7 @@
 (defn recommendation-prompt-config
   "Resolve the active workflow recommendation prompt config from the classpath."
   []
-  (->> (enumeration-seq (.getResources (clojure.lang.RT/baseLoader)
-                                       recommendation-config-resource))
-       (map read-recommendation-config)
-       (reduce merge-prompt-config default-prompt-config)))
+  (merge-prompt-config (default-prompt-config)
+                       (resource-config/merged-resource-config recommendation-config-resource
+                                                               :workflow-recommendation/prompt
+                                                               {})))

--- a/bases/cli/test/ai/miniforge/cli/workflow_recommendation_config_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_recommendation_config_test.clj
@@ -1,14 +1,31 @@
 (ns ai.miniforge.cli.workflow-recommendation-config-test
   (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.cli.workflow-recommendation-config :as cfg]))
 
+(defn- read-resource-section
+  [resource-path]
+  (-> resource-path
+      io/resource
+      slurp
+      edn/read-string
+      :workflow-recommendation/prompt))
+
 (deftest recommendation-prompt-config-test
   (testing "software-factory prompt config loads from resources"
-    (let [config (cfg/recommendation-prompt-config)]
-      (is (= "Task type (feature, bugfix, refactor, test)"
+    (let [config (cfg/recommendation-prompt-config)
+          prompt-resource (read-resource-section "config/workflow/recommendation-prompt.edn")]
+      (is (= (last (:analysis-dimensions prompt-resource))
              (last (:analysis-dimensions config))))
-      (is (= "Includes code review"
+      (is (= (get-in prompt-resource [:summary-labels :has-review])
              (get-in config [:summary-labels :has-review])))
-      (is (= "Includes testing"
+      (is (= (get-in prompt-resource [:summary-labels :has-testing])
              (get-in config [:summary-labels :has-testing]))))))
+
+(deftest default-prompt-config-loads-from-resource-test
+  (testing "fallback recommendation prompt config is resource-backed"
+    (let [default-config (cfg/default-prompt-config)
+          default-resource (read-resource-section "config/workflow/recommendation-prompt-default.edn")]
+      (is (= default-resource default-config)))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_recommender_test.clj
@@ -10,37 +10,38 @@
                              {:workflow/id :canonical-sdlc-v1
                               :workflow/task-types [:feature :refactoring]}]]
     (testing "configured prompt vocabulary is reflected in the assembled prompt"
-      (with-redefs [cfg/recommendation-prompt-config
-                    (fn []
-                      {:analysis-dimensions
-                       ["Task complexity (simple, medium, complex)"
-                        "Task type (feature, bugfix, refactor, test)"]
-                       :summary-labels
-                       {:has-review "Includes code review"
-                        :has-testing "Includes testing"}})
-                    recommender/build-workflow-summaries
-                    (fn [_workflows]
-                      "- workflow\n  Includes code review\n  Includes testing")]
-        (let [prompt (recommender/build-recommendation-prompt
-                      {:spec/title "Fix flaky test"}
-                      available-workflows)]
-          (is (.contains prompt "Task type (feature, bugfix, refactor, test)"))
-          (is (.contains prompt "Includes code review"))
-          (is (.contains prompt "Includes testing")))))
+      (let [prompt-config (cfg/recommendation-prompt-config)]
+        (with-redefs [cfg/recommendation-prompt-config
+                      (fn []
+                        prompt-config)
+                      recommender/build-workflow-summaries
+                      (fn [_workflows]
+                        (str "- workflow\n  "
+                             (get-in prompt-config [:summary-labels :has-review]) "\n  "
+                             (get-in prompt-config [:summary-labels :has-testing])))]
+          (let [prompt (recommender/build-recommendation-prompt
+                        {:spec/title "Fix flaky test"}
+                        available-workflows)]
+            (is (.contains prompt (last (:analysis-dimensions prompt-config))))
+            (is (.contains prompt (get-in prompt-config [:summary-labels :has-review])))
+            (is (.contains prompt (get-in prompt-config [:summary-labels :has-testing])))))))
 
     (testing "generic fallback vocabulary is available when no app config is present"
-      (with-redefs [cfg/recommendation-prompt-config
-                    (fn []
-                      cfg/default-prompt-config)
-                    recommender/build-workflow-summaries
-                    (fn [_workflows]
-                      "- workflow\n  Includes review checkpoints\n  Includes verification/testing")]
-        (let [prompt (recommender/build-recommendation-prompt
-                      {:spec/title "Run analytical workflow"}
-                      available-workflows)]
-          (is (.contains prompt "Work category and expected outputs"))
-          (is (.contains prompt "Includes review checkpoints"))
-          (is (.contains prompt "Includes verification/testing")))))))
+      (let [prompt-config (cfg/default-prompt-config)]
+        (with-redefs [cfg/recommendation-prompt-config
+                      (fn []
+                        prompt-config)
+                      recommender/build-workflow-summaries
+                      (fn [_workflows]
+                        (str "- workflow\n  "
+                             (get-in prompt-config [:summary-labels :has-review]) "\n  "
+                             (get-in prompt-config [:summary-labels :has-testing])))]
+          (let [prompt (recommender/build-recommendation-prompt
+                        {:spec/title "Run analytical workflow"}
+                        available-workflows)]
+            (is (.contains prompt (last (:analysis-dimensions prompt-config))))
+            (is (.contains prompt (get-in prompt-config [:summary-labels :has-review])))
+            (is (.contains prompt (get-in prompt-config [:summary-labels :has-testing])))))))))
 
 (deftest recommend-by-task-type-test
   (let [available-workflows [{:workflow/id :lean-sdlc-v1

--- a/docs/pull-requests/2026-03-12-codex-recommendation-config-resource-split.md
+++ b/docs/pull-requests/2026-03-12-codex-recommendation-config-resource-split.md
@@ -1,0 +1,36 @@
+# Recommendation Config Resource Split
+
+## Layer
+
+Infrastructure
+
+## Depends on
+
+- #307 (`codex/cli-base-split`) — merged
+- #309 (`codex/test-catalog-followup`) — open
+
+## What this adds
+
+- removes the workflow recommendation fallback prompt config from code
+- adds a base-owned default prompt resource at `config/workflow/recommendation-prompt-default.edn`
+- updates the recommendation config loader to merge resource-backed defaults with app-owned overrides
+- adds tests that prove both the app override prompt and the fallback prompt are now loaded from resources
+
+## Strata affected
+
+- `bases/cli` — workflow recommendation config loading
+- CLI recommendation tests — source-of-truth assertions for default and override prompt resources
+
+## Why
+
+- `workflow_recommendation_config.clj` still carried configuration data in code after the app-config split
+- this is the same fault line you called out earlier: prompt vocabulary is config, not logic
+- leaving the fallback map in code would make later localization and product-specific prompt shaping harder than it
+  needs to be
+
+## Verification
+
+- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-recommendation-config-test
+  'ai.miniforge.cli.workflow-recommender-test)
+  (clojure.test/run-tests 'ai.miniforge.cli.workflow-recommendation-config-test
+  'ai.miniforge.cli.workflow-recommender-test)"`


### PR DESCRIPTION
# Recommendation Config Resource Split

## Layer

Infrastructure

## Depends on

- #307 (`codex/cli-base-split`) — merged
- #309 (`codex/test-catalog-followup`) — open

## What this adds

- removes the workflow recommendation fallback prompt config from code
- adds a base-owned default prompt resource at `config/workflow/recommendation-prompt-default.edn`
- updates the recommendation config loader to merge resource-backed defaults with app-owned overrides
- adds tests that prove both the app override prompt and the fallback prompt are now loaded from resources

## Strata affected

- `bases/cli` — workflow recommendation config loading
- CLI recommendation tests — source-of-truth assertions for default and override prompt resources

## Why

- `workflow_recommendation_config.clj` still carried configuration data in code after the app-config split
- this is the same fault line you called out earlier: prompt vocabulary is config, not logic
- leaving the fallback map in code would make later localization and product-specific prompt shaping harder than it
  needs to be

## Verification

- `clojure -M:dev:test -e "(require 'ai.miniforge.cli.workflow-recommendation-config-test
  'ai.miniforge.cli.workflow-recommender-test)
  (clojure.test/run-tests 'ai.miniforge.cli.workflow-recommendation-config-test
  'ai.miniforge.cli.workflow-recommender-test)"`
