### PR TITLE
i18n: align test assertions with message catalog

### DIFF
--- a/bases/cli/test/ai/miniforge/cli/main/commands/fleet_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/fleet_test.clj
@@ -4,6 +4,7 @@
    [clojure.test :refer [deftest testing is use-fixtures]]
    [clojure.edn :as edn]
    [babashka.fs :as fs]
+   [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.main.commands.fleet :as sut]))
 
 ;; ============================================================================
@@ -126,7 +127,7 @@
   (testing "Prints error when no repo is provided"
     (let [output (with-out-str
                    (sut/fleet-add-cmd {:repo nil} nil default-config))]
-      (is (re-find #"Usage" output)))))
+      (is (.contains output "Usage")))))
 
 ;; ============================================================================
 ;; fleet-remove-cmd tests
@@ -152,7 +153,7 @@
   (testing "Prints error when no repo is provided"
     (let [output (with-out-str
                    (sut/fleet-remove-cmd {:repo nil} nil default-config))]
-      (is (re-find #"Usage" output)))))
+      (is (.contains output "Usage")))))
 
 ;; ============================================================================
 ;; fleet-status-cmd tests
@@ -164,7 +165,7 @@
       (spit path (pr-str {:fleet {:repos ["org/a" "org/b"]}}))
       (let [output (with-out-str
                      (sut/fleet-status-cmd {:config path} nil default-config))]
-        (is (re-find #"Repositories.*2" output))))))
+        (is (.contains output (messages/t :fleet/repositories {:count 2})))))))
 
 (deftest fleet-status-cmd-shows-default-state-when-no-state-file-test
   (testing "Shows zero counts when state file does not exist"
@@ -172,7 +173,7 @@
       (spit path (pr-str {:fleet {:repos []}}))
       (let [output (with-out-str
                      (sut/fleet-status-cmd {:config path} nil default-config))]
-        (is (re-find #"Active Workflows.*0" output))
-        (is (re-find #"Pending Workflows.*0" output))
-        (is (re-find #"Completed.*0" output))
-        (is (re-find #"Failed.*0" output))))))
+        (is (.contains output (messages/t :fleet/active-workflows {:count 0})))
+        (is (.contains output (messages/t :fleet/pending-workflows {:count 0})))
+        (is (.contains output (messages/t :fleet/completed {:count 0})))
+        (is (.contains output (messages/t :fleet/failed {:count 0})))))))

--- a/bases/cli/test/ai/miniforge/cli/workflow_selector_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_selector_test.clj
@@ -2,6 +2,7 @@
   "Tests for intelligent workflow selection."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.workflow-selector :as ws]))
 
 ;------------------------------------------------------------------------------ Test Data
@@ -185,14 +186,15 @@
 
 (deftest explain-selection-test
   (testing "explain-selection generates user-facing explanation"
-    (let [selection {:workflow-type :canonical-sdlc-v1
+    (let [reason (messages/t :selector/reason-multi-phase {:pr-count 6})
+          selection {:workflow-type :canonical-sdlc-v1
                      :confidence :high
-                     :reason "Multi-phase implementation with 6 PRs requires comprehensive review"}
+                     :reason reason}
           explanation (ws/explain-selection selection)]
       (is (string? explanation))
       (is (.contains explanation "canonical-sdlc-v1"))
-      (is (.contains explanation "Multi-phase implementation"))
-      (is (.contains explanation "Override with :spec/workflow-type"))))
+      (is (.contains explanation reason))
+      (is (.contains explanation (messages/t :selector/override-hint)))))
 
   (testing "explain-selection shows confidence markers"
     (let [high-conf (ws/explain-selection {:workflow-type :canonical-sdlc-v1
@@ -205,8 +207,8 @@
                                           :confidence :low
                                           :reason "Test"})]
       (is (not (.contains high-conf "confidence")))
-      (is (.contains medium-conf "medium confidence"))
-      (is (.contains low-conf "low confidence")))))
+      (is (.contains medium-conf (messages/t :selector/confidence-medium)))
+      (is (.contains low-conf (messages/t :selector/confidence-low))))))
 
 ;------------------------------------------------------------------------------ Integration Tests
 ;; End-to-end workflow selection


### PR DESCRIPTION
## Summary

- Updates `fleet_test.clj` and `workflow_selector_test.clj` to assert against `messages/t` catalog lookups instead of hardcoded string literals
- Tests now use the same source of truth (`en.edn`) as the runtime code — if catalog copy changes, tests validate against the new values automatically

Follow-up to PR #312 which externalized ~150 CLI strings to the message catalog.

### What changed

**`fleet_test.clj`** — Replaced regex patterns (`#"Repositories.*2"`) with `(messages/t :fleet/repositories {:count 2})` assertions. Added `messages` require.

**`workflow_selector_test.clj`** — Replaced hardcoded `"medium confidence"`, `"low confidence"`, `"Override with :spec/workflow-type"` with catalog lookups. Added `messages` require.

### Not changed (by design)

- **`persistence_test.clj`** — Event data fixtures (`:message "Workflow started"`) are event-stream data, not CLI display strings. The catalog has `"▶ Workflow started"` with emoji — different strings.
- **`error_classifier_test.clj`** — Tests the `agent-runtime` component's own `format-error-message`. Components can't depend on CLI bases (Polylith architecture), so these correctly test component-level formatting.
- **`views_test.clj`** — Tests the `reporting` component's own rendering, not CLI catalog strings.

## Test plan

- [x] All 1425 unit tests pass (0 failures, 0 errors)
- [x] Pre-commit hooks pass (lint, format, tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)