### PR TITLE
fix: recover implementer artifacts from workspace writes

### DIFF
--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -114,10 +114,10 @@ do NOT generate new code. Instead, output:
 Only use this when ALL acceptance criteria are already met by existing code.
 If even partial changes are needed, proceed with normal code generation.
 
-## CRITICAL: Submit Your Code via MCP Tool
+## Submit Your Code via MCP Tool
 
-You MUST call the `mcp__artifact__submit_code_artifact` tool to submit your implementation.
-This is your primary output mechanism. Do NOT output code as raw text — it will be lost.
+Preferred: call the `mcp__artifact__submit_code_artifact` tool to submit your implementation.
+This is the fastest path and carries metadata cleanly. Do NOT rely on raw text output.
 
 Call `mcp__artifact__submit_code_artifact` with these parameters:
 - `files`: array of objects with `path`, `content`, and `action` (\"create\", \"modify\", or \"delete\")
@@ -127,7 +127,8 @@ Call `mcp__artifact__submit_code_artifact` with these parameters:
 - `dependencies_added`: array of dependency strings (optional)
 
 The tool is ALWAYS available. If you encounter an error calling it, report the error.
-Do NOT fall back to raw text output under any circumstances.
+If you run out of turns before calling it, your file writes are still captured automatically.
+Still prefer the tool whenever possible.
 
 ## File Exploration via Context Cache
 
@@ -147,6 +148,5 @@ You have at most 40 tool calls total. Reserve the last 3 for submitting.
 A good-enough implementation submitted on time is better than a perfect one that never arrives.
 
 Your LAST action before finishing MUST be calling `mcp__artifact__submit_code_artifact`.
-
 Remember: Your code will be validated, tested, and reviewed by other agents.
 Write code that is easy to understand, test, and maintain."}

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -110,7 +110,8 @@
      :artifact-path artifact-path
      :pre-session-snapshot (try
                              (file-artifacts/snapshot-working-dir working-dir)
-                             (catch Exception _ nil))}))
+                             (catch Exception _
+                               (file-artifacts/empty-snapshot)))}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; MCP config generation

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -10,6 +10,7 @@
    Layer 2: Artifact reading
    Layer 3: High-level session macro"
   (:require
+   [ai.miniforge.agent.file-artifacts :as file-artifacts]
    [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -98,14 +99,18 @@
    Returns:
    - {:dir <path>, :mcp-config-path <path>, :artifact-path <path>}"
   []
-  (let [dir (str (Files/createTempDirectory
+  (let [working-dir (System/getProperty "user.dir")
+        dir (str (Files/createTempDirectory
                   "miniforge-artifact-"
                   (into-array FileAttribute [])))
         config-path (str dir "/mcp-config.json")
         artifact-path (str dir "/artifact.edn")]
     {:dir dir
      :mcp-config-path config-path
-     :artifact-path artifact-path}))
+     :artifact-path artifact-path
+     :pre-session-snapshot (try
+                             (file-artifacts/snapshot-working-dir working-dir)
+                             (catch Exception _ nil))}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; MCP config generation
@@ -420,7 +425,8 @@
        (let [result# (do ~@body)]
          {:llm-result result#
           :artifact (read-artifact session#)
-          :context-misses (read-context-misses session#)})
+          :context-misses (read-context-misses session#)
+          :pre-session-snapshot (:pre-session-snapshot session#)})
        (finally
          (cleanup-session! session#)))))
 

--- a/components/agent/src/ai/miniforge/agent/file_artifacts.clj
+++ b/components/agent/src/ai/miniforge/agent/file_artifacts.clj
@@ -54,7 +54,7 @@
       (modified? status) {:bucket :modified :path path}
       :else nil)))
 
-(defn- empty-snapshot
+(defn empty-snapshot
   "Return an empty working tree snapshot."
   []
   {:untracked #{}
@@ -153,9 +153,12 @@
    the session started."
   [pre-snapshot working-dir]
   (when pre-snapshot
-    (->> (snapshot-working-dir working-dir)
-         (changed-paths pre-snapshot)
-         (synthetic-artifact working-dir))))
+    (try
+      (->> (snapshot-working-dir working-dir)
+           (changed-paths pre-snapshot)
+           (synthetic-artifact working-dir))
+      (catch Exception _
+        nil))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/file_artifacts.clj
+++ b/components/agent/src/ai/miniforge/agent/file_artifacts.clj
@@ -1,0 +1,167 @@
+(ns ai.miniforge.agent.file-artifacts
+  "Fallback artifact collection from files written in the working tree."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.set :as set]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Porcelain parsing and artifact shaping
+
+(def ^:private artifact-manifest-name
+  "Optional metadata manifest written by the agent."
+  "miniforge-artifact.edn")
+
+(defn- tracked-addition?
+  "Return true when the porcelain status indicates a newly added tracked file."
+  [status]
+  (or (= \A (nth status 0))
+      (= \A (nth status 1))))
+
+(defn- deleted?
+  "Return true when the porcelain status indicates deletion."
+  [status]
+  (or (= \D (nth status 0))
+      (= \D (nth status 1))))
+
+(defn- modified?
+  "Return true when the porcelain status indicates a tracked file change."
+  [status]
+  (or (= \M (nth status 0))
+      (= \M (nth status 1))
+      (= \R (nth status 0))
+      (= \R (nth status 1))
+      (= \C (nth status 0))
+      (= \C (nth status 1))
+      (= \T (nth status 0))
+      (= \T (nth status 1))
+      (tracked-addition? status)))
+
+(defn- porcelain-entry
+  "Parse a single git status --porcelain=v1 line."
+  [line]
+  (let [status (subs line 0 2)
+        raw-path (subs line 3)
+        path (if (str/includes? raw-path " -> ")
+               (second (str/split raw-path #" -> " 2))
+               raw-path)]
+    (cond
+      (= status "??") {:bucket :untracked :path path}
+      (deleted? status) {:bucket :deleted :path path}
+      (tracked-addition? status) {:bucket :added :path path}
+      (modified? status) {:bucket :modified :path path}
+      :else nil)))
+
+(defn- empty-snapshot
+  "Return an empty working tree snapshot."
+  []
+  {:untracked #{}
+   :modified #{}
+   :deleted #{}
+   :added #{}})
+
+(defn- add-entry
+  "Add a parsed porcelain entry into the snapshot."
+  [snapshot {:keys [bucket path]}]
+  (update snapshot bucket conj path))
+
+(defn- manifest-path
+  "Return the manifest file path for a working dir."
+  [working-dir]
+  (str (io/file working-dir artifact-manifest-name)))
+
+(defn- read-manifest
+  "Read optional artifact metadata from the working directory."
+  [working-dir]
+  (let [path (manifest-path working-dir)
+        file (io/file path)]
+    (when (.exists file)
+      (-> (slurp file)
+          edn/read-string
+          (select-keys [:code/summary :code/tests-needed?])))))
+
+(defn- file-entry
+  "Build a synthetic artifact entry for a written file."
+  [working-dir action path]
+  {:path path
+   :content (if (= :delete action) "" (slurp (io/file working-dir path)))
+   :action action})
+
+(defn- changed-paths
+  "Compute created/modified/deleted paths attributable to the current session."
+  [pre post]
+  (let [dirty-before (apply set/union (map #(get pre % #{})
+                                           [:untracked :modified :added]))
+        created (set/union
+                 (set/difference (get post :untracked #{}) (get pre :untracked #{}))
+                 (set/difference (get post :added #{}) (get pre :added #{})))
+        modified (-> (set/difference (get post :modified #{}) (get pre :modified #{}))
+                     (set/difference dirty-before)
+                     (set/difference created))
+        deleted (-> (set/difference (get post :deleted #{}) (get pre :deleted #{}))
+                    (set/difference dirty-before))]
+    {:create (disj created artifact-manifest-name)
+     :modify (disj modified artifact-manifest-name)
+     :delete (disj deleted artifact-manifest-name)}))
+
+(defn- synthetic-artifact
+  "Build a synthetic code artifact from written file sets."
+  [working-dir changed]
+  (let [files (->> [[:create (:create changed)]
+                    [:modify (:modify changed)]
+                    [:delete (:delete changed)]]
+                   (mapcat (fn [[action paths]]
+                             (map #(file-entry working-dir action %) (sort paths))))
+                   vec)]
+    (when (seq files)
+      (merge {:code/files files
+              :code/summary (str (count files)
+                                 " files collected from agent working directory (no MCP submit)")
+              :code/language "clojure"
+              :code/tests-needed? true}
+             (read-manifest working-dir)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Working tree snapshot and fallback artifact collection
+
+(defn snapshot-working-dir
+  "Capture the current git dirty state for a working directory.
+
+   Returns sets of paths relative to working-dir. Paths already staged as new
+   files are tracked in :added so they can still be treated as :create during
+   fallback artifact synthesis."
+  [working-dir]
+  (let [{:keys [exit out err]} (shell/sh "git" "-C" working-dir
+                                         "status" "--porcelain=v1"
+                                         "--untracked-files=all"
+                                         "--ignored=no" "--" ".")]
+    (if (zero? exit)
+      (reduce add-entry
+              (empty-snapshot)
+              (keep porcelain-entry (str/split-lines out)))
+      (throw (ex-info "Failed to snapshot working directory"
+                      {:working-dir working-dir
+                       :exit exit
+                       :stderr err})))))
+
+(defn collect-written-files
+  "Collect files written during the agent session into a synthetic code artifact.
+
+   Uses the pre-session snapshot to exclude files that were already dirty before
+   the session started."
+  [pre-snapshot working-dir]
+  (when pre-snapshot
+    (->> (snapshot-working-dir working-dir)
+         (changed-paths pre-snapshot)
+         (synthetic-artifact working-dir))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (snapshot-working-dir (System/getProperty "user.dir"))
+
+  (collect-written-files (snapshot-working-dir (System/getProperty "user.dir"))
+                         (System/getProperty "user.dir"))
+
+  :leave-this-here)

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -4,6 +4,7 @@
   (:require
    [ai.miniforge.agent.artifact-session :as artifact-session]
    [ai.miniforge.agent.budget :as budget]
+   [ai.miniforge.agent.file-artifacts :as file-artifacts]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.specialized :as specialized]
@@ -388,14 +389,17 @@
 
 (defn- process-llm-response
   "Process a successful LLM response, returning the appropriate result."
-  [response artifact context logger tokens cost-usd]
+  [response artifact artifact-source context logger tokens cost-usd]
   (let [content (llm/get-content response)
         parsed (or artifact (parse-code-response content))]
     (let [tools (get response :tools-called [])]
-      (if artifact
+      (cond
+        (= :mcp artifact-source)
         (log/info logger :implementer :implementer/mcp-artifact-received
                   {:data {:file-count (count (:code/files artifact))
                           :tools-called tools}})
+
+        (nil? artifact-source)
         (log/warn logger :implementer :implementer/mcp-tool-not-called
                   {:data {:content-length (count (or content ""))
                           :tools-called tools
@@ -410,7 +414,8 @@
   "Invoke the implementer via the LLM backend."
   [llm-client user-prompt effective-system-prompt config context on-chunk logger
    existing-files]
-  (let [{:keys [llm-result artifact context-misses]}
+  (let [working-dir (System/getProperty "user.dir")
+        {:keys [llm-result artifact context-misses pre-session-snapshot]}
         (artifact-session/with-artifact-session [session]
           ;; Write context cache so MCP tools can serve from it
           (when (seq existing-files)
@@ -427,23 +432,37 @@
             (if on-chunk
               (llm/chat-stream llm-client user-prompt on-chunk
                                (merge {:system effective-system-prompt} mcp-opts))
-              (llm/chat llm-client user-prompt
-                        (merge {:system effective-system-prompt} mcp-opts)))))
+                        (llm/chat llm-client user-prompt
+                                  (merge {:system effective-system-prompt} mcp-opts)))))
         response llm-result
+        file-artifact (when-not artifact
+                        (file-artifacts/collect-written-files pre-session-snapshot
+                                                              working-dir))
+        artifact-source (cond
+                          artifact :mcp
+                          file-artifact :file-fallback
+                          :else nil)
+        effective-artifact (or artifact file-artifact)
         tokens (get response :tokens 0)
         cost-usd (get response :cost-usd)]
     (when (seq context-misses)
       (log/info logger :implementer :implementer/context-cache-misses
                 {:data {:miss-count (count context-misses)
                         :misses context-misses}}))
+    (when file-artifact
+      (log/warn logger :implementer :implementer/file-artifact-fallback
+                {:data {:file-count (count (:code/files file-artifact))
+                        :tools-called (get response :tools-called [])}}))
     (log/info logger :implementer :implementer/llm-called
               {:data {:success (llm/success? response)
                       :tokens tokens
                       :streaming? (boolean on-chunk)
-                      :mcp-artifact? (boolean artifact)
+                      :mcp-artifact? (= :mcp artifact-source)
+                      :file-artifact-fallback? (= :file-fallback artifact-source)
                       :tools-called (get response :tools-called [])}})
     (if (llm/success? response)
-      (process-llm-response response artifact context logger tokens cost-usd)
+      (process-llm-response response effective-artifact artifact-source
+                            context logger tokens cost-usd)
       (response/error (or (:message (llm/get-error response))
                           (messages/t :error/llm-failed))))))
 

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -15,6 +15,7 @@
         (is (string? (:dir s)))
         (is (string? (:mcp-config-path s)))
         (is (string? (:artifact-path s)))
+        (is (map? (:pre-session-snapshot s)))
         (is (.exists (io/file (:dir s))))
         (is (.startsWith (:dir s) (System/getProperty "java.io.tmpdir")))
         (is (.endsWith (:mcp-config-path s) "/mcp-config.json"))

--- a/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
@@ -1,0 +1,122 @@
+(ns ai.miniforge.agent.file-artifacts-test
+  (:require
+   [ai.miniforge.agent.file-artifacts :as sut]
+   [clojure.java.io :as io]
+   [clojure.test :as test :refer [deftest testing is]]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test helpers
+
+(defn- temp-dir
+  "Create a temp directory for file artifact tests."
+  []
+  (str (java.nio.file.Files/createTempDirectory
+        "file-artifacts-test-"
+        (into-array java.nio.file.attribute.FileAttribute []))))
+
+(defn- delete-tree!
+  "Delete a temp directory recursively."
+  [dir]
+  (doseq [file (reverse (file-seq (io/file dir)))]
+    (.delete ^java.io.File file)))
+
+(defn- write-file!
+  "Write a file relative to the temp working directory."
+  [dir path content]
+  (let [file (io/file dir path)]
+    (.mkdirs (.getParentFile file))
+    (spit file content)))
+
+(defn- make-snapshot
+  "Create a snapshot map for tests."
+  [& {:keys [untracked modified deleted added]
+      :or {untracked #{}
+           modified #{}
+           deleted #{}
+           added #{}}}]
+  {:untracked untracked
+   :modified modified
+   :deleted deleted
+   :added added})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Unit tests
+
+(deftest snapshot-working-dir-test
+  (testing "parses git porcelain output into working tree buckets"
+    (with-redefs [clojure.java.shell/sh
+                  (fn [& _]
+                    {:exit 0
+                     :out (str "?? src/new_file.clj\n"
+                               " M src/changed.clj\n"
+                               "D  src/deleted.clj\n"
+                               "A  src/staged_new.clj\n")
+                     :err ""})]
+      (is (= {:untracked #{"src/new_file.clj"}
+              :modified #{"src/changed.clj"}
+              :deleted #{"src/deleted.clj"}
+              :added #{"src/staged_new.clj"}}
+             (sut/snapshot-working-dir "/tmp/work"))))))
+
+(deftest collect-written-files-test
+  (testing "collects only files attributable to the current session"
+    (let [dir (temp-dir)
+          pre (make-snapshot :modified #{"src/already_dirty.clj"})]
+      (try
+        (write-file! dir "src/new_file.clj" "(ns new-file)")
+        (write-file! dir "src/changed.clj" "(ns changed)")
+        (write-file! dir "src/already_dirty.clj" "(ns keep-out)")
+        (with-redefs [ai.miniforge.agent.file-artifacts/snapshot-working-dir
+                      (fn [_]
+                        (make-snapshot
+                         :untracked #{"src/new_file.clj"}
+                         :modified #{"src/changed.clj" "src/already_dirty.clj"}
+                         :deleted #{"src/deleted.clj"}))]
+          (is (= {:code/files [{:path "src/new_file.clj"
+                                :content "(ns new-file)"
+                                :action :create}
+                               {:path "src/changed.clj"
+                                :content "(ns changed)"
+                                :action :modify}
+                               {:path "src/deleted.clj"
+                                :content ""
+                                :action :delete}]
+                  :code/summary "3 files collected from agent working directory (no MCP submit)"
+                  :code/language "clojure"
+                  :code/tests-needed? true}
+                 (sut/collect-written-files pre dir))))
+        (finally
+          (delete-tree! dir)))))
+
+  (testing "returns nil when nothing changed"
+    (let [pre (make-snapshot :modified #{"src/already_dirty.clj"})]
+      (with-redefs [ai.miniforge.agent.file-artifacts/snapshot-working-dir
+                    (fn [_] pre)]
+        (is (nil? (sut/collect-written-files pre "/tmp/work"))))))
+
+  (testing "merges optional artifact manifest metadata"
+    (let [dir (temp-dir)
+          pre (make-snapshot)]
+      (try
+        (write-file! dir "src/new_file.clj" "(ns new-file)")
+        (write-file! dir "miniforge-artifact.edn"
+                     "{:code/summary \"Collected from manifest\"\n :code/tests-needed? false}")
+        (with-redefs [ai.miniforge.agent.file-artifacts/snapshot-working-dir
+                      (fn [_]
+                        (make-snapshot
+                         :untracked #{"src/new_file.clj" "miniforge-artifact.edn"}))]
+          (is (= {:code/files [{:path "src/new_file.clj"
+                                :content "(ns new-file)"
+                                :action :create}]
+                  :code/summary "Collected from manifest"
+                  :code/language "clojure"
+                  :code/tests-needed? false}
+                 (sut/collect-written-files pre dir))))
+        (finally
+          (delete-tree! dir))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (test/run-tests 'ai.miniforge.agent.file-artifacts-test)
+
+  :leave-this-here)

--- a/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
+++ b/components/agent/test/ai/miniforge/agent/file_artifacts_test.clj
@@ -94,6 +94,13 @@
                     (fn [_] pre)]
         (is (nil? (sut/collect-written-files pre "/tmp/work"))))))
 
+  (testing "returns nil when the working tree cannot be snapshotted"
+    (let [pre (make-snapshot)]
+      (with-redefs [ai.miniforge.agent.file-artifacts/snapshot-working-dir
+                    (fn [_]
+                      (throw (ex-info "git unavailable" {})))]
+        (is (nil? (sut/collect-written-files pre "/tmp/work"))))))
+
   (testing "merges optional artifact manifest metadata"
     (let [dir (temp-dir)
           pre (make-snapshot)]

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -1,10 +1,14 @@
 (ns ai.miniforge.agent.implementer-test
   "Tests for the Implementer agent."
   (:require
+   [ai.miniforge.agent.artifact-session :as artifact-session]
+   [ai.miniforge.agent.budget :as budget]
    [clojure.test :as test :refer [deftest testing is]]
    [clojure.string :as str]
    [ai.miniforge.agent.core :as core]
+   [ai.miniforge.agent.file-artifacts :as file-artifacts]
    [ai.miniforge.agent.implementer :as implementer]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -25,6 +29,36 @@
    :code/files [{:path "src/minimal.clj"
                  :content "(ns minimal)"
                  :action :create}]})
+
+(defn- llm-response
+  "Create a mock successful LLM response."
+  [& {:keys [content tokens cost-usd tools-called]
+      :or {content ""
+           tokens 0
+           cost-usd 0.0
+           tools-called []}}]
+  {:success true
+   :content content
+   :tokens tokens
+   :cost-usd cost-usd
+   :tools-called tools-called})
+
+(defn- session-map
+  "Create an artifact session map for tests."
+  [& {:keys [pre-session-snapshot]
+      :or {pre-session-snapshot {:untracked #{}
+                                 :modified #{}
+                                 :deleted #{}
+                                 :added #{}}}}]
+  {:dir "/tmp/miniforge-artifact-test"
+   :mcp-config-path "/tmp/miniforge-artifact-test/mcp-config.json"
+   :artifact-path "/tmp/miniforge-artifact-test/artifact.edn"
+   :pre-session-snapshot pre-session-snapshot})
+
+(defn- find-log-entry
+  "Find a specific event in collected log entries."
+  [entries event]
+  (some #(when (= event (:log/event %)) %) @entries))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Agent creation tests
@@ -58,7 +92,49 @@
                               {:task/description "Implement user login"
                                :task/type :implement})]
       (is (= :error (:status result)))
-      (is (some? (:error result))))))
+      (is (some? (:error result)))))
+
+  (testing "uses file artifact fallback when MCP artifact is missing"
+    (let [[logger entries] (log/collecting-logger {:min-level :trace})
+          fallback-artifact {:code/files [{:path "src/generated.clj"
+                                           :content "(ns generated)"
+                                           :action :create}]
+                             :code/summary "Collected from working tree"
+                             :code/language "clojure"
+                             :code/tests-needed? true}
+          response (llm-response :tokens 42 :cost-usd 0.12)
+          result (with-redefs [artifact-session/create-session!
+                               (fn [] (session-map))
+                               artifact-session/write-mcp-config!
+                               identity
+                               artifact-session/read-artifact
+                               (constantly nil)
+                               artifact-session/read-context-misses
+                               (constantly nil)
+                               artifact-session/cleanup-session!
+                               (constantly nil)
+                               budget/resolve-cost-budget-usd
+                               (fn [& _] 1.0)
+                               llm/chat
+                               (fn [& _] response)
+                               llm/success?
+                               :success
+                               llm/get-content
+                               :content
+                               file-artifacts/collect-written-files
+                               (fn [_ _] fallback-artifact)]
+                   (@#'implementer/invoke-with-llm
+                    nil "prompt" "system" {} {} nil logger []))
+          fallback-log (find-log-entry entries :implementer/file-artifact-fallback)]
+      (is (= :success (:status result)))
+      (is (= [{:path "src/generated.clj"
+               :content "(ns generated)"
+               :action :create}]
+             (get-in result [:output :code/files])))
+      (is (= "Collected from working tree"
+             (get-in result [:output :code/summary])))
+      (is (= :warn (:log/level fallback-log)))
+      (is (= 1 (get-in fallback-log [:data :file-count]))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests

--- a/docs/pull-requests/2026-04-01-codex-implementer-file-artifact-fallback.md
+++ b/docs/pull-requests/2026-04-01-codex-implementer-file-artifact-fallback.md
@@ -1,0 +1,57 @@
+# fix: recover implementer artifacts from workspace writes
+
+## Overview
+
+Add an implementer-only fallback that synthesizes a code artifact from files written in the agent working directory when
+the MCP `submit_code_artifact` tool is never called before the Claude session exits.
+
+## Motivation
+
+The implementer currently treats `artifact.edn` as mandatory. In practice, the agent can exhaust its turn budget after
+successfully writing files into the workspace but before calling the MCP submit tool, which causes the phase to fail and
+discard recoverable work.
+
+## Changes in Detail
+
+- Added `ai.miniforge.agent.file-artifacts` to snapshot the working tree before and after the implementer session, diff
+  new and modified files, and synthesize a `:code/files` artifact when needed.
+- Threaded a pre-session snapshot through `artifact-session` so implementer sessions can recover only files attributable
+  to the current run.
+- Updated the implementer to prefer the MCP artifact, fall back to collected workspace files, and log
+  `:implementer/file-artifact-fallback` when recovery is used.
+- Softened the implementer prompt so MCP submit remains preferred, while clarifying that workspace writes are captured
+  automatically if the session runs out of turns.
+- Added focused tests for the snapshot collector, session snapshot threading, and implementer fallback logging/success
+  behavior.
+
+## Scope Decision
+
+This PR keeps the fallback implementer-only.
+
+- `implementer` already has a workspace-write contract, so reconstructing `:code/files` from disk matches its output
+  semantics.
+- `tester` produces a logical test artifact and currently instructs the agent not to write files directly, so broadening
+  fallback there would change behavior rather than just recover it.
+- `releaser` emits metadata, not workspace file output, so a working-tree scan is not a faithful recovery path.
+
+## Testing Plan
+
+- `bb test`
+
+## Deployment Plan
+
+No special deployment steps. The change is internal to agent artifact handling and is safe to release with the normal
+application rollout.
+
+## Related Issues/PRs
+
+- Base branch: `main`
+- Depends on: none
+
+## Checklist
+
+- [x] Snapshot pre/post working tree state for implementer sessions
+- [x] Recover code artifacts from written files when MCP submit is missing
+- [x] Preserve MCP submit as the preferred path
+- [x] Keep unrelated prompt hard-limit work out of this PR
+- [x] Verify the changed `agent` brick tests with `bb test`


### PR DESCRIPTION
# fix: recover implementer artifacts from workspace writes

## Overview

Add an implementer-only fallback that synthesizes a code artifact from files written in the agent working directory when
the MCP `submit_code_artifact` tool is never called before the Claude session exits.

## Motivation

The implementer currently treats `artifact.edn` as mandatory. In practice, the agent can exhaust its turn budget after
successfully writing files into the workspace but before calling the MCP submit tool, which causes the phase to fail and
discard recoverable work.

## Changes in Detail

- Added `ai.miniforge.agent.file-artifacts` to snapshot the working tree before and after the implementer session, diff
  new and modified files, and synthesize a `:code/files` artifact when needed.
- Threaded a pre-session snapshot through `artifact-session` so implementer sessions can recover only files attributable
  to the current run.
- Updated the implementer to prefer the MCP artifact, fall back to collected workspace files, and log
  `:implementer/file-artifact-fallback` when recovery is used.
- Softened the implementer prompt so MCP submit remains preferred, while clarifying that workspace writes are captured
  automatically if the session runs out of turns.
- Added focused tests for the snapshot collector, session snapshot threading, and implementer fallback logging/success
  behavior.

## Scope Decision

This PR keeps the fallback implementer-only.

- `implementer` already has a workspace-write contract, so reconstructing `:code/files` from disk matches its output
  semantics.
- `tester` produces a logical test artifact and currently instructs the agent not to write files directly, so broadening
  fallback there would change behavior rather than just recover it.
- `releaser` emits metadata, not workspace file output, so a working-tree scan is not a faithful recovery path.

## Testing Plan

- `bb test`

## Deployment Plan

No special deployment steps. The change is internal to agent artifact handling and is safe to release with the normal
application rollout.

## Related Issues/PRs

- Base branch: `main`
- Depends on: none

## Checklist

- [x] Snapshot pre/post working tree state for implementer sessions
- [x] Recover code artifacts from written files when MCP submit is missing
- [x] Preserve MCP submit as the preferred path
- [x] Keep unrelated prompt hard-limit work out of this PR
- [x] Verify the changed `agent` brick tests with `bb test`
