### PR TITLE
spec: TUI supervisory control plane

### DIFF
--- a/specs/normative/N5-delta-supervisory-control-plane.md
+++ b/specs/normative/N5-delta-supervisory-control-plane.md
@@ -1,0 +1,422 @@
+# N5 Delta — Supervisory Control Plane
+
+- **Spec ID:** `N5-delta-supervisory-control-plane-v1`
+- **Version:** `0.1.0-draft`
+- **Status:** Draft
+- **Date:** 2026-04-02
+- **Amends:** N5 — Interface Standard: CLI/TUI/API
+- **Related:** N3 (event stream), N4 (policy packs), N6 (evidence), N8 (observability control), N9 (external PR
+  integration), pr-monitor-loop-v1 (autonomous PR comment resolution)
+
+## 1. Purpose
+
+This delta amends N5 to formalize the TUI as a **supervisory control plane** for agent-executed workflows, rather than a
+human-command surface.
+
+N5 §5 already establishes the right posture — the console is a monitoring interface and evidence viewer, not a PR
+management tool or chat interface. This delta sharpens that into normative requirements for the supervisory domain
+model, governance states, and bounded interventions that the TUI must support.
+
+### 1.1 What this delta adds to N5
+
+- Canonical supervisory entities the TUI renders (§3)
+- PR governance states derived from policy evaluation (§4)
+- Attention items as a first-class supervisory concept (§5)
+- Waiver semantics for policy overrides (§6)
+- Bounded intervention vocabulary (§7)
+- Monitor mode as default TUI posture (§8)
+- Durable startup and stale-read requirements (§9)
+
+### 1.2 What this delta does NOT change
+
+- N5 §2 CLI command taxonomy — unchanged
+- N5 §4 API surface — unchanged
+- N5 §6 manual override mechanisms — extended, not replaced
+- N5 §3.2 existing TUI views — retained, monitor mode added
+
+## 2. Operator model
+
+### 2.1 Primary operator
+
+N5 §5.3 establishes that the user monitors an autonomous factory. This delta makes explicit:
+
+The primary operator of miniforge workflows MUST be the agent session (Claude Code, Codex, managed orchestration loops,
+or equivalent). The agent drives workflow creation, execution, and PR operations through MCP or equivalent tool
+interfaces.
+
+### 2.2 Human role
+
+The human's role in the supervisory model is:
+
+- **Policy author** — defines governance rules that agents execute against
+- **Supervisor** — monitors agent activity and system health
+- **Exception handler** — intervenes when automation encounters conditions outside its authority
+- **Auditor** — reviews evidence bundles and governance dispositions
+
+The TUI MUST be optimized for these roles, not for direct workflow operation.
+
+## 3. Supervisory entities — v1
+
+The TUI MUST render from canonical supervisory entities. These entities MUST exist as explicit data shapes with minimum
+required keys. Implementations SHOULD validate at boundaries using open schemas (e.g., Malli `:map` with required keys;
+additional keys pass through without validation failure).
+
+### 3.1 v1 entities (MUST)
+
+The following entities are required for the supervisory TUI v1:
+
+#### WorkflowRun
+
+A concrete execution instance of a workflow, distinct from the workflow definition/spec.
+
+Minimum required keys:
+
+```clojure
+{:workflow-run/id          uuid?       ;; stable run identity
+ :workflow-run/workflow-key string?    ;; reference to workflow spec
+ :workflow-run/intent       string?    ;; human-readable intent description
+ :workflow-run/status       keyword?   ;; see §3.2
+ :workflow-run/current-phase keyword?  ;; current phase keyword
+ :workflow-run/started-at   inst?      ;; run start timestamp
+ :workflow-run/updated-at   inst?      ;; last state change timestamp
+ :workflow-run/trigger-source keyword? ;; :mcp, :cli, :api, :chain
+ :workflow-run/correlation-id uuid?}   ;; links to related entities
+```
+
+#### PolicyEvaluation
+
+An immutable record of a completed policy evaluation against a PR or artifact.
+
+Minimum required keys:
+
+```clojure
+{:policy-eval/id            uuid?
+ :policy-eval/target-type   keyword?   ;; :pr, :artifact, :workflow-output
+ :policy-eval/target-id     any?       ;; [repo number] for PRs, uuid for others
+ :policy-eval/passed?       boolean?
+ :policy-eval/packs-applied vector?    ;; pack identifiers evaluated
+ :policy-eval/violations    vector?    ;; vector of PolicyViolation maps
+ :policy-eval/evaluated-at  inst?}
+```
+
+Completed PolicyEvaluations MUST be immutable. A re-evaluation MUST produce a new record, not mutate the previous one.
+
+#### PolicyViolation
+
+A single rule failure within a PolicyEvaluation.
+
+Minimum required keys:
+
+```clojure
+{:violation/rule-id     keyword?
+ :violation/severity    keyword?   ;; :critical, :high, :medium, :low, :info
+ :violation/category    keyword?   ;; grouping key for aggregate display
+ :violation/message     string?
+ :violation/location    string?    ;; optional: file:line or entity reference
+ :violation/remediable? boolean?}  ;; whether auto-fix is available
+```
+
+#### AttentionItem
+
+A derived supervisory signal indicating something needs human awareness or action.
+
+Minimum required keys:
+
+```clojure
+{:attention/id          uuid?
+ :attention/severity    keyword?   ;; :critical, :warning, :info
+ :attention/source-type keyword?   ;; :workflow, :pr, :train, :policy, :agent
+ :attention/source-id   any?       ;; ID of the entity that triggered attention
+ :attention/summary     string?    ;; one-line description
+ :attention/derived-at  inst?      ;; when the attention was computed
+ :attention/resolved?   boolean?}  ;; whether the underlying condition resolved
+```
+
+AttentionItems MUST be derivable from canonical supervisory state. They MAY be materialized/cached for performance but
+MUST NOT be the source of truth — the underlying entity state is authoritative.
+
+#### Waiver
+
+A durable record that a policy failure has been acknowledged and overridden with justification.
+
+Minimum required keys:
+
+```clojure
+{:waiver/id              uuid?
+ :waiver/evaluation-id   uuid?      ;; the PolicyEvaluation being waived
+ :waiver/violations      vector?    ;; rule-ids being waived (subset or all)
+ :waiver/actor           string?    ;; who granted the waiver
+ :waiver/reason          string?    ;; justification
+ :waiver/timestamp       inst?}
+```
+
+A Waiver MUST NOT mutate or overwrite the original PolicyEvaluation. A waived entity MUST remain visibly waived (not
+"passing") in all supervisory projections.
+
+#### EvidenceBundle
+
+Reference to the complete audit trail for a workflow run. Already defined in N6; this delta adds the supervisory
+projection requirement:
+
+Minimum required keys for supervisory display:
+
+```clojure
+{:evidence/id            uuid?
+ :evidence/workflow-run-id uuid?
+ :evidence/intent        string?
+ :evidence/outcome       keyword?   ;; :pass, :fail, :partial
+ :evidence/phase-count   int?
+ :evidence/gate-summary  map?}      ;; {:passed N :failed N :skipped N}
+```
+
+### 3.2 Workflow execution states
+
+WorkflowRun `:workflow-run/status` MUST distinguish at least:
+
+| State | Meaning |
+|-------|---------|
+| `:queued` | Accepted but not yet started |
+| `:running` | Actively executing a phase |
+| `:paused` | Suspended by human intervention |
+| `:blocked` | Cannot proceed (dependency, gate failure) |
+| `:completed` | All phases finished successfully |
+| `:failed` | Terminal failure |
+| `:cancelled` | Cancelled by human or agent |
+
+Terminal states (`:completed`, `:failed`, `:cancelled`) MUST NOT transition back to active states. A retry MUST produce
+a new WorkflowRun.
+
+### 3.3 Existing entities carried forward
+
+The following entities already exist in sufficient form across N1, N4, N9, and existing components. They do not require
+new formalization for v1 but MUST be correlatable to v1 entities:
+
+- **AgentSession** — implemented as agent records in the `control-plane/registry` component (PR #326). The registry
+  provides: vendor, external-id, name, capabilities, status, heartbeat timestamps, metadata. The `adapter-claude-code`
+  component discovers Claude Code sessions via `~/.claude/projects/`. The orchestrator coordinates discovery, polling,
+  heartbeat monitoring, and decision delivery. States: `:idle`, `:starting`, `:executing`, `:blocked`, `:completed`,
+  `:failed`. Events: `:control-plane/agent-discovered`, `:control-plane/status-changed`,
+  `:control-plane/decision-submitted`, `:control-plane/decision-resolved`.
+- **PullRequest** — well-modeled in N9 and the pr-sync component
+- **PRTrain** — defined in N9 and the pr-train component
+- **WorkflowPhase** — defined in N2; tracked in events
+
+## 4. PR governance states
+
+PR supervisory state MUST be derived from PolicyEvaluation + Waiver records. It MUST NOT be freely editable by the UI.
+
+Required governance states:
+
+| State | Derivation |
+|-------|------------|
+| `:not-evaluated` | No PolicyEvaluation exists for this PR |
+| `:policy-passing` | Most recent evaluation has `passed? = true` |
+| `:policy-failing` | Most recent evaluation has `passed? = false`, no waiver |
+| `:waived` | Evaluation failed but a Waiver record exists covering the violations |
+| `:escalated` | Evaluation failed, no waiver, marked for human review |
+
+The TUI governance surface MUST display these states as visually distinct.
+
+## 5. Attention derivation
+
+The TUI MUST derive attention items from supervisory state. Attention items are computed, not manually created.
+
+### 5.1 Required attention rules (v1)
+
+| Condition | Severity | Summary pattern |
+|-----------|----------|----------------|
+| Workflow failed with no retry | `:critical` | "Workflow {name} failed: {error}" |
+| PR blocked on policy failure, no remediation | `:critical` | "PR {repo}#{number} failing policy, no auto-fix" |
+| PR train blocked | `:critical` | "Train blocked at {repo}#{number}: {reason}" |
+| PR monitor budget exhausted | `:critical` | "PR #{number} monitor exhausted — human action needed" |
+| PR monitor escalated | `:critical` | "PR #{number} escalated: {reason}" |
+| Workflow stale (no progress > threshold) | `:warning` | "Workflow {name} stale for {duration}" |
+| PR behind main with merge conflicts | `:warning` | "PR {repo}#{number} has merge conflicts" |
+| Policy violation on PR in active train | `:warning` | "Train PR {repo}#{number} failing policy" |
+| PR monitor budget warning | `:warning` | "PR #{number} monitor approaching budget limit" |
+| Workflow completed successfully | `:info` | "Workflow {name} completed" |
+| PR merged | `:info` | "PR {repo}#{number} merged" |
+| PR monitor fix pushed | `:info` | "PR #{number} fix pushed: {commit-sha}" |
+
+Implementations MAY add additional attention rules.
+
+Note: The PR monitor loop (`:pr-monitor/*` events from the pr-lifecycle component) is a primary source of supervisory
+events. The monitor autonomously resolves review comments on miniforge-authored PRs, emitting fine-grained events that
+the TUI MUST subscribe to for real-time visibility into the autonomous feedback loop.
+
+### 5.2 Attention lifecycle
+
+- Attention items MUST auto-resolve when the underlying condition resolves
+- `:info` items SHOULD auto-dismiss after a configurable period
+- `:critical` and `:warning` items MUST remain visible until resolved or acknowledged
+
+## 6. Waiver semantics
+
+Waivers extend N5 §6 (Manual Override Mechanisms) with durable governance semantics.
+
+### 6.1 Relationship to N5 §6 overrides
+
+N5 §6.1.2 defines gate failure overrides with justification. This delta formalizes those overrides as Waiver records
+that:
+
+- Are stored durably (not just logged in the evidence bundle)
+- Are queryable for governance reporting
+- Affect derived PR governance state (§4)
+- Are visible in the TUI governance surface
+
+### 6.2 Waiver constraints
+
+- A Waiver MUST reference a specific PolicyEvaluation
+- A Waiver MUST list which violations it covers
+- A Waiver MUST NOT retroactively change the evaluation result — the evaluation remains "failed," the PR governance
+  state becomes `:waived`
+- The TUI MUST display waived PRs distinctly from passing PRs
+
+## 7. Bounded intervention vocabulary
+
+The TUI MUST support a bounded set of supervisory interventions. These extend N5 §6 with explicit action types.
+
+### 7.1 v1 interventions (MUST)
+
+| Intervention | Target | Effect |
+|-------------|--------|--------|
+| `acknowledge` | AttentionItem | Marks item as seen; does not resolve |
+| `retry` | WorkflowRun (failed) | Creates a new run from the same spec |
+| `pause` | WorkflowRun (running) | Suspends execution |
+| `resume` | WorkflowRun (paused) | Resumes execution |
+| `cancel` | WorkflowRun (active) | Terminates execution |
+| `waive` | PolicyEvaluation | Creates a Waiver record with reason |
+| `re-evaluate` | PullRequest | Triggers a new PolicyEvaluation |
+
+### 7.2 Intervention recording
+
+Interventions MUST produce a durable record per N5 §6.2. The existing override logging schema in N5 §6.2 is sufficient;
+this delta does not add new fields.
+
+### 7.3 Boundary constraint
+
+The supervisory surface MUST NOT expand beyond the intervention vocabulary defined here without a spec amendment. It
+MUST NOT become a general-purpose command shell.
+
+## 8. Monitor mode
+
+### 8.1 Default posture
+
+The TUI SHOULD default to a monitor mode optimized for passive supervision.
+
+Monitor mode MUST display, on a single screen:
+
+- Active and recent workflow runs with live status
+- PR train or fleet summary, including PR monitor loop status per PR (monitoring/idle/exhausted)
+- Attention items requiring action
+
+Monitor mode SHOULD also display:
+
+- Aggregate policy health (pass rate, top violation categories)
+- PR monitor loop activity summary (PRs being monitored, comments pending, fixes pushed)
+
+### 8.2 Responsive rendering
+
+Monitor mode MUST render usefully at 60 columns (tmux side-pane scenario). Implementations SHOULD adapt layout to
+available width:
+
+- 60–80 columns: stacked zones, abbreviated columns
+- 80–120 columns: split layout
+- 120+ columns: full-width tables
+
+### 8.3 Drill-down
+
+From monitor mode, the user MUST be able to drill into existing detail views (N5 §3.2.2 Workflow Detail, §3.2.9 PR
+Detail) and return via Esc.
+
+### 8.4 Relationship to existing views
+
+Monitor mode is additive. Existing views defined in N5 §3.2 MUST remain accessible. Monitor mode becomes the default
+entry point; Tab or number keys navigate to other views.
+
+## 9. Durable startup and stale-read
+
+### 9.1 Startup state
+
+On launch, the TUI MUST show useful supervisory state from persisted data, even when no active workflow is running.
+
+### 9.2 Stale-read degradation
+
+If live event subscription is unavailable, the TUI MUST degrade to stale read-only supervisory state rather than
+appearing empty. The TUI SHOULD display a visible stale-data indicator.
+
+### 9.3 Catch-up
+
+When live subscription becomes available after displaying stale state, the TUI MUST catch up to current state without
+requiring a restart.
+
+## 10. Control plane integration
+
+### 10.1 Existing infrastructure
+
+The `control-plane` component (PR #326) already implements multi-vendor agent session management:
+
+- **Agent registry** — CRUD, heartbeat tracking, state transitions for agents across vendors
+- **Adapter protocol** — vendor-specific adapters (Claude Code adapter discovers sessions via `~/.claude/projects/`)
+- **Decision queue** — agents submit decisions, humans resolve them, results delivered back
+- **Heartbeat watchdog** — background liveness monitoring, stale agent detection
+- **Orchestrator** — coordinates discovery, polling, decision delivery across adapters
+- **Events** — `:control-plane/agent-discovered`, `:control-plane/status-changed`, `:control-plane/decision-submitted`,
+  `:control-plane/decision-resolved`
+
+Agent records in the registry carry: vendor, external-id, name, capabilities, status, heartbeat timestamps, metadata.
+Agent states: `:idle`, `:starting`, `:executing`, `:blocked`, `:completed`, `:failed`.
+
+### 10.2 TUI integration requirement
+
+The TUI monitor MUST display control plane state:
+
+- Active agent sessions with vendor, name, status, last heartbeat
+- Pending decisions requiring human resolution
+- Agent state transitions as they occur
+
+Control plane events (`:control-plane/*`) MUST be handled by the TUI event subscription alongside `:workflow/*` and
+`:pr-monitor/*` events.
+
+The `control-plane-completion.spec.edn` work spec covers wiring decision delivery and event emission from the
+orchestrator. The TUI work (this delta + companion work spec) covers rendering that data in monitor mode.
+
+### 10.3 Agent sessions in the monitor
+
+The monitor's workflow ticker zone SHOULD include agent session rows when the control plane is active, showing which
+agents are operating and their current state. When an agent is `:blocked` on a decision, the attention bar MUST surface
+it as a `:critical` item — the human needs to act.
+
+## 11. Deferred to Fleet
+
+The following concepts are recognized as architecturally important but deferred to Fleet-scale specifications. See
+`work/fleet-supervisory-deferred.spec.edn` for tracking.
+
+| Concept | Reason for deferral |
+|---------|-------------------|
+| `Lens` abstraction | Extract after monitor patterns stabilize |
+| Full `Intervention` audit trail | Simple recording (N5 §6.2) sufficient for v1 |
+| Event versioning | Existing event envelope sufficient for v1 |
+| Cross-entity correlation IDs | Add incrementally where missing |
+| Multi-project fleet aggregation | Single-project dogfooding is current scope |
+
+## 12. Conformance
+
+### 12.1 Supervisory entity validation
+
+Implementations MUST validate supervisory entities at component boundaries using open schemas. Unknown keys MUST pass
+through without error. Required keys MUST be present and correctly typed.
+
+### 12.2 Governance state invariants
+
+1. Every PR governance state displayed in the TUI MUST be derivable from PolicyEvaluation and Waiver records
+2. Completed PolicyEvaluations MUST be immutable
+3. Waivers MUST be separate records, not mutations of evaluations
+4. AttentionItems MUST be derivable from canonical state
+5. Terminal WorkflowRun states MUST NOT transition to active states
+
+### 12.3 Monitor mode conformance
+
+1. Monitor mode MUST render at 60 columns without data loss (truncation is acceptable, absence is not)
+2. Monitor mode MUST update without user interaction when events arrive
+3. Monitor mode MUST show attention items without requiring navigation

--- a/work/fleet-supervisory-deferred.spec.edn
+++ b/work/fleet-supervisory-deferred.spec.edn
@@ -1,0 +1,158 @@
+;; Fleet Supervisory — Deferred Concepts
+;;
+;; Concepts recognized in the supervisory control plane design that are
+;; architecturally important but deferred to Fleet-scale work. Captured
+;; here so they survive until Fleet specs are written.
+;;
+;; Origin: N5-delta-supervisory-control-plane §10, tui-dashboard-v2 discussions.
+;; Date: 2026-04-02
+
+{:spec/id "fleet-supervisory-deferred"
+ :spec/version "0.1.0"
+ :spec/created "2026-04-02"
+ :spec/status "parking-lot"
+ :spec/context "Deferred from supervisory TUI v1 to Fleet-scale specs"
+
+ :deferred-concepts
+
+ [{:id :agent-session-entity
+   :concept "AgentSession as first-class supervisory entity"
+   :status :resolved
+   :resolution
+   "ALREADY EXISTS as agent records in control-plane/registry (PR #326).
+    The control-plane component provides: agent registry with CRUD,
+    heartbeat tracking, state transitions, vendor-specific adapters
+    (adapter-claude-code discovers sessions via ~/.claude/projects/),
+    decision queue, and orchestrator. Agent records carry: :agent/vendor,
+    :agent/external-id, :agent/name, :agent/capabilities, :agent/status,
+    :agent/heartbeat-interval-ms, :agent/metadata, :agent/tags.
+
+    States: :idle, :starting, :executing, :blocked, :completed, :failed.
+
+    The TUI supervisory work spec (tui-supervisory-control-plane-v1)
+    includes control plane event subscription and agent session rendering
+    in the monitor screen. No additional entity design needed.
+
+    Remaining Fleet-scale work: control-plane-completion.spec.edn covers
+    wiring decision delivery and event emission from the orchestrator."
+   :original-design-questions-answered
+   ["Discovery: adapter-claude-code scans ~/.claude/projects/ for active sessions"
+    "Registration: adapter discovers and registers via orchestrator discovery loop"
+    "Session end: heartbeat watchdog detects stale agents; PID liveness check"]}
+
+  {:id :lens-abstraction
+   :concept "Lens as a first-class projection contract"
+   :description
+   "A lens is a named projection strategy over canonical supervisory state.
+    Each lens declares: identity, source entities, projection builder,
+    default filters/sorts, drill targets. The monitor surface would be
+    backed by lenses rather than hard-coded projection functions.
+
+    Deferred because: defining a lens contract before the monitor exists
+    risks premature abstraction. The Clojure data-oriented approach
+    (pure projection functions of model) is sufficient for v1. Extract
+    the lens contract after monitor patterns stabilize."
+   :triggers
+   ["Monitor has 3+ stable projection patterns to generalize"
+    "Fleet dashboard needs to reuse the same projections"
+    "Custom/user-defined views are requested"]
+   :minimum-contract
+   {:lens/id "keyword"
+    :lens/source-entities "vector of entity type keywords"
+    :lens/projection-fn "fn [supervisory-state opts] -> projection-data"
+    :lens/default-sort "keyword or comparator"
+    :lens/drill-targets "map of selection-type -> target-view"}
+   :built-in-lenses
+   [:workflows :pr-trains :policy-health :attention :agents]}
+
+  {:id :full-intervention-audit
+   :concept "Complete intervention audit trail with attribution"
+   :description
+   "Every supervisory action that changes execution or governance
+    disposition produces a durable Intervention record with full
+    attribution (who, when, what, why, affected entities).
+
+    v1 uses the existing N5 §6.2 override logging in evidence bundles.
+    The full audit trail adds: queryable intervention history,
+    intervention-driven attention items, intervention effectiveness
+    metrics.
+
+    Deferred because: N5 §6.2 override logging is sufficient for
+    single-user dogfooding. Full audit becomes important for
+    multi-user Fleet governance and compliance."
+   :triggers
+   ["Multi-user access to supervisory surface"
+    "Compliance requirements (SOC2, FedRAMP)"
+    "Intervention effectiveness analysis"]
+   :minimum-keys
+   [:intervention/id :intervention/type :intervention/target-type
+    :intervention/target-id :intervention/actor :intervention/reason
+    :intervention/timestamp :intervention/outcome]}
+
+  {:id :event-versioning
+   :concept "Versioned event envelope with schema evolution"
+   :description
+   "N3 defines event envelope fields but does not include a :version
+    field on individual events. For Fleet-scale, events should carry
+    schema version to support forward/backward compatibility across
+    versions of miniforge processing the same event store.
+
+    Deferred because: single-version deployment in dogfooding means
+    all producers and consumers share the same schema. Versioning
+    becomes important when: Fleet aggregates events from multiple
+    miniforge instances, or event stores persist across upgrades."
+   :triggers
+   ["Fleet aggregation across miniforge instances"
+    "Long-term event store persistence across version upgrades"
+    "Third-party event consumers"]}
+
+  {:id :cross-entity-correlation
+   :concept "Systematic correlation IDs across entity boundaries"
+   :description
+   "The normative delta identified required correlations:
+    - agent session -> workflow runs
+    - workflow runs -> PRs
+    - workflow runs -> PR trains
+    - PRs -> policy evaluations
+    - policy evaluations -> evidence bundles
+    - interventions -> affected entities
+
+    Some correlations exist (workflow-id on events, PR identity on
+    evaluations). Others are missing (workflow-run -> PR linkage is
+    implicit via branch matching).
+
+    v1 adds correlation IDs incrementally where they block the monitor.
+    Systematic correlation is a Fleet concern."
+   :triggers
+   ["Monitor needs a correlation that doesn't exist yet"
+    "Fleet dashboard needs cross-entity navigation"
+    "Audit trail requires full entity graph traversal"]
+   :existing-correlations
+   ["workflow-id on workflow events (N3)"
+    "PR identity [repo number] on policy evaluations"
+    "train-id on PR train events (N9)"]
+   :missing-correlations
+   ["workflow-run-id -> PR (currently inferred from branch)"
+    "agent-session-id -> workflow-runs (agent session doesn't exist yet)"
+    "policy-evaluation-id -> evidence-bundle-id (weak link)"]}
+
+  {:id :fleet-aggregation
+   :concept "Multi-project fleet dashboard with aggregate metrics"
+   :description
+   "The supervisory model should scale to showing dozens of projects,
+    hundreds of concurrent workflows, aggregate policy pass rates,
+    throughput trends, cost attribution across projects/agents.
+
+    Deferred because: single-project dogfooding is current scope.
+    The v1 monitor architecture should not preclude Fleet aggregation
+    but does not need to implement it."
+   :triggers
+   ["Monitoring >1 project simultaneously"
+    "Policy effectiveness trends over time"
+    "Cost/throughput analysis across projects"]
+   :capabilities
+   ["Multi-project supervisory state aggregation"
+    "Policy pass-rate trends (time series)"
+    "Agent utilization and cost attribution"
+    "Cross-project attention rollup"
+    "Anomaly detection across fleet"]}]}

--- a/work/pr-monitor-loop.spec.edn
+++ b/work/pr-monitor-loop.spec.edn
@@ -181,7 +181,15 @@
    :priority :p2
    :description
    "Extend the PR Fleet (:pr-fleet) view to show monitor loop status inline:
-    last-polled time, comment count, attempts remaining, last action taken."
+    last-polled time, comment count, attempts remaining, last action taken.
+
+    NOTE: This deliverable is subsumed by tui-supervisory-control-plane-v1
+    (WS2 live-event-subscription + WS3 monitor-screen). The supervisory TUI
+    work spec includes :pr-monitor/* event handling in the monitor mode,
+    including attention items for budget-exhausted/escalated events. PR
+    monitor status will be visible in the monitor screen's PR zone rather
+    than only in the legacy PR Fleet view."
+   :superseded-by "tui-supervisory-control-plane-v1"
    :tests
    ["PR row shows monitor status when observe phase is active"]}]
 

--- a/work/tui-supervisory-control-plane.spec.edn
+++ b/work/tui-supervisory-control-plane.spec.edn
@@ -1,0 +1,596 @@
+;; TUI Supervisory Control Plane — Work Spec
+;;
+;; Build-oriented work spec for evolving the miniforge TUI into a
+;; supervisory control plane for agent-executed workflows.
+;;
+;; Normative contract: specs/normative/N5-delta-supervisory-control-plane.md
+;; Deferred Fleet items: work/fleet-supervisory-deferred.spec.edn
+;; Supersedes: work/tui-fidelity.spec.edn, work/tui-dashboard-v2.spec.edn
+
+{:spec/id "tui-supervisory-control-plane-v1"
+ :spec/version "0.1.0"
+ :spec/created "2026-04-02"
+ :spec/status "draft"
+ :spec/type :work-spec
+ :spec/depends-on ["N5-delta-supervisory-control-plane-v1"]
+ :spec/supersedes ["tui-fidelity-v1" "tui-dashboard-v2"]
+ :spec/related ["pr-monitor-loop-v1" "pr-comment-monitoring"
+                "control-plane-completion"]
+
+ :title "TUI Supervisory Control Plane — Work Spec"
+
+ :problem
+ "The human works inside Claude Code or Codex. The agent drives miniforge
+  through MCP. The human wants live visibility into workflow progress,
+  PR trains, governance, and exceptions — without leaving the agent session.
+
+  Today this requires tailing workflow files or launching GitHub. The TUI
+  exists but reflects an older human-command model: command mode, chat,
+  batch operations are the focus. Live visibility, durable startup, and
+  governance surfaces are under-built.
+
+  The PR monitor loop (pr-monitor-loop-v1, merged 2026-04-01) adds a
+  concrete autonomous feedback loop: miniforge monitors its own PRs,
+  classifies review comments, pushes fixes, and posts replies — all
+  emitting :pr-monitor/* events. This is the first real-world source of
+  supervisory events the TUI needs to render. The monitor loop's Phase 4
+  deliverable (:tui-pr-monitor-view) is subsumed by this work spec.
+
+  The center of gravity needs to shift from 'human operates the system'
+  to 'human supervises agent-operated system.'"
+
+ ;; -------------------------------------------------------------------------
+ ;; Workstreams
+ ;; -------------------------------------------------------------------------
+
+ :workstreams
+
+ [{:ws :ws1
+   :name "Supervisory domain formalization"
+   :purpose
+   "Make the supervisory entities explicit so the monitor renders from
+    canonical data, not ad-hoc model keys. This is foundation work —
+    without it, the monitor will be visually improved but brittle."
+
+   :deliverables
+   [{:id :supervisory-entities
+     :description
+     "Introduce Malli schemas for the v1 supervisory entities defined in
+      the normative delta §3: WorkflowRun, PolicyEvaluation, PolicyViolation,
+      AttentionItem, Waiver, EvidenceBundle (supervisory projection).
+
+      Schemas MUST be open (:map with required keys, additional keys pass
+      through). This allows experimentation — we validate what we use,
+      ignore what we don't yet need.
+
+      These may live in a new `supervisory-model` component or as schemas
+      within existing components (tui-views, policy-pack, etc). Prefer
+      whichever avoids circular dependencies."
+     :approach
+     "Define schemas, add coercion/validation at component boundaries
+      (persistence load, event translation, PR sync). Existing data shapes
+      are close — this is mostly naming, organizing, and adding Malli."
+     :tests
+     ["Malli schema validates a well-formed WorkflowRun"
+      "Extra keys pass validation without error"
+      "Missing required keys fail validation"
+      "PolicyEvaluation with violations validates correctly"
+      "Waiver schema validates with evaluation-id reference"]}
+
+    {:id :projection-builders
+     :description
+     "Define pure projection functions with stable input/output contracts
+      for each monitor zone:
+      - workflow-ticker: [supervisory-state] -> [{:run ... :status ... :phase ...}]
+      - pr-train-strip: [supervisory-state] -> {:train-progress ... :fleet-summary ...}
+      - policy-health:  [supervisory-state] -> {:pass-rate ... :violations-by-category ...}
+      - attention:      [supervisory-state] -> [{:severity ... :summary ... :source ...}]
+
+      These replace the current pattern where views reach into raw model
+      keys with implicit business logic."
+     :tests
+     ["Workflow ticker projection returns sorted active-first list"
+      "Policy health projection computes correct pass rate"
+      "Attention projection derives items from model state"
+      "Projections return stable shapes when model is empty"]}
+
+    {:id :governance-state-derivation
+     :description
+     "Implement the PR governance state derivation from the normative delta §4:
+      :not-evaluated, :policy-passing, :policy-failing, :waived, :escalated.
+
+      Currently policy disposition is implicit — a PR either has policy data
+      or doesn't. Formalize this into an explicit derived state."
+     :tests
+     ["PR with no evaluation returns :not-evaluated"
+      "PR with passing evaluation returns :policy-passing"
+      "PR with failing evaluation and no waiver returns :policy-failing"
+      "PR with failing evaluation and waiver returns :waived"]}]
+
+   :acceptance
+   ["Monitor zones can be described in terms of projection builders"
+    "No view depends on hidden ad-hoc state for supervisory meaning"
+    "PR governance state is always derivable, never hardcoded"]}
+
+  {:ws :ws2
+   :name "Durable startup, replay, and live subscription"
+   :purpose
+   "The TUI must be useful immediately on startup and stay current.
+    This is the #1 functional gap today."
+
+   :deliverables
+   [{:id :startup-load
+     :description
+     "On startup, load recent supervisory state from disk:
+      - Workflow runs from ~/.miniforge/workflows/ index
+      - PR state from sync cache
+      - Policy evaluation results from pr-cache
+      - Derive attention items and governance states from loaded data
+
+      The standalone TUI already calls persistence/load-workflows-into-model.
+      Verify this path works end-to-end and produces valid supervisory
+      entities. Add PR + policy loading to the startup path if missing."
+     :tests
+     ["Workflows from disk appear in model after init"
+      "PR state loaded from cache on startup"
+      "Policy evaluations loaded and governance states derived"
+      "Empty disk state produces valid empty model, not nil/crash"]}
+
+    {:id :live-event-subscription
+     :description
+     "Wire event-stream subscription to update supervisory projections
+      during active runs. The file-subscription path exists but model
+      updates during runs are incomplete.
+
+      Required event → model mappings:
+      - :workflow/started → add WorkflowRun to model
+      - :workflow/phase-changed → update current-phase, status
+      - :agent/status → update agent activity text
+      - :gate/evaluated → append gate result, re-derive governance state
+      - :workflow/completed → set terminal status
+      - :workflow/failed → set terminal status + error
+      - :pr/synced → update PR data, re-derive governance state
+
+      PR monitor loop events (from pr-lifecycle component, merged 2026-04-01):
+      - :pr-monitor/loop-started → mark PR as actively monitored
+      - :pr-monitor/comment-received → increment pending comment count
+      - :pr-monitor/comment-classified → update classification (change-request/question/bot)
+      - :pr-monitor/fix-started → show fix in progress for PR
+      - :pr-monitor/fix-pushed → update PR with new commit SHA
+      - :pr-monitor/reply-posted → decrement pending, show last action
+      - :pr-monitor/budget-warning → surface as attention item (warning)
+      - :pr-monitor/budget-exhausted → surface as attention item (critical)
+      - :pr-monitor/escalated → surface as attention item (critical)
+      - :pr-monitor/cycle-completed → update cycle stats
+      - :pr-monitor/loop-stopped → mark PR monitoring as inactive
+
+      These events already have constructors in monitor_events.clj with
+      consistent payloads including :pr/id. The TUI subscription layer
+      needs handlers for the :pr-monitor/* event family.
+
+      Control plane events (from control-plane component, PR #326):
+      - :control-plane/agent-discovered → add agent session to model
+      - :control-plane/status-changed → update agent status/task
+      - :control-plane/decision-submitted → add pending decision, mark agent blocked
+      - :control-plane/decision-resolved → clear pending decision, unblock agent
+
+      The control-plane orchestrator (control-plane-completion.spec.edn)
+      will emit these events once wired. The TUI must subscribe to them
+      alongside workflow and PR monitor events. Agent sessions come from
+      the registry (adapter-claude-code discovers Claude Code sessions,
+      adapter-miniforge handles miniforge's own agents).
+
+      NOTE: The 'AgentSession' entity from the normative delta discussion
+      ALREADY EXISTS as agent records in control-plane/registry. The
+      registry provides: vendor, external-id, name, capabilities, status,
+      heartbeat timestamps, metadata. No new entity definition needed —
+      just wire the TUI to render registry state."
+     :tests
+     ["Model updates when workflow phase changes during active run"
+      "Gate results accumulate in real time"
+      "Completed/failed events set terminal status"
+      "New workflow appears in model when started from agent session"
+      "PR monitor events update PR monitoring state in model"
+      "Budget exhaustion from monitor loop creates attention item"
+      "Agent discovered event adds agent session to model"
+      "Decision submitted event surfaces in attention bar as critical"
+      "Agent status change updates agent display in monitor"]}
+
+    {:id :stale-read-degradation
+     :description
+     "When live subscription is unavailable, display stale state from
+      the most recent startup load with a visible indicator (e.g.,
+      '⊘ stale' in the status bar with timestamp of last update).
+
+      Do not show an empty screen. Do not silently display stale data
+      without indicating staleness."
+     :tests
+     ["TUI shows data from startup load when no events arrive"
+      "Stale indicator visible when subscription is disconnected"
+      "Stale indicator disappears when live events resume"]}]
+
+   :acceptance
+   ["Launching TUI with no active workflow shows recent runs and PR state"
+    "Starting a workflow from Claude Code updates TUI in real time"
+    "Restarting TUI reconstructs state without requiring fresh activity"
+    "Subscription outage does not yield empty screen"]}
+
+  {:ws :ws3
+   :name "Monitor mode"
+   :purpose "The default supervisory surface — glance and understand."
+
+   :deliverables
+   [{:id :monitor-screen
+     :description
+     "New :monitor view as the default screen. Single-screen layout with:
+
+      Agent Sessions zone (when control plane active):
+        Shows discovered agent sessions from control-plane registry:
+        [vendor-icon] agent-name  status  task  heartbeat
+        e.g.: 🤖 Claude Code: miniforge  executing  PR review  5s ago
+              🤖 Codex: data-pipeline     blocked    awaiting decision
+        When an agent is :blocked on a decision, the row highlights
+        and the attention bar surfaces it.
+
+      Workflow Ticker zone:
+        [status] name  phase  duration  agent-status
+        e.g.: ● plan-auth  implement  3m  agent working
+              ✓ fix-login  complete   12m
+              ✗ add-metrics failed    8m  gate: coverage
+
+      PR Train / Fleet zone:
+        When train active: ▓▓▓░░ 3/5 merged  Next: #247 (CI passing)
+        When no train:     12 open │ 3 ready │ 1 blocked │ 2 policy-fail
+        When monitor active: show per-PR monitor status inline
+          e.g.: #247 ● monitoring (2 comments, 1 fix pushed)
+                #251 ⊘ budget exhausted — escalated
+
+      Attention Bar zone (bottom):
+        Color-coded items: red=critical, yellow=warning, dim=info
+        Auto-derived from supervisory state per normative delta §5
+
+      Policy Health zone (when width permits):
+        Pass rate: 87% (26/30)  Top violations: missing-tests (3)
+
+      Selection: arrow keys highlight, Enter drills into detail, Esc returns."
+     :tests
+     ["Monitor renders with all zones populated"
+      "Workflow ticker shows active workflows with correct status chars"
+      "PR zone shows train progress or fleet summary"
+      "Attention bar surfaces derived items"
+      "Enter drills into selected item"
+      "Esc returns to monitor from any detail view"
+      "Empty state shows guidance, not blank screen"]}
+
+    {:id :narrow-width-rendering
+     :description
+     "Monitor mode must work at 60 columns (tmux right pane).
+
+      At 60-80 cols:
+      - Workflow rows: icon + name (truncated) + phase + duration
+      - PR rows: repo#number + policy-icon
+      - Footer: abbreviated keybindings
+      - Box borders optional (save 2 columns)
+
+      At 80-120 cols:
+      - Add agent status column to workflows
+      - Add title column to PRs
+      - Full footer
+
+      At 120+ cols:
+      - Full-width tables per existing layout
+
+      Width detection via terminal cols on startup."
+     :tests
+     ["Table renders without overflow at 60 columns"
+      "Text truncation with ellipsis for long names"
+      "Layout adapts when terminal width changes"]}
+
+    {:id :monitor-as-default
+     :description
+     "Monitor becomes the default view on startup. Existing views
+      (workflow-list, pr-fleet, evidence, etc.) remain accessible via
+      Tab/number keys. The model's initial :view should be :monitor.
+
+      Update model/init-model, model/top-level-views, and screens.edn."
+     :tests
+     ["TUI starts in :monitor view"
+      "Tab cycles to existing views"
+      "Number keys jump to specific views"
+      "Returning from detail goes to monitor, not workflow-list"]}]
+
+   :acceptance
+   ["Monitor mode useful in a tmux right pane at 60 columns"
+    "Active workflows and PR disposition visible without navigation"
+    "Attention items visible without drilling in"]}
+
+  {:ws :ws4
+   :name "Governance surface"
+   :purpose "Answer 'are my policies working?' from the monitor."
+
+   :deliverables
+   [{:id :policy-health-zone
+     :description
+     "Aggregate policy health in the monitor's policy zone:
+      - Pass rate as percentage (N passing / N total)
+      - Top violation categories with counts
+      - PRs in each governance state (:passing, :failing, :waived)
+
+      Backed by the policy-health projection builder from WS1."
+     :tests
+     ["Pass rate computed correctly from evaluations"
+      "Violation categories grouped and counted"
+      "Governance states shown with correct counts"
+      "Zero-violation state shows 'All PRs passing policy'"]}
+
+    {:id :waiver-recording
+     :description
+     "Implement Waiver entity persistence and the :waive intervention.
+      When a user selects a failing PR and invokes waive (from the
+      intervention menu), prompt for reason, create a Waiver record,
+      re-derive the PR's governance state.
+
+      Waiver storage: ~/.miniforge/waivers/{eval-id}.edn
+      Waivers loaded on startup and applied to governance state derivation."
+     :tests
+     ["Waiver record persisted to disk"
+      "Waiver loaded on startup"
+      "PR governance state changes from :policy-failing to :waived"
+      "Waived PR displays distinctly from passing PR"
+      "Original PolicyEvaluation unchanged after waiver"]}
+
+    {:id :governance-drill-down
+     :description
+     "From the policy health zone, drill into violations:
+      - Select a violation category → see all PRs with that violation
+      - Select a PR → see full policy evaluation detail and evidence
+      - Waived violations shown with waiver reason"
+     :tests
+     ["Drill from violation category to PR list"
+      "Drill from PR to policy evaluation detail"
+      "Waiver reason visible in drill-down"]}]
+
+   :acceptance
+   ["User can answer 'are my review policies working?' from monitor"
+    "Failing/waived/passing states visually distinct"
+    "Drill-down shows evidence behind governance disposition"]}
+
+  {:ws :ws5
+   :name "Attention and bounded intervention"
+   :purpose "Compress the system into actionable exceptions."
+
+   :deliverables
+   [{:id :attention-derivation
+     :description
+     "Implement the attention derivation rules from the normative delta §5.
+      On every model change, recompute attention items from supervisory state.
+      Cache for performance if needed but derive from canonical state.
+
+      Required rules: workflow failed, PR policy-blocked, train blocked,
+      workflow stale, PR conflicts, train policy violation, workflow
+      completed, PR merged.
+
+      PR monitor loop rules (from :pr-monitor/* events):
+      - :pr-monitor/budget-exhausted → critical (monitor gave up, human must act)
+      - :pr-monitor/escalated → critical (monitor explicitly escalated)
+      - :pr-monitor/budget-warning → warning (approaching limit)
+      - :pr-monitor/fix-pushed → info (autonomous fix landed)
+
+      Control plane rules (from :control-plane/* events):
+      - Agent :blocked on pending decision → critical (human must resolve)
+      - Agent heartbeat stale → warning (agent may be dead)
+      - Agent :failed → critical (agent session crashed)
+      - Agent :completed → info (session finished)"
+     :tests
+     ["Failed workflow generates critical attention item"
+      "Stale workflow generates warning after threshold"
+      "Completed workflow generates info item"
+      "Items auto-resolve when underlying condition resolves"
+      "Empty model produces empty attention list, not error"]}
+
+    {:id :intervention-menu
+     :description
+     "Bounded intervention actions from the monitor and detail views.
+      When an attention item or entity is selected, offer applicable
+      interventions:
+
+      - Failed workflow: retry, cancel
+      - Running workflow: pause
+      - Paused workflow: resume, cancel
+      - Failing PR: waive, re-evaluate
+      - Blocked agent (pending decision): resolve decision
+      - Stale/failed agent: terminate
+      - Attention item: acknowledge
+
+      Decision resolution: when an agent is :blocked on a decision,
+      the intervention menu shows the decision's summary and options
+      (from decision-queue). The human selects an option or provides
+      free-form resolution. This calls control-plane/resolve-and-deliver!
+      which delivers the result back to the agent and transitions it
+      to :running.
+
+      Present as a context menu or confirmation dialog (existing
+      confirm overlay pattern). Record the intervention per N5 §6.2."
+     :tests
+     ["Retry creates new workflow run from failed run's spec"
+      "Pause/resume change workflow status correctly"
+      "Waive creates Waiver record and updates governance state"
+      "Re-evaluate triggers new PolicyEvaluation"
+      "Resolve decision delivers result and unblocks agent"
+      "Acknowledge marks attention item as seen"
+      "Intervention recorded in evidence/override log"]}]
+
+   :acceptance
+   ["Failed workflows, blocked trains, policy failures surface automatically"
+    "Interventions are durable and bounded"
+    "UI does not expand into a general command shell"]}]
+
+ ;; -------------------------------------------------------------------------
+ ;; Phasing
+ ;; -------------------------------------------------------------------------
+
+ :phases
+ [{:phase 1
+   :name "Foundation + live data"
+   :workstreams [:ws1 :ws2]
+   :description
+   "Formalize supervisory entities (Malli schemas, projection builders,
+    governance state derivation) and fix startup load + live subscription.
+    After this phase, the model is clean and the data flows work."
+   :validation
+   "Start a workflow from Claude Code. TUI model updates in real time.
+    Restart TUI — recent state reappears from disk. Supervisory entities
+    validate against schemas."}
+
+  {:phase 2
+   :name "Usable side-pane monitor"
+   :workstreams [:ws3]
+   :description
+   "Build the monitor screen, responsive layout, and drill-down.
+    This is the first dogfooding milestone — useful in a tmux right pane."
+   :validation
+   "Run mf tui in a tmux right pane. Start a workflow from Claude Code.
+    Watch it progress through phases. See PR status. All at 60 columns,
+    without touching the TUI."}
+
+  {:phase 3
+   :name "Governance visibility"
+   :workstreams [:ws4]
+   :description
+   "Policy health aggregation, waiver recording, governance drill-down.
+    The TUI becomes more than a workflow progress screen."
+   :validation
+   "After agents review 10 PRs, monitor shows pass rate, violation
+    categories, governance states. Waive a failing PR with reason —
+    state changes to :waived. Drill into violations to see evidence."}
+
+  {:phase 4
+   :name "Attention and intervention"
+   :workstreams [:ws5]
+   :description
+   "Derived attention items and bounded intervention menu. Completes
+    the shift from passive visibility to supervisory control."
+   :validation
+   "A workflow fails — attention bar shows critical item without
+    navigation. Select it, choose retry — new run starts. A PR fails
+    policy in the train — warning surfaces. Waive it with reason."}]
+
+ ;; -------------------------------------------------------------------------
+ ;; Acceptance scenarios
+ ;; -------------------------------------------------------------------------
+
+ :scenarios
+ [{:id :side-pane-dogfooding
+   :name "Side-pane dogfooding"
+   :steps
+   ["Open Claude Code or Codex"
+    "Agent starts a workflow through MCP"
+    "TUI in right pane immediately shows the run"
+    "Phases update live"
+    "Related PR/train state visible when review/release completes"
+    "Policy disposition visible when evaluation occurs"
+    "A failure creates an attention item without requiring navigation"]}
+
+  {:id :restart-and-catchup
+   :name "Restart and catch-up"
+   :steps
+   ["Run workflows"
+    "Close the TUI"
+    "Reopen it"
+    "Recent runs, PR state, and governance state appear immediately"
+    "Live updates resume when fresh events arrive"]}
+
+  {:id :governance-exception
+   :name "Governance exception"
+   :steps
+   ["A PR fails policy"
+    "Monitor shows the violation category and failing governance state"
+    "Drill down reveals evidence"
+    "Waive with reason"
+    "Governance state changes to :waived, visible and auditable"]}
+
+  {:id :blocked-train
+   :name "Blocked train"
+   :steps
+   ["A PR train becomes blocked (CI or policy failure)"
+    "Train strip reflects blocked state"
+    "Attention bar surfaces it"
+    "Drill into the blocked PR to see the failing gate"]}
+
+  {:id :pr-monitor-loop-visibility
+   :name "PR monitor loop visibility"
+   :steps
+   ["Agent creates a PR via miniforge workflow (Release phase)"
+    "Observe phase starts the PR monitor loop"
+    "TUI shows PR with 'monitoring' status in fleet zone"
+    "Reviewer leaves a comment on the PR"
+    ":pr-monitor/comment-received event updates TUI — pending count increments"
+    "Monitor classifies and fixes — :pr-monitor/fix-pushed updates TUI"
+    "If budget exhausts — critical attention item surfaces without navigation"
+    "Monitor loop stops (PR merged or budget) — monitoring status clears"]}]
+
+ ;; -------------------------------------------------------------------------
+ ;; Deprioritized features
+ ;; -------------------------------------------------------------------------
+
+ :deprioritized
+ [{:feature "Command mode (:decompose, :review, :remediate)"
+   :reason "Agent handles these via MCP"
+   :status "Keep as-is, accessible from existing views"}
+
+  {:feature "Chat integration (c key → LLM conversation)"
+   :reason "Agent session IS the conversation"
+   :status "Keep as-is"}
+
+  {:feature "Batch selection / visual mode"
+   :reason "Agent handles batch operations via MCP"
+   :status "Keep as-is"}
+
+  {:feature "Repo manager view"
+   :reason "One-time setup, not a monitoring concern"
+   :status "Keep as-is"}
+
+  {:feature "DAG Kanban view"
+   :reason "Monitor workflow ticker serves this purpose more compactly"
+   :status "Revisit if multi-workflow orchestration drives need"}
+
+  {:feature "React-style renderer (tui-react-renderer.spec)"
+   :reason "Performance sufficient for monitoring use case"
+   :status "Defer until rendering is measurably slow"}
+
+  {:feature "PR decomposition workflow (tui-decomposition-workflow.spec)"
+   :reason "Agent handles decomposition via MCP"
+   :status "Defer"}]
+
+ ;; -------------------------------------------------------------------------
+ ;; Risks
+ ;; -------------------------------------------------------------------------
+
+ :risks
+ [{:risk "UI built ahead of model"
+   :description
+   "If monitor mode is built before supervisory entities and projections
+    are formalized, the result will be another UI layer with brittle
+    hidden semantics."
+   :mitigation "Phase 1 (WS1 + WS2) is prerequisite for Phase 2 (WS3)"}
+
+  {:risk "Over-specifying entities before validation"
+   :description
+   "Defining exhaustive entity shapes before the monitor exists to
+    validate them against risks premature formalization."
+   :mitigation
+   "Malli open schemas — validate required keys, ignore the rest.
+    Entity shapes grow as we learn what we actually use."}
+
+  {:risk "Governance ambiguity"
+   :description
+   "If PR governance state is not explicitly derived from policy
+    evaluations and waivers, the TUI will present governance status
+    ambiguously."
+   :mitigation "WS1 formalizes governance state derivation before WS4 builds on it"}
+
+  {:risk "Passive dashboard framing"
+   :description
+   "If framed as read-only monitoring, bounded interventions will remain
+    underspecified and the control-plane value will be weaker."
+   :mitigation "WS5 explicitly implements intervention vocabulary"}]}


### PR DESCRIPTION
## Summary

- Reframe the TUI from a human-operated command surface to a **supervisory control plane** for agent-executed workflows and policy-governed PR operations
- Add N5 normative delta defining supervisory entities (WorkflowRun, PolicyEvaluation, AttentionItem, Waiver), PR governance states, attention derivation, bounded interventions, and monitor mode
- Add work spec with 5 workstreams (domain formalization → durable startup → monitor screen → governance surface → attention/intervention) across 4 phases
- Add fleet deferred parking lot for concepts punted to Fleet scale (lens abstraction, full audit trail, event versioning, fleet aggregation)
- Integrate with existing PR monitor loop (`:pr-monitor/*` events) and control-plane component (agent registry, decision queue, session discovery)
- Update pr-monitor-loop spec to note Phase 4 TUI deliverable is subsumed by this work

## Context

Current dogfooding workflow: human sits in Claude Code/Codex, agent drives miniforge via MCP, human needs live visibility into workflows and PRs without leaving the agent session. The TUI should run in a tmux right pane as a monitor-first dashboard, not a command-driven control plane.

Key design decisions:
- Monitor-first: auto-updating, 60-column capable, minimal interaction
- Policy-centric: PR review is policy pass/fail/waived, not human-read-diff
- Bounded interventions: acknowledge, retry, pause/resume, waive, resolve decision — not a general shell
- Open Malli schemas: validate required keys, extra keys pass through
- Deferred Fleet concepts captured in parking lot so they don't get lost

## Test plan

- [ ] Verify normative delta references are consistent with existing N5 sections
- [ ] Verify work spec deliverables cover all normative requirements
- [ ] Verify fleet deferred captures all concepts punted from v1
- [ ] Verify pr-monitor-loop spec update is accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)