### PR TITLE
refactor: componentize context-cache MCP tools

### DIFF
--- a/components/mcp-artifact-server/deps.edn
+++ b/components/mcp-artifact-server/deps.edn
@@ -1,2 +1,3 @@
 {:paths ["src" "resources"]
- :deps {cheshire/cheshire {:mvn/version "5.13.0"}}}
+ :deps {cheshire/cheshire {:mvn/version "5.13.0"}
+        ai.miniforge/messages {:local/root "../messages"}}}

--- a/components/mcp-artifact-server/resources/config/mcp-artifact-server/messages/en-US.edn
+++ b/components/mcp-artifact-server/resources/config/mcp-artifact-server/messages/en-US.edn
@@ -1,0 +1,16 @@
+{:mcp-artifact-server/messages
+ {;; Tool dispatch
+  :tool/unknown                "Unknown tool: {tool-name}"
+  :tool/artifact-written       "Artifact written: {path}"
+  :tool/no-builder             "No builder registered for: {key}"
+  :tool/no-handler             "No handler registered for: {key}"
+
+  ;; Context cache lifecycle
+  :cache/loaded                "Context cache loaded: {count} files"
+  :cache/load-failed           "WARN: failed to load context cache: {error}"
+  :cache/misses-written        "Context misses written: {count} misses to {path}"
+
+  ;; Context tool responses
+  :context/read-error          "Error reading {path}: file not found or unreadable"
+  :context/no-grep-matches     "No matches found."
+  :context/no-glob-matches     "No files matched the pattern."}}

--- a/components/mcp-artifact-server/resources/mcp-artifact-server/tool-registry.edn
+++ b/components/mcp-artifact-server/resources/mcp-artifact-server/tool-registry.edn
@@ -169,4 +169,51 @@
   {"branch_name"    {:check :non-blank :msg "branch_name is required"}
    "commit_message" {:check :non-blank :msg "commit_message is required"}
    "pr_title"       {:check :non-blank :msg "pr_title is required"}
-   "pr_description" {:check :non-blank :msg "pr_description is required"}}}}
+   "pr_description" {:check :non-blank :msg "pr_description is required"}}}
+
+ ;; -------------------------------------------------------------------------- Context cache tools
+ ;; These use :handler (not :builder) — they return {:content [...]} directly
+ ;; without producing an artifact.
+
+ "context_read"
+ {:handler :context-read
+  :tool-def
+  {:name "context_read"
+   :description "Read a file. Checks the pre-loaded context cache first (instant). Falls back to filesystem on cache miss. Use this instead of the Read tool."
+   :inputSchema
+   {:type "object"
+    :required ["path"]
+    :properties
+    {"path"   {:type "string" :description "File path relative to project root"}
+     "offset" {:type "integer" :description "Line number to start reading from (0-based)"}
+     "limit"  {:type "integer" :description "Maximum number of lines to return"}}}}
+  :required-params
+  {"path" {:check :non-blank :msg "path is required"}}}
+
+ "context_grep"
+ {:handler :context-grep
+  :tool-def
+  {:name "context_grep"
+   :description "Search file contents for a regex pattern. Searches the pre-loaded context cache first (instant). Falls back to ripgrep on cache miss. Use this instead of the Grep tool."
+   :inputSchema
+   {:type "object"
+    :required ["pattern"]
+    :properties
+    {"pattern" {:type "string" :description "Regex pattern to search for"}
+     "path"    {:type "string" :description "Specific file path to search in (optional)"}
+     "glob"    {:type "string" :description "Glob pattern to filter files (optional, e.g. \"*.clj\")"}}}}
+  :required-params
+  {"pattern" {:check :non-blank :msg "pattern is required"}}}
+
+ "context_glob"
+ {:handler :context-glob
+  :tool-def
+  {:name "context_glob"
+   :description "Find files matching a glob pattern. Searches the pre-loaded context cache first (instant), then also checks the filesystem. Use this instead of the Glob tool."
+   :inputSchema
+   {:type "object"
+    :required ["pattern"]
+    :properties
+    {"pattern" {:type "string" :description "Glob pattern to match files (e.g. \"**/*.clj\", \"src/**/*.ts\")"}}}}
+  :required-params
+  {"pattern" {:check :non-blank :msg "pattern is required"}}}}

--- a/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/context_cache.clj
+++ b/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/context_cache.clj
@@ -170,91 +170,137 @@
   (:files @cache-state))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Tool handler functions
+;; Read-through cache: resolve content from cache or filesystem
 
-(defn handle-context-read
-  "Handler for context_read MCP tool.
-   Cache hit → return content. Miss → read from filesystem, cache, record miss."
-  [params]
-  (let [path   (get params "path")
-        offset (get params "offset")
-        limit  (get params "limit")
-        cached (cache-get path)]
-    (if cached
-      {:content [{:type "text" :text (apply-offset-limit cached offset limit)}]}
+(defn- read-through
+  "Resolve file content: cache hit returns instantly, miss reads from disk,
+   caches the content, and records the miss. Returns content string or nil."
+  [path]
+  (or (cache-get path)
       (try
-        (let [content (slurp path)
-              tokens  (estimate-tokens content)]
+        (let [content (slurp path)]
           (cache-put! path content)
-          (record-miss! "context_read" {:path path} tokens)
-          {:content [{:type "text" :text (apply-offset-limit content offset limit)}]})
-        (catch Exception e
-          {:content [{:type "text"
-                      :text (str "Error reading " path ": " (ex-message e))}]
-           :isError true})))))
+          (record-miss! "context_read" {:path path} (estimate-tokens content))
+          content)
+        (catch Exception _ nil))))
 
