### PR TITLE
fix: release phase NPE when plan returns already-satisfied with 0 tasks

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/release.clj
@@ -200,9 +200,12 @@
                    (log/create-logger {:min-level :debug :output :human}))
         ;; Emit phase-started telemetry event
         _ (phase/emit-phase-started! ctx :release)]
-    ;; Short-circuit: skip release only when implement was already-implemented
-    ;; AND there are no git changes from other phases (tests, docs, specs, etc.)
-    (if (and (= :already-implemented impl-status)
+    ;; Short-circuit: skip release when there is nothing to release.
+    ;; This covers:
+    ;; - implement returned :already-implemented (no new code)
+    ;; - plan returned :already-satisfied (DAG had 0 tasks, no implement ran)
+    ;; In both cases, only skip if there are also no git changes from other phases.
+    (if (and (#{:already-implemented :already-satisfied nil} impl-status)
              (empty? (git-dirty-files (ctx-worktree-path ctx))))
       (-> (phase-result/enter-context ctx :release nil gates budget start-time
                                       (phase-result/skipped :already-implemented))
@@ -262,7 +265,7 @@
   [ctx]
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
-        duration-ms (- end-time start-time)
+        duration-ms (if start-time (- end-time start-time) 0)
         result (get-in ctx [:phase :result])
         release-data (when (= :success (:status result)) (:output result))
         release-metrics (get release-data :release/metrics {})


### PR DESCRIPTION
## Summary

Fixes NPE in release phase when the planner detects specs are already satisfied (0 DAG tasks). The release phase retried 6 times then crashed with `NullPointerException` in `leave-release`.

**Root cause**: `enter-release` only short-circuited on `:already-implemented` status, but when the planner returns `:already-satisfied` the implement phase completes with nil status. This caused `build-workflow-state` to throw `:release/zero-files`, and `leave-release` then computed `(- end-time nil)` because `:started-at` was never set.

**Fix**:
- `enter-release`: short-circuit on `#{:already-implemented :already-satisfied nil}` (not just `:already-implemented`)
- `leave-release`: guard `duration-ms` against nil `start-time`

## Test plan

- [x] All pre-commit tests pass
- [x] Discovered during dogfood run of simple-refactor.edn

🤖 Generated with [Claude Code](https://claude.com/claude-code)