### PR TITLE
feat: add BM25 lexical search to repo-index

### DIFF
--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -34,6 +34,11 @@ You receive:
    If you need to reference or modify a file not in \"Existing Files in Scope\",
    mention the path from the repo map in your code artifact.
 
+4. **Search Results** may be provided when the orchestrator has searched the
+   codebase for files relevant to your task. These show ranked file matches
+   with preview snippets. Use them to understand existing patterns before
+   generating code.
+
 ## Output Format
 
 You must output a structured code artifact as a Clojure map:

--- a/components/agent/test/ai/miniforge/agent/interface_test.clj
+++ b/components/agent/test/ai/miniforge/agent/interface_test.clj
@@ -107,9 +107,9 @@
                                            :model "mock"})
           result (agent/invoke a test-task {:llm-backend mock-llm})]
       (is (map? result))
-      ;; Agent invoke returns {:status :success/:error :output {...} ...}
-      (is (contains? result :status))
-      (is (contains? result :output)))))
+      ;; BaseAgent invoke returns {:success bool :outputs [...] ...}
+      (is (contains? result :success))
+      (is (contains? result :outputs)))))
 
 (deftest validate-test
   (testing "validates correct output"

--- a/components/repo-index/resources/config/repo-index/search.edn
+++ b/components/repo-index/resources/config/repo-index/search.edn
@@ -1,0 +1,11 @@
+{:repo-index/search
+ {;; BM25 tuning parameters.
+  ;; k1: term frequency saturation (higher = more weight to repeated terms)
+  ;; b:  document length normalization (0 = no normalization, 1 = full)
+  :bm25-k1 1.2
+  :bm25-b  0.75
+
+  ;; Default search result limits
+  :default-max-results  10
+  :default-context-lines 3
+  :default-max-hits      5}}

--- a/components/repo-index/src/ai/miniforge/repo_index/factory.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/factory.clj
@@ -99,3 +99,13 @@
   "Create a render accumulator with updated fields."
   [text tokens shown truncated?]
   {:text text :tokens tokens :shown shown :truncated? truncated?})
+
+;------------------------------------------------------------------------------ Layer 0
+;; SearchHit (returned by search-lex)
+
+(defn ->search-hit
+  "Create a search hit result map."
+  [path score snippets]
+  {:path path
+   :score score
+   :snippets snippets})

--- a/components/repo-index/src/ai/miniforge/repo_index/factory.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/factory.clj
@@ -101,7 +101,14 @@
   {:text text :tokens tokens :shown shown :truncated? truncated?})
 
 ;------------------------------------------------------------------------------ Layer 0
-;; SearchHit (returned by search-lex)
+;; Search domain maps
+
+(defn ->snippet
+  "Create a search result snippet map."
+  [start-line end-line text]
+  {:start-line start-line
+   :end-line end-line
+   :text text})
 
 (defn ->search-hit
   "Create a search hit result map."
@@ -109,3 +116,26 @@
   {:path path
    :score score
    :snippets snippets})
+
+(defn ->doc-entry
+  "Create a document entry for the search inverted index."
+  [path token-count term-freqs content]
+  {:path path
+   :token-count token-count
+   :term-freqs term-freqs
+   :content content})
+
+(defn ->inverted-index
+  "Create an empty inverted index accumulator."
+  []
+  {:term->doc-ids {}
+   :doc-freq {}})
+
+(defn ->search-index
+  "Create a SearchIndex map from docs, corpus stats, and inverted index."
+  [doc-map doc-count avg-doc-length term->doc-ids doc-freq]
+  {:docs doc-map
+   :doc-count doc-count
+   :avg-doc-length avg-doc-length
+   :term->doc-ids term->doc-ids
+   :doc-freq doc-freq})

--- a/components/repo-index/src/ai/miniforge/repo_index/interface.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/interface.clj
@@ -28,6 +28,7 @@
             [ai.miniforge.repo-index.factory :as factory]
             [ai.miniforge.repo-index.scanner :as scanner]
             [ai.miniforge.repo-index.repo-map :as repo-map]
+            [ai.miniforge.repo-index.search-lex :as search-lex]
             [ai.miniforge.repo-index.storage :as storage]
             [clojure.java.io :as io]
             [clojure.string :as str]))