-(defn handle-context-grep
-  "Handler for context_grep MCP tool.
-   Searches cached files first, falls back to ripgrep on cache miss."
-  [params]
-  (let [pattern-str (get params "pattern")
-        target-path (get params "path")
-        glob-filter (get params "glob")
-        files       (cached-files)
-        files-to-search (cond
-                          target-path
-                          (if-let [content (get files target-path)]
-                            {target-path content}
-                            {})
+;------------------------------------------------------------------------------ Layer 1
+;; MCP response helpers
 
-                          glob-filter
-                          (into {} (filter (fn [[p _]] (glob-matches? glob-filter p)) files))
+(defn- text-response
+  "Wrap a string in the MCP tool response shape."
+  [text]
+  {:content [{:type "text" :text text}]})
 
-                          :else files)
-        cache-results (->> files-to-search
-                           (mapcat (fn [[path content]]
-                                     (grep-file path content pattern-str)))
-                           vec)]
+(defn- error-response
+  "Wrap an error message in the MCP tool error shape."
+  [text]
+  {:content [{:type "text" :text text}] :isError true})
+
+(defn- grep-response
+  "Build MCP response from grep results. Returns formatted matches or
+   'No matches found.' when empty."
+  [results]
+  (text-response
+    (if (seq results)
+      (format-grep-results results)
+      "No matches found.")))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Grep helpers: file selection and fallback
+
+(defn filter-cached-files
+  "Select which cached files to search based on path or glob filter.
+   Returns a {path → content} map."
+  [files target-path glob-filter]
+  (cond
+    target-path  (select-keys files [target-path])
+    glob-filter  (into {} (filter (fn [[p _]] (glob-matches? glob-filter p))) files)
+    :else        files))
+
+(defn- search-cached-files
+  "Grep across a map of {path → content} for a pattern.
+   Returns a flat vector of grep result maps."
+  [files-map pattern-str]
+  (into [] (mapcat (fn [[path content]] (grep-file path content pattern-str))) files-map))
+
+(defn- cache-new-files!
+  "Cache files discovered by shell grep that aren't already cached.
+   Records a miss for each newly cached file."
+  [results pattern-str known-files]
+  (doseq [path (distinct (map :path results))
+          :when (not (contains? known-files path))]
+    (try
+      (let [content (slurp path)]
+        (cache-put! path content)
+        (record-miss! "context_grep" {:path path :pattern pattern-str}
+                      (estimate-tokens content)))
+      (catch Exception _ nil))))
+
+(defn- grep-with-fallback
+  "Search cached files first. On cache miss, fall back to ripgrep,
+   cache any newly discovered files, and record misses."
+  [pattern-str target-path glob-filter]
+  (let [files         (cached-files)
+        searchable    (filter-cached-files files target-path glob-filter)
+        cache-results (search-cached-files searchable pattern-str)]
     (if (seq cache-results)
-      {:content [{:type "text" :text (format-grep-results cache-results)}]}
-      (let [rg-results (shell-grep pattern-str (or target-path glob-filter))]
-        (when (seq rg-results)
-          (let [paths (distinct (map :path rg-results))]
-            (doseq [p paths]
-              (when-not (get files p)
-                (try
-                  (let [content (slurp p)]
-                    (cache-put! p content)
-                    (record-miss! "context_grep" {:path p :pattern pattern-str}
-                                  (estimate-tokens content)))
-                  (catch Exception _ nil))))))
-        (when (empty? rg-results)
-          (record-miss! "context_grep"
-                        {:pattern pattern-str :path target-path :glob glob-filter :hit false}
-                        0))
-        {:content [{:type "text"
-                    :text (if (seq rg-results)
-                            (format-grep-results rg-results)
-                            "No matches found.")}]}))))
+      cache-results
+      (let [rg-results (or (shell-grep pattern-str (or target-path glob-filter)) [])]
+        (if (seq rg-results)
+          (do (cache-new-files! rg-results pattern-str files)
+              rg-results)
+          (do (record-miss! "context_grep"
+                            {:pattern pattern-str :path target-path
+                             :glob glob-filter :hit false}
+                            0)
+              []))))))
 
