### PR TITLE
feat: deployment pack config

### DIFF
--- a/components/phase-deployment/deps.edn
+++ b/components/phase-deployment/deps.edn
@@ -1,0 +1,12 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/messages {:local/root "../messages"}
+        ai.miniforge/phase {:local/root "../phase"}
+        ai.miniforge/gate {:local/root "../gate"}
+        ai.miniforge/logging {:local/root "../logging"}
+        ai.miniforge/schema {:local/root "../schema"}
+        ai.miniforge/response {:local/root "../response"}
+        ai.miniforge/evidence-bundle {:local/root "../evidence-bundle"}
+        ai.miniforge/policy-pack {:local/root "../policy-pack"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {ai.miniforge/gate {:local/root "../gate"}}}}}

--- a/components/phase-deployment/resources/config/phase/deploy-defaults.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-defaults.edn
@@ -1,0 +1,17 @@
+;; Deployment phase defaults
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Default configuration for deployment phases.
+;; Overridable per-workflow via the :phase-config key in workflow EDN.
+
+{:provision {:agent nil
+             :gates [:policy-pack :provision-validated]
+             :budget {:tokens 0 :iterations 3 :time-seconds 900}}
+
+ :deploy    {:agent nil
+             :gates [:deploy-healthy]
+             :budget {:tokens 0 :iterations 3 :time-seconds 300}}
+
+ :validate  {:agent nil
+             :gates [:health-check]
+             :budget {:tokens 0 :iterations 3 :time-seconds 120}}}

--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -1,20 +1,29 @@
-;; Deployment phase messages (English)
-{:provision/preview-starting    "Starting Pulumi preview"
- :provision/preview-complete    "Pulumi preview complete"
- :provision/preview-failed      "Pulumi preview failed"
- :provision/apply-starting      "Applying infrastructure changes"
- :provision/apply-complete      "Infrastructure provisioning complete"
- :provision/apply-failed        "Infrastructure apply failed"
- :provision/error               "Provision phase error"
+{:deploy/messages
+ {:provision/preview-starting    "Starting Pulumi preview"
+  :provision/preview-complete    "Pulumi preview complete"
+  :provision/preview-failed      "Pulumi preview failed"
+  :provision/apply-starting      "Applying infrastructure changes"
+  :provision/apply-complete      "Infrastructure provisioning complete"
+  :provision/apply-failed        "Infrastructure apply failed"
+  :provision/error               "Provision phase error"
 
- :deploy/starting               "Starting application deployment"
- :deploy/applied                "Manifests applied to cluster"
- :deploy/rollout-failed         "Deployment rollout failed"
- :deploy/complete               "Application deployment complete"
- :deploy/apply-failed           "Kustomize apply failed"
- :deploy/error                  "Deploy phase error"
+  :deploy/starting               "Starting application deployment"
+  :deploy/applied                "Manifests applied to cluster"
+  :deploy/rollout-failed         "Deployment rollout failed"
+  :deploy/complete               "Application deployment complete"
+  :deploy/apply-failed           "Kustomize apply failed"
+  :deploy/error                  "Deploy phase error"
 
- :validate/starting             "Starting post-deployment validation"
- :validate/passed               "All validation checks passed"
- :validate/failed               "Validation checks failed"
- :validate/error                "Validate phase error"}
+  :validate/starting             "Starting post-deployment validation"
+  :validate/passed               "All validation checks passed"
+  :validate/failed               "Validation checks failed"
+  :validate/error                "Validate phase error"
+
+  :config-resolver/secret-access-failed
+  "Failed to access secret '{secret-name}': {error}"
+  :config-resolver/resolve-template-failed
+  "Failed to resolve {count} secrets: {unresolved}"
+  :config-resolver/resolve-map-failed
+  "Failed to resolve {count} secrets"
+  :config-resolver/validation-error
+  "Validation error: {error}"}}

