### PR TITLE
feat: add context-pack component with per-phase budget enforcement

### DIFF
--- a/components/context-pack/deps.edn
+++ b/components/context-pack/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/repo-index {:local/root "../repo-index"}
+        ai.miniforge/logging {:local/root "../logging"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/context-pack/resources/config/context-pack/budgets.edn
+++ b/components/context-pack/resources/config/context-pack/budgets.edn
@@ -1,0 +1,27 @@
+{:context-pack/budgets
+ {;; Token budgets per phase.
+  ;; Controls how much context each agent phase receives.
+  ;; Values are approximate token counts (chars ÷ 4).
+  :phase-budgets
+  {:plan     1200
+   :implement 3500
+   :test     2200
+   :review   2800}
+
+  ;; Default budget when phase is not in the map above.
+  :default-budget 2000
+
+  ;; Repo map token budget (subset of phase budget allocated to the map).
+  :repo-map-budget 500
+
+  ;; Maximum files to include in a context pack.
+  :max-files 25
+
+  ;; Maximum lines per file.
+  :max-lines-per-file 500
+
+  ;; Maximum search results to include.
+  :max-search-results 5
+
+  ;; On budget exhaustion: :fail-closed (stop) or :warn (continue with warning).
+  :exhaustion-policy :fail-closed}}

--- a/components/context-pack/src/ai/miniforge/context_pack/budget.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/budget.clj
@@ -1,0 +1,52 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.context-pack.budget
+  "Token budget enforcement for context packs.
+
+   Layer 1 — depends on config (Layer 0) and factory (Layer 0)."
+  (:require [ai.miniforge.context-pack.config :as config]
+            [ai.miniforge.context-pack.factory :as factory]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Token estimation (matches repo-map convention)
+
+(def ^:private chars-per-token 4)
+
+(defn estimate-tokens
+  "Estimate token count for a string."
+  [s]
+  (if (string? s)
+    (int (Math/ceil (/ (count s) chars-per-token)))
+    0))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Budget tracking
+
+(defn add-source
+  "Add a source to the pack, tracking its token cost.
+   Returns updated pack, or pack with :exhausted? true if over budget."
+  [pack kind path content]
+  (let [tokens (estimate-tokens content)
+        new-total (+ (:tokens-used pack) tokens)
+        over-budget? (> new-total (:budget pack))
+        policy (config/exhaustion-policy)]
+    (if (and over-budget? (= policy :fail-closed))
+      (assoc pack :exhausted? true)
+      (-> pack
+          (assoc :tokens-used new-total)
+          (update :sources conj (factory/->source kind path tokens))
+          (cond->
+            (and over-budget? (= policy :warn))
+            (assoc :exhausted? true))))))
+
+(defn tokens-remaining
+  "Get remaining token budget for a pack."
+  [pack]
+  (max 0 (- (:budget pack) (:tokens-used pack))))
+
+(defn exhausted?
+  "Check if a pack's budget is exhausted."
+  [pack]
+  (:exhausted? pack))

--- a/components/context-pack/src/ai/miniforge/context_pack/budget.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/budget.clj
@@ -10,16 +10,19 @@
             [ai.miniforge.context-pack.factory :as factory]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Token estimation (matches repo-map convention)
-
-(def ^:private chars-per-token 4)
+;; Token estimation
 
 (defn estimate-tokens
-  "Estimate token count for a string."
+  "Estimate token count for a string (~4 chars per token)."
   [s]
   (if (string? s)
-    (int (Math/ceil (/ (count s) chars-per-token)))
+    (int (Math/ceil (/ (count s) 4)))
     0))
+
+(defn would-exceed?
+  "Check if adding tokens would exceed the pack's budget."
+  [pack additional-tokens]
+  (> (+ (:tokens-used pack) additional-tokens) (:budget pack)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Budget tracking
@@ -40,6 +43,17 @@
           (cond->
             (and over-budget? (= policy :warn))
             (assoc :exhausted? true))))))
+
+(defn try-add-item
+  "Try to add an item to the pack within budget.
+   Returns updated pack if it fits, or pack with :exhausted? true if not."
+  [pack kind path content update-fn]
+  (let [tokens (estimate-tokens content)]
+    (if (would-exceed? pack tokens)
+      (assoc pack :exhausted? true)
+      (-> pack
+          update-fn
+          (add-source kind path content)))))
 
 (defn tokens-remaining
   "Get remaining token budget for a pack."

--- a/components/context-pack/src/ai/miniforge/context_pack/builder.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/builder.clj
@@ -12,6 +12,26 @@
             [ai.miniforge.context-pack.factory :as factory]
             [ai.miniforge.repo-index.interface :as repo-index]))
 
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers
+
+(defn- snippet-text
+  "Extract concatenated text from a search hit's snippets."
+  [hit]
+  (apply str (map :text (:snippets hit))))
+
+(defn- reduce-within-budget
+  "Reduce items into a pack, stopping when budget is exhausted.
+   item-fn takes (pack, item) and returns updated pack."
+  [pack items item-fn]
+  (reduce
+    (fn [p item]
+      (if (budget/exhausted? p)
+        (reduced p)
+        (item-fn p item)))
+    pack
+    items))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Pack assembly steps
 
@@ -26,55 +46,49 @@
           (assoc :repo-map rmap)
           (budget/add-source :repo-map nil rmap)))))
 
