### PR TITLE
feat: pack-bundled prompt templates — configuration is data, not code

### DIFF
--- a/components/policy-pack/resources/policy_pack/templates/defaults.edn
+++ b/components/policy-pack/resources/policy_pack/templates/defaults.edn
@@ -1,0 +1,11 @@
+;; Default prompt templates for pack-bundled template system.
+;; Packs may override these via :pack/prompt-templates.
+
+{:repair-prompt
+ "Fix the following code violation.\n\n**Rule:** {{rule-title}}\n**File:** {{file}}:{{line}}\n**Current code:** `{{current}}`\n**Issue:** {{rationale}}\n\n{{knowledge-content}}\n\nProvide the corrected code only, no explanation."
+
+ :behavior-section
+ "\n\n## Policy Rules \u2014 Required Behaviors\n\n{{behaviors}}\n"
+
+ :knowledge-section
+ "\n\n## Reference Material\n\n{{knowledge}}\n"}

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -28,6 +28,7 @@
    [ai.miniforge.policy-pack.interface.schema :as schema]
    [ai.miniforge.policy-pack.interface.intent :as intent]
    [ai.miniforge.policy-pack.interface.mapping :as mapping]
+   [ai.miniforge.policy-pack.interface.prompt-template :as prompt-template]
    [ai.miniforge.policy-pack.interface.taxonomy :as taxonomy]
    [ai.miniforge.policy-pack.mdc-compiler :as mdc-compiler]))
 
@@ -111,6 +112,13 @@
 (def load-mapping mapping/load-mapping)
 (def resolve-mapping mapping/resolve-mapping)
 (def project-report mapping/project-report)
