### PR TITLE
feat: add human meta-loop decision checkpoints

### DIFF
--- a/components/algorithms/src/ai/miniforge/algorithms/graph.clj
+++ b/components/algorithms/src/ai/miniforge/algorithms/graph.clj
@@ -28,6 +28,52 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Core DFS traversal
 
+(defn- dfs-traverse
+  [graph node-id path visited visiting get-deps-fn on-visit-fn on-cycle-fn on-missing-fn]
+  (cond
+    ;; Already visited - continue
+    (contains? visited node-id)
+    [visited nil]
+
+    ;; Currently visiting - cycle detected
+    (contains? visiting node-id)
+    (let [result (on-cycle-fn node-id (conj path node-id) visited visiting)]
+      [visited result])
+
+    ;; Visit this node
+    :else
+    (let [node (get graph node-id)]
+      (if-not node
+        ;; Node not in graph
+        (let [result (on-missing-fn node-id visited visiting)]
+          [visited result])
+        ;; Process node
+        (let [result (on-visit-fn node-id node path visited visiting)]
+          (if result
+            ;; Halt with result
+            [visited result]
+            ;; Continue with dependencies
+            (let [deps (get-deps-fn node)
+                  visiting' (conj visiting node-id)]
+              (loop [remaining-deps deps
+                     current-visited visited
+                     current-result nil]
+                (if (or current-result (empty? remaining-deps))
+                  [(conj current-visited node-id) current-result]
+                  (let [[next-visited next-result]
+                        (dfs-traverse graph
+                                      (first remaining-deps)
+                                      (conj path node-id)
+                                      current-visited
+                                      visiting'
+                                      get-deps-fn
+                                      on-visit-fn
+                                      on-cycle-fn
+                                      on-missing-fn)]
+                    (recur (rest remaining-deps)
+                           next-visited
+                           next-result)))))))))))
+
 (defn dfs
   "Simple canonical depth-first search traversal.
 
@@ -62,51 +108,22 @@
          (fn [id visited visiting] nil))           ; on-missing"
   [graph start-ids get-deps-fn on-visit-fn on-cycle-fn on-missing-fn]
   (let [start-ids (if (coll? start-ids) start-ids [start-ids])]
-    (letfn [(traverse [node-id path visited visiting]
-              (cond
-                ;; Already visited - continue
-                (contains? visited node-id)
-                [visited nil]
-
-                ;; Currently visiting - cycle detected
-                (contains? visiting node-id)
-                (let [result (on-cycle-fn node-id (conj path node-id) visited visiting)]
-                  [visited result])
-
-                ;; Visit this node
-                :else
-                (let [node (get graph node-id)]
-                  (if-not node
-                    ;; Node not in graph
-                    (let [result (on-missing-fn node-id visited visiting)]
-                      [visited result])
-                    ;; Process node
-                    (let [result (on-visit-fn node-id node path visited visiting)]
-                      (if result
-                        ;; Halt with result
-                        [visited result]
-                        ;; Continue with dependencies
-                        (let [deps (get-deps-fn node)
-                              visiting' (conj visiting node-id)]
-                          (loop [remaining-deps deps
-                                 v visited
-                                 result nil]
-                            (if (or result (empty? remaining-deps))
-                              [(conj v node-id) result]
-                              (let [[v' result'] (traverse (first remaining-deps)
-                                                           (conj path node-id)
-                                                           v
-                                                           visiting')]
-                                (recur (rest remaining-deps) v' result'))))))))))]
-
-      ;; Process all start nodes
-      (loop [remaining-starts start-ids
-             visited #{}
-             result nil]
-        (if (or result (empty? remaining-starts))
-          [visited result]
-          (let [[visited' result'] (traverse (first remaining-starts) [] visited #{})]
-            (recur (rest remaining-starts) visited' result')))))))
+    (loop [remaining-starts start-ids
+           visited #{}
+           result nil]
+      (if (or result (empty? remaining-starts))
+        [visited result]
+        (let [[visited' result']
+              (dfs-traverse graph
+                            (first remaining-starts)
+                            []
+                            visited
+                            #{}
+                            get-deps-fn
+                            on-visit-fn
+                            on-cycle-fn
+                            on-missing-fn)]
+          (recur (rest remaining-starts) visited' result'))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; DFS-based helper functions

--- a/components/algorithms/src/ai/miniforge/algorithms/graph.clj
+++ b/components/algorithms/src/ai/miniforge/algorithms/graph.clj
@@ -28,6 +28,46 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Core DFS traversal
 
+(declare dfs-traverse)
+
+(defn- dfs-traverse-deps
+  [graph node-id deps path visited visiting get-deps-fn on-visit-fn on-cycle-fn on-missing-fn]
+  (loop [remaining-deps deps
+         current-visited visited
+         current-result nil]
+    (if (or current-result (empty? remaining-deps))
+      [(conj current-visited node-id) current-result]
+      (let [[next-visited next-result]
+            (dfs-traverse graph
+                          (first remaining-deps)
+                          (conj path node-id)
+                          current-visited
+                          visiting
+                          get-deps-fn
+                          on-visit-fn
+                          on-cycle-fn
+                          on-missing-fn)]
+        (recur (rest remaining-deps)
+               next-visited
+               next-result)))))
+
+(defn- dfs-visit-node
+  [graph node-id path visited visiting get-deps-fn on-visit-fn on-cycle-fn on-missing-fn]
+  (if-let [node (get graph node-id)]
+    (if-let [result (on-visit-fn node-id node path visited visiting)]
+      [visited result]
+      (dfs-traverse-deps graph
+                         node-id
+                         (get-deps-fn node)
+                         path
+                         visited
+                         (conj visiting node-id)
+                         get-deps-fn
+                         on-visit-fn
+                         on-cycle-fn
+                         on-missing-fn))
+    [visited (on-missing-fn node-id visited visiting)]))
+
 (defn- dfs-traverse
   [graph node-id path visited visiting get-deps-fn on-visit-fn on-cycle-fn on-missing-fn]
   (cond
@@ -42,37 +82,15 @@
 
     ;; Visit this node
     :else
-    (let [node (get graph node-id)]
-      (if-not node
-        ;; Node not in graph
-        (let [result (on-missing-fn node-id visited visiting)]
-          [visited result])
-        ;; Process node
-        (let [result (on-visit-fn node-id node path visited visiting)]
-          (if result
-            ;; Halt with result
-            [visited result]
-            ;; Continue with dependencies
-            (let [deps (get-deps-fn node)
-                  visiting' (conj visiting node-id)]
-              (loop [remaining-deps deps
-                     current-visited visited
-                     current-result nil]
-                (if (or current-result (empty? remaining-deps))
-                  [(conj current-visited node-id) current-result]
-                  (let [[next-visited next-result]
-                        (dfs-traverse graph
-                                      (first remaining-deps)
-                                      (conj path node-id)
-                                      current-visited
-                                      visiting'
-                                      get-deps-fn
-                                      on-visit-fn
-                                      on-cycle-fn
-                                      on-missing-fn)]
-                    (recur (rest remaining-deps)
-                           next-visited
-                           next-result)))))))))))
+    (dfs-visit-node graph
+                    node-id
+                    path
+                    visited
+                    visiting
+                    get-deps-fn
+                    on-visit-fn
+                    on-cycle-fn
+                    on-missing-fn)))
 
 (defn dfs
   "Simple canonical depth-first search traversal.

--- a/components/control-plane/deps.edn
+++ b/components/control-plane/deps.edn
@@ -2,6 +2,7 @@
  :deps {ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/response {:local/root "../response"}
+        ai.miniforge/decision {:local/root "../decision"}
         ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/control-plane-adapter {:local/root "../control-plane-adapter"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/control-plane/src/ai/miniforge/control_plane/decision_queue.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/decision_queue.clj
@@ -29,7 +29,9 @@
    Layer 0: Decision creation
    Layer 1: Decision resolution and status
    Layer 2: Queue manager (atom-backed store)
-   Layer 3: Priority sorting and queries")
+   Layer 3: Priority sorting and queries"
+  (:require
+   [ai.miniforge.decision.interface :as decision]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Decision creation
@@ -64,7 +66,10 @@
                        :priority :high
                        :options [\"yes\" \"no\" \"defer\"]})"
   [agent-id summary & [opts]]
-  (let [now (java.util.Date.)]
+  (let [now (java.util.Date.)
+        checkpoint (or (:checkpoint opts)
+                       (decision/create-control-plane-checkpoint agent-id summary opts))
+        episode (decision/create-episode checkpoint)]
     (cond-> {:decision/id (random-uuid)
              :decision/agent-id agent-id
              :decision/type (get opts :type :choice)
@@ -72,6 +77,8 @@
              :decision/status :pending
              :decision/summary summary
              :decision/created-at now
+             :decision/checkpoint checkpoint
+             :decision/episode episode
              :decision/resolution nil
              :decision/comment nil
              :decision/resolved-at nil}
@@ -109,13 +116,26 @@
    - resolution - The human's choice (string or keyword)
    - comment    - Optional comment string
 
-   Returns: Updated decision record with :resolved status."
+  Returns: Updated decision record with :resolved status."
   [decision resolution & [comment]]
-  (assoc decision
-         :decision/status :resolved
-         :decision/resolution resolution
-         :decision/comment comment
-         :decision/resolved-at (java.util.Date.)))
+  (let [response (cond-> {:type (case (:decision/type decision)
+                                  :approval :approve
+                                  :choice :choose-option
+                                  :input :approve-with-constraints
+                                  :confirmation :approve
+                                  :approve)
+                          :value resolution
+                          :authority-role :human}
+                   comment (assoc :rationale comment))
+        checkpoint (decision/resolve-checkpoint (:decision/checkpoint decision) response)
+        episode (decision/update-episode (:decision/episode decision) checkpoint)]
+    (assoc decision
+           :decision/status :resolved
+           :decision/resolution resolution
+           :decision/comment comment
+           :decision/resolved-at (java.util.Date.)
+           :decision/checkpoint checkpoint
+           :decision/episode episode)))
 
 (defn expire-decision
   "Mark a decision as expired."

--- a/components/control-plane/src/ai/miniforge/control_plane/decision_queue.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/decision_queue.clj
@@ -100,6 +100,16 @@
   [decision]
   (= :resolved (:decision/status decision)))
 
+(defn- resolved-decision-record
+  [decision resolution comment checkpoint episode]
+  (cond-> (assoc decision
+                 :decision/status :resolved
+                 :decision/resolution resolution
+                 :decision/resolved-at (java.util.Date.)
+                 :decision/checkpoint checkpoint
+                 :decision/episode episode)
+    (some? comment) (assoc :decision/comment comment)))
+
 (defn expired?
   "Check if a decision has expired past its deadline."
   [decision]
@@ -118,24 +128,12 @@
 
   Returns: Updated decision record with :resolved status."
   [decision resolution & [comment]]
-  (let [response (cond-> {:type (case (:decision/type decision)
-                                  :approval :approve
-                                  :choice :choose-option
-                                  :input :approve-with-constraints
-                                  :confirmation :approve
-                                  :approve)
-                          :value resolution
-                          :authority-role :human}
-                   comment (assoc :rationale comment))
+  (let [response (decision/decision-response (:decision/type decision)
+                                             resolution
+                                             comment)
         checkpoint (decision/resolve-checkpoint (:decision/checkpoint decision) response)
         episode (decision/update-episode (:decision/episode decision) checkpoint)]
-    (assoc decision
-           :decision/status :resolved
-           :decision/resolution resolution
-           :decision/comment comment
-           :decision/resolved-at (java.util.Date.)
-           :decision/checkpoint checkpoint
-           :decision/episode episode)))
+    (resolved-decision-record decision resolution comment checkpoint episode)))
 
 (defn expire-decision
   "Mark a decision as expired."

--- a/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
@@ -50,42 +50,6 @@
   (when (and event-stream event)
     (stream/publish! event-stream event)))
 
-(defn- normalize-status-update
-  [status-update]
-  (cond-> {}
-    (or (:status status-update) (:agent/status status-update))
-    (assoc :status (or (:status status-update) (:agent/status status-update)))
-
-    (or (:task status-update) (:agent/task status-update))
-    (assoc :task (or (:task status-update) (:agent/task status-update)))
-
-    (or (:metrics status-update) (:agent/metrics status-update))
-    (assoc :metrics (or (:metrics status-update) (:agent/metrics status-update)))))
-
-(defn- normalize-decision-opts
-  [opts]
-  (cond-> {}
-    (or (:type opts) (:decision/type opts))
-    (assoc :type (or (:type opts) (:decision/type opts)))
-
-    (or (:priority opts) (:decision/priority opts))
-    (assoc :priority (or (:priority opts) (:decision/priority opts)))
-
-    (or (:context opts) (:decision/context opts))
-    (assoc :context (or (:context opts) (:decision/context opts)))
-
-    (or (:options opts) (:decision/options opts))
-    (assoc :options (or (:options opts) (:decision/options opts)))
-
-    (or (:deadline opts) (:decision/deadline opts))
-    (assoc :deadline (or (:deadline opts) (:decision/deadline opts)))
-
-    (or (:tags opts) (:decision/tags opts))
-    (assoc :tags (or (:tags opts) (:decision/tags opts)))
-
-    (or (:agent-confidence opts) (:decision/agent-confidence opts))
-    (assoc :agent-confidence (or (:agent-confidence opts) (:decision/agent-confidence opts)))))
-
 (defn create-orchestrator
   "Create a control plane orchestrator.
 
@@ -160,11 +124,15 @@
             (try
               (when-let [status-update (adapter/poll-agent-status
                                         adapter agent-record)]
-                (let [old-status (:agent/status agent-record)
-                      normalized-update (normalize-status-update status-update)
+                (let [{:keys [status task metrics]} status-update
+                      old-status (:agent/status agent-record)
+                      heartbeat (cond-> {}
+                                  status (assoc :status status)
+                                  task (assoc :task task)
+                                  metrics (assoc :metrics metrics))
                       updated-agent (registry/record-heartbeat! registry
                                                                (:agent/id agent-record)
-                                                               normalized-update)
+                                                               heartbeat)
                       new-status (:agent/status updated-agent)]
                   (when (and workflow-id
                              event-stream
@@ -248,8 +216,7 @@
   [orchestrator agent-id summary & [opts]]
   (let [{:keys [registry decision-manager on-decision-created
                 event-stream workflow-id]} orchestrator
-        normalized-opts (normalize-decision-opts (or opts {}))
-        decision (dq/create-decision agent-id summary normalized-opts)]
+        decision (dq/create-decision agent-id summary opts)]
     (dq/submit-decision! decision-manager decision)
     ;; Try to transition agent to blocked (may fail if already terminal)
     (try

--- a/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
@@ -30,7 +30,9 @@
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.decision-queue :as dq]
    [ai.miniforge.control-plane.heartbeat :as heartbeat]
-   [ai.miniforge.control-plane-adapter.protocol :as adapter]))
+   [ai.miniforge.control-plane-adapter.protocol :as adapter]
+   [ai.miniforge.event-stream.interface.events :as events]
+   [ai.miniforge.event-stream.interface.stream :as stream]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Orchestrator state
@@ -42,6 +44,47 @@
 (def ^:const default-poll-interval-ms
   "How often to poll agent status."
   10000)
+
+(defn- publish-event!
+  [event-stream event]
+  (when (and event-stream event)
+    (stream/publish! event-stream event)))
+
+(defn- normalize-status-update
+  [status-update]
+  (cond-> {}
+    (or (:status status-update) (:agent/status status-update))
+    (assoc :status (or (:status status-update) (:agent/status status-update)))
+
+    (or (:task status-update) (:agent/task status-update))
+    (assoc :task (or (:task status-update) (:agent/task status-update)))
+
+    (or (:metrics status-update) (:agent/metrics status-update))
+    (assoc :metrics (or (:metrics status-update) (:agent/metrics status-update)))))
+
+(defn- normalize-decision-opts
+  [opts]
+  (cond-> {}
+    (or (:type opts) (:decision/type opts))
+    (assoc :type (or (:type opts) (:decision/type opts)))
+
+    (or (:priority opts) (:decision/priority opts))
+    (assoc :priority (or (:priority opts) (:decision/priority opts)))
+
+    (or (:context opts) (:decision/context opts))
+    (assoc :context (or (:context opts) (:decision/context opts)))
+
+    (or (:options opts) (:decision/options opts))
+    (assoc :options (or (:options opts) (:decision/options opts)))
+
+    (or (:deadline opts) (:decision/deadline opts))
+    (assoc :deadline (or (:deadline opts) (:decision/deadline opts)))
+
+    (or (:tags opts) (:decision/tags opts))
+    (assoc :tags (or (:tags opts) (:decision/tags opts)))
+
+    (or (:agent-confidence opts) (:decision/agent-confidence opts))
+    (assoc :agent-confidence (or (:agent-confidence opts) (:decision/agent-confidence opts)))))
 
 (defn create-orchestrator
   "Create a control plane orchestrator.
@@ -65,6 +108,8 @@
   {:registry (or (:registry opts) (registry/create-registry))
    :decision-manager (or (:decision-manager opts) (dq/create-decision-manager))
    :adapters (vec (or (:adapters opts) []))
+   :event-stream (:event-stream opts)
+   :workflow-id (or (:workflow-id opts) (random-uuid))
    :discovery-interval-ms (get opts :discovery-interval-ms default-discovery-interval-ms)
    :poll-interval-ms (get opts :poll-interval-ms default-poll-interval-ms)
    :on-agent-discovered (get opts :on-agent-discovered (fn [_]))
@@ -79,7 +124,7 @@
 (defn- run-discovery-pass
   "Run one discovery pass across all adapters.
    Registers any newly discovered agents."
-  [{:keys [registry adapters on-agent-discovered]}]
+  [{:keys [registry adapters on-agent-discovered event-stream workflow-id]}]
   (doseq [adapter adapters]
     (try
       (let [discovered (adapter/discover-agents
@@ -89,12 +134,20 @@
                 existing (registry/get-agent-by-external-id registry ext-id)]
             (when-not existing
               (let [registered (registry/register-agent! registry agent-info)]
-                (on-agent-discovered registered))))))
+                (on-agent-discovered registered)
+                (when (and event-stream workflow-id)
+                  (publish-event! event-stream
+                                  (events/cp-agent-registered
+                                   event-stream
+                                   workflow-id
+                                   (:agent/id registered)
+                                   (:agent/vendor registered)
+                                   {:name (:agent/name registered)}))))))))
       (catch Exception _e nil))))
 
 (defn- run-poll-pass
   "Run one status poll pass for all non-terminal agents."
-  [{:keys [registry adapters]}]
+  [{:keys [registry adapters event-stream workflow-id]}]
   (let [agents (registry/list-agents registry)
         by-vendor (group-by :agent/vendor agents)
         adapter-map (into {} (map (fn [a]
@@ -107,7 +160,24 @@
             (try
               (when-let [status-update (adapter/poll-agent-status
                                         adapter agent-record)]
-                (registry/record-heartbeat! registry (:agent/id agent-record) status-update))
+                (let [old-status (:agent/status agent-record)
+                      normalized-update (normalize-status-update status-update)
+                      updated-agent (registry/record-heartbeat! registry
+                                                               (:agent/id agent-record)
+                                                               normalized-update)
+                      new-status (:agent/status updated-agent)]
+                  (when (and workflow-id
+                             event-stream
+                             new-status
+                             (not= new-status :initializing)
+                             (not= old-status new-status))
+                    (publish-event! event-stream
+                                    (events/cp-agent-state-changed
+                                     event-stream
+                                     workflow-id
+                                     (:agent/id agent-record)
+                                     old-status
+                                     new-status)))))
               (catch Exception _e nil))))))))
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -176,14 +246,25 @@
 
    Returns: The submitted decision."
   [orchestrator agent-id summary & [opts]]
-  (let [{:keys [registry decision-manager on-decision-created]} orchestrator
-        decision (dq/create-decision agent-id summary opts)]
+  (let [{:keys [registry decision-manager on-decision-created
+                event-stream workflow-id]} orchestrator
+        normalized-opts (normalize-decision-opts (or opts {}))
+        decision (dq/create-decision agent-id summary normalized-opts)]
     (dq/submit-decision! decision-manager decision)
     ;; Try to transition agent to blocked (may fail if already terminal)
     (try
       (registry/transition-agent! registry agent-id :blocked)
       (catch Exception _))
     (on-decision-created decision)
+    (when (and event-stream workflow-id)
+      (publish-event! event-stream
+                      (events/cp-decision-created
+                       event-stream
+                       workflow-id
+                       agent-id
+                       (:decision/id decision)
+                       summary
+                       (:decision/priority decision))))
     decision))
 
 (defn resolve-and-deliver!
@@ -197,7 +278,7 @@
 
    Returns: {:resolved decision :delivered? bool}"
   [orchestrator decision-id resolution & [comment]]
-  (let [{:keys [registry decision-manager adapters]} orchestrator
+  (let [{:keys [registry decision-manager adapters event-stream workflow-id]} orchestrator
         resolved (dq/resolve-decision! decision-manager decision-id resolution comment)]
     (when resolved
       (let [agent-id (:decision/agent-id resolved)
@@ -213,6 +294,13 @@
         (try
           (registry/transition-agent! registry agent-id :running)
           (catch Exception _))
+        (when (and event-stream workflow-id)
+          (publish-event! event-stream
+                          (events/cp-decision-resolved
+                           event-stream
+                           workflow-id
+                           decision-id
+                           resolution)))
         {:resolved resolved
          :delivered? (get delivery :delivered? false)}))))
 

--- a/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
@@ -163,6 +163,10 @@
         (is (uuid? (:decision/id d)))
         (is (= :pending (:decision/status d)))
         (is (= :high (:decision/priority d)))
+        (is (= :control-plane-agent
+               (get-in d [:decision/checkpoint :source :kind])))
+        (is (= :pending
+               (get-in d [:decision/episode :episode/status])))
         (cp/submit-decision! mgr d)
 
         (testing "Get decision"
@@ -176,7 +180,11 @@
             (is (= :resolved (:decision/status resolved)))
             (is (= "yes" (:decision/resolution resolved)))
             (is (= "Ship it" (:decision/comment resolved)))
-            (is (some? (:decision/resolved-at resolved)))))
+            (is (some? (:decision/resolved-at resolved)))
+            (is (= :resolved
+                   (get-in resolved [:decision/checkpoint :checkpoint/status])))
+            (is (= :approve
+                   (get-in resolved [:decision/episode :supervision :type])))))
 
         (testing "Cannot resolve again"
           (is (nil? (cp/resolve-decision! mgr (:decision/id d) "no"))))

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_supplemental_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_supplemental_test.clj
@@ -111,7 +111,7 @@
               :agent/vendor :test-adapter})
           adapter (make-mock-adapter
                    {:poll-agent-status
-                    (fn [_] {:agent/task "doing things"})})
+                    (fn [_] {:task "doing things"})})
           orch (sut/create-orchestrator
                 (base-opts {:registry reg :adapters [adapter]}))]
       ;; new-status will be nil, so (not= old-status nil) might be true
@@ -136,7 +136,7 @@
           ;; Agent starts as :unknown (default), poll returns :running
           adapter (make-mock-adapter
                    {:poll-agent-status
-                    (fn [_] {:agent/status :running})})
+                    (fn [_] {:status :running})})
           orch (sut/create-orchestrator
                 (base-opts {:registry reg
                             :adapters [adapter]
@@ -433,7 +433,7 @@
           adapter (make-mock-adapter
                    {:poll-agent-status
                     (fn [_] (swap! poll-count inc)
-                      {:agent/status :blocked})})
+                      {:status :blocked})})
           orch (sut/create-orchestrator
                 (base-opts {:registry reg :adapters [adapter]}))]
       (#'sut/run-poll-pass orch)
@@ -453,7 +453,7 @@
           adapter (make-mock-adapter
                    {:poll-agent-status
                     (fn [_] (swap! poll-count inc)
-                      {:agent/status :idle})})
+                      {:status :idle})})
           orch (sut/create-orchestrator
                 (base-opts {:registry reg :adapters [adapter]}))]
       (#'sut/run-poll-pass orch)
@@ -561,7 +561,7 @@
                    {:poll-agent-status
                     (fn [agent-rec]
                       (swap! poll-log conj (:agent/name agent-rec))
-                      {:agent/status (:agent/status agent-rec)})})
+                      {:status (:agent/status agent-rec)})})
           orch (sut/create-orchestrator
                 (base-opts {:registry reg :adapters [adapter]}))]
       (#'sut/run-poll-pass orch)

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
@@ -329,8 +329,8 @@
           adapter (make-mock-adapter
                    {:poll-agent-status
                     (fn [_agent-record]
-                      {:agent/status :running
-                       :agent/task "working on stuff"})})
+                      {:status :running
+                       :task "working on stuff"})})
           orch (sut/create-orchestrator
                 (base-orchestrator-opts
                  {:registry reg :adapters [adapter]}))]