-(defn handle-context-glob
-  "Handler for context_glob MCP tool.
-   Matches cached paths first, unions with filesystem glob results."
-  [params]
-  (let [pattern       (get params "pattern")
-        files         (cached-files)
-        cache-matches (->> (keys files)
-                           (filter #(glob-matches? pattern %))
-                           sort
-                           vec)
+;------------------------------------------------------------------------------ Layer 1
+;; Glob helpers
+
+(defn- glob-with-union
+  "Match cached paths, union with filesystem glob, record misses for
+   files found only on disk. Returns a sequence of matched paths."
+  [pattern]
+  (let [files         (cached-files)
+        cache-matches (sort (filter #(glob-matches? pattern %) (keys files)))
         fs-matches    (or (shell-glob pattern) [])
         cache-set     (set cache-matches)
-        new-from-fs   (remove cache-set fs-matches)
-        all-matches   (concat cache-matches new-from-fs)]
+        new-from-fs   (remove cache-set fs-matches)]
     (when (seq new-from-fs)
       (record-miss! "context_glob"
                     {:pattern pattern :fs-only-count (count new-from-fs)}
                     0))
-    (if (seq all-matches)
-      {:content [{:type "text" :text (str/join "\n" all-matches)}]}
-      {:content [{:type "text" :text "No files matched the pattern."}]})))
+    (concat cache-matches new-from-fs)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Tool handler functions (compose Layer 0 + Layer 1)
+
+(defn handle-context-read
+  "Handler for context_read MCP tool."
+  [params]
+  (let [path    (get params "path")
+        offset  (get params "offset")
+        limit   (get params "limit")
+        content (read-through path)]
+    (if content
+      (text-response (apply-offset-limit content offset limit))
+      (error-response (str "Error reading " path ": file not found or unreadable")))))
+
+(defn handle-context-grep
+  "Handler for context_grep MCP tool."
+  [params]
+  (grep-response
+    (grep-with-fallback (get params "pattern")
+                        (get params "path")
+                        (get params "glob"))))
+
+(defn handle-context-glob
+  "Handler for context_glob MCP tool."
+  [params]
+  (let [matches (glob-with-union (get params "pattern"))]
+    (text-response
+      (if (seq matches)
+        (str/join "\n" matches)
+        "No files matched the pattern."))))

--- a/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/context_cache.clj
+++ b/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/context_cache.clj
@@ -1,0 +1,260 @@
+(ns ai.miniforge.mcp-artifact-server.context-cache
+  "Read-through context cache for MCP file exploration tools.
+
+   Provides context_read, context_grep, and context_glob tool handlers that
+   serve content from a pre-loaded cache (instant) with filesystem fallback.
+   Cache misses are recorded for meta-loop learning.
+
+   Layer 0: Pure helpers (token estimation, line slicing, glob matching, grep)
+   Layer 1: Stateful cache operations and tool handler functions"
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.java.shell :as shell]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pure helpers
+
+(def ^:private chars-per-token
+  "Approximate characters per token for estimation."
+  4)
+
+(defn estimate-tokens
+  "Estimate token count from a string (~4 chars per token)."
+  [s]
+  (if (string? s)
+    (int (Math/ceil (/ (count s) chars-per-token)))
+    0))
+
+(defn apply-offset-limit
+  "Apply line-based offset and limit to content string.
+   offset is 0-based line index; limit is max lines to return."
+  [content offset limit]
+  (let [lines (str/split-lines (or content ""))
+        offset (or offset 0)
+        sliced (drop offset lines)
+        limited (if limit (take limit sliced) sliced)]
+    (str/join "\n" limited)))
+
+(defn glob-matches?
+  "Check if a path matches a glob pattern.
+   Supports * (single segment) and ** (any depth)."
+  [pattern path]
+  (let [regex-str (-> pattern
+                      (str/replace "." "\\.")
+                      (str/replace "**" "<<<GLOBSTAR>>>")
+                      (str/replace "*" "[^/]*")
+                      (str/replace "<<<GLOBSTAR>>>" ".*"))
+        regex (re-pattern (str "^" regex-str "$"))]
+    (boolean (re-matches regex path))))
+
+(defn grep-file
+  "Search a file's content for a regex pattern.
+   Returns vector of {:path :line-number :text} for matching lines."
+  [path content pattern-str]
+  (try
+    (let [pattern (re-pattern pattern-str)
+          lines (str/split-lines content)]
+      (->> lines
+           (map-indexed (fn [idx line]
+                          (when (re-find pattern line)
+                            {:path path :line-number (inc idx) :text line})))
+           (filter some?)
+           vec))
+    (catch Exception _e [])))
+
+(defn format-grep-results
+  "Format grep results as path:line:text lines."
+  [results]
+  (->> results
+       (map (fn [{:keys [path line-number text]}]
+              (str path ":" line-number ":" text)))
+       (str/join "\n")))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Shell fallbacks
+
+(defn shell-grep
+  "Fall back to ripgrep for files not in cache.
+   Returns vector of {:path :line-number :text} or nil."
+  [pattern-str path-or-glob]
+  (try
+    (let [args (cond-> ["rg" "--no-heading" "-n" pattern-str]
+                 path-or-glob (conj path-or-glob))
+          {:keys [out]} (apply shell/sh args)]
+      (when-not (str/blank? out)
+        (->> (str/split-lines out)
+             (map (fn [line]
+                    (let [[file-part & rest-parts] (str/split line #":" 3)]
+                      (when (>= (count rest-parts) 1)
+                        {:path file-part
+                         :line-number (try (Integer/parseInt (first rest-parts))
+                                           (catch Exception _ 0))
+                         :text (str/join ":" (rest rest-parts))}))))
+             (filter some?)
+             vec)))
+    (catch Exception _e nil)))
+
+(defn shell-glob
+  "Fall back to filesystem glob via find.
+   Returns vector of relative file paths or nil."
+  [pattern]
+  (try
+    (let [{:keys [out]} (shell/sh "find" "." "-path" (str "./" pattern) "-type" "f")]
+      (when-not (str/blank? out)
+        (->> (str/split-lines out)
+             (map #(str/replace-first % #"^\.\/" ""))
+             (filter #(not (str/blank? %)))
+             vec)))
+    (catch Exception _e nil)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Stateful cache operations
+
+;; Cache atom holding :files (path → content) and :misses (recorded cache misses).
+(defonce cache-state
+  (atom {:files {} :misses []}))
+
+(defn reset-state!
+  "Reset cache state. Intended for test isolation."
+  []
+  (reset! cache-state {:files {} :misses []}))
+
+(defn load-cache!
+  "Load context-cache.edn from artifact-dir into the cache atom."
+  [artifact-dir]
+  (let [path (str artifact-dir "/context-cache.edn")
+        f (io/file path)]
+    (when (.exists f)
+      (try
+        (let [data (edn/read-string (slurp f))]
+          (swap! cache-state assoc :files (get data :files {}))
+          (binding [*out* *err*]
+            (println "Context cache loaded:" (count (:files data)) "files")))
+        (catch Exception e
+          (binding [*out* *err*]
+            (println "WARN: failed to load context cache:" (ex-message e))))))))
+
+(defn flush-misses!
+  "Write accumulated cache misses to context-misses.edn in artifact-dir."
+  [artifact-dir]
+  (let [misses (:misses @cache-state)]
+    (when (seq misses)
+      (let [path (str artifact-dir "/context-misses.edn")]
+        (spit path (pr-str misses))
+        (binding [*out* *err*]
+          (println "Context misses written:" (count misses) "misses to" path))))))
+
+(defn- record-miss!
+  "Record a cache miss for meta-loop learning."
+  [tool-name params tokens]
+  (swap! cache-state update :misses conj
+         (merge {:tool tool-name
+                 :tokens tokens
+                 :timestamp (str (java.time.Instant/now))}
+                params)))
+
+(defn- cache-get
+  "Get cached content for a path, or nil if not cached."
+  [path]
+  (get-in @cache-state [:files path]))
+
+(defn- cache-put!
+  "Store content in the cache for a path."
+  [path content]
+  (swap! cache-state assoc-in [:files path] content))
+
+(defn- cached-files
+  "Return the current files map from the cache."
+  []
+  (:files @cache-state))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Tool handler functions
+
+(defn handle-context-read
+  "Handler for context_read MCP tool.
+   Cache hit → return content. Miss → read from filesystem, cache, record miss."
+  [params]
+  (let [path   (get params "path")
+        offset (get params "offset")
+        limit  (get params "limit")
+        cached (cache-get path)]
+    (if cached
+      {:content [{:type "text" :text (apply-offset-limit cached offset limit)}]}
+      (try
+        (let [content (slurp path)
+              tokens  (estimate-tokens content)]
+          (cache-put! path content)
+          (record-miss! "context_read" {:path path} tokens)
+          {:content [{:type "text" :text (apply-offset-limit content offset limit)}]})
+        (catch Exception e
+          {:content [{:type "text"
+                      :text (str "Error reading " path ": " (ex-message e))}]
+           :isError true})))))
+
+(defn handle-context-grep
+  "Handler for context_grep MCP tool.
+   Searches cached files first, falls back to ripgrep on cache miss."
+  [params]
+  (let [pattern-str (get params "pattern")
+        target-path (get params "path")
+        glob-filter (get params "glob")
+        files       (cached-files)
+        files-to-search (cond
+                          target-path
+                          (if-let [content (get files target-path)]
+                            {target-path content}
+                            {})
+
+                          glob-filter
+                          (into {} (filter (fn [[p _]] (glob-matches? glob-filter p)) files))
+
+                          :else files)
+        cache-results (->> files-to-search
+                           (mapcat (fn [[path content]]
+                                     (grep-file path content pattern-str)))
+                           vec)]
+    (if (seq cache-results)
+      {:content [{:type "text" :text (format-grep-results cache-results)}]}
+      (let [rg-results (shell-grep pattern-str (or target-path glob-filter))]
+        (when (seq rg-results)
+          (let [paths (distinct (map :path rg-results))]
+            (doseq [p paths]
+              (when-not (get files p)
+                (try
+                  (let [content (slurp p)]
+                    (cache-put! p content)
+                    (record-miss! "context_grep" {:path p :pattern pattern-str}
+                                  (estimate-tokens content)))
+                  (catch Exception _ nil))))))
+        (when (empty? rg-results)
+          (record-miss! "context_grep"
+                        {:pattern pattern-str :path target-path :glob glob-filter :hit false}
+                        0))
+        {:content [{:type "text"
+                    :text (if (seq rg-results)
+                            (format-grep-results rg-results)
+                            "No matches found.")}]}))))
+
+(defn handle-context-glob
+  "Handler for context_glob MCP tool.
+   Matches cached paths first, unions with filesystem glob results."
+  [params]
+  (let [pattern       (get params "pattern")
+        files         (cached-files)
+        cache-matches (->> (keys files)
+                           (filter #(glob-matches? pattern %))
+                           sort
+                           vec)
+        fs-matches    (or (shell-glob pattern) [])
+        cache-set     (set cache-matches)
+        new-from-fs   (remove cache-set fs-matches)
+        all-matches   (concat cache-matches new-from-fs)]
+    (when (seq new-from-fs)
+      (record-miss! "context_glob"
+                    {:pattern pattern :fs-only-count (count new-from-fs)}
+                    0))
+    (if (seq all-matches)
+      {:content [{:type "text" :text (str/join "\n" all-matches)}]}
+      {:content [{:type "text" :text "No files matched the pattern."}]})))

--- a/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/context_cache.clj
+++ b/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/context_cache.clj
@@ -7,7 +7,8 @@
 
    Layer 0: Pure helpers (token estimation, line slicing, glob matching, grep)
    Layer 1: Stateful cache operations and tool handler functions"
-  (:require [clojure.edn :as edn]
+  (:require [ai.miniforge.mcp-artifact-server.messages :as msg]
+            [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.java.shell :as shell]
             [clojure.string :as str]))
@@ -130,10 +131,10 @@
         (let [data (edn/read-string (slurp f))]
           (swap! cache-state assoc :files (get data :files {}))
           (binding [*out* *err*]
-            (println "Context cache loaded:" (count (:files data)) "files")))
+            (println (msg/t :cache/loaded {:count (count (:files data))}))))
         (catch Exception e
           (binding [*out* *err*]
-            (println "WARN: failed to load context cache:" (ex-message e))))))))
+            (println (msg/t :cache/load-failed {:error (ex-message e)}))))))))
 
 (defn flush-misses!
   "Write accumulated cache misses to context-misses.edn in artifact-dir."
@@ -143,7 +144,7 @@
       (let [path (str artifact-dir "/context-misses.edn")]
         (spit path (pr-str misses))
         (binding [*out* *err*]
-          (println "Context misses written:" (count misses) "misses to" path))))))
+          (println (msg/t :cache/misses-written {:count (count misses) :path path})))))))
 
 (defn- record-miss!
   "Record a cache miss for meta-loop learning."
@@ -199,12 +200,12 @@
 
 (defn- grep-response
   "Build MCP response from grep results. Returns formatted matches or
-   'No matches found.' when empty."
+   a no-matches message when empty."
   [results]
   (text-response
     (if (seq results)
       (format-grep-results results)
-      "No matches found.")))
+      (msg/t :context/no-grep-matches))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Grep helpers: file selection and fallback
@@ -286,7 +287,7 @@
         content (read-through path)]
     (if content
       (text-response (apply-offset-limit content offset limit))
-      (error-response (str "Error reading " path ": file not found or unreadable")))))
+      (error-response (msg/t :context/read-error {:path path})))))
 
 (defn handle-context-grep
   "Handler for context_grep MCP tool."
@@ -303,4 +304,4 @@
     (text-response
       (if (seq matches)
         (str/join "\n" matches)
-        "No files matched the pattern."))))
+        (msg/t :context/no-glob-matches)))))

