### PR TITLE
Wire knowledge base into execution loop + reduce token burn

### DIFF
--- a/components/agent/test/ai/miniforge/agent/interface_test.clj
+++ b/components/agent/test/ai/miniforge/agent/interface_test.clj
@@ -107,9 +107,9 @@
                                            :model "mock"})
           result (agent/invoke a test-task {:llm-backend mock-llm})]
       (is (map? result))
-      ;; BaseAgent invoke returns {:success bool :outputs [...] ...}
-      (is (contains? result :success))
-      (is (contains? result :outputs)))))
+      ;; Agent invoke returns {:status :success/:error :output {...} ...}
+      (is (contains? result :status))
+      (is (contains? result :output)))))
 
 (deftest validate-test
   (testing "validates correct output"

--- a/components/knowledge/resources/config/knowledge/messages/en.edn
+++ b/components/knowledge/resources/config/knowledge/messages/en.edn
@@ -2,4 +2,10 @@
  {;; Prompt formatting
   :prompt/header    "## Relevant Knowledge for {role}\n\n"
   :prompt/preamble  "The following rules and learnings apply to your task:\n\n"
-  :prompt/separator "\n---\n\n"}}
+  :prompt/separator "\n---\n\n"
+
+  ;; Learning capture
+  :learning/repair-title    "Repair success: {title}"
+  :learning/repair-content  "## Repair Context\n\nTask: {title}\nRepair iterations: {iterations}\n\n## Resolution\n\nThe {agent} resolved the issue after {iterations} attempts."
+  :learning/feedback-title  "Review feedback: {title}"
+  :learning/feedback-header "## Review Feedback\n\n"}}

--- a/components/knowledge/resources/config/knowledge/messages/en.edn
+++ b/components/knowledge/resources/config/knowledge/messages/en.edn
@@ -1,0 +1,5 @@
+{:knowledge/messages
+ {;; Prompt formatting
+  :prompt/header    "## Relevant Knowledge for {role}\n\n"
+  :prompt/preamble  "The following rules and learnings apply to your task:\n\n"
+  :prompt/separator "\n---\n\n"}}

--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -224,6 +224,24 @@
    Returns markdown string, or nil if no zettels."
   store/format-for-prompt)
 
+(defn inject-and-format
+  "Inject knowledge for an agent role and format for prompt inclusion.
+   Combines inject-knowledge + format-for-prompt into a single safe call.
+
+   Arguments:
+   - knowledge-store - KnowledgeStore instance (or nil — returns nil)
+   - role            - Agent role keyword (:planner, :implementer, etc.)
+   - tags            - Vector of keyword tags for context filtering
+
+   Returns formatted markdown string, or nil if no store or no matches."
+  [knowledge-store role tags]
+  (when knowledge-store
+    (try
+      (let [zettels (store/inject-knowledge knowledge-store role {:tags tags})]
+        (when (seq zettels)
+          (store/format-for-prompt zettels role)))
+      (catch Exception _e nil))))
+
 ;------------------------------------------------------------------------------ Layer 6
 ;; Learning capture
 
@@ -247,6 +265,54 @@
 (def capture-inner-loop-learning
   "Convenience function to capture learning from repair cycle."
   learning/capture-inner-loop-learning)
+
+(defn capture-repair-learning!
+  "Capture a learning when a repair cycle succeeds.
+   Safe to call unconditionally — no-ops when store is nil or iterations <= 1.
+
+   Arguments:
+   - knowledge-store - KnowledgeStore instance (or nil)
+   - agent-role      - Keyword (:implementer, :reviewer, etc.)
+   - task-title      - Task title string
+   - iterations      - Number of repair iterations"
+  [knowledge-store agent-role task-title iterations]
+  (when (and knowledge-store (> iterations 1))
+    (try
+      (learning/capture-inner-loop-learning
+       knowledge-store
+       {:agent agent-role
+        :title (str "Repair success: " (or task-title (name agent-role)))
+        :content (str "## Repair Context\n\n"
+                      "Task: " task-title "\n"
+                      "Repair iterations: " iterations "\n\n"
+                      "## Resolution\n\n"
+                      "The " (name agent-role) " resolved the issue after "
+                      iterations " attempts.")
+        :tags [:repair :inner-loop (keyword (name agent-role))]})
+      (catch Exception _e nil))))
+
+(defn capture-feedback-learning!
+  "Capture review feedback as a learning.
+   Safe to call unconditionally — no-ops when store is nil or feedback is empty.
+
+   Arguments:
+   - knowledge-store - KnowledgeStore instance (or nil)
+   - agent-role      - Keyword (:reviewer, etc.)
+   - task-title      - Task title string
+   - feedback        - Feedback string or data"
+  [knowledge-store agent-role task-title feedback]
+  (when (and knowledge-store feedback)
+    (try
+      (learning/capture-learning
+       knowledge-store
+       {:type :inner-loop
+        :agent agent-role
+        :title (str "Review feedback: " task-title)
+        :content (str "## Review Feedback\n\n"
+                      (if (string? feedback) feedback (pr-str feedback)))
+        :tags [:review :feedback :inner-loop]
+        :confidence 0.6})
+      (catch Exception _e nil))))
 
 (def capture-meta-loop-learning
   "Convenience function to capture learning from observed patterns."

--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -19,6 +19,7 @@
    [ai.miniforge.knowledge.store :as store]
    [ai.miniforge.knowledge.learning :as learning]
    [ai.miniforge.knowledge.loader :as loader]
+   [ai.miniforge.knowledge.messages :as messages]
    [ai.miniforge.knowledge.trust]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -277,19 +278,18 @@
    - iterations      - Number of repair iterations"
   [knowledge-store agent-role task-title iterations]
   (when (and knowledge-store (> iterations 1))
-    (try
-      (learning/capture-inner-loop-learning
-       knowledge-store
-       {:agent agent-role
-        :title (str "Repair success: " (or task-title (name agent-role)))
-        :content (str "## Repair Context\n\n"
-                      "Task: " task-title "\n"
-                      "Repair iterations: " iterations "\n\n"
-                      "## Resolution\n\n"
-                      "The " (name agent-role) " resolved the issue after "
-                      iterations " attempts.")
-        :tags [:repair :inner-loop (keyword (name agent-role))]})
-      (catch Exception _e nil))))
+    (let [display-title (or task-title (name agent-role))
+          params {:title display-title
+                  :agent (name agent-role)
+                  :iterations iterations}]
+      (try
+        (learning/capture-inner-loop-learning
+         knowledge-store
+         {:agent agent-role
+          :title (messages/t :learning/repair-title params)
+          :content (messages/t :learning/repair-content params)
+          :tags [:repair :inner-loop (keyword (name agent-role))]})
+        (catch Exception _e nil)))))
 
 (defn capture-feedback-learning!
   "Capture review feedback as a learning.
@@ -307,8 +307,8 @@
        knowledge-store
        {:type :inner-loop
         :agent agent-role
-        :title (str "Review feedback: " task-title)
-        :content (str "## Review Feedback\n\n"
+        :title (messages/t :learning/feedback-title {:title task-title})
+        :content (str (messages/t :learning/feedback-header)
                       (if (string? feedback) feedback (pr-str feedback)))
         :tags [:review :feedback :inner-loop]
         :confidence 0.6})

--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -49,6 +49,21 @@
      (create-store {:logger my-logger})"
   store/create-store)
 
+(def create-file-backed-store
+  "Create a file-backed persistent knowledge store.
+
+   On startup, scans the directory and loads all .edn files into
+   in-memory indices for fast querying. Writes are atomic (temp + rename).
+
+   Options:
+   - :path   - Base directory (default: ~/.miniforge/knowledge)
+   - :logger - Logger instance
+
+   Example:
+     (create-file-backed-store)
+     (create-file-backed-store {:path \"/repo/.miniforge/knowledge\"})"
+  store/create-file-backed-store)
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Zettel CRUD
 
@@ -198,6 +213,16 @@
 
    Returns vector of zettels relevant to the agent."
   store/inject-knowledge)
+
+(def format-for-prompt
+  "Format a collection of zettels as a markdown knowledge block for LLM context.
+
+   Arguments:
+   - zettels - Collection of zettels to format
+   - role    - Agent role keyword (for header)
+
+   Returns markdown string, or nil if no zettels."
+  store/format-for-prompt)
 
 ;------------------------------------------------------------------------------ Layer 6
 ;; Learning capture

--- a/components/knowledge/src/ai/miniforge/knowledge/messages.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/messages.clj
@@ -1,0 +1,45 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.knowledge.messages
+  "Component-level message catalog for knowledge.
+
+   Loads localized strings from EDN resources on the classpath.
+   Falls back to message key name when a key is missing."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def ^:private resource-path "config/knowledge/messages/en.edn")
+(def ^:private section-key :knowledge/messages)
+
+(defn- load-catalog []
+  (when-let [res (io/resource resource-path)]
+    (get (edn/read-string (slurp res)) section-key {})))
+
+(def ^:private catalog (delay (load-catalog)))
+
+(defn t
+  "Look up a message by key, substituting params into {placeholder} tokens."
+  ([k] (t k {}))
+  ([k params]
+   (let [template (get @catalog k (name k))]
+     (reduce-kv (fn [s pk pv]
+                  (str/replace s (str "{" (name pk) "}") (str pv)))
+                template
+                params))))

--- a/components/knowledge/src/ai/miniforge/knowledge/store.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/store.clj
@@ -1,11 +1,14 @@
 (ns ai.miniforge.knowledge.store
   "Knowledge store for zettels.
    Layer 0: In-memory store protocol and implementation
+   Layer 0.5: File-backed persistent store
    Layer 1: Query operations
    Layer 2: Agent injection"
   (:require
    [ai.miniforge.knowledge.zettel :as zettel]
    [ai.miniforge.logging.interface :as log]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -113,6 +116,138 @@
    (atom {})
    (atom {})
    (or logger (log/create-logger {:min-level :info :output (fn [_])}))))
+
+;------------------------------------------------------------------------------ Layer 0.5
+;; File-backed persistent store
+
+(defn- expand-path
+  "Expand ~ in file paths to home directory."
+  [path]
+  (if (str/starts-with? path "~")
+    (str (System/getProperty "user.home") (subs path 1))
+    path))
+
+(defn- ensure-directory
+  "Ensure a directory exists, creating it if necessary."
+  [path]
+  (let [dir (io/file path)]
+    (when-not (.exists dir)
+      (.mkdirs dir))
+    dir))
+
+(defn- uid->filename
+  "Convert a zettel UID to a safe filename."
+  [uid]
+  (-> uid
+      (str/replace #"[^a-zA-Z0-9_-]" "_")
+      (str ".edn")))
+
+
+(defn- atomic-write!
+  "Write content to file atomically via temp + rename."
+  [file content]
+  (let [parent (.getParentFile file)
+        tmp (java.io.File/createTempFile "zettel-" ".edn.tmp" parent)]
+    (try
+      (spit tmp content)
+      (.renameTo tmp file)
+      (catch Exception e
+        (when (.exists tmp) (.delete tmp))
+        (throw e)))))
+
+(defn- load-zettel-file
+  "Load a single .edn zettel file. Returns zettel map or nil."
+  [file]
+  (try
+    (edn/read-string (slurp file))
+    (catch Exception _e nil)))
+
+(defn- scan-directory
+  "Scan a directory for .edn zettel files and load them all.
+   Returns {:by-id {uuid zettel} :by-uid {uid zettel}}."
+  [dir]
+  (let [d (io/file dir)]
+    (if (.exists d)
+      (reduce
+       (fn [acc file]
+         (when-let [z (load-zettel-file file)]
+           (-> acc
+               (assoc-in [:by-id (:zettel/id z)] z)
+               (assoc-in [:by-uid (:zettel/uid z)] z))))
+       {:by-id {} :by-uid {}}
+       (->> (.listFiles d)
+            (filter #(.isFile %))
+            (filter #(str/ends-with? (.getName %) ".edn"))))
+      {:by-id {} :by-uid {}})))
+
+(defrecord FileBackedStore [base-path zettels-by-id zettels-by-uid logger]
+  KnowledgeStore
+  (put-zettel [_this zettel]
+    (let [id (:zettel/id zettel)
+          uid (:zettel/uid zettel)
+          file (io/file base-path (uid->filename uid))]
+      (ensure-directory base-path)
+      (atomic-write! file (pr-str zettel))
+      (swap! zettels-by-id assoc id zettel)
+      (swap! zettels-by-uid assoc uid zettel)
+      (log/debug logger :knowledge :knowledge/zettel-persisted
+                 {:data {:id id :uid uid :path (.getPath file)}})
+      zettel))
+
+  (get-zettel-by-id [_this id]
+    (get @zettels-by-id id))
+
+  (get-zettel-by-uid [_this uid]
+    (get @zettels-by-uid uid))
+
+  (delete-zettel [_this id]
+    (when-let [zettel (get @zettels-by-id id)]
+      (let [uid (:zettel/uid zettel)
+            file (io/file base-path (uid->filename uid))]
+        (when (.exists file) (.delete file))
+        (swap! zettels-by-id dissoc id)
+        (swap! zettels-by-uid dissoc uid)
+        (log/debug logger :knowledge :knowledge/zettel-deleted
+                   {:data {:id id :uid uid}})
+        true)))
+
+  (list-zettels [_this]
+    (mapv zettel/zettel-summary (vals @zettels-by-id)))
+
+  (query [_this query-map]
+    (let [all-zettels (vals @zettels-by-id)
+          matching (filter #(matches-query? % query-map) all-zettels)
+          limited (if-let [limit (:limit query-map)]
+                    (take limit matching)
+                    matching)]
+      (vec limited))))
+
+(defn create-file-backed-store
+  "Create a file-backed persistent knowledge store.
+
+   On startup, scans the directory and loads all .edn files into
+   in-memory indices for fast querying. Writes are atomic (temp + rename).
+
+   Options:
+   - :path   - Base directory (default: ~/.miniforge/knowledge)
+   - :logger - Logger instance
+
+   Example:
+     (create-file-backed-store)
+     (create-file-backed-store {:path \"/repo/.miniforge/knowledge\"})"
+  [& [{:keys [path logger]}]]
+  (let [base-path (expand-path (or path "~/.miniforge/knowledge"))
+        _ (ensure-directory base-path)
+        log (or logger (log/create-logger {:min-level :info :output (fn [_])}))
+        initial (scan-directory base-path)]
+    (log/debug log :knowledge :knowledge/store-initialized
+               {:data {:path base-path
+                       :zettel-count (count (:by-id initial))}})
+    (->FileBackedStore
+     base-path
+     (atom (:by-id initial))
+     (atom (:by-uid initial))
+     log)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Query operations
@@ -227,6 +362,36 @@
         combined-query (assoc base-query
                               :tags (distinct (concat manifest-tags context-tags)))]
     (query store combined-query)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Prompt formatting
+
+(defn format-zettel-for-prompt
+  "Format a single zettel as a compact markdown block for LLM context."
+  [zettel]
+  (str "### " (:zettel/title zettel)
+       (when-let [dewey (:zettel/dewey zettel)]
+         (str " [" dewey "]"))
+       (when (= :learning (:zettel/type zettel))
+         " (learning)")
+       "\n"
+       (:zettel/content zettel)
+       "\n"))
+
+(defn format-for-prompt
+  "Format a collection of zettels as a markdown knowledge block for LLM context.
+
+   Arguments:
+   - zettels - Collection of zettels to format
+   - role    - Agent role keyword (for header)
+
+   Returns markdown string, or nil if no zettels."
+  [zettels role]
+  (when (seq zettels)
+    (str "## Relevant Knowledge for " (name role) "\n\n"
+         "The following rules and learnings apply to your task:\n\n"
+         (apply str (map format-zettel-for-prompt zettels))
+         "\n---\n\n")))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/src/ai/miniforge/knowledge/store.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/store.clj
@@ -5,6 +5,7 @@
    Layer 1: Query operations
    Layer 2: Agent injection"
   (:require
+   [ai.miniforge.knowledge.messages :as messages]
    [ai.miniforge.knowledge.zettel :as zettel]
    [ai.miniforge.logging.interface :as log]
    [clojure.edn :as edn]
@@ -388,10 +389,10 @@
    Returns markdown string, or nil if no zettels."
   [zettels role]
   (when (seq zettels)
-    (str "## Relevant Knowledge for " (name role) "\n\n"
-         "The following rules and learnings apply to your task:\n\n"
+    (str (messages/t :prompt/header {:role (name role)})
+         (messages/t :prompt/preamble)
          (apply str (map format-zettel-for-prompt zettels))
-         "\n---\n\n")))
+         (messages/t :prompt/separator))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/knowledge/test/ai/miniforge/knowledge/file_backed_store_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/file_backed_store_test.clj
@@ -1,0 +1,101 @@
+(ns ai.miniforge.knowledge.file-backed-store-test
+  "Tests for FileBackedStore: persistence, round-trip, query."
+  (:require
+   [clojure.test :refer [deftest is testing use-fixtures]]
+   [ai.miniforge.knowledge.store :as store]
+   [ai.miniforge.knowledge.zettel :as zettel]
+   [clojure.java.io :as io]))
+
+(def ^:dynamic *test-dir* nil)
+
+(defn temp-dir-fixture [f]
+  (let [dir (str (System/getProperty "java.io.tmpdir")
+                 "/miniforge-kb-test-" (System/currentTimeMillis))]
+    (binding [*test-dir* dir]
+      (try
+        (f)
+        (finally
+          ;; Cleanup
+          (let [d (io/file dir)]
+            (when (.exists d)
+              (doseq [file (.listFiles d)]
+                (.delete file))
+              (.delete d))))))))
+
+(use-fixtures :each temp-dir-fixture)
+
+(deftest file-backed-store-round-trip
+  (testing "Write → restart → read round-trip"
+    (let [store1 (store/create-file-backed-store {:path *test-dir*})
+          z (zettel/create-zettel "test-uid" "Test Title"
+                                  "Test content body" :rule
+                                  :dewey "210" :tags [:clojure :test])]
+      ;; Write
+      (store/put-zettel store1 z)
+      (is (= 1 (count (store/list-zettels store1))))
+
+      ;; "Restart" — create a new store pointing to same directory
+      (let [store2 (store/create-file-backed-store {:path *test-dir*})]
+        (is (= 1 (count (store/list-zettels store2))))
+        (let [loaded (store/get-zettel-by-uid store2 "test-uid")]
+          (is (some? loaded))
+          (is (= "Test Title" (:zettel/title loaded)))
+          (is (= "Test content body" (:zettel/content loaded)))
+          (is (= :rule (:zettel/type loaded)))
+          (is (= "210" (:zettel/dewey loaded))))))))
+
+(deftest file-backed-store-delete
+  (testing "Delete removes file and index entry"
+    (let [store1 (store/create-file-backed-store {:path *test-dir*})
+          z (zettel/create-zettel "del-test" "Delete Me"
+                                  "Should be removed" :learning)]
+      (store/put-zettel store1 z)
+      (is (= 1 (count (store/list-zettels store1))))
+
+      (store/delete-zettel store1 (:zettel/id z))
+      (is (= 0 (count (store/list-zettels store1))))
+
+      ;; Restart — should still be empty
+      (let [store2 (store/create-file-backed-store {:path *test-dir*})]
+        (is (= 0 (count (store/list-zettels store2))))))))
+
+(deftest file-backed-store-query
+  (testing "Query works on file-backed store"
+    (let [s (store/create-file-backed-store {:path *test-dir*})
+          z1 (zettel/create-zettel "rule-1" "Clojure Rule"
+                                   "Use threading macros" :rule
+                                   :dewey "210" :tags [:clojure])
+          z2 (zettel/create-zettel "learning-1" "Test Pattern"
+                                   "Always test edge cases" :learning
+                                   :dewey "400" :tags [:testing])]
+      (store/put-zettel s z1)
+      (store/put-zettel s z2)
+
+      (is (= 1 (count (store/query s {:tags [:clojure]}))))
+      (is (= 1 (count (store/query s {:include-types [:learning]}))))
+      (is (= 2 (count (store/query s {})))))))
+
+(deftest file-backed-store-search
+  (testing "Text search works on file-backed store"
+    (let [s (store/create-file-backed-store {:path *test-dir*})
+          z (zettel/create-zettel "search-test" "Threading Macros"
+                                  "Use -> and ->> for readability" :rule
+                                  :tags [:clojure])]
+      (store/put-zettel s z)
+      (is (= 1 (count (store/search s "threading"))))
+      (is (= 0 (count (store/search s "nonexistent")))))))
+
+(deftest format-for-prompt-test
+  (testing "format-for-prompt renders markdown block"
+    (let [z1 (zettel/create-zettel "r1" "Rule One" "Content one" :rule :dewey "210")
+          z2 (zettel/create-zettel "l1" "Learning One" "Content two" :learning)
+          result (store/format-for-prompt [z1 z2] :implementer)]
+      (is (string? result))
+      (is (.contains result "Rule One"))
+      (is (.contains result "Learning One"))
+      (is (.contains result "(learning)"))
+      (is (.contains result "implementer"))))
+
+  (testing "format-for-prompt returns nil for empty zettels"
+    (is (nil? (store/format-for-prompt [] :planner)))
+    (is (nil? (store/format-for-prompt nil :planner)))))

--- a/components/orchestrator/resources/config/orchestrator/messages/en.edn
+++ b/components/orchestrator/resources/config/orchestrator/messages/en.edn
@@ -1,0 +1,19 @@
+{:orchestrator/messages
+ {;; Knowledge coordinator
+  :knowledge/header         "## Relevant Knowledge for {role}\n\n"
+  :knowledge/preamble       "The following rules and learnings apply to your task:\n\n"
+  :knowledge/separator      "\n---\n\n"
+
+  ;; Task routing
+  :route/reason             "Task type {task-type} maps to {agent-role}"
+
+  ;; Learning promotion
+  :promote/ready            "High confidence learning ready for promotion"
+  :promote/below-threshold  "Confidence below {threshold} threshold"
+
+  ;; Repair learning
+  :repair/title             "Repair pattern: {error-type}"
+  :repair/content           "## Repair Context\n\nTask: {task}\nAgent: {agent}\nRepair iterations: {iterations}\n\n## Pattern\n\n{fix-description}"
+
+  ;; Workflow lifecycle
+  :workflow/cancelled       "Cancelled by user"}}

--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -207,6 +207,7 @@
                                :router router
                                :budget-manager budget-mgr
                                :knowledge-coordinator knowledge-coord
+                               :knowledge-store (:knowledge-store knowledge-coord)
                                :artifact-store artifact-store})
             result (wf/run-workflow workflow-mgr spec wf-context)]
 

--- a/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/core.clj
@@ -10,6 +10,7 @@
    Workflow execution is delegated to the workflow component.
    Meta-loop management is delegated to the operator component."
   (:require
+   [ai.miniforge.orchestrator.messages :as messages]
    [ai.miniforge.orchestrator.protocol :as proto]
    [ai.miniforge.workflow.interface :as wf]
    [ai.miniforge.knowledge.interface :as knowledge]
@@ -24,13 +25,12 @@
   (let [last-repair (last repair-history)]
     {:agent agent-role
      :task-id (:task/id task)
-     :title (str "Repair pattern: " (name (:error-type last-repair)))
-     :content (str "## Repair Context\n\n"
-                   "Task: " (:task/title task) "\n"
-                   "Agent: " (name agent-role) "\n"
-                   "Repair iterations: " (count repair-history) "\n\n"
-                   "## Pattern\n\n"
-                   (:fix-description last-repair))
+     :title (messages/t :repair/title {:error-type (name (:error-type last-repair))})
+     :content (messages/t :repair/content
+                          {:task (:task/title task)
+                           :agent (name agent-role)
+                           :iterations (count repair-history)
+                           :fix-description (:fix-description last-repair)})
      :tags [:repair :inner-loop (keyword (name agent-role))]
      :confidence 0.7}))
 
@@ -62,7 +62,7 @@
     (let [task-type (:task/type task)
           agent-role (get task-type->agent-role task-type :implementer)]
       {:agent-role agent-role
-       :reason (str "Task type " task-type " maps to " agent-role)}))
+       :reason (messages/t :route/reason {:task-type task-type :agent-role agent-role})}))
 
   (can-handle? [_this task agent-role]
     (let [task-type (:task/type task)
@@ -125,10 +125,10 @@
   "Format injected knowledge as a context block."
   [zettels agent-role]
   (when (seq zettels)
-    (str "## Relevant Knowledge for " (name agent-role) "\n\n"
-         "The following rules and learnings apply to your task:\n\n"
+    (str (messages/t :knowledge/header {:role (name agent-role)})
+         (messages/t :knowledge/preamble)
          (apply str (map format-zettel-for-context zettels))
-         "\n---\n\n")))
+         (messages/t :knowledge/separator))))
 
 (defrecord SimpleKnowledgeCoordinator [knowledge-store config]
   proto/KnowledgeCoordinator
@@ -167,8 +167,8 @@
       {:promote? promotable?
        :confidence confidence
        :reason (if promotable?
-                 "High confidence learning ready for promotion"
-                 "Confidence below 0.85 threshold")})))
+                 (messages/t :promote/ready)
+                 (messages/t :promote/below-threshold {:threshold 0.85}))})))
 
 (defn create-knowledge-coordinator
   "Create a knowledge coordinator."
@@ -240,7 +240,7 @@
 
   (cancel-workflow [_this workflow-id]
     (when (wf/get-state workflow-mgr workflow-id)
-      (wf/fail workflow-mgr workflow-id {:type :cancelled :message "Cancelled by user"})
+      (wf/fail workflow-mgr workflow-id {:type :cancelled :message (messages/t :workflow/cancelled)})
       (swap! active-workflows dissoc workflow-id)
       true))
 

--- a/components/orchestrator/src/ai/miniforge/orchestrator/messages.clj
+++ b/components/orchestrator/src/ai/miniforge/orchestrator/messages.clj
@@ -1,0 +1,45 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.orchestrator.messages
+  "Component-level message catalog for orchestrator.
+
+   Loads localized strings from EDN resources on the classpath.
+   Falls back to message key name when a key is missing."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def ^:private resource-path "config/orchestrator/messages/en.edn")
+(def ^:private section-key :orchestrator/messages)
+
+(defn- load-catalog []
+  (when-let [res (io/resource resource-path)]
+    (get (edn/read-string (slurp res)) section-key {})))
+
+(def ^:private catalog (delay (load-catalog)))
+
+(defn t
+  "Look up a message by key, substituting params into {placeholder} tokens."
+  ([k] (t k {}))
+  ([k params]
+   (let [template (get @catalog k (name k))]
+     (reduce-kv (fn [s pk pv]
+                  (str/replace s (str "{" (name pk) "}") (str pv)))
+                template
+                params))))

--- a/components/phase-software-factory/deps.edn
+++ b/components/phase-software-factory/deps.edn
@@ -1,8 +1,10 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/phase {:local/root "../phase"}
         ai.miniforge/agent {:local/root "../agent"}
+        ai.miniforge/knowledge {:local/root "../knowledge"}
         ai.miniforge/response {:local/root "../response"}
-        ai.miniforge/release-executor {:local/root "../release-executor"}}
+        ai.miniforge/release-executor {:local/root "../release-executor"}
+        ai.miniforge/repo-index {:local/root "../repo-index"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {babashka/process {:mvn/version "0.5.22"}}}}}