+(defn- try-add-file
+  "Try to add a single file to the pack within budget."
+  [pack file]
+  (budget/try-add-item pack :file (:path file) (:content file)
+    #(update % :files conj file)))
+
+(defn- try-add-search-hit
+  "Try to add a single search hit to the pack within budget."
+  [pack hit]
+  (budget/try-add-item pack :search (:path hit) (snippet-text hit)
+    #(update % :search-results conj hit)))
+
+(defn- load-files
+  "Load and deduplicate files from the repo index."
+  [repo-index files-in-scope]
+  (let [max-f (config/max-files)
+        max-l (config/max-lines-per-file)]
+    (->> (repo-index/get-files repo-index (take max-f files-in-scope)
+                               {:max-lines max-l})
+         dedup/dedup-files)))
+
+(defn- load-search-results
+  "Load, deduplicate, and filter search results against already-included files."
+  [search-index query included-files]
+  (let [max-r (config/max-search-results)]
+    (->> (repo-index/search-lex search-index query {:max-results max-r})
+         dedup/dedup-search-results
+         (dedup/remove-already-included included-files))))
+
 (defn- add-files
   "Add file contents to the pack within budget."
   [pack repo-index files-in-scope]
   (if (or (not (seq files-in-scope)) (budget/exhausted? pack))
     pack
-    (let [max-f (config/max-files)
-          max-l (config/max-lines-per-file)
-          files (repo-index/get-files repo-index
-                                      (take max-f files-in-scope)
-                                      {:max-lines max-l})
-          deduped (dedup/dedup-files files)]
-      (reduce
-        (fn [p file]
-          (if (budget/exhausted? p)
-            (reduced p)
-            (let [tokens (budget/estimate-tokens (:content file))
-                  would-exhaust? (> (+ (:tokens-used p) tokens) (:budget p))]
-              (if would-exhaust?
-                (reduced (assoc p :exhausted? true))
-                (-> p
-                    (update :files conj file)
-                    (budget/add-source :file (:path file) (:content file)))))))
-        pack
-        deduped))))
+    (reduce-within-budget pack (load-files repo-index files-in-scope) try-add-file)))
 
 (defn- add-search-results
   "Add search results to the pack within budget."
   [pack search-index query]
   (if (or (nil? search-index) (nil? query) (budget/exhausted? pack))
     pack
-    (let [max-r (config/max-search-results)
-          results (repo-index/search-lex search-index query {:max-results max-r})
-          deduped (dedup/dedup-search-results results)
-          ;; Remove files already included directly
-          filtered (dedup/dedup-files-against-search deduped (:files pack))]
-      (reduce
-        (fn [p hit]
-          (if (budget/exhausted? p)
-            (reduced p)
-            (let [snippet-text (->> (:snippets hit) (map :text) (apply str))
-                  tokens (budget/estimate-tokens snippet-text)
-                  would-exhaust? (> (+ (:tokens-used p) tokens) (:budget p))]
-              (if would-exhaust?
-                (reduced (assoc p :exhausted? true))
-                (-> p
-                    (update :search-results conj hit)
-                    (budget/add-source :search (:path hit) snippet-text))))))
-        pack
-        filtered))))
+    (let [filtered (load-search-results search-index query (:files pack))]
+      (reduce-within-budget pack filtered try-add-search-hit))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public API
@@ -102,15 +116,7 @@
         (add-search-results (:search-index opts) (:search-query opts)))))
 
 (defn extend-pack
-  "Extend an existing context pack with additional files or search results.
-
-   Arguments:
-   - pack         - Existing ContextPack
-   - repo-index   - RepoIndex map
-   - opts         - Map with :files-in-scope and/or :search-index + :search-query
-
-   Returns:
-   - Updated ContextPack with additional content (budget enforced)"
+  "Extend an existing context pack with additional files or search results."
   [pack repo-index opts]
   (-> pack
       (add-files repo-index (:files-in-scope opts))

--- a/components/context-pack/src/ai/miniforge/context_pack/builder.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/builder.clj
@@ -1,0 +1,127 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.context-pack.builder
+  "Assemble context packs from repo-index data.
+
+   Layer 2 — depends on budget, dedup, config, factory."
+  (:require [ai.miniforge.context-pack.budget :as budget]
+            [ai.miniforge.context-pack.config :as config]
+            [ai.miniforge.context-pack.dedup :as dedup]
+            [ai.miniforge.context-pack.factory :as factory]
+            [ai.miniforge.repo-index.interface :as repo-index]))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pack assembly steps
+
+(defn- add-repo-map
+  "Add the repo map to the pack, consuming budget."
+  [pack repo-index]
+  (if (or (nil? repo-index) (budget/exhausted? pack))
+    pack
+    (let [map-budget (min (config/repo-map-budget) (budget/tokens-remaining pack))
+          rmap (repo-index/repo-map-text repo-index {:token-budget map-budget})]
+      (-> pack
+          (assoc :repo-map rmap)
+          (budget/add-source :repo-map nil rmap)))))
+
+(defn- add-files
+  "Add file contents to the pack within budget."
+  [pack repo-index files-in-scope]
+  (if (or (not (seq files-in-scope)) (budget/exhausted? pack))
+    pack
+    (let [max-f (config/max-files)
+          max-l (config/max-lines-per-file)
+          files (repo-index/get-files repo-index
+                                      (take max-f files-in-scope)
+                                      {:max-lines max-l})
+          deduped (dedup/dedup-files files)]
+      (reduce
+        (fn [p file]
+          (if (budget/exhausted? p)
+            (reduced p)
+            (let [tokens (budget/estimate-tokens (:content file))
+                  would-exhaust? (> (+ (:tokens-used p) tokens) (:budget p))]
+              (if would-exhaust?
+                (reduced (assoc p :exhausted? true))
+                (-> p
+                    (update :files conj file)
+                    (budget/add-source :file (:path file) (:content file)))))))
+        pack
+        deduped))))
+
+(defn- add-search-results
+  "Add search results to the pack within budget."
+  [pack search-index query]
+  (if (or (nil? search-index) (nil? query) (budget/exhausted? pack))
+    pack
+    (let [max-r (config/max-search-results)
+          results (repo-index/search-lex search-index query {:max-results max-r})
+          deduped (dedup/dedup-search-results results)
+          ;; Remove files already included directly
+          filtered (dedup/dedup-files-against-search deduped (:files pack))]
+      (reduce
+        (fn [p hit]
+          (if (budget/exhausted? p)
+            (reduced p)
+            (let [snippet-text (->> (:snippets hit) (map :text) (apply str))
+                  tokens (budget/estimate-tokens snippet-text)
+                  would-exhaust? (> (+ (:tokens-used p) tokens) (:budget p))]
+              (if would-exhaust?
+                (reduced (assoc p :exhausted? true))
+                (-> p
+                    (update :search-results conj hit)
+                    (budget/add-source :search (:path hit) snippet-text))))))
+        pack
+        filtered))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Public API
+
+(defn build-pack
+  "Assemble a context pack for a given phase.
+
+   Arguments:
+   - phase        - Phase keyword (:plan, :implement, :test, :review)
+   - repo-index   - RepoIndex map (from repo-index/build-index)
+   - opts         - Optional map:
+     - :files-in-scope - Seq of file paths to include
+     - :search-index   - SearchIndex (from repo-index/build-search-index)
+     - :search-query   - Query string for lexical search
+     - :budget         - Override token budget (default from config)
+
+   Returns:
+   - ContextPack map with :repo-map, :files, :search-results, :budget, etc."
+  [phase repo-index opts]
+  (let [budget-tokens (or (:budget opts) (config/phase-budget phase))
+        pack (factory/->context-pack phase budget-tokens nil [] [])]
+    (-> pack
+        (add-repo-map repo-index)
+        (add-files repo-index (:files-in-scope opts))
+        (add-search-results (:search-index opts) (:search-query opts)))))
+
+(defn extend-pack
+  "Extend an existing context pack with additional files or search results.
+
+   Arguments:
+   - pack         - Existing ContextPack
+   - repo-index   - RepoIndex map
+   - opts         - Map with :files-in-scope and/or :search-index + :search-query
+
+   Returns:
+   - Updated ContextPack with additional content (budget enforced)"
+  [pack repo-index opts]
+  (-> pack
+      (add-files repo-index (:files-in-scope opts))
+      (add-search-results (:search-index opts) (:search-query opts))))
+
+(defn audit
+  "Create a budget audit snapshot for a context pack."
+  [pack]
+  (factory/->budget-audit
+    (:phase pack)
+    (:budget pack)
+    (:tokens-used pack)
+    (:exhausted? pack)
+    (count (:sources pack))))

--- a/components/context-pack/src/ai/miniforge/context_pack/config.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/config.clj
@@ -1,0 +1,50 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.context-pack.config
+  "Budget configuration loaded from EDN resources.
+
+   Layer 0 — pure config loading, no domain logic."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+(def ^:private config-path "config/context-pack/budgets.edn")
+
+(defn- load-budget-config []
+  (if-let [res (io/resource config-path)]
+    (get (edn/read-string (slurp res)) :context-pack/budgets {})
+    {}))
+
+(def ^:private budget-config (delay (load-budget-config)))
+
+(defn phase-budget
+  "Get the token budget for a given phase keyword."
+  [phase]
+  (get-in @budget-config [:phase-budgets phase]
+          (get @budget-config :default-budget 2000)))
+
+(defn repo-map-budget
+  "Get the token budget allocated for the repo map."
+  []
+  (get @budget-config :repo-map-budget 500))
+
+(defn max-files
+  "Get the maximum number of files to include."
+  []
+  (get @budget-config :max-files 25))
+
+(defn max-lines-per-file
+  "Get the maximum lines per file."
+  []
+  (get @budget-config :max-lines-per-file 500))
+
+(defn max-search-results
+  "Get the maximum number of search results."
+  []
+  (get @budget-config :max-search-results 5))
+
+(defn exhaustion-policy
+  "Get the budget exhaustion policy (:fail-closed or :warn)."
+  []
+  (get @budget-config :exhaustion-policy :fail-closed))

--- a/components/context-pack/src/ai/miniforge/context_pack/dedup.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/dedup.clj
@@ -7,29 +7,31 @@
 
    Layer 0 — pure functions, no dependencies.")
 
+(defn- path-not-seen?
+  "Returns true if the file's path has not been seen, marking it as seen."
+  [seen f]
+  (let [path (:path f)]
+    (if (contains? @seen path)
+      false
+      (do (vswap! seen conj path) true))))
+
 (defn dedup-files
   "Deduplicate file entries by path, keeping the first occurrence."
   [files]
   (let [seen (volatile! #{})]
-    (filterv (fn [f]
-               (let [path (:path f)]
-                 (if (contains? @seen path)
-                   false
-                   (do (vswap! seen conj path) true))))
-             files)))
+    (filterv (partial path-not-seen? seen) files)))
 
 (defn dedup-search-results
   "Deduplicate search results by path, keeping the highest-scoring entry."
   [results]
-  (let [by-path (group-by :path results)]
-    (->> (vals by-path)
-         (mapv (fn [group]
-                 (apply max-key :score group)))
-         (sort-by :score >)
-         vec)))
+  (->> (group-by :path results)
+       vals
+       (mapv #(apply max-key :score %))
+       (sort-by :score >)
+       vec))
 
-(defn dedup-files-against-search
-  "Remove files that already appear in search results (avoid double-counting)."
-  [files search-results]
-  (let [search-paths (set (map :path search-results))]
-    (filterv #(not (contains? search-paths (:path %))) files)))
+(defn remove-already-included
+  "Remove search results whose paths are already in the included files."
+  [included-files search-results]
+  (let [included-paths (set (map :path included-files))]
+    (filterv #(not (contains? included-paths (:path %))) search-results)))

--- a/components/context-pack/src/ai/miniforge/context_pack/dedup.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/dedup.clj
@@ -1,0 +1,35 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.context-pack.dedup
+  "Deduplicate context items by identity.
+
+   Layer 0 — pure functions, no dependencies.")
+
+(defn dedup-files
+  "Deduplicate file entries by path, keeping the first occurrence."
+  [files]
+  (let [seen (volatile! #{})]
+    (filterv (fn [f]
+               (let [path (:path f)]
+                 (if (contains? @seen path)
+                   false
+                   (do (vswap! seen conj path) true))))
+             files)))
+
+(defn dedup-search-results
+  "Deduplicate search results by path, keeping the highest-scoring entry."
+  [results]
+  (let [by-path (group-by :path results)]
+    (->> (vals by-path)
+         (mapv (fn [group]
+                 (apply max-key :score group)))
+         (sort-by :score >)
+         vec)))
+
+(defn dedup-files-against-search
+  "Remove files that already appear in search results (avoid double-counting)."
+  [files search-results]
+  (let [search-paths (set (map :path search-results))]
+    (filterv #(not (contains? search-paths (:path %))) files)))

--- a/components/context-pack/src/ai/miniforge/context_pack/factory.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/factory.clj
@@ -1,0 +1,49 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.context-pack.factory
+  "Factory functions for context-pack domain maps.
+
+   Layer 0 — pure data construction.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; ContextPack
+
+(defn ->context-pack
+  "Create a ContextPack map."
+  [phase budget repo-map-text files search-results]
+  {:phase phase
+   :budget budget
+   :tokens-used 0
+   :repo-map repo-map-text
+   :files files
+   :search-results search-results
+   :exhausted? false
+   :sources []})
+
+;------------------------------------------------------------------------------ Layer 0
+;; Budget audit
+
+(defn ->budget-audit
+  "Create a budget audit snapshot."
+  [phase budget tokens-used exhausted? source-count]
+  {:phase phase
+   :budget budget
+   :tokens-used tokens-used
+   :tokens-remaining (max 0 (- budget tokens-used))
+   :exhausted? exhausted?
+   :source-count source-count
+   :utilization (if (pos? budget)
+                  (double (/ tokens-used budget))
+                  0.0)})
+
+;------------------------------------------------------------------------------ Layer 0
+;; Source tracking
+
+(defn ->source
+  "Create a source-tracking entry for audit trail."
+  [kind path tokens]
+  {:kind kind
+   :path path
+   :tokens tokens})

--- a/components/context-pack/src/ai/miniforge/context_pack/factory.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/factory.clj
@@ -47,3 +47,14 @@
   {:kind kind
    :path path
    :tokens tokens})
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pack context (used by implement phase to cache context-pack results)
+
+(defn ->pack-context
+  "Create a pack-context map for caching in execution context."
+  [repo-index context-pack]
+  {:repo-index repo-index
+   :context-pack context-pack
+   :repo-map-text (:repo-map context-pack)
+   :existing-files (:files context-pack)})

--- a/components/context-pack/src/ai/miniforge/context_pack/interface.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/interface.clj
@@ -1,0 +1,108 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.context-pack.interface
+  "Public API for the context-pack component.
+
+   Assembles bounded, auditable context documents from repo-index data
+   with per-phase token budgets.
+
+   Layer 0: Schema re-exports
+   Layer 1: Budget queries
+   Layer 2: Pack building and auditing"
+  (:require [ai.miniforge.context-pack.schema :as schema]
+            [ai.miniforge.context-pack.builder :as builder]
+            [ai.miniforge.context-pack.budget :as budget]
+            [ai.miniforge.context-pack.config :as config]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema re-exports
+
+(def ContextPack schema/ContextPack)
+(def BudgetAudit schema/BudgetAudit)
+(def Source schema/Source)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Budget queries
+
+(defn phase-budget
+  "Get the configured token budget for a phase."
+  [phase]
+  (config/phase-budget phase))
+
+(defn tokens-remaining
+  "Get remaining token budget for a context pack."
+  [pack]
+  (budget/tokens-remaining pack))
+
+(defn exhausted?
+  "Check if a pack's budget is exhausted."
+  [pack]
+  (budget/exhausted? pack))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Pack building
+
+(defn build-pack
+  "Assemble a context pack for a given phase.
+
+   Wraps repo-map + files + search results into a bounded context
+   document with per-phase token budgets.
+
+   Arguments:
+   - phase        - Phase keyword (:plan, :implement, :test, :review)
+   - repo-index   - RepoIndex map (from repo-index/build-index)
+   - opts         - Optional map:
+     - :files-in-scope - Seq of file paths to include
+     - :search-index   - SearchIndex (from repo-index/build-search-index)
+     - :search-query   - Query string for lexical search
+     - :budget         - Override token budget
+
+   Returns:
+   - ContextPack map"
+  [phase repo-index opts]
+  (builder/build-pack phase repo-index opts))
+
+(defn extend-pack
+  "Extend an existing context pack with additional content.
+
+   Arguments:
+   - pack       - Existing ContextPack
+   - repo-index - RepoIndex map
+   - opts       - Map with :files-in-scope and/or :search-index + :search-query
+
+   Returns:
+   - Updated ContextPack (budget still enforced)"
+  [pack repo-index opts]
+  (builder/extend-pack pack repo-index opts))
+
+(defn audit
+  "Create a budget audit snapshot for a context pack.
+
+   Returns:
+   - BudgetAudit map with :budget, :tokens-used, :tokens-remaining,
+     :utilization, :exhausted?, :source-count"
+  [pack]
+  (builder/audit pack))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (require '[ai.miniforge.repo-index.interface :as ri])
+  (def idx (ri/build-index "."))
+
+  ;; Build a pack for implement phase
+  (def pack (build-pack :implement idx
+              {:files-in-scope ["deps.edn" "workspace.edn"]}))
+  (:tokens-used pack)
+  (:exhausted? pack)
+  (count (:files pack))
+  (audit pack)
+
+  ;; Extend with search
+  (def si (ri/build-search-index idx))
+  (def pack2 (extend-pack pack idx
+               {:search-index si :search-query "implement phase"}))
+  (audit pack2)
+
+  :leave-this-here)

--- a/components/context-pack/src/ai/miniforge/context_pack/schema.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/schema.clj
@@ -1,0 +1,40 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.context-pack.schema
+  "Malli schemas for context-pack domain types.
+
+   Layer 0 — pure data definitions.")
+
+;------------------------------------------------------------------------------ Layer 0
+
+(def Source
+  "Schema for a source-tracking entry."
+  [:map
+   [:kind [:enum :repo-map :file :search]]
+   [:path [:maybe [:string {:min 1}]]]
+   [:tokens :int]])
+
+(def ContextPack
+  "Schema for a bounded context pack."
+  [:map
+   [:phase :keyword]
+   [:budget :int]
+   [:tokens-used :int]
+   [:repo-map [:maybe :string]]
+   [:files [:vector :map]]
+   [:search-results [:vector :map]]
+   [:exhausted? :boolean]
+   [:sources [:vector Source]]])
+
+(def BudgetAudit
+  "Schema for a budget audit snapshot."
+  [:map
+   [:phase :keyword]
+   [:budget :int]
+   [:tokens-used :int]
+   [:tokens-remaining :int]
+   [:exhausted? :boolean]
+   [:source-count :int]
+   [:utilization :double]])

--- a/components/context-pack/test/ai/miniforge/context_pack/interface_test.clj
+++ b/components/context-pack/test/ai/miniforge/context_pack/interface_test.clj
@@ -1,0 +1,118 @@
+(ns ai.miniforge.context-pack.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.context-pack.interface :as ctx]
+            [ai.miniforge.context-pack.schema :as schema]
+            [ai.miniforge.repo-index.interface :as repo-index]
+            [malli.core :as m]))
+
+(deftest phase-budget-test
+  (testing "returns configured budgets for known phases"
+    (is (= 3500 (ctx/phase-budget :implement)))
+    (is (= 1200 (ctx/phase-budget :plan)))
+    (is (= 2200 (ctx/phase-budget :test)))
+    (is (= 2800 (ctx/phase-budget :review))))
+
+  (testing "returns default budget for unknown phases"
+    (is (= 2000 (ctx/phase-budget :unknown)))))
+
+(deftest build-pack-basic-test
+  (testing "builds a context pack with repo map and files"
+    (let [idx (repo-index/build-index ".")
+          ;; Use small files that fit within budget
+          pack (ctx/build-pack :implement idx
+                 {:files-in-scope ["workspace.edn" "claude.md"]})]
+      (is (some? pack))
+      (is (= :implement (:phase pack)))
+      (is (= 3500 (:budget pack)))
+      (is (pos? (:tokens-used pack)))
+      (is (string? (:repo-map pack)))
+      (is (pos? (count (:files pack))))
+      (is (not (:exhausted? pack))))))
+
+(deftest build-pack-schema-test
+  (testing "pack conforms to ContextPack schema"
+    (let [idx (repo-index/build-index ".")
+          pack (ctx/build-pack :implement idx
+                 {:files-in-scope ["workspace.edn"]})]
+      (is (m/validate schema/ContextPack pack)
+          (str "ContextPack schema mismatch: "
+               (m/explain schema/ContextPack pack))))))
+
+(deftest build-pack-with-search-test
+  (testing "builds a pack including search results"
+    (let [idx (repo-index/build-index ".")
+          si (repo-index/build-search-index idx)
+          pack (ctx/build-pack :implement idx
+                 {:files-in-scope ["workspace.edn"]
+                  :search-index si
+                  :search-query "implement phase interceptor"})]
+      (is (pos? (count (:search-results pack))))
+      (is (pos? (:tokens-used pack))))))
+
+(deftest budget-enforcement-test
+  (testing "pack respects budget limits"
+    (let [idx (repo-index/build-index ".")
+          ;; Very small budget should truncate
+          pack (ctx/build-pack :implement idx
+                 {:files-in-scope ["deps.edn" "workspace.edn" "bb.edn"]
+                  :budget 100})]
+      ;; With only 100 tokens, can't fit much
+      (is (<= (:tokens-used pack) 200)
+          "should stay near budget (with one item overshoot possible)"))))
+
+(deftest budget-exhaustion-test
+  (testing "pack marks exhausted when budget exceeded"
+    (let [idx (repo-index/build-index ".")
+          pack (ctx/build-pack :implement idx
+                 {:files-in-scope ["deps.edn" "workspace.edn" "bb.edn"
+                                   "build.clj" "agents.md"]
+                  :budget 50})]
+      ;; 50 tokens is too small for repo-map + files
+      (is (:exhausted? pack)))))
+
+(deftest audit-test
+  (testing "audit returns budget snapshot"
+    (let [idx (repo-index/build-index ".")
+          pack (ctx/build-pack :implement idx
+                 {:files-in-scope ["workspace.edn"]})
+          a (ctx/audit pack)]
+      (is (= :implement (:phase a)))
+      (is (= 3500 (:budget a)))
+      (is (pos? (:tokens-used a)))
+      (is (pos? (:tokens-remaining a)))
+      (is (pos? (:source-count a)))
+      (is (double? (:utilization a)))
+      (is (not (:exhausted? a))))))
+
+(deftest audit-schema-test
+  (testing "audit conforms to BudgetAudit schema"
+    (let [idx (repo-index/build-index ".")
+          pack (ctx/build-pack :implement idx {:files-in-scope ["workspace.edn"]})
+          a (ctx/audit pack)]
+      (is (m/validate schema/BudgetAudit a)
+          (str "BudgetAudit schema mismatch: "
+               (m/explain schema/BudgetAudit a))))))
+
+(deftest extend-pack-test
+  (testing "extend-pack adds more content within budget"
+    (let [idx (repo-index/build-index ".")
+          pack (ctx/build-pack :implement idx {:files-in-scope ["workspace.edn"]})
+          initial-tokens (:tokens-used pack)
+          extended (ctx/extend-pack pack idx
+                     {:files-in-scope ["claude.md"]})]
+      (is (> (:tokens-used extended) initial-tokens))
+      (is (> (count (:files extended)) (count (:files pack)))))))
+
+(deftest tokens-remaining-test
+  (testing "tokens-remaining reports correct value"
+    (let [idx (repo-index/build-index ".")
+          pack (ctx/build-pack :implement idx {:files-in-scope ["workspace.edn"]})]
+      (is (= (- (:budget pack) (:tokens-used pack))
+             (ctx/tokens-remaining pack))))))
+
+(deftest dedup-test
+  (testing "duplicate files are not double-counted"
+    (let [idx (repo-index/build-index ".")
+          pack (ctx/build-pack :implement idx
+                 {:files-in-scope ["workspace.edn" "workspace.edn" "workspace.edn"]})]
+      (is (= 1 (count (:files pack)))))))

--- a/components/phase-software-factory/deps.edn
+++ b/components/phase-software-factory/deps.edn
@@ -3,6 +3,7 @@
         ai.miniforge/agent {:local/root "../agent"}
         ai.miniforge/knowledge {:local/root "../knowledge"}
         ai.miniforge/repo-index {:local/root "../repo-index"}
+        ai.miniforge/context-pack {:local/root "../context-pack"}
         ai.miniforge/response {:local/root "../response"}
         ai.miniforge/release-executor {:local/root "../release-executor"}}
  :aliases

--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -27,6 +27,7 @@
             [ai.miniforge.phase.agent-behavior :as agent-beh]
             [ai.miniforge.phase.messages :as messages]
             [ai.miniforge.agent.interface :as agent]
+            [ai.miniforge.context-pack.interface :as context-pack]
             [ai.miniforge.knowledge.interface :as knowledge]
             [ai.miniforge.repo-index.interface :as repo-index]
             [ai.miniforge.response.interface :as response]
@@ -73,14 +74,22 @@
                     [(str "\n... [" skipped " lines omitted] ...\n")]
                     tail)))))))
 
-(defn- build-repo-map-context
-  "Build a repo map for the target repository, falling back gracefully.
-   Returns {:repo-index <RepoIndex> :repo-map-text <string>} or nil."
-  [worktree-path]
+(defn- build-context-pack
+  "Build a context pack for the implement phase, falling back gracefully."
+  [worktree-path files-in-scope]
   (try
     (when-let [index (repo-index/build-index worktree-path)]
-      {:repo-index index
-       :repo-map-text (repo-index/repo-map-text index)})
+      (let [search-index (try (repo-index/build-search-index index)
+                              (catch Exception _ nil))
+            pack (context-pack/build-pack :implement index
+                   {:files-in-scope files-in-scope
+                    :search-index search-index
+                    :search-query (when (seq files-in-scope)
+                                    (first files-in-scope))})]
+        {:repo-index index
+         :context-pack pack
+         :repo-map-text (:repo-map pack)
+         :existing-files (:files pack)}))
     (catch Exception _e
       nil)))
 
@@ -105,12 +114,11 @@
       (get-in input [:intent :scope])))
 
 (defn- resolve-existing-files
-  "Load existing files from cache, repo index, or disk."
-  [ctx repo-ctx worktree-path files-in-scope]
+  "Load existing files from cache, context pack, or disk."
+  [ctx pack-ctx worktree-path files-in-scope]
   (or (get-in ctx [:execution/cached-files])
-      (if (and (:repo-index repo-ctx) (seq files-in-scope))
-        (repo-index/get-files (:repo-index repo-ctx) files-in-scope)
-        (file-ctx/load-files-in-scope worktree-path files-in-scope))))
+      (:existing-files pack-ctx)
+      (file-ctx/load-files-in-scope worktree-path files-in-scope)))
 
 (defn- resolve-review-feedback
   "Extract review feedback from phase results."
@@ -119,13 +127,15 @@
       (get-in ctx [:execution/phase-results :review :result :output :review/issues])))
 
 (defn- assoc-optional-task-fields
-  "Conditionally assoc repo-map, repo-index, and knowledge-context onto a task."
-  [task repo-ctx kb-context]
+  "Conditionally assoc repo-map, repo-index, context-pack, and knowledge-context onto a task."
+  [task pack-ctx kb-context]
   (cond-> task
-    (:repo-map-text repo-ctx)
-    (assoc :task/repo-map (:repo-map-text repo-ctx))
-    (:repo-index repo-ctx)
-    (assoc :task/repo-index (:repo-index repo-ctx))
+    (:repo-map-text pack-ctx)
+    (assoc :task/repo-map (:repo-map-text pack-ctx))
+    (:repo-index pack-ctx)
+    (assoc :task/repo-index (:repo-index pack-ctx))
+    (:context-pack pack-ctx)
+    (assoc :task/context-pack (:context-pack pack-ctx))
     kb-context
     (assoc :task/knowledge-context kb-context)))
 