@@ -39,6 +40,8 @@
 (def RepoIndex schema/RepoIndex)
 (def RepoMapEntry schema/RepoMapEntry)
 (def RepoMapSlice schema/RepoMapSlice)
+(def SearchHit schema/SearchHit)
+(def Snippet schema/Snippet)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Index building
@@ -85,6 +88,40 @@
   ([index opts] (:text (repo-map index opts))))
 
 ;------------------------------------------------------------------------------ Layer 2
+;; Lexical search
+
+(defn build-search-index
+  "Build a BM25 search index from a repo index.
+
+   Should be called once after build-index; the result is reusable for
+   multiple queries within the same session.
+
+   Arguments:
+   - repo-index - RepoIndex map from build-index
+
+   Returns:
+   - SearchIndex map (opaque, pass to search-lex)"
+  [repo-index]
+  (search-lex/build-search-index repo-index))
+
+(defn search-lex
+  "Search the codebase by keyword using BM25 ranking.
+
+   Arguments:
+   - search-index - SearchIndex from build-search-index
+   - query        - Search query string
+   - opts         - Optional map:
+     - :max-results   - Maximum results (default 10)
+     - :context-lines - Lines of context around hits (default 3)
+     - :max-hits      - Max snippet hits per file (default 5)
+
+   Returns:
+   - Vector of SearchHit maps sorted by relevance:
+     [{:path :score :snippets [{:start-line :end-line :text}]}]"
+  ([search-index query] (search-lex/search search-index query))
+  ([search-index query opts] (search-lex/search search-index query opts)))
+
+;------------------------------------------------------------------------------ Layer 3
 ;; File retrieval
 
 (defn- find-in-index

--- a/components/repo-index/src/ai/miniforge/repo_index/schema.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/schema.clj
@@ -69,6 +69,23 @@
    [:truncated? :boolean]
    [:token-estimate :int]])
 
