### PR TITLE
feat: deployment pack provision

### DIFF
--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -2,6 +2,7 @@
  {:provision/preview-starting    "Starting Pulumi preview"
   :provision/preview-complete    "Pulumi preview complete"
   :provision/preview-failed      "Pulumi preview failed"
+  :provision/invalid-config      "Provision configuration invalid: {error}"
   :provision/apply-starting      "Applying infrastructure changes"
   :provision/apply-complete      "Infrastructure provisioning complete"
   :provision/apply-failed        "Infrastructure apply failed"

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/defaults.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/defaults.clj
@@ -1,0 +1,84 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.defaults
+  "Load deployment phase defaults from EDN and register them with the phase registry."
+  (:require [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.schema.interface :as schema]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Config loading + validation
+
+(def ^:private config-path
+  "Classpath resource holding deployment phase defaults."
+  "config/phase/deploy-defaults.edn")
+
+(def DeployBudget
+  [:map
+   [:tokens {:optional true} nat-int?]
+   [:iterations {:optional true} pos-int?]
+   [:time-seconds {:optional true} pos-int?]])
+
+(def DeployPhaseDefaults
+  [:map
+   [:agent {:optional true} [:maybe keyword?]]
+   [:gates {:optional true} [:vector keyword?]]
+   [:budget {:optional true} DeployBudget]
+   [:stack-dir {:optional true} :string]
+   [:stack {:optional true} :string]
+   [:gcp-project {:optional true} :string]])
+
+(def DeployDefaultsConfig
+  [:map
+   [:provision {:optional true} DeployPhaseDefaults]
+   [:deploy {:optional true} DeployPhaseDefaults]
+   [:validate {:optional true} DeployPhaseDefaults]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
+
+(defn- load-defaults-config
+  []
+  (if-let [resource (io/resource config-path)]
+    (->> resource
+         slurp
+         edn/read-string
+         (validate! DeployDefaultsConfig))
+    {}))
+
+(def ^:private defaults-config
+  (delay (load-defaults-config)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Registry integration
+
+(defn register-defaults!
+  "Register all deployment phase defaults with the shared phase registry."
+  []
+  (doseq [[phase-kw defaults] @defaults-config]
+    (registry/register-phase-defaults! phase-kw defaults)))
+
+(defn phase-defaults
+  "Get the defaults for a deployment phase keyword."
+  [phase-kw]
+  (get @defaults-config phase-kw {}))
+
+(register-defaults!)

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/provision.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/provision.clj
@@ -120,9 +120,11 @@
         logger      (get-logger ctx)
         ;; Extract provision-specific config from workflow input
         input       (get-in ctx [:execution/input])
-        stack-dir   (or (:stack-dir input) (:stack-dir config))
-        stack       (or (:stack input) (:stack config) "dev")
-        gcp-project (or (:gcp-project input) (:gcp-project config))
+        stack-dir   (or (get input :stack-dir) (get config :stack-dir))
+        stack       (if-some [value (or (get input :stack) (get config :stack))]
+                      value
+                      "dev")
+        gcp-project (or (get input :gcp-project) (get config :gcp-project))
         env         (cond-> {}
                       gcp-project (assoc "GOOGLE_PROJECT" gcp-project))]
 

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/provision.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/provision.clj
@@ -1,0 +1,269 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.provision
+  "Provision phase interceptor.
+
+   Executes infrastructure provisioning via Pulumi:
+   1. pulumi preview --json → captures structured preview
+   2. Policy gate checks preview for destructive/unsafe operations
+   3. pulumi up --yes → applies approved changes
+   4. Captures stack outputs as phase result
+
+   Agent: none (CLI tool execution, no LLM)
+   Default gates: [:policy-pack :provision-validated]"
+  (:require [ai.miniforge.logging.interface :as log]
+            [ai.miniforge.phase.deploy.evidence :as evidence]
+            [ai.miniforge.phase.deploy.shell :as shell]
+            [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.schema.interface :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+
+(def default-config
+  "Phase defaults — overridable via workflow EDN."
+  {:gates  [:policy-pack :provision-validated]
+   :budget {:tokens 0 :iterations 3 :time-seconds 900}
+   :agent  nil})
+
+(registry/register-phase-defaults! :provision default-config)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Shared helpers
+
+(defn- get-logger
+  "Resolve logger from ctx, creating a default if absent."
+  [ctx]
+  (or (get-in ctx [:execution/logger])
+      (log/create-logger {:min-level :info :output :human})))
+
+(defn- failed-enter
+  "Build a :failed phase context for enter-time failures."
+  [ctx start-time result-map]
+  (-> ctx
+      (assoc-in [:phase :name] :provision)
+      (assoc-in [:phase :status] :failed)
+      (assoc-in [:phase :started-at] start-time)
+      (assoc-in [:phase :result] result-map)))
+
+;; Preview analysis
+
+(defn- analyze-preview
+  "Extract summary metrics from Pulumi preview JSON output.
+
+   Returns:
+     {:creates int :updates int :deletes int :sames int
+      :resources [{:type :name :action}...]}"
+  [preview-json]
+  (if-let [steps (or (:steps preview-json) (:Steps preview-json))]
+    (let [actions (map #(or (:op %) (:Op %)) steps)
+          counts  (frequencies actions)]
+      {:creates   (get counts "create" 0)
+       :updates   (get counts "update" 0)
+       :deletes   (get counts "delete" 0)
+       :sames     (get counts "same" 0)
+       :resources (mapv (fn [step]
+                          {:type   (or (:type step) (get-in step [:newState :type]))
+                           :name   (or (:urn step) (get-in step [:newState :urn]))
+                           :action (or (:op step) (:Op step))})
+                        steps)})
+    {:creates 0 :updates 0 :deletes 0 :sames 0 :resources []}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Phase interceptors + registration
+
+(defn enter-provision
+  "Execute provisioning: preview → (gate check) → apply → capture outputs.
+
+   The :enter function runs the preview and stores it as the phase artifact.
+   After :enter returns, execution.clj checks gates (including :policy-pack)
+   against the artifact. If gates pass, the leave function applies.
+
+   For provision, we split into two sub-operations:
+   - :enter does preview + stores artifact for gate checking
+   - If gates pass, we need to apply. Since gates run between enter and leave,
+     we store the 'needs apply' flag and do the apply in a post-gate callback.
+
+   Architecture note: The current phase model runs enter → gates → leave.
+   Apply must happen after gates pass but before leave. We handle this by
+   doing both preview AND apply in enter, with the policy-pack gate checking
+   the preview artifact mid-execution. The gate system checks after :enter
+   returns, but we need apply to happen only if gates pass.
+
+   Solution: enter does preview only. If gates pass, the workflow will proceed
+   to the next phase. We use a two-phase approach: provision-preview and
+   provision-apply as separate steps, OR we do the apply in enter after preview
+   and let the gate check happen on the preview artifact.
+
+   Chosen approach: Enter does preview. Stores preview as artifact for gate.
+   If gates pass, the 'leave' triggers apply. If gates fail, leave does NOT apply.
+   This aligns with the interceptor model: enter produces, gates validate, leave finalizes."
+  [ctx]
+  (let [config      (registry/merge-with-defaults (get-in ctx [:phase-config]) :provision)
+        start-time  (System/currentTimeMillis)
+        logger      (get-logger ctx)
+        ;; Extract provision-specific config from workflow input
+        input       (get-in ctx [:execution/input])
+        stack-dir   (or (:stack-dir input) (:stack-dir config))
+        stack       (or (:stack input) (:stack config) "dev")
+        gcp-project (or (:gcp-project input) (:gcp-project config))
+        env         (cond-> {}
+                      gcp-project (assoc "GOOGLE_PROJECT" gcp-project))]
+
+    (log/info logger :provision :provision/preview-starting
+              {:data {:stack-dir stack-dir :stack stack}})
+
+    ;; Step 1: Run Pulumi preview
+    (let [preview-result (shell/pulumi-preview! stack-dir :stack stack :env env)]
+      (if (schema/failed? preview-result)
+        ;; Preview failed — surface error
+        (let [error-type (shell/classify-error preview-result)]
+          (log/error logger :provision :provision/preview-failed
+                     {:data {:stderr (:stderr preview-result)
+                             :error-type error-type}})
+          (failed-enter ctx start-time
+                        {:status     :error
+                         :error      (:stderr preview-result)
+                         :error-type error-type
+                         :command    (:command preview-result)
+                         :metrics    {:duration-ms (:duration-ms preview-result)}}))
+
+        ;; Preview succeeded — analyze and store as artifact for gate checking
+        (let [preview-data    (get preview-result :parsed {})
+              analysis        (analyze-preview preview-data)
+              preview-evidence (evidence/create-evidence
+                                :evidence/pulumi-preview
+                                preview-data
+                                {:stack stack :stack-dir stack-dir
+                                 :analysis analysis})]
+          (log/info logger :provision :provision/preview-complete
+                    {:data {:creates (:creates analysis)
+                            :updates (:updates analysis)
+                            :deletes (:deletes analysis)}})
+
+          (-> ctx
+              (assoc-in [:phase :name] :provision)
+              (assoc-in [:phase :gates] (:gates config))
+              (assoc-in [:phase :budget] (:budget config))
+              (assoc-in [:phase :started-at] start-time)
+              (assoc-in [:phase :status] :pending-gates)
+              ;; Store the preview as the artifact that gates will check
+              (assoc-in [:phase :result]
+                        {:status   :preview-complete
+                         :output   preview-data
+                         :artifact {:content  preview-data
+                                    :type     :pulumi-preview
+                                    :analysis analysis}
+                         :metrics  {:duration-ms (:duration-ms preview-result)
+                                    :creates     (:creates analysis)
+                                    :updates     (:updates analysis)
+                                    :deletes     (:deletes analysis)}})
+              ;; Store evidence
+              (evidence/add-evidence-to-ctx preview-evidence)
+              ;; Store config for leave phase to use for apply
+              (assoc-in [:phase :provision-config]
+                        {:stack-dir stack-dir :stack stack :env env})))))))
+
+(defn leave-provision
+  "After gates pass: execute pulumi up and capture outputs.
+
+   Only applies if :enter succeeded and gates passed."
+  [ctx]
+  (let [phase-status (get-in ctx [:phase :status])
+        logger       (get-logger ctx)]
+
+    ;; Only apply if preview succeeded and gates passed
+    (if (or (= :failed phase-status) (= :error (get-in ctx [:phase :result :status])))
+      ;; Already failed — pass through
+      (-> ctx
+          (assoc-in [:phase :status] :failed))
+
+      ;; Gates passed — apply
+      (let [config    (get-in ctx [:phase :provision-config])
+            stack-dir (:stack-dir config)
+            stack     (:stack config)
+            env       (:env config)]
+
+        (log/info logger :provision :provision/apply-starting
+                  {:data {:stack-dir stack-dir :stack stack}})
+
+        (let [apply-result (shell/pulumi-up! stack-dir :stack stack :env env)]
+          (if (schema/failed? apply-result)
+            ;; Apply failed
+            (do
+              (log/error logger :provision :provision/apply-failed
+                         {:data {:stderr (:stderr apply-result)}})
+              (-> ctx
+                  (assoc-in [:phase :status] :failed)
+                  (update-in [:phase :result] merge
+                             {:status  :apply-failed
+                              :error   (:stderr apply-result)
+                              :metrics (merge (get-in ctx [:phase :result :metrics])
+                                              {:apply-duration-ms (:duration-ms apply-result)})})))
+
+            ;; Apply succeeded — get outputs
+            (let [outputs-result (shell/pulumi-outputs! stack-dir :stack stack)
+                  outputs        (get outputs-result :parsed {})
+                  outputs-evidence (evidence/create-evidence
+                                   :evidence/pulumi-outputs
+                                   outputs
+                                   {:stack stack})]
+              (log/info logger :provision :provision/apply-complete
+                        {:data {:output-keys (vec (keys outputs))}})
+
+              (-> ctx
+                  (assoc-in [:phase :status] :completed)
+                  (update-in [:phase :result] merge
+                             {:status  :success
+                              :outputs outputs
+                              :metrics (merge (get-in ctx [:phase :result :metrics])
+                                              {:apply-duration-ms (:duration-ms apply-result)})})
+                  (evidence/add-evidence-to-ctx outputs-evidence)))))))))
+
+(defn error-provision
+  "Handle provision phase errors."
+  [ctx ex]
+  (let [logger (get-logger ctx)]
+    (log/error logger :provision :provision/error
+               {:data {:message (ex-message ex)
+                       :data    (ex-data ex)}})
+    (-> ctx
+        (assoc-in [:phase :status] :failed)
+        (update :execution/errors (fnil conj [])
+                {:type    :provision-error
+                 :phase   :provision
+                 :message (ex-message ex)
+                 :data    (ex-data ex)}))))
+
+;; Registration
+
+(defmethod registry/get-phase-interceptor :provision
+  [_]
+  {:name   :provision
+   :enter  enter-provision
+   :leave  leave-provision
+   :error  error-provision
+   :config default-config})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Test provision phase against a real Pulumi project
+  ;; (enter-provision {:execution/input {:stack-dir "/path/to/project" :stack "dev"}})
+
+  :leave-this-here)

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/provision.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/provision.clj
@@ -17,32 +17,46 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.phase.deploy.provision
-  "Provision phase interceptor.
-
-   Executes infrastructure provisioning via Pulumi:
-   1. pulumi preview --json → captures structured preview
-   2. Policy gate checks preview for destructive/unsafe operations
-   3. pulumi up --yes → applies approved changes
-   4. Captures stack outputs as phase result
-
-   Agent: none (CLI tool execution, no LLM)
-   Default gates: [:policy-pack :provision-validated]"
+  "Provision phase interceptor."
   (:require [ai.miniforge.logging.interface :as log]
+            [ai.miniforge.phase.deploy.defaults :as defaults]
             [ai.miniforge.phase.deploy.evidence :as evidence]
+            [ai.miniforge.phase.deploy.messages :as msg]
             [ai.miniforge.phase.deploy.shell :as shell]
             [ai.miniforge.phase.registry :as registry]
             [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Defaults
+;; Defaults + schemas
 
 (def default-config
-  "Phase defaults — overridable via workflow EDN."
-  {:gates  [:policy-pack :provision-validated]
-   :budget {:tokens 0 :iterations 3 :time-seconds 900}
-   :agent  nil})
+  "Provision phase defaults loaded from EDN."
+  (defaults/phase-defaults :provision))
 
-(registry/register-phase-defaults! :provision default-config)
+(def ProvisionRunConfig
+  [:map
+   [:phase-config map?]
+   [:stack-dir :string]
+   [:stack :string]
+   [:env [:map-of :string :string]]
+   [:gcp-project {:optional true} [:maybe :string]]])
+
+(def PreviewAnalysis
+  [:map
+   [:creates nat-int?]
+   [:updates nat-int?]
+   [:deletes nat-int?]
+   [:sames nat-int?]
+   [:resources
+    [:vector
+     [:map
+      [:type {:optional true} [:maybe :string]]
+      [:name {:optional true} [:maybe :string]]
+      [:action {:optional true} [:maybe :string]]]]]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Shared helpers
@@ -62,125 +76,129 @@
       (assoc-in [:phase :started-at] start-time)
       (assoc-in [:phase :result] result-map)))
 
-;; Preview analysis
+(defn- merged-phase-config
+  [ctx phase-kw]
+  (registry/merge-with-defaults
+   (assoc (or (get-in ctx [:phase-config]) {}) :phase phase-kw)))
 
-(defn- analyze-preview
-  "Extract summary metrics from Pulumi preview JSON output.
+(defn- resolve-provision-config
+  [ctx]
+  (let [phase-config (merged-phase-config ctx :provision)
+        input        (or (get-in ctx [:execution/input]) {})
+        gcp-project  (or (get input :gcp-project)
+                         (get phase-config :gcp-project))]
+    (validate!
+     ProvisionRunConfig
+     (cond-> {:phase-config phase-config
+              :stack-dir    (or (get input :stack-dir)
+                                (get phase-config :stack-dir))
+              :stack        (get input :stack
+                                 (get phase-config :stack "dev"))
+              :env          (cond-> {}
+                              gcp-project (assoc "GOOGLE_PROJECT" gcp-project))}
+       true (assoc :gcp-project gcp-project)))))
 
-   Returns:
-     {:creates int :updates int :deletes int :sames int
-      :resources [{:type :name :action}...]}"
+(defn analyze-preview
+  "Extract summary metrics from Pulumi preview JSON output."
   [preview-json]
-  (if-let [steps (or (:steps preview-json) (:Steps preview-json))]
-    (let [actions (map #(or (:op %) (:Op %)) steps)
-          counts  (frequencies actions)]
-      {:creates   (get counts "create" 0)
-       :updates   (get counts "update" 0)
-       :deletes   (get counts "delete" 0)
-       :sames     (get counts "same" 0)
-       :resources (mapv (fn [step]
-                          {:type   (or (:type step) (get-in step [:newState :type]))
-                           :name   (or (:urn step) (get-in step [:newState :urn]))
-                           :action (or (:op step) (:Op step))})
-                        steps)})
-    {:creates 0 :updates 0 :deletes 0 :sames 0 :resources []}))
+  (let [steps   (or (:steps preview-json) (:Steps preview-json) [])
+        actions (map #(or (:op %) (:Op %)) steps)
+        counts  (frequencies actions)]
+    (validate!
+     PreviewAnalysis
+     {:creates   (get counts "create" 0)
+      :updates   (get counts "update" 0)
+      :deletes   (get counts "delete" 0)
+      :sames     (get counts "same" 0)
+      :resources (mapv (fn [step]
+                         {:type   (or (:type step) (get-in step [:newState :type]))
+                          :name   (or (:urn step) (get-in step [:newState :urn]))
+                          :action (or (:op step) (:Op step))})
+                       steps)})))
+
+(defn- preview-result
+  [preview-data analysis preview-command]
+  {:status   :preview-complete
+   :output   preview-data
+   :artifact {:content  preview-data
+              :type     :pulumi-preview
+              :analysis analysis}
+   :command  preview-command
+   :metrics  {:duration-ms (:duration-ms preview-command)
+              :creates     (:creates analysis)
+              :updates     (:updates analysis)
+              :deletes     (:deletes analysis)}})
+
+(defn- store-provision-preview
+  [ctx start-time config preview-command]
+  (let [preview-data     (get preview-command :parsed {})
+        analysis         (analyze-preview preview-data)
+        preview-evidence (evidence/create-evidence
+                          :evidence/pulumi-preview
+                          preview-data
+                          {:stack (:stack config)
+                           :stack-dir (:stack-dir config)
+                           :analysis analysis})]
+    (log/info (get-logger ctx) :provision :provision/preview-complete
+              {:data {:creates (:creates analysis)
+                      :updates (:updates analysis)
+                      :deletes (:deletes analysis)}})
+    (-> ctx
+        (assoc-in [:phase :name] :provision)
+        (assoc-in [:phase :gates] (get-in config [:phase-config :gates]))
+        (assoc-in [:phase :budget] (get-in config [:phase-config :budget]))
+        (assoc-in [:phase :started-at] start-time)
+        (assoc-in [:phase :status] :pending-gates)
+        (assoc-in [:phase :result] (preview-result preview-data
+                                                   analysis
+                                                   preview-command))
+        (evidence/add-evidence-to-ctx preview-evidence)
+        (assoc-in [:phase :provision-config]
+                  (select-keys config [:stack-dir :stack :env])))))
+
+(defn- store-provision-failure
+  [ctx start-time logger preview-result]
+  (let [error-type (shell/classify-error preview-result)]
+    (log/error logger :provision :provision/preview-failed
+               {:data {:stderr (:stderr preview-result)
+                       :error-type error-type}})
+    (failed-enter ctx start-time
+                  {:status     :error
+                   :error      (:stderr preview-result)
+                   :error-type error-type
+                   :command    (:command preview-result)
+                   :metrics    {:duration-ms (:duration-ms preview-result)}})))
+
+(defn- invalid-config-result
+  [ctx start-time ex]
+  (failed-enter ctx start-time
+                {:status :error
+                 :error  (msg/t :provision/invalid-config
+                                {:error (ex-message ex)})}))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Phase interceptors + registration
 
 (defn enter-provision
-  "Execute provisioning: preview → (gate check) → apply → capture outputs.
-
-   The :enter function runs the preview and stores it as the phase artifact.
-   After :enter returns, execution.clj checks gates (including :policy-pack)
-   against the artifact. If gates pass, the leave function applies.
-
-   For provision, we split into two sub-operations:
-   - :enter does preview + stores artifact for gate checking
-   - If gates pass, we need to apply. Since gates run between enter and leave,
-     we store the 'needs apply' flag and do the apply in a post-gate callback.
-
-   Architecture note: The current phase model runs enter → gates → leave.
-   Apply must happen after gates pass but before leave. We handle this by
-   doing both preview AND apply in enter, with the policy-pack gate checking
-   the preview artifact mid-execution. The gate system checks after :enter
-   returns, but we need apply to happen only if gates pass.
-
-   Solution: enter does preview only. If gates pass, the workflow will proceed
-   to the next phase. We use a two-phase approach: provision-preview and
-   provision-apply as separate steps, OR we do the apply in enter after preview
-   and let the gate check happen on the preview artifact.
-
-   Chosen approach: Enter does preview. Stores preview as artifact for gate.
-   If gates pass, the 'leave' triggers apply. If gates fail, leave does NOT apply.
-   This aligns with the interceptor model: enter produces, gates validate, leave finalizes."
+  "Execute provisioning preview and capture the artifact used by gates."
   [ctx]
-  (let [config      (registry/merge-with-defaults (get-in ctx [:phase-config]) :provision)
-        start-time  (System/currentTimeMillis)
-        logger      (get-logger ctx)
-        ;; Extract provision-specific config from workflow input
-        input       (get-in ctx [:execution/input])
-        stack-dir   (or (get input :stack-dir) (get config :stack-dir))
-        stack       (if-some [value (or (get input :stack) (get config :stack))]
-                      value
-                      "dev")
-        gcp-project (or (get input :gcp-project) (get config :gcp-project))
-        env         (cond-> {}
-                      gcp-project (assoc "GOOGLE_PROJECT" gcp-project))]
-
-    (log/info logger :provision :provision/preview-starting
-              {:data {:stack-dir stack-dir :stack stack}})
-
-    ;; Step 1: Run Pulumi preview
-    (let [preview-result (shell/pulumi-preview! stack-dir :stack stack :env env)]
-      (if (schema/failed? preview-result)
-        ;; Preview failed — surface error
-        (let [error-type (shell/classify-error preview-result)]
-          (log/error logger :provision :provision/preview-failed
-                     {:data {:stderr (:stderr preview-result)
-                             :error-type error-type}})
-          (failed-enter ctx start-time
-                        {:status     :error
-                         :error      (:stderr preview-result)
-                         :error-type error-type
-                         :command    (:command preview-result)
-                         :metrics    {:duration-ms (:duration-ms preview-result)}}))
-
-        ;; Preview succeeded — analyze and store as artifact for gate checking
-        (let [preview-data    (get preview-result :parsed {})
-              analysis        (analyze-preview preview-data)
-              preview-evidence (evidence/create-evidence
-                                :evidence/pulumi-preview
-                                preview-data
-                                {:stack stack :stack-dir stack-dir
-                                 :analysis analysis})]
-          (log/info logger :provision :provision/preview-complete
-                    {:data {:creates (:creates analysis)
-                            :updates (:updates analysis)
-                            :deletes (:deletes analysis)}})
-
-          (-> ctx
-              (assoc-in [:phase :name] :provision)
-              (assoc-in [:phase :gates] (:gates config))
-              (assoc-in [:phase :budget] (:budget config))
-              (assoc-in [:phase :started-at] start-time)
-              (assoc-in [:phase :status] :pending-gates)
-              ;; Store the preview as the artifact that gates will check
-              (assoc-in [:phase :result]
-                        {:status   :preview-complete
-                         :output   preview-data
-                         :artifact {:content  preview-data
-                                    :type     :pulumi-preview
-                                    :analysis analysis}
-                         :metrics  {:duration-ms (:duration-ms preview-result)
-                                    :creates     (:creates analysis)
-                                    :updates     (:updates analysis)
-                                    :deletes     (:deletes analysis)}})
-              ;; Store evidence
-              (evidence/add-evidence-to-ctx preview-evidence)
-              ;; Store config for leave phase to use for apply
-              (assoc-in [:phase :provision-config]
-                        {:stack-dir stack-dir :stack stack :env env})))))))
+  (let [start-time (System/currentTimeMillis)
+        logger     (get-logger ctx)]
+    (try
+      (let [config         (resolve-provision-config ctx)
+            stack-dir      (:stack-dir config)
+            stack          (:stack config)
+            preview-result (do
+                             (log/info logger :provision :provision/preview-starting
+                                       {:data {:stack-dir stack-dir :stack stack}})
+                             (shell/pulumi-preview! stack-dir
+                                                    :stack stack
+                                                    :env (:env config)))]
+        (if (schema/failed? preview-result)
+          (store-provision-failure ctx start-time logger preview-result)
+          (store-provision-preview ctx start-time config preview-result)))
+      (catch clojure.lang.ExceptionInfo ex
+        (invalid-config-result ctx start-time ex)))))
 
 (defn leave-provision
   "After gates pass: execute pulumi up and capture outputs.
@@ -189,25 +207,17 @@
   [ctx]
   (let [phase-status (get-in ctx [:phase :status])
         logger       (get-logger ctx)]
-
-    ;; Only apply if preview succeeded and gates passed
-    (if (or (= :failed phase-status) (= :error (get-in ctx [:phase :result :status])))
-      ;; Already failed — pass through
-      (-> ctx
-          (assoc-in [:phase :status] :failed))
-
-      ;; Gates passed — apply
+    (if (or (= :failed phase-status)
+            (= :error (get-in ctx [:phase :result :status])))
+      (assoc-in ctx [:phase :status] :failed)
       (let [config    (get-in ctx [:phase :provision-config])
             stack-dir (:stack-dir config)
             stack     (:stack config)
             env       (:env config)]
-
         (log/info logger :provision :provision/apply-starting
                   {:data {:stack-dir stack-dir :stack stack}})
-
         (let [apply-result (shell/pulumi-up! stack-dir :stack stack :env env)]
           (if (schema/failed? apply-result)
-            ;; Apply failed
             (do
               (log/error logger :provision :provision/apply-failed
                          {:data {:stderr (:stderr apply-result)}})
@@ -218,17 +228,14 @@
                               :error   (:stderr apply-result)
                               :metrics (merge (get-in ctx [:phase :result :metrics])
                                               {:apply-duration-ms (:duration-ms apply-result)})})))
-
-            ;; Apply succeeded — get outputs
-            (let [outputs-result (shell/pulumi-outputs! stack-dir :stack stack)
-                  outputs        (get outputs-result :parsed {})
+            (let [outputs-result   (shell/pulumi-outputs! stack-dir :stack stack)
+                  outputs          (get outputs-result :parsed {})
                   outputs-evidence (evidence/create-evidence
-                                   :evidence/pulumi-outputs
-                                   outputs
-                                   {:stack stack})]
+                                    :evidence/pulumi-outputs
+                                    outputs
+                                    {:stack stack})]
               (log/info logger :provision :provision/apply-complete
                         {:data {:output-keys (vec (keys outputs))}})
-
               (-> ctx
                   (assoc-in [:phase :status] :completed)
                   (update-in [:phase :result] merge
@@ -265,7 +272,5 @@
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
-  ;; Test provision phase against a real Pulumi project
-  ;; (enter-provision {:execution/input {:stack-dir "/path/to/project" :stack "dev"}})
-
+  (enter-provision {:execution/input {:stack-dir "/path/to/project" :stack "dev"}})
   :leave-this-here)

--- a/components/phase-deployment/test/ai/miniforge/phase/deploy/provision_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase/deploy/provision_test.clj
@@ -1,0 +1,45 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.provision-test
+  (:require [ai.miniforge.phase.deploy.provision :as sut]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest resolve-provision-config-test
+  (testing "workflow input overrides phase defaults and builds the shell env"
+    (let [resolved (#'sut/resolve-provision-config
+                    {:phase-config    {:stack-dir "/cfg"
+                                       :stack "staging"
+                                       :gcp-project "cfg-project"}
+                     :execution/input {:stack-dir "/input"
+                                       :gcp-project "input-project"}})]
+      (is (= "/input" (:stack-dir resolved)))
+      (is (= "staging" (:stack resolved)))
+      (is (= "input-project" (:gcp-project resolved)))
+      (is (= {"GOOGLE_PROJECT" "input-project"} (:env resolved))))))
+
+(deftest analyze-preview-test
+  (testing "preview analysis summarizes resource operations"
+    (let [analysis (sut/analyze-preview {:steps [{:op "create" :type "bucket" :urn "urn:1"}
+                                                 {:op "update" :type "svc" :urn "urn:2"}
+                                                 {:op "create" :type "topic" :urn "urn:3"}]})]
+      (is (= 2 (:creates analysis)))
+      (is (= 1 (:updates analysis)))
+      (is (= 0 (:deletes analysis)))
+      (is (= ["create" "update" "create"]
+             (mapv :action (:resources analysis)))))))

--- a/docs/pull-requests/2026-04-01-feat-deployment-pack-provision.md
+++ b/docs/pull-requests/2026-04-01-feat-deployment-pack-provision.md
@@ -1,0 +1,41 @@
+# feat: deployment pack provision
+
+## Layer
+
+Application
+
+## Depends on
+
+- `feat/deployment-pack-evidence`
+
+## Overview
+
+Adds the provision phase interceptor for Pulumi preview and apply orchestration.
+
+## Motivation
+
+Provisioning infrastructure is the first deployment use-case and needs its own reviewable interceptor before the rest of
+the pack is layered on.
+
+## Changes in Detail
+
+- Add `provision.clj` with preview analysis, apply flow, and evidence capture.
+- Register `:provision` phase defaults.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge after the foundations and before downstream deployment phases.
+
+## Related Issues/PRs
+
+- Parent feature: deployment pack
+- Follow-up stack branches: `feat/deployment-pack-deploy`, `feat/deployment-pack-validate`
+
+## Checklist
+
+- [x] Scope limited to the provision phase interceptor
+- [ ] `bb pre-commit` recorded


### PR DESCRIPTION
# feat: deployment pack provision

## Layer

Application

## Depends on

- `feat/deployment-pack-evidence`

## Overview

Adds the provision phase interceptor for Pulumi preview and apply orchestration.

## Motivation

Provisioning infrastructure is the first deployment use-case and needs its own reviewable interceptor before the rest of
the pack is layered on.

## Changes in Detail

- Add `provision.clj` with preview analysis, apply flow, and evidence capture.
- Register `:provision` phase defaults.

## Testing Plan

- Run `bb pre-commit`

## Deployment Plan

- Merge after the foundations and before downstream deployment phases.

## Related Issues/PRs

- Parent feature: deployment pack
- Follow-up stack branches: `feat/deployment-pack-deploy`, `feat/deployment-pack-validate`

## Checklist

- [x] Scope limited to the provision phase interceptor
- [ ] `bb pre-commit` recorded
