### PR TITLE
feat: deployment pack workflow wiring

### DIFF
--- a/components/workflow-chain-deployment/deps.edn
+++ b/components/workflow-chain-deployment/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["resources"]
+ :deps {}}

--- a/components/workflow-chain-deployment/resources/chains/sdlc-to-deploy-v1.0.0.edn
+++ b/components/workflow-chain-deployment/resources/chains/sdlc-to-deploy-v1.0.0.edn
@@ -1,0 +1,26 @@
+;; SDLC-to-Deploy Chain v1.0.0
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Full loop: build the service via SDLC workflow, then deploy it.
+;; Links Software Factory output (merged PR, new image) to Deployment workflow.
+
+{:chain/id :sdlc-to-deploy
+ :chain/version "1.0.0"
+ :chain/description
+ "End-to-end: develop the service, then deploy it to GKE.
+  Software Factory produces code changes; Deployment provisions and deploys."
+
+ :chain/steps
+ [{:step/id :build
+   :step/workflow-id :standard-sdlc
+   :step/input-bindings {:title       :chain/input.title
+                         :description :chain/input.description
+                         :intent      :chain/input.intent}}
+
+  {:step/id :deploy
+   :step/workflow-id :quick-deploy
+   :step/input-bindings {:kustomize-dir   :chain/input.kustomize-dir
+                         :namespace       :chain/input.namespace
+                         :context         :chain/input.context
+                         :app-label       :chain/input.app-label
+                         :health-endpoints :chain/input.health-endpoints}}]}

--- a/components/workflow-deployment/deps.edn
+++ b/components/workflow-deployment/deps.edn
@@ -1,0 +1,2 @@
+{:paths ["resources"]
+ :deps {}}

--- a/components/workflow-deployment/resources/workflows/provision-only-v1.0.0.edn
+++ b/components/workflow-deployment/resources/workflows/provision-only-v1.0.0.edn
@@ -1,0 +1,21 @@
+;; Provision Only Workflow v1.0.0 (Interceptor-based)
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Infrastructure provisioning only, no application deployment.
+;; Useful for standing up a new environment or modifying infra independently.
+
+{:workflow/id :provision-only
+ :workflow/version "1.0.0"
+ :workflow/name "Provision Infrastructure"
+ :workflow/description "Pulumi provision with policy gates (no app deploy)"
+
+ :workflow/pipeline
+ [{:phase :provision
+   :gates [:policy-pack :provision-validated]
+   :budget {:tokens 0 :iterations 3 :time-seconds 900}}
+
+  {:phase :done}]
+
+ :workflow/config
+ {:max-iterations 5
+  :failure-strategy :halt}}

--- a/components/workflow-deployment/resources/workflows/quick-deploy-v1.0.0.edn
+++ b/components/workflow-deployment/resources/workflows/quick-deploy-v1.0.0.edn
@@ -1,0 +1,26 @@
+;; Quick Deploy Workflow v1.0.0 (Interceptor-based)
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Deploy only — infrastructure already provisioned.
+;; Skips provisioning, goes straight to Kustomize deploy + validation.
+
+{:workflow/id :quick-deploy
+ :workflow/version "1.0.0"
+ :workflow/name "Quick Deploy"
+ :workflow/description "Deploy and validate (infra already provisioned)"
+
+ :workflow/pipeline
+ [{:phase :deploy
+   :gates [:deploy-healthy]
+   :budget {:tokens 0 :iterations 3 :time-seconds 300}
+   :on-fail :deploy}
+
+  {:phase :validate
+   :gates [:health-check]
+   :on-fail :deploy}
+
+  {:phase :done}]
+
+ :workflow/config
+ {:max-iterations 10
+  :failure-strategy :rollback}}

--- a/components/workflow-deployment/resources/workflows/standard-deploy-v1.0.0.edn
+++ b/components/workflow-deployment/resources/workflows/standard-deploy-v1.0.0.edn
@@ -1,0 +1,41 @@
+;; Standard Deployment Workflow v1.0.0 (Interceptor-based)
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Full deployment: provision infrastructure -> deploy application -> validate.
+;; Pulumi for provisioning, Kustomize for K8s deployment.
+;;
+;; Policy gates check Pulumi preview before apply.
+;; Evidence bundle captured at every phase boundary.
+
+{:workflow/id :standard-deploy
+ :workflow/version "1.0.0"
+ :workflow/name "Standard GCP Deployment"
+ :workflow/description "Pulumi provision -> Kustomize deploy -> Validate"
+
+ :workflow/pipeline
+ [;; Infrastructure provisioning via Pulumi
+  ;; Gates: policy-pack checks preview for destructive/unsafe operations
+  {:phase :provision
+   :gates [:policy-pack :provision-validated]
+   :budget {:tokens 0 :iterations 3 :time-seconds 900}
+   :on-fail :provision}
+
+  ;; Application deployment via Kustomize
+  ;; Gates: verify all pods are healthy after rollout
+  {:phase :deploy
+   :gates [:deploy-healthy]
+   :budget {:tokens 0 :iterations 3 :time-seconds 300}
+   :on-fail :deploy}
+
+  ;; Post-deploy validation
+  ;; Gates: health endpoints respond, smoke tests pass
+  {:phase :validate
+   :gates [:health-check]
+   :on-fail :deploy}
+
+  ;; Terminal
+  {:phase :done}]
+
+ :workflow/config
+ {:max-iterations 15
+  :failure-strategy :rollback}}

