### PR TITLE
docs: OSS readiness — README rewrite, quickstart, demo, user guide

### DIFF
--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,0 +1,113 @@
+# Miniforge Demo: Spec to PR in 5 Minutes
+
+Watch miniforge plan, implement, test, review, and open a pull request —
+on its own codebase.
+
+## What You Will See
+
+1. Miniforge reads a spec describing a new utility function
+2. The **planner** analyzes the codebase and decomposes the work into tasks
+3. The **implementer** writes the code and tests
+4. **Verification gates** check syntax, linting, and test results
+5. The **reviewer** self-reviews the diff against the spec
+6. The **releaser** creates a branch, commits, and opens a PR
+
+All of this happens autonomously. You just watch.
+
+## Prerequisites
+
+- Completed the [Quickstart](quickstart.md) (`bb bootstrap`)
+- An LLM backend: Claude Code CLI, Codex CLI, or an API key
+- A GitHub token (for PR creation): `export GITHUB_TOKEN="ghp_..."`
+  - Or run without PR creation to see the pipeline without pushing
+
+## Run the Demo
+
+```bash
+bash examples/demo/run-demo.sh
+```
+
+Or run directly:
+
+```bash
+mf run examples/demo/add-utility-function.edn
+```
+
+## What the Spec Says
+
+The demo spec asks miniforge to add a `normalize-identifier` function to the
+logging component — a pure function that converts arbitrary strings into
+keyword-safe identifiers (e.g., `"My Feature Name!"` becomes `"my-feature-name"`).
+
+This is a real, useful addition to the codebase. Miniforge is building itself.
+
+## Expected Output
+
+```text
+Parsing workflow spec: examples/demo/add-utility-function.edn
+Running workflow: Add string normalization utility to logging component
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Miniforge Workflow Runner
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+→ Phase :explore started
+✓ Phase :explore success (0ms)
+
+→ Phase :plan started
+  • Agent :plan analyzing codebase...
+  • Gate :plan-complete passed
+✓ Phase :plan success (1.2m)
+
+→ Phase :implement started
+  • Agent :implement writing code...
+  • Gate :syntax passed
+  • Gate :lint passed
+  • Gate :no-secrets passed
+✓ Phase :implement success (45s)
+
+→ Phase :verify started
+✓ Phase :verify success (8s)
+
+→ Phase :review started
+  • Agent :reviewer reviewing diff...
+✓ Phase :review success (1.5m)
+
+→ Phase :release started
+  • Creating branch, committing, pushing...
+  • PR created: https://github.com/miniforge-ai/miniforge/pull/XXX
+✓ Phase :release success
+
+✓ Workflow completed
+Tokens: 12,450 | Cost: $0.42 | Duration: 4.2m
+```
+
+## Inspecting the Results
+
+After the workflow completes:
+
+```bash
+# See what files were changed
+git diff HEAD~1
+
+# Check the PR (if GITHUB_TOKEN was set)
+gh pr view --web
+
+# View execution artifacts
+ls ~/.miniforge/artifacts/
+```
+
+## Key Takeaways
+
+- **Zero prompt engineering** — the spec describes WHAT, not HOW
+- **Policy-governed** — syntax, lint, and test gates prevent bad code
+- **Multi-agent** — specialized agents for each SDLC phase
+- **Self-improving** — miniforge can build features for itself
+- **Cost-efficient** — $0.30-0.50 per feature, intelligent model selection
+- **Traceable** — every agent decision is logged in evidence bundles
+
+## Next Steps
+
+- [Write your own spec](user-guide/writing-specs.md)
+- [Understand the phases](user-guide/phases.md)
+- [Configure LLM backends](user-guide/configuration.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,158 @@
+# Quickstart: Run Your First Workflow
+
+Get from zero to a miniforge-generated pull request in under 5 minutes.
+
+## Prerequisites
+
+- macOS or Linux
+- [Babashka](https://github.com/babashka/babashka#installation) (bb)
+- An LLM backend — one of:
+  - [Claude Code](https://claude.ai/claude-code) CLI (recommended)
+  - [Codex](https://openai.com/codex) CLI
+  - An API key (Anthropic or OpenAI)
+
+```bash
+# Install Babashka if needed
+brew install babashka/brew/babashka
+```
+
+## 1. Clone and Bootstrap
+
+```bash
+git clone https://github.com/miniforge-ai/miniforge.git
+cd miniforge
+bb bootstrap
+```
+
+This installs Java, Clojure, linters, and configures the project.
+
+## 2. LLM Backend
+
+Miniforge auto-detects installed agent CLIs. If you have Claude Code or Codex
+installed, you're ready. Otherwise, set an API key:
+
+```bash
+# Only needed if no agent CLI is installed
+export ANTHROPIC_API_KEY="sk-ant-..."
+# Or:
+# export OPENAI_API_KEY="sk-..."
+```
+
+## 3. Run a Workflow
+
+```bash
+mf run examples/workflows/simple-refactor.edn
+```
+
+You'll see miniforge work through the pipeline:
+
+```text
+→ Phase :explore started
+✓ Phase :explore success (0ms)
+
+→ Phase :plan started
+  • Agent :plan: analyzing codebase, decomposing spec into tasks...
+✓ Phase :plan success (1.2m)
+
+→ Phase :implement started
+  • Agent :implement: writing code...
+  • Gate :syntax passed
+  • Gate :lint passed
+  • Gate :no-secrets passed
+✓ Phase :implement success (45s)
+
+→ Phase :verify started
+✓ Phase :verify success (8s)
+
+→ Phase :review started
+  • Agent :reviewer: reviewing diff...
+✓ Phase :review success (1.5m)
+
+→ Phase :release started
+  • Creating branch, committing, pushing...
+  • PR created: https://github.com/you/repo/pull/123
+✓ Phase :release success
+
+✓ Workflow completed
+Tokens: 12,450 | Cost: $0.42 | Duration: 4.2m
+```
+
+## 4. Write Your Own Spec
+
+Create a file called `my-feature.edn`:
+
+```clojure
+{:spec/title "Add health check endpoint"
+
+ :spec/description
+ "Add a /health endpoint that returns HTTP 200 with a JSON body
+  containing the service name, version, and uptime."
+
+ :spec/intent {:type :feature}
+
+ :spec/constraints
+ ["Use the existing HTTP server framework"
+  "No new dependencies"]
+
+ :spec/acceptance-criteria
+ ["GET /health returns 200"
+  "Response body is valid JSON"
+  "Response includes :service, :version, :uptime-ms keys"]}
+```
+
+Run it:
+
+```bash
+mf run my-feature.edn
+```
+
+## 5. Try a Markdown Spec
+
+You can also write specs as Markdown:
+
+```markdown
+---
+title: Fix login timeout
+description: |
+  The login form times out after 5 seconds on slow connections.
+  Increase the timeout to 30 seconds and add a loading indicator.
+intent:
+  type: bugfix
+constraints:
+  - No changes to the auth backend
+  - All existing login tests must pass
+---
+
+## Context
+
+Users on mobile networks report seeing "Request timed out" errors
+when trying to log in. The current timeout is hardcoded to 5000ms
+in the fetch call.
+```
+
+Run it the same way:
+
+```bash
+mf run fix-login-timeout.md
+```
+
+## What Just Happened?
+
+When you ran `mf run`, miniforge executed a full SDLC pipeline:
+
+1. **Explore** — Scanned the codebase, loaded relevant files into context
+2. **Plan** — Decomposed your spec into a task DAG with dependencies
+3. **Implement** — Generated code via an LLM agent, validated through gates
+4. **Verify** — Ran tests, checked coverage thresholds
+5. **Review** — Self-reviewed the diff against your spec and constraints
+6. **Release** — Created a branch, committed changes, opened a PR
+
+Every phase is governed by policy gates. If the code doesn't pass syntax
+checking, linting, or tests, the agent repairs and retries automatically.
+
+## Next Steps
+
+- [Demo Guide](demo.md) — Watch miniforge improve itself
+- [Writing Specs](user-guide/writing-specs.md) — Spec format reference
+- [Phases](user-guide/phases.md) — What each pipeline phase does
+- [Configuration](user-guide/configuration.md) — LLM backends and tuning

--- a/docs/user-guide/architecture.md
+++ b/docs/user-guide/architecture.md
@@ -1,0 +1,102 @@
+# Architecture Overview
+
+Miniforge is built as a governed workflow engine with pluggable phases,
+agents, and policy packs.
+
+## Three Layers
+
+```text
+┌─────────────────────────────────────────────────────┐
+│             Surface: CLI / TUI / Web                │
+├─────────────────────────────────────────────────────┤
+│          Software Factory: SDLC Workflows           │
+│     Agents, PR Lifecycle, Fleet Management          │
+├─────────────────────────────────────────────────────┤
+│        MiniForge Core: Governed Workflow Engine      │
+│    DAG Executor, Phase Registry, Policy SDK          │
+└─────────────────────────────────────────────────────┘
+```
+
+**MiniForge Core** is the workflow engine — it executes DAGs of phases with
+gates, budgets, and retry policies. It knows nothing about software development.
+
+**Software Factory** adds SDLC-specific phases (plan, implement, verify, review,
+release), agent implementations, and PR lifecycle management.
+
+**Surface** provides CLI (`mf`), TUI (terminal dashboard), and web interfaces
+for monitoring and control.
+
+## Agent Model
+
+Each pipeline phase is driven by a specialized agent:
+
+| Phase | Agent | What It Does |
+|-------|-------|-------------|
+| Plan | Planner | Decomposes specs into task DAGs |
+| Implement | Implementer | Generates code via LLM |
+| Verify | — | Runs gates (no LLM needed) |
+| Review | Reviewer | Self-reviews diffs |
+| Release | Releaser | Generates commit/PR metadata |
+
+Agents use LLMs (Claude, GPT, local models) but are governed by policy gates.
+The agent doesn't decide if code is good enough — the gates do.
+
+## DAG Executor
+
+When a plan produces multiple tasks, they execute as a DAG:
+
+```text
+Plan output:
+  Task A (no deps)     ─┐
+  Task B (no deps)     ─┤──> parallel execution
+  Task C (depends A,B) ─┘──> waits for A and B
+
+Each task runs: implement → verify → review → release (own PR)
+```
+
+Tasks run in isolated git worktrees. Each task produces its own PR.
+The DAG executor handles dependency ordering, parallelism (up to 4 tasks),
+rate limit detection, and failure propagation.
+
+## Policy Packs
+
+Gates are organized into policy packs — composable sets of quality checks:
+
+```text
+Default gates:
+  syntax     — code parses without errors
+  lint       — no linting violations
+  no-secrets — no credentials in code
+  tests-pass — all tests pass
+```
+
+Policy packs are configured per-phase in the workflow definition. Custom
+gates can be added via the gate registry.
+
+## Component Model
+
+Miniforge uses [Polylith](https://polylith.gitbook.io/polylith/) — a
+component-based architecture where each component has:
+
+- `src/` — implementation
+- `test/` — tests
+- `resources/` — config and data
+- `interface.clj` — public API (the only file other components import)
+
+There are 40+ components covering workflow execution, agent implementations,
+policy enforcement, event streaming, and CLI/TUI/web surfaces.
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md) for development details.
+
+## Extension Points
+
+- **Custom workflows** — define new phase sequences in EDN
+- **Custom agents** — implement the agent protocol for new phase types
+- **Custom gates** — register gate functions in the gate registry
+- **Custom policy packs** — compose gates into named packs
+- **LLM backends** — add new LLM providers via the backend protocol
+
+## Further Reading
+
+- [Normative Specs (N1-N11)](../specs/normative/) — full technical specification
+- [Design Documents](../docs/design/) — architectural decisions and rationale

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,0 +1,89 @@
+# Configuration
+
+## LLM Backend
+
+Miniforge auto-detects your LLM backend in this priority order:
+
+1. **Claude Code CLI** — if `claude` is on your PATH
+2. **Codex CLI** — if `codex` is on your PATH
+3. **Anthropic API** — if `ANTHROPIC_API_KEY` is set
+4. **OpenAI API** — if `OPENAI_API_KEY` is set
+
+No configuration is needed if you have Claude Code or Codex installed.
+
+### API Key Setup
+
+```bash
+# Anthropic (Claude)
+export ANTHROPIC_API_KEY="sk-ant-..."
+
+# OpenAI
+export OPENAI_API_KEY="sk-..."
+```
+
+### GitHub Token (for PR creation)
+
+```bash
+export GITHUB_TOKEN="ghp_..."
+```
+
+Without a GitHub token, the release phase will commit and push but skip
+PR creation.
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `ANTHROPIC_API_KEY` | — | Anthropic API key |
+| `OPENAI_API_KEY` | — | OpenAI API key |
+| `GITHUB_TOKEN` | — | GitHub token for PR creation |
+| `MINIFORGE_MAX_TOKENS` | `150000` | Max tokens per workflow |
+| `MINIFORGE_MAX_ITERATIONS` | `50` | Max phase retries |
+| `MINIFORGE_MAX_PARALLEL` | `4` | Max parallel DAG tasks |
+| `MINIFORGE_MAX_COST_USD` | `100.0` | Cost budget per workflow |
+
+## Workflow Tuning
+
+Override defaults in your spec:
+
+```clojure
+{:spec/title "..."
+ :spec/description "..."
+
+ ;; Override workflow config
+ :workflow/config
+ {:max-tokens 50000
+  :max-iterations 10
+  :failure-strategy :retry}}
+```
+
+## Per-Phase Budgets
+
+Individual phases can be tuned in the workflow definition:
+
+```clojure
+{:phase :implement
+ :gates [:syntax :lint :no-secrets]
+ :budget {:tokens 50000
+          :iterations 5
+          :time-seconds 300}}
+```
+
+## User Config File
+
+Persistent configuration lives in `~/.miniforge/config.edn`:
+
+```clojure
+{:llm-backend :anthropic
+ :max-parallel 2
+ :default-workflow :canonical-sdlc}
+```
+
+## Priority Order
+
+Configuration is resolved in this order (highest priority first):
+
+1. Workflow spec overrides (`:workflow/config`)
+2. Environment variables (`MINIFORGE_*`)
+3. User config file (`~/.miniforge/config.edn`)
+4. Built-in defaults

--- a/docs/user-guide/phases.md
+++ b/docs/user-guide/phases.md
@@ -1,0 +1,137 @@
+# Pipeline Phases
+
+Miniforge executes a sequential pipeline of phases. Each phase is driven by
+an autonomous agent backed by an LLM, governed by policy gates.
+
+## The Pipeline
+
+```text
+Explore ──> Plan ──> Implement ──> Verify ──> Review ──> Release ──> Observe
+```
+
+## Phase Details
+
+### Explore
+
+**Agent:** None (deterministic)
+**Duration:** < 1 second
+
+Scans the codebase and loads relevant files into context. No LLM call —
+this is pure file I/O. Files are selected based on the spec's `:scope`
+hint and the repo's structure.
+
+The explore output is passed to all subsequent phases so agents don't
+need to re-read the codebase.
+
+### Plan
+
+**Agent:** Planner
+**Duration:** 1-3 minutes
+
+Analyzes the spec and codebase to produce a task DAG (directed acyclic graph).
+Each task has a description, type, dependencies, and acceptance criteria.
+
+If the spec is already satisfied by existing code, the planner returns
+`:already-satisfied` with evidence, and the pipeline skips to done.
+
+For multi-task plans, tasks execute in parallel where dependencies allow.
+
+### Implement
+
+**Agent:** Implementer
+**Duration:** 30 seconds - 5 minutes per task
+
+Generates code based on the task description and codebase context. The agent
+writes files directly to the execution environment.
+
+**Inner loop:** After each generation pass, the code runs through validation
+gates (syntax, lint, no-secrets). If a gate fails, the agent repairs and
+retries automatically.
+
+### Verify
+
+**Agent:** None (gate execution)
+**Duration:** 5-30 seconds
+
+Runs the full verification suite: syntax checking, linting, secret detection,
+and test execution. This is the final quality gate before review.
+
+If verification fails and `:on-fail :implement` is configured, the pipeline
+returns to the implement phase for another attempt.
+
+### Review
+
+**Agent:** Reviewer
+**Duration:** 1-3 minutes
+
+Self-reviews the diff against the original spec and constraints. The reviewer
+checks for:
+
+- Acceptance criteria satisfaction
+- Constraint compliance
+- Code quality and style
+- Potential issues or risks
+
+If the review finds issues and `:on-fail :implement` is configured, the
+pipeline loops back for fixes.
+
+### Release
+
+**Agent:** Releaser
+**Duration:** 30 seconds - 1 minute
+
+Creates a git branch, commits all changes, pushes to the remote, and opens
+a pull request. The PR includes:
+
+- Title derived from the spec
+- Body with implementation summary, file list, and test results
+- A `docs/pull-requests/` documentation file
+
+Requires a `GITHUB_TOKEN` for PR creation.
+
+### Observe
+
+**Agent:** None (monitoring loop)
+**Duration:** Up to 72 hours (configurable)
+
+Monitors the PR after creation:
+
+- Polls for CI results and review comments
+- Classifies comments (change request, question, approval, noise)
+- Auto-fixes code based on reviewer feedback
+- Auto-replies to questions
+- Attempts merge when all gates pass
+
+## Gates
+
+Gates are policy checks that run at phase boundaries:
+
+| Gate | What It Checks |
+|------|---------------|
+| `syntax` | Code parses without errors |
+| `lint` | No linting violations (clj-kondo) |
+| `no-secrets` | No API keys, passwords, or tokens in code |
+| `tests-pass` | All tests pass |
+| `coverage` | Test coverage meets threshold |
+
+## Workflow Types
+
+| Workflow | Phases | Use Case |
+|----------|--------|----------|
+| **canonical-sdlc** | All phases | Features, refactors, bug fixes |
+| **quick-fix** | implement, verify, done | Small, well-understood fixes |
+
+The workflow is auto-selected from the spec's intent or overridden with
+`:workflow/type` in the spec.
+
+## Failure and Retry
+
+Each phase has a budget (max iterations, max tokens, max time). When a phase
+fails:
+
+1. If within budget, the phase retries with the error context
+2. If `:on-fail` is set, the pipeline redirects to that phase
+3. If budget is exhausted, the workflow fails with an evidence bundle
+
+The implement → verify → review loop can iterate multiple times until all
+gates pass or the budget is exhausted.

--- a/docs/user-guide/writing-specs.md
+++ b/docs/user-guide/writing-specs.md
@@ -1,0 +1,124 @@
+# Writing Specs
+
+A spec tells miniforge what you want built. You describe the intent, constraints,
+and acceptance criteria — miniforge handles the how.
+
+## Format
+
+Specs can be written in **EDN** or **Markdown**.
+
+### EDN Format
+
+```clojure
+{:spec/title "One-line summary of what you want"
+
+ :spec/description
+ "Detailed prose description. Include context, motivation, and
+  technical details the implementer needs to know."
+
+ :spec/intent {:type :feature         ;; :feature, :bugfix, :refactor, :chore, :test
+               :scope ["src/auth/"]}  ;; optional: hint at which files/dirs
+
+ :spec/constraints
+ ["No breaking changes to the public API"
+  "All existing tests must pass"
+  "Use the existing authentication framework"]
+
+ :spec/acceptance-criteria
+ ["Users can reset their password via email"
+  "Reset tokens expire after 24 hours"
+  "Rate limiting prevents abuse (max 3 requests per hour)"]}
+```
+
+### Markdown Format
+
+```markdown
+---
+title: Add password reset flow
+description: |
+  Implement a password reset flow with email verification.
+  The user requests a reset, receives an email with a token,
+  and can set a new password.
+intent:
+  type: feature
+  scope: ["src/auth/"]
+constraints:
+  - No breaking changes to the public API
+  - All existing tests must pass
+---
+
+## Context
+
+We currently have login and signup but no way for users to recover
+a forgotten password. Support tickets for password resets are our
+#2 most common request.
+
+## Technical Notes
+
+The email service is already configured in `src/email/client.clj`.
+Use the existing `send-template` function with a new "reset" template.
+```
+
+The Markdown body (everything after the frontmatter) is appended to the
+description, giving agents additional context.
+
+## Required Fields
+
+| Field | Description |
+|-------|-------------|
+| `:spec/title` | One-line summary (max ~80 chars) |
+| `:spec/description` | Detailed prose description |
+
+Everything else is optional but recommended.
+
+## Recommended Fields
+
+| Field | Description |
+|-------|-------------|
+| `:spec/intent` | `{:type :feature}` — helps select the right workflow |
+| `:spec/constraints` | Boundaries the implementer must respect |
+| `:spec/acceptance-criteria` | How to verify the work is correct |
+
+## Optional Fields
+
+| Field | Description |
+|-------|-------------|
+| `:spec/tags` | `[:auth :security]` — for organization |
+| `:spec/repo-url` | Target a different repo |
+| `:spec/branch` | Target a specific branch |
+| `:spec/plan-tasks` | Pre-decomposed task list (skip planning) |
+
+## Intent Types
+
+| Type | When to Use |
+|------|-------------|
+| `:feature` | New functionality |
+| `:bugfix` | Fixing broken behavior |
+| `:refactor` | Improving code without changing behavior |
+| `:chore` | Maintenance, dependencies, config |
+| `:test` | Adding tests to existing code |
+| `:docs` | Documentation changes |
+| `:performance` | Performance improvements |
+
+## Tips
+
+**Be specific about acceptance criteria.** Vague criteria like "it should work"
+give the agent no way to verify success. Concrete criteria like "GET /health
+returns 200 with a JSON body containing :service and :version" are testable.
+
+**Scope constraints narrowly.** "No changes outside src/auth/" is more useful
+than "don't break anything." Narrow constraints help the agent focus.
+
+**Let miniforge plan.** Don't over-specify implementation details. Describe
+WHAT you want, not HOW to build it. The planner is good at decomposing work.
+
+**Provide context.** If there's a relevant design doc, prior art, or technical
+constraint the agent should know about, put it in the description.
+
+## Examples
+
+See `examples/workflows/` for complete spec files:
+
+- `simple-refactor.edn` — Basic refactoring with constraints
+- `implement-feature.edn` — Feature with acceptance criteria
+- `examples/demo/add-utility-function.edn` — Self-improvement demo

--- a/examples/demo/add-utility-function.edn
+++ b/examples/demo/add-utility-function.edn
@@ -1,0 +1,46 @@
+;; Demo: Miniforge building itself
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; This spec asks miniforge to add a utility function to its own codebase.
+;; Watch the full pipeline: explore → plan → implement → verify → review → release.
+;;
+;; Usage:
+;;   mf run examples/demo/add-utility-function.edn
+
+{:spec/title "Add string normalization utility to logging component"
+
+ :spec/description
+ "Add a normalize-identifier function to the logging helpers module that
+  converts arbitrary strings into valid EDN keyword-safe identifiers.
+  This is needed by multiple components for consistent identifier formatting
+  in structured log entries (e.g., converting 'My Feature Name!' to
+  :my-feature-name).
+
+  The function should:
+  - Convert to lowercase
+  - Replace spaces and underscores with hyphens
+  - Strip characters that are not alphanumeric or hyphens
+  - Collapse consecutive hyphens
+  - Trim leading/trailing hyphens
+  - Return nil for nil input, empty string for empty input"
+
+ :spec/intent {:type :feature
+               :scope ["components/logging/src/ai/miniforge/logging/helpers.clj"
+                        "components/logging/test/ai/miniforge/logging/helpers_test.clj"]}
+
+ :spec/constraints
+ ["Pure function, no side effects"
+  "Add to components/logging/src/ai/miniforge/logging/helpers.clj"
+  "Expose via components/logging/src/ai/miniforge/logging/interface.clj"
+  "Include tests in components/logging/test/ai/miniforge/logging/helpers_test.clj"
+  "Handle nil, empty string, unicode, and already-valid input"
+  "All existing tests must continue to pass"
+  "Follow the existing code style and layer conventions in helpers.clj"]
+
+ :spec/acceptance-criteria
+ ["normalize-identifier exists in ai.miniforge.logging.helpers"
+  "normalize-identifier is exported via ai.miniforge.logging.interface"
+  "Tests cover: nil, empty, spaces, underscores, special chars, unicode"
+  "Tests cover: already-valid identifiers pass through unchanged"
+  "Tests cover: consecutive special chars collapse to single hyphen"
+  "All existing logging tests continue to pass"]}

--- a/examples/demo/run-demo.sh
+++ b/examples/demo/run-demo.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -e
+
+# Miniforge Demo: Spec to PR
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+#
+# Watch miniforge plan, implement, test, review, and release a feature —
+# on its own codebase.
+
+echo ""
+echo "  ┌─────────────────────────────────────────────┐"
+echo "  │         Miniforge Demo: Spec → PR           │"
+echo "  │                                             │"
+echo "  │  Watch miniforge add a utility function     │"
+echo "  │  to its own codebase — autonomously.        │"
+echo "  └─────────────────────────────────────────────┘"
+echo ""
+
+# Check prerequisites
+MISSING=""
+
+if ! command -v bb &>/dev/null; then
+  MISSING="$MISSING\n  - Babashka (bb): brew install babashka/brew/babashka"
+fi
+
+# Check for an LLM backend: agent CLI or API key
+HAS_BACKEND=false
+if command -v claude &>/dev/null; then
+  HAS_BACKEND=true
+  echo "  LLM backend: Claude Code CLI"
+elif command -v codex &>/dev/null; then
+  HAS_BACKEND=true
+  echo "  LLM backend: Codex CLI"
+elif [ -n "$ANTHROPIC_API_KEY" ]; then
+  HAS_BACKEND=true
+  echo "  LLM backend: Anthropic API"
+elif [ -n "$OPENAI_API_KEY" ]; then
+  HAS_BACKEND=true
+  echo "  LLM backend: OpenAI API"
+fi
+
+if [ "$HAS_BACKEND" = false ]; then
+  MISSING="$MISSING\n  - LLM backend: install Claude Code or Codex CLI, or set ANTHROPIC_API_KEY / OPENAI_API_KEY"
+fi
+
+if [ -n "$MISSING" ]; then
+  echo "  Missing prerequisites:$MISSING"
+  echo ""
+  exit 1
+fi
+
+echo ""
+echo "  Starting in 3 seconds... (Ctrl-C to cancel)"
+sleep 3
+
+# Run the demo spec
+bb miniforge run examples/demo/add-utility-function.edn

--- a/readme.md
+++ b/readme.md
@@ -8,223 +8,206 @@
 
 # Miniforge
 
-Autonomous software factory — a self-directing SDLC platform built on
-multi-agent cognition, powered by [MiniForge Core](#miniforge-core).
+Write a spec. Get a pull request.
 
-## Products
+Miniforge is an autonomous software factory. You describe what you want — in
+plain English or structured EDN — and miniforge plans the work, writes the code,
+runs the tests, reviews itself, and opens a PR. No prompt engineering. No
+copy-paste. Full SDLC.
 
-This repository is a Polylith monorepo that houses three layers:
+## Before and After
 
-| Layer | Description |
-|-------|-------------|
-| **MiniForge Core** | Governed workflow engine — DAG executor, phase registry, policy SDK, shared CLI base. Designed to be embedded in any product that needs a governed workflow runtime. |
-| **Miniforge** | Autonomous software factory — SDLC workflows, fleet management, PR lifecycle, multi-agent code generation. |
-| **Data Foundry** | ETL product — data extraction, transformation, and loading workflows built on the same governed runtime. |
-
-## Installation
-
-### For End Users
-
-Install Miniforge via Homebrew:
-
-```bash
-# Add the miniforge tap
-brew tap miniforge-ai/tap
-
-# Install miniforge
-brew install miniforge
-
-# Verify installation
-miniforge version
+```text
+BEFORE                              AFTER
+──────                              ─────
+1. Write a ticket                   1. Write a spec
+2. Create a branch                  2. mf run spec.edn
+3. Read the codebase                3. Review the PR
+4. Write code
+5. Run tests
+6. Fix failures
+7. Lint
+8. Fix lint
+9. Commit
+10. Push
+11. Open PR
+12. Write PR description
+13. Wait for review
+14. Address feedback
 ```
 
-Or download directly from [GitHub Releases](https://github.com/miniforge-ai/miniforge/releases).
+## How It Works
 
-### CLI Commands
-
-```bash
-miniforge status        # Show system status
-miniforge workflows     # List all workflows
-miniforge workflow <id> # Show workflow detail
-miniforge meta          # Show meta-loop status
-miniforge version       # Show version information
-miniforge help          # Show help message
+```text
+Spec ──> Explore ──> Plan ──> Implement ──> Verify ──> Review ──> Release ──> PR
+              │           │          │            │          │           │
+              │           │          │            │          │           └─ creates branch,
+              │           │          │            │          │              commits, pushes,
+              │           │          │            │          │              opens PR
+              │           │          │            │          │
+              │           │          │            │          └─ self-reviews diff
+              │           │          │            │             against spec + constraints
+              │           │          │            │
+              │           │          │            └─ runs gates: syntax, lint,
+              │           │          │               no-secrets, tests-pass
+              │           │          │
+              │           │          └─ generates code via LLM agent
+              │           │             inner loop: generate → validate → repair
+              │           │
+              │           └─ decomposes spec into a task DAG
+              │              with dependencies and acceptance criteria
+              │
+              └─ scans the codebase, loads relevant files,
+                 queries knowledge base
 ```
 
-Note: Full workflow and meta-loop features will be available as components are integrated.
+Each phase is driven by an autonomous agent backed by an LLM. Policy gates
+govern every transition — bad code never ships. All decisions are traceable
+via evidence bundles.
 
-### For Contributors
-
-If you want to contribute to Miniforge development, follow the Quick Start guide below.
-
-## Quick Start (Development)
+## Quickstart
 
 ### Prerequisites
 
-- [Homebrew](https://brew.sh/) — Package manager (macOS/Linux)
-- [Babashka](https://github.com/babashka/babashka#installation) (bb) — Clojure scripting
+- macOS or Linux
+- [Babashka](https://github.com/babashka/babashka#installation) (`brew install babashka/brew/babashka`)
+- An LLM backend: [Claude Code](https://claude.ai/claude-code) CLI,
+  [Codex](https://openai.com/codex) CLI, or an API key (Anthropic/OpenAI)
+
+### Install and Run
 
 ```bash
-# Install Babashka if not already installed
-brew install babashka/brew/babashka
-```
-
-### Bootstrap
-
-```bash
-# Clone the repository
-git clone git@github.com:miniforge-ai/miniforge.git
+git clone https://github.com/miniforge-ai/miniforge.git
 cd miniforge
-
-# Bootstrap: install all dependencies + configure environment
 bb bootstrap
+
+# If using an API key (not needed if Claude Code or Codex CLI is installed)
+# export ANTHROPIC_API_KEY="sk-ant-..."
+
+# Run your first workflow
+mf run examples/workflows/simple-refactor.edn
 ```
 
-The `bb bootstrap` command will:
+See the [Quickstart Guide](docs/quickstart.md) for a detailed walkthrough.
 
-- Install all dependencies via Homebrew:
-  - Java (Temurin 21)
-  - Clojure CLI
-  - clj-kondo (linter)
-  - markdownlint-cli
-  - Polylith CLI
-- Configure git to use project hooks (`.githooks/`)
-- Verify your git email is set to `@miniforge.ai`
+### Write a Spec
 
-### Git Email
+A spec is a description of what you want. Two fields are required:
 
-All commits must use a `@miniforge.ai` email address. Configure it:
+```clojure
+{:spec/title "Add input validation to the signup form"
+
+ :spec/description
+ "The signup form accepts any input without validation. Add server-side
+  validation for email format, password strength (min 8 chars, 1 number),
+  and username uniqueness. Return structured error messages."
+
+ :spec/intent {:type :feature
+               :scope ["src/auth/signup.clj"]}
+
+ :spec/constraints
+ ["No breaking changes to existing API"
+  "All existing tests must pass"]
+
+ :spec/acceptance-criteria
+ ["Email validation rejects malformed addresses"
+  "Password validation enforces minimum requirements"
+  "Username uniqueness check queries the database"
+  "Error messages are structured maps, not strings"]}
+```
+
+Specs can also be written as Markdown with YAML frontmatter. See
+[Writing Specs](docs/user-guide/writing-specs.md).
+
+### Run the Demo
 
 ```bash
-git config user.email 'yourname@miniforge.ai'
+# Watch miniforge improve itself (dogfooding demo)
+bash examples/demo/run-demo.sh
 ```
 
-For automatic configuration across all miniforge repos, add to `~/.gitconfig`:
+See [Demo Guide](docs/demo.md) for a guided walkthrough.
 
-```ini
-[includeIf "gitdir:~/path/to/miniforge-repos/"]
-    path = ~/path/to/miniforge-repos/.gitconfig
-```
+## Workflow Types
 
-Then create `~/path/to/miniforge-repos/.gitconfig`:
+| Workflow | Phases | Use For |
+|----------|--------|---------|
+| **Canonical SDLC** | explore, plan, implement, verify, review, release | Features, refactors, bug fixes |
+| **Quick Fix** | implement, verify, done | Small, well-understood changes |
 
-```ini
-[user]
-    email = yourname@miniforge.ai
-```
+The workflow is selected automatically from the spec's intent, or overridden
+with `:workflow/type :quick-fix`.
 
-## Development
-
-### Local Development (Without Homebrew)
-
-For rapid development iteration, build and install locally:
+## Configuration
 
 ```bash
-# Build and install in one step (cleans old build automatically)
-bb install:local
+# LLM backend: auto-detected from installed CLIs
+# Claude Code or Codex CLI are used automatically if installed.
+# Otherwise, set an API key:
+export ANTHROPIC_API_KEY="sk-ant-..."
+# Or:
+export OPENAI_API_KEY="sk-..."
 
-# Now you can run miniforge locally
-mf version
-mf help
-mf fleet web
+# Tune execution
+export MINIFORGE_MAX_ITERATIONS=50     # max phase retries
+export MINIFORGE_MAX_TOKENS=150000     # token budget per workflow
 ```
 
-The `bb install:local` task:
-
-1. Removes old build (`rm -f dist/miniforge.jar`)
-2. Builds fresh uberjar (`bb build:cli`)
-3. Installs to `~/.local/bin/mf`
-
-**Note:** Make sure `~/.local/bin` is in your PATH:
-
-```bash
-# Add to ~/.zshrc or ~/.bashrc
-export PATH="$HOME/.local/bin:$PATH"
-```
-
-### Available Tasks
-
-Run `bb` to see all available tasks:
-
-```bash
-bb                  # List all tasks
-
-# Bootstrap & Setup
-bb bootstrap        # Full bootstrap: install deps + configure env
-bb setup            # Alias for bootstrap
-bb install:deps     # Install all dependencies
-bb upgrade:deps     # Upgrade all dependencies
-
-# Linting & Formatting
-bb lint:clj         # Lint staged Clojure files
-bb lint:clj:all     # Lint all Clojure files
-bb fmt:md           # Format staged Markdown files
-
-# Testing
-bb test             # Run unit tests
-bb test:all         # Run all tests including integration
-
-# Building
-bb build:cli        # Build Miniforge CLI as uberscript
-bb build:jar <proj> # Build JVM uberjar for a project
-bb build:all        # Build all changed projects
-bb clean            # Clean build artifacts
-
-# Git Hooks
-bb pre-commit       # Run all pre-commit checks manually
-bb hooks:uninstall  # Reset git hooks to default
-```
-
-### Project Structure (Polylith)
-
-```text
-miniforge/
-├── bases/          # Entry points (CLI, servers)
-├── components/     # Reusable building blocks
-│   ├── workflow/               # MiniForge Core — shared workflow runtime
-│   ├── workflow-software-factory/  # Miniforge — SDLC workflows
-│   ├── workflow-financial-etl/     # Data Foundry — ETL workflows (financial is one family)
-│   ├── schema/     # Malli schemas for domain types
-│   └── logging/    # Structured EDN logging
-├── projects/       # Deployable artifacts
-│   ├── miniforge/      # Miniforge (software factory) project
-│   ├── miniforge-core/ # MiniForge Core (engine-only) project
-│   └── miniforge-tui/  # Terminal UI project
-├── development/    # Dev-time utilities
-└── docs/
-    └── specs/      # Product specifications
-```
-
-## MiniForge Core
-
-MiniForge Core is the shared governed workflow engine extracted from this
-repository. It provides:
-
-- DAG executor with profile seams
-- Generic workflow runtime, triggers, and publication
-- Generic phase registry
-- Policy-pack SDK surface
-- Shared CLI base with app/config/message seams
-
-The `projects/miniforge-core/` project composes only the kernel components,
-producing a standalone artifact suitable for embedding in other products
-(Data Foundry, Fleet, or any future governed workflow application).
-
-## Documentation
-
-- [Polylith Documentation](https://polylith.gitbook.io/polylith)
-- [Product Specs](docs/specs/) — Detailed specifications
+See [Configuration Guide](docs/user-guide/configuration.md) for all options.
 
 ## Architecture
 
-See [docs/specs/architecture.spec](docs/specs/architecture.spec) for the full architecture overview.
+Miniforge is built on a governed workflow engine with pluggable phases, agents,
+and policy packs.
+
+```text
+┌─────────────────────────────────────────────────────┐
+│                    CLI / TUI / Web                   │
+├─────────────────────────────────────────────────────┤
+│              Workflow Engine (DAG Executor)           │
+│  ┌──────┐ ┌──────┐ ┌───────┐ ┌──────┐ ┌─────────┐  │
+│  │Explore│ │ Plan │ │Implmnt│ │Verify│ │ Review  │  │
+│  └──────┘ └──────┘ └───────┘ └──────┘ └─────────┘  │
+│              ↕           ↕         ↕                 │
+│         ┌────────┐  ┌────────┐  ┌──────────┐        │
+│         │ Agents │  │ Gates  │  │ Policies │        │
+│         └────────┘  └────────┘  └──────────┘        │
+├─────────────────────────────────────────────────────┤
+│           LLM Backends (Claude, GPT, Local)          │
+└─────────────────────────────────────────────────────┘
+```
+
+- **Agents**: Planner, Implementer, Tester, Reviewer, Releaser — each
+  specialized for its phase
+- **Gates**: Syntax, lint, no-secrets, tests-pass, coverage — policy enforcement
+  at every transition
+- **DAG Executor**: Plans decompose into task graphs; tasks run in parallel
+  across isolated worktrees
+
+See [Architecture Overview](docs/user-guide/architecture.md) for details.
+See [Normative Specs](specs/normative/) for the full specification.
+
+## Project Status
+
+**Alpha** — actively developed, dogfooded daily. The pipeline (spec → PR) works
+end-to-end for Clojure projects. Multi-language support, fleet orchestration,
+and the web dashboard are in progress.
+
+## Documentation
+
+- [Quickstart](docs/quickstart.md) — Run your first workflow
+- [Demo](docs/demo.md) — 5-minute guided demo
+- [Writing Specs](docs/user-guide/writing-specs.md) — How to describe work
+- [Phases](docs/user-guide/phases.md) — What the pipeline does
+- [Configuration](docs/user-guide/configuration.md) — Tuning and backends
+- [Architecture](docs/user-guide/architecture.md) — How it works
+- [Contributing](CONTRIBUTING.md) — Development setup and guidelines
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, Polylith structure,
+git conventions, and the pre-commit hook.
 
 ## License
 
-Miniforge is licensed under the [Apache License 2.0](LICENSE).
-
-Title: Miniforge.ai
-Subtitle: An agentic SDLC / fleet-control platform
-Author: Christopher Lester
-Line: Founder, Miniforge.ai (project)
-Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+[Apache License 2.0](LICENSE)


### PR DESCRIPTION
## Summary

Complete OSS documentation overhaul for YC demo readiness.

- **README rewrite**: value proposition first, before/after comparison, pipeline diagram, inline quickstart, architecture overview
- **Quickstart**: 60-second path from clone to first workflow
- **Demo**: guided 5-minute walkthrough with dogfooding spec (miniforge building itself)
- **User Guide**: writing specs (EDN + Markdown), pipeline phases, configuration, architecture

## Changes

9 files: 973 insertions, 164 deletions

🤖 Generated with [Claude Code](https://claude.com/claude-code)