### PR TITLE
fix: capsule-cleanup spec uses :bugfix not :fix

### DIFF
--- a/work/capsule-cleanup-reliability.spec.edn
+++ b/work/capsule-cleanup-reliability.spec.edn
@@ -9,7 +9,7 @@
   cover all DAG sub-workflow capsules. Each capsule created by the DAG
   orchestrator must also be cleaned up."
 
- :spec/intent {:type :fix
+ :spec/intent {:type :bugfix
                :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
                        "components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj"
                        "components/workflow/src/ai/miniforge/workflow/dag_task_runner.clj"]}


### PR DESCRIPTION
Spec validation requires :bugfix, not :fix.