--- a/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/interface.clj
+++ b/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/interface.clj
@@ -5,7 +5,7 @@
    - start-server: Run the MCP server (blocking stdin/stdout loop)
    - handle-tool-call: Direct tool invocation for in-process testing
    - tool-definitions: List of registered MCP tool definitions
-   - register-tool! / register-builder!: Extensibility points"
+   - register-tool! / register-builder! / register-handler!: Extensibility points"
   (:require [ai.miniforge.mcp-artifact-server.server :as server]
             [ai.miniforge.mcp-artifact-server.tools :as tools]))
 
@@ -54,3 +54,7 @@
 (def register-builder!
   "Register an artifact builder function. See tools/register-builder! for details."
   tools/register-builder!)
+
+(def register-handler!
+  "Register a direct handler function (no artifact). See tools/register-handler!."
+  tools/register-handler!)

--- a/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/messages.clj
+++ b/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/messages.clj
@@ -1,0 +1,9 @@
+(ns ai.miniforge.mcp-artifact-server.messages
+  "Component-level message catalog for mcp-artifact-server.
+   Delegates to the shared messages component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up an mcp-artifact-server message by key, with optional param substitution."
+  (messages/create-translator "config/mcp-artifact-server/messages/en-US.edn"
+                              :mcp-artifact-server/messages))

--- a/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/server.clj
+++ b/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/server.clj
@@ -1,7 +1,8 @@
 (ns ai.miniforge.mcp-artifact-server.server
   "Main MCP JSON-RPC 2.0 stdin/stdout loop.
    Babashka-compatible."
-  (:require [ai.miniforge.mcp-artifact-server.protocol :as protocol]
+  (:require [ai.miniforge.mcp-artifact-server.context-cache :as context-cache]
+            [ai.miniforge.mcp-artifact-server.protocol :as protocol]
             [ai.miniforge.mcp-artifact-server.tools :as tools]
             [clojure.string :as str]))
 
@@ -98,15 +99,33 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Main loop
 
+(defn- register-context-handlers!
+  "Register context-cache tool handlers in the tool handler registry."
+  []
+  (tools/register-handler! :context-read  context-cache/handle-context-read)
+  (tools/register-handler! :context-grep  context-cache/handle-context-grep)
+  (tools/register-handler! :context-glob  context-cache/handle-context-glob))
+
 (defn run-server
   "Run the MCP server loop, reading JSON-RPC messages from stdin.
+
+   Lifecycle:
+   1. Load context cache from artifact-dir (if present)
+   2. Register context-cache tool handlers
+   3. Process JSON-RPC messages until stdin closes
+   4. Flush accumulated cache misses to artifact-dir
 
    Arguments:
    - artifact-dir — directory path for artifact persistence"
   [artifact-dir]
   (log-stderr "miniforge-artifact MCP server started, artifact-dir:" artifact-dir)
-  (let [reader (java.io.BufferedReader. (java.io.InputStreamReader. System/in "UTF-8"))]
-    (loop []
-      (when-let [line (.readLine reader)]
-        (process-line line artifact-dir)
-        (recur)))))
+  (context-cache/load-cache! artifact-dir)
+  (register-context-handlers!)
+  (try
+    (let [reader (java.io.BufferedReader. (java.io.InputStreamReader. System/in "UTF-8"))]
+      (loop []
+        (when-let [line (.readLine reader)]
+          (process-line line artifact-dir)
+          (recur))))
+    (finally
+      (context-cache/flush-misses! artifact-dir))))

--- a/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/tools.clj
+++ b/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/tools.clj
@@ -5,7 +5,8 @@
    `mcp-artifact-server/tool-registry.edn` on the classpath. Builder functions
    are registered separately via `register-builder!`, enabling extensibility
    without modifying the config file."
-  (:require [clojure.edn :as edn]
+  (:require [ai.miniforge.mcp-artifact-server.messages :as msg]
+            [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]))
 
@@ -210,7 +211,7 @@
   "Resolve a builder keyword to its function."
   [builder-key]
   (or (get @builder-registry* builder-key)
-      (throw (ex-info (str "No builder registered for: " builder-key)
+      (throw (ex-info (msg/t :tool/no-builder {:key builder-key})
                       {:builder builder-key
                        :registered (keys @builder-registry*)}))))
 
@@ -231,7 +232,7 @@
   "Resolve a handler keyword to its function."
   [handler-key]
   (or (get @handler-registry* handler-key)
-      (throw (ex-info (str "No handler registered for: " handler-key)
+      (throw (ex-info (msg/t :tool/no-handler {:key handler-key})
                       {:handler handler-key
                        :registered (keys @handler-registry*)}))))
 
@@ -296,14 +297,12 @@
   (let [registry (tool-registry)
         {:keys [required-params builder handler]} (get registry tool-name)]
     (when-not (or builder handler)
-      (throw (ex-info (str "Unknown tool: " tool-name) {:code -32601})))
+      (throw (ex-info (msg/t :tool/unknown {:tool-name tool-name}) {:code -32601})))
     (validate-required-params required-params arguments)
     (if handler
-      (let [handle-fn (resolve-handler handler)]
-        (handle-fn arguments))
-      (let [build-fn (resolve-builder builder)
-            {:keys [artifact message]} (build-fn arguments)
+      ((-> handler resolve-handler) arguments)
+      (let [{:keys [artifact message]} ((resolve-builder builder) arguments)
             path (write-artifact-fn artifact)]
         (binding [*out* *err*]
-          (println "Artifact written:" path))
+          (println (msg/t :tool/artifact-written {:path path})))
         {:content [{:type "text" :text message}]}))))

--- a/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/tools.clj
+++ b/components/mcp-artifact-server/src/ai/miniforge/mcp_artifact_server/tools.clj
@@ -215,6 +215,27 @@
                        :registered (keys @builder-registry*)}))))
 
 ;------------------------------------------------------------------------------ Layer 1
