### PR TITLE
docs: clarify three-product identity across all documentation

### DIFF
--- a/DOGFOODING.md
+++ b/DOGFOODING.md
@@ -1,5 +1,7 @@
 # Miniforge Dogfooding Guide
 
+> This guide is for dogfooding **Miniforge SDLC** — using the autonomous software factory to build and improve itself.
+
 ## Overview
 
 This guide explains how to have miniforge work on itself using the DAG orchestration system.

--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -1,8 +1,12 @@
 # Intelligent Model Selection - Implementation Summary
 
+> This document describes **Miniforge SDLC's** intelligent model selection feature.
+
 ## Overview
 
-The intelligent model selection system has been fully implemented according to the specification in `work/intelligent-model-selection.edn`. This system automatically selects the optimal AI model for each task based on task characteristics, enabling cost optimization without sacrificing quality.
+The intelligent model selection system has been fully implemented according to the specification in
+`work/intelligent-model-selection.edn`. This system automatically selects the optimal AI model for each task based on
+task characteristics, enabling cost optimization without sacrificing quality.
 
 ## Implementation Status: ✅ COMPLETE
 
@@ -139,7 +143,8 @@ Environment variables:
 **Model Registry Tests** (`components/llm/test/ai/miniforge/llm/model_registry_test.clj`)
 
 - ✅ 154 lines, comprehensive coverage
-- Tests: get-model, query by capability, query by use-case, provider queries, local models, context support, recommendations
+- Tests: get-model, query by capability, query by use-case, provider queries, local models, context support,
+  recommendations
 
 **Model Selector Tests** (`components/llm/test/ai/miniforge/llm/model_selector_test.clj`)
 
@@ -156,7 +161,8 @@ Environment variables:
 **Model Selection Integration** (`components/llm/test/ai/miniforge/llm/model_selection_integration_test.clj`)
 
 - ✅ 383 lines, NEW
-- Tests: end-to-end workflows, privacy constraints, large context, cost optimization, cross-provider, transparency, all 16 models
+- Tests: end-to-end workflows, privacy constraints, large context, cost optimization, cross-provider, transparency, all
+  16 models
 
 ## Documentation
 
@@ -232,7 +238,7 @@ Every selection includes:
 
 Example:
 
-```
+```text
 🎯 Model Auto-Selected: Sonnet 4.5
 
 Task: execution-focused (confidence: 90%)
@@ -426,4 +432,5 @@ The intelligent model selection system is **fully implemented and production-rea
 7. ✅ Comprehensive test coverage
 8. ✅ Complete user documentation
 
-The system is ready for use in production workflows and can immediately start optimizing costs while maintaining code quality.
+The system is ready for use in production workflows and can immediately start optimizing costs while maintaining code
+quality.

--- a/PR_TASK_EXECUTOR.md
+++ b/PR_TASK_EXECUTOR.md
@@ -1,5 +1,7 @@
 # PR: Implement Task-Executor Component (DAG-to-PR Lifecycle Integration)
 
+> The task-executor is part of **Miniforge SDLC**, connecting the DAG scheduler to the PR lifecycle controller.
+
 ## Summary
 
 This PR implements the **task-executor** component, completing the integration between the DAG scheduler

--- a/TEST_OPPORTUNITIES.md
+++ b/TEST_OPPORTUNITIES.md
@@ -1,5 +1,7 @@
 # Fast Iteration Test Opportunities
 
+> These test opportunities target **Miniforge SDLC** components and their integration points.
+
 Analysis of components that would benefit from focused integration tests similar to `handoff_test.clj`.
 
 ## Criteria for Fast Iteration Tests
@@ -18,6 +20,7 @@ Analysis of components that would benefit from focused integration tests similar
 **Why Critical:** PR lifecycle orchestrates git operations, CI monitoring, and PR merging - all slow and complex
 
 **Proposed Test:** `pr_lifecycle_integration_test.clj`
+
 - Mock gh CLI calls and git operations
 - Test state transitions: pending → ci-running → approved → merged
 - Test error handling: CI failures, merge conflicts, rebase needed