+
+;------------------------------------------------------------------------------ Prompt templates
+
+(def interpolate prompt-template/interpolate)
+(def render-repair-prompt prompt-template/render-repair-prompt)
+(def render-behavior-section prompt-template/render-behavior-section)
+(def render-knowledge-section prompt-template/render-knowledge-section)
 
 ;------------------------------------------------------------------------------ MDC compilation
 

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface/prompt_template.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface/prompt_template.clj
@@ -1,0 +1,30 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.interface.prompt-template
+  "Pack-bundled prompt template interpolation and rendering."
+  (:require
+   [ai.miniforge.policy-pack.prompt-template :as pt]))
+
+(def interpolate pt/interpolate)
+(def render-repair-prompt pt/render-repair-prompt)
+(def render-behavior-section pt/render-behavior-section)
+(def render-knowledge-section pt/render-knowledge-section)
+(def resolve-repair-template pt/resolve-repair-template)
+(def resolve-behavior-template pt/resolve-behavior-template)
+(def resolve-knowledge-template pt/resolve-knowledge-template)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/prompt_template.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/prompt_template.clj
@@ -1,0 +1,212 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.prompt-template
+  "Pack-bundled prompt template interpolation.
+
+   Templates use {{variable}} syntax. Variables are replaced with values
+   from a context map. Unknown variables are left as-is.
+
+   Layer 0: Interpolation engine
+   Layer 1: Default templates (built-in fallbacks)
+   Layer 2: Template resolution (rule → pack → default)"
+  (:require [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Interpolation
+
+(defn interpolate
+  "Replace {{variable}} placeholders in a template string with values
+   from the bindings map. Keys can be strings or keywords.
+   Unknown variables are replaced with empty string.
+
+   Arguments:
+   - template — String with {{variable}} placeholders
+   - bindings — Map of variable names to values
+
+   Returns:
+   - Interpolated string"
+  [template bindings]
+  (str/replace template
+               #"\{\{([^}]+)\}\}"
+               (fn [[_ var-name]]
+                 (let [kw (keyword var-name)
+                       s  (str var-name)]
+                   (str (or (get bindings kw)
+                            (get bindings s)
+                            ""))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Default templates
+
+(def default-repair-prompt
+  "Default prompt template for LLM-based semantic repair.
+   Used when neither rule nor pack provides a :repair-prompt template."
+  "Fix the following code violation.
+
+**Rule:** {{rule-title}}
+**File:** {{file}}:{{line}}
+**Current code:** `{{current}}`
+**Issue:** {{rationale}}
+{{#knowledge-content}}
+
+**Reference:**
+{{knowledge-content}}
+{{/knowledge-content}}
+
+Provide the corrected code only, no explanation.")
+
+(def default-behavior-section
+  "Default template for the behavior rules section injected into agent prompts."
+  "\n\n## Policy Rules \u2014 Required Behaviors\n\n{{behaviors}}\n")
+
+(def default-knowledge-section
+  "Default template for the reference material section injected into agent prompts."
+  "\n\n## Reference Material\n\n{{knowledge}}\n")
+
+;------------------------------------------------------------------------------ Layer 2
+;; Template resolution
+
+(defn resolve-repair-template
+  "Resolve the repair prompt template for a violation.
+
+   Priority:
+   1. Rule-level :rule/repair-prompt-template
+   2. Pack-level :pack/prompt-templates :repair-prompt
+   3. Built-in default
+
+   Arguments:
+   - rule — Rule map (may have :rule/repair-prompt-template)
+   - pack — Pack map (may have :pack/prompt-templates)
+
+   Returns:
+   - Template string"
+  [rule pack]
+  (or (:rule/repair-prompt-template rule)
+      (get-in pack [:pack/prompt-templates :repair-prompt])
+      default-repair-prompt))
+
+(defn resolve-behavior-template
+  "Resolve the behavior section template.
+
+   Priority:
+   1. Pack-level :pack/prompt-templates :behavior-section
+   2. Built-in default
+
+   Arguments:
+   - pack — Pack map (may have :pack/prompt-templates)
+
+   Returns:
+   - Template string"
+  [pack]
+  (or (get-in pack [:pack/prompt-templates :behavior-section])
+      default-behavior-section))
+
+(defn resolve-knowledge-template
+  "Resolve the knowledge section template.
+
+   Priority:
+   1. Pack-level :pack/prompt-templates :knowledge-section
+   2. Built-in default
+
+   Arguments:
+   - pack — Pack map (may have :pack/prompt-templates)
+
+   Returns:
+   - Template string"
+  [pack]
+  (or (get-in pack [:pack/prompt-templates :knowledge-section])
+      default-knowledge-section))
+
+(defn render-repair-prompt
+  "Render a complete repair prompt for a violation.
+
+   Arguments:
+   - violation — Violation map with :file, :line, :current, :rationale, :rule/id
+   - rule      — Rule map with optional :rule/repair-prompt-template, :rule/knowledge-content
+   - pack      — Pack map with optional :pack/prompt-templates
+
+   Returns:
+   - {:role :user :content <interpolated string>}"
+  [violation rule pack]
+  (let [template (resolve-repair-template rule pack)
+        bindings {:file              (get violation :file "")
+                  :line              (get violation :line "")
+                  :current           (get violation :current "")
+                  :rationale         (get violation :rationale "")
+                  :rule-title        (get rule :rule/title (name (get violation :rule/id :unknown)))
+                  :knowledge-content (get rule :rule/knowledge-content "")}]
+    {:role    :user
+     :content (interpolate template bindings)}))
+
+(defn render-behavior-section
+  "Render the behavior rules section for prompt injection.
+
+   Arguments:
+   - behaviors — Seq of behavior strings
+   - pack      — Pack map with optional :pack/prompt-templates
+
+   Returns:
+   - Formatted string or nil if no behaviors"
+  [behaviors pack]
+  (when (seq behaviors)
+    (let [template (resolve-behavior-template pack)
+          numbered (->> behaviors
+                        (map-indexed (fn [i b] (str (inc i) ". " b)))
+                        (str/join "\n"))]
+      (interpolate template {:behaviors numbered}))))
+
+(defn render-knowledge-section
+  "Render the reference material section for prompt injection.
+
+   Arguments:
+   - knowledge — Seq of {:rule/title :content} maps
+   - pack      — Pack map with optional :pack/prompt-templates
+
+   Returns:
+   - Formatted string or nil if no knowledge"
+  [knowledge pack]
+  (when (seq knowledge)
+    (let [template (resolve-knowledge-template pack)
+          rendered (->> knowledge
+                        (map (fn [{:keys [rule/title content]}]
+                               (str "### " (or title "Standard") "\n\n" content)))
+                        (str/join "\n\n"))]
+      (interpolate template {:knowledge rendered}))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  ;; Basic interpolation
+  (interpolate "Hello {{name}}, welcome to {{place}}!"
+               {:name "Chris" :place "miniforge"})
+  ;; => "Hello Chris, welcome to miniforge!"
+
+  ;; Render repair prompt with default template
+  (render-repair-prompt
+   {:file "src/core.clj" :line 42 :current "(eval x)" :rationale "eval is unsafe"}
+   {:rule/title "No eval" :rule/knowledge-content "Avoid eval for security."}
+   {})
+
+  ;; Render with pack-provided template
+  (render-repair-prompt
+   {:file "main.tf" :line 10 :current "acl = \"public-read\"" :rationale "Public S3 bucket"}
+   {:rule/title "No Public S3"}
+   {:pack/prompt-templates
+    {:repair-prompt "Fix this Terraform violation:\nFile: {{file}}:{{line}}\nIssue: {{rationale}}\nFix the `{{current}}` to be private."}})
+
+  :leave-this-here)

--- a/components/policy-pack/src/ai/miniforge/policy_pack/prompt_template.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/prompt_template.clj
@@ -103,9 +103,8 @@
    Returns:
    - Template string"
   [rule pack]
-  (or (:rule/repair-prompt-template rule)
-      (get-in pack [:pack/prompt-templates :repair-prompt])
-      @default-repair-prompt))
+  (get rule :rule/repair-prompt-template
+       (get-in pack [:pack/prompt-templates :repair-prompt] @default-repair-prompt)))
 
 (defn resolve-behavior-template
   "Resolve the behavior section template.
@@ -120,8 +119,7 @@
    Returns:
    - Template string"
   [pack]
-  (or (get-in pack [:pack/prompt-templates :behavior-section])
-      @default-behavior-section))
+  (get-in pack [:pack/prompt-templates :behavior-section] @default-behavior-section))
 
 (defn resolve-knowledge-template
   "Resolve the knowledge section template.
@@ -136,8 +134,7 @@
    Returns:
    - Template string"
   [pack]
-  (or (get-in pack [:pack/prompt-templates :knowledge-section])
-      @default-knowledge-section))
+  (get-in pack [:pack/prompt-templates :knowledge-section] @default-knowledge-section))
 
 (defn render-repair-prompt
   "Render a complete repair prompt for a violation.

--- a/components/policy-pack/src/ai/miniforge/policy_pack/prompt_template.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/prompt_template.clj
@@ -25,7 +25,9 @@
    Layer 0: Interpolation engine
    Layer 1: Default templates (built-in fallbacks)
    Layer 2: Template resolution (rule → pack → default)"
-  (:require [clojure.string :as str]))
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Interpolation
@@ -52,32 +54,36 @@
                             ""))))))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Default templates
