### PR TITLE
feat: linter integration — polyglot compliance scanning

### DIFF
--- a/bases/cli/resources/config/cli/tech-fingerprints.edn
+++ b/bases/cli/resources/config/cli/tech-fingerprints.edn
@@ -9,6 +9,12 @@
 ;;     :type          — :file or :directory
 ;;     :content       — String that must appear in the file (optional, for content-based detection)
 ;;   :tech/packs      — Policy pack names to apply when detected (optional)
+;;   :tech/linter     — Linter integration (optional)
+;;     :command       — CLI command name
+;;     :args          — Arguments for lint mode (structured output)
+;;     :fix-args      — Arguments for auto-fix mode (optional)
+;;     :parser        — Parser keyword for output format
+;;     :check-cmd     — Command to verify linter is installed (optional)
 ;;
 ;; Sorted alphabetically by :tech/id.
 
@@ -21,7 +27,11 @@
   :tech/extensions ["c" "h"]}
 
  {:tech/id         :clojure
-  :tech/extensions ["clj" "cljs" "cljc" "edn"]}
+  :tech/extensions ["clj" "cljs" "cljc" "edn"]
+  :tech/linter     {:command   "clj-kondo"
+                    :args      ["--lint" "src" "--config" "{:output {:format :edn}}"]
+                    :parser    :clj-kondo
+                    :check-cmd ["clj-kondo" "--version"]}}
 
  {:tech/id         :cpp
   :tech/extensions ["cpp" "cc" "cxx" "hpp" "hxx"]}
@@ -48,7 +58,12 @@
   :tech/extensions ["fs" "fsx" "fsi"]}
 
  {:tech/id         :go
-  :tech/extensions ["go"]}
+  :tech/extensions ["go"]
+  :tech/linter     {:command   "golangci-lint"
+                    :args      ["run" "--out-format=json"]
+                    :fix-args  ["run" "--fix"]
+                    :parser    :golangci-lint
+                    :check-cmd ["golangci-lint" "--version"]}}
 
  {:tech/id         :groovy
   :tech/extensions ["groovy" "gvy"]}
@@ -60,7 +75,12 @@
   :tech/extensions ["java"]}
 
  {:tech/id         :javascript
-  :tech/extensions ["js" "mjs" "cjs" "jsx"]}
+  :tech/extensions ["js" "mjs" "cjs" "jsx"]
+  :tech/linter     {:command   "eslint"
+                    :args      ["--format=json" "."]
+                    :fix-args  ["--fix" "."]
+                    :parser    :eslint
+                    :check-cmd ["eslint" "--version"]}}
 
  {:tech/id         :json
   :tech/extensions ["json"]}
@@ -96,7 +116,12 @@
   :tech/extensions ["purs"]}
 
  {:tech/id         :python
-  :tech/extensions ["py" "pyi"]}
+  :tech/extensions ["py" "pyi"]
+  :tech/linter     {:command   "ruff"
+                    :args      ["check" "--output-format=json" "."]
+                    :fix-args  ["check" "--fix" "."]
+                    :parser    :ruff
+                    :check-cmd ["ruff" "--version"]}}
 
  {:tech/id         :r
   :tech/extensions ["r" "R" "Rmd"]}
@@ -108,7 +133,12 @@
   :tech/extensions ["rb" "rake"]}
 
  {:tech/id         :rust
-  :tech/extensions ["rs"]}
+  :tech/extensions ["rs"]
+  :tech/linter     {:command   "cargo"
+                    :args      ["clippy" "--message-format=json" "--" "-D" "warnings"]
+                    :fix-args  ["clippy" "--fix" "--allow-dirty"]
+                    :parser    :clippy
+                    :check-cmd ["cargo" "clippy" "--version"]}}
 
  {:tech/id         :scala
   :tech/extensions ["scala" "sc"]}
@@ -123,7 +153,12 @@
   :tech/extensions ["sql"]}
 
  {:tech/id         :swift
-  :tech/extensions ["swift"]}
+  :tech/extensions ["swift"]
+  :tech/linter     {:command   "swiftlint"
+                    :args      ["lint" "--reporter" "json"]
+                    :fix-args  ["lint" "--fix"]
+                    :parser    :swiftlint
+                    :check-cmd ["swiftlint" "version"]}}
 
  {:tech/id         :terraform
   :tech/extensions ["tf" "tfvars"]
@@ -133,7 +168,12 @@
   :tech/extensions ["toml"]}
 
  {:tech/id         :typescript
-  :tech/extensions ["ts" "tsx"]}
+  :tech/extensions ["ts" "tsx"]
+  :tech/linter     {:command   "eslint"
+                    :args      ["--format=json" "."]
+                    :fix-args  ["--fix" "."]
+                    :parser    :eslint
+                    :check-cmd ["eslint" "--version"]}}
 
  {:tech/id         :v
   :tech/extensions ["v"]}

