### PR TITLE
fix: DAG sub-workflows skip release/observe phases

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -167,17 +167,19 @@
   "Build a sub-workflow config for a single DAG task.
 
    Derives pipeline from the parent workflow, removing explore/plan phases
-   (the plan already exists — we're executing it). Keeps :release so each
-   DAG task produces its own PR."
+   (the plan already exists — we're executing it) and release/observe phases
+   (release happens once at the top level after all DAG tasks complete, via
+   apply-dag-success which synthesizes an implement result and resumes the
+   parent pipeline at the post-implement phase)."
   [task-def context]
   (let [parent-workflow (:execution/workflow context)
         parent-pipeline (get parent-workflow :workflow/pipeline [])
         sub-phases (->> parent-pipeline
-                        (remove #(#{:explore :plan} (:phase %)))
+                        (remove #(#{:explore :plan :release :observe} (:phase %)))
                         vec)
         sub-pipeline (if (seq sub-phases)
                        sub-phases
-                       [{:phase :implement} {:phase :release} {:phase :done}])]
+                       [{:phase :implement} {:phase :done}])]
     {:workflow/id (keyword (str "dag-task-" (:task/id task-def)))
      :workflow/version "2.0.0"
      :workflow/name (str "DAG sub-task: " (subs (str (:task/description task-def "task"))

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
@@ -402,8 +402,8 @@
                      {:phase :done}]}}
           sub-wf (dag-orch/task-sub-workflow task-def context)
           phase-names (mapv :phase (:workflow/pipeline sub-wf))]
-      (is (= [:implement :verify :review :release :done] phase-names)
-          "Sub-workflow should strip :explore and :plan but keep :release")))
+      (is (= [:implement :verify :review :done] phase-names)
+          "Sub-workflow should strip :explore, :plan, :release, and :observe")))
 
   (testing "sub-workflow with no parent pipeline falls back to minimal"
     (let [task-def {:task/id (random-uuid)
@@ -411,4 +411,4 @@
           context {:execution/workflow {:workflow/pipeline []}}
           sub-wf (dag-orch/task-sub-workflow task-def context)
           phase-names (mapv :phase (:workflow/pipeline sub-wf))]
-      (is (= [:implement :release :done] phase-names)))))
+      (is (= [:implement :done] phase-names)))))


### PR DESCRIPTION
## Summary

Missing from #438 squash-merge. DAG sub-workflows included `:release` and `:observe` phases from the parent pipeline. Each sub-workflow tried to create its own PR from its isolated worktree, which failed immediately (0ms, 0 tokens) because the sub-worktree lacks proper git remote/auth context. This caused the DAG to report all tasks as failed despite implement/verify/review succeeding.

**Fix**: Strip `:release` and `:observe` from sub-workflow pipelines. Release happens once at the top level — `apply-dag-success` already synthesizes an implement result and resumes the parent pipeline at verify → review → release.

**Trade-off**: All DAG task changes land in a single PR instead of one PR per task. Per-task PRs will return when the fleet DAG orchestrator provides proper container-level isolation (each container has a full git clone, not a worktree).

## Test plan

- [x] Updated `dag_resilience_execution_test` assertions to match new behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)