### PR TITLE
feat: workspace persistence — git push between phases for governed mode

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
@@ -55,6 +55,8 @@
 (def copy-from! proto/copy-from!)
 (def release-environment! proto/release-environment!)
 (def environment-status proto/environment-status)
+(def persist-workspace! proto/persist-workspace!)
+(def restore-workspace! proto/restore-workspace!)
 
 (def create-environment-record
   "Create an environment record."

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/executor.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/executor.clj
@@ -100,7 +100,32 @@
      Returns result with:
      {:status keyword           ; :running, :stopped, :error, :unknown
       :created-at inst
-      :resource-usage map}"))
+      :resource-usage map}")
+
+  (persist-workspace! [this environment-id opts]
+    "Persist workspace state so it survives capsule destruction.
+     For Docker: git add/commit/push to a task branch.
+     For K8s/Fleet: upload to object store (future).
+
+     Arguments:
+     - environment-id: ID from acquire-environment!
+     - opts: {:branch string         ; task branch name
+              :message string         ; commit message
+              :workdir string}        ; workspace directory
+
+     Returns result with {:persisted? bool :commit-sha string}")
+
+  (restore-workspace! [this environment-id opts]
+    "Restore workspace state from a previously persisted snapshot.
+     For Docker: git fetch/checkout the task branch.
+     For K8s/Fleet: download from object store (future).
+
+     Arguments:
+     - environment-id: ID from acquire-environment!
+     - opts: {:branch string         ; task branch to restore
+              :workdir string}        ; workspace directory
+
+     Returns result with {:restored? bool :commit-sha string}"))
 
 ;; ============================================================================
 ;; Environment Record

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
@@ -429,6 +429,43 @@
           [image-key (ensure-image! docker-path image-key :force? force?)])))
 
 ;; ============================================================================
+;; Container command execution helper
+;; ============================================================================
+
+(defn- sanitize-token
+  "Remove token credentials from a string for safe logging.
+   Handles both GitHub (x-access-token) and GitLab (oauth2) auth formats."
+  [s]
+  (-> s
+      (str/replace #"x-access-token:[^\s@]+" "x-access-token:***")
+      (str/replace #"oauth2:[^\s@]+" "oauth2:***")))
+
+(defn- container-exec-fn
+  "Build a function that executes commands inside a container.
+   Returns (fn [cmd] -> result-map).
+
+   Options:
+   - :throw-on-error? — throw ex-info on non-zero exit (default false)
+   - :error-prefix — prefix for thrown error messages
+   - :sanitize? — sanitize tokens in error messages (default false)"
+  [docker-path container-id workdir
+   & {:keys [throw-on-error? error-prefix sanitize?]
+      :or {throw-on-error? false error-prefix "Command failed" sanitize? false}}]
+  (fn [cmd]
+    (let [r (exec-in-container docker-path container-id cmd {:workdir workdir})]
+      (when (and throw-on-error?
+                 (not (zero? (get-in r [:data :exit-code] 1))))
+        (let [safe-cmd (if sanitize? (sanitize-token (str cmd)) (str cmd))
+              stderr   (if sanitize?
+                         (sanitize-token (or (get-in r [:data :stderr]) ""))
+                         (or (get-in r [:data :stderr]) ""))]
+          (throw (ex-info (str error-prefix ": " safe-cmd
+                               (when (seq stderr) (str "\n" stderr)))
+                          {:cmd safe-cmd :stderr stderr
+                           :exit (get-in r [:data :exit-code])}))))
+      r)))
+
+;; ============================================================================
 ;; Workspace Bootstrap (N11 §4.2)
 ;; ============================================================================
 
@@ -458,13 +495,6 @@
                      (str/trim (:out r))))
                  (catch Exception _ nil))))))
 
