### PR TITLE
fix: run-cmd dispatches markdown specs without EDN pre-read

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
@@ -47,11 +47,42 @@
   [path]
   (edn/read-string (slurp (str path))))
 
+(defn markdown-spec?
+  "True if path has a markdown extension."
+  [path]
+  (contains? #{"md" "markdown"} (fs/extension (str path))))
+
 ;------------------------------------------------------------------------------ Layer 1
+;; Shared workflow execution path
+
+(defn- run-spec-workflow
+  "Parse, validate, and execute a workflow spec from path.
+   Used by both the markdown and EDN code paths."
+  [spec-path opts]
+  (display/print-info (messages/t :run/parsing-spec {:path spec-path}))
+  (let [parsed-spec (spec-parser/parse-spec-file spec-path)
+        validation  (spec-parser/validate-spec parsed-spec)]
+    (if-not (:valid? validation)
+      (do
+        (display/print-error (messages/t :run/invalid-spec))
+        (doseq [error (:errors validation)]
+          (println (messages/t :run/validation-error {:error error}))))
+      (do
+        (display/print-info (messages/t :run/running-workflow {:title (:spec/title parsed-spec)}))
+        (workflow-runner/run-workflow-from-spec!
+         parsed-spec
+         (cond-> {:output :pretty :quiet false}
+           (:backend opts) (assoc :backend (:backend opts))))))))
+
+;------------------------------------------------------------------------------ Layer 2
 ;; Run command
 
 (defn run-cmd
-  "Execute a workflow from a spec, plan, or DAG file."
+  "Execute a workflow from a spec, plan, or DAG file.
+
+   Dispatch order:
+   1. Markdown files (.md/.markdown) → spec-parser directly (no EDN pre-read)
+   2. EDN/JSON files → read and detect type (:spec, :dag, :plan)"
   [opts]
   (let [{:keys [spec interactive]} opts
         resume-id (:resume opts)]
@@ -76,29 +107,24 @@
       (not (fs/exists? spec))
       (display/print-error (messages/t :run/file-not-found {:path spec}))
 
-      ;; Dispatch based on file content
+      ;; Markdown spec — route directly through spec-parser (no EDN pre-read)
+      (markdown-spec? spec)
+      (try
+        (run-spec-workflow spec opts)
+        (catch Exception e
+          (display/print-error (messages/t :run/failed {:error (ex-message e)}))
+          (when-let [data (ex-data e)]
+            (println (messages/t :run/error-details {:details (pr-str data)})))))
+
+      ;; EDN/JSON — dispatch based on file content
       :else
       (try
-        (let [parsed (read-edn-file spec)
+        (let [parsed     (read-edn-file spec)
               input-type (detect-input-type parsed)]
           (case input-type
-            ;; Spec file — existing workflow path
+            ;; Spec file
             :spec
-            (do
-              (display/print-info (messages/t :run/parsing-spec {:path spec}))
-              (let [parsed-spec (spec-parser/parse-spec-file spec)
-                    validation (spec-parser/validate-spec parsed-spec)]
-                (if-not (:valid? validation)
-                  (do
-                    (display/print-error (messages/t :run/invalid-spec))
-                    (doseq [error (:errors validation)]
-                      (println (messages/t :run/validation-error {:error error}))))
-                  (do
-                    (display/print-info (messages/t :run/running-workflow {:title (:spec/title parsed-spec)}))
-                    (workflow-runner/run-workflow-from-spec!
-                     parsed-spec
-                     (cond-> {:output :pretty :quiet false}
-                       (:backend opts) (assoc :backend (:backend opts))))))))
+            (run-spec-workflow spec opts)
 
             ;; DAG or Plan file — execute directly
             (:dag :plan)
@@ -111,10 +137,10 @@
              (messages/t :run/unrecognized-format {:path spec}))))
         (catch Exception e
           (let [error-classification (try
-                                      (let [classifier (requiring-resolve 'ai.miniforge.agent-runtime.interface/classify-error)]
-                                        (when classifier
-                                          (classifier e (ex-data e))))
-                                      (catch Exception _ nil))]
+                                       (let [classifier (requiring-resolve 'ai.miniforge.agent-runtime.interface/classify-error)]
+                                         (when classifier
+                                           (classifier e (ex-data e))))
+                                       (catch Exception _ nil))]
             (if error-classification
               (display/print-classified-error error-classification)
               (do

--- a/bases/cli/test/ai/miniforge/cli/main/commands/run_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/run_test.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.main.commands.run-test
+  "Tests for the run command — input type detection and markdown dispatch."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.cli.main.commands.run :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0: Input type detection
+
+(deftest detect-input-type-test
+  (testing "spec map detected by :spec/title"
+    (is (= :spec (sut/detect-input-type {:spec/title "T" :spec/description "D"}))))
+
+  (testing "dag map detected by :dag-id"
+    (is (= :dag (sut/detect-input-type {:dag-id "abc" :tasks []}))))
+
+  (testing "plan map detected by :plan/id"
+    (is (= :plan (sut/detect-input-type {:plan/id "p1"}))))
+
+  (testing "unrecognized map returns nil"
+    (is (nil? (sut/detect-input-type {:some/key "value"}))))
+
+  (testing "empty map returns nil"
+    (is (nil? (sut/detect-input-type {})))))
+
+(deftest markdown-spec?-test
+  (testing ".md extension is markdown"
+    (is (true? (sut/markdown-spec? "docs/design/compliance-scanner.md"))))
+
+  (testing ".markdown extension is markdown"
+    (is (true? (sut/markdown-spec? "specs/my-spec.markdown"))))
+
+  (testing ".edn extension is not markdown"
+    (is (false? (sut/markdown-spec? "specs/my-spec.edn"))))
+
+  (testing ".json extension is not markdown"
+    (is (false? (sut/markdown-spec? "specs/my-spec.json"))))
+
+  (testing ".yaml extension is not markdown"
+    (is (false? (sut/markdown-spec? "specs/my-spec.yaml"))))
+
+  (testing "path with no extension is not markdown"
+    (is (false? (sut/markdown-spec? "Makefile")))))


### PR DESCRIPTION
## Summary

- `.md`/`.markdown` files were hitting `read-edn-file` before reaching `spec-parser`, causing an EDN parse exception instead of parsing the markdown spec
- `run-cmd` now checks file extension first and routes markdown directly through `spec-parser/parse-spec-file`
- Extracts `run-spec-workflow` as a named function shared by both the markdown and EDN `:spec` paths
- Adds unit tests for `detect-input-type` and `markdown-spec?`

## What this unblocks

```bash
bb miniforge run docs/design/compliance-scanner.md
```

The compliance scanner design doc (and any other plain markdown spec) can now be fed directly to the workflow engine for planning and execution.

## Test plan

- [ ] `detect-input-type` tests: `:spec`, `:dag`, `:plan`, nil cases
- [ ] `markdown-spec?` tests: `.md`, `.markdown`, `.edn`, `.json`, `.yaml`, no-extension
- [ ] Manual: `bb miniforge run docs/design/compliance-scanner.md` reaches workflow runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)