--- a/bases/cli/src/ai/miniforge/cli/linter_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/linter_runner.clj
@@ -32,9 +32,8 @@
   "Check if a linter CLI is available on PATH."
   [check-cmd]
   (try
-    (let [result (process/sh {:cmd check-cmd :continue true
-                              :out :string :err :string})]
-      (zero? (:exit result)))
+    (zero? (:exit (process/sh {:cmd check-cmd :continue true
+                               :out :string :err :string})))
     (catch Exception _ false)))
 
 (defn- run-linter
@@ -42,12 +41,11 @@
    Returns {:exit int :out string :err string}."
   [repo-path command args]
   (try
-    (let [result (process/sh {:cmd (into [command] args)
-                              :dir (str repo-path)
-                              :continue true
-                              :out :string
-                              :err :string})]
-      result)
+    (process/sh {:cmd (into [command] args)
+                 :dir (str repo-path)
+                 :continue true
+                 :out :string
+                 :err :string})
     (catch Exception e
       {:exit -1 :out "" :err (.getMessage e)})))
 
@@ -81,123 +79,141 @@
 
 ;; ── Clippy (Rust) ───────────────────────────────────────────────────────────
 
+(defn- clippy-line->violation
+  "Convert a single clippy JSON line to a violation, or nil if not a compiler message."
+  [line]
+  (when-let [msg (parse-json-safe line)]
+    (when (= "compiler-message" (get msg :reason))
+      (let [m    (get msg :message)
+            span (first (get m :spans))
+            code (get-in m [:code :code])]
+        (when (and span code)
+          (make-violation :clippy
+                          (get span :file_name)
+                          (get span :line_start)
+                          (get span :column_start)
+                          (get m :message)
+                          code
+                          (severity-from-level (get m :level))))))))
+
 (defn- parse-clippy
-  "Parse cargo clippy --message-format=json output.
-   Each line is a separate JSON object. Filter for compiler-message types."
+  "Parse cargo clippy --message-format=json output."
   [output]
   (->> (str/split-lines output)
-       (keep (fn [line]
-               (when-let [msg (parse-json-safe line)]
-                 (when (= "compiler-message" (get msg :reason))
-                   (let [m    (get msg :message)
-                         span (first (get m :spans))
-                         code (get-in m [:code :code])]
-                     (when (and span code)
-                       (make-violation
-                        :clippy
-                        (get span :file_name)
-                        (get span :line_start)
-                        (get span :column_start)
-                        (get m :message)
-                        code
-                        (severity-from-level (get m :level)))))))))
+       (keep clippy-line->violation)
        vec))
 
 ;; ── clj-kondo (Clojure) ────────────────────────────────────────────────────
 
+(defn- kondo-finding->violation
+  "Convert a single clj-kondo finding to a violation."
+  [finding]
+  (make-violation :clj-kondo
+                  (get finding :filename)
+                  (get finding :row)
+                  (get finding :col)
+                  (get finding :message)
+                  (name (get finding :type :unknown))
+                  (severity-from-level (name (get finding :level :warning)))))
+
 (defn- parse-clj-kondo
-  "Parse clj-kondo EDN output. Output is a map with :findings vector."
+  "Parse clj-kondo EDN output."
   [output]
   (try
-    (let [data     (edn/read-string output)
-          findings (get data :findings [])]
-      (mapv (fn [f]
-              (make-violation
-               :clj-kondo
-               (get f :filename)
-               (get f :row)
-               (get f :col)
-               (get f :message)
-               (name (get f :type :unknown))
-               (severity-from-level (name (get f :level :warning)))))
-            findings))
+    (let [findings (get (edn/read-string output) :findings [])]
+      (mapv kondo-finding->violation findings))
     (catch Exception _ [])))
 
 ;; ── ESLint (JavaScript/TypeScript) ──────────────────────────────────────────
 
+(defn- eslint-severity->keyword
+  "Convert ESLint numeric severity (1=warn, 2=error) to keyword."
+  [severity]
+  (if (= 2 severity) :major :minor))
+
+(defn- eslint-message->violation
+  "Convert a single ESLint message to a violation, given the parent file path."
+  [filepath msg]
+  (make-violation :eslint
+                  filepath
+                  (get msg :line)
+                  (get msg :column)
+                  (get msg :message)
+                  (get msg :ruleId)
+                  (eslint-severity->keyword (get msg :severity))))
+
+(defn- eslint-file->violations
+  "Extract violations from a single ESLint file result."
+  [file-result]
+  (let [filepath (get file-result :filePath)]
+    (mapv #(eslint-message->violation filepath %) (get file-result :messages []))))
+
 (defn- parse-eslint
-  "Parse eslint --format=json output. Array of file results."
+  "Parse eslint --format=json output."
   [output]
-  (let [results (parse-json-safe output)]
+  (when-let [results (parse-json-safe output)]
     (when (sequential? results)
-      (->> results
-           (mapcat (fn [file-result]
-                     (let [filepath (get file-result :filePath)]
-                       (map (fn [msg]
-                              (make-violation
-                               :eslint
-                               filepath
-                               (get msg :line)
-                               (get msg :column)
-                               (get msg :message)
-                               (get msg :ruleId)
-                               (if (= 2 (get msg :severity)) :major :minor)))
-                            (get file-result :messages [])))))
-           vec))))
+      (vec (mapcat eslint-file->violations results)))))
 
 ;; ── Ruff (Python) ──────────────────────────────────────────────────────────
 
+(defn- ruff-violation->violation
+  "Convert a single ruff violation object to a standard violation."
+  [v]
+  (make-violation :ruff
+                  (get v :filename)
+                  (get-in v [:location :row])
+                  (get-in v [:location :column])
+                  (get v :message)
+                  (get v :code)
+                  (severity-from-level (get v :type "warning"))))
+
 (defn- parse-ruff
-  "Parse ruff check --output-format=json output. Array of violation objects."
+  "Parse ruff check --output-format=json output."
   [output]
-  (let [results (parse-json-safe output)]
+  (when-let [results (parse-json-safe output)]
     (when (sequential? results)
-      (mapv (fn [v]
-              (make-violation
-               :ruff
-               (get v :filename)
-               (get-in v [:location :row])
-               (get-in v [:location :column])
-               (get v :message)
-               (get v :code)
-               (severity-from-level (get v :type "warning"))))
-            results))))
+      (mapv ruff-violation->violation results))))
 
 ;; ── SwiftLint (Swift) ──────────────────────────────────────────────────────
 