@@ -137,9 +147,9 @@
         verify-failure (get-in ctx [:execution/phase-results :verify])
         worktree-path (resolve-worktree-path ctx)
         files-in-scope (resolve-files-in-scope input)
-        repo-ctx (or (get-in ctx [:execution/repo-context])
-                     (build-repo-map-context worktree-path))
-        existing-files (resolve-existing-files ctx repo-ctx worktree-path files-in-scope)
+        pack-ctx (or (get-in ctx [:execution/pack-context])
+                     (build-context-pack worktree-path files-in-scope))
+        existing-files (resolve-existing-files ctx pack-ctx worktree-path files-in-scope)
         behavior-addendum (agent-beh/load-and-filter-behaviors
                             :implement {:task {:task/intent (:intent input)}})
         review-feedback (resolve-review-feedback ctx)
@@ -155,7 +165,7 @@
                      :task/plan plan-result
                      :task/existing-files existing-files
                      :task/behavior-addendum behavior-addendum}
-                    repo-ctx kb-context)]
+                    pack-ctx kb-context)]
     (cond-> base-task
       verify-failure
       (assoc :task/verify-failures (build-verify-failures verify-failure))
@@ -194,14 +204,16 @@
         start-time (System/currentTimeMillis)
         implementer-agent (agent/create-implementer {})
         task (build-implement-task ctx)
-        ;; Cache loaded files and repo context for subsequent retries
+        ;; Cache loaded files and context pack for subsequent retries
         ctx (cond-> ctx
               (not (get-in ctx [:execution/cached-files]))
               (assoc-in [:execution/cached-files] (:task/existing-files task))
-              (and (:task/repo-index task) (not (get-in ctx [:execution/repo-context])))
-              (assoc-in [:execution/repo-context]
+              (and (:task/context-pack task) (not (get-in ctx [:execution/pack-context])))
+              (assoc-in [:execution/pack-context]
                         {:repo-index (:task/repo-index task)
-                         :repo-map-text (:task/repo-map task)}))
+                         :context-pack (:task/context-pack task)
+                         :repo-map-text (:task/repo-map task)
+                         :existing-files (:task/existing-files task)}))
         on-chunk (create-streaming-callback ctx)
         agent-ctx (cond-> ctx on-chunk (assoc :on-chunk on-chunk))
         peer-advice (collect-peer-advice ctx)

