### PR TITLE
chore: use role aliases for security and conduct contact addresses

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -27,7 +27,7 @@ appearance, race, religion, or sexual identity and orientation.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at
-**christopher@miniforge.ai**. All complaints will be reviewed and investigated promptly and fairly. The project team is
+**conduct@miniforge.ai**. All complaints will be reviewed and investigated promptly and fairly. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.
 
 ## Attribution

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
-To report a security vulnerability, email **christopher@miniforge.ai** with:
+To report a security vulnerability, email **security@miniforge.ai** with:
 
 - A description of the vulnerability and its potential impact
 - Steps to reproduce or proof-of-concept code


### PR DESCRIPTION
## Summary

- `SECURITY.md`: `christopher@miniforge.ai` → `security@miniforge.ai`
- `CODE_OF_CONDUCT.md`: `christopher@miniforge.ai` → `conduct@miniforge.ai`

Both aliases forward to `christopher@miniforge.ai` via Google Workspace. Role aliases are the standard OSS practice — reporters trust a dedicated address for vuln disclosure and CoC enforcement over a named personal address.

## Test plan

- [ ] `grep -r "@miniforge.ai" SECURITY.md CODE_OF_CONDUCT.md` shows the role aliases

🤖 Generated with [Claude Code](https://claude.com/claude-code)