### PR TITLE
feat: mapping artifact — cross-framework compliance projection

### DIFF
--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -26,6 +26,7 @@
    [ai.miniforge.policy-pack.interface.loading :as loading]
    [ai.miniforge.policy-pack.interface.registry :as registry]
    [ai.miniforge.policy-pack.interface.schema :as schema]
+   [ai.miniforge.policy-pack.interface.mapping :as mapping]
    [ai.miniforge.policy-pack.mdc-compiler :as mdc-compiler]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -93,6 +94,17 @@
 (def approval-enforcement builders/approval-enforcement)
 (def resolve-rules builders/resolve-rules)
 (def merge-rules builders/merge-rules)
+
+;------------------------------------------------------------------------------ Layer 3
+;; Mapping API
+
+(def MappingArtifact mapping/MappingArtifact)
+(def MappingEntry mapping/MappingEntry)
+(def valid-mapping? mapping/valid-mapping?)
+(def validate-mapping mapping/validate-mapping)
+(def load-mapping mapping/load-mapping)
+(def resolve-mapping mapping/resolve-mapping)
+(def project-report mapping/project-report)
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; MDC compilation

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/mapping.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/mapping.clj
@@ -1,0 +1,47 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.interface.mapping
+  "Mapping artifact loading, validation, resolution, and report projection."
+  (:require
+   [ai.miniforge.policy-pack.mapping :as mapping]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schemas
+
+(def MappingArtifact mapping/MappingArtifact)
+(def MappingEntry mapping/MappingEntry)
+(def MappingAuthorship mapping/MappingAuthorship)
+(def MappingType mapping/MappingType)
+
+;------------------------------------------------------------------------------ Layer 0
+;; Validation
+
+(def valid-mapping? mapping/valid-mapping?)
+(def validate-mapping mapping/validate-mapping)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Loading
+
+(def load-mapping mapping/load-mapping)
+
+;------------------------------------------------------------------------------ Layer 2
+;; Resolution
+
+(def resolve-mapping mapping/resolve-mapping)
+(def project-report mapping/project-report)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/mapping.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/mapping.clj
@@ -1,0 +1,213 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.mapping
+  "Mapping artifacts — first-class bridges between policy systems.
+
+   A mapping artifact connects rules/categories in one system (source) to
+   controls/requirements in another (target). Neither source nor target owns
+   the mapping; it is an independent, versioned artifact.
+
+   Layer 0: Malli schemas for MappingArtifact, MappingEntry, MappingAuthorship
+   Layer 1: Loading and validation
+   Layer 2: Resolution and report projection
+
+   Related:
+     specs/normative/N4-policy-packs.md §2.4 — Mapping artifact spec
+     docs/design/policy-pack-taxonomy.md §2.4 — Four-artifact model design"
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [malli.core :as m]
+   [malli.error :as me]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schemas
+
+(def MappingType
+  "How closely the source satisfies the target."
+  [:enum :exact :broad :partial :none])
+
+(def MappingConfidence
+  "Confidence in the mapping's accuracy."
+  [:enum :high :medium :low :unvalidated])
+
+(def MappingAuthorship
+  "Provenance metadata for a mapping artifact."
+  [:map
+   [:publisher keyword?]
+   [:confidence MappingConfidence]
+   [:validated-at {:optional true} string?]])
+
+(def MappingSystemRef
+  "Reference to a source or target system."
+  [:map
+   [:mapping/system-kind [:enum :pack :taxonomy :framework]]
+   [:mapping/system-id keyword?]
+   [:mapping/system-version {:optional true} string?]])
+
+(def MappingEntry
+  "A single mapping between a source rule/category and a target control."
+  [:map
+   [:source/rule {:optional true} keyword?]
+   [:source/category {:optional true} keyword?]
+   [:target/control {:optional true} [:maybe string?]]
+   [:mapping/type MappingType]
+   [:mapping/notes {:optional true} string?]])
+
+(def MappingArtifact
+  "Schema for a mapping artifact — bridges between policy systems."
+  [:map
+   [:mapping/id keyword?]
+   [:mapping/version string?]
+   [:mapping/source MappingSystemRef]
+   [:mapping/target MappingSystemRef]
+   [:mapping/entries [:vector MappingEntry]]
+   [:mapping/authorship {:optional true} MappingAuthorship]])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Validation
+
+(defn valid-mapping?
+  "Check if value conforms to the MappingArtifact schema."
+  [value]
+  (m/validate MappingArtifact value))
+
+(defn validate-mapping
+  "Validate a mapping artifact. Returns {:valid? bool :errors map-or-nil}."
+  [value]
+  (if (m/validate MappingArtifact value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain MappingArtifact value))}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Loading
+
+(defn load-mapping
+  "Load a mapping artifact from an EDN file.
+
+   Arguments:
+   - path — Path to the .edn mapping file
+
+   Returns:
+   - {:success? true :mapping <MappingArtifact>}
+   - {:success? false :error <message>}"
+  [path]
+  (try
+    (let [file    (io/file path)
+          content (slurp file)
+          mapping (edn/read-string content)]
+      (if (valid-mapping? mapping)
+        {:success? true :mapping mapping}
+        {:success? false
+         :error (str "Mapping validation failed: "
+                     (:errors (validate-mapping mapping)))}))
+    (catch Exception e
+      {:success? false :error (.getMessage e)})))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Resolution
+
+(defn resolve-mapping
+  "Resolve a mapping against a pack, producing matched entries.
+
+   For each mapping entry, checks whether the source rule or category
+   exists in the pack and enriches the entry with the match status.
+
+   Arguments:
+   - mapping — MappingArtifact
+   - pack    — PackManifest to match against
+
+   Returns:
+   - Vector of maps: {:source/rule :source/category :target/control
+                       :mapping/type :matched? :rule-title}"
+  [mapping pack]
+  (let [pack-rule-ids (set (map :rule/id (:pack/rules pack)))
+        pack-cat-ids  (set (map :category/id (:pack/categories pack)))]
+    (mapv (fn [entry]
+            (let [rule-match (when-let [rid (:source/rule entry)]
+                               (contains? pack-rule-ids rid))
+                  cat-match  (when-let [cid (:source/category entry)]
+                               (contains? pack-cat-ids cid))
+                  matched?   (boolean (or rule-match cat-match))
+                  rule-title (when (and rule-match (:source/rule entry))
+                               (:rule/title
+                                (first (filter #(= (:rule/id %) (:source/rule entry))
+                                               (:pack/rules pack)))))]
+              (cond-> (assoc entry :matched? matched?)
+                rule-title (assoc :rule-title rule-title))))
+          (:mapping/entries mapping))))
+
+(defn project-report
+  "Generate a compliance coverage report by projecting a mapping onto a pack.
+
+   Shows which target controls are covered (:exact, :broad, :partial),
+   which have no mapping (:none), and which are unmatched (source rule/category
+   not found in pack).
+
+   Arguments:
+   - mapping — MappingArtifact
+   - pack    — PackManifest
+
+   Returns:
+   - {:target-controls [{:control :type :matched? :source :notes} ...]
+      :summary {:exact int :broad int :partial int :none int :unmatched int}}"
+  [mapping pack]
+  (let [resolved (resolve-mapping mapping pack)
+        controls (mapv (fn [entry]
+                         {:control  (:target/control entry)
+                          :type     (:mapping/type entry)
+                          :matched? (:matched? entry)
+                          :source   (or (:source/rule entry) (:source/category entry))
+                          :notes    (:mapping/notes entry)})
+                       resolved)
+        summary  (reduce (fn [acc entry]
+                           (if (:matched? entry)
+                             (update acc (:type entry) (fnil inc 0))
+                             (update acc :unmatched (fnil inc 0))))
+                         {:exact 0 :broad 0 :partial 0 :none 0 :unmatched 0}
+                         controls)]
+    {:target-controls controls
+     :summary         summary}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Example mapping: miniforge rules → Vanta controls
+  (def example-mapping
+    {:mapping/id      :miniforge-to-vanta/core-2026
+     :mapping/version "1.0.0"
+     :mapping/source  {:mapping/system-kind :pack
+                       :mapping/system-id   :miniforge/core
+                       :mapping/system-version "1.0.0"}
+     :mapping/target  {:mapping/system-kind :framework
+                       :mapping/system-id   :vanta/soc2}
+     :mapping/entries [{:source/rule    :mf.rule/copyright-header
+                        :target/control "CC6.2"
+                        :mapping/type   :exact}
+                       {:source/category :mf.cat/operations
+                        :target/control  "CC7.1"
+                        :mapping/type    :broad}]
+     :mapping/authorship {:publisher   :miniforge
+                          :confidence  :high
+                          :validated-at "2026-04-01"}})
+
+  (valid-mapping? example-mapping)
+  ;; => true
+
+  :leave-this-here)

--- a/components/policy-pack/test/ai/miniforge/policy_pack/mapping_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/mapping_test.clj
@@ -1,0 +1,178 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.mapping-test
+  "Unit tests for mapping artifacts — schemas, loading, resolution, and projection.
+
+   Covers:
+   - Layer 0: Malli schema validation (MappingArtifact, MappingEntry, MappingAuthorship)
+   - Layer 1: Loading from EDN files
+   - Layer 2: resolve-mapping matches entries to pack rules/categories
+   - Layer 2: project-report generates coverage summaries"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.policy-pack.mapping :as sut]))
+
+;; ============================================================================
+;; Test fixtures
+;; ============================================================================
+
+(def now (java.time.Instant/now))
+
+(def test-pack
+  {:pack/id          "test-pack"
+   :pack/name        "Test Pack"
+   :pack/version     "1.0.0"
+   :pack/description "Test"
+   :pack/author      "test"
+   :pack/categories  [{:category/id :operations :category/name "Ops" :category/rules [:test/ops-rule]}]
+   :pack/rules       [{:rule/id          :test/copyright
+                        :rule/title       "Copyright Header"
+                        :rule/description "Require copyright header"
+                        :rule/severity    :minor
+                        :rule/category    "810"
+                        :rule/applies-to  {}
+                        :rule/detection   {:type :content-scan :pattern "copyright"}
+                        :rule/enforcement {:action :warn :message "Missing copyright"}}
+                       {:rule/id          :test/ops-rule
+                        :rule/title       "Ops Rule"
+                        :rule/description "Operations check"
+                        :rule/severity    :major
+                        :rule/category    "500"
+                        :rule/applies-to  {}
+                        :rule/detection   {:type :content-scan :pattern "test"}
+                        :rule/enforcement {:action :warn :message "Warning"}}]
+   :pack/created-at  now
+   :pack/updated-at  now})
+
+(def test-mapping
+  {:mapping/id      :test-to-vanta/core
+   :mapping/version "1.0.0"
+   :mapping/source  {:mapping/system-kind :pack
+                     :mapping/system-id   :test/core
+                     :mapping/system-version "1.0.0"}
+   :mapping/target  {:mapping/system-kind :framework
+                     :mapping/system-id   :vanta/soc2}
+   :mapping/entries [{:source/rule    :test/copyright
+                      :target/control "CC6.2"
+                      :mapping/type   :exact}
+                     {:source/category :operations
+                      :target/control  "CC7.1"
+                      :mapping/type    :broad
+                      :mapping/notes   "Broad category coverage"}
+                     {:source/rule    :test/nonexistent
+                      :target/control "CC8.1"
+                      :mapping/type   :partial}
+                     {:target/control "CC9.1"
+                      :mapping/type   :none
+                      :mapping/notes  "No mapping exists"}]
+   :mapping/authorship {:publisher   :test
+                        :confidence  :high
+                        :validated-at "2026-04-01"}})
+
+;; ============================================================================
+;; Schema validation tests
+;; ============================================================================
+
+(deftest valid-mapping-test
+  (testing "well-formed mapping passes validation"
+    (is (true? (sut/valid-mapping? test-mapping))))
+
+  (testing "mapping without entries fails"
+    (is (false? (sut/valid-mapping? (dissoc test-mapping :mapping/entries)))))
+
+  (testing "mapping without source fails"
+    (is (false? (sut/valid-mapping? (dissoc test-mapping :mapping/source)))))
+
+  (testing "mapping without id fails"
+    (is (false? (sut/valid-mapping? (dissoc test-mapping :mapping/id)))))
+
+  (testing "entry with invalid mapping type fails"
+    (is (false? (sut/valid-mapping?
+                 (assoc test-mapping :mapping/entries
+                        [{:source/rule :test/foo
+                          :mapping/type :invalid}]))))))
+
+(deftest mapping-entry-types-test
+  (testing "all four mapping types are valid"
+    (doseq [mt [:exact :broad :partial :none]]
+      (is (true? (sut/valid-mapping?
+                  (assoc test-mapping :mapping/entries
+                         [{:source/rule :test/copyright
+                           :target/control "CC1.1"
+                           :mapping/type mt}])))))))
+
+(deftest mapping-authorship-test
+  (testing "mapping without authorship is valid"
+    (is (true? (sut/valid-mapping? (dissoc test-mapping :mapping/authorship)))))
+
+  (testing "all confidence levels are valid"
+    (doseq [c [:high :medium :low :unvalidated]]
+      (is (true? (sut/valid-mapping?
+                  (assoc-in test-mapping [:mapping/authorship :confidence] c)))))))
+
+;; ============================================================================
+;; Resolution tests
+;; ============================================================================
+
+(deftest resolve-mapping-test
+  (testing "matched rule entry has :matched? true"
+    (let [resolved (sut/resolve-mapping test-mapping test-pack)
+          entry    (first (filter #(= :test/copyright (:source/rule %)) resolved))]
+      (is (true? (:matched? entry)))
+      (is (= "Copyright Header" (:rule-title entry)))))
+
+  (testing "unmatched rule entry has :matched? false"
+    (let [resolved (sut/resolve-mapping test-mapping test-pack)
+          entry    (first (filter #(= :test/nonexistent (:source/rule %)) resolved))]
+      (is (false? (:matched? entry)))))
+
+  (testing "category-based entry matches pack categories"
+    (let [resolved (sut/resolve-mapping test-mapping test-pack)
+          entry    (first (filter #(= :operations (:source/category %)) resolved))]
+      (is (true? (:matched? entry)))))
+
+  (testing "entry with no source rule or category is unmatched"
+    (let [resolved (sut/resolve-mapping test-mapping test-pack)
+          entry    (first (filter #(= :none (:mapping/type %)) resolved))]
+      (is (false? (:matched? entry))))))
+
+;; ============================================================================
+;; Report projection tests
+;; ============================================================================
+
+(deftest project-report-test
+  (testing "summary counts matched and unmatched entries"
+    (let [report (sut/project-report test-mapping test-pack)]
+      (is (= 1 (get-in report [:summary :exact])))
+      (is (= 1 (get-in report [:summary :broad])))
+      (is (= 0 (get-in report [:summary :partial])))
+      (is (= 0 (get-in report [:summary :none])))
+      (is (= 2 (get-in report [:summary :unmatched])))))
+
+  (testing "target-controls list has entries for each mapping entry"
+    (let [report (sut/project-report test-mapping test-pack)]
+      (is (= 4 (count (:target-controls report))))))
+
+  (testing "each control entry has required fields"
+    (let [report  (sut/project-report test-mapping test-pack)
+          control (first (:target-controls report))]
+      (is (contains? control :control))
+      (is (contains? control :type))
+      (is (contains? control :matched?))
+      (is (contains? control :source)))))


### PR DESCRIPTION
## Summary

- Implements the Mapping artifact per N4 §2.4
- MappingArtifact/MappingEntry/MappingAuthorship Malli schemas
- Mapping types: :exact, :broad, :partial, :none
- load-mapping, resolve-mapping, project-report
- 5 tests, 29 assertions

## Test plan

- [x] Mapping schema validation tests pass
- [x] Resolution and projection tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)