### PR TITLE
fix: restore :always-apply rules handling and fix datever classify

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/classify.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/classify.clj
@@ -60,7 +60,7 @@
   "Classify a :std/datever violation (DateVer version format standard)."
   [violation]
   (assoc violation
-         :auto-fixable? true
+         :auto-fixable? false
          :rationale     (msg/t :classify/datever)))
 
 (defn- classify-copyright-header

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scanner_registry.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scanner_registry.clj
@@ -134,12 +134,13 @@
 
 (defn enabled-rule-configs
   "Return the detection configs to run.
-   opts may contain :rules — a set of :rule/id keywords, or :all (default)."
+   opts may contain :rules — a set of :rule/id keywords, :all, or :always-apply (default)."
   [opts]
-  (let [requested (get opts :rules :all)]
-    (if (= requested :all)
+  (let [raw       (get opts :rules :always-apply)
+        requested (if (string? raw) (keyword (subs raw 1)) raw)]
+    (if (contains? #{:all :always-apply} requested)
       (vals registry)
-      (->> requested
+      (->> (if (keyword? requested) #{requested} requested)
            (map #(get registry %))
            (filter some?)))))
 

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/classify_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/classify_test.clj
@@ -84,11 +84,11 @@
 ;; ---------------------------------------------------------------------------
 ;; Dewey 730 classification
 
-(deftest classify-730-always-auto-fixable
-  (testing "Dewey 730 violations are always auto-fixable"
+(deftest classify-730-always-needs-review
+  (testing "Dewey 730 violations always need review — SemVer→DateVer requires human context"
     (let [v   (assoc base-730 :file "build.clj")
           [r] (classify/classify-violations [v])]
-      (is (true? (:auto-fixable? r)))
+      (is (false? (:auto-fixable? r)))
       (is (string? (:rationale r))))))
 
 ;; ---------------------------------------------------------------------------

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scan_test.clj
@@ -87,17 +87,18 @@
       (try
         ;; Set up a minimal git repo with a committed file so repo-index
         ;; can build an index (scanner uses `git ls-tree HEAD`).
-        ;; Clear GIT_DIR/GIT_WORK_TREE so pre-commit hook env doesn't
+        ;; Clear ALL GIT_* env vars so pre-commit hook env doesn't
         ;; bleed into the child git processes.
         (let [run! (fn [& cmd]
                      (let [pb (doto (ProcessBuilder. ^java.util.List (vec cmd))
                                 (.directory tmp-dir))
-                           env (.environment pb)]
-                       (.remove env "GIT_DIR")
-                       (.remove env "GIT_WORK_TREE")
-                       (.remove env "GIT_INDEX_FILE")
+                           env (.environment pb)
+                           git-keys (filterv #(re-find #"^GIT_" %) (keys env))]
+                       (doseq [k git-keys] (.remove env k))
                        (.waitFor (.start pb))))]
           (run! "git" "init")
+          ;; Disable GPG/SSH signing — 1Password agent blocks in subprocess contexts
+          (run! "git" "config" "commit.gpgsign" "false")
           (run! "git" "-c" "user.email=test@test.com" "-c" "user.name=Test"
                 "commit" "--allow-empty" "-m" "init")
 

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scanner_registry_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/scanner_registry_test.clj
@@ -112,8 +112,23 @@
 ;; ---------------------------------------------------------------------------
 ;; enabled-rule-configs
 
-(deftest enabled-rule-configs-returns-all-by-default
+(deftest enabled-rule-configs-returns-all-for-all-keyword
   (let [cfgs (registry/enabled-rule-configs {:rules :all})]
+    (is (= 3 (count cfgs)))
+    (is (every? :rule/id cfgs))))
+
+(deftest enabled-rule-configs-returns-all-for-always-apply-keyword
+  (let [cfgs (registry/enabled-rule-configs {:rules :always-apply})]
+    (is (= 3 (count cfgs)))
+    (is (every? :rule/id cfgs))))
+
+(deftest enabled-rule-configs-returns-all-for-always-apply-string
+  (let [cfgs (registry/enabled-rule-configs {:rules ":always-apply"})]
+    (is (= 3 (count cfgs)))
+    (is (every? :rule/id cfgs))))
+
+(deftest enabled-rule-configs-returns-all-when-no-rules-key
+  (let [cfgs (registry/enabled-rule-configs {})]
     (is (= 3 (count cfgs)))
     (is (every? :rule/id cfgs))))
 

--- a/docs/compliance/miniforge-execute.md
+++ b/docs/compliance/miniforge-execute.md
@@ -1,0 +1,17 @@
+---
+title: Miniforge Compliance Execute
+description: Scan, classify, plan, and auto-fix policy violations. Opens one PR per rule for auto-fixable violations.
+type: compliance-execute
+rules: :always-apply
+repo-path: "."
+---
+
+Run the full compliance remediation pipeline against the miniforge repository.
+
+Phases: scan → classify → plan → execute
+
+Output:
+
+- `.miniforge/compliance-report.edn` — machine-readable violation list
+- `docs/compliance/YYYY-MM-DD-compliance-delta.md` — remediation work spec
+- One GitHub PR per rule for auto-fixable violations


### PR DESCRIPTION
## Summary
- Restores `:always-apply` keyword support in `enabled-rule-configs` (accidentally removed by #424), which caused the scanner to return 0 violations
- Fixes `classify-datever` to return `:auto-fixable? false` — SemVer→DateVer requires human context
- Fixes flaky `scan-repo-detects-210-in-temp-dir` test by clearing all `GIT_*` env vars and disabling gpgsign in subprocess
- Adds `docs/compliance/miniforge-execute.md` workflow spec for the full execute pipeline

## Test plan
- [x] All 43 compliance-scanner tests pass (including 4 new/restored scanner-registry tests)
- [x] All 20 workflow-compliance-scanner phase tests pass
- [x] Scan now correctly finds 221 violations (was 0 before fix)
- [x] Pre-commit hook passes (scan test no longer flaky)

🤖 Generated with [Claude Code](https://claude.com/claude-code)