+(defn- swiftlint-violation->violation
+  "Convert a single SwiftLint violation object to a standard violation."
+  [v]
+  (make-violation :swiftlint
+                  (get v :file)
+                  (get v :line)
+                  (get v :character)
+                  (get v :reason)
+                  (get v :rule_id)
+                  (severity-from-level (get v :severity "warning"))))
+
 (defn- parse-swiftlint
-  "Parse swiftlint lint --reporter json output. Array of violation objects."
+  "Parse swiftlint lint --reporter json output."
   [output]
-  (let [results (parse-json-safe output)]
+  (when-let [results (parse-json-safe output)]
     (when (sequential? results)
-      (mapv (fn [v]
-              (make-violation
-               :swiftlint
-               (get v :file)
-               (get v :line)
-               (get v :character)
-               (get v :reason)
-               (get v :rule_id)
-               (severity-from-level (get v :severity "warning"))))
-            results))))
+      (mapv swiftlint-violation->violation results))))
 
 ;; ── golangci-lint (Go) ─────────────────────────────────────────────────────
+
+(defn- golangci-issue->violation
+  "Convert a single golangci-lint issue to a standard violation."
+  [issue]
+  (make-violation :golangci-lint
+                  (get-in issue [:Pos :Filename])
+                  (get-in issue [:Pos :Line])
+                  (get-in issue [:Pos :Column])
+                  (get issue :Text)
+                  (get issue :FromLinter)
+                  (severity-from-level (get issue :Severity "warning"))))
 
 (defn- parse-golangci-lint
   "Parse golangci-lint run --out-format=json output."
   [output]
-  (let [data (parse-json-safe output)]
+  (when-let [data (parse-json-safe output)]
     (when (map? data)
-      (->> (get data :Issues [])
-           (mapv (fn [issue]
-                   (make-violation
-                    :golangci-lint
-                    (get-in issue [:Pos :Filename])
-                    (get-in issue [:Pos :Line])
-                    (get-in issue [:Pos :Column])
-                    (get issue :Text)
-                    (get issue :FromLinter)
-                    (severity-from-level (get issue :Severity "warning")))))))))
+      (mapv golangci-issue->violation (get data :Issues [])))))
 
 ;; ── Parser dispatch ─────────────────────────────────────────────────────────
 
@@ -228,8 +244,7 @@
         start-ms   (System/currentTimeMillis)]
     (if-not available?
       {:tech id :violations [] :available? false :duration-ms 0}
-      (let [result     (run-linter repo-path command args)
-            output     (str (:out result))
+      (let [output     (str (:out (run-linter repo-path command args)))
             violations (parse-output parser output)
             end-ms     (System/currentTimeMillis)]
         {:tech        id
@@ -237,33 +252,41 @@
          :available?  true
          :duration-ms (- end-ms start-ms)}))))
 
