### PR TITLE
fix: restore scan :current to regex match, not full line

### DIFF
--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
@@ -43,11 +43,15 @@
 
 (defn- positive-matches
   "Find all lines in content matching pattern.
-   Returns seq of {:line int :text string}."
+   Returns seq of {:line int :text string :match string}."
   [pattern content]
   (->> (str/split-lines content)
-       (map-indexed (fn [idx line] {:line (inc idx) :text line}))
-       (filter (fn [{:keys [text]}] (re-find pattern text)))))
+       (map-indexed (fn [idx line]
+                      (let [m (re-find pattern line)]
+                        {:line  (inc idx)
+                         :text  line
+                         :match (if (string? m) m (first m))})))
+       (filter :match)))
 
 (defn- violations-for-positive-rule
   "Scan a single file with a positive-match rule (pattern = violation).
@@ -60,15 +64,15 @@
         pattern  (get rule-cfg :pattern)
         suggest  (get rule-cfg :suggest-fn)
         matches  (positive-matches pattern content)]
-    (mapv (fn [{:keys [line text]}]
+    (mapv (fn [{:keys [line match]}]
             (factory/->violation
              rule-id
              rule-cat
              title
              file-path
              line
-             (str/trim text)
-             (suggest (str/trim text))
+             match
+             (suggest match)
              false          ; classify phase fills this in
              ""))           ; classify phase fills this in
           matches)))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/execute_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/execute_test.clj
@@ -121,6 +121,19 @@
       (is (= content patched)
           "Content should be unchanged when suggested is nil and not copyright"))))
 
+(deftest embedded-pattern-replaces-only-match-test
+  (testing "patch-file-content replaces only the matched substring, not the whole line"
+    (let [content  "  (let [state (keyword (str/lower-case (or (:state check) \"\")))]\n"
+          v        {:rule/id       :std/clojure
+                    :rule/category "210"
+                    :line          1
+                    :current       "(or (:state check) \"\")"
+                    :suggested     "(get check :state \"\")"
+                    :auto-fixable? true}
+          patched  (execute/patch-file-content content [v])]
+      (is (= "  (let [state (keyword (str/lower-case (get check :state \"\")))]\n" patched)
+          "Only the matched (or ...) form should be replaced, preserving surrounding code"))))
+
 (deftest empty-violations-returns-content-unchanged-test
   (testing "patch-file-content with empty violations returns content unchanged"
     (let [content "some content\n"]


### PR DESCRIPTION
## Summary
- PR #425 accidentally reverted the scan.clj fix from #424, causing `:current` to be the full trimmed line instead of just the regex match
- This broke execute-phase replacements — entire line content was replaced with just the suggestion, destroying surrounding syntax (e.g., `(let [state (keyword (str/lower-case ...` wrappers)
- Adds regression test verifying embedded-pattern replacement preserves surrounding code

## Test plan
- [x] All 44 compliance-scanner tests pass
- [x] New `embedded-pattern-replaces-only-match-test` verifies correct partial-line replacement
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)