### PR TITLE
feat: deployment pack safety gates

### DIFF
--- a/components/phase-deployment/resources/config/phase/deploy-gates.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-gates.edn
@@ -1,0 +1,7 @@
+{:deploy/gates
+ [{:name :provision-validated
+   :description-key :gate/provision-validated-description}
+  {:name :deploy-healthy
+   :description-key :gate/deploy-healthy-description}
+  {:name :health-check
+   :description-key :gate/health-check-description}]}

--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -26,4 +26,30 @@
   :config-resolver/resolve-map-failed
   "Failed to resolve {count} secrets"
   :config-resolver/validation-error
-  "Validation error: {error}"}}
+  "Validation error: {error}"
+
+  :gate/validation-failed
+  "Deployment gate validation failed"
+  :gate/provision-validated-description
+  "Validates that infrastructure provisioning produced expected outputs"
+  :gate/deploy-healthy-description
+  "Validates all pods are in Ready state after deployment"
+  :gate/health-check-description
+  "Validates health endpoints return HTTP 2xx"
+  :gate/provision-no-outputs
+  "Provisioning produced no outputs"
+  :gate/provision-missing-outputs
+  "Missing expected outputs: {missing}"
+  :gate/deploy-no-pods
+  "No pods found after deployment"
+  :gate/deploy-pods-not-ready
+  "{ready-count}/{pod-count} pods ready"
+  :gate/health-http-failed
+  "HTTP {status-code}"
+  :gate/health-command-failed
+  "Command failed"
+
+  :policy/resource-count-limit
+  "Creating {creates} resources (limit: {limit})"
+  :policy/gke-node-limit
+  "Creating {node-pools} node pools (limit: {limit})"}}

