### PR TITLE
feat: AST analysis + state comparison detection types

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/ast.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/ast.clj
@@ -1,0 +1,196 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.ast
+  "Tree-sitter CLI wrapper for language-agnostic AST analysis.
+
+   Shells out to `tree-sitter query` for structural pattern matching.
+   No JNI, no library linking, GraalVM-safe. One interface for all
+   languages via pluggable tree-sitter grammars.
+
+   Layer 0: CLI invocation helpers
+   Layer 1: Query execution and output parsing
+   Layer 2: Match-to-violation conversion"
+  (:require
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; CLI helpers
+
+(defn tree-sitter-available?
+  "Check if the tree-sitter CLI is available on PATH."
+  []
+  (try
+    (let [pb   (ProcessBuilder. ^java.util.List ["tree-sitter" "--version"])
+          proc (.start pb)
+          _    (.waitFor proc)]
+      (zero? (.exitValue proc)))
+    (catch Exception _ false)))
+
+(defn file-extension
+  "Extract the file extension from a path (without the dot)."
+  [path]
+  (let [name (str (last (str/split (str path) #"/")))]
+    (when-let [idx (str/last-index-of name ".")]
+      (subs name (inc idx)))))
+
+(def ^:private extension->lang
+  "Map file extensions to tree-sitter language names."
+  {"clj"  "clojure"
+   "cljs" "clojure"
+   "cljc" "clojure"
+   "py"   "python"
+   "js"   "javascript"
+   "ts"   "typescript"
+   "tsx"  "tsx"
+   "rs"   "rust"
+   "go"   "go"
+   "java" "java"
+   "rb"   "ruby"
+   "swift" "swift"
+   "tf"   "hcl"
+   "yaml" "yaml"
+   "yml"  "yaml"
+   "json" "json"
+   "toml" "toml"
+   "md"   "markdown"
+   "sh"   "bash"
+   "bash" "bash"})
+
+(defn detect-language
+  "Detect tree-sitter language from file path or explicit :lang option."
+  [file-path lang-override]
+  (or lang-override
+      (get extension->lang (file-extension file-path))
+      "text"))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Query execution
+
+(defn- write-temp-query
+  "Write a query pattern to a temporary .scm file. Returns the File."
+  [query-str]
+  (let [f (java.io.File/createTempFile "ts-query-" ".scm")]
+    (.deleteOnExit f)
+    (spit f query-str)
+    f))
+
+(defn- write-temp-source
+  "Write source content to a temporary file with the right extension.
+   Returns the File."
+  [content extension]
+  (let [f (java.io.File/createTempFile "ts-src-" (str "." (or extension "txt")))]
+    (.deleteOnExit f)
+    (spit f content)
+    f))
+
+(defn- parse-query-output
+  "Parse tree-sitter query output into match maps.
+
+   Tree-sitter query output format (one match per line):
+     <file>:<row>:<col>: pattern: <idx>, capture: <name>, text: `<text>`
+
+   Returns vector of {:row int :col int :capture string :text string :pattern int}."
+  [output]
+  (when-not (str/blank? output)
+    (->> (str/split-lines output)
+         (keep (fn [line]
+                 (when-let [m (re-matches
+                               #".*:(\d+):(\d+):\s*pattern:\s*(\d+),\s*capture:\s*(\S+),\s*text:\s*`(.*)`"
+                               line)]
+                   {:row     (Integer/parseInt (nth m 1))
+                    :col     (Integer/parseInt (nth m 2))
+                    :pattern (Integer/parseInt (nth m 3))
+                    :capture (nth m 4)
+                    :text    (nth m 5)})))
+         vec)))
+
+(defn run-query
+  "Execute a tree-sitter query against source content.
+
+   Arguments:
+   - content    — Source code string
+   - query      — Tree-sitter query pattern (S-expression)
+   - lang       — Tree-sitter language name (e.g. \"clojure\")
+   - extension  — File extension for temp file (e.g. \"clj\")
+
+   Returns:
+   - {:success? true :matches [...]}
+   - {:success? false :error string}"
+  [content query lang extension]
+  (let [query-file  (write-temp-query query)
+        source-file (write-temp-source content extension)]
+    (try
+      (let [pb (ProcessBuilder. ^java.util.List
+                ["tree-sitter" "query"
+                 (.getAbsolutePath query-file)
+                 (.getAbsolutePath source-file)])
+            _    (-> (.environment pb) (.put "TREE_SITTER_LANGUAGE" lang))
+            proc (.start pb)
+            out  (slurp (.getInputStream proc))
+            err  (slurp (.getErrorStream proc))
+            _    (.waitFor proc)
+            exit (.exitValue proc)]
+        (if (zero? exit)
+          {:success? true
+           :matches  (or (parse-query-output out) [])}
+          {:success? false
+           :error    (str "tree-sitter query failed (exit " exit "): "
+                          (str/trim err))}))
+      (catch Exception e
+        {:success? false :error (.getMessage e)})
+      (finally
+        (.delete query-file)
+        (.delete source-file)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Match-to-violation helpers
+
+(defn matches->violations
+  "Convert tree-sitter query matches to violation-shaped maps.
+
+   Arguments:
+   - matches   — Vector of match maps from run-query
+   - rule-id   — Rule keyword
+   - rule-cat  — Rule category string
+   - title     — Rule title string
+   - file-path — Source file path
+
+   Returns vector of violation-shaped maps."
+  [matches rule-id rule-cat title file-path]
+  (mapv (fn [{:keys [row text]}]
+          {:rule/id       rule-id
+           :rule/category rule-cat
+           :rule/title    title
+           :file          file-path
+           :line          (inc row) ; tree-sitter is 0-indexed
+           :current       text
+           :suggested     nil
+           :auto-fixable? false
+           :rationale     ""})
+        matches))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (tree-sitter-available?)
+
+  ;; Query for function calls to `eval` in Clojure
+  (run-query "(eval x)" "(call_expression function: (identifier) @fn (#eq? @fn \"eval\"))"
+             "clojure" "clj")
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/ast.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/ast.clj
@@ -45,9 +45,9 @@
 (defn file-extension
   "Extract the file extension from a path (without the dot)."
   [path]
-  (let [name (str (last (str/split (str path) #"/")))]
-    (when-let [idx (str/last-index-of name ".")]
-      (subs name (inc idx)))))
+  (let [filename (.getName (java.io.File. (str path)))]
+    (when-let [idx (str/last-index-of filename ".")]
+      (subs filename (inc idx)))))
 
 (def ^:private extension->lang
   "Map file extensions to tree-sitter language names."

--- a/components/policy-pack/src/ai/miniforge/policy_pack/ast.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/ast.clj
@@ -27,6 +27,7 @@
    Layer 1: Query execution and output parsing
    Layer 2: Match-to-violation conversion"
   (:require
+   [ai.miniforge.policy-pack.schema :as schema]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -147,13 +148,12 @@
             _    (.waitFor proc)
             exit (.exitValue proc)]
         (if (zero? exit)
-          {:success? true
-           :matches  (or (parse-query-output out) [])}
-          {:success? false
-           :error    (str "tree-sitter query failed (exit " exit "): "
-                          (str/trim err))}))
+          (schema/success :matches (or (parse-query-output out) []) {})
+          (schema/failure :matches
+                          (str "tree-sitter query failed (exit " exit "): "
+                               (str/trim err)))))
       (catch Exception e
-        {:success? false :error (.getMessage e)})
+        (schema/failure :matches (.getMessage e)))
       (finally
         (.delete query-file)
         (.delete source-file)))))

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -27,8 +27,12 @@
    - :content-scan - Regex against artifact content
    - :diff-analysis - Regex against git diff
    - :plan-output - Parse terraform plan output
+   - :ast-analysis - Structural pattern matching via tree-sitter CLI
+   - :state-comparison - Drift detection via clojure.data/diff
    - :custom - Custom detection function"
   (:require
+   [ai.miniforge.policy-pack.ast :as ast]
+   [clojure.data :as data]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -237,6 +241,83 @@
            :message (get-in rule [:rule/enforcement :message])})))))
 
 ;------------------------------------------------------------------------------ Layer 1
+;; AST analysis detection (tree-sitter CLI)
+
+(defn detect-ast-analysis
+  "Detect violations by structural pattern matching via tree-sitter.
+
+   Requires the tree-sitter CLI to be available on PATH.
+   Falls back to nil (no violation) if tree-sitter is unavailable.
+
+   Arguments:
+   - rule - Rule with :rule/detection containing :query (tree-sitter S-expression pattern)
+   - artifact - Artifact with :artifact/content and :artifact/path
+   - context - Execution context (may contain :lang override)
+
+   Returns:
+   - Violation map if detected, nil otherwise"
+  [rule artifact context]
+  (when (ast/tree-sitter-available?)
+    (let [detection (:rule/detection rule)
+          query     (or (:query detection) (first (extract-patterns detection)))
+          content   (:artifact/content artifact)
+          path      (:artifact/path artifact "")
+          lang      (ast/detect-language path (:lang context))]
+      (when (and content query)
+        (let [ext    (ast/file-extension path)
+              result (ast/run-query content (str query) lang ext)]
+          (when (and (:success? result) (seq (:matches result)))
+            {:type          :ast-analysis
+             :rule-id       (:rule/id rule)
+             :matches       (:matches result)
+             :artifact-path path
+             :message       (get-in rule [:rule/enforcement :message])}))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; State comparison detection
+
+(defn detect-state-comparison
+  "Detect violations by comparing desired state to current state.
+
+   Uses clojure.data/diff to find structural drift between two EDN maps.
+   Detects keys/values present in desired state but different or missing
+   in current state.
+
+   Arguments:
+   - rule - Rule with :rule/detection config
+   - artifact - Artifact (unused for state comparison)
+   - context - Context with :desired-state and :current-state maps
+
+   Returns:
+   - Violation map if drift detected, nil otherwise"
+  [rule _artifact context]
+  (let [desired (:desired-state context)
+        current (:current-state context)]
+    (when (and desired current)
+      (let [[only-desired only-current _both] (data/diff desired current)]
+        (when (or (seq only-desired) (seq only-current))
+          {:type          :state-comparison
+           :rule-id       (:rule/id rule)
+           :drift         {:desired-only only-desired
+                           :current-only only-current}
+           :message       (get-in rule [:rule/enforcement :message])})))))
+
+(defn plan-resource-counts
+  "Aggregate resource change counts from terraform plan output.
+   Returns {:creates int :updates int :destroys int}."
+  [plan-output]
+  (let [resources (parse-plan-resources plan-output)]
+    (reduce (fn [acc {:keys [action]}]
+              (case action
+                :create  (update acc :creates inc)
+                :destroy (update acc :destroys inc)
+                :update  (update acc :updates inc)
+                :replace (-> acc (update :creates inc) (update :destroys inc))
+                acc))
+            {:creates 0 :updates 0 :destroys 0}
+            resources)))
+
+;------------------------------------------------------------------------------ Layer 1
 ;; Custom detection
 
 (defn detect-custom
@@ -299,9 +380,8 @@
       :diff-analysis (detect-diff-analysis rule artifact context)
       :plan-output (detect-plan-output rule artifact context)
       :custom (detect-custom rule artifact context)
-      ;; Unsupported types
-      :state-comparison nil  ; Not implemented
-      :ast-analysis nil       ; Not implemented
+      :state-comparison (detect-state-comparison rule artifact context)
+      :ast-analysis (detect-ast-analysis rule artifact context)
       nil)))
 
 (defn check-rules

--- a/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/detection.clj
@@ -32,6 +32,7 @@
    - :custom - Custom detection function"
   (:require
    [ai.miniforge.policy-pack.ast :as ast]
+   [ai.miniforge.policy-pack.schema :as schema]
    [clojure.data :as data]
    [clojure.string :as str]))
 
@@ -266,7 +267,7 @@
       (when (and content query)
         (let [ext    (ast/file-extension path)
               result (ast/run-query content (str query) lang ext)]
-          (when (and (:success? result) (seq (:matches result)))
+          (when (and (schema/succeeded? result) (seq (:matches result)))
             {:type          :ast-analysis
              :rule-id       (:rule/id rule)
              :matches       (:matches result)

--- a/components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/ast_test.clj
@@ -1,0 +1,80 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.policy-pack.ast-test
+  "Tests for tree-sitter CLI wrapper — file extension, language detection, violations."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.policy-pack.ast :as sut]
+   [ai.miniforge.policy-pack.schema :as schema]))
+
+(deftest file-extension-test
+  (testing "extracts extension from simple filename"
+    (is (= "clj" (sut/file-extension "core.clj"))))
+
+  (testing "extracts extension from full path"
+    (is (= "py" (sut/file-extension "src/main/app.py"))))
+
+  (testing "handles multiple dots"
+    (is (= "edn" (sut/file-extension "pack.test.edn"))))
+
+  (testing "returns nil for no extension"
+    (is (nil? (sut/file-extension "Makefile")))))
+
+(deftest detect-language-test
+  (testing "detects Clojure from .clj extension"
+    (is (= "clojure" (sut/detect-language "core.clj" nil))))
+
+  (testing "detects Python from .py extension"
+    (is (= "python" (sut/detect-language "app.py" nil))))
+
+  (testing "lang override takes priority"
+    (is (= "rust" (sut/detect-language "file.clj" "rust"))))
+
+  (testing "unknown extension returns text"
+    (is (= "text" (sut/detect-language "file.xyz" nil)))))
+
+(deftest matches->violations-test
+  (testing "converts matches to violation-shaped maps"
+    (let [matches [{:row 5 :col 0 :capture "fn" :text "eval" :pattern 0}
+                   {:row 10 :col 2 :capture "fn" :text "eval" :pattern 0}]
+          result  (sut/matches->violations matches :test/no-eval "200" "No eval" "src/core.clj")]
+      (is (= 2 (count result)))
+      (is (= :test/no-eval (:rule/id (first result))))
+      (is (= 6 (:line (first result))))  ;; 0-indexed row 5 → 1-indexed line 6
+      (is (= "eval" (:current (first result))))))
+
+  (testing "returns empty vector for no matches"
+    (is (= [] (sut/matches->violations [] :test/rule "200" "Title" "file.clj")))))
+
+(deftest tree-sitter-available-test
+  (testing "returns boolean"
+    (is (boolean? (sut/tree-sitter-available?)))))
+
+(deftest state-comparison-detection-test
+  (testing "detects drift between desired and current state"
+    (let [detect (requiring-resolve 'ai.miniforge.policy-pack.detection/detect-state-comparison)
+          rule    {:rule/id :test/drift :rule/enforcement {:action :warn :message "Drift"}}
+          context {:desired-state {:replicas 3 :image "v2"}
+                   :current-state {:replicas 1 :image "v1"}}
+          result  (detect rule {} context)]
+      (is (some? result))
+      (is (= :state-comparison (:type result)))))
+
+  (testing "returns nil when no drift"
+    (let [detect  (requiring-resolve 'ai.miniforge.policy-pack.detection/detect-state-comparison)
+          rule    {:rule/id :test/drift :rule/enforcement {:action :warn :message "Drift"}}
+          context {:desired-state {:replicas 3} :current-state {:replicas 3}}
+          result  (detect rule {} context)]
+      (is (nil? result)))))
+
+(deftest plan-resource-counts-test
+  (testing "counts creates, updates, destroys from plan output"
+    (let [counts (requiring-resolve 'ai.miniforge.policy-pack.detection/plan-resource-counts)
+          plan   "# aws_vpc.main will be created\n# aws_route.old will be destroyed\n# aws_subnet.main will be updated"]
+      (is (= {:creates 1 :updates 1 :destroys 1} (counts plan)))))
+
+  (testing "empty plan returns zeros"
+    (let [counts (requiring-resolve 'ai.miniforge.policy-pack.detection/plan-resource-counts)]
+      (is (= {:creates 0 :updates 0 :destroys 0} (counts "no resources"))))))


### PR DESCRIPTION
## Summary
- Adds `ast.clj` — tree-sitter CLI wrapper for language-agnostic structural pattern matching (GraalVM-safe subprocess, no JNI)
- Implements `detect-ast-analysis` in detection.clj, dispatching tree-sitter queries against artifact content with automatic language detection from file extension
- Implements `detect-state-comparison` using `clojure.data/diff` for drift detection between desired and current state maps
- Adds `plan-resource-counts` helper to aggregate Terraform plan create/update/destroy tallies
- Wires both new detection types into the unified `detect-violation` dispatcher (replaces `nil` stubs)

## Test plan
- [x] Pre-commit hook: 162 tests, 1799 assertions, 0 failures
- [x] clj-kondo lint: 0 errors, 0 warnings
- [x] GraalVM/Babashka compatibility: 5 tests, 232 assertions passed
- [ ] Manual: verify `detect-ast-analysis` with tree-sitter CLI installed and a sample query
- [ ] Manual: verify `detect-state-comparison` with differing desired/current state maps

🤖 Generated with [Claude Code](https://claude.com/claude-code)