### PR TITLE
fix: MCP tool names, Codex planning backend, rate-limit handling

### DIFF
--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -7,7 +7,7 @@
 {:prompt/id :implementer
  :prompt/version "1.0.0"
  :prompt/agent :implementer
- :prompt/max-turns 10
+ :prompt/max-turns 25
 
  :prompt/system
  "You are an Implementation Agent for an autonomous software development team.
@@ -114,29 +114,32 @@ do NOT generate new code. Instead, output:
 Only use this when ALL acceptance criteria are already met by existing code.
 If even partial changes are needed, proceed with normal code generation.
 
-## Preferred Output Method
+## CRITICAL: Submit Your Code via MCP Tool
 
-If the `submit_code_artifact` MCP tool is available, you MUST use it to submit your code.
-Call `submit_code_artifact` with:
+You MUST call the `mcp__artifact__submit_code_artifact` tool to submit your implementation.
+This is your primary output mechanism. Do NOT output code as raw text — it will be lost.
+
+Call `mcp__artifact__submit_code_artifact` with these parameters:
 - `files`: array of objects with `path`, `content`, and `action` (\"create\", \"modify\", or \"delete\")
 - `summary`: brief description of changes
 - `language`: programming language (e.g. \"clojure\")
 - `tests_needed`: boolean
 - `dependencies_added`: array of dependency strings (optional)
 
-Do NOT output raw EDN text when the MCP tool is available.
-
-The MCP tool is always available in this environment. If you encounter an error calling it,
-report the error rather than falling back to raw text output.
+The tool is ALWAYS available. If you encounter an error calling it, report the error.
+Do NOT fall back to raw text output under any circumstances.
 
 ## File Exploration via Context Cache
 
-All code context you need is pre-loaded in this prompt (repository map, existing files,
-search results). If you need to look up additional files (e.g. dependencies, related
-namespaces), use `context_read`, `context_grep`, or `context_glob` MCP tools — these
-check a pre-loaded cache first (instant) and fall back to the filesystem only when needed.
-Built-in Read, Grep, Glob tools are disabled. Minimize exploration — generate your
-implementation from the provided context when possible.
+Most code context is pre-loaded in this prompt (repository map, existing files, search results).
+If you need additional files, use these MCP tools (they check a pre-loaded cache first):
+- `mcp__artifact__context_read` — read a file by path
+- `mcp__artifact__context_grep` — search file contents by regex
+- `mcp__artifact__context_glob` — find files by glob pattern
+
+Minimize exploration — generate your implementation from the provided context when possible.
+Limit file reads to at most 3-5 files, then generate code and submit via the artifact tool.
 
 Remember: Your code will be validated, tested, and reviewed by other agents.
+Your LAST action before finishing MUST be calling `mcp__artifact__submit_code_artifact`.
 Write code that is easy to understand, test, and maintain."}

--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -102,20 +102,28 @@ work is needed, proceed with normal plan generation.
 9. **Review Points**: Include :review tasks at natural checkpoints, especially after
    significant implementation milestones.
 
-## Preferred Output Method
+## CRITICAL: Submit Your Plan via MCP Tool
 
-If the `submit_plan` MCP tool is available, you MUST use it to submit your plan.
-Call `submit_plan` with:
+You MUST call the `mcp__artifact__submit_plan` tool to submit your plan.
+This is your primary output mechanism. Do NOT output plans as raw text — they will be lost.
+
+Call `mcp__artifact__submit_plan` with:
 - `name`: short descriptive name for the plan
 - `tasks`: array of task objects with `description`, `type` (\"implement\", \"test\", \"review\", \"design\", \"deploy\", \"configure\"), and optionally `dependencies` (array of task indexes), `acceptance_criteria`, `estimated_effort`
 - `complexity`: \"low\", \"medium\", or \"high\" (optional)
 - `risks`: array of risk strings (optional)
 - `assumptions`: array of assumption strings (optional)
 
-Do NOT output raw EDN text when the MCP tool is available.
+The tool is ALWAYS available. If you encounter an error, report the error.
+Do NOT fall back to raw text output under any circumstances.
 
-The MCP tool is always available in this environment. If you encounter an error calling it,
-report the error rather than falling back to raw text output.
+If you need to explore the codebase, use these MCP tools (they check a pre-loaded cache first):
+- `mcp__artifact__context_read` — read a file by path
+- `mcp__artifact__context_grep` — search file contents by regex
+- `mcp__artifact__context_glob` — find files by glob pattern
+
+Limit file reads to what's necessary, then submit your plan.
+Your LAST action before finishing MUST be calling `mcp__artifact__submit_plan`.
 
 Remember: A good plan enables parallel execution where possible while respecting
 necessary dependencies. Optimize for clarity and testability."}

--- a/components/agent/resources/prompts/releaser.edn
+++ b/components/agent/resources/prompts/releaser.edn
@@ -83,19 +83,27 @@ How this was tested.\"
    - Brief count of files affected
    - Example: \"2 files created, 1 modified, 1 deleted\"
 
-## Preferred Output Method
+## CRITICAL: Submit Your Release Metadata via MCP Tool
 
-If the `submit_release_artifact` MCP tool is available, you MUST use it to submit your release metadata.
-Call `submit_release_artifact` with:
+You MUST call the `mcp__artifact__submit_release_artifact` tool to submit your release metadata.
+This is your primary output mechanism. Do NOT output release metadata as raw text — it will be lost.
+
+Call `mcp__artifact__submit_release_artifact` with:
 - `branch_name`: git branch name (e.g. \"feature/add-auth\")
 - `commit_message`: git commit message in conventional commits format
 - `pr_title`: pull request title (max 70 characters)
 - `pr_description`: pull request description in markdown
 - `files_summary`: brief summary of files changed (optional)
 
-Do NOT output raw EDN text when the MCP tool is available.
+The tool is ALWAYS available. If you encounter an error, report the error.
+Do NOT fall back to raw text output under any circumstances.
 
-If the tool is NOT available, fall back to the EDN output format described above.
+If you need to explore the codebase, use these MCP tools (they check a pre-loaded cache first):
+- `mcp__artifact__context_read` — read a file by path
+- `mcp__artifact__context_grep` — search file contents by regex
+- `mcp__artifact__context_glob` — find files by glob pattern
+
+Your LAST action before finishing MUST be calling `mcp__artifact__submit_release_artifact`.
 
 Remember: Your release metadata will be used for git commits and GitHub PRs.
 Write messages that help reviewers understand the changes at a glance."}

--- a/components/agent/resources/prompts/tester.edn
+++ b/components/agent/resources/prompts/tester.edn
@@ -113,12 +113,12 @@ You must output a structured test artifact as a Clojure map:
     - No shared mutable state between tests
     - Use fixtures for setup/teardown
 
-## REQUIRED Output Method — MCP Tool
+## CRITICAL: Submit Your Tests via MCP Tool
 
-You MUST submit your tests by calling the `submit_test_artifact` MCP tool.
+You MUST call the `mcp__artifact__submit_test_artifact` tool to submit your tests.
 This is your PRIMARY deliverable — if you do not call this tool, your work is lost.
 
-Call `submit_test_artifact` with:
+Call `mcp__artifact__submit_test_artifact` with:
 - `files`: array of objects with `path` and `content` (complete test namespaces)
 - `summary`: description of test coverage
 - `type`: \"unit\", \"integration\", \"property\", \"e2e\", or \"acceptance\" (optional)
@@ -126,11 +126,11 @@ Call `submit_test_artifact` with:
 - `coverage`: object with `lines`, `branches`, `functions` percentages (optional)
 
 CRITICAL RULES:
-1. You MUST call `submit_test_artifact` exactly once before finishing
+1. You MUST call `mcp__artifact__submit_test_artifact` exactly once before finishing
 2. Do NOT output raw EDN text — use the tool
-3. Do NOT use the Write tool to write test files — use `submit_test_artifact`
+3. Do NOT use the Write tool to write test files — use `mcp__artifact__submit_test_artifact`
 4. If you write tests as text without calling the tool, they will be discarded
-5. Use `context_read`, `context_grep`, `context_glob` MCP tools if you need to explore files.
+5. Use `mcp__artifact__context_read`, `mcp__artifact__context_grep`, `mcp__artifact__context_glob` if you need to explore files.
    These serve from a pre-loaded cache (instant) and fall back to filesystem only when needed.
    Built-in Read, Grep, Glob tools are disabled.
 6. Go directly to generating tests and calling the MCP tool — minimize exploration
@@ -138,12 +138,12 @@ CRITICAL RULES:
 ## Context
 
 All code you need to test is provided below in this prompt AND pre-loaded in the
-context cache. If you need to look up additional files (e.g. dependencies, related
-namespaces), use `context_read`, `context_grep`, or `context_glob` — these check
+context cache. If you need additional files, use `mcp__artifact__context_read`,
+`mcp__artifact__context_grep`, or `mcp__artifact__context_glob` — these check
 the cache first (instant) and fall back to the filesystem only when needed.
 
-Generate your tests from the provided code, then call `submit_test_artifact`.
-This is your only deliverable.
+Generate your tests from the provided code, then call `mcp__artifact__submit_test_artifact`.
+Your LAST action before finishing MUST be calling `mcp__artifact__submit_test_artifact`.
 
 Remember: Good tests are documentation. They show how the code is intended to be used
 and what behavior is expected. Make tests readable and maintainable."}

--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -39,8 +39,8 @@
 
    :implementer {:model (model/default-model-for-role :implementer)
                  :temperature 0.3
-                 :max-tokens 8000
-                 :budget {:tokens 50000 :cost-usd 2.5}}
+                 :max-tokens 16000
+                 :budget {:tokens 100000 :cost-usd 5.0}}
 
    :tester      {:model (model/default-model-for-role :tester)
                  :temperature 0.2

--- a/components/agent/src/ai/miniforge/agent/model.clj
+++ b/components/agent/src/ai/miniforge/agent/model.clj
@@ -8,8 +8,9 @@
 
 (def ^:private default-agent-models
   "Fallback model defaults when user config does not specify agent defaults."
-  {:thinking "claude-opus-4-6"
+  {:thinking "gpt-5.4"
    :execution "claude-sonnet-4-6"})
+
 
 (def ^:private thinking-roles
   "Roles that default to the higher-reasoning model tier."
@@ -41,6 +42,27 @@
    explicitly overridden."
   [role config]
   (update config :model #(or % (default-model-for-role role))))
+
+
+(defn resolve-llm-client-for-role
+  "Resolve or create an LLM client appropriate for an agent role.
+   If the role's default model uses a different backend than the provided client,
+   creates a new client with the correct backend.
+
+   Arguments:
+     role           - Agent role keyword (:planner, :implementer, etc.)
+     provided-client - The shared LLM client from workflow context (may be nil)"
+  [role provided-client]
+  (let [model-id (default-model-for-role role)
+        backend-for-model (requiring-resolve 'ai.miniforge.llm.interface/backend-for-model)
+        needed-backend (backend-for-model model-id)]
+    (if (or (nil? provided-client)
+            (= needed-backend :claude)) ;; shared client is typically :claude
+      provided-client
+      ;; Model needs a different backend — create a new client
+      (let [create-client (requiring-resolve 'ai.miniforge.llm.interface/create-client)]
+        (create-client {:backend needed-backend})))))
+
 
 (comment
   (default-model-for-role :planner)

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -288,7 +288,8 @@
 
       :invoke-fn
       (fn [context input]
-        (let [llm-client (or (:llm-backend opts) (:llm-backend context))
+        (let [llm-client (model/resolve-llm-client-for-role
+                          :planner (or (:llm-backend opts) (:llm-backend context)))
               on-chunk (:on-chunk context)
               spec-text (spec->text input)
               existing-files (:task/existing-files input)
@@ -311,10 +312,12 @@
             (let [{:keys [llm-result artifact]}
                   (artifact-session/with-artifact-session [session]
                     (let [budget-usd (budget/resolve-cost-budget-usd :planner config context)
-                          mcp-opts {:mcp-config (:mcp-config-path session)
+                          mcp-opts {:model (model/default-model-for-role :planner)
+                                    :mcp-config (:mcp-config-path session)
                                     :mcp-allowed-tools (:mcp-allowed-tools session)
                                     :supervision (:supervision session)
-                                    :budget-usd budget-usd}]
+                                    :budget-usd budget-usd
+                                    :max-turns 25}]
                       (if on-chunk
                         (llm/chat-stream llm-client user-prompt on-chunk
                                          (merge {:system @planner-system-prompt} mcp-opts))

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -216,7 +216,8 @@
                           mcp-opts {:mcp-config (:mcp-config-path session)
                                     :mcp-allowed-tools (:mcp-allowed-tools session)
                                     :supervision (:supervision session)
-                                    :budget-usd budget-usd}]
+                                    :budget-usd budget-usd
+                                    :max-turns 15}]
                       (if on-chunk
                         (llm/chat-stream llm-client user-prompt on-chunk
                                          (merge {:system @releaser-system-prompt} mcp-opts))

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -483,10 +483,10 @@
                   response (if on-chunk
                              (llm/chat-stream llm-client user-prompt on-chunk
                                               {:system @reviewer-system-prompt
-                                               :max-turns 10})
+                                               :max-turns 20})
                              (llm/chat llm-client user-prompt
                                        {:system @reviewer-system-prompt
-                                        :max-turns 10}))
+                                        :max-turns 20}))
                   tokens (get response :tokens 0)
                   cost-usd (get response :cost-usd)]
 

--- a/components/agent/test/ai/miniforge/agent/budget_test.clj
+++ b/components/agent/test/ai/miniforge/agent/budget_test.clj
@@ -10,7 +10,7 @@
   (testing "returns canonical role budgets"
     (is (= {:tokens 100000 :cost-usd 5.0}
            (budget/role-budget :planner)))
-    (is (= {:tokens 50000 :cost-usd 2.5}
+    (is (= {:tokens 100000 :cost-usd 5.0}
            (budget/role-budget :implementer))))
 
   (testing "maps specialized role aliases to canonical role budgets"
@@ -18,7 +18,7 @@
            (budget/role-budget :releaser))))
 
   (testing "falls back to implementer budget for unknown roles"
-    (is (= {:tokens 50000 :cost-usd 2.5}
+    (is (= {:tokens 100000 :cost-usd 5.0}
            (budget/role-budget :unknown-role)))))
 
 (deftest resolve-cost-budget-usd-test
@@ -45,7 +45,7 @@
            (budget/resolve-cost-budget-usd :releaser {} {}))))
 
   (testing "falls back to implementer budget for unknown roles"
-    (is (= 2.5
+    (is (= 5.0
            (budget/resolve-cost-budget-usd :unknown-role {} {})))))
 
 (deftest apply-default-budget-test

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -35,7 +35,7 @@
       (is (some? agent))
       (is (= :implementer (:role agent)))
       (is (string? (:system-prompt agent)))
-      (is (= {:tokens 50000 :cost-usd 2.5}
+      (is (= {:tokens 100000 :cost-usd 5.0}
              (get-in agent [:config :budget])))))
 
   (testing "creates implementer with custom config"

--- a/components/llm/src/ai/miniforge/llm/interface.clj
+++ b/components/llm/src/ai/miniforge/llm/interface.clj
@@ -36,6 +36,24 @@
   ([] (records/create-client))
   ([opts] (records/create-client opts)))
 
+(defn backend-for-model
+  "Look up the backend keyword for a model-id string.
+   Returns :claude, :codex, :gemini, :ollama, etc. based on the model catalog.
+   Falls back to :claude for unknown models."
+  [model-id]
+  (or (->> registry/model-registry
+           vals
+           (filter #(= (:model-id %) model-id))
+           first
+           :backend)
+      :claude))
+
+(defn create-client-for-model
+  "Create a new LLM client using the appropriate backend for a model-id.
+   Looks up the model in the catalog to determine backend."
+  [model-id]
+  (create-client {:backend (backend-for-model model-id)}))
+
 (defn mock-client
   "Create a mock client for testing.
 
@@ -154,6 +172,11 @@
   "Extract error details from a failed response."
   [response]
   (:error response))
+
+(defn rate-limited?
+  "Check if a response indicates the provider rate-limited the request."
+  [response]
+  (= :anomalies.agent/rate-limited (:anomaly response)))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Progress Monitoring

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -269,18 +269,33 @@
                                                    ctx/transition-to-completed
                                                    ctx/transition-to-failed)
                           (monitoring/clear-transient-state))
-            ;; Exponential backoff when phase is retrying
-            retrying? (= (:execution/phase-index phase-ctx)
-                         (:execution/phase-index context))
-            retry-count (get-in phase-ctx [:phase :iterations] 1)]
-        (when (and retrying? (> retry-count 1))
-          (let [backoff-ms (min 30000 (long (* 1000 (Math/pow 2 (dec retry-count)))))]
-            (Thread/sleep backoff-ms)))
-        (let [event-stream (get-in phase-ctx [:execution/opts :event-stream])
-              switch-result (check-backend-health-at-boundary! event-stream phase-ctx)]
-          (if switch-result
-            (assoc phase-ctx :self-healing/backend-switch switch-result)
-            phase-ctx))))))
+            ;; Check if phase failed due to rate limiting — if so, stop retrying
+            ;; and bubble the error up to the DAG orchestrator's resilience module
+            current-phase (:execution/current-phase phase-ctx)
+            phase-result (get-in phase-ctx [:execution/phase-results current-phase])
+            phase-error-msg (get-in phase-result [:error :message] "")
+            rate-limited? (boolean
+                           (re-find #"(?i)rate.?limit|429|hit your limit|quota.?exceeded"
+                                    (str phase-error-msg)))]
+        (if rate-limited?
+          ;; Stop retrying immediately — let the DAG orchestrator handle the wait/pause
+          (-> phase-ctx
+              (assoc :execution/status :failed)
+              (update :execution/errors conj
+                      {:type :rate-limited
+                       :message phase-error-msg}))
+          ;; Normal path: exponential backoff when phase is retrying
+          (let [retrying? (= (:execution/phase-index phase-ctx)
+                             (:execution/phase-index context))
+                retry-count (get-in phase-ctx [:phase :iterations] 1)]
+            (when (and retrying? (> retry-count 1))
+              (let [backoff-ms (min 30000 (long (* 1000 (Math/pow 2 (dec retry-count)))))]
+                (Thread/sleep backoff-ms)))
+            (let [event-stream (get-in phase-ctx [:execution/opts :event-stream])
+                  switch-result (check-backend-health-at-boundary! event-stream phase-ctx)]
+              (if switch-result
+                (assoc phase-ctx :self-healing/backend-switch switch-result)
+                phase-ctx))))))))
 
 ;------------------------------------------------------------------------------ Layer 1.5: Output extraction
 

--- a/work/finish-event-telemetry.spec.edn
+++ b/work/finish-event-telemetry.spec.edn
@@ -18,7 +18,7 @@
    zero events), missing streaming callbacks (agent output never reaches subscribers),
    WebSocket envelope mismatch (browser drops events), no browser-side refresh wiring,
    and no event query API for historical data."
- :spec/intent {:type :implement
+ :spec/intent {:type :feature
           :scope ["components/phase/src"
                   "components/web-dashboard/src"
                   "components/web-dashboard/resources/public/js"]}


### PR DESCRIPTION
## Summary

- **Fix MCP tool name mismatch (root cause of dogfood failures)**: Agent prompts referenced short tool names (`submit_code_artifact`) but Claude CLI exposes them as `mcp__artifact__submit_code_artifact`. All 4 agent prompts updated to use full `mcp__artifact__` prefixed names — implementer, planner, tester, releaser.
- **Add GPT-5.4/Codex backend for thinking roles**: Planning now routes through Codex CLI (`gpt-5.4`) instead of Claude to avoid rate-limit pressure. New `resolve-llm-client-for-role` in `model.clj` creates the correct backend client per role. Planner invocation passes `:model` to MCP opts so Codex CLI gets `-m gpt-5.4`.
- **Rate-limit short-circuit in workflow runner**: Instead of retrying rate-limited phases with exponential backoff (burning retries), the runner now detects rate-limit errors and immediately transitions to `:failed`, letting the DAG orchestrator's `dag_resilience.clj` handle tiered waits (short in-process sleep, medium checkpoint+resume, long manual).
- **Budget/turns increases**: Implementer budget 50k→100k tokens / $2.5→$5.0. Max-turns: planner 25, releaser 15, reviewer 20.
- **LLM interface additions**: `backend-for-model`, `create-client-for-model`, `rate-limited?` helpers.

## Context

Discovered during dogfooding `finish-event-telemetry.spec.edn`. The MCP tool name mismatch was the #1 blocker — agents were completing LLM calls but never calling the submit tool because it didn't exist under the short name. Rate-limit handling gap was found when Anthropic throttled at 25% remaining on the usage clock; the existing tiered wait logic in `dag_resilience.clj` was never reached because the runner was burning retries internally.

## Test plan

- [x] `bb test` — 425 tests pass (1 pre-existing error in `stream-parser-accumulates-usage-test` unrelated to this PR)
- [x] Workflow runner tests: 17/17 pass, 0 failures
- [x] Budget/implementer test expectations updated for new values
- [ ] Re-run `bb miniforge run work/finish-event-telemetry.spec.edn` end-to-end to validate plan via Codex + implement via Sonnet + rate-limit bubbles to DAG resilience

🤖 Generated with [Claude Code](https://claude.com/claude-code)