### PR TITLE
fix: increase max-turns to 10, raise context budgets to match LLM capacity

### DIFF
--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -7,6 +7,7 @@
 {:prompt/id :implementer
  :prompt/version "1.0.0"
  :prompt/agent :implementer
+ :prompt/max-turns 10
 
  :prompt/system
  "You are an Implementation Agent for an autonomous software development team.

--- a/components/agent/resources/prompts/tester.edn
+++ b/components/agent/resources/prompts/tester.edn
@@ -7,6 +7,7 @@
 {:prompt/id :tester
  :prompt/version "1.0.0"
  :prompt/agent :tester
+ :prompt/max-turns 10
 
  :prompt/system
  "You are a Testing Agent for an autonomous software development team.

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -383,7 +383,7 @@
                           :mcp-allowed-tools (:mcp-allowed-tools session)
                           :supervision (:supervision session)
                           :budget-usd budget-usd
-                          :max-turns 5}]
+                          :max-turns 10}]
             (if on-chunk
               (llm/chat-stream llm-client user-prompt on-chunk
                                (merge {:system effective-system-prompt} mcp-opts))

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -43,6 +43,10 @@
    Loaded from EDN resource for configurability."
   (delay (prompts/load-prompt :implementer)))
 
+(def ^:private implementer-prompt-data
+  "Full prompt data map for the implementer agent."
+  (delay (prompts/load-prompt-data :implementer)))
+
 ;------------------------------------------------------------------------------ Layer 0
 ;; Extension → language mapping (loaded from config)
 
@@ -379,11 +383,12 @@
   (let [{:keys [llm-result artifact]}
         (artifact-session/with-artifact-session [session]
           (let [budget-usd (budget/resolve-cost-budget-usd :implementer config context)
+                max-turns (get @implementer-prompt-data :prompt/max-turns 10)
                 mcp-opts {:mcp-config (:mcp-config-path session)
                           :mcp-allowed-tools (:mcp-allowed-tools session)
                           :supervision (:supervision session)
                           :budget-usd budget-usd
-                          :max-turns 10}]
+                          :max-turns max-turns}]
             (if on-chunk
               (llm/chat-stream llm-client user-prompt on-chunk
                                (merge {:system effective-system-prompt} mcp-opts))

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -51,6 +51,10 @@
    Loaded from EDN resource for configurability."
   (delay (prompts/load-prompt :tester)))
 
+(def ^:private tester-prompt-data
+  "Full prompt data map for the tester agent."
+  (delay (prompts/load-prompt-data :tester)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Tester functions
 
@@ -296,11 +300,12 @@
             (let [{:keys [llm-result artifact]}
                   (artifact-session/with-artifact-session [session]
                     (let [budget-usd (budget/resolve-cost-budget-usd :tester config context)
+                          max-turns (get @tester-prompt-data :prompt/max-turns 10)
                           mcp-opts {:mcp-config (:mcp-config-path session)
                                     :mcp-allowed-tools (:mcp-allowed-tools session)
                                     :supervision (:supervision session)
                                     :budget-usd budget-usd
-                                    :max-turns 10}]
+                                    :max-turns max-turns}]
                       (if on-chunk
                         (llm/chat-stream llm-client user-prompt on-chunk
                                          (merge {:system @tester-system-prompt} mcp-opts))

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -300,7 +300,7 @@
                                     :mcp-allowed-tools (:mcp-allowed-tools session)
                                     :supervision (:supervision session)
                                     :budget-usd budget-usd
-                                    :max-turns 5}]
+                                    :max-turns 10}]
                       (if on-chunk
                         (llm/chat-stream llm-client user-prompt on-chunk
                                          (merge {:system @tester-system-prompt} mcp-opts))

--- a/components/context-pack/resources/config/context-pack/budgets.edn
+++ b/components/context-pack/resources/config/context-pack/budgets.edn
@@ -2,26 +2,31 @@
  {;; Token budgets per phase.
   ;; Controls how much context each agent phase receives.
   ;; Values are approximate token counts (chars ÷ 4).
+  ;;
+  ;; Modern LLMs have 200K–1M token context windows. Input tokens are cheap
+  ;; (~$3/M Sonnet, ~$15/M Opus). Exploration turns are expensive (~$0.05-0.10
+  ;; each + 1-2 min wall time). Pre-loading sufficient context eliminates
+  ;; exploration and pays for itself in saved turns.
   :phase-budgets
-  {:plan     1200
-   :implement 3500
-   :test     2200
-   :review   2800}
+  {:plan      20000
+   :implement 100000
+   :test      60000
+   :review    40000}
 
   ;; Default budget when phase is not in the map above.
-  :default-budget 2000
+  :default-budget 40000
 
   ;; Repo map token budget (subset of phase budget allocated to the map).
-  :repo-map-budget 500
+  :repo-map-budget 5000
 
   ;; Maximum files to include in a context pack.
-  :max-files 25
+  :max-files 50
 
   ;; Maximum lines per file.
   :max-lines-per-file 500
 
   ;; Maximum search results to include.
-  :max-search-results 5
+  :max-search-results 15
 
   ;; On budget exhaustion: :fail-closed (stop) or :warn (continue with warning).
   :exhaustion-policy :fail-closed}}

--- a/components/context-pack/test/ai/miniforge/context_pack/interface_test.clj
+++ b/components/context-pack/test/ai/miniforge/context_pack/interface_test.clj
@@ -7,13 +7,13 @@
 
 (deftest phase-budget-test
   (testing "returns configured budgets for known phases"
-    (is (= 3500 (ctx/phase-budget :implement)))
-    (is (= 1200 (ctx/phase-budget :plan)))
-    (is (= 2200 (ctx/phase-budget :test)))
-    (is (= 2800 (ctx/phase-budget :review))))
+    (is (= 100000 (ctx/phase-budget :implement)))
+    (is (= 20000 (ctx/phase-budget :plan)))
+    (is (= 60000 (ctx/phase-budget :test)))
+    (is (= 40000 (ctx/phase-budget :review))))
 
   (testing "returns default budget for unknown phases"
-    (is (= 2000 (ctx/phase-budget :unknown)))))
+    (is (= 40000 (ctx/phase-budget :unknown)))))
 
 (deftest build-pack-basic-test
   (testing "builds a context pack with repo map and files"
@@ -23,7 +23,7 @@
                  {:files-in-scope ["workspace.edn" "claude.md"]})]
       (is (some? pack))
       (is (= :implement (:phase pack)))
