### PR TITLE
fix: align model IDs in config to match model catalog

### DIFF
--- a/bases/cli/resources/config/cli/backends.edn
+++ b/bases/cli/resources/config/cli/backends.edn
@@ -8,7 +8,7 @@
    :command "claude"
    :installation "npm install -g @anthropic-ai/claude-cli"
    :api-key-var "ANTHROPIC_API_KEY"
-   :models ["claude-sonnet-4-20250514" "claude-opus-4-20250514" "claude-haiku-4-20250514"]
+   :models ["claude-sonnet-4-6" "claude-opus-4-6" "claude-sonnet-4-5-20250929" "claude-haiku-4-5-20251001"]
    :check-type :cli}
 
   :codex

--- a/components/config/resources/config/default-user-config-fallback.edn
+++ b/components/config/resources/config/default-user-config-fallback.edn
@@ -12,8 +12,9 @@
   :meta-loop {:enabled true
               :max-convergence-iterations 10
               :convergence-threshold 0.95}
-  :agents {:default-models {:thinking "gpt-5.4"
-                            :execution "gpt-5.2-codex"}}
+  :agents {:default-models {:thinking   "gpt-5.4"
+                            :execution  "claude-sonnet-4-6"
+                            :escalation "claude-opus-4-6"}}
   :model-selection {:enabled true
                     :strategy :automatic
                     :cost-limit-per-task 0.10
@@ -25,7 +26,7 @@
                  :backend-auto-switch true
                  :backend-health-threshold 0.90
                  :backend-switch-cooldown-ms 1800000
-                 :allowed-failover-backends [:codex]
+                 :allowed-failover-backends [:claude :codex]
                  :max-cost-per-workflow nil}
   :dashboard {:port 7878
               :auto-open false}}}

--- a/components/phase-software-factory/resources/config/phase/defaults.edn
+++ b/components/phase-software-factory/resources/config/phase/defaults.edn
@@ -6,7 +6,7 @@
    :budget {:tokens 30000
             :iterations 8
             :time-seconds 600}
-   :model-hint :gpt-5.2-codex}
+   :model-hint :sonnet}
 
   ;; Verify phase defaults.
   :verify
@@ -15,7 +15,7 @@
    :budget {:tokens 15000
             :iterations 3
             :time-seconds 300}
-   :model-hint :gpt-5.2-codex}
+   :model-hint :sonnet}
 
   ;; Review phase defaults.
   :review
@@ -24,7 +24,7 @@
    :budget {:tokens 20000
             :iterations 2
             :time-seconds 180}
-   :model-hint :gpt-5.2-codex}
+   :model-hint :sonnet}
 
   ;; Plan phase defaults.
   :plan

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -12,8 +12,9 @@
  :meta-loop {:enabled true
               :max-convergence-iterations 10
               :convergence-threshold 0.95}
-  :agents {:default-models {:thinking "gpt-5.4"
-                            :execution "gpt-5.2-codex"}}
+  :agents {:default-models {:thinking   "gpt-5.4"
+                            :execution  "claude-sonnet-4-6"
+                            :escalation "claude-opus-4-6"}}
   :model-selection {:enabled true
                     :strategy :automatic
                     :cost-limit-per-task 0.10
@@ -25,7 +26,7 @@
                  :backend-auto-switch true
                  :backend-health-threshold 0.90
                  :backend-switch-cooldown-ms 1800000
-                 :allowed-failover-backends [:codex]
+                 :allowed-failover-backends [:claude :codex]
                  :max-cost-per-workflow nil}
   :governance {:readiness {}
                :risk {}


### PR DESCRIPTION
## Summary

- `claude-sonnet-4-20250514` is not in `llm/model-catalog.edn` — `backend-for-model` was silently falling back to `:codex` for every execution-role lookup, forcing all implementation/verify/review phases through Codex even when the user's config specified Claude
- Updated all three default configs and the CLI backends spec to use catalog-registered IDs (`claude-sonnet-4-6`, `claude-opus-4-6`)
- Added `:escalation` role default (`claude-opus-4-6`) to shipped configs
- Set `allowed-failover-backends [:claude :codex]` (was `[:codex]` only)
- Phase `defaults.edn`: implement/verify/review `model-hint` → `:sonnet`, plan stays `:gpt-5.4`

## Root cause

`resolve-llm-client-for-role` calls `backend-for-model(model-id)`. When the ID isn't in the catalog, it returns `:codex` as the default backend. A fresh Codex client is then created regardless of what backend the user configured — causing Codex rate limits on every dogfood run.

## Test plan
- [ ] Run `bb miniforge run work/finish-event-telemetry.spec.edn` — should route execution phases to Claude, not Codex
- [ ] Verify `(backend-for-model "claude-sonnet-4-6")` returns `:claude` in REPL

🤖 Generated with [Claude Code](https://claude.com/claude-code)