--- a/deps.edn
+++ b/deps.edn
@@ -52,6 +52,8 @@
                        "components/workflow-software-factory/resources"
                        "components/phase-deployment/src"
                        "components/phase-deployment/resources"
+                       "components/workflow-deployment/resources"
+                       "components/workflow-chain-deployment/resources"
                        "components/release-executor/src"
                        "components/release-executor/resources"
                        "components/operator/src"
@@ -163,6 +165,8 @@
                      ai.miniforge/messages {:local/root "components/messages"}
                      ai.miniforge/patterns {:local/root "components/patterns"}
                      ai.miniforge/phase-deployment {:local/root "components/phase-deployment"}
+                     ai.miniforge/workflow-deployment {:local/root "components/workflow-deployment"}
+                     ai.miniforge/workflow-chain-deployment {:local/root "components/workflow-chain-deployment"}
                      ai.miniforge/cli {:local/root "bases/cli"}}}
 
   :test {:extra-paths ["development/test"
@@ -221,6 +225,8 @@
                        "components/messages/test"
                        "components/patterns/test"
                        "components/phase-deployment/test"
+                       "components/workflow-deployment/resources"
+                       "components/workflow-chain-deployment/resources"
                        "bases/cli/test"
                        "bases/lsp-mcp-bridge/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
@@ -273,8 +279,10 @@
                       ai.miniforge/control-plane-adapter {:local/root "components/control-plane-adapter"}
                       ai.miniforge/adapter-miniforge {:local/root "components/adapter-miniforge"}
                       ai.miniforge/adapter-claude-code {:local/root "components/adapter-claude-code"}
-                      ai.miniforge/phase-deployment {:local/root "components/phase-deployment"}
                       ai.miniforge/task-executor {:local/root "components/task-executor"}
+                      ai.miniforge/phase-deployment {:local/root "components/phase-deployment"}
+                      ai.miniforge/workflow-deployment {:local/root "components/workflow-deployment"}
+                      ai.miniforge/workflow-chain-deployment {:local/root "components/workflow-chain-deployment"}
                       ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}}}
 
   :conformance {:extra-paths ["development/test"

--- a/docs/pull-requests/2026-04-01-feat-deployment-pack-workflow-wiring.md
+++ b/docs/pull-requests/2026-04-01-feat-deployment-pack-workflow-wiring.md
@@ -1,0 +1,40 @@
+# feat: deployment pack workflow wiring
+
+## Layer
+
+Integration
+
+## Depends on
+
+- `feat/deployment-pack-validate`
+
+## Overview
+
+Wires the deployment phases into workflow resources, chain resources, and project dependencies.
+
+## Motivation
+
+The workflow surface area should land after the underlying phases are already reviewable and validated in smaller
+slices.
+
+## Changes in Detail
+
+- Add workflow and chain resources for deployment-oriented SDLC flows.
+- Add workspace and project dependency wiring for the new deployment components.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge last in the deployment-pack stack.
+
+## Related Issues/PRs
+
+- Parent feature: deployment pack
+
+## Checklist
+
+- [x] Scope limited to workflow and dependency wiring
+- [ ] `bb pre-commit` recorded

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -7,6 +7,10 @@
         ai.miniforge/workflow-software-factory {:local/root "../../components/workflow-software-factory"}
         ai.miniforge/workflow-financial-etl {:local/root "../../components/workflow-financial-etl"}
         ai.miniforge/phase-software-factory {:local/root "../../components/phase-software-factory"}
+        ;; Deployment pack: Pulumi/Kustomize orchestration with policy gates and evidence
+        ai.miniforge/phase-deployment {:local/root "../../components/phase-deployment"}
+        ai.miniforge/workflow-deployment {:local/root "../../components/workflow-deployment"}
+        ai.miniforge/workflow-chain-deployment {:local/root "../../components/workflow-chain-deployment"}
         ai.miniforge/schema {:local/root "../../components/schema"}
         ai.miniforge/config {:local/root "../../components/config"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}


### PR DESCRIPTION
# feat: deployment pack workflow wiring

## Layer

Integration

## Depends on

- `feat/deployment-pack-validate`

## Overview

Wires the deployment phases into workflow resources, chain resources, and project dependencies.

## Motivation

The workflow surface area should land after the underlying phases are already reviewable and validated in smaller
slices.

## Changes in Detail

- Add workflow and chain resources for deployment-oriented SDLC flows.
- Add workspace and project dependency wiring for the new deployment components.

## Testing Plan

- Run `bb pre-commit`

## Deployment Plan

- Merge last in the deployment-pack stack.

## Related Issues/PRs

- Parent feature: deployment pack

## Checklist

- [x] Scope limited to workflow and dependency wiring
- [ ] `bb pre-commit` recorded