--- a/components/phase-software-factory/resources/config/phase/messages/en.edn
+++ b/components/phase-software-factory/resources/config/phase/messages/en.edn
@@ -1,0 +1,5 @@
+{:phase/messages
+ {;; Implementation phase
+  :implement/agent-error       "Agent returned error status"
+  :implement/exhausted-retries "Implementation failed after exhausting retry budget"
+  :implement/warn-no-output    "WARNING: implement phase result has no :output — artifact may be nil"}}

--- a/components/phase-software-factory/src/ai/miniforge/phase/explore.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/explore.clj
@@ -69,11 +69,10 @@
                                                     :max-lines-per-file (:max-lines-per-file config)})
 
         ;; Query KB for relevant knowledge based on spec description
-        kb-results (when-let [kb (:knowledge-store ctx)]
+        spec-desc (or (:description input) (:title input))
+        kb-results (when (and (:knowledge-store ctx) (seq spec-desc))
                      (try
-                       (let [desc (or (:description input) (:title input) "")]
-                         (when (seq desc)
-                           (take 5 (knowledge/search kb desc))))
+                       (take 5 (knowledge/search (:knowledge-store ctx) spec-desc))
                        (catch Exception _e nil)))
 
         ;; Build exploration result

--- a/components/phase-software-factory/src/ai/miniforge/phase/explore.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/explore.clj
@@ -27,7 +27,8 @@
    Agent: nil (no LLM — deterministic file loading)
    Default gates: []"
   (:require [ai.miniforge.phase.registry :as registry]
-            [ai.miniforge.phase.file-context :as file-ctx]))
+            [ai.miniforge.phase.file-context :as file-ctx]
+            [ai.miniforge.knowledge.interface :as knowledge]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Defaults
@@ -67,10 +68,20 @@
                                                    {:max-files (:max-files config)
                                                     :max-lines-per-file (:max-lines-per-file config)})
 
+        ;; Query KB for relevant knowledge based on spec description
+        kb-results (when-let [kb (:knowledge-store ctx)]
+                     (try
+                       (let [desc (or (:description input) (:title input) "")]
+                         (when (seq desc)
+                           (take 5 (knowledge/search kb desc))))
+                       (catch Exception _e nil)))
+
         ;; Build exploration result
-        exploration {:exploration/files (or loaded-files [])
-                     :exploration/file-count (count (or loaded-files []))
-                     :exploration/spec-description (:description input)}]
+        exploration (cond-> {:exploration/files (or loaded-files [])
+                             :exploration/file-count (count (or loaded-files []))
+                             :exploration/spec-description (:description input)}
+                      (seq kb-results)
+                      (assoc :exploration/knowledge kb-results))]
 
     (-> ctx
         (assoc-in [:phase :name] :explore)

--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -83,6 +83,15 @@
     (catch Exception _e
       nil)))
 
+(defn- build-verify-failures
+  "Extract lean verify-failure data from phase results."
+  [verify-result]
+  (let [test-results (get-in verify-result [:result :output :metadata :test-results])
+        test-results-lean (dissoc test-results :output)]
+    {:test-results test-results-lean
+     :test-output (truncate-test-output
+                   (get-in verify-result [:result :output :metadata :test-results :output]))}))
+
 (defn build-implement-task
   "Build the task map for the implementer agent from execution context."
   [ctx]
@@ -107,13 +116,8 @@
         review-feedback (or (get-in ctx [:execution/phase-results :review :result :output :review/feedback])
                             (get-in ctx [:execution/phase-results :review :result :output :review/issues]))
         ;; Inject knowledge for implementer
-        kb-zettels (when-let [kb (:knowledge-store ctx)]
-                     (try
-                       (knowledge/inject-knowledge kb :implementer
-                                                    {:tags (or (:tags input) [])})
-                       (catch Exception _e nil)))
-        kb-context (when (seq kb-zettels)
-                     (knowledge/format-for-prompt kb-zettels :implementer))
+        kb-context (knowledge/inject-and-format
+                    (:knowledge-store ctx) :implementer (get input :tags []))
         base-task (cond-> {:task/id (random-uuid)
                            :task/type :implement
                            :task/description (:description input)
@@ -131,14 +135,7 @@
                     (assoc :task/knowledge-context kb-context))]
     (cond-> base-task
       verify-failure
-      (assoc :task/verify-failures
-             (let [test-results (get-in verify-failure [:result :output :metadata :test-results])
-                   ;; Strip raw :output from test-results to avoid sending it twice
-                   ;; (it's already included as :test-output, truncated)
-                   test-results-lean (dissoc test-results :output)]
-               {:test-results test-results-lean
-                :test-output (truncate-test-output
-                               (get-in verify-failure [:result :output :metadata :test-results :output]))}))
+      (assoc :task/verify-failures (build-verify-failures verify-failure))
       review-feedback
       (assoc :task/review-feedback review-feedback))))
 
@@ -254,22 +251,10 @@
                         (update-in [:execution/metrics :cost-usd] (fnil + 0.0) cost-usd)
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
     ;; Capture inner-loop learning when repair succeeded (iterations > 1, completed)
-    (when (and (= :completed phase-status)
-               (> iterations 1)
-               (:knowledge-store ctx))
-      (try
-        (knowledge/capture-inner-loop-learning
-         (:knowledge-store ctx)
-         {:agent :implementer
-          :task-id (get-in ctx [:execution/input :task/id])
-          :title (str "Repair success: " (or (:title (get-in ctx [:execution/input])) "implementation"))
-          :content (str "## Repair Context\n\n"
-                        "Task: " (get-in ctx [:execution/input :title]) "\n"
-                        "Repair iterations: " iterations "\n\n"
-                        "## Resolution\n\n"
-                        "The implementer resolved the issue after " iterations " attempts.")
-          :tags [:repair :inner-loop :implementer]})
-        (catch Exception _e nil)))
+    (when (= :completed phase-status)
+      (knowledge/capture-repair-learning!
+       (:knowledge-store ctx) :implementer
+       (get-in ctx [:execution/input :title]) iterations))
     ;; Warn if result has no output and isn't already-implemented
     (when (and (not= :already-implemented agent-status)
                (nil? (:output result)))

--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -25,6 +25,7 @@
   (:require [ai.miniforge.phase.registry :as registry]
             [ai.miniforge.phase.file-context :as file-ctx]
             [ai.miniforge.phase.agent-behavior :as agent-beh]
+            [ai.miniforge.phase.messages :as messages]
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.knowledge.interface :as knowledge]
             [ai.miniforge.repo-index.interface :as repo-index]
@@ -258,7 +259,7 @@
     ;; Warn if result has no output and isn't already-implemented
     (when (and (not= :already-implemented agent-status)
                (nil? (:output result)))
-      (println "WARNING: implement phase result has no :output — artifact may be nil"))
+      (println (messages/t :implement/warn-no-output)))
     ;; Handle retrying, failure, or already-implemented outcomes
     (cond-> updated-ctx
       (registry/retrying? (:phase updated-ctx))
@@ -266,7 +267,7 @@
           (assoc-in [:phase :last-error]
                     (or (not-empty (get-in result [:error :message]))
                         (not-empty (get-in result [:output :error]))
-                        "Agent returned error status")))
+                        (messages/t :implement/agent-error))))
 
       (= :failed phase-status)
       (assoc-in [:phase :error]
@@ -274,7 +275,7 @@
                               (not-empty (get-in result [:output :error]))
                               (when (string? (:output result))
                                 (not-empty (:output result)))
-                              "Implementation failed after exhausting retry budget")
+                              (messages/t :implement/exhausted-retries))
                  :agent-status agent-status
                  :rate-limited? (boolean rate-limited?)
                  :iterations iterations})

--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -93,47 +93,69 @@
      :test-output (truncate-test-output
                    (get-in verify-result [:result :output :metadata :test-results :output]))}))
 
+(defn- resolve-worktree-path
+  "Resolve the worktree path from context, falling back to user.dir."
+  [ctx]
+  (get ctx :worktree-path (System/getProperty "user.dir")))
+
+(defn- resolve-files-in-scope
+  "Resolve files-in-scope from input, checking context and intent."
+  [input]
+  (or (get-in input [:context :files-in-scope])
+      (get-in input [:intent :scope])))
+
+(defn- resolve-existing-files
+  "Load existing files from cache, repo index, or disk."
+  [ctx repo-ctx worktree-path files-in-scope]
+  (or (get-in ctx [:execution/cached-files])
+      (if (and (:repo-index repo-ctx) (seq files-in-scope))
+        (repo-index/get-files (:repo-index repo-ctx) files-in-scope)
+        (file-ctx/load-files-in-scope worktree-path files-in-scope))))
+
+(defn- resolve-review-feedback
+  "Extract review feedback from phase results."
+  [ctx]
+  (or (get-in ctx [:execution/phase-results :review :result :output :review/feedback])
+      (get-in ctx [:execution/phase-results :review :result :output :review/issues])))
+
+(defn- assoc-optional-task-fields
+  "Conditionally assoc repo-map, repo-index, and knowledge-context onto a task."
+  [task repo-ctx kb-context]
+  (cond-> task
+    (:repo-map-text repo-ctx)
+    (assoc :task/repo-map (:repo-map-text repo-ctx))
+    (:repo-index repo-ctx)
+    (assoc :task/repo-index (:repo-index repo-ctx))
+    kb-context
+    (assoc :task/knowledge-context kb-context)))
+
 (defn build-implement-task
   "Build the task map for the implementer agent from execution context."
   [ctx]
   (let [input (get-in ctx [:execution/input])
         plan-result (get-in ctx [:execution/phase-results :plan :result :output])
         verify-failure (get-in ctx [:execution/phase-results :verify])
-        worktree-path (or (:worktree-path ctx) (System/getProperty "user.dir"))
-        files-in-scope (or (get-in input [:context :files-in-scope])
-                           (get-in input [:intent :scope]))
-        ;; Build repo index + map for the target repo (cached across retries)
+        worktree-path (resolve-worktree-path ctx)
+        files-in-scope (resolve-files-in-scope input)
         repo-ctx (or (get-in ctx [:execution/repo-context])
                      (build-repo-map-context worktree-path))
-        ;; Cache file context in execution context to avoid reloading on retries
-        ;; When repo index is available, use it for validated file loading
-        existing-files (or (get-in ctx [:execution/cached-files])
-                           (if (and (:repo-index repo-ctx) (seq files-in-scope))
-                             (repo-index/get-files (:repo-index repo-ctx) files-in-scope)
-                             (file-ctx/load-files-in-scope worktree-path files-in-scope)))
+        existing-files (resolve-existing-files ctx repo-ctx worktree-path files-in-scope)
         behavior-addendum (agent-beh/load-and-filter-behaviors
                             :implement {:task {:task/intent (:intent input)}})
-        ;; Read review feedback from phase results (survives :phase clearing between phases)
-        review-feedback (or (get-in ctx [:execution/phase-results :review :result :output :review/feedback])
-                            (get-in ctx [:execution/phase-results :review :result :output :review/issues]))
-        ;; Inject knowledge for implementer
+        review-feedback (resolve-review-feedback ctx)
         kb-context (knowledge/inject-and-format
                     (:knowledge-store ctx) :implementer (get input :tags []))
-        base-task (cond-> {:task/id (random-uuid)
-                           :task/type :implement
-                           :task/description (:description input)
-                           :task/title (:title input)
-                           :task/intent (:intent input)
-                           :task/constraints (:constraints input)
-                           :task/plan plan-result
-                           :task/existing-files existing-files
-                           :task/behavior-addendum behavior-addendum}
-                    (:repo-map-text repo-ctx)
-                    (assoc :task/repo-map (:repo-map-text repo-ctx))
-                    (:repo-index repo-ctx)
-                    (assoc :task/repo-index (:repo-index repo-ctx))
-                    kb-context
-                    (assoc :task/knowledge-context kb-context))]
+        base-task (assoc-optional-task-fields
+                    {:task/id (random-uuid)
+                     :task/type :implement
+                     :task/description (:description input)
+                     :task/title (:title input)
+                     :task/intent (:intent input)
+                     :task/constraints (:constraints input)
+                     :task/plan plan-result
+                     :task/existing-files existing-files
+                     :task/behavior-addendum behavior-addendum}
+                    repo-ctx kb-context)]
     (cond-> base-task
       verify-failure
       (assoc :task/verify-failures (build-verify-failures verify-failure))
@@ -212,6 +234,24 @@
         [(get-in result [:error :message])
          (when (string? (:output result)) (:output result))]))
 
+(defn- extract-error-message
+  "Extract the most relevant error message from an agent result."
+  [result default-msg]
+  (or (not-empty (get-in result [:error :message]))
+      (not-empty (get-in result [:output :error]))
+      default-msg))
+
+(defn- build-phase-error
+  "Build a structured phase error map from an agent result."
+  [result agent-status rate-limited? iterations]
+  {:message (or (extract-error-message result nil)
+                (when (string? (:output result))
+                  (not-empty (:output result)))
+                (messages/t :implement/exhausted-retries))
+   :agent-status agent-status
+   :rate-limited? (boolean rate-limited?)
+   :iterations iterations})
+
 (defn leave-implement
   "Post-processing for implementation phase.
 
@@ -237,7 +277,7 @@
         metrics (get result :metrics {:tokens 0 :duration-ms duration-ms})
         cost-usd (or (:cost-usd result)
                      (:cost-usd metrics)
-                     (* (:tokens metrics 0) 0.000015))
+                     (* (get metrics :tokens 0) 0.000015))
         metrics (assoc metrics :cost-usd cost-usd :duration-ms duration-ms)
         updated-ctx (-> ctx
                         (assoc-in [:phase :ended-at] end-time)
@@ -265,20 +305,11 @@
       (registry/retrying? (:phase updated-ctx))
       (-> (update-in [:phase :iterations] (fnil inc 1))
           (assoc-in [:phase :last-error]
-                    (or (not-empty (get-in result [:error :message]))
-                        (not-empty (get-in result [:output :error]))
-                        (messages/t :implement/agent-error))))
+                    (extract-error-message result (messages/t :implement/agent-error))))
 
       (= :failed phase-status)
       (assoc-in [:phase :error]
-                {:message (or (not-empty (get-in result [:error :message]))
-                              (not-empty (get-in result [:output :error]))
-                              (when (string? (:output result))
-                                (not-empty (:output result)))
-                              (messages/t :implement/exhausted-retries))
-                 :agent-status agent-status
-                 :rate-limited? (boolean rate-limited?)
-                 :iterations iterations})
+                (build-phase-error result agent-status rate-limited? iterations))
 
       (= :already-implemented agent-status)
       (assoc-in [:phase :skipped-reason] :already-implemented))))