+;; Default templates (loaded from EDN resource)
+
+(def ^:private default-templates-resource
+  "Classpath resource path for default prompt templates."
+  "policy_pack/templates/defaults.edn")
+
+(def ^:private loaded-defaults
+  "Default templates loaded from classpath EDN resource. Delay for lazy loading."
+  (delay
+    (try
+      (when-let [resource (io/resource default-templates-resource)]
+        (edn/read-string (slurp resource)))
+      (catch Exception _ {}))))
+
+(defn- default-template
+  "Get a default template by key. Returns empty string if not found."
+  [k]
+  (get @loaded-defaults k ""))
 
 (def default-repair-prompt
-  "Default prompt template for LLM-based semantic repair.
-   Used when neither rule nor pack provides a :repair-prompt template."
-  "Fix the following code violation.
-
-**Rule:** {{rule-title}}
-**File:** {{file}}:{{line}}
-**Current code:** `{{current}}`
-**Issue:** {{rationale}}
-{{#knowledge-content}}
-
-**Reference:**
-{{knowledge-content}}
-{{/knowledge-content}}
-
-Provide the corrected code only, no explanation.")
+  "Default prompt template for LLM-based semantic repair."
+  (delay (default-template :repair-prompt)))
 
 (def default-behavior-section
-  "Default template for the behavior rules section injected into agent prompts."
-  "\n\n## Policy Rules \u2014 Required Behaviors\n\n{{behaviors}}\n")
+  "Default template for the behavior rules section."
+  (delay (default-template :behavior-section)))
 
 (def default-knowledge-section
-  "Default template for the reference material section injected into agent prompts."
-  "\n\n## Reference Material\n\n{{knowledge}}\n")
+  "Default template for the reference material section."
+  (delay (default-template :knowledge-section)))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Template resolution
@@ -99,7 +105,7 @@ Provide the corrected code only, no explanation.")
   [rule pack]
   (or (:rule/repair-prompt-template rule)
       (get-in pack [:pack/prompt-templates :repair-prompt])
-      default-repair-prompt))
+      @default-repair-prompt))
 
 (defn resolve-behavior-template
   "Resolve the behavior section template.
@@ -115,7 +121,7 @@ Provide the corrected code only, no explanation.")
    - Template string"
   [pack]
   (or (get-in pack [:pack/prompt-templates :behavior-section])
-      default-behavior-section))
+      @default-behavior-section))
 
 (defn resolve-knowledge-template
   "Resolve the knowledge section template.
@@ -131,7 +137,7 @@ Provide the corrected code only, no explanation.")
    - Template string"
   [pack]
   (or (get-in pack [:pack/prompt-templates :knowledge-section])
-      default-knowledge-section))
+      @default-knowledge-section))
 
 (defn render-repair-prompt
   "Render a complete repair prompt for a violation.

--- a/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/schema.clj
@@ -218,6 +218,12 @@
    ;; Examples (for documentation and testing)
    [:rule/examples {:optional true} [:vector RuleExample]]
 
+   ;; Prompt template for LLM-based semantic repair (pack-bundled).
+   ;; Uses {{variable}} interpolation: {{file}}, {{line}}, {{current}},
+   ;; {{rationale}}, {{rule-title}}, {{knowledge-content}}.
+   ;; Overrides pack-level :repair-prompt template when present.
+   [:rule/repair-prompt-template {:optional true} string?]
+
    ;; Metadata
    [:rule/version {:optional true} string?]
    [:rule/author {:optional true} string?]
@@ -292,6 +298,11 @@
 
    ;; Taxonomy reference (N4 §2.1)
    [:pack/taxonomy-ref {:optional true} TaxonomyRef]
+
+   ;; Pack-bundled prompt templates (N4 §6).
+   ;; Keys: :behavior-section, :knowledge-section, :repair-prompt
+   ;; Templates use {{variable}} interpolation.
+   [:pack/prompt-templates {:optional true} [:map-of :keyword string?]]
 
    ;; Config overrides (governance config tuning from trusted packs)
    [:pack/config-overrides {:optional true} [:map-of :keyword :map]]

--- a/components/policy-pack/test/ai/miniforge/policy_pack/prompt_template_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/prompt_template_test.clj
@@ -59,7 +59,7 @@
       (is (= "Pack: {{current}}" (sut/resolve-repair-template rule pack)))))
 
   (testing "default used when neither rule nor pack provides"
-    (is (= sut/default-repair-prompt (sut/resolve-repair-template {} {})))))
+    (is (= @sut/default-repair-prompt (sut/resolve-repair-template {} {})))))
 
 (deftest resolve-behavior-template-test
   (testing "pack-level template wins"
@@ -67,7 +67,7 @@
       (is (= "Custom: {{behaviors}}" (sut/resolve-behavior-template pack)))))
 
   (testing "default used when pack has none"
-    (is (= sut/default-behavior-section (sut/resolve-behavior-template {})))))
+    (is (= @sut/default-behavior-section (sut/resolve-behavior-template {})))))
 
 ;; ============================================================================
 ;; Layer 2 — Rendering tests