-(defn- sanitize-token
-  "Remove token credentials from a string for safe logging.
-   Handles both GitHub (x-access-token) and GitLab (oauth2) auth formats."
-  [s]
-  (-> s
-      (str/replace #"x-access-token:[^\s@]+" "x-access-token:***")
-      (str/replace #"oauth2:[^\s@]+" "oauth2:***")))
 
 (defn- authenticated-https-url
   "Inject token credentials into an HTTPS git URL.
@@ -495,18 +525,10 @@
           clone-url (if token
                       (authenticated-https-url https-url token host-kind)
                       repo-url)
-          exec!  (fn [cmd]
-                   (let [r (exec-in-container docker-path container-name cmd
-                                              {:workdir "/"})]
-                     (when-not (zero? (get-in r [:data :exit-code] 1))
-                       ;; Sanitize token from error messages
-                       (let [safe-cmd (sanitize-token (str cmd))
-                             stderr   (sanitize-token (or (get-in r [:data :stderr]) ""))]
-                         (throw (ex-info (str "Workspace bootstrap failed: " safe-cmd
-                                              (when (seq stderr) (str "\n" stderr)))
-                                         {:cmd    safe-cmd
-                                          :stderr stderr
-                                          :exit   (get-in r [:data :exit-code])}))))))
+          exec!  (container-exec-fn docker-path container-name "/"
+                                    :throw-on-error? true
+                                    :error-prefix "Workspace bootstrap failed"
+                                    :sanitize? true)
           clone-cmd (str "git clone --branch " branch " --single-branch "
                          clone-url " " workdir)]
       (exec! clone-cmd)
@@ -594,9 +616,7 @@
           branch  (or (:branch opts) "task/unknown")
           message (or (:message opts) "phase checkpoint")]
       (try
-        (let [exec! (fn [cmd]
-                      (exec-in-container docker-path environment-id cmd
-                                         {:workdir workdir}))
+        (let [exec! (container-exec-fn docker-path environment-id workdir)
               ;; Stage all changes
               _ (exec! "git add -A")
               ;; Check if there are changes to commit
@@ -618,9 +638,7 @@
     (let [workdir (or (:workdir opts) default-workdir)
           branch  (or (:branch opts) "task/unknown")]
       (try
-        (let [exec! (fn [cmd]
-                      (exec-in-container docker-path environment-id cmd
-                                         {:workdir workdir}))
+        (let [exec! (container-exec-fn docker-path environment-id workdir)
               _ (exec! (str "git fetch origin " branch))
               _ (exec! (str "git checkout " branch))
               sha-r (exec! "git rev-parse HEAD")

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
@@ -27,6 +27,7 @@
    - resources/executor/docker/Dockerfile.task-runner-clojure (with Clojure tooling)"
   (:require
    [ai.miniforge.dag-executor.result :as result]
+   [ai.miniforge.dag-executor.workspace :as workspace]
    [ai.miniforge.dag-executor.protocols.executor :as proto]
    [clojure.java.io]
    [clojure.java.shell :as shell]
@@ -612,40 +613,14 @@
         (result/ok {:status :unknown :error (.getMessage e)}))))
 
   (persist-workspace! [_this environment-id opts]
-    (let [workdir (or (:workdir opts) default-workdir)
-          branch  (or (:branch opts) "task/unknown")
-          message (or (:message opts) "phase checkpoint")]
-      (try
-        (let [exec! (container-exec-fn docker-path environment-id workdir)
-              ;; Stage all changes
-              _ (exec! "git add -A")
-              ;; Check if there are changes to commit
-              status-r (exec! "git status --porcelain")
-              has-changes? (seq (str/trim (get-in status-r [:data :stdout] "")))]
-          (if has-changes?
-            (let [_ (exec! (str "git commit -m '" message "'"))
-                  ;; Push to task branch (create if needed)
-                  push-r (exec! (str "git push origin HEAD:" branch " --force"))
-                  ;; Get commit SHA
-                  sha-r  (exec! "git rev-parse HEAD")
-                  sha    (str/trim (get-in sha-r [:data :stdout] ""))]
-              (result/ok {:persisted? true :commit-sha sha :branch branch}))
-            (result/ok {:persisted? false :commit-sha nil :no-changes? true})))
-        (catch Exception e
-          (result/err :persist-failed (.getMessage e))))))
+    (let [exec! (container-exec-fn docker-path environment-id
+                                    (or (:workdir opts) default-workdir))]
+      (workspace/git-persist! exec! opts)))
 
   (restore-workspace! [_this environment-id opts]
-    (let [workdir (or (:workdir opts) default-workdir)
-          branch  (or (:branch opts) "task/unknown")]
-      (try
-        (let [exec! (container-exec-fn docker-path environment-id workdir)
-              _ (exec! (str "git fetch origin " branch))
-              _ (exec! (str "git checkout " branch))
-              sha-r (exec! "git rev-parse HEAD")
-              sha   (str/trim (get-in sha-r [:data :stdout] ""))]
-          (result/ok {:restored? true :commit-sha sha :branch branch}))
-        (catch Exception e
-          (result/err :restore-failed (.getMessage e)))))))
+    (let [exec! (container-exec-fn docker-path environment-id
+                                    (or (:workdir opts) default-workdir))]
+      (workspace/git-restore! exec! opts))))
 
 ;; ============================================================================
 ;; Factory

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
@@ -512,7 +512,11 @@
       (exec! clone-cmd)
       ;; Use --local (not --global) since container rootfs is read-only
       (exec! (str "git -C " workdir " config user.email 'miniforge@miniforge.ai'"))
-      (exec! (str "git -C " workdir " config user.name 'miniforge'")))))
+      (exec! (str "git -C " workdir " config user.name 'miniforge'"))
+      ;; Set push URL with token so persist-workspace! can push
+      (when token
+        (exec! (str "git -C " workdir " remote set-url --push origin "
+                    (authenticated-https-url https-url token host-kind)))))))
 
 ;; ============================================================================
 ;; DockerExecutor Record
@@ -583,7 +587,47 @@
     (try
       (inspect-container docker-path environment-id)
       (catch Exception e
-        (result/ok {:status :unknown :error (.getMessage e)})))))
+        (result/ok {:status :unknown :error (.getMessage e)}))))
+
+  (persist-workspace! [_this environment-id opts]
+    (let [workdir (or (:workdir opts) default-workdir)
+          branch  (or (:branch opts) "task/unknown")
+          message (or (:message opts) "phase checkpoint")]
+      (try
+        (let [exec! (fn [cmd]
+                      (exec-in-container docker-path environment-id cmd
+                                         {:workdir workdir}))
+              ;; Stage all changes
+              _ (exec! "git add -A")
+              ;; Check if there are changes to commit
+              status-r (exec! "git status --porcelain")
+              has-changes? (seq (str/trim (get-in status-r [:data :stdout] "")))]
+          (if has-changes?
+            (let [_ (exec! (str "git commit -m '" message "'"))
+                  ;; Push to task branch (create if needed)
+                  push-r (exec! (str "git push origin HEAD:" branch " --force"))
+                  ;; Get commit SHA
+                  sha-r  (exec! "git rev-parse HEAD")
+                  sha    (str/trim (get-in sha-r [:data :stdout] ""))]
+              (result/ok {:persisted? true :commit-sha sha :branch branch}))
+            (result/ok {:persisted? false :commit-sha nil :no-changes? true})))
+        (catch Exception e
+          (result/err :persist-failed (.getMessage e))))))
+
+  (restore-workspace! [_this environment-id opts]
+    (let [workdir (or (:workdir opts) default-workdir)
+          branch  (or (:branch opts) "task/unknown")]
+      (try
+        (let [exec! (fn [cmd]
+                      (exec-in-container docker-path environment-id cmd
+                                         {:workdir workdir}))
+              _ (exec! (str "git fetch origin " branch))
+              _ (exec! (str "git checkout " branch))
+              sha-r (exec! "git rev-parse HEAD")
+              sha   (str/trim (get-in sha-r [:data :stdout] ""))]
+          (result/ok {:restored? true :commit-sha sha :branch branch}))
+        (catch Exception e
+          (result/err :restore-failed (.getMessage e)))))))
 
 ;; ============================================================================
 ;; Factory

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/kubernetes.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/kubernetes.clj
@@ -358,7 +358,40 @@
     (try
       (get-job-status kubectl-path namespace environment-id)
       (catch Exception e
-        (result/ok {:status :unknown :error (.getMessage e)})))))
+        (result/ok {:status :unknown :error (.getMessage e)}))))
+
+  ;; K8s persistence: git push (same as Docker). Fleet tier will use object store.
+  (persist-workspace! [this environment-id opts]
+    (let [workdir (or (:workdir opts) "/workspace")
+          branch  (or (:branch opts) "task/unknown")
+          message (or (:message opts) "phase checkpoint")]
+      (try
+        (let [exec! (fn [cmd] (proto/execute! this environment-id cmd {:workdir workdir}))
+              _ (exec! "git add -A")
+              status-r (exec! "git status --porcelain")
+              has-changes? (seq (clojure.string/trim (get-in status-r [:data :stdout] "")))]
+          (if has-changes?
+            (let [_ (exec! (str "git commit -m '" message "'"))
+                  _ (exec! (str "git push origin HEAD:" branch " --force"))
+                  sha-r (exec! "git rev-parse HEAD")
+                  sha   (clojure.string/trim (get-in sha-r [:data :stdout] ""))]
+              (result/ok {:persisted? true :commit-sha sha :branch branch}))
+            (result/ok {:persisted? false :no-changes? true})))
+        (catch Exception e
+          (result/err :persist-failed (.getMessage e))))))
+
+  (restore-workspace! [this environment-id opts]
+    (let [workdir (or (:workdir opts) "/workspace")
+          branch  (or (:branch opts) "task/unknown")]
+      (try
+        (let [exec! (fn [cmd] (proto/execute! this environment-id cmd {:workdir workdir}))
+              _ (exec! (str "git fetch origin " branch))
+              _ (exec! (str "git checkout " branch))
+              sha-r (exec! "git rev-parse HEAD")
+              sha   (clojure.string/trim (get-in sha-r [:data :stdout] ""))]
+          (result/ok {:restored? true :commit-sha sha :branch branch}))
+        (catch Exception e
+          (result/err :restore-failed (.getMessage e)))))))
 
 ;; ============================================================================
 ;; Factory

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/kubernetes.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/kubernetes.clj
@@ -30,6 +30,7 @@
    resources/executor/kubernetes/job-template.yaml"
   (:require
    [ai.miniforge.dag-executor.result :as result]
+   [ai.miniforge.dag-executor.workspace :as workspace]
    [ai.miniforge.dag-executor.protocols.executor :as proto]
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
@@ -362,36 +363,14 @@
 
   ;; K8s persistence: git push (same as Docker). Fleet tier will use object store.
   (persist-workspace! [this environment-id opts]
-    (let [workdir (or (:workdir opts) "/workspace")
-          branch  (or (:branch opts) "task/unknown")
-          message (or (:message opts) "phase checkpoint")]
-      (try
-        (let [exec! (fn [cmd] (proto/execute! this environment-id cmd {:workdir workdir}))
-              _ (exec! "git add -A")
-              status-r (exec! "git status --porcelain")
-              has-changes? (seq (clojure.string/trim (get-in status-r [:data :stdout] "")))]
-          (if has-changes?
-            (let [_ (exec! (str "git commit -m '" message "'"))
-                  _ (exec! (str "git push origin HEAD:" branch " --force"))
-                  sha-r (exec! "git rev-parse HEAD")
-                  sha   (clojure.string/trim (get-in sha-r [:data :stdout] ""))]
-              (result/ok {:persisted? true :commit-sha sha :branch branch}))
-            (result/ok {:persisted? false :no-changes? true})))
-        (catch Exception e
-          (result/err :persist-failed (.getMessage e))))))
+    (let [exec! (fn [cmd] (proto/execute! this environment-id cmd
+                                          {:workdir (or (:workdir opts) "/workspace")}))]
+      (workspace/git-persist! exec! opts)))
 
   (restore-workspace! [this environment-id opts]
-    (let [workdir (or (:workdir opts) "/workspace")
-          branch  (or (:branch opts) "task/unknown")]
-      (try
-        (let [exec! (fn [cmd] (proto/execute! this environment-id cmd {:workdir workdir}))
-              _ (exec! (str "git fetch origin " branch))
-              _ (exec! (str "git checkout " branch))
-              sha-r (exec! "git rev-parse HEAD")
-              sha   (clojure.string/trim (get-in sha-r [:data :stdout] ""))]
-          (result/ok {:restored? true :commit-sha sha :branch branch}))
-        (catch Exception e
-          (result/err :restore-failed (.getMessage e)))))))
+    (let [exec! (fn [cmd] (proto/execute! this environment-id cmd
+                                          {:workdir (or (:workdir opts) "/workspace")}))]
+      (workspace/git-restore! exec! opts))))
 
 ;; ============================================================================
 ;; Factory

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -287,7 +287,15 @@
     (let [worktree-path (str base-path "/" environment-id)]
       (if (.exists (File. ^String worktree-path))
         (result/ok {:status :running})
-        (result/ok {:status :stopped})))))
+        (result/ok {:status :stopped}))))
+
+  (persist-workspace! [_this _environment-id _opts]
+    ;; Worktree files are already on host — no persistence needed
+    (result/ok {:persisted? false :no-changes? true}))
+
+  (restore-workspace! [_this _environment-id _opts]
+    ;; Worktree files are already on host — no restore needed
+    (result/ok {:restored? false})))
 
 ;; ============================================================================
 ;; Factory