@@ -351,7 +351,7 @@
           _ (registry/transition-agent! reg (:agent/id agent-rec) :completed)
           adapter (make-mock-adapter
                    {:poll-agent-status
-                    (fn [_] (swap! poll-count inc) {:agent/status :completed})})
+                    (fn [_] (swap! poll-count inc) {:status :completed})})
           orch (sut/create-orchestrator
                 (base-orchestrator-opts
                  {:registry reg :adapters [adapter]}))]
@@ -371,7 +371,7 @@
           _ (registry/transition-agent! reg (:agent/id agent-rec) :failed)
           adapter (make-mock-adapter
                    {:poll-agent-status
-                    (fn [_] (swap! poll-count inc) {:agent/status :failed})})
+                    (fn [_] (swap! poll-count inc) {:status :failed})})
           orch (sut/create-orchestrator
                 (base-orchestrator-opts
                  {:registry reg :adapters [adapter]}))]
@@ -443,7 +443,7 @@
           ;; Agent starts as :initializing, poll returns :running
           adapter (make-mock-adapter
                    {:poll-agent-status
-                    (fn [_] {:agent/status :running})})
+                    (fn [_] {:status :running})})
           orch (sut/create-orchestrator
                 (base-orchestrator-opts
                  {:registry reg
@@ -468,7 +468,7 @@
           ;; Agent starts as :initializing, poll returns :initializing (same)
           adapter (make-mock-adapter
                    {:poll-agent-status
-                    (fn [_] {:agent/status :initializing})})
+                    (fn [_] {:status :initializing})})
           orch (sut/create-orchestrator
                 (base-orchestrator-opts
                  {:registry reg
@@ -492,12 +492,12 @@
               {:adapter-id :vendor-1
                :poll-agent-status (fn [agent-rec]
                                     (swap! poll-log conj [:vendor-1 (:agent/name agent-rec)])
-                                    {:agent/status :running})})
+                                    {:status :running})})
           a2 (make-mock-adapter
               {:adapter-id :vendor-2
                :poll-agent-status (fn [agent-rec]
                                     (swap! poll-log conj [:vendor-2 (:agent/name agent-rec)])
-                                    {:agent/status :running})})
+                                    {:status :running})})
           orch (sut/create-orchestrator
                 (base-orchestrator-opts
                  {:registry reg :adapters [a1 a2]}))]
