### PR TITLE
Guard release pipeline against destructive diffs

### DIFF
--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -129,6 +129,51 @@
                      :failure {:type :write-stage-failed :errors (:errors result)}
                      :write-metrics (:metrics result)))))))))
 
+(defn step-validate-diff
+  "Validate staged diff is not destructive before committing.
+   Rejects changes that delete more tests than they add or that empty files."
+  [state]
+  (if (or (failed? state) (:sandbox? state))
+    state
+    (let [{:keys [worktree-path logger]} state
+          diff-stats (git/diff-stats worktree-path)
+          test-counts (git/count-test-defs worktree-path)]
+      (cond
+        ;; Net-negative test count — agent deleted existing tests
+        (and test-counts
+             (> (:removed test-counts) 0)
+             (> (:removed test-counts) (:added test-counts)))
+        (do
+          (when logger
+            (log/error logger :release-executor :diff/net-negative-tests
+                       {:data {:added (:added test-counts)
+                               :removed (:removed test-counts)}}))
+          (fail state :destructive-diff
+                (str "Diff removes more tests than it adds ("
+                     (:removed test-counts) " removed, "
+                     (:added test-counts) " added)")))
+
+        ;; Deletions vastly outweigh additions (> 3:1 ratio, min 20 lines)
+        (and diff-stats
+             (> (:deletions diff-stats) 20)
+             (> (:deletions diff-stats) (* 3 (max 1 (:additions diff-stats)))))
+        (do
+          (when logger
+            (log/warn logger :release-executor :diff/heavily-destructive
+                      {:data {:additions (:additions diff-stats)
+                              :deletions (:deletions diff-stats)}}))
+          (fail state :destructive-diff
+                (str "Diff is heavily destructive ("
+                     (:deletions diff-stats) " deletions vs "
+                     (:additions diff-stats) " additions)")))
+
+        :else
+        (do
+          (when logger
+            (log/debug logger :release-executor :diff/validated
+                       {:data (merge {} diff-stats test-counts)}))
+          state)))))
+
 (defn step-commit [state]
   (if (failed? state)
     state
@@ -277,6 +322,7 @@
                      step-generate-metadata
                      step-create-branch
                      step-write-and-stage
+                     step-validate-diff
                      step-commit
                      step-push
                      step-create-pr

--- a/components/release-executor/src/ai/miniforge/release_executor/git.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/git.clj
@@ -106,6 +106,43 @@
     (catch Exception e
       (result/shell-failure (.getMessage e) {:branch nil}))))
 
+(defn diff-stats
+  "Get line-level diff stats for staged changes.
+
+   Returns {:additions N :deletions N :files N} or nil on error."
+  [worktree-path]
+  (try
+    (let [result (process/shell
+                  {:dir (str worktree-path) :out :string :err :string :continue true}
+                  "git" "diff" "--cached" "--numstat")]
+      (when (zero? (:exit result))
+        (let [lines (str/split-lines (str/trim (:out result "")))
+              parsed (keep (fn [line]
+                             (when-let [[_ adds dels] (re-matches #"(\d+)\t(\d+)\t.*" line)]
+                               {:additions (parse-long adds)
+                                :deletions (parse-long dels)}))
+                           lines)]
+          {:additions (reduce + 0 (map :additions parsed))
+           :deletions (reduce + 0 (map :deletions parsed))
+           :files (count parsed)})))
+    (catch Exception _ nil)))
+
+(defn count-test-defs
+  "Count deftest forms in staged changes.
+
+   Returns {:added N :removed N} or nil on error."
+  [worktree-path]
+  (try
+    (let [result (process/shell
+                  {:dir (str worktree-path) :out :string :err :string :continue true}
+                  "git" "diff" "--cached" "-U0")]
+      (when (zero? (:exit result))
+        (let [diff-text (:out result "")
+              added (count (re-seq #"(?m)^\+.*\(deftest " diff-text))
+              removed (count (re-seq #"(?m)^-.*\(deftest " diff-text))]
+          {:added added :removed removed})))
+    (catch Exception _ nil)))
+
 (defn commit-changes!
   "Commit staged changes with the given message.
 


### PR DESCRIPTION
## Summary

Adds `step-validate-diff` to the release pipeline between write-and-stage and commit. Prevents autonomous agents from accidentally destroying existing code.

## Rules

| Check | Threshold | Action |
|-------|-----------|--------|
| Net-negative test count | removes > adds | Reject with `:destructive-diff` |
| Heavy deletion ratio | deletions > 3x additions (min 20 lines) | Reject with `:destructive-diff` |

## Motivation

PR #334 deleted 458 lines of existing tests and replaced them with an empty file. The release pipeline committed and pushed it without checking.

## Test plan

- [ ] Run miniforge on a test spec, verify diff validation passes for additive changes
- [ ] Verify a simulated destructive diff would be caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)