### PR TITLE
feat: deployment pack deploy

### DIFF
--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -9,6 +9,7 @@
   :provision/error               "Provision phase error"
 
   :deploy/starting               "Starting application deployment"
+  :deploy/invalid-config         "Deploy configuration invalid: {error}"
   :deploy/applied                "Manifests applied to cluster"
   :deploy/rollout-failed         "Deployment rollout failed"
   :deploy/complete               "Application deployment complete"

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/deploy.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/deploy.clj
@@ -119,12 +119,19 @@
         input       (get-in ctx [:execution/input])
         ;; Merge provision outputs (from previous phase) into deploy config
         prev-outputs (get-in ctx [:execution/phase-results :provision :result :outputs] {})
-        kustomize-dir   (or (:kustomize-dir input) (:kustomize-dir config))
-        namespace       (or (:namespace input) (:namespace config) "default")
-        context         (or (:context input) (:context config)
+        kustomize-dir   (or (get input :kustomize-dir) (get config :kustomize-dir))
+        namespace       (if-some [value (or (get input :namespace) (get config :namespace))]
+                            value
+                            "default")
+        context         (or (get input :context) (get config :context)
                             (:gke_context prev-outputs))
-        app-label       (or (:app-label input) (:app-label config) "ixi")
-        deployment-name (or (:deployment-name input) (:deployment-name config) app-label)]
+        app-label       (if-some [value (or (get input :app-label) (get config :app-label))]
+                            value
+                            "ixi")
+        deployment-name (if-some [value (or (get input :deployment-name)
+                                            (get config :deployment-name))]
+                            value
+                            app-label)]
 
     (log/info logger :deploy :deploy/starting
               {:data {:kustomize-dir kustomize-dir
@@ -150,7 +157,7 @@
                                :apply-stderr (get-in result [:apply-result :stderr])}})
             (failed-enter ctx start-time
                           {:status :error
-                           :error  (or (:error result)
+                           :error  (or (get result :error)
                                        (get-in result [:apply-result :stderr]))
                            :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}}))
 

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/deploy.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/deploy.clj
@@ -17,32 +17,53 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.phase.deploy.deploy
-  "Deploy phase interceptor.
-
-   Deploys application to Kubernetes via Kustomize:
-   1. kustomize build → captures rendered manifests
-   2. kubectl apply → applies manifests
-   3. kubectl rollout status → waits for rollout completion
-   4. Captures pod/service state as evidence
-
-   Agent: none (CLI tool execution, no LLM)
-   Default gates: [:deploy-healthy]"
+  "Deploy phase interceptor."
   (:require [ai.miniforge.logging.interface :as log]
+            [ai.miniforge.phase.deploy.defaults :as defaults]
             [ai.miniforge.phase.deploy.evidence :as evidence]
+            [ai.miniforge.phase.deploy.messages :as msg]
             [ai.miniforge.phase.deploy.shell :as shell]
             [ai.miniforge.phase.registry :as registry]
             [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Defaults
+;; Defaults + schemas
 
 (def default-config
-  "Phase defaults — overridable via workflow EDN."
-  {:gates  [:deploy-healthy]
-   :budget {:tokens 0 :iterations 3 :time-seconds 300}
-   :agent  nil})
+  "Deploy phase defaults loaded from EDN."
+  (defaults/phase-defaults :deploy))
 
-(registry/register-phase-defaults! :deploy default-config)
+(def DeployRunConfig
+  [:map
+   [:phase-config map?]
+   [:kustomize-dir :string]
+   [:namespace :string]
+   [:app-label :string]
+   [:deployment-name :string]
+   [:context {:optional true} [:maybe :string]]])
+
+(def RollbackInfo
+  [:map
+   [:revision {:optional true} [:maybe :string]]
+   [:image {:optional true} [:maybe :string]]
+   [:replicas {:optional true} [:maybe int?]]])
+
+(def PodSummary
+  [:map
+   [:name {:optional true} [:maybe :string]]
+   [:phase {:optional true} [:maybe :string]]
+   [:ready? :boolean]
+   [:images [:vector :string]]])
+
+(def PodState
+  [:map
+   [:pod-count nat-int?]
+   [:ready-count nat-int?]
+   [:pods [:vector PodSummary]]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Shared helpers
@@ -62,21 +83,65 @@
       (assoc-in [:phase :started-at] start-time)
       (assoc-in [:phase :result] result-map)))
 
-;; State capture helpers
+(defn- merged-phase-config
+  [ctx phase-kw]
+  (registry/merge-with-defaults
+   (assoc (or (get-in ctx [:phase-config]) {}) :phase phase-kw)))
+
+(defn- resolve-deploy-config
+  [ctx]
+  (let [phase-config  (merged-phase-config ctx :deploy)
+        input         (or (get-in ctx [:execution/input]) {})
+        prev-outputs  (or (get-in ctx [:execution/phase-results :provision :result :outputs]) {})
+        app-label     (get input :app-label
+                           (get phase-config :app-label "ixi"))
+        deploy-config {:phase-config    phase-config
+                       :kustomize-dir   (or (get input :kustomize-dir)
+                                            (get phase-config :kustomize-dir))
+                       :namespace       (get input :namespace
+                                             (get phase-config :namespace "default"))
+                       :context         (or (get input :context)
+                                            (get phase-config :context)
+                                            (get prev-outputs :gke_context))
+                       :app-label       app-label
+                       :deployment-name (get input :deployment-name
+                                             (get phase-config :deployment-name app-label))}]
+    (validate! DeployRunConfig deploy-config)))
+
+(defn- pod-ready?
+  [pod]
+  (every? :ready (get-in pod [:status :containerStatuses] [])))
+
+(defn- pod-summary
+  [pod]
+  {:name   (get-in pod [:metadata :name])
+   :phase  (get-in pod [:status :phase])
+   :ready? (pod-ready? pod)
+   :images (into [] (map :image) (get-in pod [:spec :containers] []))})
+
+(defn- build-pod-state
+  [pods]
+  (let [summaries (into [] (map pod-summary) pods)]
+    (validate!
+     PodState
+     {:pod-count   (count summaries)
+      :ready-count (count (filter :ready? summaries))
+      :pods        summaries})))
 
 (defn- capture-current-state
   "Capture current deployment state for rollback evidence."
-  [deployment-name namespace context _logger]
+  [deployment-name namespace context]
   (let [result (shell/kubectl! "get"
                                :namespace namespace
                                :context context
                                :output "json"
                                :extra-args ["deployment" deployment-name])]
     (when (schema/succeeded? result)
-      (let [parsed (:parsed result)]
-        {:revision  (get-in parsed [:metadata :annotations "deployment.kubernetes.io/revision"])
-         :image     (get-in parsed [:spec :template :spec :containers 0 :image])
-         :replicas  (get-in parsed [:status :readyReplicas])}))))
+      (validate!
+       RollbackInfo
+       {:revision (get-in result [:parsed :metadata :annotations "deployment.kubernetes.io/revision"])
+        :image    (get-in result [:parsed :spec :template :spec :containers 0 :image])
+        :replicas (get-in result [:parsed :status :readyReplicas])}))))
 
 (defn- capture-pod-state
   "Capture post-deploy pod state for evidence and gate checking."
@@ -85,150 +150,142 @@
                                         :namespace namespace
                                         :context context)]
     (when (schema/succeeded? result)
-      (let [pods (get-in result [:parsed :items] [])]
-        {:pod-count    (count pods)
-         :ready-count  (count (filter (fn [pod]
-                                        (every? :ready
-                                                (get-in pod [:status :containerStatuses] [])))
-                                      pods))
-         :pods         (mapv (fn [pod]
-                               {:name   (get-in pod [:metadata :name])
-                                :phase  (get-in pod [:status :phase])
-                                :ready? (every? :ready
-                                                (get-in pod [:status :containerStatuses] []))
-                                :images (mapv :image
-                                              (get-in pod [:spec :containers] []))})
-                             pods)}))))
+      (build-pod-state (get-in result [:parsed :items] [])))))
+
+(defn- rollout-metrics
+  [start-time pod-state]
+  {:duration-ms (- (System/currentTimeMillis) start-time)
+   :pod-count   (:pod-count pod-state)
+   :ready-count (:ready-count pod-state)})
+
+(defn- add-deploy-evidence
+  [ctx rollback-evidence manifest-evidence image-evidence]
+  (cond-> ctx
+    rollback-evidence (evidence/add-evidence-to-ctx rollback-evidence)
+    true (evidence/add-evidence-to-ctx manifest-evidence)
+    true (evidence/add-evidence-to-ctx image-evidence)))
+
+(defn- store-apply-failure
+  [ctx start-time logger result]
+  (log/error logger :deploy :deploy/apply-failed
+             {:data {:error (:error result)
+                     :build-stderr (get-in result [:build-result :stderr])
+                     :apply-stderr (get-in result [:apply-result :stderr])}})
+  (failed-enter ctx start-time
+                {:status  :error
+                 :error   (or (get result :error)
+                              (get-in result [:apply-result :stderr]))
+                 :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}}))
+
+(defn- store-rollout-failure
+  [ctx start-time logger rollout-result manifest-evidence image-evidence]
+  (log/error logger :deploy :deploy/rollout-failed
+             {:data {:stderr (:stderr rollout-result)}})
+  (-> (failed-enter ctx start-time
+                    {:status  :rollout-failed
+                     :error   (:stderr rollout-result)
+                     :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}})
+      (evidence/add-evidence-to-ctx manifest-evidence)
+      (evidence/add-evidence-to-ctx image-evidence)))
+
+(defn- store-successful-deploy
+  [ctx start-time config rollback-evidence manifest-evidence image-evidence image-digests pod-state logger]
+  (let [metrics (rollout-metrics start-time pod-state)]
+    (log/info logger :deploy :deploy/complete
+              {:data metrics})
+    (-> ctx
+        (assoc-in [:phase :name] :deploy)
+        (assoc-in [:phase :gates] (get-in config [:phase-config :gates]))
+        (assoc-in [:phase :budget] (get-in config [:phase-config :budget]))
+        (assoc-in [:phase :started-at] start-time)
+        (assoc-in [:phase :status] :completed)
+        (assoc-in [:phase :result]
+                  {:status   :success
+                   :output   {:pod-state pod-state
+                              :images    image-digests}
+                   :artifact {:content   pod-state
+                              :type      :deployment-state
+                              :app-label (:app-label config)
+                              :namespace (:namespace config)}
+                   :metrics  metrics})
+        (add-deploy-evidence rollback-evidence manifest-evidence image-evidence))))
+
+(defn- invalid-config-result
+  [ctx start-time ex]
+  (failed-enter ctx start-time
+                {:status :error
+                 :error  (msg/t :deploy/invalid-config
+                                {:error (ex-message ex)})}))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Phase interceptors + registration
 
 (defn enter-deploy
-  "Execute deployment: build manifests → apply → wait for rollout.
-
-   Reads deployment config from execution input:
-     :kustomize-dir  - Directory containing kustomization.yaml
-     :namespace      - Target K8s namespace
-     :context        - K8s context name (for multi-cluster)
-     :app-label      - App label for pod selection
-     :deployment-name - Deployment name for rollout status"
+  "Execute deployment: build manifests, apply them, and wait for rollout."
   [ctx]
-  (let [config      (registry/merge-with-defaults (get-in ctx [:phase-config]) :deploy)
-        start-time  (System/currentTimeMillis)
-        logger      (get-logger ctx)
-        input       (get-in ctx [:execution/input])
-        ;; Merge provision outputs (from previous phase) into deploy config
-        prev-outputs (get-in ctx [:execution/phase-results :provision :result :outputs] {})
-        kustomize-dir   (or (get input :kustomize-dir) (get config :kustomize-dir))
-        namespace       (if-some [value (or (get input :namespace) (get config :namespace))]
-                            value
-                            "default")
-        context         (or (get input :context) (get config :context)
-                            (:gke_context prev-outputs))
-        app-label       (if-some [value (or (get input :app-label) (get config :app-label))]
-                            value
-                            "ixi")
-        deployment-name (if-some [value (or (get input :deployment-name)
-                                            (get config :deployment-name))]
-                            value
-                            app-label)]
-
-    (log/info logger :deploy :deploy/starting
-              {:data {:kustomize-dir kustomize-dir
-                      :namespace namespace
-                      :deployment deployment-name}})
-
-    ;; Step 0: Capture current state for rollback evidence
-    (let [rollback-info     (capture-current-state deployment-name namespace context logger)
-          rollback-evidence (when rollback-info
-                              (evidence/create-evidence
-                               :evidence/rollback-info rollback-info
-                               {:deployment deployment-name :namespace namespace}))
-          ;; Step 1: Kustomize build + apply
-          result            (shell/kustomize-apply! kustomize-dir
-                                                   :namespace namespace
-                                                   :context context)]
-      (if (schema/failed? result)
-          ;; Build or apply failed
-          (do
-            (log/error logger :deploy :deploy/apply-failed
-                       {:data {:error (:error result)
-                               :build-stderr (get-in result [:build-result :stderr])
-                               :apply-stderr (get-in result [:apply-result :stderr])}})
-            (failed-enter ctx start-time
-                          {:status :error
-                           :error  (or (get result :error)
-                                       (get-in result [:apply-result :stderr]))
-                           :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}}))
-
-          ;; Step 2: Capture rendered manifests as evidence
-          (let [rendered-yaml (:rendered-yaml result)
+  (let [start-time (System/currentTimeMillis)
+        logger     (get-logger ctx)]
+    (try
+      (let [config            (resolve-deploy-config ctx)
+            rollback-info     (capture-current-state (:deployment-name config)
+                                                    (:namespace config)
+                                                    (:context config))
+            rollback-evidence (when rollback-info
+                                (evidence/create-evidence
+                                 :evidence/rollback-info
+                                 rollback-info
+                                 {:deployment (:deployment-name config)
+                                  :namespace (:namespace config)}))
+            result            (shell/kustomize-apply! (:kustomize-dir config)
+                                                      :namespace (:namespace config)
+                                                      :context (:context config))]
+        (if (schema/failed? result)
+          (store-apply-failure ctx start-time logger result)
+          (let [rendered-yaml     (:rendered-yaml result)
                 manifest-evidence (evidence/create-evidence
                                    :evidence/rendered-manifests
                                    rendered-yaml
-                                   {:kustomize-dir kustomize-dir})
-                image-digests (evidence/extract-image-digests rendered-yaml)
-                image-evidence (evidence/create-evidence
-                                :evidence/image-digests
-                                image-digests)]
-
+                                   {:kustomize-dir (:kustomize-dir config)})
+                image-digests     (evidence/extract-image-digests rendered-yaml)
+                image-evidence    (evidence/create-evidence
+                                   :evidence/image-digests
+                                   image-digests)]
             (log/info logger :deploy :deploy/applied
                       {:data {:image-count (count image-digests)}})
-
-            ;; Step 3: Wait for rollout completion
             (let [rollout-result (shell/kubectl-rollout-status!
-                                  (str "deployment/" deployment-name)
-                                  :namespace namespace
-                                  :context context
-                                  :timeout-s 300)]
+                                  (str "deployment/" (:deployment-name config))
+                                  :namespace (:namespace config)
+                                  :context (:context config)
+                                  :timeout-s 300)
+                  pod-state      (or (capture-pod-state (:app-label config)
+                                                        (:namespace config)
+                                                        (:context config))
+                                     (build-pod-state []))]
               (if (schema/failed? rollout-result)
-                ;; Rollout failed/timed out
-                (do
-                  (log/error logger :deploy :deploy/rollout-failed
-                             {:data {:stderr (:stderr rollout-result)}})
-                  (-> (failed-enter ctx start-time
-                                    {:status :rollout-failed
-                                     :error  (:stderr rollout-result)
-                                     :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}})
-                      (evidence/add-evidence-to-ctx manifest-evidence)
-                      (evidence/add-evidence-to-ctx image-evidence)))
-
-                ;; Step 4: Capture post-deploy pod state
-                (let [pod-state (capture-pod-state app-label namespace context)
-                      duration  (- (System/currentTimeMillis) start-time)]
-                  (log/info logger :deploy :deploy/complete
-                            {:data {:pod-count (:pod-count pod-state)
-                                    :ready-count (:ready-count pod-state)
-                                    :duration-ms duration}})
-                  (-> ctx
-                      (assoc-in [:phase :name] :deploy)
-                      (assoc-in [:phase :gates] (:gates config))
-                      (assoc-in [:phase :budget] (:budget config))
-                      (assoc-in [:phase :started-at] start-time)
-                      (assoc-in [:phase :status] :completed)
-                      (assoc-in [:phase :result]
-                                {:status    :success
-                                 :output    {:pod-state pod-state
-                                             :images    image-digests}
-                                 :artifact  {:content   pod-state
-                                             :type      :deployment-state
-                                             :app-label app-label
-                                             :namespace namespace}
-                                 :metrics   {:duration-ms duration
-                                             :pod-count   (:pod-count pod-state)
-                                             :ready-count (:ready-count pod-state)}})
-                      (cond-> rollback-evidence (evidence/add-evidence-to-ctx rollback-evidence))
-                      (evidence/add-evidence-to-ctx manifest-evidence)
-                      (evidence/add-evidence-to-ctx image-evidence))))))))))
+                (store-rollout-failure ctx
+                                       start-time
+                                       logger
+                                       rollout-result
+                                       manifest-evidence
+                                       image-evidence)
+                (store-successful-deploy ctx
+                                         start-time
+                                         config
+                                         rollback-evidence
+                                         manifest-evidence
+                                         image-evidence
+                                         image-digests
+                                         pod-state
+                                         logger))))))
+      (catch clojure.lang.ExceptionInfo ex
+        (invalid-config-result ctx start-time ex)))))
 
 (defn leave-deploy
   "Post-deploy: record final metrics."
   [ctx]
-  (let [status (get-in ctx [:phase :status])]
-    (if (= :completed status)
-      ctx
-      ;; If failed, ensure status is propagated
-      (assoc-in ctx [:phase :status] :failed))))
+  (if (= :completed (get-in ctx [:phase :status]))
+    ctx
+    (assoc-in ctx [:phase :status] :failed)))
 
 (defn error-deploy
   "Handle deploy phase errors."
@@ -257,9 +314,7 @@
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
-  ;; Test deploy phase (requires K8s cluster access)
-  ;; (enter-deploy {:execution/input {:kustomize-dir "/path/to/overlay"
-  ;;                                  :namespace "ixi"
-  ;;                                  :app-label "ixi"}})
-
+  (enter-deploy {:execution/input {:kustomize-dir "/path/to/overlay"
+                                   :namespace "ixi"
+                                   :app-label "ixi"}})
   :leave-this-here)

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/deploy.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/deploy.clj
@@ -1,0 +1,258 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.deploy
+  "Deploy phase interceptor.
+
+   Deploys application to Kubernetes via Kustomize:
+   1. kustomize build → captures rendered manifests
+   2. kubectl apply → applies manifests
+   3. kubectl rollout status → waits for rollout completion
+   4. Captures pod/service state as evidence
+
+   Agent: none (CLI tool execution, no LLM)
+   Default gates: [:deploy-healthy]"
+  (:require [ai.miniforge.logging.interface :as log]
+            [ai.miniforge.phase.deploy.evidence :as evidence]
+            [ai.miniforge.phase.deploy.shell :as shell]
+            [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.schema.interface :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+
+(def default-config
+  "Phase defaults — overridable via workflow EDN."
+  {:gates  [:deploy-healthy]
+   :budget {:tokens 0 :iterations 3 :time-seconds 300}
+   :agent  nil})
+
+(registry/register-phase-defaults! :deploy default-config)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Shared helpers
+
+(defn- get-logger
+  "Resolve logger from ctx, creating a default if absent."
+  [ctx]
+  (or (get-in ctx [:execution/logger])
+      (log/create-logger {:min-level :info :output :human})))
+
+(defn- failed-enter
+  "Build a :failed phase context for enter-time failures."
+  [ctx start-time result-map]
+  (-> ctx
+      (assoc-in [:phase :name] :deploy)
+      (assoc-in [:phase :status] :failed)
+      (assoc-in [:phase :started-at] start-time)
+      (assoc-in [:phase :result] result-map)))
+
+;; State capture helpers
+
+(defn- capture-current-state
+  "Capture current deployment state for rollback evidence."
+  [deployment-name namespace context _logger]
+  (let [result (shell/kubectl! "get"
+                               :namespace namespace
+                               :context context
+                               :output "json"
+                               :extra-args ["deployment" deployment-name])]
+    (when (schema/succeeded? result)
+      (let [parsed (:parsed result)]
+        {:revision  (get-in parsed [:metadata :annotations "deployment.kubernetes.io/revision"])
+         :image     (get-in parsed [:spec :template :spec :containers 0 :image])
+         :replicas  (get-in parsed [:status :readyReplicas])}))))
+
+(defn- capture-pod-state
+  "Capture post-deploy pod state for evidence and gate checking."
+  [app-label namespace context]
+  (let [result (shell/kubectl-get-pods! (str "app=" app-label)
+                                        :namespace namespace
+                                        :context context)]
+    (when (schema/succeeded? result)
+      (let [pods (get-in result [:parsed :items] [])]
+        {:pod-count    (count pods)
+         :ready-count  (count (filter (fn [pod]
+                                        (every? :ready
+                                                (get-in pod [:status :containerStatuses] [])))
+                                      pods))
+         :pods         (mapv (fn [pod]
+                               {:name   (get-in pod [:metadata :name])
+                                :phase  (get-in pod [:status :phase])
+                                :ready? (every? :ready
+                                                (get-in pod [:status :containerStatuses] []))
+                                :images (mapv :image
+                                              (get-in pod [:spec :containers] []))})
+                             pods)}))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Phase interceptors + registration
+
+(defn enter-deploy
+  "Execute deployment: build manifests → apply → wait for rollout.
+
+   Reads deployment config from execution input:
+     :kustomize-dir  - Directory containing kustomization.yaml
+     :namespace      - Target K8s namespace
+     :context        - K8s context name (for multi-cluster)
+     :app-label      - App label for pod selection
+     :deployment-name - Deployment name for rollout status"
+  [ctx]
+  (let [config      (registry/merge-with-defaults (get-in ctx [:phase-config]) :deploy)
+        start-time  (System/currentTimeMillis)
+        logger      (get-logger ctx)
+        input       (get-in ctx [:execution/input])
+        ;; Merge provision outputs (from previous phase) into deploy config
+        prev-outputs (get-in ctx [:execution/phase-results :provision :result :outputs] {})
+        kustomize-dir   (or (:kustomize-dir input) (:kustomize-dir config))
+        namespace       (or (:namespace input) (:namespace config) "default")
+        context         (or (:context input) (:context config)
+                            (:gke_context prev-outputs))
+        app-label       (or (:app-label input) (:app-label config) "ixi")
+        deployment-name (or (:deployment-name input) (:deployment-name config) app-label)]
+
+    (log/info logger :deploy :deploy/starting
+              {:data {:kustomize-dir kustomize-dir
+                      :namespace namespace
+                      :deployment deployment-name}})
+
+    ;; Step 0: Capture current state for rollback evidence
+    (let [rollback-info     (capture-current-state deployment-name namespace context logger)
+          rollback-evidence (when rollback-info
+                              (evidence/create-evidence
+                               :evidence/rollback-info rollback-info
+                               {:deployment deployment-name :namespace namespace}))
+          ;; Step 1: Kustomize build + apply
+          result            (shell/kustomize-apply! kustomize-dir
+                                                   :namespace namespace
+                                                   :context context)]
+      (if (schema/failed? result)
+          ;; Build or apply failed
+          (do
+            (log/error logger :deploy :deploy/apply-failed
+                       {:data {:error (:error result)
+                               :build-stderr (get-in result [:build-result :stderr])
+                               :apply-stderr (get-in result [:apply-result :stderr])}})
+            (failed-enter ctx start-time
+                          {:status :error
+                           :error  (or (:error result)
+                                       (get-in result [:apply-result :stderr]))
+                           :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}}))
+
+          ;; Step 2: Capture rendered manifests as evidence
+          (let [rendered-yaml (:rendered-yaml result)
+                manifest-evidence (evidence/create-evidence
+                                   :evidence/rendered-manifests
+                                   rendered-yaml
+                                   {:kustomize-dir kustomize-dir})
+                image-digests (evidence/extract-image-digests rendered-yaml)
+                image-evidence (evidence/create-evidence
+                                :evidence/image-digests
+                                image-digests)]
+
+            (log/info logger :deploy :deploy/applied
+                      {:data {:image-count (count image-digests)}})
+
+            ;; Step 3: Wait for rollout completion
+            (let [rollout-result (shell/kubectl-rollout-status!
+                                  (str "deployment/" deployment-name)
+                                  :namespace namespace
+                                  :context context
+                                  :timeout-s 300)]
+              (if (schema/failed? rollout-result)
+                ;; Rollout failed/timed out
+                (do
+                  (log/error logger :deploy :deploy/rollout-failed
+                             {:data {:stderr (:stderr rollout-result)}})
+                  (-> (failed-enter ctx start-time
+                                    {:status :rollout-failed
+                                     :error  (:stderr rollout-result)
+                                     :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}})
+                      (evidence/add-evidence-to-ctx manifest-evidence)
+                      (evidence/add-evidence-to-ctx image-evidence)))
+
+                ;; Step 4: Capture post-deploy pod state
+                (let [pod-state (capture-pod-state app-label namespace context)
+                      duration  (- (System/currentTimeMillis) start-time)]
+                  (log/info logger :deploy :deploy/complete
+                            {:data {:pod-count (:pod-count pod-state)
+                                    :ready-count (:ready-count pod-state)
+                                    :duration-ms duration}})
+                  (-> ctx
+                      (assoc-in [:phase :name] :deploy)
+                      (assoc-in [:phase :gates] (:gates config))
+                      (assoc-in [:phase :budget] (:budget config))
+                      (assoc-in [:phase :started-at] start-time)
+                      (assoc-in [:phase :status] :completed)
+                      (assoc-in [:phase :result]
+                                {:status    :success
+                                 :output    {:pod-state pod-state
+                                             :images    image-digests}
+                                 :artifact  {:content   pod-state
+                                             :type      :deployment-state
+                                             :app-label app-label
+                                             :namespace namespace}
+                                 :metrics   {:duration-ms duration
+                                             :pod-count   (:pod-count pod-state)
+                                             :ready-count (:ready-count pod-state)}})
+                      (cond-> rollback-evidence (evidence/add-evidence-to-ctx rollback-evidence))
+                      (evidence/add-evidence-to-ctx manifest-evidence)
+                      (evidence/add-evidence-to-ctx image-evidence))))))))))
+
+(defn leave-deploy
+  "Post-deploy: record final metrics."
+  [ctx]
+  (let [status (get-in ctx [:phase :status])]
+    (if (= :completed status)
+      ctx
+      ;; If failed, ensure status is propagated
+      (assoc-in ctx [:phase :status] :failed))))
+
+(defn error-deploy
+  "Handle deploy phase errors."
+  [ctx ex]
+  (let [logger (get-logger ctx)]
+    (log/error logger :deploy :deploy/error
+               {:data {:message (ex-message ex)
+                       :data    (ex-data ex)}})
+    (-> ctx
+        (assoc-in [:phase :status] :failed)
+        (update :execution/errors (fnil conj [])
+                {:type    :deploy-error
+                 :phase   :deploy
+                 :message (ex-message ex)
+                 :data    (ex-data ex)}))))
+
+;; Registration
+
+(defmethod registry/get-phase-interceptor :deploy
+  [_]
+  {:name   :deploy
+   :enter  enter-deploy
+   :leave  leave-deploy
+   :error  error-deploy
+   :config default-config})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Test deploy phase (requires K8s cluster access)
+  ;; (enter-deploy {:execution/input {:kustomize-dir "/path/to/overlay"
+  ;;                                  :namespace "ixi"
+  ;;                                  :app-label "ixi"}})
+
+  :leave-this-here)

--- a/components/phase-deployment/test/ai/miniforge/phase/deploy/deploy_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase/deploy/deploy_test.clj
@@ -1,0 +1,51 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.deploy-test
+  (:require [ai.miniforge.phase.deploy.deploy :as sut]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest resolve-deploy-config-test
+  (testing "deploy config normalizes workflow inputs and provision outputs once"
+    (let [resolved (#'sut/resolve-deploy-config
+                    {:phase-config {:kustomize-dir "/cfg"
+                                    :namespace "cfg-ns"
+                                    :app-label "cfg-app"}
+                     :execution/input {:namespace "prod"}
+                     :execution/phase-results {:provision {:result {:outputs {:gke_context "ctx-1"}}}}})]
+      (is (= "/cfg" (:kustomize-dir resolved)))
+      (is (= "prod" (:namespace resolved)))
+      (is (= "ctx-1" (:context resolved)))
+      (is (= "cfg-app" (:deployment-name resolved))))))
+
+(deftest build-pod-state-test
+  (testing "pod state summaries preserve readiness and image details"
+    (let [pod-state (#'sut/build-pod-state
+                     [{:metadata {:name "api-1"}
+                       :status {:phase "Running"
+                                :containerStatuses [{:ready true} {:ready true}]}
+                       :spec {:containers [{:image "svc:v1"} {:image "sidecar:v1"}]}}
+                      {:metadata {:name "api-2"}
+                       :status {:phase "Pending"
+                                :containerStatuses [{:ready false}]}
+                       :spec {:containers [{:image "svc:v2"}]}}])]
+      (is (= 2 (:pod-count pod-state)))
+      (is (= 1 (:ready-count pod-state)))
+      (is (= ["svc:v1" "sidecar:v1"]
+             (get-in pod-state [:pods 0 :images])))
+      (is (false? (get-in pod-state [:pods 1 :ready?]))))))

--- a/docs/pull-requests/2026-04-01-feat-deployment-pack-deploy.md
+++ b/docs/pull-requests/2026-04-01-feat-deployment-pack-deploy.md
@@ -1,0 +1,40 @@
+# feat: deployment pack deploy
+
+## Layer
+
+Application
+
+## Depends on
+
+- `feat/deployment-pack-provision`
+
+## Overview
+
+Adds the deploy phase interceptor for rendering, applying, and observing Kubernetes deployment state.
+
+## Motivation
+
+The application deployment step should be reviewed independently from provisioning and validation logic.
+
+## Changes in Detail
+
+- Add `deploy.clj` with rollback snapshotting, kustomize render/apply, rollout wait, and pod-state capture.
+- Register `:deploy` phase defaults.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge after provision and before validate.
+
+## Related Issues/PRs
+
+- Parent feature: deployment pack
+- Follow-up stack branch: `feat/deployment-pack-validate`
+
+## Checklist
+
+- [x] Scope limited to the deploy phase interceptor
+- [ ] `bb pre-commit` recorded


### PR DESCRIPTION
# feat: deployment pack deploy

## Layer

Application

## Depends on

- `feat/deployment-pack-provision`

## Overview

Adds the deploy phase interceptor for rendering, applying, and observing Kubernetes deployment state.

## Motivation

The application deployment step should be reviewed independently from provisioning and validation logic.

## Changes in Detail

- Add `deploy.clj` with rollback snapshotting, kustomize render/apply, rollout wait, and pod-state capture.
- Register `:deploy` phase defaults.

## Testing Plan

- Run `bb pre-commit`

## Deployment Plan

- Merge after provision and before validate.

## Related Issues/PRs

- Parent feature: deployment pack
- Follow-up stack branch: `feat/deployment-pack-validate`

## Checklist

- [x] Scope limited to the deploy phase interceptor
- [ ] `bb pre-commit` recorded