@@ -515,7 +515,7 @@
              {:agent/external-id "ext-orphan" :agent/name "Orphan Agent" :agent/vendor :unknown-vendor})
           adapter (make-mock-adapter
                    {:adapter-id :other-vendor
-                    :poll-agent-status (fn [_] (swap! poll-count inc) {:agent/status :running})})
+                    :poll-agent-status (fn [_] (swap! poll-count inc) {:status :running})})
           orch (sut/create-orchestrator
                 (base-orchestrator-opts
                  {:registry reg :adapters [adapter]}))]
@@ -652,9 +652,9 @@
                  {:registry reg :decision-manager dm}))
           decision (sut/submit-decision-from-agent!
                     orch (:agent/id agent-rec) "Choose deploy target"
-                    {:decision/type :choice
-                     :decision/priority :high
-                     :decision/options ["staging" "production"]})]
+                    {:type :choice
+                     :priority :high
+                     :options ["staging" "production"]})]
       (is (= :high (:decision/priority decision)))
       (is (= :choice (:decision/type decision))))))
 
@@ -901,7 +901,7 @@
           deliver-log (atom [])
           adapter (make-mock-adapter
                    {:discover-agents (fn [_] [agent-info])
-                    :poll-agent-status (fn [_] {:agent/status :running})
+                    :poll-agent-status (fn [_] {:status :running})
                     :deliver-decision (fn [_ d]
                                        (swap! deliver-log conj d)
                                        {:delivered? true})})