-      (is (= 3500 (:budget pack)))
+      (is (= 100000 (:budget pack)))
       (is (pos? (:tokens-used pack)))
       (is (string? (:repo-map pack)))
       (is (pos? (count (:files pack))))
@@ -77,7 +77,7 @@
                  {:files-in-scope ["workspace.edn"]})
           a (ctx/audit pack)]
       (is (= :implement (:phase a)))
-      (is (= 3500 (:budget a)))
+      (is (= 100000 (:budget a)))
       (is (pos? (:tokens-used a)))
       (is (pos? (:tokens-remaining a)))
       (is (pos? (:source-count a)))


### PR DESCRIPTION
## Summary

- Increase `--max-turns` from 5 to 10 (agents need 8-12 turns for complex tasks)
- Raise context-pack budgets from 1.2K-3.5K to 20K-100K tokens per phase
- Agents were exploring because they only got 1-2 files in a 3.5K budget; now they get 10-20+ files, reducing need to explore

## Why the old budgets were wrong

| Phase | Old | New | Rationale |
|-------|-----|-----|-----------|
| plan | 1,200 | 20,000 | Planner needs to see repo structure + key files |
| implement | 3,500 | 100,000 | 3.5K fits ~2 files; complex tasks touch 10+ files |
| test | 2,200 | 60,000 | Tester needs full code artifact + existing tests |
| review | 2,800 | 40,000 | Reviewer needs code + test output + context |

Input tokens are cheap ($3-15/M). Each exploration turn the agent spends reading files costs $0.05-0.10 + 1-2 min. Pre-loading context eliminates those turns.

## Codex MCP status

Codex auto-discovers MCP from `.codex/config.toml` (which `artifact_session.clj` already writes). No CLI flags needed. Codex `exec` mode doesn't have built-in file tools like Claude CLI, so it should use MCP tools more reliably.

## Test plan

- [x] Context-pack, implementer, tester, LLM tests all pass
- [ ] Re-run YC MVP spec to verify complex tasks complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)