### PR TITLE
feat: dashboard login / session auth

### DIFF
--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/interface.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/interface.clj
@@ -32,11 +32,15 @@
    Options:
    - :port - Port to listen on (default 7878)
    - :event-stream - Event stream atom for subscribing to workflow events
+   - :auth - Optional login config, e.g. {:users [{:username \"admin\" :password \"secret\"}]}
 
    Returns: server handle (use with stop!)
 
    Example:
-     (def server (start! {:port 7878 :event-stream my-stream}))"
+     (def server (start! {:port 7878
+                          :event-stream my-stream
+                          :auth {:users [{:username \"admin\"
+                                          :password \"secret\"}]}}))"
   [opts]
   (server/start-server! opts))
 

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
@@ -25,6 +25,7 @@
    [cheshire.core :as json]
    [ai.miniforge.web-dashboard.state :as state]
    [ai.miniforge.web-dashboard.views :as views]
+   [ai.miniforge.web-dashboard.server.auth :as auth]
    [ai.miniforge.web-dashboard.server.responses :as responses]
    [ai.miniforge.web-dashboard.server.filters :as filters]
    [ai.miniforge.web-dashboard.server.websocket :as websocket]
@@ -74,9 +75,27 @@
         events-ws-handler (websocket/create-events-ws-handler state workflow-connections)]
     (fn [req]
       (let [uri (:uri req)
+            auth-state (:auth @state)
             params (merge (filters/query-string->params (:query-string req))
-                          (:params req))]
+                          (:params req))
+            req (assoc req :params params)]
         (cond
+          ;; Login/logout
+          (and (= uri "/login") (= (:request-method req) :get))
+          (auth/handle-login-page auth-state req)
+
+          (and (= uri "/login") (= (:request-method req) :post))
+          (auth/handle-login-submit auth-state req)
+
+          (and (= uri "/logout") (= (:request-method req) :post))
+          (auth/handle-logout auth-state req)
+
+          ;; Auth gate for browser-facing routes
+          (and (auth/enabled? auth-state)
+               (not (auth/public-request? req))
+               (nil? (auth/current-session auth-state req)))
+          (auth/unauthorized-response auth-state req)
+
           ;; WebSocket for UI clients
           (= uri "/ws")
           (ws-handler req)
@@ -345,13 +364,15 @@
    - :port - Port to listen on (default 7878)
    - :event-stream - Event stream atom for subscribing to workflow events
    - :pr-train-manager - PR train manager instance
-   - :repo-dag-manager - Repo DAG manager instance"
-  [{:keys [port event-stream pr-train-manager repo-dag-manager]
+   - :repo-dag-manager - Repo DAG manager instance
+   - :auth - Optional dashboard auth config"
+  [{:keys [port event-stream pr-train-manager repo-dag-manager auth]
     :or {port 7878}}]
   (let [;; Create dashboard-local event stream with NO file sinks to prevent write-back loop.
         ;; The watcher reads from ~/.miniforge/events/ and publishes to this in-memory-only stream.
         dashboard-event-stream (or event-stream (es/create-event-stream {:sinks []}))
         state (state/create-state {:event-stream dashboard-event-stream
+                                   :auth (auth/build-auth-state auth)
                                    :pr-train-manager pr-train-manager
                                    :repo-dag-manager repo-dag-manager
                                    :start-time (System/currentTimeMillis)})

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/auth.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/auth.clj
@@ -1,0 +1,272 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.web-dashboard.server.auth
+  "Dashboard-local authentication and session management."
+  (:require
+   [clojure.string :as str]
+   [cheshire.core :as json]
+   [ai.miniforge.web-dashboard.server.filters :as filters]
+   [ai.miniforge.web-dashboard.server.responses :as responses]
+   [ai.miniforge.web-dashboard.views.auth :as auth-views]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pure helpers
+
+(def default-cookie-name "miniforge-dashboard-session")
+(def default-session-ttl-ms (* 12 60 60 1000))
+
+(defn- utf8-bytes
+  [value]
+  (.getBytes (str (or value "")) "UTF-8"))
+
+(defn- constant-time=
+  [left right]
+  (java.security.MessageDigest/isEqual (utf8-bytes left) (utf8-bytes right)))
+
+(defn- env-auth-config
+  []
+  (let [username (System/getenv "MINIFORGE_WEB_USERNAME")
+        password (System/getenv "MINIFORGE_WEB_PASSWORD")]
+    (when (and (seq username) (seq password))
+      {:users [{:username username
+                :password password
+                :role :operator}]})))
+
+(defn- normalize-user-entry
+  [[username config]]
+  (let [entry (if (map? config) config {:password config})
+        uname (or (:username entry) username)]
+    (when (and (seq uname) (seq (:password entry)))
+      [uname {:username uname
+              :password (:password entry)
+              :display-name (or (:display-name entry) uname)
+              :role (or (:role entry) :operator)}])))
+
+(defn- normalize-users
+  [auth-config]
+  (let [users (:users auth-config)]
+    (cond
+      (and (seq (:username auth-config)) (seq (:password auth-config)))
+      {(str (:username auth-config))
+       {:username (str (:username auth-config))
+        :password (:password auth-config)
+        :display-name (or (:display-name auth-config) (str (:username auth-config)))
+        :role (or (:role auth-config) :operator)}}
+
+      (map? users)
+      (into {}
+            (keep normalize-user-entry)
+            users)
+
+      (sequential? users)
+      (into {}
+            (keep (fn [entry]
+                    (when (and (map? entry) (seq (:username entry)) (seq (:password entry)))
+                      [(:username entry)
+                       {:username (:username entry)
+                        :password (:password entry)
+                        :display-name (or (:display-name entry) (:username entry))
+                        :role (or (:role entry) :operator)}])))
+            users)
+
+      :else
+      {})))
+
+(defn parse-cookie-header
+  "Parse a Cookie header into a string-keyed map."
+  [cookie-header]
+  (if (str/blank? cookie-header)
+    {}
+    (reduce (fn [acc cookie-part]
+              (let [[raw-name raw-value] (str/split cookie-part #"=" 2)
+                    name (some-> raw-name str/trim)
+                    value (some-> raw-value str/trim)]
+                (if (seq name)
+                  (assoc acc name (or value ""))
+                  acc)))
+            {}
+            (str/split cookie-header #";"))))
+
+(defn- safe-return-to
+  [value]
+  (let [path (or value "/")]
+    (if (and (string? path)
+             (str/starts-with? path "/")
+             (not (str/starts-with? path "//")))
+      path
+      "/")))
+
+(defn- login-page-response
+  [{:keys [error username return-to status]}]
+  (assoc (responses/html-response
+          (auth-views/login-view {:error error
+                                  :username username
+                                  :return-to (safe-return-to return-to)}))
+         :status (or status 200)))
+
+(defn- redirect-response
+  [location & [headers]]
+  {:status 302
+   :headers (merge {"Location" location} headers)
+   :body ""})
+
+(defn- session-cookie-value
+  [{:keys [cookie-name session-ttl-ms]} token]
+  (str cookie-name "=" token
+       "; Path=/; HttpOnly; SameSite=Lax; Max-Age=" (quot session-ttl-ms 1000)))
+
+(defn- clear-cookie-value
+  [{:keys [cookie-name]}]
+  (str cookie-name "=deleted; Path=/; HttpOnly; SameSite=Lax; Max-Age=0"))
+
+;------------------------------------------------------------------------------ Layer 1
+;; State and session lifecycle
+
+(defn build-auth-state
+  "Normalize dashboard auth config.
+
+   Supported inputs:
+   - {:username \"admin\" :password \"secret\"}
+   - {:users {\"admin\" {:password \"secret\"}}}
+   - {:users [{:username \"admin\" :password \"secret\" :role :operator}]}
+
+   Falls back to MINIFORGE_WEB_USERNAME / MINIFORGE_WEB_PASSWORD when unset."
+  [auth-config]
+  (let [raw-config (or auth-config (env-auth-config) {})
+        users (normalize-users raw-config)]
+    {:enabled? (boolean (seq users))
+     :cookie-name (or (:cookie-name raw-config) default-cookie-name)
+     :session-ttl-ms (or (:session-ttl-ms raw-config) default-session-ttl-ms)
+     :users users
+     :sessions (atom {})}))
+
+(defn enabled?
+  "True when dashboard login is configured."
+  [auth-state]
+  (boolean (:enabled? auth-state)))
+
+(defn public-request?
+  "Requests that must stay available without a browser session."
+  [{:keys [uri request-method]}]
+  (or (= uri "/health")
+      (and (= uri "/login") (#{:get :post} request-method))
+      (and (= uri "/logout") (= :post request-method))
+      (= uri "/ws/events")
+      (and (= uri "/api/events/ingest") (= :post request-method))
+      (and (= uri "/api/control-plane/agents/register") (= :post request-method))
+      (and (.startsWith uri "/api/control-plane/agents/")
+           (.endsWith uri "/heartbeat")
+           (= :post request-method))
+      (.startsWith uri "/css/")
+      (.startsWith uri "/js/")
+      (.startsWith uri "/img/")))
+
+(defn current-session
+  "Return the current valid session map from the request cookie."
+  [auth-state req]
+  (when (enabled? auth-state)
+    (let [token (get (parse-cookie-header (get-in req [:headers "cookie"]))
+                     (:cookie-name auth-state))
+          session (get @(:sessions auth-state) token)
+          now (System/currentTimeMillis)]
+      (when session
+        (if (< (- now (:last-seen-at session)) (:session-ttl-ms auth-state))
+          (let [updated (assoc session :last-seen-at now)]
+            (swap! (:sessions auth-state) assoc token updated)
+            updated)
+          (do
+            (swap! (:sessions auth-state) dissoc token)
+            nil))))))
+
+(defn authenticate!
+  "Authenticate credentials and create a session when valid."
+  [auth-state username password]
+  (when (enabled? auth-state)
+    (when-let [user (get (:users auth-state) username)]
+      (when (constant-time= password (:password user))
+        (let [now (System/currentTimeMillis)
+              token (str (random-uuid))
+              session {:token token
+                       :username (:username user)
+                       :display-name (:display-name user)
+                       :role (:role user)
+                       :created-at now
+                       :last-seen-at now}]
+          (swap! (:sessions auth-state) assoc token session)
+          session)))))
+
+(defn clear-session!
+  "Delete any session referenced by the request cookie."
+  [auth-state req]
+  (when (enabled? auth-state)
+    (when-let [token (get (parse-cookie-header (get-in req [:headers "cookie"]))
+                          (:cookie-name auth-state))]
+      (swap! (:sessions auth-state) dissoc token))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Request handling
+
+(defn handle-login-page
+  "Serve the login page or redirect an already authenticated user."
+  [auth-state req]
+  (if-not (enabled? auth-state)
+    (redirect-response "/")
+    (if (current-session auth-state req)
+      (redirect-response "/")
+      (login-page-response {:return-to (get (filters/query-string->params (:query-string req))
+                                            "return-to"
+                                            "/")}))))
+
+(defn handle-login-submit
+  "Process login form submission."
+  [auth-state req]
+  (let [params (filters/query-string->params (slurp (:body req)))
+        username (get params "username")
+        password (get params "password")
+        return-to (safe-return-to (get params "return-to"))]
+    (if-not (enabled? auth-state)
+      (redirect-response "/")
+      (if-let [session (authenticate! auth-state username password)]
+        (redirect-response return-to
+                           {"Set-Cookie" (session-cookie-value auth-state (:token session))})
+        (login-page-response {:status 401
+                              :error "Invalid username or password."
+                              :username username
+                              :return-to return-to})))))
+
+(defn handle-logout
+  "Clear the current session and redirect to the login page."
+  [auth-state req]
+  (clear-session! auth-state req)
+  (redirect-response "/login"
+                     {"Set-Cookie" (clear-cookie-value auth-state)}))
+
+(defn unauthorized-response
+  "Return an auth challenge response for the current request."
+  [auth-state req]
+  (let [return-to (safe-return-to
+                   (str (:uri req)
+                        (when-let [qs (:query-string req)]
+                          (when (seq qs) (str "?" qs)))))]
+    (if (and (= :get (:request-method req))
+             (not (.startsWith (:uri req) "/api/"))
+             (not= (:uri req) "/ws"))
+      (redirect-response (str "/login?return-to="
+                              (java.net.URLEncoder/encode return-to "UTF-8")))
+      {:status 401
+       :headers {"Content-Type" "application/json"
+                 "HX-Redirect" (str "/login?return-to="
+                                    (java.net.URLEncoder/encode return-to "UTF-8"))}
+       :body (json/generate-string {:error "authentication-required"})})))

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/views/auth.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/views/auth.clj
@@ -1,0 +1,69 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.web-dashboard.views.auth
+  "Login view for the web dashboard."
+  (:require
+   [hiccup.page :as page]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; View
+
+(defn login-view
+  "Render the login page."
+  [{:keys [error username return-to]}]
+  (page/html5
+   [:head
+    [:meta {:charset "utf-8"}]
+    [:meta {:name "viewport" :content "width=device-width, initial-scale=1"}]
+    [:title "Miniforge | Login"]
+    [:link {:rel "stylesheet" :href "/css/app.css"}]]
+   [:body
+    [:div.dashboard
+     [:main.main
+      [:div.page-header
+       [:h1.page-title "User Login"]]
+      [:section.section
+       [:div.cp-page
+        [:div.cp-header
+         [:h2 "Sign in to the dashboard"]
+         [:p.cp-subtitle "Use a configured dashboard account to continue."]]
+        [:div.cp-two-column
+         [:div.cp-column-main
+          [:div.cp-section
+           (when error
+             [:div.empty-state
+              [:h3 "Sign-in failed"]
+              [:p error]])
+           [:form.cp-decision-form {:method "post" :action "/login"}
+            [:input {:type "hidden"
+                     :name "return-to"
+                     :value (or return-to "/")}]
+            [:input.cp-input {:type "text"
+                              :name "username"
+                              :placeholder "Username"
+                              :value (or username "")
+                              :autocomplete "username"
+                              :required true}]
+            [:input.cp-input {:type "password"
+                              :name "password"
+                              :placeholder "Password"
+                              :autocomplete "current-password"
+                              :required true}]
+            [:button.btn.btn-sm.btn-primary {:type "submit"} "Sign in"]]]]
+         [:div.cp-column-sidebar
+          [:div.cp-section
+           [:h3 "Session policy"]
+           [:p "Dashboard sessions are browser-local and cookie-backed."]
+           [:p "Static assets and health checks remain public; dashboard views require sign-in when auth is enabled."]]]]]]]]]))

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/server/auth_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/server/auth_test.clj
@@ -1,0 +1,101 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.web-dashboard.server.auth-test
+  "Route-level tests for dashboard login."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [clojure.string :as str]
+   [ai.miniforge.web-dashboard.server :as server]
+   [ai.miniforge.web-dashboard.server.auth :as auth]
+   [ai.miniforge.web-dashboard.state.core :as state-core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test helpers
+
+(defn fresh-state
+  []
+  (state-core/create-state
+   {:auth (auth/build-auth-state
+           {:users [{:username "alice"
+                     :password "wonderland"
+                     :role :operator}]})}))
+
+(defn body-stream
+  [content]
+  (java.io.ByteArrayInputStream. (.getBytes content "UTF-8")))
+
+(defn form-request
+  [uri body & [headers]]
+  {:uri uri
+   :request-method :post
+   :headers (merge {"content-type" "application/x-www-form-urlencoded"} headers)
+   :body (body-stream body)})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Route tests
+
+(deftest protected-route-redirects-to-login-test
+  (testing "GET / redirects to login when auth is enabled"
+    (let [handler (server/create-handler (fresh-state))
+          response (handler {:uri "/" :request-method :get :headers {}})]
+      (is (= 302 (:status response)))
+      (is (str/starts-with? (get-in response [:headers "Location"]) "/login?return-to=")))))
+
+(deftest login-flow-test
+  (testing "GET /login serves a login form"
+    (let [handler (server/create-handler (fresh-state))
+          response (handler {:uri "/login" :request-method :get :headers {}})]
+      (is (= 200 (:status response)))
+      (is (str/includes? (:body response) "Sign in to the dashboard"))))
+
+  (testing "POST /login with valid credentials sets a session cookie"
+    (let [state (fresh-state)
+          handler (server/create-handler state)
+          login-response (handler (form-request "/login"
+                                                "username=alice&password=wonderland&return-to=%2Ffleet"))
+          session-cookie (get-in login-response [:headers "Set-Cookie"])
+          fleet-response (handler {:uri "/fleet"
+                                   :request-method :get
+                                   :headers {"cookie" session-cookie}})]
+      (is (= 302 (:status login-response)))
+      (is (= "/fleet" (get-in login-response [:headers "Location"])))
+      (is (str/includes? session-cookie "miniforge-dashboard-session="))
+      (is (= 200 (:status fleet-response)))))
+
+  (testing "POST /login with invalid credentials returns 401"
+    (let [handler (server/create-handler (fresh-state))
+          response (handler (form-request "/login"
+                                          "username=alice&password=incorrect&return-to=%2F"))]
+      (is (= 401 (:status response)))
+      (is (str/includes? (:body response) "Invalid username or password.")))))
+
+(deftest logout-clears-session-test
+  (testing "POST /logout clears the current session cookie"
+    (let [state (fresh-state)
+          handler (server/create-handler state)
+          login-response (handler (form-request "/login"
+                                                "username=alice&password=wonderland&return-to=%2F"))
+          session-cookie (get-in login-response [:headers "Set-Cookie"])
+          logout-response (handler {:uri "/logout"
+                                    :request-method :post
+                                    :headers {"cookie" session-cookie}
+                                    :body (body-stream "")})
+          after-logout (handler {:uri "/workflows"
+                                 :request-method :get
+                                 :headers {"cookie" session-cookie}})]
+      (is (= 302 (:status logout-response)))
+      (is (= "/login" (get-in logout-response [:headers "Location"])))
+      (is (str/includes? (get-in logout-response [:headers "Set-Cookie"]) "Max-Age=0"))
+      (is (= 302 (:status after-logout))))))


### PR DESCRIPTION
## Summary

- Adds optional cookie-backed browser login to the web dashboard
- When `MINIFORGE_WEB_USERNAME` / `MINIFORGE_WEB_PASSWORD` env vars are set (or `:auth` config passed to `start!`), all dashboard views require a browser session
- Static assets, `/health`, WebSocket event ingestion, and CLI control-plane agent endpoints stay public
- No auth config → auth disabled, all routes remain public (zero behavior change for existing setups)

## New files

| File | Purpose |
|------|---------|
| `server/auth.clj` | Auth state, session lifecycle (HMAC-free UUID tokens, 12h TTL, sliding window), request handlers: `handle-login-page`, `handle-login-submit`, `handle-logout`, `unauthorized-response` |
| `views/auth.clj` | Hiccup login page — reuses existing dashboard CSS classes (`cp-page`, `cp-input`, `btn-primary`) |
| `test/server/auth_test.clj` | Route-level tests: protected redirect, login flow (valid/invalid creds), logout + post-logout block |

## Wiring

`server.clj` changes are minimal:
- Auth state stored inside the dashboard state atom (`:auth` key)
- Login/logout routes added before the auth gate
- Auth gate short-circuits if `auth/enabled?` is false

## Configuration

```clojure
;; env vars (simplest)
MINIFORGE_WEB_USERNAME=admin
MINIFORGE_WEB_PASSWORD=secret

;; or via start! opts
(start! {:port 7878
         :auth {:users [{:username "admin"
                         :password "secret"
                         :role :operator}]}})
```

## Test plan

- [ ] `bb test` passes (auth tests compile and run)
- [ ] Start dashboard without `:auth` config — all routes accessible, no login page
- [ ] Start dashboard with `MINIFORGE_WEB_USERNAME=admin MINIFORGE_WEB_PASSWORD=secret` — `/` redirects to `/login`
- [ ] POST valid credentials → session cookie set, redirected back to original URL
- [ ] POST invalid credentials → 401, error message shown
- [ ] POST `/logout` → session cleared, cookie expired, subsequent request redirected to `/login`
- [ ] `/health`, `/ws/events`, `/api/events/ingest` remain accessible without a session

🤖 Generated with [Claude Code](https://claude.com/claude-code)