### PR TITLE
Add meta-loop pattern detection and cross-execution synthesis

### DIFF
--- a/components/knowledge/resources/config/knowledge/messages/en.edn
+++ b/components/knowledge/resources/config/knowledge/messages/en.edn
@@ -8,4 +8,9 @@
   :learning/repair-title    "Repair success: {title}"
   :learning/repair-content  "## Repair Context\n\nTask: {title}\nRepair iterations: {iterations}\n\n## Resolution\n\nThe {agent} resolved the issue after {iterations} attempts."
   :learning/feedback-title  "Review feedback: {title}"
-  :learning/feedback-header "## Review Feedback\n\n"}}
+  :learning/feedback-header "## Review Feedback\n\n"
+  :learning/observed-across  "Observed across tasks: {tasks}"
+
+  ;; Pattern detection / synthesis
+  :pattern/title   "Recurring pattern: {tag} ({count} occurrences)"
+  :pattern/content "## Recurring Pattern\n\nThe tag `{tag}` appears across {count} learnings, suggesting a systemic pattern.\n\n### Related Learnings\n\n{learnings}"}}

--- a/components/knowledge/src/ai/miniforge/knowledge/interface.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/interface.clj
@@ -318,6 +318,27 @@
   "Convenience function to capture learning from observed patterns."
   learning/capture-meta-loop-learning)
 