--- a/components/policy-pack/test/ai/miniforge/policy_pack/prompt_template_test.clj
+++ b/components/policy-pack/test/ai/miniforge/policy_pack/prompt_template_test.clj
@@ -1,0 +1,120 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.policy-pack.prompt-template-test
+  "Tests for pack-bundled prompt template interpolation and rendering."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.policy-pack.prompt-template :as sut]))
+
+;; ============================================================================
+;; Layer 0 — Interpolation engine tests
+;; ============================================================================
+
+(deftest interpolate-test
+  (testing "replaces keyword-keyed variables"
+    (is (= "Hello Chris" (sut/interpolate "Hello {{name}}" {:name "Chris"}))))
+
+  (testing "replaces string-keyed variables"
+    (is (= "Hello Chris" (sut/interpolate "Hello {{name}}" {"name" "Chris"}))))
+
+  (testing "replaces multiple variables"
+    (is (= "src/core.clj:42"
+           (sut/interpolate "{{file}}:{{line}}" {:file "src/core.clj" :line 42}))))
+
+  (testing "unknown variables become empty string"
+    (is (= "Hello " (sut/interpolate "Hello {{unknown}}" {}))))
+
+  (testing "no placeholders returns input unchanged"
+    (is (= "plain text" (sut/interpolate "plain text" {:foo "bar"})))))
+
+;; ============================================================================
+;; Layer 2 — Template resolution tests
+;; ============================================================================
+
+(deftest resolve-repair-template-test
+  (testing "rule-level template wins"
+    (let [rule {:rule/repair-prompt-template "Rule: {{current}}"}
+          pack {:pack/prompt-templates {:repair-prompt "Pack: {{current}}"}}]
+      (is (= "Rule: {{current}}" (sut/resolve-repair-template rule pack)))))
+
+  (testing "pack-level template used when rule has none"
+    (let [rule {}
+          pack {:pack/prompt-templates {:repair-prompt "Pack: {{current}}"}}]
+      (is (= "Pack: {{current}}" (sut/resolve-repair-template rule pack)))))
+
+  (testing "default used when neither rule nor pack provides"
+    (is (= sut/default-repair-prompt (sut/resolve-repair-template {} {})))))
+
+(deftest resolve-behavior-template-test
+  (testing "pack-level template wins"
+    (let [pack {:pack/prompt-templates {:behavior-section "Custom: {{behaviors}}"}}]
+      (is (= "Custom: {{behaviors}}" (sut/resolve-behavior-template pack)))))
+
+  (testing "default used when pack has none"
+    (is (= sut/default-behavior-section (sut/resolve-behavior-template {})))))
+
+;; ============================================================================
+;; Layer 2 — Rendering tests
+;; ============================================================================
+
+(deftest render-repair-prompt-test
+  (testing "renders with default template"
+    (let [violation {:file "src/core.clj" :line 42
+                     :current "(eval x)" :rationale "eval is unsafe"
+                     :rule/id :test/no-eval}
+          rule      {:rule/title "No eval"}
+          result    (sut/render-repair-prompt violation rule {})]
+      (is (= :user (:role result)))
+      (is (.contains (:content result) "No eval"))
+      (is (.contains (:content result) "src/core.clj:42"))
+      (is (.contains (:content result) "(eval x)"))))
+
+  (testing "renders with rule-provided template"
+    (let [violation {:file "main.tf" :line 10 :current "public" :rationale "bad"
+                     :rule/id :test/rule}
+          rule      {:rule/title "Test" :rule/repair-prompt-template "Fix {{file}} line {{line}}"}
+          result    (sut/render-repair-prompt violation rule {})]
+      (is (= "Fix main.tf line 10" (:content result)))))
+
+  (testing "renders with pack-provided template"
+    (let [violation {:file "a.clj" :line 1 :current "x" :rationale "y"
+                     :rule/id :test/rule}
+          rule      {:rule/title "R"}
+          pack      {:pack/prompt-templates {:repair-prompt "Pack fix: {{rationale}}"}}
+          result    (sut/render-repair-prompt violation rule pack)]
+      (is (= "Pack fix: y" (:content result))))))
+
+(deftest render-behavior-section-test
+  (testing "formats numbered behaviors"
+    (let [result (sut/render-behavior-section ["Do A" "Do B"] {})]
+      (is (.contains result "1. Do A"))
+      (is (.contains result "2. Do B"))))
+
+  (testing "returns nil for empty behaviors"
+    (is (nil? (sut/render-behavior-section [] {})))))
+
+(deftest render-knowledge-section-test
+  (testing "formats knowledge entries"
+    (let [result (sut/render-knowledge-section
+                  [{:rule/title "Rule A" :content "Content A"}] {})]
+      (is (.contains result "### Rule A"))
+      (is (.contains result "Content A"))))
+
+  (testing "returns nil for empty knowledge"
+    (is (nil? (sut/render-knowledge-section [] {})))))


### PR DESCRIPTION
## Summary

- Moves prompt construction from hardcoded strings to pack-bundled templates
- Rule-level `:rule/repair-prompt-template` for per-rule semantic repair prompts
- Pack-level `:pack/prompt-templates` map for behavior/knowledge/repair sections
- `{{variable}}` interpolation engine (no template library dependency)
- Resolution chain: rule template > pack template > built-in default
- Downstream PRs (#452, #454) should consume these instead of hardcoded builders

## Test plan

- [x] Interpolation engine tests (keyword/string keys, multiple vars, unknown vars)
- [x] Template resolution tests (rule > pack > default priority)
- [x] Rendering tests (repair prompt, behavior section, knowledge section)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)