--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -26,7 +26,10 @@
             [ai.miniforge.phase.file-context :as file-ctx]
             [ai.miniforge.phase.agent-behavior :as agent-beh]
             [ai.miniforge.agent.interface :as agent]
-            [ai.miniforge.response.interface :as response]))
+            [ai.miniforge.knowledge.interface :as knowledge]
+            [ai.miniforge.repo-index.interface :as repo-index]
+            [ai.miniforge.response.interface :as response]
+            [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Defaults
@@ -46,6 +49,40 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
 
+(def ^:private max-test-output-lines
+  "Cap raw test output sent to implementer to avoid token waste.
+   Failure summaries are typically in the first/last 30 lines."
+  60)
+
+(defn- truncate-test-output
+  "Truncate test output to max-test-output-lines, keeping head and tail."
+  [output]
+  (when (string? output)
+    (let [lines (str/split-lines output)
+          n (count lines)]
+      (if (<= n max-test-output-lines)
+        output
+        (let [head-n 30
+              tail-n 25
+              head (take head-n lines)
+              tail (take-last tail-n lines)
+              skipped (- n head-n tail-n)]
+          (str/join "\n"
+            (concat head
+                    [(str "\n... [" skipped " lines omitted] ...\n")]
+                    tail)))))))
+
+(defn- build-repo-map-context
+  "Build a repo map for the target repository, falling back gracefully.
+   Returns {:repo-index <RepoIndex> :repo-map-text <string>} or nil."
+  [worktree-path]
+  (try
+    (when-let [index (repo-index/build-index worktree-path)]
+      {:repo-index index
+       :repo-map-text (repo-index/repo-map-text index)})
+    (catch Exception _e
+      nil)))
+
 (defn build-implement-task
   "Build the task map for the implementer agent from execution context."
   [ctx]
@@ -55,26 +92,53 @@
         worktree-path (or (:worktree-path ctx) (System/getProperty "user.dir"))
         files-in-scope (or (get-in input [:context :files-in-scope])
                            (get-in input [:intent :scope]))
-        existing-files (file-ctx/load-files-in-scope worktree-path files-in-scope)
+        ;; Build repo index + map for the target repo (cached across retries)
+        repo-ctx (or (get-in ctx [:execution/repo-context])
+                     (build-repo-map-context worktree-path))
+        ;; Cache file context in execution context to avoid reloading on retries
+        ;; When repo index is available, use it for validated file loading
+        existing-files (or (get-in ctx [:execution/cached-files])
+                           (if (and (:repo-index repo-ctx) (seq files-in-scope))
+                             (repo-index/get-files (:repo-index repo-ctx) files-in-scope)
+                             (file-ctx/load-files-in-scope worktree-path files-in-scope)))
         behavior-addendum (agent-beh/load-and-filter-behaviors
                             :implement {:task {:task/intent (:intent input)}})
         ;; Read review feedback from phase results (survives :phase clearing between phases)
         review-feedback (or (get-in ctx [:execution/phase-results :review :result :output :review/feedback])
                             (get-in ctx [:execution/phase-results :review :result :output :review/issues]))
-        base-task {:task/id (random-uuid)
-                   :task/type :implement
-                   :task/description (:description input)
-                   :task/title (:title input)
-                   :task/intent (:intent input)
-                   :task/constraints (:constraints input)
-                   :task/plan plan-result
-                   :task/existing-files existing-files
-                   :task/behavior-addendum behavior-addendum}]
+        ;; Inject knowledge for implementer
+        kb-zettels (when-let [kb (:knowledge-store ctx)]
+                     (try
+                       (knowledge/inject-knowledge kb :implementer
+                                                    {:tags (or (:tags input) [])})
+                       (catch Exception _e nil)))
+        kb-context (when (seq kb-zettels)
+                     (knowledge/format-for-prompt kb-zettels :implementer))
+        base-task (cond-> {:task/id (random-uuid)
+                           :task/type :implement
+                           :task/description (:description input)
+                           :task/title (:title input)
+                           :task/intent (:intent input)
+                           :task/constraints (:constraints input)
+                           :task/plan plan-result
+                           :task/existing-files existing-files
+                           :task/behavior-addendum behavior-addendum}
+                    (:repo-map-text repo-ctx)
+                    (assoc :task/repo-map (:repo-map-text repo-ctx))
+                    (:repo-index repo-ctx)
+                    (assoc :task/repo-index (:repo-index repo-ctx))
+                    kb-context
+                    (assoc :task/knowledge-context kb-context))]
     (cond-> base-task
       verify-failure
       (assoc :task/verify-failures
-             {:test-results (get-in verify-failure [:result :output :metadata :test-results])
-              :test-output (get-in verify-failure [:result :output :metadata :test-results :output])})
+             (let [test-results (get-in verify-failure [:result :output :metadata :test-results])
+                   ;; Strip raw :output from test-results to avoid sending it twice
+                   ;; (it's already included as :test-output, truncated)
+                   test-results-lean (dissoc test-results :output)]
+               {:test-results test-results-lean
+                :test-output (truncate-test-output
+                               (get-in verify-failure [:result :output :metadata :test-results :output]))}))
       review-feedback
       (assoc :task/review-feedback review-feedback))))
 
@@ -110,6 +174,14 @@
         start-time (System/currentTimeMillis)
         implementer-agent (agent/create-implementer {})
         task (build-implement-task ctx)
+        ;; Cache loaded files and repo context for subsequent retries
+        ctx (cond-> ctx
+              (not (get-in ctx [:execution/cached-files]))
+              (assoc-in [:execution/cached-files] (:task/existing-files task))
+              (and (:task/repo-index task) (not (get-in ctx [:execution/repo-context])))
+              (assoc-in [:execution/repo-context]
+                        {:repo-index (:task/repo-index task)
+                         :repo-map-text (:task/repo-map task)}))
         on-chunk (create-streaming-callback ctx)
         agent-ctx (cond-> ctx on-chunk (assoc :on-chunk on-chunk))
         peer-advice (collect-peer-advice ctx)
@@ -181,6 +253,23 @@
                         (update-in [:execution/metrics :tokens] (fnil + 0) (:tokens metrics 0))
                         (update-in [:execution/metrics :cost-usd] (fnil + 0.0) cost-usd)
                         (update-in [:execution/metrics :duration-ms] (fnil + 0) (:duration-ms metrics 0)))]
+    ;; Capture inner-loop learning when repair succeeded (iterations > 1, completed)
+    (when (and (= :completed phase-status)
+               (> iterations 1)
+               (:knowledge-store ctx))
+      (try
+        (knowledge/capture-inner-loop-learning
+         (:knowledge-store ctx)
+         {:agent :implementer
+          :task-id (get-in ctx [:execution/input :task/id])
+          :title (str "Repair success: " (or (:title (get-in ctx [:execution/input])) "implementation"))
+          :content (str "## Repair Context\n\n"
+                        "Task: " (get-in ctx [:execution/input :title]) "\n"
+                        "Repair iterations: " iterations "\n\n"
+                        "## Resolution\n\n"
+                        "The implementer resolved the issue after " iterations " attempts.")
+          :tags [:repair :inner-loop :implementer]})
+        (catch Exception _e nil)))
     ;; Warn if result has no output and isn't already-implemented
     (when (and (not= :already-implemented agent-status)
                (nil? (:output result)))

--- a/components/phase-software-factory/src/ai/miniforge/phase/messages.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/messages.clj
@@ -1,0 +1,45 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.messages
+  "Component-level message catalog for phase-software-factory.
+
+   Loads localized strings from EDN resources on the classpath.
+   Falls back to message key name when a key is missing."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def ^:private resource-path "config/phase/messages/en.edn")
+(def ^:private section-key :phase/messages)
+
+(defn- load-catalog []
+  (when-let [res (io/resource resource-path)]
+    (get (edn/read-string (slurp res)) section-key {})))
+
+(def ^:private catalog (delay (load-catalog)))
+
+(defn t
+  "Look up a message by key, substituting params into {placeholder} tokens."
+  ([k] (t k {}))
+  ([k params]
+   (let [template (get @catalog k (name k))]
+     (reduce-kv (fn [s pk pv]
+                  (str/replace s (str "{" (name pk) "}") (str pv)))
+                template
+                params))))

--- a/components/phase-software-factory/src/ai/miniforge/phase/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/plan.clj
@@ -24,6 +24,7 @@
    Default gates: [:plan-complete]"
   (:require [ai.miniforge.phase.registry :as registry]
             [ai.miniforge.agent.interface :as agent]
+            [ai.miniforge.knowledge.interface :as knowledge]
             [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -76,8 +77,15 @@
 
 (defn build-planner-task
   "Build the task map to pass to the planner agent."
-  [input explore-result]
-  (let [existing-files (:exploration/files explore-result)]
+  [input explore-result knowledge-store]
+  (let [existing-files (:exploration/files explore-result)
+        kb-zettels (when knowledge-store
+                     (try
+                       (knowledge/inject-knowledge knowledge-store :planner
+                                                    {:tags (or (:tags input) [])})
+                       (catch Exception _e nil)))
+        kb-context (when (seq kb-zettels)
+                     (knowledge/format-for-prompt kb-zettels :planner))]
     (cond-> {:task/id (random-uuid)
              :task/type :plan
              :task/description (:description input)
@@ -85,7 +93,9 @@
              :task/intent (:intent input)
              :task/constraints (:constraints input)}
       (seq existing-files)
-      (assoc :task/existing-files existing-files))))
+      (assoc :task/existing-files existing-files)
+      kb-context
+      (assoc :task/knowledge-context kb-context))))
 
 (defn create-streaming-callback
   "Create a streaming callback for agent output, if event-stream is available."
@@ -100,7 +110,7 @@
   "Invoke the planner agent to generate a plan via LLM."
   [ctx input]
   (let [explore-result (get-in ctx [:execution/phase-results :explore :result :output])
-        task (build-planner-task input explore-result)
+        task (build-planner-task input explore-result (:knowledge-store ctx))
         on-chunk (create-streaming-callback ctx)
         agent-ctx (cond-> ctx on-chunk (assoc :on-chunk on-chunk))
         planner-agent (agent/create-planner {})]

--- a/components/phase-software-factory/src/ai/miniforge/phase/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/plan.clj
@@ -79,13 +79,8 @@
   "Build the task map to pass to the planner agent."
   [input explore-result knowledge-store]
   (let [existing-files (:exploration/files explore-result)
-        kb-zettels (when knowledge-store
-                     (try
-                       (knowledge/inject-knowledge knowledge-store :planner
-                                                    {:tags (or (:tags input) [])})
-                       (catch Exception _e nil)))
-        kb-context (when (seq kb-zettels)
-                     (knowledge/format-for-prompt kb-zettels :planner))]
+        kb-context (knowledge/inject-and-format
+                    knowledge-store :planner (get input :tags []))]
     (cond-> {:task/id (random-uuid)
              :task/type :plan
              :task/description (:description input)

--- a/components/phase-software-factory/src/ai/miniforge/phase/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/review.clj
@@ -141,21 +141,9 @@
              (< iterations max-iterations))
       (let [feedback (or (get-in result [:output :review/feedback])
                          (get-in result [:output :review/issues]))]
-        ;; Capture review feedback as learning
-        (when (and feedback (:knowledge-store ctx))
-          (try
-            (knowledge/capture-learning
-             (:knowledge-store ctx)
-             {:type :inner-loop
-              :agent :reviewer
-              :title (str "Review feedback: " (get-in ctx [:execution/input :title]))
-              :content (str "## Review Feedback\n\n"
-                            (if (string? feedback)
-                              feedback
-                              (pr-str feedback)))
-              :tags [:review :feedback :inner-loop]
-              :confidence 0.6})
-            (catch Exception _e nil)))
+        (knowledge/capture-feedback-learning!
+         (:knowledge-store ctx) :reviewer
+         (get-in ctx [:execution/input :title]) feedback)
         (-> updated-ctx
             (update-in [:phase :iterations] (fnil inc 1))
             (assoc-in [:phase :review-feedback] feedback)

--- a/components/phase-software-factory/src/ai/miniforge/phase/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/review.clj
@@ -24,6 +24,7 @@
    Default gates: [:review-approved :quality-check]"
   (:require [ai.miniforge.phase.registry :as registry]
             [ai.miniforge.agent.interface :as agent]
+            [ai.miniforge.knowledge.interface :as knowledge]
             [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -138,12 +139,27 @@
     ;; Handle changes-requested: redirect to implement with review feedback
     (if (and (= :changes-requested review-decision)
              (< iterations max-iterations))
-      (-> updated-ctx
-          (update-in [:phase :iterations] (fnil inc 1))
-          (assoc-in [:phase :review-feedback]
-                    (or (get-in result [:output :review/feedback])
-                        (get-in result [:output :review/issues])))
-          (assoc-in [:phase :redirect-to] :implement))
+      (let [feedback (or (get-in result [:output :review/feedback])
+                         (get-in result [:output :review/issues]))]
+        ;; Capture review feedback as learning
+        (when (and feedback (:knowledge-store ctx))
+          (try
+            (knowledge/capture-learning
+             (:knowledge-store ctx)
+             {:type :inner-loop
+              :agent :reviewer
+              :title (str "Review feedback: " (get-in ctx [:execution/input :title]))
+              :content (str "## Review Feedback\n\n"
+                            (if (string? feedback)
+                              feedback
+                              (pr-str feedback)))
+              :tags [:review :feedback :inner-loop]
+              :confidence 0.6})
+            (catch Exception _e nil)))
+        (-> updated-ctx
+            (update-in [:phase :iterations] (fnil inc 1))
+            (assoc-in [:phase :review-feedback] feedback)
+            (assoc-in [:phase :redirect-to] :implement)))
       updated-ctx)))
 
 (defn error-review

--- a/components/phase-software-factory/src/ai/miniforge/phase/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/review.clj
@@ -45,6 +45,31 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
 
+(defn- create-streaming-callback
+  "Create a streaming callback for agent output if event-stream is available."
+  [ctx phase-name]
+  (when-let [es (:event-stream ctx)]
+    (when-let [create-cb (requiring-resolve
+                           'ai.miniforge.event-stream.interface/create-streaming-callback)]
+      (create-cb es (:execution/id ctx) phase-name
+                 {:print? (not (:quiet ctx)) :quiet? (:quiet ctx)}))))
+
+(defn- build-review-task
+  "Build the task map for the reviewer agent from execution context."
+  [ctx]
+  (let [input (get-in ctx [:execution/input])
+        implement-result (get-in ctx [:execution/phase-results :implement :result :output])
+        verify-result (get-in ctx [:execution/phase-results :verify :result :output])]
+    {:task/id (random-uuid)
+     :task/type :review
+     :task/description (:description input)
+     :task/title (:title input)
+     :task/intent (:intent input)
+     :task/constraints (:constraints input)
+     :task/artifact (or (:artifact implement-result)
+                        implement-result)
+     :task/tests verify-result}))
+
 (defn enter-review
   "Execute review phase.
 
@@ -53,36 +78,11 @@
   (let [config (registry/merge-with-defaults (get-in ctx [:phase-config]))
         {:keys [gates budget]} config
         start-time (System/currentTimeMillis)
-
-        ;; Create reviewer agent with LLM backend from context
-        llm-backend (:llm-backend ctx)
         reviewer-agent (agent/create-reviewer
-                        (cond-> {}
-                          llm-backend (assoc :llm-backend llm-backend)))
-
-        ;; Build task from workflow input and previous phase results
-        input (get-in ctx [:execution/input])
-        implement-result (get-in ctx [:execution/phase-results :implement :result :output])
-        verify-result (get-in ctx [:execution/phase-results :verify :result :output])
-        task {:task/id (random-uuid)
-              :task/type :review
-              :task/description (:description input)
-              :task/title (:title input)
-              :task/intent (:intent input)
-              :task/constraints (:constraints input)
-              :task/artifact (or (:artifact implement-result)
-                                 implement-result) ; Extract code artifact
-              :task/tests verify-result} ; Test results if available
-
-        ;; Create streaming callback for agent output
-        on-chunk (when-let [es (:event-stream ctx)]
-                   (when-let [create-cb (requiring-resolve
-                                         'ai.miniforge.event-stream.interface/create-streaming-callback)]
-                     (create-cb es (:execution/id ctx) :review
-                                {:print? (not (:quiet ctx)) :quiet? (:quiet ctx)})))
+                        (select-keys ctx [:llm-backend]))
+        task (build-review-task ctx)
+        on-chunk (create-streaming-callback ctx :review)
         agent-ctx (cond-> ctx on-chunk (assoc :on-chunk on-chunk))
-
-        ;; Invoke agent
         result (try
                  (agent/invoke reviewer-agent task agent-ctx)
                  (catch Exception e

--- a/components/pr-sync/deps.edn
+++ b/components/pr-sync/deps.edn
@@ -1,3 +1,3 @@
-{:paths ["src"]
+{:paths ["src" "resources"]
  :deps {cheshire/cheshire {:mvn/version "5.13.0"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/components/pr-sync/resources/config/pr-sync/messages/en.edn
+++ b/components/pr-sync/resources/config/pr-sync/messages/en.edn
@@ -1,0 +1,19 @@
+{:pr-sync/messages
+ {;; Error hints by category
+  :hint/auth-failure   "Check your authentication token or repository permissions."
+  :hint/rate-limited   "You have been rate-limited. Wait a few minutes and try again."
+  :hint/not-found      "Repository not found. Check the slug or your access permissions."
+  :hint/network-error  "Network error. Check your internet connection."
+  :hint/parse-error    "Failed to parse the provider response."
+  :hint/unknown        "An unexpected error occurred."
+
+  ;; Validation messages
+  :repo/required       "Repository is required. Use owner/name or gitlab:group/name."
+  :repo/invalid-format "Invalid repository format. Expected owner/name or gitlab:group/name (not a filesystem path or URL)."
+  :repo/required-short "Repository is required."
+
+  ;; Error messages
+  :error/default       "Operation failed with no additional error details."
+  :error/parse-pr      "Failed to parse PR list for {repo}."
+  :error/parse-mr      "Failed to parse merge request list for {repo}."
+  :error/unknown       "Unknown error"}}

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -423,27 +423,27 @@
   (try
     (let [result (fetch-open-prs repo)]
       (if (succeeded? result)
-        {:status   :ok
-         :repo     repo
-         :prs      (vec (:prs result))
-         :pr-count (count (:prs result))}
+        (result-success {:status   :ok
+                         :repo     repo
+                         :prs      (vec (:prs result))
+                         :pr-count (count (:prs result))})
         (let [err-msg (or (:error result)
                           (gh-error-message (:out result) (:err result))
                           "Unknown error")
               category (classify-error err-msg)]
-          {:status         :error
-           :repo           repo
-           :error          err-msg
-           :error-category category
-           :hint           (error-hint category)})))
+          (result-failure err-msg
+                          {:status         :error
+                           :repo           repo
+                           :error-category category
+                           :hint           (error-hint category)}))))
     (catch Exception e
       (let [err-msg (ex-msg e)
             category (classify-error err-msg)]
-        {:status         :error
-         :repo           repo
-         :error          err-msg
-         :error-category category
-         :hint           (error-hint category)}))))
+        (result-failure err-msg
+                        {:status         :error
+                         :repo           repo
+                         :error-category category
+                         :hint           (error-hint category)})))))
 
 (defn build-sync-summary
   "Build a summary map from a sequence of repo sync statuses."

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -415,6 +415,16 @@
     {:error-category category
      :hint           (error-hint category)}))
 
+(defn- repo-sync-error
+  "Build a classified sync error result for a repo."
+  [repo err-msg]
+  (let [category (classify-error err-msg)]
+    (result-failure err-msg
+                    {:status         :error
+                     :repo           repo
+                     :error-category category
+                     :hint           (error-hint category)})))
+
 (defn fetch-repo-with-status
   "Fetch open PRs for a single repo and return a status map.
    Returns {:status :ok/:error, :repo str, :prs [...], :pr-count N,
@@ -427,23 +437,12 @@
                          :repo     repo
                          :prs      (vec (:prs result))
                          :pr-count (count (:prs result))})
-        (let [err-msg (or (:error result)
-                          (gh-error-message (:out result) (:err result))
-                          "Unknown error")
-              category (classify-error err-msg)]
-          (result-failure err-msg
-                          {:status         :error
-                           :repo           repo
-                           :error-category category
-                           :hint           (error-hint category)}))))
+        (repo-sync-error repo
+                         (or (:error result)
+                             (gh-error-message (:out result) (:err result))
+                             "Unknown error"))))
     (catch Exception e
-      (let [err-msg (ex-msg e)
-            category (classify-error err-msg)]
-        (result-failure err-msg
-                        {:status         :error
-                         :repo           repo
-                         :error-category category
-                         :hint           (error-hint category)})))))
+      (repo-sync-error repo (ex-msg e)))))
 
 (defn build-sync-summary
   "Build a summary map from a sequence of repo sync statuses."

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -130,7 +130,10 @@
   ([path]
    (try
      (if (.exists (io/file path))
-       (edn/read-string (slurp path))
+       (let [config (edn/read-string (slurp path))]
+         (if (map? config)
+           config
+           {:fleet {:repos []}}))
        {:fleet {:repos []}})
      (catch Exception _
        {:fleet {:repos []}}))))
@@ -235,7 +238,7 @@
                       vec)}))
         (catch Exception e
           (result-failure (str "Failed to parse PR list for " repo ".")
-                          {:repo repo :provider :github :error (.getMessage e)}))))))
+                          {:repo repo :provider :github :parse-error (.getMessage e)}))))))
 
 (defn fetch-open-github-prs
   [repo]
@@ -346,7 +349,7 @@
             :prs filtered}))
         (catch Exception e
           (result-failure (str "Failed to parse merge request list for " repo ".")
-                          {:repo repo :provider :gitlab :error (.getMessage e)}))))))
+                          {:repo repo :provider :gitlab :parse-error (.getMessage e)}))))))
 
 (defn fetch-open-gitlab-mrs
   [repo]
@@ -368,6 +371,115 @@
   (case (repo-provider repo)
     :gitlab (fetch-gitlab-mrs-by-state repo state)
     (fetch-github-prs repo state)))
