### PR TITLE
fix: raise agent max-turns to 40 and add hard-limit turn budget prompts

### DIFF
--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -7,7 +7,7 @@
 {:prompt/id :implementer
  :prompt/version "1.0.0"
  :prompt/agent :implementer
- :prompt/max-turns 25
+ :prompt/max-turns 40
 
  :prompt/system
  "You are an Implementation Agent for an autonomous software development team.
@@ -140,6 +140,13 @@ If you need additional files, use these MCP tools (they check a pre-loaded cache
 Minimize exploration — generate your implementation from the provided context when possible.
 Limit file reads to at most 3-5 files, then generate code and submit via the artifact tool.
 
-Remember: Your code will be validated, tested, and reviewed by other agents.
+## Turn Budget — HARD LIMIT
+
+You have at most 40 tool calls total. Reserve the last 3 for submitting.
+**After 5 file reads, STOP exploring and call `mcp__artifact__submit_code_artifact` immediately.**
+A good-enough implementation submitted on time is better than a perfect one that never arrives.
+
 Your LAST action before finishing MUST be calling `mcp__artifact__submit_code_artifact`.
+
+Remember: Your code will be validated, tested, and reviewed by other agents.
 Write code that is easy to understand, test, and maintain."}

--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -122,7 +122,12 @@ If you need to explore the codebase, use these MCP tools (they check a pre-loade
 - `mcp__artifact__context_grep` — search file contents by regex
 - `mcp__artifact__context_glob` — find files by glob pattern
 
-Limit file reads to what's necessary, then submit your plan.
+## Turn Budget — HARD LIMIT
+
+You have at most 40 tool calls total. Reserve the last 3 for submitting.
+**After 15 file reads, STOP exploring and call `mcp__artifact__submit_plan` immediately.**
+A good-enough plan submitted on time is better than a perfect plan that never arrives.
+
 Your LAST action before finishing MUST be calling `mcp__artifact__submit_plan`.
 
 Remember: A good plan enables parallel execution where possible while respecting

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -317,7 +317,7 @@
                                     :mcp-allowed-tools (:mcp-allowed-tools session)
                                     :supervision (:supervision session)
                                     :budget-usd budget-usd
-                                    :max-turns 25}]
+                                    :max-turns 40}]
                       (if on-chunk
                         (llm/chat-stream llm-client user-prompt on-chunk
                                          (merge {:system @planner-system-prompt} mcp-opts))


### PR DESCRIPTION
## Summary

- Raises `max-turns` from 25 → 40 in both `planner.clj` and `implementer.edn`
- Adds explicit "Turn Budget — HARD LIMIT" section to both agent system prompts: stop exploring after N reads, reserve 3 turns for submission

## Why

During the PR monitor loop dogfood run, both agents were hitting the 25-turn cap right as they tried to call the MCP submit tool. The agent spent 20+ turns on codebase exploration, reached the limit with its final message being "Let me call the submit tool now" — and then the session ended before the tool call could execute. The artifact was never captured, causing the phase to report failure even though all the code had been written to disk.

## Test plan

- [x] All 155 agent tests pass (pre-commit hook verified)
- [ ] Dogfood: run a full standard-sdlc workflow and confirm both plan and implement phases submit their MCP artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)