### PR TITLE
fix: runtime classpath, nil-safety, and workflow type coercion for dogfood run

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -443,6 +443,7 @@
                  "components/dag-executor/resources"
                  "components/task-executor/src"
                  "components/pr-lifecycle/src"
+                "components/pr-lifecycle/resources"
                  "components/release-executor/src"
                  "components/evidence-bundle/src"
                  "components/evidence-bundle/resources"

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_config.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_config.clj
@@ -40,11 +40,10 @@
 
 (defn- load-monitor-config
   []
-  (->> "config/pr-monitor/defaults.edn"
-       io/resource
-       slurp
-       edn/read-string
-       (validate! MonitorConfig)))
+  (if-let [res (io/resource "config/pr-monitor/defaults.edn")]
+    (->> res slurp edn/read-string (validate! MonitorConfig))
+    (throw (ex-info "Missing classpath resource: config/pr-monitor/defaults.edn"
+                    {:hint "Add components/pr-lifecycle/resources to your classpath"}))))
 
 (def ^:private monitor-config
   (delay (load-monitor-config)))

--- a/components/spec-parser/src/ai/miniforge/spec_parser/core.clj
+++ b/components/spec-parser/src/ai/miniforge/spec_parser/core.clj
@@ -204,7 +204,7 @@
            :spec/intent           (or intent {:type :general})
            :spec/constraints      (or constraints [])
            :spec/tags             (or tags [])
-           :spec/workflow-type    (or type :full-sdlc)
+           :spec/workflow-type    (or (some-> type keyword) :canonical-sdlc-v1)
            :spec/workflow-version (or version "latest")
            :spec/raw-data         spec}
     acceptance-criteria (assoc :spec/acceptance-criteria acceptance-criteria)

--- a/components/spec-parser/test/ai/miniforge/spec_parser/interface_test.clj
+++ b/components/spec-parser/test/ai/miniforge/spec_parser/interface_test.clj
@@ -260,9 +260,9 @@
       (is (= "Only frontmatter" (:spec/description result))))))
 
 (deftest normalize-workflow-type-default-test
-  (testing "workflow-type defaults to :full-sdlc when not provided"
+  (testing "workflow-type defaults to :canonical-sdlc-v1 when not provided"
     (let [result (spec-parser/normalize-spec {:spec/title "T" :spec/description "D"})]
-      (is (= :full-sdlc (:spec/workflow-type result)))))
+      (is (= :canonical-sdlc-v1 (:spec/workflow-type result)))))
 
   (testing "workflow-type from :workflow/type key is used when provided"
     (let [result (spec-parser/normalize-spec
@@ -281,7 +281,7 @@
           normalized (spec-parser/normalize-spec parsed)
           validation (spec-parser/validate-spec normalized)]
       (is (= "Compliance Scanner" (:spec/title normalized)))
-      (is (= :full-sdlc (:spec/workflow-type normalized)))
+      (is (= :canonical-sdlc-v1 (:spec/workflow-type normalized)))
       (is (str/includes? (:spec/description normalized) "Build a scanner"))
       (is (str/includes? (:spec/description normalized) "Detailed design goes here"))
       (is (= [:compliance :scanner] (:spec/tags normalized)))

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -65,11 +65,10 @@
 
 (defn- load-observe-phase-config
   []
-  (->> "config/workflow/observe-phase.edn"
-       io/resource
-       slurp
-       edn/read-string
-       (validate! ObservePhaseConfig)))
+  (if-let [res (io/resource "config/workflow/observe-phase.edn")]
+    (->> res slurp edn/read-string (validate! ObservePhaseConfig))
+    (throw (ex-info "Missing classpath resource: config/workflow/observe-phase.edn"
+                    {:hint "Add components/workflow/resources to your classpath"}))))
 
 (defn- load-monitor-defaults
   []

--- a/docs/design/compliance-scanner.md
+++ b/docs/design/compliance-scanner.md
@@ -5,6 +5,7 @@ delta report, generates a DAG remediation plan, and executes fixes autonomously 
 acceptance_criteria: Scan detects policy violations by rule-id, classify adds auto-fixable flag and rationale, plan
 generates DAG tasks and markdown work spec, execute applies auto-fixable fixes via dag-executor and opens PRs
 tags: [compliance, policy, scanner, dag, remediation]
+type: nimble-sdlc
 ---
 
 ## Vision


### PR DESCRIPTION
## Summary

- Add `components/pr-lifecycle/resources` to `bb.edn` miniforge dev classpath so `config/pr-monitor/defaults.edn` is resolvable at runtime (was causing `slurp nil` → "Cannot open <nil> as a Reader." during every workflow run)
- Guard `load-monitor-config` and `load-observe-phase-config` with `if-let` to emit a clear `ex-info` instead of an NPE when classpath resource is missing
- Coerce YAML string workflow type to keyword in `normalize-spec`; default to `:canonical-sdlc-v1` instead of `:full-sdlc` (which has no registered workflow definition)
- Add `type: nimble-sdlc` to `compliance-scanner.md` frontmatter to route dogfood run to correct workflow
- Update spec-parser tests to expect `:canonical-sdlc-v1` as the default workflow type

## Test plan

- [ ] All pre-commit tests pass (494 tests, 0 failures)
- [ ] `bb miniforge run docs/design/compliance-scanner.md` completes explore → plan → implement without the nil-reader error

🤖 Generated with [Claude Code](https://claude.com/claude-code)