### PR TITLE
fix: missing closing paren in reviewer.clj (blocks all CLI startup)

### DIFF
--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -615,7 +615,7 @@
                                     :gates-failed (:failed counts)
                                     :llm? false})
 
-              (build-review-result review counts duration 0))))
+              (build-review-result review counts duration 0)))))
 
       :validate-fn validate-review-artifact
 


### PR DESCRIPTION
## Summary

- One-character fix: `))))` → `)))))` in the gate-only path of `create-reviewer`'s `:invoke-fn`
- The `(fn [context input] ...)` at line 501 was missing its closing `)` before `:validate-fn`
- This caused a parse error that blocked the entire CLI from starting (`Unmatched delimiter: }, expected: ) ...`)

## Root cause

PR #346 added `enter-review`/`leave-review` calls inside the existing `invoke-fn`. The gate-only branch already had 4 closing parens (closing `build-review-result`, the gate-only `let`, the `if`, and the outer `let`), but the `fn` form itself also needed closing — so 5 were required.

## Impact

Without this fix: `bb miniforge run <spec>` crashes immediately on startup with a parse error in `reviewer.clj` before any work can be done.

## Test plan

- [x] `clojure -M:dev -e "(require 'ai.miniforge.agent.reviewer)"` exits cleanly
- [x] `bb miniforge run work/finish-event-telemetry.spec.edn` starts without parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)