+
+(defn classify-error
+  "Classify a provider error message into a category keyword."
+  [error-msg]
+  (let [msg (str/lower-case (or error-msg ""))]
+    (cond
+      (or (str/includes? msg "401") (str/includes? msg "403")
+          (str/includes? msg "bad credentials") (str/includes? msg "forbidden"))
+      :auth-failure
+
+      (or (str/includes? msg "rate limit") (str/includes? msg "rate_limit"))
+      :rate-limited
+
+      (or (str/includes? msg "404") (str/includes? msg "not found"))
+      :not-found
+
+      (or (str/includes? msg "econnrefused") (str/includes? msg "connection")
+          (str/includes? msg "timeout") (str/includes? msg "network"))
+      :network-error
+
+      (or (str/includes? msg "parse") (str/includes? msg "json")
+          (str/includes? msg "unexpected"))
+      :parse-error
+
+      :else :unknown)))
+
+(defn error-hint
+  "Return a human-readable hint for a given error category."
+  [category]
+  (case category
+    :auth-failure  "Check your authentication token or repository permissions."
+    :rate-limited  "You have been rate-limited. Wait a few minutes and try again."
+    :not-found     "Repository not found. Check the slug or your access permissions."
+    :network-error "Network error. Check your internet connection."
+    :parse-error   "Failed to parse the provider response."
+    "An unexpected error occurred."))
+
+(defn classify-sync-error
+  "Classify an error message and return a map with :error-category and :hint."
+  [error-msg]
+  (let [category (classify-error error-msg)]
+    {:error-category category
+     :hint           (error-hint category)}))
+
+(defn fetch-repo-with-status
+  "Fetch open PRs for a single repo and return a status map.
+   Returns {:status :ok/:error, :repo str, :prs [...], :pr-count N,
+            :error-category kw, :error str, :hint str}."
+  [repo]
+  (try
+    (let [result (fetch-open-prs repo)]
+      (if (succeeded? result)
+        {:status   :ok
+         :repo     repo
+         :prs      (vec (:prs result))
+         :pr-count (count (:prs result))}
+        (let [err-msg (or (:error result)
+                          (gh-error-message (:out result) (:err result))
+                          "Unknown error")
+              category (classify-error err-msg)]
+          {:status         :error
+           :repo           repo
+           :error          err-msg
+           :error-category category
+           :hint           (error-hint category)})))
+    (catch Exception e
+      (let [err-msg (ex-msg e)
+            category (classify-error err-msg)]
+        {:status         :error
+         :repo           repo
+         :error          err-msg
+         :error-category category
+         :hint           (error-hint category)}))))
+
+(defn build-sync-summary
+  "Build a summary map from a sequence of repo sync statuses."
+  [sync-statuses]
+  (let [total  (count sync-statuses)
+        ok     (count (filter #(= :ok (:status %)) sync-statuses))
+        errors (- total ok)]
+    {:total    total
+     :ok       ok
+     :errors   errors
+     :all-ok?  (zero? errors)
+     :partial? (and (pos? ok) (pos? errors))
+     :none-ok? (and (pos? total) (zero? ok))}))
+
+(defn fetch-fleet-with-status
+  "Fetch open PRs for all configured fleet repos, returning structured results.
+   Returns {:prs [...], :sync-statuses [...], :summary {...}}.
+
+   Options:
+   - :config-path  - Override config file path (for testing)
+   - :parallel?    - Use parallel fetching (default false)"
+  [& [{:keys [config-path parallel?] :or {parallel? false}}]]
+  (let [repos (get-configured-repos (or config-path default-fleet-config-path))]
+    (if (empty? repos)
+      {:prs           []
+       :sync-statuses []
+       :summary       (build-sync-summary [])}
+      (let [map-fn       (if parallel? pmap map)
+            statuses     (vec (map-fn fetch-repo-with-status repos))
+            all-prs      (->> statuses
+                              (filter #(= :ok (:status %)))
+                              (mapcat :prs)
+                              vec)]
+        {:prs           all-prs
+         :sync-statuses statuses
+         :summary       (build-sync-summary statuses)}))))
 
 (defn fetch-all-fleet-prs
   "Fetch open PRs for all configured fleet repositories.

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -429,6 +429,13 @@
                      :error-category category
                      :hint           (error-hint category)})))
 
+(defn- extract-sync-error-message
+  "Extract the most relevant error message from a failed sync result."
+  [result]
+  (or (:error result)
+      (gh-error-message (:out result) (:err result))
+      (messages/t :error/unknown)))
+
 (defn fetch-repo-with-status
   "Fetch open PRs for a single repo and return a status map.
    Returns {:status :ok/:error, :repo str, :prs [...], :pr-count N,
@@ -442,9 +449,7 @@
                          :prs      (vec (:prs result))
                          :pr-count (count (:prs result))})
         (repo-sync-error repo
-                         (or (:error result)
-                             (gh-error-message (:out result) (:err result))
-                             (messages/t :error/unknown)))))
+                         (extract-sync-error-message result))))
     (catch Exception e
       (repo-sync-error repo (ex-msg e)))))
 

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -28,6 +28,7 @@
 
    Pure status mapping lives in ai.miniforge.pr-sync.status."
   (:require
+   [ai.miniforge.pr-sync.messages :as messages]
    [ai.miniforge.pr-sync.status :as status]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -93,7 +94,7 @@
    (result-failure message nil))
   ([message data]
    (merge {:success? false :error (or (some-> message str not-empty)
-                                      "Operation failed with no additional error details.")}
+                                      (messages/t :error/default))}
           data)))
 
 (defn gh-error-message
@@ -163,10 +164,10 @@
    (let [repo (normalize-repo-slug repo-slug)]
      (cond
        (str/blank? repo)
-       (result-failure "Repository is required. Use owner/name or gitlab:group/name." {:repo repo})
+       (result-failure (messages/t :repo/required) {:repo repo})
 
        (not (valid-repo-slug? repo))
-       (result-failure "Invalid repository format. Expected owner/name or gitlab:group/name (not a filesystem path or URL)." {:repo repo})
+       (result-failure (messages/t :repo/invalid-format) {:repo repo})
 
        :else
        (let [cfg (load-fleet-config path)
@@ -186,7 +187,7 @@
   ([repo-slug path]
    (let [repo (normalize-repo-slug repo-slug)]
      (if (str/blank? repo)
-       (result-failure "Repository is required." {:repo repo})
+       (result-failure (messages/t :repo/required-short) {:repo repo})
        (let [cfg (load-fleet-config path)
              repos (normalized-repos cfg)
              existed? (some #{repo} repos)
@@ -237,7 +238,7 @@
                       (sort-by :pr/number)
                       vec)}))
         (catch Exception e
-          (result-failure (str "Failed to parse PR list for " repo ".")
+          (result-failure (messages/t :error/parse-pr {:repo repo})
                           {:repo repo :provider :github :parse-error (.getMessage e)}))))))
 
 (defn fetch-open-github-prs
@@ -348,7 +349,7 @@
             :provider :gitlab
             :prs filtered}))
         (catch Exception e
-          (result-failure (str "Failed to parse merge request list for " repo ".")
+          (result-failure (messages/t :error/parse-mr {:repo repo})
                           {:repo repo :provider :gitlab :parse-error (.getMessage e)}))))))
 
 (defn fetch-open-gitlab-mrs
@@ -397,16 +398,19 @@
 
       :else :unknown)))
 
+;; Error category → message key mapping for localized hints.
+(def ^:private error-hint-keys
+  {:auth-failure  :hint/auth-failure
+   :rate-limited  :hint/rate-limited
+   :not-found     :hint/not-found
+   :network-error :hint/network-error
+   :parse-error   :hint/parse-error
+   :unknown       :hint/unknown})
+
 (defn error-hint
   "Return a human-readable hint for a given error category."
   [category]
-  (case category
-    :auth-failure  "Check your authentication token or repository permissions."
-    :rate-limited  "You have been rate-limited. Wait a few minutes and try again."
-    :not-found     "Repository not found. Check the slug or your access permissions."
-    :network-error "Network error. Check your internet connection."
-    :parse-error   "Failed to parse the provider response."
-    "An unexpected error occurred."))
+  (messages/t (get error-hint-keys category :hint/unknown)))
 
 (defn classify-sync-error
   "Classify an error message and return a map with :error-category and :hint."
@@ -440,7 +444,7 @@
         (repo-sync-error repo
                          (or (:error result)
                              (gh-error-message (:out result) (:err result))
-                             "Unknown error"))))
+                             (messages/t :error/unknown)))))
     (catch Exception e
       (repo-sync-error repo (ex-msg e)))))
 

--- a/components/pr-sync/src/ai/miniforge/pr_sync/messages.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/messages.clj
@@ -1,0 +1,45 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-sync.messages
+  "Component-level message catalog for pr-sync.
+
+   Loads localized strings from EDN resources on the classpath.
+   Falls back to message key name when a key is missing."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def ^:private resource-path "config/pr-sync/messages/en.edn")
+(def ^:private section-key :pr-sync/messages)
+
+(defn- load-catalog []
+  (when-let [res (io/resource resource-path)]
+    (get (edn/read-string (slurp res)) section-key {})))
+
+(def ^:private catalog (delay (load-catalog)))
+
+(defn t
+  "Look up a message by key, substituting params into {placeholder} tokens."
+  ([k] (t k {}))
+  ([k params]
+   (let [template (get @catalog k (name k))]
+     (reduce-kv (fn [s pk pv]
+                  (str/replace s (str "{" (name pk) "}") (str pv)))
+                template
+                params))))