+(def detect-recurring-patterns
+  "Detect recurring patterns among learnings by grouping on tags.
+
+   Scans all learnings and flags tags with 3+ occurrences.
+
+   Options:
+   - :min-occurrences - Minimum occurrences to flag (default 3)
+   - :exclude-tags    - Tags to ignore (default #{:inner-loop :repair})
+
+   Returns vector of {:tag :count :learnings}."
+  learning/detect-recurring-patterns)
+
+(def synthesize-recurring-patterns!
+  "Detect recurring patterns and capture them as meta-loop learnings.
+
+   Scans learnings for recurring tags, creates a meta-loop learning for each
+   new pattern found. Skips patterns that already have a corresponding learning.
+
+   Returns count of new patterns synthesized."
+  learning/synthesize-recurring-patterns!)
+
 (def promote-learning
   "Promote a validated learning to a rule.
 

--- a/components/knowledge/src/ai/miniforge/knowledge/learning.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/learning.clj
@@ -228,10 +228,13 @@
   (let [patterns (detect-recurring-patterns knowledge-store)
         new-count (atom 0)]
     (doseq [{:keys [tag count learnings]} patterns]
-      ;; Check if we already captured this pattern
-      (let [existing (store/search knowledge-store
-                                   (messages/t :pattern/title {:tag (name tag) :count count}))]
-        (when (empty? (filter #(= :learning (:zettel/type %)) existing))
+      ;; Check if we already captured a pattern learning for this tag.
+      ;; Search for learnings tagged :pattern that mention this tag name.
+      (let [existing (store/query knowledge-store
+                                  {:include-types [:learning]
+                                   :tags [:pattern]
+                                   :text-search (name tag)})]
+        (when (empty? existing)
           (let [learning-list (str/join "\n" (map #(str "- " (:title %)) learnings))]
             (capture-meta-loop-learning
              knowledge-store

--- a/components/knowledge/src/ai/miniforge/knowledge/learning.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/learning.clj
@@ -1,11 +1,13 @@
 (ns ai.miniforge.knowledge.learning
   "Learning capture from agent execution.
    Layer 0: Learning capture
-   Layer 1: Learning promotion (learning -> rule)"
+   Layer 1: Learning promotion (learning -> rule)
+   Layer 2: Pattern detection"
   (:require
    [ai.miniforge.knowledge.schema :as schema]
    [ai.miniforge.knowledge.zettel :as zettel]
    [ai.miniforge.knowledge.store :as store]
+   [ai.miniforge.knowledge.messages :as messages]
    [clojure.string :as str]
    [malli.core :as m]))
 
@@ -114,9 +116,8 @@
                      :tags tags
                      :confidence (or confidence 0.85)
                      :context (when (seq related-tasks)
-                                (str "Observed across tasks: "
-                                     (str/join ", "
-                                                          (map str related-tasks))))}))
+                                (messages/t :learning/observed-across
+                                            {:tasks (str/join ", " (map str related-tasks))}))}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Learning promotion
@@ -165,6 +166,84 @@
         ;; Delete old learning and store as rule
         (store/delete-zettel knowledge-store learning-id)
         (store/put-zettel knowledge-store rule)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Pattern detection
+
+(defn detect-recurring-patterns
+  "Detect recurring patterns among learnings by grouping on tags.
+
+   Scans all learnings in the store and groups them by their tags.
+   Returns patterns where 3+ learnings share a tag, sorted by frequency.
+
+   Arguments:
+   - knowledge-store - KnowledgeStore instance
+
+   Options:
+   - :min-occurrences - Minimum occurrences to flag (default 3)
+   - :exclude-tags    - Tags to ignore when grouping (default #{:inner-loop :repair})
+
+   Returns vector of maps:
+     {:tag       keyword
+      :count     int
+      :learnings [zettel-summary...]}"
+  [knowledge-store & [{:keys [min-occurrences exclude-tags]
+                        :or {min-occurrences 3
+                             exclude-tags #{:inner-loop :repair}}}]]
+  (let [learnings (store/query knowledge-store {:include-types [:learning]})
+        ;; Build tag -> learnings index
+        tag-groups (reduce
+                    (fn [acc z]
+                      (let [tags (remove exclude-tags (:zettel/tags z []))]
+                        (reduce (fn [a tag]
+                                  (update a tag (fnil conj [])
+                                          {:id (:zettel/id z)
+                                           :uid (:zettel/uid z)
+                                           :title (:zettel/title z)
+                                           :confidence (get-in z [:zettel/source :source/confidence] 0)}))
+                                acc tags)))
+                    {} learnings)
+        ;; Filter to patterns with enough occurrences
+        patterns (->> tag-groups
+                      (filter (fn [[_tag items]] (>= (count items) min-occurrences)))
+                      (map (fn [[tag items]]
+                             {:tag tag
+                              :count (count items)
+                              :learnings items}))
+                      (sort-by :count >)
+                      vec)]
+    patterns))
+
+(defn synthesize-recurring-patterns!
+  "Detect recurring patterns and capture them as meta-loop learnings.
+
+   Scans learnings for recurring tags, creates a meta-loop learning for each
+   new pattern found. Skips patterns that already have a corresponding learning.
+
+   Arguments:
+   - knowledge-store - KnowledgeStore instance
+
+   Returns count of new patterns synthesized."
+  [knowledge-store]
+  (let [patterns (detect-recurring-patterns knowledge-store)
+        new-count (atom 0)]
+    (doseq [{:keys [tag count learnings]} patterns]
+      ;; Check if we already captured this pattern
+      (let [existing (store/search knowledge-store
+                                   (messages/t :pattern/title {:tag (name tag) :count count}))]
+        (when (empty? (filter #(= :learning (:zettel/type %)) existing))
+          (let [learning-list (str/join "\n" (map #(str "- " (:title %)) learnings))]
+            (capture-meta-loop-learning
+             knowledge-store
+             {:title (messages/t :pattern/title {:tag (name tag) :count count})
+              :content (messages/t :pattern/content {:tag (name tag)
+                                                     :count count
+                                                     :learnings learning-list})
+              :tags [tag :meta-loop :pattern]
+              :confidence 0.85
+              :related-tasks (mapv :id learnings)})
+            (swap! new-count inc)))))
+    @new-count))
 
 (defn list-learnings
   "List all learnings, optionally filtered.

--- a/components/knowledge/test/ai/miniforge/knowledge/pattern_detection_test.clj
+++ b/components/knowledge/test/ai/miniforge/knowledge/pattern_detection_test.clj
@@ -1,0 +1,183 @@
+(ns ai.miniforge.knowledge.pattern-detection-test
+  "Tests for recurring pattern detection and cross-execution synthesis."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.knowledge.interface :as knowledge]
+   [ai.miniforge.knowledge.learning :as learning]
+   [ai.miniforge.knowledge.store :as store]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- fresh-store
+  "Create a fresh in-memory knowledge store."
+  []
+  (store/create-store))
+
+(defn- seed-learnings!
+  "Seed a store with n learnings sharing the given tags.
+   Returns the store."
+  [store n tags & {:keys [agent confidence]
+                   :or {agent :implementer confidence 0.7}}]
+  (doseq [i (range n)]
+    (learning/capture-learning
+     store
+     {:type :inner-loop
+      :agent agent
+      :title (str "Learning " i " about " (name (first tags)))
+      :content (str "Content for learning " i)
+      :tags tags
+      :confidence confidence}))
+  store)
+
+;------------------------------------------------------------------------------ Layer 0
+;; detect-recurring-patterns
+
+(deftest detect-recurring-patterns-empty-store
+  (testing "Empty store returns no patterns"
+    (let [store (fresh-store)]
+      (is (empty? (knowledge/detect-recurring-patterns store))))))
+
+(deftest detect-recurring-patterns-below-threshold
+  (testing "Fewer than 3 learnings sharing a tag returns no patterns"
+    (let [store (fresh-store)]
+      (seed-learnings! store 2 [:clojure :protocol])
+      (is (empty? (knowledge/detect-recurring-patterns store))))))
+
+(deftest detect-recurring-patterns-at-threshold
+  (testing "Exactly 3 learnings sharing a tag returns a pattern"
+    (let [store (fresh-store)]
+      (seed-learnings! store 3 [:clojure :protocol])
+      (let [patterns (knowledge/detect-recurring-patterns store)]
+        (is (= 2 (count patterns))
+            "Both :clojure and :protocol should appear as patterns")
+        (is (every? #(= 3 (:count %)) patterns))
+        (is (every? #(= 3 (count (:learnings %))) patterns))))))
+
+(deftest detect-recurring-patterns-above-threshold
+  (testing "5 learnings sharing a tag returns pattern with count 5"
+    (let [store (fresh-store)]
+      (seed-learnings! store 5 [:namespace])
+      (let [patterns (knowledge/detect-recurring-patterns store)]
+        (is (= 1 (count patterns)))
+        (is (= :namespace (:tag (first patterns))))
+        (is (= 5 (:count (first patterns))))))))
+
+(deftest detect-recurring-patterns-excludes-noise-tags
+  (testing "Default exclude-tags filters :inner-loop and :repair"
+    (let [store (fresh-store)]
+      ;; These learnings only have excluded tags
+      (seed-learnings! store 5 [:inner-loop :repair])
+      (is (empty? (knowledge/detect-recurring-patterns store))))))
+
+(deftest detect-recurring-patterns-custom-threshold
+  (testing "Custom min-occurrences is respected"
+    (let [store (fresh-store)]
+      (seed-learnings! store 2 [:rare-pattern])
+      (is (empty? (knowledge/detect-recurring-patterns store)))
+      (let [patterns (knowledge/detect-recurring-patterns
+                      store {:min-occurrences 2})]
+        (is (= 1 (count patterns)))
+        (is (= :rare-pattern (:tag (first patterns))))))))
+
+(deftest detect-recurring-patterns-custom-exclude-tags
+  (testing "Custom exclude-tags overrides defaults"
+    (let [store (fresh-store)]
+      (seed-learnings! store 4 [:inner-loop :real-tag])
+      ;; Default excludes :inner-loop, so only :real-tag shows
+      (let [default-patterns (knowledge/detect-recurring-patterns store)]
+        (is (= 1 (count default-patterns)))
+        (is (= :real-tag (:tag (first default-patterns)))))
+      ;; Custom excludes nothing, so both show
+      (let [all-patterns (knowledge/detect-recurring-patterns
+                          store {:exclude-tags #{}})]
+        (is (= 2 (count all-patterns)))))))
+
+(deftest detect-recurring-patterns-sorted-by-frequency
+  (testing "Patterns are sorted by count descending"
+    (let [store (fresh-store)]
+      (seed-learnings! store 5 [:frequent])
+      (seed-learnings! store 3 [:moderate])
+      (let [patterns (knowledge/detect-recurring-patterns store)]
+        (is (= [:frequent :moderate]
+               (mapv :tag patterns)))))))
+
+(deftest detect-recurring-patterns-learning-summaries
+  (testing "Each pattern includes learning summaries with expected keys"
+    (let [store (fresh-store)]
+      (seed-learnings! store 3 [:protocol])
+      (let [patterns (knowledge/detect-recurring-patterns store)
+            learning-summaries (:learnings (first patterns))]
+        (is (= 3 (count learning-summaries)))
+        (doseq [summary learning-summaries]
+          (is (contains? summary :id))
+          (is (contains? summary :uid))
+          (is (contains? summary :title))
+          (is (contains? summary :confidence)))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; synthesize-recurring-patterns!
+
+(deftest synthesize-patterns-no-patterns
+  (testing "No patterns means 0 synthesized"
+    (let [store (fresh-store)]
+      (seed-learnings! store 2 [:not-enough])
+      (is (= 0 (knowledge/synthesize-recurring-patterns! store))))))
+
+(deftest synthesize-patterns-creates-meta-loop-learnings
+  (testing "Patterns above threshold produce meta-loop learnings"
+    (let [store (fresh-store)]
+      (seed-learnings! store 4 [:protocol])
+      (let [count-before (count (learning/list-learnings store))
+            synthesized (knowledge/synthesize-recurring-patterns! store)
+            count-after (count (learning/list-learnings store))]
+        (is (= 1 synthesized))
+        (is (= (+ count-before 1) count-after))
+        ;; The new learning should be tagged :meta-loop :pattern
+        (let [meta-learnings (learning/list-learnings store {:agent nil})
+              pattern-learning (first (filter #(some #{:pattern} (:zettel/tags %))
+                                             meta-learnings))]
+          (is (some? pattern-learning))
+          (is (some #{:meta-loop} (:zettel/tags pattern-learning)))
+          (is (some #{:protocol} (:zettel/tags pattern-learning))))))))
+
+(deftest synthesize-patterns-idempotent
+  (testing "Second call produces 0 new patterns"
+    (let [store (fresh-store)]
+      (seed-learnings! store 4 [:protocol])
+      (is (= 1 (knowledge/synthesize-recurring-patterns! store)))
+      (is (= 0 (knowledge/synthesize-recurring-patterns! store))))))
+
+(deftest synthesize-patterns-multiple-tags
+  (testing "Multiple distinct patterns each produce a learning"
+    (let [store (fresh-store)]
+      (seed-learnings! store 3 [:alpha])
+      (seed-learnings! store 3 [:beta])
+      (let [synthesized (knowledge/synthesize-recurring-patterns! store)]
+        (is (= 2 synthesized))))))
+
+(deftest synthesize-patterns-content-includes-learning-titles
+  (testing "Synthesized learning content includes titles of related learnings"
+    (let [store (fresh-store)]
+      (seed-learnings! store 3 [:namespace])
+      (knowledge/synthesize-recurring-patterns! store)
+      (let [all (learning/list-learnings store)
+            pattern-learning (first (filter #(some #{:pattern} (:zettel/tags %)) all))]
+        (is (some? pattern-learning))
+        (is (re-find #"Learning 0" (:zettel/content pattern-learning)))
+        (is (re-find #"Learning 1" (:zettel/content pattern-learning)))
+        (is (re-find #"Learning 2" (:zettel/content pattern-learning)))))))
+
+(deftest synthesize-patterns-high-confidence
+  (testing "Synthesized meta-loop learnings have 0.85 confidence"
+    (let [store (fresh-store)]
+      (seed-learnings! store 3 [:quality])
+      (knowledge/synthesize-recurring-patterns! store)
+      (let [all (learning/list-learnings store)
+            pattern-learning (first (filter #(some #{:pattern} (:zettel/tags %)) all))]
+        (is (= 0.85
+               (get-in pattern-learning [:zettel/source :source/confidence])))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests)
+  :leave-this-here)

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -315,6 +315,16 @@
             (catch Exception _e nil)))))
     (catch Exception _e nil)))
 
+(defn- synthesize-patterns!
+  "Detect recurring patterns in KB learnings and synthesize meta-loop learnings.
+   Delegates to knowledge component. No-ops when knowledge-store is nil."
+  [knowledge-store]
+  (try
+    (when knowledge-store
+      (let [synthesize (requiring-resolve 'ai.miniforge.knowledge.interface/synthesize-recurring-patterns!)]
+        (synthesize knowledge-store)))
+    (catch Exception _e nil)))
+
 (defn- observe-workflow-signal!
   "Feed workflow completion/failure signal to the operator for pattern analysis.
    No-ops when no operator is configured."
@@ -424,6 +434,9 @@
 
        ;; Post-workflow: feed signals to operator for pattern analysis
        (observe-workflow-signal! opts output-ctx)
+
+       ;; Post-workflow: synthesize recurring patterns into meta-loop learnings
+       (synthesize-patterns! (:knowledge-store opts))
 
        ;; Post-workflow: auto-promote high-confidence learnings
        (promote-mature-learnings! (:knowledge-store opts))


### PR DESCRIPTION
## Summary

Closes the learning feedback loop so that every execution compounds knowledge:

- **`detect-recurring-patterns`** — Scans all learnings in the KB, groups them by tag, and returns patterns where 3+ learnings share a tag (configurable via `:min-occurrences`, `:exclude-tags`). Sorted by frequency descending.
- **`synthesize-recurring-patterns!`** — Turns detected patterns into meta-loop learnings. Idempotent — skips patterns that already have a corresponding learning (dedup via `:pattern` tag + text-search). Returns count of new patterns synthesized.
- **`synthesize-patterns!` post-execution hook** — Wired into `workflow/runner.clj` between signal observation and learning promotion. Runs after every workflow execution.
- **i18n** — Localized the remaining embedded string in `capture-meta-loop-learning` and added pattern title/content templates to the knowledge message catalog.

### Compounding loop

```
Inner-loop repairs → learnings (capture-repair-learning!)
                          ↓
Post-workflow: detect-recurring-patterns (3+ tag co-occurrences)
                          ↓
synthesize-recurring-patterns! → meta-loop learnings
                          ↓
promote-mature-learnings! → rules (confidence ≥ 0.8)
                          ↓
inject-knowledge → agents see rules in next execution
```

### Files changed

| File | Change |
|------|--------|
| `components/knowledge/src/ai/miniforge/knowledge/learning.clj` | Layer 2: `detect-recurring-patterns`, `synthesize-recurring-patterns!`, localize `capture-meta-loop-learning` |
| `components/knowledge/src/ai/miniforge/knowledge/interface.clj` | Export new functions |
| `components/knowledge/resources/config/knowledge/messages/en.edn` | Add `:learning/observed-across`, `:pattern/title`, `:pattern/content` |
| `components/workflow/src/ai/miniforge/workflow/runner.clj` | Add `synthesize-patterns!` post-execution hook |
| `components/knowledge/test/ai/miniforge/knowledge/pattern_detection_test.clj` | **15 new tests** |

## Test plan

- [x] 584 tests pass (569 existing + 15 new), 0 failures
- [x] GraalVM compatibility tests pass
- [x] `detect-recurring-patterns` returns empty vec on empty store
- [x] `detect-recurring-patterns` returns empty vec when < 3 learnings share a tag
- [x] `detect-recurring-patterns` returns patterns at exactly 3 occurrences
- [x] `detect-recurring-patterns` excludes `:inner-loop` and `:repair` tags by default
- [x] `detect-recurring-patterns` respects custom `:min-occurrences` and `:exclude-tags`
- [x] `detect-recurring-patterns` sorts results by frequency descending
- [x] `detect-recurring-patterns` includes learning summaries with `:id`, `:uid`, `:title`, `:confidence`
- [x] `synthesize-recurring-patterns!` returns 0 when no patterns exist
- [x] `synthesize-recurring-patterns!` creates meta-loop learnings tagged `:pattern` `:meta-loop`
- [x] `synthesize-recurring-patterns!` is idempotent — second call returns 0
- [x] `synthesize-recurring-patterns!` handles multiple distinct tag patterns
- [x] Synthesized learning content includes titles of related learnings
- [x] Synthesized learnings have 0.85 confidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)