@@ -949,7 +949,7 @@
                       :agent/vendor :test-adapter}
           adapter (make-mock-adapter
                    {:discover-agents (fn [_] [agent-info])
-                    :poll-agent-status (fn [_] {:agent/status :running})
+                    :poll-agent-status (fn [_] {:status :running})
                     :deliver-decision (fn [_ _] {:delivered? true})})
           orch (sut/create-orchestrator
                 (base-orchestrator-opts

--- a/components/decision/deps.edn
+++ b/components/decision/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/decision {:local/root "../decision"}}
+ :deps {metosin/malli {:mvn/version "0.16.4"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/decision/src/ai/miniforge/decision/core.clj
+++ b/components/decision/src/ai/miniforge/decision/core.clj
@@ -1,0 +1,182 @@
+(ns ai.miniforge.decision.core
+  "Pure constructors for canonical checkpoints and episodes.
+   Layer 0: Small helper mappings
+   Layer 1: Checkpoint constructors
+   Layer 2: Episode constructors"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helper mappings
+
+(def ^:private decision-type->class
+  {:approval :approval
+   :choice :implementation-pattern-choice
+   :input :request-for-input
+   :confirmation :confirmation})
+
+(def ^:private priority->risk-tier
+  {:critical :critical
+   :high :high
+   :medium :medium
+   :low :low})
+
+(defn- option->alternative
+  [idx option]
+  {:id idx
+   :summary (str option)})
+
+(defn- summarize-loop-errors
+  [errors]
+  (->> errors
+       (keep #(or (get-in % [:anomaly :anomaly/message])
+                  (:message %)))
+       (remove str/blank?)
+       (take 2)
+       (str/join "; ")))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Checkpoint constructors
+
+(defn create-checkpoint
+  "Create a canonical normalized decision checkpoint."
+  [{:keys [checkpoint-id status created-at resolved-at requested-authority
+           source task proposal uncertainty risk context response]}]
+  (cond-> {:checkpoint/id (or checkpoint-id (random-uuid))
+           :checkpoint/status (or status :pending)
+           :checkpoint/created-at (or created-at (java.util.Date.))
+           :checkpoint/requested-authority (or requested-authority :human)
+           :source source
+           :proposal proposal}
+    task (assoc :task task)
+    uncertainty (assoc :uncertainty uncertainty)
+    risk (assoc :risk risk)
+    context (assoc :context context)
+    response (assoc :response response)
+    resolved-at (assoc :checkpoint/resolved-at resolved-at)))
+
+(defn resolve-checkpoint
+  "Resolve a checkpoint with a structured supervision response."
+  [checkpoint response]
+  (assoc checkpoint
+         :checkpoint/status :resolved
+         :checkpoint/resolved-at (java.util.Date.)
+         :response response))
+
+(defn create-control-plane-checkpoint
+  "Normalize a control-plane decision request into the canonical checkpoint shape."
+  [agent-id summary opts]
+  (let [decision-type (get opts :type :choice)
+        priority (get opts :priority :medium)
+        options (:options opts)
+        proposal (cond-> {:action-type :request-human-decision
+                          :decision-class (get decision-type->class decision-type :implementation-pattern-choice)
+                          :summary summary}
+                   (seq options) (assoc :alternatives
+                                        (mapv option->alternative (range) options)))
+        uncertainty (cond-> {:class :agent-request
+                             :reason "External or delegated agent requested human judgment."}
+                      (some? (:agent-confidence opts))
+                      (assoc :agent-confidence (:agent-confidence opts)))]
+    (create-checkpoint
+     {:source {:kind :control-plane-agent
+               :agent-id agent-id}
+      :task {:kind :control-plane-decision
+             :goal summary}
+      :proposal proposal
+      :uncertainty uncertainty
+      :risk {:tier (get priority->risk-tier priority :medium)}
+      :context (cond-> {}
+                 (:context opts) (assoc :context/text (:context opts))
+                 (:deadline opts) (assoc :context/deadline (:deadline opts))
+                 (:tags opts) (assoc :context/tags (set (:tags opts))))})))
+
+(defn create-loop-escalation-checkpoint
+  "Normalize an inner-loop escalation into the canonical checkpoint shape."
+  [loop-state opts]
+  (let [task (:loop/task loop-state)
+        artifact (:loop/artifact loop-state)
+        errors (:loop/errors loop-state)
+        content (some-> artifact :artifact/content str)
+        summary (or (:summary opts)
+                    (str "Loop escalation after "
+                         (:loop/iteration loop-state)
+                         " attempt(s) for task "
+                         (name (or (:task/type task) :unknown))))
+        diff-summary (when content
+                       (subs content 0 (min 160 (count content))))
+        task-info (cond-> {:kind :loop-escalation
+                           :goal summary}
+                    (:task/id task) (assoc :task-id (:task/id task)))
+        proposal (cond-> {:action-type :provide-guidance
+                          :decision-class :repair-escalation
+                          :summary summary}
+                   (:artifact/path artifact) (assoc :files [(:artifact/path artifact)])
+                   diff-summary (assoc :diff-summary diff-summary))]
+    (create-checkpoint
+     {:source {:kind :loop-escalation
+               :loop-id (:loop/id loop-state)}
+      :task task-info
+      :proposal proposal
+      :uncertainty {:class :validation-failure
+                    :reason (or (summarize-loop-errors errors)
+                                "Loop exhausted repair budget without convergence.")}
+      :risk {:tier (get opts :risk-tier :medium)}
+      :context {:loop/iteration (:loop/iteration loop-state)
+                :loop/state (:loop/state loop-state)
+                :loop/termination (:loop/termination loop-state)
+                :task/type (:task/type task)
+                :error-count (count errors)}})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Episode constructors
+
+(defn create-episode
+  "Create an episode shell for a checkpoint."
+  [checkpoint]
+  (let [now (java.util.Date.)]
+    (cond-> {:episode/id (random-uuid)
+             :episode/status (if (= :resolved (:checkpoint/status checkpoint))
+                               :resolved
+                               :pending)
+             :episode/created-at now
+             :episode/updated-at now
+             :checkpoint checkpoint}
+      (:response checkpoint) (assoc :supervision (:response checkpoint)))))
+
+(defn update-episode
+  "Update an existing episode from the latest checkpoint state."
+  [episode checkpoint & [opts]]
+  (cond-> (assoc episode
+                 :episode/status (cond
+                                   (:downstream-outcome opts) :completed
+                                   (= :resolved (:checkpoint/status checkpoint)) :resolved
+                                   :else :pending)
+                 :episode/updated-at (java.util.Date.)
+                 :checkpoint checkpoint)
+    (:response checkpoint) (assoc :supervision (:response checkpoint))
+    (:execution-result opts) (assoc :execution-result (:execution-result opts))
+    (:downstream-outcome opts) (assoc :downstream-outcome (:downstream-outcome opts))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def cp-checkpoint
+    (create-control-plane-checkpoint
+     (random-uuid)
+     "Should I merge PR #42?"
+     {:type :approval
+      :priority :high
+      :options ["yes" "no"]}))
+
+  (def resolved
+    (resolve-checkpoint cp-checkpoint
+                        {:type :approve
+                         :value "yes"
+                         :authority-role :human}))
+
+  (def episode
+    (create-episode cp-checkpoint))
+
+  (update-episode episode resolved)
+
+  :leave-this-here)

--- a/components/decision/src/ai/miniforge/decision/core.clj
+++ b/components/decision/src/ai/miniforge/decision/core.clj
@@ -21,6 +21,12 @@
    :medium :medium
    :low :low})
 
+(def ^:private decision-type->response-type
+  {:approval :approve
+   :choice :choose-option
+   :input :approve-with-constraints
+   :confirmation :approve})
+
 (defn- option->alternative
   [idx option]
   {:id idx
@@ -34,6 +40,101 @@
        (remove str/blank?)
        (take 2)
        (str/join "; ")))
+
+(defn- control-plane-proposal
+  [summary options decision-type]
+  (cond-> {:action-type :request-human-decision
+           :decision-class (get decision-type->class decision-type
+                                :implementation-pattern-choice)
+           :summary summary}
+    (seq options) (assoc :alternatives
+                         (mapv option->alternative (range) options))))
+
+(defn- control-plane-uncertainty
+  [agent-confidence]
+  (cond-> {:class :agent-request
+           :reason "External or delegated agent requested human judgment."}
+    (some? agent-confidence) (assoc :agent-confidence agent-confidence)))
+
+(defn- control-plane-context
+  [{:keys [context deadline tags]}]
+  (cond-> {}
+    context (assoc :context/text context)
+    deadline (assoc :context/deadline deadline)
+    (seq tags) (assoc :context/tags (set tags))))
+
+(defn- control-plane-checkpoint-input
+  [agent-id summary {:keys [type priority options agent-confidence]
+                     :as opts}]
+  {:source {:kind :control-plane-agent
+            :agent-id agent-id}
+   :task {:kind :control-plane-decision
+          :goal summary}
+   :proposal (control-plane-proposal summary options (or type :choice))
+   :uncertainty (control-plane-uncertainty agent-confidence)
+   :risk {:tier (get priority->risk-tier (or priority :medium) :medium)}
+   :context (control-plane-context opts)})
+
+(defn- loop-escalation-summary
+  [loop-state summary]
+  (or summary
+      (str "Loop escalation after "
+           (:loop/iteration loop-state)
+           " attempt(s) for task "
+           (name (or (get-in loop-state [:loop/task :task/type]) :unknown)))))
+
+(defn- loop-escalation-task
+  [task summary]
+  (cond-> {:kind :loop-escalation
+           :goal summary}
+    (:task/id task) (assoc :task-id (:task/id task))))
+
+(defn- loop-escalation-proposal
+  [artifact summary]
+  (let [content (some-> artifact :artifact/content str)
+        diff-summary (when content
+                       (subs content 0 (min 160 (count content))))]
+    (cond-> {:action-type :provide-guidance
+             :decision-class :repair-escalation
+             :summary summary}
+      (:artifact/path artifact) (assoc :files [(:artifact/path artifact)])
+      diff-summary (assoc :diff-summary diff-summary))))
+
+(defn- loop-escalation-uncertainty
+  [errors]
+  {:class :validation-failure
+   :reason (or (summarize-loop-errors errors)
+               "Loop exhausted repair budget without convergence.")})
+
+(defn- loop-escalation-context
+  [{:loop/keys [iteration state termination task errors]}]
+  {:loop/iteration iteration
+   :loop/state state
+   :loop/termination termination
+   :task/type (:task/type task)
+   :error-count (count errors)})
+
+(defn- loop-escalation-checkpoint-input
+  [loop-state {:keys [summary risk-tier]}]
+  (let [summary (loop-escalation-summary loop-state summary)
+        task (:loop/task loop-state)
+        artifact (:loop/artifact loop-state)
+        errors (:loop/errors loop-state)]
+    {:source {:kind :loop-escalation
+              :loop-id (:loop/id loop-state)}
+     :task (loop-escalation-task task summary)
+     :proposal (loop-escalation-proposal artifact summary)
+     :uncertainty (loop-escalation-uncertainty errors)
+     :risk {:tier (or risk-tier :medium)}
+     :context (loop-escalation-context loop-state)}))
+
+(defn decision-response
+  "Create a structured response from a decision type and outcome."
+  [decision-type resolution & [rationale]]
+  (cond-> {:type (get decision-type->response-type decision-type :approve)
+           :value resolution
+           :authority-role :human}
+    rationale (assoc :rationale rationale)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Checkpoint constructors
@@ -66,67 +167,14 @@
 (defn create-control-plane-checkpoint
   "Normalize a control-plane decision request into the canonical checkpoint shape."
   [agent-id summary opts]
-  (let [decision-type (get opts :type :choice)
-        priority (get opts :priority :medium)
-        options (:options opts)
-        proposal (cond-> {:action-type :request-human-decision
-                          :decision-class (get decision-type->class decision-type :implementation-pattern-choice)
-                          :summary summary}
-                   (seq options) (assoc :alternatives
-                                        (mapv option->alternative (range) options)))
-        uncertainty (cond-> {:class :agent-request
-                             :reason "External or delegated agent requested human judgment."}
-                      (some? (:agent-confidence opts))
-                      (assoc :agent-confidence (:agent-confidence opts)))]
-    (create-checkpoint
-     {:source {:kind :control-plane-agent
-               :agent-id agent-id}
-      :task {:kind :control-plane-decision
-             :goal summary}
-      :proposal proposal
-      :uncertainty uncertainty
-      :risk {:tier (get priority->risk-tier priority :medium)}
-      :context (cond-> {}
-                 (:context opts) (assoc :context/text (:context opts))
-                 (:deadline opts) (assoc :context/deadline (:deadline opts))
-                 (:tags opts) (assoc :context/tags (set (:tags opts))))})))
+  (-> (control-plane-checkpoint-input agent-id summary opts)
+      create-checkpoint))
 
 (defn create-loop-escalation-checkpoint
   "Normalize an inner-loop escalation into the canonical checkpoint shape."
   [loop-state opts]
-  (let [task (:loop/task loop-state)
-        artifact (:loop/artifact loop-state)
-        errors (:loop/errors loop-state)
-        content (some-> artifact :artifact/content str)
-        summary (or (:summary opts)
-                    (str "Loop escalation after "
-                         (:loop/iteration loop-state)
-                         " attempt(s) for task "
-                         (name (or (:task/type task) :unknown))))
-        diff-summary (when content
-                       (subs content 0 (min 160 (count content))))
-        task-info (cond-> {:kind :loop-escalation
-                           :goal summary}
-                    (:task/id task) (assoc :task-id (:task/id task)))
-        proposal (cond-> {:action-type :provide-guidance
-                          :decision-class :repair-escalation
-                          :summary summary}
-                   (:artifact/path artifact) (assoc :files [(:artifact/path artifact)])
-                   diff-summary (assoc :diff-summary diff-summary))]
-    (create-checkpoint
-     {:source {:kind :loop-escalation
-               :loop-id (:loop/id loop-state)}
-      :task task-info
-      :proposal proposal
-      :uncertainty {:class :validation-failure
-                    :reason (or (summarize-loop-errors errors)
-                                "Loop exhausted repair budget without convergence.")}
-      :risk {:tier (get opts :risk-tier :medium)}
-      :context {:loop/iteration (:loop/iteration loop-state)
-                :loop/state (:loop/state loop-state)
-                :loop/termination (:loop/termination loop-state)
-                :task/type (:task/type task)
-                :error-count (count errors)}})))
+  (-> (loop-escalation-checkpoint-input loop-state opts)
+      create-checkpoint))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Episode constructors

--- a/components/decision/src/ai/miniforge/decision/interface.clj
+++ b/components/decision/src/ai/miniforge/decision/interface.clj
@@ -1,0 +1,99 @@
+(ns ai.miniforge.decision.interface
+  "Public API for canonical decision checkpoints and episodes."
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]
+   [ai.miniforge.decision.spec :as spec]
+   [ai.miniforge.decision.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema re-exports
+
+(def DecisionCheckpoint spec/DecisionCheckpoint)
+(def DecisionEpisode spec/DecisionEpisode)
+
+(def source-kinds spec/source-kinds)
+(def authority-kinds spec/authority-kinds)
+(def checkpoint-statuses spec/checkpoint-statuses)
+(def episode-statuses spec/episode-statuses)
+(def response-types spec/response-types)
+(def risk-tiers spec/risk-tiers)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Validation helpers
+
+(defn valid?
+  "Returns true if value validates against schema."
+  [schema value]
+  (m/validate schema value))
+
+(defn validate
+  "Returns value if valid, otherwise throws."
+  [schema value]
+  (if (m/validate schema value)
+    value
+    (throw (ex-info "Decision schema validation failed"
+                    {:schema schema
+                     :value value
+                     :errors (me/humanize (m/explain schema value))}))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Public constructors
+
+(defn create-checkpoint
+  "Create a canonical decision checkpoint."
+  [opts]
+  (validate DecisionCheckpoint
+            (core/create-checkpoint opts)))
+
+(defn resolve-checkpoint
+  "Resolve a checkpoint with structured supervision."
+  [checkpoint response]
+  (validate DecisionCheckpoint
+            (core/resolve-checkpoint checkpoint response)))
+
+(defn create-episode
+  "Create a decision episode shell from a checkpoint."
+  [checkpoint]
+  (validate DecisionEpisode
+            (core/create-episode checkpoint)))
+
+(defn update-episode
+  "Update a decision episode from checkpoint state."
+  ([episode checkpoint]
+   (update-episode episode checkpoint nil))
+  ([episode checkpoint opts]
+   (validate DecisionEpisode
+             (core/update-episode episode checkpoint opts))))
+
+(defn create-control-plane-checkpoint
+  "Normalize a control-plane decision request."
+  [agent-id summary opts]
+  (validate DecisionCheckpoint
+            (core/create-control-plane-checkpoint agent-id summary opts)))
+
+(defn create-loop-escalation-checkpoint
+  "Normalize an inner-loop escalation."
+  [loop-state opts]
+  (validate DecisionCheckpoint
+            (core/create-loop-escalation-checkpoint loop-state opts)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (def checkpoint
+    (create-control-plane-checkpoint
+     (random-uuid)
+     "Should I merge PR #42?"
+     {:type :approval
+      :priority :high
+      :options ["yes" "no"]}))
+
+  (def episode (create-episode checkpoint))
+
+  (update-episode episode
+                  (resolve-checkpoint checkpoint
+                                      {:type :approve
+                                       :value "yes"
+                                       :authority-role :human}))
+
+  :leave-this-here)

--- a/components/decision/src/ai/miniforge/decision/interface.clj
+++ b/components/decision/src/ai/miniforge/decision/interface.clj
@@ -1,8 +1,6 @@
 (ns ai.miniforge.decision.interface
   "Public API for canonical decision checkpoints and episodes."
   (:require
-   [malli.core :as m]
-   [malli.error :as me]
    [ai.miniforge.decision.spec :as spec]
    [ai.miniforge.decision.core :as core]))
 
@@ -18,24 +16,16 @@
 (def episode-statuses spec/episode-statuses)
 (def response-types spec/response-types)
 (def risk-tiers spec/risk-tiers)
+(def ControlPlaneContext spec/ControlPlaneContext)
+(def LoopEscalationContext spec/LoopEscalationContext)
+(def DecisionContext spec/DecisionContext)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Validation helpers
 
-(defn valid?
-  "Returns true if value validates against schema."
-  [schema value]
-  (m/validate schema value))
-
-(defn validate
-  "Returns value if valid, otherwise throws."
-  [schema value]
-  (if (m/validate schema value)
-    value
-    (throw (ex-info "Decision schema validation failed"
-                    {:schema schema
-                     :value value
-                     :errors (me/humanize (m/explain schema value))}))))
+(def valid? spec/valid?)
+(def explain spec/explain)
+(def validate spec/validate)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public constructors
@@ -77,6 +67,12 @@
   [loop-state opts]
   (validate DecisionCheckpoint
             (core/create-loop-escalation-checkpoint loop-state opts)))
+
+(defn decision-response
+  "Create a structured supervision response."
+  [decision-type resolution & [rationale]]
+  (validate spec/DecisionResponse
+            (core/decision-response decision-type resolution rationale)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/decision/src/ai/miniforge/decision/spec.clj
+++ b/components/decision/src/ai/miniforge/decision/spec.clj
@@ -1,9 +1,11 @@
 (ns ai.miniforge.decision.spec
   "Malli schemas for canonical decision checkpoints and episodes.
    Layer 0: Enums and registry
-   Layer 1: Checkpoint and episode schemas"
+   Layer 1: Checkpoint and episode schemas
+   Layer 2: Validation helpers"
   (:require
-   [malli.core :as m]))
+   [malli.core :as m]
+   [malli.error :as me]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Enums and registry
@@ -97,6 +99,26 @@
    [:critical-paths {:optional true} [:vector :id/string]]
    [:requires-owner-review? {:optional true} boolean?]])
 
+(def ControlPlaneContext
+  "Context for control-plane decision checkpoints."
+  [:map {:registry registry}
+   [:context/text {:optional true} :id/string]
+   [:context/deadline {:optional true} :common/timestamp]
+   [:context/tags {:optional true} [:set keyword?]]])
+
+(def LoopEscalationContext
+  "Context for loop escalation checkpoints."
+  [:map {:registry registry}
+   [:loop/iteration int?]
+   [:loop/state keyword?]
+   [:loop/termination [:map [:reason keyword?]]]
+   [:task/type {:optional true} keyword?]
+   [:error-count int?]])
+
+(def DecisionContext
+  "Known context shapes for decision checkpoints."
+  [:or ControlPlaneContext LoopEscalationContext])
+
 (def DecisionResponse
   "Schema for the structured supervision response."
   [:map {:registry registry}
@@ -119,7 +141,7 @@
    [:proposal DecisionProposal]
    [:uncertainty {:optional true} DecisionUncertainty]
    [:risk {:optional true} DecisionRisk]
-   [:context {:optional true} [:map-of keyword? any?]]
+   [:context {:optional true} DecisionContext]
    [:response {:optional true} DecisionResponse]])
 
 (def DecisionEpisode
@@ -148,3 +170,24 @@
                           :summary "Choose one"}})
 
   :leave-this-here)
+
+(defn valid?
+  "Returns true if value validates against schema."
+  [schema value]
+  (m/validate schema value))
+
+(defn explain
+  "Returns a humanized explanation for schema failures."
+  [schema value]
+  (some-> (m/explain schema value)
+          me/humanize))
+
+(defn validate
+  "Returns value if valid, otherwise throws."
+  [schema value]
+  (if (valid? schema value)
+    value
+    (throw (ex-info "Decision schema validation failed"
+                    {:schema schema
+                     :value value
+                     :errors (explain schema value)}))))

--- a/components/decision/src/ai/miniforge/decision/spec.clj
+++ b/components/decision/src/ai/miniforge/decision/spec.clj
@@ -1,0 +1,150 @@
+(ns ai.miniforge.decision.spec
+  "Malli schemas for canonical decision checkpoints and episodes.
+   Layer 0: Enums and registry
+   Layer 1: Checkpoint and episode schemas"
+  (:require
+   [malli.core :as m]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Enums and registry
+
+(def source-kinds
+  "Known checkpoint producer categories."
+  [:control-plane-agent :loop-escalation :workflow-node :external-agent :policy-gate])
+
+(def authority-kinds
+  "Who may answer the checkpoint."
+  [:human :system :model :rule :hybrid])
+
+(def checkpoint-statuses
+  "Checkpoint lifecycle states."
+  [:pending :resolved :cancelled :expired])
+
+(def episode-statuses
+  "Episode lifecycle states for the initial implementation."
+  [:pending :resolved :completed])
+
+(def response-types
+  "Structured response actions supported by the initial model."
+  [:approve :approve-with-constraints :reject :choose-option
+   :request-more-evidence :reroute :mark-delegable :always-escalate :defer])
+
+(def risk-tiers
+  "Risk tiers for decision routing."
+  [:low :medium :high :critical])
+
+(def registry
+  "Malli registry for decision types."
+  {;; Common identifiers
+   :id/uuid uuid?
+   :id/string [:string {:min 1}]
+   :common/timestamp inst?
+
+   ;; Decision model enums
+   :source/kind (into [:enum] source-kinds)
+   :authority/kind (into [:enum] authority-kinds)
+   :checkpoint/status (into [:enum] checkpoint-statuses)
+   :episode/status (into [:enum] episode-statuses)
+   :response/type (into [:enum] response-types)
+   :risk/tier (into [:enum] risk-tiers)})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Canonical model
+
+(def Alternative
+  "Schema for one proposed alternative."
+  [:map {:registry registry}
+   [:id any?]
+   [:summary :id/string]])
+
+(def DecisionSource
+  "Schema for checkpoint source metadata."
+  [:map {:registry registry}
+   [:kind :source/kind]
+   [:agent-id {:optional true} :id/uuid]
+   [:agent {:optional true} :id/string]
+   [:origin-run-id {:optional true} :id/string]
+   [:loop-id {:optional true} :id/uuid]])
+
+(def DecisionTask
+  "Schema for task metadata attached to a checkpoint."
+  [:map {:registry registry}
+   [:kind keyword?]
+   [:goal {:optional true} :id/string]
+   [:task-id {:optional true} :id/uuid]])
+
+(def DecisionProposal
+  "Schema for the proposed action under judgment."
+  [:map {:registry registry}
+   [:action-type keyword?]
+   [:decision-class keyword?]
+   [:summary :id/string]
+   [:alternatives {:optional true} [:vector Alternative]]
+   [:files {:optional true} [:vector :id/string]]
+   [:diff-summary {:optional true} :id/string]])
+
+(def DecisionUncertainty
+  "Schema for uncertainty information."
+  [:map {:registry registry}
+   [:class keyword?]
+   [:reason :id/string]
+   [:agent-confidence {:optional true} [:double {:min 0.0 :max 1.0}]]])
+
+(def DecisionRisk
+  "Schema for risk data."
+  [:map {:registry registry}
+   [:tier :risk/tier]
+   [:critical-paths {:optional true} [:vector :id/string]]
+   [:requires-owner-review? {:optional true} boolean?]])
+
+(def DecisionResponse
+  "Schema for the structured supervision response."
+  [:map {:registry registry}
+   [:type :response/type]
+   [:value {:optional true} any?]
+   [:constraints {:optional true} [:vector :id/string]]
+   [:rationale {:optional true} :id/string]
+   [:authority-role :authority/kind]])
+
+(def DecisionCheckpoint
+  "Canonical normalized checkpoint."
+  [:map {:registry registry}
+   [:checkpoint/id :id/uuid]
+   [:checkpoint/status :checkpoint/status]
+   [:checkpoint/created-at :common/timestamp]
+   [:checkpoint/resolved-at {:optional true} :common/timestamp]
+   [:checkpoint/requested-authority :authority/kind]
+   [:source DecisionSource]
+   [:task {:optional true} DecisionTask]
+   [:proposal DecisionProposal]
+   [:uncertainty {:optional true} DecisionUncertainty]
+   [:risk {:optional true} DecisionRisk]
+   [:context {:optional true} [:map-of keyword? any?]]
+   [:response {:optional true} DecisionResponse]])
+
+(def DecisionEpisode
+  "Normalized decision episode. The first implementation captures
+   pending and resolved episodes before downstream outcome mining."
+  [:map {:registry registry}
+   [:episode/id :id/uuid]
+   [:episode/status :episode/status]
+   [:episode/created-at :common/timestamp]
+   [:episode/updated-at :common/timestamp]
+   [:checkpoint DecisionCheckpoint]
+   [:supervision {:optional true} DecisionResponse]
+   [:execution-result {:optional true} [:map-of keyword? any?]]
+   [:downstream-outcome {:optional true} [:map-of keyword? any?]]])
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (m/validate DecisionCheckpoint
+              {:checkpoint/id (random-uuid)
+               :checkpoint/status :pending
+               :checkpoint/created-at (java.util.Date.)
+               :checkpoint/requested-authority :human
+               :source {:kind :control-plane-agent}
+               :proposal {:action-type :request-human-decision
+                          :decision-class :choice
+                          :summary "Choose one"}})
+
+  :leave-this-here)

--- a/components/decision/test/ai/miniforge/decision/interface_test.clj
+++ b/components/decision/test/ai/miniforge/decision/interface_test.clj
@@ -1,0 +1,53 @@
+(ns ai.miniforge.decision.interface-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.decision.interface :as decision]))
+
+;------------------------------------------------------------------------------ Checkpoint tests
+
+(deftest create-control-plane-checkpoint-test
+  (testing "normalizes control-plane decision requests"
+    (let [agent-id (random-uuid)
+          checkpoint (decision/create-control-plane-checkpoint
+                      agent-id
+                      "Choose a merge strategy"
+                      {:type :choice
+                       :priority :high
+                       :options ["squash" "rebase"]})]
+      (is (= :control-plane-agent (get-in checkpoint [:source :kind])))
+      (is (= agent-id (get-in checkpoint [:source :agent-id])))
+      (is (= :pending (:checkpoint/status checkpoint)))
+      (is (= :implementation-pattern-choice
+             (get-in checkpoint [:proposal :decision-class])))
+      (is (= 2 (count (get-in checkpoint [:proposal :alternatives])))))))
+
+(deftest create-loop-escalation-checkpoint-test
+  (testing "normalizes loop escalation state"
+    (let [loop-state {:loop/id (random-uuid)
+                      :loop/state :escalated
+                      :loop/iteration 4
+                      :loop/errors [{:message "Missing paren"}]
+                      :loop/task {:task/id (random-uuid)
+                                  :task/type :implement}
+                      :loop/termination {:reason :max-iterations}}
+          checkpoint (decision/create-loop-escalation-checkpoint loop-state {})]
+      (is (= :loop-escalation (get-in checkpoint [:source :kind])))
+      (is (= :repair-escalation (get-in checkpoint [:proposal :decision-class])))
+      (is (= 4 (get-in checkpoint [:context :loop/iteration])))
+      (is (= :medium (get-in checkpoint [:risk :tier]))))))
+
+(deftest resolve-checkpoint-and-update-episode-test
+  (testing "resolved checkpoints update the episode shell"
+    (let [checkpoint (decision/create-control-plane-checkpoint
+                      (random-uuid)
+                      "Approve?"
+                      {:type :approval})
+          episode (decision/create-episode checkpoint)
+          resolved (decision/resolve-checkpoint checkpoint
+                                                {:type :approve
+                                                 :value "yes"
+                                                 :authority-role :human})
+          updated (decision/update-episode episode resolved)]
+      (is (= :resolved (:checkpoint/status resolved)))
+      (is (= :approve (get-in updated [:supervision :type])))
+      (is (= :resolved (:episode/status updated))))))

--- a/components/loop/src/ai/miniforge/loop/escalation.clj
+++ b/components/loop/src/ai/miniforge/loop/escalation.clj
@@ -139,15 +139,28 @@
 (defn- result->response
   [result]
   (case (:action result)
-    :continue {:type :approve-with-constraints
-               :value (:hints result)
-               :authority-role :human}
+    :continue (decision/decision-response :input (:hints result))
     :abort {:type :reject
             :value :abort
             :rationale (:reason result)
             :authority-role (if (:reason result) :system :human)}
     {:type :defer
      :authority-role :human}))
+
+(defn- escalated-result
+  [result checkpoint episode]
+  (assoc result
+         :escalated true
+         :decision/checkpoint checkpoint
+         :decision/episode episode))
+
+(defn- abort-escalation
+  [reason checkpoint episode]
+  {:escalated true
+   :action :abort
+   :reason reason
+   :decision/checkpoint checkpoint
+   :decision/episode episode})
 
 (defn handle-escalation
   "Handle escalation in inner loop.
@@ -170,21 +183,16 @@
         (let [resolved-checkpoint (decision/resolve-checkpoint checkpoint
                                                                (result->response result))
               updated-episode (decision/update-episode episode resolved-checkpoint)]
-          (assoc result
-                 :escalated true
-                 :decision/checkpoint resolved-checkpoint
-                 :decision/episode updated-episode)))
+          (escalated-result result resolved-checkpoint updated-episode)))
       ;; No escalation function, default to abort
       (let [result {:action :abort
                     :reason "No escalation function provided"}
             resolved-checkpoint (decision/resolve-checkpoint checkpoint
                                                              (result->response result))
             updated-episode (decision/update-episode episode resolved-checkpoint)]
-        {:escalated true
-         :action :abort
-         :reason "No escalation function provided"
-         :decision/checkpoint resolved-checkpoint
-         :decision/episode updated-episode}))))
+        (abort-escalation "No escalation function provided"
+                          resolved-checkpoint
+                          updated-episode)))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/loop/src/ai/miniforge/loop/escalation.clj
+++ b/components/loop/src/ai/miniforge/loop/escalation.clj
@@ -6,7 +6,8 @@
    Layer 1: User interaction functions
    Layer 2: Escalation integration with inner loop"
   (:require
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [ai.miniforge.decision.interface :as decision]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Prompt formatting (pure functions)
@@ -130,6 +131,24 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Inner loop integration
 
+(defn create-escalation-checkpoint
+  "Create a canonical checkpoint for an inner-loop escalation."
+  [loop-state & [opts]]
+  (decision/create-loop-escalation-checkpoint loop-state (or opts {})))
+
+(defn- result->response
+  [result]
+  (case (:action result)
+    :continue {:type :approve-with-constraints
+               :value (:hints result)
+               :authority-role :human}
+    :abort {:type :reject
+            :value :abort
+            :rationale (:reason result)
+            :authority-role (if (:reason result) :system :human)}
+    {:type :defer
+     :authority-role :human}))
+
 (defn handle-escalation
   "Handle escalation in inner loop.
    Called when loop reaches :escalated state.
@@ -142,15 +161,30 @@
    {:escalated true :action :abort} or
    {:escalated true :action :continue :hints string}"
   [loop-state context]
-  (let [escalation-fn (:escalation-fn context)]
+  (let [escalation-fn (:escalation-fn context)
+        checkpoint (create-escalation-checkpoint loop-state (:decision/checkpoint-opts context))
+        episode (decision/create-episode checkpoint)]
     (if escalation-fn
       ;; Escalation function available
       (let [result (escalation-fn loop-state :prompt-fn (:prompt-fn context))]
-        (assoc result :escalated true))
+        (let [resolved-checkpoint (decision/resolve-checkpoint checkpoint
+                                                               (result->response result))
+              updated-episode (decision/update-episode episode resolved-checkpoint)]
+          (assoc result
+                 :escalated true
+                 :decision/checkpoint resolved-checkpoint
+                 :decision/episode updated-episode)))
       ;; No escalation function, default to abort
-      {:escalated true
-       :action :abort
-       :reason "No escalation function provided"})))
+      (let [result {:action :abort
+                    :reason "No escalation function provided"}
+            resolved-checkpoint (decision/resolve-checkpoint checkpoint
+                                                             (result->response result))
+            updated-episode (decision/update-episode episode resolved-checkpoint)]
+        {:escalated true
+         :action :abort
+         :reason "No escalation function provided"
+         :decision/checkpoint resolved-checkpoint
+         :decision/episode updated-episode}))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/loop/src/ai/miniforge/loop/interface.clj
+++ b/components/loop/src/ai/miniforge/loop/interface.clj
@@ -190,6 +190,13 @@
   [loop-state context]
   (escalation/handle-escalation loop-state context))
 