--- a/components/pr-sync/test/ai/miniforge/pr_sync/build_sync_summary_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/build_sync_summary_test.clj
@@ -1,0 +1,121 @@
+(ns ai.miniforge.pr-sync.build-sync-summary-test
+  "Unit tests for build-sync-summary pure function.
+   Exercises all boolean flag combinations and arithmetic invariants."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.pr-sync.core :as core]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Empty input
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest build-sync-summary-empty-test
+  (testing "Empty sync-statuses returns zeroed summary with all-ok? true"
+    (let [s (core/build-sync-summary [])]
+      (is (= 0 (:total s)))
+      (is (= 0 (:ok s)))
+      (is (= 0 (:errors s)))
+      (is (true? (:all-ok? s)))
+      (is (false? (:partial? s)))
+      (is (false? (:none-ok? s))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; All OK
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest build-sync-summary-all-ok-test
+  (testing "All entries :ok → all-ok? true, partial? false, none-ok? false"
+    (let [statuses [{:status :ok :repo "a/b" :pr-count 2 :prs []}
+                    {:status :ok :repo "c/d" :pr-count 0 :prs []}]
+          s (core/build-sync-summary statuses)]
+      (is (= 2 (:total s)))
+      (is (= 2 (:ok s)))
+      (is (= 0 (:errors s)))
+      (is (true? (:all-ok? s)))
+      (is (false? (:partial? s)))
+      (is (false? (:none-ok? s))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; All errors
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest build-sync-summary-all-errors-test
+  (testing "All entries :error → none-ok? true, all-ok? false"
+    (let [statuses [{:status :error :repo "a/b" :error "fail"}
+                    {:status :error :repo "c/d" :error "fail"}]
+          s (core/build-sync-summary statuses)]
+      (is (= 2 (:total s)))
+      (is (= 0 (:ok s)))
+      (is (= 2 (:errors s)))
+      (is (false? (:all-ok? s)))
+      (is (false? (:partial? s)))
+      (is (true? (:none-ok? s))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Partial (mixed)
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest build-sync-summary-partial-test
+  (testing "Mix of :ok and :error → partial? true"
+    (let [statuses [{:status :ok :repo "a/b"}
+                    {:status :error :repo "c/d"}
+                    {:status :ok :repo "e/f"}]
+          s (core/build-sync-summary statuses)]
+      (is (= 3 (:total s)))
+      (is (= 2 (:ok s)))
+      (is (= 1 (:errors s)))
+      (is (false? (:all-ok? s)))
+      (is (true? (:partial? s)))
+      (is (false? (:none-ok? s))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Single entry
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest build-sync-summary-single-ok-test
+  (testing "Single :ok entry"
+    (let [s (core/build-sync-summary [{:status :ok :repo "a/b"}])]
+      (is (= 1 (:total s)))
+      (is (true? (:all-ok? s)))
+      (is (false? (:partial? s)))
+      (is (false? (:none-ok? s))))))
+
+(deftest build-sync-summary-single-error-test
+  (testing "Single :error entry"
+    (let [s (core/build-sync-summary [{:status :error :repo "a/b"}])]
+      (is (= 1 (:total s)))
+      (is (false? (:all-ok? s)))
+      (is (false? (:partial? s)))
+      (is (true? (:none-ok? s))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Arithmetic invariant: ok + errors = total
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest build-sync-summary-arithmetic-invariant-test
+  (testing "ok + errors = total for various sizes"
+    (doseq [n (range 0 8)]
+      (let [ok-count (quot n 2)
+            err-count (- n ok-count)
+            statuses (concat (repeat ok-count {:status :ok :repo "x/y"})
+                             (repeat err-count {:status :error :repo "z/w"}))
+            s (core/build-sync-summary (vec statuses))]
+        (is (= (:total s) (+ (:ok s) (:errors s)))
+            (str "invariant broken for n=" n))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Boolean flag mutual exclusivity
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest build-sync-summary-boolean-exclusivity-test
+  (testing "At most one of all-ok?, partial?, none-ok? is true (when total > 0)"
+    (doseq [statuses [;; all ok
+                      [{:status :ok} {:status :ok}]
+                      ;; all error
+                      [{:status :error} {:status :error}]
+                      ;; partial
+                      [{:status :ok} {:status :error}]]]
+      (let [s (core/build-sync-summary statuses)
+            flags (filter identity [(:all-ok? s) (:partial? s) (:none-ok? s)])]
+        (is (<= (count flags) 1)
+            (str "Multiple boolean flags true: " s))))))

--- a/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/core_test.clj
@@ -1,299 +1,697 @@
-;; Title: Miniforge.ai
-;; Subtitle: An agentic SDLC / fleet-control platform
-;; Author: Christopher Lester
-;; Line: Founder, Miniforge.ai (project)
-;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
-;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software
-;; distributed under the License is distributed on an "AS IS" BASIS,
-;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and
-;; limitations under the License.
-
 (ns ai.miniforge.pr-sync.core-test
+  "Comprehensive unit tests for pr-sync core.
+   Covers Layer 0 pure helpers, Layer 1 fleet config I/O,
+   Layer 2 provider CLI interaction (mocked), and Layer 4 discovery."
   (:require
-   [clojure.test :refer [deftest is testing]]
+   [clojure.test :refer [deftest testing is]]
+   [clojure.string :as str]
    [clojure.java.shell]
    [ai.miniforge.pr-sync.core :as core]))
 
-;; ─────────────────────────────────────────────────────────────────────────────
+;; ============================================================================
 ;; Test helpers
+;; ============================================================================
 
 (defn temp-config-path []
-  (let [f (java.io.File/createTempFile "miniforge-test-config" ".edn")]
+  (let [f (java.io.File/createTempFile "miniforge-core-test" ".edn")]
     (.deleteOnExit f)
     (.getAbsolutePath f)))
 
-;; ─────────────────────────────────────────────────────────────────────────────
-;; Fleet config tests
+(defn make-sh-router
+  "Build a mock sh function that routes based on substring matches in args."
+  [routes]
+  (fn [& args]
+    (let [match (some (fn [[substr response]]
+                        (when (some #(and (string? %) (.contains ^String % substr)) args)
+                          response))
+                      routes)]
+      (or match {:exit 1 :out "" :err "no route matched"}))))
+
+;; ============================================================================
+;; Layer 0: Pure helpers
+;; ============================================================================
+
+(deftest normalize-repo-slug-test
+  (testing "Trims whitespace and lowercases"
+    (is (= "owner/repo" (core/normalize-repo-slug "  Owner/Repo  "))))
+
+  (testing "Handles nil gracefully"
+    (is (= "" (core/normalize-repo-slug nil))))
+
+  (testing "Already normalized input is unchanged"
+    (is (= "acme/app" (core/normalize-repo-slug "acme/app"))))
+
+  (testing "GitLab prefix preserved in lowercase"
+    (is (= "gitlab:group/project" (core/normalize-repo-slug "GitLab:Group/Project")))))
+
+(deftest valid-repo-slug-test
+  (testing "Valid GitHub slugs"
+    (is (true? (core/valid-repo-slug? "owner/repo")))
+    (is (true? (core/valid-repo-slug? "my-org/my-repo.js")))
+    (is (true? (core/valid-repo-slug? "A_B/C.D"))))
+
+  (testing "Valid GitLab slugs"
+    (is (true? (core/valid-repo-slug? "gitlab:group/project")))
+    (is (true? (core/valid-repo-slug? "gitlab:org/sub/project"))))
+
+  (testing "Invalid slugs"
+    (is (false? (core/valid-repo-slug? "")))
+    (is (false? (core/valid-repo-slug? "noslash")))
+    (is (false? (core/valid-repo-slug? "/leading-slash")))
+    (is (false? (core/valid-repo-slug? "https://github.com/owner/repo")))
+    (is (false? (core/valid-repo-slug? "/absolute/path/to/repo"))))
+
+  (testing "Slugs with special chars at boundaries"
+    (is (true? (core/valid-repo-slug? "a/b")))
+    (is (false? (core/valid-repo-slug? "a/")))))
+
+(deftest repo-provider-test
+  (testing "GitHub repos return :github"
+    (is (= :github (core/repo-provider "owner/repo"))))
+
+  (testing "GitLab repos return :gitlab"
+    (is (= :gitlab (core/repo-provider "gitlab:group/project"))))
+
+  (testing "nil input returns :github (default)"
+    (is (= :github (core/repo-provider nil))))
+
+  (testing "Empty string returns :github"
+    (is (= :github (core/repo-provider "")))))
+
+(deftest provider-repo-slug-test
+  (testing "GitHub slug returned as-is"
+    (is (= "owner/repo" (core/provider-repo-slug "owner/repo"))))
+
+  (testing "GitLab prefix stripped"
+    (is (= "group/project" (core/provider-repo-slug "gitlab:group/project"))))
+
+  (testing "GitLab subgroups stripped correctly"
+    (is (= "org/sub/project" (core/provider-repo-slug "gitlab:org/sub/project")))))
+
+(deftest url-encode-test
+  (testing "Encodes special characters"
+    (is (= "hello+world" (core/url-encode "hello world")))
+    (is (= "a%2Fb" (core/url-encode "a/b"))))
+
+  (testing "Plain strings unchanged"
+    (is (= "simple" (core/url-encode "simple")))))
+
+(deftest succeeded-test
+  (testing "Returns true for success maps"
+    (is (true? (core/succeeded? {:success? true}))))
+
+  (testing "Returns false for failure maps"
+    (is (false? (core/succeeded? {:success? false}))))
+
+  (testing "Returns false for missing key"
+    (is (false? (core/succeeded? {}))))
+
+  (testing "Returns false for nil"
+    (is (false? (core/succeeded? nil)))))
+
+(deftest result-success-test
+  (testing "Creates success map with merged data"
+    (let [r (core/result-success {:foo :bar})]
+      (is (true? (:success? r)))
+      (is (= :bar (:foo r))))))
+
+(deftest result-failure-test
+  (testing "Creates failure map with message"
+    (let [r (core/result-failure "something broke")]
+      (is (false? (:success? r)))
+      (is (= "something broke" (:error r)))))
+
+  (testing "Creates failure map with message and data"
+    (let [r (core/result-failure "oops" {:repo "a/b"})]
+      (is (false? (:success? r)))
+      (is (= "oops" (:error r)))
+      (is (= "a/b" (:repo r)))))
+
+  (testing "Nil/blank message gets default"
+    (let [r (core/result-failure nil)]
+      (is (false? (:success? r)))
+      (is (string? (:error r)))
+      (is (pos? (count (:error r))))))
+
+  (testing "Empty string message gets default"
+    (let [r (core/result-failure "")]
+      (is (false? (:success? r)))
+      (is (pos? (count (:error r)))))))
+
+(deftest gh-error-message-test
+  (testing "Prefers err over out when err is non-blank"
+    (is (= "auth failed" (core/gh-error-message "output" "auth failed"))))
+
+  (testing "Falls back to out when err is blank"
+    (is (= "output msg" (core/gh-error-message "output msg" ""))))
+
+  (testing "Returns nil when both blank"
+    (is (nil? (core/gh-error-message "" ""))))
+
+  (testing "Handles nil inputs"
+    (is (nil? (core/gh-error-message nil nil)))))
+
+(deftest ex-msg-test
+  (testing "Extracts exception message"
+    (is (= "boom" (core/ex-msg (Exception. "boom")))))
+
+  (testing "Falls back to class name when message is nil"
+    (let [e (proxy [Exception] []
+              (getMessage [] nil))]
+      (is (string? (core/ex-msg e))))))
+
+(deftest normalized-limit-test
+  (testing "Uses provided integer limit when positive"
+    (is (= 10 (core/normalized-limit 10 50))))
+
+  (testing "Uses default when limit is zero"
+    (is (= 50 (core/normalized-limit 0 50))))
+
+  (testing "Uses default when limit is negative"
+    (is (= 50 (core/normalized-limit -5 50))))
+
+  (testing "Uses default when limit is nil"
+    (is (= 50 (core/normalized-limit nil 50))))
+
+  (testing "Uses default when limit is a string"
+    (is (= 50 (core/normalized-limit "10" 50)))))
+
+(deftest normalized-repos-test
+  (testing "Extracts, normalizes, and filters valid repos"
+    (let [cfg {:fleet {:repos ["Owner/Repo" "  acme/app  " "invalid" "gitlab:org/proj"]}}]
+      (is (= ["owner/repo" "acme/app" "gitlab:org/proj"]
+             (core/normalized-repos cfg)))))
+
+  (testing "Returns empty vec for missing repos key"
+    (is (= [] (core/normalized-repos {}))))
+
+  (testing "Returns empty vec for empty repos"
+    (is (= [] (core/normalized-repos {:fleet {:repos []}})))))
+
+;; ============================================================================
+;; Layer 1: Fleet config I/O
+;; ============================================================================
 
 (deftest load-fleet-config-test
-  (testing "Missing file returns default config"
-    (let [cfg (core/load-fleet-config "/tmp/nonexistent-miniforge-config-12345.edn")]
-      (is (= {:fleet {:repos []}} cfg))))
-
-  (testing "Existing file is read"
+  (testing "Loads valid config from file"
     (let [path (temp-config-path)]
-      (spit path (pr-str {:fleet {:repos ["owner/repo"]}}))
-      (let [cfg (core/load-fleet-config path)]
-        (is (= ["owner/repo"] (get-in cfg [:fleet :repos])))))))
+      (spit path (pr-str {:fleet {:repos ["a/b" "c/d"]}}))
+      (is (= {:fleet {:repos ["a/b" "c/d"]}}
+             (core/load-fleet-config path)))))
+
+  (testing "Returns default for non-existent file"
+    (is (= {:fleet {:repos []}}
+           (core/load-fleet-config "/tmp/does-not-exist-miniforge-42.edn"))))
+
+  (testing "Returns default for corrupt file"
+    (let [path (temp-config-path)]
+      (spit path "NOT VALID EDN {{{{")
+      (is (= {:fleet {:repos []}}
+             (core/load-fleet-config path))))))
+
+(deftest save-fleet-config-test
+  (testing "Writes config and reads it back"
+    (let [path (temp-config-path)
+          cfg {:fleet {:repos ["x/y"]}}]
+      (core/save-fleet-config! cfg path)
+      (is (= cfg (core/load-fleet-config path)))))
+
+  (testing "Creates parent directories"
+    (let [dir (str (System/getProperty "java.io.tmpdir")
+                   "/miniforge-test-" (System/currentTimeMillis))
+          path (str dir "/config.edn")
+          cfg {:fleet {:repos ["a/b"]}}]
+      (core/save-fleet-config! cfg path)
+      (is (= cfg (core/load-fleet-config path)))
+      ;; cleanup
+      (.delete (java.io.File. path))
+      (.delete (java.io.File. dir)))))
 
 (deftest get-configured-repos-test
-  (testing "Returns repos from config file"
+  (testing "Returns normalized, validated, distinct repos"
     (let [path (temp-config-path)]
-      (spit path (pr-str {:fleet {:repos ["Foo/Bar" "baz/qux"]}}))
-      (let [repos (core/get-configured-repos path)]
-        (is (= ["foo/bar" "baz/qux"] repos)))))
+      (spit path (pr-str {:fleet {:repos ["Owner/Repo" "owner/repo" "invalid" "a/b"]}}))
+      (is (= ["owner/repo" "a/b"]
+             (core/get-configured-repos path)))))
 
-  (testing "Filters invalid slugs"
-    (let [path (temp-config-path)]
-      (spit path (pr-str {:fleet {:repos ["valid/repo" "" "no-slash"]}}))
-      (let [repos (core/get-configured-repos path)]
-        (is (= ["valid/repo"] repos)))))
-
-  (testing "Empty config returns empty vec"
-    (let [path (temp-config-path)]
-      (spit path (pr-str {}))
-      (let [repos (core/get-configured-repos path)]
-        (is (= [] repos)))))
-
-  (testing "Keeps valid gitlab-prefixed slugs"
-    (let [path (temp-config-path)]
-      (spit path (pr-str {:fleet {:repos ["gitlab:Group/Sub/Repo"]}}))
-      (let [repos (core/get-configured-repos path)]
-        (is (= ["gitlab:group/sub/repo"] repos))))))
+  (testing "Returns empty for missing file"
+    (is (= [] (core/get-configured-repos "/tmp/nonexistent-cfg-42.edn")))))
 
 (deftest add-repo-test
-  (testing "Adds valid repo to empty config"
+  (testing "Adds new repo to empty config"
     (let [path (temp-config-path)]
       (spit path (pr-str {:fleet {:repos []}}))
-      (let [result (core/add-repo! "owner/name" path)]
-        (is (:success? result))
-        (is (:added? result))
-        (is (= "owner/name" (:repo result)))
-        (is (some #{"owner/name"} (:repos result))))))
+      (let [result (core/add-repo! "acme/app" path)]
+        (is (true? (:success? result)))
+        (is (true? (:added? result)))
+        (is (= "acme/app" (:repo result)))
+        (is (some #{"acme/app"} (:repos result))))))
 
-  (testing "Normalizes to lowercase"
+  (testing "Adding duplicate repo reports added? false"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (let [result (core/add-repo! "acme/app" path)]
+        (is (true? (:success? result)))
+        (is (false? (:added? result))))))
+
+  (testing "Adding duplicate with different case reports added? false"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (let [result (core/add-repo! "Acme/App" path)]
+        (is (true? (:success? result)))
+        (is (false? (:added? result))))))
+
+  (testing "Blank repo slug fails"
     (let [path (temp-config-path)]
       (spit path (pr-str {:fleet {:repos []}}))
-      (let [result (core/add-repo! "Owner/Name" path)]
-        (is (= "owner/name" (:repo result))))))
+      (let [result (core/add-repo! "  " path)]
+        (is (false? (:success? result)))
+        (is (string? (:error result))))))
 
-  (testing "Does not duplicate existing repo"
-    (let [path (temp-config-path)]
-      (spit path (pr-str {:fleet {:repos ["owner/name"]}}))
-      (let [result (core/add-repo! "owner/name" path)]
-        (is (:success? result))
-        (is (not (:added? result))))))
-
-  (testing "Rejects blank repo"
+  (testing "Invalid repo slug fails"
     (let [path (temp-config-path)]
       (spit path (pr-str {:fleet {:repos []}}))
-      (let [result (core/add-repo! "" path)]
-        (is (not (:success? result))))))
+      (let [result (core/add-repo! "/path/to/repo" path)]
+        (is (false? (:success? result))))))
 
-  (testing "Rejects invalid format"
+  (testing "Adds GitLab repo successfully"
     (let [path (temp-config-path)]
       (spit path (pr-str {:fleet {:repos []}}))
-      (let [result (core/add-repo! "no-slash" path)]
-        (is (not (:success? result))))))
-
-  (testing "Accepts gitlab repository format"
-    (let [path (temp-config-path)]
-      (spit path (pr-str {:fleet {:repos []}}))
-      (let [result (core/add-repo! "gitlab:Group/Sub/Repo" path)]
-        (is (:success? result))
-        (is (:added? result))
-        (is (= "gitlab:group/sub/repo" (:repo result)))))))
+      (let [result (core/add-repo! "gitlab:mygroup/myproject" path)]
+        (is (true? (:success? result)))
+        (is (true? (:added? result)))
+        (is (= "gitlab:mygroup/myproject" (:repo result)))))))
 
 (deftest remove-repo-test
   (testing "Removes existing repo"
     (let [path (temp-config-path)]
-      (spit path (pr-str {:fleet {:repos ["owner/name" "other/repo"]}}))
-      (let [result (core/remove-repo! "owner/name" path)]
-        (is (:success? result))
-        (is (:removed? result))
-        (is (not (some #{"owner/name"} (:repos result))))
-        (is (some #{"other/repo"} (:repos result))))))
+      (spit path (pr-str {:fleet {:repos ["acme/app" "other/lib"]}}))
+      (let [result (core/remove-repo! "acme/app" path)]
+        (is (true? (:success? result)))
+        (is (true? (:removed? result)))
+        (is (= ["other/lib"] (:repos result))))))
 
-  (testing "Handles non-existent repo gracefully"
+  (testing "Removing non-existent repo reports removed? false"
     (let [path (temp-config-path)]
-      (spit path (pr-str {:fleet {:repos ["owner/name"]}}))
-      (let [result (core/remove-repo! "not/here" path)]
-        (is (:success? result))
-        (is (not (:removed? result)))))))
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (let [result (core/remove-repo! "other/lib" path)]
+        (is (true? (:success? result)))
+        (is (false? (:removed? result))))))
 
-;; ─────────────────────────────────────────────────────────────────────────────
-;; GitLab state parameter mapping
+  (testing "Blank slug fails"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (let [result (core/remove-repo! "  " path)]
+        (is (false? (:success? result)))))))
+
+;; ============================================================================
+;; Layer 2: Provider CLI interaction (mocked)
+;; ============================================================================
+
+(def sample-github-pr-json
+  "[{\"number\":42,\"title\":\"Add feature\",\"url\":\"https://github.com/acme/app/pull/42\",\"state\":\"OPEN\",\"headRefName\":\"feat/new\",\"isDraft\":false,\"reviewDecision\":\"APPROVED\",\"statusCheckRollup\":[{\"conclusion\":\"SUCCESS\"}],\"mergeStateStatus\":\"CLEAN\",\"additions\":10,\"deletions\":5,\"changedFiles\":3,\"author\":{\"login\":\"dev\"}}]")
+
+(def sample-closed-pr-json
+  "[{\"number\":99,\"title\":\"Old PR\",\"url\":\"https://github.com/acme/app/pull/99\",\"state\":\"CLOSED\",\"headRefName\":\"fix/old\",\"isDraft\":false,\"reviewDecision\":null,\"statusCheckRollup\":[]}]")
+
+(deftest run-gh-test
+  (testing "Successful gh command returns success map"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 0 :out "hello" :err ""})]
+      (let [r (core/run-gh "version")]
+        (is (true? (:success? r)))
+        (is (= "hello" (:out r))))))
+
+  (testing "Failed gh command returns failure map"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "not found"})]
+      (let [r (core/run-gh "version")]
+        (is (false? (:success? r)))
+        (is (= "not found" (:err r))))))
+
+  (testing "Exception in sh call is caught"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    (throw (Exception. "gh not installed")))]
+      (let [r (core/run-gh "version")]
+        (is (false? (:success? r)))
+        (is (= "gh not installed" (:err r)))))))
+
+(deftest run-glab-test
+  (testing "Successful glab command returns success map"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 0 :out "ok" :err ""})]
+      (let [r (core/run-glab "version")]
+        (is (true? (:success? r))))))
+
+  (testing "Exception in glab call is caught"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    (throw (Exception. "glab not installed")))]
+      (let [r (core/run-glab "version")]
+        (is (false? (:success? r)))))))
+
+(deftest fetch-github-prs-test
+  (testing "Successful fetch returns sorted PRs with repo and provider"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 0 :out sample-github-pr-json :err ""})]
+      (let [result (core/fetch-github-prs "acme/app" :open)]
+        (is (true? (:success? result)))
+        (is (= "acme/app" (:repo result)))
+        (is (= :github (:provider result)))
+        (is (= 1 (count (:prs result))))
+        (is (= 42 (:pr/number (first (:prs result))))))))
+
+  (testing "CLI failure returns failure result"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "HTTP 401 Bad credentials"})]
+      (let [result (core/fetch-github-prs "acme/app" :open)]
+        (is (false? (:success? result)))
+        (is (string? (:error result))))))
+
+  (testing "Malformed JSON returns failure result"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 0 :out "NOT JSON" :err ""})]
+      (let [result (core/fetch-github-prs "acme/app" :open)]
+        (is (false? (:success? result)))))))
+
+(deftest fetch-open-github-prs-test
+  (testing "Filters out closed/merged PRs from open fetch"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 0 :out sample-closed-pr-json :err ""})]
+      (let [result (core/fetch-open-github-prs "acme/app")]
+        (is (true? (:success? result)))
+        ;; Closed PR filtered out
+        (is (empty? (:prs result)))))))
+
+(deftest fetch-open-prs-dispatches-by-provider-test
+  (testing "GitHub repo dispatches to GitHub fetch"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (if (= "gh" (first args))
+                      {:exit 0 :out "[]" :err ""}
+                      {:exit 1 :out "" :err "wrong binary"}))]  
+      (let [result (core/fetch-open-prs "acme/app")]
+        (is (true? (:success? result))))))
+
+  (testing "GitLab repo dispatches to GitLab fetch"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (if (= "glab" (first args))
+                      {:exit 0 :out "[]" :err ""}
+                      {:exit 1 :out "" :err "wrong binary"}))]  
+      (let [result (core/fetch-open-prs "gitlab:org/proj")]
+        (is (true? (:success? result)))))))
+
+(deftest fetch-prs-by-state-test
+  (testing "State parameter maps correctly for GitHub"
+    (let [captured-args (atom nil)]
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& args]
+                      (reset! captured-args (vec args))
+                      {:exit 0 :out "[]" :err ""})]
+        (core/fetch-github-prs "acme/app" :merged)
+        (is (some #{"merged"} @captured-args)))))
+
+  (testing "Default state is open"
+    (let [captured-args (atom nil)]
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& args]
+                      (reset! captured-args (vec args))
+                      {:exit 0 :out "[]" :err ""})]
+        (core/fetch-github-prs "acme/app" :open)
+        (is (some #{"open"} @captured-args))))))
 
 (deftest gitlab-state-param-test
-  (testing "Maps canonical state keywords to GitLab API parameters"
+  (testing "Maps canonical states to GitLab API values"
     (is (= "opened" (core/gitlab-state-param :open)))
     (is (= "closed" (core/gitlab-state-param :closed)))
     (is (= "merged" (core/gitlab-state-param :merged)))
-    (is (= "all"    (core/gitlab-state-param :all)))
+    (is (= "all"    (core/gitlab-state-param :all))))
+
+  (testing "Unknown state defaults to opened"
     (is (= "opened" (core/gitlab-state-param :unknown)))))
 
-(deftest fetch-prs-by-state-routes-gitlab-test
-  (testing "GitLab repos use state-aware fetch instead of hardcoded opened"
+;; ============================================================================
+;; Layer 2b: GitLab MR enrichment (mocked)
+;; ============================================================================
+
+(deftest fetch-gitlab-diff-stats-batch-test
+  (testing "Returns empty map for empty iids"
+    (is (= nil (core/fetch-gitlab-diff-stats-batch "group/proj" []))))
+
+  (testing "Returns empty map on CLI failure"
     (with-redefs [clojure.java.shell/sh
-                  (fn [& args]
-                    (if (and (= "glab" (first args))
-                             (some #(and (string? %) (.contains ^String % "state=merged")) args))
-                      {:exit 0
-                       :out "[{\"iid\":5,\"title\":\"Merged MR\",\"web_url\":\"https://gl.com/g/p/-/merge_requests/5\",\"source_branch\":\"done\",\"state\":\"merged\",\"draft\":false}]"
-                       :err ""}
-                      {:exit 1 :out "" :err "unexpected call"}))]
-      (let [result (core/fetch-prs-by-state "gitlab:g/p" :merged)]
-        (is (:success? result))
-        (is (= 1 (count (:prs result))))
-        (is (= :merged (:pr/status (first (:prs result)))))))))
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "fail"})]
+      (is (= {} (core/fetch-gitlab-diff-stats-batch "group/proj" ["1"])))))
 
-;; ─────────────────────────────────────────────────────────────────────────────
-;; Integration tests (PR fetching with mocked shell)
+  (testing "Returns stats on success"
+    (let [graphql-response "{\"data\":{\"project\":{\"mr1\":{\"diffStatsSummary\":{\"additions\":10,\"deletions\":5,\"fileCount\":3}}}}}"]
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& _args]
+                      {:exit 0 :out graphql-response :err ""})]
+        (let [stats (core/fetch-gitlab-diff-stats-batch "group/proj" ["1"])]
+          (is (= 10 (:additions (get stats "1"))))
+          (is (= 5 (:deletions (get stats "1"))))
+          (is (= 3 (:file-count (get stats "1")))))))))
 
