### PR TITLE
fix: [210] Clojure Map Access compliance pass

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/classify.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/classify.clj
@@ -103,7 +103,7 @@
   (classify-violations
    [{:rule/id :std/clojure :rule/category "210"
      :file    "components/foo/src/ai/miniforge/foo/core.clj"
-     :current "(or (:timeout m) 5000)"}
+     (get m :timeout 5000)
     {:rule/id :std/clojure :rule/category "210"
      :file    "server/handler.clj"
      :current "(or (:status m) :pending)"}

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/execute.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/execute.clj
@@ -204,9 +204,9 @@ at `docs/compliance/` for the full list.
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (patch-file-content
-   "(or (:timeout m) 5000)"
+   (get m :timeout 5000)
    [{:rule/id :std/clojure :line 1
-     :current "(or (:timeout m) 5000)" :suggested "(get m :timeout 5000)"
+     (get m :timeout 5000)
      :auto-fixable? true}])
 
   (patch-file-content

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/plan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/plan.clj
@@ -181,7 +181,7 @@
   (def viols
     [{:rule/id :std/clojure :rule/category "210" :rule/title "Clojure Map Access"
       :file "components/foo/src/core.clj" :line 10
-      :current "(or (:k m) nil)" :suggested "(get m :k nil)"
+      (get m :k nil)
       :auto-fixable? true :rationale "Literal default"}
      {:rule/id :std/header-copyright :rule/category "810" :rule/title "Copyright Header (Markdown)"
       :file "components/foo/src/core.clj" :line 1

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/ci_monitor.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/ci_monitor.clj
@@ -117,8 +117,8 @@
    Returns {:status keyword :passed [] :failed [] :pending []}"
   [checks]
   (let [grouped (group-by (fn [check]
-                            (let [state (keyword (str/lower-case (or (:state check) "")))
-                                  conclusion (keyword (str/lower-case (or (:conclusion check) "")))]
+                            (get check :state "")
+                                  (get check :conclusion "")
                               (cond
                                 (= state :completed)
                                 (case conclusion

--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -192,8 +192,8 @@
            vals
            (filter (fn [tool]
                      (let [info (tool-info tool)]
-                       (or (str/includes? (str/lower-case (or (:name info) "")) q)
-                           (str/includes? (str/lower-case (or (:description info) "")) q)))))))))
+                       (get info :name "")
+                           (get info :description "")
 
 (defn create-function-tool
   "Create a function-based tool.

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence/github.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence/github.clj
@@ -52,7 +52,7 @@
 
 (defn- successful-output [result]
   (when (zero? (:exit result))
-    (or (:out result) "")))
+    (get result :out "")
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Individual fetchers

--- a/components/tui-views/src/ai/miniforge/tui_views/update/mode.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/update/mode.clj
@@ -160,7 +160,7 @@
     :status (some-> (:status wf) name)
     :name   (:name wf)
     :phase  (some-> (:phase wf) name)
-    :error  (or (:error wf) "")
+    (get wf :error "")
     ""))
 
 (defn workflow-matches-query?
@@ -169,7 +169,7 @@
   [wf parsed]
   (let [{:keys [fields text]} parsed
         text-match? (or (str/blank? text)
-                        (str/includes? (str/lower-case (or (:name wf) ""))
+                        (get wf :name "")
                                        (str/lower-case text)))
         fields-match? (every? (fn [[field-kw values]]
                                 (let [val (str/lower-case (or (workflow-field-value wf field-kw) ""))]

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/views/workflows.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/views/workflows.clj
@@ -235,7 +235,7 @@
      [:h4.section-title "Latest Output"]
      [:pre.workflow-stream-preview
       {:id (str "wf-streaming-" (:id workflow))}
-      (or (:latest-output workflow) "")]]
+      (get workflow :latest-output "")
 
     ;; Controls — only for running workflows
     (when (= :running (:status workflow))


### PR DESCRIPTION
Auto-generated by the Miniforge compliance scanner.

Applies mechanical fixes for all auto-fixable violations of this rule.
Violations requiring semantic review are excluded — see the work spec
at `docs/compliance/` for the full list.

🤖 Generated with [Miniforge](https://miniforge.ai)