### PR TITLE
refactor: externalize phase defaults to EDN, reduce review loop

### DIFF
--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -482,9 +482,11 @@
             (let [user-prompt (build-review-prompt input)
                   response (if on-chunk
                              (llm/chat-stream llm-client user-prompt on-chunk
-                                              {:system @reviewer-system-prompt})
+                                              {:system @reviewer-system-prompt
+                                               :max-turns 10})
                              (llm/chat llm-client user-prompt
-                                       {:system @reviewer-system-prompt}))
+                                       {:system @reviewer-system-prompt
+                                        :max-turns 10}))
                   tokens (get response :tokens 0)
                   cost-usd (get response :cost-usd)]
 

--- a/components/phase-software-factory/resources/config/phase/defaults.edn
+++ b/components/phase-software-factory/resources/config/phase/defaults.edn
@@ -1,0 +1,44 @@
+{:phase/defaults
+ {;; Implementation phase defaults.
+  :implement
+  {:agent :implementer
+   :gates [:syntax :lint]
+   :budget {:tokens 30000
+            :iterations 8
+            :time-seconds 600}
+   :model-hint :sonnet-4.6}
+
+  ;; Verify phase defaults.
+  :verify
+  {:agent :tester
+   :gates [:tests-pass :coverage]
+   :budget {:tokens 15000
+            :iterations 3
+            :time-seconds 300}
+   :model-hint :haiku-4.5}
+
+  ;; Review phase defaults.
+  :review
+  {:agent :reviewer
+   :gates [:review-approved :quality-check]
+   :budget {:tokens 20000
+            :iterations 2
+            :time-seconds 180}
+   :model-hint :sonnet-4.6}
+
+  ;; Plan phase defaults.
+  :plan
+  {:agent :planner
+   :gates [:plan-complete]
+   :budget {:tokens 10000
+            :iterations 3
+            :time-seconds 300}
+   :model-hint :opus-4.6}
+
+  ;; Release phase defaults.
+  :release
+  {:agent :releaser
+   :gates [:release-ready]
+   :budget {:tokens 5000
+            :iterations 2
+            :time-seconds 180}}}}

--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -26,6 +26,7 @@
             [ai.miniforge.phase.file-context :as file-ctx]
             [ai.miniforge.phase.agent-behavior :as agent-beh]
             [ai.miniforge.phase.messages :as messages]
+            [ai.miniforge.phase.phase-config :as phase-config]
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.context-pack.interface :as context-pack]
             [ai.miniforge.context-pack.factory :as ctx-factory]
@@ -38,13 +39,8 @@
 ;; Defaults
 
 (def default-config
-  {:agent :implementer
-   :gates [:syntax :lint]
-   :budget {:tokens 30000
-            :iterations 8
-            :time-seconds 600}
-   ;; Implementation is code-heavy - hint at current Sonnet
-   :model-hint :sonnet-4.6})
+  "Phase defaults loaded from config/phase/defaults.edn."
+  (phase-config/defaults-for :implement))
 
 ;; Register defaults on load
 (registry/register-phase-defaults! :implement default-config)

--- a/components/phase-software-factory/src/ai/miniforge/phase/phase_config.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/phase_config.clj
@@ -1,0 +1,25 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.phase.phase-config
+  "Load phase defaults from EDN configuration.
+
+   Layer 0 — pure config loading, no domain logic."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+(def ^:private config-path "config/phase/defaults.edn")
+
+(defn- load-phase-defaults []
+  (if-let [res (io/resource config-path)]
+    (get (edn/read-string (slurp res)) :phase/defaults {})
+    {}))
+
+(def ^:private phase-defaults (delay (load-phase-defaults)))
+
+(defn defaults-for
+  "Get the default config map for a given phase keyword.
+   Returns the config from defaults.edn, or an empty map if not found."
+  [phase-kw]
+  (get @phase-defaults phase-kw {}))

--- a/components/phase-software-factory/src/ai/miniforge/phase/plan.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/plan.clj
@@ -23,6 +23,7 @@
    Agent: :planner
    Default gates: [:plan-complete]"
   (:require [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.phase.phase-config :as phase-config]
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.knowledge.interface :as knowledge]
             [ai.miniforge.response.interface :as response]))
