### PR TITLE
fix: serialize git worktree creation and add failure logging

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -77,25 +77,51 @@
       {:available? false
        :reason "git not found"})))
 
+(def ^:private worktree-lock
+  "JVM-level lock for git worktree add commands.
+   Git uses a config.lock file internally — concurrent worktree adds from
+   multiple threads hit this lock and fail silently. Serializing creation at
+   the JVM level prevents the conflict. Tasks still run in parallel once their
+   worktrees are acquired."
+  (Object.))
+
 (defn create-worktree
   "Create a git worktree for the task.
 
-   First tries to create a new branch, then falls back to using existing branch."
+   Serializes creation through worktree-lock to prevent concurrent git
+   config.lock conflicts when multiple sub-workflows acquire environments
+   simultaneously.
+
+   Attempts in order:
+   1. git worktree add -b <name> <path> <branch>  — new branch from branch tip
+   2. Clean up stale branch/directory and retry step 1
+   3. git worktree add --detach <path>             — detached HEAD (last resort)"
   [base-path repo-path worktree-name branch]
-  (let [worktree-path (str base-path "/" worktree-name)]
-    (ensure-directory base-path)
-    ;; Try creating with a new branch first
-    (let [result (run-git "-C" repo-path
-                          "worktree" "add" "-b" worktree-name
-                          worktree-path branch)]
-      (if (zero? (:exit result))
-        (result/ok {:worktree-path worktree-path})
-        ;; Branch might exist, try without -b
-        (let [result2 (run-git "-C" repo-path
-                               "worktree" "add" worktree-path branch)]
-          (if (zero? (:exit result2))
-            (result/ok {:worktree-path worktree-path})
-            (result/err :worktree-create-failed (:err result2))))))))
+  (locking worktree-lock
+    (let [worktree-path (str base-path "/" worktree-name)]
+      (ensure-directory base-path)
+      (let [result (run-git "-C" repo-path
+                            "worktree" "add" "-b" worktree-name
+                            worktree-path branch)]
+        (if (zero? (:exit result))
+          (result/ok {:worktree-path worktree-path})
+          ;; Failed — clean up stale branch/directory from a prior run and retry
+          (do
+            (run-shell "rm" "-rf" worktree-path)
+            (run-git "-C" repo-path "worktree" "prune")
+            (run-git "-C" repo-path "branch" "-D" worktree-name)
+            (let [result2 (run-git "-C" repo-path
+                                   "worktree" "add" "-b" worktree-name
+                                   worktree-path branch)]
+              (if (zero? (:exit result2))
+                (result/ok {:worktree-path worktree-path})
+                ;; Still failing — detached HEAD as last resort
+                (let [result3 (run-git "-C" repo-path
+                                       "worktree" "add" "--detach"
+                                       worktree-path)]
+                  (if (zero? (:exit result3))
+                    (result/ok {:worktree-path worktree-path})
+                    (result/err :worktree-create-failed (:err result3))))))))))))
 
 (defn remove-worktree
   "Remove a git worktree."

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -1,0 +1,98 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.protocols.impl.worktree-test
+  "Tests for the worktree executor: concurrent-add lock and fallback strategy."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.dag-executor.protocols.impl.worktree :as worktree]
+   [ai.miniforge.dag-executor.result :as result]))
+
+;; ============================================================================
+;; create-worktree: lock and fallback strategy
+;; ============================================================================
+
+(deftest create-worktree-succeeds-on-first-attempt-test
+  (testing "returns ok with worktree-path when git worktree add -b succeeds immediately"
+    (with-redefs [worktree/run-git     (fn [& _] {:exit 0 :out "" :err ""})
+                  worktree/run-shell   (fn [& _] {:exit 0 :out "" :err ""})
+                  worktree/ensure-directory (fn [_] nil)]
+      (let [r (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")]
+        (is (result/ok? r))
+        (is (= "/tmp/base/task-abc" (:worktree-path (:data r))))))))
+
+(deftest create-worktree-retries-after-cleanup-on-first-failure-test
+  (testing "cleans up stale branch/dir and retries -b when first add fails"
+    (let [add-b-calls (atom 0)]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (if (some #{"add"} args)
+                        (if (zero? (swap! add-b-calls inc))
+                          {:exit 0 :out "" :err ""}
+                          ;; First add-b fails; second succeeds
+                          (if (= 1 @add-b-calls)
+                            {:exit 1 :out "" :err "fatal: branch already exists"}
+                            {:exit 0 :out "" :err ""}))
+                        {:exit 0 :out "" :err ""}))
+                    worktree/run-shell        (fn [& _] {:exit 0 :out "" :err ""})
+                    worktree/ensure-directory (fn [_] nil)]
+        (let [r (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")]
+          (is (result/ok? r))
+          (is (= "/tmp/base/task-abc" (:worktree-path (:data r)))))))))
+
+(deftest create-worktree-falls-back-to-detach-when-both-branch-attempts-fail-test
+  (testing "falls back to --detach when both -b attempts fail"
+    (let [git-calls (atom [])]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (swap! git-calls conj (vec args))
+                      (cond
+                        ;; Both worktree add -b attempts fail
+                        (and (some #{"add"} args) (some #{"-b"} args))
+                        {:exit 1 :out "" :err "fatal: branch already exists"}
+                        ;; worktree add --detach succeeds
+                        (and (some #{"add"} args) (some #{"--detach"} args))
+                        {:exit 0 :out "" :err ""}
+                        ;; All other git calls (prune, branch -D) succeed
+                        :else
+                        {:exit 0 :out "" :err ""}))
+                    worktree/run-shell        (fn [& _] {:exit 0 :out "" :err ""})
+                    worktree/ensure-directory (fn [_] nil)]
+        (let [r (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")]
+          (is (result/ok? r))
+          (is (= "/tmp/base/task-abc" (:worktree-path (:data r))))
+          ;; Verify --detach was attempted
+          (is (some #(some #{"--detach"} %) @git-calls)))))))
+
+(deftest create-worktree-returns-error-when-all-attempts-fail-test
+  (testing "returns err when -b retry and --detach all fail"
+    (with-redefs [worktree/run-git
+                  (fn [& args]
+                    (if (some #{"add"} args)
+                      {:exit 1 :out "" :err "fatal: cannot create worktree"}
+                      {:exit 0 :out "" :err ""}))
+                  worktree/run-shell        (fn [& _] {:exit 0 :out "" :err ""})
+                  worktree/ensure-directory (fn [_] nil)]
+      (let [r (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")]
+        (is (not (result/ok? r)))
+        (is (= :worktree-create-failed (get-in r [:error :code])))))))
+
+(deftest worktree-lock-is-present-test
+  (testing "worktree-lock is an Object used to serialize concurrent git add calls"
+    (is (some? @#'worktree/worktree-lock))
+    (is (instance? Object @#'worktree/worktree-lock))))

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -241,16 +241,22 @@
                      :hint (messages/t :governed/no-capsule-hint)}))))
 
 (defn- build-env-record
-  "Acquire environment from executor and build the result map."
+  "Acquire environment from executor and build the result map.
+   Returns nil on failure after printing the error so the runner can skip
+   environment setup rather than throwing. Failure is visible in stdout."
   [executor workflow-id mode {:keys [acquire-env! result-ok? result-unwrap]}]
   (let [task-id    (if (uuid? workflow-id) workflow-id (random-uuid))
         env-result (acquire-env! executor task-id {})]
-    (when (result-ok? env-result)
+    (if (result-ok? env-result)
       (let [env (result-unwrap env-result)]
         {:executor       executor
          :environment-id (:environment-id env)
          :worktree-path  (:workdir env)
-         :execution-mode mode}))))
+         :execution-mode mode})
+      (do
+        (println "WARN: Failed to acquire execution environment for" workflow-id
+                 "—" (get-in env-result [:error :message] (str env-result)))
+        nil))))
 
 (defn- acquire-execution-environment!
   "Acquire an isolated execution environment before pipeline starts.

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -6,6 +6,7 @@
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.dag-executor.executor :as dag-exec]
+   [ai.miniforge.dag-executor.result :as dag-result]
    [ai.miniforge.phase.interface]))
 
 ;; ---------------------------------------------------------------------------- extract-output
@@ -200,4 +201,20 @@
              Exception #"(?i)No capsule executor available"
              (runner/run-pipeline wf {:task "Test"}
                                   {:execution-mode :governed})))))))
+
+;; ---------------------------------------------------------------------------- build-env-record: WARN on failure
+
+(deftest build-env-record-logs-warn-when-acquisition-fails-test
+  (testing "WARN is printed and pipeline completes when worktree acquisition returns an error"
+    (let [wf     {:workflow/id :test
+                  :workflow/version "1.0.0"
+                  :workflow/pipeline [{:phase :done}]}
+          output (with-out-str
+                   (with-redefs [dag-exec/acquire-environment!
+                                 (fn [& _]
+                                   (dag-result/err :worktree-create-failed
+                                                   "git worktree add failed"))]
+                     (runner/run-pipeline wf {:task "Test"} {})))]
+      (is (re-find #"WARN" output))
+      (is (re-find #"Failed to acquire execution environment" output)))))
 

--- a/docs/design/fleet-dag-orchestration.md
+++ b/docs/design/fleet-dag-orchestration.md
@@ -1,0 +1,179 @@
+# Fleet DAG Orchestration
+
+## Context
+
+The current DAG executor runs sub-workflows as JVM futures within a single process. This works
+for local and single-host execution but couples orchestrator lifetime to task execution and caps
+parallelism at host resources. The move to containerized execution creates a natural opportunity
+to decouple these concerns and support a fleet model where a single persistent orchestrator
+manages many concurrent full workflows across a cluster.
+
+## The Shift
+
+### Current model (in-process)
+
+```text
+run-dag! (JVM process)
+  └── future: sub-workflow A  →  acquire worktree  →  run pipeline  →  release
+  └── future: sub-workflow B  →  acquire worktree  →  run pipeline  →  release
+  └── future: sub-workflow C  →  acquire worktree  →  run pipeline  →  release
+  └── future: sub-workflow D  →  acquire worktree  →  run pipeline  →  release
+
+Task state lives in ConcurrentHashMap in the orchestrating JVM.
+Orchestrator must stay alive for the duration of all tasks.
+```
+
+### Target model (fleet)
+
+```text
+compile-dag! (any process, any time)
+  └── emits: DAG artifact (EDN) → submitted to fleet scheduler
+
+Fleet scheduler (persistent, long-running)
+  └── watches DAG artifact
+  └── for each ready node (dependencies satisfied):
+        → spin container → run sub-workflow to completion → signal done
+  └── on completion: unlock dependents, update DAG state
+  └── on failure:    propagate-failures, surface to governance
+
+Task state lives in an external store (DB/queue).
+Orchestrator lifetime is independent of any individual task.
+```
+
+The DAG structure becomes a first-class submission artifact. Compile once, hand off to the fleet,
+receive completion/failure events. Multiple specs can be in-flight simultaneously under a single
+fleet scheduler.
+
+## The OSS / Fleet Boundary
+
+The key question is what Miniforge OSS must provide to make fleet integration clean vs what Fleet
+adds on top.
+
+### OSS provides: fleet-ready surface
+
+#### Serializable DAG format
+
+The DAG is currently built and executed in-memory. OSS needs to be able to emit a DAG as an
+EDN artifact: a list of tasks with ids, descriptions, dependencies (edges), execution config
+(executor type, branch, env), and a budget envelope. This is the submission unit.
+
+```edn
+{:dag/id       #uuid "..."
+ :dag/spec     "path/to/spec.md"
+ :dag/tasks    [{:task/id   #uuid "..."
+                 :task/name "implement-auth"
+                 :task/deps [#uuid "..."]   ; predecessor task ids
+                 :task/spec {...}
+                 :task/budget {:tokens 50000}}
+                ...]
+ :dag/created  #inst "..."}
+```
+
+#### External state store interface
+
+Currently task state (`:pending`, `:running`, `:completed`, `:failed`) lives in a
+`ConcurrentHashMap`. OSS should define a protocol for this store and ship an in-memory default
+implementation. Fleet provides a persistent implementation (Postgres, Redis, etc.).
+
+```clojure
+(defprotocol DAGStateStore
+  (get-task-state  [store dag-id task-id])
+  (set-task-state! [store dag-id task-id state result])
+  (get-dag-state   [store dag-id])
+  (ready-tasks     [store dag-id]))   ; tasks whose deps are all :completed
+```
+
+#### Single-task runner entry point
+
+A container needs a way to run exactly one task and exit cleanly with a structured result. OSS
+should provide a CLI entry point (or bb task) that accepts a task spec, runs the sub-workflow
+pipeline, and emits a result artifact the fleet scheduler can read.
+
+```shell
+mf run-task --dag-id <id> --task-id <id> --state-endpoint <url>
+```
+
+This is the executable unit the fleet scheduler launches per container. It replaces the
+in-process future.
+
+#### Idempotent task execution
+
+Tasks need to be safe to restart if a container is lost mid-run. This means persisting
+intermediate phase results to the external state store rather than only keeping them in memory.
+The current artifact session already writes to disk; the missing piece is syncing those artifacts
+to the external store at phase boundaries.
+
+#### Completion / failure signaling
+
+Currently futures complete in-process. A containerized task runner needs to signal the external
+scheduler on completion (success + artifacts) or failure (error + propagation data). This can be
+as simple as a POST to a state endpoint, a write to a shared volume, or a queue message.
+
+### Fleet adds on top
+
+**Scheduler**: watches the state store for ready tasks, respects DAG edges, enforces concurrency
+limits per DAG and per tenant, handles retry policies.
+
+**Container orchestration**: maps each ready task to a container (Docker, ECS, k8s Job), manages
+lifecycle, collects exit codes.
+
+**Persistent state store**: implements `DAGStateStore` against Postgres or Redis; survives
+restarts; supports multiple concurrent DAGs.
+
+**Governance surface**: the scheduler is the natural place to enforce policy gates. When a task
+fails a policy check (budget, compliance, release rules), the scheduler pauses the DAG and
+surfaces to the dashboard rather than failing outright. A human approves or retries; the
+scheduler resumes without re-running completed nodes.
+
+**Multi-tenancy**: multiple orgs submit DAGs to the same fleet; scheduler tracks ownership,
+billing, quotas.
+
+**Observability**: scheduler emits events (task started, completed, failed, paused) that feed
+the dashboard. Real-time view of every in-flight workflow across the fleet.
+
+## What Does Not Change
+
+The pipeline execution logic (plan/implement/verify/release phases, agent invocations, artifact
+management) is entirely inside the containerized sub-workflow. The fleet scheduler knows nothing
+about phases — it only knows task = container = sub-workflow. The current `runner.clj` pipeline
+is already the right unit of work.
+
+The DAG dependency model and `propagate-failures` logic remain the same; they just move from
+in-process futures to the external scheduler.
+
+## Sequencing: what OSS needs before Fleet can use it
+
+The minimal OSS work that unblocks fleet integration, roughly in order:
+
+1. **Serialize DAG to EDN** — make the DAG structure emittable as a data artifact so it can be
+   submitted to the fleet scheduler without needing the OSS process to be alive.
+
+2. **`DAGStateStore` protocol + in-memory impl** — extract the ConcurrentHashMap state into a
+   protocol. In-process scheduler uses the in-memory impl unchanged. Fleet plugs in the
+   persistent impl.
+
+3. **Single-task runner CLI** — `mf run-task` entry point so a container can run one task and
+   exit cleanly with a structured result.
+
+4. **Phase-boundary artifact sync** — persist intermediate results to the state store at each
+   phase boundary so tasks are restartable.
+
+Items 1 and 3 are the minimum for fleet to start experimenting. Items 2 and 4 are needed for
+production reliability.
+
+## Open Questions
+
+- **DAG submission protocol**: push (OSS POSTs to fleet) vs pull (fleet polls a known location
+  for new DAG artifacts)? Push is simpler for the fleet; pull is simpler for OSS (just write a
+  file).
+
+- **State store coupling**: should the in-memory `DAGStateStore` impl live in OSS or in a
+  separate fleet-compat layer? Probably OSS, since in-process execution still needs it.
+
+- **Artifact visibility**: when a containerized task writes artifacts, how does the fleet
+  scheduler surface them back to the user? Options: shared volume, object store (S3), or a
+  sidecar that syncs to the state store.
+
+- **Nested DAGs**: if a sub-workflow itself generates a DAG (e.g., a large spec decomposes into
+  sub-tasks at plan time), does the fleet scheduler handle nested DAG submission dynamically, or
+  are all nodes known at compile time?


### PR DESCRIPTION
## Summary

Fixes `dag-execution-failed` where dogfood runs showed 28 tasks failed / 0 tokens / 0 duration for all tasks.

**Root cause 1 — concurrent `git config.lock` races**: The DAG orchestrator runs 4 sub-workflow futures simultaneously. Each sub-workflow calls `acquire-environment!` → `create-worktree` → `git worktree add`. Git serializes worktree adds internally via a `config.lock` file; when four threads hit `git worktree add` concurrently, 3 of 4 fail silently. Added a JVM-level `worktree-lock` Object so creation is serialized. Tasks still run in parallel once their environments are acquired.

**Root cause 2 — broken fallback**: On first-attempt failure, the old code fell back to `git worktree add <path> <branch>` (without `-b`). This always fails when `<branch>` (`main`) is already checked out in the primary worktree. Replaced with a 3-attempt strategy:
1. `git worktree add -b <name> <path> <branch>` — fresh branch from branch tip
2. Clean up stale branch/directory, prune, delete branch, retry step 1
3. `git worktree add --detach <path>` — detached HEAD as last resort

**Bonus — surfaced silent failures**: `build-env-record` was silently returning `nil` when worktree acquisition failed (using `when` instead of `if`). This `nil` cascaded to `resolve-worktree-path`, which threw `ex-info`, yielding 0 tokens for all tasks. Added a `WARN` println so failures are visible in stdout immediately.

**Cascade**: 4 first-batch tasks failed → `propagate-failures` cascaded to all 24 dependent tasks = 28 total failures.

## Test plan

- [x] Lint passes on both changed files
- [x] All 309 dag-executor + workflow + compliance-scanner tests pass (0 failures, 0 errors)
- [x] GraalVM/Babashka compatibility tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)