--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -28,6 +28,7 @@
             [ai.miniforge.phase.messages :as messages]
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.context-pack.interface :as context-pack]
+            [ai.miniforge.context-pack.factory :as ctx-factory]
             [ai.miniforge.knowledge.interface :as knowledge]
             [ai.miniforge.repo-index.interface :as repo-index]
             [ai.miniforge.response.interface :as response]
@@ -86,10 +87,7 @@
                     :search-index search-index
                     :search-query (when (seq files-in-scope)
                                     (first files-in-scope))})]
-        {:repo-index index
-         :context-pack pack
-         :repo-map-text (:repo-map pack)
-         :existing-files (:files pack)}))
+        (ctx-factory/->pack-context index pack)))
     (catch Exception _e
       nil)))
 
@@ -210,10 +208,9 @@
               (assoc-in [:execution/cached-files] (:task/existing-files task))
               (and (:task/context-pack task) (not (get-in ctx [:execution/pack-context])))
               (assoc-in [:execution/pack-context]
-                        {:repo-index (:task/repo-index task)
-                         :context-pack (:task/context-pack task)
-                         :repo-map-text (:task/repo-map task)
-                         :existing-files (:task/existing-files task)}))
+                        (ctx-factory/->pack-context
+                          (:task/repo-index task)
+                          (:task/context-pack task))))
         on-chunk (create-streaming-callback ctx)
         agent-ctx (cond-> ctx on-chunk (assoc :on-chunk on-chunk))
         peer-advice (collect-peer-advice ctx)