@@ -35,6 +38,7 @@ Analysis of components that would benefit from focused integration tests similar
 **Why Critical:** File writing bugs (like the one we just fixed) silently fail with zero files written
 
 **Proposed Test:** `release_file_writing_test.clj`
+
 - Mock git operations (branch creation, commit, push)
 - Test file writing from code artifacts
 - Verify files are staged correctly
@@ -53,6 +57,7 @@ Analysis of components that would benefit from focused integration tests similar
 **Why Critical:** Agents return structured data that flows through entire system
 
 **Proposed Test:** `agent_response_integration_test.clj`
+
 - Mock LLM responses (success, error, timeout cases)
 - Test response parsing and validation
 - Test that response structure matches what phases expect
@@ -70,6 +75,7 @@ Analysis of components that would benefit from focused integration tests similar
 **Why Critical:** Gates validate artifacts through the inner loop - failures cause repair cycles
 
 **Proposed Test:** `gate_pipeline_test.clj`
+
 - Mock gate implementations (syntax, lint, tests, security)
 - Test artifact flow through gate chain
 - Test that failures trigger repair correctly
@@ -88,6 +94,7 @@ Analysis of components that would benefit from focused integration tests similar
 **Why Critical:** Metrics must aggregate correctly across phases for cost tracking and budgets
 
 **Proposed Test:** `metrics_accumulation_test.clj`
+
 - Mock phases returning metrics
 - Test metrics flow through workflow execution
 - Test budget enforcement (token limits, time limits, iteration limits)
@@ -106,6 +113,7 @@ Analysis of components that would benefit from focused integration tests similar
 **Why Critical:** Evidence bundles must capture complete workflow state for auditability
 
 **Proposed Test:** `evidence_bundle_integration_test.clj`
+
 - Mock workflow execution with phase results
 - Test bundle assembly from context
 - Test that all required fields are present
@@ -161,6 +169,7 @@ Based on `handoff_test.clj`, successful fast iteration tests:
 ## Estimated Value
 
 Adding these 5-6 tests would:
+
 - **Reduce debug time** from hours to minutes (like the handoff bug)
 - **Enable rapid iteration** on integration logic
 - **Catch bugs earlier** in development cycle

--- a/docs/MODEL_SELECTION.md
+++ b/docs/MODEL_SELECTION.md
@@ -1,6 +1,10 @@
 # Intelligent Model Selection
 
-Miniforge automatically selects the optimal AI model for each task based on task characteristics, optimizing for quality, cost, and performance.
+> Model selection is a **Miniforge SDLC** feature that leverages MiniForge Core's agent protocol to choose the optimal
+model per task.
+
+Miniforge automatically selects the optimal AI model for each task based on task characteristics, optimizing for
+quality, cost, and performance.
 
 ## Overview
 
@@ -204,7 +208,7 @@ Force a specific model for a workflow phase:
 - Reasoning: 8/10 | Code: 8/10 | Speed: 9/10 | Cost: ¢
 - Context: 1M tokens
 
-**Gemini 2.0 Flash Thinking (Experimental)**
+#### Gemini 2.0 Flash Thinking (Experimental)
 
 - Best for: Extended reasoning, complex problem decomposition
 - Reasoning: 10/10 | Code: 8/10 | Speed: 3/10 | Cost: $$
@@ -322,7 +326,7 @@ Compare to using Opus for everything: **$0.84**
 
 Decision tree for model selection:
 
-```
+```text
 Task Type?
 │
 ├─ Privacy Required? ──> LOCAL MODELS

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,6 +1,8 @@
 # Release Process
 
-This document describes how to create and publish a new miniforge release.
+This document describes how to create and publish a new release of the **Miniforge** SDLC product (CLI/TUI). MiniForge
+Core ships as part of the monorepo and is versioned alongside Miniforge. Data Foundry does not yet have a separate
+release process.
 
 ## Prerequisites
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,5 +1,8 @@
 # Configuration Management
 
