### PR TITLE
fix: release phase accepts any file type, not just :code/files artifacts

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/release.clj
@@ -22,7 +22,10 @@
    Prepares release artifacts and creates PRs using the release-executor component.
    Agent: :releaser
    Default gates: [:release-ready]"
-  (:require [ai.miniforge.logging.interface :as log]
+  (:require [clojure.java.io :as io]
+            [clojure.java.shell :as shell]
+            [clojure.string :as str]
+            [ai.miniforge.logging.interface :as log]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.phase.registry :as registry]
             [ai.miniforge.phase.messages :as messages]
@@ -76,40 +79,63 @@
                        :implement-result-keys impl-keys
                        :hint "Implement phase may have failed or produced no output"})))))
 
-(defn- assert-has-files!
-  "Throw when implement result has zero code files."
-  [impl-status implement-result]
-  (when (and implement-result
-             (map? implement-result)
-             (not= :already-implemented impl-status)
-             (empty? (:code/files implement-result)))
-    (throw (ex-info (messages/t :release/zero-files)
-                    {:phase :release :artifact-id (:code/id implement-result)}))))
+(defn- ctx-worktree-path
+  "Resolve the working directory from phase context."
+  [ctx]
+  (or (get-in ctx [:execution/worktree-path])
+      (get-in ctx [:worktree-path])
+      (get-in ctx [:execution/opts :worktree-path])
+      (System/getProperty "user.dir")))
+
+(defn- git-dirty-files
+  "Scan git working tree for new/modified/deleted files; return as :code/files entries.
+   Used as fallback when the implement phase wrote files directly to disk
+   (design docs, specs, UX assets, etc.) rather than returning them in a
+   :code/files artifact."
+  [root-path]
+  (try
+    (let [{:keys [out]} (shell/sh "git" "status" "--porcelain" "-uall" :dir root-path)
+          lines (->> (str/split-lines (or out "")) (remove str/blank?))]
+      (->> lines
+           (keep (fn [line]
+                   (let [xy   (subs line 0 2)
+                         path (str/trim (subs line 3))
+                         file (io/file root-path path)]
+                     (cond
+                       (str/includes? xy "D") {:path path :content "" :action :delete}
+                       (.isFile file)         {:path path
+                                               :content (slurp file)
+                                               :action (if (str/starts-with? (str/trim xy) "?")
+                                                         :create
+                                                         :modify)}))))
+           vec))
+    (catch Exception _ [])))
 
 (defn build-workflow-state
-  "Build workflow state from phase context for the release executor."
+  "Build workflow state from phase context for the release executor.
+
+   Accepts any artifact shape from the implement phase:
+   - :code/files present → use them directly (standard code path)
+   - no :code/files       → fall back to git working tree (design docs, specs, etc.)"
   [ctx]
-  ;; Read implement result from execution phase results (not :phases)
-  ;; This is the canonical location where workflow runner stores phase outputs
-  ;; Phase results contain the full phase map, so extract :result :output
-  (let [impl-status (get-in ctx [:execution/phase-results :implement :result :status])
+  (let [impl-status      (get-in ctx [:execution/phase-results :implement :result :status])
         implement-result (get-in ctx [:execution/phase-results :implement :result :output])]
     (log-already-implemented! ctx impl-status)
     (assert-implement-artifact! ctx impl-status implement-result)
-    (assert-has-files! impl-status implement-result)
-    (let [code-artifacts (if-let [artifacts (:artifacts implement-result)]
-                           (map (fn [a] {:artifact/type :code
-                                         :artifact/content a})
-                                artifacts)
-                           ;; Fallback: wrap result directly
-                           [{:artifact/type :code
-                             :artifact/content implement-result}])
-          input (get-in ctx [:execution/input])]
-      {:workflow/id (or (get-in ctx [:execution/id]) (random-uuid))
-       :workflow/phase :release
-       :workflow/spec {:spec/description (or (:description input)
-                                             (:title input)
-                                             "implement changes")}
+    (let [explicit-files (not-empty (:code/files implement-result))
+          files          (or explicit-files
+                             (not-empty (git-dirty-files (ctx-worktree-path ctx)))
+                             (throw (ex-info (messages/t :release/zero-files)
+                                             {:phase :release
+                                              :artifact-id (:code/id implement-result)})))
+          code-artifacts [{:artifact/type    :code
+                           :artifact/content (assoc implement-result :code/files files)}]
+          input          (get-in ctx [:execution/input])]
+      {:workflow/id       (or (get-in ctx [:execution/id]) (random-uuid))
+       :workflow/phase    :release
+       :workflow/spec     {:spec/description (or (:description input)
+                                                 (:title input)
+                                                 "implement changes")}
        :workflow/artifacts code-artifacts})))
 
 (defn build-executor-context

--- a/components/phase-software-factory/test/ai/miniforge/phase/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/review_repair_loop_test.clj
@@ -125,7 +125,7 @@
                                          :review {:result {:output {:review/decision :changes-requested
                                                                      :review/feedback [{:severity :blocking
                                                                                          :description "Missing require"}]}}}}}
-          task (build-implement-task ctx)]
+          {:keys [task]} (build-implement-task ctx)]
       (is (= [{:severity :blocking :description "Missing require"}]
              (:task/review-feedback task))
           "Task should include review feedback from context"))))
@@ -135,6 +135,6 @@
     (let [build-implement-task #'ai.miniforge.phase.implement/build-implement-task
           ctx {:execution/input {:description "Build widget"}
                :execution/phase-results {:plan {:result {:output nil}}}}
-          task (build-implement-task ctx)]
+          {:keys [task]} (build-implement-task ctx)]
       (is (nil? (:task/review-feedback task))
           "Task should not have review feedback when none in context"))))


### PR DESCRIPTION
## Summary

- Release phase was throwing `release/zero-files` whenever the implement phase wrote files to disk directly (design docs, specs, UX assets) rather than returning them via the `:code/files` artifact structure
- Added `git-dirty-files` fallback: when no `:code/files` in the artifact, scan `git status --porcelain` for new/modified files in the working tree and use those as the commit surface
- The release executor (branch → stage → commit → push → PR) works identically regardless of artifact type
- Also fixes a pre-existing test bug: `review_repair_loop_test` was treating `build-implement-task`'s `{:task ..., :rules-manifest ...}` return value as the task itself

## Why

Dogfood runs that produce design docs, specs, or any non-code output were silently failing at the release phase. The assumption that every implement result must have `:code/files` is too narrow — miniforge can be asked to produce redlines, specs, ETL scripts, or anything else.

## Test plan

- [ ] `bb test :focus phase-software-factory` — all 48 tests pass
- [ ] Re-run `policy-pack-extensibility.spec.edn` dogfood — design doc should be committed and PRed

🤖 Generated with [Claude Code](https://claude.com/claude-code)