### PR TITLE
feat: pr monitor loop observe

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -6,20 +6,29 @@
    - CI status monitoring
    - Review monitoring
    - Comment triage (actionable vs non-actionable)
+   - Comment classification (change-request/question/bot/noise)
+   - PR monitor loop (autonomous comment resolution)
    - Automated fix generation for CI failures and review feedback
    - Merge policy enforcement
+   - Per-PR budget enforcement
 
    The PR lifecycle controller drives tasks from implementation
-   through merge with minimal manual intervention."
+   through merge with minimal manual intervention. The PR monitor
+   loop autonomously resolves reviewer comments after release."
   (:require
    [ai.miniforge.pr-lifecycle.controller :as controller]
    [ai.miniforge.pr-lifecycle.ci-monitor :as ci]
+   [ai.miniforge.pr-lifecycle.classifier :as classifier]
    [ai.miniforge.pr-lifecycle.review-monitor :as review]
    [ai.miniforge.pr-lifecycle.fix-loop :as fix]
    [ai.miniforge.pr-lifecycle.github :as github]
    [ai.miniforge.pr-lifecycle.triage :as triage]
    [ai.miniforge.pr-lifecycle.merge :as merge]
-   [ai.miniforge.pr-lifecycle.events :as events]))
+   [ai.miniforge.pr-lifecycle.events :as events]
+   [ai.miniforge.pr-lifecycle.monitor-events :as mevents]
+   [ai.miniforge.pr-lifecycle.monitor-loop :as monitor]
+   [ai.miniforge.pr-lifecycle.monitor-budget :as mbudget]
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Events
@@ -456,6 +465,141 @@
                      :on-event #(println \"Event:\" %))"
   controller/run-lifecycle!)
 
