### PR TITLE
feat: capsule infra — lazy image build, file context, default image

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
@@ -26,6 +26,7 @@
    - resources/executor/docker/Dockerfile.task-runner       (minimal Alpine)
    - resources/executor/docker/Dockerfile.task-runner-clojure (with Clojure tooling)"
   (:require
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.dag-executor.result :as result]
    [ai.miniforge.dag-executor.protocols.executor :as proto]
    [clojure.java.io]
@@ -432,63 +433,50 @@
 ;; Workspace Bootstrap (N11 §4.2)
 ;; ============================================================================
 
-(defn- ssh-url->https-url
-  "Convert git@host:owner/repo.git to https://host/owner/repo.git.
-   Works for any git host (GitHub, GitLab, Bitbucket, etc.).
-   Returns the URL unchanged if it's already HTTPS or not a recognized SSH URL."
-  [url]
-  (if-let [[_ host path] (re-matches #"git@([^:]+):(.+)" url)]
-    (str "https://" host "/" path)
-    url))
-
-(defn- resolve-git-token
-  "Resolve a git access token for capsule clone.
-   One canonical env var per provider:
-   - MINIFORGE_GIT_TOKEN — universal override (any host)
-   - GITLAB_TOKEN — GitLab hosts
-   - GH_TOKEN — GitHub hosts (fallback: `gh auth token` CLI)"
-  [host]
-  (let [raw (or (System/getenv "MINIFORGE_GIT_TOKEN")
-                (if (str/includes? (str host) "gitlab")
-                  (System/getenv "GITLAB_TOKEN")
-                  (or (System/getenv "GH_TOKEN")
-                      (try (str/trim (:out (clojure.java.shell/sh "gh" "auth" "token")))
-                           (catch Exception _ nil)))))]
-    (when (and raw (seq (str/trim raw)))
-      (str/trim raw))))
+(defn- sanitize-token
+  "Remove token credentials from a string for safe logging.
+   Handles both GitHub (x-access-token) and GitLab (oauth2) auth formats."
+  [s]
+  (-> s
+      (str/replace #"x-access-token:[^\s@]+" "x-access-token:***")
+      (str/replace #"oauth2:[^\s@]+" "oauth2:***")))
 
 (defn- authenticated-https-url
   "Inject token credentials into an HTTPS git URL.
-   Uses the host-appropriate token format (GitHub vs GitLab)."
-  [https-url token]
-  (let [gitlab? (str/includes? https-url "gitlab")]
-    (str/replace https-url #"https://"
-                 (if gitlab?
-                   (str "https://oauth2:" token "@")
-                   (str "https://x-access-token:" token "@")))))
+   Uses the host-appropriate token format based on host-kind."
+  [https-url token host-kind]
+  (str/replace https-url #"https://"
+               (if (= host-kind :gitlab)
+                 (str "https://oauth2:" token "@")
+                 (str "https://x-access-token:" token "@"))))
 
 (defn- bootstrap-workspace!
   "Clone a git repository into the container workspace after creation.
    Runs git clone, configures git identity, and checks out the target branch.
    No-op when repo-url is nil (local mode / pre-existing workspace).
-   Prefers HTTPS clone with token auth inside containers where SSH agents
-   are not available. Supports GitHub, GitLab, and other git hosts."
+   Uses config-based token resolution (profile + env fallback) rather than
+   URL-guessing. Converts SSH URLs to HTTPS for containers where SSH agents
+   are not available."
   [docker-path container-name workdir env-config]
   (when-let [repo-url (:repo-url env-config)]
     (let [branch    (or (:branch env-config) "main")
-          https-url (ssh-url->https-url repo-url)
-          host      (second (re-find #"https://([^/]+)" https-url))
-          token     (resolve-git-token host)
+          host-kind (or (:host-kind env-config)
+                        (config/infer-host-kind repo-url))
+          token     (config/resolve-git-token repo-url {:host-kind host-kind})
+          ;; Convert SSH URL to HTTPS (containers lack SSH agent)
+          https-url (if-let [[_ host path] (re-matches #"git@([^:]+):(.+)" repo-url)]
+                      (str "https://" host "/" path)
+                      repo-url)
           clone-url (if token
-                      (authenticated-https-url https-url token)
+                      (authenticated-https-url https-url token host-kind)
                       repo-url)
           exec!  (fn [cmd]
                    (let [r (exec-in-container docker-path container-name cmd
                                               {:workdir "/"})]
                      (when-not (zero? (get-in r [:data :exit-code] 1))
                        ;; Sanitize token from error messages
-                       (let [safe-cmd (clojure.string/replace (str cmd) #"x-access-token:[^\s@]+" "x-access-token:***")
-                             stderr  (clojure.string/replace (or (get-in r [:data :stderr]) "") #"x-access-token:[^\s@]+" "x-access-token:***")]
+                       (let [safe-cmd (sanitize-token (str cmd))
+                             stderr   (sanitize-token (or (get-in r [:data :stderr]) ""))]
                          (throw (ex-info (str "Workspace bootstrap failed: " safe-cmd
                                               (when (seq stderr) (str "\n" stderr)))
                                          {:cmd    safe-cmd
@@ -517,6 +505,12 @@
         (result/ok {:available? false :reason (.getMessage e)}))))
 
   (acquire-environment! [_this task-id env-config]
+    ;; Lazy image build: ensure the image exists locally before creating the container.
+    ;; Looks up image in task-runner-images by name; builds from bundled Dockerfile if missing.
+    (when-not (image-exists? docker-path image)
+      (when-let [image-key (->> task-runner-images
+                                (some (fn [[k v]] (when (= image (:image v)) k))))]
+        (ensure-image! docker-path image-key)))
     (let [container-name (str "miniforge-task-" (subs (str task-id) 0 8))
           workdir (or (:workdir env-config) default-workdir)
           create-result (create-container docker-path

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/docker_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/docker_test.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.protocols.impl.docker-test
+  "Tests for Docker executor: token sanitization, URL auth, image management."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.dag-executor.protocols.impl.docker :as docker]))
+
+;; Private fn accessor helper
+(defn- private-fn [sym]
+  (var-get (ns-resolve 'ai.miniforge.dag-executor.protocols.impl.docker sym)))
+
+;; ============================================================================
+;; sanitize-token
+;; ============================================================================
+
+(deftest sanitize-token-github-test
+  (testing "sanitizes GitHub x-access-token"
+    (let [sanitize (private-fn 'sanitize-token)]
+      (is (= "https://x-access-token:***@github.com/o/r.git"
+             (sanitize "https://x-access-token:ghp_abc123@github.com/o/r.git"))))))
+
+(deftest sanitize-token-gitlab-test
+  (testing "sanitizes GitLab oauth2 token"
+    (let [sanitize (private-fn 'sanitize-token)]
+      (is (= "https://oauth2:***@gitlab.com/g/p.git"
+             (sanitize "https://oauth2:glpat-xyz@gitlab.com/g/p.git"))))))
+
+(deftest sanitize-token-no-token-test
+  (testing "passes through strings without tokens"
+    (let [sanitize (private-fn 'sanitize-token)]
+      (is (= "git clone https://github.com/o/r.git"
+             (sanitize "git clone https://github.com/o/r.git"))))))
+
+;; ============================================================================
+;; authenticated-https-url
+;; ============================================================================
+
+(deftest authenticated-url-github-test
+  (testing "injects GitHub x-access-token"
+    (let [auth-url (private-fn 'authenticated-https-url)]
+      (is (= "https://x-access-token:tok123@github.com/o/r.git"
+             (auth-url "https://github.com/o/r.git" "tok123" :github))))))
+
+(deftest authenticated-url-gitlab-test
+  (testing "injects GitLab oauth2 token"
+    (let [auth-url (private-fn 'authenticated-https-url)]
+      (is (= "https://oauth2:tok456@gitlab.com/g/p.git"
+             (auth-url "https://gitlab.com/g/p.git" "tok456" :gitlab))))))
+
+;; ============================================================================
+;; image-exists? (public)
+;; ============================================================================
+
+(deftest image-exists-nonexistent-test
+  (testing "image-exists? returns false for nonexistent image"
+    (is (false? (docker/image-exists? nil "nonexistent/image:never")))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.dag-executor.protocols.impl.docker-test)
+  :leave-this-here)

--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -115,11 +115,34 @@
   (or (get-in input [:context :files-in-scope])
       (get-in input [:intent :scope])))
 
+(defn- load-files-from-capsule
+  "Read scope files from inside a task capsule via execute-fn.
+   Returns seq of {:path :content} maps, same shape as file-ctx/load-files-in-scope."
+  [execute-fn executor env-id worktree-path files-in-scope]
+  (when (seq files-in-scope)
+    (->> files-in-scope
+         (keep (fn [path]
+                 (try
+                   (let [full-path (str worktree-path "/" path)
+                         result (execute-fn executor env-id (str "cat " full-path)
+                                           {:workdir worktree-path})
+                         content (get-in result [:data :stdout])]
+                     (when (and content (zero? (get-in result [:data :exit-code] 1)))
+                       {:path path :content content}))
+                   (catch Exception _ nil))))
+         vec)))
+
 (defn- resolve-existing-files
-  "Load existing files from cache, context pack, or disk."
+  "Load existing files from cache, context pack, capsule, or disk."
   [ctx pack-ctx worktree-path files-in-scope]
   (or (get-in ctx [:execution/cached-files])
       (:existing-files pack-ctx)
+      ;; In governed mode, read files from inside the capsule
+      (when-let [execute-fn (get ctx :execution/execute-fn)]
+        (load-files-from-capsule execute-fn
+                                 (get ctx :execution/executor)
+                                 (get ctx :execution/environment-id)
+                                 worktree-path files-in-scope))
       (file-ctx/load-files-in-scope worktree-path files-in-scope)))
 
 (defn- resolve-review-feedback

--- a/components/phase-software-factory/test/ai/miniforge/phase/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/implement_test.clj
@@ -204,6 +204,59 @@
         (is (= :implement (first (get-in final-result [:execution :phases-completed])))
             "Implement should be added to phases-completed")))))
 
+;------------------------------------------------------------------------------ Layer 3: Capsule File Loading
+
+(deftest load-files-from-capsule-reads-via-execute-fn-test
+  (testing "load-files-from-capsule reads files via execute-fn"
+    (let [execute-fn (fn [_executor _env-id cmd _opts]
+                       (cond
+                         (= cmd "cat /workspace/src/core.clj")
+                         {:data {:stdout "(ns core)" :exit-code 0}}
+
+                         (= cmd "cat /workspace/src/util.clj")
+                         {:data {:stdout "(ns util)" :exit-code 0}}
+
+                         :else
+                         {:data {:stdout "" :exit-code 1}}))
+          result (#'implement/load-files-from-capsule
+                  execute-fn :mock-executor :mock-env-id "/workspace"
+                  ["src/core.clj" "src/util.clj"])]
+      (is (= 2 (count result)))
+      (is (= "src/core.clj" (:path (first result))))
+      (is (= "(ns core)" (:content (first result))))
+      (is (= "(ns util)" (:content (second result)))))))
+
+(deftest load-files-from-capsule-skips-missing-files-test
+  (testing "load-files-from-capsule skips files that don't exist in capsule"
+    (let [execute-fn (fn [_executor _env-id cmd _opts]
+                       (if (= cmd "cat /workspace/src/exists.clj")
+                         {:data {:stdout "(ns exists)" :exit-code 0}}
+                         {:data {:stdout "" :exit-code 1}}))
+          result (#'implement/load-files-from-capsule
+                  execute-fn :mock-executor :mock-env-id "/workspace"
+                  ["src/exists.clj" "src/missing.clj"])]
+      (is (= 1 (count result)))
+      (is (= "src/exists.clj" (:path (first result)))))))
+
+(deftest load-files-from-capsule-returns-nil-for-empty-scope-test
+  (testing "load-files-from-capsule returns nil when no files in scope"
+    (is (nil? (#'implement/load-files-from-capsule
+               (fn [& _] nil) :x :y "/w" [])))))
+
+(deftest resolve-existing-files-uses-capsule-in-governed-mode-test
+  (testing "resolve-existing-files prefers capsule path when execute-fn is on context"
+    (let [capsule-called (atom false)
+          execute-fn (fn [_executor _env-id cmd _opts]
+                       (reset! capsule-called true)
+                       {:data {:stdout "(ns capsule)" :exit-code 0}})
+          ctx {:execution/execute-fn execute-fn
+               :execution/executor :mock
+               :execution/environment-id :mock-env}
+          result (#'implement/resolve-existing-files
+                  ctx nil "/workspace" ["src/a.clj"])]
+      (is @capsule-called "Should have called execute-fn")
+      (is (= 1 (count result))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 
 (comment

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -225,7 +225,8 @@
   [mode executor-config]
   (case mode
     :governed (merge (select-keys (or executor-config {}) [:docker :kubernetes])
-                     (when-not executor-config {:docker {}}))
+                     (when-not executor-config
+                       {:docker {:image "miniforge/task-runner-clojure:latest"}}))
     {:worktree {}}))
 
 (defn- select-capsule-executor


### PR DESCRIPTION
## Summary

Infrastructure fixes discovered during N11 governed-mode dogfooding:

- **Default governed image** — `miniforge/task-runner-clojure:latest` instead of `alpine:latest` (alpine lacks git, bb, clj)
- **Lazy image build** — `acquire-environment!` auto-builds the task runner image from bundled Dockerfile if it doesn't exist locally
- **Capsule-aware file context** — `resolve-existing-files` reads scope files from inside the capsule via `execute-fn` in governed mode (host can't slurp files from container tmpfs)

## Dogfood results

Both governed-mode dogfood runs completed successfully:

| Spec | Pipeline | Result |
|------|----------|--------|
| Structured logging migration | explore → plan → implement → verify → review (reject) → implement (fix) → review (pass) → done | Success |
| Repo config & profile | implement → verify → review → done | Success |

## Test plan

- [x] Both dogfood specs complete full SDLC pipeline in governed mode
- [x] Lazy image build works (image auto-built on first run)
- [x] Capsule file loading provides context without agent exploring
- [ ] Verify `bb test :phase-software-factory` passes (pre-existing `*test-temp-dir*` issue in dogfood-generated test — not from this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)