+;; Extensible handler registry (for tools that don't produce artifacts)
+
+(defonce handler-registry*
+  (atom {}))
+
+(defn register-handler!
+  "Register a direct handler function for a tool (no artifact production).
+   handler-key is a keyword matching the :handler field in tool-registry.edn.
+   handler-fn takes params map, returns {:content [{:type \"text\" :text ...}]}."
+  [handler-key handler-fn]
+  (swap! handler-registry* assoc handler-key handler-fn))
+
+(defn resolve-handler
+  "Resolve a handler keyword to its function."
+  [handler-key]
+  (or (get @handler-registry* handler-key)
+      (throw (ex-info (str "No handler registered for: " handler-key)
+                      {:handler handler-key
+                       :registered (keys @handler-registry*)}))))
+
+;------------------------------------------------------------------------------ Layer 1
 ;; Configuration loading
 
 (defn load-registry-config
@@ -260,6 +281,10 @@
 (defn handle-tool-call
   "Handle an MCP tools/call request.
 
+   Supports two dispatch paths:
+   - :builder tools — produce an artifact, persist via write-artifact-fn
+   - :handler tools — return {:content [...]} directly (no artifact)
+
    Arguments:
    - tool-name — string name of the tool
    - arguments — map of tool arguments
@@ -269,13 +294,16 @@
    Throws on unknown tool or validation failure."
   [tool-name arguments write-artifact-fn]
   (let [registry (tool-registry)
-        {:keys [required-params builder]} (get registry tool-name)]
-    (when-not builder
+        {:keys [required-params builder handler]} (get registry tool-name)]
+    (when-not (or builder handler)
       (throw (ex-info (str "Unknown tool: " tool-name) {:code -32601})))
     (validate-required-params required-params arguments)
-    (let [build-fn (resolve-builder builder)
-          {:keys [artifact message]} (build-fn arguments)
-          path (write-artifact-fn artifact)]
-      (binding [*out* *err*]
-        (println "Artifact written:" path))
-      {:content [{:type "text" :text message}]})))
+    (if handler
+      (let [handle-fn (resolve-handler handler)]
+        (handle-fn arguments))
+      (let [build-fn (resolve-builder builder)
+            {:keys [artifact message]} (build-fn arguments)
+            path (write-artifact-fn artifact)]
+        (binding [*out* *err*]
+          (println "Artifact written:" path))
+        {:content [{:type "text" :text message}]}))))

--- a/components/mcp-artifact-server/test/ai/miniforge/mcp_artifact_server/context_cache_test.clj
+++ b/components/mcp-artifact-server/test/ai/miniforge/mcp_artifact_server/context_cache_test.clj
@@ -1,0 +1,213 @@
+(ns ai.miniforge.mcp-artifact-server.context-cache-test
+  "Unit tests for context cache pure helpers and tool handlers."
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [ai.miniforge.mcp-artifact-server.context-cache :as cache]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures
+
+(defn with-clean-cache [f]
+  (cache/reset-state!)
+  (try (f) (finally (cache/reset-state!))))
+
+(use-fixtures :each with-clean-cache)
+
+(defn with-temp-dir [f]
+  (let [dir (str (java.nio.file.Files/createTempDirectory
+                   "ctx-cache-test-"
+                   (into-array java.nio.file.attribute.FileAttribute [])))]
+    (try
+      (f dir)
+      (finally
+        (doseq [file (reverse (file-seq (io/file dir)))]
+          (.delete ^java.io.File file))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pure helper tests
+
+(deftest estimate-tokens-test
+  (testing "estimates ~4 chars per token"
+    (is (= 3 (cache/estimate-tokens "hello world!")))
+    (is (= 1 (cache/estimate-tokens "abc"))))
+
+  (testing "handles edge cases"
+    (is (= 0 (cache/estimate-tokens "")))
+    (is (= 0 (cache/estimate-tokens nil)))
+    (is (= 0 (cache/estimate-tokens 42)))))
+
+(deftest apply-offset-limit-test
+  (let [content "line0\nline1\nline2\nline3\nline4"]
+
+    (testing "no offset or limit returns all lines"
+      (is (= content (cache/apply-offset-limit content nil nil))))
+
+    (testing "offset skips lines"
+      (is (= "line2\nline3\nline4" (cache/apply-offset-limit content 2 nil))))
+
+    (testing "limit caps lines"
+      (is (= "line0\nline1" (cache/apply-offset-limit content nil 2))))
+
+    (testing "offset + limit together"
+      (is (= "line1\nline2" (cache/apply-offset-limit content 1 2))))
+
+    (testing "nil content returns empty"
+      (is (= "" (cache/apply-offset-limit nil nil nil))))))
+
+(deftest glob-matches?-test
+  (testing "single star matches one segment"
+    (is (cache/glob-matches? "src/*.clj" "src/core.clj"))
+    (is (not (cache/glob-matches? "src/*.clj" "src/nested/core.clj"))))
+
+  (testing "double star matches any depth"
+    (is (cache/glob-matches? "**/*.clj" "src/core.clj"))
+    (is (cache/glob-matches? "**/*.clj" "src/deep/nested/core.clj")))
+
+  (testing "exact match"
+    (is (cache/glob-matches? "src/core.clj" "src/core.clj"))
+    (is (not (cache/glob-matches? "src/core.clj" "src/other.clj"))))
+
+  (testing "dots are literal"
+    (is (not (cache/glob-matches? "src/*.clj" "src/corexclj")))))
+
+(deftest grep-file-test
+  (let [content "(ns core)\n\n(defn greet [name]\n  (str \"Hello, \" name))"]
+
+    (testing "finds matching lines with line numbers"
+      (let [results (cache/grep-file "src/core.clj" content "defn")]
+        (is (= 1 (count results)))
+        (is (= 3 (:line-number (first results))))
+        (is (= "src/core.clj" (:path (first results))))))
+
+    (testing "returns empty on no match"
+      (is (empty? (cache/grep-file "src/core.clj" content "zzz_nonexistent"))))
+
+    (testing "returns empty on invalid regex"
+      (is (empty? (cache/grep-file "src/core.clj" content "[invalid"))))))
+
+(deftest format-grep-results-test
+  (testing "formats as path:line:text"
+    (is (= "a.clj:1:hello\nb.clj:5:world"
+           (cache/format-grep-results
+             [{:path "a.clj" :line-number 1 :text "hello"}
+              {:path "b.clj" :line-number 5 :text "world"}])))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Tool handler tests
+
+(deftest handle-context-read-cache-hit-test
+  (testing "returns cached content"
+    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(ns core)\n(defn hello [])")
+    (let [result (cache/handle-context-read {"path" "src/core.clj"})]
+      (is (= "(ns core)\n(defn hello [])" (get-in result [:content 0 :text])))
+      (is (not (:isError result))))))
+
+(deftest handle-context-read-offset-limit-test
+  (testing "applies offset and limit on cache hit"
+    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "line0\nline1\nline2\nline3")
+    (let [result (cache/handle-context-read {"path" "src/core.clj" "offset" 1 "limit" 2})]
+      (is (= "line1\nline2" (get-in result [:content 0 :text]))))))
+
+(deftest handle-context-read-cache-miss-test
+  (testing "falls back to filesystem and records miss"
+    (with-temp-dir
+      (fn [dir]
+        (let [file-path (str dir "/uncached.txt")]
+          (spit file-path "filesystem content")
+          (let [result (cache/handle-context-read {"path" file-path})]
+            (is (= "filesystem content" (get-in result [:content 0 :text])))
+            ;; Verify it was cached
+            (is (= "filesystem content" (get-in @cache/cache-state [:files file-path])))
+            ;; Verify miss was recorded
+            (is (= 1 (count (:misses @cache/cache-state))))
+            (is (= "context_read" (:tool (first (:misses @cache/cache-state)))))))))))
+
+(deftest handle-context-read-nonexistent-test
+  (testing "returns error for nonexistent file"
+    (let [result (cache/handle-context-read {"path" "/nonexistent/path.clj"})]
+      (is (:isError result))
+      (is (re-find #"Error reading" (get-in result [:content 0 :text]))))))
+
+(deftest handle-context-grep-cache-hit-test
+  (testing "finds pattern in cached files"
+    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"]
+           "(ns alpha)\n\n(defn greet [name]\n  (str name))")
+    (swap! cache/cache-state assoc-in [:files "src/beta.clj"]
+           "(ns beta)\n\n(defn process [x]\n  (inc x))")
+    (let [result (cache/handle-context-grep {"pattern" "defn greet"})]
+      (is (re-find #"alpha\.clj" (get-in result [:content 0 :text])))
+      (is (re-find #"defn greet" (get-in result [:content 0 :text]))))))
+
+(deftest handle-context-grep-specific-file-test
+  (testing "path restricts search to one file"
+    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"]
+           "(defn greet [name] name)")
+    (swap! cache/cache-state assoc-in [:files "src/beta.clj"]
+           "(defn greet [user] user)")
+    (let [result (cache/handle-context-grep {"pattern" "defn" "path" "src/beta.clj"})]
+      (is (re-find #"beta\.clj" (get-in result [:content 0 :text])))
+      (is (not (re-find #"alpha\.clj" (get-in result [:content 0 :text])))))))
+
+(deftest handle-context-grep-glob-filter-test
+  (testing "glob filter restricts search"
+    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(defn foo [])")
+    (swap! cache/cache-state assoc-in [:files "test/core_test.clj"] "(deftest foo-test)")
+    (let [result (cache/handle-context-grep {"pattern" "def" "glob" "test/*.clj"})]
+      (is (re-find #"core_test\.clj" (get-in result [:content 0 :text])))
+      (is (not (re-find #"src/" (get-in result [:content 0 :text])))))))
+
+(deftest handle-context-grep-no-match-test
+  (testing "returns no matches message"
+    (swap! cache/cache-state assoc-in [:files "src/core.clj"] "(ns core)")
+    (let [result (cache/handle-context-grep {"pattern" "zzz_nonexistent_zzz"})]
+      (is (re-find #"[Nn]o matches" (get-in result [:content 0 :text]))))))
+
+(deftest handle-context-glob-cached-paths-test
+  (testing "matches cached file paths"
+    (swap! cache/cache-state assoc-in [:files "src/alpha.clj"] "a")
+    (swap! cache/cache-state assoc-in [:files "src/beta.clj"] "b")
+    (swap! cache/cache-state assoc-in [:files "test/alpha_test.clj"] "t")
+    (let [result (cache/handle-context-glob {"pattern" "src/*.clj"})
+          text (get-in result [:content 0 :text])]
+      (is (re-find #"alpha\.clj" text))
+      (is (re-find #"beta\.clj" text))
+      (is (not (re-find #"test/" text))))))
+
+(deftest handle-context-glob-no-match-test
+  (testing "returns no files matched message"
+    (let [result (cache/handle-context-glob {"pattern" "nonexistent/**/*.xyz"})]
+      (is (re-find #"[Nn]o files matched" (get-in result [:content 0 :text]))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Lifecycle tests
+
+(deftest load-cache-roundtrip-test
+  (testing "load-cache! reads context-cache.edn and populates atom"
+    (with-temp-dir
+      (fn [dir]
+        (spit (str dir "/context-cache.edn")
+              (pr-str {:files {"src/a.clj" "(ns a)" "src/b.clj" "(ns b)"}}))
+        (cache/load-cache! dir)
+        (is (= "(ns a)" (get-in @cache/cache-state [:files "src/a.clj"])))
+        (is (= "(ns b)" (get-in @cache/cache-state [:files "src/b.clj"])))))))
+
+(deftest flush-misses-roundtrip-test
+  (testing "flush-misses! writes misses to context-misses.edn"
+    (with-temp-dir
+      (fn [dir]
+        (swap! cache/cache-state update :misses conj
+               {:tool "context_read" :path "src/x.clj" :tokens 100
+                :timestamp "2026-01-01T00:00:00Z"})
+        (cache/flush-misses! dir)
+        (let [misses (edn/read-string (slurp (str dir "/context-misses.edn")))]
+          (is (= 1 (count misses)))
+          (is (= "context_read" (:tool (first misses))))
+          (is (= "src/x.clj" (:path (first misses)))))))))
+
+(deftest flush-misses-noop-when-empty-test
+  (testing "flush-misses! does not write file when no misses"
+    (with-temp-dir
+      (fn [dir]
+        (cache/flush-misses! dir)
+        (is (not (.exists (io/file (str dir "/context-misses.edn")))))))))

--- a/components/mcp-artifact-server/test/ai/miniforge/mcp_artifact_server/interface_test.clj
+++ b/components/mcp-artifact-server/test/ai/miniforge/mcp_artifact_server/interface_test.clj
@@ -4,6 +4,7 @@
             [clojure.edn :as edn]
             [clojure.java.io :as io]
             [ai.miniforge.mcp-artifact-server.interface :as mcp]
+            [ai.miniforge.mcp-artifact-server.tools :as tools]
             [ai.miniforge.mcp-artifact-server.protocol :as protocol]))
 
 ;------------------------------------------------------------------------------ Helpers
@@ -135,11 +136,28 @@
 ;------------------------------------------------------------------------------ Tool definitions tests
 
 (deftest tool-definitions-test
-  (testing "registry has 4 tools"
-    (is (= 4 (count (mcp/tool-definitions)))))
+  (testing "registry has at least 7 tools (4 artifact + 3 context)"
+    (is (>= (count (mcp/tool-definitions)) 7)))
 
   (testing "each tool has required fields"
     (doseq [tool (mcp/tool-definitions)]
       (is (string? (:name tool)))
       (is (string? (:description tool)))
-      (is (map? (:inputSchema tool))))))
+      (is (map? (:inputSchema tool)))))
+
+  (testing "context tools are present"
+    (let [names (set (map :name (mcp/tool-definitions)))]
+      (is (contains? names "context_read"))
+      (is (contains? names "context_grep"))
+      (is (contains? names "context_glob")))))
+
+(deftest handler-dispatch-test
+  (testing "handler tools dispatch without writing artifacts"
+    (tools/register-handler! :test-echo
+      (fn [params] {:content [{:type "text" :text (get params "msg")}]}))
+    (tools/register-tool! "test_echo"
+      {:handler :test-echo
+       :tool-def {:name "test_echo" :description "echo" :inputSchema {:type "object"}}
+       :required-params {}})
+    (let [result (mcp/handle-tool-call "test_echo" {"msg" "hello"} "/tmp/unused")]
+      (is (= "hello" (get-in result [:content 0 :text]))))))

--- a/scripts/mcp-artifact-server.bb
+++ b/scripts/mcp-artifact-server.bb
@@ -57,128 +57,6 @@
     (spit path (pr-str artifact))
     path))
 
-;; --------------------------------------------------------------------------- Context cache
-
-(def context-cache
-  "Atom holding the context cache. Loaded from context-cache.edn on startup.
-   Keys: :files — map of relative-path → content."
-  (atom {:files {}}))
-
-(def cache-misses
-  "Atom collecting cache miss records for meta-loop learning."
-  (atom []))
-
-(defn load-context-cache!
-  "Load context-cache.edn from artifact-dir if present."
-  []
-  (let [path (str artifact-dir "/context-cache.edn")]
-    (when (.exists (java.io.File. path))
-      (try
-        (let [data (read-string (slurp path))]
-          (reset! context-cache data)
-          (binding [*out* *err*]
-            (println "Context cache loaded:" (count (:files data)) "files")))
-        (catch Exception e
-          (binding [*out* *err*]
-            (println "WARN: failed to load context cache:" (ex-message e))))))))
-
-(defn write-context-misses!
-  "Write accumulated cache misses to context-misses.edn."
-  []
-  (let [misses @cache-misses]
-    (when (seq misses)
-      (let [path (str artifact-dir "/context-misses.edn")]
-        (spit path (pr-str misses))
-        (binding [*out* *err*]
-          (println "Context misses written:" (count misses) "misses to" path))))))
-
-(defn record-miss!
-  "Record a cache miss for meta-loop learning."
-  [tool-name params tokens]
-  (swap! cache-misses conj
-         (merge {:tool tool-name
-                 :tokens tokens
-                 :timestamp (str (java.time.Instant/now))}
-                params)))
-
-(defn estimate-tokens
-  "Estimate token count (~4 chars per token)."
-  [s]
-  (if (string? s)
-    (int (Math/ceil (/ (count s) 4)))
-    0))
-
-(defn apply-offset-limit
-  "Apply line-based offset and limit to content string."
-  [content offset limit]
-  (let [lines (str/split-lines content)
-        offset (or offset 0)
-        sliced (drop offset lines)
-        limited (if limit (take limit sliced) sliced)]
-    (str/join "\n" limited)))
-
-(defn glob-matches?
-  "Check if a path matches a glob pattern (basic support for * and **)."
-  [pattern path]
-  (let [regex-str (-> pattern
-                      (str/replace "." "\\.")
-                      (str/replace "**" "<<<GLOBSTAR>>>")
-                      (str/replace "*" "[^/]*")
-                      (str/replace "<<<GLOBSTAR>>>" ".*"))
-        regex (re-pattern (str "^" regex-str "$"))]
-    (boolean (re-matches regex path))))
-
-(defn grep-file
-  "Search a file's content for a regex pattern. Returns matching lines with numbers."
-  [path content pattern-str]
-  (try
-    (let [pattern (re-pattern pattern-str)
-          lines (str/split-lines content)]
-      (->> lines
-           (map-indexed (fn [idx line]
-                          (when (re-find pattern line)
-                            {:path path :line-number (inc idx) :text line})))
-           (filter some?)
-           vec))
-    (catch Exception _e [])))
-
-(defn shell-grep
-  "Fall back to rg for files not in cache."
-  [pattern-str path-or-glob]
-  (try
-    (let [args (cond-> ["rg" "--no-heading" "-n" pattern-str]
-                 path-or-glob (conj path-or-glob))
-          proc (.exec (Runtime/getRuntime) (into-array String args))
-          output (slurp (.getInputStream proc))]
-      (.waitFor proc)
-      (when-not (str/blank? output)
-        (->> (str/split-lines output)
-             (map (fn [line]
-                    (let [[file-line & rest-parts] (str/split line #":" 3)]
-                      (when (>= (count rest-parts) 1)
-                        {:path file-line
-                         :line-number (try (Integer/parseInt (first rest-parts)) (catch Exception _ 0))
-                         :text (str/join ":" (rest rest-parts))}))))
-             (filter some?)
-             vec)))
-    (catch Exception _e nil)))
-
-(defn shell-glob
-  "Fall back to filesystem glob via find or ls."
-  [pattern]
-  (try
-    (let [;; Use find with -path for glob matching
-          args ["find" "." "-path" (str "./" pattern) "-type" "f"]
-          proc (.exec (Runtime/getRuntime) (into-array String args))
-          output (slurp (.getInputStream proc))]
-      (.waitFor proc)
-      (when-not (str/blank? output)
-        (->> (str/split-lines output)
-             (map #(str/replace-first % #"^\.\/" ""))
-             (filter #(not (str/blank? %)))
-             vec)))
-    (catch Exception _e nil)))
-
 ;; --------------------------------------------------------------------------- Assertion/test counting helpers
 
 (defn count-assertions
@@ -460,162 +338,7 @@
                      files-summary
                      (assoc :release/files-summary files-summary))
          :message (str "Release artifact submitted successfully. "
-                       "Branch: " branch-name ", PR: " pr-title)}))}
-
-   ;; --------------------------------------------------------------------------- Context cache tools
-   ;; These shadow Read/Grep/Glob with a read-through, write-through cache
-   ;; backed by the context pack. Cache misses are recorded for meta-loop learning.
-
-   "context_read"
-   {:tool-def
-    {:name "context_read"
-     :description "Read a file. Checks the pre-loaded context cache first (instant). Falls back to filesystem on cache miss. Use this instead of the Read tool."
-     :inputSchema
-     {:type "object"
-      :required ["path"]
-      :properties
-      {"path"   {:type "string" :description "File path relative to project root"}
-       "offset" {:type "integer" :description "Line number to start reading from (0-based)"}
-       "limit"  {:type "integer" :description "Maximum number of lines to return"}}}}
-
-    :required-params
-    {"path" {:check #(not (str/blank? %)) :msg "path is required"}}
-
-    :build-artifact nil ;; context tools don't write artifacts
-
-    :handle-tool-call
-    (fn [params]
-      (let [path (get params "path")
-            offset (get params "offset")
-            limit (get params "limit")
-            cached (get-in @context-cache [:files path])]
-        (if cached
-          ;; Cache hit
-          (let [content (apply-offset-limit cached offset limit)]
-            {:content [{:type "text" :text content}]})
-          ;; Cache miss — read from filesystem, cache it, record miss
-          (try
-            (let [content (slurp path)
-                  tokens (estimate-tokens content)]
-              (swap! context-cache assoc-in [:files path] content)
-              (record-miss! "context_read" {:path path} tokens)
-              {:content [{:type "text" :text (apply-offset-limit content offset limit)}]})
-            (catch Exception e
-              {:content [{:type "text"
-                          :text (str "Error reading " path ": " (ex-message e))}]
-               :isError true})))))}
-
-   "context_grep"
-   {:tool-def
-    {:name "context_grep"
-     :description "Search file contents for a regex pattern. Searches the pre-loaded context cache first (instant). Falls back to ripgrep on cache miss. Use this instead of the Grep tool."
-     :inputSchema
-     {:type "object"
-      :required ["pattern"]
-      :properties
-      {"pattern" {:type "string" :description "Regex pattern to search for"}
-       "path"    {:type "string" :description "Specific file path to search in (optional)"}
-       "glob"    {:type "string" :description "Glob pattern to filter files (optional, e.g. \"*.clj\")"}}}}
-
-    :required-params
-    {"pattern" {:check #(not (str/blank? %)) :msg "pattern is required"}}
-
-    :build-artifact nil
-
-    :handle-tool-call
-    (fn [params]
-      (let [pattern-str (get params "pattern")
-            target-path (get params "path")
-            glob-filter (get params "glob")
-            cache-files (:files @context-cache)
-            ;; Filter cached files by path or glob
-            files-to-search (cond
-                              target-path
-                              (if-let [content (get cache-files target-path)]
-                                {target-path content}
-                                {})
-
-                              glob-filter
-                              (into {} (filter (fn [[p _]] (glob-matches? glob-filter p)) cache-files))
-
-                              :else cache-files)
-            ;; Search cached files
-            cache-results (->> files-to-search
-                               (mapcat (fn [[path content]]
-                                         (grep-file path content pattern-str)))
-                               vec)]
-        (if (seq cache-results)
-          ;; Cache hit — format results like ripgrep output
-          (let [formatted (->> cache-results
-                               (map (fn [{:keys [path line-number text]}]
-                                      (str path ":" line-number ":" text)))
-                               (str/join "\n"))]
-            {:content [{:type "text" :text formatted}]})
-          ;; Cache miss — fall back to rg
-          (let [rg-results (shell-grep pattern-str (or target-path glob-filter))
-                rg-text (if (seq rg-results)
-                          (->> rg-results
-                               (map (fn [{:keys [path line-number text]}]
-                                      (str path ":" line-number ":" text)))
-                               (str/join "\n"))
-                          "No matches found.")]
-            ;; Record miss and cache any files we found
-            (when (seq rg-results)
-              (let [paths (distinct (map :path rg-results))]
-                (doseq [p paths]
-                  (when-not (get cache-files p)
-                    (try
-                      (let [content (slurp p)]
-                        (swap! context-cache assoc-in [:files p] content)
-                        (record-miss! "context_grep" {:path p :pattern pattern-str}
-                                      (estimate-tokens content)))
-                      (catch Exception _ nil))))))
-            (when (empty? rg-results)
-              (record-miss! "context_grep"
-                            {:pattern pattern-str :path target-path :glob glob-filter :hit false}
-                            0))
-            {:content [{:type "text" :text rg-text}]}))))}
-
-   "context_glob"
-   {:tool-def
-    {:name "context_glob"
-     :description "Find files matching a glob pattern. Searches the pre-loaded context cache first (instant), then also checks the filesystem. Use this instead of the Glob tool."
-     :inputSchema
-     {:type "object"
-      :required ["pattern"]
-      :properties
-      {"pattern" {:type "string" :description "Glob pattern to match files (e.g. \"**/*.clj\", \"src/**/*.ts\")"}}}}
-
-    :required-params
-    {"pattern" {:check #(not (str/blank? %)) :msg "pattern is required"}}
-
-    :build-artifact nil
-
-    :handle-tool-call
-    (fn [params]
-      (let [pattern (get params "pattern")
-            cache-files (:files @context-cache)
-            ;; Match against cached paths
-            cache-matches (->> (keys cache-files)
-                               (filter #(glob-matches? pattern %))
-                               sort
-                               vec)
-            ;; Also check filesystem
-            fs-matches (or (shell-glob pattern) [])
-            ;; Union, preserving cache-first order
-            cache-set (set cache-matches)
-            new-from-fs (remove cache-set fs-matches)
-            all-matches (concat cache-matches new-from-fs)]
-        ;; Record misses for files found only on filesystem
-        (when (seq new-from-fs)
-          (record-miss! "context_glob"
-                        {:pattern pattern :fs-only-count (count new-from-fs)}
-                        0))
-        (if (seq all-matches)
-          {:content [{:type "text"
-                      :text (str/join "\n" all-matches)}]}
-          {:content [{:type "text"
-                      :text "No files matched the pattern."}]})))}})
+                       "Branch: " branch-name ", PR: " pr-title)}))}})
 
 ;; --------------------------------------------------------------------------- Generic tool handler
 
@@ -626,18 +349,14 @@
         (throw (ex-info msg {:code -32602}))))))
 
 (defn handle-tool-call [tool-name arguments]
-  (if-let [{:keys [required-params build-artifact handle-tool-call]} (get tool-registry tool-name)]
+  (if-let [{:keys [required-params build-artifact]} (get tool-registry tool-name)]
     (do
       (validate-required-params required-params arguments)
-      (if handle-tool-call
-        ;; Context tools: direct handler, no artifact
-        (handle-tool-call arguments)
-        ;; Artifact tools: build and write artifact
-        (let [{:keys [artifact message]} (build-artifact arguments)
-              path (write-artifact! artifact)]
-          (binding [*out* *err*]
-            (println "Artifact written:" path))
-          {:content [{:type "text" :text message}]})))
+      (let [{:keys [artifact message]} (build-artifact arguments)
+            path (write-artifact! artifact)]
+        (binding [*out* *err*]
+          (println "Artifact written:" path))
+        {:content [{:type "text" :text message}]}))
     (throw (ex-info (str "Unknown tool: " tool-name) {:code -32601}))))
 
 ;; --------------------------------------------------------------------------- Tool definitions (derived from registry)
@@ -671,9 +390,6 @@
     (throw (ex-info (str "Method not found: " method) {:code -32601}))))
 
 ;; --------------------------------------------------------------------------- Main loop
-
-;; Load context cache if present
-(load-context-cache!)
 
 (binding [*out* *err*]
   (println "miniforge-artifact MCP server started, artifact-dir:" artifact-dir))

--- a/scripts/test-mcp-artifact-server.bb
+++ b/scripts/test-mcp-artifact-server.bb
@@ -118,11 +118,14 @@
   (let [resp (send-request! proc (rpc-request 2 "tools/list" {}))
         tools (get-in resp [:result :tools])
         tool-names (set (map :name tools))]
-    (assert= "returns 4 tools" 4 (count tools))
+    (assert= "returns 7 tools" 7 (count tools))
     (assert-true "has submit_code_artifact" (contains? tool-names "submit_code_artifact"))
     (assert-true "has submit_plan" (contains? tool-names "submit_plan"))
     (assert-true "has submit_test_artifact" (contains? tool-names "submit_test_artifact"))
     (assert-true "has submit_release_artifact" (contains? tool-names "submit_release_artifact"))
+    (assert-true "has context_read" (contains? tool-names "context_read"))
+    (assert-true "has context_grep" (contains? tool-names "context_grep"))
+    (assert-true "has context_glob" (contains? tool-names "context_glob"))
     ;; Check input schemas exist
     (doseq [tool tools]
       (assert-true (str (:name tool) " has inputSchema") (map? (:inputSchema tool))))))


### PR DESCRIPTION
## Summary

- Moves `context_read`, `context_grep`, `context_glob` MCP tools from the babashka script (`scripts/mcp-artifact-server.bb`) into the `mcp-artifact-server` Clojure component with proper Polylith architecture
- Adds handler registry pattern (`:handler` key in tool-registry.edn) alongside existing builder registry (`:builder`), enabling tools that return results directly without producing artifacts
- Adds server lifecycle hooks: context cache loaded on startup, cache misses flushed on shutdown
- Removes ~300 lines of inline context-cache code from the babashka script

## Architecture

New file `context_cache.clj` follows stratified design:
- **Layer 0**: Pure helpers (`estimate-tokens`, `apply-offset-limit`, `glob-matches?`, `grep-file`, shell fallbacks)
- **Layer 1**: Stateful cache operations (`load-cache!`, `flush-misses!`, `cache-get`, `cache-put!`) and tool handlers

`tools.clj` gains a `handler-registry*` atom parallel to `builder-registry*`. `handle-tool-call` dispatches on `:handler` vs `:builder` key.

## Test plan

- [x] 18 new unit tests in `context_cache_test.clj` (pure helpers + handlers + lifecycle)
- [x] 9 existing `interface_test.clj` tests pass (including updated tool count and handler dispatch test)
- [x] 56 MCP integration tests pass (`bb test:mcp`) — 7 tools listed, all schemas verified
- [ ] Dogfood: run agents with context-cache to verify they use the MCP tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)