--- a/deps.edn
+++ b/deps.edn
@@ -90,6 +90,8 @@
                        "components/mcp-artifact-server/resources"
                        "components/repo-index/src"
                        "components/repo-index/resources"
+                       "components/context-pack/src"
+                       "components/context-pack/resources"
                        "bases/cli/src"
                        "bases/cli/resources"
                        "bases/lsp-mcp-bridge/src"]
@@ -139,6 +141,7 @@
                      ai.miniforge/spec-parser {:local/root "components/spec-parser"}
                      ai.miniforge/mcp-artifact-server {:local/root "components/mcp-artifact-server"}
                      ai.miniforge/repo-index {:local/root "components/repo-index"}
+                     ai.miniforge/context-pack {:local/root "components/context-pack"}
                      ai.miniforge/cli {:local/root "bases/cli"}}}
 
   :test {:extra-paths ["development/test"
@@ -188,6 +191,7 @@
                        "components/spec-parser/test"
                        "components/mcp-artifact-server/test"
                        "components/repo-index/test"
+                       "components/context-pack/test"
                        "components/task-executor/test"
                        "bases/cli/test"
                        "bases/lsp-mcp-bridge/test"]
@@ -235,6 +239,7 @@
                       ai.miniforge/spec-parser {:local/root "components/spec-parser"}
                       ai.miniforge/mcp-artifact-server {:local/root "components/mcp-artifact-server"}
                       ai.miniforge/repo-index {:local/root "components/repo-index"}
+                      ai.miniforge/context-pack {:local/root "components/context-pack"}
                       ai.miniforge/task-executor {:local/root "components/task-executor"}
                       ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}}}
 

