### PR TITLE
fix: run LLM agent in worktree directory for per-task PRs

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -107,10 +107,14 @@
 (defn create-session!
   "Create a new artifact session with a temporary directory.
 
+   Optionally accepts a workdir override (e.g., a git worktree path) for
+   the pre-session snapshot. Defaults to the JVM's current working directory.
+
    Returns:
    - {:dir <path>, :mcp-config-path <path>, :artifact-path <path>}"
-  []
-  (let [working-dir (System/getProperty "user.dir")
+  ([] (create-session! nil))
+  ([{:keys [workdir]}]
+  (let [working-dir (or workdir (System/getProperty "user.dir"))
         dir (str (Files/createTempDirectory
                   "miniforge-artifact-"
                   (into-array FileAttribute [])))
@@ -122,7 +126,7 @@
      :pre-session-snapshot (try
                              (file-artifacts/snapshot-working-dir working-dir)
                              (catch Exception _
-                               (file-artifacts/empty-snapshot)))}))
+                               (file-artifacts/empty-snapshot)))})))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; MCP server command

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -436,7 +436,8 @@
   "Invoke the implementer via the LLM backend."
   [llm-client user-prompt effective-system-prompt config context on-chunk logger
    existing-files]
-  (let [working-dir (System/getProperty "user.dir")
+  (let [working-dir (or (:execution/worktree-path context)
+                        (System/getProperty "user.dir"))
         {:keys [llm-result artifact context-misses pre-session-snapshot]}
         (artifact-session/with-artifact-session [session]
           ;; Write context cache so MCP tools can serve from it
@@ -446,11 +447,14 @@
               (artifact-session/write-context-cache! session files-map)))
           (let [budget-usd (budget/resolve-cost-budget-usd :implementer config context)
                 max-turns (get @implementer-prompt-data :prompt/max-turns 10)
-                mcp-opts {:mcp-config (:mcp-config-path session)
-                          :mcp-allowed-tools (:mcp-allowed-tools session)
-                          :supervision (:supervision session)
-                          :budget-usd budget-usd
-                          :max-turns max-turns}]
+                mcp-opts (cond-> {:mcp-config (:mcp-config-path session)
+                                  :mcp-allowed-tools (:mcp-allowed-tools session)
+                                  :supervision (:supervision session)
+                                  :budget-usd budget-usd
+                                  :max-turns max-turns}
+                           ;; Run the LLM CLI in the worktree directory so file
+                           ;; writes land in the correct execution environment.
+                           working-dir (assoc :workdir working-dir))]
             (if on-chunk
               (llm/chat-stream llm-client user-prompt on-chunk
                                (merge {:system effective-system-prompt} mcp-opts))

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -487,11 +487,12 @@
 (defn stream-exec-fn
   ([cmd on-line]
    (stream-exec-fn cmd on-line {}))
-  ([cmd on-line {:keys [progress-monitor]}]
+  ([cmd on-line {:keys [progress-monitor workdir]}]
    (let [monitor (or progress-monitor (default-progress-monitor))
          empty-stdin (ByteArrayInputStream. (byte-array 0))
          process (apply p/process (cond-> {:err :string :in empty-stdin}
-                                          (clean-env) (assoc :env (clean-env))) cmd)
+                                          (clean-env) (assoc :env (clean-env))
+                                          workdir     (assoc :dir workdir)) cmd)
          out-reader (java.io.BufferedReader.
                      (java.io.InputStreamReader. (:out process)))
          {:keys [lines timeout]} (process-stream-lines out-reader monitor on-line)
@@ -622,7 +623,8 @@
     (let [result (stream-fn
                   full-cmd
                   (stream-with-parser stream-parser on-chunk accumulated-content accumulated-usage accumulated-cost accumulated-tools)
-                  {:progress-monitor progress-monitor})
+                  {:progress-monitor progress-monitor
+                   :workdir (:workdir request)})
           exit-code (:exit result)
           timeout-info (:timeout result)
           final-content @accumulated-content

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -167,19 +167,17 @@
   "Build a sub-workflow config for a single DAG task.
 
    Derives pipeline from the parent workflow, removing explore/plan phases
-   (the plan already exists — we're executing it) and release/observe phases
-   (release happens once at the top level after all DAG tasks complete, via
-   apply-dag-success which synthesizes an implement result and resumes the
-   parent pipeline at the post-implement phase)."
+   (the plan already exists — we're executing it). Keeps :release so each
+   DAG task produces its own PR. Strips :observe (parent handles monitoring)."
   [task-def context]
   (let [parent-workflow (:execution/workflow context)
         parent-pipeline (get parent-workflow :workflow/pipeline [])
         sub-phases (->> parent-pipeline
-                        (remove #(#{:explore :plan :release :observe} (:phase %)))
+                        (remove #(#{:explore :plan :observe} (:phase %)))
                         vec)
         sub-pipeline (if (seq sub-phases)
                        sub-phases
-                       [{:phase :implement} {:phase :done}])]
+                       [{:phase :implement} {:phase :release} {:phase :done}])]
     {:workflow/id (keyword (str "dag-task-" (:task/id task-def)))
      :workflow/version "2.0.0"
      :workflow/name (str "DAG sub-task: " (subs (str (:task/description task-def "task"))

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
@@ -402,8 +402,8 @@
                      {:phase :done}]}}
           sub-wf (dag-orch/task-sub-workflow task-def context)
           phase-names (mapv :phase (:workflow/pipeline sub-wf))]
-      (is (= [:implement :verify :review :done] phase-names)
-          "Sub-workflow should strip :explore, :plan, :release, and :observe")))
+      (is (= [:implement :verify :review :release :done] phase-names)
+          "Sub-workflow should strip :explore, :plan, and :observe but keep :release")))
 
   (testing "sub-workflow with no parent pipeline falls back to minimal"
     (let [task-def {:task/id (random-uuid)
@@ -411,4 +411,4 @@
           context {:execution/workflow {:workflow/pipeline []}}
           sub-wf (dag-orch/task-sub-workflow task-def context)
           phase-names (mapv :phase (:workflow/pipeline sub-wf))]
-      (is (= [:implement :done] phase-names)))))
+      (is (= [:implement :release :done] phase-names)))))


### PR DESCRIPTION
## Summary

The implement agent (Claude Code/Codex) was running in the JVM's CWD instead of the sub-workflow's worktree. Files were written to the wrong directory, so the release phase always saw zero dirty files.

**Fix**: Thread `:workdir` from execution context → implementer → LLM client → babashka.process `:dir`. The LLM CLI now runs in the correct worktree directory.

Also restores per-task PRs (reverts #440). Each DAG sub-workflow creates its own PR.

## Changes

- `llm_client.clj`: `stream-exec-fn` accepts `:workdir`, sets `:dir` on process
- `implementer.clj`: reads `:execution/worktree-path` from context
- `artifact_session.clj`: `create-session!` accepts optional workdir
- `dag_orchestrator.clj`: restores `:release` in sub-workflow pipelines

## Test plan

- [x] All 3 files compile cleanly
- [x] Updated dag_resilience_execution_test assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)