--- a/components/phase-deployment/resources/packs/deployment-safety/pack.edn
+++ b/components/phase-deployment/resources/packs/deployment-safety/pack.edn
@@ -1,0 +1,72 @@
+;; Deployment Safety Policy Pack
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Checked by the :policy-pack gate against Pulumi preview output.
+;; Prevents destructive or unsafe infrastructure changes from applying.
+
+{:pack/id :miniforge/deployment-safety
+ :pack/version "1.0.0"
+ :pack/name "Deployment Safety"
+ :pack/description "Prevents destructive infrastructure operations and enforces deployment guardrails"
+
+ :pack/rules
+ [{:rule/id :deploy/no-destroy-production
+   :rule/title "Block production resource destruction"
+   :rule/description "Prevents deletion of critical production resources without explicit override"
+   :rule/severity :critical
+   :rule/category :safety
+   :rule/applies-to {:phases #{:provision}}
+   :rule/detection {:type :content-scan
+                    :patterns ["\"delete\""
+                               "\"replace\""
+                               "\"deleteBeforeReplace\""]}
+   :rule/enforcement {:action :block
+                      :message "Pulumi preview contains destructive operations. Review and approve explicitly."}}
+
+  {:rule/id :deploy/resource-count-limit
+   :rule/title "Large change warning"
+   :rule/description "Warns when a single operation creates or modifies more than 20 resources"
+   :rule/severity :medium
+   :rule/category :safety
+   :rule/applies-to {:phases #{:provision}}
+   :rule/detection {:type :custom
+                    :check-fn 'ai.miniforge.phase.deploy.policy/check-resource-count}
+   :rule/enforcement {:action :warn
+                      :message "Large infrastructure change detected. Verify scope is intentional."}}
+
+  {:rule/id :deploy/no-public-endpoints
+   :rule/title "Public endpoint approval"
+   :rule/description "Requires approval when creating publicly accessible resources"
+   :rule/severity :high
+   :rule/category :security
+   :rule/applies-to {:phases #{:provision}}
+   :rule/detection {:type :content-scan
+                    :patterns ["0\\.0\\.0\\.0/0"
+                               "\"EXTERNAL\""
+                               "\"allUsers\""
+                               "\"allAuthenticatedUsers\""]}
+   :rule/enforcement {:action :require-approval
+                      :message "Public access detected. Requires security review approval."}}
+
+  {:rule/id :deploy/gke-node-limit
+   :rule/title "GKE node pool size limit"
+   :rule/description "Warns when GKE node pool exceeds configured maximum"
+   :rule/severity :medium
+   :rule/category :cost
+   :rule/applies-to {:phases #{:provision}}
+   :rule/detection {:type :custom
+                    :check-fn 'ai.miniforge.phase.deploy.policy/check-gke-node-limit}
+   :rule/enforcement {:action :warn
+                      :message "GKE node pool exceeds recommended size. Verify cost impact."}}
+
+  {:rule/id :deploy/no-secrets-in-manifests
+   :rule/title "No hardcoded secrets in manifests"
+   :rule/description "Checks rendered K8s manifests for hardcoded secrets"
+   :rule/severity :critical
+   :rule/category :security
+   :rule/applies-to {:phases #{:deploy}}
+   :rule/detection {:type :content-scan
+                    :patterns ["(?i)(password|secret|api[_-]?key|token)\\s*[:=]\\s*[\"'][^\"']{8,}"
+                               "(?i)PRIVATE KEY"]}
+   :rule/enforcement {:action :block
+                      :message "Potential secrets detected in manifests. Use Secret Manager instead."}}]}

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/gates.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/gates.clj
@@ -19,168 +19,226 @@
 (ns ai.miniforge.phase.deploy.gates
   "Deployment-specific gate registrations.
 
-   Gates:
-   - :provision-validated — Pulumi outputs non-empty with expected keys
-   - :deploy-healthy      — All pods in Ready state
-   - :health-check        — HTTP health endpoints return 2xx"
-  (:require [ai.miniforge.gate.registry :as registry]))
+   Gate metadata is loaded from EDN so descriptions and registration stay
+   declarative while checks remain focused in code."
+  (:require [ai.miniforge.gate.registry :as registry]
+            [ai.miniforge.phase.deploy.messages :as msg]
+            [ai.miniforge.response.interface :as response]
+            [ai.miniforge.schema.interface :as schema]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Gate check functions
+;; Gate schemas + result constructors
 
-(defn check-provision-validated
-  "Validate that provisioning produced expected infrastructure outputs.
+(def GateError
+  [:map
+   [:type keyword?]
+   [:message :string]
+   [:expected {:optional true} any?]
+   [:actual {:optional true} any?]
+   [:pod-details {:optional true} [:vector map?]]
+   [:url {:optional true} :string]
+   [:status-code {:optional true} :int]
+   [:command {:optional true} :string]])
 
-   Checks:
-   - Pulumi outputs are non-empty
-   - Expected output keys are present (configurable via ctx :expected-outputs)
-   - No error state in outputs
+(def GateFailure
+  [:map
+   [:passed? [:= false]]
+   [:errors [:vector GateError]]
+   [:anomaly map?]])
 
-   Arguments:
-     artifact - Phase result artifact from :provision phase
-     ctx      - Execution context (may contain :expected-outputs set)"
-  [artifact ctx]
-  (let [outputs (or (:outputs artifact)
-                    (get-in artifact [:content :outputs])
-                    (get-in artifact [:artifact/content :outputs])
-                    artifact)
-        expected-keys (get ctx :expected-outputs #{})
-        output-keys   (set (keys outputs))]
-    (cond
-      (or (nil? outputs) (empty? outputs))
-      {:passed? false
-       :errors [{:type :no-outputs
-                 :message "Provisioning produced no outputs"}]}
+(def GateDefinition
+  [:map
+   [:name keyword?]
+   [:description-key keyword?]])
 
-      (and (seq expected-keys)
-           (not-every? output-keys expected-keys))
-      {:passed? false
-       :errors [{:type :missing-outputs
-                 :message (str "Missing expected outputs: "
-                              (pr-str (remove output-keys expected-keys)))
-                 :expected expected-keys
-                 :actual   output-keys}]}
+(def GateConfig
+  [:map
+   [:deploy/gates [:vector GateDefinition]]])
 
-      :else
-      {:passed? true
-       :output-count (count outputs)
-       :output-keys  (vec output-keys)})))
+(declare gate-definitions)
 
-(defn check-deploy-healthy
-  "Validate that all pods are in Ready state after deployment.
+(defn- validate-result!
+  [result-schema result]
+  (schema/validate result-schema result))
 
-   Checks:
-   - Pod count > 0
-   - All pods are Ready
-   - No pods in CrashLoopBackOff or Error state
+(defn- gate-error
+  ([error-type message-key]
+   (gate-error error-type message-key {} nil))
+  ([error-type message-key params]
+   (gate-error error-type message-key params nil))
+  ([error-type message-key params extra]
+   (reduce-kv (fn [error-map k v]
+                (if (nil? v)
+                  error-map
+                  (assoc error-map k v)))
+              {:type error-type
+               :message (msg/t message-key params)}
+              (or extra {}))))
 
-   Arguments:
-     artifact - Phase result artifact from :deploy phase (pod state)
-     ctx      - Execution context"
-  [artifact _ctx]
-  (let [pod-state (or (get-in artifact [:content])
-                      artifact)
-        pod-count   (:pod-count pod-state 0)
-        ready-count (:ready-count pod-state 0)
-        pods        (:pods pod-state [])]
-    (cond
-      (zero? pod-count)
-      {:passed? false
-       :errors [{:type :no-pods
-                 :message "No pods found after deployment"}]}
+(defn- passed
+  ([] (passed nil))
+  ([extra]
+   (merge {:passed? true} extra)))
 
-      (not= pod-count ready-count)
-      {:passed? false
-       :errors [{:type :pods-not-ready
-                 :message (str ready-count "/" pod-count " pods ready")
-                 :pod-details (filterv (complement :ready?) pods)}]}
+(defn- failed
+  [errors]
+  (validate-result!
+   GateFailure
+   {:passed? false
+    :errors errors
+    :anomaly (response/gate-anomaly
+              :anomalies.gate/validation-failed
+              (msg/t :gate/validation-failed)
+              errors)}))
 
-      :else
-      {:passed? true
-       :pod-count pod-count
-       :ready-count ready-count})))
+(defn- gate-map
+  [gate-kw check-fn]
+  (let [{:keys [description-key]} (get @gate-definitions gate-kw)]
+    {:name gate-kw
+     :description (msg/t description-key)
+     :check check-fn
+     :repair nil}))
 
-(defn check-health-endpoint
-  "Validate that health check results all passed.
+(defn- outputs-from-artifact
+  [artifact]
+  (or (get artifact :outputs)
+      (get-in artifact [:content :outputs])
+      (get-in artifact [:artifact/content :outputs])
+      artifact))
 
-   Arguments:
-     artifact - Phase result artifact from :validate phase
-     ctx      - Execution context"
-  [artifact _ctx]
-  (let [content (or (:content artifact) artifact)
-        health-results (or (:health-results content)
-                          (get-in content [:health :results])
-                          [])
-        smoke-results  (or (:smoke-results content)
-                          (get-in content [:smoke :results])
-                          [])
-        all-health-passed? (or (empty? health-results)
-                               (every? :passed? health-results))
-        all-smoke-passed?  (or (empty? smoke-results)
-                               (every? :passed? smoke-results))]
-    (cond
-      (not all-health-passed?)
-      {:passed? false
-       :errors (mapv (fn [r]
-                       {:type :health-check-failed
-                        :url  (:url r)
-                        :status-code (:status-code r)
-                        :message (or (:error r)
-                                     (str "HTTP " (:status-code r)))})
-                     (remove :passed? health-results))}
+(defn- content-from-artifact
+  [artifact]
+  (or (get artifact :content) artifact))
 
-      (not all-smoke-passed?)
-      {:passed? false
-       :errors (mapv (fn [r]
-                       {:type :smoke-test-failed
-                        :command (:command r)
-                        :message (get r :stderr "Command failed")})
-                     (remove :passed? smoke-results))}
+(defn- nested-results
+  [content direct-key nested-path]
+  (if-some [results (or (get content direct-key)
+                        (get-in content nested-path))]
+    results
+    []))
 
-      :else
-      {:passed? true
-       :health-checks-passed (count health-results)
-       :smoke-tests-passed   (count smoke-results)})))
+(defn- load-gate-config
+  []
+  (let [config (edn/read-string (slurp (io/resource "config/phase/deploy-gates.edn")))]
+    (schema/validate GateConfig config)))
+
+(def ^:private gate-definitions
+  (delay
+    (into {}
+          (map (juxt :name identity))
+          (:deploy/gates (load-gate-config)))))
 
 ;------------------------------------------------------------------------------ Layer 1
+;; Gate checks
+
+(defn check-provision-validated
+  "Validate that provisioning produced expected infrastructure outputs."
+  [artifact ctx]
+  (let [outputs (outputs-from-artifact artifact)
+        expected-keys (get ctx :expected-outputs #{})
+        output-keys   (set (keys outputs))
+        missing-keys  (vec (remove output-keys expected-keys))]
+    (cond
+      (or (nil? outputs) (empty? outputs))
+      (failed [(gate-error :no-outputs :gate/provision-no-outputs)])
+
+      (seq missing-keys)
+      (failed [(gate-error :missing-outputs
+                           :gate/provision-missing-outputs
+                           {:missing (pr-str missing-keys)}
+                           {:expected expected-keys
+                            :actual output-keys})])
+
+      :else
+      (passed {:output-count (count outputs)
+               :output-keys  (vec output-keys)}))))
+
+(defn check-deploy-healthy
+  "Validate that all pods are in Ready state after deployment."
+  [artifact _ctx]
+  (let [pod-state    (content-from-artifact artifact)
+        pod-count    (get pod-state :pod-count 0)
+        ready-count  (get pod-state :ready-count 0)
+        pods         (get pod-state :pods [])
+        failing-pods (filterv (complement :ready?) pods)]
+    (cond
+      (zero? pod-count)
+      (failed [(gate-error :no-pods :gate/deploy-no-pods)])
+
+      (not= pod-count ready-count)
+      (failed [(gate-error :pods-not-ready
+                           :gate/deploy-pods-not-ready
+                           {:ready-count ready-count
+                            :pod-count pod-count}
+                           {:pod-details failing-pods})])
+
+      :else
+      (passed {:pod-count pod-count
+               :ready-count ready-count}))))
+
+(defn check-health-endpoint
+  "Validate that health check results all passed."
+  [artifact _ctx]
+  (let [content            (content-from-artifact artifact)
+        health-results     (nested-results content :health-results [:health :results])
+        smoke-results      (nested-results content :smoke-results [:smoke :results])
+        failed-health      (remove :passed? health-results)
+        failed-smoke       (remove :passed? smoke-results)
+        all-health-passed? (or (empty? health-results) (empty? failed-health))
+        all-smoke-passed?  (or (empty? smoke-results) (empty? failed-smoke))]
+    (cond
+      (not all-health-passed?)
+      (failed (mapv (fn [result]
+                      (gate-error :health-check-failed
+                                  :gate/health-http-failed
+                                  {:status-code (get result :status-code)}
+                                  {:url (get result :url)
+                                   :status-code (get result :status-code)}))
+                    failed-health))
+
+      (not all-smoke-passed?)
+      (failed (mapv (fn [result]
+                      (gate-error :smoke-test-failed
+                                  :gate/health-command-failed
+                                  {}
+                                  {:command (get result :command)
+                                   :message (get result
+                                                 :stderr
+                                                 (msg/t :gate/health-command-failed))}))
+                    failed-smoke))
+
+      :else
+      (passed {:health-checks-passed (count health-results)
+               :smoke-tests-passed   (count smoke-results)}))))
+
+;------------------------------------------------------------------------------ Layer 2
 ;; Registration
 
-(registry/register-gate! :provision-validated)
-(registry/register-gate! :deploy-healthy)
-(registry/register-gate! :health-check)
+(doseq [gate-kw (keys @gate-definitions)]
+  (registry/register-gate! gate-kw))
 
 (defmethod registry/get-gate :provision-validated
   [_]
-  {:name        :provision-validated
-   :description "Validates that infrastructure provisioning produced expected outputs"
-   :check       check-provision-validated
-   :repair      nil})
+  (gate-map :provision-validated check-provision-validated))
 
 (defmethod registry/get-gate :deploy-healthy
   [_]
-  {:name        :deploy-healthy
-   :description "Validates all pods are in Ready state after deployment"
-   :check       check-deploy-healthy
-   :repair      nil})
+  (gate-map :deploy-healthy check-deploy-healthy))
 
 (defmethod registry/get-gate :health-check
   [_]
-  {:name        :health-check
-   :description "Validates health endpoints return HTTP 2xx"
-   :check       check-health-endpoint
-   :repair      nil})
+  (gate-map :health-check check-health-endpoint))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
-  ;; Test provision gate
   (check-provision-validated {:outputs {:gke_endpoint "https://..." :db_host "10.0.0.1"}} {})
   (check-provision-validated {} {})
 
-  ;; Test deploy gate
   (check-deploy-healthy {:pod-count 3 :ready-count 3 :pods []} {})
   (check-deploy-healthy {:pod-count 3 :ready-count 1 :pods [{:name "p1" :ready? false}]} {})
 
-  ;; Test health gate
   (check-health-endpoint {:health-results [{:passed? true :url "http://x/health"}]} {})
 
   :leave-this-here)

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/gates.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/gates.clj
@@ -1,0 +1,186 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.gates
+  "Deployment-specific gate registrations.
+
+   Gates:
+   - :provision-validated — Pulumi outputs non-empty with expected keys
+   - :deploy-healthy      — All pods in Ready state
+   - :health-check        — HTTP health endpoints return 2xx"
+  (:require [ai.miniforge.gate.registry :as registry]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Gate check functions
+
+(defn check-provision-validated
+  "Validate that provisioning produced expected infrastructure outputs.
+
+   Checks:
+   - Pulumi outputs are non-empty
+   - Expected output keys are present (configurable via ctx :expected-outputs)
+   - No error state in outputs
+
+   Arguments:
+     artifact - Phase result artifact from :provision phase
+     ctx      - Execution context (may contain :expected-outputs set)"
+  [artifact ctx]
+  (let [outputs (or (:outputs artifact)
+                    (get-in artifact [:content :outputs])
+                    (get-in artifact [:artifact/content :outputs])
+                    artifact)
+        expected-keys (get ctx :expected-outputs #{})
+        output-keys   (set (keys outputs))]
+    (cond
+      (or (nil? outputs) (empty? outputs))
+      {:passed? false
+       :errors [{:type :no-outputs
+                 :message "Provisioning produced no outputs"}]}
+
+      (and (seq expected-keys)
+           (not-every? output-keys expected-keys))
+      {:passed? false
+       :errors [{:type :missing-outputs
+                 :message (str "Missing expected outputs: "
+                              (pr-str (remove output-keys expected-keys)))
+                 :expected expected-keys
+                 :actual   output-keys}]}
+
+      :else
+      {:passed? true
+       :output-count (count outputs)
+       :output-keys  (vec output-keys)})))
+
+(defn check-deploy-healthy
+  "Validate that all pods are in Ready state after deployment.
+
+   Checks:
+   - Pod count > 0
+   - All pods are Ready
+   - No pods in CrashLoopBackOff or Error state
+
+   Arguments:
+     artifact - Phase result artifact from :deploy phase (pod state)
+     ctx      - Execution context"
+  [artifact _ctx]
+  (let [pod-state (or (get-in artifact [:content])
+                      artifact)
+        pod-count   (:pod-count pod-state 0)
+        ready-count (:ready-count pod-state 0)
+        pods        (:pods pod-state [])]
+    (cond
+      (zero? pod-count)
+      {:passed? false
+       :errors [{:type :no-pods
+                 :message "No pods found after deployment"}]}
+
+      (not= pod-count ready-count)
+      {:passed? false
+       :errors [{:type :pods-not-ready
+                 :message (str ready-count "/" pod-count " pods ready")
+                 :pod-details (filterv (complement :ready?) pods)}]}
+
+      :else
+      {:passed? true
+       :pod-count pod-count
+       :ready-count ready-count})))
+
+(defn check-health-endpoint
+  "Validate that health check results all passed.
+
+   Arguments:
+     artifact - Phase result artifact from :validate phase
+     ctx      - Execution context"
+  [artifact _ctx]
+  (let [content (or (:content artifact) artifact)
+        health-results (or (:health-results content)
+                          (get-in content [:health :results])
+                          [])
+        smoke-results  (or (:smoke-results content)
+                          (get-in content [:smoke :results])
+                          [])
+        all-health-passed? (or (empty? health-results)
+                               (every? :passed? health-results))
+        all-smoke-passed?  (or (empty? smoke-results)
+                               (every? :passed? smoke-results))]
+    (cond
+      (not all-health-passed?)
+      {:passed? false
+       :errors (mapv (fn [r]
+                       {:type :health-check-failed
+                        :url  (:url r)
+                        :status-code (:status-code r)
+                        :message (or (:error r)
+                                     (str "HTTP " (:status-code r)))})
+                     (remove :passed? health-results))}
+
+      (not all-smoke-passed?)
+      {:passed? false
+       :errors (mapv (fn [r]
+                       {:type :smoke-test-failed
+                        :command (:command r)
+                        :message (get r :stderr "Command failed")})
+                     (remove :passed? smoke-results))}
+
+      :else
+      {:passed? true
+       :health-checks-passed (count health-results)
+       :smoke-tests-passed   (count smoke-results)})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registration
+
+(registry/register-gate! :provision-validated)
+(registry/register-gate! :deploy-healthy)
+(registry/register-gate! :health-check)
+
+(defmethod registry/get-gate :provision-validated
+  [_]
+  {:name        :provision-validated
+   :description "Validates that infrastructure provisioning produced expected outputs"
+   :check       check-provision-validated
+   :repair      nil})
+
+(defmethod registry/get-gate :deploy-healthy
+  [_]
+  {:name        :deploy-healthy
+   :description "Validates all pods are in Ready state after deployment"
+   :check       check-deploy-healthy
+   :repair      nil})
+
+(defmethod registry/get-gate :health-check
+  [_]
+  {:name        :health-check
+   :description "Validates health endpoints return HTTP 2xx"
+   :check       check-health-endpoint
+   :repair      nil})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Test provision gate
+  (check-provision-validated {:outputs {:gke_endpoint "https://..." :db_host "10.0.0.1"}} {})
+  (check-provision-validated {} {})
+
+  ;; Test deploy gate
+  (check-deploy-healthy {:pod-count 3 :ready-count 3 :pods []} {})
+  (check-deploy-healthy {:pod-count 3 :ready-count 1 :pods [{:name "p1" :ready? false}]} {})
+
+  ;; Test health gate
+  (check-health-endpoint {:health-results [{:passed? true :url "http://x/health"}]} {})
+
+  :leave-this-here)

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/policy.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/policy.clj
@@ -21,73 +21,89 @@
 
    Referenced by detection entries in the deployment-safety policy pack
    via :check-fn symbols."
-  (:require [clojure.string :as str]))
+  (:require [ai.miniforge.phase.deploy.messages :as msg]
+            [ai.miniforge.schema.interface :as schema]
+            [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Preview parsing + violation helpers
+
+(def PolicyViolation
+  [:map
+   [:violation/rule-id keyword?]
+   [:violation/severity keyword?]
+   [:violation/message :string]
+   [:violation/data map?]])
+
+(defn- validate-violation!
+  [violation]
+  (schema/validate PolicyViolation violation))
+
+(defn- parse-preview
+  [content]
+  (if (string? content)
+    (try
+      (let [parse-fn (requiring-resolve 'cheshire.core/parse-string)]
+        (parse-fn content true))
+      (catch Exception _ {}))
+    content))
+
+(defn- preview-steps
+  [content]
+  (let [preview (parse-preview content)]
+    (if-some [steps (or (get preview :steps)
+                        (get preview :Steps))]
+      steps
+      [])))
+
+(defn- created-steps
+  [steps]
+  (filter #(= "create" (or (get % :op) (get % :Op))) steps))
+
+(defn- violation
+  [rule-id severity message-key params data]
+  (validate-violation!
+   {:violation/rule-id   rule-id
+    :violation/severity  severity
+    :violation/message   (msg/t message-key params)
+    :violation/data      data}))
+
+;------------------------------------------------------------------------------ Layer 1
 ;; Custom detection functions for policy pack rules
 
 (defn check-resource-count
-  "Check if a Pulumi preview creates too many resources in a single operation.
-
-   Arguments:
-     content - Pulumi preview JSON (as string or parsed map)
-     context - Detection context (may contain :max-resources, default 20)
-
-   Returns:
-     nil if no violation, or violation map."
+  "Check if a Pulumi preview creates too many resources in a single operation."
   [content context]
   (let [max-resources (get context :max-resources 20)
-        preview       (if (string? content)
-                        (try
-                          (let [parse-fn (requiring-resolve 'cheshire.core/parse-string)]
-                            (parse-fn content true))
-                          (catch Exception _ {}))
-                        content)
-        steps         (or (:steps preview) (:Steps preview) [])
-        creates       (count (filter #(= "create" (or (:op %) (:Op %))) steps))]
+        creates       (count (created-steps (preview-steps content)))]
     (when (> creates max-resources)
-      {:violation/rule-id   :deploy/resource-count-limit
-       :violation/severity  :medium
-       :violation/message   (str "Creating " creates " resources (limit: " max-resources ")")
-       :violation/data      {:creates creates :limit max-resources}})))
+      (violation :deploy/resource-count-limit
+                 :medium
+                 :policy/resource-count-limit
+                 {:creates creates
+                  :limit max-resources}
+                 {:creates creates
+                  :limit max-resources}))))
 
 (defn check-gke-node-limit
-  "Check if a GKE node pool exceeds configured maximum size.
-
-   Arguments:
-     content - Pulumi preview JSON
-     context - Detection context (may contain :max-nodes, default 10)
-
-   Returns:
-     nil if no violation, or violation map."
+  "Check if a GKE node pool exceeds configured maximum size."
   [content context]
-  (let [max-nodes (get context :max-nodes 10)
-        preview   (if (string? content)
-                    (try
-                      (let [parse-fn (requiring-resolve 'cheshire.core/parse-string)]
-                        (parse-fn content true))
-                      (catch Exception _ {}))
-                    content)
-        steps     (or (:steps preview) (:Steps preview) [])
-        node-pools (->> steps
-                        (filter #(str/includes? (str (or (:type %) ""))
-                                               "NodePool"))
-                        (filter #(= "create" (or (:op %) (:Op %)))))]
-    ;; Check each node pool's node count configuration
-    ;; (This is a simplified check — real implementation would parse the
-    ;;  resource inputs for initialNodeCount or autoscaling maxNodeCount)
-    (when (and (seq node-pools) (> (count node-pools) max-nodes))
-      {:violation/rule-id   :deploy/gke-node-limit
-       :violation/severity  :medium
-       :violation/message   (str "Creating " (count node-pools) " node pools (limit: " max-nodes ")")
-       :violation/data      {:node-pools (count node-pools) :limit max-nodes}})))
+  (let [max-nodes  (get context :max-nodes 10)
+        node-pools (->> (preview-steps content)
+                        created-steps
+                        (filter #(str/includes? (str (get % :type "")) "NodePool")))]
+    (when (> (count node-pools) max-nodes)
+      (violation :deploy/gke-node-limit
+                 :medium
+                 :policy/gke-node-limit
+                 {:node-pools (count node-pools)
+                  :limit max-nodes}
+                 {:node-pools (count node-pools)
+                  :limit max-nodes}))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (check-resource-count {:steps (repeat 25 {:op "create" :type "gcp:compute:Instance"})} {})
-  ;; => {:violation/rule-id :deploy/resource-count-limit ...}
-
   (check-resource-count {:steps (repeat 5 {:op "create"})} {})
-  ;; => nil
 
   :leave-this-here)

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/policy.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/policy.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.policy
+  "Custom policy check functions for deployment safety rules.
+
+   Referenced by detection entries in the deployment-safety policy pack
+   via :check-fn symbols."
+  (:require [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Custom detection functions for policy pack rules
+
+(defn check-resource-count
+  "Check if a Pulumi preview creates too many resources in a single operation.
+
+   Arguments:
+     content - Pulumi preview JSON (as string or parsed map)
+     context - Detection context (may contain :max-resources, default 20)
+
+   Returns:
+     nil if no violation, or violation map."
+  [content context]
+  (let [max-resources (get context :max-resources 20)
+        preview       (if (string? content)
+                        (try
+                          (let [parse-fn (requiring-resolve 'cheshire.core/parse-string)]
+                            (parse-fn content true))
+                          (catch Exception _ {}))
+                        content)
+        steps         (or (:steps preview) (:Steps preview) [])
+        creates       (count (filter #(= "create" (or (:op %) (:Op %))) steps))]
+    (when (> creates max-resources)
+      {:violation/rule-id   :deploy/resource-count-limit
+       :violation/severity  :medium
+       :violation/message   (str "Creating " creates " resources (limit: " max-resources ")")
+       :violation/data      {:creates creates :limit max-resources}})))
+
+(defn check-gke-node-limit
+  "Check if a GKE node pool exceeds configured maximum size.
+
+   Arguments:
+     content - Pulumi preview JSON
+     context - Detection context (may contain :max-nodes, default 10)
+
+   Returns:
+     nil if no violation, or violation map."
+  [content context]
+  (let [max-nodes (get context :max-nodes 10)
+        preview   (if (string? content)
+                    (try
+                      (let [parse-fn (requiring-resolve 'cheshire.core/parse-string)]
+                        (parse-fn content true))
+                      (catch Exception _ {}))
+                    content)
+        steps     (or (:steps preview) (:Steps preview) [])
+        node-pools (->> steps
+                        (filter #(str/includes? (str (or (:type %) ""))
+                                               "NodePool"))
+                        (filter #(= "create" (or (:op %) (:Op %)))))]
+    ;; Check each node pool's node count configuration
+    ;; (This is a simplified check — real implementation would parse the
+    ;;  resource inputs for initialNodeCount or autoscaling maxNodeCount)
+    (when (and (seq node-pools) (> (count node-pools) max-nodes))
+      {:violation/rule-id   :deploy/gke-node-limit
+       :violation/severity  :medium
+       :violation/message   (str "Creating " (count node-pools) " node pools (limit: " max-nodes ")")
+       :violation/data      {:node-pools (count node-pools) :limit max-nodes}})))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (check-resource-count {:steps (repeat 25 {:op "create" :type "gcp:compute:Instance"})} {})
+  ;; => {:violation/rule-id :deploy/resource-count-limit ...}
+
+  (check-resource-count {:steps (repeat 5 {:op "create"})} {})
+  ;; => nil
+
+  :leave-this-here)

--- a/components/phase-deployment/test/ai/miniforge/phase/deploy/gates_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase/deploy/gates_test.clj
@@ -1,0 +1,48 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.gates-test
+  (:require [ai.miniforge.gate.registry :as registry]
+            [ai.miniforge.phase.deploy.gates :as sut]
+            [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Deployment gate tests
+
+(deftest check-provision-validated-test
+  (testing "returns a failed gate result when outputs are missing"
+    (let [result (sut/check-provision-validated {} {})]
+      (is (false? (:passed? result)))
+      (is (= :no-outputs (get-in result [:errors 0 :type])))))
+
+  (testing "returns a failed gate result when expected outputs are missing"
+    (let [result (sut/check-provision-validated {:outputs {:db-host "10.0.0.1"}}
+                                                {:expected-outputs #{:db-host :db-port}})]
+      (is (false? (:passed? result)))
+      (is (= :missing-outputs (get-in result [:errors 0 :type]))))))
+
+(deftest check-health-endpoint-test
+  (testing "falls back to the localized default message for failed smoke tests"
+    (let [result (sut/check-health-endpoint {:smoke-results [{:passed? false :command "curl"}]} {})]
+      (is (false? (:passed? result)))
+      (is (= "Command failed" (get-in result [:errors 0 :message]))))))
+
+(deftest gate-registration-test
+  (testing "gate descriptions are loaded from EDN-backed configuration"
+    (is (= "Validates health endpoints return HTTP 2xx"
+           (:description (registry/get-gate :health-check))))))

--- a/components/phase-deployment/test/ai/miniforge/phase/deploy/policy_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase/deploy/policy_test.clj
@@ -1,0 +1,51 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.policy-test
+  (:require
+   [ai.miniforge.phase.deploy.policy :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Deployment policy tests
+
+(deftest check-resource-count-test
+  (testing "returns a violation when create count exceeds the configured limit"
+    (let [result (sut/check-resource-count {:steps (repeat 3 {:op "create"})}
+                                           {:max-resources 2})]
+      (is (= :deploy/resource-count-limit (:violation/rule-id result)))
+      (is (= 3 (get-in result [:violation/data :creates])))))
+
+  (testing "returns nil when create count stays within the limit"
+    (is (nil? (sut/check-resource-count {:steps (repeat 2 {:op "create"})}
+                                        {:max-resources 2})))))
+
+(deftest check-gke-node-limit-test
+  (testing "counts node pools in Pulumi preview data"
+    (let [result (sut/check-gke-node-limit
+                  {:steps [{:op "create" :type "gcp:container/nodePool:NodePool"}
+                           {:op "create" :type "gcp:container/nodePool:NodePool"}]}
+                  {:max-nodes 1})]
+      (is (= :deploy/gke-node-limit (:violation/rule-id result)))
+      (is (= 2 (get-in result [:violation/data :node-pools])))))
+
+  (testing "accepts preview JSON using capitalized Pulumi keys"
+    (let [result (sut/check-gke-node-limit
+                  {:Steps [{:Op "create" :type "gcp:container/nodePool:NodePool"}]}
+                  {:max-nodes 2})]
+      (is (nil? result)))))

--- a/docs/pull-requests/2026-04-01-feat-deployment-pack-safety-gates.md
+++ b/docs/pull-requests/2026-04-01-feat-deployment-pack-safety-gates.md
@@ -1,0 +1,43 @@
+# feat: deployment pack safety gates
+
+## Layer
+
+Domain
+
+## Depends on
+
+- `feat/deployment-pack-config`
+
+## Overview
+
+Adds the deployment safety pack, custom policy checks, and deployment gate registrations.
+
+## Motivation
+
+Provision and validation phases need explicit policy and gate logic before they can safely operate against
+infrastructure and clusters.
+
+## Changes in Detail
+
+- Add the `deployment-safety` pack resource.
+- Add policy helper functions for Pulumi preview analysis.
+- Add deployment gate registrations and focused policy tests.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge after config foundations and before phase interceptors.
+
+## Related Issues/PRs
+
+- Parent feature: deployment pack
+- Follow-up stack branches: `feat/deployment-pack-provision`, `feat/deployment-pack-validate`
+
+## Checklist
+
+- [x] Scope limited to safety policy and gate rules
+- [x] Tests added for policy helpers
+- [ ] `bb pre-commit` recorded


### PR DESCRIPTION
# feat: deployment pack safety gates

## Layer

Domain

## Depends on

- `feat/deployment-pack-config`

## Overview

Adds the deployment safety pack, custom policy checks, and deployment gate registrations.

## Motivation

Provision and validation phases need explicit policy and gate logic before they can safely operate against
infrastructure and clusters.

## Changes in Detail

- Add the `deployment-safety` pack resource.
- Add policy helper functions for Pulumi preview analysis.
- Add deployment gate registrations and focused policy tests.

## Testing Plan

- Run `bb pre-commit`

## Deployment Plan

- Merge after config foundations and before phase interceptors.

## Related Issues/PRs

- Parent feature: deployment pack
- Follow-up stack branches: `feat/deployment-pack-provision`, `feat/deployment-pack-validate`

## Checklist

- [x] Scope limited to safety policy and gate rules
- [x] Tests added for policy helpers
- [ ] `bb pre-commit` recorded
