### PR TITLE
fix: add control-plane to miniforge jar dependencies

### DIFF
--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -51,8 +51,10 @@
         ai.miniforge/tui-engine {:local/root "../../components/tui-engine"}
         ai.miniforge/tui-views {:local/root "../../components/tui-views"}
         ai.miniforge/pr-sync {:local/root "../../components/pr-sync"}
-        ;; Web dashboard
+        ;; Web dashboard and control plane
         ai.miniforge/web-dashboard {:local/root "../../components/web-dashboard"}
+        ai.miniforge/control-plane {:local/root "../../components/control-plane"}
+        ai.miniforge/control-plane-adapter {:local/root "../../components/control-plane-adapter"}
         ;; LSP-to-MCP bridge (separate entry point for Claude Code integration)
         ai.miniforge/lsp-mcp-bridge {:local/root "../../bases/lsp-mcp-bridge"}
         ai.miniforge/messages {:local/root "../../components/messages"}


### PR DESCRIPTION
## Summary

- `mf web` was crashing with `Could not locate ai/miniforge/control_plane/interface` on startup
- `control-plane` component is required by `web-dashboard` but was missing from `projects/miniforge/deps.edn`
- Added both `control-plane` and `control-plane-adapter` to the project deps

## Test plan

- [ ] `mf web` starts without the classpath error
- [ ] Dashboard is accessible at localhost:7878

🤖 Generated with [Claude Code](https://claude.com/claude-code)