### PR TITLE
feat: add 3 work specs for remaining N11 capsule gaps

### DIFF
--- a/work/capsule-cleanup-reliability.spec.edn
+++ b/work/capsule-cleanup-reliability.spec.edn
@@ -1,0 +1,30 @@
+{:spec/title "Reliable capsule cleanup on failure"
+
+ :spec/description
+ "Docker containers from governed-mode runs linger after pipeline errors or
+  timeouts. The runner's release-execution-environment! must be called in all
+  exit paths — success, failure, exception, and timeout.
+
+  Currently the runner has a try/finally but the environment release may not
+  cover all DAG sub-workflow capsules. Each capsule created by the DAG
+  orchestrator must also be cleaned up."
+
+ :spec/intent {:type :fix
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj"
+                       "components/workflow/src/ai/miniforge/workflow/dag_task_runner.clj"]}
+
+ :spec/constraints
+ ["release-execution-environment! must be called in finally blocks"
+  "DAG sub-workflow capsules must be tracked and cleaned up"
+  "Cleanup must not throw — wrap in try/catch"
+  "Log cleanup actions at debug level"
+  "Do not change the public API of run-pipeline"]
+
+ :spec/acceptance-criteria
+ ["No lingering miniforge-task-* containers after pipeline success"
+  "No lingering containers after pipeline failure"
+  "No lingering containers after pipeline timeout"
+  "docker ps --filter name=miniforge-task returns empty after any run"]
+
+ :workflow/type :canonical-sdlc}

--- a/work/capsule-release-pr.spec.edn
+++ b/work/capsule-release-pr.spec.edn
@@ -1,0 +1,36 @@
+{:spec/title "Release phase creates PR from inside capsule"
+
+ :spec/description
+ "The release phase must create git branches and PRs from inside the task
+  capsule in governed mode. Currently, git push and gh pr create run on the
+  host via shell/sh. In governed mode, these must route through execute-fn.
+
+  The GitHub token (resolved via config/resolve-git-token) must be injected
+  into the capsule's git credential config so git push works. The gh CLI
+  inside the capsule must be authenticated via GH_TOKEN env var.
+
+  The bootstrap-workspace! function already injects the token into the clone
+  URL. For push, git needs the token configured as a credential helper or
+  the remote URL must include the token (already the case from clone)."
+
+ :spec/intent {:type :refactor
+               :scope ["components/phase-software-factory/src/ai/miniforge/phase/release.clj"
+                       "components/release-executor/src/ai/miniforge/release_executor/core.clj"]}
+
+ :spec/constraints
+ ["All changes gated on :execution/mode :governed — local mode unchanged"
+  "Token must never appear in logs or error messages (use sanitize-token)"
+  "Use :execution/execute-fn from context — do not require dag-executor"
+  "gh CLI authentication via GH_TOKEN env var injected at container creation"
+  "Release executor must detect governed mode and route git/gh through executor"
+  "Existing release tests must continue to pass"]
+
+ :spec/acceptance-criteria
+ ["In governed mode, git push runs inside capsule via execute-fn"
+  "In governed mode, gh pr create runs inside capsule via execute-fn"
+  "GH_TOKEN injected into container env during acquire-environment!"
+  "PR URL returned in release result"
+  "Local mode behavior unchanged"
+  "Token sanitized in all error paths"]
+
+ :workflow/type :canonical-sdlc}

--- a/work/evidence-execution-mode.spec.edn
+++ b/work/evidence-execution-mode.spec.edn
@@ -1,0 +1,29 @@
+{:spec/title "Evidence bundle records execution mode"
+
+ :spec/description
+ "Per N11 §9.1, each task capsule must produce an evidence record containing
+  :evidence/execution-mode #{:local :governed}. Currently no execution mode
+  is recorded in evidence bundles.
+
+  The evidence record should also include :evidence/runtime-class (:docker,
+  :k8s, :worktree) when available, and :evidence/image-digest for governed
+  mode containers."
+
+ :spec/intent {:type :feature
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/phase-software-factory/src/ai/miniforge/phase/release.clj"]}
+
+ :spec/constraints
+ ["Evidence fields added to the workflow result/metrics, not a new store"
+  "execution-mode comes from :execution/mode on context"
+  "runtime-class comes from executor-type on the executor"
+  "image-digest is optional (SHOULD per N11 §11)"
+  "Existing tests must pass"]
+
+ :spec/acceptance-criteria
+ [":evidence/execution-mode present in workflow result when pipeline completes"
+  ":evidence/runtime-class present when executor is available"
+  "Local mode records :local, governed records :governed"
+  "Evidence fields visible in event stream phase-completed events"]
+
+ :workflow/type :canonical-sdlc}


### PR DESCRIPTION
## Summary

Three work specs for remaining N11 capsule isolation gaps:

1. **capsule-release-pr** — PR creation from inside governed capsule (git push + gh pr create via execute-fn)
2. **evidence-execution-mode** — Record :local/:governed in evidence bundle (N11 §9.1)
3. **capsule-cleanup-reliability** — Reliable container cleanup on failure/timeout

## Test plan

- [ ] Each spec will be run as `bb miniforge run -m governed work/<spec>.edn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)