+(defn create-escalation-checkpoint
+  "Create a canonical checkpoint for an inner-loop escalation."
+  ([loop-state]
+   (escalation/create-escalation-checkpoint loop-state))
+  ([loop-state opts]
+   (escalation/create-escalation-checkpoint loop-state opts)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Gates API
 

--- a/components/loop/test/ai/miniforge/loop/escalation_test.clj
+++ b/components/loop/test/ai/miniforge/loop/escalation_test.clj
@@ -110,12 +110,18 @@
                                                {:escalation-fn mock-escalation})]
       (is (:escalated result))
       (is (= :continue (:action result)))
-      (is (= "hint" (:hints result)))))
+      (is (= "hint" (:hints result)))
+      (is (= :resolved
+             (get-in result [:decision/checkpoint :checkpoint/status])))
+      (is (= :approve-with-constraints
+             (get-in result [:decision/episode :supervision :type])))))
 
   (testing "defaults to abort when no escalation function"
     (let [result (escalation/handle-escalation mock-loop-state {})]
       (is (:escalated result))
-      (is (= :abort (:action result)))))
+      (is (= :abort (:action result)))
+      (is (= :system
+             (get-in result [:decision/episode :supervision :authority-role])))))
 
   (testing "passes custom prompt-fn through"
     (let [custom-prompt (fn [_] {:type :hints :content "custom"})
@@ -127,6 +133,14 @@
                                                 :prompt-fn custom-prompt})]
       (is (= :continue (:action result)))
       (is (= "custom" (:hints result))))))
