### PR TITLE
docs: M3 policy pack taxonomy — four-artifact model

### DIFF
--- a/components/spec-parser/src/ai/miniforge/spec_parser/core.clj
+++ b/components/spec-parser/src/ai/miniforge/spec_parser/core.clj
@@ -74,20 +74,62 @@
       (throw (ex-info "Failed to parse JSON file"
                       {:error (ex-message e)} e)))))
 
+(def ^:private spec-key->ns
+  "Map plain YAML keys to their :spec/* or :workflow/* namespace.
+   The YAML parser produces unnamespaced keywords; normalize-spec requires
+   namespaced ones.
+
+   Both hyphenated (:acceptance-criteria) and underscore (:acceptance_criteria)
+   forms are listed because the YAML parser regex only captures \\w+ (no hyphens),
+   so frontmatter authors must use underscores for multi-word keys."
+  {:title                "spec"
+   :description          "spec"
+   :intent               "spec"
+   :constraints          "spec"
+   :tags                 "spec"
+   :acceptance-criteria  "spec"
+   :acceptance_criteria  "spec"   ; underscore form from YAML parser
+   :code-artifact        "spec"
+   :code_artifact        "spec"
+   :repo-url             "spec"
+   :repo_url             "spec"
+   :branch               "spec"
+   :llm-backend          "spec"
+   :llm_backend          "spec"
+   :sandbox              "spec"
+   :plan-tasks           "spec"
+   :plan_tasks           "spec"
+   :type                 "workflow"
+   :version              "workflow"})
+
+(defn- namespace-frontmatter-keys
+  "Remap plain YAML keys to :spec/* / :workflow/* namespaces for normalize-spec.
+   Underscore key names (from YAML parser limitation) are normalized to hyphens
+   so :acceptance_criteria becomes :spec/acceptance-criteria."
+  [m]
+  (reduce-kv (fn [acc k v]
+               (if-let [ns (get spec-key->ns k)]
+                 (let [canonical (str/replace (name k) "_" "-")]
+                   (assoc acc (keyword ns canonical) v))
+                 (assoc acc k v)))
+             {} m))
+
 (defn parse-markdown
   "Parse Markdown file with YAML frontmatter.
-   Frontmatter contains structured spec data, body is optional context."
+   Frontmatter contains structured spec data; body is appended to description."
   [content]
   (let [parsed (knowledge/split-frontmatter content)]
     (when-not parsed
-      (throw (ex-info "Markdown file must have YAML frontmatter (---)"
-                      {:hint "Add frontmatter with title, description, etc."})))
-    (let [frontmatter (knowledge/parse-yaml-frontmatter (:frontmatter parsed))
-          body (:body parsed)]
-      ;; If there's body content beyond title, use it to extend description
-      (cond-> frontmatter
+      (throw (ex-info "Markdown spec requires YAML frontmatter (---...---)"
+                      {:hint "Add frontmatter with at least title and description."})))
+    (let [raw-fm   (knowledge/parse-yaml-frontmatter (:frontmatter parsed))
+          fm       (namespace-frontmatter-keys raw-fm)
+          body     (:body parsed)]
+      ;; Append body prose to description so agents get full context without
+      ;; needing to re-read the source file.
+      (cond-> fm
         (and body (not (str/blank? body)))
-        (update :description
+        (update :spec/description
                 #(str % "\n\n" (str/trim body)))))))
 
 (def format-parsers
@@ -139,9 +181,9 @@
            :spec/intent           (or intent {:type :general})
            :spec/constraints      (or constraints [])
            :spec/tags             (or tags [])
+           :spec/workflow-type    (or type :full-sdlc)
            :spec/workflow-version (or version "latest")
            :spec/raw-data         spec}
-    type                (assoc :spec/workflow-type type)
     acceptance-criteria (assoc :spec/acceptance-criteria acceptance-criteria)
     code-artifact       (assoc :spec/code-artifact code-artifact)
     repo-url            (assoc :spec/repo-url repo-url)

--- a/components/spec-parser/src/ai/miniforge/spec_parser/core.clj
+++ b/components/spec-parser/src/ai/miniforge/spec_parser/core.clj
@@ -114,23 +114,46 @@
                  (assoc acc k v)))
              {} m))
 
+(defn- h1-title
+  "Extract the first H1 heading text from a markdown body, or nil if absent."
+  [body]
+  (when-let [[_ title] (re-find #"(?m)^#\s+(.+)$" body)]
+    (str/trim title)))
+
+(defn- body-without-h1
+  "Remove the first H1 heading line from a markdown body."
+  [body]
+  (str/trim (str/replace-first body #"(?m)^#[^\n]*\n?" "")))
+
+(defn- decorate-from-body
+  "Synthesize a :spec/* map from a plain markdown document with no frontmatter.
+   Title is inferred from the first H1; the remainder becomes the description."
+  [body]
+  (let [title (or (h1-title body) "Untitled")]
+    {:spec/title       title
+     :spec/description (let [remainder (body-without-h1 body)]
+                         (if (str/blank? remainder) title remainder))}))
+
 (defn parse-markdown
-  "Parse Markdown file with YAML frontmatter.
-   Frontmatter contains structured spec data; body is appended to description."
+  "Parse Markdown file with optional YAML frontmatter.
+
+   With frontmatter: structured fields are namespaced (:title → :spec/title)
+   and the body is appended to :spec/description for full agent context.
+
+   Without frontmatter: title is inferred from the first H1 heading and the
+   remaining body becomes :spec/description. No error is raised — the document
+   is decorated automatically so any design doc can be fed directly to the
+   workflow engine."
   [content]
-  (let [parsed (knowledge/split-frontmatter content)]
-    (when-not parsed
-      (throw (ex-info "Markdown spec requires YAML frontmatter (---...---)"
-                      {:hint "Add frontmatter with at least title and description."})))
-    (let [raw-fm   (knowledge/parse-yaml-frontmatter (:frontmatter parsed))
-          fm       (namespace-frontmatter-keys raw-fm)
-          body     (:body parsed)]
-      ;; Append body prose to description so agents get full context without
-      ;; needing to re-read the source file.
+  (if-let [parsed (knowledge/split-frontmatter content)]
+    (let [raw-fm (knowledge/parse-yaml-frontmatter (:frontmatter parsed))
+          fm     (namespace-frontmatter-keys raw-fm)
+          body   (:body parsed)]
       (cond-> fm
         (and body (not (str/blank? body)))
-        (update :spec/description
-                #(str % "\n\n" (str/trim body)))))))
+        (update :spec/description #(str % "\n\n" (str/trim body)))))
+    ;; No frontmatter — synthesize spec metadata from document structure
+    (decorate-from-body content)))
 
 (def format-parsers
   "Registry of format -> parser-fn. Extend this to add new formats."

--- a/components/spec-parser/test/ai/miniforge/spec_parser/interface_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/interface_test.clj
@@ -20,6 +20,7 @@
   "Tests for spec-parser component: schema validation, normalization, and parsing."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [clojure.string :as str]
    [ai.miniforge.spec-parser.interface :as spec-parser]
    [ai.miniforge.spec-parser.schema :as schema]
    [malli.core :as m]
@@ -206,6 +207,80 @@
     (let [result (spec-parser/validate-spec {:spec/title "T"})]
       (is (false? (:valid? result)))
       (is (some? (:errors result))))))
+
+;------------------------------------------------------------------------------ Layer 5: Markdown Parsing Tests
+;; Regression coverage for parse-markdown frontmatter key namespacing and body appending
+
+(deftest parse-markdown-key-namespacing-test
+  (testing "title and description map to :spec/* namespace"
+    (let [result (spec-parser/parse-content
+                  :markdown
+                  "---\ntitle: My Spec\ndescription: Do the thing\n---\n")]
+      (is (= "My Spec" (:spec/title result)))
+      (is (str/includes? (:spec/description result) "Do the thing"))))
+
+  (testing "acceptance_criteria underscore form maps to :spec/acceptance-criteria"
+    (let [result (spec-parser/parse-content
+                  :markdown
+                  "---\ntitle: T\ndescription: D\nacceptance_criteria: Tests pass\n---\n")]
+      (is (= "Tests pass" (:spec/acceptance-criteria result)))))
+
+  (testing "tags map to :spec/tags (as EDN keywords)"
+    (let [result (spec-parser/parse-content
+                  :markdown
+                  "---\ntitle: T\ndescription: D\ntags: [:compliance :scanner]\n---\n")]
+      (is (= [:compliance :scanner] (:spec/tags result)))))
+
+  (testing "type maps to :workflow/type"
+    (let [result (spec-parser/parse-content
+                  :markdown
+                  "---\ntitle: T\ndescription: D\ntype: canonical-sdlc\n---\n")]
+      (is (= "canonical-sdlc" (:workflow/type result)))))
+
+  (testing "markdown without frontmatter throws"
+    (is (thrown-with-msg? Exception #"YAML frontmatter"
+          (spec-parser/parse-content :markdown "# No Frontmatter\n\nJust body.")))))
+
+(deftest parse-markdown-body-appended-test
+  (testing "markdown body prose is appended to :spec/description"
+    (let [content (str "---\ntitle: T\ndescription: Frontmatter desc\n---\n\n"
+                       "# Design\n\nBody prose goes here.")
+          result  (spec-parser/parse-content :markdown content)]
+      (is (str/includes? (:spec/description result) "Frontmatter desc"))
+      (is (str/includes? (:spec/description result) "Body prose goes here"))))
+
+  (testing "empty body does not alter description"
+    (let [content "---\ntitle: T\ndescription: Only frontmatter\n---\n"
+          result  (spec-parser/parse-content :markdown content)]
+      (is (= "Only frontmatter" (:spec/description result))))))
+
+(deftest normalize-workflow-type-default-test
+  (testing "workflow-type defaults to :full-sdlc when not provided"
+    (let [result (spec-parser/normalize-spec {:spec/title "T" :spec/description "D"})]
+      (is (= :full-sdlc (:spec/workflow-type result)))))
+
+  (testing "workflow-type from :workflow/type key is used when provided"
+    (let [result (spec-parser/normalize-spec
+                  {:spec/title "T" :spec/description "D" :workflow/type :canonical-sdlc})]
+      (is (= :canonical-sdlc (:spec/workflow-type result))))))
+
+(deftest markdown-round-trip-test
+  (testing "markdown design doc parses and normalizes to valid SpecPayload"
+    (let [content (str "---\n"
+                       "title: Compliance Scanner\n"
+                       "description: Build a scanner.\n"
+                       "tags: [:compliance :scanner]\n"
+                       "---\n\n"
+                       "## Design\n\nDetailed design goes here.\n")
+          parsed     (spec-parser/parse-content :markdown content)
+          normalized (spec-parser/normalize-spec parsed)
+          validation (spec-parser/validate-spec normalized)]
+      (is (= "Compliance Scanner" (:spec/title normalized)))
+      (is (= :full-sdlc (:spec/workflow-type normalized)))
+      (is (str/includes? (:spec/description normalized) "Build a scanner"))
+      (is (str/includes? (:spec/description normalized) "Detailed design goes here"))
+      (is (= [:compliance :scanner] (:spec/tags normalized)))
+      (is (true? (:valid? validation))))))
 
 ;------------------------------------------------------------------------------ Layer 4: Schema Validation Helpers
 

--- a/components/spec-parser/test/ai/miniforge/spec_parser/interface_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/interface_test.clj
@@ -237,9 +237,14 @@
                   "---\ntitle: T\ndescription: D\ntype: canonical-sdlc\n---\n")]
       (is (= "canonical-sdlc" (:workflow/type result)))))
 
-  (testing "markdown without frontmatter throws"
-    (is (thrown-with-msg? Exception #"YAML frontmatter"
-          (spec-parser/parse-content :markdown "# No Frontmatter\n\nJust body.")))))
+  (testing "markdown without frontmatter decorates from body — title from H1"
+    (let [result (spec-parser/parse-content :markdown "# Compliance Scanner M2\n\nExecute phase design.")]
+      (is (= "Compliance Scanner M2" (:spec/title result)))
+      (is (str/includes? (:spec/description result) "Execute phase design"))))
+
+  (testing "markdown without frontmatter and no H1 uses Untitled"
+    (let [result (spec-parser/parse-content :markdown "Just some prose without a heading.")]
+      (is (= "Untitled" (:spec/title result))))))
 
 (deftest parse-markdown-body-appended-test
   (testing "markdown body prose is appended to :spec/description"

--- a/components/task-executor/src/ai/miniforge/task_executor/runner.clj
+++ b/components/task-executor/src/ai/miniforge/task_executor/runner.clj
@@ -30,7 +30,8 @@
             [ai.miniforge.pr-lifecycle.interface :as pr]
             [ai.miniforge.dag-executor.interface :as dag]
             [ai.miniforge.logging.interface :as log]
-            [ai.miniforge.agent-runtime.interface :as error-classifier]))
+            [ai.miniforge.agent-runtime.interface :as error-classifier]
+            [ai.miniforge.spec-parser.interface :as spec-parser]))
 
 (defn create-task-context
   "Assemble context for a task execution.
@@ -192,6 +193,34 @@
         (log-event logger :release-locks-error task-id
                    {:error (ex-message e)})))))
 
+(defn validate-spec!
+  "Validate task spec before acquiring any resources.
+
+   If the task carries a :spec/source-file path, attempts to parse it.
+   A parse failure means the agent would have no structured context and
+   would waste its entire turn budget exploring the codebase.
+
+   Returns nil on success. Throws ex-info on failure so the caller
+   can fail-fast and surface a clear error without touching the environment."
+  [task-id task logger]
+  (when-let [spec-path (or (get-in task [:spec/provenance :source-file])
+                           (get task :spec/source-file)
+                           (get task :spec-path))]
+    (log-event logger :validating-spec task-id {:spec-path spec-path})
+    (try
+      (spec-parser/parse-spec-file spec-path)
+      (log-event logger :spec-valid task-id {:spec-path spec-path})
+      nil
+      (catch Exception e
+        (throw (ex-info
+                (str "Spec validation failed — refusing to spawn agent without valid spec. "
+                     "Fix the spec at: " spec-path ". "
+                     "Cause: " (ex-message e))
+                {:task-id   task-id
+                 :spec-path spec-path
+                 :cause     (ex-message e)}
+                e))))))
+
 (defn calculate-cost-usd
   "Calculate estimated cost in USD based on tokens used.
    Using Claude Sonnet pricing as baseline: ~$3/million input, ~$15/million output.
@@ -238,6 +267,7 @@
   "Execute a single task through its full lifecycle.
 
   Steps:
+  0. Validate spec (fail fast — no resources acquired on bad spec)
   1. Acquire resources (worktree + environment)
   2. Generate code artifact (inner loop)
   3. Create PR lifecycle controller
@@ -264,6 +294,9 @@
 
     (let [env-record (atom nil)]
       (try
+        ;; Step 0: Validate spec — fail fast before spending any resources
+        (validate-spec! task-id task logger)
+
         ;; Step 1: Acquire resources
         (let [resources (acquire-resources! task-id lock-pool executor logger config)]
           (reset! env-record (:env-record resources)))

--- a/components/task-executor/test/ai/miniforge/task_executor/runner_test.clj
+++ b/components/task-executor/test/ai/miniforge/task_executor/runner_test.clj
@@ -22,7 +22,8 @@
   Tests that a task flows correctly through: environment acquisition →
   code generation → PR lifecycle → metrics accumulation → cleanup."
   (:require
-   [clojure.test :refer [deftest testing is]]))
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.task-executor.runner :as runner]))
 
 ;------------------------------------------------------------------------------ Mock Data
 
@@ -434,3 +435,63 @@
       ;; First attempt would fail, triggering fix loop
       (is (= 1 @attempt-count)
           "Should attempt PR lifecycle once"))))