--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -1,0 +1,20 @@
+;; Deployment phase messages (English)
+{:provision/preview-starting    "Starting Pulumi preview"
+ :provision/preview-complete    "Pulumi preview complete"
+ :provision/preview-failed      "Pulumi preview failed"
+ :provision/apply-starting      "Applying infrastructure changes"
+ :provision/apply-complete      "Infrastructure provisioning complete"
+ :provision/apply-failed        "Infrastructure apply failed"
+ :provision/error               "Provision phase error"
+
+ :deploy/starting               "Starting application deployment"
+ :deploy/applied                "Manifests applied to cluster"
+ :deploy/rollout-failed         "Deployment rollout failed"
+ :deploy/complete               "Application deployment complete"
+ :deploy/apply-failed           "Kustomize apply failed"
+ :deploy/error                  "Deploy phase error"
+
+ :validate/starting             "Starting post-deployment validation"
+ :validate/passed               "All validation checks passed"
+ :validate/failed               "Validation checks failed"
+ :validate/error                "Validate phase error"}

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/config_resolver.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/config_resolver.clj
@@ -1,0 +1,236 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.config-resolver
+  "GCP Secret Manager config resolver.
+
+   Reads non-secret infrastructure configuration from GCP Secret Manager,
+   resolves template placeholders, and validates against a Malli schema.
+   Produces evidence of what was resolved from where.
+
+   Placeholder syntax: ${gcp-sm:secret-name}
+
+   Note: This is a focused inline resolver for the pilot. If multi-cloud
+   config resolution becomes needed, evaluate Data Foundry's connector
+   protocol as the abstraction layer."
+  (:require [ai.miniforge.schema.interface :as schema]
+            [clojure.set :as set]
+            [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Placeholder parsing
+
+(def ^:private placeholder-pattern
+  "Regex for GCP Secret Manager placeholders: ${gcp-sm:secret-name}"
+  #"\$\{gcp-sm:([^}]+)\}")
+
+(defn extract-placeholders
+  "Extract all ${gcp-sm:*} placeholders from a template string.
+
+   Arguments:
+     template - String with placeholders
+
+   Returns:
+     Set of secret names (without the ${gcp-sm:} wrapper)"
+  [template]
+  (->> (re-seq placeholder-pattern template)
+       (map second)
+       set))
+
+(defn extract-placeholders-from-map
+  "Extract all placeholders from a nested map of values.
+
+   Arguments:
+     m - Map (possibly nested) with string values containing placeholders
+
+   Returns:
+     Set of secret names"
+  [m]
+  (let [walk-fn (fn walk [v]
+                  (cond
+                    (string? v) (extract-placeholders v)
+                    (map? v)    (apply set/union #{} (map walk (vals v)))
+                    (coll? v)   (apply set/union #{} (map walk v))
+                    :else       #{}))]
+    (walk-fn m)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; GCP Secret Manager access
+
+(defn- access-secret
+  "Access a secret version from GCP Secret Manager.
+
+   Uses the GCP Java SDK with Application Default Credentials (ADC).
+   Lazy-loads the SDK to avoid hard dependency.
+
+   Arguments:
+     gcp-project - GCP project ID
+     secret-name - Secret name
+
+   Returns:
+     {:success? true :value string}
+     {:success? false :error string}"
+  [gcp-project secret-name]
+  (try
+    (let [;; Lazy-load GCP SDK classes
+          client-class (Class/forName "com.google.cloud.secretmanager.v1.SecretManagerServiceClient")
+          create-fn    (.getMethod client-class "create" (into-array Class []))
+          access-fn    (.getMethod client-class "accessSecretVersion"
+                                  (into-array Class [String]))
+          ;; Build the secret version name
+          version-name (str "projects/" gcp-project "/secrets/" secret-name "/versions/latest")
+          ;; Access the secret
+          client       (.invoke create-fn nil (into-array Object []))
+          response     (.invoke access-fn client (into-array Object [version-name]))
+          payload-fn   (.getMethod (.getClass response) "getPayload" (into-array Class []))
+          payload      (.invoke payload-fn response (into-array Object []))
+          data-fn      (.getMethod (.getClass payload) "getData" (into-array Class []))
+          data         (.invoke data-fn payload (into-array Object []))
+          to-string-fn (.getMethod (.getClass data) "toStringUtf8" (into-array Class []))
+          value        (.invoke to-string-fn data (into-array Object []))]
+      ;; Close client
+      (try (.close client) (catch Exception _))
+      (schema/success :value value))
+    (catch Exception e
+      (schema/failure :value (str "Failed to access secret '" secret-name "': " (ex-message e))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Template resolution + validation
+
+(defn resolve-template
+  "Resolve all ${gcp-sm:*} placeholders in a template string.
+
+   Arguments:
+     template    - String with ${gcp-sm:secret-name} placeholders
+     gcp-project - GCP project ID
+
+   Returns:
+     {:success?  true
+      :resolved  string (template with placeholders replaced)
+      :log       [{:secret :resolved? :error}...] (evidence of what was resolved)}
+     {:success?  false
+      :error     string
+      :unresolved [secret-names...]}"
+  [template gcp-project]
+  (let [placeholders (extract-placeholders template)
+        resolution-log (atom [])
+        errors         (atom [])
+        resolved (reduce
+                  (fn [tmpl secret-name]
+                    (let [result (access-secret gcp-project secret-name)]
+                      (if (schema/succeeded? result)
+                        (do (swap! resolution-log conj
+                                   {:secret    secret-name
+                                    :resolved? true
+                                    :timestamp (System/currentTimeMillis)})
+                            (str/replace tmpl
+                                         (str "${gcp-sm:" secret-name "}")
+                                         (:value result)))
+                        (do (swap! resolution-log conj
+                                   {:secret    secret-name
+                                    :resolved? false
+                                    :error     (:error result)
+                                    :timestamp (System/currentTimeMillis)})
+                            (swap! errors conj secret-name)
+                            tmpl))))
+                  template
+                  placeholders)]
+    (if (seq @errors)
+      (schema/failure :resolved (str "Failed to resolve " (count @errors) " secrets: " (pr-str @errors))
+                      {:unresolved @errors
+                       :log        @resolution-log})
+      (schema/success :resolved resolved
+                      {:log @resolution-log}))))
+
+(defn resolve-map
+  "Resolve all ${gcp-sm:*} placeholders in a nested map.
+
+   Arguments:
+     m           - Map with string values containing placeholders
+     gcp-project - GCP project ID
+
+   Returns:
+     {:success?       true
+      :resolved-values map (with all placeholders replaced)
+      :log            [...]}
+     {:success?       false
+      :error          string
+      :unresolved     [...]}"
+  [m gcp-project]
+  (let [log-acc    (atom [])
+        errors-acc (atom [])
+        walk-fn    (fn walk [v]
+                     (cond
+                       (string? v)
+                       (if (seq (extract-placeholders v))
+                         (let [result (resolve-template v gcp-project)]
+                           (swap! log-acc into (:log result))
+                           (if (schema/succeeded? result)
+                             (:resolved result)
+                             (do (swap! errors-acc into (:unresolved result))
+                                 v)))
+                         v)
+                       (map? v)    (into {} (map (fn [[k val]] [k (walk val)]) v))
+                       (vector? v) (mapv walk v)
+                       (seq? v)    (map walk v)
+                       :else       v))
+        resolved (walk-fn m)]
+    (if (seq @errors-acc)
+      (schema/failure :resolved-values (str "Failed to resolve " (count @errors-acc) " secrets")
+                      {:unresolved @errors-acc
+                       :log        @log-acc})
+      (schema/success :resolved-values resolved
+                      {:log @log-acc}))))
+
+;; Schema validation (uses Malli via requiring-resolve)
+
+(defn validate-config
+  "Validate resolved config against a Malli schema.
+
+   Arguments:
+     config - Resolved config map
+     schema - Malli schema (vector form)
+
+   Returns:
+     {:valid?  boolean
+      :errors  nil or humanized error map}"
+  [config schema]
+  (try
+    (let [validate-fn (requiring-resolve 'malli.core/validate)
+          explain-fn  (requiring-resolve 'malli.core/explain)
+          humanize-fn (requiring-resolve 'malli.error/humanize)]
+      (if (validate-fn schema config)
+        (schema/valid)
+        (schema/invalid-with-errors (humanize-fn (explain-fn schema config)))))
+    (catch Exception e
+      (schema/invalid-with-errors {:_schema (str "Validation error: " (ex-message e))}))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Parse placeholders
+  (extract-placeholders "host: ${gcp-sm:db-host}, port: ${gcp-sm:db-port}")
+  ;; => #{"db-host" "db-port"}
+
+  ;; Resolve (requires GCP auth)
+  ;; (resolve-template "host: ${gcp-sm:db-host}" "my-project")
+
+  ;; Validate
+  ;; (validate-config {:db-host "10.0.0.1" :db-port 5432}
+  ;;                  [:map [:db-host :string] [:db-port :int]])
+
+  :leave-this-here)

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/config_resolver.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/config_resolver.clj
@@ -28,16 +28,85 @@
    Note: This is a focused inline resolver for the pilot. If multi-cloud
    config resolution becomes needed, evaluate Data Foundry's connector
    protocol as the abstraction layer."
-  (:require [ai.miniforge.schema.interface :as schema]
+  (:require [ai.miniforge.phase.deploy.messages :as msg]
+            [ai.miniforge.schema.interface :as schema]
             [clojure.set :as set]
             [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Placeholder parsing
+;; Placeholder parsing + schemas
 
 (def ^:private placeholder-pattern
   "Regex for GCP Secret Manager placeholders: ${gcp-sm:secret-name}"
   #"\$\{gcp-sm:([^}]+)\}")
+
+(def ResolutionLogEntry
+  [:map
+   [:secret :string]
+   [:resolved? :boolean]
+   [:timestamp :int]
+   [:error {:optional true} :string]])
+
+(def ResolveTemplateSuccess
+  [:map
+   [:success? [:= true]]
+   [:resolved :string]
+   [:log [:vector ResolutionLogEntry]]])
+
+(def ResolveTemplateFailure
+  [:map
+   [:success? [:= false]]
+   [:resolved nil?]
+   [:error :string]
+   [:anomaly map?]
+   [:unresolved [:vector :string]]
+   [:log [:vector ResolutionLogEntry]]])
+
+(def ResolveMapSuccess
+  [:map
+   [:success? [:= true]]
+   [:resolved-values map?]
+   [:log [:vector ResolutionLogEntry]]])
+
+(def ResolveMapFailure
+  [:map
+   [:success? [:= false]]
+   [:resolved-values nil?]
+   [:error :string]
+   [:anomaly map?]
+   [:unresolved [:vector :string]]
+   [:log [:vector ResolutionLogEntry]]])
+
+(declare access-secret)
+
+(defn- validate-result!
+  [result-schema result]
+  (schema/validate result-schema result))
+
+(defn- timestamp-now
+  []
+  (System/currentTimeMillis))
+
+(defn- log-entry
+  [secret-name resolved? & [error-message]]
+  (cond-> {:secret secret-name
+           :resolved? resolved?
+           :timestamp (timestamp-now)}
+    error-message (assoc :error error-message)))
+
+(defn- apply-secret-resolution
+  [tmpl gcp-project secret-name resolution-log errors]
+  (let [result (access-secret gcp-project secret-name)]
+    (if (schema/succeeded? result)
+      (do
+        (swap! resolution-log conj (log-entry secret-name true))
+        (str/replace tmpl
+                     (str "${gcp-sm:" secret-name "}")
+                     (:value result)))
+      (do
+        (swap! resolution-log conj (log-entry secret-name false (:error result)))
+        (swap! errors conj secret-name)
+        tmpl))))
 
 (defn extract-placeholders
   "Extract all ${gcp-sm:*} placeholders from a template string.
@@ -107,7 +176,10 @@
       (try (.close client) (catch Exception _))
       (schema/success :value value))
     (catch Exception e
-      (schema/failure :value (str "Failed to access secret '" secret-name "': " (ex-message e))))))
+      (schema/failure :value
+                      (msg/t :config-resolver/secret-access-failed
+                             {:secret-name secret-name
+                              :error (ex-message e)})))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Template resolution + validation
@@ -132,30 +204,24 @@
         errors         (atom [])
         resolved (reduce
                   (fn [tmpl secret-name]
-                    (let [result (access-secret gcp-project secret-name)]
-                      (if (schema/succeeded? result)
-                        (do (swap! resolution-log conj
-                                   {:secret    secret-name
-                                    :resolved? true
-                                    :timestamp (System/currentTimeMillis)})
-                            (str/replace tmpl
-                                         (str "${gcp-sm:" secret-name "}")
-                                         (:value result)))
-                        (do (swap! resolution-log conj
-                                   {:secret    secret-name
-                                    :resolved? false
-                                    :error     (:error result)
-                                    :timestamp (System/currentTimeMillis)})
-                            (swap! errors conj secret-name)
-                            tmpl))))
+                    (apply-secret-resolution tmpl
+                                             gcp-project
+                                             secret-name
+                                             resolution-log
+                                             errors))
                   template
                   placeholders)]
-    (if (seq @errors)
-      (schema/failure :resolved (str "Failed to resolve " (count @errors) " secrets: " (pr-str @errors))
-                      {:unresolved @errors
-                       :log        @resolution-log})
-      (schema/success :resolved resolved
-                      {:log @resolution-log}))))
+    (validate-result!
+     (if (seq @errors) ResolveTemplateFailure ResolveTemplateSuccess)
+     (if (seq @errors)
+       (schema/failure :resolved
+                       (msg/t :config-resolver/resolve-template-failed
+                              {:count (count @errors)
+                               :unresolved (pr-str @errors)})
+                       {:unresolved @errors
+                        :log        @resolution-log})
+       (schema/success :resolved resolved
+                       {:log @resolution-log})))))
 
 (defn resolve-map
   "Resolve all ${gcp-sm:*} placeholders in a nested map.
@@ -190,12 +256,16 @@
                        (seq? v)    (map walk v)
                        :else       v))
         resolved (walk-fn m)]
-    (if (seq @errors-acc)
-      (schema/failure :resolved-values (str "Failed to resolve " (count @errors-acc) " secrets")
-                      {:unresolved @errors-acc
-                       :log        @log-acc})
-      (schema/success :resolved-values resolved
-                      {:log @log-acc}))))
+    (validate-result!
+     (if (seq @errors-acc) ResolveMapFailure ResolveMapSuccess)
+     (if (seq @errors-acc)
+       (schema/failure :resolved-values
+                       (msg/t :config-resolver/resolve-map-failed
+                              {:count (count @errors-acc)})
+                       {:unresolved @errors-acc
+                        :log        @log-acc})
+       (schema/success :resolved-values resolved
+                       {:log @log-acc})))))
 
 ;; Schema validation (uses Malli via requiring-resolve)
 
@@ -209,16 +279,18 @@
    Returns:
      {:valid?  boolean
       :errors  nil or humanized error map}"
-  [config schema]
+  [config config-schema]
   (try
     (let [validate-fn (requiring-resolve 'malli.core/validate)
           explain-fn  (requiring-resolve 'malli.core/explain)
           humanize-fn (requiring-resolve 'malli.error/humanize)]
-      (if (validate-fn schema config)
+      (if (validate-fn config-schema config)
         (schema/valid)
-        (schema/invalid-with-errors (humanize-fn (explain-fn schema config)))))
+        (schema/invalid-with-errors (humanize-fn (explain-fn config-schema config)))))
     (catch Exception e
-      (schema/invalid-with-errors {:_schema (str "Validation error: " (ex-message e))}))))
+      (schema/invalid-with-errors
+       {:_schema (msg/t :config-resolver/validation-error
+                        {:error (ex-message e)})}))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/messages.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/messages.clj
@@ -1,0 +1,30 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.messages
+  "Component-level message catalog for phase-deployment.
+   Delegates to the shared messages component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Message translator
+
+(def t
+  "Look up a deployment phase message by key, with optional param substitution."
+  (messages/create-translator "config/phase/deploy-messages/en-US.edn"
+                              :deploy/messages))

--- a/components/phase-deployment/test/ai/miniforge/phase/deploy/config_resolver_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase/deploy/config_resolver_test.clj
@@ -1,0 +1,61 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.config-resolver-test
+  (:require
+   [ai.miniforge.phase.deploy.config-resolver :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Config resolver tests
+
+(deftest extract-placeholders-test
+  (testing "extracts placeholders from a single template string"
+    (is (= #{"db-host" "db-port"}
+           (sut/extract-placeholders
+            "postgres://${gcp-sm:db-host}:${gcp-sm:db-port}/app"))))
+
+  (testing "returns an empty set when no placeholders are present"
+    (is (= #{}
+           (sut/extract-placeholders "plain-text")))))
+
+(deftest extract-placeholders-from-map-test
+  (testing "walks nested maps and vectors"
+    (is (= #{"db-host" "db-port" "api-key"}
+           (sut/extract-placeholders-from-map
+            {:database {:host "${gcp-sm:db-host}"
+                        :port "${gcp-sm:db-port}"}
+             :services [{:name "api"
+                         :key "${gcp-sm:api-key}"}]
+             :replicas 2})))))
+
+(deftest validate-config-test
+  (testing "returns a valid result for matching config"
+    (is (= {:valid? true}
+           (sut/validate-config {:db-host "10.0.0.1" :db-port 5432}
+                                [:map
+                                 [:db-host :string]
+                                 [:db-port :int]]))))
+
+  (testing "returns invalid-with-errors for schema mismatches"
+    (let [result (sut/validate-config {:db-host "10.0.0.1" :db-port "5432"}
+                                      [:map
+                                       [:db-host :string]
+                                       [:db-port :int]])]
+      (is (false? (:valid? result)))
+      (is (map? (:errors result))))))

--- a/components/schema/src/ai/miniforge/schema/interface.clj
+++ b/components/schema/src/ai/miniforge/schema/interface.clj
@@ -184,6 +184,18 @@
              :anomaly (response/from-exception ex)}
             opts))))
 
+(defn succeeded?
+  "Returns true if result represents a successful operation.
+   Prefer over direct :success? key access."
+  [result]
+  (true? (:success? result)))
+
+(defn failed?
+  "Returns true if result represents a failed operation.
+   Prefer over direct :success? key access."
+  [result]
+  (not (true? (:success? result))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation response helpers
 

--- a/deps.edn
+++ b/deps.edn
@@ -50,6 +50,8 @@
                        "components/workflow-financial-etl/resources"
                        "components/workflow-chain-software-factory/resources"
                        "components/workflow-software-factory/resources"
+                       "components/phase-deployment/src"
+                       "components/phase-deployment/resources"
                        "components/release-executor/src"
                        "components/release-executor/resources"
                        "components/operator/src"
@@ -160,6 +162,7 @@
                      ai.miniforge/adapter-claude-code {:local/root "components/adapter-claude-code"}
                      ai.miniforge/messages {:local/root "components/messages"}
                      ai.miniforge/patterns {:local/root "components/patterns"}
+                     ai.miniforge/phase-deployment {:local/root "components/phase-deployment"}
                      ai.miniforge/cli {:local/root "bases/cli"}}}
 
   :test {:extra-paths ["development/test"
@@ -217,6 +220,7 @@
                        "components/task-executor/test"
                        "components/messages/test"
                        "components/patterns/test"
+                       "components/phase-deployment/test"
                        "bases/cli/test"
                        "bases/lsp-mcp-bridge/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
@@ -269,6 +273,7 @@
                       ai.miniforge/control-plane-adapter {:local/root "components/control-plane-adapter"}
                       ai.miniforge/adapter-miniforge {:local/root "components/adapter-miniforge"}
                       ai.miniforge/adapter-claude-code {:local/root "components/adapter-claude-code"}
+                      ai.miniforge/phase-deployment {:local/root "components/phase-deployment"}
                       ai.miniforge/task-executor {:local/root "components/task-executor"}
                       ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}}}
 

--- a/docs/pull-requests/2026-04-01-feat-deployment-pack-config.md
+++ b/docs/pull-requests/2026-04-01-feat-deployment-pack-config.md
@@ -1,0 +1,49 @@
+# feat: deployment pack config
+
+## Layer
+
+Foundations
+
+## Depends on
+
+- `main`
+
+## Overview
+
+Adds the deployment pack configuration foundations: deployment defaults, message catalog wiring, schema predicates, and
+GCP Secret Manager config resolution.
+
+## Motivation
+
+The deployment phases need typed configuration and deterministic config expansion before any deployment safety or
+runtime orchestration can exist.
+
+## Changes in Detail
+
+- Add `phase-deployment` component dependencies and deployment config resources.
+- Add `deploy/messages` translator wiring.
+- Extend the schema interface with result helpers used by deployment code.
+- Add `config_resolver.clj` and focused resolver tests.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Validation
+
+- `bb pre-commit` passed
+
+## Deployment Plan
+
+- Merge first in the deployment-pack stack.
+
+## Related Issues/PRs
+
+- Parent feature: deployment pack
+- Follow-up stack branches: `feat/deployment-pack-safety-gates`, `feat/deployment-pack-shell`
+
+## Checklist
+
+- [x] Scope limited to configuration foundations
+- [x] Tests added for resolver behavior
+- [x] `bb pre-commit` recorded


### PR DESCRIPTION
# feat: deployment pack config

## Layer

Foundations

## Depends on

- `main`

## Overview

Adds the deployment pack configuration foundations: deployment defaults, message catalog wiring, schema predicates, and
GCP Secret Manager config resolution.

## Motivation

The deployment phases need typed configuration and deterministic config expansion before any deployment safety or
runtime orchestration can exist.

## Changes in Detail

- Add `phase-deployment` component dependencies and deployment config resources.
- Add `deploy/messages` translator wiring.
- Extend the schema interface with result helpers used by deployment code.
- Add `config_resolver.clj` and focused resolver tests.

## Testing Plan

- Run `bb pre-commit`

## Validation

- `bb pre-commit` passed

## Deployment Plan

- Merge first in the deployment-pack stack.

## Related Issues/PRs

- Parent feature: deployment pack
- Follow-up stack branches: `feat/deployment-pack-safety-gates`, `feat/deployment-pack-shell`

## Checklist

- [x] Scope limited to configuration foundations
- [x] Tests added for resolver behavior
- [x] `bb pre-commit` recorded