--- a/docs/pull-requests/2026-03-15-feat-context-pack-budget.md
+++ b/docs/pull-requests/2026-03-15-feat-context-pack-budget.md
@@ -1,0 +1,72 @@
+# feat: Add context-pack component with per-phase budget enforcement
+
+## Overview
+
+Adds a new `components/context-pack/` component that wraps repo-map + files +
+search results into bounded, auditable context documents with per-phase token
+budgets. Wired into the implement phase to replace ad-hoc context assembly.
+
+This is Iteration 3 of the Repo Indexer plan.
+
+## Motivation
+
+Previously, context assembly was ad-hoc — the implement phase independently
+loaded repo-map, files, and search results without coordinated budget tracking.
+Files that exceeded the token budget were included anyway, wasting tokens.
+There was no way to audit how much of the budget each source consumed.
+
+Context-pack provides:
+
+- Per-phase token budgets (plan: 1200, implement: 3500, test: 2200, review: 2800)
+- Pre-flight budget checks before including each item
+- Deduplication of files across sources (direct include vs search results)
+- Audit trail showing per-source token consumption and utilization
+
+## Changes in Detail
+
+### New: `components/context-pack/`
+
+| File | Purpose |
+|------|---------|
+| `config.clj` | Load budgets from EDN resource |
+| `factory.clj` | Factory functions: `->context-pack`, `->budget-audit`, `->source` |
+| `schema.clj` | Malli schemas: ContextPack, BudgetAudit, Source |
+| `budget.clj` | Token estimation, budget tracking, exhaustion detection |
+| `dedup.clj` | Deduplicate files by path, search results by score, cross-source |
+| `builder.clj` | Assemble packs: `build-pack`, `extend-pack`, `audit` |
+| `interface.clj` | Public API |
+| `budgets.edn` | Phase budget config (EDN resource) |
+
+### Modified: `components/phase-software-factory/`
+
+- `deps.edn`: Added context-pack dependency
+- `implement.clj`: Replaced `build-repo-map-context` with `build-context-pack`
+  which uses `context-pack/build-pack` for coordinated budget-enforced assembly;
+  cached as `execution/pack-context` for retries; context pack passed to agent
+  via `:task/context-pack`
+
+## Testing Plan
+
+- [x] 11 tests: budget queries, pack building, schema conformance, search
+  integration, budget enforcement, exhaustion detection, audit snapshots,
+  extend-pack, tokens-remaining, deduplication
+- [x] Implement phase tests pass
+- [ ] Dogfood: compare token usage with context-pack vs ad-hoc assembly
+
+## Related
+
+- Iteration 1: PR #317 (scanner + repo map)
+- Iteration 2: PR #320 (BM25 search)
+- Spec: N1-architecture.md §2.28–§2.30
+
+## Checklist
+
+- [x] Context-pack component scaffold
+- [x] Budget config in EDN
+- [x] Factory functions for all domain maps
+- [x] Schemas for all types
+- [x] Budget enforcement (fail-closed by default)
+- [x] Deduplication (files, search results, cross-source)
+- [x] Implement phase wiring
+- [x] Tests passing
+- [x] PR documentation


### PR DESCRIPTION
## Summary

- New `components/context-pack/` component that assembles bounded context documents with per-phase token budgets
- Pre-flight budget checks before including each file (skip items that would exceed budget instead of including and over-spending)
- Deduplication across sources (files vs search results)
- Audit trail: per-source token consumption and utilization percentage
- Wired into implement phase, replacing ad-hoc context assembly

## Budget defaults (configurable via EDN)

| Phase | Budget |
|-------|--------|
| plan | 1,200 tokens |
| implement | 3,500 tokens |
| test | 2,200 tokens |
| review | 2,800 tokens |

## Test plan

- [x] 11 context-pack tests (budget queries, pack building, schema conformance, search integration, budget enforcement, exhaustion, audit, extend-pack, dedup)
- [x] Implement phase tests pass
- [ ] Dogfood: compare token usage with context-pack vs ad-hoc assembly

See `docs/pull-requests/2026-03-15-feat-context-pack-budget.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)