### PR TITLE
feat: pr monitor loop classifier

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj
@@ -26,11 +26,42 @@
    Human comment classification uses an LLM call with structured output
    when a generate-fn is provided, falling back to keyword-based heuristics."
   (:require
+   [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.pr-lifecycle.triage :as triage]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Bot detection
+;; Schemas + bot detection
+
+(def ClassifiedComment
+  [:map
+   [:category keyword?]
+   [:confidence keyword?]
+   [:method keyword?]
+   [:comment map?]])
+
+(def ClassificationStats
+  [:map
+   [:total nat-int?]
+   [:change-requests nat-int?]
+   [:questions nat-int?]
+   [:approvals nat-int?]
+   [:bot-comments nat-int?]
+   [:noise nat-int?]])
+
+(def ClassifiedCommentsBatch
+  [:map
+   [:change-requests [:vector ClassifiedComment]]
+   [:questions [:vector ClassifiedComment]]
+   [:approvals [:vector ClassifiedComment]]
+   [:bot-comments [:vector ClassifiedComment]]
+   [:noise [:vector ClassifiedComment]]
+   [:all [:vector ClassifiedComment]]
+   [:stats ClassificationStats]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
 
 (def bot-login-patterns
   "Login substrings and suffixes for known bots."
@@ -125,6 +156,52 @@ Do not include any other text.")
 ;------------------------------------------------------------------------------ Layer 2
 ;; Unified classifier
 
+(defn- heuristic-category
+  [body]
+  (cond
+    (question-comment? body)                                          :question
+    (pos? (triage/score-indicators body triage/actionable-indicators)) :change-request
+    (approval-comment? body)                                          :approval
+    :else                                                             :noise))
+
+(defn- build-classification
+  [category confidence method comment]
+  (validate!
+   ClassifiedComment
+   {:category category
+    :confidence confidence
+    :method method
+    :comment comment}))
+
+(defn- llm-category
+  [body generate-fn]
+  (let [prompt   (build-classify-prompt body)
+        response (try (generate-fn prompt) (catch Exception _e nil))]
+    (parse-llm-classification response)))
+
+(defn- classify-human-comment
+  [comment body generate-fn]
+  (if generate-fn
+    (if-let [category (llm-category body generate-fn)]
+      (build-classification category :high :llm comment)
+      (build-classification (heuristic-category body) :low :heuristic-fallback comment))
+    (build-classification (heuristic-category body) :medium :heuristic comment)))
+
+(defn- grouped-comments
+  [classified-comments]
+  (group-by :category classified-comments))
+
+(defn- stats-for
+  [classified-comments grouped]
+  (validate!
+   ClassificationStats
+   {:total           (count classified-comments)
+    :change-requests (count (get grouped :change-request))
+    :questions       (count (get grouped :question))
+    :approvals       (count (get grouped :approval))
+    :bot-comments    (count (get grouped :bot-comment))
+    :noise           (count (get grouped :noise))}))
+
 (defn classify-comment
   "Classify a single comment into a category.
 
@@ -149,52 +226,20 @@ Do not include any other text.")
     (cond
       ;; 1. Self-comment: always noise (loop prevention — never respond to own comments)
       (and self-author author (= author self-author))
-      {:category   :noise
-       :confidence :high
-       :method     :self-filter
-       :comment    comment}
+      (build-classification :noise :high :self-filter comment)
 
       ;; 2. Bot detection by author login pattern
       (bot-author? author)
-      {:category   :bot-comment
-       :confidence :high
-       :method     :bot-rule
-       :comment    comment}
+      (build-classification :bot-comment :high :bot-rule comment)
 
       ;; 3. Pure approval with no actionable indicators
       (and (approval-comment? body)
            (zero? (triage/score-indicators body triage/actionable-indicators)))
-      {:category   :approval
-       :confidence :high
-       :method     :heuristic
-       :comment    comment}
+      (build-classification :approval :high :heuristic comment)
 
-      ;; 4. LLM-based classification for ambiguous human comments
-      generate-fn
-      (let [prompt   (build-classify-prompt body)
-            response (try (generate-fn prompt) (catch Exception _e nil))
-            category (parse-llm-classification response)]
-        {:category   (or category
-                         ;; Fallback to heuristic if LLM fails or returns garbage
-                         (cond
-                           (question-comment? body) :question
-                           (pos? (triage/score-indicators body triage/actionable-indicators)) :change-request
-                           (approval-comment? body) :approval
-                           :else :noise))
-         :confidence (if category :high :low)
-         :method     (if category :llm :heuristic-fallback)
-         :comment    comment})
-
-      ;; 5. Heuristic fallback (no LLM available)
+      ;; 4. Heuristic or LLM-based classification for other human comments
       :else
-      {:category   (cond
-                     (question-comment? body)                                            :question
-                     (pos? (triage/score-indicators body triage/actionable-indicators))   :change-request
-                     (approval-comment? body)                                            :approval
-                     :else                                                               :noise)
-       :confidence :medium
-       :method     :heuristic
-       :comment    comment})))
+      (classify-human-comment comment body generate-fn))))
 
 (defn classify-comments
   "Classify a batch of comments.
@@ -215,23 +260,20 @@ Do not include any other text.")
     :all             [classified...]
     :stats           {:total n :change-requests n ...}}"
   [comments & {:keys [generate-fn self-author]}]