+(defn- lintable-techs
+  "Filter fingerprints to those with linters that are in the detected set."
+  [fingerprints detected-techs]
+  (->> fingerprints
+       (filter :tech/linter)
+       (filter #(contains? detected-techs (:tech/id %)))))
+
 (defn run-all-linters
   "Run linters for all detected technologies that have a linter configured.
-   Returns {:linter-results [...] :total-violations int :total-duration-ms int}."
+   Returns {:linter-results [...] :total-violations int :total-duration-ms int :violations [...]}."
   [repo-path fingerprints detected-techs]
-  (let [lintable (->> fingerprints
-                      (filter :tech/linter)
-                      (filter #(contains? detected-techs (:tech/id %))))
-        results  (mapv #(run-linter-for-tech repo-path %) lintable)
-        all-viols (mapcat :violations results)]
+  (let [results   (mapv #(run-linter-for-tech repo-path %) (lintable-techs fingerprints detected-techs))
+        all-viols (vec (mapcat :violations results))]
     {:linter-results    results
      :total-violations  (count all-viols)
      :total-duration-ms (reduce + 0 (map :duration-ms results))
-     :violations        (vec all-viols)}))
+     :violations        all-viols}))
+
+(defn- try-fix-tech
+  "Attempt to run a linter's fix command. Returns {:tech id :exit code} or nil."
+  [repo-path {:keys [tech/id tech/linter]}]
+  (let [{:keys [command fix-args check-cmd]} linter]
+    (when (linter-available? (or check-cmd [command "--version"]))
+      {:tech id :exit (:exit (run-linter repo-path command fix-args))})))
+
+(defn- fixable-techs
+  "Filter fingerprints to those with fix-args that are in the detected set."
+  [fingerprints detected-techs]
+  (->> fingerprints
+       (filter :tech/linter)
+       (filter #(get-in % [:tech/linter :fix-args]))
+       (filter #(contains? detected-techs (:tech/id %)))))
 
 (defn run-linter-fixes
   "Run linter fix commands for all detected technologies.
-   Returns {:fixed [...] :failed [...]}."
+   Returns {:fixed [...]}."
   [repo-path fingerprints detected-techs]
-  (let [fixable (->> fingerprints
-                     (filter :tech/linter)
-                     (filter #(get-in % [:tech/linter :fix-args]))
-                     (filter #(contains? detected-techs (:tech/id %))))]
-    {:fixed
-     (vec
-      (keep (fn [{:keys [tech/id tech/linter]}]
-              (let [{:keys [command fix-args check-cmd]} linter]
-                (when (linter-available? (or check-cmd [command "--version"]))
-                  (let [result (run-linter repo-path command fix-args)]
-                    {:tech id :exit (:exit result)}))))
-            fixable))}))
+  {:fixed (vec (keep #(try-fix-tech repo-path %) (fixable-techs fingerprints detected-techs)))})

--- a/bases/cli/src/ai/miniforge/cli/linter_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/linter_runner.clj
@@ -1,0 +1,269 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.cli.linter-runner
+  "Run language-specific linters and parse output into standard violations.
+
+   Each linter's structured output (JSON/EDN) is parsed into the unified
+   violation shape used by the compliance scanner pipeline.
+
+   Layer 0: Linter availability checking and subprocess execution
+   Layer 1: Output parsers (one per linter format)
+   Layer 2: Orchestration — detect languages, run available linters, merge results"
+  (:require
+   [babashka.process :as process]
+   [cheshire.core :as json]
+   [clojure.edn :as edn]
+   [clojure.string :as str]))
+
+(defn- parse-json-safe
+  "Parse JSON string to Clojure data, returning nil on failure."
+  [s]
+  (when-not (str/blank? s)
+    (try
+      (json/parse-string s true)
+      (catch Exception _ nil))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Subprocess execution
+
+(defn linter-available?
+  "Check if a linter CLI is available on PATH."
+  [check-cmd]
+  (try
+    (let [result (process/sh {:cmd check-cmd :continue true
+                              :out :string :err :string})]
+      (zero? (:exit result)))
+    (catch Exception _ false)))
+
+(defn- run-linter
+  "Run a linter subprocess in the repo directory.
+   Returns {:exit int :out string :err string}."
+  [repo-path command args]
+  (try
+    (let [result (process/sh {:cmd (into [command] args)
+                              :dir (str repo-path)
+                              :continue true
+                              :out :string
+                              :err :string})]
+      result)
+    (catch Exception e
+      {:exit -1 :out "" :err (.getMessage e)})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Output parsers — each returns a vector of violation maps
+
+(defn- severity-from-level
+  "Map linter severity levels to standard severity keywords."
+  [level]
+  (case (str/lower-case (str level))
+    ("error" "e" "critical" "deny")  :critical
+    ("warning" "w" "warn" "major")   :major
+    ("info" "i" "note" "convention") :minor
+    ("hint" "style" "refactor")      :info
+    :minor))
+
+(defn- make-violation
+  "Build a standard violation map from linter output fields."
+  [linter-id file line column message code severity]
+  {:rule/id       (keyword (name linter-id) (or code "lint"))
+   :rule/category "lint"
+   :rule/title    (str (name linter-id) "/" (or code "lint"))
+   :rule/severity severity
+   :file          (str file)
+   :line          (or line 0)
+   :column        (or column 0)
+   :current       (or message "")
+   :suggested     nil
+   :auto-fixable? false
+   :rationale     (str (name linter-id) ": " (or message ""))})
+
+;; ── Clippy (Rust) ───────────────────────────────────────────────────────────
+
+(defn- parse-clippy
+  "Parse cargo clippy --message-format=json output.
+   Each line is a separate JSON object. Filter for compiler-message types."
+  [output]
+  (->> (str/split-lines output)
+       (keep (fn [line]
+               (when-let [msg (parse-json-safe line)]
+                 (when (= "compiler-message" (get msg :reason))
+                   (let [m    (get msg :message)
+                         span (first (get m :spans))
+                         code (get-in m [:code :code])]
+                     (when (and span code)
+                       (make-violation
+                        :clippy
+                        (get span :file_name)
+                        (get span :line_start)
+                        (get span :column_start)
+                        (get m :message)
+                        code
+                        (severity-from-level (get m :level)))))))))
+       vec))
+
+;; ── clj-kondo (Clojure) ────────────────────────────────────────────────────
+
+(defn- parse-clj-kondo
+  "Parse clj-kondo EDN output. Output is a map with :findings vector."
+  [output]
+  (try
+    (let [data     (edn/read-string output)
+          findings (get data :findings [])]
+      (mapv (fn [f]
+              (make-violation
+               :clj-kondo
+               (get f :filename)
+               (get f :row)
+               (get f :col)
+               (get f :message)
+               (name (get f :type :unknown))
+               (severity-from-level (name (get f :level :warning)))))
+            findings))
+    (catch Exception _ [])))
+
+;; ── ESLint (JavaScript/TypeScript) ──────────────────────────────────────────
+
+(defn- parse-eslint
+  "Parse eslint --format=json output. Array of file results."
+  [output]
+  (let [results (parse-json-safe output)]
+    (when (sequential? results)
+      (->> results
+           (mapcat (fn [file-result]
+                     (let [filepath (get file-result :filePath)]
+                       (map (fn [msg]
+                              (make-violation
+                               :eslint
+                               filepath
+                               (get msg :line)
+                               (get msg :column)
+                               (get msg :message)
+                               (get msg :ruleId)
+                               (if (= 2 (get msg :severity)) :major :minor)))
+                            (get file-result :messages [])))))
+           vec))))
+
+;; ── Ruff (Python) ──────────────────────────────────────────────────────────
+
+(defn- parse-ruff
+  "Parse ruff check --output-format=json output. Array of violation objects."
+  [output]
+  (let [results (parse-json-safe output)]
+    (when (sequential? results)
+      (mapv (fn [v]
+              (make-violation
+               :ruff
+               (get v :filename)
+               (get-in v [:location :row])
+               (get-in v [:location :column])
+               (get v :message)
+               (get v :code)
+               (severity-from-level (get v :type "warning"))))
+            results))))
+
+;; ── SwiftLint (Swift) ──────────────────────────────────────────────────────
+
+(defn- parse-swiftlint
+  "Parse swiftlint lint --reporter json output. Array of violation objects."
+  [output]
+  (let [results (parse-json-safe output)]
+    (when (sequential? results)
+      (mapv (fn [v]
+              (make-violation
+               :swiftlint
+               (get v :file)
+               (get v :line)
+               (get v :character)
+               (get v :reason)
+               (get v :rule_id)
+               (severity-from-level (get v :severity "warning"))))
+            results))))
+
+;; ── golangci-lint (Go) ─────────────────────────────────────────────────────
+
+(defn- parse-golangci-lint
+  "Parse golangci-lint run --out-format=json output."
+  [output]
+  (let [data (parse-json-safe output)]
+    (when (map? data)
+      (->> (get data :Issues [])
+           (mapv (fn [issue]
+                   (make-violation
+                    :golangci-lint
+                    (get-in issue [:Pos :Filename])
+                    (get-in issue [:Pos :Line])
+                    (get-in issue [:Pos :Column])
+                    (get issue :Text)
+                    (get issue :FromLinter)
+                    (severity-from-level (get issue :Severity "warning")))))))))
+
+;; ── Parser dispatch ─────────────────────────────────────────────────────────
+
+(def ^:private parsers
+  {:clippy        parse-clippy
+   :clj-kondo     parse-clj-kondo
+   :eslint        parse-eslint
+   :ruff          parse-ruff
+   :swiftlint     parse-swiftlint
+   :golangci-lint parse-golangci-lint})
+
+(defn- parse-output
+  "Parse linter output using the registered parser."
+  [parser-key output]
+  (if-let [parser (get parsers parser-key)]
+    (or (parser output) [])
+    []))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Orchestration
+
+(defn run-linter-for-tech
+  "Run a single linter for a detected technology.
+   Returns {:tech keyword :violations [...] :available? bool :duration-ms int}."
+  [repo-path {:keys [tech/id tech/linter]}]
+  (let [{:keys [command args parser check-cmd]} linter
+        available? (linter-available? (or check-cmd [command "--version"]))
+        start-ms   (System/currentTimeMillis)]
+    (if-not available?
+      {:tech id :violations [] :available? false :duration-ms 0}
+      (let [result     (run-linter repo-path command args)
+            output     (str (:out result))
+            violations (parse-output parser output)
+            end-ms     (System/currentTimeMillis)]
+        {:tech        id
+         :violations  violations
+         :available?  true
+         :duration-ms (- end-ms start-ms)}))))
+
+(defn run-all-linters
+  "Run linters for all detected technologies that have a linter configured.
+   Returns {:linter-results [...] :total-violations int :total-duration-ms int}."
+  [repo-path fingerprints detected-techs]
+  (let [lintable (->> fingerprints
+                      (filter :tech/linter)
+                      (filter #(contains? detected-techs (:tech/id %))))
+        results  (mapv #(run-linter-for-tech repo-path %) lintable)
+        all-viols (mapcat :violations results)]
+    {:linter-results    results
+     :total-violations  (count all-viols)
+     :total-duration-ms (reduce + 0 (map :duration-ms results))
+     :violations        (vec all-viols)}))
+
+(defn run-linter-fixes
+  "Run linter fix commands for all detected technologies.
+   Returns {:fixed [...] :failed [...]}."
+  [repo-path fingerprints detected-techs]
+  (let [fixable (->> fingerprints
+                     (filter :tech/linter)
+                     (filter #(get-in % [:tech/linter :fix-args]))
+                     (filter #(contains? detected-techs (:tech/id %))))]
+    {:fixed
+     (vec
+      (keep (fn [{:keys [tech/id tech/linter]}]
+              (let [{:keys [command fix-args check-cmd]} linter]
+                (when (linter-available? (or check-cmd [command "--version"]))
+                  (let [result (run-linter repo-path command fix-args)]
+                    {:tech id :exit (:exit result)}))))
+            fixable))}))

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -316,7 +316,8 @@
            :since     {:alias :s}
            :standards {:default ".standards"}
            :execute   {:coerce :boolean :alias :x}
-           :report    {:coerce :boolean :default true}}}
+           :report    {:coerce :boolean :default true}
+           :no-lint   {:coerce :boolean}}}
 
    ;; Run command
    {:cmds ["run"]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/scan.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/scan.clj
@@ -26,8 +26,10 @@
    [babashka.fs :as fs]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
+   [ai.miniforge.cli.linter-runner :as linter]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.repo-analyzer :as analyzer]
    [ai.miniforge.compliance-scanner.interface :as scanner]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -130,21 +132,77 @@
             " violation(s) across "
             (get exec-result :files-changed 0) " file(s)")))))
 
+(defn- run-linters
+  "Run language-specific linters for detected technologies.
+   Returns vector of linter violations."
+  [repo-path repo-config]
+  (let [detected (get repo-config :repo/technologies #{})
+        fps      @analyzer/fingerprints]
+    (when (seq detected)
+      (let [result (linter/run-all-linters repo-path fps detected)]
+        (doseq [{:keys [tech available? violations duration-ms]} (:linter-results result)]
+          (cond
+            (not available?)
+            (display/print-info (str "  " (name tech) ": linter not installed (skipped)"))
+
+            (seq violations)
+            (display/print-info (str "  " (name tech) ": " (count violations)
+                                     " finding(s) (" duration-ms "ms)"))
+
+            :else
+            (display/print-info (str "  " (name tech) ": clean (" duration-ms "ms)"))))
+        (:violations result)))))
+
+(defn- run-linter-fixes!
+  "Run linter --fix for detected technologies."
+  [repo-path repo-config]
+  (let [detected (get repo-config :repo/technologies #{})
+        fps      @analyzer/fingerprints
+        result   (linter/run-linter-fixes repo-path fps detected)]
+    (doseq [{:keys [tech exit]} (:fixed result)]
+      (display/print-info (str "  " (name tech) ": fix " (if (zero? exit) "applied" "failed"))))))
+
 (defn- run-scan
-  "Execute the scan→classify→plan→execute pipeline."
+  "Execute the scan→linters→classify→plan→execute pipeline."
   [repo-path opts]
-  (let [standards  (get opts :standards default-standards-path)
-        scan-opts  (build-scan-opts repo-path opts)
-        report?    (get opts :report false)
-        execute?   (get opts :execute false)]
+  (let [standards   (get opts :standards default-standards-path)
+        scan-opts   (build-scan-opts repo-path opts)
+        report?     (get opts :report false)
+        execute?    (get opts :execute false)
+        no-lint?    (get opts :no-lint false)
+        repo-config (load-repo-config repo-path)]
+
+    ;; Phase 1: Policy pack scan
     (display/print-info (str "Scanning " repo-path " ..."))
-    (let [scan-result (-> (scanner/scan repo-path standards scan-opts)
-                          print-scan-summary)
-          violations  (:violations scan-result)]
-      (when (seq violations)
-        (let [classified  (classify-and-report violations)
+    (let [scan-result     (-> (scanner/scan repo-path standards scan-opts)
+                              print-scan-summary)
+          policy-viols    (:violations scan-result)
+
+          ;; Phase 1b: Linter scan
+          linter-viols    (when-not no-lint?
+                            (when repo-config
+                              (display/print-info "Running linters...")
+                              (run-linters repo-path repo-config)))
+
+          ;; Merge violations
+          all-violations  (vec (concat policy-viols (or linter-viols [])))]
+
+      (when (and (seq linter-viols) (seq policy-viols))
+        (display/print-info
+         (str "Combined: " (count all-violations) " total ("
+              (count policy-viols) " policy + "
+              (count linter-viols) " linter)")))
+
+      (when (seq all-violations)
+        (let [classified  (classify-and-report all-violations)
               plan-result (plan-and-print classified repo-path report?)]
-          (execute-if-requested plan-result repo-path execute?))))))
+
+          ;; Execute: run both linter fixes and policy auto-fixes
+          (when execute?
+            (when (and repo-config (not no-lint?))
+              (display/print-info "Running linter fixes...")
+              (run-linter-fixes! repo-path repo-config))
+            (execute-if-requested plan-result repo-path true)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Command entry point

--- a/bases/cli/src/ai/miniforge/cli/repo_analyzer.clj
+++ b/bases/cli/src/ai/miniforge/cli/repo_analyzer.clj
@@ -14,6 +14,7 @@
    Layer 2: Pack selection and full analysis"
   (:require
    [babashka.fs :as fs]
+   [babashka.process :as process]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]))
@@ -99,8 +100,10 @@
   "Detect git host from remote URL."
   [repo-path]
   (try
-    (let [url (:out (clojure.java.shell/sh "git" "remote" "get-url" "origin"
-                                            :dir (str repo-path)))]
+    (let [url (:out (process/sh {:cmd ["git" "remote" "get-url" "origin"]
+                                    :dir (str repo-path)
+                                    :continue true
+                                    :out :string :err :string}))]
       (cond
         (str/includes? url "github.com")    :github
         (str/includes? url "gitlab")        :gitlab

--- a/bases/cli/test/ai/miniforge/cli/linter_runner_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/linter_runner_test.clj
@@ -1,0 +1,99 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.cli.linter-runner-test
+  "Tests for linter runner — parsing, availability, orchestration."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.cli.linter-runner :as sut]))
+
+;; Access private parsers via var
+(def parse-clippy (var-get #'sut/parse-clippy))
+(def parse-clj-kondo (var-get #'sut/parse-clj-kondo))
+(def parse-eslint (var-get #'sut/parse-eslint))
+(def parse-ruff (var-get #'sut/parse-ruff))
+(def parse-swiftlint (var-get #'sut/parse-swiftlint))
+(def severity-from-level (var-get #'sut/severity-from-level))
+
+;; ============================================================================
+;; Severity mapping
+;; ============================================================================
+
+(deftest severity-from-level-test
+  (testing "maps error levels to :critical"
+    (is (= :critical (severity-from-level "error")))
+    (is (= :critical (severity-from-level "E"))))
+
+  (testing "maps warning levels to :major"
+    (is (= :major (severity-from-level "warning")))
+    (is (= :major (severity-from-level "warn"))))
+
+  (testing "maps info levels to :minor"
+    (is (= :minor (severity-from-level "info")))
+    (is (= :minor (severity-from-level "convention"))))
+
+  (testing "maps style levels to :info"
+    (is (= :info (severity-from-level "style")))
+    (is (= :info (severity-from-level "hint")))))
+
+;; ============================================================================
+;; clj-kondo parser
+;; ============================================================================
+
+(deftest parse-clj-kondo-test
+  (testing "parses EDN findings"
+    (let [output "{:findings [{:type :unresolved-symbol :filename \"src/core.clj\" :row 10 :col 5 :level :error :message \"Unresolved symbol: foo\"}]}"
+          result (parse-clj-kondo output)]
+      (is (= 1 (count result)))
+      (is (= "src/core.clj" (:file (first result))))
+      (is (= 10 (:line (first result))))
+      (is (= :critical (:rule/severity (first result))))))
+
+  (testing "returns empty for no findings"
+    (is (= [] (parse-clj-kondo "{:findings []}")))))
+
+;; ============================================================================
+;; ESLint parser
+;; ============================================================================
+
+(deftest parse-eslint-test
+  (testing "parses JSON array of file results"
+    (let [output "[{\"filePath\":\"/src/app.js\",\"messages\":[{\"ruleId\":\"no-unused-vars\",\"severity\":2,\"message\":\"x is unused\",\"line\":5,\"column\":3}]}]"
+          result (parse-eslint output)]
+      (is (= 1 (count result)))
+      (is (= "/src/app.js" (:file (first result))))
+      (is (= :major (:rule/severity (first result)))))))
+
+;; ============================================================================
+;; Ruff parser
+;; ============================================================================
+
+(deftest parse-ruff-test
+  (testing "parses JSON array of violations"
+    (let [output "[{\"code\":\"F401\",\"message\":\"unused import\",\"filename\":\"app.py\",\"location\":{\"row\":1,\"column\":1},\"type\":\"warning\"}]"
+          result (parse-ruff output)]
+      (is (= 1 (count result)))
+      (is (= "app.py" (:file (first result))))
+      (is (= :major (:rule/severity (first result)))))))
+
+;; ============================================================================
+;; Orchestration
+;; ============================================================================
+
+(deftest run-all-linters-no-linters-test
+  (testing "returns empty when no technologies detected"
+    (let [result (sut/run-all-linters "." [] #{})]
+      (is (= 0 (:total-violations result)))
+      (is (empty? (:violations result))))))
+
+(deftest run-all-linters-skips-unavailable-test
+  (testing "gracefully skips unavailable linters"
+    (let [fps [{:tech/id :fake-lang
+                :tech/linter {:command "nonexistent-linter-xyz"
+                              :args ["--lint"]
+                              :parser :eslint
+                              :check-cmd ["nonexistent-linter-xyz" "--version"]}}]
+          result (sut/run-all-linters "." fps #{:fake-lang})]
+      (is (= 0 (:total-violations result)))
+      (is (false? (get-in (first (:linter-results result)) [:available?]))))))

--- a/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
@@ -23,7 +23,8 @@
                     :foundations/no-unwrap-in-lib
                     :foundations/no-force-unwrap-swift
                     :foundations/no-force-cast-swift
-                    :foundations/no-todo-fixme]}]
+                    :foundations/no-todo-fixme
+                    :foundations/no-requiring-resolve]}]
 
  :pack/rules
  [{:rule/id          :foundations/no-hardcoded-secrets
@@ -175,7 +176,22 @@
                       :pattern "(?i)(TODO|FIXME|HACK|XXX)\\s*[:(]"}
    :rule/enforcement {:action :audit
                       :message "TODO/FIXME comment found. Resolve before release or convert to a tracked issue."
-                      :remediation "Resolve the TODO, or create an issue and reference it in the comment."}}]
+                      :remediation "Resolve the TODO, or create an issue and reference it in the comment."}}
+
+  {:rule/id          :foundations/no-requiring-resolve
+   :rule/title       "No requiring-resolve in Clojure"
+   :rule/description "Detects requiring-resolve calls. Direct namespace requires are preferred — requiring-resolve is only appropriate for true plugin/extension points where the dependency is genuinely optional at the module level."
+   :rule/severity    :minor
+   :rule/category    "001"
+   :rule/applies-to  {:file-globs ["**/*.clj" "**/*.cljc"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "\\(requiring-resolve\\s"}
+   :rule/remediation {:strategy :manual
+                      :auto-fixable-default false}
+   :rule/enforcement {:action :warn
+                      :message "requiring-resolve detected. Use direct require unless the dependency is a genuine plugin/extension point."
+                      :remediation "Replace (requiring-resolve 'ns/fn) with a direct (:require [ns :as alias]) and call alias/fn."}}]
 
  :pack/created-at #inst "2026-04-08T00:00:00Z"
  :pack/updated-at #inst "2026-04-08T00:00:00Z"}

--- a/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
+++ b/components/policy-pack/resources/policy_pack/packs/foundations-1.0.0.pack.edn
@@ -24,7 +24,8 @@
                     :foundations/no-force-unwrap-swift
                     :foundations/no-force-cast-swift
                     :foundations/no-todo-fixme
-                    :foundations/no-requiring-resolve]}]
+                    :foundations/no-requiring-resolve
+                    :foundations/no-inline-anon-fns]}]
 
  :pack/rules
  [{:rule/id          :foundations/no-hardcoded-secrets
@@ -191,7 +192,22 @@
                       :auto-fixable-default false}
    :rule/enforcement {:action :warn
                       :message "requiring-resolve detected. Use direct require unless the dependency is a genuine plugin/extension point."
-                      :remediation "Replace (requiring-resolve 'ns/fn) with a direct (:require [ns :as alias]) and call alias/fn."}}]
+                      :remediation "Replace (requiring-resolve 'ns/fn) with a direct (:require [ns :as alias]) and call alias/fn."}}
+
+  {:rule/id          :foundations/no-inline-anon-fns
+   :rule/title       "No Inline Anonymous Functions in Pipelines"
+   :rule/description "Detects multi-line anonymous functions passed to map, keep, filter, mapcat, reduce. Extract to named defn- for testability and readability."
+   :rule/severity    :minor
+   :rule/category    "001"
+   :rule/applies-to  {:file-globs ["**/*.clj" "**/*.cljc"]
+                       :phases #{:implement :review}}
+   :rule/detection   {:type :content-scan
+                      :pattern "(?:map|keep|filter|mapcat|remove|reduce)\\s+\\(fn\\s+\\["}
+   :rule/remediation {:strategy :manual
+                      :auto-fixable-default false}
+   :rule/enforcement {:action :audit
+                      :message "Anonymous function in pipeline. Extract to named defn- for independent testability."
+                      :remediation "Extract the anonymous function to a named private function (defn-) and pass it by name."}}]
 
  :pack/created-at #inst "2026-04-08T00:00:00Z"
  :pack/updated-at #inst "2026-04-08T00:00:00Z"}


### PR DESCRIPTION
## Summary

- `bb miniforge scan` now runs language-specific linters alongside policy pack scanning
- Linter output parsed into standard violation format, merged into classify→plan→execute pipeline
- Supported: Clippy (Rust), clj-kondo (Clojure), ESLint (JS/TS), ruff (Python), SwiftLint (Swift), golangci-lint (Go)
- Linters auto-detected from tech-fingerprints.edn, skipped gracefully when not installed
- `--execute` runs both linter `--fix` and policy auto-fixes
- `--no-lint` for policy-only mode

## Test plan

- [x] risk-dashboard: Clippy runs clean, SwiftLint skipped (not installed)
- [x] miniforge: clj-kondo runs clean, ESLint skipped
- [x] Parser unit tests for clj-kondo, ESLint, ruff formats
- [x] Unavailable linters skipped gracefully
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)