### PR TITLE
fix: clean agent content in TUI — unescape \n, filter SSE events, strip markdown links

### DIFF
--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -269,14 +269,26 @@
       :cards (mapv (fn [wf] {:label (:name wf) :status (get wf :status :success)}) done)}]))
 
 (defn project-agent-output
-  "Project agent output text as a single-row data vector for a text widget."
+  "Project agent output as tree nodes for the agent output panel.
+   Splits and cleans raw agent content for readable display.
+   Uses :_panel-cols (injected by interpreter) for word-wrapping."
   [model]
   (let [detail (:detail model)
         agent (:current-agent detail)
-        output (get detail :agent-output "")]
-    [{:label (if agent
-               (str "[" (name (get agent :type :agent)) "] " output)
-               (if (seq output) output "No agent output"))}]))
+        output (get detail :agent-output "")
+        panel-cols (or (:_panel-cols model) 80)
+        wrap-width (max 20 (- panel-cols 4))]
+    (if (empty? output)
+      [(trees/tree-node "No agent output" 0 false trees/status-info)]
+      (let [agent-name (when agent (name (get agent :agent :agent)))
+            header (when agent-name
+                     [(trees/tree-node (str "[" agent-name "]") 0 false trees/status-warning)])
+            lines (trees/clean-agent-content output)]
+        (into (or header [])
+              (mapcat (fn [line]
+                        (mapv #(trees/tree-node % 0)
+                              (helpers/wrap-text line wrap-width)))
+                      lines))))))
 
 (def ^:private browse-sayings
   ["Rummaging through repos..."

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -276,7 +276,7 @@
   (let [detail (:detail model)
         agent (:current-agent detail)
         output (get detail :agent-output "")
-        panel-cols (or (:_panel-cols model) 80)
+        panel-cols (get model :_panel-cols 80)
         wrap-width (max 20 (- panel-cols 4))]
     (if (empty? output)
       [(trees/tree-node "No agent output" 0 false trees/status-info)]

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
@@ -494,6 +494,18 @@
                :depth 0 :expandable? false})
             phases))))
 
+(defn clean-agent-content
+  "Clean raw agent content for display:
+   - Unescape literal \\n sequences to real newlines
+   - Remove JSON SSE event lines (lines starting with '{\"type\":')
+   - Strip markdown link syntax [text](url) → text"
+  [content]
+  (->> (-> (or content "")
+           (str/replace "\\n" "\n"))
+       str/split-lines
+       (remove #(str/starts-with? (str/trim %) "{\"type\":"))
+       (map #(str/replace % #"\[([^\]]+)\]\([^)]+\)" "$1"))))
+
 (defn project-chat-messages
   "Project chat messages as tree nodes for the agent panel.
    Shows conversation history with role-based styling and numbered actions.
@@ -513,7 +525,7 @@
                         (fn [{:keys [role content]}]
                           (let [prefix (if (= :user role) "You" "Agent")
                                 fg     (if (= :user role) status-info status-pass)
-                                lines  (str/split-lines (or content ""))]
+                                lines  (clean-agent-content content)]
                             (into [(tree-node (str prefix ":") 0 false fg)]
                                   (mapcat (fn [line]
                                             (mapv #(tree-node (str "  " %) 1)

--- a/components/tui-views/test/ai/miniforge/tui_views/view/project_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/view/project_test.clj
@@ -2,7 +2,8 @@
   "Unit tests for extracted helper functions in project.clj."
   (:require
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.tui-views.view.project :as sut]))
+   [ai.miniforge.tui-views.view.project :as sut]
+   [ai.miniforge.tui-views.view.project.trees :as trees]))
 
 ;; ============================================================================
 ;; readiness-state
@@ -583,3 +584,33 @@
     (let [row (pr-row-with-size 0 0)]
       (is (= "—" (:ready row)))
       (is (= [0 180 80] (:ready-fg row))))))
+
+;; ============================================================================
+;; clean-agent-content
+;; ============================================================================
+
+(deftest clean-agent-content-unescapes-newlines
+  (testing "literal \\n becomes real newline, splitting into multiple lines"
+    (let [lines (trees/clean-agent-content "line one\\nline two\\nline three")]
+      (is (= ["line one" "line two" "line three"] (vec lines))))))
+
+(deftest clean-agent-content-filters-sse-events
+  (testing "JSON SSE event lines are removed"
+    (let [content "Review complete\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":100}}\nDone"
+          lines (trees/clean-agent-content content)]
+      (is (= ["Review complete" "Done"] (vec lines))))))
+
+(deftest clean-agent-content-strips-markdown-links
+  (testing "markdown [text](url) links become plain text"
+    (let [lines (trees/clean-agent-content "See [foo.clj](/path/to/foo.clj#L42) for details")]
+      (is (= ["See foo.clj for details"] (vec lines))))))
+
+(deftest clean-agent-content-nil-safe
+  (testing "nil content returns a sequence with one empty string"
+    (is (= [""] (vec (trees/clean-agent-content nil))))))
+
+(deftest clean-agent-content-combined
+  (testing "unescapes, filters SSE, and strips links together"
+    (let [content "Issue 1: missing test\\n{\"type\":\"turn.completed\"}\nSee [foo.clj](/foo.clj) for context"
+          lines (trees/clean-agent-content content)]
+      (is (= ["Issue 1: missing test" "See foo.clj for context"] (vec lines))))))


### PR DESCRIPTION
## Summary

- Add `clean-agent-content` helper in `trees.clj` that: (1) unescapes literal `\n` sequences to real newlines, (2) filters out JSON SSE event lines (`{"type":...}`), and (3) strips markdown `[text](url)` → `text`
- Apply it in `project-chat-messages` (PR detail "Agent" panel) — fixes raw escaped content visible in screenshot
- Rewrite `project-agent-output` (workflow detail "Agent Output" panel) to return tree nodes with proper line-splitting and word-wrapping instead of a single flat label; also fixes agent name lookup (`:agent` key, not `:type`)
- 5 unit tests for `clean-agent-content` covering each transformation and the combined case

## Test plan

- [ ] Launch TUI after a reviewer run — Agent panel shows clean paragraphs instead of `\n` escapes and `{"type":"turn.completed"...}` lines
- [ ] Markdown links like `[file.clj](/path/to/file.clj#L42)` render as plain `file.clj`
- [ ] Agent Output panel in workflow detail wraps long lines rather than showing one huge concatenated string
- [ ] All 605 tui-views unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)