@@ -31,13 +32,8 @@
 ;; Defaults
 
 (def default-config
-  {:agent :planner
-   :gates [:plan-complete]
-   :budget {:tokens 10000
-            :iterations 3
-            :time-seconds 300}
-   ;; Planning requires complex reasoning - hint at Opus
-   :model-hint :opus-4.6})
+  "Phase defaults loaded from config/phase/defaults.edn."
+  (phase-config/defaults-for :plan))
 
 ;; Register defaults on load
 (registry/register-phase-defaults! :plan default-config)

--- a/components/phase-software-factory/src/ai/miniforge/phase/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/release.clj
@@ -23,6 +23,7 @@
    Agent: :releaser
    Default gates: [:release-ready]"
   (:require [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.phase.phase-config :as phase-config]
             [ai.miniforge.release-executor.interface :as release-executor]
             [ai.miniforge.response.interface :as response]))
 
@@ -30,11 +31,8 @@
 ;; Defaults
 
 (def default-config
-  {:agent :releaser
-   :gates [:release-ready]
-   :budget {:tokens 5000
-            :iterations 2
-            :time-seconds 180}})
+  "Phase defaults loaded from config/phase/defaults.edn."
+  (phase-config/defaults-for :release))
 
 ;; Register defaults on load
 (registry/register-phase-defaults! :release default-config)

--- a/components/phase-software-factory/src/ai/miniforge/phase/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/review.clj
@@ -23,6 +23,7 @@
    Agent: :reviewer
    Default gates: [:review-approved :quality-check]"
   (:require [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.phase.phase-config :as phase-config]
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.knowledge.interface :as knowledge]
             [ai.miniforge.response.interface :as response]))
@@ -31,13 +32,8 @@
 ;; Defaults
 
 (def default-config
-  {:agent :reviewer
-   :gates [:review-approved :quality-check]
-   :budget {:tokens 20000
-            :iterations 4
-            :time-seconds 180}
-   ;; Code review needs balanced capabilities - hint at current Sonnet
-   :model-hint :sonnet-4.6})
+  "Phase defaults loaded from config/phase/defaults.edn."
+  (phase-config/defaults-for :review))
 
 ;; Register defaults on load
 (registry/register-phase-defaults! :review default-config)

--- a/components/phase-software-factory/src/ai/miniforge/phase/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/verify.clj
@@ -23,6 +23,7 @@
    Agent: :tester
    Default gates: [:tests-pass :coverage]"
   (:require [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.phase.phase-config :as phase-config]
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.task.interface :as task]
             [ai.miniforge.response.interface :as response]
@@ -34,13 +35,8 @@
 ;; Defaults
 
 (def default-config
-  {:agent :tester
-   :gates [:tests-pass :coverage]
-   :budget {:tokens 15000
-            :iterations 3
-            :time-seconds 300}
-   ;; Verification can use fast validation - hint at Haiku
-   :model-hint :haiku-4.5})
+  "Phase defaults loaded from config/phase/defaults.edn."
+  (phase-config/defaults-for :verify))
 
 (def ^:private timeout-message-fragment
   "Substring that marks a non-actionable verify timeout."


### PR DESCRIPTION
## Summary

- Extract all hardcoded phase defaults to `config/phase/defaults.edn`
- New `phase_config.clj` loader — all phase interceptors now call `phase-config/defaults-for`
- Add `--max-turns 10` to reviewer agent (was uncapped, explored for minutes)
- Reduce review iteration budget from 4 to 2

## Why

Hardcoded defaults in each phase `.clj` file meant changing budgets, iterations, or model hints required code changes and a rebuild. Now all defaults live in one EDN file that can eventually be projected to `~/.miniforge/config/`.

The review iteration reduction (4→2) eliminates the nit-picking loop where the reviewer kept requesting minor changes, cycling 3-4 times per task.

## Dogfooding results

| Run | Tasks | Implement cycles | Review rejections | Avg implement time |
|-----|-------|-----------------|-------------------|-------------------|
| Baseline | 2/8 | 8 | 1 (looped) | 8.6m |
| +100K budget | 5/8 | 13 | 15 (looped) | 5.9m |
| **This PR** | **8/8** | **11** | **0** | **4.8m** |

## Test plan

- [x] All phase modules load cleanly
- [x] Pre-commit hooks pass
- [x] Dogfood: 8/8 YC MVP tasks completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)