### PR TITLE
feat: pr monitor loop budget events

### DIFF
--- a/components/pr-lifecycle/resources/config/pr-monitor/defaults.edn
+++ b/components/pr-lifecycle/resources/config/pr-monitor/defaults.edn
@@ -1,0 +1,6 @@
+{:pr-monitor/defaults
+ {:poll-interval-ms 60000
+  :self-author nil
+  :max-fix-attempts-per-comment 3
+  :max-total-fix-attempts-per-pr 10
+  :abandon-after-hours 72}}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj
@@ -26,11 +26,42 @@
    Human comment classification uses an LLM call with structured output
    when a generate-fn is provided, falling back to keyword-based heuristics."
   (:require
+   [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.pr-lifecycle.triage :as triage]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Bot detection
+;; Schemas + bot detection
+
+(def ClassifiedComment
+  [:map
+   [:category keyword?]
+   [:confidence keyword?]
+   [:method keyword?]
+   [:comment map?]])
+
+(def ClassificationStats
+  [:map
+   [:total nat-int?]
+   [:change-requests nat-int?]
+   [:questions nat-int?]
+   [:approvals nat-int?]
+   [:bot-comments nat-int?]
+   [:noise nat-int?]])
+
+(def ClassifiedCommentsBatch
+  [:map
+   [:change-requests [:vector ClassifiedComment]]
+   [:questions [:vector ClassifiedComment]]
+   [:approvals [:vector ClassifiedComment]]
+   [:bot-comments [:vector ClassifiedComment]]
+   [:noise [:vector ClassifiedComment]]
+   [:all [:vector ClassifiedComment]]
+   [:stats ClassificationStats]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
 
 (def bot-login-patterns
   "Login substrings and suffixes for known bots."
@@ -125,6 +156,52 @@ Do not include any other text.")
 ;------------------------------------------------------------------------------ Layer 2
 ;; Unified classifier
 
+(defn- heuristic-category
+  [body]
+  (cond
+    (question-comment? body)                                          :question
+    (pos? (triage/score-indicators body triage/actionable-indicators)) :change-request
+    (approval-comment? body)                                          :approval
+    :else                                                             :noise))
+
+(defn- build-classification
+  [category confidence method comment]
+  (validate!
+   ClassifiedComment
+   {:category category
+    :confidence confidence
+    :method method
+    :comment comment}))
+
+(defn- llm-category
+  [body generate-fn]
+  (let [prompt   (build-classify-prompt body)
+        response (try (generate-fn prompt) (catch Exception _e nil))]
+    (parse-llm-classification response)))
+
+(defn- classify-human-comment
+  [comment body generate-fn]
+  (if generate-fn
+    (if-let [category (llm-category body generate-fn)]
+      (build-classification category :high :llm comment)
+      (build-classification (heuristic-category body) :low :heuristic-fallback comment))
+    (build-classification (heuristic-category body) :medium :heuristic comment)))
+
+(defn- grouped-comments
+  [classified-comments]
+  (group-by :category classified-comments))
+
+(defn- stats-for
+  [classified-comments grouped]
+  (validate!
+   ClassificationStats
+   {:total           (count classified-comments)
+    :change-requests (count (get grouped :change-request))
+    :questions       (count (get grouped :question))
+    :approvals       (count (get grouped :approval))
+    :bot-comments    (count (get grouped :bot-comment))
+    :noise           (count (get grouped :noise))}))
+
 (defn classify-comment
   "Classify a single comment into a category.
 
@@ -149,52 +226,20 @@ Do not include any other text.")
     (cond
       ;; 1. Self-comment: always noise (loop prevention — never respond to own comments)
       (and self-author author (= author self-author))
-      {:category   :noise
-       :confidence :high
-       :method     :self-filter
-       :comment    comment}
+      (build-classification :noise :high :self-filter comment)
 
       ;; 2. Bot detection by author login pattern
       (bot-author? author)
-      {:category   :bot-comment
-       :confidence :high
-       :method     :bot-rule
-       :comment    comment}
+      (build-classification :bot-comment :high :bot-rule comment)
 
       ;; 3. Pure approval with no actionable indicators
       (and (approval-comment? body)
            (zero? (triage/score-indicators body triage/actionable-indicators)))
-      {:category   :approval
-       :confidence :high
-       :method     :heuristic
-       :comment    comment}
+      (build-classification :approval :high :heuristic comment)
 
-      ;; 4. LLM-based classification for ambiguous human comments
-      generate-fn
-      (let [prompt   (build-classify-prompt body)
-            response (try (generate-fn prompt) (catch Exception _e nil))
-            category (parse-llm-classification response)]
-        {:category   (or category
-                         ;; Fallback to heuristic if LLM fails or returns garbage
-                         (cond
-                           (question-comment? body) :question
-                           (pos? (triage/score-indicators body triage/actionable-indicators)) :change-request
-                           (approval-comment? body) :approval
-                           :else :noise))
-         :confidence (if category :high :low)
-         :method     (if category :llm :heuristic-fallback)
-         :comment    comment})
-
-      ;; 5. Heuristic fallback (no LLM available)
+      ;; 4. Heuristic or LLM-based classification for other human comments
       :else
-      {:category   (cond
-                     (question-comment? body)                                            :question
-                     (pos? (triage/score-indicators body triage/actionable-indicators))   :change-request
-                     (approval-comment? body)                                            :approval
-                     :else                                                               :noise)
-       :confidence :medium
-       :method     :heuristic
-       :comment    comment})))
+      (classify-human-comment comment body generate-fn))))
 
 (defn classify-comments
   "Classify a batch of comments.
@@ -215,23 +260,20 @@ Do not include any other text.")
     :all             [classified...]
     :stats           {:total n :change-requests n ...}}"
   [comments & {:keys [generate-fn self-author]}]
