### PR TITLE
fix: release phase contains? fix and regression tests

### DIFF
--- a/.clj-kondo/imports/babashka/sci/sci/core.clj
+++ b/.clj-kondo/imports/babashka/sci/sci/core.clj
@@ -1,21 +1,3 @@
-;; Title: Miniforge.ai
-;; Subtitle: An agentic SDLC / fleet-control platform
-;; Author: Christopher Lester
-;; Line: Founder, Miniforge.ai (project)
-;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
-;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software
-;; distributed under the License is distributed on an "AS IS" BASIS,
-;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and
-;; limitations under the License.
-
 (ns sci.core)
 
 (defmacro copy-ns

--- a/.clj-kondo/imports/hiccup/hiccup/hiccup/hooks.clj
+++ b/.clj-kondo/imports/hiccup/hiccup/hiccup/hooks.clj
@@ -1,21 +1,3 @@
-;; Title: Miniforge.ai
-;; Subtitle: An agentic SDLC / fleet-control platform
-;; Author: Christopher Lester
-;; Line: Founder, Miniforge.ai (project)
-;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
-;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software
-;; distributed under the License is distributed on an "AS IS" BASIS,
-;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and
-;; limitations under the License.
-
 (ns hiccup.hooks
   (:require [clj-kondo.hooks-api :as api]
             [clojure.set :as set]))

--- a/.clj-kondo/imports/http-kit/http-kit/httpkit/with_channel.clj
+++ b/.clj-kondo/imports/http-kit/http-kit/httpkit/with_channel.clj
@@ -1,21 +1,3 @@
-;; Title: Miniforge.ai
-;; Subtitle: An agentic SDLC / fleet-control platform
-;; Author: Christopher Lester
-;; Line: Founder, Miniforge.ai (project)
-;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
-;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software
-;; distributed under the License is distributed on an "AS IS" BASIS,
-;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and
-;; limitations under the License.
-
 (ns httpkit.with-channel
   (:require [clj-kondo.hooks-api :as api]))
 

--- a/.clj-kondo/imports/potemkin/potemkin/potemkin/namespaces.clj
+++ b/.clj-kondo/imports/potemkin/potemkin/potemkin/namespaces.clj
@@ -1,21 +1,3 @@
-;; Title: Miniforge.ai
-;; Subtitle: An agentic SDLC / fleet-control platform
-;; Author: Christopher Lester
-;; Line: Founder, Miniforge.ai (project)
-;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
-;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software
-;; distributed under the License is distributed on an "AS IS" BASIS,
-;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and
-;; limitations under the License.
-
 (ns potemkin.namespaces
   (:require [clj-kondo.hooks-api :as api]))
 

--- a/.clj-kondo/imports/taoensso/encore/taoensso/encore.clj
+++ b/.clj-kondo/imports/taoensso/encore/taoensso/encore.clj
@@ -1,21 +1,3 @@
-;; Title: Miniforge.ai
-;; Subtitle: An agentic SDLC / fleet-control platform
-;; Author: Christopher Lester
-;; Line: Founder, Miniforge.ai (project)
-;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
-;;
-;; Licensed under the Apache License, Version 2.0 (the "License");
-;; you may not use this file except in compliance with the License.
-;; You may obtain a copy of the License at
-;;
-;;     http://www.apache.org/licenses/LICENSE-2.0
-;;
-;; Unless required by applicable law or agreed to in writing, software
-;; distributed under the License is distributed on an "AS IS" BASIS,
-;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-;; See the License for the specific language governing permissions and
-;; limitations under the License.
-
 (ns taoensso.encore
   "I don't personally use clj-kondo, so these hooks are
   kindly authored and maintained by contributors.

--- a/components/phase-software-factory/src/ai/miniforge/phase/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/release.clj
@@ -205,7 +205,7 @@
     ;; - implement returned :already-implemented (no new code)
     ;; - plan returned :already-satisfied (DAG had 0 tasks, no implement ran)
     ;; In both cases, only skip if there are also no git changes from other phases.
-    (if (and (#{:already-implemented :already-satisfied nil} impl-status)
+    (if (and (contains? #{:already-implemented :already-satisfied nil} impl-status)
              (empty? (git-dirty-files (ctx-worktree-path ctx))))
       (-> (phase-result/enter-context ctx :release nil gates budget start-time
                                       (phase-result/skipped :already-implemented))

--- a/components/phase-software-factory/test/ai/miniforge/phase/artifact_persistence_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/artifact_persistence_test.clj
@@ -103,14 +103,14 @@
             (is (= :verify (:phase data)))
             (is (some? (:hint data)))))))))
 
-(deftest test-release-fails-when-no-implement-result
-  (testing "release phase throws when implement phase result is absent"
+(deftest test-release-skips-when-no-implement-result
+  (testing "release phase skips when implement phase result is absent and worktree is clean"
     (let [ctx (-> (create-base-context)
                   ;; No implement result in phase-results (phase never ran)
-                  (assoc :worktree-path *test-worktree*))]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Release phase has no code artifact"
-                            (execute-phase-enter :release ctx))))))
+                  (assoc :worktree-path *test-worktree*))
+          result (execute-phase-enter :release ctx)]
+      (is (= :completed (get-in result [:phase :status]))
+          "Release should skip (complete) when implement status is nil and no dirty files"))))
 
 (deftest test-release-fails-with-failed-implement
   (testing "release phase throws when implement result shows failure status"

--- a/components/phase-software-factory/test/ai/miniforge/phase/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/release_test.clj
@@ -332,6 +332,51 @@
           (is (= "release chunk" (:chunk/delta (first chunk-events))))
           (is (= :release (:agent/id (first chunk-events)))))))))
 