--- a/components/dag-executor/src/ai/miniforge/dag_executor/workspace.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/workspace.clj
@@ -1,0 +1,71 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.workspace
+  "Git-based workspace persistence shared by Docker and K8s executors.
+
+   Provides persist and restore functions that take an exec-fn (command
+   executor for the environment) and delegate the git operations. Each
+   executor implementation constructs its own exec-fn and passes it here.
+
+   OSS tier uses git push/fetch. Fleet tier will add object store
+   (S3/GCS/MinIO) as an alternative persistence backend."
+  (:require
+   [ai.miniforge.dag-executor.result :as result]
+   [clojure.string :as str]))
+
+(defn git-persist!
+  "Persist workspace via git commit + push.
+
+   Arguments:
+   - exec-fn: (fn [cmd] -> result-map) — executes a shell command in the environment
+   - opts: {:branch string, :message string}
+
+   Returns result monad with {:persisted? bool :commit-sha string :branch string}"
+  [exec-fn {:keys [branch message] :or {branch "task/unknown" message "phase checkpoint"}}]
+  (try
+    (let [_ (exec-fn "git add -A")
+          status-r (exec-fn "git status --porcelain")
+          has-changes? (seq (str/trim (get-in status-r [:data :stdout] "")))]
+      (if has-changes?
+        (let [_ (exec-fn (str "git commit -m '" message "'"))
+              _ (exec-fn (str "git push origin HEAD:" branch " --force"))
+              sha-r (exec-fn "git rev-parse HEAD")
+              sha   (str/trim (get-in sha-r [:data :stdout] ""))]
+          (result/ok {:persisted? true :commit-sha sha :branch branch}))
+        (result/ok {:persisted? false :commit-sha nil :no-changes? true})))
+    (catch Exception e
+      (result/err :persist-failed (.getMessage e)))))
+
+(defn git-restore!
+  "Restore workspace via git fetch + checkout.
+
+   Arguments:
+   - exec-fn: (fn [cmd] -> result-map) — executes a shell command in the environment
+   - opts: {:branch string}
+
+   Returns result monad with {:restored? bool :commit-sha string :branch string}"
+  [exec-fn {:keys [branch] :or {branch "task/unknown"}}]
+  (try
+    (let [_ (exec-fn (str "git fetch origin " branch))
+          _ (exec-fn (str "git checkout " branch))
+          sha-r (exec-fn "git rev-parse HEAD")
+          sha   (str/trim (get-in sha-r [:data :stdout] ""))]
+      (result/ok {:restored? true :commit-sha sha :branch branch}))
+    (catch Exception e
+      (result/err :restore-failed (.getMessage e)))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/docker_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/docker_test.clj
@@ -20,6 +20,8 @@
   "Tests for Docker executor: token sanitization, URL auth, image management."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [clojure.string]
+   [ai.miniforge.dag-executor.protocols.executor :as proto]
    [ai.miniforge.dag-executor.protocols.impl.docker :as docker]))
 
 ;; Private fn accessor helper