-(deftest fetch-all-fleet-prs-multi-provider-test
-  (testing "Fetches open items from both GitHub and GitLab repositories"
+(deftest enrich-gitlab-mrs-with-diff-stats-test
+  (testing "Skips enrichment when no open MRs"
+    (let [mrs [{:iid "1" :state "closed"}
+               {:iid "2" :state "merged"}]]
+      (is (= mrs (core/enrich-gitlab-mrs-with-diff-stats "g/p" mrs)))))
+
+  (testing "Enriches open MRs with diff stats"
+    (let [graphql-response "{\"data\":{\"project\":{\"mr10\":{\"diffStatsSummary\":{\"additions\":20,\"deletions\":3,\"fileCount\":2}}}}}"
+          mrs [{:iid "10" :state "opened"}
+               {:iid "20" :state "closed"}]]
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& _args]
+                      {:exit 0 :out graphql-response :err ""})]
+        (let [enriched (core/enrich-gitlab-mrs-with-diff-stats "g/p" mrs)]
+          ;; Open MR enriched
+          (is (= 20 (:additions (first enriched))))
+          (is (= 3 (:deletions (first enriched))))
+          ;; Closed MR unchanged
+          (is (nil? (:additions (second enriched)))))))))
+
+;; ============================================================================
+;; Layer 2c: fetch-all-fleet-prs
+;; ============================================================================
+
+(deftest fetch-all-fleet-prs-test
+  (testing "Returns flat vector of PRs from all repos"
     (let [path (temp-config-path)]
-      (spit path (pr-str {:fleet {:repos ["owner/repo" "gitlab:team/service"]}}))
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"acme/app" {:exit 0 :out sample-github-pr-json :err ""}})]
+        (let [prs (core/fetch-all-fleet-prs {:config-path path})]
+          (is (vector? prs))
+          (is (= 1 (count prs)))
+          (is (= 42 (:pr/number (first prs))))))))
+
+  (testing "Returns empty for empty fleet"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos []}}))
+      (is (= [] (core/fetch-all-fleet-prs {:config-path path})))))
+
+  (testing "Filters out failed repos"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app" "bad/repo"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"acme/app" {:exit 0 :out sample-github-pr-json :err ""}
+                      "bad/repo" {:exit 1 :out "" :err "fail"}})]
+        (let [prs (core/fetch-all-fleet-prs {:config-path path})]
+          (is (= 1 (count prs))))))))
+
+;; ============================================================================
+;; Layer 3: Error classification (supplementary to error_classification_test)
+;; ============================================================================
+
+(deftest classify-sync-error-priority-test
+  (testing "First matching pattern wins (401 before rate_limit)"
+    (let [result (core/classify-sync-error "401 rate limit")]
+      (is (= :auth-failure (:error-category result))))))
+
+(deftest fetch-repo-with-status-gitlab-test
+  (testing "GitLab repo errors are classified"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "HTTP 404 Not Found"})]
+      (let [status (core/fetch-repo-with-status "gitlab:group/proj")]
+        (is (= :error (:status status)))
+        (is (= :not-found (:error-category status)))
+        (is (= "gitlab:group/proj" (:repo status)))))))
+
+;; ============================================================================
+;; Layer 4: Discovery
+;; ============================================================================
+
+(deftest discover-repos-test
+  (testing "Discovers repos from org and adds to config"
+    (let [path (temp-config-path)
+          api-response "[{\"full_name\":\"myorg/repo1\"},{\"full_name\":\"myorg/repo2\"}]"]
+      (spit path (pr-str {:fleet {:repos []}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& _args]
+                      {:exit 0 :out api-response :err ""})]
+        (let [result (core/discover-repos! {:owner "myorg" :config-path path})]
+          (is (true? (:success? result)))
+          (is (= 2 (:discovered result)))
+          (is (= 2 (:added result)))
+          ;; Repos persisted
+          (is (= ["myorg/repo1" "myorg/repo2"]
+                 (core/get-configured-repos path)))))))
+
+  (testing "Skips already-configured repos"
+    (let [path (temp-config-path)
+          api-response "[{\"full_name\":\"myorg/repo1\"},{\"full_name\":\"myorg/repo2\"}]"]
+      (spit path (pr-str {:fleet {:repos ["myorg/repo1"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& _args]
+                      {:exit 0 :out api-response :err ""})]
+        (let [result (core/discover-repos! {:owner "myorg" :config-path path})]
+          (is (true? (:success? result)))
+          (is (= 2 (:discovered result)))
+          (is (= 1 (:added result)))))))
+
+  (testing "CLI failure returns failure result"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos []}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& _args]
+                      {:exit 1 :out "" :err "auth required"})]
+        (let [result (core/discover-repos! {:owner "myorg" :config-path path})]
+          (is (false? (:success? result)))))))
+
+  (testing "Respects limit parameter"
+    (let [path (temp-config-path)
+          api-response (str "[" (str/join ","
+                                  (map #(str "{\"full_name\":\"org/r" % "\"}") (range 10))) "]")]
+      (spit path (pr-str {:fleet {:repos []}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& _args]
+                      {:exit 0 :out api-response :err ""})]
+        (let [result (core/discover-repos! {:owner "org" :limit 3 :config-path path})]
+          (is (true? (:success? result)))
+          (is (= 3 (:discovered result))))))))
+
+;; ============================================================================
+;; Layer 4b: Viewer repos helpers
+;; ============================================================================
+
+(deftest viewer-repos-gh-args-test
+  (testing "First page has no after cursor"
+    (let [args (core/viewer-repos-gh-args 50 [] nil)]
+      (is (some #{"api"} args))
+      (is (some #{"graphql"} args))
+      (is (not (some #(and (string? %) (.startsWith ^String % "after=")) args)))))
+
+  (testing "Subsequent page includes after cursor"
+    (let [args (core/viewer-repos-gh-args 50 [] "cursor123")]
+      (is (some #(= "after=cursor123" %) args)))))
+
+(deftest parse-viewer-repos-page-test
+  (testing "Extracts repos and pagination from GraphQL response"
+    (let [parsed {:data {:viewer {:repositories
+                                   {:nodes [{:nameWithOwner "org/repo1"}
+                                            {:nameWithOwner "org/repo2"}]
+                                    :pageInfo {:hasNextPage true
+                                               :endCursor "abc123"}}}}}
+          result (core/parse-viewer-repos-page parsed)]
+      (is (= ["org/repo1" "org/repo2"] (:repos result)))
+      (is (true? (:has-next? result)))
+      (is (= "abc123" (:cursor result)))))
+
+  (testing "Handles empty response"
+    (let [result (core/parse-viewer-repos-page {:data {:viewer {:repositories {:nodes [] :pageInfo {}}}}})] 
+      (is (empty? (:repos result)))
+      (is (false? (:has-next? result))))))
+
+(deftest parse-gh-full-name-repos-test
+  (testing "Parses, normalizes, and limits repos from JSON"
+    (let [json "[{\"full_name\":\"Org/Repo1\"},{\"full_name\":\"Org/Repo2\"},{\"full_name\":\"Org/Repo3\"}]"]
+      (is (= ["org/repo1" "org/repo2"] (core/parse-gh-full-name-repos json 2))))))
+
+(deftest parse-glab-project-repos-test
+  (testing "Parses GitLab projects with gitlab: prefix"
+    (let [json "[{\"path_with_namespace\":\"group/project1\"},{\"path_with_namespace\":\"group/sub/project2\"}]"]
+      (is (= ["gitlab:group/project1" "gitlab:group/sub/project2"]
+             (core/parse-glab-project-repos json 100))))))
+
+;; ============================================================================
+;; Layer 4c: list-org-repos dispatch
+;; ============================================================================
+
+(deftest list-org-repos-unknown-provider-test
+  (testing "Unknown provider returns failure"
+    (let [result (core/list-org-repos {:provider :bitbucket :owner "org"})]
+      (is (false? (:success? result)))
+      (is (.contains ^String (:error result) "Unknown provider")))))
+
+(deftest list-org-repos-github-owner-test
+  (testing "GitHub with owner fetches org repos"
+    (let [api-response "[{\"full_name\":\"myorg/repo1\"}]"]
       (with-redefs [clojure.java.shell/sh
                     (fn [& args]
-                      (cond
-                        (and (= "gh" (first args))
-                             (some #{"pr"} args)
-                             (some #{"list"} args))
-                        {:exit 0
-                         :out "[{\"number\":12,\"title\":\"Fix GH\",\"url\":\"https://github.com/owner/repo/pull/12\",\"state\":\"OPEN\",\"headRefName\":\"fix-gh\",\"isDraft\":false,\"reviewDecision\":null,\"statusCheckRollup\":[{\"conclusion\":\"SUCCESS\"}]}]"
-                         :err ""}
+                      (if (some #(and (string? %) (.contains ^String % "orgs/myorg")) args)
+                        {:exit 0 :out api-response :err ""}
+                        {:exit 1 :out "" :err ""}))] 
+        (let [result (core/list-org-repos {:provider :github :owner "myorg" :limit 50})]
+          (is (true? (:success? result)))
+          (is (= ["myorg/repo1"] (:repos result))))))))
 
-                        (and (= "glab" (first args))
-                             (some #(and (string? %) (.contains ^String % "/merge_requests")) args))
-                        {:exit 0
-                         :out "[{\"iid\":34,\"title\":\"Fix GL\",\"web_url\":\"https://gitlab.com/team/service/-/merge_requests/34\",\"source_branch\":\"fix-gl\",\"state\":\"opened\",\"draft\":false,\"merge_status\":\"can_be_merged\",\"head_pipeline\":{\"status\":\"success\"}}]"
-                         :err ""}
+(deftest list-gitlab-repos-test
+  (testing "GitLab repos fetched with correct endpoint"
+    (let [api-response "[{\"path_with_namespace\":\"grp/proj\"}]"]
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& _args]
+                      {:exit 0 :out api-response :err ""})]
+        (let [result (core/list-gitlab-repos {:owner "grp" :limit 50})]
+          (is (true? (:success? result)))
+          (is (= :gitlab (:provider result)))
+          (is (= ["gitlab:grp/proj"] (:repos result))))))))
 
-                        :else
-                        {:exit 1 :out "" :err (str "unexpected call: " args)}))]
-        (let [prs (core/fetch-all-fleet-prs {:config-path path})]
-          (is (= 2 (count prs)))
-          (is (some #(= "owner/repo" (:pr/repo %)) prs))
-          (is (some #(= "gitlab:team/service" (:pr/repo %)) prs))
-          (is (some #(= :merge-ready (:pr/status %)) prs)))))))
-
-(deftest list-org-repos-test
-  (testing "Without owner, lists viewer-accessible repos plus org repositories"
+(deftest list-org-repos-all-provider-test
+  (testing ":all provider combines GitHub and GitLab results"
     (with-redefs [clojure.java.shell/sh
                   (fn [& args]
                     (cond
-                      (and (= "gh" (first args))
-                           (some #{"graphql"} args))
-                      {:exit 0
-                       :out "{\"data\":{\"viewer\":{\"repositories\":{\"nodes\":[{\"nameWithOwner\":\"Org/RepoA\"},{\"nameWithOwner\":\"me/repo-b\"}],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}}"
-                       :err ""}
+                      (= "gh" (first args))
+                      {:exit 0 :out "[{\"full_name\":\"org/gh-repo\"}]" :err ""}
 
-                      (and (= "gh" (first args))
-                           (some #(and (string? %) (.contains ^String % "user/orgs")) args))
-                      {:exit 0
-                       :out "[{\"login\":\"kiddom\"}]"
-                       :err ""}
-
-                      (and (= "gh" (first args))
-                           (some #(and (string? %) (.contains ^String % "orgs/kiddom/repos")) args))
-                      {:exit 0
-                       :out "[{\"full_name\":\"kiddom/platform\"}]"
-                       :err ""}
+                      (= "glab" (first args))
+                      {:exit 0 :out "[{\"path_with_namespace\":\"org/gl-repo\"}]" :err ""}
 
                       :else
-                      {:exit 1 :out "" :err "unexpected call"}))]
-      (let [result (core/list-org-repos {})]
-        (is (:success? result))
-        (is (= ["org/repoa" "me/repo-b" "kiddom/platform"] (:repos result))))))
+                      {:exit 1 :out "" :err "unknown"}))]
+      (let [result (core/list-org-repos {:provider :all :owner "org" :limit 50})]
+        (is (true? (:success? result)))
+        (is (some #{"org/gh-repo"} (:repos result)))
+        (is (some #{"gitlab:org/gl-repo"} (:repos result)))))))
 
-  (testing "Falls back to user/repos when GraphQL listing fails"
+(deftest list-github-viewer-orgs-test
+  (testing "Returns org names on success"
     (with-redefs [clojure.java.shell/sh
-                  (fn [& args]
-                    (cond
-                      (and (= "gh" (first args))
-                           (some #{"graphql"} args))
-                      {:exit 1 :out "" :err "forbidden"}
+                  (fn [& _args]
+                    {:exit 0 :out "[{\"login\":\"MyOrg\"},{\"login\":\"Other\"}]" :err ""})]
+      (let [result (core/list-github-viewer-orgs)]
+        (is (true? (:success? result)))
+        (is (= ["myorg" "other"] (:orgs result))))))
 
-                      (and (= "gh" (first args))
-                           (some #(and (string? %) (.contains ^String % "user/orgs")) args))
-                      {:exit 1 :out "" :err "sso required"}
-
-                      (and (= "gh" (first args))
-                           (some #(and (string? %) (.contains ^String % "user/repos")) args))
-                      {:exit 0
-                       :out "[{\"full_name\":\"fallback/repo1\"},{\"full_name\":\"fallback/repo2\"}]"
-                       :err ""}
-
-                      :else
-                      {:exit 1 :out "" :err "unexpected call"}))]
-      (let [result (core/list-org-repos {:limit 10})]
-        (is (:success? result))
-        (is (= ["fallback/repo1" "fallback/repo2"] (:repos result))))))
-
-  (testing "Nil limit is normalized and does not throw"
+  (testing "Returns failure on CLI error"
     (with-redefs [clojure.java.shell/sh
-                  (fn [& args]
-                    (cond
-                      (and (= "gh" (first args))
-                           (some #{"graphql"} args))
-                      {:exit 0
-                       :out "{\"data\":{\"viewer\":{\"repositories\":{\"nodes\":[{\"nameWithOwner\":\"Org/RepoA\"}],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}}"
-                       :err ""}
-
-                      (and (= "gh" (first args))
-                           (some #(and (string? %) (.contains ^String % "user/orgs")) args))
-                      {:exit 0 :out "[]" :err ""}
-
-                      :else
-                      {:exit 1 :out "" :err "unexpected call"}))]
-      (let [result (core/list-org-repos {:limit nil})]
-        (is (:success? result))
-        (is (= ["org/repoa"] (:repos result))))))
-
-  (testing "GitLab provider returns prefixed repositories"
-    (with-redefs [clojure.java.shell/sh
-                  (fn [& args]
-                    (cond
-                      (and (= "glab" (first args))
-                           (some #(and (string? %) (.contains ^String % "projects?membership=true")) args))
-                      {:exit 0
-                       :out "[{\"path_with_namespace\":\"Platform/API\"},{\"path_with_namespace\":\"Data/ETL\"}]"
-                       :err ""}
-                      :else
-                      {:exit 1 :out "" :err "unexpected call"}))]
-      (let [result (core/list-org-repos {:provider :gitlab})]
-        (is (:success? result))
-        (is (= ["gitlab:platform/api" "gitlab:data/etl"] (:repos result))))))
-
-  (testing "Provider :all merges GitHub and GitLab repositories"
-    (with-redefs [clojure.java.shell/sh
-                  (fn [& args]
-                    (cond
-                      (and (= "gh" (first args))
-                           (some #{"graphql"} args))
-                      {:exit 0
-                       :out "{\"data\":{\"viewer\":{\"repositories\":{\"nodes\":[{\"nameWithOwner\":\"Org/RepoA\"}],\"pageInfo\":{\"hasNextPage\":false,\"endCursor\":null}}}}}"
-                       :err ""}
-
-                      (and (= "gh" (first args))
-                           (some #(and (string? %) (.contains ^String % "user/orgs")) args))
-                      {:exit 0 :out "[]" :err ""}
-
-                      (and (= "glab" (first args))
-                           (some #(and (string? %) (.contains ^String % "projects?membership=true")) args))
-                      {:exit 0 :out "[{\"path_with_namespace\":\"Platform/API\"}]" :err ""}
-
-                      :else
-                      {:exit 1 :out "" :err "unexpected call"}))]
-      (let [result (core/list-org-repos {:provider :all})]
-        (is (:success? result))
-        (is (= ["org/repoa" "gitlab:platform/api"] (:repos result)))))))
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "unauthorized"})]
+      (let [result (core/list-github-viewer-orgs)]
+        (is (false? (:success? result)))))))

--- a/components/pr-sync/test/ai/miniforge/pr_sync/fleet_parallel_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/fleet_parallel_test.clj
@@ -1,0 +1,95 @@
+(ns ai.miniforge.pr-sync.fleet-parallel-test
+  "Tests for fleet sync with :parallel? option and fetch-all-fleet-prs :state."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.java.shell]
+   [ai.miniforge.pr-sync.core :as core]))
+
+(defn temp-config-path []
+  (let [f (java.io.File/createTempFile "miniforge-parallel-test" ".edn")]
+    (.deleteOnExit f)
+    (.getAbsolutePath f)))
+
+(def sample-pr-json
+  "[{\"number\":1,\"title\":\"PR 1\",\"url\":\"https://github.com/a/b/pull/1\",\"state\":\"OPEN\",\"headRefName\":\"feat/x\",\"isDraft\":false,\"reviewDecision\":null,\"statusCheckRollup\":[]}]")
+
+(defn make-sh-router
+  [routes]
+  (fn [& args]
+    (let [match (some (fn [[substr response]]
+                        (when (some #(and (string? %) (.contains ^String % substr)) args)
+                          response))
+                      routes)]
+      (or match {:exit 1 :out "" :err "no route matched"}))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; fetch-fleet-with-status :parallel? true
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-fleet-with-status-parallel-test
+  (testing "Parallel mode produces same results as sequential"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app" "other/lib"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"acme/app"  {:exit 0 :out sample-pr-json :err ""}
+                      "other/lib" {:exit 0 :out "[]" :err ""}})]
+        (let [seq-result (core/fetch-fleet-with-status {:config-path path :parallel? false})
+              par-result (core/fetch-fleet-with-status {:config-path path :parallel? true})]
+          ;; Same PR count
+          (is (= (count (:prs seq-result)) (count (:prs par-result))))
+          ;; Same summary
+          (is (= (:summary seq-result) (:summary par-result)))
+          ;; Same sync status count
+          (is (= (count (:sync-statuses seq-result))
+                 (count (:sync-statuses par-result)))))))))
+
+(deftest fetch-fleet-with-status-parallel-with-errors-test
+  (testing "Parallel mode handles partial failures correctly"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["ok/repo" "bad/repo"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"ok/repo"  {:exit 0 :out sample-pr-json :err ""}
+                      "bad/repo" {:exit 1 :out "" :err "HTTP 500 Internal Server Error"}})]
+        (let [result (core/fetch-fleet-with-status {:config-path path :parallel? true})]
+          (is (= 1 (count (:prs result))))
+          (is (= 2 (count (:sync-statuses result))))
+          (is (true? (get-in result [:summary :partial?]))))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; fetch-all-fleet-prs with :state option
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(def sample-merged-pr-json
+  "[{\"number\":99,\"title\":\"Merged\",\"url\":\"https://github.com/a/b/pull/99\",\"state\":\"MERGED\",\"headRefName\":\"feat/done\",\"isDraft\":false,\"mergedAt\":\"2026-01-01T00:00:00Z\",\"reviewDecision\":null,\"statusCheckRollup\":[]}]")
+
+(deftest fetch-all-fleet-prs-with-state-test
+  (testing ":state :merged passes through to fetch-prs-by-state"
+    (let [path (temp-config-path)
+          captured-state (atom nil)]
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& args]
+                      ;; Capture the state arg passed to gh
+                      (when-let [s (some #(when (and (string? %) (#{ "merged" "closed" "all"} %)) %)
+                                         args)]
+                        (reset! captured-state s))
+                      {:exit 0 :out sample-merged-pr-json :err ""})]
+        (let [prs (core/fetch-all-fleet-prs {:config-path path :state :merged})]
+          (is (vector? prs))
+          (is (= "merged" @captured-state)))))))
+
+(deftest fetch-all-fleet-prs-default-state-is-open-test
+  (testing "Default state is :open"
+    (let [path (temp-config-path)
+          captured-state (atom nil)]
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& args]
+                      (when-let [s (some #(when (and (string? %) (#{ "open" "merged" "closed" "all"} %)) %)
+                                         args)]
+                        (reset! captured-state s))
+                      {:exit 0 :out "[]" :err ""})]
+        (core/fetch-all-fleet-prs {:config-path path})
+        (is (= "open" @captured-state))))))

--- a/components/pr-sync/test/ai/miniforge/pr_sync/gitlab_fetch_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/gitlab_fetch_test.clj
@@ -1,0 +1,201 @@
+(ns ai.miniforge.pr-sync.gitlab-fetch-test
+  "Unit tests for GitLab MR fetching and enrichment via mocked glab CLI."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.java.shell]
+   [cheshire.core :as json]
+   [ai.miniforge.pr-sync.core :as core]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Sample GitLab API responses
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(def sample-open-mr
+  {:iid 42
+   :title "Add auth"
+   :web_url "https://gitlab.com/grp/proj/-/merge_requests/42"
+   :state "opened"
+   :source_branch "feat/auth"
+   :draft false
+   :merge_status "can_be_merged"
+   :head_pipeline {:status "success"}
+   :author {:username "dev"}
+   :additions 0 :deletions 0 :changes_count 1})
+
+(def sample-closed-mr
+  {:iid 10
+   :title "Old fix"
+   :web_url "https://gitlab.com/grp/proj/-/merge_requests/10"
+   :state "closed"
+   :source_branch "fix/old"
+   :draft false
+   :merge_status "cannot_be_merged"
+   :head_pipeline nil
+   :author {:username "dev"}})
+
+(def sample-merged-mr
+  {:iid 5
+   :title "Initial"
+   :web_url "https://gitlab.com/grp/proj/-/merge_requests/5"
+   :state "merged"
+   :source_branch "feat/init"
+   :draft false
+   :merge_status "can_be_merged"
+   :head_pipeline {:status "success"}
+   :author {:username "dev"}})
+
+(defn glab-sh-mock
+  "Build a mock sh that responds to glab api calls with the given JSON body."
+  [json-body]
+  (fn [& args]
+    (if (= "glab" (first args))
+      {:exit 0 :out (json/generate-string json-body) :err ""}
+      {:exit 1 :out "" :err "wrong binary"})))
+
+(defn glab-sh-failure
+  [err-msg]
+  (fn [& args]
+    (if (= "glab" (first args))
+      {:exit 1 :out "" :err err-msg}
+      {:exit 1 :out "" :err "wrong binary"})))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; fetch-gitlab-mrs-by-state — success
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-gitlab-mrs-by-state-open-test
+  (testing "Fetches open MRs and returns normalized TrainPR maps"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (cond
+                      ;; REST list endpoint
+                      (some #(and (string? %) (.contains ^String % "merge_requests")) args)
+                      {:exit 0 :out (json/generate-string [sample-open-mr]) :err ""}
+                      ;; GraphQL diff stats endpoint
+                      (some #(and (string? %) (.contains ^String % "graphql")) args)
+                      {:exit 0 :out (json/generate-string
+                                     {:data {:project {:mr42 {:diffStatsSummary
+                                                              {:additions 15 :deletions 3 :fileCount 2}}}}})
+                       :err ""}
+                      :else {:exit 1 :out "" :err "unmatched"}))]
+      (let [result (core/fetch-gitlab-mrs-by-state "gitlab:grp/proj" :open)]
+        (is (true? (:success? result)))
+        (is (= :gitlab (:provider result)))
+        (is (= "gitlab:grp/proj" (:repo result)))
+        (is (= 1 (count (:prs result))))
+        (let [pr (first (:prs result))]
+          (is (= 42 (:pr/number pr)))
+          (is (= "Add auth" (:pr/title pr)))
+          ;; Enriched diff stats
+          (is (= 15 (:pr/additions pr)))
+          (is (= 3 (:pr/deletions pr))))))))
+
+(deftest fetch-gitlab-mrs-by-state-closed-test
+  (testing "Closed state does not enrich with diff stats"
+    (with-redefs [clojure.java.shell/sh
+                  (glab-sh-mock [sample-closed-mr])]
+      (let [result (core/fetch-gitlab-mrs-by-state "gitlab:grp/proj" :closed)]
+        (is (true? (:success? result)))
+        (is (= 1 (count (:prs result))))
+        (is (= :closed (:pr/status (first (:prs result)))))))))
+
+(deftest fetch-gitlab-mrs-by-state-merged-test
+  (testing "Merged MRs are returned for :merged state"
+    (with-redefs [clojure.java.shell/sh
+                  (glab-sh-mock [sample-merged-mr])]
+      (let [result (core/fetch-gitlab-mrs-by-state "gitlab:grp/proj" :merged)]
+        (is (true? (:success? result)))
+        (is (= 1 (count (:prs result))))
+        (is (= :merged (:pr/status (first (:prs result)))))))))
+
+(deftest fetch-gitlab-mrs-by-state-all-test
+  (testing ":all state returns open, closed, and merged MRs"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (cond
+                      (some #(and (string? %) (.contains ^String % "merge_requests")) args)
+                      {:exit 0 :out (json/generate-string [sample-open-mr sample-closed-mr sample-merged-mr]) :err ""}
+                      ;; GraphQL diff stats for open MR
+                      (some #(and (string? %) (.contains ^String % "graphql")) args)
+                      {:exit 0 :out (json/generate-string {:data {:project {}}}) :err ""}
+                      :else {:exit 1 :out "" :err ""}))] 
+      (let [result (core/fetch-gitlab-mrs-by-state "gitlab:grp/proj" :all)]
+        (is (true? (:success? result)))
+        ;; :all returns everything, no post-filtering
+        (is (= 3 (count (:prs result))))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; fetch-gitlab-mrs-by-state — failure
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-gitlab-mrs-by-state-cli-failure-test
+  (testing "CLI failure returns failure result with provider"
+    (with-redefs [clojure.java.shell/sh
+                  (glab-sh-failure "HTTP 401 Unauthorized")]
+      (let [result (core/fetch-gitlab-mrs-by-state "gitlab:grp/proj" :open)]
+        (is (false? (:success? result)))
+        (is (= :gitlab (:provider result)))
+        (is (string? (:error result)))))))
+
+(deftest fetch-gitlab-mrs-by-state-malformed-json-test
+  (testing "Malformed JSON returns parse failure"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (if (= "glab" (first args))
+                      {:exit 0 :out "NOT JSON{" :err ""}
+                      {:exit 1 :out "" :err ""}))]
+      (let [result (core/fetch-gitlab-mrs-by-state "gitlab:grp/proj" :open)]
+        (is (false? (:success? result)))
+        (is (.contains ^String (:error result) "parse"))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; fetch-open-gitlab-mrs delegates to fetch-gitlab-mrs-by-state
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-open-gitlab-mrs-test
+  (testing "fetch-open-gitlab-mrs returns only open/draft MRs"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (cond
+                      (some #(and (string? %) (.contains ^String % "merge_requests")) args)
+                      {:exit 0 :out (json/generate-string [sample-open-mr]) :err ""}
+                      (some #(and (string? %) (.contains ^String % "graphql")) args)
+                      {:exit 0 :out (json/generate-string {:data {:project {}}}) :err ""}
+                      :else {:exit 1 :out "" :err ""}))]
+      (let [result (core/fetch-open-gitlab-mrs "gitlab:grp/proj")]
+        (is (true? (:success? result)))
+        (is (= 1 (count (:prs result))))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; fetch-prs-by-state dispatches GitLab
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-prs-by-state-gitlab-dispatch-test
+  (testing "fetch-prs-by-state dispatches to GitLab for gitlab: repos"
+    (with-redefs [clojure.java.shell/sh
+                  (glab-sh-mock [sample-merged-mr])]
+      (let [result (core/fetch-prs-by-state "gitlab:grp/proj" :merged)]
+        (is (true? (:success? result)))
+        (is (= :gitlab (:provider result)))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; State filtering — open state excludes closed/merged
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-gitlab-open-filters-closed-mrs-test
+  (testing "Open fetch filters out any closed/merged MRs leaked by API"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& args]
+                    (cond
+                      (some #(and (string? %) (.contains ^String % "merge_requests")) args)
+                      ;; API leaks a closed MR alongside the open one
+                      {:exit 0 :out (json/generate-string [sample-open-mr sample-closed-mr]) :err ""}
+                      (some #(and (string? %) (.contains ^String % "graphql")) args)
+                      {:exit 0 :out (json/generate-string {:data {:project {}}}) :err ""}
+                      :else {:exit 1 :out "" :err ""}))]
+      (let [result (core/fetch-gitlab-mrs-by-state "gitlab:grp/proj" :open)
+            statuses (set (map :pr/status (:prs result)))]
+        (is (true? (:success? result)))
+        ;; Closed should be filtered out
+        (is (not (contains? statuses :closed)))
+        (is (not (contains? statuses :merged)))))))

--- a/components/pr-sync/test/ai/miniforge/pr_sync/ingestion_test.clj
+++ b/components/pr-sync/test/ai/miniforge/pr_sync/ingestion_test.clj
@@ -1,0 +1,429 @@
+(ns ai.miniforge.pr-sync.ingestion-test
+  "Integration tests for hardened PR ingestion.
+   Tests flaky provider responses, partial sync, and error recovery."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.java.shell]
+   [ai.miniforge.pr-sync.core :as core]))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Test helpers
+
+(defn temp-config-path []
+  (let [f (java.io.File/createTempFile "miniforge-ingest-test" ".edn")]
+    (.deleteOnExit f)
+    (.getAbsolutePath f)))
+
+(def github-pr-json
+  "[{\"number\":1,\"title\":\"Fix bug\",\"url\":\"https://github.com/acme/app/pull/1\",\"state\":\"OPEN\",\"headRefName\":\"fix/bug\",\"isDraft\":false,\"reviewDecision\":\"APPROVED\",\"statusCheckRollup\":[{\"conclusion\":\"SUCCESS\"}]}]")
+
+(def github-pr-json-2
+  "[{\"number\":5,\"title\":\"Add feature\",\"url\":\"https://github.com/other/lib/pull/5\",\"state\":\"OPEN\",\"headRefName\":\"feat/new\",\"isDraft\":false,\"reviewDecision\":null,\"statusCheckRollup\":[]}]")
+
+(def github-multi-pr-json
+  "[{\"number\":1,\"title\":\"PR one\",\"url\":\"https://github.com/acme/app/pull/1\",\"state\":\"OPEN\",\"headRefName\":\"fix/one\",\"isDraft\":false,\"reviewDecision\":null,\"statusCheckRollup\":[]},{\"number\":2,\"title\":\"PR two\",\"url\":\"https://github.com/acme/app/pull/2\",\"state\":\"OPEN\",\"headRefName\":\"fix/two\",\"isDraft\":true,\"reviewDecision\":null,\"statusCheckRollup\":[]}]")
+
+(defn make-sh-router
+  "Build a mock sh function that routes calls based on repo slug presence in args.
+   routes is a map of {substring -> {:exit N :out S :err S}}."
+  [routes]
+  (fn [& args]
+    (let [match (some (fn [[substr response]]
+                        (when (some #(and (string? %) (.contains ^String % substr)) args)
+                          response))
+                      routes)]
+      (or match {:exit 1 :out "" :err "no route matched"}))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Partial sync tests — one or more repos fail while others succeed
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-fleet-with-status-partial-sync-test
+  (testing "Partial sync: one repo succeeds, one fails — both get status entries"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app" "broken/repo"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& args]
+                      (cond
+                        ;; acme/app succeeds
+                        (and (= "gh" (first args))
+                             (some #(and (string? %) (.contains ^String % "acme/app")) args))
+                        {:exit 0 :out github-pr-json :err ""}
+
+                        ;; broken/repo fails with auth error
+                        (and (= "gh" (first args))
+                             (some #(and (string? %) (.contains ^String % "broken/repo")) args))
+                        {:exit 1 :out "" :err "HTTP 401 Bad credentials"}
+
+                        :else
+                        {:exit 1 :out "" :err "unexpected"}))]
+        (let [result (core/fetch-fleet-with-status {:config-path path})]
+          ;; PRs from successful repo are present
+          (is (= 1 (count (:prs result))))
+          (is (= "acme/app" (:pr/repo (first (:prs result)))))
+
+          ;; Both repos have sync status entries
+          (is (= 2 (count (:sync-statuses result))))
+
+          ;; Summary shows partial success
+          (is (= 1 (get-in result [:summary :ok])))
+          (is (= 1 (get-in result [:summary :errors])))
+          (is (true? (get-in result [:summary :partial?])))
+          (is (false? (get-in result [:summary :all-ok?])))
+
+          ;; Failed repo has classified error
+          (let [failed (first (filter #(= :error (:status %)) (:sync-statuses result)))]
+            (is (= "broken/repo" (:repo failed)))
+            (is (= :auth-failure (:error-category failed)))
+            (is (string? (:hint failed)))))))))
+
+(deftest fetch-fleet-with-status-partial-sync-three-repos-test
+  (testing "Three repos: two succeed, one fails — partial summary"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app" "other/lib" "broken/repo"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"acme/app"    {:exit 0 :out github-pr-json :err ""}
+                      "other/lib"   {:exit 0 :out github-pr-json-2 :err ""}
+                      "broken/repo" {:exit 1 :out "" :err "HTTP 403 Forbidden"}})]
+        (let [result (core/fetch-fleet-with-status {:config-path path})]
+          (is (= 2 (count (:prs result))))
+          (is (= 3 (count (:sync-statuses result))))
+          (is (= 2 (get-in result [:summary :ok])))
+          (is (= 1 (get-in result [:summary :errors])))
+          (is (true? (get-in result [:summary :partial?])))
+          (is (= 3 (get-in result [:summary :total]))))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; All-fail scenario
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-fleet-with-status-all-fail-test
+  (testing "All repos fail — returns empty PRs with full error details"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["a/b" "c/d"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& _args]
+                      {:exit 1 :out "" :err "ECONNREFUSED"})]
+        (let [result (core/fetch-fleet-with-status {:config-path path})]
+          (is (empty? (:prs result)))
+          (is (= 2 (count (:sync-statuses result))))
+          (is (true? (get-in result [:summary :none-ok?])))
+          (is (= 0 (get-in result [:summary :ok])))
+          (is (false? (get-in result [:summary :all-ok?]))))))))
+
+(deftest fetch-fleet-with-status-all-fail-distinct-errors-test
+  (testing "All repos fail with different errors — each error classified independently"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["a/b" "c/d"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"a/b" {:exit 1 :out "" :err "HTTP 401 Bad credentials"}
+                      "c/d" {:exit 1 :out "" :err "API rate limit exceeded"}})]
+        (let [result (core/fetch-fleet-with-status {:config-path path})
+              statuses (:sync-statuses result)
+              categories (set (map :error-category statuses))]
+          (is (= 2 (count statuses)))
+          (is (contains? categories :auth-failure))
+          (is (contains? categories :rate-limited)))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; All-succeed scenario
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-fleet-with-status-all-succeed-test
+  (testing "All repos succeed — all-ok summary"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app" "other/lib"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"acme/app"  {:exit 0 :out github-pr-json :err ""}
+                      "other/lib" {:exit 0 :out github-pr-json-2 :err ""}})]
+        (let [result (core/fetch-fleet-with-status {:config-path path})]
+          (is (= 2 (count (:prs result))))
+          (is (true? (get-in result [:summary :all-ok?])))
+          (is (false? (get-in result [:summary :partial?])))
+          (is (false? (get-in result [:summary :none-ok?])))
+          (is (= 2 (get-in result [:summary :ok])))
+          (is (= 0 (get-in result [:summary :errors]))))))))
+
+(deftest fetch-fleet-with-status-all-succeed-multi-prs-test
+  (testing "Repo returning multiple PRs — all PRs collected"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"acme/app" {:exit 0 :out github-multi-pr-json :err ""}})]
+        (let [result (core/fetch-fleet-with-status {:config-path path})]
+          (is (= 2 (count (:prs result))))
+          (is (every? #(= "acme/app" (:pr/repo %)) (:prs result)))
+          (is (true? (get-in result [:summary :all-ok?]))))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Empty / edge-case fleet configs
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-fleet-with-status-empty-fleet-test
+  (testing "Empty fleet — returns empty result with clean summary"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos []}}))
+      (let [result (core/fetch-fleet-with-status {:config-path path})]
+        (is (empty? (:prs result)))
+        (is (empty? (:sync-statuses result)))
+        (is (true? (get-in result [:summary :all-ok?])))
+        (is (= 0 (get-in result [:summary :total])))))))
+
+(deftest fetch-fleet-with-status-missing-config-test
+  (testing "Missing config file — treated as empty fleet, no crash"
+    (let [result (core/fetch-fleet-with-status
+                  {:config-path "/tmp/nonexistent-miniforge-ingest-42.edn"})]
+      (is (empty? (:prs result)))
+      (is (empty? (:sync-statuses result)))
+      (is (true? (get-in result [:summary :all-ok?]))))))
+
+(deftest fetch-fleet-with-status-single-repo-success-test
+  (testing "Single repo fleet with success — summary counts correct"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"acme/app" {:exit 0 :out github-pr-json :err ""}})]
+        (let [result (core/fetch-fleet-with-status {:config-path path})]
+          (is (= 1 (count (:prs result))))
+          (is (= 1 (count (:sync-statuses result))))
+          (is (= 1 (get-in result [:summary :total])))
+          (is (= 1 (get-in result [:summary :ok])))
+          (is (= 0 (get-in result [:summary :errors]))))))))
+
+(deftest fetch-fleet-with-status-repo-with-no-open-prs-test
+  (testing "Repo returns empty PR list — success with zero PRs"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"acme/app" {:exit 0 :out "[]" :err ""}})]
+        (let [result (core/fetch-fleet-with-status {:config-path path})]
+          (is (empty? (:prs result)))
+          (is (= 1 (count (:sync-statuses result))))
+          (is (true? (get-in result [:summary :all-ok?]))))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Per-repo status tests (fetch-repo-with-status)
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-repo-with-status-flaky-provider-test
+  (testing "Flaky provider returns error — sync status captures it"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "API rate limit exceeded"})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :error (:status status)))
+        (is (= "acme/app" (:repo status)))
+        (is (= :rate-limited (:error-category status)))
+        (is (string? (:hint status))))))
+
+  (testing "Provider returns malformed JSON — sync status captures parse error"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 0 :out "NOT JSON" :err ""})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :error (:status status)))
+        (is (= :parse-error (:error-category status))))))
+
+  (testing "Provider succeeds — sync status captures success"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 0 :out github-pr-json :err ""})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :ok (:status status)))
+        (is (= 1 (:pr-count status)))
+        (is (vector? (:prs status)))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Error classification — each error category
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-repo-with-status-auth-failure-test
+  (testing "401 Bad credentials classified as :auth-failure"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "HTTP 401 Bad credentials"})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :auth-failure (:error-category status))))))
+
+  (testing "403 Forbidden classified as :auth-failure"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "HTTP 403 Forbidden"})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :auth-failure (:error-category status)))))))
+
+(deftest fetch-repo-with-status-rate-limited-test
+  (testing "Rate limit message classified as :rate-limited"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "API rate limit exceeded"})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :rate-limited (:error-category status)))
+        (is (string? (:hint status)))))))
+
+(deftest fetch-repo-with-status-network-error-test
+  (testing "Connection refused classified as network/unknown error"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "ECONNREFUSED"})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :error (:status status)))
+        (is (some? (:error-category status)))))))
+
+(deftest fetch-repo-with-status-not-found-test
+  (testing "404 Not Found gets appropriate classification"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "HTTP 404 Not Found"})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :error (:status status)))
+        (is (some? (:error-category status)))
+        (is (= "acme/app" (:repo status)))))))
+
+(deftest fetch-repo-with-status-empty-json-array-test
+  (testing "Empty JSON array is a successful sync with zero PRs"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 0 :out "[]" :err ""})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :ok (:status status)))
+        (is (= 0 (:pr-count status)))
+        (is (empty? (:prs status)))))))
+
+(deftest fetch-repo-with-status-empty-output-test
+  (testing "Exit 0 with empty output classified as parse error or empty"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 0 :out "" :err ""})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        ;; Either error/parse-error or ok with empty — implementation decides
+        (is (contains? #{:ok :error} (:status status)))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Exception safety tests
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-repo-with-status-exception-safety-test
+  (testing "Runtime exception in provider call is caught and classified"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    (throw (Exception. "connection reset by peer")))]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :error (:status status)))
+        (is (string? (:error status)))
+        (is (some? (:error-category status)))))))
+
+(deftest fetch-repo-with-status-npe-safety-test
+  (testing "NullPointerException in provider call is caught gracefully"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    (throw (NullPointerException. "simulated NPE")))]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :error (:status status)))
+        (is (some? (:error-category status)))))))
+
+(deftest fetch-fleet-with-status-exception-in-one-repo-test
+  (testing "Exception in one repo does not crash the entire fleet sync"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app" "crash/repo"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& args]
+                      (cond
+                        (some #(and (string? %) (.contains ^String % "acme/app")) args)
+                        {:exit 0 :out github-pr-json :err ""}
+
+                        (some #(and (string? %) (.contains ^String % "crash/repo")) args)
+                        (throw (RuntimeException. "provider exploded"))
+
+                        :else
+                        {:exit 1 :out "" :err "unexpected"}))]
+        (let [result (core/fetch-fleet-with-status {:config-path path})]
+          ;; Successful repo's PRs still present
+          (is (= 1 (count (:prs result))))
+          (is (= "acme/app" (:pr/repo (first (:prs result)))))
+          ;; Failed repo captured in statuses
+          (is (= 2 (count (:sync-statuses result))))
+          (is (true? (get-in result [:summary :partial?]))))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Status entry structure validation
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest fetch-repo-with-status-ok-structure-test
+  (testing "Successful status entry has expected keys"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 0 :out github-pr-json :err ""})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :ok (:status status)))
+        (is (= "acme/app" (:repo status)))
+        (is (integer? (:pr-count status)))
+        (is (vector? (:prs status)))
+        ;; PRs have expected train-pr keys
+        (let [pr (first (:prs status))]
+          (is (= 1 (:pr/number pr)))
+          (is (= "Fix bug" (:pr/title pr))))))))
+
+(deftest fetch-repo-with-status-error-structure-test
+  (testing "Error status entry has expected keys"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _args]
+                    {:exit 1 :out "" :err "HTTP 401 Bad credentials"})]
+      (let [status (core/fetch-repo-with-status "acme/app")]
+        (is (= :error (:status status)))
+        (is (= "acme/app" (:repo status)))
+        (is (keyword? (:error-category status)))
+        (is (string? (:hint status)))))))
+
+;; ─────────────────────────────────────────────────────────────────────────────
+;; Summary invariant tests
+;; ─────────────────────────────────────────────────────────────────────────────
+
+(deftest summary-invariants-test
+  (testing "Summary :ok + :errors = :total always holds"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app" "broken/repo" "other/lib"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"acme/app"    {:exit 0 :out github-pr-json :err ""}
+                      "broken/repo" {:exit 1 :out "" :err "HTTP 500 Internal Server Error"}
+                      "other/lib"   {:exit 0 :out github-pr-json-2 :err ""}})]
+        (let [result (core/fetch-fleet-with-status {:config-path path})
+              summary (:summary result)]
+          (is (= (:total summary)
+                 (+ (:ok summary) (:errors summary))))
+          ;; partial? is true iff some ok and some errors
+          (is (= (:partial? summary)
+                 (and (pos? (:ok summary)) (pos? (:errors summary)))))
+          ;; all-ok? and none-ok? are mutually exclusive of partial?
+          (is (not (and (:all-ok? summary) (:partial? summary))))
+          (is (not (and (:none-ok? summary) (:partial? summary)))))))))
+
+(deftest summary-boolean-flags-all-ok-test
+  (testing "all-ok? is true only when errors = 0 and total > 0"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["acme/app"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (make-sh-router
+                     {"acme/app" {:exit 0 :out github-pr-json :err ""}})]
+        (let [summary (get-in (core/fetch-fleet-with-status {:config-path path}) [:summary])]
+          (is (true? (:all-ok? summary)))
+          (is (false? (:partial? summary)))
+          (is (false? (:none-ok? summary))))))))
+
+(deftest summary-boolean-flags-none-ok-test
+  (testing "none-ok? is true only when ok = 0 and total > 0"
+    (let [path (temp-config-path)]
+      (spit path (pr-str {:fleet {:repos ["a/b"]}}))
+      (with-redefs [clojure.java.shell/sh
+                    (fn [& _args] {:exit 1 :out "" :err "timeout"})]
+        (let [summary (get-in (core/fetch-fleet-with-status {:config-path path}) [:summary])]
+          (is (true? (:none-ok? summary)))
+          (is (false? (:all-ok? summary)))
+          (is (false? (:partial? summary))))))))

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -10,6 +10,7 @@
         ai.miniforge/tool {:local/root "../tool"}
         ai.miniforge/policy {:local/root "../policy"}      ; Gate evaluation
         ai.miniforge/heuristic {:local/root "../heuristic"} ; Workflow storage
