### PR TITLE
feat: default dogfood execution to GPT fallback

### DIFF
--- a/bases/cli/resources/config/cli/backends.edn
+++ b/bases/cli/resources/config/cli/backends.edn
@@ -1,0 +1,61 @@
+{:backend/defaults
+ {:current :codex}
+
+ :backend/specs
+ {:claude
+  {:provider "Anthropic"
+   :description "Claude via Anthropic CLI"
+   :command "claude"
+   :installation "npm install -g @anthropic-ai/claude-cli"
+   :api-key-var "ANTHROPIC_API_KEY"
+   :models ["claude-sonnet-4-20250514" "claude-opus-4-20250514" "claude-haiku-4-20250514"]
+   :check-type :cli}
+
+  :codex
+  {:provider "Codex"
+   :description "Codex via Codex CLI"
+   :command "codex"
+   :installation "Install from https://codex.dev"
+   :api-key-var nil
+   :models ["gpt-5.3-codex" "gpt-5.2-codex" "gpt-5.2" "gpt-5.1-codex-max"]
+   :check-type :cli
+   :docs-url "https://codex.dev"}
+
+  :openai
+  {:provider "OpenAI"
+   :description "OpenAI GPT-4 via API"
+   :command nil
+   :installation "Set OPENAI_API_KEY environment variable"
+   :api-key-var "OPENAI_API_KEY"
+   :models ["gpt-4-turbo" "gpt-4" "gpt-3.5-turbo"]
+   :check-type :api-key
+   :docs-url "https://platform.openai.com/api-keys"}
+
+  :cursor
+  {:provider "Cursor"
+   :description "Cursor AI via CLI"
+   :command "cursor-cli"
+   :installation "Install from https://cursor.sh"
+   :api-key-var nil
+   :models ["cursor-default"]
+   :check-type :cli
+   :docs-url "https://cursor.sh"}
+
+  :ollama
+  {:provider "Ollama"
+   :description "Local models via Ollama"
+   :command "ollama"
+   :installation "brew install ollama"
+   :api-key-var nil
+   :models ["codellama" "llama2" "mistral"]
+   :check-type :cli
+   :docs-url "https://ollama.ai"}
+
+  :echo
+  {:provider "Test"
+   :description "Echo backend for testing (no actual LLM)"
+   :command "echo"
+   :installation "Built-in"
+   :api-key-var nil
+   :models ["echo"]
+   :check-type :builtin}}}

--- a/bases/cli/src/ai/miniforge/cli/backends.clj
+++ b/bases/cli/src/ai/miniforge/cli/backends.clj
@@ -150,7 +150,7 @@
   (or (:backend (:llm config))
       (when-let [env-backend (System/getenv "MINIFORGE_LLM_BACKEND")]
         (keyword env-backend))
-      :claude))
+      :codex))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Display helpers

--- a/bases/cli/src/ai/miniforge/cli/backends.clj
+++ b/bases/cli/src/ai/miniforge/cli/backends.clj
@@ -5,69 +5,35 @@
   (:require
    [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.resource-config :as resource-config]
    [babashka.process :as process]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Backend specifications
 
+(def ^:private backend-config-resource
+  "Classpath resource path for backend metadata and defaults."
+  "config/cli/backends.edn")
+
+(def ^:private backend-config
+  (resource-config/merged-resource-config
+   backend-config-resource
+   nil
+   {:backend/defaults {:current :codex}
+    :backend/specs {}}))
+
 (def backend-specs
-  {:claude
-   {:provider "Anthropic"
-    :description "Claude via Anthropic CLI"
-    :command "claude"
-    :installation "npm install -g @anthropic-ai/claude-cli"
-    :api-key-var "ANTHROPIC_API_KEY"
-    :models ["claude-sonnet-4-20250514" "claude-opus-4-20250514" "claude-haiku-4-20250514"]
-    :check-type :cli}
+  (:backend/specs backend-config))
 
-   :codex
-   {:provider "Codex"
-    :description "Codex via Codex CLI"
-    :command "codex"
-    :installation "Install from https://codex.dev"
-    :api-key-var nil
-    :models ["gpt-5.3-codex" "gpt-5.2-codex" "gpt-5.2" "gpt-5.1-codex-max"]
-    :check-type :cli
-    :docs-url "https://codex.dev"}
+(def ^:private backend-defaults
+  (:backend/defaults backend-config))
 
-   :openai
-   {:provider "OpenAI"
-    :description "OpenAI GPT-4 via API"
-    :command nil
-    :installation "Set OPENAI_API_KEY environment variable"
-    :api-key-var "OPENAI_API_KEY"
-    :models ["gpt-4-turbo" "gpt-4" "gpt-3.5-turbo"]
-    :check-type :api-key
-    :docs-url "https://platform.openai.com/api-keys"}
-
-   :cursor
-   {:provider "Cursor"
-    :description "Cursor AI via CLI"
-    :command "cursor-cli"
-    :installation "Install from https://cursor.sh"
-    :api-key-var nil
-    :models ["cursor-default"]
-    :check-type :cli
-    :docs-url "https://cursor.sh"}
-
-   :ollama
-   {:provider "Ollama"
-    :description "Local models via Ollama"
-    :command "ollama"
-    :installation "brew install ollama"
-    :api-key-var nil
-    :models ["codellama" "llama2" "mistral"]
-    :check-type :cli
-    :docs-url "https://ollama.ai"}
-
-   :echo
-   {:provider "Test"
-    :description "Echo backend for testing (no actual LLM)"
-    :command "echo"
-    :installation "Built-in"
-    :api-key-var nil
-    :models ["echo"]
-    :check-type :builtin}})
+(defn- availability-status
+  "Build a standard backend availability status map."
+  [available status message]
+  {:available available
+   :status status
+   :message message})
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Status checking
@@ -99,32 +65,20 @@
         {:keys [check-type command api-key-var]} spec]
     (case check-type
       :builtin
-      {:available true
-       :status :available
-       :message "Built-in (always available)"}
+      (availability-status true :available "Built-in (always available)")
 
       :cli
       (if (check-command-available? command)
-        {:available true
-         :status :available
-         :message (str command " CLI found")}
-        {:available false
-         :status :not-installed
-         :message (str command " not found on PATH")})
+        (availability-status true :available (str command " CLI found"))
+        (availability-status false :not-installed (str command " not found on PATH")))
 
       :api-key
       (if (check-api-key-set? api-key-var)
-        {:available true
-         :status :available
-         :message (str api-key-var " is set")}
-        {:available false
-         :status :needs-key
-         :message (str "Needs " api-key-var)})
+        (availability-status true :available (str api-key-var " is set"))
+        (availability-status false :needs-key (str "Needs " api-key-var)))
 
       ;; Unknown check type