-  (let [classified (mapv #(classify-comment %
-                                            :generate-fn generate-fn
-                                            :self-author self-author)
-                         comments)
-        by-cat     (group-by :category classified)]
-    {:change-requests (vec (get by-cat :change-request))
-     :questions       (vec (get by-cat :question))
-     :approvals       (vec (get by-cat :approval))
-     :bot-comments    (vec (get by-cat :bot-comment))
-     :noise           (vec (get by-cat :noise))
-     :all             classified
-     :stats           {:total           (count classified)
-                       :change-requests (count (get by-cat :change-request))
-                       :questions       (count (get by-cat :question))
-                       :approvals       (count (get by-cat :approval))
-                       :bot-comments    (count (get by-cat :bot-comment))
-                       :noise           (count (get by-cat :noise))}}))
+  (let [classified (into [] (map #(classify-comment %
+                                                   :generate-fn generate-fn
+                                                   :self-author self-author))
+                          comments)
+        grouped    (grouped-comments classified)]
+    (validate!
+     ClassifiedCommentsBatch
+     {:change-requests (vec (get grouped :change-request))
+      :questions       (vec (get grouped :question))
+      :approvals       (vec (get grouped :approval))
+      :bot-comments    (vec (get grouped :bot-comment))
+      :noise           (vec (get grouped :noise))
+      :all             classified
+      :stats           (stats-for classified grouped)})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj
@@ -1,0 +1,269 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.classifier
+  "Comment classification for PR reviews.
+
+   Classifies each GitHub comment into one of:
+   - :change-request — reviewer asking for a specific code change
+   - :question — reviewer asking for clarification
+   - :approval — reviewer expressing approval
+   - :bot-comment — automated tool (Dependabot, CodeQL, Codecov, Renovate)
+   - :noise — emoji reactions, acknowledgements requiring no action
+
+   Bot detection uses author login matching against known patterns.
+   Human comment classification uses an LLM call with structured output
+   when a generate-fn is provided, falling back to keyword-based heuristics."
+  (:require
+   [ai.miniforge.pr-lifecycle.triage :as triage]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Bot detection
+
+(def bot-login-patterns
+  "Login substrings and suffixes for known bots."
+  #{"dependabot" "renovate" "codecov" "github-actions"
+    "stale" "mergify" "greenkeeper" "snyk-bot"
+    "sonarcloud" "codeclimate" "coveralls"
+    "hound" "percy" "chromatic" "netlify"})
+
+(defn bot-author?
+  "Check if a comment author is a bot.
+
+   Matches known bot login patterns and the [bot] suffix convention."
+  [author]
+  (when (and author (string? author) (seq author))
+    (let [lower (str/lower-case author)]
+      (or (some #(str/includes? lower %) bot-login-patterns)
+          (str/ends-with? lower "[bot]")
+          (str/ends-with? lower "-bot")
+          (str/ends-with? lower "-app")))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Approval detection
+
+(def approval-phrases
+  "Phrases that indicate approval."
+  #{"lgtm" "looks good to me" "looks good" "approved" "ship it"
+    "+1" "looks great" "well done" "nice work" "excellent"
+    "no objections" "good to go" "thumbs up"})
+
+(defn approval-comment?
+  "Check if a comment body expresses approval."
+  [body]
+  (when (and body (seq body))
+    (let [lower (str/lower-case (str/trim body))]
+      (boolean (some #(str/includes? lower %) approval-phrases)))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Question detection (heuristic)
+
+(def ^:private question-patterns
+  "Regex patterns that suggest a comment is a question."
+  [#"\?"
+   #"(?i)^(why|what|how|when|where|could you|can you|would you|should we|is this|are these|do we|does this)"
+   #"(?i)\b(curious|wondering|question|clarify|explain|understand|reason for)\b"])
+
+(defn question-comment?
+  "Check if a comment body is a question (heuristic)."
+  [body]
+  (when (and body (seq body))
+    (boolean (some #(re-find % body) question-patterns))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; LLM-based classification
+
+(def classification-prompt-template
+  "Prompt template for LLM-based comment classification.
+
+   The generate-fn receives this prompt and returns a single category word."
+  "Classify the following GitHub PR review comment into exactly one category.
+
+Categories:
+- change-request: The reviewer is asking for a specific code change, fix, or improvement.
+- question: The reviewer is asking a question for clarification, not requesting a change.
+- approval: The reviewer is expressing approval or satisfaction with the code.
+- noise: The comment is an acknowledgement, emoji, \"thanks\", or requires no action.
+
+Comment:
+\"%s\"
+
+Respond with ONLY the category name (change-request, question, approval, or noise).
+Do not include any other text.")
+
+(defn build-classify-prompt
+  "Build the classification prompt for a comment body."
+  [body]
+  (format classification-prompt-template (str/replace (or body "") "\"" "\\\"" )))
+
+(defn parse-llm-classification
+  "Parse the LLM response into a classification keyword.
+
+   Returns nil if the response cannot be parsed."
+  [response]
+  (when (and response (seq (str/trim response)))
+    (let [cleaned (-> response str/trim str/lower-case (str/replace #"[^a-z-]" ""))]
+      (get {"change-request" :change-request
+            "changerequest"  :change-request
+            "question"       :question
+            "approval"       :approval
+            "noise"          :noise}
+           cleaned))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Unified classifier
+
+(defn classify-comment
+  "Classify a single comment into a category.
+
+   Arguments:
+   - comment: Map with :body, :author, :id, :path, :line keys
+
+   Options:
+   - :generate-fn — LLM generation function (fn [prompt] → response-string).
+     When provided, human comments are classified via LLM.
+     When absent, falls back to keyword-based heuristics.
+   - :self-author — Author login to filter out self-comments (loop prevention).
+     Comments from this author are always classified as :noise.
+
+   Returns:
+   {:category keyword   ; :change-request :question :approval :bot-comment :noise
+    :confidence keyword  ; :high :medium :low
+    :method keyword      ; :self-filter :bot-rule :llm :heuristic :heuristic-fallback
+    :comment map}"
+  [comment & {:keys [generate-fn self-author]}]
+  (let [body   (or (:body comment) (:comment/body comment) "")
+        author (or (:author comment) (:comment/author comment))]
+    (cond
+      ;; 1. Self-comment: always noise (loop prevention — never respond to own comments)
+      (and self-author author (= author self-author))
+      {:category   :noise
+       :confidence :high
+       :method     :self-filter
+       :comment    comment}
+
+      ;; 2. Bot detection by author login pattern
+      (bot-author? author)
+      {:category   :bot-comment
+       :confidence :high
+       :method     :bot-rule
+       :comment    comment}
+
+      ;; 3. Pure approval with no actionable indicators
+      (and (approval-comment? body)
+           (zero? (triage/score-indicators body triage/actionable-indicators)))
+      {:category   :approval
+       :confidence :high
+       :method     :heuristic
+       :comment    comment}
+
+      ;; 4. LLM-based classification for ambiguous human comments
+      generate-fn
+      (let [prompt   (build-classify-prompt body)
+            response (try (generate-fn prompt) (catch Exception _e nil))
+            category (parse-llm-classification response)]
+        {:category   (or category
+                         ;; Fallback to heuristic if LLM fails or returns garbage
+                         (cond
+                           (question-comment? body) :question
+                           (pos? (triage/score-indicators body triage/actionable-indicators)) :change-request
+                           (approval-comment? body) :approval
+                           :else :noise))
+         :confidence (if category :high :low)
+         :method     (if category :llm :heuristic-fallback)
+         :comment    comment})
+
+      ;; 5. Heuristic fallback (no LLM available)
+      :else
+      {:category   (cond
+                     (question-comment? body)                                            :question
+                     (pos? (triage/score-indicators body triage/actionable-indicators))   :change-request
+                     (approval-comment? body)                                            :approval
+                     :else                                                               :noise)
+       :confidence :medium
+       :method     :heuristic
+       :comment    comment})))
+
+(defn classify-comments
+  "Classify a batch of comments.
+
+   Arguments:
+   - comments: Sequence of comment maps
+
+   Options:
+   - :generate-fn — LLM generation function
+   - :self-author — Author login to filter self-comments
+
+   Returns:
+   {:change-requests [classified...]
+    :questions       [classified...]
+    :approvals       [classified...]
+    :bot-comments    [classified...]
+    :noise           [classified...]
+    :all             [classified...]
+    :stats           {:total n :change-requests n ...}}"
+  [comments & {:keys [generate-fn self-author]}]
+  (let [classified (mapv #(classify-comment %
+                                            :generate-fn generate-fn
+                                            :self-author self-author)
+                         comments)
+        by-cat     (group-by :category classified)]
+    {:change-requests (vec (get by-cat :change-request))
+     :questions       (vec (get by-cat :question))
+     :approvals       (vec (get by-cat :approval))
+     :bot-comments    (vec (get by-cat :bot-comment))
+     :noise           (vec (get by-cat :noise))
+     :all             classified
+     :stats           {:total           (count classified)
+                       :change-requests (count (get by-cat :change-request))
+                       :questions       (count (get by-cat :question))
+                       :approvals       (count (get by-cat :approval))
+                       :bot-comments    (count (get by-cat :bot-comment))
+                       :noise           (count (get by-cat :noise))}}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Bot detection
+  (bot-author? "dependabot[bot]")        ; => true
+  (bot-author? "renovate[bot]")          ; => true
+  (bot-author? "human-reviewer")         ; => nil (falsey)
+
+  ;; Classify individual comments
+  (classify-comment {:body "Please fix the null pointer exception" :author "alice"})
+  ; => {:category :change-request :confidence :medium :method :heuristic ...}
+
+  (classify-comment {:body "Why did you choose this approach?" :author "bob"})
+  ; => {:category :question :confidence :medium :method :heuristic ...}
+
+  (classify-comment {:body "LGTM!" :author "charlie"})
+  ; => {:category :approval :confidence :high :method :heuristic ...}
+
+  (classify-comment {:body "Bumps lodash from 4.17.20 to 4.17.21" :author "dependabot[bot]"})
+  ; => {:category :bot-comment :confidence :high :method :bot-rule ...}
+
+  ;; Self-comment loop prevention
+  (classify-comment {:body "Fixed in commit abc123" :author "miniforge-bot"}
+                    :self-author "miniforge-bot")
+  ; => {:category :noise :confidence :high :method :self-filter ...}
+
+  ;; Batch classification
+  (classify-comments
+   [{:body "Please add tests" :author "alice"}
+    {:body "Looks good!" :author "bob"}
+    {:body "Why this approach?" :author "charlie"}
+    {:body "Security scan passed" :author "codeql[bot]"}])
+  ; => {:change-requests [...] :questions [...] :approvals [...] ...}
+
+  :leave-this-here)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_budget.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_budget.clj
@@ -17,22 +17,35 @@
 
    Tracks fix attempts per comment, total attempts per PR, and time bounds.
    Budget limits are hard stops — when exhausted, all autonomous action
-   ceases and an escalation event is emitted.
+  ceases and an escalation event is emitted.
 
    Budget state is persisted in ~/.miniforge/state/pr-monitor/ so that
    restarts do not reset counters."
   (:require
+   [ai.miniforge.pr-lifecycle.monitor-config :as config]
+   [ai.miniforge.schema.interface :as schema]
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Budget defaults
+;; Schemas + budget defaults
 
-(def default-budget
-  "Default budget limits for the PR monitor loop."
-  {:max-fix-attempts-per-comment 3
-   :max-total-fix-attempts-per-pr 10
-   :abandon-after-hours 72})
+(def BudgetState
+  [:map
+   [:pr-number pos-int?]
+   [:limits [:map
+             [:max-fix-attempts-per-comment pos-int?]
+             [:max-total-fix-attempts-per-pr pos-int?]
+             [:abandon-after-hours pos-int?]]]
+   [:comment-attempts [:map-of int? nat-int?]]
+   [:total-attempts nat-int?]
+   [:started-at inst?]
+   [:questions-answered nat-int?]
+   [:fixes-pushed nat-int?]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Budget state
@@ -46,14 +59,16 @@
 
    Returns budget state map."
   [pr-number & [config]]
-  (let [limits (merge default-budget config)]
-    {:pr-number pr-number
-     :limits limits
-     :comment-attempts {}   ; comment-id → attempt-count
-     :total-attempts 0
-     :started-at (java.util.Date.)
-     :questions-answered 0
-     :fixes-pushed 0}))
+  (let [limits (merge (config/budget-defaults) config)]
+    (validate!
+     BudgetState
+     {:pr-number pr-number
+      :limits limits
+      :comment-attempts {}
+      :total-attempts 0
+      :started-at (java.util.Date.)
+      :questions-answered 0
+      :fixes-pushed 0})))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Budget operations

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_budget.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_budget.clj
@@ -1,0 +1,198 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-budget
+  "Per-PR budget tracking for the PR monitor loop.
+
+   Tracks fix attempts per comment, total attempts per PR, and time bounds.
+   Budget limits are hard stops — when exhausted, all autonomous action
+   ceases and an escalation event is emitted.
+
+   Budget state is persisted in ~/.miniforge/state/pr-monitor/ so that
+   restarts do not reset counters."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Budget defaults
+
+(def default-budget
+  "Default budget limits for the PR monitor loop."
+  {:max-fix-attempts-per-comment 3
+   :max-total-fix-attempts-per-pr 10
+   :abandon-after-hours 72})
+
+;------------------------------------------------------------------------------ Layer 0
+;; Budget state
+
+(defn create-budget
+  "Create a new budget tracker for a PR.
+
+   Arguments:
+   - pr-number: PR number
+   - config: Optional budget config overrides
+
+   Returns budget state map."
+  [pr-number & [config]]
+  (let [limits (merge default-budget config)]
+    {:pr-number pr-number
+     :limits limits
+     :comment-attempts {}   ; comment-id → attempt-count
+     :total-attempts 0
+     :started-at (java.util.Date.)
+     :questions-answered 0
+     :fixes-pushed 0}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Budget operations
+
+(defn record-fix-attempt
+  "Record a fix attempt for a comment. Returns updated budget state."
+  [budget comment-id]
+  (-> budget
+      (update-in [:comment-attempts comment-id] (fnil inc 0))
+      (update :total-attempts inc)))
+
+(defn record-question-answered
+  "Record a question answered (does not consume fix budget)."
+  [budget]
+  (update budget :questions-answered inc))
+
+(defn record-fix-pushed
+  "Record a successful fix push."
+  [budget]
+  (update budget :fixes-pushed inc))
+
+(defn comment-attempts-remaining
+  "How many fix attempts remain for a specific comment."
+  [budget comment-id]
+  (let [max-per-comment (get-in budget [:limits :max-fix-attempts-per-comment])
+        used (get-in budget [:comment-attempts comment-id] 0)]
+    (max 0 (- max-per-comment used))))
+
+(defn total-attempts-remaining
+  "How many total fix attempts remain for the PR."
+  [budget]
+  (let [max-total (get-in budget [:limits :max-total-fix-attempts-per-pr])
+        used (:total-attempts budget)]
+    (max 0 (- max-total used))))
+
+(defn hours-elapsed
+  "Hours elapsed since monitoring started."
+  [budget]
+  (let [started (.getTime ^java.util.Date (:started-at budget))
+        now (System/currentTimeMillis)]
+    (/ (double (- now started)) 3600000.0)))
+
+(defn time-remaining-hours
+  "Hours remaining before abandon deadline."
+  [budget]
+  (let [max-hours (get-in budget [:limits :abandon-after-hours])]
+    (max 0.0 (- (double max-hours) (hours-elapsed budget)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Budget checks (hard stops)
+
+(defn comment-budget-exhausted?
+  "Check if the per-comment budget is exhausted."
+  [budget comment-id]
+  (zero? (comment-attempts-remaining budget comment-id)))
+
+(defn pr-budget-exhausted?
+  "Check if the total PR budget is exhausted."
+  [budget]
+  (zero? (total-attempts-remaining budget)))
+
+(defn time-budget-exhausted?
+  "Check if the time budget is exhausted."
+  [budget]
+  (<= (time-remaining-hours budget) 0.0))
+
+(defn any-budget-exhausted?
+  "Check if any budget dimension is exhausted.
+
+   Returns nil if budget OK, or a keyword indicating which limit was hit:
+   :comment-limit, :pr-limit, or :time-limit."
+  [budget comment-id]
+  (cond
+    (time-budget-exhausted? budget)                     :time-limit
+    (pr-budget-exhausted? budget)                       :pr-limit
+    (and comment-id
+         (comment-budget-exhausted? budget comment-id)) :comment-limit
+    :else                                               nil))
+
+(defn budget-summary
+  "Generate a summary of current budget status for events and logging."
+  [budget]
+  {:total-attempts-used (:total-attempts budget)
+   :total-attempts-remaining (total-attempts-remaining budget)
+   :hours-elapsed (hours-elapsed budget)
+   :hours-remaining (time-remaining-hours budget)
+   :fixes-pushed (:fixes-pushed budget)
+   :questions-answered (:questions-answered budget)
+   :comment-attempts (:comment-attempts budget)})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Budget persistence
+
+(def ^:private state-dir
+  (str (System/getProperty "user.home") "/.miniforge/state/pr-monitor"))
+
+(defn save-budget!
+  "Persist budget state to disk."
+  [budget]
+  (let [dir (io/file state-dir)
+        _ (when-not (.exists dir) (.mkdirs dir))
+        f (io/file state-dir (str "budget-" (:pr-number budget) ".edn"))]
+    (spit f (pr-str budget))))
+
+(defn load-budget
+  "Load persisted budget for a PR, if it exists."
+  [pr-number]
+  (let [f (io/file state-dir (str "budget-" pr-number ".edn"))]
+    (when (.exists f)
+      (try
+        (edn/read-string (slurp f))
+        (catch Exception _e nil)))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create budget
+  (def b (create-budget 123))
+
+  ;; Record attempts
+  (def b2 (-> b
+               (record-fix-attempt 456)
+               (record-fix-attempt 456)
+               (record-fix-attempt 789)))
+
+  ;; Check limits
+  (comment-attempts-remaining b2 456) ; => 1
+  (total-attempts-remaining b2)       ; => 7
+  (any-budget-exhausted? b2 456)      ; => nil
+
+  ;; After 3 attempts on same comment
+  (def b3 (record-fix-attempt b2 456))
+  (comment-budget-exhausted? b3 456)  ; => true
+  (any-budget-exhausted? b3 456)      ; => :comment-limit
+
+  ;; Summary
+  (budget-summary b3)
+
+  ;; Persistence
+  (save-budget! b3)
+  (load-budget 123)
+
+  :leave-this-here)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_config.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_config.clj
@@ -1,0 +1,66 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-config
+  "Load shared PR monitor defaults from EDN configuration."
+  (:require
+   [ai.miniforge.schema.interface :as schema]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schemas + config loading
+
+(def MonitorDefaults
+  [:map
+   [:poll-interval-ms nat-int?]
+   [:self-author {:optional true} [:maybe :string]]
+   [:max-fix-attempts-per-comment pos-int?]
+   [:max-total-fix-attempts-per-pr pos-int?]
+   [:abandon-after-hours pos-int?]])
+
+(def MonitorConfig
+  [:map
+   [:pr-monitor/defaults MonitorDefaults]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
+
+(defn- load-monitor-config
+  []
+  (->> "config/pr-monitor/defaults.edn"
+       io/resource
+       slurp
+       edn/read-string
+       (validate! MonitorConfig)))
+
+(def ^:private monitor-config
+  (delay (load-monitor-config)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Public helpers
+
+(defn monitor-defaults
+  "Return the shared PR monitor defaults map."
+  []
+  (:pr-monitor/defaults @monitor-config))
+
+(defn budget-defaults
+  "Return just the budget-related defaults used by the monitor loop."
+  []
+  (select-keys (monitor-defaults)
+               [:max-fix-attempts-per-comment
+                :max-total-fix-attempts-per-pr
+                :abandon-after-hours]))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_events.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_events.clj
@@ -1,0 +1,159 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-events
+  "PR monitor loop event types and constructors.
+
+   These events track the autonomous PR monitor loop activity:
+   polling, classification, fix cycles, replies, and budget enforcement.
+   Complement the base :pr/* events in events.clj with finer-grained
+   :pr-monitor/* events for TUI visibility."
+  (:require
+   [ai.miniforge.pr-lifecycle.events :as events]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Event types
+
+(def monitor-event-types
+  "Valid PR monitor loop event types."
+  #{:pr-monitor/poll-completed       ; Poll cycle completed
+    :pr-monitor/comment-received     ; New comment detected
+    :pr-monitor/comment-classified   ; Comment classified into category
+    :pr-monitor/fix-started          ; Fix cycle initiated for change-request
+    :pr-monitor/fix-pushed           ; Fix committed and pushed
+    :pr-monitor/reply-posted         ; Reply comment posted to PR
+    :pr-monitor/question-answered    ; Question answered via LLM reply
+    :pr-monitor/budget-warning       ; Budget approaching limit
+    :pr-monitor/budget-exhausted     ; Budget exceeded — hard stop
+    :pr-monitor/escalated            ; Escalated to human intervention
+    :pr-monitor/cycle-completed      ; Full monitor cycle completed
+    :pr-monitor/loop-started         ; Monitor loop started for a PR
+    :pr-monitor/loop-stopped})       ; Monitor loop stopped
+
+;------------------------------------------------------------------------------ Layer 1
+;; Event constructors
+
+(defn poll-completed
+  "Create a poll-completed event."
+  [pr-number data]
+  (events/create-event :pr-monitor/poll-completed
+                       (merge {:pr/id pr-number} data)))
+
+(defn comment-received
+  "Create a comment-received event."
+  [pr-number comment-data]
+  (events/create-event :pr-monitor/comment-received
+                       {:pr/id pr-number
+                        :comment comment-data}))
+
+(defn comment-classified
+  "Create a comment-classified event."
+  [pr-number comment-data classification]
+  (events/create-event :pr-monitor/comment-classified
+                       {:pr/id pr-number
+                        :comment comment-data
+                        :classification classification}))
+
+(defn fix-started
+  "Create a fix-started event."
+  [pr-number comment-id attempt]
+  (events/create-event :pr-monitor/fix-started
+                       {:pr/id pr-number
+                        :comment/id comment-id
+                        :fix/attempt attempt}))
+
+(defn fix-pushed
+  "Create a fix-pushed event."
+  [pr-number comment-id commit-sha]
+  (events/create-event :pr-monitor/fix-pushed
+                       {:pr/id pr-number
+                        :comment/id comment-id
+                        :pr/sha commit-sha}))
+
+(defn reply-posted
+  "Create a reply-posted event."
+  [pr-number comment-id reply-type]
+  (events/create-event :pr-monitor/reply-posted
+                       {:pr/id pr-number
+                        :comment/id comment-id
+                        :reply/type reply-type}))
+
+(defn question-answered
+  "Create a question-answered event."
+  [pr-number comment-id]
+  (events/create-event :pr-monitor/question-answered
+                       {:pr/id pr-number
+                        :comment/id comment-id}))
+
+(defn budget-warning
+  "Create a budget-warning event."
+  [pr-number budget-remaining budget-total]
+  (events/create-event :pr-monitor/budget-warning
+                       {:pr/id pr-number
+                        :budget/remaining budget-remaining
+                        :budget/total budget-total}))
+
+(defn budget-exhausted
+  "Create a budget-exhausted event. This is a hard stop."
+  [pr-number budget-data]
+  (events/create-event :pr-monitor/budget-exhausted
+                       (merge {:pr/id pr-number} budget-data)))
+
+(defn escalated
+  "Create an escalated-to-human event."
+  [pr-number reason data]
+  (events/create-event :pr-monitor/escalated
+                       (merge {:pr/id pr-number
+                               :escalation/reason reason}
+                              data)))
+
+(defn cycle-completed
+  "Create a cycle-completed event."
+  [pr-number cycle-data]
+  (events/create-event :pr-monitor/cycle-completed
+                       (merge {:pr/id pr-number} cycle-data)))
+
+(defn loop-started
+  "Create a loop-started event."
+  [pr-number config]
+  (events/create-event :pr-monitor/loop-started
+                       {:pr/id pr-number
+                        :config (select-keys config [:poll-interval-ms
+                                                     :max-fix-attempts-per-comment
+                                                     :max-total-fix-attempts-per-pr
+                                                     :abandon-after-hours])}))
+
+(defn loop-stopped
+  "Create a loop-stopped event."
+  [pr-number reason]
+  (events/create-event :pr-monitor/loop-stopped
+                       {:pr/id pr-number
+                        :stop/reason reason}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Create events
+  (poll-completed 123 {:new-comment-count 3})
+  ;; => {:event/id uuid :event/type :pr-monitor/poll-completed :pr/id 123 ...}
+
+  (comment-received 123 {:comment/body "Please fix this" :comment/author "alice"})
+
+  (budget-exhausted 123 {:exhausted-by :pr-limit :total-attempts 10})
+
+  (loop-started 123 {:poll-interval-ms 60000
+                     :max-fix-attempts-per-comment 3
+                     :max-total-fix-attempts-per-pr 10
+                     :abandon-after-hours 72})
+
+  :leave-this-here)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/classifier_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/classifier_test.clj
@@ -1,0 +1,63 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.classifier-test
+  (:require
+   [ai.miniforge.pr-lifecycle.classifier :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Classifier tests
+
+(deftest classify-comment-test
+  (testing "filters self comments as noise"
+    (is (= {:category :noise
+            :confidence :high
+            :method :self-filter}
+           (select-keys (sut/classify-comment {:body "Fixed in commit abc123"
+                                               :author "miniforge-bot"}
+                                              :self-author "miniforge-bot")
+                        [:category :confidence :method]))))
+
+  (testing "detects bot comments from author login"
+    (is (= :bot-comment
+           (:category (sut/classify-comment {:body "Automated scan"
+                                             :author "dependabot[bot]"})))))
+
+  (testing "uses heuristic approval detection when there are no actionable indicators"
+    (is (= :approval
+           (:category (sut/classify-comment {:body "LGTM, ship it"
+                                             :author "reviewer"})))))
+
+  (testing "falls back to question detection when LLM classification is unavailable"
+    (is (= {:category :question
+            :confidence :low
+            :method :heuristic-fallback}
+           (select-keys (sut/classify-comment {:body "Why did you choose this approach?"
+                                               :author "reviewer"}
+                                              :generate-fn (fn [_] "not-a-category"))
+                        [:category :confidence :method])))))
+
+(deftest classify-comments-batch-test
+  (testing "groups comments by category and reports stats"
+    (let [result (sut/classify-comments
+                  [{:body "Please add tests" :author "alice"}
+                   {:body "Looks good" :author "bob"}
+                   {:body "Why this approach?" :author "carol"}
+                   {:body "Dependency update" :author "renovate[bot]"}])]
+      (is (= 4 (get-in result [:stats :total])))
+      (is (= 1 (count (:change-requests result))))
+      (is (= 1 (count (:approvals result))))
+      (is (= 1 (count (:questions result))))
+      (is (= 1 (count (:bot-comments result)))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_budget_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_budget_test.clj
@@ -1,0 +1,54 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-budget-test
+  (:require
+   [ai.miniforge.pr-lifecycle.monitor-budget :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Budget tests
+
+(deftest record-fix-attempt-test
+  (testing "increments comment-local and total attempt counters"
+    (let [budget (-> (sut/create-budget 42)
+                     (sut/record-fix-attempt 1001)
+                     (sut/record-fix-attempt 1001)
+                     (sut/record-fix-attempt 1002))]
+      (is (= 2 (get-in budget [:comment-attempts 1001])))
+      (is (= 1 (get-in budget [:comment-attempts 1002])))
+      (is (= 3 (:total-attempts budget)))
+      (is (= 1 (sut/comment-attempts-remaining budget 1001)))
+      (is (= 7 (sut/total-attempts-remaining budget))))))
+
+(deftest any-budget-exhausted-test
+  (testing "reports comment limit when a single comment runs out of attempts"
+    (let [budget (-> (sut/create-budget 42)
+                     (sut/record-fix-attempt 1001)
+                     (sut/record-fix-attempt 1001)
+                     (sut/record-fix-attempt 1001))]
+      (is (= :comment-limit (sut/any-budget-exhausted? budget 1001)))))
+
+  (testing "reports PR limit when the total attempt budget is exhausted"
+    (let [budget (reduce (fn [state comment-id]
+                           (sut/record-fix-attempt state comment-id))
+                         (sut/create-budget 42 {:max-total-fix-attempts-per-pr 2})
+                         [1001 1002])]
+      (is (= :pr-limit (sut/any-budget-exhausted? budget 1003)))))
+
+  (testing "reports time limit when abandon-after-hours has elapsed"
+    (let [budget (assoc (sut/create-budget 42 {:abandon-after-hours 1})
+                        :started-at
+                        (java.util.Date. (- (System/currentTimeMillis) (* 2 3600000))))]
+      (is (= :time-limit (sut/any-budget-exhausted? budget 1001))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_budget_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_budget_test.clj
@@ -21,6 +21,12 @@
 ;; Budget tests
 
 (deftest record-fix-attempt-test
+  (testing "defaults are loaded from monitor config"
+    (let [budget (sut/create-budget 42)]
+      (is (= 3 (get-in budget [:limits :max-fix-attempts-per-comment])))
+      (is (= 10 (get-in budget [:limits :max-total-fix-attempts-per-pr])))
+      (is (= 72 (get-in budget [:limits :abandon-after-hours])))))
+
   (testing "increments comment-local and total attempt counters"
     (let [budget (-> (sut/create-budget 42)
                      (sut/record-fix-attempt 1001)

--- a/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-budget-events.md
+++ b/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-budget-events.md
@@ -1,0 +1,42 @@
+# feat: pr monitor loop budget events
+
+## Layer
+
+Foundations
+
+## Depends on
+
+- `feat/pr-monitor-loop-classifier`
+
+## Overview
+
+Adds PR monitor budget tracking and the monitor-specific event constructors.
+
+## Motivation
+
+The monitor loop needs hard-stop budget state and a stable event vocabulary before pollers or loop orchestration are
+introduced.
+
+## Changes in Detail
+
+- Add `monitor_budget.clj`.
+- Add `monitor_events.clj`.
+- Add focused budget tests.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge after the classifier and before the poller and loop branches.
+
+## Related Issues/PRs
+
+- Parent feature: PR monitor loop
+- Follow-up stack branch: `feat/pr-monitor-loop-poller`
+
+## Checklist
+
+- [x] Scope limited to budget state and event modeling
+- [ ] `bb pre-commit` recorded

--- a/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-classifier.md
+++ b/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-classifier.md
@@ -1,0 +1,41 @@
+# feat: pr monitor loop classifier
+
+## Layer
+
+Domain
+
+## Depends on
+
+- `feat/pr-monitor-loop-spec`
+
+## Overview
+
+Adds comment classification for PR review comments plus focused unit coverage.
+
+## Motivation
+
+The monitor loop needs a reviewable, testable way to distinguish change requests, questions, approvals, bot comments,
+and noise before any orchestration is added.
+
+## Changes in Detail
+
+- Add `classifier.clj`.
+- Add focused classifier tests.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge after the work spec and before polling/orchestration branches.
+
+## Related Issues/PRs
+
+- Parent feature: PR monitor loop
+- Follow-up stack branch: `feat/pr-monitor-loop-budget-events`
+
+## Checklist
+
+- [x] Scope limited to comment classification
+- [ ] `bb pre-commit` recorded


### PR DESCRIPTION
# feat: pr monitor loop budget events

## Layer

Foundations

## Depends on

- `feat/pr-monitor-loop-classifier`

## Overview

Adds PR monitor budget tracking and the monitor-specific event constructors.

## Motivation

The monitor loop needs hard-stop budget state and a stable event vocabulary before pollers or loop orchestration are
introduced.

## Changes in Detail

- Add `monitor_budget.clj`.
- Add `monitor_events.clj`.
- Add focused budget tests.

## Testing Plan

- Run `bb pre-commit`

## Deployment Plan

- Merge after the classifier and before the poller and loop branches.

## Related Issues/PRs

- Parent feature: PR monitor loop
- Follow-up stack branch: `feat/pr-monitor-loop-poller`

## Checklist

- [x] Scope limited to budget state and event modeling
- [ ] `bb pre-commit` recorded
