### PR TITLE
feat: deployment pack validate

### DIFF
--- a/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
+++ b/components/phase-deployment/resources/config/phase/deploy-messages/en-US.edn
@@ -17,6 +17,7 @@
   :deploy/error                  "Deploy phase error"
 
   :validate/starting             "Starting post-deployment validation"
+  :validate/invalid-config       "Validate configuration invalid: {error}"
   :validate/passed               "All validation checks passed"
   :validate/failed               "Validation checks failed"
   :validate/error                "Validate phase error"

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/validate.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/validate.clj
@@ -17,15 +17,11 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.phase.deploy.validate
-  "Validate phase interceptor.
-
-   Post-deployment validation: health checks, smoke tests, connectivity.
-   Runs after deploy phase completes to verify the deployment is functional.
-
-   Agent: none (HTTP checks and CLI commands, no LLM)
-   Default gates: [:health-check]"
+  "Validate phase interceptor."
   (:require [ai.miniforge.logging.interface :as log]
+            [ai.miniforge.phase.deploy.defaults :as defaults]
             [ai.miniforge.phase.deploy.evidence :as evidence]
+            [ai.miniforge.phase.deploy.messages :as msg]
             [ai.miniforge.phase.deploy.shell :as shell]
             [ai.miniforge.phase.registry :as registry]
             [ai.miniforge.schema.interface :as schema]
@@ -33,15 +29,45 @@
   (:import [java.net HttpURLConnection URL]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Defaults
+;; Defaults + schemas
 
 (def default-config
-  "Phase defaults — overridable via workflow EDN."
-  {:gates  [:health-check]
-   :budget {:tokens 0 :iterations 3 :time-seconds 120}
-   :agent  nil})
+  "Validate phase defaults loaded from EDN."
+  (defaults/phase-defaults :validate))
 
-(registry/register-phase-defaults! :validate default-config)
+(def ValidateRunConfig
+  [:map
+   [:phase-config map?]
+   [:health-endpoints [:vector :string]]
+   [:smoke-commands [:vector :string]]
+   [:retries pos-int?]
+   [:retry-delay-ms nat-int?]])
+
+(def HealthCheckResult
+  [:map
+   [:passed? :boolean]
+   [:url :string]
+   [:status-code {:optional true} [:maybe int?]]
+   [:duration-ms nat-int?]
+   [:attempts {:optional true} pos-int?]
+   [:error {:optional true} :string]])
+
+(def SmokeTestResult
+  [:map
+   [:command :string]
+   [:passed? :boolean]
+   [:stdout {:optional true} [:maybe :string]]
+   [:stderr {:optional true} [:maybe :string]]
+   [:duration-ms nat-int?]])
+
+(def ValidationBatch
+  [:map
+   [:passed? :boolean]
+   [:results [:vector any?]]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Shared helpers
@@ -52,21 +78,71 @@
   (or (get-in ctx [:execution/logger])
       (log/create-logger {:min-level :info :output :human})))
 
+(defn- merged-phase-config
+  [ctx phase-kw]
+  (registry/merge-with-defaults
+   (assoc (or (get-in ctx [:phase-config]) {}) :phase phase-kw)))
+
+(defn- resolve-validate-config
+  [ctx]
+  (let [phase-config (merged-phase-config ctx :validate)
+        input        (or (get-in ctx [:execution/input]) {})]
+    (validate!
+     ValidateRunConfig
+     {:phase-config     phase-config
+      :health-endpoints (get input :health-endpoints
+                             (get phase-config :health-endpoints []))
+      :smoke-commands   (get input :smoke-commands
+                             (get phase-config :smoke-commands []))
+      :retries          (get input :retries
+                             (get phase-config :retries 3))
+      :retry-delay-ms   (get input :retry-delay-ms
+                             (get phase-config :retry-delay-ms 5000))})))
+
+(defn- passed?
+  [result]
+  (true? (:passed? result)))
+
+(defn- batch-result
+  [result-schema results]
+  (validate!
+   ValidationBatch
+   {:passed? (every? passed? results)
+    :results (mapv #(validate! result-schema %) results)}))
+
+(defn- passed-check
+  [url status-code duration-ms]
+  (validate!
+   HealthCheckResult
+   {:passed? true
+    :url url
+    :status-code status-code
+    :duration-ms duration-ms}))
+
+(defn- failed-check
+  [url status-code duration-ms error]
+  (validate!
+   HealthCheckResult
+   {:passed? false
+    :url url
+    :status-code status-code
+    :duration-ms duration-ms
+    :error error}))
+
+(defn- smoke-test-result
+  [cmd result]
+  (validate!
+   SmokeTestResult
+   {:command     cmd
+    :passed?     (schema/succeeded? result)
+    :stdout      (:stdout result)
+    :stderr      (:stderr result)
+    :duration-ms (:duration-ms result)}))
+
 ;; Health check execution + smoke tests
 
 (defn- http-health-check
-  "Execute an HTTP health check against an endpoint.
-
-   Arguments:
-     url        - Full URL to check (e.g. \"http://svc.ns.svc.cluster.local/health\")
-     timeout-ms - Connection and read timeout (default 10000)
-
-   Returns:
-     {:passed?     boolean
-      :url         string
-      :status-code int (or nil on connection failure)
-      :duration-ms long
-      :error       string (if failed)}"
+  "Execute an HTTP health check against an endpoint."
   [url & {:keys [timeout-ms] :or {timeout-ms 10000}}]
   (let [start (System/currentTimeMillis)]
     (try
@@ -78,147 +154,119 @@
             status (.getResponseCode conn)
             duration (- (System/currentTimeMillis) start)]
         (.disconnect conn)
-        {:passed?     (<= 200 status 299)
-         :url         url
-         :status-code status
-         :duration-ms duration})
+        (if (<= 200 status 299)
+          (passed-check url status duration)
+          (failed-check url status duration nil)))
       (catch Exception e
-        {:passed?     false
-         :url         url
-         :status-code nil
-         :duration-ms (- (System/currentTimeMillis) start)
-         :error       (ex-message e)}))))
+        (failed-check url
+                      nil
+                      (- (System/currentTimeMillis) start)
+                      (ex-message e))))))
 
 (defn- check-health-endpoints
-  "Check multiple health endpoints with retry.
-
-   Arguments:
-     endpoints   - Vector of URL strings
-     retries     - Number of retries per endpoint (default 3)
-     retry-delay - Milliseconds between retries (default 5000)
-
-   Returns:
-     {:all-passed? boolean
-      :results     [{:url :passed? :status-code :duration-ms :attempts}]}"
+  "Check multiple health endpoints with retry."
   [endpoints & {:keys [retries retry-delay] :or {retries 3 retry-delay 5000}}]
-  (let [results
-        (mapv (fn [url]
-                (loop [attempt 1]
-                  (let [result (http-health-check url)]
-                    (if (or (get result :passed? false) (>= attempt retries))
-                      (assoc result :attempts attempt)
-                      (do (Thread/sleep retry-delay)
-                          (recur (inc attempt)))))))
-              endpoints)]
-    {:all-passed? (every? :passed? results)
-     :results     results}))
-
-;; Smoke test execution
+  (let [results (mapv (fn [url]
+                        (loop [attempt 1]
+                          (let [result (http-health-check url)]
+                            (if (or (get result :passed? false)
+                                    (>= attempt retries))
+                              (assoc result :attempts attempt)
+                              (do
+                                (Thread/sleep retry-delay)
+                                (recur (inc attempt)))))))
+                      endpoints)]
+    (batch-result HealthCheckResult results)))
 
 (defn- run-smoke-tests
-  "Execute smoke test commands.
+  "Execute smoke test commands."
+  [commands]
+  (let [results (mapv (fn [cmd]
+                        (let [[bin & args] (str/split cmd #"\s+")
+                              result (shell/sh-with-timeout bin (vec args) :timeout-ms 30000)]
+                          (smoke-test-result cmd result)))
+                      commands)]
+    (batch-result SmokeTestResult results)))
 
-   Arguments:
-     commands - Vector of shell command strings
-     opts     - :namespace, :context for kubectl-based tests
+(defn- validation-metrics
+  [duration health-results smoke-results]
+  {:duration-ms   duration
+   :checks-run    (+ (count (:results health-results))
+                     (count (:results smoke-results)))
+   :checks-passed (+ (count (filter :passed? (:results health-results)))
+                     (count (filter :passed? (:results smoke-results))))})
 
-   Returns:
-     {:all-passed? boolean
-      :results     [{:command :passed? :stdout :stderr :duration-ms}]}"
-  [commands & {:keys [_namespace _context]}]
-  (let [results
-        (mapv (fn [cmd]
-                (let [[bin & args] (str/split cmd #"\s+")
-                      result (shell/sh-with-timeout bin (vec args) :timeout-ms 30000)]
-                  {:command     cmd
-                   :passed?     (schema/succeeded? result)
-                   :stdout      (:stdout result)
-                   :stderr      (:stderr result)
-                   :duration-ms (:duration-ms result)}))
-              commands)]
-    {:all-passed? (every? :passed? results)
-     :results     results}))
+(defn- log-validation-outcome
+  [logger duration health-results smoke-results]
+  (if (and (:passed? health-results) (:passed? smoke-results))
+    (log/info logger :validate :validate/passed
+              {:data {:duration-ms duration}})
+    (log/error logger :validate :validate/failed
+               {:data {:health-failures (count (remove :passed? (:results health-results)))
+                       :smoke-failures  (count (remove :passed? (:results smoke-results)))}})))
+
+(defn- invalid-config-result
+  [ctx start-time ex]
+  (-> ctx
+      (assoc-in [:phase :name] :validate)
+      (assoc-in [:phase :status] :failed)
+      (assoc-in [:phase :started-at] start-time)
+      (assoc-in [:phase :result]
+                {:status :error
+                 :error  (msg/t :validate/invalid-config
+                                {:error (ex-message ex)})})))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Phase interceptors + registration
 
 (defn enter-validate
-  "Execute post-deployment validation.
-
-   Reads validation config from execution input:
-     :health-endpoints - Vector of HTTP URLs to health-check
-     :smoke-commands   - Optional vector of shell commands to run
-     :retries          - Number of health check retries (default 3)
-     :retry-delay-ms   - Delay between retries (default 5000)"
+  "Execute post-deployment validation."
   [ctx]
-  (let [config       (registry/merge-with-defaults (get-in ctx [:phase-config]) :validate)
-        start-time   (System/currentTimeMillis)
-        logger       (get-logger ctx)
-        input        (get-in ctx [:execution/input])
-        endpoints    (if-some [value (or (get input :health-endpoints)
-                                         (get config :health-endpoints))]
-                       value
-                       [])
-        smoke-cmds   (if-some [value (or (get input :smoke-commands)
-                                         (get config :smoke-commands))]
-                       value
-                       [])
-        retries      (get input :retries 3)
-        retry-delay  (get input :retry-delay-ms 5000)]
-
-    (log/info logger :validate :validate/starting
-              {:data {:endpoint-count (count endpoints)
-                      :smoke-count    (count smoke-cmds)}})
-
-    ;; Step 1: Health checks
-    (let [health-results (if (seq endpoints)
-                           (check-health-endpoints endpoints
-                                                   :retries retries
-                                                   :retry-delay retry-delay)
-                           {:all-passed? true :results []})
-
-          ;; Step 2: Smoke tests
-          smoke-results (if (seq smoke-cmds)
-                          (run-smoke-tests smoke-cmds)
-                          {:all-passed? true :results []})
-
-          all-passed? (and (:all-passed? health-results)
-                          (:all-passed? smoke-results))
-          duration    (- (System/currentTimeMillis) start-time)
-
-          validation-evidence (evidence/create-evidence
-                               :evidence/validation-results
-                               {:health-checks (:results health-results)
-                                :smoke-tests   (:results smoke-results)
-                                :all-passed?   all-passed?})]
-
-      (if all-passed?
-        (log/info logger :validate :validate/passed
-                  {:data {:duration-ms duration}})
-        (log/error logger :validate :validate/failed
-                   {:data {:health-failures (count (remove :passed? (:results health-results)))
-                           :smoke-failures  (count (remove :passed? (:results smoke-results)))}}))
-
-      (-> ctx
-          (assoc-in [:phase :name] :validate)
-          (assoc-in [:phase :gates] (:gates config))
-          (assoc-in [:phase :budget] (:budget config))
-          (assoc-in [:phase :started-at] start-time)
-          (assoc-in [:phase :status] (if all-passed? :completed :failed))
-          (assoc-in [:phase :result]
-                    {:status   (if all-passed? :success :validation-failed)
-                     :output   {:health health-results
-                                :smoke  smoke-results}
-                     :artifact {:content    {:health-results (:results health-results)
+  (let [start-time (System/currentTimeMillis)
+        logger     (get-logger ctx)]
+    (try
+      (let [config            (resolve-validate-config ctx)
+            endpoints         (:health-endpoints config)
+            smoke-commands    (:smoke-commands config)
+            _                 (log/info logger :validate :validate/starting
+                                        {:data {:endpoint-count (count endpoints)
+                                                :smoke-count    (count smoke-commands)}})
+            health-results    (if (seq endpoints)
+                                (check-health-endpoints endpoints
+                                                        :retries (:retries config)
+                                                        :retry-delay (:retry-delay-ms config))
+                                (batch-result HealthCheckResult []))
+            smoke-results     (if (seq smoke-commands)
+                                (run-smoke-tests smoke-commands)
+                                (batch-result SmokeTestResult []))
+            validation-passed? (and (:passed? health-results)
+                                    (:passed? smoke-results))
+            duration          (- (System/currentTimeMillis) start-time)
+            metrics           (validation-metrics duration health-results smoke-results)
+            validation-evidence (evidence/create-evidence
+                                 :evidence/validation-results
+                                 {:health-checks (:results health-results)
+                                  :smoke-tests   (:results smoke-results)
+                                  :passed?       validation-passed?})]
+        (log-validation-outcome logger duration health-results smoke-results)
+        (-> ctx
+            (assoc-in [:phase :name] :validate)
+            (assoc-in [:phase :gates] (get-in config [:phase-config :gates]))
+            (assoc-in [:phase :budget] (get-in config [:phase-config :budget]))
+            (assoc-in [:phase :started-at] start-time)
+            (assoc-in [:phase :status] (if validation-passed? :completed :failed))
+            (assoc-in [:phase :result]
+                      {:status   (if validation-passed? :success :validation-failed)
+                       :output   {:health health-results
+                                  :smoke  smoke-results}
+                       :artifact {:content  {:health-results (:results health-results)
                                              :smoke-results  (:results smoke-results)}
-                                :type       :validation-state
-                                :all-passed? all-passed?}
-                     :metrics  {:duration-ms  duration
-                                :checks-run   (+ (count (:results health-results))
-                                                 (count (:results smoke-results)))
-                                :checks-passed (+ (count (filter :passed? (:results health-results)))
-                                                  (count (filter :passed? (:results smoke-results))))}})
-          (evidence/add-evidence-to-ctx validation-evidence)))))
+                                  :type     :validation-state
+                                  :passed? validation-passed?}
+                       :metrics  metrics})
+            (evidence/add-evidence-to-ctx validation-evidence)))
+      (catch clojure.lang.ExceptionInfo ex
+        (invalid-config-result ctx start-time ex)))))
 
 (defn leave-validate
   "Post-validation: pass through."
@@ -252,7 +300,5 @@
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
-  ;; Test validation against a running service
-  ;; (enter-validate {:execution/input {:health-endpoints ["http://localhost:5555/healthz"]}})
-
+  (enter-validate {:execution/input {:health-endpoints ["http://localhost:5555/healthz"]}})
   :leave-this-here)

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/validate.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/validate.clj
@@ -105,7 +105,7 @@
         (mapv (fn [url]
                 (loop [attempt 1]
                   (let [result (http-health-check url)]
-                    (if (or (:passed? result) (>= attempt retries))
+                    (if (or (get result :passed? false) (>= attempt retries))
                       (assoc result :attempts attempt)
                       (do (Thread/sleep retry-delay)
                           (recur (inc attempt)))))))
@@ -155,8 +155,14 @@
         start-time   (System/currentTimeMillis)
         logger       (get-logger ctx)
         input        (get-in ctx [:execution/input])
-        endpoints    (or (:health-endpoints input) (:health-endpoints config) [])
-        smoke-cmds   (or (:smoke-commands input) (:smoke-commands config) [])
+        endpoints    (if-some [value (or (get input :health-endpoints)
+                                         (get config :health-endpoints))]
+                       value
+                       [])
+        smoke-cmds   (if-some [value (or (get input :smoke-commands)
+                                         (get config :smoke-commands))]
+                       value
+                       [])
         retries      (get input :retries 3)
         retry-delay  (get input :retry-delay-ms 5000)]
 

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/validate.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/validate.clj
@@ -1,0 +1,252 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.validate
+  "Validate phase interceptor.
+
+   Post-deployment validation: health checks, smoke tests, connectivity.
+   Runs after deploy phase completes to verify the deployment is functional.
+
+   Agent: none (HTTP checks and CLI commands, no LLM)
+   Default gates: [:health-check]"
+  (:require [ai.miniforge.logging.interface :as log]
+            [ai.miniforge.phase.deploy.evidence :as evidence]
+            [ai.miniforge.phase.deploy.shell :as shell]
+            [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.schema.interface :as schema]
+            [clojure.string :as str])
+  (:import [java.net HttpURLConnection URL]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+
+(def default-config
+  "Phase defaults — overridable via workflow EDN."
+  {:gates  [:health-check]
+   :budget {:tokens 0 :iterations 3 :time-seconds 120}
+   :agent  nil})
+
+(registry/register-phase-defaults! :validate default-config)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Shared helpers
+
+(defn- get-logger
+  "Resolve logger from ctx, creating a default if absent."
+  [ctx]
+  (or (get-in ctx [:execution/logger])
+      (log/create-logger {:min-level :info :output :human})))
+
+;; Health check execution + smoke tests
+
+(defn- http-health-check
+  "Execute an HTTP health check against an endpoint.
+
+   Arguments:
+     url        - Full URL to check (e.g. \"http://svc.ns.svc.cluster.local/health\")
+     timeout-ms - Connection and read timeout (default 10000)
+
+   Returns:
+     {:passed?     boolean
+      :url         string
+      :status-code int (or nil on connection failure)
+      :duration-ms long
+      :error       string (if failed)}"
+  [url & {:keys [timeout-ms] :or {timeout-ms 10000}}]
+  (let [start (System/currentTimeMillis)]
+    (try
+      (let [conn (doto ^HttpURLConnection (.openConnection (URL. url))
+                   (.setRequestMethod "GET")
+                   (.setConnectTimeout timeout-ms)
+                   (.setReadTimeout timeout-ms)
+                   (.setInstanceFollowRedirects true))
+            status (.getResponseCode conn)
+            duration (- (System/currentTimeMillis) start)]
+        (.disconnect conn)
+        {:passed?     (<= 200 status 299)
+         :url         url
+         :status-code status
+         :duration-ms duration})
+      (catch Exception e
+        {:passed?     false
+         :url         url
+         :status-code nil
+         :duration-ms (- (System/currentTimeMillis) start)
+         :error       (ex-message e)}))))
+
+(defn- check-health-endpoints
+  "Check multiple health endpoints with retry.
+
+   Arguments:
+     endpoints   - Vector of URL strings
+     retries     - Number of retries per endpoint (default 3)
+     retry-delay - Milliseconds between retries (default 5000)
+
+   Returns:
+     {:all-passed? boolean
+      :results     [{:url :passed? :status-code :duration-ms :attempts}]}"
+  [endpoints & {:keys [retries retry-delay] :or {retries 3 retry-delay 5000}}]
+  (let [results
+        (mapv (fn [url]
+                (loop [attempt 1]
+                  (let [result (http-health-check url)]
+                    (if (or (:passed? result) (>= attempt retries))
+                      (assoc result :attempts attempt)
+                      (do (Thread/sleep retry-delay)
+                          (recur (inc attempt)))))))
+              endpoints)]
+    {:all-passed? (every? :passed? results)
+     :results     results}))
+
+;; Smoke test execution
+
+(defn- run-smoke-tests
+  "Execute smoke test commands.
+
+   Arguments:
+     commands - Vector of shell command strings
+     opts     - :namespace, :context for kubectl-based tests
+
+   Returns:
+     {:all-passed? boolean
+      :results     [{:command :passed? :stdout :stderr :duration-ms}]}"
+  [commands & {:keys [_namespace _context]}]
+  (let [results
+        (mapv (fn [cmd]
+                (let [[bin & args] (str/split cmd #"\s+")
+                      result (shell/sh-with-timeout bin (vec args) :timeout-ms 30000)]
+                  {:command     cmd
+                   :passed?     (schema/succeeded? result)
+                   :stdout      (:stdout result)
+                   :stderr      (:stderr result)
+                   :duration-ms (:duration-ms result)}))
+              commands)]
+    {:all-passed? (every? :passed? results)
+     :results     results}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Phase interceptors + registration
+
+(defn enter-validate
+  "Execute post-deployment validation.
+
+   Reads validation config from execution input:
+     :health-endpoints - Vector of HTTP URLs to health-check
+     :smoke-commands   - Optional vector of shell commands to run
+     :retries          - Number of health check retries (default 3)
+     :retry-delay-ms   - Delay between retries (default 5000)"
+  [ctx]
+  (let [config       (registry/merge-with-defaults (get-in ctx [:phase-config]) :validate)
+        start-time   (System/currentTimeMillis)
+        logger       (get-logger ctx)
+        input        (get-in ctx [:execution/input])
+        endpoints    (or (:health-endpoints input) (:health-endpoints config) [])
+        smoke-cmds   (or (:smoke-commands input) (:smoke-commands config) [])
+        retries      (get input :retries 3)
+        retry-delay  (get input :retry-delay-ms 5000)]
+
+    (log/info logger :validate :validate/starting
+              {:data {:endpoint-count (count endpoints)
+                      :smoke-count    (count smoke-cmds)}})
+
+    ;; Step 1: Health checks
+    (let [health-results (if (seq endpoints)
+                           (check-health-endpoints endpoints
+                                                   :retries retries
+                                                   :retry-delay retry-delay)
+                           {:all-passed? true :results []})
+
+          ;; Step 2: Smoke tests
+          smoke-results (if (seq smoke-cmds)
+                          (run-smoke-tests smoke-cmds)
+                          {:all-passed? true :results []})
+
+          all-passed? (and (:all-passed? health-results)
+                          (:all-passed? smoke-results))
+          duration    (- (System/currentTimeMillis) start-time)
+
+          validation-evidence (evidence/create-evidence
+                               :evidence/validation-results
+                               {:health-checks (:results health-results)
+                                :smoke-tests   (:results smoke-results)
+                                :all-passed?   all-passed?})]
+
+      (if all-passed?
+        (log/info logger :validate :validate/passed
+                  {:data {:duration-ms duration}})
+        (log/error logger :validate :validate/failed
+                   {:data {:health-failures (count (remove :passed? (:results health-results)))
+                           :smoke-failures  (count (remove :passed? (:results smoke-results)))}}))
+
+      (-> ctx
+          (assoc-in [:phase :name] :validate)
+          (assoc-in [:phase :gates] (:gates config))
+          (assoc-in [:phase :budget] (:budget config))
+          (assoc-in [:phase :started-at] start-time)
+          (assoc-in [:phase :status] (if all-passed? :completed :failed))
+          (assoc-in [:phase :result]
+                    {:status   (if all-passed? :success :validation-failed)
+                     :output   {:health health-results
+                                :smoke  smoke-results}
+                     :artifact {:content    {:health-results (:results health-results)
+                                             :smoke-results  (:results smoke-results)}
+                                :type       :validation-state
+                                :all-passed? all-passed?}
+                     :metrics  {:duration-ms  duration
+                                :checks-run   (+ (count (:results health-results))
+                                                 (count (:results smoke-results)))
+                                :checks-passed (+ (count (filter :passed? (:results health-results)))
+                                                  (count (filter :passed? (:results smoke-results))))}})
+          (evidence/add-evidence-to-ctx validation-evidence)))))
+
+(defn leave-validate
+  "Post-validation: pass through."
+  [ctx]
+  ctx)
+
+(defn error-validate
+  "Handle validate phase errors."
+  [ctx ex]
+  (let [logger (get-logger ctx)]
+    (log/error logger :validate :validate/error
+               {:data {:message (ex-message ex)
+                       :data    (ex-data ex)}})
+    (-> ctx
+        (assoc-in [:phase :status] :failed)
+        (update :execution/errors (fnil conj [])
+                {:type    :validate-error
+                 :phase   :validate
+                 :message (ex-message ex)
+                 :data    (ex-data ex)}))))
+
+;; Registration
+
+(defmethod registry/get-phase-interceptor :validate
+  [_]
+  {:name   :validate
+   :enter  enter-validate
+   :leave  leave-validate
+   :error  error-validate
+   :config default-config})
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Test validation against a running service
+  ;; (enter-validate {:execution/input {:health-endpoints ["http://localhost:5555/healthz"]}})
+
+  :leave-this-here)

--- a/components/phase-deployment/test/ai/miniforge/phase/deploy/validate_test.clj
+++ b/components/phase-deployment/test/ai/miniforge/phase/deploy/validate_test.clj
@@ -1,0 +1,47 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.phase.deploy.validate-test
+  (:require [ai.miniforge.phase.deploy.validate :as sut]
+            [clojure.test :refer [deftest is testing]]))
+
+(deftest resolve-validate-config-test
+  (testing "input overrides phase config and defaults are normalized once"
+    (let [resolved (#'sut/resolve-validate-config
+                    {:phase-config {:health-endpoints ["http://cfg/health"]
+                                    :smoke-commands ["echo cfg"]
+                                    :retry-delay-ms 1000}
+                     :execution/input {:smoke-commands ["echo input"]}})]
+      (is (= ["http://cfg/health"] (:health-endpoints resolved)))
+      (is (= ["echo input"] (:smoke-commands resolved)))
+      (is (= 3 (:retries resolved)))
+      (is (= 1000 (:retry-delay-ms resolved))))))
+
+(deftest check-health-endpoints-retries-until-pass-test
+  (testing "health checks retry until a passing result is returned"
+    (let [attempts (atom 0)]
+      (with-redefs [sut/http-health-check
+                    (fn [_url]
+                      (swap! attempts inc)
+                      (if (= 2 @attempts)
+                        {:passed? true :url "http://svc/health" :status-code 200 :duration-ms 10}
+                        {:passed? false :url "http://svc/health" :status-code 503 :duration-ms 10}))]
+        (let [result (#'sut/check-health-endpoints ["http://svc/health"] :retries 3 :retry-delay 0)]
+          (is (true? (:passed? result)))
+          (is (= 2 (:attempts (first (:results result)))))
+          (is (= 2 @attempts)))))))

--- a/docs/pull-requests/2026-04-01-feat-deployment-pack-validate.md
+++ b/docs/pull-requests/2026-04-01-feat-deployment-pack-validate.md
@@ -1,0 +1,40 @@
+# feat: deployment pack validate
+
+## Layer
+
+Application
+
+## Depends on
+
+- `feat/deployment-pack-deploy`
+
+## Overview
+
+Adds the validate phase interceptor for HTTP health checks and smoke tests after deployment.
+
+## Motivation
+
+Post-deployment verification should be reviewable on its own instead of being bundled into deploy or workflow wiring.
+
+## Changes in Detail
+
+- Add `validate.clj` with endpoint retries and smoke-test execution.
+- Register `:validate` phase defaults.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge after deploy and before workflow wiring.
+
+## Related Issues/PRs
+
+- Parent feature: deployment pack
+- Follow-up stack branch: `feat/deployment-pack-workflow-wiring`
+
+## Checklist
+
+- [x] Scope limited to the validate phase interceptor
+- [ ] `bb pre-commit` recorded


### PR DESCRIPTION
# feat: deployment pack validate

## Layer

Application

## Depends on

- `feat/deployment-pack-deploy`

## Overview

Adds the validate phase interceptor for HTTP health checks and smoke tests after deployment.

## Motivation

Post-deployment verification should be reviewable on its own instead of being bundled into deploy or workflow wiring.

## Changes in Detail

- Add `validate.clj` with endpoint retries and smoke-test execution.
- Register `:validate` phase defaults.

## Testing Plan

- Run `bb pre-commit`

## Deployment Plan

- Merge after deploy and before workflow wiring.

## Related Issues/PRs

- Parent feature: deployment pack
- Follow-up stack branch: `feat/deployment-pack-workflow-wiring`

## Checklist

- [x] Scope limited to the validate phase interceptor
- [ ] `bb pre-commit` recorded