-  (let [classified (mapv #(classify-comment %
-                                            :generate-fn generate-fn
-                                            :self-author self-author)
-                         comments)
-        by-cat     (group-by :category classified)]
-    {:change-requests (vec (get by-cat :change-request))
-     :questions       (vec (get by-cat :question))
-     :approvals       (vec (get by-cat :approval))
-     :bot-comments    (vec (get by-cat :bot-comment))
-     :noise           (vec (get by-cat :noise))
-     :all             classified
-     :stats           {:total           (count classified)
-                       :change-requests (count (get by-cat :change-request))
-                       :questions       (count (get by-cat :question))
-                       :approvals       (count (get by-cat :approval))
-                       :bot-comments    (count (get by-cat :bot-comment))
-                       :noise           (count (get by-cat :noise))}}))
+  (let [classified (into [] (map #(classify-comment %
+                                                   :generate-fn generate-fn
+                                                   :self-author self-author))
+                          comments)
+        grouped    (grouped-comments classified)]
+    (validate!
+     ClassifiedCommentsBatch
+     {:change-requests (vec (get grouped :change-request))
+      :questions       (vec (get grouped :question))
+      :approvals       (vec (get grouped :approval))
+      :bot-comments    (vec (get grouped :bot-comment))
+      :noise           (vec (get grouped :noise))
+      :all             classified
+      :stats           (stats-for classified grouped)})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj
@@ -1,0 +1,269 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.classifier
+  "Comment classification for PR reviews.
+
+   Classifies each GitHub comment into one of:
+   - :change-request — reviewer asking for a specific code change
+   - :question — reviewer asking for clarification
+   - :approval — reviewer expressing approval
+   - :bot-comment — automated tool (Dependabot, CodeQL, Codecov, Renovate)
+   - :noise — emoji reactions, acknowledgements requiring no action
+
+   Bot detection uses author login matching against known patterns.
+   Human comment classification uses an LLM call with structured output
+   when a generate-fn is provided, falling back to keyword-based heuristics."
+  (:require
+   [ai.miniforge.pr-lifecycle.triage :as triage]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Bot detection
+
+(def bot-login-patterns
+  "Login substrings and suffixes for known bots."
+  #{"dependabot" "renovate" "codecov" "github-actions"
+    "stale" "mergify" "greenkeeper" "snyk-bot"
+    "sonarcloud" "codeclimate" "coveralls"
+    "hound" "percy" "chromatic" "netlify"})
+
+(defn bot-author?
+  "Check if a comment author is a bot.
+
+   Matches known bot login patterns and the [bot] suffix convention."
+  [author]
+  (when (and author (string? author) (seq author))
+    (let [lower (str/lower-case author)]
+      (or (some #(str/includes? lower %) bot-login-patterns)
+          (str/ends-with? lower "[bot]")
+          (str/ends-with? lower "-bot")
+          (str/ends-with? lower "-app")))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Approval detection
+
+(def approval-phrases
+  "Phrases that indicate approval."
+  #{"lgtm" "looks good to me" "looks good" "approved" "ship it"
+    "+1" "looks great" "well done" "nice work" "excellent"
+    "no objections" "good to go" "thumbs up"})
+
+(defn approval-comment?
+  "Check if a comment body expresses approval."
+  [body]
+  (when (and body (seq body))
+    (let [lower (str/lower-case (str/trim body))]
+      (boolean (some #(str/includes? lower %) approval-phrases)))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Question detection (heuristic)
+
+(def ^:private question-patterns
+  "Regex patterns that suggest a comment is a question."
+  [#"\?"
+   #"(?i)^(why|what|how|when|where|could you|can you|would you|should we|is this|are these|do we|does this)"
+   #"(?i)\b(curious|wondering|question|clarify|explain|understand|reason for)\b"])
+
+(defn question-comment?
+  "Check if a comment body is a question (heuristic)."
+  [body]
+  (when (and body (seq body))
+    (boolean (some #(re-find % body) question-patterns))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; LLM-based classification
+
+(def classification-prompt-template
+  "Prompt template for LLM-based comment classification.
+
+   The generate-fn receives this prompt and returns a single category word."
+  "Classify the following GitHub PR review comment into exactly one category.
+
+Categories:
+- change-request: The reviewer is asking for a specific code change, fix, or improvement.
+- question: The reviewer is asking a question for clarification, not requesting a change.
+- approval: The reviewer is expressing approval or satisfaction with the code.
+- noise: The comment is an acknowledgement, emoji, \"thanks\", or requires no action.
+
+Comment:
+\"%s\"
+
+Respond with ONLY the category name (change-request, question, approval, or noise).
+Do not include any other text.")
+
+(defn build-classify-prompt
+  "Build the classification prompt for a comment body."
+  [body]
+  (format classification-prompt-template (str/replace (or body "") "\"" "\\\"" )))
+
+(defn parse-llm-classification
+  "Parse the LLM response into a classification keyword.
+
+   Returns nil if the response cannot be parsed."
+  [response]
+  (when (and response (seq (str/trim response)))
+    (let [cleaned (-> response str/trim str/lower-case (str/replace #"[^a-z-]" ""))]
+      (get {"change-request" :change-request
+            "changerequest"  :change-request
+            "question"       :question
+            "approval"       :approval
+            "noise"          :noise}
+           cleaned))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Unified classifier
+
+(defn classify-comment
+  "Classify a single comment into a category.
+
+   Arguments:
+   - comment: Map with :body, :author, :id, :path, :line keys
+
+   Options:
+   - :generate-fn — LLM generation function (fn [prompt] → response-string).
+     When provided, human comments are classified via LLM.
+     When absent, falls back to keyword-based heuristics.
+   - :self-author — Author login to filter out self-comments (loop prevention).
+     Comments from this author are always classified as :noise.
+
+   Returns:
+   {:category keyword   ; :change-request :question :approval :bot-comment :noise
+    :confidence keyword  ; :high :medium :low
+    :method keyword      ; :self-filter :bot-rule :llm :heuristic :heuristic-fallback
+    :comment map}"
+  [comment & {:keys [generate-fn self-author]}]
+  (let [body   (or (:body comment) (:comment/body comment) "")
+        author (or (:author comment) (:comment/author comment))]
+    (cond
+      ;; 1. Self-comment: always noise (loop prevention — never respond to own comments)
+      (and self-author author (= author self-author))
+      {:category   :noise
+       :confidence :high
+       :method     :self-filter
+       :comment    comment}
+
+      ;; 2. Bot detection by author login pattern
+      (bot-author? author)
+      {:category   :bot-comment
+       :confidence :high
+       :method     :bot-rule
+       :comment    comment}
+
+      ;; 3. Pure approval with no actionable indicators
+      (and (approval-comment? body)
+           (zero? (triage/score-indicators body triage/actionable-indicators)))
+      {:category   :approval
+       :confidence :high
+       :method     :heuristic
+       :comment    comment}
+
+      ;; 4. LLM-based classification for ambiguous human comments
+      generate-fn
+      (let [prompt   (build-classify-prompt body)
+            response (try (generate-fn prompt) (catch Exception _e nil))
+            category (parse-llm-classification response)]
+        {:category   (or category
+                         ;; Fallback to heuristic if LLM fails or returns garbage
+                         (cond
+                           (question-comment? body) :question
+                           (pos? (triage/score-indicators body triage/actionable-indicators)) :change-request
+                           (approval-comment? body) :approval
+                           :else :noise))
+         :confidence (if category :high :low)
+         :method     (if category :llm :heuristic-fallback)
+         :comment    comment})
+
+      ;; 5. Heuristic fallback (no LLM available)
+      :else
+      {:category   (cond
+                     (question-comment? body)                                            :question
+                     (pos? (triage/score-indicators body triage/actionable-indicators))   :change-request
+                     (approval-comment? body)                                            :approval
+                     :else                                                               :noise)
+       :confidence :medium
+       :method     :heuristic
+       :comment    comment})))
+
+(defn classify-comments
+  "Classify a batch of comments.
+
+   Arguments:
+   - comments: Sequence of comment maps
+
+   Options:
+   - :generate-fn — LLM generation function
+   - :self-author — Author login to filter self-comments
+
+   Returns:
+   {:change-requests [classified...]
+    :questions       [classified...]
+    :approvals       [classified...]
+    :bot-comments    [classified...]
+    :noise           [classified...]
+    :all             [classified...]
+    :stats           {:total n :change-requests n ...}}"
+  [comments & {:keys [generate-fn self-author]}]
+  (let [classified (mapv #(classify-comment %
+                                            :generate-fn generate-fn
+                                            :self-author self-author)
+                         comments)
+        by-cat     (group-by :category classified)]
+    {:change-requests (vec (get by-cat :change-request))
+     :questions       (vec (get by-cat :question))
+     :approvals       (vec (get by-cat :approval))
+     :bot-comments    (vec (get by-cat :bot-comment))
+     :noise           (vec (get by-cat :noise))
+     :all             classified
+     :stats           {:total           (count classified)
+                       :change-requests (count (get by-cat :change-request))
+                       :questions       (count (get by-cat :question))
+                       :approvals       (count (get by-cat :approval))
+                       :bot-comments    (count (get by-cat :bot-comment))
+                       :noise           (count (get by-cat :noise))}}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Bot detection
+  (bot-author? "dependabot[bot]")        ; => true
+  (bot-author? "renovate[bot]")          ; => true
+  (bot-author? "human-reviewer")         ; => nil (falsey)
+
+  ;; Classify individual comments
+  (classify-comment {:body "Please fix the null pointer exception" :author "alice"})
+  ; => {:category :change-request :confidence :medium :method :heuristic ...}
+
+  (classify-comment {:body "Why did you choose this approach?" :author "bob"})
+  ; => {:category :question :confidence :medium :method :heuristic ...}
+
+  (classify-comment {:body "LGTM!" :author "charlie"})
+  ; => {:category :approval :confidence :high :method :heuristic ...}
+
+  (classify-comment {:body "Bumps lodash from 4.17.20 to 4.17.21" :author "dependabot[bot]"})
+  ; => {:category :bot-comment :confidence :high :method :bot-rule ...}
+
+  ;; Self-comment loop prevention
+  (classify-comment {:body "Fixed in commit abc123" :author "miniforge-bot"}
+                    :self-author "miniforge-bot")
+  ; => {:category :noise :confidence :high :method :self-filter ...}
+
+  ;; Batch classification
+  (classify-comments
+   [{:body "Please add tests" :author "alice"}
+    {:body "Looks good!" :author "bob"}
+    {:body "Why this approach?" :author "charlie"}
+    {:body "Security scan passed" :author "codeql[bot]"}])
+  ; => {:change-requests [...] :questions [...] :approvals [...] ...}
+
+  :leave-this-here)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/classifier_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/classifier_test.clj
@@ -1,0 +1,63 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.classifier-test
+  (:require
+   [ai.miniforge.pr-lifecycle.classifier :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Classifier tests
+
+(deftest classify-comment-test
+  (testing "filters self comments as noise"
+    (is (= {:category :noise
+            :confidence :high
+            :method :self-filter}
+           (select-keys (sut/classify-comment {:body "Fixed in commit abc123"
+                                               :author "miniforge-bot"}
+                                              :self-author "miniforge-bot")
+                        [:category :confidence :method]))))
+
+  (testing "detects bot comments from author login"
+    (is (= :bot-comment
+           (:category (sut/classify-comment {:body "Automated scan"
+                                             :author "dependabot[bot]"})))))
+
+  (testing "uses heuristic approval detection when there are no actionable indicators"
+    (is (= :approval
+           (:category (sut/classify-comment {:body "LGTM, ship it"
+                                             :author "reviewer"})))))
+
+  (testing "falls back to question detection when LLM classification is unavailable"
+    (is (= {:category :question
+            :confidence :low
+            :method :heuristic-fallback}
+           (select-keys (sut/classify-comment {:body "Why did you choose this approach?"
+                                               :author "reviewer"}
+                                              :generate-fn (fn [_] "not-a-category"))
+                        [:category :confidence :method])))))
+
+(deftest classify-comments-batch-test
+  (testing "groups comments by category and reports stats"
+    (let [result (sut/classify-comments
+                  [{:body "Please add tests" :author "alice"}
+                   {:body "Looks good" :author "bob"}
+                   {:body "Why this approach?" :author "carol"}
+                   {:body "Dependency update" :author "renovate[bot]"}])]
+      (is (= 4 (get-in result [:stats :total])))
+      (is (= 1 (count (:change-requests result))))
+      (is (= 1 (count (:approvals result))))
+      (is (= 1 (count (:questions result))))
+      (is (= 1 (count (:bot-comments result)))))))

--- a/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-classifier.md
+++ b/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-classifier.md
@@ -1,0 +1,41 @@
+# feat: pr monitor loop classifier
+
+## Layer
+
+Domain
+
+## Depends on
+
+- `feat/pr-monitor-loop-spec`
+
+## Overview
+
+Adds comment classification for PR review comments plus focused unit coverage.
+
+## Motivation
+
+The monitor loop needs a reviewable, testable way to distinguish change requests, questions, approvals, bot comments,
+and noise before any orchestration is added.
+
+## Changes in Detail
+
+- Add `classifier.clj`.
+- Add focused classifier tests.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge after the work spec and before polling/orchestration branches.
+
+## Related Issues/PRs
+
+- Parent feature: PR monitor loop
+- Follow-up stack branch: `feat/pr-monitor-loop-budget-events`
+
+## Checklist
+
+- [x] Scope limited to comment classification
+- [ ] `bb pre-commit` recorded

--- a/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-spec.md
+++ b/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-spec.md
@@ -1,0 +1,40 @@
+# feat: pr monitor loop spec
+
+## Layer
+
+Foundations
+
+## Depends on
+
+- `main`
+
+## Overview
+
+Adds the written work spec for the PR monitor loop before the implementation stack lands.
+
+## Motivation
+
+The monitor loop spans polling, classification, orchestration, and observe-phase wiring. The restack is easier to review
+when the intended behavior is captured first.
+
+## Changes in Detail
+
+- Add `work/pr-monitor-loop.spec.edn`.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge first in the PR monitor stack.
+
+## Related Issues/PRs
+
+- Parent feature: PR monitor loop
+- Follow-up stack branch: `feat/pr-monitor-loop-classifier`
+
+## Checklist
+
+- [x] Scope limited to the implementation contract
+- [ ] `bb pre-commit` recorded

--- a/work/pr-monitor-loop.spec.edn
+++ b/work/pr-monitor-loop.spec.edn
@@ -1,0 +1,243 @@
+{:spec/id "pr-monitor-loop-v1"
+ :spec/version "0.1.0"
+ :spec/created "2026-03-30"
+ :spec/status "active"
+ :workflow/type :standard-sdlc
+
+ :spec/title "PR Monitor Loop: Autonomous Comment Resolution and Change Iteration"
+
+ :spec/description
+ "Build the PR monitor loop: poll open miniforge-authored PRs for new review
+  comments, classify each comment (change-request/question/bot/noise), and route
+  to the appropriate handler. Change-requests trigger implement→test→push→reply.
+  Questions get an LLM reply without code changes. Budgets are enforced per PR.
+  Events emitted for TUI visibility. Wired into the N2 Observe phase."
+
+ :title "PR Monitor Loop: Autonomous Comment Resolution and Change Iteration"
+
+ :description
+ "miniforge will watch its own open PRs and autonomously resolve incoming
+  review comments — answering questions, implementing requested changes, pushing
+  updated commits, and posting reply comments — closing the feedback loop without
+  human involvement on every cycle.
+
+  This is the first phase of the PR Monitoring Workflow described in
+  informative/pr-monitoring-workflow.md. Success means a miniforge-authored PR
+  can receive reviewer comments and reach merge-ready state without manual
+  re-triggering."
+
+ :context
+ {:normative-refs
+  ["N2 §7 — Observe phase: PR lifecycle after release"
+   "N3 §3.x — :pr-monitor/* event types"
+   "N6 §2.5 — pr-lifecycle evidence extension"
+   "N9 — External PR Integration: PR Work Item model, readiness computation"
+   "informative/pr-monitoring-workflow.md — full workflow design reference"]
+
+  :current-state
+  ["Release phase creates PRs and pushes branches"
+   "No polling or webhook listener watches open PRs after creation"
+   "Reviewer comments accumulate with no autonomous response"
+   "Human must manually re-trigger a workflow to address feedback"
+   "The :observe phase in N2 is declared but not implemented"]
+
+  :existing-components
+  ["agent — implementer, reviewer, tester already exist"
+   "event-stream — append-only event emission"
+   "llm — Claude CLI integration"
+   "config — user config with github token"
+   "artifact — provenance model for all outputs"
+   "workflow — state machine, phase executor"]
+
+  :missing-pieces
+  ["GitHub polling/webhook listener (thin adapter)"
+   "Comment classifier (question / change-request / approval / bot)"
+   "PR monitor agent — routes events to existing agents"
+   "Push + reply comment after fix cycle"
+   "Budget enforcement (max fix attempts, abandon-after)"]}
+
+ :objectives
+ ["Poll open miniforge-authored PRs for new comments on a configurable interval"
+  "Classify each comment: question, change-request, bot-comment, or approval"
+  "For change-requests: hand off to implementer → tester → reviewer inner loop, push fix, post reply"
+  "For questions: generate a clarifying reply and post it without pushing code"
+  "For bot comments (Dependabot, CodeQL, Codecov): parse and act per existing rules"
+  "Track attempt budgets; escalate to human when budget exhausted"
+  "Emit :pr-monitor/* events for TUI/web visibility"
+  "Add pr-lifecycle evidence to the workflow evidence bundle"]
+
+ :deliverables
+ [{:id :github-pr-poller
+   :type :component-or-adapter
+   :path "components/github/src/ai/miniforge/github/pr_poller.clj"
+   :priority :p0
+   :description
+   "Polls GitHub API for open PRs owned by miniforge (identified by author or label).
+    Returns new comments since last poll watermark. Persists watermark in ~/.miniforge/state/."
+   :interfaces
+   {:public-api
+    ["(poll-open-prs config) → [{:pr/url :pr/number :comments [...]}]"
+     "(latest-comments-since pr-url since-timestamp) → [comment]"
+     "(post-comment pr-url body) → {:comment-id ...}"
+     "(push-branch branch-name commit-msg files) → {:sha ...}"]}
+   :config-keys
+   [":github/token (from config)"
+    ":github/poll-interval-seconds (default 60)"
+    ":github/owner and :github/repo (or inferred from git remote)"]
+   :tests
+   ["Poll returns normalized comment maps"
+    "Watermark persisted and advanced correctly"
+    "Post comment returns comment-id"]}
+
+  {:id :comment-classifier
+   :type :fn-or-agent
+   :path "components/agent/src/ai/miniforge/agent/pr_monitor.clj"
+   :priority :p0
+   :description
+   "Classifies each GitHub comment into one of:
+    :question — reviewer asking for clarification
+    :change-request — reviewer asking for code change
+    :approval — reviewer approving
+    :bot-comment — automated tool (Dependabot, CodeQL, Codecov, Renovate)
+    :noise — emoji reactions, acknowledgements requiring no action"
+   :approach
+   "Use a small LLM call with structured output. Bot detection first
+    (author login matching known bot patterns), then LLM classification for human comments."
+   :tests
+   ["Classify change-request correctly"
+    "Classify question correctly"
+    "Detect bot comment by author login"
+    "Classify approval correctly"]}
+
+  {:id :pr-monitor-agent
+   :type :agent
+   :path "components/agent/src/ai/miniforge/agent/pr_monitor.clj"
+   :priority :p0
+   :description
+   "Orchestrates the PR monitor loop. Receives classified comment events and
+    routes them to appropriate handlers. Tracks attempt budgets. Emits events."
+   :responsibilities
+   ["Receive poll results and classify comments"
+    "Route change-requests to implementer → tester inner loop"
+    "Route questions to LLM reply generator"
+    "Route bot comments to bot-specific handlers"
+    "After successful fix: push branch, post reply comment citing changes"
+    "Track budget per PR; emit :pr-monitor/budget-exhausted and escalate when exceeded"
+    "Emit :pr-monitor/comment-received, :pr-monitor/fix-pushed, :pr-monitor/reply-posted events"]
+   :budget-defaults
+   {:max-fix-attempts-per-comment 3
+    :max-total-fix-attempts-per-pr 10
+    :abandon-after-hours 72}
+   :tests
+   ["Routes change-request → implementer correctly"
+    "Routes question → reply generator"
+    "Pushes branch after fix and posts reply"
+    "Exhausts budget and escalates"
+    "Emits correct event types"]}
+
+  {:id :pr-monitor-loop-integration
+   :type :integration
+   :path "components/workflow/src/ai/miniforge/workflow/observe_phase.clj"
+   :priority :p1
+   :description
+   "Wires the PR monitor agent into the N2 Observe phase. After Release phase
+    creates a PR, the Observe phase starts the monitor loop for that PR and runs
+    until PR is merged, abandoned, or budget exhausted."
+   :phase-contract
+   {:entry "Release phase has pushed a branch and created a PR"
+    :exit-conditions
+    ["PR merged (detected by GitHub API)"
+     "Budget exhausted (human escalation emitted)"
+     "PR closed externally"]
+    :outputs [:pr-lifecycle-evidence]}
+   :tests
+   ["Observe phase starts after release"
+    "Monitor loop terminates on merge"
+    "Monitor loop terminates on budget exhaustion"]}
+
+  {:id :pr-lifecycle-evidence
+   :type :evidence-extension
+   :path "components/artifact/src/ai/miniforge/artifact/evidence.clj"
+   :priority :p1
+   :description
+   "Adds :evidence/pr-lifecycle to the workflow evidence bundle per N6 §2.5."
+   :schema
+   {:created-at :inst
+    :pr-url :string
+    :comments-received :int
+    :comments-addressed :int
+    :fixes-pushed [{:comment-id :int :sha :string :at :inst}]
+    :questions-answered [{:comment-id :int :at :inst}]
+    :budget-remaining :int
+    :closed-reason :keyword
+    :total-monitoring-duration-hours :float}
+   :tests
+   ["Evidence bundle includes :pr-lifecycle key after observe phase"
+    "Evidence schema validates correctly"]}
+
+  {:id :tui-pr-monitor-view
+   :type :tui-extension
+   :path "components/tui-views/..."
+   :priority :p2
+   :description
+   "Extend the PR Fleet (:pr-fleet) view to show monitor loop status inline:
+    last-polled time, comment count, attempts remaining, last action taken."
+   :tests
+   ["PR row shows monitor status when observe phase is active"]}]
+
+ :implementation-strategy
+ {:approach "Bottom-up: poller → classifier → agent → integration"
+  :phases
+  [{:phase 1
+    :focus "GitHub poller + comment classifier"
+    :deliverables [:github-pr-poller :comment-classifier]
+    :validation "Can poll a real PR and classify comments correctly"}
+
+   {:phase 2
+    :focus "PR monitor agent with change-request and question routing"
+    :deliverables [:pr-monitor-agent]
+    :validation "Agent routes, fixes, pushes, and replies autonomously in a test PR"}
+
+   {:phase 3
+    :focus "Observe phase wiring and evidence"
+    :deliverables [:pr-monitor-loop-integration :pr-lifecycle-evidence]
+    :validation "Full dogfood: miniforge's own PRs reach merge-ready autonomously"}
+
+   {:phase 4
+    :focus "TUI visibility"
+    :deliverables [:tui-pr-monitor-view]
+    :validation "Monitor loop status visible in PR Fleet view"}]
+
+  :dogfooding-notes
+  "Phase 3 should be validated by using miniforge to submit a PR to itself,
+   then having a human leave review comments and watching them get resolved.
+   This is the core dogfood loop described in the project's dogfood order (item a)."}
+
+ :constraints
+ {:architecture
+  ["Must follow stratified design"
+   "GitHub adapter must be isolated behind an interface"
+   "All state must be persisted in ~/.miniforge/ (not in-process only)"
+   "Poller must be safe to restart (idempotent watermark)"]
+  :safety
+  ["Must never force-push or amend published commits — always new commit"
+   "Must post reply comment before or simultaneously with push, never silently"
+   "Must not respond to its own bot comments (loop prevention)"
+   "Change-request responses must go through tester gate before push"]
+  :budget
+  ["Budget limits are hard stops, not soft warnings"
+   "Escalation must emit a human-visible event and stop all autonomous action"]}
+
+ :success-criteria
+ [{:criterion "Poller detects new comments within 2× poll interval"
+   :validation "Integration test with mock GitHub responses"}
+  {:criterion "Change-request → fix → push → reply completes autonomously"
+   :validation "Dogfood test on a real miniforge PR"}
+  {:criterion "Question → reply posted without pushing code"
+   :validation "Unit test verifying no git operations for :question class"}
+  {:criterion "Budget exhaustion escalates correctly"
+   :validation "Simulated budget-exceeded scenario emits correct events"}
+  {:criterion "Evidence bundle contains :pr-lifecycle after observe phase"
+   :validation "Schema validation test"}
+  {:criterion "TUI shows monitor loop activity in PR Fleet view"
+   :validation "Visual check during live dogfood run"}]}


### PR DESCRIPTION
# feat: pr monitor loop classifier

## Layer

Domain

## Depends on

- `feat/pr-monitor-loop-spec`

## Overview

Adds comment classification for PR review comments plus focused unit coverage.

## Motivation

The monitor loop needs a reviewable, testable way to distinguish change requests, questions, approvals, bot comments,
and noise before any orchestration is added.

## Changes in Detail

- Add `classifier.clj`.
- Add focused classifier tests.

## Testing Plan

- Run `bb pre-commit`

## Deployment Plan

- Merge after the work spec and before polling/orchestration branches.

## Related Issues/PRs

- Parent feature: PR monitor loop
- Follow-up stack branch: `feat/pr-monitor-loop-budget-events`

## Checklist

- [x] Scope limited to comment classification
- [ ] `bb pre-commit` recorded
