### PR TITLE
feat: agent knowledge-content injection alongside behavioral rules

### DIFF
--- a/components/phase/src/ai/miniforge/phase/agent_behavior.clj
+++ b/components/phase/src/ai/miniforge/phase/agent_behavior.clj
@@ -51,6 +51,22 @@
        (map :rule/agent-behavior)
        (filterv some?)))
 
+(defn extract-knowledge-content
+  "Extract non-nil :rule/knowledge-content strings from a seq of rules.
+
+   Arguments:
+   - rules - Seq of rule maps
+
+   Returns:
+   - Vector of {:rule/id keyword :rule/title string :content string}"
+  [rules]
+  (->> rules
+       (filter :rule/knowledge-content)
+       (mapv (fn [r]
+               {:rule/id    (:rule/id r)
+                :rule/title (:rule/title r)
+                :content    (:rule/knowledge-content r)}))))
+
 (defn format-behavior-addendum
   "Format behavior strings as a numbered markdown section for prompt injection.
 
@@ -65,6 +81,23 @@
          (->> behaviors
               (map-indexed (fn [i b] (str (inc i) ". " b)))
               (str/join "\n"))
+         "\n")))
+
+(defn format-knowledge-addendum
+  "Format knowledge content as a reference material section for prompt injection.
+
+   Arguments:
+   - knowledge - Seq of {:rule/id :rule/title :content} maps
+
+   Returns:
+   - Formatted string or nil if no knowledge"
+  [knowledge]
+  (when (seq knowledge)
+    (str "\n\n## Reference Material\n\n"
+         (->> knowledge
+              (map (fn [{:keys [rule/title content]}]
+                     (str "### " (or title "Standard") "\n\n" content)))
+              (str/join "\n\n"))
          "\n")))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -202,8 +235,12 @@
                                    (or context-gated [])))
 
           filtered  (into always-matched other-matched)
-          behaviors (extract-agent-behaviors filtered)]
-      (format-behavior-addendum behaviors))
+          behaviors (extract-agent-behaviors filtered)
+          knowledge (extract-knowledge-content filtered)
+          behavior-section  (format-behavior-addendum behaviors)
+          knowledge-section (format-knowledge-addendum knowledge)]
+      (when (or behavior-section knowledge-section)
+        (str behavior-section knowledge-section)))
     (catch Exception _
       nil)))
 

--- a/components/phase/test/ai/miniforge/phase/agent_behavior_test.clj
+++ b/components/phase/test/ai/miniforge/phase/agent_behavior_test.clj
@@ -247,6 +247,52 @@
       (is (str/includes? addendum "1. Check imports."))
       (is (str/includes? addendum "2. Validate schema.")))))
 
+;; ============================================================================
+;; Layer 0 — extract-knowledge-content tests
+;; ============================================================================
+
+(deftest extract-knowledge-content-test
+  (testing "extracts rules with :rule/knowledge-content"
+    (let [result (sut/extract-knowledge-content
+                  [{:rule/id :r1 :rule/title "Rule 1" :rule/knowledge-content "Content 1"}
+                   {:rule/id :r2 :rule/title "Rule 2"}
+                   {:rule/id :r3 :rule/title "Rule 3" :rule/knowledge-content "Content 3"}])]
+      (is (= 2 (count result)))
+      (is (= :r1 (:rule/id (first result))))
+      (is (= "Content 1" (:content (first result))))))
+
+  (testing "returns empty vector when no knowledge content"
+    (is (= [] (sut/extract-knowledge-content [{:rule/id :r1}]))))
+
+  (testing "returns empty vector for empty input"
+    (is (= [] (sut/extract-knowledge-content [])))))
+
+;; ============================================================================
+;; Layer 0 — format-knowledge-addendum tests
+;; ============================================================================
+
+(deftest format-knowledge-addendum-test
+  (testing "formats knowledge as Reference Material section"
+    (let [result (sut/format-knowledge-addendum
+                  [{:rule/title "Rule A" :content "Body A"}])]
+      (is (string? result))
+      (is (str/includes? result "## Reference Material"))
+      (is (str/includes? result "### Rule A"))
+      (is (str/includes? result "Body A"))))
+
+  (testing "formats multiple knowledge entries"
+    (let [result (sut/format-knowledge-addendum
+                  [{:rule/title "R1" :content "C1"}
+                   {:rule/title "R2" :content "C2"}])]
+      (is (str/includes? result "### R1"))
+      (is (str/includes? result "### R2"))))
+
+  (testing "returns nil for empty knowledge"
+    (is (nil? (sut/format-knowledge-addendum []))))
+
+  (testing "returns nil for nil knowledge"
+    (is (nil? (sut/format-knowledge-addendum nil)))))
+
 (deftest empty-rules-produce-nil-addendum-test
   (testing "no applicable rules → nil addendum (no empty section injected)"
     (let [behaviors (sut/extract-agent-behaviors [])


### PR DESCRIPTION
## Summary

- Adds `extract-knowledge-content` function to pull `:rule/knowledge-content` from policy pack rules
- Adds `format-knowledge-addendum` function to render a Reference Material section for prompt injection
- Updates `load-and-filter-behaviors` to emit both behavior directives and knowledge content in the prompt addendum

## Test plan

- [x] All 23 phase component tests pass (agent-behavior, loader, interface)
- [x] Clojure linting clean
- [x] GraalVM/Babashka compatibility tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)