+;------------------------------------------------------------------------------ Regression: already-satisfied / nil implement status
+
+(deftest release-skips-when-plan-already-satisfied-test
+  (testing "release phase skips without NPE when plan returned already-satisfied (0 DAG tasks)"
+    ;; When the planner detects specs are already satisfied, the DAG runs with
+    ;; 0 tasks. The implement result has nil :status. The release phase must
+    ;; short-circuit cleanly instead of throwing :release/zero-files and then
+    ;; NPE-ing in leave-release on (- end-time nil).
+    (let [ctx {:execution/id (random-uuid)
+               :execution/input {:description "Already done" :title "Noop"}
+               :execution/metrics {:tokens 0 :duration-ms 0}
+               :execution/phase-results {:implement {:result {:status nil}}}
+               :worktree-path *test-worktree*}
+          ctx-with-config (assoc ctx :phase-config {:phase :release})
+          interceptor (registry/get-phase-interceptor {:phase :release})
+          result ((:enter interceptor) ctx-with-config)]
+      (is (= :completed (get-in result [:phase :status]))
+          "Release should complete (skip) when implement status is nil and no dirty files"))))
+
+(deftest release-skips-when-implement-already-implemented-test
+  (testing "release phase skips when implement returned :already-implemented"
+    (let [ctx {:execution/id (random-uuid)
+               :execution/input {:description "Already done" :title "Noop"}
+               :execution/metrics {:tokens 0 :duration-ms 0}
+               :execution/phase-results {:implement {:result {:status :already-implemented}}}
+               :worktree-path *test-worktree*}
+          ctx-with-config (assoc ctx :phase-config {:phase :release})
+          interceptor (registry/get-phase-interceptor {:phase :release})
+          result ((:enter interceptor) ctx-with-config)]
+      (is (= :completed (get-in result [:phase :status]))
+          "Release should complete (skip) when implement status is :already-implemented"))))
+
+(deftest leave-release-handles-nil-start-time-test
+  (testing "leave-release does not NPE when :started-at is nil"
+    ;; When enter-release throws before setting :started-at, leave-release
+    ;; must handle nil start-time gracefully.
+    (let [interceptor (registry/get-phase-interceptor {:phase :release})
+          ctx {:phase {:result {:status :error}
+                       :budget {:iterations 2}}
+               :execution/metrics {:tokens 0 :duration-ms 0}}
+          result ((:leave interceptor) ctx)]
+      (is (some? result) "leave-release should not throw")
+      (is (= 0 (get-in result [:phase :duration-ms]))
+          "Duration should default to 0 when start-time is nil"))))
+
 ;------------------------------------------------------------------------------ Layer 2: Interceptor Leave Tests
 
 (deftest leave-release-records-metrics-test


### PR DESCRIPTION
## Summary

Follow-up to #436. Fixes `#{nil}` returning nil (falsy) when called with nil — uses `contains?` instead. Adds 3 regression tests and updates artifact_persistence_test to match new skip-on-nil behavior.

## Test plan

- [x] All pre-commit tests pass
- [x] 3 new regression tests: nil status skip, already-implemented skip, nil start-time in leave

🤖 Generated with [Claude Code](https://claude.com/claude-code)