+        ai.miniforge/knowledge {:local/root "../knowledge"} ; KB for post-execution learning promotion
         ai.miniforge/phase {:local/root "../phase"}        ; Phase interceptors
         ai.miniforge/gate {:local/root "../gate"}          ; Gate interceptors
         babashka/fs {:mvn/version "0.5.22"}

--- a/components/workflow/resources/config/workflow/messages/en.edn
+++ b/components/workflow/resources/config/workflow/messages/en.edn
@@ -1,0 +1,19 @@
+{:workflow/messages
+ {;; Event publishing warnings
+  :warn/websocket-send       "Warning: Failed to send event via WebSocket: {error}"
+  :warn/publish-event        "Warning: Failed to publish event: {error}"
+  :warn/publish-started      "Warning: Failed to publish workflow-started event: {error}"
+  :warn/publish-completed    "Warning: Failed to publish workflow-completed event: {error}"
+  :warn/publish-phase-started   "Warning: Failed to publish phase-started event: {error}"
+  :warn/publish-phase-completed "Warning: Failed to publish phase-completed event: {error}"
+  :warn/health-check         "Warning: Self-healing health check failed: {error}"
+
+  ;; Workflow status messages
+  :status/failed             "Workflow failed"
+  :status/gate-failed        "Gate validation failed"
+  :status/no-phases          "Workflow has no phases"
+  :status/max-phases         "Exceeded maximum phase count: {max-phases}"
+  :status/paused             "⏸  Workflow paused, waiting for resume..."
+  :status/stopped-dashboard  "⏹  Workflow stopped by dashboard"
+  :status/stopped-control    "Workflow stopped by control plane"
+  :status/empty-completion   "Workflow completed but produced no artifacts or phase results"}}

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -68,7 +68,8 @@
       :execution/streaming-activity []
       :execution/files-written #{}}
      ;; Merge opts into top-level context so :llm-backend is accessible to agents