+;------------------------------------------------------------------------------ Layer 1.5
+;; Comment classification (category-based, complements triage)
+
+(def categorize-comment
+  "Classify a comment into a category: :change-request :question :approval
+   :bot-comment :noise.
+
+   Arguments:
+   - comment: Map with :body, :author, :id, :path, :line keys
+
+   Options:
+   - :generate-fn — LLM generation function for ambiguous comments
+   - :self-author — Author login to filter self-comments (loop prevention)
+
+   Returns {:category keyword :confidence keyword :method keyword :comment map}
+
+   Example:
+     (categorize-comment {:body \"Please fix the null pointer\" :author \"alice\"})
+     ; => {:category :change-request :confidence :medium :method :heuristic ...}"
+  classifier/classify-comment)
+
+(def categorize-comments
+  "Classify a batch of comments into categories.
+
+   Returns {:change-requests [...] :questions [...] :approvals [...]
+            :bot-comments [...] :noise [...] :all [...] :stats {...}}
+
+   Example:
+     (categorize-comments [{:body \"Add tests\" :author \"alice\"}
+                           {:body \"LGTM!\" :author \"bob\"}]
+                          :self-author \"miniforge[bot]\")"
+  classifier/classify-comments)
+
+;------------------------------------------------------------------------------ Layer 5.5
+;; PR Poller (GitHub adapter)
+
+(def poll-open-prs
+  "Poll GitHub for open PRs authored by a given login.
+   Returns DAG result with :prs vector of PR info maps."
+  poller/poll-open-prs)
+
+(def fetch-pr-comments
+  "Fetch all comments for a PR (review + issue comments).
+   Returns DAG result with :comments vector."
+  poller/fetch-pr-comments)
+
+(def post-pr-comment
+  "Post an issue comment on a PR.
+   Returns DAG result with :comment-posted true."
+  poller/post-comment)
+
+(def load-watermarks
+  "Load polling watermarks from persistent storage."
+  poller/load-watermarks)
+
+(def save-watermarks!
+  "Persist polling watermarks to disk."
+  poller/save-watermarks!)
+
+;------------------------------------------------------------------------------ Layer 6
+;; PR Monitor Loop (autonomous comment resolution)
+
+(def create-pr-monitor
+  "Create a PR monitor loop state.
+
+   Required config keys:
+   - :worktree-path — path to git repo
+   - :self-author — miniforge's GitHub login
+
+   Optional config keys:
+   - :poll-interval-ms — polling interval (default 60000)
+   - :event-bus — event bus for TUI visibility
+   - :logger — structured logger
+   - :generate-fn — LLM generation function
+   - :max-fix-attempts-per-comment — per-comment limit (default 3)
+   - :max-total-fix-attempts-per-pr — per-PR limit (default 10)
+   - :abandon-after-hours — time limit (default 72)
+
+   Returns monitor state atom.
+
+   Example:
+     (def m (create-pr-monitor {:worktree-path \"/repo\"
+                                :self-author \"miniforge[bot]\"
+                                :generate-fn my-llm-fn}))"
+  monitor/create-monitor)
+
+(def run-pr-monitor-loop
+  "Run the PR monitor loop continuously.
+
+   Polls open PRs, classifies comments, routes to handlers.
+   Runs until stopped, budget exhausted, or no open PRs remain.
+
+   Arguments:
+   - monitor: Monitor state atom (from create-pr-monitor)
+   - author: GitHub login to filter PRs by
+
+   Returns evidence summary when loop completes."
+  monitor/run-monitor-loop)
+
+(def stop-pr-monitor-loop
+  "Stop a running PR monitor loop gracefully."
+  monitor/stop-monitor-loop)
+
+(def pr-monitor-evidence
+  "Get current evidence from the PR monitor."
+  monitor/monitor-evidence)
+
+(def pr-monitor-running?
+  "Check if the PR monitor loop is currently running."
+  monitor/monitor-running?)
+
+;------------------------------------------------------------------------------ Layer 6
+;; PR Monitor Budget
+
+(def create-pr-budget
+  "Create a budget tracker for a PR.
+   Returns budget state map."
+  mbudget/create-budget)
+
+(def budget-summary
+  "Get budget status summary for events and logging."
+  mbudget/budget-summary)
+
+(def any-budget-exhausted?
+  "Check if any budget dimension is exhausted.
+   Returns nil if OK, or :comment-limit :pr-limit :time-limit."
+  mbudget/any-budget-exhausted?)
+
+;------------------------------------------------------------------------------ Layer 6
+;; PR Monitor Events
+
+(def monitor-event-types
+  "Valid PR monitor loop event types (:pr-monitor/*)."
+  mevents/monitor-event-types)
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Quick example: Full PR lifecycle
@@ -494,5 +638,32 @@
    [{:name "tests" :state "COMPLETED" :conclusion "SUCCESS"}
     {:name "lint" :state "COMPLETED" :conclusion "FAILURE"}])
   ; => {:status :failure :passed [...] :failed [...] ...}
+
+  ;; Comment classification example
+  (categorize-comment {:body "Please fix the null pointer" :author "alice"})
+  ; => {:category :change-request :confidence :medium :method :heuristic ...}
+
+  (categorize-comments [{:body "Add tests" :author "alice"}
+                        {:body "LGTM!" :author "bob"}
+                        {:body "Why this approach?" :author "charlie"}
+                        {:body "Security scan ok" :author "codeql[bot]"}])
+  ; => {:change-requests [...] :questions [...] :approvals [...] ...}
+
+  ;; PR monitor loop example
+  (def m (create-pr-monitor
+          {:worktree-path "/path/to/repo"
+           :self-author "miniforge[bot]"
+           :generate-fn (fn [prompt] "mock response")
+           :event-bus bus}))
+
+  ;; Start loop in background
+  ;; (future (run-pr-monitor-loop m "miniforge[bot]"))
+
+  ;; Stop gracefully
+  ;; (stop-pr-monitor-loop m)
+
+  ;; Get evidence
+  (pr-monitor-evidence m)
+  ; => {:comments-received 5 :comments-addressed 3 :fixes-pushed [...] ...}
 
   :leave-this-here)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_handlers.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_handlers.clj
@@ -1,0 +1,212 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-handlers
+  "Comment handlers for the PR monitor loop."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.pr-lifecycle.fix-loop :as fix-loop]
+   [ai.miniforge.pr-lifecycle.monitor-budget :as budget]
+   [ai.miniforge.pr-lifecycle.monitor-events :as mevents]
+   [ai.miniforge.pr-lifecycle.monitor-state :as state]
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers
+
+(defn- succeeded?
+  [result]
+  (true? (:success? result)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Comment handlers
+
+(defn handle-change-request
+  "Handle a change-request comment by running one fix-loop attempt."
+  [monitor pr-info classified-comment]
+  (let [{:keys [worktree-path generate-fn logger event-bus]} (:config @monitor)
+        pr-number (:pr/number pr-info)
+        comment (:comment classified-comment)
+        comment-id (:comment/id comment)
+        pr-budget (state/get-or-create-budget monitor pr-number)]
+    (if-let [exhausted (budget/any-budget-exhausted? pr-budget comment-id)]
+      (let [summary (budget/budget-summary pr-budget)]
+        (state/emit! monitor (mevents/budget-exhausted pr-number
+                               (assoc summary :exhausted-by exhausted)))
+        (state/emit! monitor (mevents/escalated pr-number :budget-exhausted
+                               {:comment-id comment-id
+                                :budget-summary summary}))
+        (when logger
+          (log/warn logger :pr-monitor :handler/budget-exhausted
+                    {:message (str "Budget exhausted for PR #" pr-number ": "
+                                   (name exhausted))
+                     :data summary}))
+        {:success? false
+         :reason :budget-exhausted
+         :exhausted-by exhausted})
+      (if-not generate-fn
+        (do
+          (when logger
+            (log/warn logger :pr-monitor :handler/no-generate-fn
+                      {:message "Cannot fix change-request — no generate-fn configured"}))
+          {:success? false :reason :no-generate-fn})
+        (let [updated-budget (budget/record-fix-attempt pr-budget comment-id)
+              _ (state/update-budget! monitor pr-number updated-budget)
+              attempt (get-in updated-budget [:comment-attempts comment-id])
+              _ (state/emit! monitor (mevents/fix-started pr-number comment-id attempt))
+              task {:task/id (random-uuid)
+                    :task/type :fix
+                    :task/acceptance-criteria
+                    [(str "Address review comment: " (:comment/body comment))]}
+              failure-info {:type :review-changes
+                            :summary (:comment/body comment)
+                            :comments [{:body (:comment/body comment)
+                                        :author (:comment/author comment)
+                                        :path (:comment/path comment)
+                                        :line (:comment/line comment)}]
+                            :affected-files (when (:comment/path comment)
+                                              [(:comment/path comment)])
+                            :comment-id comment-id
+                            :parent-pr-number pr-number}
+              context {:logger logger
+                       :worktree-path worktree-path}
+              fix-result (fix-loop/run-fix-loop
+                          task pr-info failure-info generate-fn context
+                          :worktree-path worktree-path
+                          :max-attempts 1
+                          :event-bus event-bus
+                          :auto-resolve-comments true)]
+          (if (succeeded? fix-result)
+            (let [commit-sha (:commit-sha fix-result)
+                  final-budget (budget/record-fix-pushed updated-budget)]
+              (state/update-budget! monitor pr-number final-budget)
+              (state/emit! monitor (mevents/fix-pushed pr-number comment-id commit-sha))
+              (let [reply-body (str "Addressed in commit " commit-sha
+                                    ".\n\n---\n*Fixed by miniforge's autonomous PR monitor.*")]
+                (poller/post-comment worktree-path pr-number reply-body)
+                (state/emit! monitor (mevents/reply-posted pr-number comment-id
+                                                           :fix-reply)))
+              (swap! monitor update-in [:evidence :fixes-pushed] conj
+                     {:comment-id comment-id :sha commit-sha :at (java.util.Date.)})
+              (swap! monitor update-in [:evidence :comments-addressed] inc)
+              (when logger
+                (log/info logger :pr-monitor :handler/fix-pushed
+                          {:message (str "Fix pushed for comment on PR #" pr-number)
+                           :data {:commit-sha commit-sha :attempt attempt}}))
+              {:success? true :commit-sha commit-sha :attempt attempt})
+            (do
+              (when logger
+                (log/warn logger :pr-monitor :handler/fix-failed
+                          {:message (str "Fix failed for comment on PR #" pr-number)
+                           :data {:reason (:reason fix-result) :attempt attempt}}))
+              {:success? false :reason (:reason fix-result) :attempt attempt})))))))
+
+(defn handle-question
+  "Handle a question comment by generating and posting a reply."
+  [monitor pr-info classified-comment]
+  (let [{:keys [worktree-path generate-fn logger]} (:config @monitor)
+        pr-number (:pr/number pr-info)
+        comment (:comment classified-comment)
+        comment-id (:comment/id comment)
+        body (:comment/body comment)]
+    (if-not generate-fn
+      (do
+        (when logger
+          (log/warn logger :pr-monitor :handler/no-generate-fn
+                    {:message "Cannot answer question — no generate-fn configured"
+                     :data {:pr-number pr-number}}))
+        {:success? false :reason :no-generate-fn})
+      (let [prompt (str "You are miniforge, an autonomous software development agent. "
+                        "A reviewer left this question on a pull request you authored. "
+                        "Answer clearly and concisely. Do not make code changes.\n\n"
+                        "Question:\n" body "\n\n"
+                        "Write only the answer text, no preamble.")
+            answer (try
+                     (generate-fn prompt)
+                     (catch Exception e
+                       (when logger
+                         (log/error logger :pr-monitor :handler/llm-error
+                                    {:message "LLM call failed for question"
+                                     :data {:error (.getMessage e)}}))
+                       nil))]
+        (if answer
+          (let [reply-body (str answer
+                                "\n\n---\n*Answered by miniforge's autonomous PR monitor.*")
+                post-result (poller/post-comment worktree-path pr-number reply-body)]
+            (if (dag/ok? post-result)
+              (do
+                (state/emit! monitor (mevents/question-answered pr-number comment-id))
+                (state/emit! monitor (mevents/reply-posted pr-number comment-id
+                                                           :question-reply))
+                (let [pr-budget (state/get-or-create-budget monitor pr-number)]
+                  (state/update-budget! monitor pr-number
+                                        (budget/record-question-answered pr-budget)))
+                (swap! monitor update-in [:evidence :questions-answered] conj
+                       {:comment-id comment-id :at (java.util.Date.)})
+                (swap! monitor update-in [:evidence :comments-addressed] inc)
+                (when logger
+                  (log/info logger :pr-monitor :handler/question-answered
+                            {:message (str "Answered question on PR #" pr-number)
+                             :data {:comment-id comment-id}}))
+                {:success? true :type :question-answered})
+              (do
+                (when logger
+                  (log/warn logger :pr-monitor :handler/post-failed
+                            {:message "Failed to post question answer"
+                             :data {:pr-number pr-number}}))
+                {:success? false :reason :post-failed})))
+          {:success? false :reason :llm-failed})))))
+
+(defn handle-bot-comment
+  "Handle a bot comment. Log and skip."
+  [monitor _pr-info classified-comment]
+  (let [logger (get-in @monitor [:config :logger])
+        comment (:comment classified-comment)]
+    (when logger
+      (log/debug logger :pr-monitor :handler/bot-comment
+                 {:message "Bot comment — skipping"
+                  :data {:author (:comment/author comment)}}))
+    {:success? true :type :bot-skipped}))
+
+(defn handle-approval
+  "Handle an approval comment. Log and skip."
+  [monitor pr-info classified-comment]
+  (let [logger (get-in @monitor [:config :logger])
+        pr-number (:pr/number pr-info)
+        comment (:comment classified-comment)]
+    (when logger
+      (log/info logger :pr-monitor :handler/approval
+                {:message (str "Approval received on PR #" pr-number)
+                 :data {:author (:comment/author comment)}}))
+    {:success? true :type :approval-noted}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Routing
+
+(defn route-comment
+  "Route a classified comment to the appropriate handler."
+  [monitor pr-info classified]
+  (case (:category classified)
+    :change-request (handle-change-request monitor pr-info classified)
+    :question (handle-question monitor pr-info classified)
+    :bot-comment (handle-bot-comment monitor pr-info classified)
+    :approval (handle-approval monitor pr-info classified)
+    :noise {:success? true :type :noise-skipped}
+    {:success? true :type :unknown-skipped :category (:category classified)}))
+

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -26,78 +26,199 @@
    [ai.miniforge.pr-lifecycle.monitor-events :as mevents]
    [ai.miniforge.pr-lifecycle.monitor-handlers :as handlers]
    [ai.miniforge.pr-lifecycle.monitor-state :as state]
-   [ai.miniforge.pr-lifecycle.pr-poller :as poller]))
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]
+   [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; API compatibility
+;; API compatibility + schemas
 
 (def create-monitor
   "Compatibility alias for monitor creation."
   state/create-monitor)
 
+(def CycleResult
+  [:map
+   [:processed nat-int?]
+   [:results [:vector any?]]
+   [:new-comments nat-int?]
+   [:stopped? {:optional true} :boolean]
+   [:stop-reason {:optional true} keyword?]
+   [:error {:optional true} any?]
+   [:classified-stats {:optional true} map?]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
+
 ;------------------------------------------------------------------------------ Layer 1
-;; Single cycle
+;; Single cycle helpers
+
+(defn- cycle-result
+  [result]
+  (validate! CycleResult result))
+
+(defn- time-budget-stop-result
+  [_pr-number]
+  (cycle-result {:processed 0
+                 :results []
+                 :new-comments 0
+                 :stopped? true
+                 :stop-reason :time-budget-exhausted}))
+
+(defn- poll-error-result
+  [poll-result]
+  (cycle-result {:processed 0
+                 :results []
+                 :new-comments 0
+                 :error (:error poll-result)}))
+
+(defn- emit-time-budget-stop!
+  [monitor pr-number pr-budget]
+  (let [summary (budget/budget-summary pr-budget)]
+    (state/emit! monitor (mevents/budget-exhausted pr-number
+                                                   (assoc summary :exhausted-by :time-limit)))
+    (state/emit! monitor (mevents/escalated pr-number :time-limit
+                                            {:budget-summary summary}))))
+
+(defn- classify-comments
+  [new-comments generate-fn self-author]
+  (if (seq new-comments)
+    (classifier/classify-comments new-comments
+                                  :generate-fn generate-fn
+                                  :self-author self-author)
+    {:change-requests []
+     :questions []
+     :approvals []
+     :bot-comments []
+     :noise []
+     :all []
+     :stats {:total 0
+             :change-requests 0
+             :questions 0
+             :approvals 0
+             :bot-comments 0
+             :noise 0}}))
+
+(defn- actionable-comments
+  [classified]
+  (concat (:change-requests classified)
+          (:questions classified)))
+
+(defn- emit-classification-events!
+  [monitor pr-number classified]
+  (doseq [classification (:all classified)]
+    (state/emit! monitor
+                 (mevents/comment-received pr-number
+                                           (:comment classification)))
+    (state/emit! monitor
+                 (mevents/comment-classified pr-number
+                                             (:comment classification)
+                                             {:category (:category classification)
+                                              :confidence (:confidence classification)
+                                              :method (:method classification)}))))
+
+(defn- persist-poll-state!
+  [monitor pr-number watermarks new-comments]
+  (swap! monitor assoc :watermarks watermarks)
+  (poller/save-watermarks! watermarks)
+  (swap! monitor update-in [:evidence :comments-received] + (count new-comments))
+  (state/emit! monitor
+               (mevents/poll-completed pr-number
+                                       {:new-comment-count (count new-comments)})))
+
+(defn- route-actionable-comments
+  [monitor pr-info classified]
+  (into [] (map #(handlers/route-comment monitor pr-info %))
+        (actionable-comments classified)))
+
+(defn- completed-cycle-result
+  [pr-number new-comments classified results]
+  (let [classified-stats (:stats classified)]
+    (cycle-result {:processed (count results)
+                   :results results
+                   :new-comments (count new-comments)
+                   :classified-stats classified-stats})))
 
 (defn run-cycle
   "Run one poll → classify → route cycle for a single PR."
   [monitor pr-info]
   (let [{:keys [worktree-path self-author generate-fn logger]} (:config @monitor)
-        pr-number (:pr/number pr-info)
+        pr-number  (:pr/number pr-info)
         watermarks (:watermarks @monitor)
-        pr-budget (state/get-or-create-budget monitor pr-number)]
+        pr-budget  (state/get-or-create-budget monitor pr-number)]
     (if (budget/time-budget-exhausted? pr-budget)
       (do
-        (state/emit! monitor (mevents/budget-exhausted pr-number
-                               (assoc (budget/budget-summary pr-budget)
-                                      :exhausted-by :time-limit)))
-        (state/emit! monitor (mevents/escalated pr-number :time-limit
-                               {:budget-summary (budget/budget-summary pr-budget)}))
-        {:processed 0 :results [] :new-comments 0
-         :stopped? true :stop-reason :time-budget-exhausted})
+        (emit-time-budget-stop! monitor pr-number pr-budget)
+        (time-budget-stop-result pr-number))
       (let [poll-result (poller/poll-pr-for-new-comments
                          worktree-path pr-number watermarks logger)]
         (if (dag/err? poll-result)
-          {:processed 0 :results [] :new-comments 0
-           :error (:error poll-result)}
+          (poll-error-result poll-result)
           (let [{:keys [new-comments watermarks]} (:data poll-result)
-                _ (swap! monitor assoc :watermarks watermarks)
-                _ (poller/save-watermarks! watermarks)
-                _ (swap! monitor update-in [:evidence :comments-received]
-                         + (count new-comments))
-                _ (state/emit! monitor
-                               (mevents/poll-completed pr-number
-                                                       {:new-comment-count
-                                                        (count new-comments)}))
-                classified (when (seq new-comments)
-                             (classifier/classify-comments new-comments
-                               :generate-fn generate-fn
-                               :self-author self-author))
-                _ (doseq [classification (:all classified)]
-                    (state/emit! monitor
-                                 (mevents/comment-received pr-number
-                                                           (:comment classification)))
-                    (state/emit! monitor
-                                 (mevents/comment-classified
-                                  pr-number
-                                  (:comment classification)
-                                  {:category (:category classification)
-                                   :confidence (:confidence classification)
-                                   :method (:method classification)})))
-                actionable (concat (:change-requests classified)
-                                   (:questions classified))
-                results (mapv #(handlers/route-comment monitor pr-info %) actionable)]
+                _          (persist-poll-state! monitor pr-number watermarks new-comments)
+                classified (classify-comments new-comments generate-fn self-author)
+                _          (emit-classification-events! monitor pr-number classified)
+                results    (route-actionable-comments monitor pr-info classified)]
             (state/emit! monitor
                          (mevents/cycle-completed pr-number
                                                   {:new-comments (count new-comments)
                                                    :classified-stats (:stats classified)
                                                    :actions-taken (count results)}))
-            {:processed (count results)
-             :results results
-             :new-comments (count new-comments)
-             :classified-stats (:stats classified)}))))))
+            (completed-cycle-result pr-number new-comments classified results)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Loop lifecycle
+
+(declare step-monitor-loop!)
+
+(defn- retry-after-poll-error!
+  [monitor author logger poll-interval-ms pr-result]
+  (when logger
+    (log/warn logger :pr-monitor :loop/poll-prs-failed
+              {:message "Failed to poll open PRs — retrying"
+               :data {:error (:error pr-result)}}))
+  (Thread/sleep poll-interval-ms)
+  (step-monitor-loop! monitor author))
+
+(defn- stop-when-no-open-prs!
+  [monitor logger]
+  (when logger
+    (log/info logger :pr-monitor :loop/no-open-prs
+              {:message "No open PRs found — stopping monitor loop"}))
+  (swap! monitor assoc :running? false))
+
+(defn- log-cycle-stop
+  [logger pr cycle-result]
+  (when (and (:stopped? cycle-result) logger)
+    (log/info logger :pr-monitor :loop/pr-budget-stopped
+              {:message (str "PR #" (:pr/number pr)
+                             " stopped: "
+                             (:stop-reason cycle-result))})))
+
+(defn- run-pr-cycle!
+  [monitor logger pr]
+  (when (:running? @monitor)
+    (try
+      (log-cycle-stop logger pr (run-cycle monitor pr))
+      (catch Exception e
+        (when logger
+          (log/error logger :pr-monitor :loop/cycle-error
+                     {:message "Error in monitor cycle"
+                      :data {:pr-number (:pr/number pr)
+                             :error (.getMessage e)}}))))))
+
+(defn- finalize-loop-iteration!
+  [monitor]
+  (swap! monitor (fn [state-map]
+                   (-> state-map
+                       (update :cycles inc)
+                       (assoc :last-cycle-at (java.util.Date.))))))
+
+(defn- continue-loop!
+  [monitor author poll-interval-ms]
+  (when (:running? @monitor)
+    (Thread/sleep poll-interval-ms)
+    (step-monitor-loop! monitor author)))
 
 (defn- step-monitor-loop!
   [monitor author]
@@ -106,45 +227,16 @@
       (let [pr-result (poller/poll-open-prs worktree-path author)]
         (cond
           (dag/err? pr-result)
-          (do
-            (when logger
-              (log/warn logger :pr-monitor :loop/poll-prs-failed
-                        {:message "Failed to poll open PRs — retrying"
-                         :data {:error (:error pr-result)}}))
-            (Thread/sleep poll-interval-ms)
-            (step-monitor-loop! monitor author))
+          (retry-after-poll-error! monitor author logger poll-interval-ms pr-result)
 
           (empty? (:prs (:data pr-result)))
-          (do
-            (when logger
-              (log/info logger :pr-monitor :loop/no-open-prs
-                        {:message "No open PRs found — stopping monitor loop"}))
-            (swap! monitor assoc :running? false))
+          (stop-when-no-open-prs! monitor logger)
 
           :else
           (let [prs (:prs (:data pr-result))]
-            (doseq [pr prs]
-              (when (:running? @monitor)
-                (try
-                  (let [cycle-result (run-cycle monitor pr)]
-                    (when (and (:stopped? cycle-result) logger)
-                      (log/info logger :pr-monitor :loop/pr-budget-stopped
-                                {:message (str "PR #" (:pr/number pr)
-                                               " stopped: "
-                                               (:stop-reason cycle-result))})))
-                  (catch Exception e
-                    (when logger
-                      (log/error logger :pr-monitor :loop/cycle-error
-                                 {:message "Error in monitor cycle"
-                                  :data {:pr-number (:pr/number pr)
-                                         :error (.getMessage e)}})))))
-            (swap! monitor (fn [state-map]
-                             (-> state-map
-                                 (update :cycles inc)
-                                 (assoc :last-cycle-at (java.util.Date.)))))
-            (when (:running? @monitor)
-              (Thread/sleep poll-interval-ms)
-              (step-monitor-loop! monitor author)))))))))
+            (run! #(run-pr-cycle! monitor logger %) prs)
+            (finalize-loop-iteration! monitor)
+            (continue-loop! monitor author poll-interval-ms)))))))
 
 (defn run-monitor-loop
   "Run the PR monitor loop continuously until stopped."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -132,7 +132,7 @@
         (actionable-comments classified)))
 
 (defn- completed-cycle-result
-  [pr-number new-comments classified results]
+  [new-comments classified results]
   (let [classified-stats (:stats classified)]
     (cycle-result {:processed (count results)
                    :results results
@@ -164,7 +164,7 @@
                                                   {:new-comments (count new-comments)
                                                    :classified-stats (:stats classified)
                                                    :actions-taken (count results)}))
-            (completed-cycle-result pr-number new-comments classified results)))))))
+            (completed-cycle-result new-comments classified results)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Loop lifecycle

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -1,0 +1,177 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-loop
+  "PR monitor loop orchestration."
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.pr-lifecycle.classifier :as classifier]
+   [ai.miniforge.pr-lifecycle.monitor-budget :as budget]
+   [ai.miniforge.pr-lifecycle.monitor-events :as mevents]
+   [ai.miniforge.pr-lifecycle.monitor-handlers :as handlers]
+   [ai.miniforge.pr-lifecycle.monitor-state :as state]
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; API compatibility
+
+(def create-monitor
+  "Compatibility alias for monitor creation."
+  state/create-monitor)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Single cycle
+
+(defn run-cycle
+  "Run one poll → classify → route cycle for a single PR."
+  [monitor pr-info]
+  (let [{:keys [worktree-path self-author generate-fn logger]} (:config @monitor)
+        pr-number (:pr/number pr-info)
+        watermarks (:watermarks @monitor)
+        pr-budget (state/get-or-create-budget monitor pr-number)]
+    (if (budget/time-budget-exhausted? pr-budget)
+      (do
+        (state/emit! monitor (mevents/budget-exhausted pr-number
+                               (assoc (budget/budget-summary pr-budget)
+                                      :exhausted-by :time-limit)))
+        (state/emit! monitor (mevents/escalated pr-number :time-limit
+                               {:budget-summary (budget/budget-summary pr-budget)}))
+        {:processed 0 :results [] :new-comments 0
+         :stopped? true :stop-reason :time-budget-exhausted})
+      (let [poll-result (poller/poll-pr-for-new-comments
+                         worktree-path pr-number watermarks logger)]
+        (if (dag/err? poll-result)
+          {:processed 0 :results [] :new-comments 0
+           :error (:error poll-result)}
+          (let [{:keys [new-comments watermarks]} (:data poll-result)
+                _ (swap! monitor assoc :watermarks watermarks)
+                _ (poller/save-watermarks! watermarks)
+                _ (swap! monitor update-in [:evidence :comments-received]
+                         + (count new-comments))
+                _ (state/emit! monitor
+                               (mevents/poll-completed pr-number
+                                                       {:new-comment-count
+                                                        (count new-comments)}))
+                classified (when (seq new-comments)
+                             (classifier/classify-comments new-comments
+                               :generate-fn generate-fn
+                               :self-author self-author))
+                _ (doseq [classification (:all classified)]
+                    (state/emit! monitor
+                                 (mevents/comment-received pr-number
+                                                           (:comment classification)))
+                    (state/emit! monitor
+                                 (mevents/comment-classified
+                                  pr-number
+                                  (:comment classification)
+                                  {:category (:category classification)
+                                   :confidence (:confidence classification)
+                                   :method (:method classification)})))
+                actionable (concat (:change-requests classified)
+                                   (:questions classified))
+                results (mapv #(handlers/route-comment monitor pr-info %) actionable)]
+            (state/emit! monitor
+                         (mevents/cycle-completed pr-number
+                                                  {:new-comments (count new-comments)
+                                                   :classified-stats (:stats classified)
+                                                   :actions-taken (count results)}))
+            {:processed (count results)
+             :results results
+             :new-comments (count new-comments)
+             :classified-stats (:stats classified)}))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Loop lifecycle
+
+(defn run-monitor-loop
+  "Run the PR monitor loop continuously until stopped."
+  [monitor author]
+  (let [{:keys [poll-interval-ms logger worktree-path]} (:config @monitor)]
+    (swap! monitor assoc :running? true :started-at (java.util.Date.))
+    (state/log-loop-start! monitor author)
+    (loop []
+      (when (:running? @monitor)
+        (let [pr-result (poller/poll-open-prs worktree-path author)]
+          (cond
+            (dag/err? pr-result)
+            (do
+              (when logger
+                (log/warn logger :pr-monitor :loop/poll-prs-failed
+                          {:message "Failed to poll open PRs — retrying"
+                           :data {:error (:error pr-result)}}))
+              (Thread/sleep poll-interval-ms)
+              (recur))
+
+            (empty? (:prs (:data pr-result)))
+            (do
+              (when logger
+                (log/info logger :pr-monitor :loop/no-open-prs
+                          {:message "No open PRs found — stopping monitor loop"}))
+              (swap! monitor assoc :running? false))
+
+            :else
+            (let [prs (:prs (:data pr-result))]
+              (doseq [pr prs]
+                (when (:running? @monitor)
+                  (try
+                    (let [cycle-result (run-cycle monitor pr)]
+                      (when (and (:stopped? cycle-result) logger)
+                        (log/info logger :pr-monitor :loop/pr-budget-stopped
+                                  {:message (str "PR #" (:pr/number pr)
+                                                 " stopped: "
+                                                 (:stop-reason cycle-result))})))
+                    (catch Exception e
+                      (when logger
+                        (log/error logger :pr-monitor :loop/cycle-error
+                                   {:message "Error in monitor cycle"
+                                    :data {:pr-number (:pr/number pr)
+                                           :error (.getMessage e)}})))))
+              (swap! monitor (fn [state-map]
+                               (-> state-map
+                                   (update :cycles inc)
+                                   (assoc :last-cycle-at (java.util.Date.)))))
+              (when (:running? @monitor)
+                (Thread/sleep poll-interval-ms)
+                (recur))))))))
+    (when logger
+      (log/info logger :pr-monitor :loop/stopped
+                {:message "PR monitor loop stopped"
+                 :data {:cycles (:cycles @monitor)}}))
+    (let [evidence (:evidence @monitor)]
+      (merge evidence
+             {:cycles (:cycles @monitor)
+              :duration-hours (when-let [started (:started-at @monitor)]
+                                (/ (double (- (System/currentTimeMillis)
+                                              (.getTime ^java.util.Date started)))
+                                   3600000.0))}))))
+
+(defn stop-monitor-loop
+  "Stop a running monitor loop gracefully."
+  [monitor]
+  (swap! monitor assoc :running? false))
+
+(defn monitor-running?
+  "Check if the monitor loop is currently running."
+  [monitor]
+  (:running? @monitor))
+
+(defn monitor-evidence
+  "Get current evidence from the monitor."
+  [monitor]
+  (:evidence @monitor))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj
@@ -99,56 +99,60 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Loop lifecycle
 
+(defn- step-monitor-loop!
+  [monitor author]
+  (let [{:keys [poll-interval-ms logger worktree-path]} (:config @monitor)]
+    (when (:running? @monitor)
+      (let [pr-result (poller/poll-open-prs worktree-path author)]
+        (cond
+          (dag/err? pr-result)
+          (do
+            (when logger
+              (log/warn logger :pr-monitor :loop/poll-prs-failed
+                        {:message "Failed to poll open PRs — retrying"
+                         :data {:error (:error pr-result)}}))
+            (Thread/sleep poll-interval-ms)
+            (step-monitor-loop! monitor author))
+
+          (empty? (:prs (:data pr-result)))
+          (do
+            (when logger
+              (log/info logger :pr-monitor :loop/no-open-prs
+                        {:message "No open PRs found — stopping monitor loop"}))
+            (swap! monitor assoc :running? false))
+
+          :else
+          (let [prs (:prs (:data pr-result))]
+            (doseq [pr prs]
+              (when (:running? @monitor)
+                (try
+                  (let [cycle-result (run-cycle monitor pr)]
+                    (when (and (:stopped? cycle-result) logger)
+                      (log/info logger :pr-monitor :loop/pr-budget-stopped
+                                {:message (str "PR #" (:pr/number pr)
+                                               " stopped: "
+                                               (:stop-reason cycle-result))})))
+                  (catch Exception e
+                    (when logger
+                      (log/error logger :pr-monitor :loop/cycle-error
+                                 {:message "Error in monitor cycle"
+                                  :data {:pr-number (:pr/number pr)
+                                         :error (.getMessage e)}})))))
+            (swap! monitor (fn [state-map]
+                             (-> state-map
+                                 (update :cycles inc)
+                                 (assoc :last-cycle-at (java.util.Date.)))))
+            (when (:running? @monitor)
+              (Thread/sleep poll-interval-ms)
+              (step-monitor-loop! monitor author)))))))))
+
 (defn run-monitor-loop
   "Run the PR monitor loop continuously until stopped."
   [monitor author]
-  (let [{:keys [poll-interval-ms logger worktree-path]} (:config @monitor)]
+  (let [{:keys [logger]} (:config @monitor)]
     (swap! monitor assoc :running? true :started-at (java.util.Date.))
     (state/log-loop-start! monitor author)
-    (loop []
-      (when (:running? @monitor)
-        (let [pr-result (poller/poll-open-prs worktree-path author)]
-          (cond
-            (dag/err? pr-result)
-            (do
-              (when logger
-                (log/warn logger :pr-monitor :loop/poll-prs-failed
-                          {:message "Failed to poll open PRs — retrying"
-                           :data {:error (:error pr-result)}}))
-              (Thread/sleep poll-interval-ms)
-              (recur))
-
-            (empty? (:prs (:data pr-result)))
-            (do
-              (when logger
-                (log/info logger :pr-monitor :loop/no-open-prs
-                          {:message "No open PRs found — stopping monitor loop"}))
-              (swap! monitor assoc :running? false))
-
-            :else
-            (let [prs (:prs (:data pr-result))]
-              (doseq [pr prs]
-                (when (:running? @monitor)
-                  (try
-                    (let [cycle-result (run-cycle monitor pr)]
-                      (when (and (:stopped? cycle-result) logger)
-                        (log/info logger :pr-monitor :loop/pr-budget-stopped
-                                  {:message (str "PR #" (:pr/number pr)
-                                                 " stopped: "
-                                                 (:stop-reason cycle-result))})))
-                    (catch Exception e
-                      (when logger
-                        (log/error logger :pr-monitor :loop/cycle-error
-                                   {:message "Error in monitor cycle"
-                                    :data {:pr-number (:pr/number pr)
-                                           :error (.getMessage e)}})))))
-              (swap! monitor (fn [state-map]
-                               (-> state-map
-                                   (update :cycles inc)
-                                   (assoc :last-cycle-at (java.util.Date.)))))
-              (when (:running? @monitor)
-                (Thread/sleep poll-interval-ms)
-                (recur))))))))
+    (step-monitor-loop! monitor author)
     (when logger
       (log/info logger :pr-monitor :loop/stopped
                 {:message "PR monitor loop stopped"

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_loop_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/monitor_loop_test.clj
@@ -1,0 +1,34 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.monitor-loop-test
+  (:require
+   [ai.miniforge.pr-lifecycle.monitor-loop :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest actionable-comments-test
+  (testing "change requests and questions are routed, approvals are not"
+    (let [classified {:change-requests [{:comment {:id 1}}]
+                      :questions [{:comment {:id 2}}]
+                      :approvals [{:comment {:id 3}}]}]
+      (is (= [1 2]
+             (mapv #(get-in % [:comment :id])
+                   (#'sut/actionable-comments classified)))))))
+
+(deftest time-budget-stop-result-test
+  (testing "time budget exhaustion yields a stopped cycle result"
+    (let [result (#'sut/time-budget-stop-result 42)]
+      (is (= 0 (:processed result)))
+      (is (true? (:stopped? result)))
+      (is (= :time-budget-exhausted (:stop-reason result))))))

--- a/components/workflow-software-factory/resources/workflows/canonical-sdlc-v1.0.0.edn
+++ b/components/workflow-software-factory/resources/workflows/canonical-sdlc-v1.0.0.edn
@@ -168,7 +168,7 @@
     :repair-strategy :none}
    :phase/gates [:metrics-collected]
    :phase/budget {:tokens 5000 :time-seconds 120 :iterations 1}
-   :phase/next [{:target :meta-loop}]
+   :phase/next []
    :phase/metrics [:total-iterations :total-tokens :total-time :success-outcome]}]
 
  ;; ──────────────────────────────────────────────────────────────────────────

--- a/components/workflow-software-factory/resources/workflows/lean-sdlc-v1.0.0.edn
+++ b/components/workflow-software-factory/resources/workflows/lean-sdlc-v1.0.0.edn
@@ -100,7 +100,7 @@
     :repair-strategy :none}
    :phase/gates [:metrics-collected]
    :phase/budget {:tokens 2000 :time-seconds 60 :iterations 1}
-   :phase/next [{:target :meta-loop}]
+   :phase/next []
    :phase/metrics [:total-time :total-tokens]}]
 
  :workflow/config

--- a/components/workflow/resources/config/workflow/observe-phase.edn
+++ b/components/workflow/resources/config/workflow/observe-phase.edn
@@ -1,0 +1,6 @@
+{:observe/phase-defaults
+ {:agent nil
+  :gates []
+  :budget {:tokens 0
+           :iterations 1
+           :time-seconds 259200}}}

--- a/components/workflow/src/ai/miniforge/workflow/loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/loader.clj
@@ -87,15 +87,20 @@
 
 (defn find-latest-versioned-resource
   "Scan classpath for the highest versioned workflow file matching workflow-id.
-   Looks for workflows/<workflow-id>-v*.edn files and returns the path with
-   the highest version number. Works inside uberjars."
+   Supports two naming conventions:
+   - <workflow-id>-v<semver>.edn  (e.g. standard-sdlc-v2.0.0.edn for :standard-sdlc)
+   - <workflow-id>.<semver>.edn   (e.g. lean-sdlc-v1.0.0.edn for :lean-sdlc-v1)
+   Returns the classpath-relative path for the highest-sorted match."
   [workflow-id]
-  (let [prefix (str (name workflow-id) "-v")
-        candidates (->> (list-resource-names "workflows")
-                        (filter #(str/ends-with? % ".edn"))
-                        (filter #(str/starts-with? % prefix))
-                        sort
-                        reverse)]
+  (let [id-str       (name workflow-id)
+        prefix-dash  (str id-str "-v")
+        prefix-dot   (str id-str ".")
+        candidates   (->> (list-resource-names "workflows")
+                          (filter #(str/ends-with? % ".edn"))
+                          (filter #(or (str/starts-with? % prefix-dash)
+                                       (str/starts-with? % prefix-dot)))
+                          sort
+                          reverse)]
     (when-let [filename (first candidates)]
       (str "workflows/" filename))))
 

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -24,26 +24,94 @@
    phase of the standard SDLC workflow: plan → implement → verify →
    review → release → observe."
   (:require [ai.miniforge.phase.registry :as registry]
-            [ai.miniforge.response.interface :as response]))
+            [ai.miniforge.response.interface :as response]
+            [ai.miniforge.schema.interface :as schema]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Defaults
+;; Config loading + defaults
+
+(def ObservePhaseDefaults
+  [:map
+   [:agent {:optional true} [:maybe keyword?]]
+   [:gates [:vector keyword?]]
+   [:budget [:map
+             [:tokens nat-int?]
+             [:iterations pos-int?]
+             [:time-seconds pos-int?]]]])
+
+(def ObservePhaseConfig
+  [:map
+   [:observe/phase-defaults ObservePhaseDefaults]])
+
+(def ObserveMonitorConfig
+  [:map
+   [:worktree-path :string]
+   [:self-author [:maybe :string]]
+   [:generate-fn {:optional true} any?]
+   [:event-bus {:optional true} any?]
+   [:logger {:optional true} any?]
+   [:poll-interval-ms nat-int?]
+   [:max-fix-attempts-per-comment pos-int?]
+   [:max-total-fix-attempts-per-pr pos-int?]
+   [:abandon-after-hours pos-int?]])
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
+
+(defn- load-observe-phase-config
+  []
+  (->> "config/workflow/observe-phase.edn"
+       io/resource
+       slurp
+       edn/read-string
+       (validate! ObservePhaseConfig)))
+
+(defn- load-monitor-defaults
+  []
+  (let [defaults-fn (requiring-resolve
+                     'ai.miniforge.pr-lifecycle.monitor-config/monitor-defaults)]
+    (defaults-fn)))
+
+(defn- present-overrides
+  [overrides]
+  (into {} (remove (comp nil? val)) overrides))
 
 (def default-config
-  "Default Observe phase configuration.
-   Agent is nil because this phase is pure orchestration — it delegates
-   to the PR monitor loop which internally uses generate-fn for fixes."
-  {:agent nil
-   :gates []
-   :budget {:tokens 0
-            :iterations 1
-            :time-seconds 259200}}) ; 72 hours default
+  "Default Observe phase configuration loaded from EDN."
+  (:observe/phase-defaults (load-observe-phase-config)))
 
 ;; Register defaults on load
 (registry/register-phase-defaults! :observe default-config)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
+
+(defn- resolve-monitor-config
+  [ctx logger generate-fn event-bus]
+  (let [worktree-path (or (get-in ctx [:execution/worktree-path])
+                          (get-in ctx [:worktree-path]))
+        shared-defaults (load-monitor-defaults)]
+    (validate!
+     ObserveMonitorConfig
+     (merge shared-defaults
+            {:worktree-path worktree-path
+             :self-author (or (get-in ctx [:execution/self-author])
+                              (get-in ctx [:config :github/self-author])
+                              (:self-author shared-defaults))
+             :generate-fn generate-fn
+             :event-bus event-bus
+             :logger logger}
+            (present-overrides
+             {:poll-interval-ms (get-in ctx [:config :pr-monitor/poll-interval-ms])
+              :max-fix-attempts-per-comment
+              (get-in ctx [:config :pr-monitor/max-fix-attempts-per-comment])
+              :max-total-fix-attempts-per-pr
+              (get-in ctx [:config :pr-monitor/max-total-fix-attempts-per-pr])
+              :abandon-after-hours
+              (get-in ctx [:config :pr-monitor/abandon-after-hours])})))))
 
 (defn enter-observe
   "Execute the Observe phase.
@@ -79,27 +147,10 @@
                               'ai.miniforge.pr-lifecycle.monitor-loop/run-monitor-loop)
 
             logger (get-in ctx [:execution/logger])
-            worktree-path (or (get-in ctx [:execution/worktree-path])
-                              (get-in ctx [:worktree-path]))
             generate-fn (get-in ctx [:execution/generate-fn])
             event-bus (get-in ctx [:execution/event-bus])
-            self-author (or (get-in ctx [:execution/self-author])
-                            (get-in ctx [:config :github/self-author])
-                            "miniforge[bot]")
-
-            monitor-config {:worktree-path worktree-path
-                            :self-author self-author
-                            :generate-fn generate-fn
-                            :event-bus event-bus
-                            :logger logger
-                            :poll-interval-ms
-                            (get-in ctx [:config :pr-monitor/poll-interval-ms] 60000)
-                            :max-fix-attempts-per-comment
-                            (get-in ctx [:config :pr-monitor/max-fix-attempts-per-comment] 3)
-                            :max-total-fix-attempts-per-pr
-                            (get-in ctx [:config :pr-monitor/max-total-fix-attempts-per-pr] 10)
-                            :abandon-after-hours
-                            (get-in ctx [:config :pr-monitor/abandon-after-hours] 72)}
+            monitor-config (resolve-monitor-config ctx logger generate-fn event-bus)
+            self-author (:self-author monitor-config)
 
             monitor (create-monitor monitor-config)
             evidence (run-monitor-loop monitor self-author)

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -1,0 +1,174 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.observe-phase
+  "N2 Observe phase: autonomous PR monitoring after release.
+
+   Wires the PR monitor loop into the workflow execution pipeline.
+   After the Release phase creates a PR, the Observe phase starts
+   the monitor loop and runs until the PR is merged, abandoned,
+   or budget exhausted.
+
+   This is the N2 §7 implementation. The Observe phase is the final
+   phase of the standard SDLC workflow: plan → implement → verify →
+   review → release → observe."
+  (:require [ai.miniforge.phase.registry :as registry]
+            [ai.miniforge.response.interface :as response]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Defaults
+
+(def default-config
+  "Default Observe phase configuration.
+   Agent is nil because this phase is pure orchestration — it delegates
+   to the PR monitor loop which internally uses generate-fn for fixes."
+  {:agent nil
+   :gates []
+   :budget {:tokens 0
+            :iterations 1
+            :time-seconds 259200}}) ; 72 hours default
+
+;; Register defaults on load
+(registry/register-phase-defaults! :observe default-config)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Interceptor implementation
+
+(defn enter-observe
+  "Execute the Observe phase.
+
+   Reads PR info from context (set by Release phase), creates and runs
+   the PR monitor loop until a terminal condition is reached:
+   - All PRs merged
+   - Budget exhausted (human escalation emitted)
+   - PRs closed externally
+   - No open PRs remain
+
+   Uses requiring-resolve to avoid circular component dependencies."
+  [ctx]
+  (let [pr-infos (or (get-in ctx [:execution/dag-pr-infos])
+                     ;; Single PR from release phase
+                     (when-let [pr-info (get-in ctx [:execution/phase-results :release :pr-info])]
+                       [pr-info]))
+        start-time (System/currentTimeMillis)]
+
+    (if (empty? pr-infos)
+      ;; No PRs to observe — skip phase
+      (-> ctx
+          (assoc-in [:phase :name] :observe)
+          (assoc-in [:phase :status] :completed)
+          (assoc-in [:phase :result]
+                    (response/success {:observe/status :skipped
+                                       :observe/reason "No PRs to observe"})))
+
+      ;; Resolve monitor-loop at runtime to avoid circular deps
+      (let [create-monitor (requiring-resolve
+                            'ai.miniforge.pr-lifecycle.monitor-loop/create-monitor)
+            run-monitor-loop (requiring-resolve
+                              'ai.miniforge.pr-lifecycle.monitor-loop/run-monitor-loop)
+
+            logger (get-in ctx [:execution/logger])
+            worktree-path (or (get-in ctx [:execution/worktree-path])
+                              (get-in ctx [:worktree-path]))
+            generate-fn (get-in ctx [:execution/generate-fn])
+            event-bus (get-in ctx [:execution/event-bus])
+            self-author (or (get-in ctx [:execution/self-author])
+                            (get-in ctx [:config :github/self-author])
+                            "miniforge[bot]")
+
+            monitor-config {:worktree-path worktree-path
+                            :self-author self-author
+                            :generate-fn generate-fn
+                            :event-bus event-bus
+                            :logger logger
+                            :poll-interval-ms
+                            (get-in ctx [:config :pr-monitor/poll-interval-ms] 60000)
+                            :max-fix-attempts-per-comment
+                            (get-in ctx [:config :pr-monitor/max-fix-attempts-per-comment] 3)
+                            :max-total-fix-attempts-per-pr
+                            (get-in ctx [:config :pr-monitor/max-total-fix-attempts-per-pr] 10)
+                            :abandon-after-hours
+                            (get-in ctx [:config :pr-monitor/abandon-after-hours] 72)}
+
+            monitor (create-monitor monitor-config)
+            evidence (run-monitor-loop monitor self-author)
+
+            result-data {:observe/status :completed
+                         :observe/evidence evidence
+                         :observe/prs-monitored (count pr-infos)
+                         :observe/duration-hours (:duration-hours evidence)
+                         :observe/comments-received (:comments-received evidence)
+                         :observe/comments-addressed (:comments-addressed evidence)
+                         :observe/fixes-pushed (count (:fixes-pushed evidence))
+                         :observe/questions-answered (count (:questions-answered evidence))}]
+
+        (-> ctx
+            (assoc-in [:phase :name] :observe)
+            (assoc-in [:phase :started-at] start-time)
+            (assoc-in [:phase :status] :completed)
+            (assoc-in [:phase :result] (response/success result-data))
+            (assoc :execution/pr-lifecycle-evidence evidence))))))
+
+(defn leave-observe
+  "Post-processing for Observe phase. Records evidence and duration metrics."
+  [ctx]
+  (let [start-time (get-in ctx [:phase :started-at] (System/currentTimeMillis))
+        end-time (System/currentTimeMillis)
+        duration-ms (- end-time start-time)]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:metrics :observe :duration-ms] duration-ms)
+        (update-in [:execution :phases-completed] (fnil conj []) :observe)
+        (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
+
+(defn error-observe
+  "Handle Observe phase errors."
+  [ctx ex]
+  (-> ctx
+      (assoc-in [:phase :status] :failed)
+      (assoc-in [:phase :error] {:message (ex-message ex)
+                                  :data (ex-data ex)})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry method
+
+(defmethod registry/get-phase-interceptor :observe
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name ::observe
+     :config merged
+     :enter (fn [ctx]
+              (enter-observe (assoc ctx :phase-config merged)))
+     :leave leave-observe
+     :error error-observe}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Get interceptor
+  (registry/get-phase-interceptor {:phase :observe})
+
+  ;; Check defaults
+  (registry/phase-defaults :observe)
+
+  ;; Typical execution context keys the Observe phase reads:
+  ;; :execution/dag-pr-infos — vector of PR info maps from Release phase
+  ;; :execution/logger — structured logger
+  ;; :execution/worktree-path — git repo path
+  ;; :execution/generate-fn — LLM generation function
+  ;; :execution/event-bus — PR lifecycle event bus
+  ;; :execution/self-author — miniforge's GitHub login
+  ;; :config :pr-monitor/* — monitor config overrides
+
+  :leave-this-here)

--- a/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
@@ -1,0 +1,40 @@
+;; Copyright 2025 miniforge.ai
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.observe-phase-test
+  (:require
+   [ai.miniforge.workflow.observe-phase :as sut]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest default-config-loaded-from-edn-test
+  (testing "observe phase defaults come from resource config"
+    (is (= 259200 (get-in sut/default-config [:budget :time-seconds])))
+    (is (= [] (:gates sut/default-config)))))
+
+(deftest resolve-monitor-config-test
+  (testing "context overrides are merged over shared monitor defaults"
+    (with-redefs [sut/load-monitor-defaults
+                  (fn []
+                    {:poll-interval-ms 60000
+                     :self-author nil
+                     :max-fix-attempts-per-comment 3
+                     :max-total-fix-attempts-per-pr 10
+                     :abandon-after-hours 72})]
+      (let [config (#'sut/resolve-monitor-config
+                    {:execution/worktree-path "/tmp/repo"
+                     :execution/self-author "miniforge[bot]"
+                     :config {:pr-monitor/poll-interval-ms 15000}} nil nil nil)]
+        (is (= 15000 (:poll-interval-ms config)))
+        (is (= "miniforge[bot]" (:self-author config)))
+        (is (= 10 (:max-total-fix-attempts-per-pr config)))))))

--- a/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-core.md
+++ b/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-core.md
@@ -1,0 +1,40 @@
+# feat: pr monitor loop core
+
+## Layer
+
+Application
+
+## Depends on
+
+- `feat/pr-monitor-loop-handlers`
+
+## Overview
+
+Adds the loop orchestration namespace on top of the extracted state and handler layers.
+
+## Motivation
+
+This branch restores the monitor loop behavior after the state and handler extractions, while keeping the loop core
+itself reviewable as a focused unit.
+
+## Changes in Detail
+
+- Add the slimmed `monitor_loop.clj`.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge before the final observe-phase wiring branch.
+
+## Related Issues/PRs
+
+- Parent feature: PR monitor loop
+- Follow-up stack branch: `feat/pr-monitor-loop-observe`
+
+## Checklist
+
+- [x] Scope limited to loop orchestration
+- [ ] `bb pre-commit` recorded

--- a/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-handlers.md
+++ b/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-handlers.md
@@ -1,0 +1,40 @@
+# feat: pr monitor loop handlers
+
+## Layer
+
+Application
+
+## Depends on
+
+- `feat/pr-monitor-loop-state`
+
+## Overview
+
+Splits the monitor comment handlers into their own namespace.
+
+## Motivation
+
+Keeping routing and handler behavior separate from loop state and loop execution makes the monitor stack reviewable in
+smaller slices and keeps the eventual loop core branch under the small-PR limit.
+
+## Changes in Detail
+
+- Add `monitor_handlers.clj`.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge before the loop core branch.
+
+## Related Issues/PRs
+
+- Parent feature: PR monitor loop
+- Follow-up stack branch: `feat/pr-monitor-loop-core`
+
+## Checklist
+
+- [x] Scope limited to comment handling and routing
+- [ ] `bb pre-commit` recorded

--- a/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-observe.md
+++ b/docs/pull-requests/2026-04-01-feat-pr-monitor-loop-observe.md
@@ -1,0 +1,41 @@
+# feat: pr monitor loop observe
+
+## Layer
+
+Integration
+
+## Depends on
+
+- `feat/pr-monitor-loop-core`
+
+## Overview
+
+Wires the PR monitor loop into the workflow observe phase and the public pr-lifecycle interface.
+
+## Motivation
+
+The monitor stack is only useful once the workflow layer can invoke it and downstream callers can reach the new API from
+the component interface.
+
+## Changes in Detail
+
+- Add `observe_phase.clj`.
+- Export the PR monitor API from `pr-lifecycle/interface.clj`.
+- Update workflow loader and SDLC workflow resources to include observe-phase wiring.
+
+## Testing Plan
+
+- Run `bb pre-commit`
+
+## Deployment Plan
+
+- Merge last in the PR monitor loop stack.
+
+## Related Issues/PRs
+
+- Parent feature: PR monitor loop
+
+## Checklist
+
+- [x] Scope limited to integration and public API wiring
+- [ ] `bb pre-commit` recorded


### PR DESCRIPTION
# feat: pr monitor loop observe

## Layer

Integration

## Depends on

- `feat/pr-monitor-loop-core`

## Overview

Wires the PR monitor loop into the workflow observe phase and the public pr-lifecycle interface.

## Motivation

The monitor stack is only useful once the workflow layer can invoke it and downstream callers can reach the new API from
the component interface.

## Changes in Detail

- Add `observe_phase.clj`.
- Export the PR monitor API from `pr-lifecycle/interface.clj`.
- Update workflow loader and SDLC workflow resources to include observe-phase wiring.

## Testing Plan

- Run `bb pre-commit`

## Deployment Plan

- Merge last in the PR monitor loop stack.

## Related Issues/PRs

- Parent feature: PR monitor loop

## Checklist

- [x] Scope limited to integration and public API wiring
- [ ] `bb pre-commit` recorded
