### PR TITLE
fix(tui): workflow navigation, evidence display, and status icons

### DIFF
--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -566,9 +566,9 @@
   (let [train-mgr (pr-train/create-manager)
         app (tui/create-app
              {:init   (fn []
-                        (persistence-pr/load-all-into-model
-                         (model/init-model)
-                         {:limit (:load-limit opts 100)}))
+                        (-> (model/init-model)
+                            (persistence/load-workflows-into-model {:limit (:load-limit opts 100)})
+                            (persistence-pr/load-all-into-model    {:limit (:load-limit opts 100)})))
               :update update/update-model
               :view   view/root-view
               :screen (:screen opts)

--- a/components/tui-views/src/ai/miniforge/tui_views/model.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/model.clj
@@ -114,7 +114,7 @@
 
 (defn make-workflow
   "Create a workflow summary map for the model."
-  [{:keys [id name status phase progress started-at]}]
+  [{:keys [id name status phase progress started-at gate-results]}]
   {:id           id
    :name         (or name (str "workflow-" (subs (str id) 0 8)))
    :status       (or status :pending)
@@ -122,7 +122,7 @@
    :progress     (or progress 0)
    :started-at   started-at
    :agents       {}
-   :gate-results []})
+   :gate-results (or gate-results [])})
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Repo manager helpers

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
@@ -521,7 +521,8 @@
    :progress (:progress wf)
    :started-at (:started-at wf)
    :duration-ms (:duration-ms wf)
-   :error (:error wf)})
+   :error (:error wf)
+   :gate-results (get wf :gate-results [])})
 
 (defn read-index
   "Read the workflow index from disk. Returns map of {workflow-id -> entry}."

--- a/components/tui-views/src/ai/miniforge/tui_views/transition.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/transition.clj
@@ -86,10 +86,25 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; View switches
 
+(def detail-defaults
+  "Default values for workflow drill-down state. Mirrors model/init-model :detail."
+  {:workflow-id    nil
+   :phases         []
+   :current-agent  nil
+   :agent-output   ""
+   :evidence       nil
+   :artifacts      []
+   :expanded-nodes #{}
+   :focused-pane   0
+   :selected-pr    nil
+   :pr-readiness   nil
+   :pr-risk        nil
+   :selected-train nil})
+
 (defn switch-view
-  "Switch to a top-level view, resetting navigation state."
+  "Switch to a top-level view, resetting navigation and detail state."
   [model view-key]
   (-> model
       (merge selection-defaults filter-defaults)
       (assoc :view view-key)
-      (assoc-in [:detail :workflow-id] nil)))
+      (assoc :detail detail-defaults)))

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project.clj
@@ -360,7 +360,7 @@
    :project/train-prs      (helpers/memoize-by project-train-prs
                              (fn [m] (get-in m [:detail :selected-train])))
    :project/evidence-tree  (helpers/memoize-by trees/project-evidence-tree
-                             (fn [m] (:detail m)))
+                             (fn [m] [(:detail m) (:workflows m)]))
    :project/artifacts      (helpers/memoize-by project-artifacts
                              (fn [m] (get-in m [:detail :artifacts])))
    :project/kanban-columns (helpers/memoize-by project-kanban-columns

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
@@ -68,7 +68,14 @@
 
 (defn status-char [status]
   (case status
-    :running "●" :success "✓" :failed "✗" :blocked "◐" :archived "⊘" "○"))
+    :running   "●"
+    :success   "✓"
+    :completed "✓"
+    :failed    "✗"
+    :blocked   "◐"
+    :stale     "⊘"
+    :archived  "⊘"
+    "○"))
 
 (defn format-progress-bar [pct width]
   (let [pct (or pct 0)

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj
@@ -460,18 +460,50 @@
       (not linked-wf)
       (conj (tree-node "Workflow: not linked" 0)))))
 
-(defn project-evidence-tree
-  "Build evidence tree nodes."
-  [model]
-  (let [detail (:detail model)
-        evidence (:evidence detail)
-        phases (:phases detail)]
+(defn- aggregate-evidence-nodes
+  "Build evidence summary nodes across all workflows for the top-level view."
+  [workflows]
+  (if (empty? workflows)
+    [{:label "No workflows loaded" :depth 0 :expandable? false}]
     (into []
-      (concat
-       (intent-nodes evidence)
-       (phase-nodes phases)
-       (validation-nodes evidence)
-       (policy-evidence-nodes evidence)))))
+      (mapcat (fn [wf]
+                (let [gate-results (get wf :gate-results [])
+                      total  (count gate-results)
+                      passed (count (filter :passed? gate-results))
+                      status (:status wf)
+                      phase  (:phase wf)
+                      gates-str (if (zero? total)
+                                  "no gates recorded"
+                                  (str passed "/" total " gates passed"))
+                      row-fg (case status
+                               (:success :completed) status-pass
+                               :running              status-info
+                               :failed               status-fail
+                               nil)]
+                  [{:label (str (helpers/status-char status) " " (:name wf "?"))
+                    :depth 0 :expandable? false :fg row-fg}
+                   {:label (str "  " gates-str
+                                (when phase (str " \u2502 " (name phase))))
+                    :depth 1 :expandable? false}]))
+              workflows))))
+
+(defn project-evidence-tree
+  "Build evidence tree nodes.
+   When a workflow is selected (leaf context), shows that workflow's evidence detail.
+   At the top-level aggregate view (no workflow selected), shows a summary across all workflows."
+  [model]
+  (let [workflow-id (get-in model [:detail :workflow-id])]
+    (if workflow-id
+      (let [detail   (:detail model)
+            evidence (:evidence detail)
+            phases   (:phases detail)]
+        (into []
+          (concat
+           (intent-nodes evidence)
+           (phase-nodes phases)
+           (validation-nodes evidence)
+           (policy-evidence-nodes evidence))))
+      (aggregate-evidence-nodes (get model :workflows [])))))
 
 (defn project-phase-tree
   "Project workflow phases as tree nodes for the detail view."


### PR DESCRIPTION
## Summary

- **Tab navigation fixed**: `switch-view` now resets the entire `:detail` map to defaults when cycling top-level views (was only clearing `[:detail :workflow-id]`), so stale per-workflow evidence/artifacts/phase data no longer bleeds into aggregate views
- **Top-level Evidence view shows aggregate**: `project-evidence-tree` now branches on whether a workflow is selected — no selection shows a per-workflow summary (name, status, gate pass/fail counts) across all loaded workflows; selecting a workflow still shows full evidence detail
- **Gate results survive index round-trip**: `workflow->index-entry` now persists `:gate-results`; `model/make-workflow` passes it through (was always initializing to `[]`)
- **Completed/stale status icons fixed**: `status-char` maps `:completed` → `"✓"` and `:stale` → `"⊘"` (was falling through to `"○"` / pending for all terminal workflows)

## Test plan

- [ ] Tab from PR Fleet cycles through all top-level views: Workflows → Evidence → Artifacts → DAG → Repos → PR Fleet
- [ ] Evidence view at top level shows list of workflows with gate counts, not empty/misleading content
- [ ] Drill into a workflow (Enter), Tab to Evidence sub-view shows that workflow's evidence detail
- [ ] Completed workflows show `✓` in the workflow list, not `○`
- [ ] Stale workflows show `⊘`, not `○`
- [ ] Gate pass/fail counts visible in top-level Evidence view for workflows that have run gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)