-     (select-keys opts [:llm-backend :artifact-store :on-phase-start :on-phase-complete
+     (select-keys opts [:llm-backend :artifact-store :knowledge-store
+                       :on-phase-start :on-phase-complete
                        :executor :environment-id :sandbox-workdir
                        :on-chunk :event-stream :worktree-path]))))
 

--- a/components/workflow/src/ai/miniforge/workflow/messages.clj
+++ b/components/workflow/src/ai/miniforge/workflow/messages.clj
@@ -1,0 +1,45 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.messages
+  "Component-level message catalog for workflow.
+
+   Loads localized strings from EDN resources on the classpath.
+   Falls back to message key name when a key is missing."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def ^:private resource-path "config/workflow/messages/en.edn")
+(def ^:private section-key :workflow/messages)
+
+(defn- load-catalog []
+  (when-let [res (io/resource resource-path)]
+    (get (edn/read-string (slurp res)) section-key {})))
+
+(def ^:private catalog (delay (load-catalog)))
+
+(defn t
+  "Look up a message by key, substituting params into {placeholder} tokens."
+  ([k] (t k {}))
+  ([k params]
+   (let [template (get @catalog k (name k))]
+     (reduce-kv (fn [s pk pv]
+                  (str/replace s (str "{" (name pk) "}") (str pv)))
+                template
+                params))))

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -29,6 +29,7 @@
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.workflow.context :as ctx]
             [ai.miniforge.workflow.execution :as exec]
+            [ai.miniforge.workflow.messages :as messages]
             [ai.miniforge.workflow.monitoring :as monitoring]
             [cheshire.core :as json]))
 
@@ -49,7 +50,7 @@
               (when-let [send-fn (ns-resolve http-ns 'send!)]
                 (send-fn ws (json/generate-string event)))))
           (catch Exception e
-            (println "Warning: Failed to send event via WebSocket:" (ex-message e))))
+            (println (messages/t :warn/websocket-send {:error (ex-message e)}))))
 
         ;; In-memory event stream (same process)
         :else
@@ -58,7 +59,7 @@
             (when-let [publish! (ns-resolve es-ns 'publish!)]
               (publish! event-stream event)))))
       (catch Exception e
-        (println "Warning: Failed to publish event:" (ex-message e))))))
+        (println (messages/t :warn/publish-event {:error (ex-message e)}))))))
 
 (defn publish-workflow-started!
   "Publish workflow started event using N3-compliant constructor."
@@ -72,7 +73,7 @@
                                          (select-keys (:execution/workflow context)
                                                       [:workflow/id :workflow/version]))))
       (catch Exception e
-        (println "Warning: Failed to publish workflow-started event:" (ex-message e))))))
+        (println (messages/t :warn/publish-started {:error (ex-message e)}))))))
 
 (defn publish-workflow-completed!
   "Publish workflow completed/failed event using N3-compliant constructor."
@@ -95,13 +96,13 @@
         (if (= status :failed)
           (publish-event! event-stream
                           (workflow-failed event-stream wf-id
-                                          {:message "Workflow failed"
+                                          {:message (messages/t :status/failed)
                                            :errors (:execution/errors context)}))
           (publish-event! event-stream
                           (workflow-completed event-stream wf-id status duration-ms
                                               (when (seq metrics-opts) metrics-opts)))))
       (catch Exception e
-        (println "Warning: Failed to publish workflow-completed event:" (ex-message e))))))
+        (println (messages/t :warn/publish-completed {:error (ex-message e)}))))))
 
 (defn publish-phase-started!
   "Publish phase started event."
@@ -113,7 +114,7 @@
                         (phase-started event-stream (:execution/id context) phase-name
                                        {:phase/index (:execution/phase-index context)})))
       (catch Exception e
-        (println "Warning: Failed to publish phase-started event:" (ex-message e))))))
+        (println (messages/t :warn/publish-phase-started {:error (ex-message e)}))))))
 
 (defn publish-phase-completed!
   "Publish phase completed event."
@@ -128,7 +129,7 @@
           error-info (when-not succeeded?
                        (or (:error result)
                            (when-let [msg (get-in result [:phase/gate-errors])]
-                             {:message "Gate validation failed" :details msg})
+                             {:message (messages/t :status/gate-failed) :details msg})
                            (when-let [msg (:message result)]
                              {:message msg})))
           redirect-to (:redirect-to result)
@@ -147,7 +148,7 @@
                           (phase-completed event-stream (:execution/id context) phase-name
                                            event-data)))
         (catch Exception e
-          (println "Warning: Failed to publish phase-completed event:" (ex-message e)))))))
+          (println (messages/t :warn/publish-phase-completed {:error (ex-message e)})))))))
 
 (defn check-backend-health-at-boundary!
   "Check backend health at phase boundary. Returns switch-result or nil."
@@ -166,7 +167,7 @@
             (publish-event! event-stream (emit-fn sh-ctx switch-result)))
           switch-result)))
     (catch Exception e
-      (println "Warning: Self-healing health check failed:" (ex-message e))
+      (println (messages/t :warn/health-check {:error (ex-message e)}))
       nil)))
 
 ;------------------------------------------------------------------------------ Layer 0: Pipeline helpers
@@ -203,29 +204,31 @@
 (defn handle-empty-pipeline
   "Handle error case of empty pipeline."
   [context]
-  (-> context
-      (update :execution/errors conj
-              {:type :empty-pipeline
-               :message "Workflow has no phases"})
-      (update :execution/response-chain
-              response/add-failure :pipeline
-              :anomalies.workflow/empty-pipeline
-              {:error "Workflow has no phases"})
-      (ctx/transition-to-failed)))
+  (let [msg (messages/t :status/no-phases)]
+    (-> context
+        (update :execution/errors conj
+                {:type :empty-pipeline
+                 :message msg})
+        (update :execution/response-chain
+                response/add-failure :pipeline
+                :anomalies.workflow/empty-pipeline
+                {:error msg})
+        (ctx/transition-to-failed))))
 
 (defn handle-max-phases-exceeded
   "Handle error case of max phases exceeded."
   [context max-phases]
-  (-> context
-      (update :execution/errors conj
-              {:type :max-phases-exceeded
-               :message (str "Exceeded maximum phase count: " max-phases)})
-      (update :execution/response-chain
-              response/add-failure :pipeline
-              :anomalies.workflow/max-phases
-              {:error (str "Exceeded maximum phase count: " max-phases)
-               :max-phases max-phases})
-      (ctx/transition-to-failed)))
+  (let [msg (messages/t :status/max-phases {:max-phases max-phases})]
+    (-> context
+        (update :execution/errors conj
+                {:type :max-phases-exceeded
+                 :message msg})
+        (update :execution/response-chain
+                response/add-failure :pipeline
+                :anomalies.workflow/max-phases
+                {:error msg
+                 :max-phases max-phases})
+        (ctx/transition-to-failed))))
 
 (defn terminal-state?
   "Check if workflow is in terminal state."
@@ -242,14 +245,14 @@
 
         ;; Handle pause - wait until resumed
         _ (when (:paused state)
-            (println "⏸  Workflow paused, waiting for resume...")
+            (println (messages/t :status/paused))
             (while (:paused @control-state)
               (Thread/sleep 1000)))
 
         ;; Check for stop command
         _ (when (:stopped state)
-            (println "⏹  Workflow stopped by dashboard")
-            (throw (ex-info "Workflow stopped by control plane" {:reason :dashboard-stop})))
+            (println (messages/t :status/stopped-dashboard))
+            (throw (ex-info (messages/t :status/stopped-control) {:reason :dashboard-stop})))
 
         ;; Check workflow health via meta-agents
         coordinator (:execution/meta-coordinator context)
@@ -393,7 +396,7 @@
                        (-> final-ctx
                            (update :execution/errors conj
                                    {:type :empty-completion
-                                    :message "Workflow completed but produced no artifacts or phase results"})
+                                    :message (messages/t :status/empty-completion)})
                            (assoc :execution/status :completed-with-warnings))
                        final-ctx)
            ;; Extract output and publish workflow completed event

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -315,6 +315,24 @@
             (catch Exception _e nil)))))
     (catch Exception _e nil)))
 
+(defn- observe-workflow-signal!
+  "Feed workflow completion/failure signal to the operator for pattern analysis.
+   No-ops when no operator is configured."
+  [opts output-ctx]
+  (try
+    (when-let [operator (:operator opts)]
+      (let [observe-fn (requiring-resolve 'ai.miniforge.operator.interface/observe-signal)
+            signal-type (if (phase/succeeded? output-ctx)
+                          :workflow-complete
+                          :workflow-failed)]
+        (observe-fn operator
+                    {:signal/type signal-type
+                     :workflow-id (:execution/id output-ctx)
+                     :phase-results (:execution/phase-results output-ctx)
+                     :metrics (:execution/metrics output-ctx)
+                     :timestamp (java.time.Instant/now)})))
+    (catch Exception _e nil)))
+
 ;------------------------------------------------------------------------------ Layer 2: Main entry point
 
 (defn run-pipeline
@@ -405,19 +423,7 @@
          (publish-workflow-completed! event-stream output-ctx))
 
        ;; Post-workflow: feed signals to operator for pattern analysis
-       (try
-         (when-let [operator (:operator opts)]
-           (let [observe-fn (requiring-resolve 'ai.miniforge.operator.interface/observe-signal)
-                 signal-type (if (phase/succeeded? output-ctx)
-                               :workflow-complete
-                               :workflow-failed)]
-             (observe-fn operator
-                         {:signal/type signal-type
-                          :workflow-id (:execution/id output-ctx)
-                          :phase-results (:execution/phase-results output-ctx)
-                          :metrics (:execution/metrics output-ctx)
-                          :timestamp (java.time.Instant/now)})))
-         (catch Exception _e nil))
+       (observe-workflow-signal! opts output-ctx)
 
        ;; Post-workflow: auto-promote high-confidence learnings
        (promote-mature-learnings! (:knowledge-store opts))

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -295,6 +295,23 @@
             :last-phase-result last-result
             :status (:execution/status ctx)})))
 
+;------------------------------------------------------------------------------ Layer 1.75: Post-execution hooks
+
+(defn promote-mature-learnings!
+  "Query promotable learnings from KB and auto-promote high-confidence ones.
+   No-ops when knowledge-store is nil."
+  [knowledge-store]
+  (try
+    (when knowledge-store
+      (let [list-learnings (requiring-resolve 'ai.miniforge.knowledge.interface/list-learnings)
+            promote-learning (requiring-resolve 'ai.miniforge.knowledge.interface/promote-learning)
+            promotable (list-learnings knowledge-store {:promotable? true})]
+        (doseq [learning promotable]
+          (try
+            (promote-learning knowledge-store (:zettel/id learning) {})
+            (catch Exception _e nil)))))
+    (catch Exception _e nil)))
+
 ;------------------------------------------------------------------------------ Layer 2: Main entry point
 
 (defn run-pipeline
@@ -400,16 +417,7 @@
          (catch Exception _e nil))
 
        ;; Post-workflow: auto-promote high-confidence learnings
-       (try
-         (when-let [kb (:knowledge-store opts)]
-           (let [knowledge-ns (requiring-resolve 'ai.miniforge.knowledge.interface/list-learnings)
-                 promote-fn (requiring-resolve 'ai.miniforge.knowledge.interface/promote-learning)
-                 promotable (knowledge-ns kb {:promotable? true})]
-             (doseq [learning promotable]
-               (try
-                 (promote-fn kb (:zettel/id learning) {})
-                 (catch Exception _e nil)))))
-         (catch Exception _e nil))
+       (promote-mature-learnings! (:knowledge-store opts))
 
        output-ctx))))
 

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -399,6 +399,18 @@
                           :timestamp (java.time.Instant/now)})))
          (catch Exception _e nil))
 
+       ;; Post-workflow: auto-promote high-confidence learnings
+       (try
+         (when-let [kb (:knowledge-store opts)]
+           (let [knowledge-ns (requiring-resolve 'ai.miniforge.knowledge.interface/list-learnings)
+                 promote-fn (requiring-resolve 'ai.miniforge.knowledge.interface/promote-learning)
+                 promotable (knowledge-ns kb {:promotable? true})]
+             (doseq [learning promotable]
+               (try
+                 (promote-fn kb (:zettel/id learning) {})
+                 (catch Exception _e nil)))))
+         (catch Exception _e nil))
+
        output-ctx))))
 
 ;------------------------------------------------------------------------------ Rich Comment


### PR DESCRIPTION
## Summary

- **KB Persistence (Phase A)**: New `FileBackedStore` in the knowledge component — atomic writes (temp+rename), startup directory scan, per-user `~/.miniforge/knowledge/` storage. One `.edn` file per zettel keyed by UID.
- **KB Wiring (Phase B)**: Thread `:knowledge-store` through the execution context so every phase can read/write knowledge:
  - **Explore**: text-searches KB with spec description, attaches top-5 matches as `:exploration/knowledge`
  - **Plan**: injects planner-relevant zettels via `inject-knowledge`, formats as `:task/knowledge-context`
  - **Implement**: injects implementer-relevant zettels; captures inner-loop learning when repair succeeds (iterations > 1)
  - **Review**: captures review feedback as learning when review redirects to implement
- **Prompt formatting (Phase B6)**: `format-for-prompt` renders zettels as bounded markdown blocks — rules, learnings, dewey codes
- **Meta-loop (Phase C)**: post-execution hook in `runner.clj` queries promotable learnings (confidence ≥ 0.8) and auto-promotes them to rules
- **pr-sync fixes**: implements 3 missing functions (`fetch-fleet-with-status`, `fetch-repo-with-status`, `classify-sync-error`), fixes `load-fleet-config` corrupt-file handling, fixes `result-failure` key collision in GitLab/GitHub error paths, fixes stale `invoke-test` assertions

## Key files

| File | Change |
|------|--------|
| `knowledge/store.clj` | `FileBackedStore` + `format-for-prompt` |
| `knowledge/interface.clj` | Expose `create-file-backed-store`, `format-for-prompt` |
| `workflow/context.clj` | Thread `:knowledge-store` through `select-keys` |
| `orchestrator/core.clj` | Pass `knowledge-store` from coordinator into wf-context |
| `phase/explore.clj` | KB text-search on spec description |
| `phase/plan.clj` | KB injection for planner |
| `phase/implement.clj` | KB injection for implementer + inner-loop learning capture |
| `phase/review.clj` | Review feedback learning capture |
| `workflow/runner.clj` | Post-execution learning promotion hook |
| `pr-sync/core.clj` | Missing functions + bug fixes |

## Test plan

- [x] `FileBackedStore` round-trip: write → restart → read (5 tests, 22 assertions)
- [x] pr-sync fleet-parallel, build-sync-summary, core, ingestion tests all green
- [x] Full pre-commit suite: 569 tests, 2387 passes, 0 failures, 0 errors
- [ ] Integration: run a workflow with KB wired, verify knowledge injected into agent prompts
- [ ] Integration: run workflow twice with repair — second run should have learning from first

🤖 Generated with [Claude Code](https://claude.com/claude-code)