@@ -71,6 +73,72 @@
 (deftest image-exists-nonexistent-test
   (testing "image-exists? returns false for nonexistent image"
     (is (false? (docker/image-exists? nil "nonexistent/image:never")))))
+
+;; ============================================================================
+;; persist-workspace!
+;; ============================================================================
+
+(deftest persist-workspace-with-changes-test
+  (testing "persist-workspace! commits and pushes when there are dirty files"
+    (let [commands (atom [])
+          executor (docker/create-docker-executor {:image "test:latest"})]
+      (with-redefs [docker/exec-in-container
+                    (fn [_docker-path _env-id cmd _opts]
+                      (swap! commands conj cmd)
+                      (cond
+                        (= cmd "git status --porcelain")
+                        {:data {:exit-code 0 :stdout "M src/core.clj\n"}}
+
+                        (= cmd "git rev-parse HEAD")
+                        {:data {:exit-code 0 :stdout "abc123\n"}}
+
+                        :else
+                        {:data {:exit-code 0 :stdout "" :stderr ""}}))]
+        (let [result (proto/persist-workspace! executor "container-1"
+                                               {:branch "task/test-123"
+                                                :message "implement completed"
+                                                :workdir "/workspace"})]
+          (is (true? (get-in result [:data :persisted?])))
+          (is (= "abc123" (get-in result [:data :commit-sha])))
+          (is (some #(= "git add -A" %) @commands))
+          (is (some #(clojure.string/includes? % "git commit") @commands))
+          (is (some #(clojure.string/includes? % "git push") @commands)))))))
+
+(deftest persist-workspace-no-changes-test
+  (testing "persist-workspace! returns {:persisted? false} when no dirty files"
+    (let [executor (docker/create-docker-executor {:image "test:latest"})]
+      (with-redefs [docker/exec-in-container
+                    (fn [_docker-path _env-id cmd _opts]
+                      (if (= cmd "git status --porcelain")
+                        {:data {:exit-code 0 :stdout ""}}
+                        {:data {:exit-code 0 :stdout "" :stderr ""}}))]
+        (let [result (proto/persist-workspace! executor "container-1"
+                                               {:branch "task/test-123"
+                                                :workdir "/workspace"})]
+          (is (false? (get-in result [:data :persisted?])))
+          (is (true? (get-in result [:data :no-changes?]))))))))
+
+;; ============================================================================
+;; restore-workspace!
+;; ============================================================================
+
+(deftest restore-workspace-test
+  (testing "restore-workspace! fetches and checks out task branch"
+    (let [commands (atom [])
+          executor (docker/create-docker-executor {:image "test:latest"})]
+      (with-redefs [docker/exec-in-container
+                    (fn [_docker-path _env-id cmd _opts]
+                      (swap! commands conj cmd)
+                      (if (= cmd "git rev-parse HEAD")
+                        {:data {:exit-code 0 :stdout "def456\n"}}
+                        {:data {:exit-code 0 :stdout "" :stderr ""}}))]
+        (let [result (proto/restore-workspace! executor "container-1"
+                                               {:branch "task/test-123"
+                                                :workdir "/workspace"})]
+          (is (true? (get-in result [:data :restored?])))
+          (is (= "def456" (get-in result [:data :commit-sha])))
+          (is (some #(clojure.string/includes? % "git fetch") @commands))
+          (is (some #(clojure.string/includes? % "git checkout") @commands)))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -20,6 +20,7 @@
   "Tests for the worktree executor: concurrent-add lock and fallback strategy."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.dag-executor.protocols.executor :as proto]
    [ai.miniforge.dag-executor.protocols.impl.worktree :as worktree]
    [ai.miniforge.dag-executor.result :as result]))
 
@@ -96,3 +97,25 @@
   (testing "worktree-lock is an Object used to serialize concurrent git add calls"
     (is (some? @#'worktree/worktree-lock))
     (is (instance? Object @#'worktree/worktree-lock))))
+
+;; ============================================================================
+;; persist-workspace! / restore-workspace! (no-op for worktree)
+;; ============================================================================
+
+(deftest persist-workspace-noop-test
+  (testing "worktree persist-workspace! is a no-op — files are already on host"
+    (let [executor (worktree/create-worktree-executor {})]
+      (with-redefs [worktree/run-git   (fn [& _] {:exit 0 :out "" :err ""})
+                    worktree/run-shell (fn [& _] {:exit 0 :out "" :err ""})]
+        (let [r (proto/persist-workspace! executor "env-1" {:branch "task/x"})]
+          (is (result/ok? r))
+          (is (false? (get-in r [:data :persisted?]))))))))
+
+(deftest restore-workspace-noop-test
+  (testing "worktree restore-workspace! is a no-op"
+    (let [executor (worktree/create-worktree-executor {})]
+      (with-redefs [worktree/run-git   (fn [& _] {:exit 0 :out "" :err ""})
+                    worktree/run-shell (fn [& _] {:exit 0 :out "" :err ""})]
+        (let [r (proto/restore-workspace! executor "env-1" {:branch "task/x"})]
+          (is (result/ok? r))
+          (is (false? (get-in r [:data :restored?]))))))))

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -372,6 +372,21 @@
                                                    ctx/transition-to-completed
                                                    ctx/transition-to-failed)
                           (monitoring/clear-transient-state))
+            ;; Persist workspace after phase completes (governed mode only).
+            ;; Git commit + push to task branch so changes survive capsule destruction.
+            _ (when-let [executor (get context :execution/executor)]
+                (when (= :governed (get context :execution/mode))
+                  (let [env-id (get context :execution/environment-id)
+                        branch (get context :execution/task-branch)
+                        phase  (or (:execution/current-phase phase-ctx) "unknown")]
+                    (try
+                      (dag-exec/persist-workspace! executor env-id
+                                                   {:branch  branch
+                                                    :message (str phase " phase completed")
+                                                    :workdir (get context :execution/worktree-path)})
+                      (catch Exception e
+                        (log/warn runner-logger :workflow :workflow/persist-failed
+                                  {:message (str "Workspace persist failed: " (ex-message e))}))))))
             ;; Check if phase failed due to rate limiting — if so, stop retrying
             ;; and bubble the error up to the DAG orchestrator's resilience module
             current-phase (:execution/current-phase phase-ctx)
@@ -553,6 +568,10 @@
                                 ;; requiring dag-executor (N11 §6.2, §9.3)
                                 :execution/execute-fn (when governed? dag-exec/execute!)
                                 :execution/exec-fn capsule-exec-fn
+                                ;; Task branch for workspace persistence (git push between phases)
+                                :execution/task-branch (when governed?
+                                                         (str "task/" (or (get opts :environment-id)
+                                                                         (subs (str (random-uuid)) 0 8))))
                                 ;; Injected so dag-orchestrator can call back into the
                                 ;; runner without a circular namespace dependency.
                                 :execution/run-pipeline-fn run-pipeline))]


### PR DESCRIPTION
## Summary

Add `persist-workspace!` / `restore-workspace!` to the `TaskExecutor` protocol. After each phase in governed mode, the runner commits changes inside the capsule and pushes to a `task/<id>` branch. This ensures code survives capsule destruction and enables the release phase to create PRs.

### Changes

- **Protocol**: `persist-workspace!` and `restore-workspace!` on `TaskExecutor`
- **Docker impl**: `git add -A && git commit && git push origin HEAD:task/<id> --force`
- **K8s impl**: same git-based persistence (fleet tier will add object store)
- **Worktree impl**: no-op (files already on host)
- **Runner**: calls `persist-workspace!` after each phase in governed mode
- **Bootstrap**: sets push URL with token for authenticated push

### Architecture

```
Phase N completes
  → git add -A && git commit (inside capsule)
  → git push origin HEAD:task/<id> (to remote)
  
Phase N+1 starts
  → changes already in capsule (same container)
  → if new capsule: git fetch + checkout task/<id>

Release phase
  → push task branch, create PR from it
```

OSS tier uses git push. Fleet/K8s tier will add S3/MinIO object store (separate repo).

## Test plan

- [x] 271 tests, 0 failures (dag-executor + workflow)
- [ ] Dogfood: `bb miniforge run -m governed` persists changes between phases
- [ ] Release phase creates PR from task branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)