### PR TITLE
feat: reference policy packs — 11 standard packs (53 rules) per N4 §5

### DIFF
--- a/components/policy-pack/resources/policy_pack/packs/capability-grant-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/capability-grant-1.0.0.pack.edn
@@ -1,0 +1,70 @@
+;; Capability Grant Policy Pack — capability-based access control for agents.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, §2.3
+;; Dewey category: 001 (Foundations & Core Principles)
+
+{:pack/id          "miniforge/capability-grant"
+ :pack/name        "Capability Grant"
+ :pack/version     "1.0.0"
+ :pack/description "Capability-based access control rules for agents: declaration requirements, default-deny writes, scope enforcement, and reapproval workflows."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "001"
+   :category/name "Capability Grant"
+   :category/rules [:cap/require-declaration
+                    :cap/deny-default-writes
+                    :cap/enforce-scope
+                    :cap/require-reapproval]}]
+
+ :pack/rules
+ [{:rule/id          :cap/require-declaration
+   :rule/title       "Require Capability Declaration"
+   :rule/description "Ensures agents declare all required capabilities before task execution begins. Undeclared capabilities cannot be exercised, enforcing the principle of least privilege at the declaration layer."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:plan}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Agent has not declared required capabilities. All capabilities must be declared before execution."
+                      :remediation "Add a complete capability declaration to the agent's task manifest."}}
+
+  {:rule/id          :cap/deny-default-writes
+   :rule/title       "Deny Default Write Access"
+   :rule/description "Enforces default-deny for write operations. Agents must explicitly request and be granted write capabilities; implicit write access is never assumed."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Write operation attempted without explicit write capability grant. Write access is deny-by-default."
+                      :remediation "Grant write capability explicitly in the task specification, scoped to the required paths."}}
+
+  {:rule/id          :cap/enforce-scope
+   :rule/title       "Enforce Capability Scope"
+   :rule/description "Validates that exercised capabilities remain within their granted scope boundaries. A capability granted for path A must not be used to operate on path B."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Capability exercised outside its granted scope. Operations must remain within the boundaries of the granted capability."
+                      :remediation "Restrict operations to the scope of the granted capability, or request an expanded grant."}}
+
+  {:rule/id          :cap/require-reapproval
+   :rule/title       "Require Reapproval for Scope Changes"
+   :rule/description "Requires human reapproval when an agent's capability scope changes mid-task. Prevents incremental scope creep by requiring explicit human acknowledgement of expanded access."
+   :rule/severity    :major
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Capability scope change detected mid-task. Scope expansions require human reapproval."
+                      :approvers [:human]
+                      :remediation "Submit a scope-change request through the approval workflow before proceeding."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/control-action-governance-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/control-action-governance-1.0.0.pack.edn
@@ -1,0 +1,70 @@
+;; Control Action Governance Policy Pack — RBAC, multi-party approval, audit, and risk classification.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, §2.3
+;; Dewey category: 001 (Foundations & Core Principles)
+
+{:pack/id          "miniforge/control-action-governance"
+ :pack/name        "Control Action Governance"
+ :pack/version     "1.0.0"
+ :pack/description "Control-plane action governance: role-based access control, multi-party approval for sensitive operations, immutable audit logging, and risk classification of control actions."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "001"
+   :category/name "Control Action Governance"
+   :category/rules [:ctrl/require-rbac
+                    :ctrl/multi-party-approval
+                    :ctrl/audit-logging
+                    :ctrl/risk-classification]}]
+
+ :pack/rules
+ [{:rule/id          :ctrl/require-rbac
+   :rule/title       "Require Role-Based Access Control"
+   :rule/description "Ensures all control-plane actions are gated by RBAC. Actions without a valid role binding are rejected. Prevents unauthorized agents or humans from executing administrative operations."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:plan :implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Control action lacks RBAC authorization. The actor does not have a role binding for this operation."
+                      :remediation "Assign the appropriate role to the actor via the RBAC configuration."}}
+
+  {:rule/id          :ctrl/multi-party-approval
+   :rule/title       "Multi-Party Approval"
+   :rule/description "Mandates that sensitive control-plane actions (policy changes, trust promotions, environment modifications) require approval from multiple parties. Prevents single-actor compromise from modifying governance controls."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Sensitive control action requires multi-party approval. At least two authorized approvers must sign off."
+                      :approvers [:human :security]
+                      :remediation "Submit the control action through the multi-party approval workflow."}}
+
+  {:rule/id          :ctrl/audit-logging
+   :rule/title       "Audit Logging"
+   :rule/description "Ensures every control-plane action is recorded in the immutable audit log with actor identity, timestamp, action type, and outcome. Audit log gaps are treated as critical violations."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Control action was not recorded in the audit log. All control-plane actions must produce an immutable audit record."
+                      :remediation "Ensure the audit logging subsystem is operational and the action emits a complete audit event."}}
+
+  {:rule/id          :ctrl/risk-classification
+   :rule/title       "Risk Classification"
+   :rule/description "Classifies control actions by risk level (low, medium, high, critical) and applies proportional governance controls. Higher-risk actions require stronger authentication, additional approvals, and tighter blast-radius limits."
+   :rule/severity    :major
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:plan}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :warn
+                      :message "Control action risk classification could not be determined. Classify the action's risk level to apply appropriate governance controls."
+                      :remediation "Add a risk classification (:low, :medium, :high, :critical) to the control action metadata."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/data-foundry-quality-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/data-foundry-quality-1.0.0.pack.edn
@@ -1,0 +1,163 @@
+;; Data Foundry Quality Policy Pack — data quality and integrity validation rules.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, §2.3
+;; Dewey category: 400 (Testing & Quality)
+
+{:pack/id          "miniforge/data-foundry-quality"
+ :pack/name        "Data Foundry Quality"
+ :pack/version     "1.0.0"
+ :pack/description "Data quality and integrity rules for data foundry pipelines: financial accounting invariants, macro-level distribution checks, cross-table valuation consistency, and time-series completeness."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "400"
+   :category/name "Financial Integrity"
+   :category/rules [:dfq/accounting-equation
+                    :dfq/gaap-receivables
+                    :dfq/inventory-non-negative
+                    :dfq/material-account]}
+  {:category/id   "400"
+   :category/name "Macro Quality"
+   :category/rules [:dfq/distribution-drift
+                    :dfq/row-count-stability
+                    :dfq/temporal-continuity]}
+  {:category/id   "400"
+   :category/name "Valuation Consistency"
+   :category/rules [:dfq/cross-table-sum
+                    :dfq/derivation-chain
+                    :dfq/timestamp-ordering]}
+  {:category/id   "400"
+   :category/name "Time Series Completeness"
+   :category/rules [:dfq/no-missing-periods]}]
+
+ :pack/rules
+ [;; --- Financial Integrity ---
+  {:rule/id          :dfq/accounting-equation
+   :rule/title       "Accounting Equation Balance"
+   :rule/description "Validates that Assets = Liabilities + Equity holds across all financial datasets. The fundamental accounting equation must balance within a configurable tolerance to detect data corruption or transformation errors."
+   :rule/severity    :critical
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Accounting equation imbalance detected (Assets != Liabilities + Equity). Financial data integrity is compromised."
+                      :remediation "Investigate the source of the imbalance. Check recent ETL transformations for dropped or duplicated records."}}
+
+  {:rule/id          :dfq/gaap-receivables
+   :rule/title       "GAAP Receivables Validation"
+   :rule/description "Validates accounts receivable entries against GAAP recognition criteria: revenue must be recognized when earned, receivables must have matching revenue entries, and allowance for doubtful accounts must be maintained."
+   :rule/severity    :critical
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "GAAP receivables validation failed. Receivables do not meet recognition criteria."
+                      :remediation "Review receivable entries for GAAP compliance: matching revenue recognition, proper aging, and doubtful account allowances."}}
+
+  {:rule/id          :dfq/inventory-non-negative
+   :rule/title       "Inventory Non-Negative"
+   :rule/description "Ensures inventory quantities and valuations are never negative. Negative inventory indicates a data error, incorrect adjustment, or missing receipt transaction."
+   :rule/severity    :critical
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Negative inventory detected. Inventory quantities and valuations must be non-negative."
+                      :remediation "Identify the transactions causing negative inventory and correct the data or add missing receipt entries."}}
+
+  {:rule/id          :dfq/material-account
+   :rule/title       "Material Account Variance"
+   :rule/description "Flags material account balances that deviate beyond a configurable threshold from the prior period. Sudden large variances may indicate data pipeline errors, misclassifications, or fraud."
+   :rule/severity    :major
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Material account variance exceeds threshold. Review the variance before publishing."
+                      :remediation "Investigate the cause of the variance. If legitimate, document the business reason and approve."}}
+
+  ;; --- Macro Quality ---
+  {:rule/id          :dfq/distribution-drift
+   :rule/title       "Distribution Drift Detection"
+   :rule/description "Detects statistical distribution drift between consecutive data loads. Column-level distribution changes (mean, stddev, percentiles) beyond configured thresholds indicate upstream schema changes or data quality degradation."
+   :rule/severity    :major
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Distribution drift detected. Column statistics deviate significantly from the baseline."
+                      :remediation "Compare the current distribution against the baseline. Investigate upstream changes if drift is unexpected."}}
+
+  {:rule/id          :dfq/row-count-stability
+   :rule/title       "Row Count Stability"
+   :rule/description "Validates that row counts for incremental loads fall within expected bounds based on historical patterns. Sudden drops or spikes indicate data loss, duplication, or upstream failures."
+   :rule/severity    :major
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Row count outside expected bounds. Current load deviates significantly from historical pattern."
+                      :remediation "Verify the source system is operating normally. Check for data loss or duplication in the pipeline."}}
+
+  {:rule/id          :dfq/temporal-continuity
+   :rule/title       "Temporal Continuity"
+   :rule/description "Ensures time-partitioned data has no gaps or overlaps between partitions. Missing partitions indicate incomplete loads; overlapping partitions indicate duplicate processing."
+   :rule/severity    :major
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Temporal discontinuity detected. Data partitions have gaps or overlaps."
+                      :remediation "Backfill missing partitions or deduplicate overlapping partitions."}}
+
+  ;; --- Valuation Consistency ---
+  {:rule/id          :dfq/cross-table-sum
+   :rule/title       "Cross-Table Sum Reconciliation"
+   :rule/description "Validates that aggregate sums across related tables reconcile within tolerance. Detail tables must sum to their corresponding summary tables; orphaned or missing records break this invariant."
+   :rule/severity    :critical
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Cross-table sum reconciliation failed. Detail records do not sum to the summary total."
+                      :remediation "Identify mismatched records between detail and summary tables. Check for orphaned or dropped records."}}
+
+  {:rule/id          :dfq/derivation-chain
+   :rule/title       "Derivation Chain Integrity"
+   :rule/description "Validates that derived/computed columns maintain consistency with their source columns. When source values change, all downstream derivations must be recalculated. Stale derivations indicate broken refresh logic."
+   :rule/severity    :major
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Derivation chain inconsistency detected. Derived values do not match their source inputs."
+                      :remediation "Trigger a full recalculation of derived columns or investigate the broken derivation step."}}
+
+  {:rule/id          :dfq/timestamp-ordering
+   :rule/title       "Timestamp Ordering"
+   :rule/description "Validates that temporal ordering invariants hold: created_at <= updated_at, start_time <= end_time, and event timestamps are monotonically increasing within a partition. Violations indicate clock skew or processing errors."
+   :rule/severity    :major
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Timestamp ordering violation detected. Temporal ordering invariants are broken."
+                      :remediation "Investigate clock skew or out-of-order event processing. Correct timestamps or reprocess the affected partition."}}
+
+  ;; --- Time Series Completeness ---
+  {:rule/id          :dfq/no-missing-periods
+   :rule/title       "No Missing Periods"
+   :rule/description "Validates that time-series datasets contain data for every expected period (hour, day, week, month) with no gaps. Missing periods break downstream aggregations, dashboards, and forecasting models."
+   :rule/severity    :major
+   :rule/category    "400"
+   :rule/applies-to  {:phases #{:verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Missing time-series periods detected. Expected periods are absent from the dataset."
+                      :remediation "Backfill the missing periods from the source system or insert placeholder records if data is genuinely absent."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/external-pr-evaluation-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/external-pr-evaluation-1.0.0.pack.edn
@@ -1,0 +1,57 @@
+;; External PR Evaluation Policy Pack — governance for external pull request handling.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, §2.3
+;; Dewey category: 700 (Workflows & Processes)
+
+{:pack/id          "miniforge/external-pr-evaluation"
+ :pack/name        "External PR Evaluation"
+ :pack/version     "1.0.0"
+ :pack/description "Governance rules for external pull request evaluation: policy compliance checks, trigger-based governance, and feedback loop governance."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "700"
+   :category/name "External PR Evaluation"
+   :category/rules [:extpr/policy-check
+                    :extpr/trigger-governance
+                    :extpr/feedback-governance]}]
+
+ :pack/rules
+ [{:rule/id          :extpr/policy-check
+   :rule/title       "External PR Policy Check"
+   :rule/description "Validates that external pull requests pass all applicable policy pack rules before merge eligibility. PRs from outside the organization receive the full policy evaluation pipeline."
+   :rule/severity    :critical
+   :rule/category    "700"
+   :rule/applies-to  {:phases #{:review}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "External PR has not passed all required policy checks. All policy rules must pass before the PR is eligible for merge."
+                      :remediation "Resolve all policy violations identified in the PR review before requesting re-evaluation."}}
+
+  {:rule/id          :extpr/trigger-governance
+   :rule/title       "Trigger Governance"
+   :rule/description "Ensures PR evaluation triggers (webhooks, scheduled scans, manual invocations) are authorized and follow the configured trigger policy. Prevents unauthorized or spoofed evaluation triggers."
+   :rule/severity    :major
+   :rule/category    "700"
+   :rule/applies-to  {:phases #{:review}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "PR evaluation trigger does not match the authorized trigger policy. Verify the trigger source and authorization."
+                      :remediation "Use an authorized trigger mechanism (webhook secret, GitHub App, or configured CI pipeline)."}}
+
+  {:rule/id          :extpr/feedback-governance
+   :rule/title       "Feedback Governance"
+   :rule/description "Governs how evaluation feedback is communicated back to PR authors. Ensures feedback follows the configured format, includes actionable remediation guidance, and does not leak internal policy details to external contributors."
+   :rule/severity    :minor
+   :rule/category    "700"
+   :rule/applies-to  {:phases #{:review}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :warn
+                      :message "PR feedback does not conform to the feedback governance policy. Review the feedback format and content."
+                      :remediation "Ensure feedback uses the configured template, includes remediation hints, and redacts internal policy implementation details."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
@@ -1,0 +1,78 @@
+;; Foundations Policy Pack — universal compliance baselines.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, §2.3
+;; Dewey category: 001 (Foundations & Core Principles)
+
+{:pack/id          "miniforge/foundations"
+ :pack/name        "Foundations"
+ :pack/version     "1.0.0"
+ :pack/description "Universal compliance baselines: secrets detection, resource tagging, naming conventions, and public-access prevention."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "001"
+   :category/name "Foundations"
+   :category/rules [:foundations/no-hardcoded-secrets
+                    :foundations/require-resource-tags
+                    :foundations/enforce-naming-convention
+                    :foundations/no-public-resources]}]
+
+ :pack/rules
+ [{:rule/id          :foundations/no-hardcoded-secrets
+   :rule/title       "No Hardcoded Secrets"
+   :rule/description "Detects hardcoded API keys, passwords, tokens, and secrets in source files. Credentials must be injected via environment variables or a secrets manager."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:file-globs ["**/*.tf" "**/*.yaml" "**/*.yml" "**/*.json" "**/*.clj" "**/*.py" "**/*.ts" "**/*.js"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "(?i)(password|secret|api[._-]?key|token)\\s*[:=]\\s*[\"'][^\"']{8,}"}
+   :rule/enforcement {:action :hard-halt
+                      :message "Hardcoded secret detected. Use environment variables or a secrets manager instead."
+                      :remediation "Replace the literal value with a reference to a secrets manager or environment variable."}}
+
+  {:rule/id          :foundations/require-resource-tags
+   :rule/title       "Require Resource Tags"
+   :rule/description "Ensures Terraform resources include a tags block. Untagged resources violate cost-allocation and ownership-tracking policies."
+   :rule/severity    :major
+   :rule/category    "001"
+   :rule/applies-to  {:file-globs ["**/*.tf"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type    :content-scan
+                      :mode    :negative
+                      :pattern "tags\\s*="}
+   :rule/enforcement {:action :require-approval
+                      :message "Terraform resource is missing a tags block. All cloud resources must be tagged for cost allocation and ownership."
+                      :remediation "Add a tags = { ... } block with at minimum: Environment, Team, and ManagedBy."}}
+
+  {:rule/id          :foundations/enforce-naming-convention
+   :rule/title       "Enforce Naming Convention"
+   :rule/description "Scans for Terraform resource names that do not follow snake_case convention. Consistent naming prevents confusion across modules."
+   :rule/severity    :minor
+   :rule/category    "001"
+   :rule/applies-to  {:file-globs ["**/*.tf"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "resource\\s+\"[^\"]+\"\\s+\"[^\"]*[A-Z-][^\"]*\""}
+   :rule/enforcement {:action :warn
+                      :message "Resource name does not follow snake_case convention."
+                      :remediation "Rename the resource using lowercase letters and underscores only."}}
+
+  {:rule/id          :foundations/no-public-resources
+   :rule/title       "No Public Resources"
+   :rule/description "Prevents cloud resources from being configured with public access. Public ACLs and open access policies must be explicitly approved."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:file-globs ["**/*.tf" "**/*.yaml" "**/*.yml"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "(?i)acl\\s*=\\s*\"public"}
+   :rule/enforcement {:action :hard-halt
+                      :message "Public ACL detected. Cloud resources must not be publicly accessible without explicit security review."
+                      :remediation "Remove the public ACL or replace with 'private'. If public access is required, obtain security approval."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/kubernetes-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/kubernetes-1.0.0.pack.edn
@@ -1,0 +1,93 @@
+;; Kubernetes Policy Pack — container and workload security rules.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, §2.3
+;; Dewey category: 320 (Frameworks & Platforms — Kubernetes)
+
+{:pack/id          "miniforge/kubernetes"
+ :pack/name        "Kubernetes"
+ :pack/version     "1.0.0"
+ :pack/description "Kubernetes workload compliance rules covering image tagging, resource limits, privilege escalation, health probes, and network isolation."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "320"
+   :category/name "Kubernetes"
+   :category/rules [:k8s/no-latest-tag
+                    :k8s/require-resource-limits
+                    :k8s/no-privileged
+                    :k8s/require-probes
+                    :k8s/no-host-network]}]
+
+ :pack/rules
+ [{:rule/id          :k8s/no-latest-tag
+   :rule/title       "No Latest Image Tag"
+   :rule/description "Detects container images using the :latest tag. Mutable tags make deployments non-reproducible and break rollback guarantees."
+   :rule/severity    :major
+   :rule/category    "320"
+   :rule/applies-to  {:file-globs ["**/*.yaml" "**/*.yml"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "image:\\s*\\S+:latest"}
+   :rule/enforcement {:action :require-approval
+                      :message "Container image uses :latest tag. Pin images to a specific digest or immutable version tag."
+                      :remediation "Replace :latest with a specific version tag (e.g., v1.2.3) or SHA256 digest."}}
+
+  {:rule/id          :k8s/require-resource-limits
+   :rule/title       "Require Resource Limits"
+   :rule/description "Ensures all containers declare CPU and memory limits. Missing limits allow unbounded resource consumption and noisy-neighbor failures."
+   :rule/severity    :major
+   :rule/category    "320"
+   :rule/applies-to  {:file-globs ["**/*.yaml" "**/*.yml"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type    :content-scan
+                      :mode    :negative
+                      :pattern "resources:\\s*\\n\\s+limits:"}
+   :rule/enforcement {:action :require-approval
+                      :message "Container is missing resource limits. All containers must declare CPU and memory limits."
+                      :remediation "Add a resources.limits block specifying cpu and memory limits."}}
+
+  {:rule/id          :k8s/no-privileged
+   :rule/title       "No Privileged Containers"
+   :rule/description "Detects containers running in privileged mode. Privileged containers bypass kernel security boundaries and can compromise the host."
+   :rule/severity    :critical
+   :rule/category    "320"
+   :rule/applies-to  {:file-globs ["**/*.yaml" "**/*.yml"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "privileged:\\s*true"}
+   :rule/enforcement {:action :hard-halt
+                      :message "Privileged container detected. Containers must not run in privileged mode."
+                      :remediation "Remove privileged: true or set privileged: false. Use specific capabilities instead."}}
+
+  {:rule/id          :k8s/require-probes
+   :rule/title       "Require Health Probes"
+   :rule/description "Ensures containers declare liveness and readiness probes. Missing probes prevent Kubernetes from detecting and recovering from failures."
+   :rule/severity    :major
+   :rule/category    "320"
+   :rule/applies-to  {:file-globs ["**/*.yaml" "**/*.yml"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type    :content-scan
+                      :mode    :negative
+                      :pattern "(?:livenessProbe|readinessProbe):"}
+   :rule/enforcement {:action :warn
+                      :message "Container is missing liveness or readiness probes. Both probes should be defined for production workloads."
+                      :remediation "Add livenessProbe and readinessProbe configurations with appropriate HTTP, TCP, or exec checks."}}
+
+  {:rule/id          :k8s/no-host-network
+   :rule/title       "No Host Network"
+   :rule/description "Detects pods using hostNetwork: true. Host networking bypasses pod network isolation and exposes all host ports to the container."
+   :rule/severity    :critical
+   :rule/category    "320"
+   :rule/applies-to  {:file-globs ["**/*.yaml" "**/*.yml"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "hostNetwork:\\s*true"}
+   :rule/enforcement {:action :hard-halt
+                      :message "Pod uses host networking. Host network access must be avoided to maintain network isolation."
+                      :remediation "Remove hostNetwork: true. Use standard pod networking with NetworkPolicies for access control."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/opsv-governance-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/opsv-governance-1.0.0.pack.edn
@@ -1,0 +1,94 @@
+;; OPSV Governance Policy Pack — observe-plan-stabilize-verify lifecycle gates.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, §2.3
+;; Dewey category: 500 (Operations & Infrastructure)
+
+{:pack/id          "miniforge/opsv-governance"
+ :pack/name        "OPSV Governance"
+ :pack/version     "1.0.0"
+ :pack/description "Observe-Plan-Stabilize-Verify lifecycle gates: instrumentation, environment promotion, blast-radius control, abort conditions, actuation authorization, and evidence completeness."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "500"
+   :category/name "OPSV Governance"
+   :category/rules [:opsv/instrumentation-gate
+                    :opsv/environment-gate
+                    :opsv/blast-radius-gate
+                    :opsv/abort-gate
+                    :opsv/actuation-gate
+                    :opsv/evidence-completeness]}]
+
+ :pack/rules
+ [{:rule/id          :opsv/instrumentation-gate
+   :rule/title       "Instrumentation Gate"
+   :rule/description "Validates that the target environment has adequate observability instrumentation (metrics, logs, traces) before any change is applied. Changes to unmonitored environments are blocked."
+   :rule/severity    :critical
+   :rule/category    "500"
+   :rule/applies-to  {:phases #{:plan :implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Target environment lacks required instrumentation. Deploy observability infrastructure before applying changes."
+                      :remediation "Ensure metrics, logging, and tracing are configured and healthy in the target environment."}}
+
+  {:rule/id          :opsv/environment-gate
+   :rule/title       "Environment Promotion Gate"
+   :rule/description "Enforces the environment promotion order (dev -> staging -> production). Changes must pass lower environments before promotion. Skipping environments requires explicit override."
+   :rule/severity    :critical
+   :rule/category    "500"
+   :rule/applies-to  {:phases #{:implement :review}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Environment promotion order violated. Changes must pass through lower environments before production deployment."
+                      :remediation "Deploy to the next environment in the promotion chain, or request an explicit environment-skip override."}}
+
+  {:rule/id          :opsv/blast-radius-gate
+   :rule/title       "Blast Radius Gate"
+   :rule/description "Evaluates the potential blast radius of a change and enforces graduated rollout controls. Changes affecting more than the configured threshold of resources require canary or blue-green deployment."
+   :rule/severity    :critical
+   :rule/category    "500"
+   :rule/applies-to  {:phases #{:plan :implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Change blast radius exceeds threshold. Use canary or blue-green deployment strategy."
+                      :approvers [:senior-engineer]
+                      :remediation "Reduce the change scope or configure a graduated rollout strategy (canary, blue-green, or feature flag)."}}
+
+  {:rule/id          :opsv/abort-gate
+   :rule/title       "Abort Condition Gate"
+   :rule/description "Validates that rollback/abort conditions are defined before deployment proceeds. Every deployment must have a clear abort signal (error rate, latency, health check) and automated rollback trigger."
+   :rule/severity    :major
+   :rule/category    "500"
+   :rule/applies-to  {:phases #{:plan}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Deployment is missing abort conditions. Define rollback triggers (error rate threshold, latency SLO, health check failures) before proceeding."
+                      :remediation "Add abort-condition configuration specifying the metrics thresholds that trigger automated rollback."}}
+
+  {:rule/id          :opsv/actuation-gate
+   :rule/title       "Actuation Authorization Gate"
+   :rule/description "Ensures that the actor (human or agent) performing the deployment has the required authorization for the target environment and change type. Separates planning authorization from actuation authorization."
+   :rule/severity    :critical
+   :rule/category    "500"
+   :rule/applies-to  {:phases #{:implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Actuation not authorized. The actor does not have deployment authorization for this environment and change type."
+                      :remediation "Obtain actuation authorization from the environment owner or use an authorized deployment identity."}}
+
+  {:rule/id          :opsv/evidence-completeness
+   :rule/title       "Evidence Completeness"
+   :rule/description "Validates that all required evidence artifacts (plan output, approval records, test results, observability baseline) are present before marking a deployment as complete. Incomplete evidence blocks phase transition."
+   :rule/severity    :major
+   :rule/category    "500"
+   :rule/applies-to  {:phases #{:review :verify}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Deployment evidence is incomplete. All required artifacts must be collected before phase completion."
+                      :remediation "Collect and attach the missing evidence artifacts (plan output, approval records, test results, observability baseline)."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/pack-high-risk-action-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/pack-high-risk-action-1.0.0.pack.edn
@@ -1,0 +1,58 @@
+;; High Risk Action Policy Pack — governance for dangerous operations.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, §2.3
+;; Dewey category: 001 (Foundations & Core Principles)
+
+{:pack/id          "miniforge/high-risk-action"
+ :pack/name        "High Risk Action"
+ :pack/version     "1.0.0"
+ :pack/description "Governance rules for high-risk agent actions: justification requirements, production environment restrictions, and audit logging for connector-mediated operations."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "001"
+   :category/name "High Risk Action"
+   :category/rules [:risk/require-justification
+                    :risk/production-restrictions
+                    :risk/audit-connector-actions]}]
+
+ :pack/rules
+ [{:rule/id          :risk/require-justification
+   :rule/title       "Require Justification for High-Risk Actions"
+   :rule/description "Mandates that agents provide an explicit justification before executing high-risk actions such as destructive operations, privilege escalation, or external service mutations. The justification is recorded in the audit trail."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "High-risk action requires a justification. Provide a rationale before proceeding."
+                      :approvers [:human :senior-engineer]
+                      :remediation "Include a :justification field explaining why this high-risk action is necessary."}}
+
+  {:rule/id          :risk/production-restrictions
+   :rule/title       "Production Environment Restrictions"
+   :rule/description "Enforces additional controls when agents operate against production environments. Production mutations require elevated approval and are subject to blast-radius limits."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement :review}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Production environment operation detected. Production mutations require elevated approval and blast-radius controls."
+                      :remediation "Route this operation through the production change-management workflow."}}
+
+  {:rule/id          :risk/audit-connector-actions
+   :rule/title       "Audit Connector Actions"
+   :rule/description "Ensures all connector-mediated external actions (API calls, database writes, messaging) are recorded in the immutable audit log. Connector actions without audit trail are rejected."
+   :rule/severity    :major
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Connector action must be recorded in the audit trail. Ensure audit logging is enabled for this connector."
+                      :remediation "Enable audit logging for the connector before executing external actions."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/pack-trust-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/pack-trust-1.0.0.pack.edn
@@ -1,0 +1,57 @@
+;; Pack Trust Policy Pack — trust chain and provenance validation.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, N1 §2.10.2
+;; Dewey category: 001 (Foundations & Core Principles)
+
+{:pack/id          "miniforge/pack-trust"
+ :pack/name        "Pack Trust"
+ :pack/version     "1.0.0"
+ :pack/description "Trust chain validation rules for policy packs: signature verification, publisher allowlisting, and minimum trust-level enforcement."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "001"
+   :category/name "Pack Trust"
+   :category/rules [:trust/require-signature
+                    :trust/publisher-allowlist
+                    :trust/minimum-trust-level]}]
+
+ :pack/rules
+ [{:rule/id          :trust/require-signature
+   :rule/title       "Require Pack Signature"
+   :rule/description "Validates that instruction-authority packs carry a cryptographic signature. Unsigned packs with :authority/instruction must not be loaded, preventing supply-chain injection of untrusted behavioral directives."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:plan :implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Pack with instruction authority is missing a cryptographic signature. Only signed packs may provide agent behavioral directives."
+                      :remediation "Sign the pack using the miniforge pack-signing tool before distribution."}}
+
+  {:rule/id          :trust/publisher-allowlist
+   :rule/title       "Publisher Allowlist"
+   :rule/description "Verifies that the pack publisher is on the organization's approved publisher list. Packs from unapproved publishers are rejected to prevent unauthorized policy injection."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:plan :implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Pack publisher is not in the approved publisher allowlist. Contact your administrator to approve this publisher."
+                      :remediation "Add the publisher to the organization's pack publisher allowlist."}}
+
+  {:rule/id          :trust/minimum-trust-level
+   :rule/title       "Minimum Trust Level"
+   :rule/description "Enforces that packs loaded for instruction authority meet the minimum trust level (:trusted). Untrusted or tainted packs are restricted to data-only authority, preventing trust escalation."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:plan :implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Pack trust level is below the required minimum for its declared authority channel. Untrusted packs cannot provide instruction authority."
+                      :remediation "Promote the pack to :trusted via the platform trust workflow, or downgrade its authority to :authority/data."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/task-scope-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/task-scope-1.0.0.pack.edn
@@ -1,0 +1,81 @@
+;; Task Scope Policy Pack — agent task boundary enforcement.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, §2.3
+;; Dewey category: 001 (Foundations & Core Principles)
+
+{:pack/id          "miniforge/task-scope"
+ :pack/name        "Task Scope"
+ :pack/version     "1.0.0"
+ :pack/description "Agent task scope enforcement: capabilities declaration, tool invocation boundaries, file path restrictions, knowledge scope limits, and execution timeouts."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "001"
+   :category/name "Task Scope"
+   :category/rules [:scope/require-capabilities
+                    :scope/enforce-tool-scope
+                    :scope/enforce-path-scope
+                    :scope/enforce-knowledge-scope
+                    :scope/enforce-timeout]}]
+
+ :pack/rules
+ [{:rule/id          :scope/require-capabilities
+   :rule/title       "Require Capabilities Declaration"
+   :rule/description "Ensures every agent task declares its required capabilities before execution. Tasks without capability declarations cannot be verified against the principle of least privilege."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:plan :implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Task is missing a capabilities declaration. All tasks must declare the capabilities they require."
+                      :remediation "Add a :task/capabilities vector to the task specification listing all required capabilities."}}
+
+  {:rule/id          :scope/enforce-tool-scope
+   :rule/title       "Enforce Tool Invocation Scope"
+   :rule/description "Validates that agent tool invocations remain within the scope granted by the task's capability declaration. Tool calls outside declared scope indicate a potential prompt injection or scope creep."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Tool invocation outside declared task scope. The agent attempted to use a tool not granted by its capability declaration."
+                      :remediation "Either add the tool to the task's capability declaration or remove the out-of-scope tool call."}}
+
+  {:rule/id          :scope/enforce-path-scope
+   :rule/title       "Enforce File Path Scope"
+   :rule/description "Validates that file operations target only paths within the task's declared path scope. Prevents agents from reading or modifying files outside their assigned workspace."
+   :rule/severity    :critical
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement :review}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "File operation targets a path outside the declared task scope. Agents may only access files within their assigned path boundaries."
+                      :remediation "Restrict file operations to the paths declared in the task scope, or expand the scope with appropriate approval."}}
+
+  {:rule/id          :scope/enforce-knowledge-scope
+   :rule/title       "Enforce Knowledge Scope"
+   :rule/description "Validates that agents only access policy packs and knowledge bases granted to the current task. Prevents cross-task information leakage and unauthorized pack consumption."
+   :rule/severity    :major
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:plan :implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :require-approval
+                      :message "Agent attempted to access knowledge outside its declared scope. Knowledge access must be constrained to the task's granted packs."
+                      :remediation "Add the required pack to the task's knowledge scope declaration."}}
+
+  {:rule/id          :scope/enforce-timeout
+   :rule/title       "Enforce Execution Timeout"
+   :rule/description "Monitors agent execution time against the task's declared timeout. Runaway agents that exceed their time budget must be halted to prevent resource exhaustion and cost overruns."
+   :rule/severity    :major
+   :rule/category    "001"
+   :rule/applies-to  {:phases #{:implement}}
+   :rule/detection   {:type :custom}
+   :rule/enforcement {:action :hard-halt
+                      :message "Agent execution has exceeded the task timeout. The task will be terminated to prevent resource exhaustion."
+                      :remediation "Increase the task timeout if the workload genuinely requires more time, or decompose into smaller tasks."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/terraform-aws-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/terraform-aws-1.0.0.pack.edn
@@ -1,0 +1,93 @@
+;; Terraform AWS Policy Pack — AWS-specific infrastructure compliance rules.
+;; Reference: N4 Policy Packs & Gates Standard §2.2, §2.3
+;; Dewey category: 500 (Operations & Infrastructure)
+
+{:pack/id          "miniforge/terraform-aws"
+ :pack/name        "Terraform AWS"
+ :pack/version     "1.0.0"
+ :pack/description "AWS-specific Terraform compliance rules covering S3 bucket security, encryption, network ingress, VPC placement, and instance type governance."
+ :pack/author      "miniforge.ai"
+ :pack/license     "Apache-2.0"
+ :pack/trust-level :trusted
+ :pack/authority   :authority/instruction
+ :pack/taxonomy-ref {:taxonomy/id :miniforge/dewey :taxonomy/min-version "1.0.0"}
+
+ :pack/categories
+ [{:category/id   "500"
+   :category/name "Terraform AWS"
+   :category/rules [:tf-aws/no-public-s3
+                    :tf-aws/require-encryption
+                    :tf-aws/no-open-ingress
+                    :tf-aws/require-vpc
+                    :tf-aws/approved-instance-types]}]
+
+ :pack/rules
+ [{:rule/id          :tf-aws/no-public-s3
+   :rule/title       "No Public S3 Buckets"
+   :rule/description "Prevents S3 buckets from being configured with public-read ACL. Public S3 buckets are a leading cause of data breaches."
+   :rule/severity    :critical
+   :rule/category    "500"
+   :rule/applies-to  {:file-globs ["**/*.tf"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "acl\\s*=\\s*\"public-read\""}
+   :rule/enforcement {:action :hard-halt
+                      :message "S3 bucket has public-read ACL. All S3 buckets must use private ACL with explicit access policies."
+                      :remediation "Set acl = \"private\" and use S3 bucket policies or IAM for access control."}}
+
+  {:rule/id          :tf-aws/require-encryption
+   :rule/title       "Require Encryption Configuration"
+   :rule/description "Ensures all storage and data resources include an encryption_configuration block. Data at rest must be encrypted per security baseline."
+   :rule/severity    :critical
+   :rule/category    "500"
+   :rule/applies-to  {:file-globs ["**/*.tf"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type    :content-scan
+                      :mode    :negative
+                      :pattern "encryption_configuration"}
+   :rule/enforcement {:action :hard-halt
+                      :message "Resource is missing encryption_configuration. All data-at-rest must be encrypted."
+                      :remediation "Add an encryption_configuration block using AWS KMS or AES-256."}}
+
+  {:rule/id          :tf-aws/no-open-ingress
+   :rule/title       "No Open Ingress (0.0.0.0/0)"
+   :rule/description "Detects security group rules that allow ingress from 0.0.0.0/0. Open ingress exposes services to the public internet."
+   :rule/severity    :critical
+   :rule/category    "500"
+   :rule/applies-to  {:file-globs ["**/*.tf"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "cidr_blocks\\s*=\\s*\\[\"0\\.0\\.0\\.0/0\"\\]"}
+   :rule/enforcement {:action :hard-halt
+                      :message "Security group allows ingress from 0.0.0.0/0. Restrict CIDR blocks to known IP ranges."
+                      :remediation "Replace 0.0.0.0/0 with specific CIDR ranges for your network."}}
+
+  {:rule/id          :tf-aws/require-vpc
+   :rule/title       "Require VPC Placement"
+   :rule/description "Ensures compute and database resources include a vpc_id or subnet_id reference. Resources outside a VPC lack network-level isolation."
+   :rule/severity    :major
+   :rule/category    "500"
+   :rule/applies-to  {:file-globs ["**/*.tf"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type    :content-scan
+                      :mode    :negative
+                      :pattern "(?:vpc_id|subnet_id|subnet_ids)"}
+   :rule/enforcement {:action :require-approval
+                      :message "Resource appears to lack VPC placement (no vpc_id or subnet_id). All compute and data resources must reside within a VPC."
+                      :remediation "Add a vpc_id or subnet_id argument referencing an appropriate VPC."}}
+
+  {:rule/id          :tf-aws/approved-instance-types
+   :rule/title       "Approved Instance Types Only"
+   :rule/description "Detects EC2 instance types outside the approved list. Unapproved instance types may violate cost or compliance constraints."
+   :rule/severity    :major
+   :rule/category    "500"
+   :rule/applies-to  {:file-globs ["**/*.tf"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "instance_type\\s*=\\s*\"(?!t3\\.|t4g\\.|m5\\.|m6i\\.|c5\\.|c6i\\.|r5\\.|r6i\\.)"}
+   :rule/enforcement {:action :require-approval
+                      :message "Instance type is not in the approved list (t3, t4g, m5, m6i, c5, c6i, r5, r6i families)."
+                      :remediation "Use an instance type from the approved families: t3, t4g, m5, m6i, c5, c6i, r5, r6i."}}]
+
+ :pack/created-at #inst "2026-04-08T00:00:00Z"
+ :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/standard_packs_test.clj
@@ -1,0 +1,82 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.standard-packs-test
+  "Tests for the 11 standard reference policy packs (N4 §5).
+
+   Validates:
+   - All packs load from classpath resources
+   - All packs conform to PackManifest schema
+   - All packs have taxonomy-ref pointing to miniforge/dewey
+   - Rule counts match spec"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+(def ^:private pack-specs
+  "Expected pack metadata for each reference pack."
+  [{:file "foundations-1.0.0.pack.edn"     :id "miniforge/foundations"            :min-rules 4}
+   {:file "terraform-aws-1.0.0.pack.edn"  :id "miniforge/terraform-aws"          :min-rules 5}
+   {:file "kubernetes-1.0.0.pack.edn"      :id "miniforge/kubernetes"             :min-rules 5}
+   {:file "pack-trust-1.0.0.pack.edn"     :id "miniforge/pack-trust"             :min-rules 3}
+   {:file "task-scope-1.0.0.pack.edn"     :id "miniforge/task-scope"             :min-rules 5}
+   {:file "capability-grant-1.0.0.pack.edn" :id "miniforge/capability-grant"     :min-rules 4}
+   {:file "pack-high-risk-action-1.0.0.pack.edn" :id "miniforge/high-risk-action" :min-rules 3}
+   {:file "external-pr-evaluation-1.0.0.pack.edn" :id "miniforge/external-pr-evaluation" :min-rules 3}
+   {:file "opsv-governance-1.0.0.pack.edn" :id "miniforge/opsv-governance"       :min-rules 6}
+   {:file "control-action-governance-1.0.0.pack.edn" :id "miniforge/control-action-governance" :min-rules 4}
+   {:file "data-foundry-quality-1.0.0.pack.edn" :id "miniforge/data-foundry-quality" :min-rules 11}])
+
+(defn- load-pack-resource [filename]
+  (let [path (str "policy_pack/packs/" filename)]
+    (when-let [resource (io/resource path)]
+      (edn/read-string (slurp resource)))))
+
+(deftest all-standard-packs-load-test
+  (doseq [{:keys [file id min-rules]} pack-specs]
+    (testing (str "Pack " file " loads and validates")
+      (let [pack (load-pack-resource file)]
+        (is (some? pack) (str "Resource not found: " file))
+        (when pack
+          (is (= id (:pack/id pack)) (str file " has correct ID"))
+          (is (>= (count (:pack/rules pack)) min-rules)
+              (str file " has at least " min-rules " rules"))
+          (is (= :miniforge/dewey (get-in pack [:pack/taxonomy-ref :taxonomy/id]))
+              (str file " references miniforge/dewey taxonomy")))))))
+
+(deftest all-packs-have-valid-rules-test
+  (doseq [{:keys [file]} pack-specs]
+    (testing (str "Rules in " file " have required fields")
+      (when-let [pack (load-pack-resource file)]
+        (doseq [rule (:pack/rules pack)]
+          (is (keyword? (:rule/id rule)) (str "Rule in " file " has keyword :rule/id"))
+          (is (string? (:rule/title rule)) (str "Rule " (:rule/id rule) " has title"))
+          (is (#{:critical :major :minor :info} (:rule/severity rule))
+              (str "Rule " (:rule/id rule) " has valid severity"))
+          (is (map? (:rule/detection rule)) (str "Rule " (:rule/id rule) " has detection"))
+          (is (map? (:rule/enforcement rule)) (str "Rule " (:rule/id rule) " has enforcement")))))))
+
+(deftest total-reference-rules-test
+  (testing "total reference rules across all packs is at least 53"
+    (let [total (->> pack-specs
+                     (keep (fn [{:keys [file]}]
+                             (when-let [pack (load-pack-resource file)]
+                               (count (:pack/rules pack)))))
+                     (reduce + 0))]
+      (is (>= total 53) (str "Expected at least 53 rules, got " total)))))


### PR DESCRIPTION
Adds 11 standard policy packs (53 rules total) implementing N4 section 5 reference packs covering infrastructure, agent governance, workflow governance, and data quality. Includes standard_packs_test.clj with 310 assertions.