+
+(deftest create-escalation-checkpoint-test
+  (testing "creates canonical checkpoint data from loop state"
+    (let [checkpoint (escalation/create-escalation-checkpoint mock-loop-state)]
+      (is (= :loop-escalation (get-in checkpoint [:source :kind])))
+      (is (= :repair-escalation
+             (get-in checkpoint [:proposal :decision-class])))
+      (is (= 5 (get-in checkpoint [:context :loop/iteration]))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/deps.edn
+++ b/deps.edn
@@ -26,6 +26,7 @@
                        "components/task/resources"
                        "components/task-executor/src"
                        "components/task-executor/resources"
+                       "components/decision/src"
                        "components/loop/src"
                        "components/loop/resources"
                        "components/knowledge/src"
@@ -116,6 +117,7 @@
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/task {:local/root "components/task"}
                       ai.miniforge/task-executor {:local/root "components/task-executor"}
+                      ai.miniforge/decision {:local/root "components/decision"}
                       ai.miniforge/loop {:local/root "components/loop"}
                       ai.miniforge/knowledge {:local/root "components/knowledge"}
                       ai.miniforge/policy {:local/root "components/policy"}
@@ -172,6 +174,7 @@
                        "components/agent/test"
                        "components/agent-runtime/test"
                        "components/task/test"
+                       "components/decision/test"
                        "components/loop/test"
                        "components/knowledge/test"
                        "components/policy/test"
@@ -224,6 +227,7 @@
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/task {:local/root "components/task"}
+                      ai.miniforge/decision {:local/root "components/decision"}
                       ai.miniforge/loop {:local/root "components/loop"}
                       ai.miniforge/knowledge {:local/root "components/knowledge"}
                       ai.miniforge/policy {:local/root "components/policy"}

--- a/docs/pull-requests/2026-03-24-codex-human-meta-loop.md
+++ b/docs/pull-requests/2026-03-24-codex-human-meta-loop.md
@@ -1,0 +1,111 @@
+# feat: human meta-loop checkpoint model
+
+## Overview
+
+Introduces the first implementation slice for the human meta-loop spec:
+a canonical normalized decision model that both the control-plane queue and
+inner-loop escalation path can emit.
+
+This does not build the inbox, rule miner, or delegated-mode runtime yet.
+It establishes the shared artifact those later features need: a versioned,
+structured checkpoint and episode shape.
+
+The branch also includes a small reader-fix in `components/algorithms` for
+`graph.clj`. That parse error was already present on `origin/main` after the
+rebase and blocked `bb pre-commit` from completing, so it is included here to
+keep the branch reviewable and commit hooks green.
+
+## Motivation
+
+The current repo has two adjacent but separate concepts:
+
+- control-plane decisions for external or supervised agents
+- loop escalation for retry-budget exhaustion
+
+Both represent judgment checkpoints, but they use incompatible shapes.
+That makes it hard to build one inbox, one audit trail, and one eventual
+delegation-acquisition pipeline.
+
+This PR starts by normalizing the data before expanding UI or automation.
+
+## Changes In Detail
+
+### 1. New `decision` component
+
+Adds a pure component for canonical decision artifacts:
+
+- `DecisionCheckpoint`
+- `DecisionEpisode`
+- constructors and update helpers
+- producer helpers for control-plane decisions and loop escalations
+
+### 2. Control-plane queue enrichment
+
+`components/control-plane` now keeps its existing `:decision/*` API while
+attaching:
+
+- `:decision/checkpoint`
+- `:decision/episode`
+
+That preserves current consumers while giving downstream features a shared
+normalized representation.
+
+### 3. Loop escalation bridge
+
+`components/loop` now emits the same normalized checkpoint/episode model when
+an inner loop escalates or aborts.
+
+This makes loop escalation a first-class checkpoint producer instead of an
+isolated prompt UX.
+
+### 4. Reader fix for `algorithms/graph.clj`
+
+Repairs a malformed DFS implementation in `components/algorithms` that broke
+namespace loading under both Clojure and Babashka/GraalVM.
+
+This is not part of the product feature itself, but it was required to satisfy
+normal pre-commit discipline on the rebased branch.
+
+## Testing Plan
+
+Targeted namespace validation:
+
+```bash
+CLJ_CONFIG=/tmp/codex-clojure-config clojure -M:test -e "(require '[clojure.test :as t] '[ai.miniforge.decision.interface-test]) (let [r (t/run-tests 'ai.miniforge.decision.interface-test)] (System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"
+
+CLJ_CONFIG=/tmp/codex-clojure-config clojure -M:test -e "(require '[clojure.test :as t] '[ai.miniforge.loop.escalation-test]) (let [r (t/run-tests 'ai.miniforge.loop.escalation-test)] (System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"
+
+CLJ_CONFIG=/tmp/codex-clojure-config clojure -M:test -e "(require '[clojure.test :as t] '[ai.miniforge.control-plane.interface-test]) (let [r (t/run-tests 'ai.miniforge.control-plane.interface-test)] (System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"
+```
+
+Full changed-bricks and compatibility validation:
+
+```bash
+CLJ_CONFIG=/tmp/codex-clojure-config bb pre-commit
+```
+
+## Deployment Plan
+
+Safe incremental change:
+
+- legacy `:decision/*` fields remain intact
+- new checkpoint/episode data is additive
+- no UI migration is required yet
+
+## Related Issues/PRs
+
+- Human meta-loop spec provided for this branch: `miniforge-human-meta-loop-spec.md`
+- Existing escalation UX foundation:
+  `docs/pull-requests/2026-01-24-feat-human-escalation-ux.md`
+
+## Checklist
+
+- [x] Canonical checkpoint schema added
+- [x] Canonical episode schema added
+- [x] Control-plane decisions emit normalized data
+- [x] Loop escalation emits normalized data
+- [x] Targeted tests passing
+- [ ] Unified inbox UI
+- [ ] Episode persistence/warehouse
+- [ ] Similar-decision retrieval
+- [ ] Delegation rule mining


### PR DESCRIPTION
# feat: human meta-loop checkpoint model

## Overview

Introduces the first implementation slice for the human meta-loop spec:
a canonical normalized decision model that both the control-plane queue and
inner-loop escalation path can emit.

This does not build the inbox, rule miner, or delegated-mode runtime yet.
It establishes the shared artifact those later features need: a versioned,
structured checkpoint and episode shape.

The branch also includes a small reader-fix in `components/algorithms` for
`graph.clj`. That parse error was already present on `origin/main` after the
rebase and blocked `bb pre-commit` from completing, so it is included here to
keep the branch reviewable and commit hooks green.

## Motivation

The current repo has two adjacent but separate concepts:

- control-plane decisions for external or supervised agents
- loop escalation for retry-budget exhaustion

Both represent judgment checkpoints, but they use incompatible shapes.
That makes it hard to build one inbox, one audit trail, and one eventual
delegation-acquisition pipeline.

This PR starts by normalizing the data before expanding UI or automation.

## Changes In Detail

### 1. New `decision` component

Adds a pure component for canonical decision artifacts:

- `DecisionCheckpoint`
- `DecisionEpisode`
- constructors and update helpers
- producer helpers for control-plane decisions and loop escalations

### 2. Control-plane queue enrichment

`components/control-plane` now keeps its existing `:decision/*` API while
attaching:

- `:decision/checkpoint`
- `:decision/episode`

That preserves current consumers while giving downstream features a shared
normalized representation.

### 3. Loop escalation bridge

`components/loop` now emits the same normalized checkpoint/episode model when
an inner loop escalates or aborts.

This makes loop escalation a first-class checkpoint producer instead of an
isolated prompt UX.

### 4. Reader fix for `algorithms/graph.clj`

Repairs a malformed DFS implementation in `components/algorithms` that broke
namespace loading under both Clojure and Babashka/GraalVM.

This is not part of the product feature itself, but it was required to satisfy
normal pre-commit discipline on the rebased branch.

## Testing Plan

Targeted namespace validation:

```bash
CLJ_CONFIG=/tmp/codex-clojure-config clojure -M:test -e "(require '[clojure.test :as t] '[ai.miniforge.decision.interface-test]) (let [r (t/run-tests 'ai.miniforge.decision.interface-test)] (System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"

CLJ_CONFIG=/tmp/codex-clojure-config clojure -M:test -e "(require '[clojure.test :as t] '[ai.miniforge.loop.escalation-test]) (let [r (t/run-tests 'ai.miniforge.loop.escalation-test)] (System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"

CLJ_CONFIG=/tmp/codex-clojure-config clojure -M:test -e "(require '[clojure.test :as t] '[ai.miniforge.control-plane.interface-test]) (let [r (t/run-tests 'ai.miniforge.control-plane.interface-test)] (System/exit (if (zero? (+ (:fail r) (:error r))) 0 1)))"
```

Full changed-bricks and compatibility validation:

```bash
CLJ_CONFIG=/tmp/codex-clojure-config bb pre-commit
```

## Deployment Plan

Safe incremental change:

- legacy `:decision/*` fields remain intact
- new checkpoint/episode data is additive
- no UI migration is required yet

## Related Issues/PRs

- Human meta-loop spec provided for this branch: `miniforge-human-meta-loop-spec.md`
- Existing escalation UX foundation:
  `docs/pull-requests/2026-01-24-feat-human-escalation-ux.md`

## Checklist

- [x] Canonical checkpoint schema added
- [x] Canonical episode schema added
- [x] Control-plane decisions emit normalized data
- [x] Loop escalation emits normalized data
- [x] Targeted tests passing
- [ ] Unified inbox UI
- [ ] Episode persistence/warehouse
- [ ] Similar-decision retrieval
- [ ] Delegation rule mining