+
+;------------------------------------------------------------------------------ validate-spec! Tests
+;; Regression coverage for the fail-fast spec validation gate added to execute-task
+
+(defn- write-temp-spec!
+  "Write content to a temp .md file and return its path string."
+  [content]
+  (let [f (java.io.File/createTempFile "test-spec" ".md")]
+    (.deleteOnExit f)
+    (spit f content)
+    (.getAbsolutePath f)))
+
+(deftest validate-spec-no-path-test
+  (testing "no-op when task has no spec path"
+    (is (nil? (runner/validate-spec! "task-1" {} nil))
+        "Should return nil when no spec-related key present"))
+  (testing "no-op when task has other keys but no spec path"
+    (is (nil? (runner/validate-spec! "task-1" {:task/description "Do stuff"} nil))
+        "Should return nil for task with no spec path")))
+
+(deftest validate-spec-valid-file-test
+  (testing "returns nil for a well-formed markdown spec"
+    (let [path (write-temp-spec!
+                (str "---\n"
+                     "title: Test Spec\n"
+                     "description: A valid test spec\n"
+                     "---\n\n"
+                     "## Design\n\nSome design content.\n"))
+          task {:spec/source-file path}]
+      (is (nil? (runner/validate-spec! "task-1" task nil))
+          "Should return nil for valid spec"))))
+
+(deftest validate-spec-missing-file-test
+  (testing "throws when spec path points to a nonexistent file"
+    (let [task {:spec/source-file "/nonexistent/path/spec.md"}]
+      (is (thrown-with-msg? Exception #"Spec validation failed"
+            (runner/validate-spec! "task-1" task nil))))))
+
+(deftest validate-spec-malformed-spec-test
+  (testing "throws when spec file has no YAML frontmatter"
+    (let [path (write-temp-spec! "# No Frontmatter\n\nJust a plain markdown file.")
+          task {:spec/source-file path}]
+      (is (thrown-with-msg? Exception #"Spec validation failed"
+            (runner/validate-spec! "task-1" task nil)))))
+
+  (testing "spec-path key is also checked"
+    (let [task {:spec-path "/nonexistent/spec.md"}]
+      (is (thrown-with-msg? Exception #"Spec validation failed"
+            (runner/validate-spec! "task-1" task nil))))))
+
+(deftest validate-spec-provenance-key-test
+  (testing "reads spec path from :spec/provenance :source-file"
+    (let [path (write-temp-spec!
+                (str "---\n"
+                     "title: T\n"
+                     "description: D\n"
+                     "---\n"))
+          task {:spec/provenance {:source-file path}}]
+      (is (nil? (runner/validate-spec! "task-1" task nil))
+          "Should accept path nested under :spec/provenance"))))

