### PR TITLE
feat: pr monitor loop core

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_handlers.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_handlers.clj
@@ -1,0 +1,212 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-handlers
+  "Comment handlers for the PR monitor loop."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.pr-lifecycle.fix-loop :as fix-loop]
+   [ai.miniforge.pr-lifecycle.monitor-budget :as budget]
+   [ai.miniforge.pr-lifecycle.monitor-events :as mevents]
+   [ai.miniforge.pr-lifecycle.monitor-state :as state]
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers
+
+(defn- succeeded?
+  [result]
+  (true? (:success? result)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Comment handlers
+
+(defn handle-change-request
+  "Handle a change-request comment by running one fix-loop attempt."
+  [monitor pr-info classified-comment]
+  (let [{:keys [worktree-path generate-fn logger event-bus]} (:config @monitor)
+        pr-number (:pr/number pr-info)
+        comment (:comment classified-comment)
+        comment-id (:comment/id comment)
+        pr-budget (state/get-or-create-budget monitor pr-number)]
+    (if-let [exhausted (budget/any-budget-exhausted? pr-budget comment-id)]
+      (let [summary (budget/budget-summary pr-budget)]
+        (state/emit! monitor (mevents/budget-exhausted pr-number
+                               (assoc summary :exhausted-by exhausted)))
+        (state/emit! monitor (mevents/escalated pr-number :budget-exhausted
+                               {:comment-id comment-id
+                                :budget-summary summary}))
+        (when logger
+          (log/warn logger :pr-monitor :handler/budget-exhausted
+                    {:message (str "Budget exhausted for PR #" pr-number ": "
+                                   (name exhausted))
+                     :data summary}))
+        {:success? false
+         :reason :budget-exhausted
+         :exhausted-by exhausted})
+      (if-not generate-fn
+        (do
+          (when logger
+            (log/warn logger :pr-monitor :handler/no-generate-fn
+                      {:message "Cannot fix change-request — no generate-fn configured"}))
+          {:success? false :reason :no-generate-fn})
+        (let [updated-budget (budget/record-fix-attempt pr-budget comment-id)
+              _ (state/update-budget! monitor pr-number updated-budget)
+              attempt (get-in updated-budget [:comment-attempts comment-id])
+              _ (state/emit! monitor (mevents/fix-started pr-number comment-id attempt))
+              task {:task/id (random-uuid)
+                    :task/type :fix
+                    :task/acceptance-criteria
+                    [(str "Address review comment: " (:comment/body comment))]}
+              failure-info {:type :review-changes
+                            :summary (:comment/body comment)
+                            :comments [{:body (:comment/body comment)
+                                        :author (:comment/author comment)
+                                        :path (:comment/path comment)
+                                        :line (:comment/line comment)}]
+                            :affected-files (when (:comment/path comment)
+                                              [(:comment/path comment)])
+                            :comment-id comment-id
+                            :parent-pr-number pr-number}
+              context {:logger logger
+                       :worktree-path worktree-path}
+              fix-result (fix-loop/run-fix-loop
+                          task pr-info failure-info generate-fn context
+                          :worktree-path worktree-path
+                          :max-attempts 1
+                          :event-bus event-bus
+                          :auto-resolve-comments true)]
+          (if (succeeded? fix-result)
+            (let [commit-sha (:commit-sha fix-result)
+                  final-budget (budget/record-fix-pushed updated-budget)]
+              (state/update-budget! monitor pr-number final-budget)
+              (state/emit! monitor (mevents/fix-pushed pr-number comment-id commit-sha))
+              (let [reply-body (str "Addressed in commit " commit-sha
+                                    ".\n\n---\n*Fixed by miniforge's autonomous PR monitor.*")]
+                (poller/post-comment worktree-path pr-number reply-body)
+                (state/emit! monitor (mevents/reply-posted pr-number comment-id
+                                                           :fix-reply)))
+              (swap! monitor update-in [:evidence :fixes-pushed] conj
+                     {:comment-id comment-id :sha commit-sha :at (java.util.Date.)})
+              (swap! monitor update-in [:evidence :comments-addressed] inc)
+              (when logger
+                (log/info logger :pr-monitor :handler/fix-pushed
+                          {:message (str "Fix pushed for comment on PR #" pr-number)
+                           :data {:commit-sha commit-sha :attempt attempt}}))
+              {:success? true :commit-sha commit-sha :attempt attempt})
+            (do
+              (when logger
+                (log/warn logger :pr-monitor :handler/fix-failed
+                          {:message (str "Fix failed for comment on PR #" pr-number)
+                           :data {:reason (:reason fix-result) :attempt attempt}}))
+              {:success? false :reason (:reason fix-result) :attempt attempt})))))))
+
+(defn handle-question
+  "Handle a question comment by generating and posting a reply."
+  [monitor pr-info classified-comment]
+  (let [{:keys [worktree-path generate-fn logger]} (:config @monitor)
+        pr-number (:pr/number pr-info)
+        comment (:comment classified-comment)
+        comment-id (:comment/id comment)
+        body (:comment/body comment)]
+    (if-not generate-fn
+      (do
+        (when logger
+          (log/warn logger :pr-monitor :handler/no-generate-fn
+                    {:message "Cannot answer question — no generate-fn configured"
+                     :data {:pr-number pr-number}}))
+        {:success? false :reason :no-generate-fn})
+      (let [prompt (str "You are miniforge, an autonomous software development agent. "
+                        "A reviewer left this question on a pull request you authored. "
+                        "Answer clearly and concisely. Do not make code changes.\n\n"
+                        "Question:\n" body "\n\n"
+                        "Write only the answer text, no preamble.")
+            answer (try
+                     (generate-fn prompt)
+                     (catch Exception e
+                       (when logger
+                         (log/error logger :pr-monitor :handler/llm-error
+                                    {:message "LLM call failed for question"
+                                     :data {:error (.getMessage e)}}))
+                       nil))]
+        (if answer
+          (let [reply-body (str answer
+                                "\n\n---\n*Answered by miniforge's autonomous PR monitor.*")
+                post-result (poller/post-comment worktree-path pr-number reply-body)]
+            (if (dag/ok? post-result)
+              (do
+                (state/emit! monitor (mevents/question-answered pr-number comment-id))
+                (state/emit! monitor (mevents/reply-posted pr-number comment-id
+                                                           :question-reply))
+                (let [pr-budget (state/get-or-create-budget monitor pr-number)]
+                  (state/update-budget! monitor pr-number
+                                        (budget/record-question-answered pr-budget)))
+                (swap! monitor update-in [:evidence :questions-answered] conj
+                       {:comment-id comment-id :at (java.util.Date.)})
+                (swap! monitor update-in [:evidence :comments-addressed] inc)
+                (when logger
+                  (log/info logger :pr-monitor :handler/question-answered
+                            {:message (str "Answered question on PR #" pr-number)
+                             :data {:comment-id comment-id}}))
+                {:success? true :type :question-answered})
+              (do
+                (when logger
+                  (log/warn logger :pr-monitor :handler/post-failed
+                            {:message "Failed to post question answer"
+                             :data {:pr-number pr-number}}))
+                {:success? false :reason :post-failed})))
+          {:success? false :reason :llm-failed})))))
+
+(defn handle-bot-comment
+  "Handle a bot comment. Log and skip."
+  [monitor _pr-info classified-comment]
+  (let [logger (get-in @monitor [:config :logger])
+        comment (:comment classified-comment)]
+    (when logger
+      (log/debug logger :pr-monitor :handler/bot-comment
+                 {:message "Bot comment — skipping"
+                  :data {:author (:comment/author comment)}}))
+    {:success? true :type :bot-skipped}))
+
+(defn handle-approval
+  "Handle an approval comment. Log and skip."
+  [monitor pr-info classified-comment]
+  (let [logger (get-in @monitor [:config :logger])
+        pr-number (:pr/number pr-info)
+        comment (:comment classified-comment)]
+    (when logger
+      (log/info logger :pr-monitor :handler/approval
+                {:message (str "Approval received on PR #" pr-number)
+                 :data {:author (:comment/author comment)}}))
+    {:success? true :type :approval-noted}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Routing
+
+(defn route-comment
+  "Route a classified comment to the appropriate handler."
+  [monitor pr-info classified]
+  (case (:category classified)
+    :change-request (handle-change-request monitor pr-info classified)
+    :question (handle-question monitor pr-info classified)
+    :bot-comment (handle-bot-comment monitor pr-info classified)
+    :approval (handle-approval monitor pr-info classified)
+    :noise {:success? true :type :noise-skipped}
+    {:success? true :type :unknown-skipped :category (:category classified)}))
+

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -26,78 +26,199 @@
    [ai.miniforge.pr-lifecycle.monitor-events :as mevents]
    [ai.miniforge.pr-lifecycle.monitor-handlers :as handlers]
    [ai.miniforge.pr-lifecycle.monitor-state :as state]
-   [ai.miniforge.pr-lifecycle.pr-poller :as poller]))
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]
+   [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; API compatibility
+;; API compatibility + schemas
 
 (def create-monitor
   "Compatibility alias for monitor creation."
   state/create-monitor)
 
+(def CycleResult
+  [:map
+   [:processed nat-int?]
+   [:results [:vector any?]]
+   [:new-comments nat-int?]
+   [:stopped? {:optional true} :boolean]
+   [:stop-reason {:optional true} keyword?]
+   [:error {:optional true} any?]
+   [:classified-stats {:optional true} map?]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
+
 ;------------------------------------------------------------------------------ Layer 1
-;; Single cycle
+;; Single cycle helpers
+
+(defn- cycle-result
+  [result]
+  (validate! CycleResult result))
+
+(defn- time-budget-stop-result
+  [_pr-number]
+  (cycle-result {:processed 0
+                 :results []
+                 :new-comments 0
+                 :stopped? true
+                 :stop-reason :time-budget-exhausted}))
+
+(defn- poll-error-result
+  [poll-result]
+  (cycle-result {:processed 0
+                 :results []
+                 :new-comments 0
+                 :error (:error poll-result)}))
+
+(defn- emit-time-budget-stop!
+  [monitor pr-number pr-budget]
+  (let [summary (budget/budget-summary pr-budget)]
+    (state/emit! monitor (mevents/budget-exhausted pr-number
+                                                   (assoc summary :exhausted-by :time-limit)))
+    (state/emit! monitor (mevents/escalated pr-number :time-limit
+                                            {:budget-summary summary}))))
+
+(defn- classify-comments
+  [new-comments generate-fn self-author]
+  (if (seq new-comments)
+    (classifier/classify-comments new-comments
+                                  :generate-fn generate-fn
+                                  :self-author self-author)
+    {:change-requests []
+     :questions []
+     :approvals []
+     :bot-comments []
+     :noise []
+     :all []
+     :stats {:total 0
+             :change-requests 0
+             :questions 0
+             :approvals 0
+             :bot-comments 0
+             :noise 0}}))
+
+(defn- actionable-comments
+  [classified]
+  (concat (:change-requests classified)
+          (:questions classified)))
+
+(defn- emit-classification-events!
+  [monitor pr-number classified]
+  (doseq [classification (:all classified)]
+    (state/emit! monitor
+                 (mevents/comment-received pr-number
+                                           (:comment classification)))
+    (state/emit! monitor
+                 (mevents/comment-classified pr-number
+                                             (:comment classification)
+                                             {:category (:category classification)
+                                              :confidence (:confidence classification)
+                                              :method (:method classification)}))))
+
+(defn- persist-poll-state!
+  [monitor pr-number watermarks new-comments]
+  (swap! monitor assoc :watermarks watermarks)
+  (poller/save-watermarks! watermarks)
+  (swap! monitor update-in [:evidence :comments-received] + (count new-comments))
+  (state/emit! monitor
+               (mevents/poll-completed pr-number
+                                       {:new-comment-count (count new-comments)})))
+
+(defn- route-actionable-comments
+  [monitor pr-info classified]
+  (into [] (map #(handlers/route-comment monitor pr-info %))
+        (actionable-comments classified)))
+
+(defn- completed-cycle-result
+  [pr-number new-comments classified results]
+  (let [classified-stats (:stats classified)]
+    (cycle-result {:processed (count results)
+                   :results results
+                   :new-comments (count new-comments)
+                   :classified-stats classified-stats})))
 
 (defn run-cycle
   "Run one poll → classify → route cycle for a single PR."
   [monitor pr-info]
   (let [{:keys [worktree-path self-author generate-fn logger]} (:config @monitor)
-        pr-number (:pr/number pr-info)
+        pr-number  (:pr/number pr-info)
         watermarks (:watermarks @monitor)
-        pr-budget (state/get-or-create-budget monitor pr-number)]
+        pr-budget  (state/get-or-create-budget monitor pr-number)]
     (if (budget/time-budget-exhausted? pr-budget)
       (do
-        (state/emit! monitor (mevents/budget-exhausted pr-number
-                               (assoc (budget/budget-summary pr-budget)
-                                      :exhausted-by :time-limit)))
-        (state/emit! monitor (mevents/escalated pr-number :time-limit
-                               {:budget-summary (budget/budget-summary pr-budget)}))
-        {:processed 0 :results [] :new-comments 0
-         :stopped? true :stop-reason :time-budget-exhausted})
+        (emit-time-budget-stop! monitor pr-number pr-budget)
+        (time-budget-stop-result pr-number))
       (let [poll-result (poller/poll-pr-for-new-comments
                          worktree-path pr-number watermarks logger)]
         (if (dag/err? poll-result)
-          {:processed 0 :results [] :new-comments 0
-           :error (:error poll-result)}
+          (poll-error-result poll-result)
           (let [{:keys [new-comments watermarks]} (:data poll-result)
-                _ (swap! monitor assoc :watermarks watermarks)
-                _ (poller/save-watermarks! watermarks)
-                _ (swap! monitor update-in [:evidence :comments-received]
-                         + (count new-comments))
-                _ (state/emit! monitor
-                               (mevents/poll-completed pr-number
-                                                       {:new-comment-count
-                                                        (count new-comments)}))
-                classified (when (seq new-comments)
-                             (classifier/classify-comments new-comments
-                               :generate-fn generate-fn
-                               :self-author self-author))
-                _ (doseq [classification (:all classified)]
-                    (state/emit! monitor
-                                 (mevents/comment-received pr-number
-                                                           (:comment classification)))
-                    (state/emit! monitor
-                                 (mevents/comment-classified
-                                  pr-number
-                                  (:comment classification)
-                                  {:category (:category classification)
-                                   :confidence (:confidence classification)
-                                   :method (:method classification)})))
-                actionable (concat (:change-requests classified)
-                                   (:questions classified))
-                results (mapv #(handlers/route-comment monitor pr-info %) actionable)]
+                _          (persist-poll-state! monitor pr-number watermarks new-comments)
+                classified (classify-comments new-comments generate-fn self-author)
+                _          (emit-classification-events! monitor pr-number classified)
+                results    (route-actionable-comments monitor pr-info classified)]
             (state/emit! monitor
                          (mevents/cycle-completed pr-number
                                                   {:new-comments (count new-comments)
                                                    :classified-stats (:stats classified)
                                                    :actions-taken (count results)}))
-            {:processed (count results)
-             :results results
-             :new-comments (count new-comments)
-             :classified-stats (:stats classified)}))))))
+            (completed-cycle-result pr-number new-comments classified results)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Loop lifecycle
+
+(declare step-monitor-loop!)
+
+(defn- retry-after-poll-error!
+  [monitor author logger poll-interval-ms pr-result]
+  (when logger
+    (log/warn logger :pr-monitor :loop/poll-prs-failed
+              {:message "Failed to poll open PRs — retrying"
+               :data {:error (:error pr-result)}}))
+  (Thread/sleep poll-interval-ms)
+  (step-monitor-loop! monitor author))
+
+(defn- stop-when-no-open-prs!
+  [monitor logger]
+  (when logger
+    (log/info logger :pr-monitor :loop/no-open-prs
+              {:message "No open PRs found — stopping monitor loop"}))
+  (swap! monitor assoc :running? false))
+
+(defn- log-cycle-stop
+  [logger pr cycle-result]
+  (when (and (:stopped? cycle-result) logger)
+    (log/info logger :pr-monitor :loop/pr-budget-stopped
+              {:message (str "PR #" (:pr/number pr)
+                             " stopped: "
+                             (:stop-reason cycle-result))})))
+
+(defn- run-pr-cycle!
+  [monitor logger pr]
+  (when (:running? @monitor)
+    (try
+      (log-cycle-stop logger pr (run-cycle monitor pr))
+      (catch Exception e
+        (when logger
+          (log/error logger :pr-monitor :loop/cycle-error
+                     {:message "Error in monitor cycle"
+                      :data {:pr-number (:pr/number pr)
+                             :error (.getMessage e)}}))))))
+
+(defn- finalize-loop-iteration!
+  [monitor]
+  (swap! monitor (fn [state-map]
+                   (-> state-map
+                       (update :cycles inc)
+                       (assoc :last-cycle-at (java.util.Date.))))))
+
+(defn- continue-loop!
+  [monitor author poll-interval-ms]
+  (when (:running? @monitor)
+    (Thread/sleep poll-interval-ms)
+    (step-monitor-loop! monitor author)))
 
 (defn- step-monitor-loop!
   [monitor author]
@@ -106,45 +227,16 @@
       (let [pr-result (poller/poll-open-prs worktree-path author)]
         (cond
           (dag/err? pr-result)
-          (do
-            (when logger
-              (log/warn logger :pr-monitor :loop/poll-prs-failed
-                        {:message "Failed to poll open PRs — retrying"
-                         :data {:error (:error pr-result)}}))
-            (Thread/sleep poll-interval-ms)
-            (step-monitor-loop! monitor author))
+          (retry-after-poll-error! monitor author logger poll-interval-ms pr-result)
 
           (empty? (:prs (:data pr-result)))
-          (do
-            (when logger
-              (log/info logger :pr-monitor :loop/no-open-prs
-                        {:message "No open PRs found — stopping monitor loop"}))
-            (swap! monitor assoc :running? false))
+          (stop-when-no-open-prs! monitor logger)
 
           :else
           (let [prs (:prs (:data pr-result))]
-            (doseq [pr prs]
-              (when (:running? @monitor)
-                (try
-                  (let [cycle-result (run-cycle monitor pr)]
-                    (when (and (:stopped? cycle-result) logger)
-                      (log/info logger :pr-monitor :loop/pr-budget-stopped
-                                {:message (str "PR #" (:pr/number pr)
-                                               " stopped: "
-                                               (:stop-reason cycle-result))})))
-                  (catch Exception e
-                    (when logger
-                      (log/error logger :pr-monitor :loop/cycle-error
-                                 {:message "Error in monitor cycle"
-                                  :data {:pr-number (:pr/number pr)
-                                         :error (.getMessage e)}})))))
-            (swap! monitor (fn [state-map]
-                             (-> state-map
-                                 (update :cycles inc)
-                                 (assoc :last-cycle-at (java.util.Date.)))))
-            (when (:running? @monitor)
-              (Thread/sleep poll-interval-ms)
-              (step-monitor-loop! monitor author)))))))))
+            (run! #(run-pr-cycle! monitor logger %) prs)
+            (finalize-loop-iteration! monitor)
+            (continue-loop! monitor author poll-interval-ms)))))))
 
 (defn run-monitor-loop
   "Run the PR monitor loop continuously until stopped."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -132,7 +132,7 @@
         (actionable-comments classified)))
 
 (defn- completed-cycle-result
-  [pr-number new-comments classified results]
+  [new-comments classified results]
   (let [classified-stats (:stats classified)]
     (cycle-result {:processed (count results)
                    :results results
@@ -164,7 +164,7 @@
                                                   {:new-comments (count new-comments)
                                                    :classified-stats (:stats classified)
                                                    :actions-taken (count results)}))
-            (completed-cycle-result pr-number new-comments classified results)))))))
+            (completed-cycle-result new-comments classified results)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Loop lifecycle

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -1,0 +1,177 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-loop
+  "PR monitor loop orchestration."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.pr-lifecycle.classifier :as classifier]
+   [ai.miniforge.pr-lifecycle.monitor-budget :as budget]
+   [ai.miniforge.pr-lifecycle.monitor-events :as mevents]
+   [ai.miniforge.pr-lifecycle.monitor-handlers :as handlers]
+   [ai.miniforge.pr-lifecycle.monitor-state :as state]
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; API compatibility
+
+(def create-monitor
+  "Compatibility alias for monitor creation."
+  state/create-monitor)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Single cycle
+
+(defn run-cycle
+  "Run one poll → classify → route cycle for a single PR."
+  [monitor pr-info]
+  (let [{:keys [worktree-path self-author generate-fn logger]} (:config @monitor)
+        pr-number (:pr/number pr-info)
+        watermarks (:watermarks @monitor)
+        pr-budget (state/get-or-create-budget monitor pr-number)]
+    (if (budget/time-budget-exhausted? pr-budget)
+      (do
+        (state/emit! monitor (mevents/budget-exhausted pr-number
+                               (assoc (budget/budget-summary pr-budget)
+                                      :exhausted-by :time-limit)))
+        (state/emit! monitor (mevents/escalated pr-number :time-limit
+                               {:budget-summary (budget/budget-summary pr-budget)}))
+        {:processed 0 :results [] :new-comments 0
+         :stopped? true :stop-reason :time-budget-exhausted})
+      (let [poll-result (poller/poll-pr-for-new-comments
+                         worktree-path pr-number watermarks logger)]
+        (if (dag/err? poll-result)
+          {:processed 0 :results [] :new-comments 0
+           :error (:error poll-result)}
+          (let [{:keys [new-comments watermarks]} (:data poll-result)
+                _ (swap! monitor assoc :watermarks watermarks)
+                _ (poller/save-watermarks! watermarks)
+                _ (swap! monitor update-in [:evidence :comments-received]
+                         + (count new-comments))
+                _ (state/emit! monitor
+                               (mevents/poll-completed pr-number
+                                                       {:new-comment-count
+                                                        (count new-comments)}))
+                classified (when (seq new-comments)
+                             (classifier/classify-comments new-comments
+                               :generate-fn generate-fn
+                               :self-author self-author))
+                _ (doseq [classification (:all classified)]
+                    (state/emit! monitor
+                                 (mevents/comment-received pr-number
+                                                           (:comment classification)))
+                    (state/emit! monitor
+                                 (mevents/comment-classified
+                                  pr-number
+                                  (:comment classification)
+                                  {:category (:category classification)
+                                   :confidence (:confidence classification)
+                                   :method (:method classification)})))
+                actionable (concat (:change-requests classified)
+                                   (:questions classified))
+                results (mapv #(handlers/route-comment monitor pr-info %) actionable)]
+            (state/emit! monitor
+                         (mevents/cycle-completed pr-number
+                                                  {:new-comments (count new-comments)
+                                                   :classified-stats (:stats classified)
+                                                   :actions-taken (count results)}))
+            {:processed (count results)
+             :results results
+             :new-comments (count new-comments)
+             :classified-stats (:stats classified)}))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Loop lifecycle
+
+(defn run-monitor-loop
+  "Run the PR monitor loop continuously until stopped."
+  [monitor author]
+  (let [{:keys [poll-interval-ms logger worktree-path]} (:config @monitor)]
+    (swap! monitor assoc :running? true :started-at (java.util.Date.))
+    (state/log-loop-start! monitor author)
+    (loop []
+      (when (:running? @monitor)
+        (let [pr-result (poller/poll-open-prs worktree-path author)]
+          (cond
+            (dag/err? pr-result)
+            (do
+              (when logger
+                (log/warn logger :pr-monitor :loop/poll-prs-failed
+                          {:message "Failed to poll open PRs — retrying"
+                           :data {:error (:error pr-result)}}))
+              (Thread/sleep poll-interval-ms)
+              (recur))
+
+            (empty? (:prs (:data pr-result)))
+            (do
+              (when logger
+                (log/info logger :pr-monitor :loop/no-open-prs
+                          {:message "No open PRs found — stopping monitor loop"}))
+              (swap! monitor assoc :running? false))
+
+            :else
+            (let [prs (:prs (:data pr-result))]
+              (doseq [pr prs]
+                (when (:running? @monitor)
+                  (try
+                    (let [cycle-result (run-cycle monitor pr)]
+                      (when (and (:stopped? cycle-result) logger)
+                        (log/info logger :pr-monitor :loop/pr-budget-stopped
+                                  {:message (str "PR #" (:pr/number pr)
+                                                 " stopped: "
+                                                 (:stop-reason cycle-result))})))
+                    (catch Exception e
+                      (when logger
+                        (log/error logger :pr-monitor :loop/cycle-error
+                                   {:message "Error in monitor cycle"
+                                    :data {:pr-number (:pr/number pr)
+                                           :error (.getMessage e)}})))))
+              (swap! monitor (fn [state-map]
+                               (-> state-map
+                                   (update :cycles inc)
+                                   (assoc :last-cycle-at (java.util.Date.)))))
+              (when (:running? @monitor)
+                (Thread/sleep poll-interval-ms)
+                (recur))))))))
+    (when logger
+      (log/info logger :pr-monitor :loop/stopped
+                {:message "PR monitor loop stopped"
+                 :data {:cycles (:cycles @monitor)}}))
+    (let [evidence (:evidence @monitor)]
+      (merge evidence
+             {:cycles (:cycles @monitor)
+              :duration-hours (when-let [started (:started-at @monitor)]
+                                (/ (double (- (System/currentTimeMillis)
+                                              (.getTime ^java.util.Date started)))
+                                   3600000.0))}))))
+
+(defn stop-monitor-loop
+  "Stop a running monitor loop gracefully."
+  [monitor]
+  (swap! monitor assoc :running? false))
+
+(defn monitor-running?
+  "Check if the monitor loop is currently running."
+  [monitor]
+  (:running? @monitor))
+
+(defn monitor-evidence
+  "Get current evidence from the monitor."
+  [monitor]
+  (:evidence @monitor))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -99,56 +99,60 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Loop lifecycle
 
+(defn- step-monitor-loop!
+  [monitor author]
+  (let [{:keys [poll-interval-ms logger worktree-path]} (:config @monitor)]
+    (when (:running? @monitor)
+      (let [pr-result (poller/poll-open-prs worktree-path author)]
+        (cond
+          (dag/err? pr-result)
+          (do
+            (when logger
+              (log/warn logger :pr-monitor :loop/poll-prs-failed
+                        {:message "Failed to poll open PRs — retrying"
+                         :data {:error (:error pr-result)}}))
+            (Thread/sleep poll-interval-ms)
+            (step-monitor-loop! monitor author))
+
+          (empty? (:prs (:data pr-result)))
+          (do
+            (when logger
+              (log/info logger :pr-monitor :loop/no-open-prs
+                        {:message "No open PRs found — stopping monitor loop"}))
+            (swap! monitor assoc :running? false))
+
+          :else
+          (let [prs (:prs (:data pr-result))]
+            (doseq [pr prs]
+              (when (:running? @monitor)
+                (try
+                  (let [cycle-result (run-cycle monitor pr)]
+                    (when (and (:stopped? cycle-result) logger)
+                      (log/info logger :pr-monitor :loop/pr-budget-stopped
+                                {:message (str "PR #" (:pr/number pr)
+                                               " stopped: "
+                                               (:stop-reason cycle-result))})))
+                  (catch Exception e
+                    (when logger
+                      (log/error logger :pr-monitor :loop/cycle-error
+                                 {:message "Error in monitor cycle"
+                                  :data {:pr-number (:pr/number pr)
+                                         :error (.getMessage e)}})))))
+            (swap! monitor (fn [state-map]
+                             (-> state-map
+                                 (update :cycles inc)
+                                 (assoc :last-cycle-at (java.util.Date.)))))
+            (when (:running? @monitor)
+              (Thread/sleep poll-interval-ms)
+              (step-monitor-loop! monitor author)))))))))
+
 (defn run-monitor-loop
   "Run the PR monitor loop continuously until stopped."
   [monitor author]
-  (let [{:keys [poll-interval-ms logger worktree-path]} (:config @monitor)]
+  (let [{:keys [logger]} (:config @monitor)]
     (swap! monitor assoc :running? true :started-at (java.util.Date.))
     (state/log-loop-start! monitor author)
-    (loop []
-      (when (:running? @monitor)
-        (let [pr-result (poller/poll-open-prs worktree-path author)]
-          (cond
-            (dag/err? pr-result)
-            (do
-              (when logger
-                (log/warn logger :pr-monitor :loop/poll-prs-failed
-                          {:message "Failed to poll open PRs — retrying"
-                           :data {:error (:error pr-result)}}))
-              (Thread/sleep poll-interval-ms)
-              (recur))
-
-            (empty? (:prs (:data pr-result)))
-            (do
-              (when logger
-                (log/info logger :pr-monitor :loop/no-open-prs
-                          {:message "No open PRs found — stopping monitor loop"}))
-              (swap! monitor assoc :running? false))
-
-            :else
-            (let [prs (:prs (:data pr-result))]
-              (doseq [pr prs]
-                (when (:running? @monitor)
-                  (try
-                    (let [cycle-result (run-cycle monitor pr)]
-                      (when (and (:stopped? cycle-result) logger)
-                        (log/info logger :pr-monitor :loop/pr-budget-stopped
-                                  {:message (str "PR #" (:pr/number pr)
-                                                 " stopped: "
-                                                 (:stop-reason cycle-result))})))
-                    (catch Exception e
-                      (when logger
-                        (log/error logger :pr-monitor :loop/cycle-error
-                                   {:message "Error in monitor cycle"
-                                    :data {:pr-number (:pr/number pr)
-                                           :error (.getMessage e)}})))))
-              (swap! monitor (fn [state-map]
-                               (-> state-map
-                                   (update :cycles inc)
-                                   (assoc :last-cycle-at (java.util.Date.)))))
-              (when (:running? @monitor)
-                (Thread/sleep poll-interval-ms)
-                (recur))))))))
+    (step-monitor-loop! monitor author)
     (when logger
       (log/info logger :pr-monitor :loop/stopped
                 {:message "PR monitor loop stopped"

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_loop_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_loop_test.clj
@@ -1,0 +1,34 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-loop-test
+  (:require
+   [ai.miniforge.pr-lifecycle.monitor-loop :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest actionable-comments-test
+  (testing "change requests and questions are routed, approvals are not"
+    (let [classified {:change-requests [{:comment {:id 1}}]
+                      :questions [{:comment {:id 2}}]
+                      :approvals [{:comment {:id 3}}]}]
+      (is (= [1 2]
+             (mapv #(get-in % [:comment :id])
+                   (#'sut/actionable-comments classified)))))))
+
+(deftest time-budget-stop-result-test
+  (testing "time budget exhaustion yields a stopped cycle result"
+    (let [result (#'sut/time-budget-stop-result 42)]
+      (is (= 0 (:processed result)))
+      (is (true? (:stopped? result)))
+      (is (= :time-budget-exhausted (:stop-reason result))))))

--- a/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-core.md
+++ b/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-core.md
@@ -1,0 +1,40 @@
+# feat: pr monitor loop core
+
+## Layer
+
+Application
+
+## Depends on
+
+- `feat/pr-monitor-loop-handlers`
+
+## Overview
+
+Adds the loop orchestration namespace on top of the extracted state and handler layers.
+
+## Motivation
+
+This branch restores the monitor loop behavior after the state and handler extractions, while keeping the loop core
+itself reviewable as a focused unit.
+
+## Changes in Detail
+
+- Add the slimmed `monitor_loop.clj`.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge before the final observe-phase wiring branch.
+
+## Related Issues/PRs
+
+- Parent feature: PR monitor loop
+- Follow-up stack branch: `feat/pr-monitor-loop-observe`
+
+## Checklist
+
+- [x] Scope limited to loop orchestration
+- [ ] `bb pre-commit` recorded

--- a/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-handlers.md
+++ b/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-handlers.md
@@ -1,0 +1,40 @@
+# feat: pr monitor loop handlers
+
+## Layer
+
+Application
+
+## Depends on
+
+- `feat/pr-monitor-loop-state`
+
+## Overview
+
+Splits the monitor comment handlers into their own namespace.
+
+## Motivation
+
+Keeping routing and handler behavior separate from loop state and loop execution makes the monitor stack reviewable in
+smaller slices and keeps the eventual loop core branch under the small-PR limit.
+
+## Changes in Detail
+
+- Add `monitor_handlers.clj`.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge before the loop core branch.
+
+## Related Issues/PRs
+
+- Parent feature: PR monitor loop
+- Follow-up stack branch: `feat/pr-monitor-loop-core`
+
+## Checklist
+
+- [x] Scope limited to comment handling and routing
+- [ ] `bb pre-commit` recorded


### PR DESCRIPTION
# feat: pr monitor loop core

## Layer

Application

## Depends on

- `feat/pr-monitor-loop-handlers`

## Overview

Adds the loop orchestration namespace on top of the extracted state and handler layers.

## Motivation

This branch restores the monitor loop behavior after the state and handler extractions, while keeping the loop core
itself reviewable as a focused unit.

## Changes in Detail

- Add the slimmed `monitor_loop.clj`.

## Testing Plan

- Run `bb pre-commit`

## Deployment Plan

- Merge before the final observe-phase wiring branch.

## Related Issues/PRs

- Parent feature: PR monitor loop
- Follow-up stack branch: `feat/pr-monitor-loop-observe`

## Checklist

- [x] Scope limited to loop orchestration
- [ ] `bb pre-commit` recorded
