### PR TITLE
fix: restore compliance execute capability deleted by #424

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/execute.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/execute.clj
@@ -1,0 +1,218 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.execute
+  "Apply auto-fixable violations to files and create one PR per rule.
+
+   Layer 0: File patch helpers (pure)
+   Layer 1: Git shell helpers
+   Layer 2: Per-rule fix, commit, and PR
+   Layer 3: Top-level execute! entry point"
+  (:require [clojure.java.shell :as shell]
+            [clojure.string     :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; File patch helpers
+
+(def ^:private md-copyright-header
+  "Standard copyright comment prepended to markdown files missing a header."
+  (str "<!--\n"
+       "  Title: Miniforge.ai\n"
+       "  Author: Christopher Lester (christopher@miniforge.ai)\n"
+       "  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n"
+       "-->\n"))
+
+(defn- apply-line-replacement
+  "Replace the first occurrence of :current with :suggested on the violation's line.
+   lines is a vector of strings (0-indexed). line numbers in violations are 1-indexed."
+  [lines violation]
+  (let [idx       (dec (get violation :line 1))
+        current   (get violation :current "")
+        suggested (get violation :suggested)]
+    (if (and suggested (< idx (count lines)) (str/includes? (get lines idx "") current))
+      (update lines idx str/replace-first current suggested)
+      lines)))
+
+(defn- apply-copyright-prepend
+  "Prepend the standard markdown copyright header to a content string."
+  [content]
+  (str md-copyright-header "\n" content))
+
+(defn patch-file-content
+  "Apply all violations for one file to its string content. Pure — no I/O.
+
+   Line-replacement violations are applied bottom-up (descending line number) so
+   prior edits do not shift subsequent line indices. Copyright header violations
+   are prepended after all line edits, since they add a line at position 0."
+  [content violations]
+  (let [copyright-viols (filter #(= :std/header-copyright (get % :rule/id)) violations)
+        line-viols      (remove #(= :std/header-copyright (get % :rule/id)) violations)
+        ;; Preserve trailing newline: split with limit -1 keeps trailing empty segment
+        lines           (str/split content #"\n" -1)
+        patched-lines   (reduce apply-line-replacement lines (sort-by :line > line-viols))
+        patched         (str/join "\n" patched-lines)]
+    (if (seq copyright-viols)
+      (apply-copyright-prepend patched)
+      patched)))
+
+(defn- patch-file!
+  "Apply auto-fixable violations to a file on disk. No-op if content is unchanged.
+   Returns the absolute file path."
+  [repo-path file violations]
+  (let [path    (str repo-path "/" file)
+        content (slurp path)
+        patched (patch-file-content content violations)]
+    (when-not (= content patched)
+      (spit path patched))
+    path))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Git shell helpers
+
+(defn- git!
+  "Run a git command in repo-path directory. Returns the sh result map.
+   Logs non-zero exit codes for debugging (branch -D failures are expected)."
+  [repo-path & args]
+  (let [result (apply shell/sh "git" (concat args [:dir repo-path]))]
+    (when (and (not (zero? (:exit result)))
+               (not (str/includes? (str args) "branch")))  ;; branch -D may fail safely
+      (println (str "  git " (str/join " " args) " → exit " (:exit result)))
+      (when-not (str/blank? (:err result))
+        (println (str "  stderr: " (str/trim (:err result))))))
+    result))
+
+(defn- branch-slug
+  "Convert a rule category and title to a valid git branch segment."
+  [category title]
+  (-> (str/lower-case title)
+      (str/replace #"[^a-z0-9]+" "-")
+      (str/replace #"-+$" "")
+      (->> (str "fix/compliance-" category "-"))))
+
+(defn- reset-to-origin-main!
+  "Detach HEAD at origin/main, giving a clean base for the next rule branch."
+  [repo-path]
+  (git! repo-path "fetch" "origin" "main" "--quiet")
+  (git! repo-path "checkout" "--detach" "origin/main"))
+
+(defn- create-rule-branch!
+  "Create and checkout a new branch from origin/main. Deletes if already exists."
+  [repo-path branch]
+  (git! repo-path "branch" "-D" branch)  ;; safe to fail if absent
+  (git! repo-path "checkout" "-b" branch "origin/main"))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Per-rule fix, commit, and PR
+
+(def ^:private pr-body
+  "Auto-generated by the Miniforge compliance scanner.
+
+Applies mechanical fixes for all auto-fixable violations of this rule.
+Violations requiring semantic review are excluded — see the work spec
+at `docs/compliance/` for the full list.
+
+\uD83E\uDD16 Generated with [Miniforge](https://miniforge.ai)")
+
+(defn- fix-and-pr-for-rule!
+  "Create a branch, apply auto-fixable fixes, commit, push, and open a PR.
+   Returns a result map with :branch, :pr-url, :violations-fixed, :files-changed."
+  [repo-path rule-id category title tasks]
+  (let [branch   (branch-slug category title)
+        pr-title (str "fix: [" category "] " title " compliance pass")]
+    (reset-to-origin-main! repo-path)
+    (create-rule-branch! repo-path branch)
+    (let [auto-tasks      (filter #(some :auto-fixable? (get % :task/violations)) tasks)
+          patched-files   (mapv (fn [task]
+                                  (let [file  (get task :task/file)
+                                        viols (filter :auto-fixable? (get task :task/violations))]
+                                    (patch-file! repo-path file viols)
+                                    file))
+                                auto-tasks)
+          violations-fixed (transduce
+                            (map #(count (filter :auto-fixable? (get % :task/violations))))
+                            + 0 auto-tasks)]
+      ;; Stage changed files
+      (apply git! repo-path "add" patched-files)
+      ;; Commit — skip pre-commit hook; changes are mechanically verified by the scanner
+      (git! repo-path "commit" "--no-verify" "-m"
+            (str "fix: [" category "] " title " compliance pass ("
+                 (count patched-files) " file" (when (> (count patched-files) 1) "s") ")"))
+      ;; Push (force-with-lease in case branch already exists from a prior run)
+      (git! repo-path "push" "origin"
+            (str branch ":refs/heads/" branch) "--force-with-lease")
+      ;; Create PR via gh CLI
+      (let [pr-result (shell/sh "gh" "pr" "create"
+                                "--base"  "main"
+                                "--head"  branch
+                                "--title" pr-title
+                                "--body"  pr-body
+                                :dir repo-path)
+            pr-url    (str/trim (:out pr-result))]
+        {:rule/id          rule-id
+         :branch           branch
+         :pr-url           pr-url
+         :violations-fixed violations-fixed
+         :files-changed    (count patched-files)}))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Top-level entry point
+
+(defn execute!
+  "Apply all auto-fixable violations and create one PR per rule.
+
+   Reads DAG tasks from plan, groups by :task/rule-id, and for each rule
+   with auto-fixable violations: creates a branch, patches files, commits,
+   pushes, and opens a GitHub PR.
+
+   Arguments:
+   - plan      - Plan map with :dag-tasks
+   - repo-path - string path to the repo/worktree root
+
+   Returns map with :prs (vector), :violations-fixed (int), :files-changed (int)."
+  [plan repo-path]
+  (let [dag-tasks  (get plan :dag-tasks [])
+        auto-tasks (filter #(some :auto-fixable? (get % :task/violations)) dag-tasks)
+        by-rule    (group-by :task/rule-id auto-tasks)]
+    (if (empty? by-rule)
+      {:prs [] :violations-fixed 0 :files-changed 0}
+      (let [prs (mapv (fn [[rule-id tasks]]
+                        (let [first-v (first (get (first tasks) :task/violations []))]
+                          (fix-and-pr-for-rule! repo-path rule-id
+                                                (get first-v :rule/category "0")
+                                                (get first-v :rule/title (name rule-id))
+                                                tasks)))
+                      by-rule)]
+        {:prs              prs
+         :violations-fixed (transduce (map :violations-fixed) + 0 prs)
+         :files-changed    (transduce (map :files-changed)    + 0 prs)}))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (patch-file-content
+   "(or (:timeout m) 5000)"
+   [{:rule/id :std/clojure :line 1
+     :current "(or (:timeout m) 5000)" :suggested "(get m :timeout 5000)"
+     :auto-fixable? true}])
+
+  (patch-file-content
+   "# My Doc\n\nSome content.\n"
+   [{:rule/id :std/header-copyright :line 1
+     :current "(missing copyright header)" :suggested nil
+     :auto-fixable? true}])
+
+  :leave-this-here)

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
@@ -29,7 +29,8 @@
             [ai.miniforge.compliance-scanner.scan     :as scan]
             [ai.miniforge.compliance-scanner.classify :as classify]
             [ai.miniforge.compliance-scanner.plan     :as plan]
-            [ai.miniforge.compliance-scanner.report   :as report]))
+            [ai.miniforge.compliance-scanner.report   :as report]
+            [ai.miniforge.compliance-scanner.execute  :as execute]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
@@ -114,6 +115,17 @@
         delta-report (factory/->delta-report repo-path standards-path timestamp
                                              (:summary plan) classified)]
     (write-report! delta-report repo-path)))
+
+(defn execute!
+  "Apply all auto-fixable violations and create one PR per rule.
+
+   Arguments:
+   - plan      - Plan map with :dag-tasks (from the plan phase)
+   - repo-path - string path to the repo/worktree root
+
+   Returns map with :prs (vector of per-rule results), :violations-fixed, :files-changed."
+  [plan repo-path]
+  (execute/execute! plan repo-path))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Convenience orchestrator

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/execute_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/execute_test.clj
@@ -1,0 +1,132 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.execute-test
+  "Unit tests for execute/patch-file-content — the pure file-patching logic."
+  (:require [clojure.test   :refer [deftest testing is]]
+            [clojure.string :as str]
+            [ai.miniforge.compliance-scanner.execute :as execute]))
+
+;------------------------------------------------------------------------------ Fixtures
+
+(def clojure-violation
+  {:rule/id       :std/clojure
+   :rule/category "210"
+   :line          3
+   :current       "(or (:timeout m) 5000)"
+   :suggested     "(get m :timeout 5000)"
+   :auto-fixable? true})
+
+(def datever-violation
+  {:rule/id       :std/datever
+   :rule/category "730"
+   :line          2
+   :current       "1.2.3"
+   :suggested     "1.2.3.0"
+   :auto-fixable? true})
+
+(def copyright-violation
+  {:rule/id       :std/header-copyright
+   :rule/category "810"
+   :line          1
+   :current       "(missing copyright header)"
+   :suggested     nil
+   :auto-fixable? true})
+
+;------------------------------------------------------------------------------ patch-file-content tests
+
+(deftest line-replacement-applies-on-correct-line-test
+  (testing "patch-file-content replaces :current with :suggested on the correct line"
+    (let [content  "line1\nline2\n(or (:timeout m) 5000)\nline4\n"
+          patched  (execute/patch-file-content content [clojure-violation])]
+      (is (str/includes? patched "(get m :timeout 5000)")
+          "Should contain the suggested replacement")
+      (is (not (str/includes? patched "(or (:timeout m) 5000)"))
+          "Should not contain the original text"))))
+
+(deftest line-replacement-only-modifies-target-line-test
+  (testing "patch-file-content leaves other lines untouched"
+    (let [content  "line1\nline2\n(or (:timeout m) 5000)\nline4\n"
+          patched  (execute/patch-file-content content [clojure-violation])
+          lines    (str/split-lines patched)]
+      (is (= "line1" (get lines 0)) "Line 1 unchanged")
+      (is (= "line2" (get lines 1)) "Line 2 unchanged")
+      (is (= "line4" (get lines 3)) "Line 4 unchanged"))))
+
+(deftest trailing-newline-preserved-test
+  (testing "patch-file-content preserves trailing newline"
+    (let [content "(or (:timeout m) 5000)\n"
+          v       (assoc clojure-violation :line 1)
+          patched (execute/patch-file-content content [v])]
+      (is (str/ends-with? patched "\n")
+          "Trailing newline should be preserved"))))
+
+(deftest no-trailing-newline-preserved-test
+  (testing "patch-file-content preserves absence of trailing newline"
+    (let [content "(or (:timeout m) 5000)"
+          v       (assoc clojure-violation :line 1)
+          patched (execute/patch-file-content content [v])]
+      (is (not (str/ends-with? patched "\n"))
+          "No trailing newline should not be added"))))
+
+(deftest multiple-violations-same-file-applied-test
+  (testing "patch-file-content applies multiple violations to the same file"
+    (let [content  "line1\n1.2.3\n(or (:timeout m) 5000)\nline4\n"
+          patched  (execute/patch-file-content content [clojure-violation datever-violation])]
+      (is (str/includes? patched "1.2.3.0")    "DateVer fix applied")
+      (is (str/includes? patched "(get m :timeout 5000)") "Clojure map access fix applied"))))
+
+(deftest copyright-header-prepended-test
+  (testing "patch-file-content prepends copyright header for missing-header violations"
+    (let [content "# My Doc\n\nSome content.\n"
+          patched (execute/patch-file-content content [copyright-violation])]
+      (is (str/starts-with? patched "<!--")
+          "Patched content should start with HTML comment")
+      (is (str/includes? patched "Christopher Lester")
+          "Copyright header should contain author name")
+      (is (str/includes? patched "# My Doc")
+          "Original content should be preserved after the header"))))
+
+(deftest copyright-header-before-line-edits-test
+  (testing "copyright prepend does not shift line indices for line-replacement violations"
+    (let [content  "(or (:timeout m) 5000)\nline2\n"
+          v-clj    (assoc clojure-violation :line 1)
+          patched  (execute/patch-file-content content [v-clj copyright-violation])]
+      (is (str/includes? patched "(get m :timeout 5000)")
+          "Clojure fix should still be applied")
+      (is (str/starts-with? patched "<!--")
+          "Copyright header should be at the top"))))
+
+(deftest no-change-when-suggested-nil-and-not-copyright-test
+  (testing "patch-file-content skips violations with nil suggested that aren't copyright"
+    (let [content "original content\n"
+          v       {:rule/id :std/clojure :line 1 :current "original content"
+                   :suggested nil :auto-fixable? false}
+          patched (execute/patch-file-content content [v])]
+      (is (= content patched)
+          "Content should be unchanged when suggested is nil and not copyright"))))
+
+(deftest empty-violations-returns-content-unchanged-test
+  (testing "patch-file-content with empty violations returns content unchanged"
+    (let [content "some content\n"]
+      (is (= content (execute/patch-file-content content []))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.compliance-scanner.execute-test)
+  :leave-this-here)

--- a/components/workflow-compliance-scanner/resources/workflows/compliance-execute-v1.0.0.edn
+++ b/components/workflow-compliance-scanner/resources/workflows/compliance-execute-v1.0.0.edn
@@ -1,0 +1,30 @@
+;; Compliance Execute Workflow v1.0.0
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Full compliance remediation pipeline: scan → classify → plan → execute.
+;; All phases are pure-code (no LLM). The execute phase applies auto-fixable
+;; violations directly to files in the worktree, commits per rule, and opens
+;; one GitHub PR per rule via the gh CLI.
+;;
+;; Pipeline: compliance-scan → compliance-classify → compliance-plan
+;;           → compliance-execute → done
+
+{:workflow/id      :compliance-execute
+ :workflow/version "1.0.0"
+ :workflow/name    "Compliance Execute Workflow"
+ :workflow/description
+ "Scan a repository for policy violations, classify them, generate a plan,
+  then apply all auto-fixable violations and open one PR per rule.
+  Violations requiring semantic review are excluded from the auto-fix pass
+  and documented in the work spec."
+
+ :workflow/pipeline
+ [{:phase :compliance-scan}
+  {:phase :compliance-classify}
+  {:phase :compliance-plan}
+  {:phase :compliance-execute}
+  {:phase :done}]
+
+ :workflow/config
+ {:max-tokens     5000
+  :max-iterations 10}}

--- a/components/workflow-compliance-scanner/src/ai/miniforge/workflow_compliance_scanner/phases.clj
+++ b/components/workflow-compliance-scanner/src/ai/miniforge/workflow_compliance_scanner/phases.clj
@@ -17,17 +17,19 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.workflow-compliance-scanner.phases
-  "Phase interceptors for the compliance scan workflow.
+  "Phase interceptors for the compliance scan and execute workflows.
 
-   Three pure-code phases — no LLM invocation:
+   Four pure-code phases — no LLM invocation:
      :compliance-scan     — scan repo for violations via scanner-registry
      :compliance-classify — classify each violation as auto-fixable or needs-review
      :compliance-plan     — generate delta report + remediation work spec
+     :compliance-execute  — apply auto-fixable fixes, commit, open PRs per rule
 
    Context threading:
      :compliance-scan     stores :output at [:execution/phase-results :compliance-scan :result :output]
      :compliance-classify reads from that path, stores classified violations
-     :compliance-plan     reads classified violations, writes files, stores plan"
+     :compliance-plan     reads classified violations, writes files, stores plan
+     :compliance-execute  reads plan, applies fixes, commits, creates PRs"
   (:require
    [ai.miniforge.compliance-scanner.interface :as compliance-scanner]
    [ai.miniforge.phase.phase-result           :as phase-result]
@@ -75,10 +77,16 @@
    :gates []
    :budget {:tokens 5000 :iterations 1 :time-seconds 120}})
 
+(def default-execute-config
+  {:agent nil
+   :gates []
+   :budget {:tokens 5000 :iterations 1 :time-seconds 1800}})
+
 ;; Register defaults on load
 (registry/register-phase-defaults! :compliance-scan     default-scan-config)
 (registry/register-phase-defaults! :compliance-classify default-classify-config)
 (registry/register-phase-defaults! :compliance-plan     default-plan-config)
+(registry/register-phase-defaults! :compliance-execute  default-execute-config)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; :compliance-scan interceptor
@@ -216,6 +224,52 @@
       (assoc-in [:phase :status] :failed)
       (assoc-in [:phase :error] (phase-result/exception-error ex))))
 
+;------------------------------------------------------------------------------ Layer 1
+;; :compliance-execute interceptor
+
+(defn enter-compliance-execute
+  "Execute compliance execute phase.
+   Reads the plan from phase results, applies auto-fixable violations to files
+   in the worktree, commits per rule, and opens one GitHub PR per rule."
+  [ctx]
+  (let [start-time (System/currentTimeMillis)
+        repo-path  (resolve-repo-path ctx)
+        plan       (get-in ctx [:execution/phase-results :compliance-plan :result :output :plan])
+        result     (compliance-scanner/execute! plan repo-path)]
+    (phase-result/enter-context ctx :compliance-execute nil [] default-execute-config start-time
+                                {:status :success :output result})))
+
+(defn leave-compliance-execute
+  "Post-processing for compliance execute phase.
+   Records PR count and violations-fixed in metrics."
+  [ctx]
+  (let [start-time       (get-in ctx [:phase :started-at])
+        end-time         (System/currentTimeMillis)
+        duration-ms      (- end-time start-time)
+        output           (get-in ctx [:phase :result :output])
+        pr-count         (count (get output :prs []))
+        violations-fixed (get output :violations-fixed 0)
+        files-changed    (get output :files-changed 0)]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (assoc-in [:phase :metrics] {:pr-count         pr-count
+                                     :violations-fixed violations-fixed
+                                     :files-changed    files-changed
+                                     :duration-ms      duration-ms})
+        (assoc-in [:execution/phase-results :compliance-execute :result]
+                  (get-in ctx [:phase :result]))
+        (update-in [:execution :phases-completed] (fnil conj []) :compliance-execute)
+        (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
+
+(defn error-compliance-execute
+  "Handle compliance execute phase errors."
+  [ctx ex]
+  (-> ctx
+      (assoc-in [:phase :status] :failed)
+      (assoc-in [:phase :error] (phase-result/exception-error ex))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Registry methods
 
@@ -246,16 +300,27 @@
      :leave  leave-compliance-plan
      :error  error-compliance-plan}))
 
+(defmethod registry/get-phase-interceptor :compliance-execute
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name   ::compliance-execute
+     :config merged
+     :enter  (fn [ctx] (enter-compliance-execute (assoc ctx :phase-config merged)))
+     :leave  leave-compliance-execute
+     :error  error-compliance-execute}))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Check registered defaults
   (registry/phase-defaults :compliance-scan)
   (registry/phase-defaults :compliance-classify)
   (registry/phase-defaults :compliance-plan)
+  (registry/phase-defaults :compliance-execute)
 
   ;; Get interceptors
   (registry/get-phase-interceptor {:phase :compliance-scan})
   (registry/get-phase-interceptor {:phase :compliance-classify})
   (registry/get-phase-interceptor {:phase :compliance-plan})
+  (registry/get-phase-interceptor {:phase :compliance-execute})
 
   :leave-this-here)

--- a/components/workflow-compliance-scanner/test/ai/miniforge/workflow_compliance_scanner/phases_test.clj
+++ b/components/workflow-compliance-scanner/test/ai/miniforge/workflow_compliance_scanner/phases_test.clj
@@ -256,6 +256,51 @@
         (is (= [:compliance-plan] (get-in left-ctx [:execution :phases-completed]))
             ":compliance-plan should be added to phases-completed")))))
 
+;------------------------------------------------------------------------------ :compliance-execute Tests
+
+(deftest phases-execute-registered-in-registry-test
+  (testing ":compliance-execute defaults are registered"
+    (is (some? (registry/phase-defaults :compliance-execute)))))
+
+(deftest phase-execute-default-budget-test
+  (testing ":compliance-execute has correct default budget"
+    (let [defaults (registry/phase-defaults :compliance-execute)]
+      (is (= 5000 (get-in defaults [:budget :tokens])))
+      (is (= 1 (get-in defaults [:budget :iterations])))
+      (is (= 1800 (get-in defaults [:budget :time-seconds]))))))
+
+(deftest enter-compliance-execute-stores-execute-result-test
+  (testing "enter-compliance-execute calls execute! and stores output"
+    (let [stub-exec-result {:prs [{:rule/id :std/clojure :branch "fix/compliance-210" :pr-url "https://github.com/org/repo/pull/1" :violations-fixed 5 :files-changed 3}] :violations-fixed 5 :files-changed 3}]
+      (with-redefs [compliance-scanner/execute! (fn [_plan _repo] stub-exec-result)]
+        (let [ctx (-> (base-ctx)
+                      (assoc-in [:execution/phase-results :compliance-plan :result :output :plan] stub-plan))
+              result (phases/enter-compliance-execute ctx)]
+          (is (= :compliance-execute (get-in result [:phase :name])))
+          (is (= :running (get-in result [:phase :status])))
+          (is (= stub-exec-result (get-in result [:phase :result :output]))))))))
+
+(deftest leave-compliance-execute-records-metrics-test
+  (testing "leave-compliance-execute records metrics"
+    (let [stub-exec-result {:prs [{:violations-fixed 5 :files-changed 3} {:violations-fixed 1 :files-changed 1}] :violations-fixed 6 :files-changed 4}]
+      (with-redefs [compliance-scanner/execute! (fn [_plan _repo] stub-exec-result)]
+        (let [ctx (-> (base-ctx)
+                      (assoc-in [:execution/phase-results :compliance-plan :result :output :plan] stub-plan))
+              entered (phases/enter-compliance-execute ctx)
+              left-ctx (phases/leave-compliance-execute entered)]
+          (is (= :completed (get-in left-ctx [:phase :status])))
+          (is (= 2 (get-in left-ctx [:phase :metrics :pr-count])))
+          (is (= 6 (get-in left-ctx [:phase :metrics :violations-fixed])))
+          (is (= 4 (get-in left-ctx [:phase :metrics :files-changed]))))))))
+
+(deftest error-compliance-execute-sets-failed-status-test
+  (testing "error-compliance-execute sets :failed status"
+    (let [ctx (base-ctx)
+          ex (ex-info "Execute failed" {:reason :git-error})
+          result (phases/error-compliance-execute ctx ex)]
+      (is (= :failed (get-in result [:phase :status])))
+      (is (= "Execute failed" (get-in result [:phase :error :message]))))))
+
 ;------------------------------------------------------------------------------ Error Handler Tests
 
 (deftest error-compliance-scan-sets-failed-status-test


### PR DESCRIPTION
## Summary
- Restores `execute.clj`, `execute_test.clj`, and `compliance-execute-v1.0.0.edn` that were accidentally deleted by the revert commit in #424 (the worktree had dirty state from the #420 branch)
- Adds `execute!` to the compliance-scanner interface and wires the `:compliance-execute` phase into the workflow-compliance-scanner phases with enter/leave/error interceptors and registry registration
- Updates `git!` docstring to reflect logging behavior (not throwing), consistent with the actual implementation

## Test plan
- [x] All 1444 existing tests pass (0 failures, 0 errors)
- [x] New execute phase tests: registry registration, default budget, enter/leave/error handlers
- [x] Pure-function `patch-file-content` tests restored (line replacement, copyright prepend, multi-violation, edge cases)
- [x] Pre-commit linting passes (clj-kondo: 0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)