+> This document covers configuration for the **Miniforge** SDLC product (CLI/TUI). MiniForge Core exposes configuration
+seams that products customize via their own `app.edn`; the settings below are Miniforge-specific defaults and overrides.
+
 Miniforge uses [Aero](https://github.com/juxt/aero) for centralized configuration with environment variable overrides.
 
 ## Configuration File

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,9 @@
 # Miniforge Deployment
 
+> This document describes deployment of the **Miniforge** SDLC product (the CLI/TUI). MiniForge Core is a library/kernel
+embedded in products and is not deployed standalone. Data Foundry (generic ETL product built on MiniForge Core) will
+have its own deployment strategy in the future.
+
 ## Two-Package Architecture
 
 Miniforge uses a two-package deployment model to optimize for both speed and features:

--- a/docs/development-guidelines.md
+++ b/docs/development-guidelines.md
@@ -1,5 +1,8 @@
 # Development Guidelines
 
+> These guidelines apply to the Miniforge monorepo, which houses three products: **MiniForge Core** (the governed
+workflow engine), **Miniforge** (the autonomous SDLC product), and **Data Foundry** (the generic ETL product).
+
 **Purpose:** This document defines development practices for miniforge contributors to avoid
 common anti-patterns that degrade code quality and team velocity.
 

--- a/docs/gap-analysis-n1-n9.md
+++ b/docs/gap-analysis-n1-n9.md
@@ -1,5 +1,8 @@
 # Gap Analysis: Current State vs. Normative Specs (N1-N9)
 
+> The normative specs (N1-N9) define the **MiniForge Core** engine contract; **Miniforge SDLC** serves as the reference
+implementation.
+
 **Date:** 2026-02-13
 **Baseline commit:** 5c975b6 (+ PR #174 self-healing wiring)
 

--- a/docs/meta-agents.md
+++ b/docs/meta-agents.md
@@ -1,5 +1,7 @@
 # Meta-Agent Architecture
 
+> Meta-agents are a **Miniforge SDLC** feature, built on top of the MiniForge Core workflow engine.
+
 Miniforge uses a **team of specialized meta-agents** to monitor and control workflow execution. This is
 analogous to how the main workflow uses specialized agents (Planner, Implementer, Tester, Reviewer), but
 applied at the meta level.

--- a/docs/test-plan-cli-integration.md
+++ b/docs/test-plan-cli-integration.md
@@ -1,5 +1,7 @@
 # CLI Integration Test Plan
 
+> This test plan covers the **Miniforge SDLC** CLI and its integration with external coding-assistant backends.
+
 ## Overview
 
 This document defines the test plan for integrating miniforge with external CLI tools

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,6 +1,19 @@
 # miniforge Specifications
 
-This directory contains the **canonical specifications** for miniforge.
+This directory contains the **canonical specifications** for the miniforge ecosystem.
+
+## Three-Product Architecture
+
+The miniforge ecosystem comprises three products built on a shared kernel:
+
+- **MiniForge Core** — the governed workflow engine (kernel/runtime). Normative specs N1-N6 define its contract:
+  architecture, workflow execution, event stream, policy packs, interface standards, and evidence/provenance. Any
+  product built on the engine must conform to these six specs.
+- **Miniforge** — the autonomous software factory (SDLC product). Consumes MiniForge Core and adds SDLC-specific
+  capabilities defined in N5 and N7-N10 (fleet mode, observability control, external PR integration, governed tool
+  execution).
+- **Data Foundry** — a generic ETL product built on MiniForge Core. Consumes the same N1-N6 engine contract with
+  ETL-specific workflow packs and policy configurations.
 
 ## Entry Point
 
@@ -10,7 +23,7 @@ The spec index is the authoritative map of all normative and informative documen
 
 ## Directory Structure
 
-```
+```text
 specs/
 ├── SPEC_INDEX.md              # START HERE - Complete spec catalog
 ├── README.md                  # This file
@@ -39,9 +52,10 @@ specs/
 
 ## Normative vs. Informative
 
-### Normative Specifications (N1-N6)
+### Normative Specifications (N1-N6) — MiniForge Core Contract
 
-**Normative specs** define **contractual requirements** for miniforge implementations.
+**Normative specs N1-N6** define the **contractual requirements** for MiniForge Core — the shared engine that both
+  Miniforge (SDLC) and Data Foundry consume.
 
 - Use RFC 2119 keywords: MUST, SHALL, SHOULD, MAY
 - Breaking changes require version bump

--- a/specs/SPEC_INDEX.md
+++ b/specs/SPEC_INDEX.md
@@ -6,6 +6,19 @@
 
 ---
 
+## Three-Product Architecture
+
+These specifications define three products built on a shared kernel:
+
+- **MiniForge Core** (N1-N6) — the governed workflow engine. These six core specs define the engine contract that all
+  products must conform to.
+- **Miniforge** (N1-N10) — the autonomous software factory for SDLC. Consumes Core plus extension specs N7-N10 for fleet
+  operations, observability control, external PR integration, and governed tool execution.
+- **Data Foundry** (N1-N6) — a generic ETL product. Consumes the same Core engine contract with domain-specific workflow
+  packs and policy configurations.
+
+---
+
 ## What miniforge Is (Canonical Description)
 
 **miniforge** executes a **workflow DAG** (planner → implementer → tester → reviewer → release
@@ -30,9 +43,13 @@ drill-down without scraping logs.
 These specifications define contractual requirements for miniforge implementations.
 They use RFC 2119 terminology (MUST, SHALL, SHOULD, MAY).
 
-**Core specs (N1-N6):** Fundamental contracts for architecture, workflows, events, policy, UI, and evidence.
+**Core specs (N1-N6) — MiniForge Core contract.** Fundamental contracts for architecture, workflows, events, policy, UI,
+  and evidence. These define the shared engine consumed by all products (Miniforge SDLC, Data Foundry, and any future
+  product).
 
-**Extension specs (N7+):** Cross-cutting capabilities that extend core specs (Fleet Mode, Control Interface).
+**Extension specs (N7+) — product-specific capabilities.** Cross-cutting capabilities that extend core specs. Currently
+  these are Miniforge SDLC concerns (Fleet Mode, Control Interface, PR Integration, Governed Tool Execution); Data
+  Foundry does not consume N7-N10.
 
 ### N1 — Core Architecture & Concepts ✅
 

--- a/work/README.md
+++ b/work/README.md
@@ -1,5 +1,8 @@
 # work/
 
+> These work specs drive **Miniforge SDLC** development — they are consumed by the Miniforge autonomous factory to plan
+and execute development tasks.
+
 This directory contains **ephemeral workflow specifications and task definitions**
 that are **inputs to miniforge** for active development work.
 


### PR DESCRIPTION
## Summary

- Adds product-identity context to 15 doc files clarifying which product each applies to: **MiniForge Core** (engine/kernel), **Miniforge** (SDLC product), or **Data Foundry** (generic ETL)
- Critical docs (deployment, release, configuration) get substantive notes distinguishing deployable products from the Core library
- Spec docs (SPEC_INDEX, specs/README) clarify N1-N6 as the Core contract vs N7+ as SDLC-specific extensions
- Fixes pre-existing markdownlint errors (unfenced code blocks, emphasis-as-heading) in touched files

### Files updated

| Priority | Files |
|----------|-------|
| Critical | `docs/deployment.md`, `docs/RELEASE.md`, `docs/configuration.md` |
| Specs | `specs/SPEC_INDEX.md`, `specs/README.md` |
| Medium | `docs/development-guidelines.md`, `docs/meta-agents.md`, `docs/MODEL_SELECTION.md`, `docs/test-plan-cli-integration.md`, `docs/gap-analysis-n1-n9.md`, `DOGFOODING.md`, `IMPLEMENTATION_SUMMARY.md`, `PR_TASK_EXECUTOR.md`, `work/README.md`, `TEST_OPPORTUNITIES.md` |

## Test plan

- [x] All 1425 unit tests pass (0 failures, 0 errors)
- [x] Pre-commit hooks pass (lint, markdownlint, tests, GraalVM compat)
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)