### PR TITLE
fix: handle nil coalesce in ci-monitor and tool search

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/ci_monitor.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/ci_monitor.clj
@@ -117,8 +117,8 @@
    Returns {:status keyword :passed [] :failed [] :pending []}"
   [checks]
   (let [grouped (group-by (fn [check]
-                            (let [state (keyword (str/lower-case (get check :state "")))
-                                  conclusion (keyword (str/lower-case (get check :conclusion "")))]
+                            (let [state (keyword (str/lower-case (or (:state check) "")))
+                                  conclusion (keyword (str/lower-case (or (:conclusion check) "")))]
                               (cond
                                 (= state :completed)
                                 (case conclusion

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/ci_monitor.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/ci_monitor.clj
@@ -105,6 +105,14 @@
       (dag/ok {:raw (:output (:data result))})
       result)))
 
+;------------------------------------------------------------------------------ Layer 0.5
+;; Value coercion
+
+(defn- keywordize-val
+  "Coerce a map value to a lower-case keyword, returning `default` when nil."
+  [m k default]
+  (or (some-> (get m k) str/lower-case keyword) default))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Status computation
 
@@ -117,8 +125,8 @@
    Returns {:status keyword :passed [] :failed [] :pending []}"
   [checks]
   (let [grouped (group-by (fn [check]
-                            (let [state (keyword (str/lower-case (or (:state check) "")))
-                                  conclusion (keyword (str/lower-case (or (:conclusion check) "")))]
+                            (let [state      (keywordize-val check :state :unknown)
+                                  conclusion (keywordize-val check :conclusion :unknown)]
                               (cond
                                 (= state :completed)
                                 (case conclusion

--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -192,8 +192,8 @@
            vals
            (filter (fn [tool]
                      (let [info (tool-info tool)]
-                       (or (str/includes? (str/lower-case (get info :name "")) q)
-                           (str/includes? (str/lower-case (get info :description "")) q)))))))))
+                       (or (str/includes? (str/lower-case (or (:name info) "")) q)
+                           (str/includes? (str/lower-case (or (:description info) "")) q)))))))))
 
 (defn create-function-tool
   "Create a function-based tool.


### PR DESCRIPTION
## Summary

- Fix NPE in `ci-monitor/compute-ci-status` when `:state` or `:conclusion` is explicitly `nil` (GitHub API returns `null` for queued checks)
- Fix NPE in `tool/find-tools` when `:description` is `nil` on a registered tool

Root cause: `(get m :key "")` returns `nil` when the key is present with a `nil` value — the default only applies when the key is absent. Changed to `(or (:key m) "")` which coalesces both cases.

## Test plan

- [x] `ci-monitor-property-test`: 9 tests, 1199 assertions, 0 failures (was 7 errors)
- [x] `tool/interface-test`: 14 tests, 59 assertions, 0 failures (was 1 error)
- [x] Full pr-lifecycle suite: 266 tests, 1880 assertions, 0 failures
- [x] Pre-commit hook passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)