### PR TITLE
fix: governed mode clones main, not host worktree branch

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -270,7 +270,11 @@
           ;; Infer repo URL and branch for execution environment (Docker clone / worktree).
           ;; Reuses sandbox helpers which fall back to `git remote get-url origin`.
           repo-url (sandbox/infer-repo-url spec enriched-spec)
-          branch   (sandbox/infer-branch spec enriched-spec)
+          ;; In governed mode, always clone main — the capsule creates a fresh
+          ;; working copy, not a checkout of the host worktree's branch.
+          branch   (if (= :governed (:execution-mode opts))
+                     (or (:spec/branch spec) "main")
+                     (sandbox/infer-branch spec enriched-spec))
           workflow-input (context/spec->workflow-input enriched-spec)
           artifact-store (create-artifact-store quiet)
           event-stream (es/create-event-stream)


### PR DESCRIPTION
## Summary

Governed mode capsules clone main instead of the host worktree's current branch. The capsule creates a fresh repo copy — using the host's branch name fails when the branch doesn't exist on the remote.

All 3 governed dogfood runs failed at bootstrap because `infer-branch` returned the local worktree branch (`feat/capsule-release-pr` etc.) which was never pushed.

## Test plan

- [ ] Retry 3 dogfood specs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)