+;------------------------------------------------------------------------------ Layer 0
+;; Search Hit
+
+(def Snippet
+  "Schema for a search result snippet."
+  [:map
+   [:start-line :int]
+   [:end-line :int]
+   [:text [:string {:min 0}]]])
+
+(def SearchHit
+  "Schema for a single search result."
+  [:map
+   [:path [:string {:min 1}]]
+   [:score :double]
+   [:snippets [:vector Snippet]]])
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (require '[malli.core :as m])

--- a/components/repo-index/src/ai/miniforge/repo_index/search_lex.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/search_lex.clj
@@ -1,0 +1,249 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.repo-index.search-lex
+  "BM25 lexical search over repo file contents.
+
+   Pure Clojure implementation — no JNI dependencies. Suitable for
+   single-repo indexing (thousands of files, not millions).
+
+   Layer 1 — depends on factory (Layer 0)."
+  (:require [clojure.java.io :as io]
+            [clojure.string :as str]
+            [ai.miniforge.repo-index.factory :as factory]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Tokenization
+
+(defn- tokenize
+  "Split text into lowercase word tokens."
+  [text]
+  (->> (str/split (str/lower-case text) #"[^a-z0-9_-]+")
+       (remove str/blank?)))
+
+;------------------------------------------------------------------------------ Layer 0
+;; BM25 parameters (config)
+
+(def ^:private bm25-k1
+  "Term frequency saturation parameter."
+  1.2)
+
+(def ^:private bm25-b
+  "Document length normalization parameter."
+  0.75)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Index construction
+
+(defn- read-file-content
+  "Read file content from disk. Returns nil for binary/unreadable files."
+  [repo-root path]
+  (try
+    (let [f (io/file repo-root path)]
+      (when (.isFile f)
+        (slurp f)))
+    (catch Exception _
+      nil)))
+
+(defn- build-doc-entry
+  "Build a document entry for the inverted index."
+  [repo-root {:keys [path]}]
+  (when-let [content (read-file-content repo-root path)]
+    (let [tokens (tokenize content)
+          tf (frequencies tokens)]
+      {:path path
+       :token-count (count tokens)
+       :term-freqs tf
+       :content content})))
+
+(defn- build-inverted-index
+  "Build an inverted index from document entries.
+   Returns {:term->doc-ids {term #{doc-id ...}} :doc-freq {term count}}."
+  [docs]
+  (reduce
+    (fn [acc {:keys [path term-freqs]}]
+      (reduce-kv
+        (fn [acc2 term _freq]
+          (-> acc2
+              (update-in [:term->doc-ids term] (fnil conj #{}) path)
+              (update-in [:doc-freq term] (fnil inc 0))))
+        acc
+        term-freqs))
+    {:term->doc-ids {} :doc-freq {}}
+    docs))
+
+(defn build-search-index
+  "Build a BM25 search index from a repo index.
+
+   Arguments:
+   - repo-index - RepoIndex map from scanner/scan or build-index
+
+   Returns:
+   - SearchIndex map with inverted index, doc entries, and corpus stats"
+  [repo-index]
+  (let [repo-root (:repo-root repo-index)
+        files (->> (:files repo-index)
+                   (remove :generated?))
+        docs (->> files
+                  (keep (partial build-doc-entry repo-root))
+                  vec)
+        avg-dl (if (seq docs)
+                 (double (/ (reduce + 0 (map :token-count docs))
+                            (count docs)))
+                 0.0)
+        doc-map (into {} (map (fn [d] [(:path d) d]) docs))
+        inv-idx (build-inverted-index docs)]
+    {:docs doc-map
+     :doc-count (count docs)
+     :avg-doc-length avg-dl
+     :term->doc-ids (:term->doc-ids inv-idx)
+     :doc-freq (:doc-freq inv-idx)}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; BM25 scoring
+
+(defn- idf
+  "Compute inverse document frequency for a term."
+  [doc-count doc-freq-for-term]
+  (Math/log (+ 1.0 (/ (- doc-count doc-freq-for-term 0.5)
+                       (+ doc-freq-for-term 0.5)))))
+
+(defn- bm25-term-score
+  "Compute BM25 score for a single term in a single document."
+  [tf-in-doc doc-length avg-doc-length idf-value]
+  (let [numerator (* tf-in-doc (+ bm25-k1 1.0))
+        denominator (+ tf-in-doc
+                       (* bm25-k1
+                          (+ (- 1.0 bm25-b)
+                             (* bm25-b (/ doc-length avg-doc-length)))))]
+    (* idf-value (/ numerator denominator))))
+
+(defn- score-document
+  "Score a document against query terms."
+  [doc query-terms search-index]
+  (let [{:keys [avg-doc-length doc-count doc-freq]} search-index
+        {:keys [term-freqs token-count]} doc]
+    (reduce
+      (fn [score term]
+        (let [tf (get term-freqs term 0)]
+          (if (zero? tf)
+            score
+            (let [df (get doc-freq term 1)
+                  idf-val (idf doc-count df)]
+              (+ score (bm25-term-score tf token-count avg-doc-length idf-val))))))
+      0.0
+      query-terms)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Context extraction
+
+(def ^:private default-context-lines 3)
+(def ^:private default-max-hits 5)
+
+(defn- extract-snippet
+  "Extract a snippet around a matching line with context."
+  [lines line-idx context-lines]
+  (let [start (max 0 (- line-idx context-lines))
+        end (min (count lines) (+ line-idx context-lines 1))]
+    {:start-line (inc start)
+     :end-line (inc (dec end))
+     :text (str/join "\n" (subvec lines start end))}))
+
+(defn- find-matching-lines
+  "Find line indices containing any query term."
+  [content query-terms]
+  (let [lines (str/split-lines content)
+        lower-lines (mapv str/lower-case lines)]
+    (->> (range (count lower-lines))
+         (filter (fn [i]
+                   (let [line (nth lower-lines i)]
+                     (some #(str/includes? line %) query-terms))))
+         vec)))
+
+(defn- build-snippets
+  "Build preview snippets for matching lines in a document."
+  [content query-terms context-lines max-hits]
+  (let [lines (into [] (str/split-lines content))
+        matching (find-matching-lines content query-terms)]
+    (->> matching
+         (take max-hits)
+         (mapv #(extract-snippet lines % context-lines))
+         (filterv #(not (str/blank? (:text %)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Public search API
+
+(defn search
+  "Search the index with a query string.
+
+   Arguments:
+   - search-index - SearchIndex from build-search-index
+   - query        - Search query string
+   - opts         - Optional map:
+     - :max-results   - Maximum results to return (default 10)
+     - :context-lines - Lines of context around hits (default 3)
+     - :max-hits      - Max snippet hits per file (default 5)
+
+   Returns:
+   - Vector of SearchHit maps, sorted by BM25 score descending:
+     [{:path :score :snippets [{:start-line :end-line :text}]}]"
+  ([search-index query] (search search-index query {}))
+  ([search-index query opts]
+   (let [max-results (or (:max-results opts) 10)
+         context-lines (or (:context-lines opts) default-context-lines)
+         max-hits (or (:max-hits opts) default-max-hits)
+         query-terms (tokenize query)
+         candidate-paths (reduce
+                           (fn [paths term]
+                             (into paths (get (:term->doc-ids search-index) term #{})))
+                           #{}
+                           query-terms)
+         scored (->> candidate-paths
+                     (map (fn [path]
+                            (let [doc (get (:docs search-index) path)]
+                              {:path path
+                               :score (score-document doc query-terms search-index)
+                               :doc doc})))
+                     (sort-by :score >)
+                     (take max-results))]
+     (->> scored
+          (mapv (fn [{:keys [path score doc]}]
+                  (factory/->search-hit
+                    path score
+                    (build-snippets (:content doc) query-terms
+                                    context-lines max-hits))))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (require '[ai.miniforge.repo-index.scanner :as scanner])
+
+  (def idx (scanner/scan "."))
+  (def si (build-search-index idx))
+
+  (:doc-count si)
+  (:avg-doc-length si)
+
+  (def results (search si "implement phase interceptor"))
+  (count results)
+  (map :path results)
+  (first results)
+
+  (def results2 (search si "BM25 search" {:max-results 5}))
+  (map (juxt :path :score) results2)
+
+  :leave-this-here)

--- a/components/repo-index/src/ai/miniforge/repo_index/search_lex.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/search_lex.clj
@@ -23,9 +23,28 @@
    single-repo indexing (thousands of files, not millions).
 
    Layer 1 — depends on factory (Layer 0)."
-  (:require [clojure.java.io :as io]
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
             [clojure.string :as str]
             [ai.miniforge.repo-index.factory :as factory]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Configuration (loaded from EDN resource)
+
+(def ^:private config-path "config/repo-index/search.edn")
+
+(defn- load-search-config []
+  (if-let [res (io/resource config-path)]
+    (get (edn/read-string (slurp res)) :repo-index/search {})
+    {}))
+
+(def ^:private search-config (delay (load-search-config)))
+
+(defn- bm25-k1 [] (get @search-config :bm25-k1 1.2))
+(defn- bm25-b  [] (get @search-config :bm25-b 0.75))
+(defn- default-max-results [] (get @search-config :default-max-results 10))
+(defn- default-context-lines [] (get @search-config :default-context-lines 3))
+(defn- default-max-hits [] (get @search-config :default-max-hits 5))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Tokenization
@@ -35,17 +54,6 @@
   [text]
   (->> (str/split (str/lower-case text) #"[^a-z0-9_-]+")
        (remove str/blank?)))
-
-;------------------------------------------------------------------------------ Layer 0
-;; BM25 parameters (config)
-
-(def ^:private bm25-k1
-  "Term frequency saturation parameter."
-  1.2)
-
-(def ^:private bm25-b
-  "Document length normalization parameter."
-  0.75)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Index construction
@@ -64,12 +72,8 @@
   "Build a document entry for the inverted index."
   [repo-root {:keys [path]}]
   (when-let [content (read-file-content repo-root path)]
-    (let [tokens (tokenize content)
-          tf (frequencies tokens)]
-      {:path path
-       :token-count (count tokens)
-       :term-freqs tf
-       :content content})))
+    (let [tokens (tokenize content)]
+      (factory/->doc-entry path (count tokens) (frequencies tokens) content))))
 
 (defn- build-inverted-index
   "Build an inverted index from document entries.
@@ -84,8 +88,15 @@
               (update-in [:doc-freq term] (fnil inc 0))))
         acc
         term-freqs))
-    {:term->doc-ids {} :doc-freq {}}
+    (factory/->inverted-index)
     docs))
+
+(defn- compute-avg-doc-length
+  "Compute average document length from doc entries."
+  [docs]
+  (if (seq docs)
+    (double (/ (reduce + 0 (map :token-count docs)) (count docs)))
+    0.0))
 
 (defn build-search-index
   "Build a BM25 search index from a repo index.
@@ -97,22 +108,14 @@
    - SearchIndex map with inverted index, doc entries, and corpus stats"
   [repo-index]
   (let [repo-root (:repo-root repo-index)
-        files (->> (:files repo-index)
-                   (remove :generated?))
-        docs (->> files
-                  (keep (partial build-doc-entry repo-root))
-                  vec)
-        avg-dl (if (seq docs)
-                 (double (/ (reduce + 0 (map :token-count docs))
-                            (count docs)))
-                 0.0)
+        files (->> (:files repo-index) (remove :generated?))
+        docs (->> files (keep (partial build-doc-entry repo-root)) vec)
         doc-map (into {} (map (fn [d] [(:path d) d]) docs))
         inv-idx (build-inverted-index docs)]
-    {:docs doc-map
-     :doc-count (count docs)
-     :avg-doc-length avg-dl
-     :term->doc-ids (:term->doc-ids inv-idx)
-     :doc-freq (:doc-freq inv-idx)}))
+    (factory/->search-index doc-map (count docs)
+                            (compute-avg-doc-length docs)
+                            (:term->doc-ids inv-idx)
+                            (:doc-freq inv-idx))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; BM25 scoring
@@ -126,11 +129,11 @@
 (defn- bm25-term-score
   "Compute BM25 score for a single term in a single document."
   [tf-in-doc doc-length avg-doc-length idf-value]
-  (let [numerator (* tf-in-doc (+ bm25-k1 1.0))
+  (let [k1 (bm25-k1)
+        b (bm25-b)
+        numerator (* tf-in-doc (+ k1 1.0))
         denominator (+ tf-in-doc
-                       (* bm25-k1
-                          (+ (- 1.0 bm25-b)
-                             (* bm25-b (/ doc-length avg-doc-length)))))]
+                       (* k1 (+ (- 1.0 b) (* b (/ doc-length avg-doc-length)))))]
     (* idf-value (/ numerator denominator))))
 
 (defn- score-document
@@ -152,17 +155,13 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Context extraction
 
-(def ^:private default-context-lines 3)
-(def ^:private default-max-hits 5)
-
 (defn- extract-snippet
   "Extract a snippet around a matching line with context."
   [lines line-idx context-lines]
   (let [start (max 0 (- line-idx context-lines))
         end (min (count lines) (+ line-idx context-lines 1))]
-    {:start-line (inc start)
-     :end-line (inc (dec end))
-     :text (str/join "\n" (subvec lines start end))}))
+    (factory/->snippet (inc start) (inc (dec end))
+                       (str/join "\n" (subvec lines start end)))))
 
 (defn- find-matching-lines
   "Find line indices containing any query term."
@@ -185,6 +184,30 @@
          (mapv #(extract-snippet lines % context-lines))
          (filterv #(not (str/blank? (:text %)))))))
 
+;------------------------------------------------------------------------------ Layer 1
+;; Candidate collection
+
+(defn- collect-candidates
+  "Collect all document paths matching any query term."
+  [search-index query-terms]
+  (reduce
+    (fn [paths term]
+      (into paths (get (:term->doc-ids search-index) term #{})))
+    #{}
+    query-terms))
+
+(defn- score-and-rank
+  "Score candidate documents and return top results."
+  [search-index candidate-paths query-terms max-results]
+  (->> candidate-paths
+       (map (fn [path]
+              (let [doc (get (:docs search-index) path)]
+                {:path path
+                 :score (score-document doc query-terms search-index)
+                 :doc doc})))
+       (sort-by :score >)
+       (take max-results)))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public search API
 
@@ -195,38 +218,26 @@
    - search-index - SearchIndex from build-search-index
    - query        - Search query string
    - opts         - Optional map:
-     - :max-results   - Maximum results to return (default 10)
-     - :context-lines - Lines of context around hits (default 3)
-     - :max-hits      - Max snippet hits per file (default 5)
+     - :max-results   - Maximum results to return (default from config)
+     - :context-lines - Lines of context around hits (default from config)
+     - :max-hits      - Max snippet hits per file (default from config)
 
    Returns:
    - Vector of SearchHit maps, sorted by BM25 score descending:
      [{:path :score :snippets [{:start-line :end-line :text}]}]"
   ([search-index query] (search search-index query {}))
   ([search-index query opts]
-   (let [max-results (or (:max-results opts) 10)
-         context-lines (or (:context-lines opts) default-context-lines)
-         max-hits (or (:max-hits opts) default-max-hits)
+   (let [max-results (or (:max-results opts) (default-max-results))
+         ctx-lines (or (:context-lines opts) (default-context-lines))
+         max-hits (or (:max-hits opts) (default-max-hits))
          query-terms (tokenize query)
-         candidate-paths (reduce
-                           (fn [paths term]
-                             (into paths (get (:term->doc-ids search-index) term #{})))
-                           #{}
-                           query-terms)
-         scored (->> candidate-paths
-                     (map (fn [path]
-                            (let [doc (get (:docs search-index) path)]
-                              {:path path
-                               :score (score-document doc query-terms search-index)
-                               :doc doc})))
-                     (sort-by :score >)
-                     (take max-results))]
+         candidates (collect-candidates search-index query-terms)
+         scored (score-and-rank search-index candidates query-terms max-results)]
      (->> scored
           (mapv (fn [{:keys [path score doc]}]
                   (factory/->search-hit
                     path score
-                    (build-snippets (:content doc) query-terms
-                                    context-lines max-hits))))))))
+                    (build-snippets (:content doc) query-terms ctx-lines max-hits))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
@@ -242,8 +253,5 @@
   (count results)
   (map :path results)
   (first results)
-
-  (def results2 (search si "BM25 search" {:max-results 5}))
-  (map (juxt :path :score) results2)
 
   :leave-this-here)

--- a/components/repo-index/test/ai/miniforge/repo_index/search_lex_test.clj
+++ b/components/repo-index/test/ai/miniforge/repo_index/search_lex_test.clj
@@ -67,10 +67,12 @@
           (is (string? (:text s))))))))
 
 (deftest search-no-results-test
-  (testing "search returns empty vector for nonsense query"
+  (testing "search returns empty vector when no terms match"
     (let [idx (repo-index/build-index ".")
           si (repo-index/build-search-index idx)
-          results (repo-index/search-lex si "xyzzy-nonexistent-gibberish-qwerty")]
+          ;; Generate a query dynamically so it doesn't appear as a literal in any file
+          nonsense (str (random-uuid) (random-uuid))
+          results (repo-index/search-lex si nonsense)]
       (is (vector? results))
       (is (zero? (count results))))))
 

--- a/components/repo-index/test/ai/miniforge/repo_index/search_lex_test.clj
+++ b/components/repo-index/test/ai/miniforge/repo_index/search_lex_test.clj
@@ -1,0 +1,83 @@
+(ns ai.miniforge.repo-index.search-lex-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.repo-index.interface :as repo-index]
+            [ai.miniforge.repo-index.schema :as schema]
+            [malli.core :as m]))
+
+(deftest build-search-index-test
+  (testing "builds a search index from a repo index"
+    (let [idx (repo-index/build-index ".")
+          si (repo-index/build-search-index idx)]
+      (is (some? si))
+      (is (pos? (:doc-count si)))
+      (is (pos? (:avg-doc-length si)))
+      (is (map? (:docs si)))
+      (is (map? (:term->doc-ids si)))
+      (is (map? (:doc-freq si))))))
+
+(deftest search-basic-test
+  (testing "search returns ranked results"
+    (let [idx (repo-index/build-index ".")
+          si (repo-index/build-search-index idx)
+          results (repo-index/search-lex si "scanner language detection")]
+      (is (vector? results))
+      (is (pos? (count results)))
+      (is (every? #(contains? % :path) results))
+      (is (every? #(contains? % :score) results))
+      (is (every? #(contains? % :snippets) results)))))
+
+(deftest search-schema-test
+  (testing "search results conform to SearchHit schema"
+    (let [idx (repo-index/build-index ".")
+          si (repo-index/build-search-index idx)
+          results (repo-index/search-lex si "implement phase")]
+      (doseq [hit results]
+        (is (m/validate schema/SearchHit hit)
+            (str "SearchHit schema mismatch for " (:path hit)))))))
+
+(deftest search-relevance-test
+  (testing "search ranks relevant files in top results"
+    (let [idx (repo-index/build-index ".")
+          si (repo-index/build-search-index idx)
+          results (repo-index/search-lex si "repo-index scanner")
+          top-paths (set (map :path (take 5 results)))]
+      (is (pos? (count results)))
+      (is (some #(re-find #"scanner" %) top-paths)
+          (str "Expected scanner file in top 5, got: " top-paths)))))
+
+(deftest search-max-results-test
+  (testing "search respects :max-results"
+    (let [idx (repo-index/build-index ".")
+          si (repo-index/build-search-index idx)
+          results (repo-index/search-lex si "defn" {:max-results 3})]
+      (is (<= (count results) 3)))))
+
+(deftest search-snippets-test
+  (testing "snippets contain context around matches"
+    (let [idx (repo-index/build-index ".")
+          si (repo-index/build-search-index idx)
+          results (repo-index/search-lex si "build-search-index")]
+      (is (pos? (count results)))
+      (let [first-hit (first results)
+            snippets (:snippets first-hit)]
+        (is (pos? (count snippets)))
+        (doseq [s snippets]
+          (is (pos? (:start-line s)))
+          (is (>= (:end-line s) (:start-line s)))
+          (is (string? (:text s))))))))
+
+(deftest search-no-results-test
+  (testing "search returns empty vector for nonsense query"
+    (let [idx (repo-index/build-index ".")
+          si (repo-index/build-search-index idx)
+          results (repo-index/search-lex si "xyzzy-nonexistent-gibberish-qwerty")]
+      (is (vector? results))
+      (is (zero? (count results))))))
+
+(deftest search-scores-descending-test
+  (testing "results are sorted by score descending"
+    (let [idx (repo-index/build-index ".")
+          si (repo-index/build-search-index idx)
+          results (repo-index/search-lex si "interface namespace")]
+      (when (> (count results) 1)
+        (is (apply >= (map :score results)))))))

--- a/components/tool-registry/resources/tools/repo/search-lex.edn
+++ b/components/tool-registry/resources/tools/repo/search-lex.edn
@@ -1,0 +1,25 @@
+;; Lexical search tool — BM25 keyword search over repo file contents
+;;
+;; Agents invoke this to find files relevant to their task by keyword,
+;; instead of relying on the orchestrator to guess which files are needed.
+
+{:tool/id          :repo/search-lex
+ :tool/type        :function
+ :tool/name        "Repo Lexical Search"
+ :tool/description "Search repository files by keyword using BM25 ranking. Returns ranked file paths with preview snippets showing matching lines in context."
+ :tool/version     "1.0.0"
+
+ :tool/config
+ {:function/namespace "ai.miniforge.repo-index.interface"
+  :function/name      "search-lex"
+  :function/params    {:query        {:type :string  :required true
+                                      :description "Search query — keywords, function names, error messages, etc."}
+                       :max-results  {:type :int     :required false :default 10
+                                      :description "Maximum number of file results to return"}
+                       :context-lines {:type :int    :required false :default 3
+                                       :description "Lines of context around each matching line"}}}
+
+ :tool/capabilities  #{:code/navigation}
+ :tool/requires      #{}
+ :tool/enabled       true
+ :tool/tags          #{:search :lexical :bm25 :repo-index}}

--- a/docs/pull-requests/2026-03-15-feat-repo-index-bm25-search.md
+++ b/docs/pull-requests/2026-03-15-feat-repo-index-bm25-search.md
@@ -1,0 +1,63 @@
+# feat: Add BM25 lexical search to repo-index
+
+## Overview
+
+Adds keyword search to the repo-index component so agents can find relevant files
+by searching instead of relying on the orchestrator to guess which files to include.
+
+This is Iteration 2 of the Repo Indexer plan.
+
+## Motivation
+
+With Iteration 1, agents get a repo map (table of contents) but still can't search
+for specific code patterns, function names, or error messages. They only see files
+the orchestrator pre-selects. BM25 search lets agents find the 2-3 files they
+actually need, expected to reduce token usage by ~40% for the implement phase.
+
+## Changes in Detail
+
+### New: `search_lex.clj`
+
+Pure Clojure BM25 implementation — no JNI dependencies. Suitable for single-repo
+indexing (thousands of files).
+
+- `build-search-index` — builds inverted index with TF-IDF from repo-index files
+- `search` — query → ranked hits with preview snippets (3 lines context, 5 max hits)
+- Tokenization, IDF, BM25 scoring, context extraction all as small extracted functions
+
+### Extended: existing files
+
+| File | Change |
+|------|--------|
+| `factory.clj` | Added `->search-hit` factory |
+| `schema.clj` | Added `Snippet` and `SearchHit` schemas |
+| `interface.clj` | Added `build-search-index`, `search-lex`, `SearchHit`, `Snippet` exports |
+| `implementer.edn` | Added Search Results context description |
+
+### New: tool registration
+
+- `components/tool-registry/resources/tools/repo/search-lex.edn` — registers
+  `repo.search-lex` as a `:function` tool with query/max-results/context-lines params
+
+## Testing Plan
+
+- [x] 8 search tests: index building, basic search, schema conformance, relevance,
+  max-results limit, snippet context, empty results, score ordering
+- [x] All existing repo-index tests still pass
+- [ ] Dogfood: run a work spec and verify search results improve file selection
+
+## Related
+
+- Iteration 1: PR #317 (scanner + repo map)
+- Spec: N1-architecture.md §2.27–§2.30
+
+## Checklist
+
+- [x] BM25 search implementation
+- [x] Factory function for SearchHit
+- [x] Malli schemas for SearchHit and Snippet
+- [x] Interface wired
+- [x] Tool registration EDN
+- [x] Implementer prompt updated
+- [x] Tests passing
+- [x] PR documentation

--- a/scripts/test-changed-bricks.bb
+++ b/scripts/test-changed-bricks.bb
@@ -102,12 +102,13 @@
       (fn [groups [group-key members]]
         (let [present (filter brick-names members)]
           (if (<= (count present) 1)
-            groups  ; nothing to merge
+            groups
             (let [merged-nses (vec (mapcat #(get groups %) present))
                   without (apply dissoc groups present)]
               (assoc without group-key merged-nses)))))
       brick-groups
       affinity-groups)))
+
 
 ;; --------------------------------------------------------------------------- Main
 


### PR DESCRIPTION
## Summary

- Add pure Clojure BM25 search (`search_lex.clj`) to the repo-index component — agents can now find files by keyword instead of relying on orchestrator guessing
- Register `repo.search-lex` tool in tool-registry for agent invocation
- Fix pre-existing `agent.interface-test` invoke-test assertions (expected `:status`/`:output` but BaseAgent returns `:success`/`:outputs`)

## Token Impact

Agents can search for the 2-3 files they actually need instead of getting 25 guessed files. Expected ~40% token reduction for implement phase.

## New files

| File | Lines | Purpose |
|------|-------|---------|
| `search_lex.clj` | 200 | BM25 inverted index, TF-IDF scoring, context snippet extraction |
| `search_lex_test.clj` | 80 | 8 tests covering index build, search, schema, relevance, limits, snippets |
| `tools/repo/search-lex.edn` | 25 | Tool registration for `repo.search-lex` |

## Test plan

- [x] 8 search-specific tests pass (index building, basic search, schema conformance, relevance ranking, max-results, snippets, empty results, score ordering)
- [x] All 598 brick tests pass with 0 failures
- [x] Pre-existing invoke-test failure fixed
- [ ] Dogfood: run work spec and compare search-assisted file selection vs blind loading

See `docs/pull-requests/2026-03-15-feat-repo-index-bm25-search.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)