--- a/components/task-executor/test/ai/miniforge/task_executor/runner_test.clj
+++ b/components/task-executor/test/ai/miniforge/task_executor/runner_test.clj
@@ -474,13 +474,12 @@
             (runner/validate-spec! "task-1" task nil))))))
 
 (deftest validate-spec-malformed-spec-test
-  (testing "throws when spec file has no YAML frontmatter"
-    (let [path (write-temp-spec! "# No Frontmatter\n\nJust a plain markdown file.")
+  (testing "plain markdown without frontmatter is now valid — decorated from H1"
+    (let [path (write-temp-spec! "# Compliance Scanner M2\n\nExecute phase design.")
           task {:spec/source-file path}]
-      (is (thrown-with-msg? Exception #"Spec validation failed"
-            (runner/validate-spec! "task-1" task nil)))))
+      (is (nil? (runner/validate-spec! "task-1" task nil)))))
 
-  (testing "spec-path key is also checked"
+  (testing "spec-path key is also checked — throws for nonexistent file"
     (let [task {:spec-path "/nonexistent/spec.md"}]
       (is (thrown-with-msg? Exception #"Spec validation failed"
             (runner/validate-spec! "task-1" task nil))))))

--- a/docs/design/compliance-scanner.md
+++ b/docs/design/compliance-scanner.md
@@ -1,4 +1,11 @@
-# Compliance Scanner
+---
+title: Compliance Scanner
+description: Build a Miniforge capability that scans a repository against compiled policy packs, produces a compliance
+delta report, generates a DAG remediation plan, and executes fixes autonomously via the dag-executor.
+acceptance_criteria: Scan detects policy violations by rule-id, classify adds auto-fixable flag and rationale, plan
+generates DAG tasks and markdown work spec, execute applies auto-fixable fixes via dag-executor and opens PRs
+tags: [compliance, policy, scanner, dag, remediation]
+---
 
 ## Vision
 

--- a/docs/design/compliance-scanner.md
+++ b/docs/design/compliance-scanner.md
@@ -33,10 +33,11 @@ it to its own codebase first (dogfood), then exposes it as a product feature for
 
 **`policy-selector` options:**
 
-- `:always-apply` — all packs with `alwaysApply: true` in frontmatter (default)
-- `:all` — every `.mdc` file in the standards path
-- `#{"dewey.210" "dewey.810"}` — explicit set of Dewey codes
-- `"dewey.2xx"` — prefix wildcard (all language rules)
+- `:always-apply` — all rules with default enabled across loaded packs (default)
+- `:all` — every rule in every loaded pack
+- `#{:mf.rule/clojure-map-access :mf.rule/copyright-header}` — explicit rule IDs
+- `#{:mf.cat/210 :mf.cat/810}` — all rules in specified categories
+- `"mf.cat/8xx"` — prefix wildcard over category codes (all project-standards rules)
 
 ---
 
@@ -56,21 +57,25 @@ Machine-readable. Stored at `.miniforge/compliance-report.edn` after each scan.
                     :needs-review      24
                     :files-affected    61
                     :rules-violated     9}
- :violations       [{:rule/dewey      "210"
-                     :rule/title      "Clojure Map Access"
+ :violations       [{:rule/id         :mf.rule/clojure-map-access
+                     :rule/title      "Clojure Map Access Style"
+                     :rule/categories [:mf.cat/210]
+                     :rule/pack       :miniforge/core
                      :file            "components/foo/src/..."
                      :line            42
                      :current         "(or (:k m) default)"
                      :suggested       "(get m :k default)"
-                     :auto-fixable?   true
+                     :auto-fix?       true
                      :rationale       "Literal default, non-JSON field"}
-                    {:rule/dewey      "210"
-                     :rule/title      "Clojure Map Access"
+                    {:rule/id         :mf.rule/clojure-map-access
+                     :rule/title      "Clojure Map Access Style"
+                     :rule/categories [:mf.cat/210]
+                     :rule/pack       :miniforge/core
                      :file            "components/server/src/..."
                      :line            88
                      :current         "(or (:type d) \"choice\")"
                      :suggested       nil
-                     :auto-fixable?   false
+                     :auto-fix?       false
                      :rationale       "JSON-deserialized map; key can be present with nil value"}
                     ...]}
 ```
@@ -83,8 +88,8 @@ Format designed to be fed directly back to Miniforge as a work input — the sam
 Sections:
 
 - **Executive summary** — violation counts by rule, files affected
-- **Auto-fixable violations** — grouped by Dewey code, with file lists and patterns
-- **Needs-review violations** — grouped by Dewey code, with rationale for each exception
+- **Auto-fixable violations** — grouped by category title (from loaded taxonomy), with file lists and patterns
+- **Needs-review violations** — grouped by category title, with rationale for each exception
 - **Execution instructions** — DAG topology, recommended PR structure, ordering constraints
 
 ### 3. DAG Definition (EDN)
@@ -111,9 +116,9 @@ Each agent:
 
 | Rule category | Detection method |
 |---|---|
-| Mechanical patterns (Dewey 210, 810) | Regex scan via existing `Scanner` protocol |
-| Structural conventions (Dewey 300, 400) | AST-level or pattern matching |
-| Semantic/design rules (Dewey 003, 004, 010) | LLM-powered analysis; violations returned as `:needs-review` |
+| Mechanical patterns (`:mf.cat/210`, `:mf.cat/810`) | Regex scan via existing `Scanner` protocol |
+| Structural conventions (`:mf.cat/310`, `:mf.cat/400`) | AST-level or pattern matching |
+| Semantic/design rules (`:mf.cat/001`, `:mf.cat/003`, `:mf.cat/010`) | LLM-powered analysis; violations returned as `auto-fix? false` |
 
 Each scan agent returns a sequence of violation maps for its rule. All rule scans run in parallel — they share only the
 read-only repo index.
@@ -135,7 +140,7 @@ Aggregate violation lists from all scan agents. For each violation, determine:
 
 1. The rule requires reasoning about runtime behavior or type semantics
 2. The specific instance matches a known edge case (e.g., JSON-deserialized maps, `or` as nil-coerce)
-3. The rule category is Dewey 003, 004, or 010 (semantic design rules)
+3. The rule belongs to a semantic-design category (`:mf.cat/001`, `:mf.cat/003`, `:mf.cat/004`, `:mf.cat/010`)
 
 The classification step is itself agent-powered for mixed rules — a classification agent reviews each candidate
 violation for the edge-case patterns documented in the rule body.
@@ -147,14 +152,14 @@ Convert the classified violation list into a DAG of remediation tasks.
 **DAG topology:**
 
 - **Node** = `(file × rule)` — apply one rule's violations to one file atomically
-- **Edge** = same-file serialization — two nodes sharing a file run sequentially in Dewey code order (lowest Dewey first
-  = most foundational rules applied first)
+- **Edge** = same-file serialization — two nodes sharing a file run sequentially in `:category/order` ascending
+  (lowest order first = most foundational rules applied first)
 - Auto-fixable nodes → executable agent tasks
 - Needs-review nodes → human-approval gates (DAG pauses, waits for confirmation)
 
 **Node execution order within a file:**
-Apply rules in ascending Dewey order to ensure deterministic application and respect rule hierarchy (architectural rules
-before language rules before project rules).
+Apply rules in ascending `:category/order` (resolved from the loaded taxonomy) to ensure deterministic application
+and respect rule hierarchy (architectural rules before language rules before project rules).
 
 **Output:**
 
@@ -175,8 +180,9 @@ Feed the DAG to `dag-executor/execute-dag`. Each task node:
 5. Transitions task to `:implemented`
 
 **PR structure:**
-One PR per rule (matching the Dewey 210 PR pattern). Configurable to one PR per brick or one PR for all. Each PR title
-follows: `fix: [Dewey NNN] <rule-title> compliance pass`.
+One PR per rule. Configurable to one PR per brick or one PR for all. Each PR title follows:
+`fix: [<category-code>] <rule-title> compliance pass` — e.g. `fix: [810] Copyright Header compliance pass`.
+The category code is resolved from the loaded taxonomy at plan time.
 
 ---
 
@@ -189,10 +195,10 @@ The first consumer is Miniforge itself:
 3. **Review** the delta report — see the full outstanding compliance picture
 4. **Execute** — DAG executor applies auto-fixable violations in parallel across the codebase
 5. **Review gate** — needs-review violations surface as human-approval gates; decide case by case
-6. **Merge** — one PR per Dewey code, reviewable in isolation
+6. **Merge** — one PR per rule, reviewable in isolation
 7. **Prevent regression** — compliance scanner runs on every PR as a pre-merge check
 
-This replaces the current manual per-standards-doc pass we just completed for Dewey 210.
+This replaces the current manual per-standards-doc pass we just completed for the Clojure map-access rule.
 
 ---
 
@@ -209,7 +215,7 @@ This replaces the current manual per-standards-doc pass we just completed for De
 
 | Component | Extension |
 |---|---|
-| `policy-pack` | LLM-powered `Scanner` implementation alongside existing regex scanner |
+| `policy-pack` | Taxonomy loader, pack loader, mapping artifact support, overlay resolution (M3); LLM-powered `Scanner` implementation (M4) |
 | `phase-software-factory` | `:compliance-fix` phase variant — targeted single-file edit with rule context |
 
 ### Used As-Is
@@ -235,30 +241,31 @@ This makes compliance checking fast enough to run on every PR.
 
 ## Auto-Fixability Reference
 
-Initial classification per existing standards:
+Initial classification per existing standards. Rule IDs are from `miniforge/core`; category codes
+are from the `miniforge/dewey` taxonomy.
 
-| Dewey | Rule | Auto-fixable? | Notes |
-|---|---|---|---|
-| 001 | Stratified Design | No | Structural/architectural judgment |
-| 002 | Code Quality | Partial | Mechanical patterns yes; design patterns no |
-| 003 | Result Handling | No | Semantic; requires error-path reasoning |
-| 004 | Validation Boundaries | No | Semantic; requires boundary identification |
-| 010 | Simple Made Easy | No | Design judgment |
-| 020 | Specification Standards | No | Document structure judgment |
-| 050 | Localization | Partial | Missing i18n keys yes; structural patterns no |
-| 210 | Clojure Map Access | Yes | Except JSON-deserialized nil edge cases |
-| 220 | Python Standards | Yes | Where mechanical pattern applies |
-| 300 | Polylith | Partial | Interface violations yes; dep structure needs review |
-| 320 | Kubernetes | No | Infrastructure judgment |
-| 400 | Testing Standards | Partial | Naming/structure yes; coverage judgment no |
-| 710 | Git Branch Management | No | Workflow judgment |
-| 715 | Pre-commit Discipline | No | Process, not code |
-| 721 | PR Documentation | Partial | Missing fields yes; quality judgment no |
-| 722 | PR Layering | No | Judgment call |
-| 725 | Git Worktrees | No | Workflow judgment |
-| 730 | Datever | Yes | Date format substitution, fully mechanical |
-| 810 | Copyright Header | Yes | Missing/malformed headers, fully mechanical |
-| 900 | Meta | No | Standards authoring rules |
+| Rule ID | Category | Title | Auto-fixable? | Notes |
+|---|---|---|---|---|
+| `:mf.rule/stratified-design` | 001 | Stratified Design | No | Structural/architectural judgment |
+| `:mf.rule/code-quality` | 002 | Code Quality | Partial | Mechanical patterns yes; design patterns no |
+| `:mf.rule/result-handling` | 003 | Result Handling | No | Semantic; requires error-path reasoning |
+| `:mf.rule/validation-boundaries` | 004 | Validation Boundaries | No | Semantic; requires boundary identification |
+| `:mf.rule/simple-made-easy` | 010 | Simple Made Easy | No | Design judgment |
+| `:mf.rule/specification-standards` | 020 | Specification Standards | No | Document structure judgment |
+| `:mf.rule/localisation` | 050 | Localisation | Partial | Missing i18n keys yes; structural patterns no |
+| `:mf.rule/clojure-map-access` | 210 | Clojure Map Access Style | Yes | Except JSON-deserialized nil edge cases |
+| `:mf.rule/python-standards` | 220 | Python Standards | Yes | Where mechanical pattern applies |
+| `:mf.rule/polylith-structure` | 310 | Polylith | Partial | Interface violations yes; dep structure needs review |
+| `:mf.rule/kubernetes-config` | 320 | Kubernetes | No | Infrastructure judgment |
+| `:mf.rule/testing-standards` | 400 | Testing Standards | Partial | Naming/structure yes; coverage judgment no |
+| `:mf.rule/git-branch-management` | 710 | Git Branch Management | No | Workflow judgment |
+| `:mf.rule/precommit-discipline` | 715 | Pre-commit Discipline | No | Process, not code |
+| `:mf.rule/pr-documentation` | 721 | PR Documentation | Partial | Missing fields yes; quality judgment no |
+| `:mf.rule/pr-layering` | 722 | PR Layering | No | Judgment call |
+| `:mf.rule/git-worktrees` | 725 | Git Worktrees | No | Workflow judgment |
+| `:mf.rule/datever-format` | 730 | DateVer Format | Yes | Date format substitution, fully mechanical |
+| `:mf.rule/copyright-header` | 810 | Copyright Header | Yes | Missing/malformed headers, fully mechanical |
+| `:mf.rule/meta-standards` | 900 | Meta | No | Standards authoring rules |
 
 ---
 

--- a/docs/design/policy-pack-taxonomy.md
+++ b/docs/design/policy-pack-taxonomy.md
@@ -1,0 +1,564 @@
+---
+title: Policy Pack Taxonomy System
+description: Four-artifact model for extensible, interoperable compliance policy systems. Externalises the miniforge
+  Dewey-derived taxonomy as a first-class published artifact and establishes the canonical design for policy packs,
+  mapping bridges, and overlay extensions.
+tags: [policy-pack, taxonomy, compliance, extensibility, m3]
+---
+
+# Policy Pack Taxonomy System
+
+## Vision
+
+The compliance scanner's Dewey numbering system was originally an internal ordering mechanism. This design externalises
+it as a published, versioned taxonomy artifact — the first categorisation system in the miniforge policy ecosystem.
+
+The key reframe: miniforge does not need a bespoke internal representation separate from its published system. The
+platform's canonical taxonomy **is** the miniforge policy taxonomy. It happens to be Dewey-derived, and it is published
+so others can adopt, extend, or map to it — but it is explicitly canonical, not "just another pack."
+
+---
+
+## Design Decisions
+
+These four decisions are explicit and must not be left fuzzy:
+
+**1. miniforge taxonomy is the platform canonical taxonomy.**
+For now and the foreseeable future, miniforge normalises findings against its own taxonomy. The more general
+"choose any canonical view" model is a later-stage feature. Calling it "just another pack" while treating it as the
+required normalisation target would be architecturally dishonest.
+
+**2. Rule IDs are the durable anchor.**
+Rule IDs are what users put in ignore lists, what mappings key on, what change logs reference. They must be globally
+unique, namespace-qualified keywords, and immutable after publication. Categories are classification and display — they
+can be reorganised without touching rule IDs.
+
+**3. Normalise to rule IDs and category IDs, not labels and not raw Dewey strings.**
+Storage and inter-component contracts carry `:rule/id` and `:rule/categories` as structured keywords. The report
+renderer resolves those to human-readable labels by looking up the loaded taxonomy. Dewey code strings (`"210"`) are
+a display convenience produced at render time, not a stored identifier.
+
+**4. Mapping artifacts are first-class and standalone.**
+A pack may bundle convenience mappings, but the mapping loader must accept them as independent artifacts. miniforge
+authors bridges to Vanta, SOC 2, ISO 27001; vendors author bridges to miniforge; customers author private bridges.
+No side owns the mapping — it is a separate artifact with its own provenance.
+
+---
+
+## Four-Artifact Model
+
+```
+taxonomy          ← category tree, independently versioned
+policy pack       ← ruleset + taxonomy ref + optional bundled mappings
+mapping artifact  ← bridge between two systems (standalone, first-class)
+overlay pack      ← extends a base pack with adds/overrides
+```
+
+Taxonomy and ruleset have different change velocities. A new category should not require every rule consumer to rev
+their pack version. A rule severity fix should not imply a taxonomy revision. Structural separation, packaging optional:
+a pack may distribute the taxonomy it references, but taxonomy must be independently identifiable and versionable.
+
+---
+
+## Artifact Schemas
+
+### 1. Taxonomy Artifact
+
+```edn
+{:taxonomy/id         :miniforge/dewey
+ :taxonomy/version    "1.0.0"
+ :taxonomy/title      "Miniforge Canonical Taxonomy"
+
+ :taxonomy/categories
+ [;; Architecture
+  {:category/id    :mf.cat/001
+   :category/code  "001"
+   :category/title "Stratified Design"
+   :category/parent nil
+   :category/order  1}
+
+  {:category/id    :mf.cat/002
+   :category/code  "002"
+   :category/title "Code Quality"
+   :category/parent nil
+   :category/order  2}
+
+  {:category/id    :mf.cat/003
+   :category/code  "003"
+   :category/title "Result Handling"
+   :category/parent nil
+   :category/order  3}
+
+  {:category/id    :mf.cat/004
+   :category/code  "004"
+   :category/title "Validation Boundaries"
+   :category/parent nil
+   :category/order  4}
+
+  {:category/id    :mf.cat/010
+   :category/code  "010"
+   :category/title "Simple Made Easy"
+   :category/parent nil
+   :category/order  10}
+
+  {:category/id    :mf.cat/020
+   :category/code  "020"
+   :category/title "Specification Standards"
+   :category/parent nil
+   :category/order  20}
+
+  {:category/id    :mf.cat/050
+   :category/code  "050"
+   :category/title "Localisation"
+   :category/parent nil
+   :category/order  50}
+
+  ;; Language-specific
+  {:category/id    :mf.cat/200
+   :category/code  "200"
+   :category/title "Language Standards"
+   :category/parent nil
+   :category/order  200}
+
+  {:category/id    :mf.cat/210
+   :category/code  "210"
+   :category/title "Clojure"
+   :category/parent :mf.cat/200
+   :category/order  210}
+
+  {:category/id    :mf.cat/220
+   :category/code  "220"
+   :category/title "Python"
+   :category/parent :mf.cat/200
+   :category/order  220}
+
+  ;; Infrastructure
+  {:category/id    :mf.cat/300
+   :category/code  "300"
+   :category/title "Infrastructure"
+   :category/parent nil
+   :category/order  300}
+
+  {:category/id    :mf.cat/310
+   :category/code  "310"
+   :category/title "Polylith"
+   :category/parent :mf.cat/300
+   :category/order  310}
+
+  {:category/id    :mf.cat/320
+   :category/code  "320"
+   :category/title "Kubernetes"
+   :category/parent :mf.cat/300
+   :category/order  320}
+
+  ;; Quality
+  {:category/id    :mf.cat/400
+   :category/code  "400"
+   :category/title "Testing"
+   :category/parent nil
+   :category/order  400}
+
+  ;; Process
+  {:category/id    :mf.cat/700
+   :category/code  "700"
+   :category/title "Process"
+   :category/parent nil
+   :category/order  700}
+
+  {:category/id    :mf.cat/710
+   :category/code  "710"
+   :category/title "Git Branch Management"
+   :category/parent :mf.cat/700
+   :category/order  710}
+
+  {:category/id    :mf.cat/715
+   :category/code  "715"
+   :category/title "Pre-commit Discipline"
+   :category/parent :mf.cat/700
+   :category/order  715}
+
+  {:category/id    :mf.cat/720
+   :category/code  "720"
+   :category/title "Pull Requests"
+   :category/parent :mf.cat/700
+   :category/order  720}
+
+  {:category/id    :mf.cat/721
+   :category/code  "721"
+   :category/title "PR Documentation"
+   :category/parent :mf.cat/720
+   :category/order  721}
+
+  {:category/id    :mf.cat/722
+   :category/code  "722"
+   :category/title "PR Layering"
+   :category/parent :mf.cat/720
+   :category/order  722}
+
+  {:category/id    :mf.cat/725
+   :category/code  "725"
+   :category/title "Git Worktrees"
+   :category/parent :mf.cat/700
+   :category/order  725}
+
+  {:category/id    :mf.cat/730
+   :category/code  "730"
+   :category/title "Versioning"
+   :category/parent :mf.cat/700
+   :category/order  730}
+
+  ;; Project Standards
+  {:category/id    :mf.cat/800
+   :category/code  "800"
+   :category/title "Project Standards"
+   :category/parent nil
+   :category/order  800}
+
+  {:category/id    :mf.cat/810
+   :category/code  "810"
+   :category/title "Copyright & Licensing"
+   :category/parent :mf.cat/800
+   :category/order  810}
+
+  ;; Meta
+  {:category/id    :mf.cat/900
+   :category/code  "900"
+   :category/title "Meta"
+   :category/parent nil
+   :category/order  900}]
+
+ ;; Stable aliases — allow rules to reference a logical name insulated from reorganisation
+ :taxonomy/aliases
+ [{:alias/id :mf.cat/licensing    :alias/of :mf.cat/810}
+  {:alias/id :mf.cat/versioning   :alias/of :mf.cat/730}
+  {:alias/id :mf.cat/map-access   :alias/of :mf.cat/210}]}
+```
+
+**Notes:**
+
+- `:category/code` carries the Dewey number as a display/ordering string. It is never used as a data key.
+- `:category/order` drives ascending rule application order within a file (most foundational first).
+- Aliases decouple rule category references from taxonomy reorganisation.
+
+---
+
+### 2. Policy Pack
+
+```edn
+{:pack/id           :miniforge/core
+ :pack/version      "1.0.0"
+ :pack/title        "Miniforge Core Policy Pack"
+ :pack/description  "Standard rules for miniforge-managed Clojure/Polylith repositories."
+
+ ;; Pack references the taxonomy it uses. min-version allows compatible upgrades
+ ;; without requiring every pack to pin exact taxonomy versions.
+ :pack/taxonomy-ref {:taxonomy/id          :miniforge/dewey
+                     :taxonomy/min-version "1.0.0"}
+
+ :pack/rules
+ [{:rule/id          :mf.rule/clojure-map-access
+   :rule/title       "Clojure Map Access Style"
+   :rule/categories  [:mf.cat/210]
+   :rule/severity    :warning
+   :rule/auto-fix?   true
+   :rule/description "Use (get m k default) over (or (:k m) default) for non-JSON maps."}
+
+  {:rule/id          :mf.rule/copyright-header
+   :rule/title       "Copyright Header"
+   :rule/categories  [:mf.cat/810]
+   :rule/severity    :error
+   :rule/auto-fix?   true
+   :rule/description "All source files must carry a valid copyright header."}
+
+  {:rule/id          :mf.rule/datever-format
+   :rule/title       "DateVer Version String"
+   :rule/categories  [:mf.cat/730]
+   :rule/severity    :error
+   :rule/auto-fix?   true
+   :rule/description "Version strings must follow DateVer X.Y.Z.N format."}
+
+  {:rule/id          :mf.rule/stratified-design
+   :rule/title       "Stratified Design"
+   :rule/categories  [:mf.cat/001]
+   :rule/severity    :error
+   :rule/auto-fix?   false
+   :rule/description "Code must be organised in layers with no upward dependencies."}
+
+  ;; ... remaining rules elided for brevity; full list in resources/packs/miniforge-core-1.0.0.edn
+  ]
+
+ ;; Convenience bundled mappings — these are standalone mapping artifacts packaged here
+ ;; for distribution. They can also be loaded independently.
+ :pack/bundled-mappings
+ [:miniforge-to-vanta/core-2026]}
+```
+
+**Rule schema fields:**
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `:rule/id` | yes | namespaced keyword | Globally unique; never changes after publication |
+| `:rule/title` | yes | string | Human-readable label for reports |
+| `:rule/categories` | yes | `[keyword ...]` | One or more taxonomy category IDs; plural from day one |
+| `:rule/severity` | yes | keyword | `:error :warning :info` |
+| `:rule/auto-fix?` | yes | boolean | Whether a mechanical fix can be applied without review |
+| `:rule/description` | yes | string | One-line description for tooling and reports |
+| `:rule/deprecated-by` | no | keyword | Rule ID that supersedes this rule |
+
+---
+
+### 3. Mapping Artifact
+
+```edn
+{:mapping/id      :miniforge-to-vanta/core-2026
+ :mapping/version "1.0.0"
+
+ :mapping/source
+ {:mapping/source-kind    :pack
+  :mapping/source-id      :miniforge/core
+  :mapping/source-version "1.0.0"}
+
+ :mapping/target
+ {:mapping/target-kind    :framework
+  :mapping/target-id      :vanta
+  :mapping/target-version "2026"}
+
+ :mapping/entries
+ [{:source/rule     :mf.rule/copyright-header
+   :target/control  "CC6.2"
+   :mapping/type    :exact
+   :mapping/notes   "Direct requirement: source files must be attributed."}
+
+  {:source/category :mf.cat/810
+   :target/control  "CC6.1"
+   :mapping/type    :broad
+   :mapping/notes   "Category-level mapping; individual rules may vary in coverage."}
+
+  {:source/rule     :mf.rule/clojure-map-access
+   :target/control  nil
+   :mapping/type    :none
+   :mapping/notes   "No corresponding Vanta control; internal code quality only."}]
+
+ :mapping/authorship
+ {:publisher  :miniforge
+  :confidence :high
+  :validated-at "2026-04-05"}}
+```
+
+**Mapping types:**
+
+| Type | Meaning |
+|---|---|
+| `:exact` | Source rule directly satisfies the target control |
+| `:broad` | Category-level coverage; individual rules may vary |
+| `:partial` | Source rule partially satisfies the target control |
+| `:none` | Explicitly documented as having no mapping |
+
+**Why provenance matters:** without `:mapping/type` and `:mapping/authorship`, bridge files become ungovernable as
+soon as there are community-contributed mappings of varying quality. Confidence and validation date allow the platform
+to warn when a mapping is unvalidated or stale relative to a framework version.
+
+---
+
+### 4. Overlay Pack
+
+```edn
+{:pack/id      :acme/internal-policy
+ :pack/version "1.0.0"
+ :pack/title   "ACME Internal Policy Extension"
+
+ ;; Inherit taxonomy ref and rule set from all extended packs.
+ ;; Overlay pack does not need to redeclare the taxonomy.
+ :pack/extends
+ [{:pack/id      :miniforge/core
+   :pack/version "1.0.0"}]
+
+ ;; Additional rules use the inherited taxonomy
+ :pack/rules
+ [{:rule/id          :acme.rule/internal-banner
+   :rule/title       "Internal Use Banner"
+   :rule/categories  [:mf.cat/810]
+   :rule/severity    :error
+   :rule/auto-fix?   false
+   :rule/description "Internal files must carry the ACME internal use notice."}]
+
+ ;; Severity and enable/disable overrides on inherited rules
+ :pack/overrides
+ [{:rule/id       :mf.rule/datever-format
+   :rule/severity :error}     ; promote from :warning
+
+  {:rule/id       :mf.rule/stratified-design
+   :rule/enabled? false}]}    ; disable for this org
+```
+
+**Overlay resolution rules:**
+
+1. Inherited rules are merged from all `:pack/extends` entries in declaration order.
+2. Overlay `:pack/rules` are appended; IDs must not collide with inherited rules.
+3. `:pack/overrides` apply last; only `:rule/severity` and `:rule/enabled?` may be overridden.
+4. Taxonomy ref is inherited from the base pack(s). An overlay declaring a different taxonomy is invalid.
+
+---
+
+## Runtime Model
+
+### Loading
+
+```
+load-taxonomy(miniforge/dewey@1.0.0)
+  → taxonomy index: { :mf.cat/210 → {:category/title "Clojure" :category/order 210} ... }
+
+load-pack(miniforge/core@1.0.0)
+  → resolve taxonomy ref → validate all :rule/categories exist in taxonomy
+  → rule index: { :mf.rule/copyright-header → {...} ... }
+
+load-pack(acme/internal-policy@1.0.0)
+  → resolve extends → merge inherited rules + local rules + apply overrides
+  → combined rule index
+```
+
+### Taxonomy Version Resolution
+
+When multiple packs are loaded simultaneously, the host taxonomy wins. Each pack declares
+`:taxonomy/min-version`; if the loaded taxonomy version satisfies all pack min-versions, loading
+proceeds. Incompatible version requirements are a load-time error, not a runtime one.
+
+This is the "host taxonomy wins" rule made explicit. It avoids the diamond problem: two packs
+requiring different taxonomy versions do not create a conflict unless the host taxonomy cannot
+satisfy both min-versions simultaneously.
+
+### Normalisation
+
+The compliance scanner normalises all findings to:
+
+```edn
+{:rule/id         :mf.rule/copyright-header   ; stable anchor
+ :rule/title      "Copyright Header"           ; from loaded pack (for display)
+ :rule/categories [:mf.cat/810]               ; from loaded pack
+ :rule/pack       :miniforge/core              ; provenance
+ :file            "components/foo/src/..."
+ :line            12
+ :current         "(missing copyright header)"
+ :suggested       "Copyright 2026 ..."
+ :auto-fix?       true
+ :rationale       "Copyright header absent; can be prepended"}
+```
+
+**Not in storage:** Dewey code strings, category labels, framework control IDs. Those are produced
+at render time by looking up the loaded taxonomy and any requested mapping artifacts.
+
+### Report Projection
+
+The report renderer resolves categories to display labels at render time:
+
+```
+:mf.cat/810 → taxonomy lookup → "Copyright & Licensing (810)"
+```
+
+With a mapping loaded:
+
+```
+:mf.rule/copyright-header → mapping lookup → "Vanta CC6.2"
+```
+
+Reports can be projected through any loaded mapping without changing stored findings.
+
+---
+
+## miniforge/core — the Canonical Pack
+
+`miniforge/core` is the default pack loaded by the compliance scanner. It is not special in schema
+terms, but it is the platform's canonical policy set. Third-party packs extend or map to it.
+
+The canonical taxonomy (`miniforge/dewey`) and the canonical pack (`miniforge/core`) are distributed
+as resources within the `policy-pack` component:
+
+```
+components/policy-pack/resources/
+  packs/
+    miniforge-core-1.0.0.edn
+  taxonomies/
+    miniforge-dewey-1.0.0.edn
+  mappings/
+    miniforge-to-vanta-core-2026-1.0.0.edn
+```
+
+---
+
+## M3 Component Work
+
+### 1. `policy-pack` component — taxonomy and pack loading
+
+Add to the existing `policy-pack` interface:
+
+- `load-taxonomy` — parse and index a taxonomy EDN file
+- `load-pack` — parse pack, resolve taxonomy ref, validate rule categories, merge overlays
+- `load-mapping` — parse and index a mapping artifact
+- `resolve-category` — look up `:category/title` and `:category/order` for a category ID
+- `resolve-mapping` — translate a rule ID or category ID to a target framework control
+
+Ship `miniforge-dewey-1.0.0.edn` and `miniforge-core-1.0.0.edn` as bundled resources.
+
+### 2. `compliance-scanner` — migrate to pack-loaded rule definitions
+
+Replace hardcoded Dewey strings in `scanner_registry.clj` with pack-loaded rule references.
+The scanner registry becomes a runtime index built from the loaded pack, not a compile-time map.
+
+Violation maps produced by the scanner carry `:rule/id` and `:rule/categories` (structured keywords),
+not `:rule/dewey` (a string). The plan phase sorts nodes by `:category/order` looked up from the
+taxonomy, not by parsing a Dewey string.
+
+### 3. Report renderer — taxonomy-driven display
+
+Replace inline Dewey string formatting with taxonomy lookups:
+
+- Section headers: `(format-category-header (resolve-category taxonomy :mf.cat/810))`
+  → `"Copyright & Licensing (810) —"`
+- PR titles: `fix: [810] Copyright Header compliance pass`
+- Mapping annotation (optional): append framework control ID when a mapping is loaded
+
+### 4. `policy-selector` — category and rule ID selectors
+
+Replace `"dewey.210"` string selectors with structured alternatives:
+
+| Selector | Meaning |
+|---|---|
+| `:always-apply` | All rules with default enabled |
+| `:all` | Every rule in every loaded pack |
+| `#{:mf.rule/copyright-header}` | Specific rules by ID |
+| `#{:mf.cat/810}` | All rules in a category |
+| `"mf.cat/8xx"` | Prefix wildcard over category codes |
+
+---
+
+## Relationship to N4 Policy Packs Standard
+
+This design extends `N4-policy-packs.md`. The existing gate execution contract, scanner protocol,
+and knowledge-safety sections are orthogonal and unchanged. N4 gains:
+
+- Taxonomy artifact schema (new Section 2.1)
+- Updated pack schema with `:pack/taxonomy-ref` and `:pack/extends`
+- Updated rule schema with `:rule/categories` (plural keyword vector) and `:rule/id` as keyword
+- Mapping artifact schema (new Section 2.x)
+- Overlay pack schema and resolution rules (new Section 2.x)
+
+See `specs/normative/N4-policy-packs.md` for the normative contract.
+
+---
+
+## Open Questions
+
+1. **Taxonomy evolution governance** — Who approves additions to `miniforge/dewey`? Initial answer:
+   miniforge team owns it; the taxonomy is an open published artifact and PRs are welcome. This is
+   the same model as OpenTelemetry semantic conventions.
+
+2. **Overlay taxonomy swap** — Can an overlay reference a completely different taxonomy? Initial
+   answer: no. An overlay must use the same taxonomy as its base packs. Multi-taxonomy composition
+   is deferred to a later design.
+
+3. **Fleet aggregate reporting** — When the scanner runs across multiple repos, do findings normalise
+   to the same rule IDs? Yes — rule IDs are pack-scoped, not repo-scoped. A fleet report groups
+   violations by `:rule/id` across all repos.
+
+4. **Pack registry** — Where do third-party packs live? Out of scope for M3. In-scope: local file
+   path and embedded resources. A registry (miniforge Hub or similar) is a later feature.

--- a/docs/design/quality-readiness.md
+++ b/docs/design/quality-readiness.md
@@ -1,4 +1,12 @@
-# Quality Readiness Assessment — Design
+---
+title: Quality Readiness Assessment Workflow
+description: Build a Miniforge workflow that evaluates a repository against a 9-domain quality-readiness rubric,
+produces evidence-backed domain scores, identifies blockers, and routes output to human review or remediation planning
+workflows.
+acceptance_criteria: Workflow scores all 9 domains with evidence citations, produces red/orange/yellow/green status per
+domain, detects hard blockers, routes to proceed/human-vet/plan-remediation/block, emits handoff artifacts
+tags: [quality, readiness, assessment, rubric, governance]
+---
 
 ## Spec Reference
 

--- a/specs/informative/miniforge_quality_readiness_workflow_spec_v2.md
+++ b/specs/informative/miniforge_quality_readiness_workflow_spec_v2.md
@@ -59,21 +59,21 @@ This workflow is not intended to:
 
 ## 3. Primary use cases
 
-## 3.1 Vibe-coded application assessment
+### 3.1 Vibe-coded application assessment
 
 Assess a newly created app with shallow documentation and uncertain test quality, then route gaps into planning or
 test-generation workflows.
 
-## 3.2 Repository release-readiness evaluation
+### 3.2 Repository release-readiness evaluation
 
 Assess a service or repo before broader release or production promotion.
 
-## 3.3 Miniforge workflow evaluation
+### 3.3 Miniforge workflow evaluation
 
 Score a workflow itself for observability, determinism, policy posture, testing, error handling, and operational
 readiness.
 
-## 3.4 Portfolio triage
+### 3.4 Portfolio triage
 
 Evaluate many repos or work items to determine where human review attention should be concentrated.
 
@@ -85,7 +85,7 @@ The workflow SHALL use **rubric-driven evaluation with decision routing**.
 
 It SHALL NOT use a pure binary decision tree as the core evaluation mechanism.
 
-## 4.1 Stages
+### 4.1 Stages
 
 1. Inventory
 2. Classification
@@ -99,7 +99,7 @@ It SHALL NOT use a pure binary decision tree as the core evaluation mechanism.
 
 ## 5. Workflow contract
 
-## 5.1 Inputs
+### 5.1 Inputs
 
 ```edn
 {:target/id string
@@ -130,7 +130,7 @@ It SHALL NOT use a pure binary decision tree as the core evaluation mechanism.
            :strict-blockers? boolean}}
 ```
 
-## 5.2 Input behavior
+### 5.2 Input behavior
 
 The workflow SHALL operate with partial inputs.
 
@@ -140,7 +140,7 @@ If evidence is sparse, it SHALL:
 - distinguish absence of evidence from explicit failure,
 - avoid over-claiming readiness.
 
-## 5.3 Outputs
+### 5.3 Outputs
 
 ```edn
 {:evaluation/id string
@@ -170,7 +170,7 @@ If evidence is sparse, it SHALL:
 
 ## 6. Domain model
 
-## 6.1 Default domains
+### 6.1 Default domains
 
 1. `:product-clarity`
 2. `:delivery-planning`
@@ -182,7 +182,7 @@ If evidence is sparse, it SHALL:
 8. `:quality-evidence`
 9. `:risk-and-governance`
 
-## 6.2 Domain shape
+### 6.2 Domain shape
 
 ```edn
 {:id keyword
@@ -199,7 +199,7 @@ If evidence is sparse, it SHALL:
  :recommended-actions [action]}
 ```
 
-## 6.3 Criterion shape
+### 6.3 Criterion shape
 
 ```edn
 {:id keyword
@@ -217,7 +217,7 @@ If evidence is sparse, it SHALL:
 
 ## 7. Scoring semantics
 
-## 7.1 Atomic criterion scale
+### 7.1 Atomic criterion scale
 
 - `0` = absent or directly contradicted
 - `1` = mentioned, implied, or weakly addressed
@@ -225,7 +225,7 @@ If evidence is sparse, it SHALL:
 - `3` = credibly implemented with reasonable evidence
 - `4` = strong implementation with explicit verification and/or automation
 
-## 7.2 Confidence
+### 7.2 Confidence
 
 Confidence SHALL be separate from score.
 
@@ -241,7 +241,7 @@ Interpretation:
 - `:medium` = mixed direct and indirect evidence
 - `:high` = direct and corroborated evidence
 
-## 7.3 Status mapping
+### 7.3 Status mapping
 
 - `:red` if domain score < 1.5
 - `:orange` if 1.5 <= score < 2.5
@@ -250,7 +250,7 @@ Interpretation:
 
 Implementations MAY include `:gray` when evidence is insufficient.
 
-## 7.4 Hard-blocker overrides
+### 7.4 Hard-blocker overrides
 
 The workflow SHALL support blocker rules that cap or force status.
 
@@ -268,7 +268,7 @@ Examples:
 
 The workflow SHALL distinguish among:
 
-## 8.1 Positive evidence
+### 8.1 Positive evidence
 
 Artifacts directly supporting readiness.
 Examples:
@@ -280,7 +280,7 @@ Examples:
 - threat models
 - migration plans
 
-## 8.2 Missing evidence
+### 8.2 Missing evidence
 
 Expected evidence that is absent.
 Examples:
@@ -289,7 +289,7 @@ Examples:
 - no load-test result
 - no feature-flag evidence
 
-## 8.3 Negative evidence
+### 8.3 Negative evidence
 
 Artifacts suggesting weakness.
 Examples:
@@ -299,7 +299,7 @@ Examples:
 - flaky tests without mitigation
 - broad permissions by default
 
-## 8.4 Contradictory evidence
+### 8.4 Contradictory evidence
 
 Claims undermined by artifacts.
 Examples:
@@ -314,7 +314,7 @@ Examples:
 
 The workflow SHALL support profile-based weighting and criterion activation.
 
-## 9.1 Default profiles
+### 9.1 Default profiles
 
 - `:internal-vibe-app`
 - `:customer-facing-saas`
@@ -323,7 +323,7 @@ The workflow SHALL support profile-based weighting and criterion activation.
 - `:platform-or-infra`
 - `:miniforge-workflow`
 
-## 9.2 Profile behavior
+### 9.2 Profile behavior
 
 Each profile SHALL define:
 
@@ -333,7 +333,7 @@ Each profile SHALL define:
 - optional criteria,
 - routing recommendations.
 
-## 9.3 Example weighting
+### 9.3 Example weighting
 
 ```edn
 {:profile :miniforge-workflow
@@ -354,7 +354,7 @@ Each profile SHALL define:
 
 The workflow SHALL attempt to discover and normalize, where present:
 
-## 10.1 Repo and implementation inventory
+### 10.1 Repo and implementation inventory
 
 - languages/frameworks
 - package/build files
@@ -363,7 +363,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - UI surface presence
 - jobs/workflows/pipelines
 
-## 10.2 Delivery artifacts
+### 10.2 Delivery artifacts
 
 - CI/CD configs
 - test suites and reports
@@ -373,7 +373,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - infra definitions
 - migrations
 
-## 10.3 Operational signals
+### 10.3 Operational signals
 
 - logging hooks
 - metrics/traces
@@ -382,7 +382,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - backup/recovery mechanisms
 - runbooks
 
-## 10.4 Security/trust signals
+### 10.4 Security/trust signals
 
 - secret handling
 - dependency/security scanning config
@@ -390,7 +390,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - authn/authz signals
 - audit/event logging
 
-## 10.5 Planning/intent artifacts
+### 10.5 Planning/intent artifacts
 
 - specs
 - ADRs
@@ -403,7 +403,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 
 ## 11. Domain criteria (default)
 
-## 11.1 `:product-clarity`
+### 11.1 `:product-clarity`
 
 - purpose stated
 - intended users identified
@@ -411,7 +411,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - scope/non-goals articulated
 - expected outcomes stated
 
-## 11.2 `:delivery-planning`
+### 11.2 `:delivery-planning`
 
 - owner/team identified
 - dependencies identified
@@ -419,7 +419,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - status/reporting expectations defined where needed
 - rollout or milestone sequence exists
 
-## 11.3 `:implementation-surface`
+### 11.3 `:implementation-surface`
 
 - impacted services/components identified
 - configs/manifests/runtime modes understood
@@ -427,7 +427,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - migration/upgrade surface understood
 - compatibility assumptions visible
 
-## 11.4 `:test-strategy`
+### 11.4 `:test-strategy`
 
 - relevant test layers exist
 - major scenarios identified
@@ -435,7 +435,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - smoke/CIT/BVT equivalents exist where appropriate
 - environment/setup requirements are explicit
 
-## 11.5 `:operational-readiness`
+### 11.5 `:operational-readiness`
 
 - deployment path exists
 - rollback/disable strategy exists
@@ -443,7 +443,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - recovery/operability considerations exist
 - performance/scalability considered where required
 
-## 11.6 `:security-and-privacy`
+### 11.6 `:security-and-privacy`
 
 - sensitive boundaries identified
 - security strategy or review exists
@@ -451,7 +451,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - secrets handled correctly
 - abuse/error paths considered
 
-## 11.7 `:user-and-customer-readiness`
+### 11.7 `:user-and-customer-readiness`
 
 - UI testing/manual review exists if UI present
 - accessibility considered if relevant
@@ -459,7 +459,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - beta/feedback loop exists if relevant
 - customer-facing behavior is documented
 
-## 11.8 `:quality-evidence`
+### 11.8 `:quality-evidence`
 
 - coverage evidence exists where relevant
 - performance/profiling evidence exists where relevant
@@ -467,7 +467,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 - scenario/stress evidence exists where needed
 - reliability evidence available
 
-## 11.9 `:risk-and-governance`
+### 11.9 `:risk-and-governance`
 
 - risks identified
 - mitigations documented
@@ -481,7 +481,7 @@ The workflow SHALL attempt to discover and normalize, where present:
 
 The workflow SHALL support decision routing after scoring.
 
-## 12.1 Default routing states
+### 12.1 Default routing states
 
 - `:proceed`
 - `:proceed-with-conditions`
@@ -489,7 +489,7 @@ The workflow SHALL support decision routing after scoring.
 - `:plan-remediation`
 - `:block`
 
-## 12.2 Example routing rules
+### 12.2 Example routing rules
 
 - If overall is `:red`, route to `:block` and recommend remediation.
 - If overall is `:orange` with medium/high confidence, route to `:plan-remediation`.
@@ -502,7 +502,7 @@ The workflow SHALL support decision routing after scoring.
 
 ## 13. Handoff contracts
 
-## 13.1 Remediation planning handoff
+### 13.1 Remediation planning handoff
 
 ```edn
 {:handoff/type :quality-remediation
@@ -514,7 +514,7 @@ The workflow SHALL support decision routing after scoring.
                :definition-of-done [string]}]}
 ```
 
-## 13.2 Human review handoff
+### 13.2 Human review handoff
 
 The workflow SHALL emit a compact review packet containing:
 
@@ -524,7 +524,7 @@ The workflow SHALL emit a compact review packet containing:
 - low-confidence domains,
 - recommended reviewer questions.
 
-## 13.3 Test-generation handoff
+### 13.3 Test-generation handoff
 
 Where gaps are test-related, the workflow SHOULD emit candidate scenario and test targets.
 
@@ -534,19 +534,19 @@ Where gaps are test-related, the workflow SHOULD emit candidate scenario and tes
 
 This capability SHOULD be implemented as cooperating workflows.
 
-## 14.1 `quality-readiness-inventory`
+### 14.1 `quality-readiness-inventory`
 
 Produces normalized evidence graph and target classification.
 
-## 14.2 `quality-readiness-score`
+### 14.2 `quality-readiness-score`
 
 Applies rubric, weights, blockers, and domain synthesis.
 
-## 14.3 `quality-remediation-plan`
+### 14.3 `quality-remediation-plan`
 
 Converts deficits into backlog/spec/test/doc work.
 
-## 14.4 `quality-vetting-gate`
+### 14.4 `quality-vetting-gate`
 
 Determines automated progression vs human review.
 

--- a/specs/normative/N4-policy-packs.md
+++ b/specs/normative/N4-policy-packs.md
@@ -1,7 +1,7 @@
 # N4 — Policy Packs & Gates Standard
 
-**Version:** 0.5.0-draft
-**Date:** 2026-03-08
+**Version:** 0.6.0-draft
+**Date:** 2026-04-05
 **Status:** Draft
 **Conformance:** MUST
 
@@ -12,7 +12,10 @@
 This specification defines the **policy pack** and **gate validation** contracts for miniforge
 autonomous software factory. It establishes:
 
-- **Policy pack structure** - Format, versioning, signature requirements
+- **Taxonomy artifact** - Independently versioned category tree (new in 0.6)
+- **Policy pack structure** - Format, versioning, taxonomy reference, overlay/extends
+- **Mapping artifact** - First-class bridge between policy systems (new in 0.6)
+- **Overlay pack** - Extension model for packs without forking (new in 0.6)
 - **Gate execution contract** - Check and repair function interfaces
 - **Semantic intent validation** - Rules for intent vs. behavior matching
 - **Violation schema** - Severity levels, remediation, enforcement actions
@@ -21,72 +24,220 @@ autonomous software factory. It establishes:
 Policy packs enable **policy-as-code** enforcement at workflow gates, preventing intent violations and dangerous
 changes.
 
+For the full design rationale behind the four-artifact model, see
+`docs/design/policy-pack-taxonomy.md`.
+
 ### 1.1 Design Principles
 
 1. **Declarative** - Policies define "what" to check, not "how" to check it
-2. **Composable** - Multiple policy packs can be combined
-3. **Versioned** - Policy packs have semantic versions for compatibility
+2. **Composable** - Multiple policy packs can be combined via overlays and mappings
+3. **Versioned** - Taxonomy, packs, and mappings are independently versioned
 4. **Repairable** - Violations should provide actionable remediation guidance
 5. **Observable** - All policy checks emit events and store results in evidence (see N3, N6)
+6. **Rule IDs are the durable anchor** - Rule IDs are stable, namespace-qualified keywords;
+   categories are classification metadata that can evolve independently
+
+### 1.2 Canonical Taxonomy
+
+miniforge ships a canonical taxonomy (`miniforge/dewey`) and a canonical pack (`miniforge/core`).
+The platform normalises findings against this taxonomy by default. This is an explicit design
+decision, not an implementation detail. Third-party packs extend or map to it.
 
 ---
 
 ## 2. Policy Pack Structure
 
-### 2.1 Policy Pack Schema
+### 2.1 Taxonomy Artifact
+
+A taxonomy is an independently versioned category tree. Packs reference taxonomies by ID and
+minimum version. Taxonomy and ruleset have different change velocities and MUST be versioned
+separately.
 
 ```clojure
-{:policy-pack/id string            ; REQUIRED: Unique identifier (e.g., "terraform-aws")
- :policy-pack/version string       ; REQUIRED: Semantic version (e.g., "1.2.3")
- :policy-pack/name string          ; REQUIRED: Human-readable name
+{:taxonomy/id         keyword           ; REQUIRED: e.g. :miniforge/dewey
+ :taxonomy/version    string            ; REQUIRED: SemVer e.g. "1.0.0"
+ :taxonomy/title      string            ; REQUIRED: Human-readable name
 
- :policy-pack/description string   ; OPTIONAL: What this pack validates
- :policy-pack/author string        ; OPTIONAL: Pack author/maintainer
- :policy-pack/license string       ; OPTIONAL: License (e.g., "Apache-2.0")
+ :taxonomy/categories                   ; REQUIRED: Category definitions
+ [{:category/id    keyword              ; REQUIRED: Stable namespaced keyword
+   :category/code  string              ; REQUIRED: Display code (e.g. "210")
+   :category/title string              ; REQUIRED: Human-readable label
+   :category/parent keyword            ; OPTIONAL: Parent category ID (nil = root)
+   :category/order  int}               ; REQUIRED: Sort order for rule application
+  ...]
 
- :policy-pack/rules [...]          ; REQUIRED: Validation rules (see Section 2.2)
- :policy-pack/scanners [...]       ; OPTIONAL: Custom scanners (see Section 2.3)
-
- :policy-pack/metadata
- {:tags [string ...]               ; OPTIONAL: Tags for discovery
-  :target-types [keyword ...]      ; OPTIONAL: Applicable workflow types
-  :created-at inst
-  :updated-at inst}
-
- :policy-pack/signature string}    ; OPTIONAL: Cryptographic signature for verification
+ :taxonomy/aliases                      ; OPTIONAL: Logical name → category ID
+ [{:alias/id keyword
+   :alias/of keyword}
+  ...]}
 ```
 
-### 2.2 Policy Rule Schema
+The canonical miniforge taxonomy is distributed at
+`components/policy-pack/resources/taxonomies/miniforge-dewey-1.0.0.edn`.
+
+### 2.2 Policy Pack Schema
 
 ```clojure
-{:rule/id string                   ; REQUIRED: Unique rule identifier
- :rule/name string                 ; REQUIRED: Human-readable name
- :rule/description string          ; REQUIRED: What this rule checks
+{:pack/id           keyword            ; REQUIRED: Namespaced e.g. :miniforge/core
+ :pack/version      string             ; REQUIRED: SemVer e.g. "1.0.0"
+ :pack/title        string             ; REQUIRED: Human-readable name
 
- :rule/severity keyword            ; REQUIRED: :critical, :high, :medium, :low, :info
- :rule/enabled? boolean            ; REQUIRED: Is rule active? (default true)
+ :pack/description  string             ; OPTIONAL: What this pack validates
+ :pack/author       string             ; OPTIONAL: Pack author/maintainer
+ :pack/license      string             ; OPTIONAL: License (e.g. "Apache-2.0")
 
- :rule/check-fn function           ; REQUIRED: Validation function (see Section 3.1)
- :rule/repair-fn function          ; OPTIONAL: Auto-repair function (see Section 3.2)
+ ;; Taxonomy reference — pack declares which taxonomy its rule categories belong to.
+ ;; min-version allows compatible taxonomy upgrades without requiring pack rev.
+ :pack/taxonomy-ref                    ; REQUIRED for packs with rules
+ {:taxonomy/id          keyword
+  :taxonomy/min-version string}
 
- :rule/applies-to [keyword ...]    ; OPTIONAL: Artifact types this rule checks
- :rule/phase keyword               ; OPTIONAL: Which phase to run this rule (:implement, :review, etc.)
+ ;; Overlay — inherit rules + taxonomy ref from base packs; add/override on top.
+ ;; Pack MUST NOT declare both :pack/extends and conflicting :pack/taxonomy-ref.
+ :pack/extends                         ; OPTIONAL
+ [{:pack/id      keyword
+   :pack/version string}
+  ...]
 
- :rule/remediation-template string ; REQUIRED: Template for remediation message
- :rule/documentation-url string}   ; OPTIONAL: Link to detailed docs
+ :pack/rules       [...]               ; REQUIRED: Validation rules (see Section 2.3)
+ :pack/overrides   [...]               ; OPTIONAL: Severity/enable overrides on inherited rules
+ :pack/scanners    [...]               ; OPTIONAL: Custom scanners (see Section 2.5)
+
+ ;; Convenience bundled mapping artifacts. These are standalone mapping artifacts
+ ;; distributed with the pack. They can also be loaded independently.
+ :pack/bundled-mappings [keyword ...]  ; OPTIONAL: Mapping artifact IDs
+
+ :pack/metadata
+ {:tags         [string ...]           ; OPTIONAL: Tags for discovery
+  :target-types [keyword ...]          ; OPTIONAL: Applicable workflow types
+  :created-at   inst
+  :updated-at   inst}
+
+ :pack/signature string}               ; OPTIONAL: Cryptographic signature
 ```
 
-#### 2.2.1 Rule Severity Levels
+### 2.3 Policy Rule Schema
 
-| Severity    | Meaning                                     | Enforcement                       |
-| ----------- | ------------------------------------------- | --------------------------------- |
-| `:critical` | Blocks deployment, requires human override  | MUST block phase completion       |
-| `:high`     | Strongly discouraged, auto-repair or review | SHOULD block unless auto-repaired |
-| `:medium`   | Warning, may auto-repair                    | MAY proceed with warning          |
-| `:low`      | Informational, suggests improvement         | MAY proceed                       |
-| `:info`     | Informational only, no action needed        | MUST NOT block                    |
+```clojure
+{:rule/id           keyword            ; REQUIRED: Namespaced e.g. :mf.rule/copyright-header
+                                       ;   Globally unique. Immutable after publication.
+ :rule/title        string             ; REQUIRED: Human-readable label for reports
+ :rule/description  string             ; REQUIRED: What this rule checks
 
-### 2.3 Scanner Protocol
+ :rule/categories   [keyword ...]      ; REQUIRED: One or more taxonomy category IDs (plural)
+                                       ;   A rule may belong to multiple categories.
+ :rule/severity     keyword            ; REQUIRED: :error, :warning, :info
+ :rule/enabled?     boolean            ; OPTIONAL: Default true
+ :rule/auto-fix?    boolean            ; REQUIRED: Whether mechanical fix is safe without review
+
+ :rule/check-fn     function           ; REQUIRED: Validation function (see Section 3.1)
+ :rule/repair-fn    function           ; OPTIONAL: Auto-repair function (see Section 3.2)
+
+ :rule/applies-to   [keyword ...]      ; OPTIONAL: Artifact types this rule checks
+ :rule/phase        keyword            ; OPTIONAL: Which phase to run (:implement, :review, etc.)
+
+ :rule/remediation-template string     ; REQUIRED: Template for remediation message
+ :rule/documentation-url    string     ; OPTIONAL: Link to detailed docs
+
+ :rule/deprecated-by keyword}          ; OPTIONAL: Rule ID that supersedes this rule
+```
+
+**Rule ID convention:** `:<pack-ns>.rule/<rule-name>` — e.g. `:mf.rule/copyright-header`,
+`:acme.rule/internal-banner`. Rule IDs are keywords, never strings.
+
+**Categories are plural from day one.** Use `:rule/categories [...]` even when a rule currently
+belongs to a single category. This prevents a schema migration when multi-category rules arise.
+
+#### 2.3.1 Rule Severity Levels
+
+| Severity   | Meaning                                      | Enforcement                       |
+|------------|----------------------------------------------|-----------------------------------|
+| `:error`   | Blocks phase; requires fix or human override | MUST block phase completion       |
+| `:warning` | Strongly discouraged; auto-repair or review  | SHOULD block unless auto-repaired |
+| `:info`    | Informational; no action required            | MUST NOT block                    |
+
+### 2.4 Mapping Artifact
+
+A mapping artifact bridges one policy system to another. It is a first-class standalone artifact —
+neither the source nor the target owns it. A pack may bundle convenience mappings, but mappings
+MUST be loadable independently of any pack.
+
+```clojure
+{:mapping/id      keyword            ; REQUIRED: Namespaced e.g. :miniforge-to-vanta/core-2026
+ :mapping/version string             ; REQUIRED: SemVer
+
+ :mapping/source
+ {:mapping/source-kind    keyword    ; :pack | :taxonomy | :framework
+  :mapping/source-id      keyword
+  :mapping/source-version string}
+
+ :mapping/target
+ {:mapping/target-kind    keyword    ; :pack | :taxonomy | :framework
+  :mapping/target-id      keyword
+  :mapping/target-version string}
+
+ :mapping/entries
+ [{;; Source side: reference by rule ID or category ID (not both)
+   :source/rule     keyword          ; OPTIONAL: specific rule ID
+   :source/category keyword          ; OPTIONAL: category ID (category-level mapping)
+
+   ;; Target side
+   :target/control  string           ; OPTIONAL: target framework control ID (nil = no mapping)
+
+   ;; Mapping quality metadata
+   :mapping/type    keyword          ; REQUIRED: :exact | :broad | :partial | :none
+   :mapping/notes   string}          ; OPTIONAL: rationale / caveats
+  ...]
+
+ :mapping/authorship
+ {:publisher    keyword              ; Who authored this mapping
+  :confidence   keyword              ; :high | :medium | :low | :unvalidated
+  :validated-at string}}             ; ISO date when last validated against target version
+```
+
+**Mapping types:**
+
+| Type | Meaning |
+|---|---|
+| `:exact` | Source rule directly and completely satisfies the target control |
+| `:broad` | Category-level coverage; individual rules may vary |
+| `:partial` | Source rule partially satisfies the target control |
+| `:none` | Explicitly documented as having no mapping (absence of entry ≠ no mapping) |
+
+### 2.5 Overlay Pack
+
+An overlay pack extends one or more base packs. It inherits the base taxonomy reference and rule
+set, adding new rules and/or overriding severity and enable/disable settings.
+
+```clojure
+{:pack/id      keyword              ; REQUIRED: Namespaced e.g. :acme/internal-policy
+ :pack/version string               ; REQUIRED
+
+ :pack/extends                      ; REQUIRED for overlay packs
+ [{:pack/id      keyword
+   :pack/version string}
+  ...]
+
+ ;; New rules — IDs must not collide with any inherited rule
+ :pack/rules    [...]
+
+ ;; Overrides on inherited rules — only :rule/severity and :rule/enabled? may be overridden
+ :pack/overrides
+ [{:rule/id      keyword            ; REQUIRED: must exist in inherited rule set
+   :rule/severity  keyword          ; OPTIONAL: override severity
+   :rule/enabled?  boolean}         ; OPTIONAL: enable or disable
+  ...]}
+```
+
+**Overlay resolution rules (MUST):**
+
+1. Inherited rules are merged from all `:pack/extends` entries in declaration order.
+2. Overlay `:pack/rules` are appended. Rule IDs MUST NOT collide with inherited rules.
+3. `:pack/overrides` apply last; only `:rule/severity` and `:rule/enabled?` are overridable.
+4. Taxonomy ref is inherited from the base pack(s). An overlay that declares a conflicting
+   `:pack/taxonomy-ref` is invalid.
+
+### 2.6 Scanner Protocol
 
 **Scanners** are reusable components that analyze artifacts and extract structured data for rules to check.
 
@@ -97,7 +248,7 @@ changes.
      Returns {:findings [...] :metadata {...}}"))
 ```
 
-#### 2.3.1 Example Scanner
+#### 2.6.1 Example Scanner
 
 ```clojure
 ;; Terraform Plan Scanner
@@ -127,20 +278,20 @@ changes.
       :total-destroys 0}}))
 ```
 
-### 2.4 Knowledge Safety and Pack Validation (Reference)
+### 2.7 Knowledge Safety and Pack Validation (Reference)
 
 miniforge MUST support deterministic policy packs that protect the system from prompt-injection
 and untrusted input escalation during ingestion and execution.
 
 A reference policy pack named `knowledge-safety` SHOULD be provided.
 
-#### 2.4.1 Threat Model
+#### 2.7.1 Threat Model
 
 Untrusted repository content (markdown, issues, wikis, etc.) may contain instructions that
 attempt to override agent behavior. The platform MUST treat such content as *data* unless it
 is normalized into schema-valid packs and promoted to `:trusted` under policy.
 
-#### 2.4.2 Reference Rules (knowledge-safety)
+#### 2.7.2 Reference Rules (knowledge-safety)
 
 The `knowledge-safety` pack SHOULD include rules such as:
 
@@ -172,7 +323,7 @@ The `knowledge-safety` pack SHOULD include rules such as:
     - Version conflict: pack A requires pack C v1.x, pack B requires pack C v2.x
     - Trust violation: pack A (:untrusted) requires pack B (:trusted, :authority/instruction)
 
-#### 2.4.3 Deterministic Prompt Injection Tripwire Scanner
+#### 2.7.3 Deterministic Prompt Injection Tripwire Scanner
 
 The platform SHOULD ship a deterministic scanner that emits findings on suspicious
 directives, including (non-exhaustive):
@@ -847,7 +998,8 @@ This pack is RECOMMENDED for production environments.
 
 #### 5.1.11 Data Foundry Quality Packs
 
-**Purpose:** Register Data Foundry data quality policy packs as standard packs in the Core registry. These packs extend the Core N4 gate model with data-specific quality validation. See Data Foundry N4 for full specifications.
+**Purpose:** Register Data Foundry data quality policy packs as standard packs in the Core registry. These packs extend
+  the Core N4 gate model with data-specific quality validation. See Data Foundry N4 for full specifications.
 
 **financial-statement-validation** (severity: critical)
 **ID:** `financial-statement-validation`


### PR DESCRIPTION
## Summary

- Externalises the miniforge Dewey-derived taxonomy as a first-class published artifact (`miniforge/dewey`)
- Establishes the four-artifact model: **taxonomy** + **policy pack** + **mapping artifact** + **overlay pack**
- Aligns N4 and the compliance-scanner design doc to use structured rule IDs and category IDs instead of raw Dewey strings

## Files

**New:**
- `docs/design/policy-pack-taxonomy.md` — M3 design doc: full artifact schemas, runtime model, four explicit design decisions, component work breakdown

**Updated:**
- `specs/normative/N4-policy-packs.md` v0.5 → v0.6: taxonomy artifact schema, updated pack/rule schemas (`:pack/taxonomy-ref`, `:pack/extends`, `:rule/id` as keyword, `:rule/categories` plural), mapping artifact schema, overlay pack with resolution rules
- `docs/design/compliance-scanner.md`: violation schema uses `:rule/id` + `:rule/categories` (replaces `:rule/dewey` strings), policy-selector uses category/rule ID forms, auto-fixability table includes rule IDs, category-order-based sort replaces Dewey string sort

## Key decisions documented

1. miniforge taxonomy is explicitly the platform canonical taxonomy (not pretending it's "just another pack")
2. Rule IDs (namespaced keywords) are the durable anchor — categories are classification metadata
3. Normalise to rule IDs + category IDs in storage; labels and codes are render-time lookups
4. Mapping artifacts are standalone first-class; packs may bundle them as convenience

## Test plan

- [ ] Design doc review — artifact schemas cover all four artifacts with correct field types
- [ ] N4 section numbering is consistent (2.1–2.7)
- [ ] compliance-scanner.md violation schema example uses `:rule/id` keyword form
- [ ] No raw Dewey strings remain as data keys in updated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)