-      {:available false
-       :status :unknown
-       :message "Unknown backend type"})))
+      (availability-status false :unknown "Unknown backend type"))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Backend information
@@ -150,7 +104,7 @@
   (or (:backend (:llm config))
       (when-let [env-backend (System/getenv "MINIFORGE_LLM_BACKEND")]
         (keyword env-backend))
-      :codex))
+      (get backend-defaults :current :codex)))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Display helpers

--- a/bases/cli/src/ai/miniforge/cli/config.clj
+++ b/bases/cli/src/ai/miniforge/cli/config.clj
@@ -18,8 +18,8 @@
   (app-config/config-path))
 
 (def default-config
-  {:llm {:backend :claude
-         :model "claude-sonnet-4-20250514"
+  {:llm {:backend :codex
+         :model "gpt-5.2-codex"
          :timeout-ms 300000
          :line-timeout-ms 60000
          :max-tokens 4000}
@@ -342,7 +342,7 @@
   [config workflow-override]
   (or workflow-override
       (get-in config [:llm :backend])
-      :claude))
+      :codex))
 
 (defn get-llm-timeout
   "Get LLM timeout from config."

--- a/bases/cli/test/ai/miniforge/cli/backends_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/backends_test.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.cli.backends-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.cli.backends :as backends]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Resource-backed backend config
+
+(deftest backend-specs-loaded-from-resource-test
+  (testing "backend specs include codex from resource config"
+    (is (= "Codex" (get-in backends/backend-specs [:codex :provider]))))
+
+  (testing "current backend fallback comes from resource defaults"
+    (is (= :codex (backends/get-current-backend {})))))

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -475,7 +475,7 @@
       (fn [context input]
         (let [llm-client (model/resolve-llm-client-for-role
                           :implementer
-                          (or (:llm-backend opts) (:llm-backend context)))
+                          (get opts :llm-backend (:llm-backend context)))
               on-chunk (:on-chunk context)
               task-text (task->text input)
               effective-system-prompt (build-effective-system-prompt input)

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -473,7 +473,9 @@
 
       :invoke-fn
       (fn [context input]
-        (let [llm-client (or (:llm-backend opts) (:llm-backend context))
+        (let [llm-client (model/resolve-llm-client-for-role
+                          :implementer
+                          (or (:llm-backend opts) (:llm-backend context)))
               on-chunk (:on-chunk context)
               task-text (task->text input)
               effective-system-prompt (build-effective-system-prompt input)

--- a/components/agent/src/ai/miniforge/agent/model.clj
+++ b/components/agent/src/ai/miniforge/agent/model.clj
@@ -9,7 +9,7 @@
 (def ^:private default-agent-models
   "Fallback model defaults when user config does not specify agent defaults."
   {:thinking "gpt-5.4"
-   :execution "claude-sonnet-4-6"})
+   :execution "gpt-5.2-codex"})
 
 
 (def ^:private thinking-roles
@@ -26,16 +26,13 @@
                     (get-in cfg [:llm :model])
                     (:execution default-agent-models))}))
 
-(def ^:private configured-agent-models
-  "Memoized agent default models from merged config."
-  (delay (load-configured-agent-models)))
-
 (defn default-model-for-role
   "Return the configured default model id for an agent role."
   [role]
-  (if (thinking-roles role)
-    (:thinking @configured-agent-models)
-    (:execution @configured-agent-models)))
+  (let [{:keys [thinking execution]} (load-configured-agent-models)]
+    (if (thinking-roles role)
+      thinking
+      execution)))
 
 (defn apply-default-model
   "Ensure a config map carries the configured default model for a role unless
@@ -55,13 +52,19 @@
   [role provided-client]
   (let [model-id (default-model-for-role role)
         backend-for-model (requiring-resolve 'ai.miniforge.llm.interface/backend-for-model)
-        needed-backend (backend-for-model model-id)]
-    (if (or (nil? provided-client)
-            (= needed-backend :claude)) ;; shared client is typically :claude
+        client-backend (requiring-resolve 'ai.miniforge.llm.interface/client-backend)
+        create-client (requiring-resolve 'ai.miniforge.llm.interface/create-client)
+        needed-backend (backend-for-model model-id)
+        current-backend (client-backend provided-client)]
+    (cond
+      (nil? provided-client)
+      nil
+
+      (= current-backend needed-backend)
       provided-client
-      ;; Model needs a different backend — create a new client
-      (let [create-client (requiring-resolve 'ai.miniforge.llm.interface/create-client)]
-        (create-client {:backend needed-backend})))))
+
+      :else
+      (create-client {:backend needed-backend}))))
 
 
 (comment

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -289,7 +289,7 @@
       :invoke-fn
       (fn [context input]
         (let [llm-client (model/resolve-llm-client-for-role
-                          :planner (or (:llm-backend opts) (:llm-backend context)))
+                          :planner (get opts :llm-backend (:llm-backend context)))
               on-chunk (:on-chunk context)
               spec-text (spec->text input)
               existing-files (:task/existing-files input)

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -205,7 +205,9 @@
 
       :invoke-fn
       (fn [context input]
-        (let [llm-client (or (:llm-backend opts) (:llm-backend context))
+        (let [llm-client (model/resolve-llm-client-for-role
+                          :releaser
+                          (or (:llm-backend opts) (:llm-backend context)))
               on-chunk (:on-chunk context)
               user-prompt (input->text input context)]
           (if llm-client

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -207,7 +207,7 @@
       (fn [context input]
         (let [llm-client (model/resolve-llm-client-for-role
                           :releaser
-                          (or (:llm-backend opts) (:llm-backend context)))
+                          (get opts :llm-backend (:llm-backend context)))
               on-chunk (:on-chunk context)
               user-prompt (input->text input context)]
           (if llm-client

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -469,7 +469,7 @@
       (fn [context input]
         (let [llm-client (model/resolve-llm-client-for-role
                           :reviewer
-                          (or (:llm-backend opts) (:llm-backend context)))
+                          (get opts :llm-backend (:llm-backend context)))
               on-chunk (:on-chunk context)
               [artifact artifact-id] (extract-artifact-and-id input)
               start-time (System/currentTimeMillis)]

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -467,7 +467,9 @@
 
       :invoke-fn
       (fn [context input]
-        (let [llm-client (or (:llm-backend opts) (:llm-backend context))
+        (let [llm-client (model/resolve-llm-client-for-role
+                          :reviewer
+                          (or (:llm-backend opts) (:llm-backend context)))
               on-chunk (:on-chunk context)
               [artifact artifact-id] (extract-artifact-and-id input)
               start-time (System/currentTimeMillis)]

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -281,7 +281,7 @@
       (fn [context input]
         (let [llm-client (model/resolve-llm-client-for-role
                           :tester
-                          (or (:llm-backend opts) (:llm-backend context)))
+                          (get opts :llm-backend (:llm-backend context)))
               on-chunk (:on-chunk context)
               ;; Input can be a code artifact or a map with :code and :spec
               code-artifact (or (:code input) input)

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -279,7 +279,9 @@
 
       :invoke-fn
       (fn [context input]
-        (let [llm-client (or (:llm-backend opts) (:llm-backend context))
+        (let [llm-client (model/resolve-llm-client-for-role
+                          :tester
+                          (or (:llm-backend opts) (:llm-backend context)))
               on-chunk (:on-chunk context)
               ;; Input can be a code artifact or a map with :code and :spec
               code-artifact (or (:code input) input)

--- a/components/agent/test/ai/miniforge/agent/model_test.clj
+++ b/components/agent/test/ai/miniforge/agent/model_test.clj
@@ -1,0 +1,54 @@
+(ns ai.miniforge.agent.model-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.agent.model :as model]
+   [ai.miniforge.config.interface :as config]
+   [ai.miniforge.llm.interface :as llm]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Default model policy
+
+(deftest default-model-for-role-test
+  (testing "thinking roles default to GPT thinking model"
+    (with-redefs [config/load-merged-config
+                  (fn []
+                    {:agents {:default-models {:thinking "gpt-5.4"
+                                               :execution "gpt-5.2-codex"}}})]
+      (is (= "gpt-5.4" (model/default-model-for-role :planner)))))
+
+  (testing "execution roles default to GPT execution model"
+    (with-redefs [config/load-merged-config
+                  (fn []
+                    {:agents {:default-models {:thinking "gpt-5.4"
+                                               :execution "gpt-5.2-codex"}}})]
+      (is (= "gpt-5.2-codex" (model/default-model-for-role :implementer)))
+      (is (= "gpt-5.2-codex" (model/default-model-for-role :reviewer))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Backend resolution
+
+(deftest resolve-llm-client-for-role-test
+  (testing "reuses the provided client when it already matches the role backend"
+    (let [client (llm/create-client {:backend :codex})]
+      (with-redefs [config/load-merged-config
+                    (fn []
+                      {:agents {:default-models {:thinking "gpt-5.4"
+                                                 :execution "gpt-5.2-codex"}}})]
+        (is (= client (model/resolve-llm-client-for-role :implementer client))))))
+
+  (testing "creates a role-specific client when execution model needs a different backend"
+    (let [shared-client (llm/create-client {:backend :claude})
+          resolved (with-redefs [config/load-merged-config
+                                 (fn []
+                                   {:agents {:default-models {:thinking "gpt-5.4"
+                                                              :execution "gpt-5.2-codex"}}})]
+                     (model/resolve-llm-client-for-role :implementer shared-client))]
+      (is (= :codex (llm/client-backend resolved)))))
+
+  (testing "returns nil when no shared client is available"
+    (let [resolved (with-redefs [config/load-merged-config
+                                 (fn []
+                                   {:agents {:default-models {:thinking "gpt-5.4"
+                                                              :execution "gpt-5.2-codex"}}})]
+                     (model/resolve-llm-client-for-role :implementer nil))]
+      (is (nil? resolved)))))

--- a/components/config/resources/config/default-user-config-fallback.edn
+++ b/components/config/resources/config/default-user-config-fallback.edn
@@ -1,0 +1,31 @@
+{:description "Fallback default user configuration for MiniForge Core"
+ :config
+ {:llm {:backend :codex
+        :model "gpt-5.2-codex"
+        :timeout-ms 300000
+        :line-timeout-ms 60000
+        :max-tokens 4000}
+  :workflow {:max-iterations 50
+             :max-tokens 150000
+             :failure-strategy :retry}
+  :artifacts {:dir "~/.miniforge/artifacts"}
+  :meta-loop {:enabled true
+              :max-convergence-iterations 10
+              :convergence-threshold 0.95}
+  :agents {:default-models {:thinking "gpt-5.4"
+                            :execution "gpt-5.2-codex"}}
+  :model-selection {:enabled true
+                    :strategy :automatic
+                    :cost-limit-per-task 0.10
+                    :prefer-speed false
+                    :allow-downgrade true
+                    :require-local false}
+  :self-healing {:enabled true
+                 :workaround-auto-apply true
+                 :backend-auto-switch true
+                 :backend-health-threshold 0.90
+                 :backend-switch-cooldown-ms 1800000
+                 :allowed-failover-backends [:codex]
+                 :max-cost-per-workflow nil}
+  :dashboard {:port 7878
+              :auto-open false}}}

--- a/components/config/src/ai/miniforge/config/user.clj
+++ b/components/config/src/ai/miniforge/config/user.clj
@@ -29,8 +29,8 @@
       (:config (edn/read-string (slurp resource)))
       (catch Exception _e
         ;; Fallback if resource loading fails
-        {:llm {:backend :claude
-               :model "claude-sonnet-4-6"
+        {:llm {:backend :codex
+               :model "gpt-5.2-codex"
                :timeout-ms 300000
                :line-timeout-ms 60000
                :max-tokens 4000}
@@ -41,8 +41,8 @@
          :meta-loop {:enabled true
                      :max-convergence-iterations 10
                      :convergence-threshold 0.95}
-         :agents {:default-models {:thinking "claude-opus-4-6"
-                                   :execution "claude-sonnet-4-6"}}
+         :agents {:default-models {:thinking "gpt-5.4"
+                                   :execution "gpt-5.2-codex"}}
          :model-selection {:enabled true
                            :strategy :automatic
                            :cost-limit-per-task 0.10
@@ -53,12 +53,13 @@
                         :workaround-auto-apply true
                         :backend-auto-switch true
                         :backend-health-threshold 0.90
-                        :backend-switch-cooldown-ms 1800000}
+                        :backend-switch-cooldown-ms 1800000
+                        :allowed-failover-backends [:codex]}
          :dashboard {:port 7878
                      :auto-open false}}))
     ;; Fallback if resource not found
-    {:llm {:backend :claude
-           :model "claude-sonnet-4-6"
+    {:llm {:backend :codex
+           :model "gpt-5.2-codex"
            :timeout-ms 300000
            :line-timeout-ms 60000
            :max-tokens 4000}
@@ -69,21 +70,22 @@
      :meta-loop {:enabled true
                  :max-convergence-iterations 10
                  :convergence-threshold 0.95}
-     :agents {:default-models {:thinking "claude-opus-4-6"
-                               :execution "claude-sonnet-4-6"}}
+     :agents {:default-models {:thinking "gpt-5.4"
+                               :execution "gpt-5.2-codex"}}
      :model-selection {:enabled true
                        :strategy :automatic
                        :cost-limit-per-task 0.10
                        :prefer-speed false
                        :allow-downgrade true
                        :require-local false}
-         :self-healing {:enabled true
-                        :workaround-auto-apply true
-                        :backend-auto-switch true
-                        :backend-health-threshold 0.90
-                        :backend-switch-cooldown-ms 1800000}
-         :dashboard {:port 7878
-                     :auto-open false}}))
+     :self-healing {:enabled true
+                    :workaround-auto-apply true
+                    :backend-auto-switch true
+                    :backend-health-threshold 0.90
+                    :backend-switch-cooldown-ms 1800000
+                    :allowed-failover-backends [:codex]}
+     :dashboard {:port 7878
+                 :auto-open false}}))
 
 (def default-config
   "Default configuration values loaded from resources/config/default-user-config.edn"

--- a/components/config/src/ai/miniforge/config/user.clj
+++ b/components/config/src/ai/miniforge/config/user.clj
@@ -19,73 +19,31 @@
   "Default location for user config file."
   (str (fs/home) "/.miniforge/config.edn"))
 
+(def ^:private default-config-resource-path
+  "Primary resource path for shipped user config defaults."
+  "config/default-user-config.edn")
+
+(def ^:private fallback-config-resource-path
+  "Fallback resource path when the primary config cannot be loaded."
+  "config/default-user-config-fallback.edn")
+
+(defn- read-config-resource
+  "Read an EDN config resource, returning nil on missing resource or parse failure."
+  [resource-path]
+  (when-let [resource (io/resource resource-path)]
+    (try
+      (edn/read-string (slurp resource))
+      (catch Exception _e
+        nil))))
+
 (defn load-default-config
   "Load default configuration from resources.
 
-   Returns: Default config map or hardcoded fallback"
+   Returns: Default config map or resource-backed fallback."
   []
-  (if-let [resource (io/resource "config/default-user-config.edn")]
-    (try
-      (:config (edn/read-string (slurp resource)))
-      (catch Exception _e
-        ;; Fallback if resource loading fails
-        {:llm {:backend :codex
-               :model "gpt-5.2-codex"
-               :timeout-ms 300000
-               :line-timeout-ms 60000
-               :max-tokens 4000}
-         :workflow {:max-iterations 50
-                    :max-tokens 150000
-                    :failure-strategy :retry}
-         :artifacts {:dir (str (fs/home) "/.miniforge/artifacts")}
-         :meta-loop {:enabled true
-                     :max-convergence-iterations 10
-                     :convergence-threshold 0.95}
-         :agents {:default-models {:thinking "gpt-5.4"
-                                   :execution "gpt-5.2-codex"}}
-         :model-selection {:enabled true
-                           :strategy :automatic
-                           :cost-limit-per-task 0.10
-                           :prefer-speed false
-                           :allow-downgrade true
-                           :require-local false}
-         :self-healing {:enabled true
-                        :workaround-auto-apply true
-                        :backend-auto-switch true
-                        :backend-health-threshold 0.90
-                        :backend-switch-cooldown-ms 1800000
-                        :allowed-failover-backends [:codex]}
-         :dashboard {:port 7878
-                     :auto-open false}}))
-    ;; Fallback if resource not found
-    {:llm {:backend :codex
-           :model "gpt-5.2-codex"
-           :timeout-ms 300000
-           :line-timeout-ms 60000
-           :max-tokens 4000}
-     :workflow {:max-iterations 50
-                :max-tokens 150000
-                :failure-strategy :retry}
-     :artifacts {:dir (str (fs/home) "/.miniforge/artifacts")}
-     :meta-loop {:enabled true
-                 :max-convergence-iterations 10
-                 :convergence-threshold 0.95}
-     :agents {:default-models {:thinking "gpt-5.4"
-                               :execution "gpt-5.2-codex"}}
-     :model-selection {:enabled true
-                       :strategy :automatic
-                       :cost-limit-per-task 0.10
-                       :prefer-speed false
-                       :allow-downgrade true
-                       :require-local false}
-     :self-healing {:enabled true
-                    :workaround-auto-apply true
-                    :backend-auto-switch true
-                    :backend-health-threshold 0.90
-                    :backend-switch-cooldown-ms 1800000
-                    :allowed-failover-backends [:codex]}
-     :dashboard {:port 7878
-                 :auto-open false}}))
+  (or (some-> (read-config-resource default-config-resource-path) :config)
+      (some-> (read-config-resource fallback-config-resource-path) :config)
+      {}))
 
 (def default-config
   "Default configuration values loaded from resources/config/default-user-config.edn"

--- a/components/config/test/ai/miniforge/config/user_defaults_test.clj
+++ b/components/config/test/ai/miniforge/config/user_defaults_test.clj
@@ -1,0 +1,20 @@
+(ns ai.miniforge.config.user-defaults-test
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.config.interface :as config]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Default config policy
+
+(deftest default-config-prefers-gpt-execution-test
+  (let [cfg config/default-config]
+    (testing "default llm backend prefers codex"
+      (is (= :codex (get-in cfg [:llm :backend])))
+      (is (= "gpt-5.2-codex" (get-in cfg [:llm :model]))))
+
+    (testing "default agent models use GPT for thinking and execution"
+      (is (= "gpt-5.4" (get-in cfg [:agents :default-models :thinking])))
+      (is (= "gpt-5.2-codex" (get-in cfg [:agents :default-models :execution]))))
+
+    (testing "default self-healing enables codex failover"
+      (is (= [:codex] (get-in cfg [:self-healing :allowed-failover-backends]))))))

--- a/components/config/test/ai/miniforge/config/user_defaults_test.clj
+++ b/components/config/test/ai/miniforge/config/user_defaults_test.clj
@@ -1,7 +1,9 @@
 (ns ai.miniforge.config.user-defaults-test
   (:require
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.config.interface :as config]))
+   [clojure.java.io :as io]
+   [ai.miniforge.config.interface :as config]
+   [ai.miniforge.config.user :as user]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Default config policy
@@ -18,3 +20,15 @@
 
     (testing "default self-healing enables codex failover"
       (is (= [:codex] (get-in cfg [:self-healing :allowed-failover-backends]))))))
+
+(deftest load-default-config-falls-back-to-edn-resource-test
+  (let [orig-resource io/resource]
+    (with-redefs [io/resource (fn [path]
+                                (case path
+                                  "config/default-user-config.edn" nil
+                                  "config/default-user-config-fallback.edn"
+                                  (orig-resource "config/default-user-config-fallback.edn")
+                                  nil))]
+      (let [cfg (user/load-default-config)]
+        (is (= :codex (get-in cfg [:llm :backend])))
+        (is (= "gpt-5.2-codex" (get-in cfg [:agents :default-models :execution])))))))

--- a/components/llm/src/ai/miniforge/llm/interface.clj
+++ b/components/llm/src/ai/miniforge/llm/interface.clj
@@ -26,11 +26,11 @@
   "Create a new LLM client using a CLI backend.
 
    Options:
-   - :backend - Backend keyword (:claude, :cursor, :echo) - default :claude
+   - :backend - Backend keyword (:codex, :claude, :cursor, :echo) - default :codex
    - :logger  - Optional logger for request/response logging
 
    Example:
-     (create-client)                    ; uses claude CLI
+     (create-client)                    ; uses codex CLI
      (create-client {:backend :cursor}) ; uses cursor CLI
      (create-client {:backend :claude :logger my-logger})"
   ([] (records/create-client))
@@ -39,14 +39,22 @@
 (defn backend-for-model
   "Look up the backend keyword for a model-id string.
    Returns :claude, :codex, :gemini, :ollama, etc. based on the model catalog.
-   Falls back to :claude for unknown models."
+   Falls back to :codex for unknown models."
   [model-id]
   (or (->> registry/model-registry
            vals
            (filter #(= (:model-id %) model-id))
            first
            :backend)
-      :claude))
+      :codex))
+
+(defn client-backend
+  "Return the backend keyword configured for an LLM client."
+  [client]
+  (when client
+    (-> client
+        p/get-config
+        :backend)))
 
 (defn create-client-for-model
   "Create a new LLM client using the appropriate backend for a model-id.

--- a/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
@@ -24,16 +24,16 @@
   "Create a new LLM client using a CLI backend.
 
    Options:
-   - :backend - Backend keyword (:claude, :cursor, :echo) - default :claude
+   - :backend - Backend keyword (:codex, :claude, :cursor, :echo) - default :codex
    - :logger  - Optional logger for request/response logging
    - :exec-fn - Optional execution function override (for testing)
 
    Example:
-     (create-client)  ; uses claude CLI
+     (create-client)  ; uses codex CLI
      (create-client {:backend :cursor})
      (create-client {:backend :claude :logger my-logger})"
   ([] (create-client {}))
-  ([{:keys [backend logger exec-fn] :or {backend :claude}}]
+  ([{:keys [backend logger exec-fn] :or {backend :codex}}]
    (when-not (contains? impl/backends backend)
      (throw (ex-info (str "Unknown backend: " backend)
                      {:backend backend

--- a/components/phase-software-factory/resources/config/phase/defaults.edn
+++ b/components/phase-software-factory/resources/config/phase/defaults.edn
@@ -6,7 +6,7 @@
    :budget {:tokens 30000
             :iterations 8
             :time-seconds 600}
-   :model-hint :sonnet-4.6}
+   :model-hint :gpt-5.2-codex}
 
   ;; Verify phase defaults.
   :verify
@@ -15,7 +15,7 @@
    :budget {:tokens 15000
             :iterations 3
             :time-seconds 300}
-   :model-hint :haiku-4.5}
+   :model-hint :gpt-5.2-codex}
 
   ;; Review phase defaults.
   :review
@@ -24,7 +24,7 @@
    :budget {:tokens 20000
             :iterations 2
             :time-seconds 180}
-   :model-hint :sonnet-4.6}
+   :model-hint :gpt-5.2-codex}
 
   ;; Plan phase defaults.
   :plan
@@ -33,7 +33,7 @@
    :budget {:tokens 10000
             :iterations 3
             :time-seconds 300}
-   :model-hint :opus-4.6}
+   :model-hint :gpt-5.4}
 
   ;; Release phase defaults.
   :release

--- a/development/src/ai/miniforge/meta_runner.clj
+++ b/development/src/ai/miniforge/meta_runner.clj
@@ -2,7 +2,7 @@
   "Meta-Meta Loop Runner.
 
    This namespace provides functions to execute miniforge workflows
-   using the real Claude CLI backend, enabling miniforge to work on
+   using the configured real LLM backend, enabling miniforge to work on
    improving itself (dogfooding).
 
    The meta-meta loop (human operator) uses this to:
@@ -10,6 +10,7 @@
    2. Monitor progress through logging and artifacts
    3. Intervene when the meta-loop cannot self-correct"
   (:require
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.orchestrator.interface :as orch]
    [ai.miniforge.knowledge.interface :as knowledge]
@@ -87,8 +88,10 @@
         _ (fs/create-dirs a-store-dir)
         a-store (artifact/create-store {:dir a-store-dir})
 
-        ;; Create LLM client with real Claude CLI
-        llm-client (llm/create-client {:backend :claude :logger logger})
+        ;; Create LLM client using configured backend so dogfooding can
+        ;; continue when one provider is rate limited.
+        llm-backend (get-in (config/load-merged-config) [:llm :backend] :codex)
+        llm-client (llm/create-client {:backend llm-backend :logger logger})
 
         ;; Create operator if requested
         op (when with-operator?
@@ -101,6 +104,7 @@
 
     {:orchestrator orchestrator
      :llm-client llm-client
+     :llm-backend llm-backend
      :knowledge-store k-store
      :artifact-store a-store
      :operator op

--- a/docs/pull-requests/2026-03-28-feat-gpt-execution-fallback.md
+++ b/docs/pull-requests/2026-03-28-feat-gpt-execution-fallback.md
@@ -27,9 +27,10 @@ None.
 - Updated agent model policy so execution roles default to `gpt-5.2-codex` and thinking defaults to `gpt-5.4`.
 - Wired execution-role agents to resolve a backend-specific client when the shared workflow client is on the wrong backend.
 - Changed shipped config defaults so `:llm.backend` is `:codex`, execution model defaults to GPT, and self-healing allows `[:codex]` failover.
+- Moved backend metadata and config fallback defaults into shipped EDN resources instead of hardcoding them in Clojure namespaces.
 - Updated phase model hints so plan/implement/verify/review align with GPT-backed execution.
 - Updated dogfood utilities to use configured backend selection instead of assuming Claude and to accept Codex/OpenAI availability in prerequisite checks.
-- Added focused tests for role-based backend resolution and default config policy.
+- Added focused tests for role-based backend resolution, default config policy, fallback-resource loading, and resource-backed backend defaults.
 
 ## Strata Affected
 - `ai.miniforge.llm.interface` and `ai.miniforge.llm.protocols.records.llm-client` - default backend policy and backend introspection

--- a/docs/pull-requests/2026-03-28-feat-gpt-execution-fallback.md
+++ b/docs/pull-requests/2026-03-28-feat-gpt-execution-fallback.md
@@ -1,0 +1,66 @@
+# feat: use GPT execution backend for dogfooding fallback
+
+## Overview
+Switch Miniforge dogfooding and execution defaults away from Claude-first behavior so work can continue when Claude is rate limited. The PR makes Codex/GPT the default execution backend and enables Codex failover by default.
+
+## Motivation
+Dogfooding hit Claude rate limits in the active worktree and the runtime still had multiple Claude-first assumptions:
+
+- shipped config defaulted to Claude
+- execution agents reused the shared workflow client even when their model implied another backend
+- dogfood tooling assumed Claude availability
+- backend failover existed, but default config did not opt into a fallback backend
+
+This left the pipeline unable to recover cleanly when Claude was exhausted.
+
+## Layer
+Application / Adapter wiring
+
+## Base Branch
+`main`
+
+## Depends On
+None.
+
+## Changes in Detail
+- Updated LLM client defaults to prefer `:codex` and added client backend introspection.
+- Updated agent model policy so execution roles default to `gpt-5.2-codex` and thinking defaults to `gpt-5.4`.
+- Wired execution-role agents to resolve a backend-specific client when the shared workflow client is on the wrong backend.
+- Changed shipped config defaults so `:llm.backend` is `:codex`, execution model defaults to GPT, and self-healing allows `[:codex]` failover.
+- Updated phase model hints so plan/implement/verify/review align with GPT-backed execution.
+- Updated dogfood utilities to use configured backend selection instead of assuming Claude and to accept Codex/OpenAI availability in prerequisite checks.
+- Added focused tests for role-based backend resolution and default config policy.
+
+## Strata Affected
+- `ai.miniforge.llm.interface` and `ai.miniforge.llm.protocols.records.llm-client` - default backend policy and backend introspection
+- `ai.miniforge.agent.model` - role model policy and backend-aware client resolution
+- `ai.miniforge.agent.{implementer,tester,reviewer,releaser}` - execution roles now resolve role-specific backend clients
+- `ai.miniforge.config.user` and CLI config/backends - shipped default backend/failover policy
+- `ai.miniforge.meta-runner` and `tasks/dogfood.clj` - dogfood entry points now honor configured GPT/Codex backend
+
+## Testing Plan
+- [x] Focused agent/config verification passes in a clean worktree:
+  `clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.llm.interface 'ai.miniforge.agent.model-test 'ai.miniforge.config.user-defaults-test 'ai.miniforge.agent.implementer-test 'ai.miniforge.agent.tester-test 'ai.miniforge.agent.releaser-test) ..."`
+- [x] CLI config namespaces load cleanly:
+  `clojure -M:dev:test -e "(require 'ai.miniforge.cli.config 'ai.miniforge.cli.backends)"`
+- [ ] Full pre-commit / full test suite
+  Not run here because broader repo issues already fail outside this change set.
+
+## Deployment Plan
+- Merge normally.
+- Dogfood runs will pick up Codex/GPT execution by default after deploy.
+- Existing users can still override `:llm.backend` and `:llm.model` explicitly.
+
+## Related Issues/PRs
+- Triggered by March 28, 2026 dogfood runs hitting Claude rate limits during pipeline execution.
+
+## Risks and Notes
+- `components/agent/src/ai/miniforge/agent/reviewer.clj` currently has a pre-existing parse error in `HEAD` unrelated to this PR.
+- `components/llm/test/ai/miniforge/llm/interface_test.clj` contains a pre-existing wrong-arity test failure unrelated to this PR.
+- This PR intentionally does not modify unrelated dirty worktree files from the source branch.
+
+## Checklist
+- [x] Isolated onto a clean branch from `main`
+- [x] Added PR doc under `docs/pull-requests/`
+- [x] Kept unrelated worktree changes out of this PR
+- [x] Verified focused behavior for GPT execution backend selection

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -1,7 +1,7 @@
 {:description "Default user configuration for MiniForge Core"
  :config
- {:llm {:backend :claude
-        :model "claude-sonnet-4-6"
+ {:llm {:backend :codex
+        :model "gpt-5.2-codex"
         :timeout-ms 300000
         :line-timeout-ms 60000
         :max-tokens 4000}
@@ -12,8 +12,8 @@
  :meta-loop {:enabled true
               :max-convergence-iterations 10
               :convergence-threshold 0.95}
-  :agents {:default-models {:thinking "claude-opus-4-6"
-                            :execution "claude-sonnet-4-6"}}
+  :agents {:default-models {:thinking "gpt-5.4"
+                            :execution "gpt-5.2-codex"}}
   :model-selection {:enabled true
                     :strategy :automatic
                     :cost-limit-per-task 0.10
@@ -25,7 +25,7 @@
                  :backend-auto-switch true
                  :backend-health-threshold 0.90
                  :backend-switch-cooldown-ms 1800000
-                 :allowed-failover-backends []
+                 :allowed-failover-backends [:codex]
                  :max-cost-per-workflow nil}
   :governance {:readiness {}
                :risk {}

--- a/tasks/dogfood.clj
+++ b/tasks/dogfood.clj
@@ -2,18 +2,29 @@
   (:require
    [babashka.process :as p]))
 
+(defn command-available? [cmd]
+  (zero? (:exit (p/sh {:continue true :out :discard :err :discard} "which" cmd))))
+
 (defn check []
   (println "🔍 Checking dogfooding prerequisites...")
   (let [github-token (System/getenv "GITHUB_TOKEN")
         anthropic-key (System/getenv "ANTHROPIC_API_KEY")
+        openai-key (System/getenv "OPENAI_API_KEY")
+        codex-cli (command-available? "codex")
         git-clean (zero? (:exit (p/sh {:continue true} "git" "diff" "--quiet")))
         checks {:github-token (some? github-token)
-                :anthropic-key (some? anthropic-key)
+                :llm-backend (or codex-cli (some? anthropic-key) (some? openai-key))
                 :git-clean git-clean}]
     (doseq [[check passed?] checks]
       (println (format "  %s %s"
                        (if passed? "✅" "❌")
                        (name check))))
+    (println (format "  %s backend-source"
+                     (cond
+                       codex-cli "✅ codex-cli"
+                       anthropic-key "✅ anthropic-api-key"
+                       openai-key "✅ openai-api-key"
+                       :else "❌ none")))
     (if (every? val checks)
       (do (println "\n✅ Ready for dogfooding!")
           (System/exit 0))


### PR DESCRIPTION
# feat: use GPT execution backend for dogfooding fallback

## Overview
Switch Miniforge dogfooding and execution defaults away from Claude-first behavior so work can continue when Claude is rate limited. The PR makes Codex/GPT the default execution backend and enables Codex failover by default.

## Motivation
Dogfooding hit Claude rate limits in the active worktree and the runtime still had multiple Claude-first assumptions:

- shipped config defaulted to Claude
- execution agents reused the shared workflow client even when their model implied another backend
- dogfood tooling assumed Claude availability
- backend failover existed, but default config did not opt into a fallback backend

This left the pipeline unable to recover cleanly when Claude was exhausted.

## Layer
Application / Adapter wiring

## Base Branch
`main`

## Depends On
None.

## Changes in Detail
- Updated LLM client defaults to prefer `:codex` and added client backend introspection.
- Updated agent model policy so execution roles default to `gpt-5.2-codex` and thinking defaults to `gpt-5.4`.
- Wired execution-role agents to resolve a backend-specific client when the shared workflow client is on the wrong backend.
- Changed shipped config defaults so `:llm.backend` is `:codex`, execution model defaults to GPT, and self-healing allows `[:codex]` failover.
- Updated phase model hints so plan/implement/verify/review align with GPT-backed execution.
- Updated dogfood utilities to use configured backend selection instead of assuming Claude and to accept Codex/OpenAI availability in prerequisite checks.
- Added focused tests for role-based backend resolution and default config policy.

## Strata Affected
- `ai.miniforge.llm.interface` and `ai.miniforge.llm.protocols.records.llm-client` - default backend policy and backend introspection
- `ai.miniforge.agent.model` - role model policy and backend-aware client resolution
- `ai.miniforge.agent.{implementer,tester,reviewer,releaser}` - execution roles now resolve role-specific backend clients
- `ai.miniforge.config.user` and CLI config/backends - shipped default backend/failover policy
- `ai.miniforge.meta-runner` and `tasks/dogfood.clj` - dogfood entry points now honor configured GPT/Codex backend

## Testing Plan
- [x] Focused agent/config verification passes in a clean worktree:
  `clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.llm.interface 'ai.miniforge.agent.model-test 'ai.miniforge.config.user-defaults-test 'ai.miniforge.agent.implementer-test 'ai.miniforge.agent.tester-test 'ai.miniforge.agent.releaser-test) ..."`
- [x] CLI config namespaces load cleanly:
  `clojure -M:dev:test -e "(require 'ai.miniforge.cli.config 'ai.miniforge.cli.backends)"`
- [ ] Full pre-commit / full test suite
  Not run here because broader repo issues already fail outside this change set.

## Deployment Plan
- Merge normally.
- Dogfood runs will pick up Codex/GPT execution by default after deploy.
- Existing users can still override `:llm.backend` and `:llm.model` explicitly.

## Related Issues/PRs
- Triggered by March 28, 2026 dogfood runs hitting Claude rate limits during pipeline execution.

## Risks and Notes
- `components/agent/src/ai/miniforge/agent/reviewer.clj` currently has a pre-existing parse error in `HEAD` unrelated to this PR.
- `components/llm/test/ai/miniforge/llm/interface_test.clj` contains a pre-existing wrong-arity test failure unrelated to this PR.
- This PR intentionally does not modify unrelated dirty worktree files from the source branch.

## Checklist
- [x] Isolated onto a clean branch from `main`
- [x] Added PR doc under `docs/pull-requests/`
- [x] Kept unrelated worktree changes out of this PR
- [x] Verified focused behavior for GPT execution backend selection
