### PR TITLE
feat: import Data Foundry into miniforge monorepo

### DIFF
--- a/components/connector-auth/deps.edn
+++ b/components/connector-auth/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src" "resources"]
+ :deps {}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector-auth/resources/config/connector-auth/messages/en-US.edn
+++ b/components/connector-auth/resources/config/connector-auth/messages/en-US.edn
@@ -1,0 +1,8 @@
+{:connector-auth/messages
+ {;; Validation errors
+  :validate/method-required        ":auth/method is required"
+  :validate/method-unsupported     "Unsupported auth method: {method}. Must be one of: {allowed}"
+  :validate/credential-id-required ":auth/credential-id is required"
+  :validate/credential-id-empty    ":auth/credential-id must not be empty"
+  :validate/inline-secrets         "Credential reference must not contain inline secrets. Found forbidden keys: {keys}"
+  :validate/missing-field          "Missing required field {field} for auth method {method}"}}

--- a/components/connector-auth/src/ai/miniforge/data_foundry/connector_auth/core.clj
+++ b/components/connector-auth/src/ai/miniforge/data_foundry/connector_auth/core.clj
@@ -1,0 +1,70 @@
+(ns ai.miniforge.data-foundry.connector-auth.core
+  (:require [ai.miniforge.data-foundry.connector-auth.messages :as msg]))
+
+(def ^:private method-required-fields
+  "Required fields per auth method, per N2 §5.2"
+  {:api-key          #{:auth/credential-id}
+   :basic            #{:auth/credential-id}
+   :certificate      #{:auth/credential-id :auth/certificate-path}
+   :none             #{}
+   :oauth2           #{:auth/credential-id :auth/client-id :auth/token-endpoint}
+   :vault-reference  #{:auth/credential-id :auth/vault-path}})
+
+(def ^:private forbidden-keys
+  "Keys that must never appear in a credential reference (N2 §5.1)"
+  #{:auth/password :auth/secret :auth/api-key-value :auth/token
+    :auth/private-key :auth/secret-key :auth/access-key})
+
+(defn required-fields-for-method
+  [method]
+  (get method-required-fields method #{}))
+
+(defn inline-secret?
+  "Check if credential ref contains inline secrets."
+  [cred-ref]
+  (boolean (some #(contains? cred-ref %) forbidden-keys)))
+
+(defn validate-credential-ref
+  "Validate a credential reference."
+  [{:auth/keys [method credential-id] :as cred-ref}]
+  (let [errors
+        (cond-> []
+          (nil? method)
+          (conj (msg/t :validate/method-required))
+
+          (and method (not (contains? (set (keys method-required-fields)) method)))
+          (conj (msg/t :validate/method-unsupported
+                       {:method method :allowed (keys method-required-fields)}))
+
+          (and (not= method :none) (nil? credential-id))
+          (conj (msg/t :validate/credential-id-required))
+
+          (and (not= method :none) (string? credential-id) (empty? credential-id))
+          (conj (msg/t :validate/credential-id-empty))
+
+          (inline-secret? cred-ref)
+          (conj (msg/t :validate/inline-secrets
+                       {:keys (filterv #(contains? cred-ref %) forbidden-keys)})))
+        ;; Check method-specific required fields
+        method-errors
+        (when method
+          (let [required (get method-required-fields method)]
+            (for [field required
+                  :when (nil? (get cred-ref field))]
+              (msg/t :validate/missing-field {:field field :method method}))))]
+    (let [all-errors (vec (concat errors method-errors))]
+      (if (empty? all-errors)
+        {:success? true}
+        {:success? false :errors all-errors}))))
+
+(defn create-credential-ref
+  "Create a validated credential reference."
+  [opts]
+  (let [cred-ref (select-keys opts
+                              [:auth/method :auth/credential-id :auth/credential-scope
+                               :auth/client-id :auth/token-endpoint
+                               :auth/certificate-path :auth/vault-path])
+        validation (validate-credential-ref cred-ref)]
+    (if (:success? validation)
+      {:success? true :credential-ref cred-ref}
+      {:success? false :errors (:errors validation)})))

--- a/components/connector-auth/src/ai/miniforge/data_foundry/connector_auth/interface.clj
+++ b/components/connector-auth/src/ai/miniforge/data_foundry/connector_auth/interface.clj
@@ -1,0 +1,37 @@
+(ns ai.miniforge.data-foundry.connector-auth.interface
+  (:require [ai.miniforge.data-foundry.connector-auth.core :as core]))
+
+;; -- Auth Methods --
+(def auth-methods
+  "N2 §5.2 supported authentication methods"
+  #{:api-key :basic :certificate :none :oauth2 :vault-reference})
+
+(defn valid-auth-method?
+  "Returns true if method is a supported authentication method."
+  [method]
+  (contains? auth-methods method))
+
+;; -- Credential Reference Model --
+(defn create-credential-ref
+  "Create a credential reference (never contains actual secrets).
+   Required: :auth/method, :auth/credential-id
+   Optional: :auth/credential-scope, :auth/client-id, :auth/token-endpoint,
+             :auth/certificate-path, :auth/vault-path"
+  [opts]
+  (core/create-credential-ref opts))
+
+(defn validate-credential-ref
+  "Validate a credential reference. Returns {:success? true} or {:success? false :errors [...]}"
+  [cred-ref]
+  (core/validate-credential-ref cred-ref))
+
+(defn required-fields-for-method
+  "Returns set of required fields for a given auth method."
+  [method]
+  (core/required-fields-for-method method))
+
+(defn inline-secret?
+  "Returns true if the credential reference appears to contain inline secrets (violation of N2 §5.1).
+   Checks for common secret-like keys."
+  [cred-ref]
+  (core/inline-secret? cred-ref))

--- a/components/connector-auth/src/ai/miniforge/data_foundry/connector_auth/messages.clj
+++ b/components/connector-auth/src/ai/miniforge/data_foundry/connector_auth/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.connector-auth.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/connector-auth/messages/en-US.edn" :connector-auth/messages))

--- a/components/connector-auth/test/ai/miniforge/data_foundry/connector_auth/interface_test.clj
+++ b/components/connector-auth/test/ai/miniforge/data_foundry/connector_auth/interface_test.clj
@@ -1,0 +1,95 @@
+(ns ai.miniforge.data-foundry.connector-auth.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector-auth.interface :as auth]))
+
+(deftest auth-methods-test
+  (testing "N2 §5.2 all methods present"
+    (is (= #{:api-key :basic :certificate :none :oauth2 :vault-reference}
+           auth/auth-methods))
+    (is (true? (auth/valid-auth-method? :api-key)))
+    (is (true? (auth/valid-auth-method? :none)))
+    (is (false? (auth/valid-auth-method? :unknown)))))
+
+(deftest create-credential-ref-test
+  (testing "AUTH-01: Valid API key credential ref"
+    (let [result (auth/create-credential-ref
+                  {:auth/method :api-key
+                   :auth/credential-id "cred-fred-api-12345"
+                   :auth/credential-scope "fred.stlouisfed.org"})]
+      (is (:success? result))
+      (is (= :api-key (get-in result [:credential-ref :auth/method])))
+      (is (= "cred-fred-api-12345" (get-in result [:credential-ref :auth/credential-id])))))
+
+  (testing "AUTH-02: Valid OAuth2 credential ref"
+    (let [result (auth/create-credential-ref
+                  {:auth/method :oauth2
+                   :auth/credential-id "cred-oauth-123"
+                   :auth/client-id "client-abc"
+                   :auth/token-endpoint "https://auth.example.com/token"})]
+      (is (:success? result))))
+
+  (testing "AUTH-03: Valid basic auth credential ref"
+    (let [result (auth/create-credential-ref
+                  {:auth/method :basic
+                   :auth/credential-id "cred-postgres-user"})]
+      (is (:success? result))))
+
+  (testing "Valid certificate credential ref"
+    (let [result (auth/create-credential-ref
+                  {:auth/method :certificate
+                   :auth/credential-id "cred-cert-123"
+                   :auth/certificate-path "/etc/certs/client.pem"})]
+      (is (:success? result))))
+
+  (testing "Valid vault reference credential ref"
+    (let [result (auth/create-credential-ref
+                  {:auth/method :vault-reference
+                   :auth/credential-id "cred-aws-s3-role"
+                   :auth/vault-path "secret/aws/s3-user"})]
+      (is (:success? result))))
+
+  (testing "Valid :none credential ref (no credential-id needed)"
+    (let [result (auth/create-credential-ref {:auth/method :none})]
+      (is (:success? result))
+      (is (= :none (get-in result [:credential-ref :auth/method]))))))
+
+(deftest validation-errors-test
+  (testing "AUTH-04: Missing auth method"
+    (let [result (auth/create-credential-ref {:auth/credential-id "x"})]
+      (is (not (:success? result)))
+      (is (some #(re-find #"method" %) (:errors result)))))
+
+  (testing "Missing credential-id"
+    (let [result (auth/create-credential-ref {:auth/method :api-key})]
+      (is (not (:success? result)))))
+
+  (testing "OAuth2 missing required fields"
+    (let [result (auth/create-credential-ref
+                  {:auth/method :oauth2
+                   :auth/credential-id "x"})]
+      (is (not (:success? result)))
+      (is (some #(re-find #"client-id" %) (:errors result))))))
+
+(deftest inline-secret-detection-test
+  (testing "N2 §5.1: Detect inline secrets"
+    (is (true? (auth/inline-secret?
+                {:auth/method :api-key
+                 :auth/credential-id "x"
+                 :auth/password "hunter2"})))
+    (is (true? (auth/inline-secret?
+                {:auth/method :api-key
+                 :auth/credential-id "x"
+                 :auth/secret "s3cr3t"})))
+    (is (false? (auth/inline-secret?
+                 {:auth/method :api-key
+                  :auth/credential-id "x"
+                  :auth/credential-scope "example.com"})))))
+
+(deftest required-fields-test
+  (testing "Method-specific required fields"
+    (is (= #{:auth/credential-id} (auth/required-fields-for-method :api-key)))
+    (is (= #{:auth/credential-id :auth/client-id :auth/token-endpoint}
+           (auth/required-fields-for-method :oauth2)))
+    (is (= #{:auth/credential-id :auth/vault-path}
+           (auth/required-fields-for-method :vault-reference)))
+    (is (= #{} (auth/required-fields-for-method :none)))))

--- a/components/connector-edgar/deps.edn
+++ b/components/connector-edgar/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector      {:local/root "../connector"}
+        ai.miniforge.data-foundry/connector-auth  {:local/root "../connector-auth"}
+        ai.miniforge.data-foundry/connector-retry {:local/root "../connector-retry"}
+        hato/hato                       {:mvn/version "1.0.0"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector-edgar/resources/config/connector-edgar/messages/en-US.edn
+++ b/components/connector-edgar/resources/config/connector-edgar/messages/en-US.edn
@@ -1,0 +1,16 @@
+{:connector-edgar/messages
+ {;; Lifecycle
+  :edgar/connect-success   "Connected to EDGAR: {form-type}"
+  :edgar/close-success     "Closed EDGAR handle: {handle}"
+  :edgar/handle-not-found  "EDGAR handle not found: {handle}"
+
+  ;; Config validation
+  :edgar/form-type-required    ":edgar/form-type is required"
+  :edgar/user-agent-required   ":edgar/user-agent is required"
+  :edgar/aggregation-required  ":edgar/aggregation is required"
+
+  ;; Extract
+  :edgar/aggregation-unknown  "Unknown aggregation type: {agg}"
+  :edgar/search-failed     "EDGAR EFTS search failed: {error}"
+  :edgar/fetch-failed      "Failed to fetch filing {adsh}: {error}"
+  :edgar/parse-failed      "Failed to parse filing XML: {error}"}}

--- a/components/connector-edgar/src/ai/miniforge/data_foundry/connector_edgar/core.clj
+++ b/components/connector-edgar/src/ai/miniforge/data_foundry/connector_edgar/core.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.data-foundry.connector-edgar.core
+  "EdgarConnector defrecord — thin protocol wrapper delegating to impl."
+  (:require [ai.miniforge.data-foundry.connector.protocol :as proto]
+            [ai.miniforge.data-foundry.connector-edgar.impl :as impl]))
+
+(defrecord EdgarConnector []
+  proto/Connector
+  (connect    [_ config auth]                      (impl/do-connect config auth))
+  (close      [_ handle]                           (impl/do-close handle))
+
+  proto/SourceConnector
+  (discover   [_ handle _opts]                     (impl/do-discover handle))
+  (extract    [_ handle _schema-name opts]         (impl/do-extract handle opts))
+  (checkpoint [_ _handle _connector-id cursor]     (impl/do-checkpoint cursor)))

--- a/components/connector-edgar/src/ai/miniforge/data_foundry/connector_edgar/impl.clj
+++ b/components/connector-edgar/src/ai/miniforge/data_foundry/connector_edgar/impl.clj
@@ -1,0 +1,229 @@
+(ns ai.miniforge.data-foundry.connector-edgar.impl
+  "Implementation functions for the EDGAR connector.
+   Queries SEC EDGAR EFTS for filings, fetches filing documents,
+   and extracts structured data from XML."
+  (:require [ai.miniforge.data-foundry.connector.handles :as h]
+            [ai.miniforge.data-foundry.connector.result :as result]
+            [ai.miniforge.data-foundry.connector-edgar.messages :as msg]
+            [ai.miniforge.data-foundry.connector-http.rate-limit :as rate]
+            [ai.miniforge.schema.interface :as schema]
+            [clojure.data.json :as json]
+            [hato.client :as hc])
+  (:import [java.io ByteArrayInputStream]
+           [java.time LocalDate]
+           [java.time.format DateTimeFormatter]
+           [java.time.temporal TemporalAdjusters]
+           [java.util UUID]
+           [javax.xml.parsers DocumentBuilderFactory]
+           [org.w3c.dom Element NodeList]))
+
+;; -- Handle state --
+
+(def ^:private handles (h/create))
+
+(defn get-handle [handle] (h/get-handle handles handle))
+(defn store-handle! [handle state] (h/store-handle! handles handle state))
+(defn remove-handle! [handle] (h/remove-handle! handles handle))
+
+;; -- Rate limiting --
+
+(def ^:private last-request-at (atom 0))
+
+(defn- rate-limit!
+  "Sleep to enforce requests-per-second."
+  [rps]
+  (reset! last-request-at (rate/time-based-acquire! rps @last-request-at)))
+
+;; -- HTTP helpers --
+
+(defn- fetch-url
+  "Fetch a URL with the SEC-required User-Agent header."
+  [url user-agent]
+  (rate-limit! 8)
+  (let [resp (hc/get url {:headers          {"User-Agent" user-agent}
+                           :as               :byte-array
+                           :throw-exceptions false
+                           :connect-timeout  30000
+                           :timeout          30000})
+        status (:status resp)]
+    (when (<= 200 status 299)
+      (:body resp))))
+
+(defn- fetch-json
+  "Fetch a URL and parse response as JSON."
+  [url user-agent]
+  (when-let [body (fetch-url url user-agent)]
+    (json/read-str (String. ^bytes body "UTF-8") :key-fn keyword)))
+
+;; -- XML parsing --
+
+(defn- parse-xml
+  "Parse a byte array as XML, return the Document root Element."
+  [^bytes xml-bytes]
+  (let [factory (DocumentBuilderFactory/newInstance)
+        builder (.newDocumentBuilder factory)
+        doc     (.parse builder (ByteArrayInputStream. xml-bytes))]
+    (.getDocumentElement doc)))
+
+(defn- elements-by-tag
+  "Get all descendant elements with a given tag name."
+  [^Element el ^String tag]
+  (let [^NodeList nl (.getElementsByTagName el tag)]
+    (for [i (range (.getLength nl))]
+      (.item nl i))))
+
+(defn- text-content
+  "Get text content of the first child element matching tag, or nil."
+  [^Element el ^String tag]
+  (when-let [children (seq (elements-by-tag el tag))]
+    (let [text (.getTextContent ^Element (first children))]
+      (when-not (empty? text) text))))
+
+;; -- EDGAR EFTS API --
+
+(def ^:private efts-base "https://efts.sec.gov/LATEST/search-index")
+(def ^:private archives-base "https://www.sec.gov/Archives/edgar/data")
+
+(defn- search-filings
+  "Search EDGAR EFTS for filings of a given form type in a date range."
+  [form-type start-date end-date sample-size user-agent]
+  (let [url (str efts-base
+                 "?q=%22" form-type "%22"
+                 "&forms=" form-type
+                 "&dateRange=custom"
+                 "&startdt=" start-date
+                 "&enddt=" end-date
+                 "&_source=adsh,ciks,file_date"
+                 "&from=0&size=" sample-size)]
+    (when-let [data (fetch-json url user-agent)]
+      (get-in data [:hits :hits]))))
+
+(defn- fetch-filing-xml
+  "Fetch a filing's XML document. Tries common filenames."
+  [adsh cik user-agent filenames]
+  (let [adsh-path (clojure.string/replace adsh "-" "")
+        cik-num   (str (parse-long cik))]
+    (some (fn [fname]
+            (fetch-url (str archives-base "/" cik-num "/" adsh-path "/" fname)
+                       user-agent))
+          filenames)))
+
+;; -- Form 4 transaction extraction --
+
+(defn- extract-form4-transactions
+  "Extract open-market P/S transactions from Form 4 XML bytes."
+  [^bytes xml-bytes transaction-codes]
+  (try
+    (let [root (parse-xml xml-bytes)]
+      (for [^Element txn (elements-by-tag root "nonDerivativeTransaction")
+            :let [code   (text-content txn "transactionCode")
+                  shares (text-content txn "transactionShares")
+                  price  (text-content txn "transactionPricePerShare")]
+            :when (and code (contains? transaction-codes code))]
+        {:code   code
+         :shares (when shares (parse-double shares))
+         :price  (when price (parse-double price))}))
+    (catch Exception _ [])))
+
+;; -- Aggregation --
+
+(defn- monthly-windows
+  "Generate [start end] date string pairs for each month from start to today."
+  [^String start-date-str]
+  (let [start  (LocalDate/parse start-date-str)
+        today  (LocalDate/now)
+        fmt    DateTimeFormatter/ISO_LOCAL_DATE]
+    (loop [d (.withDayOfMonth start 1)
+           windows []]
+      (if (.isAfter d (.withDayOfMonth today 1))
+        windows
+        (let [month-end (.with d (TemporalAdjusters/lastDayOfMonth))
+              end       (if (.isAfter month-end today) today month-end)]
+          (recur (.plusMonths d 1)
+                 (conj windows [(.format d fmt) (.format end fmt)])))))))
+
+(defn- fetch-filing-transactions
+  "Fetch and extract transactions from a single EFTS hit."
+  [hit user-agent filenames transaction-codes]
+  (let [src  (:_source hit)
+        adsh (:adsh src)
+        cik  (first (:ciks src))]
+    (when (and adsh cik)
+      (when-let [xml (fetch-filing-xml adsh cik user-agent filenames)]
+        (extract-form4-transactions xml transaction-codes)))))
+
+(defn- count-by-code
+  "Count transactions matching a given code."
+  [txns code]
+  (count (filter #(= code (:code %)) txns)))
+
+(defn- aggregate-buy-sell-ratio
+  "Aggregate Form 4 transactions into monthly buy:sell ratio records."
+  [config user-agent]
+  (let [{:edgar/keys [start-date sample-size transaction-codes
+                      series-id filing-filenames]} config
+        codes   (or transaction-codes #{"P" "S"})
+        fnames  (or filing-filenames ["form4.xml" "ownership.xml" "primary_doc.xml"])
+        windows (monthly-windows (or start-date "2025-01-01"))]
+    (vec
+     (for [[start end] windows
+           :let [hits    (or (search-filings "4" start end
+                                             (or sample-size 200)
+                                             user-agent)
+                             [])
+                 sample  (take (or sample-size 200) hits)
+                 txns    (mapcat #(fetch-filing-transactions % user-agent fnames codes) sample)
+                 buys    (count-by-code txns "P")
+                 sells   (count-by-code txns "S")
+                 ratio   (if (pos? sells)
+                           (double (/ buys sells))
+                           0.0)]]
+       {:date      start
+        :series_id (or series-id "INSIDER_BUY_SELL_RATIO")
+        :value     (format "%.4f" ratio)}))))
+
+;; -- Lifecycle --
+
+(defn do-connect
+  "Validate config, register handle."
+  [config _auth]
+  (let [form-type  (:edgar/form-type config)
+        user-agent (:edgar/user-agent config)
+        aggregation (:edgar/aggregation config)]
+    (cond
+      (nil? form-type)   (throw (ex-info (msg/t :edgar/form-type-required) {:config config}))
+      (nil? user-agent)  (throw (ex-info (msg/t :edgar/user-agent-required) {:config config}))
+      (nil? aggregation) (throw (ex-info (msg/t :edgar/aggregation-required) {:config config}))
+      :else
+      (let [handle (str (UUID/randomUUID))]
+        (store-handle! handle {:config config})
+        (result/connect-result handle)))))
+
+(defn do-close [handle]
+  (remove-handle! handle)
+  (result/close-result))
+
+;; -- Source --
+
+(defn do-discover [handle]
+  (if-let [{:keys [config]} (get-handle handle)]
+    (result/discover-result [{:schema/name      (:edgar/form-type config)
+                              :schema/aggregation (:edgar/aggregation config)}])
+    (throw (ex-info (msg/t :edgar/handle-not-found {:handle handle}) {:handle handle}))))
+
+(defn do-extract
+  "Extract aggregated records from EDGAR filings."
+  [handle _opts]
+  (if-let [{:keys [config]} (get-handle handle)]
+    (let [user-agent (:edgar/user-agent config)
+          records    (case (:edgar/aggregation config)
+                       :monthly-buy-sell-ratio
+                       (aggregate-buy-sell-ratio config user-agent)
+
+                       (throw (ex-info (msg/t :edgar/aggregation-unknown {:agg (:edgar/aggregation config)})
+                                       {:aggregation (:edgar/aggregation config)})))]
+      (result/extract-result records nil false))
+    (throw (ex-info (msg/t :edgar/handle-not-found {:handle handle}) {:handle handle}))))
+
+(defn do-checkpoint [cursor-state]
+  (result/checkpoint-result cursor-state))

--- a/components/connector-edgar/src/ai/miniforge/data_foundry/connector_edgar/interface.clj
+++ b/components/connector-edgar/src/ai/miniforge/data_foundry/connector_edgar/interface.clj
@@ -1,0 +1,17 @@
+(ns ai.miniforge.data-foundry.connector-edgar.interface
+  "Public API for the EDGAR connector component."
+  (:require [ai.miniforge.data-foundry.connector-edgar.core :as core]))
+
+(defn create-edgar-connector
+  "Create a new EdgarConnector instance."
+  []
+  (core/->EdgarConnector))
+
+(def connector-metadata
+  "Registration metadata for the EDGAR connector."
+  {:connector/name         "SEC EDGAR Connector"
+   :connector/type         :source
+   :connector/version      "0.1.0"
+   :connector/capabilities #{:cap/batch :cap/rate-limiting}
+   :connector/auth-methods #{:none}
+   :connector/maintainer   "data-foundry"})

--- a/components/connector-edgar/src/ai/miniforge/data_foundry/connector_edgar/messages.clj
+++ b/components/connector-edgar/src/ai/miniforge/data_foundry/connector_edgar/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.connector-edgar.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/connector-edgar/messages/en-US.edn" :connector-edgar/messages))

--- a/components/connector-edgar/test/ai/miniforge/data_foundry/connector_edgar/interface_test.clj
+++ b/components/connector-edgar/test/ai/miniforge/data_foundry/connector_edgar/interface_test.clj
@@ -1,0 +1,91 @@
+(ns ai.miniforge.data-foundry.connector-edgar.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector-edgar.impl :as impl]))
+
+(deftest connect-validates-config-test
+  (testing "do-connect requires form-type, user-agent, aggregation"
+    (is (thrown? Exception (impl/do-connect {} nil)))
+    (is (thrown? Exception (impl/do-connect {:edgar/form-type "4"} nil)))
+    (is (thrown? Exception
+                (impl/do-connect {:edgar/form-type "4"
+                                  :edgar/user-agent "Test/1.0"} nil)))))
+
+(deftest connect-close-lifecycle-test
+  (testing "connect and close work"
+    (let [config {:edgar/form-type   "4"
+                  :edgar/user-agent  "Test/1.0 test@test.com"
+                  :edgar/aggregation :monthly-buy-sell-ratio}
+          result (impl/do-connect config nil)]
+      (is (string? (:connection/handle result)))
+      (is (= :connected (:connector/status result)))
+      (let [close-result (impl/do-close (:connection/handle result))]
+        (is (= :closed (:connector/status close-result)))))))
+
+(deftest extract-form4-transactions-test
+  (testing "extracts P and S transactions from Form 4 XML"
+    (let [xml-str "<?xml version=\"1.0\"?>
+<ownershipDocument>
+  <nonDerivativeTable>
+    <nonDerivativeTransaction>
+      <transactionAmounts>
+        <transactionShares><value>1000</value></transactionShares>
+        <transactionPricePerShare><value>50.00</value></transactionPricePerShare>
+        <transactionAcquiredDisposedCode><value>A</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+      <transactionCoding>
+        <transactionCode>P</transactionCode>
+      </transactionCoding>
+    </nonDerivativeTransaction>
+    <nonDerivativeTransaction>
+      <transactionAmounts>
+        <transactionShares><value>500</value></transactionShares>
+        <transactionPricePerShare><value>55.00</value></transactionPricePerShare>
+        <transactionAcquiredDisposedCode><value>D</value></transactionAcquiredDisposedCode>
+      </transactionAmounts>
+      <transactionCoding>
+        <transactionCode>S</transactionCode>
+      </transactionCoding>
+    </nonDerivativeTransaction>
+    <nonDerivativeTransaction>
+      <transactionAmounts>
+        <transactionShares><value>200</value></transactionShares>
+        <transactionPricePerShare><value>48.00</value></transactionPricePerShare>
+      </transactionAmounts>
+      <transactionCoding>
+        <transactionCode>A</transactionCode>
+      </transactionCoding>
+    </nonDerivativeTransaction>
+  </nonDerivativeTable>
+</ownershipDocument>"
+          txns (#'impl/extract-form4-transactions (.getBytes xml-str "UTF-8") #{"P" "S"})]
+      (is (= 2 (count txns)))
+      (is (= "P" (:code (first txns))))
+      (is (= 1000.0 (:shares (first txns))))
+      (is (= "S" (:code (second txns))))
+      (is (= 500.0 (:shares (second txns)))))))
+
+(deftest extract-form4-transactions-invalid-xml-test
+  (testing "invalid XML returns empty"
+    (let [txns (#'impl/extract-form4-transactions (.getBytes "not xml" "UTF-8") #{"P" "S"})]
+      (is (empty? txns)))))
+
+(deftest monthly-windows-test
+  (testing "generates monthly windows from start date"
+    (let [windows (#'impl/monthly-windows "2026-01-01")]
+      (is (pos? (count windows)))
+      (is (= "2026-01-01" (first (first windows))))
+      ;; Each window is [start end]
+      (doseq [[s e] windows]
+        (is (string? s))
+        (is (string? e))))))
+
+(deftest discover-test
+  (testing "discover returns form type info"
+    (let [config {:edgar/form-type   "4"
+                  :edgar/user-agent  "Test/1.0"
+                  :edgar/aggregation :monthly-buy-sell-ratio}
+          handle (:connection/handle (impl/do-connect config nil))
+          result (impl/do-discover handle)]
+      (is (= 1 (:discover/total-count result)))
+      (is (= "4" (:schema/name (first (:schemas result)))))
+      (impl/do-close handle))))

--- a/components/connector-excel/deps.edn
+++ b/components/connector-excel/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector      {:local/root "../connector"}
+        ai.miniforge.data-foundry/connector-auth  {:local/root "../connector-auth"}
+        ai.miniforge.data-foundry/connector-retry {:local/root "../connector-retry"}
+        hato/hato                       {:mvn/version "1.0.0"}
+        dk.ative/docjure                {:mvn/version "1.19.0"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector-excel/resources/config/connector-excel/messages/en-US.edn
+++ b/components/connector-excel/resources/config/connector-excel/messages/en-US.edn
@@ -1,0 +1,15 @@
+{:connector-excel/messages
+ {;; Lifecycle
+  :excel/connect-success   "Connected to Excel source: {url}"
+  :excel/close-success     "Closed Excel handle: {handle}"
+  :excel/handle-not-found  "Excel handle not found: {handle}"
+
+  ;; Config validation
+  :excel/url-required      ":excel/url is required"
+  :excel/sheet-required    ":excel/sheet-name is required"
+  :excel/columns-required  ":excel/columns mapping is required"
+
+  ;; Extract
+  :excel/download-failed   "Failed to download Excel file: {error}"
+  :excel/parse-failed      "Failed to parse Excel file: {error}"
+  :excel/sheet-not-found   "Sheet not found: {sheet}"}}

--- a/components/connector-excel/src/ai/miniforge/data_foundry/connector_excel/core.clj
+++ b/components/connector-excel/src/ai/miniforge/data_foundry/connector_excel/core.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.data-foundry.connector-excel.core
+  "ExcelConnector defrecord — thin protocol wrapper delegating to impl."
+  (:require [ai.miniforge.data-foundry.connector.protocol :as proto]
+            [ai.miniforge.data-foundry.connector-excel.impl :as impl]))
+
+(defrecord ExcelConnector []
+  proto/Connector
+  (connect    [_ config auth]                      (impl/do-connect config auth))
+  (close      [_ handle]                           (impl/do-close handle))
+
+  proto/SourceConnector
+  (discover   [_ handle _opts]                     (impl/do-discover handle))
+  (extract    [_ handle _schema-name opts]         (impl/do-extract handle opts))
+  (checkpoint [_ _handle _connector-id cursor]     (impl/do-checkpoint cursor)))

--- a/components/connector-excel/src/ai/miniforge/data_foundry/connector_excel/impl.clj
+++ b/components/connector-excel/src/ai/miniforge/data_foundry/connector_excel/impl.clj
@@ -1,0 +1,170 @@
+(ns ai.miniforge.data-foundry.connector-excel.impl
+  "Implementation functions for the Excel connector.
+   Downloads a remote Excel file and extracts records using column mappings."
+  (:require [ai.miniforge.data-foundry.connector.handles :as h]
+            [ai.miniforge.data-foundry.connector.result :as result]
+            [ai.miniforge.data-foundry.connector-excel.messages :as msg]
+            [ai.miniforge.schema.interface :as schema]
+            [hato.client :as hc])
+  (:import [java.io File FileOutputStream]
+           [java.util UUID]
+           [org.apache.poi.ss.usermodel WorkbookFactory Cell CellType DateUtil]))
+
+;; -- Handle state --
+
+(def ^:private handles (h/create))
+
+(defn get-handle [handle] (h/get-handle handles handle))
+(defn store-handle! [handle state] (h/store-handle! handles handle state))
+(defn remove-handle! [handle] (h/remove-handle! handles handle))
+
+;; -- Excel parsing --
+
+(defn- cell-value
+  "Extract a typed value from a POI Cell."
+  [^Cell cell]
+  (when cell
+    (case (.name (.getCellType cell))
+      "NUMERIC" (if (DateUtil/isCellDateFormatted cell)
+                  (.getDateCellValue cell)
+                  (.getNumericCellValue cell))
+      "STRING"  (.getStringCellValue cell)
+      "BOOLEAN" (.getBooleanCellValue cell)
+      "BLANK"   nil
+      "FORMULA" (try (.getNumericCellValue cell)
+                     (catch Exception _ (.getStringCellValue cell)))
+      nil)))
+
+(defn- row-to-record
+  "Extract a record map from a POI Row using column index→keyword mapping."
+  [row columns]
+  (when row
+    (reduce-kv
+     (fn [m col-idx field-key]
+       (let [cell (.getCell row col-idx)
+             v    (cell-value cell)]
+         (if (some? v)
+           (assoc m field-key v)
+           m)))
+     {}
+     columns)))
+
+(defn parse-sheet
+  "Parse an Excel sheet into records using column mapping.
+   columns: map of column-index (int) to keyword field name.
+   data-start-row: 0-indexed row to start reading data from.
+   row-filter: optional predicate fn applied to raw row map."
+  [workbook sheet-name columns data-start-row row-filter]
+  (if-let [sheet (.getSheet workbook sheet-name)]
+    (let [last-row (.getLastRowNum sheet)]
+      (loop [row-idx data-start-row
+             records (transient [])]
+        (if (> row-idx last-row)
+          (persistent! records)
+          (let [record (row-to-record (.getRow sheet row-idx) columns)]
+            (recur (inc row-idx)
+                   (if (and record
+                            (seq record)
+                            (or (nil? row-filter) (row-filter record)))
+                     (conj! records record)
+                     records))))))
+    (throw (ex-info (msg/t :excel/sheet-not-found {:sheet sheet-name})
+                    {:sheet sheet-name}))))
+
+;; -- Filtering --
+
+(defn- min-value-filter
+  "Create a filter that keeps records where :date >= min-val."
+  [min-val]
+  (fn [record]
+    (let [v (:date record)]
+      (and (number? v) (>= v min-val)))))
+
+;; -- Record normalization --
+
+(defn- decimal-year-to-iso
+  "Convert a decimal year (e.g. 2026.03) to ISO date string (2026-03-01)."
+  [d]
+  (let [year  (int d)
+        month (Math/round (* (- d year) 100.0))]
+    (format "%d-%02d-01" year (max 1 month))))
+
+(defn- normalize-record
+  "Normalize a record: convert decimal-year dates, enrich with series-id."
+  [date-fmt series-id record]
+  (cond-> record
+    (and (= date-fmt :decimal-year) (number? (:date record)))
+    (assoc :date (decimal-year-to-iso (:date record)))
+    series-id
+    (assoc :series_id series-id)))
+
+;; -- Download --
+
+(defn- download-to-temp
+  "Download a URL to a temporary file. Returns the File."
+  [url]
+  (let [resp (hc/get url {:as               :byte-array
+                          :headers           {"User-Agent" "Mozilla/5.0"}
+                          :throw-exceptions  false})
+        status (:status resp)]
+    (when-not (<= 200 status 299)
+      (throw (ex-info (msg/t :excel/download-failed {:error (str "HTTP " status)})
+                      {:status status})))
+    (let [tmp (File/createTempFile "connector-excel-" ".xls")]
+      (.deleteOnExit tmp)
+      (with-open [out (FileOutputStream. tmp)]
+        (.write out ^bytes (:body resp)))
+      tmp)))
+
+;; -- Lifecycle --
+
+(defn do-connect
+  "Validate config, download file, register handle."
+  [config _auth]
+  (let [url        (:excel/url config)
+        sheet-name (:excel/sheet-name config)
+        columns    (:excel/columns config)]
+    (cond
+      (nil? url)        (throw (ex-info (msg/t :excel/url-required) {:config config}))
+      (nil? sheet-name) (throw (ex-info (msg/t :excel/sheet-required) {:config config}))
+      (nil? columns)    (throw (ex-info (msg/t :excel/columns-required) {:config config}))
+      :else
+      (let [handle (str (UUID/randomUUID))
+            tmp-file (download-to-temp url)
+            workbook (WorkbookFactory/create tmp-file)]
+        (store-handle! handle {:config   config
+                               :workbook workbook
+                               :tmp-file tmp-file})
+        (result/connect-result handle)))))
+
+(defn do-close [handle]
+  (when-let [{:keys [workbook tmp-file]} (get-handle handle)]
+    (try (.close workbook) (catch Exception _))
+    (try (.delete ^File tmp-file) (catch Exception _)))
+  (remove-handle! handle)
+  (result/close-result))
+
+;; -- Source --
+
+(defn do-discover [handle]
+  (if-let [{:keys [config]} (get-handle handle)]
+    (result/discover-result [{:schema/name    (:excel/sheet-name config)
+                              :schema/url     (:excel/url config)}])
+    (throw (ex-info (msg/t :excel/handle-not-found {:handle handle}) {:handle handle}))))
+
+(defn do-extract
+  "Parse the Excel sheet and return records."
+  [handle _opts]
+  (if-let [{:keys [config workbook]} (get-handle handle)]
+    (let [{:excel/keys [sheet-name columns data-start-row series-id]} config
+          filter-fn (when-let [min-val (:excel/min-value config)]
+                      (min-value-filter min-val))
+          records   (parse-sheet workbook sheet-name columns
+                                 (or data-start-row 0) filter-fn)
+          date-fmt  (:excel/date-format config)
+          enriched  (mapv (partial normalize-record date-fmt series-id) records)]
+      (result/extract-result enriched nil false))
+    (throw (ex-info (msg/t :excel/handle-not-found {:handle handle}) {:handle handle}))))
+
+(defn do-checkpoint [cursor-state]
+  (result/checkpoint-result cursor-state))

--- a/components/connector-excel/src/ai/miniforge/data_foundry/connector_excel/interface.clj
+++ b/components/connector-excel/src/ai/miniforge/data_foundry/connector_excel/interface.clj
@@ -1,0 +1,17 @@
+(ns ai.miniforge.data-foundry.connector-excel.interface
+  "Public API for the Excel connector component."
+  (:require [ai.miniforge.data-foundry.connector-excel.core :as core]))
+
+(defn create-excel-connector
+  "Create a new ExcelConnector instance."
+  []
+  (core/->ExcelConnector))
+
+(def connector-metadata
+  "Registration metadata for the Excel connector."
+  {:connector/name         "Excel File Connector"
+   :connector/type         :source
+   :connector/version      "0.1.0"
+   :connector/capabilities #{:cap/batch}
+   :connector/auth-methods #{:none}
+   :connector/maintainer   "data-foundry"})

--- a/components/connector-excel/src/ai/miniforge/data_foundry/connector_excel/messages.clj
+++ b/components/connector-excel/src/ai/miniforge/data_foundry/connector_excel/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.connector-excel.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/connector-excel/messages/en-US.edn" :connector-excel/messages))

--- a/components/connector-excel/test/ai/miniforge/data_foundry/connector_excel/interface_test.clj
+++ b/components/connector-excel/test/ai/miniforge/data_foundry/connector_excel/interface_test.clj
@@ -1,0 +1,108 @@
+(ns ai.miniforge.data-foundry.connector-excel.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector-excel.impl :as impl]))
+
+(deftest cell-value-nil-test
+  (testing "nil cell returns nil"
+    (is (nil? (#'impl/cell-value nil)))))
+
+(deftest parse-sheet-column-mapping-test
+  (testing "parse-sheet extracts records with column mapping"
+    ;; Create an in-memory workbook to test against
+    (let [wb   (org.apache.poi.xssf.usermodel.XSSFWorkbook.)
+          sheet (.createSheet wb "TestSheet")
+          row0  (.createRow sheet 0)]
+      ;; Header row (skipped by data-start-row)
+      (-> (.createCell row0 0) (.setCellValue "Date"))
+      (-> (.createCell row0 1) (.setCellValue "Value"))
+      ;; Data rows
+      (let [row1 (.createRow sheet 1)]
+        (-> (.createCell row1 0) (.setCellValue 2025.01))
+        (-> (.createCell row1 1) (.setCellValue 35.5)))
+      (let [row2 (.createRow sheet 2)]
+        (-> (.createCell row2 0) (.setCellValue 2025.02))
+        (-> (.createCell row2 1) (.setCellValue 36.1)))
+
+      (let [records (impl/parse-sheet wb "TestSheet" {0 :date 1 :value} 1 nil)]
+        (is (= 2 (count records)))
+        (is (= 2025.01 (:date (first records))))
+        (is (= 35.5 (:value (first records))))
+        (is (= 36.1 (:value (second records)))))
+      (.close wb))))
+
+(deftest parse-sheet-with-filter-test
+  (testing "parse-sheet applies row filter"
+    (let [wb    (org.apache.poi.xssf.usermodel.XSSFWorkbook.)
+          sheet (.createSheet wb "Filtered")]
+      (let [r (.createRow sheet 0)]
+        (-> (.createCell r 0) (.setCellValue 2019.12))
+        (-> (.createCell r 1) (.setCellValue 30.0)))
+      (let [r (.createRow sheet 1)]
+        (-> (.createCell r 0) (.setCellValue 2020.01))
+        (-> (.createCell r 1) (.setCellValue 31.0)))
+      (let [r (.createRow sheet 2)]
+        (-> (.createCell r 0) (.setCellValue 2021.06))
+        (-> (.createCell r 1) (.setCellValue 38.0)))
+
+      (let [records (impl/parse-sheet wb "Filtered" {0 :date 1 :value} 0
+                                       (fn [rec] (>= (:date rec) 2020.0)))]
+        (is (= 2 (count records)))
+        (is (= 2020.01 (:date (first records)))))
+      (.close wb))))
+
+(deftest parse-sheet-missing-sheet-test
+  (testing "parse-sheet throws on missing sheet"
+    (let [wb (org.apache.poi.xssf.usermodel.XSSFWorkbook.)]
+      (.createSheet wb "Other")
+      (is (thrown? Exception (impl/parse-sheet wb "Missing" {0 :x} 0 nil)))
+      (.close wb))))
+
+(deftest extract-enriches-series-id-test
+  (testing "do-extract enriches records with series-id"
+    (let [wb    (org.apache.poi.xssf.usermodel.XSSFWorkbook.)
+          sheet (.createSheet wb "Data")]
+      (let [r (.createRow sheet 0)]
+        (-> (.createCell r 0) (.setCellValue 2025.01))
+        (-> (.createCell r 1) (.setCellValue 42.0)))
+
+      (let [handle (str (java.util.UUID/randomUUID))]
+        (impl/store-handle! handle {:config   {:excel/sheet-name "Data"
+                                               :excel/columns    {0 :date 1 :value}
+                                               :excel/data-start-row 0
+                                               :excel/series-id  "TEST_SERIES"}
+                                    :workbook wb
+                                    :tmp-file nil})
+        (let [result (impl/do-extract handle {})]
+          (is (= 1 (count (:records result))))
+          (is (= "TEST_SERIES" (:series_id (first (:records result))))))
+        (impl/remove-handle! handle))
+      (.close wb))))
+
+(deftest extract-decimal-year-date-format-test
+  (testing "do-extract normalizes decimal-year dates to ISO"
+    (let [wb    (org.apache.poi.xssf.usermodel.XSSFWorkbook.)
+          sheet (.createSheet wb "Data")]
+      (let [r (.createRow sheet 0)]
+        (-> (.createCell r 0) (.setCellValue 2026.03))
+        (-> (.createCell r 1) (.setCellValue 37.5)))
+
+      (let [handle (str (java.util.UUID/randomUUID))]
+        (impl/store-handle! handle {:config   {:excel/sheet-name  "Data"
+                                               :excel/columns     {0 :date 1 :value}
+                                               :excel/data-start-row 0
+                                               :excel/date-format :decimal-year
+                                               :excel/series-id   "CAPE10"}
+                                    :workbook wb
+                                    :tmp-file nil})
+        (let [result (impl/do-extract handle {})
+              rec    (first (:records result))]
+          (is (= "2026-03-01" (:date rec)))
+          (is (= "CAPE10" (:series_id rec))))
+        (impl/remove-handle! handle))
+      (.close wb))))
+
+(deftest connect-validates-config-test
+  (testing "do-connect requires url, sheet-name, columns"
+    (is (thrown? Exception (impl/do-connect {} nil)))
+    (is (thrown? Exception (impl/do-connect {:excel/url "x"} nil)))
+    (is (thrown? Exception (impl/do-connect {:excel/url "x" :excel/sheet-name "S"} nil)))))

--- a/components/connector-file/deps.edn
+++ b/components/connector-file/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector {:local/root "../connector"}
+        org.clojure/data.csv      {:mvn/version "1.1.0"}
+        org.clojure/data.json     {:mvn/version "2.5.1"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector-file/resources/config/connector-file/messages/en-US.edn
+++ b/components/connector-file/resources/config/connector-file/messages/en-US.edn
@@ -1,0 +1,16 @@
+{:connector-file/messages
+ {;; Lifecycle
+  :file/connect-success    "Connected to file: {path}"
+  :file/close-success      "Closed file handle: {handle}"
+  :file/handle-not-found   "File handle not found: {handle}"
+
+  ;; Extract
+  :file/path-required      ":file/path is required"
+  :file/format-required    ":file/format is required"
+  :file/format-unsupported "Unsupported file format: {format}. Must be one of: csv, json, edn"
+  :file/not-found          "File not found: {path}"
+  :file/read-error         "Error reading file {path}: {error}"
+
+  ;; Publish
+  :file/write-error        "Error writing file {path}: {error}"
+  :file/publish-success    "Published {count} records to {path}"}}

--- a/components/connector-file/src/ai/miniforge/data_foundry/connector_file/core.clj
+++ b/components/connector-file/src/ai/miniforge/data_foundry/connector_file/core.clj
@@ -1,0 +1,17 @@
+(ns ai.miniforge.data-foundry.connector-file.core
+  "FileConnector defrecord — thin protocol wrapper delegating to impl."
+  (:require [ai.miniforge.data-foundry.connector.protocol :as proto]
+            [ai.miniforge.data-foundry.connector-file.impl :as impl]))
+
+(defrecord FileConnector []
+  proto/Connector
+  (connect    [_ config _auth]                  (impl/do-connect config))
+  (close      [_ handle]                        (impl/do-close handle))
+
+  proto/SourceConnector
+  (discover   [_ handle _opts]                  (impl/do-discover handle))
+  (extract    [_ handle _schema-name opts]      (impl/do-extract handle opts))
+  (checkpoint [_ _handle _connector-id cursor]  (impl/do-checkpoint cursor))
+
+  proto/SinkConnector
+  (publish    [_ handle _schema-name records opts] (impl/do-publish handle records opts)))

--- a/components/connector-file/src/ai/miniforge/data_foundry/connector_file/impl.clj
+++ b/components/connector-file/src/ai/miniforge/data_foundry/connector_file/impl.clj
@@ -1,0 +1,87 @@
+(ns ai.miniforge.data-foundry.connector-file.impl
+  "Implementation functions for the file connector.
+   Pure logic separated from protocol wiring."
+  (:require [ai.miniforge.data-foundry.connector.handles :as h]
+            [ai.miniforge.data-foundry.connector.result :as result]
+            [ai.miniforge.data-foundry.connector-file.reader :as reader]
+            [ai.miniforge.data-foundry.connector-file.writer :as writer]
+            [ai.miniforge.data-foundry.connector-file.messages :as msg]
+            [clojure.java.io :as io])
+  (:import [java.util UUID]))
+
+(def supported-formats #{:csv :json :edn})
+
+(def ^:private handles (h/create))
+
+(defn get-handle [handle] (h/get-handle handles handle))
+(defn store-handle! [handle state] (h/store-handle! handles handle state))
+(defn remove-handle! [handle] (h/remove-handle! handles handle))
+
+;; -- Lifecycle --
+
+(defn do-connect
+  "Validate config and register a handle. Returns connect-result map."
+  [config]
+  (let [path (:file/path config)
+        fmt  (:file/format config)]
+    (cond
+      (nil? path) (throw (ex-info (msg/t :file/path-required) {:config config}))
+      (nil? fmt)  (throw (ex-info (msg/t :file/format-required) {:config config}))
+      (not (contains? supported-formats fmt))
+      (throw (ex-info (msg/t :file/format-unsupported {:format fmt}) {:format fmt}))
+
+      :else
+      (let [handle (str (UUID/randomUUID))]
+        (store-handle! handle {:file/path path :file/format fmt})
+        (result/connect-result handle)))))
+
+(defn do-close
+  "Remove handle and return close-result map."
+  [handle]
+  (remove-handle! handle)
+  (result/close-result))
+
+;; -- Source --
+
+(defn do-discover
+  "Return schema metadata for the connected file."
+  [handle]
+  (if-let [{:file/keys [path]} (get-handle handle)]
+    (result/discover-result [{:schema/name (.getName (io/file path))
+                              :schema/path path}])
+    (throw (ex-info (msg/t :file/handle-not-found {:handle handle}) {:handle handle}))))
+
+(defn do-extract
+  "Read records from file with offset-based cursor pagination."
+  [handle opts]
+  (if-let [{:file/keys [path format]} (get-handle handle)]
+    (let [file (io/file path)]
+      (when-not (.exists file)
+        (throw (ex-info (msg/t :file/not-found {:path path}) {:path path})))
+      (let [all-records (reader/read-file path format)
+            batch-size  (or (:extract/batch-size opts) (count all-records))
+            offset      (or (get-in opts [:extract/cursor :cursor/value]) 0)
+            batch       (vec (take batch-size (drop offset all-records)))
+            new-offset  (+ offset (count batch))
+            has-more    (< new-offset (count all-records))]
+        (result/extract-result
+         batch
+         {:cursor/type :offset :cursor/value new-offset}
+         has-more)))
+    (throw (ex-info (msg/t :file/handle-not-found {:handle handle}) {:handle handle}))))
+
+(defn do-checkpoint
+  "Persist cursor state (no-op for files, returns committed)."
+  [cursor-state]
+  (result/checkpoint-result cursor-state))
+
+;; -- Sink --
+
+(defn do-publish
+  "Write records to file. Returns publish-result map."
+  [handle records opts]
+  (if-let [{:file/keys [path format]} (get-handle handle)]
+    (let [mode    (or (:publish/mode opts) :overwrite)
+          written (writer/write-file path records format mode)]
+      (result/publish-result written 0))
+    (throw (ex-info (msg/t :file/handle-not-found {:handle handle}) {:handle handle}))))

--- a/components/connector-file/src/ai/miniforge/data_foundry/connector_file/interface.clj
+++ b/components/connector-file/src/ai/miniforge/data_foundry/connector_file/interface.clj
@@ -1,0 +1,18 @@
+(ns ai.miniforge.data-foundry.connector-file.interface
+  "Public API for the file connector component."
+  (:require [ai.miniforge.data-foundry.connector-file.core :as core]))
+
+(defn create-file-connector
+  "Create a new FileConnector instance."
+  []
+  (core/->FileConnector))
+
+(def connector-metadata
+  "Registration metadata for the file connector."
+  {:connector/name         "File Connector"
+   :connector/type         :bidirectional
+   :connector/version      "0.1.0"
+   :connector/capabilities #{:cap/batch}
+   :connector/auth-methods #{:none}
+   :connector/retry-policy {:retry/strategy :none :retry/max-attempts 1}
+   :connector/maintainer   "data-foundry"})

--- a/components/connector-file/src/ai/miniforge/data_foundry/connector_file/messages.clj
+++ b/components/connector-file/src/ai/miniforge/data_foundry/connector_file/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.connector-file.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/connector-file/messages/en-US.edn" :connector-file/messages))

--- a/components/connector-file/src/ai/miniforge/data_foundry/connector_file/reader.clj
+++ b/components/connector-file/src/ai/miniforge/data_foundry/connector_file/reader.clj
@@ -1,0 +1,36 @@
+(ns ai.miniforge.data-foundry.connector-file.reader
+  "File reading for CSV, JSON, and EDN formats."
+  (:require [clojure.data.csv :as csv]
+            [clojure.data.json :as json]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+(defn read-csv
+  "Read CSV file, returning vector of maps keyed by header row."
+  [path]
+  (with-open [rdr (io/reader path)]
+    (let [data (csv/read-csv rdr)
+          headers (map keyword (first data))
+          rows (rest data)]
+      (mapv #(zipmap headers %) rows))))
+
+(defn read-json
+  "Read JSON file, returning vector of maps."
+  [path]
+  (with-open [rdr (io/reader path)]
+    (let [data (json/read rdr :key-fn keyword)]
+      (if (vector? data) data [data]))))
+
+(defn read-edn
+  "Read EDN file, returning vector of maps."
+  [path]
+  (let [data (edn/read-string (slurp path))]
+    (if (vector? data) data [data])))
+
+(defn read-file
+  "Read file in the given format. Returns vector of record maps."
+  [path format]
+  (case format
+    :csv  (read-csv path)
+    :json (read-json path)
+    :edn  (read-edn path)))

--- a/components/connector-file/src/ai/miniforge/data_foundry/connector_file/writer.clj
+++ b/components/connector-file/src/ai/miniforge/data_foundry/connector_file/writer.clj
@@ -1,0 +1,37 @@
+(ns ai.miniforge.data-foundry.connector-file.writer
+  "File writing for JSON and EDN formats."
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]))
+
+(defn write-json
+  "Write records as JSON array to file."
+  [path records mode]
+  (let [existing (when (and (= mode :append) (.exists (io/file path)))
+                   (with-open [rdr (io/reader path)]
+                     (json/read rdr :key-fn keyword)))
+        all-records (if existing
+                      (into (vec existing) records)
+                      (vec records))]
+    (io/make-parents path)
+    (with-open [wtr (io/writer path)]
+      (json/write all-records wtr))
+    (count records)))
+
+(defn write-edn
+  "Write records as EDN vector to file."
+  [path records mode]
+  (let [existing (when (and (= mode :append) (.exists (io/file path)))
+                   (read-string (slurp path)))
+        all-records (if existing
+                      (into (vec existing) records)
+                      (vec records))]
+    (io/make-parents path)
+    (spit path (pr-str all-records))
+    (count records)))
+
+(defn write-file
+  "Write records to file in the given format. Returns count written."
+  [path records format mode]
+  (case format
+    :json (write-json path records mode)
+    :edn  (write-edn path records mode)))

--- a/components/connector-file/test/ai/miniforge/data_foundry/connector_file/interface_test.clj
+++ b/components/connector-file/test/ai/miniforge/data_foundry/connector_file/interface_test.clj
@@ -1,0 +1,261 @@
+(ns ai.miniforge.data-foundry.connector-file.interface-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.java.io :as io]
+            [clojure.data.json :as json]
+            [ai.miniforge.data-foundry.connector-file.interface :as file-conn]
+            [ai.miniforge.data-foundry.connector.interface :as conn]))
+
+;; ---------------------------------------------------------------------------
+;; Test fixtures — temp directory with sample files
+;; ---------------------------------------------------------------------------
+
+(def ^:private test-dir "target/test-connector-file")
+
+(def ^:private csv-content "id,name,value\n1,alpha,100\n2,beta,200\n3,gamma,300\n4,delta,400\n5,epsilon,500\n")
+
+(def ^:private json-content
+  [{:id 1 :name "alpha" :value 100}
+   {:id 2 :name "beta"  :value 200}
+   {:id 3 :name "gamma" :value 300}])
+
+(def ^:private edn-content
+  [{:id 1 :name "alpha" :value 100}
+   {:id 2 :name "beta"  :value 200}])
+
+(defn- setup-test-files []
+  (.mkdirs (io/file test-dir))
+  (spit (str test-dir "/test.csv") csv-content)
+  (with-open [wtr (io/writer (str test-dir "/test.json"))]
+    (json/write json-content wtr))
+  (spit (str test-dir "/test.edn") (pr-str edn-content)))
+
+(defn- cleanup-test-files []
+  (doseq [f (.listFiles (io/file test-dir))]
+    (.delete f))
+  (.delete (io/file test-dir)))
+
+(use-fixtures :each
+  (fn [f]
+    (setup-test-files)
+    (try (f) (finally (cleanup-test-files)))))
+
+;; ---------------------------------------------------------------------------
+;; Connector metadata
+;; ---------------------------------------------------------------------------
+
+(deftest connector-metadata-test
+  (testing "File connector metadata"
+    (let [meta file-conn/connector-metadata]
+      (is (= :bidirectional (:connector/type meta)))
+      (is (= #{:cap/batch} (:connector/capabilities meta)))
+      (is (= #{:none} (:connector/auth-methods meta))))))
+
+;; ---------------------------------------------------------------------------
+;; Connect / close lifecycle
+;; ---------------------------------------------------------------------------
+
+(deftest connect-close-lifecycle-test
+  (testing "Connect and close lifecycle"
+    (let [fc (file-conn/create-file-connector)
+          connect-result (conn/connect fc {:file/path (str test-dir "/test.csv")
+                                           :file/format :csv} {})]
+      (is (= :connected (:connector/status connect-result)))
+      (is (string? (:connection/handle connect-result)))
+      (let [close-result (conn/close fc (:connection/handle connect-result))]
+        (is (= :closed (:connector/status close-result)))))))
+
+(deftest connect-missing-path-test
+  (testing "Connect fails without :file/path"
+    (let [fc (file-conn/create-file-connector)]
+      (is (thrown? Exception (conn/connect fc {:file/format :csv} {}))))))
+
+(deftest connect-missing-format-test
+  (testing "Connect fails without :file/format"
+    (let [fc (file-conn/create-file-connector)]
+      (is (thrown? Exception (conn/connect fc {:file/path "foo.csv"} {}))))))
+
+(deftest connect-unsupported-format-test
+  (testing "Connect fails with unsupported format"
+    (let [fc (file-conn/create-file-connector)]
+      (is (thrown? Exception (conn/connect fc {:file/path "foo.xml"
+                                               :file/format :xml} {}))))))
+
+;; ---------------------------------------------------------------------------
+;; Extract — CSV
+;; ---------------------------------------------------------------------------
+
+(deftest extract-csv-all-test
+  (testing "Extract all records from CSV"
+    (let [fc (file-conn/create-file-connector)
+          handle (:connection/handle
+                  (conn/connect fc {:file/path (str test-dir "/test.csv")
+                                    :file/format :csv} {}))
+          result (conn/extract fc handle "test" {})]
+      (is (= 5 (:extract/row-count result)))
+      (is (= 5 (count (:records result))))
+      (is (false? (:extract/has-more result)))
+      (is (= "1" (:id (first (:records result)))))
+      (conn/close fc handle))))
+
+(deftest extract-csv-pagination-test
+  (testing "Extract with batch pagination"
+    (let [fc (file-conn/create-file-connector)
+          handle (:connection/handle
+                  (conn/connect fc {:file/path (str test-dir "/test.csv")
+                                    :file/format :csv} {}))
+          ;; First batch of 2
+          r1 (conn/extract fc handle "test" {:extract/batch-size 2})
+          _ (is (= 2 (:extract/row-count r1)))
+          _ (is (true? (:extract/has-more r1)))
+          _ (is (= 2 (get-in r1 [:extract/cursor :cursor/value])))
+
+          ;; Second batch of 2 using cursor
+          r2 (conn/extract fc handle "test" {:extract/batch-size 2
+                                              :extract/cursor (:extract/cursor r1)})
+          _ (is (= 2 (:extract/row-count r2)))
+          _ (is (true? (:extract/has-more r2)))
+
+          ;; Third batch — remainder
+          r3 (conn/extract fc handle "test" {:extract/batch-size 2
+                                              :extract/cursor (:extract/cursor r2)})]
+      (is (= 1 (:extract/row-count r3)))
+      (is (false? (:extract/has-more r3)))
+      (conn/close fc handle))))
+
+;; ---------------------------------------------------------------------------
+;; Extract — JSON
+;; ---------------------------------------------------------------------------
+
+(deftest extract-json-test
+  (testing "Extract all records from JSON"
+    (let [fc (file-conn/create-file-connector)
+          handle (:connection/handle
+                  (conn/connect fc {:file/path (str test-dir "/test.json")
+                                    :file/format :json} {}))
+          result (conn/extract fc handle "test" {})]
+      (is (= 3 (:extract/row-count result)))
+      (is (= 1 (:id (first (:records result)))))
+      (conn/close fc handle))))
+
+;; ---------------------------------------------------------------------------
+;; Extract — EDN
+;; ---------------------------------------------------------------------------
+
+(deftest extract-edn-test
+  (testing "Extract all records from EDN"
+    (let [fc (file-conn/create-file-connector)
+          handle (:connection/handle
+                  (conn/connect fc {:file/path (str test-dir "/test.edn")
+                                    :file/format :edn} {}))
+          result (conn/extract fc handle "test" {})]
+      (is (= 2 (:extract/row-count result)))
+      (is (= "alpha" (:name (first (:records result)))))
+      (conn/close fc handle))))
+
+;; ---------------------------------------------------------------------------
+;; Extract — file not found
+;; ---------------------------------------------------------------------------
+
+(deftest extract-file-not-found-test
+  (testing "Extract fails when file does not exist"
+    (let [fc (file-conn/create-file-connector)
+          handle (:connection/handle
+                  (conn/connect fc {:file/path (str test-dir "/nonexistent.csv")
+                                    :file/format :csv} {}))]
+      (is (thrown? Exception (conn/extract fc handle "test" {})))
+      (conn/close fc handle))))
+
+;; ---------------------------------------------------------------------------
+;; Publish — JSON overwrite
+;; ---------------------------------------------------------------------------
+
+(deftest publish-json-overwrite-test
+  (testing "Publish records to JSON file (overwrite mode)"
+    (let [fc (file-conn/create-file-connector)
+          out-path (str test-dir "/output.json")
+          handle (:connection/handle
+                  (conn/connect fc {:file/path out-path
+                                    :file/format :json} {}))
+          records [{:id 10 :name "x"} {:id 20 :name "y"}]
+          result (conn/publish fc handle "out" records {:publish/mode :overwrite})]
+      (is (= 2 (:publish/records-written result)))
+      (is (= 0 (:publish/records-failed result)))
+      ;; Verify file contents
+      (let [written (with-open [rdr (io/reader out-path)]
+                      (json/read rdr :key-fn keyword))]
+        (is (= 2 (count written)))
+        (is (= 10 (:id (first written)))))
+      (conn/close fc handle))))
+
+;; ---------------------------------------------------------------------------
+;; Publish — JSON append
+;; ---------------------------------------------------------------------------
+
+(deftest publish-json-append-test
+  (testing "Publish records to JSON file (append mode)"
+    (let [fc (file-conn/create-file-connector)
+          out-path (str test-dir "/append.json")
+          ;; First write
+          h1 (:connection/handle
+              (conn/connect fc {:file/path out-path :file/format :json} {}))
+          _ (conn/publish fc h1 "out" [{:id 1}] {:publish/mode :overwrite})
+          _ (conn/close fc h1)
+          ;; Append
+          h2 (:connection/handle
+              (conn/connect fc {:file/path out-path :file/format :json} {}))
+          result (conn/publish fc h2 "out" [{:id 2}] {:publish/mode :append})]
+      (is (= 1 (:publish/records-written result)))
+      ;; Verify both records present
+      (let [written (with-open [rdr (io/reader out-path)]
+                      (json/read rdr :key-fn keyword))]
+        (is (= 2 (count written))))
+      (conn/close fc h2))))
+
+;; ---------------------------------------------------------------------------
+;; Publish — EDN
+;; ---------------------------------------------------------------------------
+
+(deftest publish-edn-test
+  (testing "Publish records to EDN file"
+    (let [fc (file-conn/create-file-connector)
+          out-path (str test-dir "/output.edn")
+          handle (:connection/handle
+                  (conn/connect fc {:file/path out-path
+                                    :file/format :edn} {}))
+          records [{:id 1 :val "a"} {:id 2 :val "b"}]
+          result (conn/publish fc handle "out" records {:publish/mode :overwrite})]
+      (is (= 2 (:publish/records-written result)))
+      (let [written (read-string (slurp out-path))]
+        (is (= 2 (count written))))
+      (conn/close fc handle))))
+
+;; ---------------------------------------------------------------------------
+;; Discover
+;; ---------------------------------------------------------------------------
+
+(deftest discover-test
+  (testing "Discover returns schema info for connected file"
+    (let [fc (file-conn/create-file-connector)
+          handle (:connection/handle
+                  (conn/connect fc {:file/path (str test-dir "/test.csv")
+                                    :file/format :csv} {}))
+          result (conn/discover fc handle {})]
+      (is (= 1 (:discover/total-count result)))
+      (is (= "test.csv" (:schema/name (first (:schemas result)))))
+      (conn/close fc handle))))
+
+;; ---------------------------------------------------------------------------
+;; Checkpoint
+;; ---------------------------------------------------------------------------
+
+(deftest checkpoint-test
+  (testing "Checkpoint persists cursor state"
+    (let [fc (file-conn/create-file-connector)
+          handle (:connection/handle
+                  (conn/connect fc {:file/path (str test-dir "/test.csv")
+                                    :file/format :csv} {}))
+          cursor {:cursor/type :offset :cursor/value 5}
+          result (conn/checkpoint fc handle "file-conn-1" cursor)]
+      (is (= :committed (:checkpoint/status result)))
+      (is (uuid? (:checkpoint/id result)))
+      (conn/close fc handle))))

--- a/components/connector-github/deps.edn
+++ b/components/connector-github/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector      {:local/root "../connector"}
+        ai.miniforge.data-foundry/connector-auth  {:local/root "../connector-auth"}
+        ai.miniforge.data-foundry/connector-http  {:local/root "../connector-http"}
+        ai.miniforge/schema             {:local/root "../../../miniforge/components/schema"}
+        hato/hato                       {:mvn/version "1.0.0"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector-github/deps.edn
+++ b/components/connector-github/deps.edn
@@ -2,7 +2,7 @@
  :deps {ai.miniforge.data-foundry/connector      {:local/root "../connector"}
         ai.miniforge.data-foundry/connector-auth  {:local/root "../connector-auth"}
         ai.miniforge.data-foundry/connector-http  {:local/root "../connector-http"}
-        ai.miniforge/schema             {:local/root "../../../miniforge/components/schema"}
+        ai.miniforge/schema             {:local/root "../schema"}
         hato/hato                       {:mvn/version "1.0.0"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector-github/resources/config/connector-github/messages/en-US.edn
+++ b/components/connector-github/resources/config/connector-github/messages/en-US.edn
@@ -1,0 +1,19 @@
+{:connector-github/messages
+ {;; Lifecycle
+  :github/connect-success    "Connected to GitHub API: {base-url}"
+  :github/close-success      "Closed GitHub handle: {handle}"
+  :github/handle-not-found   "GitHub handle not found: {handle}"
+
+  ;; Config validation
+  :github/owner-or-org-required  "Either :github/org or :github/owner is required"
+  :github/auth-required          "Auth config is required for GitHub API"
+  :github/auth-invalid           "Auth validation failed: {errors}"
+  :github/config-invalid         "GitHub config validation failed: {errors}"
+
+  ;; Resources
+  :github/resources-not-found "GitHub resource definitions not found: {path}"
+
+  ;; Extract
+  :github/request-failed     "GitHub API request failed: {status} {error}"
+  :github/rate-limited       "Rate limited by GitHub API (429)"
+  :github/resource-unknown   "Unknown GitHub resource type: {resource}"}}

--- a/components/connector-github/resources/config/connector-github/resources.edn
+++ b/components/connector-github/resources/config/connector-github/resources.edn
@@ -1,0 +1,34 @@
+{:repos    {:endpoint            "/orgs/{org}/repos"
+           :user-endpoint       "/users/{owner}/repos"
+           :sort-param          "updated"
+           :direction-param     "desc"
+           :per-page            100
+           :incremental-param   "since"
+           :cursor-type         :timestamp-watermark}
+ :issues   {:endpoint            "/repos/{owner}/{repo}/issues"
+            :sort-param          "updated"
+            :direction-param     "desc"
+            :per-page            100
+            :incremental-param   "since"
+            :cursor-type         :timestamp-watermark
+            :query-params        {:state "all"}}
+ :pulls    {:endpoint            "/repos/{owner}/{repo}/pulls"
+            :sort-param          "updated"
+            :direction-param     "desc"
+            :per-page            100
+            :incremental-param   "since"
+            :cursor-type         :timestamp-watermark
+            :query-params        {:state "all"}}
+ :reviews  {:endpoint            "/repos/{owner}/{repo}/pulls/{pull_number}/reviews"
+            :per-page            100
+            :cursor-type         :offset}
+ :commits  {:endpoint            "/repos/{owner}/{repo}/commits"
+            :per-page            100
+            :incremental-param   "since"
+            :cursor-type         :timestamp-watermark}
+ :comments {:endpoint            "/repos/{owner}/{repo}/issues/comments"
+            :sort-param          "updated"
+            :direction-param     "desc"
+            :per-page            100
+            :incremental-param   "since"
+            :cursor-type         :timestamp-watermark}}

--- a/components/connector-github/src/ai/miniforge/data_foundry/connector_github/core.clj
+++ b/components/connector-github/src/ai/miniforge/data_foundry/connector_github/core.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.data-foundry.connector-github.core
+  "GitHubConnector defrecord — thin protocol wrapper delegating to impl."
+  (:require [ai.miniforge.data-foundry.connector.protocol :as proto]
+            [ai.miniforge.data-foundry.connector-github.impl :as impl]))
+
+(defrecord GitHubConnector []
+  proto/Connector
+  (connect    [_ config auth]                      (impl/do-connect config auth))
+  (close      [_ handle]                           (impl/do-close handle))
+
+  proto/SourceConnector
+  (discover   [_ handle _opts]                     (impl/do-discover handle))
+  (extract    [_ handle schema-name opts]          (impl/do-extract handle schema-name opts))
+  (checkpoint [_ _handle _connector-id cursor]     (impl/do-checkpoint cursor)))

--- a/components/connector-github/src/ai/miniforge/data_foundry/connector_github/impl.clj
+++ b/components/connector-github/src/ai/miniforge/data_foundry/connector_github/impl.clj
@@ -1,0 +1,246 @@
+(ns ai.miniforge.data-foundry.connector-github.impl
+  "Implementation functions for the GitHub REST API connector."
+  (:require [ai.miniforge.data-foundry.connector.handles :as h]
+            [ai.miniforge.data-foundry.connector.result :as result]
+            [ai.miniforge.data-foundry.connector-auth.core :as auth]
+            [ai.miniforge.data-foundry.connector-github.messages :as msg]
+            [ai.miniforge.data-foundry.connector-github.resources :as resources]
+            [ai.miniforge.data-foundry.connector-github.schema :as gh-schema]
+            [ai.miniforge.data-foundry.connector-http.cursors :as cursors]
+            [ai.miniforge.data-foundry.connector-http.rate-limit :as rate]
+            [ai.miniforge.data-foundry.connector-http.request :as request])
+  (:import [java.util UUID]))
+
+;; -- Handle state --
+
+(def ^:private handles (h/create))
+
+(defn get-handle [handle] (h/get-handle handles handle))
+(defn store-handle! [handle state] (h/store-handle! handles handle state))
+(defn remove-handle! [handle] (h/remove-handle! handles handle))
+(defn touch-handle! [handle] (h/touch-handle! handles handle))
+
+;; -- Auth --
+
+(defn- build-auth-headers
+  "Build authorization headers from auth config.
+   Supports :api-key (Bearer token) and :oauth2 (Bearer token)."
+  [{:auth/keys [method credential-id]}]
+  (case method
+    :api-key {"Authorization" (str "Bearer " credential-id)}
+    :oauth2  {"Authorization" (str "Bearer " credential-id)}
+    {}))
+
+;; -- Rate limiting --
+;; Uses response-header-driven rate limiting via connector-http/rate-limit.
+;; GitHub returns x-ratelimit-remaining and x-ratelimit-reset on every response.
+
+(def ^:private github-rate-headers
+  {:remaining "x-ratelimit-remaining"
+   :reset     "x-ratelimit-reset"
+   :limit     "x-ratelimit-limit"})
+
+(defn- update-rate-limits!
+  "Parse rate limit headers from a response and store in handle state."
+  [handle response-headers]
+  (when-let [info (rate/parse-rate-headers response-headers github-rate-headers)]
+    (rate/update-rate-state! handles handle info)))
+
+;; -- Record filters --
+
+(defn- issue-not-pr?
+  "Predicate: true if a GitHub issue record is NOT a pull request.
+   GitHub's /issues endpoint returns PRs mixed in — they have a :pull_request key."
+  [record]
+  (nil? (:pull_request record)))
+
+(defn- filter-issues
+  "Filter PRs from issues endpoint results. Only applied to :issues resource."
+  [resource-key records]
+  (if (= :issues resource-key)
+    (filterv issue-not-pr? records)
+    records))
+
+;; -- HTTP helpers --
+
+(defn- github-headers
+  "Merge auth headers with GitHub-required headers."
+  [auth-headers]
+  (merge auth-headers
+         {"Accept"               "application/vnd.github+json"
+          "X-GitHub-Api-Version" "2022-11-28"}))
+
+(defn- error-response
+  [status resp]
+  (request/error-response status resp
+    {:rate-limited   (msg/t :github/rate-limited)
+     :request-failed (fn [s e] (msg/t :github/request-failed {:status s :error e}))}))
+
+(defn- do-request
+  [url headers query-params]
+  (request/do-request url headers query-params error-response))
+
+(defn- response-records
+  [resource-key resp]
+  (filter-issues resource-key (request/coerce-records (:body resp))))
+
+(defn- final-cursor
+  [resource-def records]
+  (cursors/last-record-cursor resource-def records))
+
+(defn- page-fetch-result
+  [records cursor]
+  {:records records
+   :cursor  cursor})
+
+(defn- timestamp-value
+  "Extract the most recent timestamp from a record.
+   Reviews use :submitted_at; other resources use :updated_at/:created_at."
+  [record]
+  (or (:updated_at record)
+      (:created_at record)
+      (:submitted_at record)))
+
+(defn- fetch-all-pages
+  [handle resource-key resource-def headers url query-params]
+  (loop [next-request-url url
+         next-query-params query-params
+         accumulated []]
+    (rate/acquire-permit! handles handle {})
+    (let [resp (request/throw-on-failure! (do-request next-request-url headers next-query-params))]
+      (update-rate-limits! handle (:headers resp))
+      (touch-handle! handle)
+      (if (:not-modified resp)
+        (page-fetch-result [] nil)
+        (let [page-records (response-records resource-key resp)
+              all-records  (into accumulated page-records)]
+          (if-let [next-link (request/next-url resp)]
+            (recur next-link nil all-records)
+            (page-fetch-result all-records
+                               (final-cursor resource-def all-records))))))))
+
+
+(defn- resource-records
+  [handle resource-key resource-def config headers cursor opts]
+  (let [url          (resources/build-url (:github/base-url config) resource-def config)
+        query-params (resources/build-query-params resource-def cursor opts)]
+    (:records (fetch-all-pages handle resource-key resource-def headers url query-params))))
+
+(defn- enrich-review
+  [pull review]
+  (assoc review
+         :pull_number (:number pull)
+         :pull_id (:id pull)
+         :pull_title (:title pull)
+         :pull_html_url (:html_url pull)
+         :pull_state (:state pull)))
+
+(defn- pull-review-records
+  [handle reviews-resource config headers cursor opts pull]
+  (let [review-config (assoc config :github/pull-number (:number pull))
+        records       (resource-records handle :reviews reviews-resource review-config headers nil opts)]
+    (->> records
+         (map #(enrich-review pull %))
+         (filter #(cursors/after-cursor? timestamp-value cursor %)))))
+
+(defn- extract-reviews
+  [handle config headers cursor opts]
+  (let [pulls-resource (resources/get-resource :pulls)
+        pulls          (resource-records handle :pulls pulls-resource config headers cursor opts)
+        reviews        (->> pulls
+                            (mapcat #(pull-review-records handle
+                                                          (resources/get-resource :reviews)
+                                                          config
+                                                          headers
+                                                          cursor
+                                                          opts
+                                                          %))
+                            (cursors/sort-by-timestamp timestamp-value)
+                            vec)]
+    (result/extract-result reviews (cursors/max-timestamp-cursor timestamp-value reviews) false)))
+
+;; -- Helpers --
+
+(defn- require-handle!
+  "Retrieve handle state or throw."
+  [handle]
+  (or (get-handle handle)
+      (throw (ex-info (msg/t :github/handle-not-found {:handle handle})
+                      {:handle handle}))))
+
+(defn- require-resource!
+  "Look up resource def or throw."
+  [schema-name]
+  (or (resources/get-resource (keyword schema-name))
+      (throw (ex-info (msg/t :github/resource-unknown {:resource schema-name})
+                      {:resource schema-name}))))
+
+(defn- validation-errors
+  "Extract errors from a validation result, centralizing knowledge of the :errors key."
+  [result]
+  (:errors result))
+
+(defn- validate-connect!
+  "Validate config and auth sequentially, throwing on first failure."
+  [config auth]
+  (let [config-result (gh-schema/validate-config config)
+        auth-result   (when auth (auth/validate-credential-ref auth))]
+    (cond
+      (gh-schema/invalid? config-result)
+      (let [errs (validation-errors config-result)]
+        (throw (ex-info (msg/t :github/config-invalid {:errors errs}) {:errors errs})))
+
+      (and (nil? (:github/org config)) (nil? (:github/owner config)))
+      (throw (ex-info (msg/t :github/owner-or-org-required) {:config config}))
+
+      (and auth-result (not (:success? auth-result)))
+      (let [errs (validation-errors auth-result)]
+        (throw (ex-info (msg/t :github/auth-invalid {:errors errs}) {:errors errs}))))))
+
+;; -- Lifecycle --
+(defn do-connect
+  "Validate config and auth, register handle. Returns connect-result."
+  [config auth]
+  (validate-connect! config auth)
+  (let [handle       (str (UUID/randomUUID))
+        base-url     (get config :github/base-url "https://api.github.com")
+        auth-headers (if (:auth/method auth) (build-auth-headers auth) {})]
+    (store-handle! handle {:config          (assoc config :github/base-url base-url)
+                           :auth-headers    auth-headers
+                           :last-request-at nil})
+    (result/connect-result handle)))
+
+(defn do-close
+  "Remove handle state. Returns close-result."
+  [handle]
+  (remove-handle! handle)
+  (result/close-result))
+
+;; -- Source --
+
+(defn do-discover
+  "Return available resource schemas based on config."
+  [handle]
+  (require-handle! handle)
+  (result/discover-result (resources/resource-schemas)))
+
+(defn do-extract
+  "Extract records from a GitHub API resource."
+  [handle schema-name opts]
+  (let [handle-state (require-handle! handle)
+        resource-def (require-resource! schema-name)
+        resource-key (keyword schema-name)
+        {:keys [config auth-headers]} handle-state
+        cursor       (:extract/cursor opts)
+        headers      (github-headers auth-headers)]
+    (if (= "reviews" schema-name)
+      (extract-reviews handle config headers cursor opts)
+      (let [url          (resources/build-url (:github/base-url config) resource-def config)
+            query-params (resources/build-query-params resource-def cursor opts)
+            {:keys [records cursor]} (fetch-all-pages handle resource-key resource-def headers url query-params)]
+        (result/extract-result records cursor false)))))
+
+(defn do-checkpoint
+  "Persist cursor state. Returns checkpoint-result."
+  [cursor-state]
+  (result/checkpoint-result cursor-state))

--- a/components/connector-github/src/ai/miniforge/data_foundry/connector_github/interface.clj
+++ b/components/connector-github/src/ai/miniforge/data_foundry/connector_github/interface.clj
@@ -1,0 +1,20 @@
+(ns ai.miniforge.data-foundry.connector-github.interface
+  "Public API for the GitHub REST API connector component."
+  (:require [ai.miniforge.data-foundry.connector-github.core :as core]))
+
+(defn create-github-connector
+  "Create a new GitHubConnector instance."
+  []
+  (core/->GitHubConnector))
+
+(def connector-metadata
+  "Registration metadata for the GitHub REST API connector."
+  {:connector/name         "GitHub REST API Connector"
+   :connector/type         :source
+   :connector/version      "0.1.0"
+   :connector/capabilities #{:cap/discovery :cap/incremental :cap/pagination :cap/rate-limiting}
+   :connector/auth-methods #{:api-key :oauth2}
+   :connector/retry-policy {:retry/strategy       :exponential-backoff
+                            :retry/max-attempts   3
+                            :retry/base-delay-ms  1000}
+   :connector/maintainer   "data-foundry"})

--- a/components/connector-github/src/ai/miniforge/data_foundry/connector_github/messages.clj
+++ b/components/connector-github/src/ai/miniforge/data_foundry/connector_github/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.connector-github.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/connector-github/messages/en-US.edn" :connector-github/messages))

--- a/components/connector-github/src/ai/miniforge/data_foundry/connector_github/resources.clj
+++ b/components/connector-github/src/ai/miniforge/data_foundry/connector_github/resources.clj
@@ -1,0 +1,65 @@
+(ns ai.miniforge.data-foundry.connector-github.resources
+  "GitHub resource type registry and URL/param builders.
+   Resource definitions are loaded from an EDN resource file at startup."
+  (:require [ai.miniforge.data-foundry.connector-github.messages :as msg]
+            [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+(def ^:private resource-path "config/connector-github/resources.edn")
+
+(defn- load-resources []
+  (if-let [res (io/resource resource-path)]
+    (edn/read-string (slurp res))
+    (throw (ex-info (msg/t :github/resources-not-found {:path resource-path})
+                    {:path resource-path}))))
+
+(def github-resources
+  "Registry of GitHub REST API v3 resource types, loaded from EDN."
+  (delay (load-resources)))
+
+(defn get-resource
+  "Look up a resource definition by key."
+  [resource-key]
+  (get @github-resources resource-key))
+
+(defn build-url
+  "Build a GitHub API URL by substituting {org}, {owner}, {repo}, {pull_number}
+   from config into the resource endpoint template."
+  [base-url resource-def config]
+  (let [endpoint (if (and (:user-endpoint resource-def)
+                          (not (:github/org config))
+                          (:github/owner config))
+                   (:user-endpoint resource-def)
+                   (:endpoint resource-def))]
+    (str base-url
+         (-> endpoint
+             (str/replace "{org}" (or (:github/org config) ""))
+             (str/replace "{owner}" (or (:github/owner config) ""))
+             (str/replace "{repo}" (or (:github/repo config) ""))
+             (str/replace "{pull_number}" (str (or (:github/pull-number config) "")))))))
+
+(defn build-query-params
+  "Build query params for a GitHub API request, merging resource defaults,
+   sort/direction, per_page, and incremental cursor value."
+  [resource-def cursor opts]
+  (let [base-params  (or (:query-params resource-def) {})
+        per-page     (or (:extract/batch-size opts) (:per-page resource-def) 100)
+        sort-param   (:sort-param resource-def)
+        direction    (:direction-param resource-def)
+        incr-param   (:incremental-param resource-def)
+        cursor-value (get-in cursor [:cursor/value])]
+    (cond-> (assoc base-params "per_page" per-page)
+      sort-param   (assoc "sort" sort-param)
+      direction    (assoc "direction" direction)
+      (and incr-param cursor-value)
+      (assoc incr-param cursor-value))))
+
+(defn resource-schemas
+  "Return discover-compatible schema list for all known GitHub resources."
+  []
+  (mapv (fn [[resource-key resource-def]]
+          {:schema/name     (name resource-key)
+           :schema/endpoint (:endpoint resource-def)
+           :schema/type     (:cursor-type resource-def)})
+        @github-resources))

--- a/components/connector-github/src/ai/miniforge/data_foundry/connector_github/resources.clj
+++ b/components/connector-github/src/ai/miniforge/data_foundry/connector_github/resources.clj
@@ -43,8 +43,8 @@
   "Build query params for a GitHub API request, merging resource defaults,
    sort/direction, per_page, and incremental cursor value."
   [resource-def cursor opts]
-  (let [base-params  (or (:query-params resource-def) {})
-        per-page     (or (:extract/batch-size opts) (:per-page resource-def) 100)
+  (let [base-params  (get resource-def :query-params {})
+        per-page     (get opts :extract/batch-size (get resource-def :per-page 100))
         sort-param   (:sort-param resource-def)
         direction    (:direction-param resource-def)
         incr-param   (:incremental-param resource-def)

--- a/components/connector-github/src/ai/miniforge/data_foundry/connector_github/schema.clj
+++ b/components/connector-github/src/ai/miniforge/data_foundry/connector_github/schema.clj
@@ -1,0 +1,95 @@
+(ns ai.miniforge.data-foundry.connector-github.schema
+  "Malli schemas for the GitHub connector.
+
+   Layer 0: Enums and base types
+   Layer 1: GitHubConfig and ConnectorMetadata schemas
+   Layer 2: Validation helpers"
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Enums and base types
+
+(def auth-methods
+  [:api-key :oauth2])
+
+(def AuthMethod
+  (into [:enum] auth-methods))
+
+(def capabilities
+  [:cap/discovery :cap/incremental :cap/pagination :cap/rate-limiting])
+
+(def Capability
+  (into [:enum] capabilities))
+
+(def connector-types
+  [:source :sink])
+
+(def ConnectorType
+  (into [:enum] connector-types))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Config and metadata schemas
+
+(def GitHubConfig
+  "Schema for GitHub connector configuration.
+   Requires either :github/org or :github/owner (or both)."
+  [:map
+   [:github/base-url {:optional true} string?]
+   [:github/org {:optional true} [:maybe string?]]
+   [:github/owner {:optional true} [:maybe string?]]
+   [:github/repo {:optional true} string?]
+   [:github/pull-number {:optional true} int?]])
+
+(def ConnectorMetadata
+  "Schema for connector registration metadata."
+  [:map
+   [:connector/name string?]
+   [:connector/type ConnectorType]
+   [:connector/version string?]
+   [:connector/capabilities [:set Capability]]
+   [:connector/auth-methods [:set AuthMethod]]
+   [:connector/retry-policy
+    [:map
+     [:retry/strategy keyword?]
+     [:retry/max-attempts int?]
+     [:retry/base-delay-ms int?]]]
+   [:connector/maintainer string?]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; Validation helpers
+
+(defn valid?
+  "1-arity: predicate on a validation result map — true iff :valid? is true.
+   2-arity: validate value against a Malli schema."
+  ([result] (true? (:valid? result)))
+  ([schema value] (m/validate schema value)))
+
+(defn invalid?
+  "Predicate: did this validation result fail? Complement of valid?/1."
+  [result]
+  (not (valid? result)))
+
+(defn validate
+  "Validate value against schema. Returns {:valid? bool :errors map-or-nil}."
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn explain
+  [schema value]
+  (when-let [explanation (m/explain schema value)]
+    (me/humanize explanation)))
+
+(defn validate-config
+  "Validate a GitHub connector config map."
+  [value]
+  (validate GitHubConfig value))
+
+(defn validate-metadata
+  "Validate connector metadata."
+  [value]
+  (validate ConnectorMetadata value))

--- a/components/connector-github/test/ai/miniforge/data_foundry/connector_github/impl_test.clj
+++ b/components/connector-github/test/ai/miniforge/data_foundry/connector_github/impl_test.clj
@@ -1,0 +1,294 @@
+(ns ai.miniforge.data-foundry.connector-github.impl-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector-github.impl :as impl]
+            [ai.miniforge.data-foundry.connector-github.resources :as resources]
+            [ai.miniforge.data-foundry.connector-http.rate-limit :as rate]
+            [ai.miniforge.data-foundry.connector-http.etag :as etag]
+            [ai.miniforge.schema.interface :as schema]))
+
+(deftest resource-schemas-test
+  (testing "resource-schemas returns all known resources"
+    (let [schemas (resources/resource-schemas)]
+      (is (= 6 (count schemas)))
+      (is (every? :schema/name schemas))
+      (is (every? :schema/endpoint schemas))
+      (is (every? :schema/type schemas))
+      (is (some #(= "repos" (:schema/name %)) schemas))
+      (is (some #(= "issues" (:schema/name %)) schemas))
+      (is (some #(= "pulls" (:schema/name %)) schemas))
+      (is (some #(= "commits" (:schema/name %)) schemas))
+      (is (some #(= "comments" (:schema/name %)) schemas))
+      (is (some #(= "reviews" (:schema/name %)) schemas)))))
+
+(deftest build-url-test
+  (testing "builds org repos URL"
+    (let [resource-def (resources/get-resource :repos)
+          config       {:github/org "myorg"}
+          url          (resources/build-url "https://api.github.com" resource-def config)]
+      (is (= "https://api.github.com/orgs/myorg/repos" url))))
+
+  (testing "builds user repos URL when only owner is provided"
+    (let [resource-def (resources/get-resource :repos)
+          config       {:github/owner "myuser"}
+          url          (resources/build-url "https://api.github.com" resource-def config)]
+      (is (= "https://api.github.com/users/myuser/repos" url))))
+
+  (testing "builds issues URL with owner and repo"
+    (let [resource-def (resources/get-resource :issues)
+          config       {:github/owner "myuser" :github/repo "myrepo"}
+          url          (resources/build-url "https://api.github.com" resource-def config)]
+      (is (= "https://api.github.com/repos/myuser/myrepo/issues" url))))
+
+  (testing "builds commits URL"
+    (let [resource-def (resources/get-resource :commits)
+          config       {:github/owner "myuser" :github/repo "myrepo"}
+          url          (resources/build-url "https://api.github.com" resource-def config)]
+      (is (= "https://api.github.com/repos/myuser/myrepo/commits" url))))
+
+  (testing "builds reviews URL with pull number"
+    (let [resource-def (resources/get-resource :reviews)
+          config       {:github/owner "myuser" :github/repo "myrepo" :github/pull-number 42}
+          url          (resources/build-url "https://api.github.com" resource-def config)]
+      (is (= "https://api.github.com/repos/myuser/myrepo/pulls/42/reviews" url)))))
+
+(deftest build-query-params-test
+  (testing "includes default params and per_page"
+    (let [resource-def (resources/get-resource :issues)
+          params       (resources/build-query-params resource-def nil {})]
+      (is (= 100 (get params "per_page")))
+      (is (= "all" (get params :state)))
+      (is (= "updated" (get params "sort")))
+      (is (= "desc" (get params "direction")))))
+
+  (testing "includes cursor value for incremental"
+    (let [resource-def (resources/get-resource :issues)
+          cursor       {:cursor/type :timestamp-watermark :cursor/value "2026-01-01T00:00:00Z"}
+          params       (resources/build-query-params resource-def cursor {})]
+      (is (= "2026-01-01T00:00:00Z" (get params "since")))))
+
+  (testing "respects batch-size override"
+    (let [resource-def (resources/get-resource :repos)
+          params       (resources/build-query-params resource-def nil {:extract/batch-size 50})]
+      (is (= 50 (get params "per_page")))))
+
+  (testing "omits incremental param when no cursor"
+    (let [resource-def (resources/get-resource :commits)
+          params       (resources/build-query-params resource-def nil {})]
+      (is (nil? (get params "since"))))))
+
+(deftest connect-validates-config-test
+  (testing "do-connect requires org or owner"
+    (is (thrown? Exception (impl/do-connect {} nil)))))
+
+(deftest connect-close-lifecycle-test
+  (testing "connect and close work with org"
+    (let [config {:github/org "test-org"}
+          result (impl/do-connect config nil)]
+      (is (string? (:connection/handle result)))
+      (is (= :connected (:connector/status result)))
+      (let [close-result (impl/do-close (:connection/handle result))]
+        (is (= :closed (:connector/status close-result))))))
+
+  (testing "connect and close work with owner"
+    (let [config {:github/owner "test-user"}
+          result (impl/do-connect config nil)]
+      (is (string? (:connection/handle result)))
+      (is (= :connected (:connector/status result)))
+      (impl/do-close (:connection/handle result)))))
+
+(deftest discover-test
+  (testing "discover returns all resource schemas"
+    (let [config {:github/org "test-org"}
+          handle (:connection/handle (impl/do-connect config nil))
+          result (impl/do-discover handle)]
+      (is (= 6 (:discover/total-count result)))
+      (is (= 6 (count (:schemas result))))
+      (impl/do-close handle))))
+
+(deftest extract-follows-link-pagination-test
+  (testing "do-extract drains paginated GitHub responses before returning"
+    (let [config {:github/owner "test-user" :github/repo "test-repo"}
+          handle (:connection/handle (impl/do-connect config nil))
+          calls  (atom [])]
+      (try
+        (with-redefs-fn
+          {#'impl/do-request
+           (fn [url _headers _params]
+             (swap! calls conj url)
+             (if (= "https://api.github.com/repos/test-user/test-repo/issues?page=2" url)
+               (schema/success :body [{:number 2 :title "Second issue"}]
+                               {:headers {}})
+               (schema/success :body [{:number 1 :title "First issue"}]
+                               {:headers {"link" "<https://api.github.com/repos/test-user/test-repo/issues?page=2>; rel=\"next\""}})))}
+          (fn []
+            (let [result (impl/do-extract handle "issues" {})]
+              (is (= 2 (:extract/row-count result)))
+              (is (false? (:extract/has-more result)))
+              (is (= [1 2] (mapv :number (:records result))))
+              (is (= 2 (count @calls))))))
+        (finally
+          (impl/do-close handle))))))
+
+(deftest extract-reviews-fans-out-across-pulls-test
+  (testing "review extraction enumerates pull reviews and preserves parent linkage"
+    (let [handle (:connection/handle (impl/do-connect {:github/owner "test-user"
+                                                       :github/repo "test-repo"} nil))
+          pulls-url "https://api.github.com/repos/test-user/test-repo/pulls"
+          review-url-1 "https://api.github.com/repos/test-user/test-repo/pulls/11/reviews"
+          review-url-2 "https://api.github.com/repos/test-user/test-repo/pulls/22/reviews"]
+      (try
+        (with-redefs-fn
+          {#'impl/do-request
+           (fn [url _headers _params]
+             (cond
+               (= pulls-url url)
+               (schema/success :body [{:id 101 :number 11
+                                       :title "First pull"
+                                       :state "open"
+                                       :updated_at "2026-03-20T10:00:00Z"
+                                       :html_url "https://github.com/test-user/test-repo/pull/11"}
+                                      {:id 202 :number 22
+                                       :title "Second pull"
+                                       :state "closed"
+                                       :updated_at "2026-03-20T11:00:00Z"
+                                       :html_url "https://github.com/test-user/test-repo/pull/22"}]
+                               {:headers {}})
+
+               (= review-url-1 url)
+               (schema/success :body [{:id 1001
+                                       :body "Looks good"
+                                       :submitted_at "2026-03-20T10:30:00Z"
+                                       :state "APPROVED"}]
+                               {:headers {}})
+
+               (= review-url-2 url)
+               (schema/success :body [{:id 1002
+                                       :body "Needs one more test"
+                                       :submitted_at "2026-03-20T11:30:00Z"
+                                       :state "CHANGES_REQUESTED"}]
+                               {:headers {}})
+
+               :else
+               (throw (ex-info "Unexpected URL" {:url url}))))}
+          (fn []
+            (let [result (impl/do-extract handle "reviews" {})
+                  records (:records result)]
+              (is (= 2 (:extract/row-count result)))
+              (is (= [1001 1002] (mapv :id records)))
+              (is (= [11 22] (mapv :pull_number records)))
+              (is (= ["First pull" "Second pull"] (mapv :pull_title records)))
+              (is (= {:cursor/type :timestamp-watermark
+                      :cursor/value "2026-03-20T11:30:00Z"}
+                     (:extract/cursor result))))))
+        (finally
+          (impl/do-close handle))))))
+
+(deftest extract-reviews-filters-by-cursor-test
+  (testing "review extraction filters out reviews at or before the prior cursor"
+    (let [handle (:connection/handle (impl/do-connect {:github/owner "test-user"
+                                                       :github/repo "test-repo"} nil))
+          pulls-url "https://api.github.com/repos/test-user/test-repo/pulls"
+          review-url "https://api.github.com/repos/test-user/test-repo/pulls/11/reviews"]
+      (try
+        (with-redefs-fn
+          {#'impl/do-request
+           (fn [url _headers _params]
+             (cond
+               (= pulls-url url)
+               (schema/success :body [{:id 101 :number 11
+                                       :title "First pull"
+                                       :updated_at "2026-03-21T10:00:00Z"
+                                       :html_url "https://github.com/test-user/test-repo/pull/11"}]
+                               {:headers {}})
+
+               (= review-url url)
+               (schema/success :body [{:id 1001
+                                       :body "Older review"
+                                       :submitted_at "2026-03-21T09:59:00Z"
+                                       :state "COMMENTED"}
+                                      {:id 1002
+                                       :body "Fresh review"
+                                       :submitted_at "2026-03-21T10:30:00Z"
+                                       :state "APPROVED"}]
+                               {:headers {}})
+
+               :else
+               (throw (ex-info "Unexpected URL" {:url url}))))}
+          (fn []
+            (let [result (impl/do-extract handle "reviews"
+                                          {:extract/cursor {:cursor/type :timestamp-watermark
+                                                            :cursor/value "2026-03-21T10:00:00Z"}})]
+              (is (= 1 (:extract/row-count result)))
+              (is (= [1002] (mapv :id (:records result))))
+              (is (= {:cursor/type :timestamp-watermark
+                      :cursor/value "2026-03-21T10:30:00Z"}
+                     (:extract/cursor result))))))
+        (finally
+          (impl/do-close handle))))))
+
+(deftest checkpoint-test
+  (testing "checkpoint returns committed result"
+    (let [cursor {:cursor/type :timestamp-watermark :cursor/value "2026-01-01T00:00:00Z"}
+          result (impl/do-checkpoint cursor)]
+      (is (= :committed (:checkpoint/status result)))
+      (is (= cursor (:checkpoint/cursor result))))))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Issue filtering tests
+
+(deftest issue-filtering-test
+  (testing "issue-not-pr? returns true for plain issues"
+    (is (true? (#'impl/issue-not-pr? {:number 1 :title "Bug"}))))
+
+  (testing "issue-not-pr? returns false for PRs in issues endpoint"
+    (is (false? (#'impl/issue-not-pr? {:number 2 :title "PR" :pull_request {:url "..."}}))))
+
+  (testing "filter-issues removes PRs from :issues resource"
+    (let [records [{:number 1 :title "Issue"}
+                   {:number 2 :title "PR" :pull_request {:url "..."}}
+                   {:number 3 :title "Another issue"}]
+          filtered (#'impl/filter-issues :issues records)]
+      (is (= 2 (count filtered)))
+      (is (every? #(nil? (:pull_request %)) filtered))))
+
+  (testing "filter-issues passes through non-issues resources unchanged"
+    (let [records [{:number 1 :pull_request {:url "..."}}
+                   {:number 2 :pull_request {:url "..."}}]
+          result (#'impl/filter-issues :pulls records)]
+      (is (= 2 (count result))))))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Rate limit header integration tests
+
+(deftest rate-limit-header-capture-test
+  (testing "update-rate-limits! stores parsed rate info in handle"
+    (let [handle "test-handle"
+          ;; Manually store a handle
+          _ (impl/store-handle! handle {:config {} :auth-headers {} :last-request-at nil})
+          headers {"x-ratelimit-remaining" "4995"
+                   "x-ratelimit-reset" "1711468800"
+                   "x-ratelimit-limit" "5000"}]
+      (#'impl/update-rate-limits! handle headers)
+      (let [state (impl/get-handle handle)]
+        (is (= 4995 (get-in state [:rate-limit :remaining])))
+        (is (= 1711468800 (get-in state [:rate-limit :reset-epoch]))))
+      (impl/remove-handle! handle))))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; ETag integration tests
+
+(deftest etag-integration-test
+  (testing "ETag cache starts empty for unknown URLs"
+    (etag/clear-cache!)
+    (is (nil? (etag/get-etag "https://api.github.com/repos/test/test/issues"))))
+
+  (testing "add-etag-header is no-op without cached etag"
+    (etag/clear-cache!)
+    (let [headers (#'impl/github-headers {})]
+      (is (nil? (get (etag/add-etag-header headers "https://example.com") "If-None-Match")))))
+
+  (testing "add-etag-header includes cached etag"
+    (etag/clear-cache!)
+    (etag/store-etag! "https://example.com" "W/\"test-etag\"")
+    (let [headers (etag/add-etag-header {} "https://example.com")]
+      (is (= "W/\"test-etag\"" (get headers "If-None-Match"))))))

--- a/components/connector-gitlab/deps.edn
+++ b/components/connector-gitlab/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector      {:local/root "../connector"}
+        ai.miniforge.data-foundry/connector-auth  {:local/root "../connector-auth"}
+        ai.miniforge.data-foundry/connector-http  {:local/root "../connector-http"}
+        hato/hato                       {:mvn/version "1.0.0"}
+        metosin/malli                   {:mvn/version "0.16.4"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector-gitlab/resources/config/connector-gitlab/messages/en-US.edn
+++ b/components/connector-gitlab/resources/config/connector-gitlab/messages/en-US.edn
@@ -1,0 +1,10 @@
+{:connector-gitlab/messages
+ {:gitlab/connect-success     "Connected to GitLab API: {base-url}"
+  :gitlab/close-success       "Closed GitLab handle: {handle}"
+  :gitlab/handle-not-found    "GitLab handle not found: {handle}"
+  :gitlab/project-required    "GitLab connector requires :gitlab/project-id or :gitlab/project-path in config"
+  :gitlab/auth-invalid        "Auth validation failed: {errors}"
+  :gitlab/request-failed      "GitLab API request failed: {status} {error}"
+  :gitlab/rate-limited        "Rate limited by GitLab API (429)"
+  :gitlab/resource-unknown    "Unknown GitLab resource type: {resource}"
+  :gitlab/config-invalid      "GitLab config validation failed: {errors}"}}

--- a/components/connector-gitlab/resources/config/connector-gitlab/resources.edn
+++ b/components/connector-gitlab/resources/config/connector-gitlab/resources.edn
@@ -1,0 +1,55 @@
+{:merge-requests {:endpoint           "/projects/{project}/merge_requests"
+                  :order-by           "updated_at"
+                  :sort               "desc"
+                  :per-page           100
+                  :incremental-param  "updated_after"
+                  :cursor-type        :timestamp-watermark
+                  :query-params       {:state "all"}}
+
+ :issues         {:endpoint           "/projects/{project}/issues"
+                  :order-by           "updated_at"
+                  :sort               "desc"
+                  :per-page           100
+                  :incremental-param  "updated_after"
+                  :cursor-type        :timestamp-watermark
+                  :query-params       {:state "all"}}
+
+ :milestones     {:endpoint           "/projects/{project}/milestones"
+                  :order-by           "updated_at"
+                  :sort               "desc"
+                  :per-page           100
+                  :incremental-param  "updated_after"
+                  :cursor-type        :timestamp-watermark
+                  :query-params       {:state "all"}}
+
+ :iterations     {:endpoint           "/projects/{project}/iterations"
+                  :order-by           "updated_at"
+                  :sort               "desc"
+                  :per-page           100
+                  :incremental-param  "updated_after"
+                  :cursor-type        :timestamp-watermark
+                  :query-params       {:state "all"}
+                  :optional?          true}
+
+ :boards         {:endpoint           "/projects/{project}/boards"
+                  :per-page           100
+                  :cursor-type        :offset
+                  :query-params       {}}
+
+ :pipelines      {:endpoint           "/projects/{project}/pipelines"
+                  :order-by           "updated_at"
+                  :sort               "desc"
+                  :per-page           100
+                  :cursor-type        :timestamp-watermark
+                  :query-params       {}}
+
+ :notes          {:endpoint           "/projects/{project}/{noteable_kind}/{noteable_iid}/notes"
+                  :order-by           "updated_at"
+                  :sort               "desc"
+                  :per-page           100
+                  :cursor-type        :timestamp-watermark}
+
+ :commits        {:endpoint           "/projects/{project}/repository/commits"
+                  :per-page           100
+                  :incremental-param  "since"
+                  :cursor-type        :timestamp-watermark}}

--- a/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/core.clj
+++ b/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/core.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.data-foundry.connector-gitlab.core
+  "GitLabConnector defrecord — thin protocol wrapper delegating to impl."
+  (:require [ai.miniforge.data-foundry.connector.protocol :as proto]
+            [ai.miniforge.data-foundry.connector-gitlab.impl :as impl]))
+
+(defrecord GitLabConnector []
+  proto/Connector
+  (connect    [_ config auth]                      (impl/do-connect config auth))
+  (close      [_ handle]                           (impl/do-close handle))
+
+  proto/SourceConnector
+  (discover   [_ handle _opts]                     (impl/do-discover handle))
+  (extract    [_ handle schema-name opts]          (impl/do-extract handle schema-name opts))
+  (checkpoint [_ _handle _connector-id cursor]     (impl/do-checkpoint cursor)))

--- a/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/impl.clj
+++ b/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/impl.clj
@@ -153,11 +153,11 @@
 
 (defn- note-parent-records
   [handle config auth-headers cursor opts]
-  (mapcat (fn [{:keys [resource-key] :as scope}]
+  (letfn [(scope->parent-pairs [{:keys [resource-key] :as scope}]
             (let [resource-def (require-resource! (name resource-key))
                   records      (resource-records handle resource-def config auth-headers cursor opts)]
-              (map #(vector scope %) records)))
-          note-parent-scopes))
+              (map #(vector scope %) records)))]
+    (mapcat scope->parent-pairs note-parent-scopes)))
 
 (defn- enrich-note
   [scope parent note]

--- a/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/impl.clj
+++ b/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/impl.clj
@@ -1,0 +1,244 @@
+(ns ai.miniforge.data-foundry.connector-gitlab.impl
+  "Implementation functions for the GitLab REST API connector.
+   Small composable functions organized in a stratified DAG."
+  (:require [ai.miniforge.data-foundry.connector.handles :as h]
+            [ai.miniforge.data-foundry.connector.result :as result]
+            [ai.miniforge.data-foundry.connector-auth.core :as auth]
+            [ai.miniforge.data-foundry.connector-gitlab.messages :as msg]
+            [ai.miniforge.data-foundry.connector-gitlab.resources :as resources]
+            [ai.miniforge.data-foundry.connector-gitlab.schema :as schema]
+            [ai.miniforge.data-foundry.connector-http.cursors :as cursors]
+            [ai.miniforge.data-foundry.connector-http.rate-limit :as rate]
+            [ai.miniforge.data-foundry.connector-http.request :as request])
+  (:import [java.util UUID]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Handle state
+
+(def ^:private handles (h/create))
+
+(defn- get-handle    [handle] (h/get-handle handles handle))
+(defn- store-handle! [handle state] (h/store-handle! handles handle state))
+(defn- remove-handle! [handle] (h/remove-handle! handles handle))
+(defn- touch-handle! [handle] (h/touch-handle! handles handle))
+
+(defn- require-handle!
+  "Retrieve handle state or throw."
+  [handle]
+  (or (get-handle handle)
+      (throw (ex-info (msg/t :gitlab/handle-not-found {:handle handle})
+                      {:handle handle}))))
+
+;; Auth
+
+(defn- build-auth-headers
+  "Build authorization headers for GitLab API.
+   Both :api-key and :oauth2 use Bearer — GitLab accepts Bearer for
+   PATs, OAuth tokens, and project/group tokens."
+  [{:auth/keys [method credential-id]}]
+  (case method
+    :api-key {"Authorization" (str "Bearer " credential-id)}
+    :oauth2  {"Authorization" (str "Bearer " credential-id)}
+    {}))
+
+(defn- resolve-auth-headers
+  "Build auth headers from auth config, defaulting to empty map."
+  [auth]
+  (if (:auth/method auth)
+    (build-auth-headers auth)
+    {}))
+
+;; Rate limiting — response-header-driven via connector-http/rate-limit.
+;; GitLab returns ratelimit-remaining and ratelimit-reset on every response.
+
+(def ^:private gitlab-rate-headers
+  {:remaining "ratelimit-remaining"
+   :reset     "ratelimit-reset"
+   :limit     "ratelimit-limit"})
+
+(defn- update-rate-limits!
+  "Parse rate limit headers from a response and store in handle state."
+  [handle response-headers]
+  (when-let [info (rate/parse-rate-headers response-headers gitlab-rate-headers)]
+    (rate/update-rate-state! handles handle info)))
+
+;; Config predicates
+
+(defn- has-project?
+  "Check if config identifies a GitLab project."
+  [config]
+  (some? (or (:gitlab/project-id config) (:gitlab/project-path config))))
+
+(defn- validate-auth!
+  "Validate auth credential reference, throwing on failure."
+  [auth]
+  (when auth
+    (let [result (auth/validate-credential-ref auth)]
+      (when-not (:success? result)
+        (throw (ex-info (msg/t :gitlab/auth-invalid {:errors (:errors result)})
+                        {:errors (:errors result)}))))))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; HTTP
+
+(defn- error-response
+  [status resp]
+  (request/error-response status resp
+    {:rate-limited   (msg/t :gitlab/rate-limited)
+     :request-failed (fn [s e] (msg/t :gitlab/request-failed {:status s :error e}))}))
+
+(defn- do-request
+  [url headers query-params]
+  (request/do-request url headers query-params error-response))
+
+
+(defn- response-records
+  [resp]
+  (request/coerce-records (:body resp)))
+
+(defn- final-cursor
+  [resource-def records]
+  (cursors/last-record-cursor resource-def records))
+
+(defn- page-fetch-result
+  [records cursor]
+  {:records records
+   :cursor  cursor})
+
+(def ^:private note-parent-scopes
+  [{:resource-key   :issues
+    :noteable-kind  "issues"
+    :noteable-type  "Issue"}
+   {:resource-key   :merge-requests
+    :noteable-kind  "merge_requests"
+    :noteable-type  "MergeRequest"}])
+
+(defn- fetch-all-pages
+  [handle resource-def url headers query-params]
+  (loop [next-request-url url
+         next-query-params query-params
+         accumulated []]
+    (rate/acquire-permit! handles handle {})
+    (let [resp (request/throw-on-failure! (do-request next-request-url headers next-query-params))]
+      (update-rate-limits! handle (:headers resp))
+      (touch-handle! handle)
+      (if (:not-modified resp)
+        (page-fetch-result [] nil)
+        (let [page-records (response-records resp)
+              all-records  (into accumulated page-records)]
+          (if-let [next-link (request/next-url resp)]
+            (recur next-link nil all-records)
+            (page-fetch-result all-records
+                               (final-cursor resource-def all-records))))))))
+
+(defn- timestamp-value
+  [record]
+  (or (:updated_at record)
+      (:created_at record)))
+
+;; Resource lookup
+
+(defn- require-resource!
+  "Look up resource def or throw."
+  [schema-name]
+  (or (resources/get-resource (keyword schema-name))
+      (throw (ex-info (msg/t :gitlab/resource-unknown {:resource schema-name})
+                      {:resource schema-name}))))
+
+(defn- resource-records
+  [handle resource-def config auth-headers cursor opts]
+  (let [url    (resources/build-url (:gitlab/base-url config) resource-def config)
+        params (resources/build-query-params resource-def cursor opts)]
+    (:records (fetch-all-pages handle resource-def url auth-headers params))))
+
+(defn- note-parent-records
+  [handle config auth-headers cursor opts]
+  (mapcat (fn [{:keys [resource-key] :as scope}]
+            (let [resource-def (require-resource! (name resource-key))
+                  records      (resource-records handle resource-def config auth-headers cursor opts)]
+              (map #(vector scope %) records)))
+          note-parent-scopes))
+
+(defn- enrich-note
+  [scope parent note]
+  (assoc note
+         :project_id (or (:project_id note) (:project_id parent))
+         :noteable_type (or (:noteable_type note) (:noteable-type scope))
+         :noteable_kind (:noteable-kind scope)
+         :noteable_iid (:iid parent)
+         :noteable_id (:id parent)
+         :noteable_title (:title parent)
+         :noteable_web_url (:web_url parent)
+         :noteable_state (:state parent)))
+
+(defn- parent-note-records
+  [handle notes-resource config auth-headers cursor opts [scope parent]]
+  (let [note-config (assoc config
+                           :gitlab/noteable-kind (:noteable-kind scope)
+                           :gitlab/noteable-iid (:iid parent))
+        records     (resource-records handle notes-resource note-config auth-headers nil opts)]
+    (->> records
+         (map #(enrich-note scope parent %))
+         (filter #(cursors/after-cursor? timestamp-value cursor %)))))
+
+(defn- extract-project-notes
+  [handle config auth-headers cursor opts]
+  (let [notes-resource (require-resource! "notes")
+        notes         (->> (note-parent-records handle config auth-headers cursor opts)
+                           (mapcat #(parent-note-records handle notes-resource config auth-headers cursor opts %))
+                           (cursors/sort-by-timestamp timestamp-value)
+                           vec)]
+    (result/extract-result notes (cursors/max-timestamp-cursor timestamp-value notes) false)))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Lifecycle and source operations
+
+(defn do-connect
+  "Validate config at boundary, register handle."
+  [config auth]
+  (let [config (assoc config :gitlab/base-url
+                      (get config :gitlab/base-url "https://gitlab.com"))]
+    (when-not (has-project? config)
+      (throw (ex-info (msg/t :gitlab/project-required) {:config config})))
+    (schema/validate! schema/GitLabConfig config)
+    (validate-auth! auth)
+    (let [handle (str (UUID/randomUUID))]
+      (store-handle! handle {:config       config
+                              :auth-headers (resolve-auth-headers auth)
+                              :last-request-at nil})
+      (result/connect-result handle))))
+
+(defn do-close [handle]
+  (remove-handle! handle)
+  (result/close-result))
+
+(defn do-discover [handle]
+  (require-handle! handle)
+  (result/discover-result (resources/resource-schemas)))
+
+(defn do-extract
+  "Extract records from a GitLab API resource."
+  [handle schema-name opts]
+  (let [handle-state (require-handle! handle)
+        resource-def (require-resource! schema-name)
+        {:keys [config auth-headers]} handle-state]
+    (if (= "notes" schema-name)
+      (extract-project-notes handle config auth-headers (:extract/cursor opts) opts)
+      (let [url     (resources/build-url (:gitlab/base-url config) resource-def config)
+            params  (resources/build-query-params resource-def (:extract/cursor opts) opts)
+            fetch   (fn [] (let [{:keys [records cursor]}
+                                 (fetch-all-pages handle resource-def url auth-headers params)]
+                             (result/extract-result records cursor false)))]
+        (if (:optional? resource-def)
+          (try (fetch)
+               (catch clojure.lang.ExceptionInfo e
+                 (when-not (= :permanent (:error-type (ex-data e))) (throw e))
+                 (result/extract-result [] nil false)))
+          (fetch))))))
+
+(defn do-checkpoint [cursor-state]
+  (result/checkpoint-result cursor-state))
+
+(comment
+  ;; (do-connect {:gitlab/project-path "engrammicai/ixi-services/services/ixi"} nil)
+  )

--- a/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/interface.clj
+++ b/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/interface.clj
@@ -1,0 +1,35 @@
+(ns ai.miniforge.data-foundry.connector-gitlab.interface
+  "Public API for the GitLab REST API connector component."
+  (:require [ai.miniforge.data-foundry.connector-gitlab.core :as core]
+            [ai.miniforge.data-foundry.connector-gitlab.schema :as schema]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Schemas (exported for consumers)
+
+(def GitLabConfig
+  "Malli schema for GitLab connector configuration."
+  schema/GitLabConfig)
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Factory and metadata
+
+(defn create-gitlab-connector
+  "Create a new GitLabConnector instance."
+  []
+  (core/->GitLabConnector))
+
+(def connector-metadata
+  "Registration metadata for the GitLab REST API connector."
+  {:connector/name         "GitLab REST API Connector"
+   :connector/type         :source
+   :connector/version      "0.1.0"
+   :connector/capabilities #{:cap/discovery :cap/incremental :cap/pagination :cap/rate-limiting}
+   :connector/auth-methods #{:api-key :oauth2}
+   :connector/retry-policy {:retry/strategy       :exponential-backoff
+                            :retry/max-attempts   3
+                            :retry/base-delay-ms  1000}
+   :connector/maintainer   "data-foundry"})
+
+(comment
+  ;; (create-gitlab-connector)
+  )

--- a/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/messages.clj
+++ b/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.connector-gitlab.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/connector-gitlab/messages/en-US.edn" :connector-gitlab/messages))

--- a/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/resources.clj
+++ b/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/resources.clj
@@ -1,0 +1,71 @@
+(ns ai.miniforge.data-foundry.connector-gitlab.resources
+  "GitLab API v4 resource type registry and URL/param builders.
+   Resource definitions are loaded from an EDN resource file at startup."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Resource loading
+
+(def ^:private resource-path "config/connector-gitlab/resources.edn")
+
+(defn- load-resources []
+  (if-let [res (io/resource resource-path)]
+    (edn/read-string (slurp res))
+    (throw (ex-info (str "GitLab resource definitions not found: " resource-path)
+                    {:path resource-path}))))
+
+(def gitlab-resources
+  "Registry of GitLab REST API v4 resource types, loaded from EDN."
+  (delay (load-resources)))
+
+(defn get-resource
+  "Look up a resource definition by key."
+  [resource-key]
+  (get @gitlab-resources resource-key))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; URL and param builders
+
+(defn- encode-project
+  "URL-encode a project path, or pass through a numeric project-id."
+  [config]
+  (or (:gitlab/project-id config)
+      (java.net.URLEncoder/encode (str (:gitlab/project-path config)) "UTF-8")))
+
+(defn build-url
+  "Build a GitLab API URL by substituting path parameters."
+  [base-url resource-def config]
+  (str base-url "/api/v4"
+       (-> (:endpoint resource-def)
+           (str/replace "{project}" (str (encode-project config)))
+           (str/replace "{issue_iid}" (str (get config :gitlab/issue-iid "")))
+           (str/replace "{noteable_kind}" (str (get config :gitlab/noteable-kind "")))
+           (str/replace "{noteable_iid}" (str (get config :gitlab/noteable-iid ""))))))
+
+(defn build-query-params
+  "Build query params for a GitLab API request."
+  [resource-def cursor opts]
+  (let [base-params  (get resource-def :query-params {})
+        per-page     (get opts :extract/batch-size (get resource-def :per-page 100))
+        incr-param   (:incremental-param resource-def)
+        cursor-value (get-in cursor [:cursor/value])]
+    (cond-> (assoc base-params "per_page" per-page)
+      (:order-by resource-def)      (assoc "order_by" (:order-by resource-def))
+      (:sort resource-def)          (assoc "sort" (:sort resource-def))
+      (and incr-param cursor-value) (assoc incr-param cursor-value))))
+
+(defn resource-schemas
+  "Return discover-compatible schema list for all known GitLab resources."
+  []
+  (mapv (fn [[k v]]
+          {:schema/name     (name k)
+           :schema/endpoint (:endpoint v)
+           :schema/type     (:cursor-type v)})
+        @gitlab-resources))
+
+(comment
+  ;; (build-url "https://gitlab.com" (get-resource :merge-requests)
+  ;;            {:gitlab/project-path "engrammicai/ixi-services/services/ixi"})
+  )

--- a/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/schema.clj
+++ b/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/schema.clj
@@ -1,0 +1,40 @@
+(ns ai.miniforge.data-foundry.connector-gitlab.schema
+  "Malli schemas for the GitLab connector."
+  (:require [malli.core :as m]
+            [malli.error :as me]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Schemas
+
+(def GitLabConfig
+  "Schema for GitLab connector configuration.
+   Requires either :gitlab/project-id or :gitlab/project-path."
+  [:map
+   [:gitlab/base-url {:optional true} string?]
+   [:gitlab/project-id {:optional true} [:maybe [:or int? string?]]]
+   [:gitlab/project-path {:optional true} [:maybe string?]]
+   [:gitlab/issue-iid {:optional true} int?]])
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Validation
+
+(defn validate
+  "Validate value against schema."
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn validate!
+  "Validate and throw on failure."
+  [schema value]
+  (when-not (m/validate schema value)
+    (throw (ex-info "GitLab config validation failed"
+                    {:errors (me/humanize (m/explain schema value))
+                     :value value})))
+  value)
+
+(comment
+  ;; (validate GitLabConfig {:gitlab/project-path "mygroup/myrepo"})
+  )

--- a/components/connector-gitlab/test/ai/miniforge/data_foundry/connector_gitlab/impl_test.clj
+++ b/components/connector-gitlab/test/ai/miniforge/data_foundry/connector_gitlab/impl_test.clj
@@ -1,0 +1,249 @@
+(ns ai.miniforge.data-foundry.connector-gitlab.impl-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector-gitlab.impl :as impl]
+            [ai.miniforge.data-foundry.connector-gitlab.resources :as resources]
+            [ai.miniforge.schema.interface :as schema]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Fixtures
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Tests
+
+(deftest resource-schemas-test
+  (testing "resource-schemas returns all known resources"
+    (let [schemas (resources/resource-schemas)]
+      (is (= 8 (count schemas)))
+      (is (every? :schema/name schemas))
+      (is (some #(= "merge-requests" (:schema/name %)) schemas))
+      (is (some #(= "issues" (:schema/name %)) schemas))
+      (is (some #(= "milestones" (:schema/name %)) schemas))
+      (is (some #(= "iterations" (:schema/name %)) schemas))
+      (is (some #(= "boards" (:schema/name %)) schemas))
+      (is (some #(= "pipelines" (:schema/name %)) schemas))
+      (is (some #(= "commits" (:schema/name %)) schemas))
+      (is (some #(= "notes" (:schema/name %)) schemas)))))
+
+(deftest build-url-test
+  (testing "builds project MR URL with project-path"
+    (let [resource-def (resources/get-resource :merge-requests)
+          config {:gitlab/project-path "engrammicai/ixi-services/services/ixi"}
+          url (resources/build-url "https://gitlab.com" resource-def config)]
+      (is (clojure.string/includes? url "/api/v4/projects/"))
+      (is (clojure.string/includes? url "/merge_requests"))))
+
+  (testing "builds project URL with project-id"
+    (let [resource-def (resources/get-resource :issues)
+          config {:gitlab/project-id 42376374}
+          url (resources/build-url "https://gitlab.com" resource-def config)]
+      (is (= "https://gitlab.com/api/v4/projects/42376374/issues" url))))
+
+  (testing "builds commits URL"
+    (let [resource-def (resources/get-resource :commits)
+          config {:gitlab/project-id 123}
+          url (resources/build-url "https://gitlab.com" resource-def config)]
+      (is (= "https://gitlab.com/api/v4/projects/123/repository/commits" url))))
+
+  (testing "builds milestones URL"
+    (let [resource-def (resources/get-resource :milestones)
+          config {:gitlab/project-id 123}
+          url (resources/build-url "https://gitlab.com" resource-def config)]
+      (is (= "https://gitlab.com/api/v4/projects/123/milestones" url))))
+
+  (testing "builds iterations URL"
+    (let [resource-def (resources/get-resource :iterations)
+          config {:gitlab/project-id 123}
+          url (resources/build-url "https://gitlab.com" resource-def config)]
+      (is (= "https://gitlab.com/api/v4/projects/123/iterations" url))))
+
+  (testing "builds boards URL"
+    (let [resource-def (resources/get-resource :boards)
+          config {:gitlab/project-id 123}
+          url (resources/build-url "https://gitlab.com" resource-def config)]
+      (is (= "https://gitlab.com/api/v4/projects/123/boards" url))))
+
+  (testing "builds note URL"
+    (let [resource-def (resources/get-resource :notes)
+          config {:gitlab/project-id 123
+                  :gitlab/noteable-kind "merge_requests"
+                  :gitlab/noteable-iid 42}
+          url (resources/build-url "https://gitlab.com" resource-def config)]
+      (is (= "https://gitlab.com/api/v4/projects/123/merge_requests/42/notes" url)))))
+
+(deftest build-query-params-test
+  (testing "includes defaults and per_page"
+    (let [resource-def (resources/get-resource :issues)
+          params (resources/build-query-params resource-def nil {})]
+      (is (= 100 (get params "per_page")))
+      (is (= "all" (get params :state)))
+      (is (= "updated_at" (get params "order_by")))
+      (is (= "desc" (get params "sort"))))))
+
+  (testing "includes cursor for incremental"
+    (let [resource-def (resources/get-resource :merge-requests)
+          cursor {:cursor/type :timestamp-watermark :cursor/value "2026-01-01T00:00:00Z"}
+          params (resources/build-query-params resource-def cursor {})]
+      (is (= "2026-01-01T00:00:00Z" (get params "updated_after")))))
+
+  (testing "boards omit incremental params"
+    (let [resource-def (resources/get-resource :boards)
+          cursor {:cursor/type :offset :cursor/value 100}
+          params (resources/build-query-params resource-def cursor {})]
+      (is (nil? (get params "updated_after")))
+      (is (= 100 (get params "per_page")))))
+
+(deftest connect-validates-config-test
+  (testing "do-connect requires project-id or project-path"
+    (is (thrown? Exception (impl/do-connect {} nil)))))
+
+(deftest connect-close-lifecycle-test
+  (testing "connect and close with project-path"
+    (let [result (impl/do-connect {:gitlab/project-path "mygroup/myrepo"} nil)]
+      (is (= :connected (:connector/status result)))
+      (is (string? (:connection/handle result)))
+      (let [close-result (impl/do-close (:connection/handle result))]
+        (is (= :closed (:connector/status close-result)))))))
+
+(deftest discover-test
+  (testing "discover returns all resources"
+    (let [handle (:connection/handle (impl/do-connect {:gitlab/project-id 1} nil))
+          result (impl/do-discover handle)]
+      (is (= 8 (:discover/total-count result)))
+      (impl/do-close handle))))
+
+(deftest extract-follows-link-pagination-test
+  (testing "do-extract drains paginated GitLab responses before returning"
+    (let [handle (:connection/handle (impl/do-connect {:gitlab/project-id 1} nil))
+          calls  (atom [])]
+      (try
+        (with-redefs-fn
+          {#'impl/do-request
+           (fn [url _headers _params]
+             (swap! calls conj url)
+             (if (= "https://gitlab.com/api/v4/projects/1/issues?page=2" url)
+               (schema/success :body [{:iid 2 :project_id 1 :title "Second"}]
+                               {:headers {}})
+               (schema/success :body [{:iid 1 :project_id 1 :title "First"}]
+                               {:headers {"link" "<https://gitlab.com/api/v4/projects/1/issues?page=2>; rel=\"next\""}})))}
+          (fn []
+            (let [result (impl/do-extract handle "issues" {})]
+              (is (= 2 (:extract/row-count result)))
+              (is (false? (:extract/has-more result)))
+              (is (= [1 2] (mapv :iid (:records result))))
+              (is (= 2 (count @calls))))))
+        (finally
+          (impl/do-close handle))))))
+
+(deftest extract-notes-fans-out-across-parent-records-test
+  (testing "notes extraction enumerates issue and merge request notes with parent linkage"
+    (let [handle (:connection/handle (impl/do-connect {:gitlab/project-id 1} nil))
+          issue-url "https://gitlab.com/api/v4/projects/1/issues"
+          mr-url "https://gitlab.com/api/v4/projects/1/merge_requests"
+          issue-note-url "https://gitlab.com/api/v4/projects/1/issues/11/notes"
+          mr-note-url "https://gitlab.com/api/v4/projects/1/merge_requests/22/notes"]
+      (try
+        (with-redefs-fn
+          {#'impl/do-request
+           (fn [url _headers _params]
+             (cond
+               (= issue-url url)
+               (schema/success :body [{:id 101 :iid 11 :project_id 1
+                                       :title "Issue parent"
+                                       :state "opened"
+                                       :updated_at "2026-03-20T10:00:00Z"
+                                       :web_url "https://gitlab.com/group/repo/-/issues/11"}]
+                               {:headers {}})
+
+               (= mr-url url)
+               (schema/success :body [{:id 202 :iid 22 :project_id 1
+                                       :title "MR parent"
+                                       :state "merged"
+                                       :updated_at "2026-03-20T11:00:00Z"
+                                       :web_url "https://gitlab.com/group/repo/-/merge_requests/22"}]
+                               {:headers {}})
+
+               (= issue-note-url url)
+               (schema/success :body [{:id 1001
+                                       :body "Issue note"
+                                       :updated_at "2026-03-20T10:30:00Z"
+                                       :created_at "2026-03-20T10:30:00Z"}]
+                               {:headers {}})
+
+               (= mr-note-url url)
+               (schema/success :body [{:id 1002
+                                       :body "MR note"
+                                       :updated_at "2026-03-20T11:30:00Z"
+                                       :created_at "2026-03-20T11:30:00Z"}]
+                               {:headers {}})
+
+               :else
+               (throw (ex-info "Unexpected URL" {:url url}))))}
+          (fn []
+            (let [result (impl/do-extract handle "notes" {})
+                  records (:records result)]
+              (is (= 2 (:extract/row-count result)))
+              (is (= [1001 1002] (mapv :id records)))
+              (is (= [11 22] (mapv :noteable_iid records)))
+              (is (= ["Issue" "MergeRequest"] (mapv :noteable_type records)))
+              (is (= ["Issue parent" "MR parent"] (mapv :noteable_title records)))
+              (is (= {:cursor/type :timestamp-watermark
+                      :cursor/value "2026-03-20T11:30:00Z"}
+                     (:extract/cursor result))))))
+        (finally
+          (impl/do-close handle))))))
+
+(deftest extract-notes-filters-by-cursor-test
+  (testing "notes extraction filters out notes at or before the prior cursor"
+    (let [handle (:connection/handle (impl/do-connect {:gitlab/project-id 1} nil))
+          issue-url "https://gitlab.com/api/v4/projects/1/issues"
+          mr-url "https://gitlab.com/api/v4/projects/1/merge_requests"
+          issue-note-url "https://gitlab.com/api/v4/projects/1/issues/11/notes"]
+      (try
+        (with-redefs-fn
+          {#'impl/do-request
+           (fn [url _headers _params]
+             (cond
+               (= issue-url url)
+               (schema/success :body [{:id 101 :iid 11 :project_id 1
+                                       :title "Issue parent"
+                                       :updated_at "2026-03-21T10:00:00Z"
+                                       :web_url "https://gitlab.com/group/repo/-/issues/11"}]
+                               {:headers {}})
+
+               (= mr-url url)
+               (schema/success :body [] {:headers {}})
+
+               (= issue-note-url url)
+               (schema/success :body [{:id 1001
+                                       :body "Old note"
+                                       :updated_at "2026-03-21T09:59:00Z"
+                                       :created_at "2026-03-21T09:59:00Z"}
+                                      {:id 1002
+                                       :body "Fresh note"
+                                       :updated_at "2026-03-21T10:30:00Z"
+                                       :created_at "2026-03-21T10:30:00Z"}]
+                               {:headers {}})
+
+               :else
+               (throw (ex-info "Unexpected URL" {:url url}))))}
+          (fn []
+            (let [result (impl/do-extract handle "notes"
+                                          {:extract/cursor {:cursor/type :timestamp-watermark
+                                                            :cursor/value "2026-03-21T10:00:00Z"}})]
+              (is (= 1 (:extract/row-count result)))
+              (is (= [1002] (mapv :id (:records result))))
+              (is (= {:cursor/type :timestamp-watermark
+                      :cursor/value "2026-03-21T10:30:00Z"}
+                     (:extract/cursor result))))))
+        (finally
+          (impl/do-close handle))))))
+
+(deftest checkpoint-test
+  (testing "checkpoint returns committed"
+    (let [cursor {:cursor/type :timestamp-watermark :cursor/value "2026-01-01T00:00:00Z"}
+          result (impl/do-checkpoint cursor)]
+      (is (= :committed (:checkpoint/status result))))))
+
+(comment
+  ;; Run: clj -M:dev:test -n ai.miniforge.data-foundry.connector-gitlab.impl-test
+  )

--- a/components/connector-http/deps.edn
+++ b/components/connector-http/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector      {:local/root "../connector"}
+        ai.miniforge.data-foundry/connector-auth  {:local/root "../connector-auth"}
+        ai.miniforge.data-foundry/connector-retry {:local/root "../connector-retry"}
+        hato/hato                       {:mvn/version "1.0.0"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector-http/resources/config/connector-http/messages/en-US.edn
+++ b/components/connector-http/resources/config/connector-http/messages/en-US.edn
@@ -1,0 +1,17 @@
+{:connector-http/messages
+ {;; Lifecycle
+  :http/connect-success    "Connected to HTTP endpoint: {url}"
+  :http/close-success      "Closed HTTP handle: {handle}"
+  :http/handle-not-found   "HTTP handle not found: {handle}"
+
+  ;; Config validation
+  :http/base-url-required  ":http/base-url is required"
+  :http/endpoint-required  ":http/endpoint is required"
+
+  ;; Extract
+  :http/request-failed     "HTTP request failed: {status} {error}"
+  :http/timeout            "HTTP request timed out for {url}"
+  :http/rate-limited       "Rate limited by server (429)"
+
+  ;; Auth
+  :http/auth-header-set    "Auth header configured for method {method}"}}

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/core.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/core.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.data-foundry.connector-http.core
+  "HttpConnector defrecord — thin protocol wrapper delegating to impl."
+  (:require [ai.miniforge.data-foundry.connector.protocol :as proto]
+            [ai.miniforge.data-foundry.connector-http.impl :as impl]))
+
+(defrecord HttpConnector []
+  proto/Connector
+  (connect    [_ config auth]                      (impl/do-connect config auth))
+  (close      [_ handle]                           (impl/do-close handle))
+
+  proto/SourceConnector
+  (discover   [_ handle _opts]                     (impl/do-discover handle))
+  (extract    [_ handle _schema-name opts]         (impl/do-extract handle opts))
+  (checkpoint [_ _handle _connector-id cursor]     (impl/do-checkpoint cursor)))

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/cursors.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/cursors.clj
@@ -1,0 +1,59 @@
+(ns ai.miniforge.data-foundry.connector-http.cursors
+  "Shared timestamp-watermark cursor utilities for REST API connectors.
+
+   Layer 0: Timestamp parsing
+   Layer 1: Per-record cursor predicates and builders
+   Layer 2: Collection-level cursor operations"
+  (:require [clojure.string :as str])
+  (:import [java.time Instant]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Timestamp parsing
+
+(defn parse-timestamp
+  "Parse an ISO-8601 timestamp string to Instant, or nil if blank/nil."
+  [value]
+  (when (and (string? value) (not (str/blank? value)))
+    (Instant/parse value)))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Per-record cursor predicates and builders
+
+(defn after-cursor?
+  "True if record's timestamp is strictly after the cursor timestamp.
+   timestamp-fn: (fn [record] iso-string-or-nil)
+   Always returns true when cursor is nil (no prior watermark)."
+  [timestamp-fn cursor record]
+  (if-let [cursor-ts (some-> cursor :cursor/value parse-timestamp)]
+    (some-> (timestamp-fn record)
+            parse-timestamp
+            (.isAfter cursor-ts))
+    true))
+
+(defn last-record-cursor
+  "Compute a :timestamp-watermark cursor from the last record's :updated_at or :created_at.
+   Returns nil if records is empty or resource-def :cursor-type is not :timestamp-watermark."
+  [resource-def records]
+  (when-let [last-record (last records)]
+    (when (= :timestamp-watermark (:cursor-type resource-def))
+      {:cursor/type  :timestamp-watermark
+       :cursor/value (or (:updated_at last-record)
+                         (:created_at last-record))})))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Collection-level cursor operations
+
+(defn sort-by-timestamp
+  "Sort records ascending by timestamp. Records with nil timestamps sort first.
+   timestamp-fn: (fn [record] iso-string-or-nil)"
+  [timestamp-fn records]
+  (sort-by #(or (timestamp-fn %) "") records))
+
+(defn max-timestamp-cursor
+  "Compute a :timestamp-watermark cursor from the maximum timestamp across records.
+   Returns nil if records is empty or none have a timestamp.
+   timestamp-fn: (fn [record] iso-string-or-nil)"
+  [timestamp-fn records]
+  (when-let [latest-ts (some->> records (keep timestamp-fn) sort last)]
+    {:cursor/type  :timestamp-watermark
+     :cursor/value latest-ts}))

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/etag.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/etag.clj
@@ -1,0 +1,51 @@
+(ns ai.miniforge.data-foundry.connector-http.etag
+  "Shared ETag caching for conditional HTTP requests.
+   Stores ETags per URL, adds If-None-Match headers to subsequent requests.
+   304 Not Modified responses don't count against rate limits.")
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Cache
+
+(defonce ^:private cache (atom {}))
+
+(defn get-etag
+  "Retrieve cached ETag for a URL."
+  [url]
+  (get @cache url))
+
+(defn store-etag!
+  "Cache an ETag for a URL."
+  [url etag]
+  (when etag
+    (swap! cache assoc url etag)))
+
+(defn clear-cache!
+  "Clear the entire ETag cache. Useful for testing."
+  []
+  (reset! cache {}))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Header helpers
+
+(defn add-etag-header
+  "Add If-None-Match header if we have a cached ETag for this URL."
+  [headers url]
+  (if-let [etag (get-etag url)]
+    (assoc headers "If-None-Match" etag)
+    headers))
+
+(defn extract-etag
+  "Extract the ETag header from response headers."
+  [response-headers]
+  (get response-headers "etag"))
+
+(defn not-modified?
+  "Check if an HTTP status indicates Not Modified."
+  [status]
+  (= 304 status))
+
+(comment
+  ;; (store-etag! "https://api.github.com/repos/org/repo/pulls" "W/\"abc123\"")
+  ;; (add-etag-header {} "https://api.github.com/repos/org/repo/pulls")
+  ;; => {"If-None-Match" "W/\"abc123\""}
+  )

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/impl.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/impl.clj
@@ -1,0 +1,197 @@
+(ns ai.miniforge.data-foundry.connector-http.impl
+  "Implementation functions for the HTTP connector.
+   Pure logic separated from protocol wiring."
+  (:require [ai.miniforge.data-foundry.connector.handles :as h]
+            [ai.miniforge.data-foundry.connector.result :as result]
+            [ai.miniforge.data-foundry.connector-http.pagination :as page]
+            [ai.miniforge.data-foundry.connector-http.messages :as msg]
+            [ai.miniforge.schema.interface :as schema]
+            [hato.client :as hc]
+            [clojure.data.json :as json])
+  (:import [java.util UUID]))
+
+;; -- Handle state --
+
+(def ^:private handles (h/create))
+
+(defn get-handle [handle] (h/get-handle handles handle))
+(defn store-handle! [handle state] (h/store-handle! handles handle state))
+(defn remove-handle! [handle] (h/remove-handle! handles handle))
+(defn touch-handle! [handle] (h/touch-handle! handles handle))
+
+;; -- Auth --
+
+(defn build-auth-headers
+  "Build auth headers from auth config."
+  [{:auth/keys [method credential-id]}]
+  (case method
+    :api-key {"Authorization" (str "Bearer " credential-id)}
+    :basic   {"Authorization" (str "Basic " credential-id)}
+    {}))
+
+;; -- Rate limiting --
+
+(defn enforce-rate-limit!
+  "Sleep if needed to enforce requests-per-second."
+  [handle-state]
+  (when-let [rps (get-in handle-state [:config :http/rate-limit :requests-per-second])]
+    (when-let [last-req (:last-request-at handle-state)]
+      (let [min-interval-ms (/ 1000.0 rps)
+            elapsed (- (System/currentTimeMillis) last-req)]
+        (when (< elapsed min-interval-ms)
+          (Thread/sleep (long (- min-interval-ms elapsed))))))))
+
+;; -- HTTP --
+
+(defn do-request
+  "Execute an HTTP GET request. Returns schema/success or schema/failure."
+  [url headers query-params]
+  (let [resp (hc/get url {:headers          headers
+                          :query-params     query-params
+                          :as               :string
+                          :throw-exceptions false})
+        status (:status resp)]
+    (cond
+      (<= 200 status 299)
+      (schema/success :body (json/read-str (:body resp) :key-fn keyword))
+
+      (= 429 status)
+      (schema/failure :body (msg/t :http/rate-limited)
+                      {:error-type :rate-limited})
+
+      (<= 500 status 599)
+      (schema/failure :body (msg/t :http/request-failed {:status status :error "server error"})
+                      {:error-type :transient})
+
+      :else
+      (schema/failure :body (msg/t :http/request-failed {:status status :error (:body resp)})
+                      {:error-type :permanent}))))
+
+(defn extract-records
+  "Extract records from response body using configured response-path."
+  [body response-path]
+  (let [data (if response-path (get-in body response-path) body)]
+    (cond
+      (sequential? data) (vec data)
+      (some? data)       [data]
+      :else              [])))
+
+;; -- Pagination helpers --
+
+(defn build-page-params
+  "Build query-params map for the current page."
+  [pagination offset cursor-value batch-size]
+  (case (:type pagination)
+    :offset (page/offset-params pagination offset batch-size)
+    :cursor (page/cursor-params pagination cursor-value batch-size)
+    {}))
+
+(defn page-has-more?
+  "Determine if more pages exist after this batch."
+  [pagination body offset record-count]
+  (case (:type pagination)
+    :offset (page/has-more-offset? body pagination offset record-count)
+    :cursor (some? (page/extract-cursor-value body pagination))
+    false))
+
+(defn next-cursor-value
+  "Compute the cursor value for the next page."
+  [pagination body offset record-count]
+  (case (:type pagination)
+    :offset (page/next-offset offset record-count)
+    :cursor (page/extract-cursor-value body pagination)
+    nil))
+
+;; -- Lifecycle --
+
+(defn do-connect
+  "Validate config, register handle. Returns connect-result."
+  [config auth]
+  (let [base-url (:http/base-url config)
+        endpoint (:http/endpoint config)]
+    (cond
+      (nil? base-url) (throw (ex-info (msg/t :http/base-url-required) {:config config}))
+      (nil? endpoint) (throw (ex-info (msg/t :http/endpoint-required) {:config config}))
+
+      :else
+      (let [handle       (str (UUID/randomUUID))
+            auth-headers (if (and auth (:auth/method auth))
+                           (build-auth-headers auth)
+                           {})]
+        (store-handle! handle {:config       config
+                               :auth-headers auth-headers
+                               :last-request-at nil})
+        (result/connect-result handle)))))
+
+(defn do-close [handle]
+  (remove-handle! handle)
+  (result/close-result))
+
+;; -- Source --
+
+(defn do-discover [handle]
+  (if-let [{:keys [config]} (get-handle handle)]
+    (result/discover-result [{:schema/name    (:http/endpoint config)
+                              :schema/base-url (:http/base-url config)}])
+    (throw (ex-info (msg/t :http/handle-not-found {:handle handle}) {:handle handle}))))
+
+(defn- fetch-single
+  "Fetch one page of records for a single query-params set.
+   Returns the records vector."
+  [url headers base-query-params response-path pagination opts]
+  (let [batch-size   (or (:extract/batch-size opts) (get pagination :page-size 100))
+        cursor-value (get-in opts [:extract/cursor :cursor/value])
+        offset       (or cursor-value 0)
+        query-params (merge base-query-params
+                            (build-page-params pagination offset cursor-value batch-size))
+        resp         (do-request url headers query-params)]
+    (when-not (:success? resp)
+      (throw (ex-info (str (:error resp)) {:error-type (:error-type resp)})))
+    (let [body     (:body resp)
+          records  (extract-records body response-path)
+          has-more (page-has-more? pagination body offset (count records))
+          next-val (next-cursor-value pagination body offset (count records))
+          cursor   (when next-val
+                     {:cursor/type  (or (:type pagination) :offset)
+                      :cursor/value next-val})]
+      {:records records :cursor cursor :has-more has-more})))
+
+(defn do-extract
+  "Fetch records from the HTTP API.
+   If the handle's config contains :batch/param-sets, fetches all param sets
+   in parallel via pmap, enriching each record with its param-set keys.
+   Otherwise fetches a single page."
+  [handle opts]
+  (if-let [handle-state (get-handle handle)]
+    (let [{:keys [config auth-headers]} handle-state
+          url           (str (:http/base-url config) (:http/endpoint config))
+          headers       (merge (:http/headers config {}) auth-headers)
+          pagination    (:http/pagination config)
+          base-qp       (:http/query-params config {})
+          response-path (:http/response-path config)]
+
+      (if-let [param-sets (:batch/param-sets config)]
+        ;; Batch mode: pmap over param sets, enrich records with param keys
+        (let [all-records (vec (apply concat
+                                     (pmap (fn [params]
+                                             (let [{:keys [records]} (fetch-single
+                                                                      url headers
+                                                                      (merge base-qp params)
+                                                                      response-path pagination opts)]
+                                               (mapv #(merge % params) records)))
+                                           param-sets)))]
+          (touch-handle! handle)
+          (result/extract-result all-records nil false))
+
+        ;; Single mode: one fetch with pagination
+        (do
+          (enforce-rate-limit! handle-state)
+          (let [{:keys [records cursor has-more]}
+                (fetch-single url headers base-qp response-path pagination opts)]
+            (touch-handle! handle)
+            (result/extract-result records cursor has-more)))))
+
+    (throw (ex-info (msg/t :http/handle-not-found {:handle handle}) {:handle handle}))))
+
+(defn do-checkpoint [cursor-state]
+  (result/checkpoint-result cursor-state))

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/impl.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/impl.clj
@@ -152,7 +152,7 @@
           has-more (page-has-more? pagination body offset (count records))
           next-val (next-cursor-value pagination body offset (count records))
           cursor   (when next-val
-                     {:cursor/type  (or (:type pagination) :offset)
+                     {:cursor/type  (get pagination :type :offset)
                       :cursor/value next-val})]
       {:records records :cursor cursor :has-more has-more})))
 
@@ -172,16 +172,16 @@
 
       (if-let [param-sets (:batch/param-sets config)]
         ;; Batch mode: pmap over param sets, enrich records with param keys
-        (let [all-records (vec (apply concat
-                                     (pmap (fn [params]
-                                             (let [{:keys [records]} (fetch-single
-                                                                      url headers
-                                                                      (merge base-qp params)
-                                                                      response-path pagination opts)]
-                                               (mapv #(merge % params) records)))
-                                           param-sets)))]
-          (touch-handle! handle)
-          (result/extract-result all-records nil false))
+        (letfn [(fetch-and-enrich [params]
+                  (let [{:keys [records]} (fetch-single
+                                           url headers
+                                           (merge base-qp params)
+                                           response-path pagination opts)]
+                    (mapv #(merge % params) records)))]
+          (let [all-records (vec (apply concat
+                                       (pmap fetch-and-enrich param-sets)))]
+            (touch-handle! handle)
+            (result/extract-result all-records nil false)))
 
         ;; Single mode: one fetch with pagination
         (do

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/interface.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/interface.clj
@@ -1,0 +1,20 @@
+(ns ai.miniforge.data-foundry.connector-http.interface
+  "Public API for the HTTP connector component."
+  (:require [ai.miniforge.data-foundry.connector-http.core :as core]))
+
+(defn create-http-connector
+  "Create a new HttpConnector instance."
+  []
+  (core/->HttpConnector))
+
+(def connector-metadata
+  "Registration metadata for the HTTP connector."
+  {:connector/name         "HTTP REST Connector"
+   :connector/type         :source
+   :connector/version      "0.1.0"
+   :connector/capabilities #{:cap/discovery :cap/incremental :cap/pagination :cap/rate-limiting}
+   :connector/auth-methods #{:api-key :basic :none}
+   :connector/retry-policy {:retry/strategy :exponential-backoff
+                            :retry/max-attempts 3
+                            :retry/base-delay-ms 1000}
+   :connector/maintainer   "data-foundry"})

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/messages.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.connector-http.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/connector-http/messages/en-US.edn" :connector-http/messages))

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/pagination.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/pagination.clj
@@ -1,0 +1,61 @@
+(ns ai.miniforge.data-foundry.connector-http.pagination
+  "Pagination strategies for HTTP extraction."
+  (:require [clojure.string :as str]))
+
+(defn offset-params
+  "Build query params for offset-based pagination."
+  [{:keys [param page-size-param]} offset page-size]
+  {(or param "offset") offset
+   (or page-size-param "limit") page-size})
+
+(defn cursor-params
+  "Build query params for cursor-based pagination."
+  [{:keys [param page-size-param]} cursor-value page-size]
+  (cond-> {(or page-size-param "limit") page-size}
+    cursor-value (assoc (or param "cursor") cursor-value)))
+
+(defn next-offset
+  "Calculate next offset for offset-based pagination."
+  [current-offset records-count]
+  (+ current-offset records-count))
+
+(defn has-more-offset?
+  "Determine if more pages exist for offset pagination."
+  [response-body {:keys [total-path]} current-offset records-count]
+  (if total-path
+    (let [total (get-in response-body total-path)]
+      (and (number? total) (< (+ current-offset records-count) total)))
+    (pos? records-count)))
+
+(defn extract-cursor-value
+  "Extract next cursor value from response for cursor-based pagination."
+  [response-body {:keys [next-cursor-path]}]
+  (when next-cursor-path
+    (get-in response-body next-cursor-path)))
+
+;; --------------------------------------------------------------------------
+;; Link-header pagination (RFC 5988)
+;; --------------------------------------------------------------------------
+
+(defn parse-link-header
+  "Parse an HTTP Link header into a map of {rel url}.
+   Example: '<https://api.github.com/repos?page=2>; rel=\"next\"'
+   → {\"next\" \"https://api.github.com/repos?page=2\"}"
+  [link-header]
+  (when link-header
+    (into {}
+          (for [part  (str/split link-header #",\s*")
+                :let  [[_ url] (re-find #"<([^>]+)>" part)
+                       [_ rel] (re-find #"rel=\"([^\"]+)\"" part)]
+                :when (and url rel)]
+            [rel url]))))
+
+(defn link-header-next-url
+  "Extract the 'next' URL from a parsed Link header map."
+  [links]
+  (get links "next"))
+
+(defn link-header-has-more?
+  "Check if a Link header indicates more pages."
+  [links]
+  (boolean (link-header-next-url links)))

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/rate_limit.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/rate_limit.clj
@@ -1,0 +1,90 @@
+(ns ai.miniforge.data-foundry.connector-http.rate-limit
+  "Shared response-header-driven rate limiting for API connectors.
+   Reads rate limit headers from HTTP responses and backs off when
+   approaching the limit. Works with GitHub, GitLab, and any provider
+   that returns standard rate limit headers."
+  (:import [java.util.concurrent Executors ScheduledExecutorService TimeUnit]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Header parsing
+
+(defn- parse-long-header
+  "Parse a header value as a long, returning nil on failure."
+  [headers header-name]
+  (when-let [v (get headers header-name)]
+    (try (Long/parseLong (str v)) (catch NumberFormatException _ nil))))
+
+(defn parse-rate-headers
+  "Extract rate limit info from response headers using a provider mapping.
+   mapping: {:remaining \"x-ratelimit-remaining\" :reset \"x-ratelimit-reset\" :limit \"x-ratelimit-limit\"}
+   Returns: {:remaining long :reset-epoch long :limit long} or nil if headers absent."
+  [headers mapping]
+  (let [remaining (parse-long-header headers (:remaining mapping))
+        reset-at  (parse-long-header headers (:reset mapping))
+        limit     (parse-long-header headers (:limit mapping))]
+    (when (and remaining reset-at)
+      {:remaining   remaining
+       :reset-epoch reset-at
+       :limit       limit})))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; State management
+
+(defn update-rate-state!
+  "Store rate limit info in a handle's atom state."
+  [handles-atom handle rate-info]
+  (when rate-info
+    (swap! handles-atom assoc-in [handle :rate-limit] rate-info)))
+
+(defn- ms-until-reset
+  "Milliseconds until the rate limit resets. Returns 0 if already past."
+  [reset-epoch]
+  (max 0 (- (* reset-epoch 1000) (System/currentTimeMillis))))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Permit acquisition
+
+(defonce ^:private ^ScheduledExecutorService executor
+  (Executors/newSingleThreadScheduledExecutor))
+
+(def ^:private default-threshold
+  "Back off when remaining requests drops below this threshold."
+  10)
+
+(defn acquire-permit!
+  "Check rate limit state and wait if remaining is below threshold.
+   Uses a ScheduledExecutorService for non-blocking delay.
+   opts: {:threshold long} — override the default remaining threshold."
+  [handles-atom handle opts]
+  (when-let [rate-info (get-in @handles-atom [handle :rate-limit])]
+    (let [remaining (:remaining rate-info)
+          threshold (get opts :threshold default-threshold)]
+      (when (and remaining (< remaining threshold))
+        (let [wait-ms (ms-until-reset (:reset-epoch rate-info))]
+          (when (pos? wait-ms)
+            (let [p (promise)]
+              (.schedule executor
+                         ^Runnable (fn [] (deliver p true))
+                         (long (min wait-ms 60000)) ;; cap at 60s
+                         TimeUnit/MILLISECONDS)
+              @p)))))))
+
+;;------------------------------------------------------------------------------ Layer 3
+;; Time-based (interval) rate limiting
+
+(defn time-based-acquire!
+  "Sleep if needed to enforce a requests-per-second limit.
+   Takes rps (number) and last-request-ms (epoch millis; 0 or nil means no prior request).
+   Returns current epoch-ms for use as the new last-request-at timestamp."
+  [rps last-request-ms]
+  (let [min-interval-ms (/ 1000.0 rps)
+        elapsed         (- (System/currentTimeMillis) (or last-request-ms 0))]
+    (when (< elapsed min-interval-ms)
+      (Thread/sleep (long (- min-interval-ms elapsed)))))
+  (System/currentTimeMillis))
+
+(comment
+  ;; Provider header mappings:
+  ;; GitHub:  {:remaining "x-ratelimit-remaining" :reset "x-ratelimit-reset" :limit "x-ratelimit-limit"}
+  ;; GitLab:  {:remaining "ratelimit-remaining"   :reset "ratelimit-reset"   :limit "ratelimit-limit"}
+  )

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/request.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/request.clj
@@ -1,0 +1,93 @@
+(ns ai.miniforge.data-foundry.connector-http.request
+  "Shared HTTP GET request pattern for REST API connectors.
+   Handles ETag conditional requests, response classification, and
+   Link-header pagination. Connectors supply connector-specific error
+   messages; everything else is shared.
+
+   Layer 0: Predicates and classifiers
+   Layer 1: Response builders
+   Layer 2: Request execution and post-request helpers"
+  (:require [ai.miniforge.data-foundry.connector-http.etag :as etag]
+            [ai.miniforge.data-foundry.connector-http.pagination :as page]
+            [ai.miniforge.schema.interface :as schema]
+            [clojure.data.json :as json]
+            [hato.client :as hc]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Predicates and classifiers
+
+(defn ok?
+  "Predicate: is the HTTP status a success (2xx)?"
+  [status]
+  (<= 200 status 299))
+
+(defn classify-error
+  "Classify a non-success HTTP status into an error category keyword."
+  [status]
+  (cond
+    (= 429 status)      :rate-limited
+    (<= 500 status 599) :server-error
+    :else               :client-error))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Response builders
+
+(defn success-response
+  "Build a schema/success from a 2xx response. Caches the ETag for the URL."
+  [url resp]
+  (etag/store-etag! url (etag/extract-etag (:headers resp)))
+  (schema/success :body (json/read-str (:body resp) :key-fn keyword)
+                  {:headers (:headers resp)}))
+
+(defn not-modified-response
+  "Build a schema/success for a 304 Not Modified response."
+  [resp]
+  (schema/success :body nil {:headers (:headers resp) :not-modified true}))
+
+(defn error-response
+  "Build a schema/failure from a non-success, non-304 response.
+   msgs map: {:rate-limited string :request-failed (fn [status err-str] string)}"
+  [status resp msgs]
+  (let [request-failed (:request-failed msgs)]
+    (case (classify-error status)
+      :rate-limited (schema/failure :body (:rate-limited msgs)                      {:error-type :rate-limited})
+      :server-error (schema/failure :body (request-failed status "server error")    {:error-type :transient})
+      :client-error (schema/failure :body (request-failed status (:body resp))      {:error-type :permanent}))))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Request execution and post-request helpers
+
+(defn do-request
+  "Execute an HTTP GET. Returns schema/success or schema/failure.
+   Supports ETag conditional requests via If-None-Match header.
+   error-fn: (fn [status resp] schema/failure) — supplies connector-specific messages."
+  [url headers query-params error-fn]
+  (let [resp   (hc/get url {:headers          (etag/add-etag-header headers url)
+                             :query-params     query-params
+                             :as               :string
+                             :throw-exceptions false})
+        status (:status resp)]
+    (cond
+      (etag/not-modified? status) (not-modified-response resp)
+      (ok? status)                (success-response url resp)
+      :else                       (error-fn status resp))))
+
+(defn throw-on-failure!
+  "Throw an ex-info if result is a failure. Returns result unchanged on success."
+  [result]
+  (when-not (:success? result)
+    (throw (ex-info (str (:error result)) {:error-type (:error-type result)})))
+  result)
+
+(defn next-url
+  "Extract the 'next' page URL from a response's Link header, or nil."
+  [resp]
+  (some-> (:headers resp)
+          (get "link")
+          page/parse-link-header
+          page/link-header-next-url))
+
+(defn coerce-records
+  "Coerce a response body to a vector of records."
+  [body]
+  (if (sequential? body) (vec body) [body]))

--- a/components/connector-http/test/ai/miniforge/data_foundry/connector_http/cursors_test.clj
+++ b/components/connector-http/test/ai/miniforge/data_foundry/connector_http/cursors_test.clj
@@ -1,0 +1,133 @@
+(ns ai.miniforge.data-foundry.connector-http.cursors-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector-http.cursors :as cursors]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Fixtures
+
+(def ^:private ts-fn
+  "Standard timestamp extractor for test records."
+  #(or (:updated_at %) (:created_at %)))
+
+(def ^:private resource-def
+  {:cursor-type :timestamp-watermark})
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Tests
+
+(deftest parse-timestamp-test
+  (testing "parses valid ISO-8601 timestamp to Instant"
+    (is (some? (cursors/parse-timestamp "2024-01-15T10:00:00Z"))))
+
+  (testing "returns nil for nil input"
+    (is (nil? (cursors/parse-timestamp nil))))
+
+  (testing "returns nil for empty string"
+    (is (nil? (cursors/parse-timestamp ""))))
+
+  (testing "returns nil for blank string"
+    (is (nil? (cursors/parse-timestamp "   ")))))
+
+(deftest after-cursor?-test
+  (testing "returns true when cursor is nil (no prior watermark)"
+    (is (true? (cursors/after-cursor? ts-fn nil {:updated_at "2024-01-15T10:00:00Z"}))))
+
+  (testing "returns true when record is strictly after cursor timestamp"
+    (is (true? (cursors/after-cursor? ts-fn
+                                      {:cursor/type  :timestamp-watermark
+                                       :cursor/value "2024-01-14T00:00:00Z"}
+                                      {:updated_at "2024-01-15T10:00:00Z"}))))
+
+  (testing "returns false when record is before cursor timestamp"
+    (is (false? (cursors/after-cursor? ts-fn
+                                       {:cursor/type  :timestamp-watermark
+                                        :cursor/value "2024-01-16T00:00:00Z"}
+                                       {:updated_at "2024-01-15T10:00:00Z"}))))
+
+  (testing "returns false when record equals cursor timestamp (not strictly after)"
+    (is (false? (cursors/after-cursor? ts-fn
+                                       {:cursor/type  :timestamp-watermark
+                                        :cursor/value "2024-01-15T10:00:00Z"}
+                                       {:updated_at "2024-01-15T10:00:00Z"}))))
+
+  (testing "uses :created_at when :updated_at is absent"
+    (is (true? (cursors/after-cursor? ts-fn
+                                      {:cursor/type  :timestamp-watermark
+                                       :cursor/value "2024-01-14T00:00:00Z"}
+                                      {:created_at "2024-01-15T10:00:00Z"})))))
+
+(deftest last-record-cursor-test
+  (testing "returns nil for empty records"
+    (is (nil? (cursors/last-record-cursor resource-def []))))
+
+  (testing "returns nil for non-watermark resource cursor-type"
+    (is (nil? (cursors/last-record-cursor {:cursor-type :offset}
+                                          [{:updated_at "2024-01-15T10:00:00Z"}]))))
+
+  (testing "returns nil for resource with no cursor-type"
+    (is (nil? (cursors/last-record-cursor {}
+                                          [{:updated_at "2024-01-15T10:00:00Z"}]))))
+
+  (testing "returns cursor from last record :updated_at"
+    (let [cursor (cursors/last-record-cursor resource-def
+                                             [{:updated_at "2024-01-14T00:00:00Z"}
+                                              {:updated_at "2024-01-15T10:00:00Z"}])]
+      (is (= :timestamp-watermark (:cursor/type cursor)))
+      (is (= "2024-01-15T10:00:00Z" (:cursor/value cursor)))))
+
+  (testing "falls back to :created_at when :updated_at absent"
+    (let [cursor (cursors/last-record-cursor resource-def
+                                             [{:created_at "2024-01-15T10:00:00Z"}])]
+      (is (= "2024-01-15T10:00:00Z" (:cursor/value cursor))))))
+
+(deftest sort-by-timestamp-test
+  (testing "sorts records ascending by timestamp"
+    (let [records [{:updated_at "2024-01-15T10:00:00Z"}
+                   {:updated_at "2024-01-13T08:00:00Z"}
+                   {:updated_at "2024-01-14T09:00:00Z"}]
+          sorted  (cursors/sort-by-timestamp ts-fn records)]
+      (is (= ["2024-01-13T08:00:00Z" "2024-01-14T09:00:00Z" "2024-01-15T10:00:00Z"]
+             (mapv :updated_at sorted)))))
+
+  (testing "records with nil timestamps sort first"
+    (let [records [{:updated_at "2024-01-15T10:00:00Z"}
+                   {:title "no timestamp"}
+                   {:updated_at "2024-01-13T00:00:00Z"}]
+          sorted  (cursors/sort-by-timestamp ts-fn records)]
+      (is (nil? (ts-fn (first sorted))))))
+
+  (testing "empty collection returns empty"
+    (is (empty? (cursors/sort-by-timestamp ts-fn [])))))
+
+(deftest max-timestamp-cursor-test
+  (testing "returns nil for empty records"
+    (is (nil? (cursors/max-timestamp-cursor ts-fn []))))
+
+  (testing "returns nil when no records have timestamps"
+    (is (nil? (cursors/max-timestamp-cursor ts-fn [{:title "no ts"}]))))
+
+  (testing "returns cursor with maximum timestamp"
+    (let [records [{:updated_at "2024-01-13T08:00:00Z"}
+                   {:updated_at "2024-01-15T10:00:00Z"}
+                   {:updated_at "2024-01-14T09:00:00Z"}]
+          cursor  (cursors/max-timestamp-cursor ts-fn records)]
+      (is (= :timestamp-watermark (:cursor/type cursor)))
+      (is (= "2024-01-15T10:00:00Z" (:cursor/value cursor)))))
+
+  (testing "skips records without timestamps when finding max"
+    (let [records [{:updated_at "2024-01-15T10:00:00Z"}
+                   {:title "no ts"}
+                   {:updated_at "2024-01-13T00:00:00Z"}]
+          cursor  (cursors/max-timestamp-cursor ts-fn records)]
+      (is (= "2024-01-15T10:00:00Z" (:cursor/value cursor)))))
+
+  (testing "custom timestamp-fn uses alternate fields"
+    (let [submitted-fn #(:submitted_at %)
+          records [{:submitted_at "2024-01-15T10:00:00Z"}
+                   {:submitted_at "2024-01-13T08:00:00Z"}]
+          cursor  (cursors/max-timestamp-cursor submitted-fn records)]
+      (is (= "2024-01-15T10:00:00Z" (:cursor/value cursor))))))
+
+(comment
+  ;; Run: clj -M:dev:test -n ai.miniforge.data-foundry.connector-http.cursors-test
+  )

--- a/components/connector-http/test/ai/miniforge/data_foundry/connector_http/etag_test.clj
+++ b/components/connector-http/test/ai/miniforge/data_foundry/connector_http/etag_test.clj
@@ -1,0 +1,61 @@
+(ns ai.miniforge.data-foundry.connector-http.etag-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [ai.miniforge.data-foundry.connector-http.etag :as etag]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Fixtures
+
+(use-fixtures :each (fn [f] (etag/clear-cache!) (f)))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Tests
+
+(deftest store-and-retrieve-etag-test
+  (testing "stores and retrieves ETag for URL"
+    (etag/store-etag! "https://api.github.com/repos/org/repo/pulls" "W/\"abc123\"")
+    (is (= "W/\"abc123\"" (etag/get-etag "https://api.github.com/repos/org/repo/pulls"))))
+
+  (testing "returns nil for unknown URL"
+    (is (nil? (etag/get-etag "https://unknown.example.com"))))
+
+  (testing "ignores nil etag"
+    (etag/store-etag! "https://example.com" nil)
+    (is (nil? (etag/get-etag "https://example.com")))))
+
+(deftest add-etag-header-test
+  (testing "adds If-None-Match when ETag cached"
+    (etag/store-etag! "https://example.com" "W/\"xyz\"")
+    (let [headers (etag/add-etag-header {"Accept" "application/json"} "https://example.com")]
+      (is (= "W/\"xyz\"" (get headers "If-None-Match")))
+      (is (= "application/json" (get headers "Accept")))))
+
+  (testing "returns headers unchanged when no cached ETag"
+    (let [headers (etag/add-etag-header {"Accept" "text/html"} "https://uncached.com")]
+      (is (nil? (get headers "If-None-Match")))
+      (is (= "text/html" (get headers "Accept"))))))
+
+(deftest extract-etag-test
+  (testing "extracts etag from response headers"
+    (is (= "W/\"abc\"" (etag/extract-etag {"etag" "W/\"abc\""}))))
+
+  (testing "returns nil when no etag header"
+    (is (nil? (etag/extract-etag {"content-type" "application/json"})))))
+
+(deftest not-modified-test
+  (testing "304 is not-modified"
+    (is (true? (etag/not-modified? 304))))
+
+  (testing "200 is not not-modified"
+    (is (false? (etag/not-modified? 200)))))
+
+(deftest clear-cache-test
+  (testing "clear-cache! removes all entries"
+    (etag/store-etag! "https://a.com" "e1")
+    (etag/store-etag! "https://b.com" "e2")
+    (etag/clear-cache!)
+    (is (nil? (etag/get-etag "https://a.com")))
+    (is (nil? (etag/get-etag "https://b.com")))))
+
+(comment
+  ;; Run: clj -M:dev:test -n ai.miniforge.data-foundry.connector-http.etag-test
+  )

--- a/components/connector-http/test/ai/miniforge/data_foundry/connector_http/interface_test.clj
+++ b/components/connector-http/test/ai/miniforge/data_foundry/connector_http/interface_test.clj
@@ -1,0 +1,306 @@
+(ns ai.miniforge.data-foundry.connector-http.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector-http.interface :as http-conn]
+            [ai.miniforge.data-foundry.connector-http.impl :as impl]
+            [ai.miniforge.data-foundry.connector.interface :as conn]))
+
+;; ---------------------------------------------------------------------------
+;; Connector metadata
+;; ---------------------------------------------------------------------------
+
+(deftest connector-metadata-test
+  (testing "HTTP connector metadata"
+    (let [meta http-conn/connector-metadata]
+      (is (= :source (:connector/type meta)))
+      (is (contains? (:connector/capabilities meta) :cap/pagination))
+      (is (contains? (:connector/auth-methods meta) :api-key)))))
+
+;; ---------------------------------------------------------------------------
+;; Connect / close lifecycle
+;; ---------------------------------------------------------------------------
+
+(deftest connect-close-lifecycle-test
+  (testing "Connect and close lifecycle"
+    (let [hc (http-conn/create-http-connector)
+          result (conn/connect hc {:http/base-url "https://api.example.com"
+                                    :http/endpoint "/data"} {})]
+      (is (= :connected (:connector/status result)))
+      (is (string? (:connection/handle result)))
+      (let [close-result (conn/close hc (:connection/handle result))]
+        (is (= :closed (:connector/status close-result)))))))
+
+(deftest connect-missing-base-url-test
+  (testing "Connect fails without :http/base-url"
+    (let [hc (http-conn/create-http-connector)]
+      (is (thrown? Exception (conn/connect hc {:http/endpoint "/data"} {}))))))
+
+(deftest connect-missing-endpoint-test
+  (testing "Connect fails without :http/endpoint"
+    (let [hc (http-conn/create-http-connector)]
+      (is (thrown? Exception (conn/connect hc {:http/base-url "https://api.example.com"} {}))))))
+
+;; ---------------------------------------------------------------------------
+;; Extract with stubbed HTTP (override do-request)
+;; ---------------------------------------------------------------------------
+
+(deftest extract-simple-test
+  (testing "Extract with simple JSON array response"
+    (with-redefs [impl/do-request
+                  (fn [_url _headers _params]
+                    {:success? true
+                     :body [{:id 1 :name "alpha"} {:id 2 :name "beta"}]})]
+      (let [hc (http-conn/create-http-connector)
+            handle (:connection/handle
+                    (conn/connect hc {:http/base-url "https://api.example.com"
+                                      :http/endpoint "/data"} {}))
+            result (conn/extract hc handle "data" {})]
+        (is (= 2 (:extract/row-count result)))
+        (is (= [{:id 1 :name "alpha"} {:id 2 :name "beta"}] (:records result)))
+        (conn/close hc handle)))))
+
+(deftest extract-nested-response-path-test
+  (testing "Extract with nested response path"
+    (with-redefs [impl/do-request
+                  (fn [_url _headers _params]
+                    {:success? true
+                     :body {:hits {:hits [{:id 1} {:id 2} {:id 3}]
+                                   :total 10}}})]
+      (let [hc (http-conn/create-http-connector)
+            handle (:connection/handle
+                    (conn/connect hc {:http/base-url "https://api.example.com"
+                                      :http/endpoint "/search"
+                                      :http/response-path [:hits :hits]} {}))
+            result (conn/extract hc handle "search" {})]
+        (is (= 3 (:extract/row-count result)))
+        (is (= [{:id 1} {:id 2} {:id 3}] (:records result)))
+        (conn/close hc handle)))))
+
+(deftest extract-offset-pagination-test
+  (testing "Extract with offset-based pagination"
+    (let [call-count (atom 0)]
+      (with-redefs [impl/do-request
+                    (fn [_url _headers params]
+                      (swap! call-count inc)
+                      (let [offset (get params "from" 0)]
+                        {:success? true
+                         :body {:hits {:hits (if (< offset 4)
+                                              [{:id (+ offset 1)} {:id (+ offset 2)}]
+                                              [])
+                                       :total 4}}}))]
+        (let [hc (http-conn/create-http-connector)
+              handle (:connection/handle
+                      (conn/connect hc {:http/base-url "https://api.example.com"
+                                        :http/endpoint "/search"
+                                        :http/response-path [:hits :hits]
+                                        :http/pagination {:type :offset
+                                                          :param "from"
+                                                          :page-size-param "size"
+                                                          :total-path [:hits :total]}} {}))
+              ;; First page
+              r1 (conn/extract hc handle "search" {:extract/batch-size 2})]
+          (is (= 2 (:extract/row-count r1)))
+          (is (true? (:extract/has-more r1)))
+          (is (= 2 (get-in r1 [:extract/cursor :cursor/value])))
+
+          ;; Second page
+          (let [r2 (conn/extract hc handle "search"
+                                 {:extract/batch-size 2
+                                  :extract/cursor (:extract/cursor r1)})]
+            (is (= 2 (:extract/row-count r2)))
+            (is (false? (:extract/has-more r2))))
+          (conn/close hc handle))))))
+
+(deftest extract-cursor-pagination-test
+  (testing "Extract with cursor-based pagination"
+    (with-redefs [impl/do-request
+                  (fn [_url _headers params]
+                    (if (get params "cursor")
+                      {:success? true
+                       :body {:data [{:id 3}] :next_cursor nil}}
+                      {:success? true
+                       :body {:data [{:id 1} {:id 2}] :next_cursor "abc123"}}))]
+      (let [hc (http-conn/create-http-connector)
+            handle (:connection/handle
+                    (conn/connect hc {:http/base-url "https://api.example.com"
+                                      :http/endpoint "/data"
+                                      :http/response-path [:data]
+                                      :http/pagination {:type :cursor
+                                                        :param "cursor"
+                                                        :next-cursor-path [:next_cursor]}} {}))
+            ;; First page
+            r1 (conn/extract hc handle "data" {:extract/batch-size 2})]
+        (is (= 2 (:extract/row-count r1)))
+        (is (true? (:extract/has-more r1)))
+        (is (= "abc123" (get-in r1 [:extract/cursor :cursor/value])))
+
+        ;; Second page
+        (let [r2 (conn/extract hc handle "data"
+                               {:extract/batch-size 2
+                                :extract/cursor (:extract/cursor r1)})]
+          (is (= 1 (:extract/row-count r2)))
+          (is (false? (:extract/has-more r2))))
+        (conn/close hc handle)))))
+
+(deftest extract-http-error-test
+  (testing "Extract throws on HTTP 500"
+    (with-redefs [impl/do-request
+                  (fn [_url _headers _params]
+                    {:success? false :error-type :transient
+                     :error "HTTP request failed"})]
+      (let [hc (http-conn/create-http-connector)
+            handle (:connection/handle
+                    (conn/connect hc {:http/base-url "https://api.example.com"
+                                      :http/endpoint "/data"} {}))]
+        (is (thrown? Exception (conn/extract hc handle "data" {})))
+        (conn/close hc handle)))))
+
+(deftest extract-rate-limited-test
+  (testing "Extract throws on HTTP 429"
+    (with-redefs [impl/do-request
+                  (fn [_url _headers _params]
+                    {:success? false :error-type :rate-limited
+                     :error "Rate limited by server (429)"})]
+      (let [hc (http-conn/create-http-connector)
+            handle (:connection/handle
+                    (conn/connect hc {:http/base-url "https://api.example.com"
+                                      :http/endpoint "/data"} {}))]
+        (is (thrown-with-msg? Exception #"Rate limited"
+                              (conn/extract hc handle "data" {})))
+        (conn/close hc handle)))))
+
+;; ---------------------------------------------------------------------------
+;; Batch extract
+;; ---------------------------------------------------------------------------
+
+(deftest batch-extract-parallel-test
+  (testing "Extract with :batch/param-sets fetches all param sets in parallel"
+    (let [calls (atom [])]
+      (with-redefs [impl/do-request
+                    (fn [_url _headers params]
+                      (swap! calls conj params)
+                      (let [series (get params :series_id)]
+                        {:success? true
+                         :body {:observations [{:date "2026-01-01" :value "1.23"}
+                                               {:date "2026-01-02" :value "4.56"}]}}))]
+        (let [hc (http-conn/create-http-connector)
+              handle (:connection/handle
+                      (conn/connect hc {:http/base-url "https://api.example.com"
+                                         :http/endpoint "/series/observations"
+                                         :http/query-params {:api_key "test-key"
+                                                             :file_type "json"}
+                                         :http/response-path [:observations]
+                                         :batch/param-sets [{:series_id "DGS2"}
+                                                            {:series_id "DGS10"}
+                                                            {:series_id "DGS30"}]} {}))
+              result (conn/extract hc handle "observations" {})]
+          ;; 3 param-sets × 2 records each = 6 total
+          (is (= 6 (:extract/row-count result)))
+          ;; All 3 series called
+          (is (= 3 (count @calls)))
+          ;; No pagination in batch mode
+          (is (nil? (:extract/cursor result)))
+          (is (false? (:extract/has-more result)))
+          (conn/close hc handle))))))
+
+(deftest batch-extract-enriches-records-test
+  (testing "Batch extract merges param-set keys into each record"
+    (with-redefs [impl/do-request
+                  (fn [_url _headers params]
+                    {:success? true
+                     :body {:data [{:date "2026-01-01" :value "1.0"}]}})]
+      (let [hc (http-conn/create-http-connector)
+            handle (:connection/handle
+                    (conn/connect hc {:http/base-url "https://api.example.com"
+                                       :http/endpoint "/data"
+                                       :http/response-path [:data]
+                                       :batch/param-sets [{:series_id "AAA"}
+                                                          {:series_id "BBB"}]} {}))
+            result (conn/extract hc handle "data" {})
+            records (:records result)]
+        (is (= 2 (count records)))
+        (is (= "AAA" (:series_id (first records))))
+        (is (= "BBB" (:series_id (second records))))
+        ;; Original fields preserved
+        (is (= "2026-01-01" (:date (first records))))
+        (conn/close hc handle)))))
+
+(deftest batch-extract-error-propagates-test
+  (testing "Batch extract propagates errors from individual fetches"
+    (with-redefs [impl/do-request
+                  (fn [_url _headers params]
+                    (if (= "BAD" (:series_id params))
+                      {:success? false :error "Not found" :error-type :permanent}
+                      {:success? true :body {:data [{:value "ok"}]}}))]
+      (let [hc (http-conn/create-http-connector)
+            handle (:connection/handle
+                    (conn/connect hc {:http/base-url "https://api.example.com"
+                                       :http/endpoint "/data"
+                                       :http/response-path [:data]
+                                       :batch/param-sets [{:series_id "GOOD"}
+                                                          {:series_id "BAD"}]} {}))]
+        (is (thrown? Exception (conn/extract hc handle "data" {})))
+        (conn/close hc handle)))))
+
+;; ---------------------------------------------------------------------------
+;; Auth header construction
+;; ---------------------------------------------------------------------------
+
+(deftest auth-header-api-key-test
+  (testing "API key auth sets Bearer header"
+    (with-redefs [impl/do-request
+                  (fn [_url headers _params]
+                    (is (= "Bearer my-api-key" (get headers "Authorization")))
+                    {:success? true :body []})]
+      (let [hc (http-conn/create-http-connector)
+            handle (:connection/handle
+                    (conn/connect hc {:http/base-url "https://api.example.com"
+                                      :http/endpoint "/data"}
+                                 {:auth/method :api-key
+                                  :auth/credential-id "my-api-key"}))]
+        (conn/extract hc handle "data" {})
+        (conn/close hc handle)))))
+
+(deftest auth-header-basic-test
+  (testing "Basic auth sets Basic header"
+    (with-redefs [impl/do-request
+                  (fn [_url headers _params]
+                    (is (= "Basic dXNlcjpwYXNz" (get headers "Authorization")))
+                    {:success? true :body []})]
+      (let [hc (http-conn/create-http-connector)
+            handle (:connection/handle
+                    (conn/connect hc {:http/base-url "https://api.example.com"
+                                      :http/endpoint "/data"}
+                                 {:auth/method :basic
+                                  :auth/credential-id "dXNlcjpwYXNz"}))]
+        (conn/extract hc handle "data" {})
+        (conn/close hc handle)))))
+
+;; ---------------------------------------------------------------------------
+;; Discover
+;; ---------------------------------------------------------------------------
+
+(deftest discover-test
+  (testing "Discover returns endpoint info"
+    (let [hc (http-conn/create-http-connector)
+          handle (:connection/handle
+                  (conn/connect hc {:http/base-url "https://api.example.com"
+                                    :http/endpoint "/search"} {}))
+          result (conn/discover hc handle {})]
+      (is (= 1 (:discover/total-count result)))
+      (is (= "/search" (:schema/name (first (:schemas result)))))
+      (conn/close hc handle))))
+
+;; ---------------------------------------------------------------------------
+;; Checkpoint
+;; ---------------------------------------------------------------------------
+
+(deftest checkpoint-test
+  (testing "Checkpoint returns committed status"
+    (let [hc (http-conn/create-http-connector)
+          handle (:connection/handle
+                  (conn/connect hc {:http/base-url "https://api.example.com"
+                                    :http/endpoint "/data"} {}))
+          cursor {:cursor/type :offset :cursor/value 100}
+          result (conn/checkpoint hc handle "http-conn-1" cursor)]
+      (is (= :committed (:checkpoint/status result)))
+      (conn/close hc handle))))

--- a/components/connector-http/test/ai/miniforge/data_foundry/connector_http/rate_limit_test.clj
+++ b/components/connector-http/test/ai/miniforge/data_foundry/connector_http/rate_limit_test.clj
@@ -1,0 +1,62 @@
+(ns ai.miniforge.data-foundry.connector-http.rate-limit-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector-http.rate-limit :as rate]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Fixtures
+
+(def github-mapping
+  {:remaining "x-ratelimit-remaining" :reset "x-ratelimit-reset" :limit "x-ratelimit-limit"})
+
+(def gitlab-mapping
+  {:remaining "ratelimit-remaining" :reset "ratelimit-reset" :limit "ratelimit-limit"})
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Tests
+
+(deftest parse-rate-headers-test
+  (testing "parses GitHub rate limit headers"
+    (let [headers {"x-ratelimit-remaining" "4990"
+                   "x-ratelimit-reset" "1711468800"
+                   "x-ratelimit-limit" "5000"}
+          info (rate/parse-rate-headers headers github-mapping)]
+      (is (= 4990 (:remaining info)))
+      (is (= 1711468800 (:reset-epoch info)))
+      (is (= 5000 (:limit info)))))
+
+  (testing "parses GitLab rate limit headers"
+    (let [headers {"ratelimit-remaining" "295"
+                   "ratelimit-reset" "1711468800"
+                   "ratelimit-limit" "300"}
+          info (rate/parse-rate-headers headers gitlab-mapping)]
+      (is (= 295 (:remaining info)))
+      (is (= 300 (:limit info)))))
+
+  (testing "returns nil when headers absent"
+    (is (nil? (rate/parse-rate-headers {} github-mapping))))
+
+  (testing "handles non-numeric values gracefully"
+    (is (nil? (rate/parse-rate-headers {"x-ratelimit-remaining" "bogus"
+                                        "x-ratelimit-reset" "also-bogus"}
+                                       github-mapping)))))
+
+(deftest update-rate-state-test
+  (testing "stores rate info in handle atom"
+    (let [handles (atom {"h1" {:config {}}})]
+      (rate/update-rate-state! handles "h1" {:remaining 100 :reset-epoch 99999})
+      (is (= 100 (get-in @handles ["h1" :rate-limit :remaining])))))
+
+  (testing "no-op when rate-info is nil"
+    (let [handles (atom {"h1" {:config {}}})]
+      (rate/update-rate-state! handles "h1" nil)
+      (is (nil? (get-in @handles ["h1" :rate-limit]))))))
+
+(deftest acquire-permit-no-block-test
+  (testing "does not block when remaining is above threshold"
+    (let [handles (atom {"h1" {:rate-limit {:remaining 4990 :reset-epoch 9999999999}}})]
+      ;; Should return immediately (nil = no wait needed)
+      (is (nil? (rate/acquire-permit! handles "h1" {}))))))
+
+(comment
+  ;; Run: clj -M:dev:test -n ai.miniforge.data-foundry.connector-http.rate-limit-test
+  )

--- a/components/connector-http/test/ai/miniforge/data_foundry/connector_http/request_test.clj
+++ b/components/connector-http/test/ai/miniforge/data_foundry/connector_http/request_test.clj
@@ -1,0 +1,166 @@
+(ns ai.miniforge.data-foundry.connector-http.request-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [ai.miniforge.data-foundry.connector-http.etag :as etag]
+            [ai.miniforge.data-foundry.connector-http.request :as request]
+            [hato.client :as hc]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Fixtures
+
+(use-fixtures :each (fn [f] (etag/clear-cache!) (f)))
+
+(def ^:private error-msgs
+  {:rate-limited   "Rate limited"
+   :request-failed (fn [s e] (str "Failed " s ": " e))})
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Tests
+
+(deftest ok?-test
+  (testing "200 is ok"  (is (true?  (request/ok? 200))))
+  (testing "299 is ok"  (is (true?  (request/ok? 299))))
+  (testing "404 is not" (is (false? (request/ok? 404))))
+  (testing "500 is not" (is (false? (request/ok? 500))))
+  (testing "304 is not" (is (false? (request/ok? 304)))))
+
+(deftest classify-error-test
+  (testing "429 is :rate-limited"  (is (= :rate-limited  (request/classify-error 429))))
+  (testing "500 is :server-error"  (is (= :server-error  (request/classify-error 500))))
+  (testing "503 is :server-error"  (is (= :server-error  (request/classify-error 503))))
+  (testing "404 is :client-error"  (is (= :client-error  (request/classify-error 404))))
+  (testing "401 is :client-error"  (is (= :client-error  (request/classify-error 401)))))
+
+(deftest success-response-test
+  (testing "parses JSON body and carries headers"
+    (let [url    "https://api.example.com/repos"
+          resp   {:status 200 :body "[{\"id\":1}]" :headers {"content-type" "application/json"}}
+          result (request/success-response url resp)]
+      (is (true? (:success? result)))
+      (is (= [{:id 1}] (:body result)))
+      (is (= {"content-type" "application/json"} (:headers result)))))
+
+  (testing "caches ETag from response headers"
+    (let [url  "https://api.example.com/etag-resource"
+          resp {:status 200 :body "{}" :headers {"etag" "W/\"abc123\""}}]
+      (request/success-response url resp)
+      (is (= "W/\"abc123\"" (etag/get-etag url)))))
+
+  (testing "no error when response has no ETag header"
+    (let [url  "https://api.example.com/no-etag"
+          resp {:status 200 :body "[]" :headers {}}]
+      (is (some? (request/success-response url resp))))))
+
+(deftest not-modified-response-test
+  (testing "returns success with nil body and :not-modified true"
+    (let [result (request/not-modified-response {:status 304 :headers {"etag" "W/\"abc\""}})]
+      (is (true? (:success? result)))
+      (is (nil? (:body result)))
+      (is (true? (:not-modified result))))))
+
+(deftest error-response-test
+  (testing "rate-limited response has :rate-limited error-type"
+    (let [result (request/error-response 429 {:body ""} error-msgs)]
+      (is (false? (:success? result)))
+      (is (= :rate-limited (:error-type result)))))
+
+  (testing "server error response has :transient error-type"
+    (let [result (request/error-response 500 {:body "internal error"} error-msgs)]
+      (is (false? (:success? result)))
+      (is (= :transient (:error-type result)))))
+
+  (testing "client error response has :permanent error-type"
+    (let [result (request/error-response 404 {:body "not found"} error-msgs)]
+      (is (false? (:success? result)))
+      (is (= :permanent (:error-type result)))))
+
+  (testing "server error calls :request-failed fn with 'server error' string"
+    (let [calls (atom [])
+          msgs  {:rate-limited   ""
+                 :request-failed (fn [s e] (swap! calls conj {:status s :error e}) "")}]
+      (request/error-response 503 {:body "gateway timeout"} msgs)
+      (is (= 1 (count @calls)))
+      (is (= "server error" (:error (first @calls))))))
+
+  (testing "client error calls :request-failed fn with response body"
+    (let [calls (atom [])
+          msgs  {:rate-limited   ""
+                 :request-failed (fn [s e] (swap! calls conj {:status s :error e}) "")}]
+      (request/error-response 403 {:body "forbidden"} msgs)
+      (is (= "forbidden" (:error (first @calls)))))))
+
+(deftest do-request-test
+  (testing "returns success for 2xx"
+    (with-redefs [hc/get (fn [_ _] {:status 200 :body "[{\"id\":1}]" :headers {}})]
+      (let [result (request/do-request "https://example.com" {} {} (fn [_ _] nil))]
+        (is (true? (:success? result)))
+        (is (= [{:id 1}] (:body result))))))
+
+  (testing "returns not-modified for 304"
+    (with-redefs [hc/get (fn [_ _] {:status 304 :body "" :headers {}})]
+      (let [result (request/do-request "https://example.com" {} {} (fn [_ _] nil))]
+        (is (true? (:success? result)))
+        (is (nil? (:body result)))
+        (is (true? (:not-modified result))))))
+
+  (testing "delegates non-2xx non-304 to error-fn"
+    (with-redefs [hc/get (fn [_ _] {:status 429 :body "" :headers {}})]
+      (let [called (atom nil)]
+        (request/do-request "https://example.com" {} {}
+                            (fn [s r] (reset! called s) {:success? false :error-type :rate-limited}))
+        (is (= 429 @called)))))
+
+  (testing "adds If-None-Match when ETag is cached"
+    (etag/store-etag! "https://example.com/cached" "W/\"xyz\"")
+    (let [received-headers (atom nil)]
+      (with-redefs [hc/get (fn [_ opts] (reset! received-headers (:headers opts))
+                              {:status 200 :body "[]" :headers {}})]
+        (request/do-request "https://example.com/cached" {} {} (fn [_ _] nil))
+        (is (= "W/\"xyz\"" (get @received-headers "If-None-Match")))))))
+
+(deftest throw-on-failure!-test
+  (testing "returns result unchanged on success"
+    (let [result {:success? true :body [{:id 1}]}]
+      (is (= result (request/throw-on-failure! result)))))
+
+  (testing "throws ex-info on failure"
+    (is (thrown? clojure.lang.ExceptionInfo
+          (request/throw-on-failure! {:success? false :error "failed" :error-type :permanent}))))
+
+  (testing "thrown exception carries error-type in ex-data"
+    (try
+      (request/throw-on-failure! {:success? false :error "transient" :error-type :transient})
+      (catch clojure.lang.ExceptionInfo e
+        (is (= :transient (:error-type (ex-data e))))))))
+
+(deftest next-url-test
+  (testing "returns next URL from Link header"
+    (let [link "<https://api.example.com?page=2>; rel=\"next\", <https://api.example.com?page=5>; rel=\"last\""
+          resp {:headers {"link" link}}]
+      (is (= "https://api.example.com?page=2" (request/next-url resp)))))
+
+  (testing "returns nil when no next rel in Link header"
+    (let [resp {:headers {"link" "<https://api.example.com?page=5>; rel=\"last\""}}]
+      (is (nil? (request/next-url resp)))))
+
+  (testing "returns nil when no Link header"
+    (is (nil? (request/next-url {:headers {}}))))
+
+  (testing "returns nil when headers are absent"
+    (is (nil? (request/next-url {})))))
+
+(deftest coerce-records-test
+  (testing "vector body returned as vec"
+    (is (= [{:a 1} {:b 2}] (request/coerce-records [{:a 1} {:b 2}]))))
+
+  (testing "map body wrapped in vector"
+    (is (= [{:id 1}] (request/coerce-records {:id 1}))))
+
+  (testing "list body coerced to vector"
+    (is (= [{:a 1}] (request/coerce-records (list {:a 1})))))
+
+  (testing "empty vector stays empty"
+    (is (= [] (request/coerce-records [])))))
+
+(comment
+  ;; Run: clj -M:dev:test -n ai.miniforge.data-foundry.connector-http.request-test
+  )

--- a/components/connector-jira/deps.edn
+++ b/components/connector-jira/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector      {:local/root "../connector"}
+        ai.miniforge.data-foundry/connector-auth  {:local/root "../connector-auth"}
+        ai.miniforge.data-foundry/connector-http  {:local/root "../connector-http"}
+        hato/hato                       {:mvn/version "1.0.0"}
+        metosin/malli                   {:mvn/version "0.16.4"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector-jira/resources/config/connector-jira/messages/en-US.edn
+++ b/components/connector-jira/resources/config/connector-jira/messages/en-US.edn
@@ -1,0 +1,7 @@
+{:connector-jira/messages
+ {:jira/handle-not-found   "Handle not found: {handle}"
+  :jira/auth-invalid       "Invalid auth: {errors}"
+  :jira/site-required      "Jira config requires :jira/site (e.g. \"mycompany\")"
+  :jira/resource-unknown   "Unknown Jira resource: {resource}"
+  :jira/rate-limited       "Jira API rate limited"
+  :jira/request-failed     "Jira API request failed (HTTP {status}): {error}"}}

--- a/components/connector-jira/resources/config/connector-jira/resources.edn
+++ b/components/connector-jira/resources/config/connector-jira/resources.edn
@@ -1,0 +1,31 @@
+{:issues     {:endpoint          "/rest/api/3/search/jql"
+              :cursor-type       :timestamp-watermark
+              :per-page          100
+              :pagination        :offset
+              :response-key      :issues
+              :uses-jql          true
+              :default-fields    "id,key,summary,status,updated,created,assignee,description,issuetype,priority"}
+
+ :projects   {:endpoint          "/rest/api/3/project/search"
+              :cursor-type       nil
+              :per-page          50
+              :pagination        :offset
+              :response-key      :values}
+
+ :boards     {:endpoint          "/rest/agile/1.0/board"
+              :cursor-type       nil
+              :per-page          50
+              :pagination        :offset
+              :response-key      :values}
+
+ :sprints    {:endpoint          "/rest/agile/1.0/board/{board_id}/sprint"
+              :cursor-type       nil
+              :per-page          50
+              :pagination        :offset
+              :response-key      :values}
+
+ :comments   {:endpoint          "/rest/api/3/issue/{issue_key}/comment"
+              :cursor-type       nil
+              :per-page          100
+              :pagination        :offset
+              :response-key      :comments}}

--- a/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/core.clj
+++ b/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/core.clj
@@ -1,0 +1,14 @@
+(ns ai.miniforge.data-foundry.connector-jira.core
+  "JiraConnector defrecord — thin protocol wrapper delegating to impl."
+  (:require [ai.miniforge.data-foundry.connector.protocol :as proto]
+            [ai.miniforge.data-foundry.connector-jira.impl :as impl]))
+
+(defrecord JiraConnector []
+  proto/Connector
+  (connect    [_ config auth]                      (impl/do-connect config auth))
+  (close      [_ handle]                           (impl/do-close handle))
+
+  proto/SourceConnector
+  (discover   [_ handle _opts]                     (impl/do-discover handle))
+  (extract    [_ handle schema-name opts]          (impl/do-extract handle schema-name opts))
+  (checkpoint [_ _handle _connector-id cursor]     (impl/do-checkpoint cursor)))

--- a/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/impl.clj
+++ b/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/impl.clj
@@ -1,0 +1,147 @@
+(ns ai.miniforge.data-foundry.connector-jira.impl
+  "Implementation functions for the Jira Cloud REST API connector.
+   Small composable functions organized in a stratified DAG."
+  (:require [ai.miniforge.data-foundry.connector.handles :as h]
+            [ai.miniforge.data-foundry.connector.result :as result]
+            [ai.miniforge.data-foundry.connector-auth.core :as auth]
+            [ai.miniforge.data-foundry.connector-jira.messages :as msg]
+            [ai.miniforge.data-foundry.connector-jira.resources :as resources]
+            [ai.miniforge.data-foundry.connector-jira.schema :as schema]
+            [ai.miniforge.data-foundry.connector-http.cursors :as cursors]
+            [ai.miniforge.data-foundry.connector-http.request :as request])
+  (:import [java.util Base64 UUID]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Handle state
+
+(def ^:private handles (h/create))
+
+(defn- get-handle    [handle] (h/get-handle handles handle))
+(defn- store-handle! [handle state] (h/store-handle! handles handle state))
+(defn- remove-handle! [handle] (h/remove-handle! handles handle))
+(defn- touch-handle! [handle] (h/touch-handle! handles handle))
+
+(defn- require-handle!
+  "Retrieve handle state or throw."
+  [handle]
+  (or (get-handle handle)
+      (throw (ex-info (msg/t :jira/handle-not-found {:handle handle})
+                      {:handle handle}))))
+
+;; Auth — Jira Cloud uses Basic auth (email:api-token)
+
+(defn- build-auth-headers
+  "Build authorization headers for Jira Cloud.
+   Basic auth: Base64(email:api-token)."
+  [config {:auth/keys [credential-id]}]
+  (let [email (or (:jira/email config) (:auth/email config))
+        token credential-id
+        encoded (.encodeToString (Base64/getEncoder) (.getBytes (str email ":" token)))]
+    {"Authorization" (str "Basic " encoded)
+     "Accept"        "application/json"
+     "Content-Type"  "application/json"}))
+
+(defn- resolve-auth-headers
+  "Build auth headers from config + auth, defaulting to empty map."
+  [config auth]
+  (if (:auth/credential-id auth)
+    (build-auth-headers config auth)
+    {}))
+
+(defn- validate-auth!
+  "Validate auth credential reference, throwing on failure."
+  [auth]
+  (when auth
+    (let [result (auth/validate-credential-ref auth)]
+      (when-not (:success? result)
+        (throw (ex-info (msg/t :jira/auth-invalid {:errors (:errors result)})
+                        {:errors (:errors result)}))))))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; HTTP — Jira uses offset pagination (startAt + maxResults), not Link headers.
+
+(defn- error-response
+  [status resp]
+  (request/error-response status resp
+    {:rate-limited   (msg/t :jira/rate-limited)
+     :request-failed (fn [s e] (msg/t :jira/request-failed {:status s :error e}))}))
+
+(defn- do-request
+  [url headers query-params]
+  (request/do-request url headers query-params error-response))
+
+(defn- require-resource!
+  "Look up resource def or throw."
+  [schema-name]
+  (or (resources/get-resource (keyword schema-name))
+      (throw (ex-info (msg/t :jira/resource-unknown {:resource schema-name})
+                      {:resource schema-name}))))
+
+(defn- timestamp-value
+  [record]
+  (or (:updated record)
+      (get-in record [:fields :updated])
+      (get-in record [:fields :created])))
+
+(defn- fetch-all-pages
+  "Fetch all pages from a Jira endpoint using offset pagination.
+   response-key is the JSON key containing the records array (e.g. :issues, :values)."
+  [handle url headers query-params response-key]
+  (loop [start-at   0
+         accumulated []]
+    (touch-handle! handle)
+    (let [params (assoc query-params "startAt" start-at)
+          resp   (request/throw-on-failure! (do-request url headers params))
+          body   (:body resp)
+          records (get body response-key [])
+          all-records (into accumulated records)
+          total  (get body :total (count all-records))]
+      (if (or (empty? records) (>= (count all-records) total))
+        all-records
+        (recur (count all-records) all-records)))))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Lifecycle and source operations
+
+(defn do-connect
+  "Validate config at boundary, register handle."
+  [config auth]
+  (when-not (:jira/site config)
+    (throw (ex-info (msg/t :jira/site-required) {:config config})))
+  (schema/validate! schema/JiraConfig config)
+  (validate-auth! auth)
+  (let [handle (str (UUID/randomUUID))
+        base-url (resources/build-base-url config)]
+    (store-handle! handle {:config       (assoc config :jira/base-url base-url)
+                            :auth-headers (resolve-auth-headers config auth)
+                            :last-request-at nil})
+    (result/connect-result handle)))
+
+(defn do-close [handle]
+  (remove-handle! handle)
+  (result/close-result))
+
+(defn do-discover [handle]
+  (require-handle! handle)
+  (result/discover-result (resources/resource-schemas)))
+
+(defn do-extract
+  "Extract records from a Jira Cloud API resource.
+   Validates records at the API boundary — malformed records from
+   the Jira API are filtered out before entering the pipeline."
+  [handle schema-name opts]
+  (let [handle-state (require-handle! handle)
+        resource-def (require-resource! schema-name)
+        resource-key (keyword schema-name)
+        {:keys [config auth-headers]} handle-state
+        url          (resources/build-url (:jira/base-url config) resource-def config)
+        params       (resources/build-query-params resource-def (:extract/cursor opts) opts config)
+        response-key (or (:response-key resource-def) :values)
+        raw-records  (fetch-all-pages handle url auth-headers params response-key)
+        records      (schema/validate-records resource-key raw-records)
+        cursor       (when (= :timestamp-watermark (:cursor-type resource-def))
+                       (cursors/max-timestamp-cursor timestamp-value records))]
+    (result/extract-result records cursor false)))
+
+(defn do-checkpoint [cursor-state]
+  (result/checkpoint-result cursor-state))

--- a/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/impl.clj
+++ b/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/impl.clj
@@ -136,7 +136,7 @@
         {:keys [config auth-headers]} handle-state
         url          (resources/build-url (:jira/base-url config) resource-def config)
         params       (resources/build-query-params resource-def (:extract/cursor opts) opts config)
-        response-key (or (:response-key resource-def) :values)
+        response-key (get resource-def :response-key :values)
         raw-records  (fetch-all-pages handle url auth-headers params response-key)
         records      (schema/validate-records resource-key raw-records)
         cursor       (when (= :timestamp-watermark (:cursor-type resource-def))

--- a/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/interface.clj
+++ b/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/interface.clj
@@ -1,0 +1,31 @@
+(ns ai.miniforge.data-foundry.connector-jira.interface
+  "Public API for the Jira Cloud REST API connector component."
+  (:require [ai.miniforge.data-foundry.connector-jira.core :as core]
+            [ai.miniforge.data-foundry.connector-jira.schema :as schema]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Schemas (exported for consumers)
+
+(def JiraConfig
+  "Malli schema for Jira connector configuration."
+  schema/JiraConfig)
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Factory and metadata
+
+(defn create-jira-connector
+  "Create a new JiraConnector instance."
+  []
+  (core/->JiraConnector))
+
+(def connector-metadata
+  "Registration metadata for the Jira Cloud REST API connector."
+  {:connector/name         "Jira Cloud REST API Connector"
+   :connector/type         :source
+   :connector/version      "0.1.0"
+   :connector/capabilities #{:cap/discovery :cap/incremental :cap/pagination}
+   :connector/auth-methods #{:basic}
+   :connector/retry-policy {:retry/strategy       :exponential-backoff
+                            :retry/max-attempts   3
+                            :retry/base-delay-ms  1000}
+   :connector/maintainer   "data-foundry"})

--- a/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/messages.clj
+++ b/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/messages.clj
@@ -1,0 +1,8 @@
+(ns ai.miniforge.data-foundry.connector-jira.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/connector-jira/messages/en-US.edn"
+                              :connector-jira/messages))

--- a/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/resources.clj
+++ b/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/resources.clj
@@ -1,0 +1,90 @@
+(ns ai.miniforge.data-foundry.connector-jira.resources
+  "Jira Cloud REST API resource type registry and URL/param builders.
+   Resource definitions are loaded from an EDN resource file at startup."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Resource loading
+
+(def ^:private resource-path "config/connector-jira/resources.edn")
+
+(defn- load-resources []
+  (if-let [res (io/resource resource-path)]
+    (edn/read-string (slurp res))
+    (throw (ex-info (str "Jira resource definitions not found: " resource-path)
+                    {:path resource-path}))))
+
+(def jira-resources
+  "Registry of Jira Cloud REST API resource types, loaded from EDN."
+  (delay (load-resources)))
+
+(defn get-resource
+  "Look up a resource definition by key."
+  [resource-key]
+  (get @jira-resources resource-key))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; URL and param builders
+
+(defn build-base-url
+  "Build the Jira Cloud base URL from config.
+   When :jira/cloud-id is present, uses the Atlassian API gateway — required for
+   scoped API tokens (tokens with explicit permission scopes).
+   Falls back to the classic site URL for classic (unscoped) API tokens."
+  [config]
+  (if-let [cloud-id (:jira/cloud-id config)]
+    (str "https://api.atlassian.com/ex/jira/" cloud-id)
+    (str "https://" (:jira/site config) ".atlassian.net")))
+
+(defn build-url
+  "Build a Jira API URL by substituting path parameters."
+  [base-url resource-def config]
+  (str base-url
+       (-> (:endpoint resource-def)
+           (str/replace "{board_id}" (str (get config :jira/board-id "")))
+           (str/replace "{issue_key}" (str (get config :jira/issue-key ""))))))
+
+(defn- resolved-project-key
+  "Return :jira/project-key from config only if it is a real resolved value.
+   Treats nil, blank, and unresolved placeholders (${...}) as absent."
+  [config]
+  (let [pk (:jira/project-key config)]
+    (when (and (string? pk)
+               (not (str/blank? pk))
+               (not (str/starts-with? pk "${")))
+      pk)))
+
+(defn build-query-params
+  "Build query params for a Jira API request.
+   For the issues resource, constructs JQL with optional project and cursor filters.
+
+   The /rest/api/3/search/jql endpoint rejects unbounded queries (ORDER BY alone).
+   We always include an `updated >= <date>` predicate: the cursor value when
+   available, or a far-past sentinel on first run to fetch all issues."
+  [resource-def cursor opts config]
+  (let [per-page (get opts :extract/batch-size (get resource-def :per-page 100))
+        params   (cond-> {"maxResults" per-page}
+                   (:default-fields resource-def)
+                   (assoc "fields" (:default-fields resource-def)))]
+    (if (:uses-jql resource-def)
+      (let [project-key    (resolved-project-key config)
+            project-clause (when project-key (str "project = " project-key))
+            cursor-val     (get-in cursor [:cursor/value])
+            since-date     (or cursor-val "2000-01-01 00:00")
+            since-clause   (str "updated >= \"" since-date "\"")
+            clauses        (remove nil? [project-clause since-clause])
+            jql            (str (str/join " AND " clauses) " ORDER BY updated DESC")]
+        (assoc params "jql" jql))
+      ;; Other resources: no JQL
+      params)))
+
+(defn resource-schemas
+  "Return discover-compatible schema list for all known Jira resources."
+  []
+  (mapv (fn [[k v]]
+          {:schema/name     (name k)
+           :schema/endpoint (:endpoint v)
+           :schema/type     (:cursor-type v)})
+        @jira-resources))

--- a/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/schema.clj
+++ b/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/schema.clj
@@ -1,0 +1,116 @@
+(ns ai.miniforge.data-foundry.connector-jira.schema
+  "Malli schemas for the Jira connector.
+
+   Two categories of schemas:
+   1. Config schemas — validated at connect time (inbound from user)
+   2. Response schemas — validated at extract time (inbound from Jira API)"
+  (:require [malli.core :as m]
+            [malli.error :as me]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Config schemas (user → connector boundary)
+
+(def JiraConfig
+  "Schema for Jira connector configuration.
+   Requires :jira/site (the Atlassian subdomain, e.g. \"mycompany\")."
+  [:map
+   [:jira/site string?]
+   [:jira/project-key {:optional true} [:maybe string?]]
+   [:jira/board-id {:optional true} [:maybe [:or int? string?]]]
+   [:jira/issue-key {:optional true} [:maybe string?]]
+   [:jira/email {:optional true} [:maybe string?]]
+   [:jira/cloud-id {:optional true} [:maybe string?]]])
+
+;;------------------------------------------------------------------------------ Layer 1
+;; API response schemas (Jira API → connector boundary)
+
+(def JiraIssue
+  "Schema for a Jira issue record from /rest/api/3/search."
+  [:map
+   [:id string?]
+   [:key string?]
+   [:fields [:map
+             [:summary {:optional true} [:maybe string?]]
+             [:status {:optional true} [:maybe [:map [:name {:optional true} string?]]]]
+             [:updated {:optional true} [:maybe string?]]
+             [:created {:optional true} [:maybe string?]]]]])
+
+(def JiraProject
+  "Schema for a Jira project record from /rest/api/3/project/search."
+  [:map
+   [:id string?]
+   [:key string?]
+   [:name string?]])
+
+(def JiraBoard
+  "Schema for a Jira board record from /rest/agile/1.0/board."
+  [:map
+   [:id int?]
+   [:name string?]])
+
+(def JiraSprint
+  "Schema for a Jira sprint record from the sprints endpoint."
+  [:map
+   [:id int?]
+   [:name string?]
+   [:state string?]])
+
+(def JiraComment
+  "Schema for a Jira comment record from issue comments endpoint."
+  [:map
+   [:id string?]
+   [:body {:optional true} :any]
+   [:created {:optional true} [:maybe string?]]
+   [:updated {:optional true} [:maybe string?]]])
+
+(def JiraPaginatedResponse
+  "Schema for the offset-paginated response envelope."
+  [:map
+   [:startAt int?]
+   [:maxResults int?]
+   [:total int?]])
+
+(def ^:private resource->schema
+  {:issues   JiraIssue
+   :projects JiraProject
+   :boards   JiraBoard
+   :sprints  JiraSprint
+   :comments JiraComment})
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Validation
+
+(defn validate
+  "Validate value against schema."
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn validate!
+  "Validate and throw on failure."
+  [schema value]
+  (when-not (m/validate schema value)
+    (throw (ex-info "Jira config validation failed"
+                    {:errors (me/humanize (m/explain schema value))
+                     :value value})))
+  value)
+
+(defn validate-response
+  "Validate a paginated response envelope. Returns {:valid? bool :errors ...}."
+  [body]
+  (validate JiraPaginatedResponse body))
+
+(defn record-schema
+  "Look up the record schema for a resource keyword, or nil."
+  [resource-key]
+  (get resource->schema resource-key))
+
+(defn validate-records
+  "Validate a batch of records against the schema for the given resource.
+   Returns records unchanged if valid; logs and filters invalid records."
+  [resource-key records]
+  (if-let [schema (record-schema resource-key)]
+    (filterv #(m/validate schema %) records)
+    records))

--- a/components/connector-jira/test/ai/miniforge/data_foundry/connector_jira/impl_test.clj
+++ b/components/connector-jira/test/ai/miniforge/data_foundry/connector_jira/impl_test.clj
@@ -1,0 +1,273 @@
+(ns ai.miniforge.data-foundry.connector-jira.impl-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector-jira.impl :as impl]
+            [ai.miniforge.data-foundry.connector-jira.resources :as resources]
+            [ai.miniforge.data-foundry.connector-jira.schema :as jira-schema]
+            [ai.miniforge.schema.interface :as schema]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Resource registry tests
+
+(deftest resource-schemas-test
+  (testing "resource-schemas returns all known resources"
+    (let [schemas (resources/resource-schemas)]
+      (is (= 5 (count schemas)))
+      (is (every? :schema/name schemas))
+      (is (some #(= "issues" (:schema/name %)) schemas))
+      (is (some #(= "projects" (:schema/name %)) schemas))
+      (is (some #(= "boards" (:schema/name %)) schemas))
+      (is (some #(= "sprints" (:schema/name %)) schemas))
+      (is (some #(= "comments" (:schema/name %)) schemas)))))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; URL building tests
+
+(deftest build-base-url-test
+  (testing "builds classic site URL from :jira/site"
+    (is (= "https://mycompany.atlassian.net"
+           (resources/build-base-url {:jira/site "mycompany"}))))
+
+  (testing "builds API gateway URL when :jira/cloud-id is present"
+    (is (= "https://api.atlassian.com/ex/jira/abc-123"
+           (resources/build-base-url {:jira/site "mycompany" :jira/cloud-id "abc-123"})))))
+
+(deftest build-url-test
+  (testing "builds issues search URL"
+    (let [resource-def (resources/get-resource :issues)
+          url (resources/build-url "https://myco.atlassian.net" resource-def {})]
+      (is (= "https://myco.atlassian.net/rest/api/3/search/jql" url))))
+
+  (testing "builds projects URL"
+    (let [resource-def (resources/get-resource :projects)
+          url (resources/build-url "https://myco.atlassian.net" resource-def {})]
+      (is (= "https://myco.atlassian.net/rest/api/3/project/search" url))))
+
+  (testing "builds boards URL"
+    (let [resource-def (resources/get-resource :boards)
+          url (resources/build-url "https://myco.atlassian.net" resource-def {})]
+      (is (= "https://myco.atlassian.net/rest/agile/1.0/board" url))))
+
+  (testing "builds sprints URL with board-id"
+    (let [resource-def (resources/get-resource :sprints)
+          config {:jira/board-id 42}
+          url (resources/build-url "https://myco.atlassian.net" resource-def config)]
+      (is (= "https://myco.atlassian.net/rest/agile/1.0/board/42/sprint" url))))
+
+  (testing "builds comments URL with issue-key"
+    (let [resource-def (resources/get-resource :comments)
+          config {:jira/issue-key "PROJ-123"}
+          url (resources/build-url "https://myco.atlassian.net" resource-def config)]
+      (is (= "https://myco.atlassian.net/rest/api/3/issue/PROJ-123/comment" url)))))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Query param building
+
+(deftest build-query-params-test
+  (testing "issues: includes JQL with project key and default fields"
+    (let [resource-def (resources/get-resource :issues)
+          params (resources/build-query-params resource-def nil {} {:jira/project-key "PROJ"})]
+      (is (= 100 (get params "maxResults")))
+      (is (clojure.string/includes? (get params "jql") "project = PROJ"))
+      (is (clojure.string/includes? (get params "jql") "ORDER BY updated DESC"))
+      (is (string? (get params "fields")))
+      (is (clojure.string/includes? (get params "fields") "key"))))
+
+  (testing "issues: includes cursor value in JQL"
+    (let [resource-def (resources/get-resource :issues)
+          cursor {:cursor/type :timestamp-watermark :cursor/value "2026-01-15 10:00"}
+          params (resources/build-query-params resource-def cursor {} {:jira/project-key "PROJ"})]
+      (is (clojure.string/includes? (get params "jql") "updated >= \"2026-01-15 10:00\""))))
+
+  (testing "issues: no project clause when project-key is absent; sentinel date used"
+    (let [resource-def (resources/get-resource :issues)
+          params (resources/build-query-params resource-def nil {} {})]
+      (is (not (clojure.string/includes? (get params "jql") "project")))
+      (is (clojure.string/includes? (get params "jql") "updated >= \"2000-01-01"))
+      (is (clojure.string/includes? (get params "jql") "ORDER BY updated DESC"))))
+
+  (testing "issues: no project clause when project-key is unresolved placeholder; sentinel date used"
+    (let [resource-def (resources/get-resource :issues)
+          params (resources/build-query-params resource-def nil {} {:jira/project-key "${JIRA_PROJECT_KEY}"})]
+      (is (not (clojure.string/includes? (get params "jql") "project")))
+      (is (clojure.string/includes? (get params "jql") "updated >= \"2000-01-01"))
+      (is (clojure.string/includes? (get params "jql") "ORDER BY updated DESC"))))
+
+  (testing "non-issues: no JQL"
+    (let [resource-def (resources/get-resource :boards)
+          params (resources/build-query-params resource-def nil {} {})]
+      (is (= 50 (get params "maxResults")))
+      (is (nil? (get params "jql"))))))
+
+;;------------------------------------------------------------------------------ Layer 3
+;; Connect / close lifecycle
+
+(deftest connect-validates-config-test
+  (testing "do-connect requires :jira/site"
+    (is (thrown? Exception (impl/do-connect {} nil)))))
+
+(deftest connect-close-lifecycle-test
+  (testing "connect and close with valid config"
+    (let [result (impl/do-connect {:jira/site "mycompany"} nil)]
+      (is (= :connected (:connector/status result)))
+      (is (string? (:connection/handle result)))
+      (let [close-result (impl/do-close (:connection/handle result))]
+        (is (= :closed (:connector/status close-result)))))))
+
+(deftest discover-test
+  (testing "discover returns all resources"
+    (let [handle (:connection/handle (impl/do-connect {:jira/site "mycompany"} nil))
+          result (impl/do-discover handle)]
+      (is (= 5 (:discover/total-count result)))
+      (impl/do-close handle))))
+
+;;------------------------------------------------------------------------------ Layer 4
+;; Extract with mocked HTTP
+
+(deftest extract-issues-offset-pagination-test
+  (testing "do-extract drains offset-paginated Jira responses"
+    (let [handle (:connection/handle (impl/do-connect {:jira/site "test"
+                                                       :jira/project-key "PROJ"} nil))
+          calls  (atom [])]
+      (try
+        (with-redefs-fn
+          {#'impl/do-request
+           (fn [url _headers params]
+             (swap! calls conj params)
+             (let [start-at (get params "startAt" 0)]
+               (if (zero? start-at)
+                 (schema/success :body {:issues [{:id "1" :key "PROJ-1"
+                                                  :fields {:updated "2026-03-20T10:00:00.000+0000"}}
+                                                 {:id "2" :key "PROJ-2"
+                                                  :fields {:updated "2026-03-20T11:00:00.000+0000"}}]
+                                        :startAt 0 :maxResults 2 :total 3}
+                                 {:headers {}})
+                 (schema/success :body {:issues [{:id "3" :key "PROJ-3"
+                                                  :fields {:updated "2026-03-20T12:00:00.000+0000"}}]
+                                        :startAt 2 :maxResults 2 :total 3}
+                                 {:headers {}}))))}
+          (fn []
+            (let [result (impl/do-extract handle "issues" {})]
+              (is (= 3 (:extract/row-count result)))
+              (is (false? (:extract/has-more result)))
+              (is (= ["PROJ-1" "PROJ-2" "PROJ-3"] (mapv :key (:records result))))
+              ;; Two pages fetched
+              (is (= 2 (count @calls))))))
+        (finally
+          (impl/do-close handle))))))
+
+(deftest extract-projects-test
+  (testing "do-extract for projects uses :values response key"
+    (let [handle (:connection/handle (impl/do-connect {:jira/site "test"} nil))]
+      (try
+        (with-redefs-fn
+          {#'impl/do-request
+           (fn [_url _headers _params]
+             (schema/success :body {:values [{:id "10001" :key "PROJ" :name "My Project"}]
+                                    :startAt 0 :maxResults 50 :total 1}
+                             {:headers {}}))}
+          (fn []
+            (let [result (impl/do-extract handle "projects" {})]
+              (is (= 1 (:extract/row-count result)))
+              (is (= "PROJ" (:key (first (:records result))))))))
+        (finally
+          (impl/do-close handle))))))
+
+(deftest extract-unknown-resource-test
+  (testing "do-extract throws for unknown resource"
+    (let [handle (:connection/handle (impl/do-connect {:jira/site "test"} nil))]
+      (try
+        (is (thrown? Exception (impl/do-extract handle "nonexistent" {})))
+        (finally
+          (impl/do-close handle))))))
+
+(deftest checkpoint-test
+  (testing "checkpoint returns committed"
+    (let [cursor {:cursor/type :timestamp-watermark :cursor/value "2026-01-01 00:00"}
+          result (impl/do-checkpoint cursor)]
+      (is (= :committed (:checkpoint/status result))))))
+
+;;------------------------------------------------------------------------------ Layer 5
+;; Boundary schema validation
+
+(deftest config-schema-validation-test
+  (testing "valid config passes"
+    (is (:valid? (jira-schema/validate jira-schema/JiraConfig
+                                       {:jira/site "mycompany"
+                                        :jira/project-key "PROJ"}))))
+
+  (testing "missing :jira/site fails"
+    (is (not (:valid? (jira-schema/validate jira-schema/JiraConfig
+                                            {:jira/project-key "PROJ"})))))
+
+  (testing "extra keys are allowed (open map)"
+    (is (:valid? (jira-schema/validate jira-schema/JiraConfig
+                                       {:jira/site "mycompany"
+                                        :auth/method :basic})))))
+
+(deftest response-schema-validation-test
+  (testing "valid paginated response passes"
+    (is (:valid? (jira-schema/validate-response
+                  {:startAt 0 :maxResults 50 :total 100}))))
+
+  (testing "missing :total fails"
+    (is (not (:valid? (jira-schema/validate-response
+                       {:startAt 0 :maxResults 50}))))))
+
+(deftest issue-schema-validation-test
+  (testing "valid issue passes"
+    (is (:valid? (jira-schema/validate jira-schema/JiraIssue
+                                       {:id "10001" :key "PROJ-1"
+                                        :fields {:summary "A bug"
+                                                 :updated "2026-03-20T10:00:00.000+0000"}}))))
+
+  (testing "issue missing :key fails"
+    (is (not (:valid? (jira-schema/validate jira-schema/JiraIssue
+                                            {:id "10001"
+                                             :fields {:summary "A bug"}})))))
+
+  (testing "issue missing :id fails"
+    (is (not (:valid? (jira-schema/validate jira-schema/JiraIssue
+                                            {:key "PROJ-1"
+                                             :fields {:summary "A bug"}}))))))
+
+(deftest validate-records-filters-invalid-test
+  (testing "valid records pass through"
+    (let [records [{:id "1" :key "PROJ-1" :fields {:summary "ok"}}
+                   {:id "2" :key "PROJ-2" :fields {:summary "also ok"}}]]
+      (is (= 2 (count (jira-schema/validate-records :issues records))))))
+
+  (testing "invalid records are filtered out"
+    (let [records [{:id "1" :key "PROJ-1" :fields {:summary "ok"}}
+                   {:garbage true}
+                   {:id "3" :key "PROJ-3" :fields {:summary "fine"}}]]
+      (is (= 2 (count (jira-schema/validate-records :issues records))))))
+
+  (testing "unknown resource key returns records unchanged"
+    (let [records [{:anything "goes"}]]
+      (is (= 1 (count (jira-schema/validate-records :unknown records)))))))
+
+(deftest extract-filters-malformed-api-records-test
+  (testing "extract drops records that fail schema validation"
+    (let [handle (:connection/handle (impl/do-connect {:jira/site "test"
+                                                       :jira/project-key "PROJ"} nil))]
+      (try
+        (with-redefs-fn
+          {#'impl/do-request
+           (fn [_url _headers _params]
+             (schema/success :body {:issues [;; Valid
+                                             {:id "1" :key "PROJ-1"
+                                              :fields {:updated "2026-03-20T10:00:00.000+0000"}}
+                                             ;; Malformed — missing :id and :key
+                                             {:fields {:summary "broken"}}
+                                             ;; Valid
+                                             {:id "3" :key "PROJ-3"
+                                              :fields {:updated "2026-03-20T12:00:00.000+0000"}}]
+                                    :startAt 0 :maxResults 100 :total 3}
+                             {:headers {}}))}
+          (fn []
+            (let [result (impl/do-extract handle "issues" {})]
+              ;; Only 2 valid records survive
+              (is (= 2 (:extract/row-count result)))
+              (is (= ["PROJ-1" "PROJ-3"] (mapv :key (:records result)))))))
+        (finally
+          (impl/do-close handle))))))

--- a/components/connector-pipeline-output/deps.edn
+++ b/components/connector-pipeline-output/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector {:local/root "../connector"}
+        metosin/malli             {:mvn/version "0.16.4"}
+        org.clojure/data.json     {:mvn/version "2.5.1"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector-pipeline-output/resources/config/connector-pipeline-output/messages/en-US.edn
+++ b/components/connector-pipeline-output/resources/config/connector-pipeline-output/messages/en-US.edn
@@ -1,0 +1,11 @@
+{:connector-pipeline-output/messages
+ {;; Lifecycle
+  :output/handle-not-found    "Pipeline output handle not found: {handle}"
+
+  ;; Config validation
+  :output/dir-required        "Pipeline output requires :output/dir in config"
+  :output/format-unsupported  "Unsupported output format: {format}. Supported: edn, json"
+
+  ;; Write
+  :output/write-failed        "Failed to write pipeline output: {error}"
+  :output/manifest-written    "Pipeline output manifest written: {path}"}}

--- a/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/core.clj
+++ b/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/core.clj
@@ -1,0 +1,12 @@
+(ns ai.miniforge.data-foundry.connector-pipeline-output.core
+  "PipelineOutputConnector defrecord — thin protocol wrapper delegating to impl."
+  (:require [ai.miniforge.data-foundry.connector.protocol :as proto]
+            [ai.miniforge.data-foundry.connector-pipeline-output.impl :as impl]))
+
+(defrecord PipelineOutputConnector []
+  proto/Connector
+  (connect    [_ config _auth]                     (impl/do-connect config))
+  (close      [_ handle]                           (impl/do-close handle))
+
+  proto/SinkConnector
+  (publish    [_ handle _schema-name records opts] (impl/do-publish handle records opts)))

--- a/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/format.clj
+++ b/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/format.clj
@@ -1,0 +1,76 @@
+(ns ai.miniforge.data-foundry.connector-pipeline-output.format
+  "Pluggable format transforms for pipeline output.
+   Each format writes records and returns the filename used."
+  (:require [clojure.data.json :as json]
+            [clojure.java.io :as io]
+            [clojure.string]))
+
+(defmulti write-records
+  "Write records to the output directory in the given format.
+   Returns the filename of the written records file."
+  (fn [format _output-dir _run-id _records] format))
+
+(defmethod write-records :edn
+  [_ output-dir run-id records]
+  (let [filename "records.edn"
+        path (str output-dir "/" run-id "/" filename)]
+    (io/make-parents path)
+    (spit path (pr-str (vec records)))
+    filename))
+
+(defmethod write-records :json
+  [_ output-dir run-id records]
+  (let [filename "records.json"
+        path (str output-dir "/" run-id "/" filename)]
+    (io/make-parents path)
+    (with-open [wtr (io/writer path)]
+      (json/write records wtr))
+    filename))
+
+(defmethod write-records :default
+  [format _ _ _]
+  (throw (ex-info (str "Unsupported output format: " format)
+                  {:format format})))
+
+(defn- sanitize-name
+  "Sanitize a dataset name for use in filenames."
+  [name]
+  (-> (str name)
+      (clojure.string/replace #"[^a-zA-Z0-9_-]" "_")
+      (clojure.string/lower-case)))
+
+(defn write-dataset-records
+  "Write records grouped by dataset name into separate files.
+   Returns a vector of {:dataset name :filename str :count int}."
+  [format output-dir run-id datasets]
+  (mapv (fn [[dataset-name records]]
+          (let [safe-name (sanitize-name dataset-name)
+                ext       (case format :edn "edn" :json "json" "edn")
+                filename  (str "records-" safe-name "." ext)
+                path      (str output-dir "/" run-id "/" filename)]
+            (io/make-parents path)
+            (case format
+              :edn  (spit path (pr-str (vec records)))
+              :json (with-open [wtr (io/writer path)]
+                      (json/write records wtr)))
+            {:dataset  dataset-name
+             :filename filename
+             :count    (count records)}))
+        datasets))
+
+(defn write-manifest
+  "Write the manifest EDN file for a pipeline run."
+  [output-dir run-id manifest]
+  (let [path (str output-dir "/" run-id "/manifest.edn")]
+    (io/make-parents path)
+    (spit path (pr-str manifest))
+    path))
+
+(defn write-json-schema
+  "Write the manifest JSON Schema for non-Clojure consumers."
+  [output-dir run-id json-schema-map]
+  (let [path (str output-dir "/" run-id "/manifest.schema.json")]
+    (io/make-parents path)
+    (with-open [wtr (io/writer path)]
+      (json/write json-schema-map wtr))
+    path))

--- a/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/impl.clj
+++ b/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/impl.clj
@@ -1,0 +1,107 @@
+(ns ai.miniforge.data-foundry.connector-pipeline-output.impl
+  "Implementation functions for the pipeline output connector."
+  (:require [ai.miniforge.data-foundry.connector.result :as result]
+            [ai.miniforge.data-foundry.connector-pipeline-output.format :as fmt]
+            [ai.miniforge.data-foundry.connector-pipeline-output.messages :as msg]
+            [ai.miniforge.data-foundry.connector-pipeline-output.schema :as schema])
+  (:import [java.time Instant]
+           [java.util UUID]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Handle state
+
+(def ^:private handles (atom {}))
+
+(defn- get-handle [handle] (get @handles handle))
+(defn- store-handle! [handle state] (swap! handles assoc handle state))
+(defn- remove-handle! [handle] (swap! handles dissoc handle))
+
+(defn- require-handle!
+  "Retrieve handle state or throw."
+  [handle]
+  (or (get-handle handle)
+      (throw (ex-info (msg/t :output/handle-not-found {:handle handle})
+                      {:handle handle}))))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Lifecycle
+
+(defn do-connect
+  "Validate config at boundary and register handle."
+  [config]
+  (let [config-with-defaults (cond-> config
+                               (not (:output/format config))
+                               (assoc :output/format :edn))]
+    (schema/validate! schema/OutputConfig config-with-defaults)
+    (let [handle (str (UUID/randomUUID))]
+      (store-handle! handle {:output/dir           (:output/dir config-with-defaults)
+                              :output/format        (:output/format config-with-defaults)
+                              :output/run-id        (get config :output/run-id (str (UUID/randomUUID)))
+                              :output/pipeline-name (:output/pipeline-name config)})
+      (result/connect-result handle))))
+
+(defn do-close [handle]
+  (remove-handle! handle)
+  (result/close-result))
+
+;; Manifest factory
+
+(defn- build-manifest
+  "Build a manifest map."
+  [handle-state schema-name records-file record-count]
+  {:manifest/version       "1.0"
+   :manifest/run-id        (:output/run-id handle-state)
+   :manifest/pipeline-name (:output/pipeline-name handle-state)
+   :manifest/format        (:output/format handle-state)
+   :manifest/record-count  record-count
+   :manifest/schema-name   schema-name
+   :manifest/created-at    (str (Instant/now))
+   :manifest/records-file  records-file})
+
+;; Write helpers
+
+(defn- write-and-validate-manifest!
+  "Build, validate, and write the manifest + JSON Schema."
+  [handle-state dir run-id schema-name records-file record-count datasets]
+  (let [manifest (cond-> (build-manifest handle-state schema-name records-file record-count)
+                   (seq datasets) (assoc :manifest/datasets datasets))]
+    (schema/validate! schema/Manifest (dissoc manifest :manifest/datasets))
+    (fmt/write-manifest dir run-id manifest)
+    (fmt/write-json-schema dir run-id (schema/manifest-json-schema))))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Sink operations
+
+(defn- publish-combined!
+  "Write all records as a single file."
+  [handle-state records opts]
+  (let [{:output/keys [dir format run-id]} handle-state
+        records-file (fmt/write-records format dir run-id records)]
+    (write-and-validate-manifest! handle-state dir run-id
+                                   (:publish/schema-name opts) records-file (count records) nil)
+    (result/publish-result (count records) 0)))
+
+(defn- publish-per-dataset!
+  "Write separate record files per dataset, plus a combined file."
+  [handle-state records datasets opts]
+  (let [{:output/keys [dir format run-id]} handle-state
+        dataset-files (fmt/write-dataset-records format dir run-id datasets)
+        combined-file (fmt/write-records format dir run-id records)]
+    (write-and-validate-manifest! handle-state dir run-id
+                                   (:publish/schema-name opts) combined-file (count records) dataset-files)
+    (result/publish-result (count records) 0)))
+
+(defn do-publish
+  "Write records to the pipeline output store.
+   When :publish/datasets is present in opts with >1 dataset, writes
+   separate files per dataset alongside the combined records file."
+  [handle records opts]
+  (let [handle-state (require-handle! handle)
+        datasets     (:publish/datasets opts)]
+    (if (and datasets (> (count datasets) 1))
+      (publish-per-dataset! handle-state records datasets opts)
+      (publish-combined! handle-state records opts))))
+
+(comment
+  ;; (do-connect {:output/dir "output/test" :output/format :edn})
+  )

--- a/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/interface.clj
+++ b/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/interface.clj
@@ -1,0 +1,62 @@
+(ns ai.miniforge.data-foundry.connector-pipeline-output.interface
+  "Public API for the pipeline output connector.
+   A generic file-based sink that writes pipeline results in a structured
+   format (EDN default, JSON via format transform) for downstream consumers.
+
+   Exposes Malli and JSON Schema definitions for the output contract so
+   consumers can validate manifests and configure pipelines correctly."
+  (:require [ai.miniforge.data-foundry.connector-pipeline-output.core :as core]
+            [ai.miniforge.data-foundry.connector-pipeline-output.schema :as schema]))
+
+(defn create-pipeline-output-connector
+  "Create a new PipelineOutputConnector instance."
+  []
+  (core/->PipelineOutputConnector))
+
+(def connector-metadata
+  "Registration metadata for the pipeline output connector."
+  {:connector/name         "Pipeline Output Connector"
+   :connector/type         :sink
+   :connector/version      "0.1.0"
+   :connector/capabilities #{:cap/batch}
+   :connector/auth-methods #{:none}
+   :connector/retry-policy {:retry/strategy :none :retry/max-attempts 1}
+   :connector/maintainer   "data-foundry"})
+
+;; -- Public Contract Schemas (Malli) --
+
+(def Manifest
+  "Malli schema for pipeline output manifest.
+   Consumers use this to validate manifests read from the output store."
+  schema/Manifest)
+
+(def OutputConfig
+  "Malli schema for pipeline output connector config.
+   Pipeline packs use this to validate their output stage config."
+  schema/OutputConfig)
+
+;; -- Public Contract Schemas (JSON Schema) --
+
+(defn manifest-json-schema
+  "Return the Manifest as JSON Schema for non-Clojure consumers."
+  []
+  (schema/manifest-json-schema))
+
+(defn config-json-schema
+  "Return the OutputConfig as JSON Schema for non-Clojure consumers."
+  []
+  (schema/config-json-schema))
+
+;; -- Validation --
+
+(defn validate-manifest
+  "Validate a manifest map against the Manifest schema.
+   Returns {:valid? bool :errors map-or-nil}."
+  [manifest]
+  (schema/validate-manifest manifest))
+
+(defn validate-config
+  "Validate a config map against the OutputConfig schema.
+   Returns {:valid? bool :errors map-or-nil}."
+  [config]
+  (schema/validate-config config))

--- a/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/messages.clj
+++ b/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.connector-pipeline-output.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/connector-pipeline-output/messages/en-US.edn" :connector-pipeline-output/messages))

--- a/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/schema.clj
+++ b/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/schema.clj
@@ -1,0 +1,87 @@
+(ns ai.miniforge.data-foundry.connector-pipeline-output.schema
+  "Malli schemas, validation, and JSON Schema export for the pipeline
+   output contract. These schemas define the public API that downstream
+   consumers depend on."
+  (:require [malli.core :as m]
+            [malli.error :as me]
+            [malli.json-schema :as json-schema]))
+
+;; -------------------------------------------------------------------------- Layer 0
+;; Enums
+
+(def supported-formats #{:edn :json})
+
+(def OutputFormat
+  "Supported record output formats."
+  [:enum :edn :json])
+
+;; -------------------------------------------------------------------------- Layer 1
+;; Schemas
+
+(def OutputConfig
+  "Config schema for pipeline output connector.
+   :output/dir is required; all others have defaults."
+  [:map
+   [:output/dir [:string {:min 1}]]
+   [:output/format {:optional true} OutputFormat]
+   [:output/run-id {:optional true} [:string {:min 1}]]
+   [:output/pipeline-name {:optional true} [:string {:min 1}]]])
+
+(def Manifest
+  "Schema for the pipeline output manifest file.
+   This is the public contract — consumers read the manifest to discover
+   what was produced and where."
+  [:map
+   [:manifest/version [:= "1.0"]]
+   [:manifest/run-id [:string {:min 1}]]
+   [:manifest/pipeline-name {:optional true} [:maybe [:string {:min 1}]]]
+   [:manifest/format OutputFormat]
+   [:manifest/record-count [:int {:min 0}]]
+   [:manifest/schema-name {:optional true} [:maybe :string]]
+   [:manifest/created-at [:string {:min 1}]]
+   [:manifest/records-file [:string {:min 1}]]])
+
+;; -------------------------------------------------------------------------- Layer 2
+;; Validation
+
+(defn validate
+  "Validate value against schema.
+   Returns {:valid? bool :errors map-or-nil}."
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn validate!
+  "Validate value against schema, throwing on failure."
+  [schema value]
+  (when-not (m/validate schema value)
+    (throw (ex-info "Schema validation failed"
+                    {:errors (me/humanize (m/explain schema value))
+                     :value  value})))
+  value)
+
+(defn validate-config
+  "Validate a pipeline output config map."
+  [value]
+  (validate OutputConfig value))
+
+(defn validate-manifest
+  "Validate a pipeline output manifest map."
+  [value]
+  (validate Manifest value))
+
+;; -------------------------------------------------------------------------- Layer 3
+;; JSON Schema export (for non-Clojure consumers)
+
+(defn manifest-json-schema
+  "Return the Manifest schema as JSON Schema (for external consumers).
+   Write this to the output directory so non-Clojure clients can validate."
+  []
+  (json-schema/transform Manifest))
+
+(defn config-json-schema
+  "Return the OutputConfig schema as JSON Schema."
+  []
+  (json-schema/transform OutputConfig))

--- a/components/connector-pipeline-output/test/ai/miniforge/data_foundry/connector_pipeline_output/impl_test.clj
+++ b/components/connector-pipeline-output/test/ai/miniforge/data_foundry/connector_pipeline_output/impl_test.clj
@@ -1,0 +1,224 @@
+(ns ai.miniforge.data-foundry.connector-pipeline-output.impl-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [clojure.java.io :as io]
+            [clojure.edn :as edn]
+            [clojure.data.json :as json]
+            [ai.miniforge.data-foundry.connector-pipeline-output.impl :as impl]
+            [ai.miniforge.data-foundry.connector-pipeline-output.schema :as schema]
+            [ai.miniforge.data-foundry.connector-pipeline-output.interface :as iface]))
+
+(def ^:private test-dir "target/test-output")
+
+(defn- clean-test-dir [f]
+  (let [dir (io/file test-dir)]
+    (when (.exists dir)
+      (doseq [file (reverse (file-seq dir))]
+        (.delete file)))
+    (f)
+    (when (.exists dir)
+      (doseq [file (reverse (file-seq dir))]
+        (.delete file)))))
+
+(use-fixtures :each clean-test-dir)
+
+(deftest connect-requires-dir
+  (testing "connect throws without :output/dir"
+    (is (thrown? Exception (impl/do-connect {})))))
+
+(deftest connect-rejects-unsupported-format
+  (testing "connect throws on unsupported format"
+    (is (thrown? Exception
+                 (impl/do-connect {:output/dir test-dir
+                                   :output/format :xml})))))
+
+(deftest connect-close-lifecycle
+  (testing "connect and close work with defaults"
+    (let [result (impl/do-connect {:output/dir test-dir})
+          handle (:connection/handle result)]
+      (is (= :connected (:connector/status result)))
+      (is (string? handle))
+      (let [close-result (impl/do-close handle)]
+        (is (= :closed (:connector/status close-result)))))))
+
+(deftest publish-edn-test
+  (testing "publish writes manifest.edn and records.edn"
+    (let [run-id "test-run-001"
+          config {:output/dir test-dir
+                  :output/format :edn
+                  :output/run-id run-id
+                  :output/pipeline-name "test-pipeline"}
+          handle (:connection/handle (impl/do-connect config))
+          records [{:id 1 :name "alpha"} {:id 2 :name "beta"}]
+          result (impl/do-publish handle records {})]
+
+      (is (= 2 (:publish/records-written result)))
+      (is (= 0 (:publish/records-failed result)))
+
+      ;; Verify manifest
+      (let [manifest (edn/read-string (slurp (str test-dir "/" run-id "/manifest.edn")))]
+        (is (= "1.0" (:manifest/version manifest)))
+        (is (= run-id (:manifest/run-id manifest)))
+        (is (= "test-pipeline" (:manifest/pipeline-name manifest)))
+        (is (= :edn (:manifest/format manifest)))
+        (is (= 2 (:manifest/record-count manifest)))
+        (is (= "records.edn" (:manifest/records-file manifest)))
+        (is (string? (:manifest/created-at manifest))))
+
+      ;; Verify records
+      (let [written-records (edn/read-string (slurp (str test-dir "/" run-id "/records.edn")))]
+        (is (= 2 (count written-records)))
+        (is (= "alpha" (:name (first written-records)))))
+
+      (impl/do-close handle))))
+
+(deftest publish-json-test
+  (testing "publish writes manifest.edn and records.json"
+    (let [run-id "test-run-json"
+          config {:output/dir test-dir
+                  :output/format :json
+                  :output/run-id run-id}
+          handle (:connection/handle (impl/do-connect config))
+          records [{:x 1} {:x 2} {:x 3}]
+          result (impl/do-publish handle records {})]
+
+      (is (= 3 (:publish/records-written result)))
+
+      ;; Manifest is always EDN
+      (let [manifest (edn/read-string (slurp (str test-dir "/" run-id "/manifest.edn")))]
+        (is (= :json (:manifest/format manifest)))
+        (is (= "records.json" (:manifest/records-file manifest))))
+
+      ;; Records are JSON
+      (let [written (with-open [rdr (io/reader (str test-dir "/" run-id "/records.json"))]
+                      (json/read rdr :key-fn keyword))]
+        (is (= 3 (count written)))
+        (is (= 1 (:x (first written)))))
+
+      (impl/do-close handle))))
+
+(deftest publish-default-format-test
+  (testing "defaults to EDN when no format specified"
+    (let [run-id "test-default"
+          config {:output/dir test-dir :output/run-id run-id}
+          handle (:connection/handle (impl/do-connect config))
+          _ (impl/do-publish handle [{:a 1}] {})
+          manifest (edn/read-string (slurp (str test-dir "/" run-id "/manifest.edn")))]
+      (is (= :edn (:manifest/format manifest)))
+      (impl/do-close handle))))
+
+(deftest publish-auto-run-id-test
+  (testing "auto-generates run-id when not provided"
+    (let [config {:output/dir test-dir}
+          handle (:connection/handle (impl/do-connect config))
+          _ (impl/do-publish handle [{:a 1}] {})
+          ;; Find the generated run-id directory
+          run-dirs (.listFiles (io/file test-dir))]
+      (is (= 1 (count run-dirs)))
+      (is (.exists (io/file (first run-dirs) "manifest.edn")))
+      (impl/do-close handle))))
+
+(deftest publish-writes-json-schema-test
+  (testing "publish writes manifest.schema.json alongside manifest"
+    (let [run-id "test-json-schema"
+          config {:output/dir test-dir :output/run-id run-id}
+          handle (:connection/handle (impl/do-connect config))
+          _ (impl/do-publish handle [{:a 1}] {})
+          schema-file (io/file (str test-dir "/" run-id "/manifest.schema.json"))]
+      (is (.exists schema-file))
+      (let [json-schema (with-open [rdr (io/reader schema-file)]
+                          (json/read rdr :key-fn keyword))]
+        (is (= "object" (:type json-schema)))
+        (is (contains? (:properties json-schema) (keyword "manifest/version"))))
+      (impl/do-close handle))))
+
+(deftest schema-validation-test
+  (testing "valid config passes validation"
+    (let [result (schema/validate-config {:output/dir "output/"})]
+      (is (true? (:valid? result)))))
+
+  (testing "invalid config fails validation"
+    (let [result (schema/validate-config {})]
+      (is (false? (:valid? result)))
+      (is (some? (:errors result)))))
+
+  (testing "valid manifest passes validation"
+    (let [manifest {:manifest/version "1.0"
+                    :manifest/run-id "run-001"
+                    :manifest/format :edn
+                    :manifest/record-count 10
+                    :manifest/created-at "2026-03-25T00:00:00Z"
+                    :manifest/records-file "records.edn"}
+          result (schema/validate-manifest manifest)]
+      (is (true? (:valid? result)))))
+
+  (testing "invalid manifest fails validation"
+    (let [result (schema/validate-manifest {:manifest/version "2.0"})]
+      (is (false? (:valid? result))))))
+
+(deftest publish-per-dataset-test
+  (testing "publish writes separate files per dataset when datasets provided"
+    (let [run-id "test-datasets"
+          config {:output/dir test-dir :output/format :edn :output/run-id run-id}
+          handle (:connection/handle (impl/do-connect config))
+          all-records [{:type "pr" :n 1} {:type "pr" :n 2}
+                       {:type "issue" :n 3} {:type "issue" :n 4} {:type "issue" :n 5}]
+          datasets {"Ingest PRs" [{:type "pr" :n 1} {:type "pr" :n 2}]
+                    "Ingest Issues" [{:type "issue" :n 3} {:type "issue" :n 4} {:type "issue" :n 5}]}
+          result (impl/do-publish handle all-records {:publish/datasets datasets})]
+
+      (is (= 5 (:publish/records-written result)))
+
+      ;; Combined records file exists
+      (is (.exists (io/file (str test-dir "/" run-id "/records.edn"))))
+
+      ;; Per-dataset files exist
+      (is (.exists (io/file (str test-dir "/" run-id "/records-ingest_prs.edn"))))
+      (is (.exists (io/file (str test-dir "/" run-id "/records-ingest_issues.edn"))))
+
+      ;; Per-dataset files have correct record counts
+      (let [pr-records (edn/read-string (slurp (str test-dir "/" run-id "/records-ingest_prs.edn")))
+            issue-records (edn/read-string (slurp (str test-dir "/" run-id "/records-ingest_issues.edn")))]
+        (is (= 2 (count pr-records)))
+        (is (= 5 (count (edn/read-string (slurp (str test-dir "/" run-id "/records.edn"))))))
+        (is (= 3 (count issue-records))))
+
+      ;; Manifest includes datasets
+      (let [manifest (edn/read-string (slurp (str test-dir "/" run-id "/manifest.edn")))]
+        (is (= 5 (:manifest/record-count manifest)))
+        (is (= 2 (count (:manifest/datasets manifest))))
+        (is (every? :filename (:manifest/datasets manifest)))
+        (is (every? :count (:manifest/datasets manifest))))
+
+      (impl/do-close handle))))
+
+(deftest publish-single-dataset-uses-combined-test
+  (testing "single dataset falls back to combined output (no per-dataset files)"
+    (let [run-id "test-single-ds"
+          config {:output/dir test-dir :output/format :edn :output/run-id run-id}
+          handle (:connection/handle (impl/do-connect config))
+          datasets {"Only Stage" [{:a 1}]}
+          result (impl/do-publish handle [{:a 1}] {:publish/datasets datasets})]
+
+      (is (= 1 (:publish/records-written result)))
+      (is (.exists (io/file (str test-dir "/" run-id "/records.edn"))))
+      ;; No per-dataset file for single dataset
+      (let [manifest (edn/read-string (slurp (str test-dir "/" run-id "/manifest.edn")))]
+        (is (nil? (:manifest/datasets manifest))))
+      (impl/do-close handle))))
+
+(deftest interface-exposes-schemas-test
+  (testing "interface exposes Malli schemas"
+    (is (some? iface/Manifest))
+    (is (some? iface/OutputConfig)))
+
+  (testing "interface exposes JSON Schema generators"
+    (let [manifest-js (iface/manifest-json-schema)
+          config-js (iface/config-json-schema)]
+      (is (= "object" (:type manifest-js)))
+      (is (= "object" (:type config-js)))
+      (is (contains? (:properties manifest-js) (keyword "manifest/version")))
+      (is (contains? (:properties config-js) (keyword "output/dir")))))
+
+  (testing "interface exposes validation helpers"
+    (is (true? (:valid? (iface/validate-config {:output/dir "x"}))))
+    (is (false? (:valid? (iface/validate-config {}))))))

--- a/components/connector-retry/deps.edn
+++ b/components/connector-retry/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src" "resources"]
+ :deps {}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector-retry/src/ai/miniforge/data_foundry/connector_retry/backoff.clj
+++ b/components/connector-retry/src/ai/miniforge/data_foundry/connector_retry/backoff.clj
@@ -1,0 +1,43 @@
+(ns ai.miniforge.data-foundry.connector-retry.backoff)
+
+(defn- fixed-delay
+  [{:retry/keys [initial-delay-ms]}]
+  initial-delay-ms)
+
+(defn- exponential-delay
+  [{:retry/keys [initial-delay-ms max-delay-ms backoff-multiplier] :or {backoff-multiplier 2.0}} attempt]
+  (let [delay (* initial-delay-ms (Math/pow backoff-multiplier attempt))]
+    (long (if max-delay-ms (min delay max-delay-ms) delay))))
+
+(def default-jitter
+  "Default jitter range. Override via :retry/jitter-min and :retry/jitter-max in policy."
+  {:retry/jitter-min 0.5
+   :retry/jitter-max 1.0})
+
+(defn- jittered-exponential-delay
+  [policy attempt]
+  (let [base (exponential-delay policy attempt)
+        {:retry/keys [jitter-min jitter-max]}
+        (merge default-jitter policy)
+        jitter (+ jitter-min (* (- jitter-max jitter-min) (Math/random)))]
+    (long (* base jitter))))
+
+(defn compute-delay
+  "Compute delay in ms for given attempt (0-indexed)."
+  [{:retry/keys [strategy] :as policy} attempt]
+  (case strategy
+    :fixed (fixed-delay policy)
+    :exponential (exponential-delay policy attempt)
+    :jittered-exponential (jittered-exponential-delay policy attempt)
+    (throw (ex-info (str "Unknown retry strategy: " strategy) {:strategy strategy}))))
+
+(defn should-retry?
+  "Returns true if retry should be attempted."
+  [{:retry/keys [max-attempts]} attempt error-category]
+  (and (< attempt (dec max-attempts))
+       (contains? #{:transient :rate-limited} error-category)))
+
+(defn retry-sequence
+  "Returns a sequence of delay values for all attempts."
+  [{:retry/keys [max-attempts] :as policy}]
+  (mapv #(compute-delay policy %) (range max-attempts)))

--- a/components/connector-retry/src/ai/miniforge/data_foundry/connector_retry/circuit_breaker.clj
+++ b/components/connector-retry/src/ai/miniforge/data_foundry/connector_retry/circuit_breaker.clj
@@ -1,0 +1,56 @@
+(ns ai.miniforge.data-foundry.connector-retry.circuit-breaker)
+
+(def default-config
+  "Default circuit breaker configuration. Override via create-circuit-breaker opts."
+  {:breaker/failure-threshold 5
+   :breaker/reset-timeout-ms  60000})
+
+(defn create-circuit-breaker
+  "Create initial circuit breaker state.
+   Merges provided opts over default-config."
+  [opts]
+  (let [{:breaker/keys [failure-threshold reset-timeout-ms]}
+        (merge default-config opts)]
+    {:breaker/state :closed
+     :breaker/failure-count 0
+     :breaker/failure-threshold failure-threshold
+     :breaker/reset-timeout-ms reset-timeout-ms
+     :breaker/last-failure-at nil
+     :breaker/last-success-at nil}))
+
+(defn breaker-state
+  "Return effective breaker state, considering timeout for half-open transition."
+  [{:breaker/keys [state last-failure-at reset-timeout-ms]} now-ms]
+  (if (and (= state :open)
+           last-failure-at
+           (>= (- now-ms last-failure-at) reset-timeout-ms))
+    :half-open
+    state))
+
+(defn allow-request?
+  "Returns true if the breaker allows a request."
+  [breaker now-ms]
+  (let [effective (breaker-state breaker now-ms)]
+    (not= effective :open)))
+
+(defn record-success
+  "Record a successful operation."
+  [breaker]
+  (assoc breaker
+         :breaker/state :closed
+         :breaker/failure-count 0
+         :breaker/last-success-at (System/currentTimeMillis)))
+
+(defn record-failure
+  "Record a failed operation. Opens breaker if threshold exceeded."
+  [{:breaker/keys [failure-count failure-threshold] :as breaker}]
+  (let [new-count (inc failure-count)
+        now (System/currentTimeMillis)]
+    (if (>= new-count failure-threshold)
+      (assoc breaker
+             :breaker/state :open
+             :breaker/failure-count new-count
+             :breaker/last-failure-at now)
+      (assoc breaker
+             :breaker/failure-count new-count
+             :breaker/last-failure-at now))))

--- a/components/connector-retry/src/ai/miniforge/data_foundry/connector_retry/interface.clj
+++ b/components/connector-retry/src/ai/miniforge/data_foundry/connector_retry/interface.clj
@@ -1,0 +1,64 @@
+(ns ai.miniforge.data-foundry.connector-retry.interface
+  (:require [ai.miniforge.data-foundry.connector-retry.backoff :as backoff]
+            [ai.miniforge.data-foundry.connector-retry.circuit-breaker :as cb]))
+
+;; -- Error Classification --
+(def error-categories
+  "N2 §6.1 error categories"
+  #{:transient :permanent :rate-limited})
+
+(defn retryable?
+  "Returns true if the error category allows retry."
+  [error-category]
+  (contains? #{:transient :rate-limited} error-category))
+
+;; -- Backoff Strategies --
+(defn compute-delay
+  "Compute retry delay in ms for a given attempt using the retry policy.
+   Policy keys: :retry/strategy (:fixed, :exponential, :jittered-exponential)
+                :retry/initial-delay-ms
+                :retry/max-delay-ms (optional)
+                :retry/backoff-multiplier (for exponential, default 2.0)
+                :retry/jitter-min (for jittered, default 0.5)
+                :retry/jitter-max (for jittered, default 1.0)"
+  [policy attempt]
+  (backoff/compute-delay policy attempt))
+
+(defn should-retry?
+  "Returns true if retry should be attempted given policy and attempt number."
+  [policy attempt error-category]
+  (backoff/should-retry? policy attempt error-category))
+
+(defn retry-sequence
+  "Returns a lazy sequence of delay values for attempts 0..max-attempts-1."
+  [policy]
+  (backoff/retry-sequence policy))
+
+;; -- Circuit Breaker --
+(defn create-circuit-breaker
+  "Create a circuit breaker state map.
+   Options: :breaker/failure-threshold (default 5)
+            :breaker/reset-timeout-ms (default 60000)"
+  ([] (cb/create-circuit-breaker {}))
+  ([opts] (cb/create-circuit-breaker opts)))
+
+(defn record-success
+  "Record a successful operation. Returns updated breaker state."
+  [breaker]
+  (cb/record-success breaker))
+
+(defn record-failure
+  "Record a failed operation. Returns updated breaker state."
+  [breaker]
+  (cb/record-failure breaker))
+
+(defn allow-request?
+  "Returns true if the circuit breaker allows a request through.
+   Checks current time against reset timeout for half-open transition."
+  ([breaker] (cb/allow-request? breaker (System/currentTimeMillis)))
+  ([breaker now-ms] (cb/allow-request? breaker now-ms)))
+
+(defn breaker-state
+  "Returns current breaker state: :closed, :open, or :half-open"
+  ([breaker] (cb/breaker-state breaker (System/currentTimeMillis)))
+  ([breaker now-ms] (cb/breaker-state breaker now-ms)))

--- a/components/connector-retry/test/ai/miniforge/data_foundry/connector_retry/interface_test.clj
+++ b/components/connector-retry/test/ai/miniforge/data_foundry/connector_retry/interface_test.clj
@@ -1,0 +1,104 @@
+(ns ai.miniforge.data-foundry.connector-retry.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector-retry.interface :as retry]))
+
+(deftest error-classification-test
+  (testing "N2 §6.1 error categories"
+    (is (true? (retry/retryable? :transient)))
+    (is (true? (retry/retryable? :rate-limited)))
+    (is (false? (retry/retryable? :permanent)))))
+
+(deftest fixed-backoff-test
+  (testing "N2 §6.3.1 fixed backoff"
+    (let [policy {:retry/strategy :fixed
+                  :retry/max-attempts 3
+                  :retry/initial-delay-ms 1000}]
+      (is (= 1000 (retry/compute-delay policy 0)))
+      (is (= 1000 (retry/compute-delay policy 1)))
+      (is (= 1000 (retry/compute-delay policy 2))))))
+
+(deftest exponential-backoff-test
+  (testing "N2 §6.3.2 exponential backoff"
+    (let [policy {:retry/strategy :exponential
+                  :retry/max-attempts 5
+                  :retry/initial-delay-ms 1000
+                  :retry/max-delay-ms 60000
+                  :retry/backoff-multiplier 2.0}]
+      (is (= 1000 (retry/compute-delay policy 0)))
+      (is (= 2000 (retry/compute-delay policy 1)))
+      (is (= 4000 (retry/compute-delay policy 2)))
+      (is (= 8000 (retry/compute-delay policy 3)))
+      (is (= 16000 (retry/compute-delay policy 4))))))
+
+(deftest exponential-backoff-cap-test
+  (testing "Delay capped at max-delay-ms"
+    (let [policy {:retry/strategy :exponential
+                  :retry/max-attempts 10
+                  :retry/initial-delay-ms 1000
+                  :retry/max-delay-ms 5000
+                  :retry/backoff-multiplier 2.0}]
+      (is (= 4000 (retry/compute-delay policy 2)))
+      (is (= 5000 (retry/compute-delay policy 3)))
+      (is (= 5000 (retry/compute-delay policy 9))))))
+
+(deftest jittered-backoff-test
+  (testing "N2 §6.3.3 jittered exponential - within expected range"
+    (let [policy {:retry/strategy :jittered-exponential
+                  :retry/max-attempts 3
+                  :retry/initial-delay-ms 1000
+                  :retry/max-delay-ms 60000
+                  :retry/backoff-multiplier 2.0}
+          delays (repeatedly 100 #(retry/compute-delay policy 1))
+          base 2000]
+      ;; jitter = base * (0.5 + random(0,1)) so range is [base*0.5, base*1.5)
+      (is (every? #(and (>= % (* base 0.5)) (< % (* base 1.5))) delays)))))
+
+(deftest should-retry-test
+  (testing "ERR-01: Transient error retries"
+    (let [policy {:retry/strategy :exponential
+                  :retry/max-attempts 5
+                  :retry/initial-delay-ms 1000}]
+      (is (true? (retry/should-retry? policy 0 :transient)))
+      (is (true? (retry/should-retry? policy 3 :transient)))
+      (is (false? (retry/should-retry? policy 4 :transient)))))
+
+  (testing "ERR-02: Permanent error never retries"
+    (let [policy {:retry/strategy :fixed
+                  :retry/max-attempts 5
+                  :retry/initial-delay-ms 1000}]
+      (is (false? (retry/should-retry? policy 0 :permanent))))))
+
+(deftest retry-sequence-test
+  (testing "Full sequence of delays"
+    (let [policy {:retry/strategy :exponential
+                  :retry/max-attempts 4
+                  :retry/initial-delay-ms 500
+                  :retry/backoff-multiplier 2.0}]
+      (is (= [500 1000 2000 4000] (retry/retry-sequence policy))))))
+
+(deftest circuit-breaker-test
+  (testing "ERR-03: Circuit breaker opens after threshold"
+    (let [cb (retry/create-circuit-breaker {:breaker/failure-threshold 3
+                                            :breaker/reset-timeout-ms 5000})
+          cb1 (retry/record-failure cb)
+          cb2 (retry/record-failure cb1)
+          cb3 (retry/record-failure cb2)]
+      (is (= :closed (retry/breaker-state cb1)))
+      (is (= :closed (retry/breaker-state cb2)))
+      (is (= :open (retry/breaker-state cb3)))
+      (is (false? (retry/allow-request? cb3)))))
+
+  (testing "ERR-04: Circuit breaker half-open recovery"
+    (let [now (System/currentTimeMillis)
+          cb {:breaker/state :open
+              :breaker/failure-count 5
+              :breaker/failure-threshold 5
+              :breaker/reset-timeout-ms 1000
+              :breaker/last-failure-at (- now 2000)
+              :breaker/last-success-at nil}]
+      ;; After timeout, should be half-open
+      (is (= :half-open (retry/breaker-state cb now)))
+      (is (true? (retry/allow-request? cb now)))
+      ;; Success resets to closed
+      (let [recovered (retry/record-success cb)]
+        (is (= :closed (retry/breaker-state recovered)))))))

--- a/components/connector/deps.edn
+++ b/components/connector/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge.data-foundry/connector-auth  {:local/root "../connector-auth"}
         ai.miniforge.data-foundry/connector-retry {:local/root "../connector-retry"}
-        ai.miniforge/event-stream       {:local/root "../../../miniforge/components/event-stream"}
-        ai.miniforge/schema             {:local/root "../../../miniforge/components/schema"}
-        ai.miniforge/tool               {:local/root "../../../miniforge/components/tool"}}
+        ai.miniforge/event-stream       {:local/root "../event-stream"}
+        ai.miniforge/schema             {:local/root "../schema"}
+        ai.miniforge/tool               {:local/root "../tool"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector/deps.edn
+++ b/components/connector/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector-auth  {:local/root "../connector-auth"}
+        ai.miniforge.data-foundry/connector-retry {:local/root "../connector-retry"}
+        ai.miniforge/event-stream       {:local/root "../../../miniforge/components/event-stream"}
+        ai.miniforge/schema             {:local/root "../../../miniforge/components/schema"}
+        ai.miniforge/tool               {:local/root "../../../miniforge/components/tool"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/connector/resources/config/connector/messages/en-US.edn
+++ b/components/connector/resources/config/connector/messages/en-US.edn
@@ -1,0 +1,18 @@
+{:connector/messages
+ {;; Connector validation (core.clj)
+  :connector/id-required                ":connector/id is required"
+  :connector/name-must-be-string        ":connector/name must be a string"
+  :connector/type-invalid               ":connector/type must be one of {allowed}"
+  :connector/version-must-be-string     ":connector/version must be a string"
+  :connector/capabilities-must-be-set   ":connector/capabilities must be a set"
+  :connector/capabilities-empty         ":connector/capabilities must not be empty"
+  :connector/auth-methods-must-be-set   ":connector/auth-methods must be a set"
+  :connector/auth-methods-empty         ":connector/auth-methods must not be empty"
+  :connector/retry-policy-required      ":connector/retry-policy is required"
+  :connector/retry-strategy-required    ":connector/retry-policy must have :retry/strategy"
+  :connector/retry-max-attempts-required ":connector/retry-policy must have :retry/max-attempts"
+  :connector/maintainer-must-be-string  ":connector/maintainer must be a string"
+
+  ;; Cursor validation (cursor.clj)
+  :cursor/type-required                 ":cursor/type is required"
+  :cursor/type-invalid                  ":cursor/type must be one of {allowed}"}}

--- a/components/connector/src/ai/miniforge/data_foundry/connector/core.clj
+++ b/components/connector/src/ai/miniforge/data_foundry/connector/core.clj
@@ -1,0 +1,69 @@
+(ns ai.miniforge.data-foundry.connector.core
+  (:require [ai.miniforge.data-foundry.connector.messages :as msg])
+  (:import [java.util UUID]
+           [java.time Instant]))
+
+(def connector-types
+  "N2 §1 connector types"
+  #{:source :sink :bidirectional})
+
+(def connector-capabilities
+  "N2 §1.4 connector capabilities"
+  #{:cap/discovery :cap/incremental :cap/batch :cap/upsert
+    :cap/transactions :cap/rate-limiting :cap/pagination})
+
+(defn validate-connector
+  "Validate a connector registration against N2 §7.1."
+  [{:connector/keys [id name type version capabilities auth-methods
+                     retry-policy maintainer]}]
+  (let [errors
+        (cond-> []
+          (nil? id)
+          (conj (msg/t :connector/id-required))
+
+          (not (string? name))
+          (conj (msg/t :connector/name-must-be-string))
+
+          (not (contains? connector-types type))
+          (conj (msg/t :connector/type-invalid {:allowed connector-types}))
+
+          (not (string? version))
+          (conj (msg/t :connector/version-must-be-string))
+
+          (not (set? capabilities))
+          (conj (msg/t :connector/capabilities-must-be-set))
+
+          (and (set? capabilities) (empty? capabilities))
+          (conj (msg/t :connector/capabilities-empty))
+
+          (not (set? auth-methods))
+          (conj (msg/t :connector/auth-methods-must-be-set))
+
+          (and (set? auth-methods) (empty? auth-methods))
+          (conj (msg/t :connector/auth-methods-empty))
+
+          (nil? retry-policy)
+          (conj (msg/t :connector/retry-policy-required))
+
+          (and retry-policy (nil? (:retry/strategy retry-policy)))
+          (conj (msg/t :connector/retry-strategy-required))
+
+          (and retry-policy (nil? (:retry/max-attempts retry-policy)))
+          (conj (msg/t :connector/retry-max-attempts-required))
+
+          (not (string? maintainer))
+          (conj (msg/t :connector/maintainer-must-be-string)))]
+    (if (empty? errors)
+      {:success? true}
+      {:success? false :errors errors})))
+
+(defn create-connector
+  "Create a connector registration with defaults."
+  [opts]
+  (let [connector (cond-> opts
+                    (nil? (:connector/id opts))
+                    (assoc :connector/id (UUID/randomUUID)))
+        validation (validate-connector connector)]
+    (if (:success? validation)
+      {:success? true :connector connector}
+      {:success? false :errors (:errors validation)})))

--- a/components/connector/src/ai/miniforge/data_foundry/connector/cursor.clj
+++ b/components/connector/src/ai/miniforge/data_foundry/connector/cursor.clj
@@ -1,0 +1,35 @@
+(ns ai.miniforge.data-foundry.connector.cursor
+  (:require [ai.miniforge.data-foundry.connector.messages :as msg])
+  (:import [java.time Instant]))
+
+(def cursor-types
+  "N2 §2.2.1 cursor types"
+  #{:timestamp-watermark :offset :sequence-id :version-id})
+
+(defn validate-cursor
+  "Validate cursor structure."
+  [{:cursor/keys [type] :as cursor}]
+  (let [errors
+        (cond-> []
+          (nil? type)
+          (conj (msg/t :cursor/type-required))
+
+          (and type (not (contains? cursor-types type)))
+          (conj (msg/t :cursor/type-invalid {:allowed cursor-types})))]
+    (if (empty? errors)
+      {:success? true}
+      {:success? false :errors errors})))
+
+(defn create-cursor
+  "Create a cursor of the given type."
+  [cursor-type initial-value]
+  {:cursor/type cursor-type
+   :cursor/value initial-value
+   :cursor/last-retrieved-at (Instant/now)})
+
+(defn advance-cursor
+  "Advance cursor to new position."
+  [cursor new-value]
+  (assoc cursor
+         :cursor/value new-value
+         :cursor/last-retrieved-at (Instant/now)))

--- a/components/connector/src/ai/miniforge/data_foundry/connector/handles.clj
+++ b/components/connector/src/ai/miniforge/data_foundry/connector/handles.clj
@@ -1,0 +1,38 @@
+(ns ai.miniforge.data-foundry.connector.handles
+  "Shared in-memory handle store for connector implementations.
+   Each connector creates its own private store atom; these functions
+   provide the shared CRUD operations over it.
+
+   Layer 0: Store creation
+   Layer 1: Store operations")
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Store creation
+
+(defn create
+  "Create a new, empty handle store atom."
+  []
+  (atom {}))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Store operations
+
+(defn get-handle
+  "Look up handle state by handle ID. Returns nil if not found."
+  [store handle]
+  (get @store handle))
+
+(defn store-handle!
+  "Associate handle ID with state in the store."
+  [store handle state]
+  (swap! store assoc handle state))
+
+(defn remove-handle!
+  "Remove a handle and its state from the store."
+  [store handle]
+  (swap! store dissoc handle))
+
+(defn touch-handle!
+  "Record the current time as :last-request-at for a handle."
+  [store handle]
+  (swap! store assoc-in [handle :last-request-at] (System/currentTimeMillis)))

--- a/components/connector/src/ai/miniforge/data_foundry/connector/interface.clj
+++ b/components/connector/src/ai/miniforge/data_foundry/connector/interface.clj
@@ -1,0 +1,103 @@
+(ns ai.miniforge.data-foundry.connector.interface
+  (:require [ai.miniforge.data-foundry.connector.core :as core]
+            [ai.miniforge.data-foundry.connector.state :as state]
+            [ai.miniforge.data-foundry.connector.cursor :as cursor]
+            [ai.miniforge.data-foundry.connector.protocol :as protocol]
+            [ai.miniforge.data-foundry.connector.result :as result]))
+
+;; -- Connector Protocol --
+(def Connector protocol/Connector)
+(def SourceConnector protocol/SourceConnector)
+(def SinkConnector protocol/SinkConnector)
+
+;; -- Protocol Method Delegates --
+(defn connect
+  "Establish connection to external system."
+  [connector config auth]
+  (protocol/connect connector config auth))
+
+(defn close
+  "Terminate connection and release resources."
+  [connector handle]
+  (protocol/close connector handle))
+
+(defn discover
+  "Discover available schemas from source connector."
+  [connector handle opts]
+  (protocol/discover connector handle opts))
+
+(defn extract
+  "Extract records from source connector."
+  [connector handle schema-name opts]
+  (protocol/extract connector handle schema-name opts))
+
+(defn checkpoint
+  "Persist cursor state for source connector."
+  [connector handle connector-id cursor-state]
+  (protocol/checkpoint connector handle connector-id cursor-state))
+
+(defn publish
+  "Write records to sink connector."
+  [connector handle schema-name records opts]
+  (protocol/publish connector handle schema-name records opts))
+
+;; -- Connector Types --
+(def connector-types core/connector-types)
+(def connector-capabilities core/connector-capabilities)
+
+;; -- Registration --
+(defn create-connector
+  "Create a connector registration map.
+   Required: :connector/name, :connector/type, :connector/version,
+             :connector/capabilities, :connector/auth-methods,
+             :connector/retry-policy, :connector/maintainer
+   Returns {:success? true :connector ...} or {:success? false :errors [...]}"
+  [opts]
+  (core/create-connector opts))
+
+(defn validate-connector
+  "Validate a connector registration against N2 §7.1."
+  [connector]
+  (core/validate-connector connector))
+
+;; -- Connector State --
+(defn create-connector-state
+  "Create initial ConnectorState for a connector instance."
+  [connector-id]
+  (state/create-connector-state connector-id))
+
+(defn update-state
+  "Update connector state. Returns new state."
+  [state updates]
+  (state/update-state state updates))
+
+(defn record-batch
+  "Record a batch of processed records in state."
+  [state records-processed records-failed]
+  (state/record-batch state records-processed records-failed))
+
+;; -- Cursor --
+(def cursor-types cursor/cursor-types)
+
+(defn create-cursor
+  "Create a cursor of the given type with initial value."
+  [cursor-type initial-value]
+  (cursor/create-cursor cursor-type initial-value))
+
+(defn advance-cursor
+  "Advance cursor to new position. Returns updated cursor."
+  [cursor new-value]
+  (cursor/advance-cursor cursor new-value))
+
+(defn validate-cursor
+  "Validate cursor structure."
+  [cursor]
+  (cursor/validate-cursor cursor))
+
+;; -- Result Factories --
+(def connect-result result/connect-result)
+(def close-result result/close-result)
+(def discover-result result/discover-result)
+(def extract-result result/extract-result)
+(def checkpoint-result result/checkpoint-result)
+(def publish-result result/publish-result)

--- a/components/connector/src/ai/miniforge/data_foundry/connector/messages.clj
+++ b/components/connector/src/ai/miniforge/data_foundry/connector/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.connector.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/connector/messages/en-US.edn" :connector/messages))

--- a/components/connector/src/ai/miniforge/data_foundry/connector/protocol.clj
+++ b/components/connector/src/ai/miniforge/data_foundry/connector/protocol.clj
@@ -1,0 +1,22 @@
+(ns ai.miniforge.data-foundry.connector.protocol)
+
+(defprotocol Connector
+  "Base connector protocol. All connectors must implement connect and close."
+  (connect [this config auth]
+    "Establish connection. Returns {:connection/handle str :connector/status keyword}")
+  (close [this handle]
+    "Terminate connection. Returns {:connector/status :closed}"))
+
+(defprotocol SourceConnector
+  "Source connector protocol for data extraction."
+  (discover [this handle opts]
+    "Discover available schemas. Returns {:schemas [...] :discover/total-count long}")
+  (extract [this handle schema-name opts]
+    "Extract records. Returns {:records [...] :extract/cursor map :extract/has-more bool}")
+  (checkpoint [this handle connector-id cursor-state]
+    "Persist cursor state. Returns {:checkpoint/id uuid :checkpoint/status :committed}"))
+
+(defprotocol SinkConnector
+  "Sink connector protocol for data publication."
+  (publish [this handle schema-name records opts]
+    "Write records. Returns {:publish/records-written long :publish/records-failed long}"))

--- a/components/connector/src/ai/miniforge/data_foundry/connector/result.clj
+++ b/components/connector/src/ai/miniforge/data_foundry/connector/result.clj
@@ -1,0 +1,54 @@
+(ns ai.miniforge.data-foundry.connector.result
+  "Factory functions for connector protocol result maps.
+   Every protocol method returns a well-known shape — these factories
+   centralize construction so implementations stay DRY."
+  (:import [java.time Instant]
+           [java.util UUID]))
+
+;; -- Connector lifecycle --
+
+(defn connect-result
+  "Build the map returned by Connector/connect."
+  [handle]
+  {:connection/handle    handle
+   :connector/status     :connected
+   :connection/opened-at (Instant/now)})
+
+(defn close-result
+  "Build the map returned by Connector/close."
+  []
+  {:connector/status     :closed
+   :connection/closed-at (Instant/now)})
+
+;; -- SourceConnector --
+
+(defn discover-result
+  "Build the map returned by SourceConnector/discover."
+  [schemas]
+  {:schemas              schemas
+   :discover/total-count (count schemas)})
+
+(defn extract-result
+  "Build the map returned by SourceConnector/extract."
+  [records cursor has-more]
+  {:records              records
+   :extract/cursor       cursor
+   :extract/has-more     has-more
+   :extract/row-count    (count records)
+   :extract/completed-at (Instant/now)})
+
+(defn checkpoint-result
+  "Build the map returned by SourceConnector/checkpoint."
+  [cursor-state]
+  {:checkpoint/id      (UUID/randomUUID)
+   :checkpoint/created (Instant/now)
+   :checkpoint/status  :committed
+   :checkpoint/cursor  cursor-state})
+
+;; -- SinkConnector --
+
+(defn publish-result
+  "Build the map returned by SinkConnector/publish."
+  [records-written records-failed]
+  {:publish/records-written records-written
+   :publish/records-failed  records-failed})

--- a/components/connector/src/ai/miniforge/data_foundry/connector/state.clj
+++ b/components/connector/src/ai/miniforge/data_foundry/connector/state.clj
@@ -1,0 +1,28 @@
+(ns ai.miniforge.data-foundry.connector.state
+  (:import [java.util UUID]
+           [java.time Instant]))
+
+(defn create-connector-state
+  "Create initial ConnectorState per N2 §1.5."
+  [connector-id]
+  {:connector-state/id (UUID/randomUUID)
+   :connector-state/connector-id connector-id
+   :connector-state/cursor {}
+   :connector-state/last-run (Instant/now)
+   :connector-state/records-processed 0
+   :connector-state/records-failed 0
+   :connector-state/status :pending
+   :connector-state/checkpoints []})
+
+(defn update-state
+  "Merge updates into connector state."
+  [state updates]
+  (merge state updates))
+
+(defn record-batch
+  "Record a batch of processed/failed records."
+  [state records-processed records-failed]
+  (-> state
+      (update :connector-state/records-processed + records-processed)
+      (update :connector-state/records-failed + records-failed)
+      (assoc :connector-state/last-run (Instant/now))))

--- a/components/connector/test/ai/miniforge/data_foundry/connector/handles_test.clj
+++ b/components/connector/test/ai/miniforge/data_foundry/connector/handles_test.clj
@@ -1,0 +1,75 @@
+(ns ai.miniforge.data-foundry.connector.handles-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector.handles :as h]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Tests
+
+(deftest create-test
+  (testing "creates an empty store atom"
+    (let [store (h/create)]
+      (is (instance? clojure.lang.Atom store))
+      (is (= {} @store)))))
+
+(deftest get-handle-test
+  (testing "returns nil for unknown handle"
+    (let [store (h/create)]
+      (is (nil? (h/get-handle store "missing")))))
+
+  (testing "returns stored state"
+    (let [store (h/create)]
+      (h/store-handle! store "h1" {:config {:url "https://example.com"}})
+      (is (= {:config {:url "https://example.com"}} (h/get-handle store "h1")))))
+
+  (testing "stores are independent"
+    (let [s1 (h/create)
+          s2 (h/create)]
+      (h/store-handle! s1 "h1" {:data 1})
+      (is (nil? (h/get-handle s2 "h1"))))))
+
+(deftest store-handle!-test
+  (testing "stores and overwrites handle state"
+    (let [store (h/create)]
+      (h/store-handle! store "h1" {:v 1})
+      (h/store-handle! store "h1" {:v 2})
+      (is (= {:v 2} (h/get-handle store "h1")))))
+
+  (testing "stores multiple handles independently"
+    (let [store (h/create)]
+      (h/store-handle! store "h1" {:a 1})
+      (h/store-handle! store "h2" {:b 2})
+      (is (= {:a 1} (h/get-handle store "h1")))
+      (is (= {:b 2} (h/get-handle store "h2"))))))
+
+(deftest remove-handle!-test
+  (testing "removes an existing handle"
+    (let [store (h/create)]
+      (h/store-handle! store "h1" {:data 1})
+      (h/remove-handle! store "h1")
+      (is (nil? (h/get-handle store "h1")))))
+
+  (testing "no-op for unknown handle"
+    (let [store (h/create)]
+      (h/remove-handle! store "nonexistent")
+      (is (= {} @store)))))
+
+(deftest touch-handle!-test
+  (testing "sets :last-request-at to a recent epoch-ms"
+    (let [store  (h/create)
+          before (System/currentTimeMillis)]
+      (h/store-handle! store "h1" {:config {}})
+      (h/touch-handle! store "h1")
+      (let [ts (get-in @store ["h1" :last-request-at])]
+        (is (some? ts))
+        (is (>= ts before))
+        (is (<= ts (System/currentTimeMillis))))))
+
+  (testing "does not disturb other handle state"
+    (let [store (h/create)]
+      (h/store-handle! store "h1" {:config {:url "x"}})
+      (h/touch-handle! store "h1")
+      (is (= {:url "x"} (:config (h/get-handle store "h1")))))))
+
+(comment
+  ;; Run: clj -M:dev:test -n ai.miniforge.data-foundry.connector.handles-test
+  )

--- a/components/connector/test/ai/miniforge/data_foundry/connector/interface_test.clj
+++ b/components/connector/test/ai/miniforge/data_foundry/connector/interface_test.clj
@@ -1,0 +1,463 @@
+(ns ai.miniforge.data-foundry.connector.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.connector.interface :as conn]
+            [ai.miniforge.data-foundry.connector.messages :as msg]))
+
+(deftest connector-types-test
+  (testing "N2 §1 connector types"
+    (is (= #{:source :sink :bidirectional} conn/connector-types))))
+
+(deftest connector-capabilities-test
+  (testing "N2 §1.4 capabilities"
+    (is (contains? conn/connector-capabilities :cap/discovery))
+    (is (contains? conn/connector-capabilities :cap/incremental))
+    (is (contains? conn/connector-capabilities :cap/batch))
+    (is (contains? conn/connector-capabilities :cap/upsert))
+    (is (contains? conn/connector-capabilities :cap/transactions))
+    (is (contains? conn/connector-capabilities :cap/rate-limiting))
+    (is (contains? conn/connector-capabilities :cap/pagination))))
+
+;; ---------------------------------------------------------------------------
+;; validate-connector
+;; ---------------------------------------------------------------------------
+
+(def ^:private valid-connector
+  {:connector/id (java.util.UUID/randomUUID)
+   :connector/name "Test Source"
+   :connector/type :source
+   :connector/version "1.0.0"
+   :connector/capabilities #{:cap/discovery :cap/batch}
+   :connector/auth-methods #{:api-key}
+   :connector/retry-policy {:retry/strategy :exponential
+                            :retry/max-attempts 3
+                            :retry/initial-delay-ms 1000}
+   :connector/maintainer "test-team"})
+
+(deftest validate-connector-happy-test
+  (testing "Fully valid connector passes validation"
+    (let [result (conn/validate-connector valid-connector)]
+      (is (:success? result))
+      (is (nil? (:errors result))))))
+
+(deftest validate-connector-missing-id-test
+  (testing "Missing :connector/id"
+    (let [result (conn/validate-connector (dissoc valid-connector :connector/id))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/id-required) %) (:errors result))))))
+
+(deftest validate-connector-missing-name-test
+  (testing "Missing :connector/name"
+    (let [result (conn/validate-connector (dissoc valid-connector :connector/name))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/name-must-be-string) %) (:errors result))))))
+
+(deftest validate-connector-invalid-name-test
+  (testing "Non-string :connector/name"
+    (let [result (conn/validate-connector (assoc valid-connector :connector/name 42))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/name-must-be-string) %) (:errors result))))))
+
+(deftest validate-connector-invalid-type-test
+  (testing "Invalid :connector/type"
+    (let [result (conn/validate-connector (assoc valid-connector :connector/type :invalid))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/type-invalid {:allowed conn/connector-types}) %)
+                (:errors result))))))
+
+(deftest validate-connector-missing-type-test
+  (testing "Missing :connector/type"
+    (let [result (conn/validate-connector (dissoc valid-connector :connector/type))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/type-invalid {:allowed conn/connector-types}) %)
+                (:errors result))))))
+
+(deftest validate-connector-missing-version-test
+  (testing "Missing :connector/version"
+    (let [result (conn/validate-connector (dissoc valid-connector :connector/version))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/version-must-be-string) %) (:errors result))))))
+
+(deftest validate-connector-invalid-version-test
+  (testing "Non-string :connector/version"
+    (let [result (conn/validate-connector (assoc valid-connector :connector/version 123))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/version-must-be-string) %) (:errors result))))))
+
+(deftest validate-connector-missing-auth-methods-test
+  (testing "Missing :connector/auth-methods"
+    (let [result (conn/validate-connector (dissoc valid-connector :connector/auth-methods))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/auth-methods-must-be-set) %) (:errors result))))))
+
+(deftest validate-connector-empty-auth-methods-test
+  (testing "Empty :connector/auth-methods"
+    (let [result (conn/validate-connector (assoc valid-connector :connector/auth-methods #{}))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/auth-methods-empty) %) (:errors result))))))
+
+(deftest validate-connector-non-set-auth-methods-test
+  (testing "Non-set :connector/auth-methods"
+    (let [result (conn/validate-connector (assoc valid-connector :connector/auth-methods [:api-key]))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/auth-methods-must-be-set) %) (:errors result))))))
+
+(deftest validate-connector-missing-maintainer-test
+  (testing "Missing :connector/maintainer"
+    (let [result (conn/validate-connector (dissoc valid-connector :connector/maintainer))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/maintainer-must-be-string) %) (:errors result))))))
+
+(deftest validate-connector-non-string-maintainer-test
+  (testing "Non-string :connector/maintainer"
+    (let [result (conn/validate-connector (assoc valid-connector :connector/maintainer :team))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/maintainer-must-be-string) %) (:errors result))))))
+
+(deftest validate-connector-missing-capabilities-test
+  (testing "Missing :connector/capabilities"
+    (let [result (conn/validate-connector (dissoc valid-connector :connector/capabilities))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/capabilities-must-be-set) %) (:errors result))))))
+
+(deftest validate-connector-empty-capabilities-test
+  (testing "Empty :connector/capabilities"
+    (let [result (conn/validate-connector (assoc valid-connector :connector/capabilities #{}))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/capabilities-empty) %) (:errors result))))))
+
+(deftest validate-connector-missing-retry-policy-test
+  (testing "Missing :connector/retry-policy"
+    (let [result (conn/validate-connector (dissoc valid-connector :connector/retry-policy))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/retry-policy-required) %) (:errors result))))))
+
+(deftest validate-connector-retry-policy-missing-strategy-test
+  (testing "Retry policy without :retry/strategy"
+    (let [result (conn/validate-connector
+                  (assoc valid-connector :connector/retry-policy
+                         {:retry/max-attempts 3}))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/retry-strategy-required) %) (:errors result))))))
+
+(deftest validate-connector-retry-policy-missing-max-attempts-test
+  (testing "Retry policy without :retry/max-attempts"
+    (let [result (conn/validate-connector
+                  (assoc valid-connector :connector/retry-policy
+                         {:retry/strategy :exponential}))]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/retry-max-attempts-required) %) (:errors result))))))
+
+(deftest validate-connector-multiple-errors-test
+  (testing "Multiple validation errors accumulate"
+    (let [result (conn/validate-connector {})]
+      (is (not (:success? result)))
+      (is (> (count (:errors result)) 1))
+      ;; Should report id, name, type, version, capabilities, auth-methods,
+      ;; retry-policy, and maintainer errors
+      (is (>= (count (:errors result)) 8)))))
+
+;; ---------------------------------------------------------------------------
+;; create-connector
+;; ---------------------------------------------------------------------------
+
+(deftest create-connector-test
+  (testing "SC-01: Create valid source connector"
+    (let [result (conn/create-connector
+                  {:connector/name "Test Source"
+                   :connector/type :source
+                   :connector/version "1.0.0"
+                   :connector/capabilities #{:cap/discovery :cap/batch}
+                   :connector/auth-methods #{:api-key}
+                   :connector/retry-policy {:retry/strategy :exponential
+                                            :retry/max-attempts 3
+                                            :retry/initial-delay-ms 1000}
+                   :connector/maintainer "test-team"})]
+      (is (:success? result))
+      (is (some? (get-in result [:connector :connector/id])))))
+
+  (testing "Reject invalid connector type"
+    (let [result (conn/create-connector
+                  {:connector/name "Bad"
+                   :connector/type :invalid
+                   :connector/version "1.0.0"
+                   :connector/capabilities #{:cap/batch}
+                   :connector/auth-methods #{:api-key}
+                   :connector/retry-policy {:retry/strategy :fixed :retry/max-attempts 1}
+                   :connector/maintainer "x"})]
+      (is (not (:success? result))))))
+
+(deftest create-connector-auto-id-test
+  (testing "Auto-generates :connector/id when not provided"
+    (let [result (conn/create-connector
+                  {:connector/name "Auto ID"
+                   :connector/type :sink
+                   :connector/version "2.0.0"
+                   :connector/capabilities #{:cap/batch}
+                   :connector/auth-methods #{:basic}
+                   :connector/retry-policy {:retry/strategy :fixed
+                                            :retry/max-attempts 1}
+                   :connector/maintainer "team-a"})]
+      (is (:success? result))
+      (is (uuid? (get-in result [:connector :connector/id]))))))
+
+(deftest create-connector-preserves-provided-id-test
+  (testing "Preserves :connector/id when provided"
+    (let [id (java.util.UUID/randomUUID)
+          result (conn/create-connector
+                  {:connector/id id
+                   :connector/name "With ID"
+                   :connector/type :bidirectional
+                   :connector/version "1.0.0"
+                   :connector/capabilities #{:cap/upsert}
+                   :connector/auth-methods #{:oauth2}
+                   :connector/retry-policy {:retry/strategy :exponential
+                                            :retry/max-attempts 5
+                                            :retry/initial-delay-ms 500}
+                   :connector/maintainer "team-b"})]
+      (is (:success? result))
+      (is (= id (get-in result [:connector :connector/id]))))))
+
+(deftest create-connector-missing-name-test
+  (testing "Reject missing :connector/name"
+    (let [result (conn/create-connector
+                  {:connector/type :source
+                   :connector/version "1.0.0"
+                   :connector/capabilities #{:cap/batch}
+                   :connector/auth-methods #{:api-key}
+                   :connector/retry-policy {:retry/strategy :fixed :retry/max-attempts 1}
+                   :connector/maintainer "team"})]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/name-must-be-string) %) (:errors result))))))
+
+(deftest create-connector-missing-type-test
+  (testing "Reject missing :connector/type"
+    (let [result (conn/create-connector
+                  {:connector/name "No Type"
+                   :connector/version "1.0.0"
+                   :connector/capabilities #{:cap/batch}
+                   :connector/auth-methods #{:api-key}
+                   :connector/retry-policy {:retry/strategy :fixed :retry/max-attempts 1}
+                   :connector/maintainer "team"})]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/type-invalid {:allowed conn/connector-types}) %)
+                (:errors result))))))
+
+(deftest create-connector-missing-version-test
+  (testing "Reject missing :connector/version"
+    (let [result (conn/create-connector
+                  {:connector/name "No Version"
+                   :connector/type :source
+                   :connector/capabilities #{:cap/batch}
+                   :connector/auth-methods #{:api-key}
+                   :connector/retry-policy {:retry/strategy :fixed :retry/max-attempts 1}
+                   :connector/maintainer "team"})]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/version-must-be-string) %) (:errors result))))))
+
+(deftest create-connector-missing-maintainer-test
+  (testing "Reject missing :connector/maintainer"
+    (let [result (conn/create-connector
+                  {:connector/name "No Maintainer"
+                   :connector/type :source
+                   :connector/version "1.0.0"
+                   :connector/capabilities #{:cap/batch}
+                   :connector/auth-methods #{:api-key}
+                   :connector/retry-policy {:retry/strategy :fixed :retry/max-attempts 1}})]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :connector/maintainer-must-be-string) %) (:errors result))))))
+
+(deftest create-connector-empty-map-test
+  (testing "Empty map returns multiple errors"
+    (let [result (conn/create-connector {})]
+      (is (not (:success? result)))
+      (is (> (count (:errors result)) 1)))))
+
+;; ---------------------------------------------------------------------------
+;; connector-state
+;; ---------------------------------------------------------------------------
+
+(deftest connector-state-test
+  (testing "State tracking"
+    (let [conn-id (java.util.UUID/randomUUID)
+          state (conn/create-connector-state conn-id)]
+      (is (= conn-id (:connector-state/connector-id state)))
+      (is (= :pending (:connector-state/status state)))
+      (is (= 0 (:connector-state/records-processed state)))
+
+      (let [updated (conn/record-batch state 100 2)]
+        (is (= 100 (:connector-state/records-processed updated)))
+        (is (= 2 (:connector-state/records-failed updated)))
+
+        (let [again (conn/record-batch updated 50 0)]
+          (is (= 150 (:connector-state/records-processed again)))
+          (is (= 2 (:connector-state/records-failed again))))))))
+
+(deftest connector-state-initial-fields-test
+  (testing "Initial state has all required fields"
+    (let [conn-id (java.util.UUID/randomUUID)
+          state (conn/create-connector-state conn-id)]
+      (is (uuid? (:connector-state/id state)))
+      (is (= conn-id (:connector-state/connector-id state)))
+      (is (= {} (:connector-state/cursor state)))
+      (is (inst? (:connector-state/last-run state)))
+      (is (= 0 (:connector-state/records-processed state)))
+      (is (= 0 (:connector-state/records-failed state)))
+      (is (= :pending (:connector-state/status state)))
+      (is (= [] (:connector-state/checkpoints state))))))
+
+(deftest connector-state-lifecycle-test
+  (testing "Full lifecycle: create -> record-batch multiple times -> accumulate"
+    (let [conn-id (java.util.UUID/randomUUID)
+          state (conn/create-connector-state conn-id)
+          after-batch-1 (conn/record-batch state 500 10)
+          after-batch-2 (conn/record-batch after-batch-1 300 5)
+          after-batch-3 (conn/record-batch after-batch-2 200 0)
+          after-batch-4 (conn/record-batch after-batch-3 1000 50)]
+      ;; Verify accumulation across four batches
+      (is (= 2000 (:connector-state/records-processed after-batch-4)))
+      (is (= 65 (:connector-state/records-failed after-batch-4)))
+      ;; Connector-id unchanged
+      (is (= conn-id (:connector-state/connector-id after-batch-4)))
+      ;; last-run updated
+      (is (inst? (:connector-state/last-run after-batch-4))))))
+
+(deftest connector-state-record-batch-zero-test
+  (testing "Recording zero-count batch is idempotent on counts"
+    (let [state (conn/create-connector-state (java.util.UUID/randomUUID))
+          after (conn/record-batch state 0 0)]
+      (is (= 0 (:connector-state/records-processed after)))
+      (is (= 0 (:connector-state/records-failed after))))))
+
+;; ---------------------------------------------------------------------------
+;; update-state
+;; ---------------------------------------------------------------------------
+
+(deftest update-state-status-change-test
+  (testing "Update status from :pending to :running"
+    (let [state (conn/create-connector-state (java.util.UUID/randomUUID))
+          updated (conn/update-state state {:connector-state/status :running})]
+      (is (= :running (:connector-state/status updated)))
+      ;; Other fields preserved
+      (is (= 0 (:connector-state/records-processed updated))))))
+
+(deftest update-state-error-recording-test
+  (testing "Record error information in state"
+    (let [state (conn/create-connector-state (java.util.UUID/randomUUID))
+          updated (conn/update-state state {:connector-state/status :error
+                                            :connector-state/error-message "Connection timeout"})]
+      (is (= :error (:connector-state/status updated)))
+      (is (= "Connection timeout" (:connector-state/error-message updated))))))
+
+(deftest update-state-cursor-test
+  (testing "Update cursor in state"
+    (let [state (conn/create-connector-state (java.util.UUID/randomUUID))
+          cursor {:cursor/type :offset :cursor/value 42}
+          updated (conn/update-state state {:connector-state/cursor cursor})]
+      (is (= cursor (:connector-state/cursor updated))))))
+
+(deftest update-state-multiple-fields-test
+  (testing "Update multiple fields simultaneously"
+    (let [state (conn/create-connector-state (java.util.UUID/randomUUID))
+          updated (conn/update-state state {:connector-state/status :completed
+                                            :connector-state/records-processed 999})]
+      (is (= :completed (:connector-state/status updated)))
+      (is (= 999 (:connector-state/records-processed updated))))))
+
+(deftest update-state-preserves-id-test
+  (testing "Update preserves connector-state/id and connector-id"
+    (let [conn-id (java.util.UUID/randomUUID)
+          state (conn/create-connector-state conn-id)
+          state-id (:connector-state/id state)
+          updated (conn/update-state state {:connector-state/status :running})]
+      (is (= state-id (:connector-state/id updated)))
+      (is (= conn-id (:connector-state/connector-id updated))))))
+
+;; ---------------------------------------------------------------------------
+;; cursor
+;; ---------------------------------------------------------------------------
+
+(deftest cursor-test
+  (testing "N2 §2.2.1 cursor types"
+    (is (= #{:timestamp-watermark :offset :sequence-id :version-id}
+           conn/cursor-types)))
+
+  (testing "Create and advance cursor"
+    (let [cursor (conn/create-cursor :timestamp-watermark #inst "2026-01-01")]
+      (is (= :timestamp-watermark (:cursor/type cursor)))
+      (is (= #inst "2026-01-01" (:cursor/value cursor)))
+
+      (let [advanced (conn/advance-cursor cursor #inst "2026-03-13")]
+        (is (= #inst "2026-03-13" (:cursor/value advanced))))))
+
+  (testing "Validate cursor"
+    (is (:success? (conn/validate-cursor {:cursor/type :offset})))
+    (is (not (:success? (conn/validate-cursor {:cursor/type :invalid}))))
+    (is (not (:success? (conn/validate-cursor {}))))))
+
+(deftest cursor-all-types-test
+  (testing "All cursor types are valid"
+    (doseq [ct conn/cursor-types]
+      (is (:success? (conn/validate-cursor {:cursor/type ct}))
+          (str "Cursor type " ct " should be valid")))))
+
+(deftest cursor-invalid-type-test
+  (testing "Invalid cursor types rejected"
+    (doseq [bad [:invalid :unknown :random :timestamp nil]]
+      (let [result (conn/validate-cursor {:cursor/type bad})]
+        (is (not (:success? result))
+            (str "Cursor type " bad " should be invalid"))))))
+
+(deftest cursor-missing-type-test
+  (testing "Missing :cursor/type"
+    (let [result (conn/validate-cursor {})]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :cursor/type-required) %) (:errors result))))))
+
+(deftest cursor-nil-type-test
+  (testing "Explicit nil :cursor/type"
+    (let [result (conn/validate-cursor {:cursor/type nil})]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :cursor/type-required) %) (:errors result))))))
+
+(deftest cursor-invalid-type-error-message-test
+  (testing "Invalid cursor type produces correct error message"
+    (let [result (conn/validate-cursor {:cursor/type :bogus})]
+      (is (not (:success? result)))
+      (is (some #(= (msg/t :cursor/type-invalid {:allowed conn/cursor-types}) %)
+                (:errors result))))))
+
+(deftest cursor-create-offset-test
+  (testing "Create offset cursor"
+    (let [cursor (conn/create-cursor :offset 0)]
+      (is (= :offset (:cursor/type cursor)))
+      (is (= 0 (:cursor/value cursor)))
+      (is (inst? (:cursor/last-retrieved-at cursor))))))
+
+(deftest cursor-create-sequence-id-test
+  (testing "Create sequence-id cursor"
+    (let [cursor (conn/create-cursor :sequence-id "seq-001")]
+      (is (= :sequence-id (:cursor/type cursor)))
+      (is (= "seq-001" (:cursor/value cursor))))))
+
+(deftest cursor-advance-preserves-type-test
+  (testing "Advancing cursor preserves type"
+    (let [cursor (conn/create-cursor :offset 0)
+          advanced (conn/advance-cursor cursor 100)]
+      (is (= :offset (:cursor/type advanced)))
+      (is (= 100 (:cursor/value advanced)))
+      (is (inst? (:cursor/last-retrieved-at advanced))))))
+
+(deftest cursor-advance-updates-timestamp-test
+  (testing "Advancing cursor updates last-retrieved-at"
+    (let [cursor (conn/create-cursor :offset 0)
+          t1 (:cursor/last-retrieved-at cursor)
+          _ (Thread/sleep 5)
+          advanced (conn/advance-cursor cursor 1)
+          t2 (:cursor/last-retrieved-at advanced)]
+      (is (.isAfter t2 t1)))))
+
+(deftest cursor-empty-map-test
+  (testing "Empty map fails validation"
+    (let [result (conn/validate-cursor {})]
+      (is (not (:success? result)))
+      (is (= 1 (count (:errors result)))))))

--- a/components/cursor-store/deps.edn
+++ b/components/cursor-store/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/schema   {:local/root "../../../miniforge/components/schema"}
+        ai.miniforge/logging  {:local/root "../../../miniforge/components/logging"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/cursor-store/deps.edn
+++ b/components/cursor-store/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema   {:local/root "../../../miniforge/components/schema"}
-        ai.miniforge/logging  {:local/root "../../../miniforge/components/logging"}}
+ :deps {ai.miniforge/schema   {:local/root "../schema"}
+        ai.miniforge/logging  {:local/root "../logging"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/cursor-store/src/ai/miniforge/data_foundry/cursor_store/interface.clj
+++ b/components/cursor-store/src/ai/miniforge/data_foundry/cursor_store/interface.clj
@@ -1,0 +1,29 @@
+(ns ai.miniforge.data-foundry.cursor-store.interface
+  "Public API for file-based cursor persistence.
+
+   Cursors are stored as EDN at:
+     <pipeline-dir>/.cursors/<pipeline-filename>
+
+   The on-disk map is keyed by [connector-ref schema-name] for stable
+   identity across runs (stage UUIDs are regenerated each run).
+   prior-cursor in pipeline-runner looks up by this composite key."
+  (:require [ai.miniforge.data-foundry.cursor-store.store :as store]))
+
+(defn save-cursors
+  "Persist connector cursors after a pipeline run.
+   logger         — logger instance (or nil)
+   pipeline-path  — path to the pipeline EDN file (cursor path is derived from it)
+   cursor-map     — {stage-uuid → cursor-entry} as returned in :pipeline-run/connector-cursors
+   Returns schema/success with :cursors (normalized map) or schema/failure."
+  [logger pipeline-path cursor-map]
+  (store/save-cursors logger pipeline-path cursor-map))
+
+(defn load-cursors
+  "Load persisted cursors for a pipeline.
+   logger         — logger instance (or nil)
+   pipeline-path  — path to the pipeline EDN file
+   Returns schema/success with :cursors key ({[conn-ref schema-name] → cursor-entry}).
+   Returns schema/success with empty map on first run.
+   Returns schema/failure only on parse errors."
+  [logger pipeline-path]
+  (store/load-cursors logger pipeline-path))

--- a/components/cursor-store/src/ai/miniforge/data_foundry/cursor_store/store.clj
+++ b/components/cursor-store/src/ai/miniforge/data_foundry/cursor_store/store.clj
@@ -1,0 +1,117 @@
+(ns ai.miniforge.data-foundry.cursor-store.store
+  "File-based cursor persistence.
+
+   Layer 0 — pure conversion helpers
+   Layer 1 — file I/O (save-cursors, load-cursors)"
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.pprint :as pp]
+            [clojure.walk :as walk]
+            [ai.miniforge.logging.interface :as log]
+            [ai.miniforge.schema.interface :as schema])
+  (:import [java.io StringWriter]
+           [java.time Instant]))
+
+;;------------------------------------------------------------------------------ Layer 0 — pure helpers
+
+(defn- cursor-file
+  "Derive cursor EDN file from a pipeline file path.
+   <pipeline-dir>/.cursors/<pipeline-filename>"
+  [pipeline-path]
+  (let [f   (io/file pipeline-path)
+        dir (or (.getParentFile f) (io/file "."))]
+    (io/file dir ".cursors" (.getName f))))
+
+(defn- normalize-for-storage
+  "Re-key {stage-uuid → cursor-entry} to {[connector-ref schema-name] → cursor-entry}.
+   Entries missing connector-ref or schema-name are dropped with a warning."
+  [logger cursor-map]
+  (reduce-kv
+   (fn [acc _id entry]
+     (let [cref  (:stage/connector-ref entry)
+           sname (:stage/schema-name entry)]
+       (if (and cref sname)
+         (assoc acc [cref sname] entry)
+         (do (when logger
+               (log/warn logger :cursor-store :cursor-store/entry-dropped
+                         {:message "Cursor entry dropped — missing connector-ref or schema-name"
+                          :data {:stage/name (or (:stage/name entry) "unknown")}}))
+             acc))))
+   {}
+   cursor-map))
+
+(defn- stringify-instants
+  "Convert all java.time.Instant values to ISO-8601 strings.
+   Clojure's pprint emits #object[java.time.Instant ...] which is not valid EDN;
+   storing as a plain string keeps the file fully EDN-readable.
+   :cursor/updated-at is audit metadata — it is not used in cursor lookup logic."
+  [v]
+  (walk/postwalk (fn [x] (if (instance? Instant x) (str x) x)) v))
+
+(defn- write-edn
+  "Render a value to a pretty-printed EDN string."
+  [v]
+  (let [sw (StringWriter.)]
+    (pp/pprint (stringify-instants v) sw)
+    (str sw)))
+
+(defn- read-edn
+  "Parse an EDN string."
+  [s]
+  (edn/read-string s))
+
+;;------------------------------------------------------------------------------ Layer 1 — I/O
+
+(defn save-cursors
+  "Persist connector cursors to <pipeline-dir>/.cursors/<pipeline-filename>.
+   cursor-map is the raw {stage-uuid → cursor-entry} map from
+   :pipeline-run/connector-cursors. Returns schema/success or schema/failure."
+  [logger pipeline-path cursor-map]
+  (try
+    (let [normalized (normalize-for-storage logger cursor-map)
+          file       (cursor-file pipeline-path)]
+      (if (empty? normalized)
+        (do (when logger
+              (log/info logger :cursor-store :cursor-store/no-cursors
+                        {:message "No cursors to save — no ingest stages completed with cursors"}))
+            (schema/success :cursors normalized))
+        (let [dir (.getParentFile file)]
+          (.mkdirs dir)
+          (spit file (write-edn normalized))
+          (when logger
+            (log/info logger :cursor-store :cursor-store/saved
+                      {:message (str "Saved " (count normalized) " cursor(s)")
+                       :data {:count (count normalized) :path (str file)}}))
+          (schema/success :cursors normalized))))
+    (catch Exception e
+      (when logger
+        (log/error logger :cursor-store :cursor-store/write-failed
+                   {:message (str "Failed to write cursor file: " (.getMessage e))
+                    :data {:path pipeline-path :error (.getMessage e)}}))
+      (schema/failure :cursors (.getMessage e)))))
+
+(defn load-cursors
+  "Load persisted cursors for a pipeline. Returns schema/success with
+   :cursors key (map keyed by [connector-ref schema-name]).
+   Returns schema/success with {} on first run (no file yet).
+   Returns schema/failure only on parse errors."
+  [logger pipeline-path]
+  (try
+    (let [file (cursor-file pipeline-path)]
+      (if (.exists file)
+        (let [cursors (read-edn (slurp file))]
+          (when logger
+            (log/info logger :cursor-store :cursor-store/loaded
+                      {:message (str "Loaded " (count cursors) " cursor(s)")
+                       :data {:count (count cursors) :path (str file)}}))
+          (schema/success :cursors cursors))
+        (do (when logger
+              (log/info logger :cursor-store :cursor-store/first-run
+                        {:message "No prior cursors found — starting fresh"}))
+            (schema/success :cursors {}))))
+    (catch Exception e
+      (when logger
+        (log/error logger :cursor-store :cursor-store/read-failed
+                   {:message (str "Failed to read cursor file: " (.getMessage e))
+                    :data {:path pipeline-path :error (.getMessage e)}}))
+      (schema/failure :cursors (.getMessage e)))))

--- a/components/cursor-store/test/ai/miniforge/data_foundry/cursor_store/interface_test.clj
+++ b/components/cursor-store/test/ai/miniforge/data_foundry/cursor_store/interface_test.clj
@@ -1,0 +1,108 @@
+(ns ai.miniforge.data-foundry.cursor-store.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.cursor-store.interface :as sut]
+            [ai.miniforge.logging.interface :as log])
+  (:import [java.time Instant]))
+
+(defn- tmp-pipeline-path []
+  (str (System/getProperty "java.io.tmpdir")
+       "/cursor-store-test-"
+       (random-uuid)
+       "/pipelines/pipeline.edn"))
+
+(def ^:private logger (log/create-logger {:min-level :debug :output :human}))
+
+;; ---------------------------------------------------------------------------
+;; load-cursors
+
+(deftest load-cursors-first-run-test
+  (testing "Returns empty map when no cursor file exists yet"
+    (let [result (sut/load-cursors logger (tmp-pipeline-path))]
+      (is (:success? result))
+      (is (= {} (:cursors result))))))
+
+;; ---------------------------------------------------------------------------
+;; round-trip
+
+(deftest round-trip-test
+  (testing "save then load preserves cursor data with stable key"
+    (let [path      (tmp-pipeline-path)
+          stage-id  (random-uuid)
+          conn-ref  :conn/gitlab
+          schema    "issues"
+          instant   (Instant/now)
+          cursor-map {stage-id {:stage/id            stage-id
+                                :stage/name          "Ingest Issues"
+                                :stage/connector-ref conn-ref
+                                :stage/schema-name   schema
+                                :cursor              {:cursor/type  :offset
+                                                      :cursor/value 42}
+                                :cursor/updated-at   instant}}]
+      (is (:success? (sut/save-cursors logger path cursor-map)))
+      (let [result (sut/load-cursors logger path)]
+        (is (:success? result))
+        (let [loaded (get (:cursors result) [conn-ref schema])]
+          (is (some? loaded))
+          (is (= :offset (get-in loaded [:cursor :cursor/type])))
+          (is (= 42 (get-in loaded [:cursor :cursor/value])))
+          ;; :cursor/updated-at is stored as an ISO-8601 string (Instant not EDN-printable)
+          (is (string? (:cursor/updated-at loaded)))
+          (is (= (str instant) (:cursor/updated-at loaded))))))))
+
+(deftest multi-stage-round-trip-test
+  (testing "Multiple stages produce multiple entries keyed by connector/schema"
+    (let [path  (tmp-pipeline-path)
+          id-1  (random-uuid)
+          id-2  (random-uuid)
+          cursor-map {id-1 {:stage/connector-ref :conn/gitlab
+                             :stage/schema-name   "issues"
+                             :cursor              {:cursor/type :offset :cursor/value 10}
+                             :cursor/updated-at   (Instant/now)}
+                      id-2 {:stage/connector-ref :conn/gitlab
+                             :stage/schema-name   "merge-requests"
+                             :cursor              {:cursor/type :offset :cursor/value 5}
+                             :cursor/updated-at   (Instant/now)}}]
+      (sut/save-cursors logger path cursor-map)
+      (let [loaded (:cursors (sut/load-cursors logger path))]
+        (is (= 2 (count loaded)))
+        (is (= 10 (get-in loaded [[:conn/gitlab "issues"] :cursor :cursor/value])))
+        (is (= 5 (get-in loaded [[:conn/gitlab "merge-requests"] :cursor :cursor/value])))))))
+
+;; ---------------------------------------------------------------------------
+;; normalization
+
+(deftest normalization-drops-incomplete-entries-test
+  (testing "Entries without connector-ref or schema-name are excluded"
+    (let [path     (tmp-pipeline-path)
+          good-id  (random-uuid)
+          bad-id   (random-uuid)
+          cursor-map {good-id {:stage/connector-ref :conn/github
+                               :stage/schema-name   "pulls"
+                               :cursor              {:cursor/type :offset :cursor/value 1}
+                               :cursor/updated-at   (Instant/now)}
+                      bad-id  {:stage/name        "No-ref stage"
+                               :cursor            {:cursor/type :offset :cursor/value 2}
+                               :cursor/updated-at (Instant/now)}}]
+      (sut/save-cursors logger path cursor-map)
+      (let [loaded (:cursors (sut/load-cursors logger path))]
+        (is (= 1 (count loaded)))
+        (is (contains? loaded [:conn/github "pulls"]))))))
+
+;; ---------------------------------------------------------------------------
+;; idempotency — second save overwrites first
+
+(deftest overwrite-test
+  (testing "Saving again overwrites prior cursor with updated value"
+    (let [path     (tmp-pipeline-path)
+          conn-ref :conn/gitlab
+          schema   "issues"
+          run1 {(random-uuid) {:stage/connector-ref conn-ref :stage/schema-name schema
+                               :cursor {:cursor/type :offset :cursor/value 10}
+                               :cursor/updated-at (Instant/now)}}
+          run2 {(random-uuid) {:stage/connector-ref conn-ref :stage/schema-name schema
+                               :cursor {:cursor/type :offset :cursor/value 20}
+                               :cursor/updated-at (Instant/now)}}]
+      (sut/save-cursors logger path run1)
+      (sut/save-cursors logger path run2)
+      (let [loaded (:cursors (sut/load-cursors logger path))]
+        (is (= 20 (get-in loaded [[conn-ref schema] :cursor :cursor/value])))))))

--- a/components/data-quality/deps.edn
+++ b/components/data-quality/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/dataset-schema {:local/root "../dataset-schema"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/data-quality/resources/config/data-quality/messages/en-US.edn
+++ b/components/data-quality/resources/config/data-quality/messages/en-US.edn
@@ -1,0 +1,10 @@
+{:data-quality/messages
+ {;; Rule violations
+  :violation/required       "Field \"{field}\" is required but missing or nil"
+  :violation/type-check     "Field \"{field}\" expected type {expected}, got {actual}"
+  :violation/range          "Field \"{field}\" value {value} is outside range [{min}, {max}]"
+  :violation/pattern        "Field \"{field}\" value \"{value}\" does not match pattern {pattern}"
+  :violation/custom         "Custom rule \"{rule}\" failed: {message}"
+
+  ;; Report
+  :report/no-rules          "No rules provided for evaluation"}}

--- a/components/data-quality/src/ai/miniforge/data_foundry/data_quality/core.clj
+++ b/components/data-quality/src/ai/miniforge/data_foundry/data_quality/core.clj
@@ -20,18 +20,20 @@
         (range)
         records))
 
+(defn- pass-record
+  "Return the record when all its evaluations pass error-severity rules, else nil."
+  [{:keys [record evaluations]}]
+  (let [has-error (some (fn [e]
+                          (and (not (:valid? e))
+                               (= :error (:severity e))))
+                        evaluations)]
+    (when-not has-error record)))
+
 (defn filter-passed
   "Return records that pass all :error-severity rules.
    Warnings do not cause filtering."
   [evaluation]
-  (vec
-   (keep (fn [{:keys [record evaluations]}]
-           (let [has-error (some (fn [e]
-                                  (and (not (:valid? e))
-                                       (= :error (:severity e))))
-                                evaluations)]
-             (when-not has-error record)))
-         evaluation)))
+  (vec (keep pass-record evaluation)))
 
 ;; -- Report helpers (decomposed from generate-report) --
 
@@ -44,15 +46,17 @@
          :when (not valid?)]
      (result/violation record-index id field severity message))))
 
+(defn- tally-field-violation
+  "Accumulate a violation count for a field, skipping nil fields."
+  [acc {:keys [field]}]
+  (if field
+    (update-in acc [field :violations] (fnil inc 0))
+    acc))
+
 (defn- compute-field-summary
   "Compute per-field violation counts and pass rates."
   [violations total]
-  (let [counts (reduce (fn [acc {:keys [field]}]
-                         (if field
-                           (update-in acc [field :violations] (fnil inc 0))
-                           acc))
-                       {}
-                       violations)]
+  (let [counts (reduce tally-field-violation {} violations)]
     (reduce-kv (fn [acc field {:keys [violations]}]
                  (assoc acc field
                         {:violations violations

--- a/components/data-quality/src/ai/miniforge/data_foundry/data_quality/core.clj
+++ b/components/data-quality/src/ai/miniforge/data_foundry/data_quality/core.clj
@@ -1,0 +1,74 @@
+(ns ai.miniforge.data-foundry.data-quality.core
+  "Evaluation engine and report generation for data quality."
+  (:require [ai.miniforge.data-foundry.data-quality.result :as result]))
+
+(defn evaluate-record
+  "Evaluate a single record against all rules.
+   Returns vector of {:rule/id :field :severity :valid? :message}."
+  [rules record]
+  (mapv (fn [{:rule/keys [id field severity check-fn]}]
+          (let [r (check-fn record)]
+            (merge {:rule/id id :field field :severity severity} r)))
+        rules))
+
+(defn evaluate-records
+  "Evaluate all records against all rules.
+   Returns vector of evaluation-entry maps."
+  [rules records]
+  (mapv (fn [idx record]
+          (result/evaluation-entry idx record (evaluate-record rules record)))
+        (range)
+        records))
+
+(defn filter-passed
+  "Return records that pass all :error-severity rules.
+   Warnings do not cause filtering."
+  [evaluation]
+  (vec
+   (keep (fn [{:keys [record evaluations]}]
+           (let [has-error (some (fn [e]
+                                  (and (not (:valid? e))
+                                       (= :error (:severity e))))
+                                evaluations)]
+             (when-not has-error record)))
+         evaluation)))
+
+;; -- Report helpers (decomposed from generate-report) --
+
+(defn- collect-violations
+  "Extract violation records from a full evaluation."
+  [evaluation]
+  (vec
+   (for [{:keys [record-index evaluations]} evaluation
+         {:keys [valid? rule/id field severity message]} evaluations
+         :when (not valid?)]
+     (result/violation record-index id field severity message))))
+
+(defn- compute-field-summary
+  "Compute per-field violation counts and pass rates."
+  [violations total]
+  (let [counts (reduce (fn [acc {:keys [field]}]
+                         (if field
+                           (update-in acc [field :violations] (fnil inc 0))
+                           acc))
+                       {}
+                       violations)]
+    (reduce-kv (fn [acc field {:keys [violations]}]
+                 (assoc acc field
+                        {:violations violations
+                         :pass-rate  (if (zero? total)
+                                       1.0
+                                       (double (/ (- total violations) total)))}))
+               {}
+               counts)))
+
+(defn generate-report
+  "Build a quality report with field-level summary statistics."
+  [pack-id evaluation]
+  (let [total      (count evaluation)
+        violations (collect-violations evaluation)
+        failed     (count (distinct (map :record-index violations)))
+        passed     (- total failed)]
+    (result/quality-report pack-id total passed failed
+                           violations
+                           (compute-field-summary violations total))))

--- a/components/data-quality/src/ai/miniforge/data_foundry/data_quality/interface.clj
+++ b/components/data-quality/src/ai/miniforge/data_foundry/data_quality/interface.clj
@@ -1,0 +1,57 @@
+(ns ai.miniforge.data-foundry.data-quality.interface
+  "Public API for the data-quality component."
+  (:require [ai.miniforge.data-foundry.data-quality.core :as core]
+            [ai.miniforge.data-foundry.data-quality.rules :as rules]))
+
+;; -- Rule Constructors --
+
+(defn required-rule
+  "Create a rule checking field presence and non-nil value.
+   Options: :severity (:error | :warning), default :error"
+  [field & opts]
+  (apply rules/required-rule field opts))
+
+(defn type-check-rule
+  "Create a rule checking field value type against dataset-schema field types.
+   Options: :severity (:error | :warning), default :error"
+  [field expected-type & opts]
+  (apply rules/type-check-rule field expected-type opts))
+
+(defn range-rule
+  "Create a rule checking numeric bounds: min <= value <= max.
+   Options: :severity (:error | :warning), default :error"
+  [field min-val max-val & opts]
+  (apply rules/range-rule field min-val max-val opts))
+
+(defn pattern-rule
+  "Create a rule checking string field against regex pattern.
+   Options: :severity (:error | :warning), default :warning"
+  [field pattern & opts]
+  (apply rules/pattern-rule field pattern opts))
+
+(defn custom-rule
+  "Create a rule with arbitrary check function.
+   check-fn: (fn [record] {:valid? bool :message str})
+   Options: :severity (:error | :warning), default :error"
+  [rule-id check-fn & opts]
+  (apply rules/custom-rule rule-id check-fn opts))
+
+;; -- Evaluation --
+
+(defn evaluate-records
+  "Evaluate all records against all rules.
+   Returns vector of {:record-index :record :evaluations [...]}."
+  [rules records]
+  (core/evaluate-records rules records))
+
+(defn filter-passed
+  "Return records passing all :error-severity rules. Warnings pass through."
+  [evaluation]
+  (core/filter-passed evaluation))
+
+(defn generate-report
+  "Build quality report with field-level summary statistics.
+   Returns {:report/pack-id :report/total :report/passed :report/failed
+            :report/violations [...] :report/field-summary {...}}"
+  [pack-id evaluation]
+  (core/generate-report pack-id evaluation))

--- a/components/data-quality/src/ai/miniforge/data_foundry/data_quality/messages.clj
+++ b/components/data-quality/src/ai/miniforge/data_foundry/data_quality/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.data-quality.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/data-quality/messages/en-US.edn" :data-quality/messages))

--- a/components/data-quality/src/ai/miniforge/data_foundry/data_quality/result.clj
+++ b/components/data-quality/src/ai/miniforge/data_foundry/data_quality/result.clj
@@ -1,0 +1,28 @@
+(ns ai.miniforge.data-foundry.data-quality.result
+  "Factory functions for data-quality result maps.")
+
+(defn evaluation-entry
+  "Build one entry in an evaluation vector."
+  [record-index record evaluations]
+  {:record-index record-index
+   :record       record
+   :evaluations  evaluations})
+
+(defn violation
+  "Build a single violation record."
+  [record-index rule-id field severity message]
+  {:record-index record-index
+   :rule-id      rule-id
+   :field        (when field (name field))
+   :severity     severity
+   :message      message})
+
+(defn quality-report
+  "Build a quality report map."
+  [pack-id total passed failed violations field-summary]
+  {:report/pack-id       pack-id
+   :report/total         total
+   :report/passed        passed
+   :report/failed        failed
+   :report/violations    violations
+   :report/field-summary field-summary})

--- a/components/data-quality/src/ai/miniforge/data_foundry/data_quality/rules.clj
+++ b/components/data-quality/src/ai/miniforge/data_foundry/data_quality/rules.clj
@@ -1,0 +1,90 @@
+(ns ai.miniforge.data-foundry.data-quality.rules
+  "Built-in rule constructors for data quality checks."
+  (:require [ai.miniforge.data-foundry.data-quality.messages :as msg]))
+
+(defn required-rule
+  "Create a rule that checks field presence and non-nil value."
+  [field & {:keys [severity] :or {severity :error}}]
+  {:rule/id       (keyword (str "required-" (name field)))
+   :rule/type     :required
+   :rule/field    field
+   :rule/severity severity
+   :rule/check-fn (fn [record]
+                    (let [v (get record field)]
+                      (if (and (some? v) (not (and (string? v) (empty? v))))
+                        {:valid? true}
+                        {:valid? false
+                         :message (msg/t :violation/required {:field (name field)})})))})
+
+(defn type-check-rule
+  "Create a rule that checks a field's value type."
+  [field expected-type & {:keys [severity] :or {severity :error}}]
+  (let [type-pred (case expected-type
+                    :string  string?
+                    :int     int?
+                    :long    int?  ;; int? covers both int and long in Clojure
+                    :decimal decimal?
+                    :double  (fn [v] (or (double? v) (float? v)))
+                    :boolean boolean?
+                    :uuid    uuid?
+                    ;; Default: always pass (unknown types are not checked)
+                    (constantly true))]
+    {:rule/id       (keyword (str "type-" (name field) "-" (name expected-type)))
+     :rule/type     :type-check
+     :rule/field    field
+     :rule/severity severity
+     :rule/check-fn (fn [record]
+                      (let [v (get record field)]
+                        (if (or (nil? v) (type-pred v))
+                          {:valid? true}
+                          {:valid? false
+                           :message (msg/t :violation/type-check
+                                           {:field (name field)
+                                            :expected expected-type
+                                            :actual (type v)})})))}))
+
+(defn range-rule
+  "Create a rule that checks numeric bounds: min <= value <= max."
+  [field min-val max-val & {:keys [severity] :or {severity :error}}]
+  {:rule/id       (keyword (str "range-" (name field)))
+   :rule/type     :range
+   :rule/field    field
+   :rule/severity severity
+   :rule/check-fn (fn [record]
+                    (let [v (get record field)]
+                      (if (or (nil? v)
+                              (and (number? v) (<= min-val v max-val)))
+                        {:valid? true}
+                        {:valid? false
+                         :message (msg/t :violation/range
+                                         {:field (name field)
+                                          :value v
+                                          :min min-val
+                                          :max max-val})})))})
+
+(defn pattern-rule
+  "Create a rule that checks a string field against a regex pattern."
+  [field pattern & {:keys [severity] :or {severity :warning}}]
+  {:rule/id       (keyword (str "pattern-" (name field)))
+   :rule/type     :pattern
+   :rule/field    field
+   :rule/severity severity
+   :rule/check-fn (fn [record]
+                    (let [v (get record field)]
+                      (if (or (nil? v)
+                              (and (string? v) (re-matches pattern v)))
+                        {:valid? true}
+                        {:valid? false
+                         :message (msg/t :violation/pattern
+                                         {:field (name field)
+                                          :value v
+                                          :pattern (str pattern)})})))})
+
+(defn custom-rule
+  "Create a rule with an arbitrary check function.
+   check-fn: (fn [record] {:valid? bool :message str})"
+  [rule-id check-fn & {:keys [severity] :or {severity :error}}]
+  {:rule/id       rule-id
+   :rule/type     :custom
+   :rule/severity severity
+   :rule/check-fn check-fn})

--- a/components/data-quality/test/ai/miniforge/data_foundry/data_quality/interface_test.clj
+++ b/components/data-quality/test/ai/miniforge/data_foundry/data_quality/interface_test.clj
@@ -1,0 +1,214 @@
+(ns ai.miniforge.data-foundry.data-quality.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.data-quality.interface :as dq]))
+
+;; ---------------------------------------------------------------------------
+;; Rule constructors
+;; ---------------------------------------------------------------------------
+
+(deftest required-rule-test
+  (testing "Required rule — present value passes"
+    (let [rule (dq/required-rule :cik)
+          result ((:rule/check-fn rule) {:cik "0001234567"})]
+      (is (:valid? result))))
+
+  (testing "Required rule — nil value fails"
+    (let [rule (dq/required-rule :cik)
+          result ((:rule/check-fn rule) {:cik nil})]
+      (is (not (:valid? result)))))
+
+  (testing "Required rule — missing key fails"
+    (let [rule (dq/required-rule :cik)
+          result ((:rule/check-fn rule) {:name "ACME"})]
+      (is (not (:valid? result)))))
+
+  (testing "Required rule — empty string fails"
+    (let [rule (dq/required-rule :cik)
+          result ((:rule/check-fn rule) {:cik ""})]
+      (is (not (:valid? result))))))
+
+(deftest type-check-rule-test
+  (testing "Type check — string passes"
+    (let [rule (dq/type-check-rule :name :string)
+          result ((:rule/check-fn rule) {:name "ACME Corp"})]
+      (is (:valid? result))))
+
+  (testing "Type check — wrong type fails"
+    (let [rule (dq/type-check-rule :name :string)
+          result ((:rule/check-fn rule) {:name 42})]
+      (is (not (:valid? result)))))
+
+  (testing "Type check — nil passes (nil means absent, not wrong type)"
+    (let [rule (dq/type-check-rule :name :string)
+          result ((:rule/check-fn rule) {:name nil})]
+      (is (:valid? result))))
+
+  (testing "Type check — long/int"
+    (let [rule (dq/type-check-rule :count :long)
+          result ((:rule/check-fn rule) {:count 42})]
+      (is (:valid? result)))))
+
+(deftest range-rule-test
+  (testing "Range rule — value in range passes"
+    (let [rule (dq/range-rule :market_cap 0 1e15)
+          result ((:rule/check-fn rule) {:market_cap 5000000.0})]
+      (is (:valid? result))))
+
+  (testing "Range rule — value below min fails"
+    (let [rule (dq/range-rule :market_cap 0 1e15)
+          result ((:rule/check-fn rule) {:market_cap -100})]
+      (is (not (:valid? result)))))
+
+  (testing "Range rule — value above max fails"
+    (let [rule (dq/range-rule :market_cap 0 1e15)
+          result ((:rule/check-fn rule) {:market_cap 2e15})]
+      (is (not (:valid? result)))))
+
+  (testing "Range rule — nil passes"
+    (let [rule (dq/range-rule :market_cap 0 1e15)
+          result ((:rule/check-fn rule) {:market_cap nil})]
+      (is (:valid? result)))))
+
+(deftest pattern-rule-test
+  (testing "Pattern rule — matching value passes"
+    (let [rule (dq/pattern-rule :cik #"\d{10}")
+          result ((:rule/check-fn rule) {:cik "0001234567"})]
+      (is (:valid? result))))
+
+  (testing "Pattern rule — non-matching value fails"
+    (let [rule (dq/pattern-rule :cik #"\d{10}")
+          result ((:rule/check-fn rule) {:cik "abc"})]
+      (is (not (:valid? result)))))
+
+  (testing "Pattern rule — nil passes"
+    (let [rule (dq/pattern-rule :cik #"\d{10}")
+          result ((:rule/check-fn rule) {:cik nil})]
+      (is (:valid? result))))
+
+  (testing "Pattern rule — default severity is :warning"
+    (let [rule (dq/pattern-rule :cik #"\d+")]
+      (is (= :warning (:rule/severity rule))))))
+
+(deftest custom-rule-test
+  (testing "Custom rule — passes"
+    (let [rule (dq/custom-rule :positive-value
+                               (fn [r] (if (pos? (:value r))
+                                         {:valid? true}
+                                         {:valid? false :message "Must be positive"})))
+          result ((:rule/check-fn rule) {:value 10})]
+      (is (:valid? result))))
+
+  (testing "Custom rule — fails"
+    (let [rule (dq/custom-rule :positive-value
+                               (fn [r] (if (pos? (:value r))
+                                         {:valid? true}
+                                         {:valid? false :message "Must be positive"})))
+          result ((:rule/check-fn rule) {:value -1})]
+      (is (not (:valid? result)))
+      (is (= "Must be positive" (:message result))))))
+
+;; ---------------------------------------------------------------------------
+;; Evaluate records
+;; ---------------------------------------------------------------------------
+
+(deftest evaluate-records-single-rule-test
+  (testing "Evaluate records with single rule"
+    (let [rules [(dq/required-rule :cik)]
+          records [{:cik "001"} {:cik nil} {:name "X"}]
+          result (dq/evaluate-records rules records)]
+      (is (= 3 (count result)))
+      ;; First record passes
+      (is (:valid? (first (:evaluations (first result)))))
+      ;; Second record fails
+      (is (not (:valid? (first (:evaluations (second result)))))))))
+
+(deftest evaluate-records-multiple-rules-test
+  (testing "Evaluate records with multiple rules"
+    (let [rules [(dq/required-rule :cik)
+                 (dq/type-check-rule :market_cap :long)]
+          records [{:cik "001" :market_cap 5000}
+                   {:cik nil :market_cap "not-a-number"}]
+          result (dq/evaluate-records rules records)]
+      ;; First record: both pass
+      (is (every? :valid? (:evaluations (first result))))
+      ;; Second record: both fail
+      (is (every? (complement :valid?) (:evaluations (second result)))))))
+
+;; ---------------------------------------------------------------------------
+;; Filter passed
+;; ---------------------------------------------------------------------------
+
+(deftest filter-passed-test
+  (testing "Filter keeps records passing all error-severity rules"
+    (let [rules [(dq/required-rule :cik)]
+          records [{:cik "001" :name "A"} {:cik nil :name "B"} {:cik "003" :name "C"}]
+          evaluation (dq/evaluate-records rules records)
+          passed (dq/filter-passed evaluation)]
+      (is (= 2 (count passed)))
+      (is (= "A" (:name (first passed))))
+      (is (= "C" (:name (second passed)))))))
+
+(deftest filter-passed-warnings-pass-through-test
+  (testing "Warnings do not cause filtering"
+    (let [rules [(dq/required-rule :cik :severity :warning)]
+          records [{:cik nil :name "A"}]
+          evaluation (dq/evaluate-records rules records)
+          passed (dq/filter-passed evaluation)]
+      (is (= 1 (count passed)))
+      (is (= "A" (:name (first passed)))))))
+
+;; ---------------------------------------------------------------------------
+;; Generate report
+;; ---------------------------------------------------------------------------
+
+(deftest generate-report-test
+  (testing "Report generation with field summaries"
+    (let [rules [(dq/required-rule :cik)
+                 (dq/range-rule :market_cap 0 1e15)]
+          records [{:cik "001" :market_cap 5000}
+                   {:cik nil :market_cap 5000}
+                   {:cik "003" :market_cap -100}
+                   {:cik "004" :market_cap 1000}]
+          evaluation (dq/evaluate-records rules records)
+          report (dq/generate-report :financial-quality evaluation)]
+      (is (= :financial-quality (:report/pack-id report)))
+      (is (= 4 (:report/total report)))
+      (is (= 2 (:report/passed report)))
+      (is (= 2 (:report/failed report)))
+      (is (= 2 (count (:report/violations report))))
+      ;; Field summary
+      (is (contains? (:report/field-summary report) "cik"))
+      (is (= 1 (get-in report [:report/field-summary "cik" :violations]))))))
+
+(deftest generate-report-all-pass-test
+  (testing "Report with all records passing"
+    (let [rules [(dq/required-rule :id)]
+          records [{:id 1} {:id 2}]
+          evaluation (dq/evaluate-records rules records)
+          report (dq/generate-report :all-pass evaluation)]
+      (is (= 2 (:report/passed report)))
+      (is (= 0 (:report/failed report)))
+      (is (empty? (:report/violations report))))))
+
+;; ---------------------------------------------------------------------------
+;; Financial filing scenario (integration-style)
+;; ---------------------------------------------------------------------------
+
+(deftest financial-filing-quality-test
+  (testing "Financial filing quality rules"
+    (let [rules [(dq/required-rule :cik)
+                 (dq/type-check-rule :filing_date :string)
+                 (dq/range-rule :market_cap 0 1e15)]
+          records [{:cik "0001234567" :filing_date "2024-01-15" :market_cap 50000000}
+                   {:cik nil :filing_date "2024-02-01" :market_cap 1000000}
+                   {:cik "0009876543" :filing_date 20240301 :market_cap -500}
+                   {:cik "0001111111" :filing_date "2024-03-15" :market_cap 75000000}]
+          evaluation (dq/evaluate-records rules records)
+          passed (dq/filter-passed evaluation)
+          report (dq/generate-report :sec-filings evaluation)]
+      ;; Records 0 and 3 pass, record 1 fails (nil cik), record 2 fails (bad type + negative cap)
+      (is (= 2 (count passed)))
+      (is (= "0001234567" (:cik (first passed))))
+      (is (= "0001111111" (:cik (second passed))))
+      (is (= 2 (:report/failed report)))
+      (is (pos? (count (:report/violations report)))))))

--- a/components/dataset-schema/deps.edn
+++ b/components/dataset-schema/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema {:local/root "../../../miniforge/components/schema"}}
+ :deps {ai.miniforge/schema {:local/root "../schema"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/dataset-schema/deps.edn
+++ b/components/dataset-schema/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/schema {:local/root "../../../miniforge/components/schema"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/dataset-schema/resources/config/dataset-schema/messages/en-US.edn
+++ b/components/dataset-schema/resources/config/dataset-schema/messages/en-US.edn
@@ -1,0 +1,18 @@
+{:dataset-schema/messages
+ {;; Field validation
+  :field/name-must-be-string     "Field :field/name must be a string"
+  :field/name-must-not-be-empty  "Field :field/name must not be empty"
+  :field/type-invalid            "Field :field/type {type} is not a valid type. Must be one of: {allowed}"
+  :field/nullable-must-be-bool   "Field :field/nullable? must be a boolean"
+
+  ;; Schema validation
+  :schema/id-required            "Schema :schema/id is required"
+  :schema/name-must-be-string    "Schema :schema/name must be a string"
+  :schema/name-pattern-mismatch  "Schema :schema/name must match pattern {pattern}"
+  :schema/version-must-be-string "Schema :schema/version must be a string"
+  :schema/fields-must-be-vector  "Schema :schema/fields must be a vector"
+  :schema/fields-must-not-be-empty "Schema :schema/fields must not be empty"
+
+  ;; Field-level error prefix
+  :schema/field-error            "Field '{name}': {error}"
+  :schema/duplicate-field        "Duplicate field name: {name}"}}

--- a/components/dataset-schema/src/ai/miniforge/data_foundry/dataset_schema/core.clj
+++ b/components/dataset-schema/src/ai/miniforge/data_foundry/dataset_schema/core.clj
@@ -1,0 +1,105 @@
+(ns ai.miniforge.data-foundry.dataset-schema.core
+  (:require [ai.miniforge.data-foundry.dataset-schema.field-types :as ft]
+            [ai.miniforge.data-foundry.dataset-schema.messages :as msg])
+  (:import [java.util UUID]
+           [java.time Instant]))
+
+(def dataset-types
+  "Enumerated dataset types per N1 §2.2"
+  #{:table :time-series :document-collection :graph :feature-set :report})
+
+(def default-config
+  "Default schema validation configuration."
+  {:schema/name-min-length 3
+   :schema/name-max-length 128})
+
+(def ^:private name-pattern
+  (let [{:schema/keys [name-min-length name-max-length]} default-config]
+    (re-pattern (str "^[a-z0-9_-]{" name-min-length "," name-max-length "}$"))))
+
+(defn- validate-field-impl
+  "Validate a single field definition. Returns vector of error strings."
+  [{:field/keys [name type nullable?] :as field}]
+  (cond-> []
+    (not (string? name))
+    (conj (msg/t :field/name-must-be-string))
+
+    (and (string? name) (empty? name))
+    (conj (msg/t :field/name-must-not-be-empty))
+
+    (not (ft/valid-field-type? type))
+    (conj (msg/t :field/type-invalid {:type type :allowed ft/field-types}))
+
+    (not (boolean? nullable?))
+    (conj (msg/t :field/nullable-must-be-bool))))
+
+(defn validate-field
+  "Validate a single field definition."
+  [field]
+  (let [errors (validate-field-impl field)]
+    (if (empty? errors)
+      {:success? true}
+      {:success? false :errors errors})))
+
+(defn- validate-schema-impl
+  "Returns vector of error strings for a schema."
+  [{:schema/keys [id name version fields] :as schema}]
+  (let [base-errors
+        (cond-> []
+          (nil? id)
+          (conj (msg/t :schema/id-required))
+
+          (not (string? name))
+          (conj (msg/t :schema/name-must-be-string))
+
+          (and (string? name) (not (re-matches name-pattern name)))
+          (conj (msg/t :schema/name-pattern-mismatch {:pattern name-pattern}))
+
+          (not (string? version))
+          (conj (msg/t :schema/version-must-be-string))
+
+          (not (vector? fields))
+          (conj (msg/t :schema/fields-must-be-vector))
+
+          (and (vector? fields) (empty? fields))
+          (conj (msg/t :schema/fields-must-not-be-empty)))
+
+        field-errors
+        (when (and (vector? fields) (seq fields))
+          (mapcat
+           (fn [f]
+             (map #(msg/t :schema/field-error {:name (:field/name f) :error %})
+                  (validate-field-impl f)))
+           fields))
+
+        dup-errors
+        (when (and (vector? fields) (seq fields))
+          (let [names (map :field/name fields)
+                dupes (for [[n c] (frequencies names) :when (> c 1)] n)]
+            (map #(msg/t :schema/duplicate-field {:name %}) dupes)))]
+
+    (vec (concat base-errors field-errors dup-errors))))
+
+(defn validate-schema
+  "Validate a schema definition against N1 §4."
+  [schema]
+  (let [errors (validate-schema-impl schema)]
+    (if (empty? errors)
+      {:success? true}
+      {:success? false :errors errors})))
+
+(defn create-schema
+  "Create a new schema definition with defaults.
+   Required keys: :schema/name, :schema/version, :schema/fields
+   Optional: :schema/id (auto-generated), :schema/constraints, :schema/parent-version"
+  [opts]
+  (let [schema (cond-> opts
+                 (nil? (:schema/id opts))
+                 (assoc :schema/id (UUID/randomUUID))
+
+                 (nil? (:schema/created-at opts))
+                 (assoc :schema/created-at (Instant/now)))
+        validation (validate-schema schema)]
+    (if (:success? validation)
+      {:success? true :schema schema}
+      {:success? false :errors (:errors validation)})))

--- a/components/dataset-schema/src/ai/miniforge/data_foundry/dataset_schema/evolution.clj
+++ b/components/dataset-schema/src/ai/miniforge/data_foundry/dataset_schema/evolution.clj
@@ -1,0 +1,117 @@
+(ns ai.miniforge.data-foundry.dataset-schema.evolution
+  (:require [ai.miniforge.data-foundry.dataset-schema.field-types :as ft]
+            [clojure.set]))
+
+(defn- field-map
+  "Convert field vector to map keyed by :field/name."
+  [fields]
+  (into {} (map (juxt :field/name identity)) fields))
+
+(defn diff-schemas
+  "Compute structural diff between two schemas.
+   Returns {:added [field-names] :removed [field-names] :changed [{:field field-name :changes [...]}]}"
+  [old-schema new-schema]
+  (let [old-fields (field-map (:schema/fields old-schema))
+        new-fields (field-map (:schema/fields new-schema))
+        old-names  (set (keys old-fields))
+        new-names  (set (keys new-fields))
+        added      (vec (sort (clojure.set/difference new-names old-names)))
+        removed    (vec (sort (clojure.set/difference old-names new-names)))
+        common     (clojure.set/intersection old-names new-names)
+        changed    (vec
+                    (for [n (sort common)
+                          :let [old-f (get old-fields n)
+                                new-f (get new-fields n)]
+                          :when (not= old-f new-f)]
+                      {:field n
+                       :old old-f
+                       :new new-f}))]
+    {:added added :removed removed :changed changed}))
+
+(defn- classify-field-change
+  "Classify a single field change. Returns :backward-compatible, :requires-migration, or :breaking."
+  [{:keys [old new]}]
+  (let [old-type (:field/type old)
+        new-type (:field/type new)
+        old-nullable (:field/nullable? old)
+        new-nullable (:field/nullable? new)
+        old-enum (:field/enum old)
+        new-enum (:field/enum new)]
+    (cond
+      ;; Type changed
+      (and (not= old-type new-type)
+           (ft/type-widening-compatible? old-type new-type))
+      :backward-compatible
+
+      (and (not= old-type new-type)
+           (not (ft/type-widening-compatible? old-type new-type))
+           (ft/type-widening-compatible? new-type old-type))
+      :requires-migration
+
+      (and (not= old-type new-type)
+           (not (ft/type-widening-compatible? old-type new-type))
+           (not (ft/type-widening-compatible? new-type old-type)))
+      :breaking
+
+      ;; Relaxing nullability: backward compatible
+      (and (not old-nullable) new-nullable)
+      :backward-compatible
+
+      ;; Tightening nullability: requires migration
+      (and old-nullable (not new-nullable))
+      :requires-migration
+
+      ;; Expanding enum: backward compatible
+      (and old-enum new-enum
+           (every? (set new-enum) old-enum)
+           (> (count new-enum) (count old-enum)))
+      :backward-compatible
+
+      ;; Reducing enum: requires migration
+      (and old-enum new-enum
+           (not (every? (set new-enum) old-enum)))
+      :requires-migration
+
+      ;; Precision/scale changes: requires migration
+      (or (not= (:field/precision old) (:field/precision new))
+          (not= (:field/scale old) (:field/scale new)))
+      :requires-migration
+
+      ;; Other changes
+      :else :backward-compatible)))
+
+(defn- classify-added-field
+  "Classify an added field."
+  [new-schema field-name]
+  (let [field (first (filter #(= (:field/name %) field-name)
+                             (:schema/fields new-schema)))]
+    (if (:field/nullable? field)
+      :backward-compatible
+      :requires-migration)))
+
+(def ^:private severity-order
+  {:backward-compatible 0
+   :requires-migration 1
+   :breaking 2})
+
+(defn classify-evolution
+  "Classify the overall evolution between two schema versions.
+   Returns the most severe classification among all changes:
+   :backward-compatible, :requires-migration, or :breaking"
+  [old-schema new-schema]
+  (let [{:keys [added removed changed]} (diff-schemas old-schema new-schema)]
+    (if (and (empty? added) (empty? removed) (empty? changed))
+      :backward-compatible
+      (let [classifications
+            (concat
+             ;; Removed fields require migration
+             (when (seq removed) [:requires-migration])
+             ;; Added fields
+             (map #(classify-added-field new-schema %) added)
+             ;; Changed fields
+             (map classify-field-change changed))]
+        (reduce
+         (fn [worst c]
+           (if (> (severity-order c) (severity-order worst)) c worst))
+         :backward-compatible
+         classifications)))))

--- a/components/dataset-schema/src/ai/miniforge/data_foundry/dataset_schema/field_types.clj
+++ b/components/dataset-schema/src/ai/miniforge/data_foundry/dataset_schema/field_types.clj
@@ -1,0 +1,21 @@
+(ns ai.miniforge.data-foundry.dataset-schema.field-types)
+
+(def field-types
+  "Enumerated field types per N1 §4.2"
+  #{:string :int :long :decimal :double :boolean :date :instant :uuid :json :bytes})
+
+(defn valid-field-type?
+  "Returns true if type is a valid field type."
+  [t]
+  (contains? field-types t))
+
+(def ^:private type-widening-graph
+  "Map from narrow type to set of wider types it can promote to without data loss."
+  {:int    #{:long :decimal :double}
+   :long   #{:decimal :double}
+   :double #{:decimal}})
+
+(defn type-widening-compatible?
+  "Returns true if widening from `from-type` to `to-type` is safe (backward compatible)."
+  [from-type to-type]
+  (contains? (get type-widening-graph from-type #{}) to-type))

--- a/components/dataset-schema/src/ai/miniforge/data_foundry/dataset_schema/interface.clj
+++ b/components/dataset-schema/src/ai/miniforge/data_foundry/dataset_schema/interface.clj
@@ -1,0 +1,39 @@
+(ns ai.miniforge.data-foundry.dataset-schema.interface
+  (:require [ai.miniforge.data-foundry.dataset-schema.core :as core]
+            [ai.miniforge.data-foundry.dataset-schema.evolution :as evolution]
+            [ai.miniforge.data-foundry.dataset-schema.field-types :as field-types]))
+
+;; -- Dataset Types --
+(def dataset-types core/dataset-types)
+
+;; -- Field Types --
+(def field-types field-types/field-types)
+(def valid-field-type? field-types/valid-field-type?)
+(def type-widening-compatible? field-types/type-widening-compatible?)
+
+;; -- Schema CRUD --
+(defn create-schema
+  "Create a new schema definition. Returns {:success? true :schema ...} or {:success? false :error ...}"
+  [opts]
+  (core/create-schema opts))
+
+(defn validate-schema
+  "Validate a schema definition against N1 §4. Returns {:success? true} or {:success? false :errors [...]}"
+  [schema]
+  (core/validate-schema schema))
+
+(defn validate-field
+  "Validate a single field definition. Returns {:success? true} or {:success? false :errors [...]}"
+  [field]
+  (core/validate-field field))
+
+;; -- Schema Evolution --
+(defn classify-evolution
+  "Classify changes between two schema versions. Returns one of: :backward-compatible, :requires-migration, :breaking"
+  [old-schema new-schema]
+  (evolution/classify-evolution old-schema new-schema))
+
+(defn diff-schemas
+  "Return detailed diff between two schemas. Returns {:added [...] :removed [...] :changed [...]}"
+  [old-schema new-schema]
+  (evolution/diff-schemas old-schema new-schema))

--- a/components/dataset-schema/src/ai/miniforge/data_foundry/dataset_schema/messages.clj
+++ b/components/dataset-schema/src/ai/miniforge/data_foundry/dataset_schema/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.dataset-schema.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/dataset-schema/messages/en-US.edn" :dataset-schema/messages))

--- a/components/dataset-schema/test/ai/miniforge/data_foundry/dataset_schema/interface_test.clj
+++ b/components/dataset-schema/test/ai/miniforge/data_foundry/dataset_schema/interface_test.clj
@@ -1,0 +1,112 @@
+(ns ai.miniforge.data-foundry.dataset-schema.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.dataset-schema.interface :as ds]))
+
+(deftest dataset-types-test
+  (testing "All N1 §2.2 dataset types present"
+    (is (= #{:table :time-series :document-collection :graph :feature-set :report}
+           ds/dataset-types))))
+
+(deftest field-types-test
+  (testing "All N1 §4.2 field types present"
+    (is (= #{:string :int :long :decimal :double :boolean :date :instant :uuid :json :bytes}
+           ds/field-types))
+    (is (true? (ds/valid-field-type? :string)))
+    (is (false? (ds/valid-field-type? :invalid)))))
+
+(deftest type-widening-test
+  (testing "N1 §5.2 backward-compatible type widening"
+    (is (true? (ds/type-widening-compatible? :int :long)))
+    (is (true? (ds/type-widening-compatible? :int :decimal)))
+    (is (false? (ds/type-widening-compatible? :long :int)))
+    (is (false? (ds/type-widening-compatible? :string :int)))))
+
+(deftest create-schema-test
+  (testing "T1: Create schema with valid fields"
+    (let [result (ds/create-schema
+                  {:schema/name "test_schema"
+                   :schema/version "1.0.0"
+                   :schema/fields
+                   [{:field/name "id" :field/type :string :field/nullable? false}
+                    {:field/name "value" :field/type :decimal :field/nullable? true}]})]
+      (is (:success? result))
+      (is (some? (get-in result [:schema :schema/id])))
+      (is (some? (get-in result [:schema :schema/created-at])))))
+
+  (testing "T2: Reject schema with duplicate field names"
+    (let [result (ds/create-schema
+                  {:schema/name "bad_schema"
+                   :schema/version "1.0.0"
+                   :schema/fields
+                   [{:field/name "id" :field/type :string :field/nullable? false}
+                    {:field/name "id" :field/type :int :field/nullable? false}]})]
+      (is (not (:success? result)))
+      (is (some #(re-find #"Duplicate" %) (:errors result))))))
+
+(deftest validate-schema-test
+  (testing "Reject invalid field type"
+    (let [result (ds/validate-schema
+                  {:schema/id (java.util.UUID/randomUUID)
+                   :schema/name "test_schema"
+                   :schema/version "1.0.0"
+                   :schema/fields
+                   [{:field/name "x" :field/type :invalid :field/nullable? false}]})]
+      (is (not (:success? result)))))
+
+  (testing "Reject empty fields"
+    (let [result (ds/validate-schema
+                  {:schema/id (java.util.UUID/randomUUID)
+                   :schema/name "test_schema"
+                   :schema/version "1.0.0"
+                   :schema/fields []})]
+      (is (not (:success? result))))))
+
+(deftest schema-evolution-test
+  (testing "T3: Backward compatible - add optional field"
+    (let [v1 {:schema/version "1.0.0"
+              :schema/fields
+              [{:field/name "id" :field/type :string :field/nullable? false}
+               {:field/name "price" :field/type :decimal :field/nullable? false}]}
+          v2 {:schema/version "1.1.0"
+              :schema/fields
+              [{:field/name "id" :field/type :string :field/nullable? false}
+               {:field/name "price" :field/type :decimal :field/nullable? false}
+               {:field/name "currency" :field/type :string :field/nullable? true}]}]
+      (is (= :backward-compatible (ds/classify-evolution v1 v2)))))
+
+  (testing "Backward compatible - widen type int->long"
+    (let [v1 {:schema/fields [{:field/name "count" :field/type :int :field/nullable? false}]}
+          v2 {:schema/fields [{:field/name "count" :field/type :long :field/nullable? false}]}]
+      (is (= :backward-compatible (ds/classify-evolution v1 v2)))))
+
+  (testing "Backward compatible - relax nullability"
+    (let [v1 {:schema/fields [{:field/name "x" :field/type :string :field/nullable? false}]}
+          v2 {:schema/fields [{:field/name "x" :field/type :string :field/nullable? true}]}]
+      (is (= :backward-compatible (ds/classify-evolution v1 v2)))))
+
+  (testing "T4: Requires migration - add required field"
+    (let [v1 {:schema/fields [{:field/name "id" :field/type :string :field/nullable? false}]}
+          v2 {:schema/fields [{:field/name "id" :field/type :string :field/nullable? false}
+                              {:field/name "new_req" :field/type :string :field/nullable? false}]}]
+      (is (= :requires-migration (ds/classify-evolution v1 v2)))))
+
+  (testing "Requires migration - remove field"
+    (let [v1 {:schema/fields [{:field/name "a" :field/type :string :field/nullable? false}
+                              {:field/name "b" :field/type :string :field/nullable? false}]}
+          v2 {:schema/fields [{:field/name "a" :field/type :string :field/nullable? false}]}]
+      (is (= :requires-migration (ds/classify-evolution v1 v2)))))
+
+  (testing "Breaking - incompatible type change"
+    (let [v1 {:schema/fields [{:field/name "x" :field/type :string :field/nullable? false}]}
+          v2 {:schema/fields [{:field/name "x" :field/type :date :field/nullable? false}]}]
+      (is (= :breaking (ds/classify-evolution v1 v2)))))
+
+  (testing "Diff schemas"
+    (let [v1 {:schema/fields [{:field/name "a" :field/type :string :field/nullable? false}
+                              {:field/name "b" :field/type :int :field/nullable? false}]}
+          v2 {:schema/fields [{:field/name "a" :field/type :string :field/nullable? true}
+                              {:field/name "c" :field/type :string :field/nullable? true}]}
+          diff (ds/diff-schemas v1 v2)]
+      (is (= ["c"] (:added diff)))
+      (is (= ["b"] (:removed diff)))
+      (is (= 1 (count (:changed diff)))))))

--- a/components/dataset/deps.edn
+++ b/components/dataset/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge.data-foundry/dataset-schema {:local/root "../dataset-schema"}
-        ai.miniforge/artifact        {:local/root "../../../miniforge/components/artifact"}
-        ai.miniforge/evidence-bundle {:local/root "../../../miniforge/components/evidence-bundle"}
-        ai.miniforge/schema          {:local/root "../../../miniforge/components/schema"}}
+        ai.miniforge/artifact        {:local/root "../artifact"}
+        ai.miniforge/evidence-bundle {:local/root "../evidence-bundle"}
+        ai.miniforge/schema          {:local/root "../schema"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/dataset/deps.edn
+++ b/components/dataset/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/dataset-schema {:local/root "../dataset-schema"}
+        ai.miniforge/artifact        {:local/root "../../../miniforge/components/artifact"}
+        ai.miniforge/evidence-bundle {:local/root "../../../miniforge/components/evidence-bundle"}
+        ai.miniforge/schema          {:local/root "../../../miniforge/components/schema"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/dataset/resources/config/dataset/messages/en-US.edn
+++ b/components/dataset/resources/config/dataset/messages/en-US.edn
@@ -1,0 +1,28 @@
+{:dataset/messages
+ {;; Dataset validation (core.clj)
+  :dataset/id-required              ":dataset/id is required"
+  :dataset/name-must-be-string      ":dataset/name must be a string"
+  :dataset/name-pattern-mismatch    ":dataset/name must match {pattern}"
+  :dataset/type-invalid             ":dataset/type must be one of {allowed}"
+  :dataset/schema-required          ":dataset/schema is required"
+  :dataset/storage-location-required ":dataset/storage-location is required"
+  :dataset/version-required         ":dataset/version is required"
+  :dataset/lineage-required         ":dataset/lineage is required"
+  :dataset/content-hash-invalid     ":dataset/content-hash must be a valid SHA-256 hex string"
+
+  ;; Dataset version validation (version.clj)
+  :version/id-required              ":dataset-version/id is required"
+  :version/dataset-id-required      ":dataset-version/dataset-id is required"
+  :version/timestamp-required       ":dataset-version/timestamp is required"
+  :version/workflow-run-id-required ":dataset-version/workflow-run-id is required"
+  :version/content-hash-invalid     ":dataset-version/content-hash must be valid SHA-256"
+  :version/content-hash-required    ":dataset-version/content-hash is required"
+  :version/row-count-required       ":dataset-version/row-count is required"
+  :version/row-count-non-negative   ":dataset-version/row-count must be >= 0"
+  :version/schema-version-required  ":dataset-version/schema-version is required"
+
+  ;; Partition validation (partition.clj)
+  :partition/strategy-invalid       ":partition/strategy must be one of {allowed}"
+  :partition/keys-must-be-vector    ":partition/keys must be a vector"
+  :partition/keys-must-not-be-empty ":partition/keys must not be empty"
+  :partition/retention-days-range   ":partition/retention-days must be between {min} and {max}"}}

--- a/components/dataset/src/ai/miniforge/data_foundry/dataset/artifact_bridge.clj
+++ b/components/dataset/src/ai/miniforge/data_foundry/dataset/artifact_bridge.clj
@@ -1,0 +1,29 @@
+(ns ai.miniforge.data-foundry.dataset.artifact-bridge)
+
+(defn dataset->artifact
+  "Convert a dataset to a Core artifact map per N1 §9.1.
+   Maps :dataset/id -> :artifact/id, :dataset/type -> :artifact/type, etc."
+  [{:dataset/keys [id type content-hash created-at metadata] :as dataset}]
+  {:artifact/id id
+   :artifact/type (or type :dataset)
+   :artifact/content-hash content-hash
+   :artifact/created-at created-at
+   :artifact/metadata (merge metadata
+                             {:dataset/name (:dataset/name dataset)
+                              :dataset/schema (:dataset/schema dataset)
+                              :dataset/storage-location (:dataset/storage-location dataset)
+                              :dataset/version (:dataset/version dataset)
+                              :dataset/lineage (:dataset/lineage dataset)
+                              :dataset/partitioning (:dataset/partitioning dataset)})})
+
+(defn artifact->dataset-ref
+  "Extract dataset reference info from a Core artifact."
+  [{:artifact/keys [id type content-hash created-at metadata]}]
+  (merge
+   {:dataset/id id
+    :dataset/type type
+    :dataset/content-hash content-hash
+    :dataset/created-at created-at}
+   (select-keys metadata [:dataset/name :dataset/schema :dataset/storage-location
+                           :dataset/version :dataset/lineage :dataset/partitioning
+                           :dataset/metadata])))

--- a/components/dataset/src/ai/miniforge/data_foundry/dataset/core.clj
+++ b/components/dataset/src/ai/miniforge/data_foundry/dataset/core.clj
@@ -1,0 +1,108 @@
+(ns ai.miniforge.data-foundry.dataset.core
+  (:require [ai.miniforge.data-foundry.dataset-schema.interface :as ds-schema]
+            [ai.miniforge.data-foundry.dataset.artifact-bridge :as bridge]
+            [ai.miniforge.data-foundry.dataset.messages :as msg]
+            [ai.miniforge.artifact.interface :as artifact])
+  (:import [java.util UUID]
+           [java.time Instant]))
+
+(def default-config
+  "Default dataset validation configuration."
+  {:dataset/name-min-length 3
+   :dataset/name-max-length 128
+   :dataset/hash-length     64})
+
+(def ^:private name-pattern
+  (let [{:dataset/keys [name-min-length name-max-length]} default-config]
+    (re-pattern (str "^[a-z0-9_-]{" name-min-length "," name-max-length "}$"))))
+
+(def ^:private sha256-pattern
+  (re-pattern (str "^[a-f0-9]{" (:dataset/hash-length default-config) "}$")))
+
+(defn validate-dataset
+  "Validate a dataset map against N1 §3."
+  [{:dataset/keys [id name type schema storage-location version lineage content-hash] :as dataset}]
+  (let [errors
+        (cond-> []
+          (nil? id)
+          (conj (msg/t :dataset/id-required))
+
+          (not (string? name))
+          (conj (msg/t :dataset/name-must-be-string))
+
+          (and (string? name) (not (re-matches name-pattern name)))
+          (conj (msg/t :dataset/name-pattern-mismatch {:pattern name-pattern}))
+
+          (not (contains? ds-schema/dataset-types type))
+          (conj (msg/t :dataset/type-invalid {:allowed ds-schema/dataset-types}))
+
+          (nil? schema)
+          (conj (msg/t :dataset/schema-required))
+
+          (nil? storage-location)
+          (conj (msg/t :dataset/storage-location-required))
+
+          (nil? version)
+          (conj (msg/t :dataset/version-required))
+
+          (nil? lineage)
+          (conj (msg/t :dataset/lineage-required))
+
+          (and content-hash (not (re-matches sha256-pattern content-hash)))
+          (conj (msg/t :dataset/content-hash-invalid)))]
+    (if (empty? errors)
+      {:success? true}
+      {:success? false :errors errors})))
+
+(defn create-dataset
+  "Create a new dataset with defaults."
+  [opts]
+  (let [now (Instant/now)
+        dataset (cond-> opts
+                  (nil? (:dataset/id opts))
+                  (assoc :dataset/id (UUID/randomUUID))
+
+                  (nil? (:dataset/created-at opts))
+                  (assoc :dataset/created-at now)
+
+                  (nil? (:dataset/lineage opts))
+                  (assoc :dataset/lineage {:lineage/source-datasets []
+                                           :lineage/transformations []})
+
+                  (nil? (:dataset/content-hash opts))
+                  (assoc :dataset/content-hash
+                         (apply str (repeat (:dataset/hash-length default-config) "0"))))
+        validation (validate-dataset dataset)]
+    (if (:success? validation)
+      {:success? true :dataset dataset}
+      {:success? false :errors (:errors validation)})))
+
+(defn get-dataset
+  "Retrieve dataset from store by ID."
+  [store dataset-id]
+  ;; In MVP, we use the artifact store's load-artifact
+  ;; and convert back via bridge
+  (try
+    (when-let [artifact (artifact/load-artifact store dataset-id)]
+      (bridge/artifact->dataset-ref artifact))
+    (catch Exception _e nil)))
+
+(defn save-dataset!
+  "Save dataset to artifact store."
+  [store dataset]
+  (try
+    (let [artifact (bridge/dataset->artifact dataset)]
+      (artifact/save! store artifact)
+      {:success? true})
+    (catch Exception e
+      {:success? false :error (.getMessage e)})))
+
+(defn query-datasets
+  "Query datasets from store."
+  [store {:dataset/keys [type name] :as criteria}]
+  (try
+    (let [artifacts (if type
+                      (artifact/query-by-type store type)
+                      (artifact/query store criteria))]
+      (mapv bridge/artifact->dataset-ref artifacts))
+    (catch Exception _e [])))

--- a/components/dataset/src/ai/miniforge/data_foundry/dataset/interface.clj
+++ b/components/dataset/src/ai/miniforge/data_foundry/dataset/interface.clj
@@ -1,0 +1,72 @@
+(ns ai.miniforge.data-foundry.dataset.interface
+  (:require [ai.miniforge.data-foundry.dataset.core :as core]
+            [ai.miniforge.data-foundry.dataset.version :as version]
+            [ai.miniforge.data-foundry.dataset.partition :as partition]
+            [ai.miniforge.data-foundry.dataset.artifact-bridge :as bridge]))
+
+;; -- Dataset CRUD --
+(defn create-dataset
+  "Create a new dataset. Registers as Core artifact.
+   Required: :dataset/name, :dataset/type, :dataset/schema, :dataset/storage-location
+   Returns {:success? true :dataset ...} or {:success? false :errors [...]}"
+  [opts]
+  (core/create-dataset opts))
+
+(defn validate-dataset
+  "Validate a dataset map against N1 §3. Returns {:success? true} or {:success? false :errors [...]}"
+  [dataset]
+  (core/validate-dataset dataset))
+
+(defn get-dataset
+  "Retrieve a dataset by ID from a store. Returns dataset or nil."
+  [store dataset-id]
+  (core/get-dataset store dataset-id))
+
+(defn save-dataset!
+  "Persist dataset to artifact store. Returns {:success? true} or {:success? false :error ...}"
+  [store dataset]
+  (core/save-dataset! store dataset))
+
+(defn query-datasets
+  "Query datasets by criteria. Supports :dataset/type, :dataset/name, :dataset/tags."
+  [store criteria]
+  (core/query-datasets store criteria))
+
+;; -- Versioning --
+(defn create-version
+  "Create a new immutable dataset version.
+   Required: :dataset-version/dataset-id, :dataset-version/content-hash,
+             :dataset-version/row-count, :dataset-version/schema-version,
+             :dataset-version/workflow-run-id
+   Returns {:success? true :version ...}"
+  [opts]
+  (version/create-version opts))
+
+(defn validate-version
+  "Validate a dataset version against N1 §6. Returns {:success? true} or {:success? false :errors [...]}"
+  [version]
+  (version/validate-version version))
+
+;; -- Partitioning --
+(defn create-partition-strategy
+  "Create a partition strategy.
+   Required: :partition/strategy (:time, :entity, :composite, :hash), :partition/keys
+   Optional: :partition/retention-days"
+  [opts]
+  (partition/create-partition-strategy opts))
+
+(defn validate-partition-strategy
+  "Validate a partition strategy against N1 §7."
+  [strategy]
+  (partition/validate-partition-strategy strategy))
+
+;; -- Artifact Bridge --
+(defn dataset->artifact
+  "Convert a dataset to a Core artifact map per N1 §9.1."
+  [dataset]
+  (bridge/dataset->artifact dataset))
+
+(defn artifact->dataset-ref
+  "Extract dataset reference info from a Core artifact."
+  [artifact]
+  (bridge/artifact->dataset-ref artifact))

--- a/components/dataset/src/ai/miniforge/data_foundry/dataset/messages.clj
+++ b/components/dataset/src/ai/miniforge/data_foundry/dataset/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.dataset.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/dataset/messages/en-US.edn" :dataset/messages))

--- a/components/dataset/src/ai/miniforge/data_foundry/dataset/partition.clj
+++ b/components/dataset/src/ai/miniforge/data_foundry/dataset/partition.clj
@@ -1,0 +1,43 @@
+(ns ai.miniforge.data-foundry.dataset.partition
+  (:require [ai.miniforge.data-foundry.dataset.messages :as msg]))
+
+(def partition-strategies
+  "N1 §7.2 supported partition strategies"
+  #{:time :entity :composite :hash})
+
+(def default-config
+  "Default partition configuration."
+  {:partition/retention-days-min 1
+   :partition/retention-days-max 36500})
+
+(defn validate-partition-strategy
+  "Validate a partition strategy against N1 §7."
+  [{:partition/keys [strategy keys retention-days]}]
+  (let [{:partition/keys [retention-days-min retention-days-max]} default-config
+        errors
+        (cond-> []
+          (not (contains? partition-strategies strategy))
+          (conj (msg/t :partition/strategy-invalid {:allowed partition-strategies}))
+
+          (not (vector? keys))
+          (conj (msg/t :partition/keys-must-be-vector))
+
+          (and (vector? keys) (empty? keys))
+          (conj (msg/t :partition/keys-must-not-be-empty))
+
+          (and retention-days
+               (or (< retention-days retention-days-min)
+                   (> retention-days retention-days-max)))
+          (conj (msg/t :partition/retention-days-range
+                       {:min retention-days-min :max retention-days-max})))]
+    (if (empty? errors)
+      {:success? true}
+      {:success? false :errors errors})))
+
+(defn create-partition-strategy
+  "Create a validated partition strategy."
+  [opts]
+  (let [validation (validate-partition-strategy opts)]
+    (if (:success? validation)
+      {:success? true :partition-strategy opts}
+      {:success? false :errors (:errors validation)})))

--- a/components/dataset/src/ai/miniforge/data_foundry/dataset/version.clj
+++ b/components/dataset/src/ai/miniforge/data_foundry/dataset/version.clj
@@ -1,0 +1,56 @@
+(ns ai.miniforge.data-foundry.dataset.version
+  (:require [ai.miniforge.data-foundry.dataset.messages :as msg])
+  (:import [java.util UUID]
+           [java.time Instant]))
+
+(def ^:private sha256-pattern #"^[a-f0-9]{64}$")
+
+(defn validate-version
+  "Validate a dataset version against N1 §6."
+  [{:dataset-version/keys [id dataset-id timestamp workflow-run-id
+                            content-hash row-count schema-version]}]
+  (let [errors
+        (cond-> []
+          (nil? id)
+          (conj (msg/t :version/id-required))
+
+          (nil? dataset-id)
+          (conj (msg/t :version/dataset-id-required))
+
+          (nil? timestamp)
+          (conj (msg/t :version/timestamp-required))
+
+          (nil? workflow-run-id)
+          (conj (msg/t :version/workflow-run-id-required))
+
+          (and content-hash (not (re-matches sha256-pattern content-hash)))
+          (conj (msg/t :version/content-hash-invalid))
+
+          (nil? content-hash)
+          (conj (msg/t :version/content-hash-required))
+
+          (nil? row-count)
+          (conj (msg/t :version/row-count-required))
+
+          (and row-count (neg? row-count))
+          (conj (msg/t :version/row-count-non-negative))
+
+          (nil? schema-version)
+          (conj (msg/t :version/schema-version-required)))]
+    (if (empty? errors)
+      {:success? true}
+      {:success? false :errors errors})))
+
+(defn create-version
+  "Create a new immutable dataset version."
+  [opts]
+  (let [version (cond-> opts
+                  (nil? (:dataset-version/id opts))
+                  (assoc :dataset-version/id (UUID/randomUUID))
+
+                  (nil? (:dataset-version/timestamp opts))
+                  (assoc :dataset-version/timestamp (Instant/now)))
+        validation (validate-version version)]
+    (if (:success? validation)
+      {:success? true :version version}
+      {:success? false :errors (:errors validation)})))

--- a/components/dataset/test/ai/miniforge/data_foundry/dataset/interface_test.clj
+++ b/components/dataset/test/ai/miniforge/data_foundry/dataset/interface_test.clj
@@ -1,0 +1,105 @@
+(ns ai.miniforge.data-foundry.dataset.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.dataset.interface :as ds]))
+
+(deftest create-dataset-test
+  (testing "T1: Create dataset with valid schema"
+    (let [result (ds/create-dataset
+                  {:dataset/name "test_dataset"
+                   :dataset/type :table
+                   :dataset/schema {:schema/id (java.util.UUID/randomUUID)
+                                    :schema/version "1.0.0"
+                                    :schema/fields [{:field/name "id"
+                                                     :field/type :string
+                                                     :field/nullable? false}]}
+                   :dataset/storage-location {:storage/backend :local
+                                              :storage/path "/tmp/test"
+                                              :storage/format :edn}
+                   :dataset/version {:dataset-version/id (java.util.UUID/randomUUID)
+                                     :dataset-version/timestamp (java.time.Instant/now)
+                                     :dataset-version/content-hash (apply str (repeat 64 "a"))
+                                     :dataset-version/row-count 100
+                                     :dataset-version/workflow-run-id (java.util.UUID/randomUUID)}})]
+      (is (:success? result))
+      (is (some? (get-in result [:dataset :dataset/id])))
+      (is (some? (get-in result [:dataset :dataset/created-at])))))
+
+  (testing "Reject invalid dataset type"
+    (let [result (ds/create-dataset
+                  {:dataset/name "bad"
+                   :dataset/type :invalid-type
+                   :dataset/schema {}
+                   :dataset/storage-location {}
+                   :dataset/version {}})]
+      (is (not (:success? result))))))
+
+(deftest validate-dataset-test
+  (testing "Reject invalid name pattern"
+    (let [result (ds/validate-dataset
+                  {:dataset/id (java.util.UUID/randomUUID)
+                   :dataset/name "UPPERCASE"
+                   :dataset/type :table
+                   :dataset/schema {}
+                   :dataset/storage-location {}
+                   :dataset/version {}
+                   :dataset/lineage {}
+                   :dataset/content-hash (apply str (repeat 64 "a"))})]
+      (is (not (:success? result))))))
+
+(deftest create-version-test
+  (testing "T6: Create valid dataset version"
+    (let [result (ds/create-version
+                  {:dataset-version/dataset-id (java.util.UUID/randomUUID)
+                   :dataset-version/content-hash (apply str (repeat 64 "b"))
+                   :dataset-version/row-count 5000
+                   :dataset-version/schema-version "1.0.0"
+                   :dataset-version/workflow-run-id (java.util.UUID/randomUUID)})]
+      (is (:success? result))
+      (is (some? (get-in result [:version :dataset-version/id])))))
+
+  (testing "Reject negative row count"
+    (let [result (ds/create-version
+                  {:dataset-version/dataset-id (java.util.UUID/randomUUID)
+                   :dataset-version/content-hash (apply str (repeat 64 "c"))
+                   :dataset-version/row-count -1
+                   :dataset-version/schema-version "1.0.0"
+                   :dataset-version/workflow-run-id (java.util.UUID/randomUUID)})]
+      (is (not (:success? result))))))
+
+(deftest partition-strategy-test
+  (testing "T5: Valid partition strategies"
+    (doseq [strategy [:time :entity :composite :hash]]
+      (let [result (ds/create-partition-strategy
+                    {:partition/strategy strategy
+                     :partition/keys ["date"]})]
+        (is (:success? result) (str "Strategy " strategy " should be valid")))))
+
+  (testing "Reject invalid strategy"
+    (let [result (ds/create-partition-strategy
+                  {:partition/strategy :invalid
+                   :partition/keys ["x"]})]
+      (is (not (:success? result)))))
+
+  (testing "Reject out-of-range retention"
+    (let [result (ds/create-partition-strategy
+                  {:partition/strategy :time
+                   :partition/keys ["date"]
+                   :partition/retention-days 50000})]
+      (is (not (:success? result))))))
+
+(deftest artifact-bridge-test
+  (testing "N1 §9.1: Dataset to artifact mapping"
+    (let [ds-id (java.util.UUID/randomUUID)
+          dataset {:dataset/id ds-id
+                   :dataset/name "test"
+                   :dataset/type :table
+                   :dataset/content-hash (apply str (repeat 64 "d"))
+                   :dataset/created-at (java.time.Instant/now)
+                   :dataset/schema {:schema/version "1.0.0"}
+                   :dataset/storage-location {:storage/path "/tmp"}
+                   :dataset/version {:dataset-version/id (java.util.UUID/randomUUID)}
+                   :dataset/lineage {:lineage/source-datasets []}}
+          artifact (ds/dataset->artifact dataset)]
+      (is (= ds-id (:artifact/id artifact)))
+      (is (= :table (:artifact/type artifact)))
+      (is (= (apply str (repeat 64 "d")) (:artifact/content-hash artifact))))))

--- a/components/metric-registry/deps.edn
+++ b/components/metric-registry/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema {:local/root "../../../miniforge/components/schema"}}
+ :deps {ai.miniforge/schema {:local/root "../schema"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/metric-registry/deps.edn
+++ b/components/metric-registry/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/schema {:local/root "../../../miniforge/components/schema"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/metric-registry/resources/config/metric-registry/messages/en-US.edn
+++ b/components/metric-registry/resources/config/metric-registry/messages/en-US.edn
@@ -1,0 +1,5 @@
+{:metric-registry/messages
+ {;; Loading
+  :registry/file-not-found   "File not found: {path}"
+  :registry/invalid          "Invalid registry: {errors}"
+  :registry/read-error       "Error reading registry: {error}"}}

--- a/components/metric-registry/src/ai/miniforge/data_foundry/metric_registry/interface.clj
+++ b/components/metric-registry/src/ai/miniforge/data_foundry/metric_registry/interface.clj
@@ -1,0 +1,91 @@
+(ns ai.miniforge.data-foundry.metric-registry.interface
+  "Public API for the metric-registry component.
+
+   Provides schema validation and pure query functions over metric registries.
+   Registries are plain data (EDN maps) — this component has no state."
+  (:require
+   [ai.miniforge.schema.interface :as schema]
+   [ai.miniforge.data-foundry.metric-registry.schema :as reg-schema]
+   [ai.miniforge.data-foundry.metric-registry.lookup :as lookup]
+   [ai.miniforge.data-foundry.metric-registry.messages :as msg]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;; -- Schema re-exports --
+(def AcquisitionClass reg-schema/AcquisitionClass)
+(def ImplementationMode reg-schema/ImplementationMode)
+(def RefreshCadence reg-schema/RefreshCadence)
+(def RedistributionRisk reg-schema/RedistributionRisk)
+(def MetricDirection reg-schema/MetricDirection)
+(def MetricUnit reg-schema/MetricUnit)
+(def MetricEntry reg-schema/MetricEntry)
+(def MetricFamily reg-schema/MetricFamily)
+(def MetricRegistry reg-schema/MetricRegistry)
+
+;; -- Enum value sets --
+(def acquisition-classes reg-schema/acquisition-classes)
+(def implementation-modes reg-schema/implementation-modes)
+(def refresh-cadences reg-schema/refresh-cadences)
+(def redistribution-risks reg-schema/redistribution-risks)
+(def metric-directions reg-schema/metric-directions)
+(def metric-units reg-schema/metric-units)
+
+;; -- Validation --
+(def valid-metric? reg-schema/valid-metric?)
+(def valid-family? reg-schema/valid-family?)
+(def valid-registry? reg-schema/valid-registry?)
+(def validate-registry reg-schema/validate-registry)
+
+;; -- Loading --
+(defn load-registry
+  "Load a metric registry from an EDN file path.
+   Returns {:success? true :registry ...} or {:success? false :error ...}"
+  [path]
+  (try
+    (let [source (io/file path)]
+      (if (.exists source)
+        (let [content (slurp source)
+              registry (edn/read-string content)
+              validation (reg-schema/validate-registry registry)]
+          (if (:valid? validation)
+            (schema/success :registry registry)
+            (schema/failure :registry (msg/t :registry/invalid {:errors (:errors validation)}))))
+        (schema/failure :registry (msg/t :registry/file-not-found {:path path}))))
+    (catch Exception e
+      (schema/exception-failure :registry e))))
+
+;; -- Lookups --
+(defn all-metrics
+  "Return flat sequence of all metrics across all families."
+  [registry]
+  (lookup/all-metrics registry))
+
+(defn find-metric
+  "Find a single metric by id. Returns nil if not found."
+  [registry metric-id]
+  (lookup/find-metric registry metric-id))
+
+(defn find-metrics-by-family
+  "Return all metrics in a given family."
+  [registry family-id]
+  (lookup/find-metrics-by-family registry family-id))
+
+(defn find-metrics-by-source-type
+  "Return all metrics matching a given acquisition class."
+  [registry source-type]
+  (lookup/find-metrics-by-source-type registry source-type))
+
+(defn find-metrics-by-pipeline
+  "Return metric ids mapped to a given pipeline name."
+  [registry pipeline-name]
+  (lookup/find-metrics-by-pipeline registry pipeline-name))
+
+(defn family-ids
+  "Return all family ids in the registry."
+  [registry]
+  (lookup/family-ids registry))
+
+(defn metric-count
+  "Return total number of metrics across all families."
+  [registry]
+  (lookup/metric-count registry))

--- a/components/metric-registry/src/ai/miniforge/data_foundry/metric_registry/lookup.clj
+++ b/components/metric-registry/src/ai/miniforge/data_foundry/metric_registry/lookup.clj
@@ -1,0 +1,40 @@
+(ns ai.miniforge.data-foundry.metric-registry.lookup
+  "Pure query functions over metric registry data.")
+
+(defn all-metrics
+  "Return flat sequence of all metrics across all families."
+  [registry]
+  (mapcat :family/metrics (:registry/families registry)))
+
+(defn find-metric
+  "Find a single metric by id. Returns nil if not found."
+  [registry metric-id]
+  (some (fn [m] (when (= metric-id (:metric/id m)) m))
+        (all-metrics registry)))
+
+(defn find-metrics-by-family
+  "Return all metrics in a given family."
+  [registry family-id]
+  (some (fn [f] (when (= family-id (:family/id f)) (:family/metrics f)))
+        (:registry/families registry)))
+
+(defn find-metrics-by-source-type
+  "Return all metrics with a given acquisition class."
+  [registry source-type]
+  (filter #(= source-type (:metric/source-type %))
+          (all-metrics registry)))
+
+(defn find-metrics-by-pipeline
+  "Return metric ids mapped to a given pipeline name."
+  [registry pipeline-name]
+  (get-in registry [:registry/pipeline-metric-map pipeline-name]))
+
+(defn family-ids
+  "Return all family ids in the registry."
+  [registry]
+  (mapv :family/id (:registry/families registry)))
+
+(defn metric-count
+  "Return total number of metrics across all families."
+  [registry]
+  (count (all-metrics registry)))

--- a/components/metric-registry/src/ai/miniforge/data_foundry/metric_registry/messages.clj
+++ b/components/metric-registry/src/ai/miniforge/data_foundry/metric_registry/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.metric-registry.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/metric-registry/messages/en-US.edn" :metric-registry/messages))

--- a/components/metric-registry/src/ai/miniforge/data_foundry/metric_registry/schema.clj
+++ b/components/metric-registry/src/ai/miniforge/data_foundry/metric_registry/schema.clj
@@ -1,0 +1,122 @@
+(ns ai.miniforge.data-foundry.metric-registry.schema
+  "Malli schemas for metric registry.
+
+   Layer 0: Enums and base types
+   Layer 1: Metric entry and family schemas
+   Layer 2: Registry schema and validation helpers"
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Enums and base types
+
+(def acquisition-classes
+  "Four-layer acquisition taxonomy for metric sourcing."
+  [:public_canonical :official_market :premium_benchmark :house_factor])
+
+(def AcquisitionClass
+  (into [:enum] acquisition-classes))
+
+(def implementation-modes
+  [:pull :derive :vendor :deprecated])
+
+(def ImplementationMode
+  (into [:enum] implementation-modes))
+
+(def refresh-cadences
+  [:realtime :daily :weekly :monthly :quarterly :annual])
+
+(def RefreshCadence
+  (into [:enum] refresh-cadences))
+
+(def redistribution-risks
+  [:none :low :medium :high])
+
+(def RedistributionRisk
+  (into [:enum] redistribution-risks))
+
+(def metric-directions
+  [:normal :inverse])
+
+(def MetricDirection
+  (into [:enum] metric-directions))
+
+(def metric-units
+  [:percent :ratio :index :basis-points :count :usd :level])
+
+(def MetricUnit
+  (into [:enum] metric-units))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Metric entry and family schemas
+
+(def MetricEntry
+  "Schema for an individual metric definition."
+  [:map
+   [:metric/id string?]
+   [:metric/name string?]
+   [:metric/source-type AcquisitionClass]
+   [:metric/source-system string?]
+   [:metric/refresh-cadence RefreshCadence]
+   [:metric/implementation-mode ImplementationMode]
+   [:metric/license-required boolean?]
+   [:metric/redistribution-risk RedistributionRisk]
+   [:metric/direction MetricDirection]
+   [:metric/unit MetricUnit]
+   [:metric/description {:optional true} string?]
+   [:metric/series-id {:optional true} string?]])
+
+(def MetricFamily
+  "Schema for a group of related metrics."
+  [:map
+   [:family/id keyword?]
+   [:family/name string?]
+   [:family/metrics [:vector MetricEntry]]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry schema
+
+(def MetricRegistry
+  "Schema for the complete metric registry."
+  [:map
+   [:registry/id string?]
+   [:registry/version string?]
+   [:registry/families [:vector MetricFamily]]
+   [:registry/pipeline-metric-map {:optional true} [:map-of string? [:vector string?]]]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; Validation helpers
+
+(defn valid?
+  [schema value]
+  (m/validate schema value))
+
+(defn validate
+  "Validate value against schema. Returns {:valid? bool :errors map-or-nil}."
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn explain
+  [schema value]
+  (when-let [explanation (m/explain schema value)]
+    (me/humanize explanation)))
+
+(defn valid-metric?
+  [value]
+  (valid? MetricEntry value))
+
+(defn valid-family?
+  [value]
+  (valid? MetricFamily value))
+
+(defn valid-registry?
+  [value]
+  (valid? MetricRegistry value))
+
+(defn validate-registry
+  [value]
+  (validate MetricRegistry value))

--- a/components/metric-registry/test/ai/miniforge/data_foundry/metric_registry/interface_test.clj
+++ b/components/metric-registry/test/ai/miniforge/data_foundry/metric_registry/interface_test.clj
@@ -1,0 +1,156 @@
+(ns ai.miniforge.data-foundry.metric-registry.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.metric-registry.interface :as mr]))
+
+(def ^:private sample-metric
+  {:metric/id              "T10Y2Y"
+   :metric/name            "10Y-2Y Treasury Spread"
+   :metric/source-type     :public_canonical
+   :metric/source-system   "FRED"
+   :metric/refresh-cadence :daily
+   :metric/implementation-mode :pull
+   :metric/license-required false
+   :metric/redistribution-risk :none
+   :metric/direction       :normal
+   :metric/unit            :percent})
+
+(def ^:private sample-house-metric
+  {:metric/id              "BUFFETT_INDICATOR"
+   :metric/name            "Buffett Indicator (Market Cap / GDP)"
+   :metric/source-type     :house_factor
+   :metric/source-system   "internal"
+   :metric/refresh-cadence :quarterly
+   :metric/implementation-mode :derive
+   :metric/license-required false
+   :metric/redistribution-risk :none
+   :metric/direction       :inverse
+   :metric/unit            :ratio})
+
+(def ^:private sample-registry
+  {:registry/id      "risk-metrics"
+   :registry/version "2026.03.17"
+   :registry/families
+   [{:family/id       :yield-curve
+     :family/name     "Yield Curve & Credit Spreads"
+     :family/metrics  [sample-metric]}
+    {:family/id       :house-factors
+     :family/name     "House Factors"
+     :family/metrics  [sample-house-metric]}]
+   :registry/pipeline-metric-map
+   {"fred-risk-data" ["T10Y2Y" "BUFFETT_INDICATOR"]}})
+
+;; -- Schema validation --
+
+(deftest valid-metric-test
+  (testing "Valid public canonical metric passes"
+    (is (true? (mr/valid-metric? sample-metric))))
+
+  (testing "Valid house factor metric passes"
+    (is (true? (mr/valid-metric? sample-house-metric))))
+
+  (testing "Missing required field fails"
+    (is (false? (mr/valid-metric? (dissoc sample-metric :metric/source-type)))))
+
+  (testing "Invalid enum value fails"
+    (is (false? (mr/valid-metric? (assoc sample-metric :metric/source-type :invalid))))))
+
+(deftest valid-family-test
+  (testing "Valid family passes"
+    (is (true? (mr/valid-family?
+                {:family/id :yield-curve
+                 :family/name "Yield Curve"
+                 :family/metrics [sample-metric]}))))
+
+  (testing "Empty metrics vector passes"
+    (is (true? (mr/valid-family?
+                {:family/id :empty
+                 :family/name "Empty"
+                 :family/metrics []})))))
+
+(deftest validate-registry-test
+  (testing "Valid registry passes"
+    (let [result (mr/validate-registry sample-registry)]
+      (is (true? (:valid? result)))
+      (is (nil? (:errors result)))))
+
+  (testing "Missing registry/id fails"
+    (let [result (mr/validate-registry (dissoc sample-registry :registry/id))]
+      (is (false? (:valid? result)))
+      (is (some? (:errors result)))))
+
+  (testing "Invalid metric within family fails"
+    (let [bad (assoc-in sample-registry
+                        [:registry/families 0 :family/metrics 0 :metric/source-type]
+                        :invalid)
+          result (mr/validate-registry bad)]
+      (is (false? (:valid? result))))))
+
+;; -- Enum value sets --
+
+(deftest enum-sets-test
+  (testing "Acquisition classes"
+    (is (= [:public_canonical :official_market :premium_benchmark :house_factor]
+           mr/acquisition-classes)))
+
+  (testing "Implementation modes"
+    (is (= [:pull :derive :vendor :deprecated]
+           mr/implementation-modes)))
+
+  (testing "Refresh cadences"
+    (is (= [:realtime :daily :weekly :monthly :quarterly :annual]
+           mr/refresh-cadences))))
+
+;; -- Lookup functions --
+
+(deftest all-metrics-test
+  (testing "Returns all metrics across families"
+    (is (= 2 (count (mr/all-metrics sample-registry))))))
+
+(deftest find-metric-test
+  (testing "Find existing metric by id"
+    (let [m (mr/find-metric sample-registry "T10Y2Y")]
+      (is (some? m))
+      (is (= "10Y-2Y Treasury Spread" (:metric/name m)))))
+
+  (testing "Returns nil for missing metric"
+    (is (nil? (mr/find-metric sample-registry "NONEXISTENT")))))
+
+(deftest find-metrics-by-family-test
+  (testing "Find metrics in yield-curve family"
+    (let [ms (mr/find-metrics-by-family sample-registry :yield-curve)]
+      (is (= 1 (count ms)))
+      (is (= "T10Y2Y" (:metric/id (first ms))))))
+
+  (testing "Returns nil for missing family"
+    (is (nil? (mr/find-metrics-by-family sample-registry :nonexistent)))))
+
+(deftest find-metrics-by-source-type-test
+  (testing "Find public canonical metrics"
+    (let [ms (mr/find-metrics-by-source-type sample-registry :public_canonical)]
+      (is (= 1 (count ms)))
+      (is (= "T10Y2Y" (:metric/id (first ms))))))
+
+  (testing "Find house factors"
+    (let [ms (mr/find-metrics-by-source-type sample-registry :house_factor)]
+      (is (= 1 (count ms)))
+      (is (= "BUFFETT_INDICATOR" (:metric/id (first ms))))))
+
+  (testing "Returns empty for unmatched source type"
+    (is (empty? (mr/find-metrics-by-source-type sample-registry :premium_benchmark)))))
+
+(deftest find-metrics-by-pipeline-test
+  (testing "Find metrics for known pipeline"
+    (is (= ["T10Y2Y" "BUFFETT_INDICATOR"]
+           (mr/find-metrics-by-pipeline sample-registry "fred-risk-data"))))
+
+  (testing "Returns nil for unknown pipeline"
+    (is (nil? (mr/find-metrics-by-pipeline sample-registry "unknown")))))
+
+(deftest family-ids-test
+  (testing "Returns all family ids"
+    (is (= [:yield-curve :house-factors]
+           (mr/family-ids sample-registry)))))
+
+(deftest metric-count-test
+  (testing "Counts all metrics"
+    (is (= 2 (mr/metric-count sample-registry)))))

--- a/components/pipeline-config/deps.edn
+++ b/components/pipeline-config/deps.edn
@@ -2,6 +2,6 @@
  :deps {ai.miniforge.data-foundry/connector    {:local/root "../connector"}
         ai.miniforge.data-foundry/data-quality {:local/root "../data-quality"}
         ai.miniforge.data-foundry/pipeline     {:local/root "../pipeline"}
-        ai.miniforge/schema          {:local/root "../../../miniforge/components/schema"}}
+        ai.miniforge/schema          {:local/root "../schema"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/pipeline-config/deps.edn
+++ b/components/pipeline-config/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector    {:local/root "../connector"}
+        ai.miniforge.data-foundry/data-quality {:local/root "../data-quality"}
+        ai.miniforge.data-foundry/pipeline     {:local/root "../pipeline"}
+        ai.miniforge/schema          {:local/root "../../../miniforge/components/schema"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/pipeline-config/resources/config/pipeline-config/messages/en-US.edn
+++ b/components/pipeline-config/resources/config/pipeline-config/messages/en-US.edn
@@ -1,0 +1,28 @@
+{:pipeline-config/messages
+ {;; Loading
+  :load/failed                "Failed to load pipeline: {error}"
+  :load/file-not-found        "Pipeline file not found: {path}"
+  :load/parse-error           "Failed to parse pipeline EDN: {error}"
+
+  ;; Resolution
+  :resolve/missing-connector  "Connector ref not found in registry: {ref}"
+  :resolve/missing-rule       "Rule not found in registry: {id}"
+  :resolve/missing-stage-dep  "Stage dependency not found: {name}"
+  :resolve/unknown-rule-type  "Unknown rule type: {type}"
+
+  ;; Discovery
+  :discover/scanning          "Scanning for pipelines in: {path}"
+  :discover/found             "Found {count} pipeline(s)"
+
+  ;; Environment
+  :env/load-failed            "Failed to load environment config: {error}"
+  :env/file-not-found         "Environment config not found: {path}"
+
+  ;; Connector registry
+  :registry/connector-registered  "Registered connector type: {type}"
+  :registry/connector-not-found   "No connector registered for type: {type}"
+  :registry/duplicate-type        "Connector type already registered: {type}"
+
+  ;; Rule registry
+  :rule-registry/registered       "Registered rule: {id}"
+  :rule-registry/not-found        "Rule not found: {id}"}}

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/connector_registry.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/connector_registry.clj
@@ -1,0 +1,41 @@
+(ns ai.miniforge.data-foundry.pipeline-config.connector-registry
+  "Atom-backed registry mapping connector type keywords to factory functions."
+  (:require [ai.miniforge.data-foundry.pipeline-config.messages :as msg])
+  (:import [java.util UUID]))
+
+(defn create-connector-registry
+  "Create an empty connector registry."
+  []
+  (atom {}))
+
+(defn register-connector!
+  "Register a connector type with its factory function and metadata.
+   factory-fn: zero-arg function returning a connector instance.
+   metadata: connector metadata map (name, capabilities, etc.)."
+  [registry type-kw factory-fn metadata]
+  (swap! registry assoc type-kw {:factory-fn factory-fn :metadata metadata})
+  nil)
+
+(defn list-connectors
+  "Return all registered connector types with metadata."
+  [registry]
+  (into {} (map (fn [[k v]] [k (:metadata v)])) @registry))
+
+(defn instantiate-connectors
+  "Given a registry and a map of {symbolic-ref → connector-type-keyword},
+   create connector instances with assigned UUIDs.
+   Returns {:connector-refs {symbolic-ref → uuid} :connectors {uuid → instance}}."
+  [registry connector-refs]
+  (let [reg @registry]
+    (reduce-kv
+     (fn [acc ref-name type-kw]
+       (if-let [entry (get reg type-kw)]
+         (let [uuid (UUID/randomUUID)
+               instance ((:factory-fn entry))]
+           (-> acc
+               (assoc-in [:connector-refs ref-name] uuid)
+               (assoc-in [:connectors uuid] instance)))
+         (throw (ex-info (msg/t :registry/connector-not-found {:type type-kw})
+                         {:type type-kw :ref ref-name}))))
+     {:connector-refs {} :connectors {}}
+     connector-refs)))

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/connector_registry.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/connector_registry.clj
@@ -16,10 +16,15 @@
   (swap! registry assoc type-kw {:factory-fn factory-fn :metadata metadata})
   nil)
 
+(defn- entry->metadata
+  "Extract [type-kw metadata] from a registry entry."
+  [[k v]]
+  [k (:metadata v)])
+
 (defn list-connectors
   "Return all registered connector types with metadata."
   [registry]
-  (into {} (map (fn [[k v]] [k (:metadata v)])) @registry))
+  (into {} (map entry->metadata) @registry))
 
 (defn instantiate-connectors
   "Given a registry and a map of {symbolic-ref → connector-type-keyword},

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/discovery.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/discovery.clj
@@ -1,0 +1,37 @@
+(ns ai.miniforge.data-foundry.pipeline-config.discovery
+  "Find pipeline EDN files on disk.
+   NOTE: Pipeline files are currently loaded unsigned. A signing/verification
+   mechanism should be added before loading untrusted pipeline definitions
+   to mitigate injection risk."
+  (:require [clojure.java.io :as io]
+            [clojure.edn :as edn]
+            [ai.miniforge.schema.interface :as schema]))
+
+(defn- pipeline-file?
+  "Return true if the file looks like a pipeline definition."
+  [^java.io.File f]
+  (and (.isFile f)
+       (.endsWith (.getName f) ".edn")))
+
+(defn- read-pipeline-header
+  "Read just the name and version from a pipeline EDN file, without full parsing."
+  [^java.io.File f]
+  (try
+    (let [content (edn/read-string (slurp f))]
+      {:path    (.getAbsolutePath f)
+       :name    (:pipeline/name content)
+       :version (:pipeline/version content)})
+    (catch Exception _
+      {:path (.getAbsolutePath f) :name nil :version nil})))
+
+(defn discover-pipelines
+  "Scan directories for pipeline EDN files.
+   Returns schema/success with :pipelines key."
+  [search-paths]
+  (let [dirs   (keep #(let [f (io/file %)] (when (.isDirectory f) f)) search-paths)
+        files  (mapcat (fn [dir]
+                         (->> (file-seq dir)
+                              (filter pipeline-file?)))
+                       dirs)
+        headers (mapv read-pipeline-header files)]
+    (schema/success :pipelines headers)))

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/discovery.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/discovery.clj
@@ -24,14 +24,17 @@
     (catch Exception _
       {:path (.getAbsolutePath f) :name nil :version nil})))
 
+(defn- pipeline-files-in-dir
+  "Return pipeline EDN files found under dir."
+  [dir]
+  (->> (file-seq dir)
+       (filter pipeline-file?)))
+
 (defn discover-pipelines
   "Scan directories for pipeline EDN files.
    Returns schema/success with :pipelines key."
   [search-paths]
-  (let [dirs   (keep #(let [f (io/file %)] (when (.isDirectory f) f)) search-paths)
-        files  (mapcat (fn [dir]
-                         (->> (file-seq dir)
-                              (filter pipeline-file?)))
-                       dirs)
+  (let [dirs    (keep #(let [f (io/file %)] (when (.isDirectory f) f)) search-paths)
+        files   (mapcat pipeline-files-in-dir dirs)
         headers (mapv read-pipeline-header files)]
     (schema/success :pipelines headers)))

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/env.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/env.clj
@@ -1,0 +1,58 @@
+(ns ai.miniforge.data-foundry.pipeline-config.env
+  "Environment-specific configuration loading and merging."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.walk :as walk]
+            [ai.miniforge.data-foundry.pipeline-config.messages :as msg]
+            [ai.miniforge.schema.interface :as schema]))
+
+;; ---------------------------------------------------------------------------
+;; Environment variable interpolation
+;; ---------------------------------------------------------------------------
+
+(defn- resolve-env-var
+  "Replace ${VAR_NAME} placeholders in a string with System/getenv values.
+   Unresolvable vars are left as-is."
+  [s]
+  (str/replace s #"\$\{([^}]+)\}"
+               (fn [[match var-name]]
+                 (or (System/getenv var-name) match))))
+
+(defn resolve-env-vars
+  "Walk a data structure, resolving ${VAR} placeholders in all string values."
+  [config]
+  (walk/postwalk
+   (fn [v] (if (string? v) (resolve-env-var v) v))
+   config))
+
+(defn load-env-config
+  "Load an environment config EDN file.
+   Returns schema/success with :env-config key or schema/failure.
+
+   Expected format:
+     {:env/name \"development\"
+      :env/connectors {:conn/file-src {:connector/type :file ...} ...}
+      :env/stages {\"Stage Name\" {:key val} ...}}"
+  [path]
+  (try
+    (let [f (io/file path)]
+      (if (.exists f)
+        (let [config (-> (slurp f) edn/read-string resolve-env-vars)]
+          (schema/success :env-config config))
+        (schema/failure :env-config (msg/t :env/file-not-found {:path path}))))
+    (catch Exception e
+      (schema/exception-failure :env-config e))))
+
+(defn extract-connector-types
+  "Extract a {symbolic-ref → connector-type} map from env config.
+   E.g., {:conn/file-src :file, :conn/file-sink :file}."
+  [env-config]
+  (into {}
+        (map (fn [[ref-name cfg]] [ref-name (:connector/type cfg)]))
+        (:env/connectors env-config)))
+
+(defn extract-stage-configs
+  "Extract the stage config overrides map from env config."
+  [env-config]
+  (or (:env/stages env-config) {}))

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/env.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/env.clj
@@ -44,13 +44,16 @@
     (catch Exception e
       (schema/exception-failure :env-config e))))
 
+(defn- connector-entry->type
+  "Extract [ref-name connector-type] from an env connector entry."
+  [[ref-name cfg]]
+  [ref-name (:connector/type cfg)])
+
 (defn extract-connector-types
   "Extract a {symbolic-ref → connector-type} map from env config.
    E.g., {:conn/file-src :file, :conn/file-sink :file}."
   [env-config]
-  (into {}
-        (map (fn [[ref-name cfg]] [ref-name (:connector/type cfg)]))
-        (:env/connectors env-config)))
+  (into {} (map connector-entry->type) (:env/connectors env-config)))
 
 (defn extract-stage-configs
   "Extract the stage config overrides map from env config."

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/interface.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/interface.clj
@@ -1,0 +1,121 @@
+(ns ai.miniforge.data-foundry.pipeline-config.interface
+  "Public API for the pipeline-config component.
+   Bridges raw pipeline EDN definitions and runnable pipeline maps."
+  (:require [ai.miniforge.data-foundry.pipeline-config.discovery :as discovery]
+            [ai.miniforge.data-foundry.pipeline-config.loader :as loader]
+            [ai.miniforge.data-foundry.pipeline-config.resolver :as resolver]
+            [ai.miniforge.data-foundry.pipeline-config.connector-registry :as conn-reg]
+            [ai.miniforge.data-foundry.pipeline-config.rule-registry :as rule-reg]
+            [ai.miniforge.data-foundry.pipeline-config.env :as env]
+            [ai.miniforge.schema.interface :as schema]))
+
+;; -- Discovery --
+
+(defn discover-pipelines
+  "Scan directories for pipeline EDN files.
+   Returns schema/success with :pipelines key."
+  [search-paths]
+  (discovery/discover-pipelines search-paths))
+
+;; -- Loading --
+
+(defn load-pipeline
+  "Load a pipeline definition from a file path or classpath resource.
+   Returns schema/success with :pipeline key or schema/failure."
+  [path-or-resource]
+  (loader/load-pipeline path-or-resource))
+
+;; -- Resolution Context Factory --
+
+(defn create-resolution-context
+  "Create a resolution context for pipeline resolution.
+   Args:
+     connector-refs — {keyword → UUID} map of connector symbolic refs
+     dataset-refs   — {keyword → UUID} map of dataset symbolic refs
+     rule-registry  — flat rule lookup map (from resolve-rules)
+     stage-configs  — {stage-name → config-map} of env-specific overrides
+   Returns: resolution context map for resolve-pipeline."
+  [{:keys [connector-refs dataset-refs rule-registry stage-configs]
+    :or {connector-refs {} dataset-refs {} rule-registry {} stage-configs {}}}]
+  {:connector-refs connector-refs
+   :dataset-refs   dataset-refs
+   :rule-registry  rule-registry
+   :stage-configs  stage-configs})
+
+;; -- Resolution --
+
+(defn resolve-pipeline
+  "Resolve an EDN pipeline config into a runnable pipeline definition.
+   Assigns UUIDs, resolves connector/dataset refs, stage dependencies,
+   and hydrates quality rules.
+   Takes a resolution context (see create-resolution-context)."
+  [edn-config resolution-context]
+  (resolver/resolve-pipeline edn-config resolution-context))
+
+(defn load-and-resolve
+  "Load a pipeline from path, then resolve with the given context.
+   Returns schema/success with :pipeline key or schema/failure."
+  [path-or-resource resolution-context]
+  (let [load-result (loader/load-pipeline path-or-resource)]
+    (if (:success? load-result)
+      (schema/success :pipeline
+                      (resolver/resolve-pipeline (:pipeline load-result) resolution-context))
+      load-result)))
+
+;; -- Connector Registry --
+
+(defn create-connector-registry
+  "Create an empty connector registry (atom-backed)."
+  []
+  (conn-reg/create-connector-registry))
+
+(defn register-connector!
+  "Register a connector type with its factory function and metadata."
+  [registry type-kw factory-fn metadata]
+  (conn-reg/register-connector! registry type-kw factory-fn metadata))
+
+(defn list-connectors
+  "Return all registered connector types with metadata."
+  [registry]
+  (conn-reg/list-connectors registry))
+
+(defn instantiate-connectors
+  "Create connector instances from a {symbolic-ref → type-keyword} map.
+   Returns {:connector-refs {ref → uuid} :connectors {uuid → instance}}."
+  [registry connector-refs]
+  (conn-reg/instantiate-connectors registry connector-refs))
+
+;; -- Rule Registry --
+
+(defn create-rule-registry
+  "Create a rule registry with built-in rule type resolvers."
+  []
+  (rule-reg/create-rule-registry))
+
+(defn register-rule!
+  "Register a custom rule by id."
+  [registry rule-id rule-fn]
+  (rule-reg/register-rule! registry rule-id rule-fn))
+
+(defn resolve-rules
+  "Convert registry to flat lookup map for the resolver."
+  [registry]
+  (rule-reg/resolve-rules registry))
+
+;; -- Environment Config --
+
+(defn load-env-config
+  "Load an environment config EDN file.
+   Returns schema/success with :env-config key or schema/failure."
+  [path]
+  (env/load-env-config path))
+
+(defn extract-connector-types
+  "Extract {symbolic-ref → connector-type} from env config."
+  [env-config]
+  (env/extract-connector-types env-config))
+
+(defn extract-stage-configs
+  "Extract stage config overrides from env config."
+  [env-config]
+  (env/extract-stage-configs env-config))

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/loader.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/loader.clj
@@ -1,0 +1,24 @@
+(ns ai.miniforge.data-foundry.pipeline-config.loader
+  "Parse pipeline EDN from file paths or classpath resources."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]
+            [ai.miniforge.data-foundry.pipeline-config.messages :as msg]
+            [ai.miniforge.schema.interface :as schema]))
+
+(defn load-pipeline
+  "Load a pipeline definition from a file path or classpath resource.
+   Returns schema/success with :pipeline key or schema/failure."
+  [path-or-resource]
+  (try
+    (let [source (or (io/resource path-or-resource)
+                     (let [f (io/file path-or-resource)]
+                       (when (.exists f) f)))]
+      (if source
+        (let [content (slurp source)
+              pipeline (edn/read-string content)]
+          (if (and (map? pipeline) (:pipeline/name pipeline))
+            (schema/success :pipeline pipeline)
+            (schema/failure :pipeline (msg/t :load/parse-error {:error "Not a valid pipeline map"}))))
+        (schema/failure :pipeline (msg/t :load/file-not-found {:path path-or-resource}))))
+    (catch Exception e
+      (schema/exception-failure :pipeline e))))

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/messages.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.pipeline-config.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/pipeline-config/messages/en-US.edn" :pipeline-config/messages))

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/resolver.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/resolver.clj
@@ -1,0 +1,86 @@
+(ns ai.miniforge.data-foundry.pipeline-config.resolver
+  "Symbolic ref resolution for pipeline EDN configs.
+   Pure function: takes EDN config + resolution context, returns resolved map."
+  (:require [ai.miniforge.data-foundry.pipeline-config.messages :as msg])
+  (:import [java.util UUID]
+           [java.time Instant]))
+
+(defn- resolve-rule
+  "Resolve a rule descriptor map using the rule registry."
+  [rule-registry {:rule/keys [type id] :as descriptor}]
+  (case type
+    :custom (get rule-registry id)
+    ;; Built-in types: look up resolver fn by type keyword
+    (if-let [resolver (get rule-registry type)]
+      (resolver descriptor)
+      nil)))
+
+(defn- resolve-quality-pack
+  "Hydrate a quality pack's rule descriptors into live rule functions."
+  [rule-registry pack]
+  (update pack :pack/rules
+          (fn [rules] (mapv #(resolve-rule rule-registry %) rules))))
+
+(defn- resolve-stage-config
+  "Resolve quality pack rules within stage config, if present."
+  [rule-registry config]
+  (if-let [pack (:stage/quality-pack config)]
+    (assoc config :stage/quality-pack (resolve-quality-pack rule-registry pack))
+    config))
+
+(defn resolve-pipeline
+  "Resolve an EDN pipeline config into a runnable pipeline definition.
+   Assigns UUIDs to stages, resolves symbolic connector/dataset refs,
+   resolves stage dependencies by name→id, and hydrates quality rules.
+
+   resolution-context keys:
+     :connector-refs  — {keyword → UUID} map
+     :dataset-refs    — {keyword → UUID} map
+     :rule-registry   — {keyword → rule-fn-or-resolver} map
+     :stage-configs   — {stage-name → config-map} map"
+  [edn-config {:keys [connector-refs dataset-refs rule-registry
+                       stage-configs]}]
+  (let [;; Assign UUIDs to each stage
+        stages-with-ids (mapv #(assoc % :stage/id (UUID/randomUUID))
+                              (:pipeline/stages edn-config))
+
+        ;; Build name→id index for dependency resolution
+        name->id (into {} (map (juxt :stage/name :stage/id)) stages-with-ids)
+
+        ;; Resolve all symbolic refs within each stage
+        resolved-stages
+        (mapv (fn [stage]
+                (cond-> stage
+                  ;; Resolve connector-ref keyword → UUID
+                  (:stage/connector-ref stage)
+                  (update :stage/connector-ref #(get connector-refs % %))
+
+                  ;; Resolve dataset keywords → UUIDs
+                  true
+                  (update :stage/input-datasets
+                          #(mapv (fn [ds] (get dataset-refs ds ds)) %))
+
+                  true
+                  (update :stage/output-datasets
+                          #(mapv (fn [ds] (get dataset-refs ds ds)) %))
+
+                  ;; Resolve dependencies from stage names → stage IDs
+                  true
+                  (update :stage/dependencies
+                          #(mapv (fn [dep-name] (get name->id dep-name)) %))
+
+                  ;; Merge env-specific stage config (file paths, etc.)
+                  (get stage-configs (:stage/name stage))
+                  (update :stage/config merge (get stage-configs (:stage/name stage)))
+
+                  ;; Resolve quality rules in config
+                  (:stage/config stage)
+                  (update :stage/config #(resolve-stage-config rule-registry %))))
+              stages-with-ids)
+
+        now (Instant/now)]
+    (assoc edn-config
+           :pipeline/id         (UUID/randomUUID)
+           :pipeline/stages     resolved-stages
+           :pipeline/created-at now
+           :pipeline/updated-at now)))

--- a/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/rule_registry.clj
+++ b/components/pipeline-config/src/ai/miniforge/data_foundry/pipeline_config/rule_registry.clj
@@ -1,0 +1,33 @@
+(ns ai.miniforge.data-foundry.pipeline-config.rule-registry
+  "Atom-backed registry mapping rule type keywords to constructor functions."
+  (:require [ai.miniforge.data-foundry.data-quality.interface :as dq]))
+
+(defn create-rule-registry
+  "Create a rule registry pre-loaded with built-in rule type resolvers.
+   Built-in types: :required, :type-check, :range, :pattern.
+   Custom rules are registered separately by id."
+  []
+  (atom {:resolvers {:required   (fn [{:rule/keys [field]}]
+                                   (dq/required-rule field))
+                     :type-check (fn [{:rule/keys [field expected-type]}]
+                                   (dq/type-check-rule field expected-type))
+                     :range      (fn [{:rule/keys [field min max]}]
+                                   (dq/range-rule field min max))
+                     :pattern    (fn [{:rule/keys [field pattern]}]
+                                   (dq/pattern-rule field (re-pattern pattern)))}
+         :custom-rules {}}))
+
+(defn register-rule!
+  "Register a custom rule by id. rule-fn is the instantiated rule."
+  [registry rule-id rule-fn]
+  (swap! registry assoc-in [:custom-rules rule-id] rule-fn)
+  nil)
+
+(defn resolve-rules
+  "Convert a rule registry into a flat lookup map suitable for the resolver.
+   Returns a map where:
+     - built-in type keywords map to resolver fns
+     - custom rule ids map to rule instances."
+  [registry]
+  (let [{:keys [resolvers custom-rules]} @registry]
+    (merge resolvers custom-rules)))

--- a/components/pipeline-config/test/ai/miniforge/data_foundry/pipeline_config/interface_test.clj
+++ b/components/pipeline-config/test/ai/miniforge/data_foundry/pipeline_config/interface_test.clj
@@ -1,0 +1,314 @@
+(ns ai.miniforge.data-foundry.pipeline-config.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [clojure.java.io :as io]
+            [ai.miniforge.data-foundry.pipeline-config.interface :as pc]
+            [ai.miniforge.data-foundry.pipeline-config.env :as env]
+            [ai.miniforge.data-foundry.data-quality.interface :as dq])
+  (:import [java.util UUID]))
+
+;; ---------------------------------------------------------------------------
+;; Loader tests
+;; ---------------------------------------------------------------------------
+
+(deftest load-pipeline-from-classpath-test
+  (testing "loads pipeline EDN from classpath resource"
+    (let [result (pc/load-pipeline "pipelines/financial-filings-etl.edn")]
+      (is (:success? result))
+      (is (= "Financial Filings ETL" (get-in result [:pipeline :pipeline/name])))
+      (is (= 5 (count (get-in result [:pipeline :pipeline/stages])))))))
+
+(deftest load-pipeline-missing-file-test
+  (testing "returns schema/failure with anomaly for missing file"
+    (let [result (pc/load-pipeline "nonexistent/pipeline.edn")]
+      (is (not (:success? result)))
+      (is (nil? (:pipeline result)))
+      (is (some? (:error result)))
+      (is (some? (:anomaly result))))))
+
+(deftest load-pipeline-from-file-path-test
+  (testing "loads pipeline EDN from absolute file path"
+    (let [f (io/file "test/resources/pipelines/financial-filings-etl.edn")]
+      (when (.exists f)
+        (let [result (pc/load-pipeline (.getAbsolutePath f))]
+          (is (:success? result))
+          (is (= "Financial Filings ETL" (get-in result [:pipeline :pipeline/name]))))))))
+
+;; ---------------------------------------------------------------------------
+;; Resolution context factory tests
+;; ---------------------------------------------------------------------------
+
+(deftest create-resolution-context-defaults-test
+  (testing "factory provides defaults for missing keys"
+    (let [ctx (pc/create-resolution-context {})]
+      (is (= {} (:connector-refs ctx)))
+      (is (= {} (:dataset-refs ctx)))
+      (is (= {} (:rule-registry ctx)))
+      (is (= {} (:stage-configs ctx))))))
+
+(deftest create-resolution-context-preserves-values-test
+  (testing "factory preserves provided values"
+    (let [conn-refs {:conn/src (UUID/randomUUID)}
+          ctx (pc/create-resolution-context {:connector-refs conn-refs
+                                             :stage-configs {"S1" {:k :v}}})]
+      (is (= conn-refs (:connector-refs ctx)))
+      (is (= {"S1" {:k :v}} (:stage-configs ctx))))))
+
+;; ---------------------------------------------------------------------------
+;; Resolver tests
+;; ---------------------------------------------------------------------------
+
+(deftest resolve-pipeline-assigns-uuids-test
+  (testing "assigns pipeline ID and stage IDs"
+    (let [edn {:pipeline/name "Test"
+               :pipeline/version "1.0.0"
+               :pipeline/mode :full-refresh
+               :pipeline/stages [{:stage/name "S1"
+                                  :stage/family :ingest
+                                  :stage/input-datasets []
+                                  :stage/output-datasets [:ds/out]
+                                  :stage/dependencies []}]
+               :pipeline/input-datasets []
+               :pipeline/output-datasets []}
+          ctx (pc/create-resolution-context {})
+          resolved (pc/resolve-pipeline edn ctx)]
+      (is (instance? UUID (:pipeline/id resolved)))
+      (is (instance? UUID (get-in resolved [:pipeline/stages 0 :stage/id])))
+      (is (some? (:pipeline/created-at resolved))))))
+
+(deftest resolve-pipeline-resolves-connector-refs-test
+  (testing "resolves symbolic connector refs to UUIDs"
+    (let [conn-uuid (UUID/randomUUID)
+          edn {:pipeline/name "Test"
+               :pipeline/version "1.0.0"
+               :pipeline/mode :full-refresh
+               :pipeline/stages [{:stage/name "Ingest"
+                                  :stage/family :ingest
+                                  :stage/connector-ref :conn/src
+                                  :stage/input-datasets []
+                                  :stage/output-datasets [:ds/raw]
+                                  :stage/dependencies []}]
+               :pipeline/input-datasets []
+               :pipeline/output-datasets []}
+          ctx (pc/create-resolution-context {:connector-refs {:conn/src conn-uuid}})
+          resolved (pc/resolve-pipeline edn ctx)]
+      (is (= conn-uuid (get-in resolved [:pipeline/stages 0 :stage/connector-ref]))))))
+
+(deftest resolve-pipeline-resolves-dataset-refs-test
+  (testing "resolves symbolic dataset refs to UUIDs"
+    (let [ds-uuid (UUID/randomUUID)
+          edn {:pipeline/name "Test"
+               :pipeline/version "1.0.0"
+               :pipeline/mode :full-refresh
+               :pipeline/stages [{:stage/name "S1"
+                                  :stage/family :ingest
+                                  :stage/input-datasets [:ds/in]
+                                  :stage/output-datasets [:ds/out]
+                                  :stage/dependencies []}]
+               :pipeline/input-datasets []
+               :pipeline/output-datasets []}
+          ctx (pc/create-resolution-context {:dataset-refs {:ds/in ds-uuid}})
+          resolved (pc/resolve-pipeline edn ctx)]
+      (is (= ds-uuid (get-in resolved [:pipeline/stages 0 :stage/input-datasets 0]))))))
+
+(deftest resolve-pipeline-resolves-stage-dependencies-test
+  (testing "resolves stage name dependencies to stage IDs"
+    (let [edn {:pipeline/name "Test"
+               :pipeline/version "1.0.0"
+               :pipeline/mode :full-refresh
+               :pipeline/stages [{:stage/name "A"
+                                  :stage/family :ingest
+                                  :stage/input-datasets []
+                                  :stage/output-datasets [:ds/raw]
+                                  :stage/dependencies []}
+                                 {:stage/name "B"
+                                  :stage/family :normalize
+                                  :stage/input-datasets [:ds/raw]
+                                  :stage/output-datasets [:ds/norm]
+                                  :stage/dependencies ["A"]}]
+               :pipeline/input-datasets []
+               :pipeline/output-datasets []}
+          ctx (pc/create-resolution-context {})
+          resolved (pc/resolve-pipeline edn ctx)
+          stage-a-id (get-in resolved [:pipeline/stages 0 :stage/id])
+          stage-b-deps (get-in resolved [:pipeline/stages 1 :stage/dependencies])]
+      (is (= [stage-a-id] stage-b-deps)))))
+
+(deftest resolve-pipeline-merges-stage-configs-test
+  (testing "merges environment-specific stage configs"
+    (let [edn {:pipeline/name "Test"
+               :pipeline/version "1.0.0"
+               :pipeline/mode :full-refresh
+               :pipeline/stages [{:stage/name "Ingest"
+                                  :stage/family :ingest
+                                  :stage/input-datasets []
+                                  :stage/output-datasets [:ds/raw]
+                                  :stage/dependencies []
+                                  :stage/config {:base "value"}}]
+               :pipeline/input-datasets []
+               :pipeline/output-datasets []}
+          ctx (pc/create-resolution-context {:stage-configs {"Ingest" {:file/path "/data/in.csv"}}})
+          resolved (pc/resolve-pipeline edn ctx)]
+      (is (= "/data/in.csv" (get-in resolved [:pipeline/stages 0 :stage/config :file/path])))
+      (is (= "value" (get-in resolved [:pipeline/stages 0 :stage/config :base]))))))
+
+(deftest resolve-pipeline-hydrates-quality-rules-test
+  (testing "hydrates quality pack rule descriptors into live rules"
+    (let [edn {:pipeline/name "Test"
+               :pipeline/version "1.0.0"
+               :pipeline/mode :full-refresh
+               :pipeline/stages [{:stage/name "Validate"
+                                  :stage/family :validate
+                                  :stage/input-datasets [:ds/in]
+                                  :stage/output-datasets [:ds/out]
+                                  :stage/dependencies []
+                                  :stage/config {:stage/quality-pack
+                                                 {:pack/id :test-pack
+                                                  :pack/rules [{:rule/type :required :rule/field :name}]}}}]
+               :pipeline/input-datasets []
+               :pipeline/output-datasets []}
+          rule-reg (pc/create-rule-registry)
+          ctx (pc/create-resolution-context {:rule-registry (pc/resolve-rules rule-reg)})
+          resolved (pc/resolve-pipeline edn ctx)
+          hydrated-rules (get-in resolved [:pipeline/stages 0 :stage/config
+                                           :stage/quality-pack :pack/rules])]
+      (is (= 1 (count hydrated-rules)))
+      (is (map? (first hydrated-rules)))
+      (is (= :required-name (:rule/id (first hydrated-rules)))))))
+
+;; ---------------------------------------------------------------------------
+;; Connector registry tests
+;; ---------------------------------------------------------------------------
+
+(deftest connector-registry-lifecycle-test
+  (testing "register, list, and instantiate connectors"
+    (let [registry (pc/create-connector-registry)
+          factory  (fn [] {:type :mock-connector})
+          metadata {:connector/name "Mock"}]
+      (pc/register-connector! registry :mock factory metadata)
+
+      ;; list
+      (let [listed (pc/list-connectors registry)]
+        (is (= {:connector/name "Mock"} (get listed :mock))))
+
+      ;; instantiate
+      (let [result (pc/instantiate-connectors registry {:conn/src :mock})]
+        (is (instance? UUID (get-in result [:connector-refs :conn/src])))
+        (let [uuid (get-in result [:connector-refs :conn/src])
+              inst (get-in result [:connectors uuid])]
+          (is (= {:type :mock-connector} inst)))))))
+
+(deftest connector-registry-missing-type-test
+  (testing "instantiate throws for unregistered type"
+    (let [registry (pc/create-connector-registry)]
+      (is (thrown? clojure.lang.ExceptionInfo
+                   (pc/instantiate-connectors registry {:conn/src :unknown}))))))
+
+;; ---------------------------------------------------------------------------
+;; Rule registry tests
+;; ---------------------------------------------------------------------------
+
+(deftest rule-registry-builtin-types-test
+  (testing "built-in rule resolvers are present"
+    (let [registry (pc/create-rule-registry)
+          rules (pc/resolve-rules registry)]
+      (is (fn? (get rules :required)))
+      (is (fn? (get rules :type-check)))
+      (is (fn? (get rules :range)))
+      (is (fn? (get rules :pattern))))))
+
+(deftest rule-registry-custom-rule-test
+  (testing "custom rules can be registered and resolved"
+    (let [registry (pc/create-rule-registry)
+          custom-rule (dq/custom-rule :my-rule (fn [_] {:valid? true}) :severity :warning)]
+      (pc/register-rule! registry :my-rule custom-rule)
+      (let [rules (pc/resolve-rules registry)]
+        (is (= custom-rule (get rules :my-rule)))))))
+
+;; ---------------------------------------------------------------------------
+;; Environment config tests
+;; ---------------------------------------------------------------------------
+
+(deftest env-config-extract-test
+  (testing "extracts connector types and stage configs from env config"
+    (let [env-config {:env/name "test"
+                      :env/connectors {:conn/src {:connector/type :file}
+                                       :conn/api {:connector/type :http}}
+                      :env/stages {"Ingest" {:file/path "/data/in.csv"}}}]
+      (is (= {:conn/src :file :conn/api :http}
+             (pc/extract-connector-types env-config)))
+      (is (= {"Ingest" {:file/path "/data/in.csv"}}
+             (pc/extract-stage-configs env-config))))))
+
+;; ---------------------------------------------------------------------------
+;; Environment variable interpolation tests
+;; ---------------------------------------------------------------------------
+
+(deftest resolve-env-vars-string-test
+  (testing "resolves known env vars in strings"
+    ;; PATH is always set
+    (let [result (env/resolve-env-vars "${PATH}")]
+      (is (string? result))
+      (is (not= "${PATH}" result))
+      (is (= (System/getenv "PATH") result)))))
+
+(deftest resolve-env-vars-unknown-var-test
+  (testing "leaves unknown env vars as-is"
+    (let [result (env/resolve-env-vars "${DEFINITELY_NOT_SET_XYZ_12345}")]
+      (is (= "${DEFINITELY_NOT_SET_XYZ_12345}" result)))))
+
+(deftest resolve-env-vars-nested-map-test
+  (testing "walks nested maps resolving env vars in all string values"
+    (let [config {:api-key "${PATH}"
+                  :nested {:url "https://example.com/${PATH}/data"}
+                  :number 42
+                  :keyword :keep-this}
+          result (env/resolve-env-vars config)
+          path-val (System/getenv "PATH")]
+      (is (= path-val (:api-key result)))
+      (is (= (str "https://example.com/" path-val "/data") (get-in result [:nested :url])))
+      (is (= 42 (:number result)))
+      (is (= :keep-this (:keyword result))))))
+
+(deftest resolve-env-vars-in-vectors-test
+  (testing "resolves env vars inside vectors"
+    (let [result (env/resolve-env-vars [{:key "${PATH}"} "plain"])]
+      (is (= (System/getenv "PATH") (:key (first result))))
+      (is (= "plain" (second result))))))
+
+(deftest resolve-env-vars-no-placeholders-test
+  (testing "returns config unchanged when no placeholders present"
+    (let [config {:url "https://example.com" :port 8080}]
+      (is (= config (env/resolve-env-vars config))))))
+
+;; ---------------------------------------------------------------------------
+;; load-and-resolve integration test
+;; ---------------------------------------------------------------------------
+
+(deftest load-and-resolve-test
+  (testing "loads and resolves a pipeline from classpath"
+    (let [conn-uuid (UUID/randomUUID)
+          ds-uuid   (UUID/randomUUID)
+          rule-reg  (pc/create-rule-registry)
+          ctx       (pc/create-resolution-context
+                     {:connector-refs {:conn/file-src conn-uuid}
+                      :dataset-refs   {:ds/raw ds-uuid}
+                      :rule-registry  (pc/resolve-rules rule-reg)
+                      :stage-configs  {"Ingest Filings" {:file/path "/tmp/test.csv"}}})
+          result    (pc/load-and-resolve "pipelines/financial-filings-etl.edn" ctx)]
+      (is (:success? result))
+      (is (instance? UUID (get-in result [:pipeline :pipeline/id])))
+      (is (= 5 (count (get-in result [:pipeline :pipeline/stages]))))
+      ;; Verify connector ref was resolved
+      (is (= conn-uuid (get-in result [:pipeline :pipeline/stages 0 :stage/connector-ref])))
+      ;; Verify dataset ref was resolved
+      (is (= ds-uuid (get-in result [:pipeline :pipeline/stages 0 :stage/output-datasets 0])))
+      ;; Verify stage config was merged
+      (is (= "/tmp/test.csv" (get-in result [:pipeline :pipeline/stages 0 :stage/config :file/path]))))))
+
+(deftest load-and-resolve-missing-file-test
+  (testing "returns schema/failure with anomaly for missing pipeline"
+    (let [ctx (pc/create-resolution-context {})
+          result (pc/load-and-resolve "nonexistent/pipeline.edn" ctx)]
+      (is (not (:success? result)))
+      (is (nil? (:pipeline result)))
+      (is (some? (:anomaly result))))))

--- a/components/pipeline-config/test/resources/pipelines/financial-filings-etl.edn
+++ b/components/pipeline-config/test/resources/pipelines/financial-filings-etl.edn
@@ -1,0 +1,47 @@
+;; Financial Filings ETL Pipeline — Phase 1.5 integration test config
+;;
+;; Connector refs and dataset refs use symbolic names resolved at load time.
+;; Quality pack rules reference rule types resolved by the loader.
+{:pipeline/name    "Financial Filings ETL"
+ :pipeline/version "1.0.0"
+ :pipeline/mode    :full-refresh
+
+ :pipeline/stages
+ [{:stage/name           "Ingest Filings"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/file-src
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/raw]
+   :stage/dependencies    []}
+
+  {:stage/name           "Enrich from API"
+   :stage/family         :enrich
+   :stage/input-datasets  [:ds/raw]
+   :stage/output-datasets [:ds/enriched]
+   :stage/dependencies    ["Ingest Filings"]}
+
+  {:stage/name           "Normalize"
+   :stage/family         :normalize
+   :stage/input-datasets  [:ds/enriched]
+   :stage/output-datasets [:ds/norm]
+   :stage/dependencies    ["Enrich from API"]}
+
+  {:stage/name           "Validate Quality"
+   :stage/family         :validate
+   :stage/input-datasets  [:ds/norm]
+   :stage/output-datasets [:ds/valid]
+   :stage/dependencies    ["Normalize"]
+   :stage/config          {:stage/quality-pack
+                           {:pack/id :financial-filings-quality
+                            :pack/rules [{:rule/type :required :rule/field :cik}
+                                         {:rule/type :custom   :rule/id :range-market_cap}]}}}
+
+  {:stage/name           "Publish Results"
+   :stage/family         :publish
+   :stage/connector-ref  :conn/file-sink
+   :stage/input-datasets  [:ds/valid]
+   :stage/output-datasets []
+   :stage/dependencies    ["Validate Quality"]}]
+
+ :pipeline/input-datasets  []
+ :pipeline/output-datasets []}

--- a/components/pipeline-pack-store/deps.edn
+++ b/components/pipeline-pack-store/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/schema {:local/root "../../../miniforge/components/schema"}
+        ai.miniforge.data-foundry/pipeline-pack {:local/root "../pipeline-pack"}
+        ai.miniforge.data-foundry/metric-registry {:local/root "../metric-registry"}
+        datalevin/datalevin {:mvn/version "0.9.16"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/pipeline-pack-store/deps.edn
+++ b/components/pipeline-pack-store/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema {:local/root "../../../miniforge/components/schema"}
+ :deps {ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge.data-foundry/pipeline-pack {:local/root "../pipeline-pack"}
         ai.miniforge.data-foundry/metric-registry {:local/root "../metric-registry"}
         datalevin/datalevin {:mvn/version "0.9.16"}}

--- a/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/datalevin_store.clj
+++ b/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/datalevin_store.clj
@@ -1,0 +1,109 @@
+(ns ai.miniforge.data-foundry.pipeline-pack-store.datalevin-store
+  "Datalevin implementation of PackStore protocol."
+  (:require
+   [datalevin.core :as d]
+   [ai.miniforge.data-foundry.pipeline-pack-store.protocol :as proto]
+   [ai.miniforge.data-foundry.pipeline-pack-store.schema :as store-schema])
+  (:import [java.util UUID]))
+
+(defn- pack->datoms
+  "Convert a loaded pack to Datalevin transaction datoms."
+  [pack]
+  (let [manifest (:pack/manifest pack)
+        pack-id (:pack/id manifest)]
+    (into
+     ;; Pack manifest datom
+     [{:pack/id          pack-id
+       :pack/name        (:pack/name manifest)
+       :pack/version     (:pack/version manifest)
+       :pack/description (:pack/description manifest "")
+       :pack/author      (:pack/author manifest "")
+       :pack/trust-level (name (:pack/trust-level manifest :untrusted))
+       :pack/authority   (name (:pack/authority manifest :authority/data))}]
+     ;; Metric datoms (from registry if present)
+     (when-let [registry (:pack/registry pack)]
+       (for [family (:registry/families registry)
+             metric (:family/metrics family)]
+         {:metric/id          (:metric/id metric)
+          :metric/name        (:metric/name metric)
+          :metric/family-id   (name (:family/id family))
+          :metric/source-type (name (:metric/source-type metric))
+          :metric/pack-id     pack-id})))))
+
+(defn- entity->map
+  "Convert a Datalevin entity to a plain map."
+  [entity]
+  (when entity
+    (into {} entity)))
+
+(defrecord DatalevinPackStore [conn]
+  proto/PackStore
+
+  (save-pack [_this pack]
+    (let [datoms (pack->datoms pack)]
+      (d/transact! conn datoms)
+      (get-in pack [:pack/manifest :pack/id])))
+
+  (load-pack [_this pack-id]
+    (let [db (d/db conn)
+          result (d/entity db [:pack/id pack-id])]
+      (entity->map result)))
+
+  (list-packs [_this]
+    (let [db (d/db conn)
+          ids (d/q '[:find ?id :where [?e :pack/id ?id]] db)]
+      (mapv (fn [[id]] (entity->map (d/entity db [:pack/id id]))) ids)))
+
+  (save-snapshot [_this snapshot]
+    (let [id (or (:snapshot/id snapshot) (str (UUID/randomUUID)))
+          datom (assoc snapshot :snapshot/id id)]
+      (d/transact! conn [datom])
+      id))
+
+  (latest-snapshots [_this pack-id]
+    (let [db (d/db conn)
+          results (d/q '[:find ?sid ?mid ?val ?as-of
+                         :in $ ?pack-id
+                         :where
+                         [?e :snapshot/pack-id ?pack-id]
+                         [?e :snapshot/id ?sid]
+                         [?e :snapshot/metric-id ?mid]
+                         [?e :snapshot/value ?val]
+                         [?e :snapshot/as-of ?as-of]]
+                       db pack-id)]
+      ;; Group by metric-id, take latest by as-of
+      (->> results
+           (group-by second)
+           (map (fn [[metric-id rows]]
+                  (let [latest (last (sort-by #(nth % 3) rows))]
+                    {:snapshot/id        (nth latest 0)
+                     :snapshot/metric-id metric-id
+                     :snapshot/value     (nth latest 2)
+                     :snapshot/as-of     (nth latest 3)})))
+           vec)))
+
+  (save-run [_this run]
+    (let [id (or (:run/id run) (str (UUID/randomUUID)))
+          datom (assoc run :run/id id)]
+      (d/transact! conn [datom])
+      id))
+
+  (runs-for-pack [_this pack-id]
+    (let [db (d/db conn)
+          results (d/q '[:find ?e
+                         :in $ ?pack-id
+                         :where [?e :run/pack-id ?pack-id]]
+                       db pack-id)]
+      (mapv (fn [[eid]] (entity->map (d/entity db eid))) results)))
+
+  (close [_this]
+    (d/close conn)))
+
+(defn create-store
+  "Create a Datalevin-backed pack store.
+   Opts:
+     :dir - directory for persistent storage (nil = in-memory)"
+  ([] (create-store {}))
+  ([{:keys [dir schema] :or {schema store-schema/datalevin-schema}}]
+   (let [conn (d/get-conn dir schema)]
+     (->DatalevinPackStore conn))))

--- a/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/datalevin_store.clj
+++ b/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/datalevin_store.clj
@@ -36,6 +36,15 @@
   (when entity
     (into {} entity)))
 
+(defn- metric-group->latest-snapshot
+  "Given [metric-id rows] from a group-by, return the latest snapshot map."
+  [[metric-id rows]]
+  (let [latest (last (sort-by #(nth % 3) rows))]
+    {:snapshot/id        (nth latest 0)
+     :snapshot/metric-id metric-id
+     :snapshot/value     (nth latest 2)
+     :snapshot/as-of     (nth latest 3)}))
+
 (defrecord DatalevinPackStore [conn]
   proto/PackStore
 
@@ -74,12 +83,7 @@
       ;; Group by metric-id, take latest by as-of
       (->> results
            (group-by second)
-           (map (fn [[metric-id rows]]
-                  (let [latest (last (sort-by #(nth % 3) rows))]
-                    {:snapshot/id        (nth latest 0)
-                     :snapshot/metric-id metric-id
-                     :snapshot/value     (nth latest 2)
-                     :snapshot/as-of     (nth latest 3)})))
+           (map metric-group->latest-snapshot)
            vec)))
 
   (save-run [_this run]

--- a/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/interface.clj
+++ b/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/interface.clj
@@ -1,7 +1,9 @@
 (ns ai.miniforge.data-foundry.pipeline-pack-store.interface
   "Public API for pipeline pack persistence.
 
-   Uses requiring-resolve to defer Datalevin loading."
+   Uses requiring-resolve to defer Datalevin (native dep) loading.
+   This is a legitimate extension point — Datalevin pulls in JNI
+   native libraries that should not load at namespace-require time."
   (:require
    [ai.miniforge.data-foundry.pipeline-pack-store.protocol :as proto]))
 

--- a/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/interface.clj
+++ b/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/interface.clj
@@ -1,0 +1,54 @@
+(ns ai.miniforge.data-foundry.pipeline-pack-store.interface
+  "Public API for pipeline pack persistence.
+
+   Uses requiring-resolve to defer Datalevin loading."
+  (:require
+   [ai.miniforge.data-foundry.pipeline-pack-store.protocol :as proto]))
+
+;; -- Store creation --
+(defn create-store
+  "Create a pack store. Options:
+     :dir - directory for persistent storage (nil = in-memory for tests)"
+  ([] ((requiring-resolve 'ai.miniforge.data-foundry.pipeline-pack-store.datalevin-store/create-store)))
+  ([opts] ((requiring-resolve 'ai.miniforge.data-foundry.pipeline-pack-store.datalevin-store/create-store) opts)))
+
+;; -- Protocol delegations --
+(defn save-pack
+  "Persist a pack manifest and its metrics."
+  [store pack]
+  (proto/save-pack store pack))
+
+(defn load-pack
+  "Retrieve a pack by id."
+  [store pack-id]
+  (proto/load-pack store pack-id))
+
+(defn list-packs
+  "List all stored packs."
+  [store]
+  (proto/list-packs store))
+
+(defn save-snapshot
+  "Save a metric value snapshot."
+  [store snapshot]
+  (proto/save-snapshot store snapshot))
+
+(defn latest-snapshots
+  "Get the latest snapshot for each metric in a pack."
+  [store pack-id]
+  (proto/latest-snapshots store pack-id))
+
+(defn save-run
+  "Save a pipeline run record."
+  [store run]
+  (proto/save-run store run))
+
+(defn runs-for-pack
+  "Get all runs for a pack."
+  [store pack-id]
+  (proto/runs-for-pack store pack-id))
+
+(defn close
+  "Close the store and release resources."
+  [store]
+  (proto/close store))

--- a/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/protocol.clj
+++ b/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/protocol.clj
@@ -1,0 +1,27 @@
+(ns ai.miniforge.data-foundry.pipeline-pack-store.protocol
+  "Protocol definition for pipeline pack persistence.")
+
+(defprotocol PackStore
+  (save-pack [this pack]
+    "Persist a pack manifest and its metrics. Returns pack-id.")
+
+  (load-pack [this pack-id]
+    "Retrieve a pack by id. Returns nil if not found.")
+
+  (list-packs [this]
+    "List all stored packs. Returns vector of pack manifests.")
+
+  (save-snapshot [this snapshot]
+    "Save a metric value snapshot. Returns snapshot-id.")
+
+  (latest-snapshots [this pack-id]
+    "Get the latest snapshot for each metric in a pack. Returns vector of snapshots.")
+
+  (save-run [this run]
+    "Save a pipeline run record. Returns run-id.")
+
+  (runs-for-pack [this pack-id]
+    "Get all runs for a pack. Returns vector of run records.")
+
+  (close [this]
+    "Close the store and release resources."))

--- a/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/schema.clj
+++ b/components/pipeline-pack-store/src/ai/miniforge/data_foundry/pipeline_pack_store/schema.clj
@@ -1,0 +1,36 @@
+(ns ai.miniforge.data-foundry.pipeline-pack-store.schema
+  "Datalevin schema for pipeline pack store.")
+
+(def datalevin-schema
+  {;; Pack manifests
+   :pack/id            {:db/unique :db.unique/identity}
+   :pack/name          {}
+   :pack/version       {}
+   :pack/description   {}
+   :pack/author        {}
+   :pack/trust-level   {}
+   :pack/authority     {}
+
+   ;; Metrics
+   :metric/id          {:db/unique :db.unique/identity}
+   :metric/name        {}
+   :metric/family-id   {}
+   :metric/source-type {}
+   :metric/pack-id     {}
+
+   ;; Metric value snapshots
+   :snapshot/id         {:db/unique :db.unique/identity}
+   :snapshot/metric-id  {}
+   :snapshot/value      {}
+   :snapshot/as-of      {}
+   :snapshot/pipeline-run-id {}
+   :snapshot/pack-id    {}
+
+   ;; Pipeline runs
+   :run/id             {:db/unique :db.unique/identity}
+   :run/pack-id        {}
+   :run/pipeline-name  {}
+   :run/status         {}
+   :run/started-at     {}
+   :run/finished-at    {}
+   :run/metric-count   {}})

--- a/components/pipeline-pack-store/test/ai/miniforge/data_foundry/pipeline_pack_store/interface_test.clj
+++ b/components/pipeline-pack-store/test/ai/miniforge/data_foundry/pipeline_pack_store/interface_test.clj
@@ -1,0 +1,142 @@
+(ns ai.miniforge.data-foundry.pipeline-pack-store.interface-test
+  (:require [clojure.test :refer [deftest is testing use-fixtures]]
+            [ai.miniforge.data-foundry.pipeline-pack-store.interface :as store]))
+
+(def ^:private ^:dynamic *store* nil)
+
+(defn- with-store [f]
+  (let [s (store/create-store)]
+    (binding [*store* s]
+      (try
+        (f)
+        (finally
+          (store/close s))))))
+
+(use-fixtures :each with-store)
+
+(def ^:private sample-pack
+  {:pack/manifest {:pack/id          "test-pack"
+                   :pack/name        "Test Pack"
+                   :pack/version     "2026.03.17"
+                   :pack/description "A test pack"
+                   :pack/author      "test"
+                   :pack/trust-level :untrusted
+                   :pack/authority   :authority/data}
+   :pack/dir "/tmp/test"
+   :pack/pipelines []
+   :pack/envs []
+   :pack/registry
+   {:registry/id "test-metrics"
+    :registry/version "2026.03.17"
+    :registry/families
+    [{:family/id :test-family
+      :family/name "Test Family"
+      :family/metrics
+      [{:metric/id "M1" :metric/name "Metric 1"
+        :metric/source-type :public_canonical
+        :metric/source-system "FRED"
+        :metric/refresh-cadence :daily
+        :metric/implementation-mode :pull
+        :metric/license-required false
+        :metric/redistribution-risk :none
+        :metric/direction :normal
+        :metric/unit :percent}
+       {:metric/id "M2" :metric/name "Metric 2"
+        :metric/source-type :house_factor
+        :metric/source-system "internal"
+        :metric/refresh-cadence :quarterly
+        :metric/implementation-mode :derive
+        :metric/license-required false
+        :metric/redistribution-risk :none
+        :metric/direction :inverse
+        :metric/unit :ratio}]}]}})
+
+;; -- Pack CRUD --
+
+(deftest save-and-load-pack-test
+  (testing "Save and retrieve pack"
+    (let [pack-id (store/save-pack *store* sample-pack)
+          loaded (store/load-pack *store* "test-pack")]
+      (is (= "test-pack" pack-id))
+      (is (some? loaded))
+      (is (= "Test Pack" (:pack/name loaded)))
+      (is (= "2026.03.17" (:pack/version loaded)))))
+
+  (testing "Load nonexistent pack returns nil"
+    (is (nil? (store/load-pack *store* "nonexistent")))))
+
+(deftest list-packs-test
+  (testing "List stored packs"
+    (store/save-pack *store* sample-pack)
+    (let [packs (store/list-packs *store*)]
+      (is (= 1 (count packs)))
+      (is (= "test-pack" (:pack/id (first packs)))))))
+
+;; -- Metrics persisted with pack --
+
+(deftest metrics-persisted-test
+  (testing "Metrics from registry are stored"
+    (store/save-pack *store* sample-pack)
+    (let [m1 (store/load-pack *store* "M1")]
+      ;; M1 is stored as a metric entity, not a pack entity
+      ;; But we can query via Datalevin directly through the store
+      ;; For now just verify the pack itself loaded
+      (is (some? (store/load-pack *store* "test-pack"))))))
+
+;; -- Snapshots --
+
+(deftest snapshot-test
+  (testing "Save and query snapshots"
+    (store/save-pack *store* sample-pack)
+    (store/save-snapshot *store*
+                         {:snapshot/metric-id "M1"
+                          :snapshot/value 1.5
+                          :snapshot/as-of "2026-03-17"
+                          :snapshot/pipeline-run-id "run-1"
+                          :snapshot/pack-id "test-pack"})
+    (store/save-snapshot *store*
+                         {:snapshot/metric-id "M2"
+                          :snapshot/value 0.85
+                          :snapshot/as-of "2026-03-17"
+                          :snapshot/pipeline-run-id "run-1"
+                          :snapshot/pack-id "test-pack"})
+    (let [latest (store/latest-snapshots *store* "test-pack")]
+      (is (= 2 (count latest)))
+      (is (= #{"M1" "M2"} (set (map :snapshot/metric-id latest)))))))
+
+(deftest snapshot-latest-wins-test
+  (testing "Latest snapshot by as-of wins"
+    (store/save-pack *store* sample-pack)
+    (store/save-snapshot *store*
+                         {:snapshot/metric-id "M1"
+                          :snapshot/value 1.0
+                          :snapshot/as-of "2026-03-16"
+                          :snapshot/pipeline-run-id "run-1"
+                          :snapshot/pack-id "test-pack"})
+    (store/save-snapshot *store*
+                         {:snapshot/metric-id "M1"
+                          :snapshot/value 2.0
+                          :snapshot/as-of "2026-03-17"
+                          :snapshot/pipeline-run-id "run-2"
+                          :snapshot/pack-id "test-pack"})
+    (let [latest (store/latest-snapshots *store* "test-pack")
+          m1 (first (filter #(= "M1" (:snapshot/metric-id %)) latest))]
+      (is (= 1 (count latest)))
+      (is (= 2.0 (:snapshot/value m1))))))
+
+;; -- Runs --
+
+(deftest run-test
+  (testing "Save and query runs"
+    (store/save-pack *store* sample-pack)
+    (let [run-id (store/save-run *store*
+                                 {:run/pack-id "test-pack"
+                                  :run/pipeline-name "Test Pipeline"
+                                  :run/status "completed"
+                                  :run/started-at "2026-03-17T10:00:00Z"
+                                  :run/finished-at "2026-03-17T10:05:00Z"
+                                  :run/metric-count 2})
+          runs (store/runs-for-pack *store* "test-pack")]
+      (is (some? run-id))
+      (is (= 1 (count runs)))
+      (is (= "completed" (:run/status (first runs)))))))

--- a/components/pipeline-pack/deps.edn
+++ b/components/pipeline-pack/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema {:local/root "../../../miniforge/components/schema"}
+ :deps {ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge.data-foundry/metric-registry {:local/root "../metric-registry"}
         ai.miniforge.data-foundry/pipeline-config {:local/root "../pipeline-config"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/pipeline-pack/deps.edn
+++ b/components/pipeline-pack/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/schema {:local/root "../../../miniforge/components/schema"}
+        ai.miniforge.data-foundry/metric-registry {:local/root "../metric-registry"}
+        ai.miniforge.data-foundry/pipeline-config {:local/root "../pipeline-config"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/pipeline-pack/resources/config/pipeline-pack/messages/en-US.edn
+++ b/components/pipeline-pack/resources/config/pipeline-pack/messages/en-US.edn
@@ -1,0 +1,10 @@
+{:pipeline-pack/messages
+ {;; Loader errors
+  :pack/dir-not-found        "Directory not found: {path}"
+  :pack/manifest-not-found   "No pack.edn in: {path}"
+  :pack/manifest-read-error  "Failed to read pack.edn: {error}"
+  :pack/manifest-invalid     "Invalid manifest: {errors}"
+  :pack/registry-not-found   "Metric registry not found: {path}"
+
+  ;; Trust validation
+  :pack/trust-violation       "Pack '{id}' has :authority/instruction but trust level is {trust} (requires :trusted)"}}

--- a/components/pipeline-pack/src/ai/miniforge/data_foundry/pipeline_pack/interface.clj
+++ b/components/pipeline-pack/src/ai/miniforge/data_foundry/pipeline_pack/interface.clj
@@ -1,0 +1,80 @@
+(ns ai.miniforge.data-foundry.pipeline-pack.interface
+  "Public API for the pipeline-pack component.
+
+   Provides pack loading, discovery, registry management, and trust validation."
+  (:require
+   [ai.miniforge.data-foundry.pipeline-pack.schema :as pack-schema]
+   [ai.miniforge.data-foundry.pipeline-pack.loader :as loader]
+   [ai.miniforge.data-foundry.pipeline-pack.registry :as registry]))
+
+;; -- Schema re-exports --
+(def TrustLevel pack-schema/TrustLevel)
+(def AuthorityChannel pack-schema/AuthorityChannel)
+(def PipelinePackManifest pack-schema/PipelinePackManifest)
+(def trust-levels pack-schema/trust-levels)
+(def authority-channels pack-schema/authority-channels)
+
+;; -- Validation --
+(def valid-manifest? pack-schema/valid-manifest?)
+(def validate-manifest pack-schema/validate-manifest)
+
+;; -- Loading --
+(defn load-pack
+  "Load a pipeline pack from a directory path.
+   Returns {:success? true :pack ...} or {:success? false :error ...}"
+  [dir-path]
+  (loader/load-pack-from-directory dir-path))
+
+(defn discover-packs
+  "Discover all pipeline packs in a directory.
+   Returns vector of {:path string :pack-id string}."
+  [packs-dir]
+  (loader/discover-packs packs-dir))
+
+(defn load-all-packs
+  "Load all packs from a packs directory.
+   Returns {:loaded [...] :failed [...]}."
+  [packs-dir]
+  (loader/load-all-packs packs-dir))
+
+;; -- Registry --
+(defn create-registry
+  "Create a new empty pack registry (atom-backed)."
+  []
+  (registry/create-registry))
+
+(defn register-pack!
+  "Register a loaded pack in the registry."
+  [reg pack]
+  (registry/register-pack! reg pack))
+
+(defn unregister-pack!
+  "Remove a pack from the registry by id."
+  [reg pack-id]
+  (registry/unregister-pack! reg pack-id))
+
+(defn get-pack
+  "Get a pack by id from registry."
+  [reg pack-id]
+  (registry/get-pack reg pack-id))
+
+(defn list-packs
+  "List all registered packs."
+  [reg]
+  (registry/list-packs reg))
+
+(defn list-pack-ids
+  "List all registered pack ids."
+  [reg]
+  (registry/list-pack-ids reg))
+
+(defn pack-count
+  "Return number of registered packs."
+  [reg]
+  (registry/pack-count reg))
+
+;; -- Trust --
+(defn validate-pack-trust
+  "Validate that a pack's trust/authority combination is legal."
+  [pack]
+  (registry/validate-pack-trust pack))

--- a/components/pipeline-pack/src/ai/miniforge/data_foundry/pipeline_pack/loader.clj
+++ b/components/pipeline-pack/src/ai/miniforge/data_foundry/pipeline_pack/loader.clj
@@ -1,0 +1,192 @@
+(ns ai.miniforge.data-foundry.pipeline-pack.loader
+  "Load pipeline packs from disk.
+
+   Layer 0: EDN parsing, normalization
+   Layer 1: Directory loader (reads manifest, resolves relative paths)
+   Layer 2: Discovery and batch loading"
+  (:require
+   [ai.miniforge.schema.interface :as schema]
+   [ai.miniforge.data-foundry.pipeline-pack.schema :as pack-schema]
+   [ai.miniforge.data-foundry.pipeline-pack.messages :as msg]
+   [ai.miniforge.data-foundry.metric-registry.interface :as metric-registry]
+   [clojure.java.io :as io]
+   [clojure.edn :as edn]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; EDN parsing and normalization
+
+(defn safe-read-edn
+  "Safely read EDN from a file. Returns {:success? bool :data any :error string}."
+  [file]
+  (try
+    (let [content (slurp file)
+          data (edn/read-string content)]
+      {:success? true :data data :error nil})
+    (catch Exception e
+      {:success? false :data nil :error (.getMessage e)})))
+
+(defn ensure-instant
+  "Convert timestamp representations to Instant."
+  [value]
+  (cond
+    (inst? value) value
+    (string? value) (try
+                      (java.time.Instant/parse value)
+                      (catch Exception _
+                        (java.time.Instant/now)))
+    :else (java.time.Instant/now)))
+
+(defn normalize-manifest
+  "Normalize a pack manifest, applying defaults."
+  [manifest]
+  (-> manifest
+      (update :pack/trust-level #(or % :untrusted))
+      (update :pack/authority #(or % :authority/data))
+      (update :pack/pipelines #(or % []))
+      (update :pack/envs #(or % []))
+      (update :pack/extends #(or % []))
+      (update :pack/created-at ensure-instant)
+      (update :pack/updated-at ensure-instant)
+      (cond->
+        (and (:pack/connector-types manifest)
+             (not (set? (:pack/connector-types manifest))))
+        (update :pack/connector-types set))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Path helpers
+
+(defn- resolve-relative-path
+  "Resolve a relative path against a base directory."
+  [dir relative]
+  (.getPath (io/file dir relative)))
+
+(defn- load-metric-registry-file
+  "Load a metric registry relative to a pack directory."
+  [dir registry-path]
+  (let [reg-file (io/file dir registry-path)]
+    (if (.exists reg-file)
+      (metric-registry/load-registry (.getPath reg-file))
+      (schema/failure :registry (msg/t :pack/registry-not-found {:path registry-path})))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Directory loader — helpers
+
+(defn- resolve-pipelines
+  "Resolve pipeline paths relative to pack directory."
+  [dir manifest]
+  (mapv (partial resolve-relative-path dir) (:pack/pipelines manifest)))
+
+(defn- resolve-envs
+  "Resolve env paths relative to pack directory."
+  [dir manifest]
+  (mapv (partial resolve-relative-path dir) (:pack/envs manifest)))
+
+(defn- attach-registry
+  "Attach metric registry result to a pack map."
+  [pack registry-result]
+  (cond
+    (nil? registry-result)          pack
+    (:success? registry-result)     (assoc pack :pack/registry (:registry registry-result))
+    :else                           (assoc pack :pack/registry-error (:error registry-result))))
+
+(defn- build-pack-from-manifest
+  "Given a validated manifest and its directory, resolve paths, load registry,
+   and assemble the pack map."
+  [dir manifest]
+  (let [registry-path   (:pack/metric-registry manifest)
+        registry-result (when registry-path
+                          (load-metric-registry-file dir registry-path))
+        pack (-> {:pack/manifest  manifest
+                  :pack/dir       (.getPath dir)
+                  :pack/pipelines (resolve-pipelines dir manifest)
+                  :pack/envs      (resolve-envs dir manifest)}
+                 (attach-registry registry-result))]
+    (schema/success :pack pack)))
+
+(defn- read-and-validate-manifest
+  "Read pack.edn, normalize, validate, and build the pack if valid."
+  [dir manifest-file]
+  (let [{:keys [success? data error]} (safe-read-edn manifest-file)]
+    (if-not success?
+      (schema/failure :pack (msg/t :pack/manifest-read-error {:error error}))
+      (let [manifest (normalize-manifest data)
+            {:keys [valid? errors]} (pack-schema/validate-manifest manifest)]
+        (if-not valid?
+          (schema/failure :pack (msg/t :pack/manifest-invalid {:errors (pr-str errors)}))
+          (build-pack-from-manifest dir manifest))))))
+
+;; Directory loader — public
+
+(defn load-pack-from-directory
+  "Load a pipeline pack from a directory.
+
+   Expected structure:
+     my-pack/
+       pack.edn              — manifest
+       metric-registry.edn   — optional metric registry
+       pipelines/             — pipeline definitions (paths in manifest)
+       envs/                  — env configs (paths in manifest)
+
+   Returns lazy pack: manifest + registry loaded, pipeline paths resolved but not parsed.
+   Caller uses pipeline-config/load-pipeline on demand."
+  [dir-path]
+  (let [dir (io/file dir-path)
+        manifest-file (io/file dir "pack.edn")]
+    (cond
+      (not (.exists dir))
+      (schema/failure :pack (msg/t :pack/dir-not-found {:path dir-path}))
+
+      (not (.exists manifest-file))
+      (schema/failure :pack (msg/t :pack/manifest-not-found {:path dir-path}))
+
+      :else
+      (read-and-validate-manifest dir manifest-file))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Discovery
+
+(defn- directory? [f] (.isDirectory f))
+
+(defn- has-manifest? [dir] (.exists (io/file dir "pack.edn")))
+
+(defn- dir->pack-entry
+  "Convert a directory File to a discovery entry."
+  [d]
+  {:path (.getPath d) :pack-id (.getName d)})
+
+(defn discover-packs
+  "Discover all pipeline packs in a directory.
+
+   Looks for subdirectories containing pack.edn.
+
+   Returns vector of {:path string :pack-id string}."
+  [packs-dir]
+  (let [dir (io/file packs-dir)]
+    (when (.exists dir)
+      (->> (.listFiles dir)
+           (filter directory?)
+           (filter has-manifest?)
+           (mapv dir->pack-entry)))))
+
+(defn- load-discovered-pack
+  "Load a single discovered pack entry, tagging with pack-id and path."
+  [{:keys [path pack-id]}]
+  (assoc (load-pack-from-directory path)
+         :pack-id pack-id
+         :path path))
+
+(defn- failed-pack-summary
+  "Extract summary fields from a failed pack load result."
+  [result]
+  (select-keys result [:pack-id :path :error]))
+
+(defn load-all-packs
+  "Load all packs from a packs directory.
+
+   Returns {:loaded [...] :failed [...]}."
+  [packs-dir]
+  (let [discovered (discover-packs packs-dir)
+        results (mapv load-discovered-pack discovered)
+        loaded (vec (keep :pack (filter :success? results)))
+        failed (vec (map failed-pack-summary (remove :success? results)))]
+    {:loaded loaded :failed failed}))

--- a/components/pipeline-pack/src/ai/miniforge/data_foundry/pipeline_pack/messages.clj
+++ b/components/pipeline-pack/src/ai/miniforge/data_foundry/pipeline_pack/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.pipeline-pack.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/pipeline-pack/messages/en-US.edn" :pipeline-pack/messages))

--- a/components/pipeline-pack/src/ai/miniforge/data_foundry/pipeline_pack/registry.clj
+++ b/components/pipeline-pack/src/ai/miniforge/data_foundry/pipeline_pack/registry.clj
@@ -1,0 +1,71 @@
+(ns ai.miniforge.data-foundry.pipeline-pack.registry
+  "In-memory pipeline pack registry.
+
+   Atom-backed store for loaded packs. Supports register, list, query, and
+   trust validation."
+  (:require [ai.miniforge.data-foundry.pipeline-pack.messages :as msg]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Registry creation
+
+(defn create-registry
+  "Create a new empty pack registry."
+  []
+  (atom {}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Mutations
+
+(defn register-pack!
+  "Register a loaded pack in the registry. Returns the registry.
+   Pack must have :pack/manifest with :pack/id."
+  [registry pack]
+  (let [pack-id (get-in pack [:pack/manifest :pack/id])]
+    (swap! registry assoc pack-id pack)
+    registry))
+
+(defn unregister-pack!
+  "Remove a pack from the registry by id."
+  [registry pack-id]
+  (swap! registry dissoc pack-id)
+  registry)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Queries
+
+(defn get-pack
+  "Get a pack by id. Returns nil if not found."
+  [registry pack-id]
+  (get @registry pack-id))
+
+(defn list-packs
+  "List all registered packs. Returns vector of pack maps."
+  [registry]
+  (vec (vals @registry)))
+
+(defn list-pack-ids
+  "List all registered pack ids."
+  [registry]
+  (vec (keys @registry)))
+
+(defn pack-count
+  "Return number of registered packs."
+  [registry]
+  (count @registry))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Trust validation
+
+(defn validate-pack-trust
+  "Validate that a pack's trust level is compatible with its authority.
+   Data-only packs (:authority/data) work at any trust level.
+   Instruction packs (:authority/instruction) require :trusted."
+  [pack]
+  (let [manifest (:pack/manifest pack)
+        trust (:pack/trust-level manifest)
+        authority (:pack/authority manifest)]
+    (if (and (= authority :authority/instruction)
+             (not= trust :trusted))
+      {:valid? false
+       :error (msg/t :pack/trust-violation {:id (:pack/id manifest) :trust trust})}
+      {:valid? true})))

--- a/components/pipeline-pack/src/ai/miniforge/data_foundry/pipeline_pack/schema.clj
+++ b/components/pipeline-pack/src/ai/miniforge/data_foundry/pipeline_pack/schema.clj
@@ -1,0 +1,77 @@
+(ns ai.miniforge.data-foundry.pipeline-pack.schema
+  "Malli schemas for pipeline pack manifests.
+
+   Layer 0: Enums (TrustLevel, AuthorityChannel)
+   Layer 1: PackManifest schema
+   Layer 2: Validation helpers"
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Enums
+
+(def trust-levels
+  [:tainted :untrusted :trusted])
+
+(def TrustLevel
+  (into [:enum] trust-levels))
+
+(def authority-channels
+  [:authority/data :authority/instruction])
+
+(def AuthorityChannel
+  (into [:enum] authority-channels))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pack manifest schema
+
+(def PipelinePackManifest
+  "Schema for a pipeline pack manifest.
+
+   Trust model mirrors policy-pack:
+   - :untrusted (default) — data-only packs, no code execution
+   - :trusted — may use :authority/instruction (code-bearing packs)
+   - :tainted — flagged, must not be used for instruction"
+  [:map
+   [:pack/id string?]
+   [:pack/name string?]
+   [:pack/version string?]
+   [:pack/description string?]
+   [:pack/author string?]
+   [:pack/trust-level TrustLevel]
+   [:pack/authority AuthorityChannel]
+   [:pack/pipelines [:vector string?]]
+   [:pack/envs [:vector string?]]
+   [:pack/metric-registry {:optional true} string?]
+   [:pack/connector-types {:optional true} [:set keyword?]]
+   [:pack/extends {:optional true} [:vector [:map [:pack-id string?]]]]
+   [:pack/created-at inst?]
+   [:pack/updated-at inst?]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; Validation helpers
+
+(defn valid?
+  [schema value]
+  (m/validate schema value))
+
+(defn validate
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn explain
+  [schema value]
+  (when-let [explanation (m/explain schema value)]
+    (me/humanize explanation)))
+
+(defn valid-manifest?
+  [value]
+  (valid? PipelinePackManifest value))
+
+(defn validate-manifest
+  [value]
+  (validate PipelinePackManifest value))

--- a/components/pipeline-pack/test/ai/miniforge/data_foundry/pipeline_pack/interface_test.clj
+++ b/components/pipeline-pack/test/ai/miniforge/data_foundry/pipeline_pack/interface_test.clj
@@ -1,0 +1,33 @@
+(ns ai.miniforge.data-foundry.pipeline-pack.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.pipeline-pack.interface :as pp]
+            [clojure.java.io :as io]))
+
+(def ^:private simple-pack-dir
+  (-> (io/resource "test-packs/simple-pack/pack.edn")
+      io/file .getParentFile .getPath))
+
+(deftest interface-load-test
+  (testing "Load pack via interface"
+    (let [result (pp/load-pack simple-pack-dir)]
+      (is (:success? result))
+      (is (= "simple-pack" (get-in result [:pack :pack/manifest :pack/id]))))))
+
+(deftest interface-registry-test
+  (testing "Full registry workflow via interface"
+    (let [result (pp/load-pack simple-pack-dir)
+          pack (:pack result)
+          reg (pp/create-registry)]
+      (pp/register-pack! reg pack)
+      (is (= 1 (pp/pack-count reg)))
+      (is (= ["simple-pack"] (pp/list-pack-ids reg)))
+      (is (some? (pp/get-pack reg "simple-pack")))
+
+      (pp/unregister-pack! reg "simple-pack")
+      (is (= 0 (pp/pack-count reg))))))
+
+(deftest interface-trust-test
+  (testing "Trust validation via interface"
+    (let [result (pp/load-pack simple-pack-dir)
+          pack (:pack result)]
+      (is (:valid? (pp/validate-pack-trust pack))))))

--- a/components/pipeline-pack/test/ai/miniforge/data_foundry/pipeline_pack/loader_test.clj
+++ b/components/pipeline-pack/test/ai/miniforge/data_foundry/pipeline_pack/loader_test.clj
@@ -1,0 +1,97 @@
+(ns ai.miniforge.data-foundry.pipeline-pack.loader-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.pipeline-pack.loader :as loader]
+            [ai.miniforge.data-foundry.pipeline-pack.schema :as pack-schema]
+            [clojure.java.io :as io]))
+
+(def ^:private simple-pack-dir
+  (-> (io/resource "test-packs/simple-pack/pack.edn")
+      io/file .getParentFile .getPath))
+
+(def ^:private test-packs-dir
+  (-> (io/resource "test-packs/simple-pack/pack.edn")
+      io/file .getParentFile .getParentFile .getPath))
+
+;; -- Schema validation --
+
+(deftest validate-manifest-test
+  (testing "Valid manifest passes"
+    (let [manifest {:pack/id "test" :pack/name "Test" :pack/version "1.0"
+                    :pack/description "Test pack" :pack/author "test"
+                    :pack/trust-level :untrusted :pack/authority :authority/data
+                    :pack/pipelines ["p.edn"] :pack/envs ["e.edn"]
+                    :pack/created-at (java.time.Instant/now)
+                    :pack/updated-at (java.time.Instant/now)}]
+      (is (true? (pack-schema/valid-manifest? manifest)))))
+
+  (testing "Missing required field fails"
+    (is (false? (pack-schema/valid-manifest? {:pack/id "test"}))))
+
+  (testing "Invalid trust level fails"
+    (is (false? (pack-schema/valid-manifest?
+                 {:pack/id "test" :pack/name "Test" :pack/version "1.0"
+                  :pack/description "d" :pack/author "a"
+                  :pack/trust-level :invalid
+                  :pack/authority :authority/data
+                  :pack/pipelines [] :pack/envs []
+                  :pack/created-at (java.time.Instant/now)
+                  :pack/updated-at (java.time.Instant/now)})))))
+
+;; -- Loader --
+
+(deftest load-pack-from-directory-test
+  (testing "Load valid pack from test fixtures"
+    (let [result (loader/load-pack-from-directory simple-pack-dir)]
+      (is (:success? result))
+      (let [pack (:pack result)]
+        (is (= "simple-pack" (get-in pack [:pack/manifest :pack/id])))
+        (is (= :untrusted (get-in pack [:pack/manifest :pack/trust-level])))
+        (is (= :authority/data (get-in pack [:pack/manifest :pack/authority])))
+        (is (= 1 (count (:pack/pipelines pack))))
+        (is (= 1 (count (:pack/envs pack))))
+        (is (.endsWith (first (:pack/pipelines pack)) "test-pipeline.edn")))))
+
+  (testing "Pack includes loaded metric registry"
+    (let [result (loader/load-pack-from-directory simple-pack-dir)
+          pack (:pack result)]
+      (is (some? (:pack/registry pack)))
+      (is (= "test-metrics" (:registry/id (:pack/registry pack))))))
+
+  (testing "Nonexistent directory returns failure"
+    (let [result (loader/load-pack-from-directory "/nonexistent/path")]
+      (is (not (:success? result)))))
+
+  (testing "Directory without pack.edn returns failure"
+    (let [result (loader/load-pack-from-directory test-packs-dir)]
+      (is (not (:success? result))))))
+
+;; -- Normalization --
+
+(deftest normalize-defaults-test
+  (testing "Defaults applied to minimal manifest"
+    (let [minimal {:pack/id "x" :pack/name "X" :pack/version "1"
+                   :pack/description "d" :pack/author "a"
+                   :pack/created-at #inst "2026-03-17"
+                   :pack/updated-at #inst "2026-03-17"}
+          normalized (loader/normalize-manifest minimal)]
+      (is (= :untrusted (:pack/trust-level normalized)))
+      (is (= :authority/data (:pack/authority normalized)))
+      (is (= [] (:pack/pipelines normalized)))
+      (is (= [] (:pack/envs normalized))))))
+
+;; -- Discovery --
+
+(deftest discover-packs-test
+  (testing "Discovers packs in test directory"
+    (let [packs (loader/discover-packs test-packs-dir)]
+      (is (= 1 (count packs)))
+      (is (= "simple-pack" (:pack-id (first packs))))))
+
+  (testing "Returns nil for nonexistent directory"
+    (is (nil? (loader/discover-packs "/nonexistent")))))
+
+(deftest load-all-packs-test
+  (testing "Loads all discovered packs"
+    (let [result (loader/load-all-packs test-packs-dir)]
+      (is (= 1 (count (:loaded result))))
+      (is (empty? (:failed result))))))

--- a/components/pipeline-pack/test/ai/miniforge/data_foundry/pipeline_pack/registry_test.clj
+++ b/components/pipeline-pack/test/ai/miniforge/data_foundry/pipeline_pack/registry_test.clj
@@ -1,0 +1,86 @@
+(ns ai.miniforge.data-foundry.pipeline-pack.registry-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.pipeline-pack.registry :as registry]))
+
+(def ^:private sample-pack
+  {:pack/manifest {:pack/id "test-pack"
+                   :pack/name "Test Pack"
+                   :pack/trust-level :untrusted
+                   :pack/authority :authority/data}
+   :pack/dir "/tmp/test"
+   :pack/pipelines ["/tmp/test/p.edn"]
+   :pack/envs ["/tmp/test/e.edn"]})
+
+(def ^:private trusted-instruction-pack
+  {:pack/manifest {:pack/id "trusted-instr"
+                   :pack/name "Trusted Instruction Pack"
+                   :pack/trust-level :trusted
+                   :pack/authority :authority/instruction}
+   :pack/dir "/tmp/trusted"
+   :pack/pipelines []
+   :pack/envs []})
+
+(def ^:private untrusted-instruction-pack
+  {:pack/manifest {:pack/id "bad-pack"
+                   :pack/name "Bad Pack"
+                   :pack/trust-level :untrusted
+                   :pack/authority :authority/instruction}
+   :pack/dir "/tmp/bad"
+   :pack/pipelines []
+   :pack/envs []})
+
+;; -- Registry CRUD --
+
+(deftest registry-lifecycle-test
+  (testing "Create empty registry"
+    (let [reg (registry/create-registry)]
+      (is (= 0 (registry/pack-count reg)))))
+
+  (testing "Register and retrieve pack"
+    (let [reg (registry/create-registry)]
+      (registry/register-pack! reg sample-pack)
+      (is (= 1 (registry/pack-count reg)))
+      (let [retrieved (registry/get-pack reg "test-pack")]
+        (is (some? retrieved))
+        (is (= "test-pack" (get-in retrieved [:pack/manifest :pack/id]))))))
+
+  (testing "List packs and ids"
+    (let [reg (registry/create-registry)]
+      (registry/register-pack! reg sample-pack)
+      (registry/register-pack! reg trusted-instruction-pack)
+      (is (= 2 (registry/pack-count reg)))
+      (is (= #{"test-pack" "trusted-instr"} (set (registry/list-pack-ids reg))))
+      (is (= 2 (count (registry/list-packs reg))))))
+
+  (testing "Unregister pack"
+    (let [reg (registry/create-registry)]
+      (registry/register-pack! reg sample-pack)
+      (registry/unregister-pack! reg "test-pack")
+      (is (= 0 (registry/pack-count reg)))
+      (is (nil? (registry/get-pack reg "test-pack")))))
+
+  (testing "Get nonexistent pack returns nil"
+    (let [reg (registry/create-registry)]
+      (is (nil? (registry/get-pack reg "nope"))))))
+
+;; -- Trust validation --
+
+(deftest trust-validation-test
+  (testing "Data-only + untrusted is valid"
+    (let [result (registry/validate-pack-trust sample-pack)]
+      (is (:valid? result))))
+
+  (testing "Instruction + trusted is valid"
+    (let [result (registry/validate-pack-trust trusted-instruction-pack)]
+      (is (:valid? result))))
+
+  (testing "Instruction + untrusted is invalid"
+    (let [result (registry/validate-pack-trust untrusted-instruction-pack)]
+      (is (not (:valid? result)))
+      (is (some? (:error result)))))
+
+  (testing "Data-only + tainted is valid (data packs work at any trust)"
+    (let [tainted-data {:pack/manifest {:pack/id "tainted"
+                                        :pack/trust-level :tainted
+                                        :pack/authority :authority/data}}]
+      (is (:valid? (registry/validate-pack-trust tainted-data))))))

--- a/components/pipeline-pack/test/resources/test-packs/simple-pack/envs/local.edn
+++ b/components/pipeline-pack/test/resources/test-packs/simple-pack/envs/local.edn
@@ -1,0 +1,5 @@
+{:env/name "test-local"
+ :env/connectors
+ {:conn/test-src {:connector/type :file}}
+ :env/stages
+ {"Ingest" {:file/path "test-data.json" :file/format :json}}}

--- a/components/pipeline-pack/test/resources/test-packs/simple-pack/metric-registry.edn
+++ b/components/pipeline-pack/test/resources/test-packs/simple-pack/metric-registry.edn
@@ -1,0 +1,18 @@
+{:registry/id      "test-metrics"
+ :registry/version "2026.03.17"
+ :registry/families
+ [{:family/id       :test-family
+   :family/name     "Test Metrics"
+   :family/metrics
+   [{:metric/id              "TEST_METRIC_1"
+     :metric/name            "Test Metric 1"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "TEST"
+     :metric/refresh-cadence :daily
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :percent}]}]
+ :registry/pipeline-metric-map
+ {"test-pipeline" ["TEST_METRIC_1"]}}

--- a/components/pipeline-pack/test/resources/test-packs/simple-pack/pack.edn
+++ b/components/pipeline-pack/test/resources/test-packs/simple-pack/pack.edn
@@ -1,0 +1,14 @@
+{:pack/id          "simple-pack"
+ :pack/name        "Simple Test Pack"
+ :pack/version     "2026.03.17"
+ :pack/description "A minimal pipeline pack for testing"
+ :pack/author      "test"
+ :pack/trust-level :untrusted
+ :pack/authority   :authority/data
+ :pack/pipelines   ["pipelines/test-pipeline.edn"]
+ :pack/envs        ["envs/local.edn"]
+ :pack/metric-registry "metric-registry.edn"
+ :pack/connector-types #{:http :file}
+ :pack/extends     []
+ :pack/created-at  #inst "2026-03-17T00:00:00Z"
+ :pack/updated-at  #inst "2026-03-17T00:00:00Z"}

--- a/components/pipeline-pack/test/resources/test-packs/simple-pack/pipelines/test-pipeline.edn
+++ b/components/pipeline-pack/test/resources/test-packs/simple-pack/pipelines/test-pipeline.edn
@@ -1,0 +1,12 @@
+{:pipeline/name    "Test Pipeline"
+ :pipeline/version "0.1.0"
+ :pipeline/mode    :full-refresh
+ :pipeline/stages
+ [{:stage/name           "Ingest"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/test-src
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/raw]
+   :stage/dependencies    []}]
+ :pipeline/input-datasets  []
+ :pipeline/output-datasets []}

--- a/components/pipeline-runner/deps.edn
+++ b/components/pipeline-runner/deps.edn
@@ -3,8 +3,8 @@
         ai.miniforge.data-foundry/data-quality  {:local/root "../data-quality"}
         ai.miniforge.data-foundry/dataset       {:local/root "../dataset"}
         ai.miniforge.data-foundry/pipeline      {:local/root "../pipeline"}
-        ai.miniforge/dag-executor     {:local/root "../../../miniforge/components/dag-executor"}
-        ai.miniforge/event-stream     {:local/root "../../../miniforge/components/event-stream"}
-        ai.miniforge/schema           {:local/root "../../../miniforge/components/schema"}}
+        ai.miniforge/dag-executor     {:local/root "../dag-executor"}
+        ai.miniforge/event-stream     {:local/root "../event-stream"}
+        ai.miniforge/schema           {:local/root "../schema"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/pipeline-runner/deps.edn
+++ b/components/pipeline-runner/deps.edn
@@ -1,0 +1,10 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge.data-foundry/connector     {:local/root "../connector"}
+        ai.miniforge.data-foundry/data-quality  {:local/root "../data-quality"}
+        ai.miniforge.data-foundry/dataset       {:local/root "../dataset"}
+        ai.miniforge.data-foundry/pipeline      {:local/root "../pipeline"}
+        ai.miniforge/dag-executor     {:local/root "../../../miniforge/components/dag-executor"}
+        ai.miniforge/event-stream     {:local/root "../../../miniforge/components/event-stream"}
+        ai.miniforge/schema           {:local/root "../../../miniforge/components/schema"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/pipeline-runner/resources/config/pipeline-runner/messages/en-US.edn
+++ b/components/pipeline-runner/resources/config/pipeline-runner/messages/en-US.edn
@@ -1,0 +1,11 @@
+{:pipeline-runner/messages
+ {;; Pipeline run validation (core.clj)
+  :run/id-required          ":pipeline-run/id is required"
+  :run/pipeline-id-required ":pipeline-run/pipeline-id is required"
+  :run/version-required     ":pipeline-run/version is required"
+  :run/mode-invalid         ":pipeline-run/mode is invalid"
+  :run/status-invalid       ":pipeline-run/status is invalid"
+
+  ;; Execution errors (run.clj)
+  :run/connector-not-found  "No connector found for ref: {ref}"
+  :run/stage-failed         "Stage failed: {name}"}}

--- a/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/core.clj
+++ b/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/core.clj
@@ -1,0 +1,42 @@
+(ns ai.miniforge.data-foundry.pipeline-runner.core
+  (:require [ai.miniforge.data-foundry.pipeline-runner.messages :as msg]
+            [ai.miniforge.schema.interface :as schema])
+  (:import [java.util UUID]
+           [java.time Instant]))
+
+(def run-statuses
+  #{:pending :executing :completed :failed :cancelled})
+
+(defn create-pipeline-run
+  "Create a new PipelineRun per N3 §2.4."
+  [{:pipeline-run/keys [pipeline-id version mode] :as opts}]
+  (let [now (Instant/now)
+        run (merge
+             {:pipeline-run/id (UUID/randomUUID)
+              :pipeline-run/pipeline-id pipeline-id
+              :pipeline-run/version version
+              :pipeline-run/mode (or mode :full-refresh)
+              :pipeline-run/status :pending
+              :pipeline-run/input-dataset-versions []
+              :pipeline-run/output-dataset-versions []
+              :pipeline-run/stage-runs []
+              :pipeline-run/connector-cursors {}
+              :pipeline-run/policy-evaluations []
+              :pipeline-run/created-at now}
+             (dissoc opts :pipeline-run/pipeline-id :pipeline-run/version :pipeline-run/mode))]
+    (schema/success :pipeline-run run)))
+
+(defn validate-pipeline-run
+  [{:pipeline-run/keys [id pipeline-id version mode status]}]
+  (let [errors
+        (cond-> []
+          (nil? id) (conj (msg/t :run/id-required))
+          (nil? pipeline-id) (conj (msg/t :run/pipeline-id-required))
+          (nil? version) (conj (msg/t :run/version-required))
+          (not (contains? #{:full-refresh :incremental :backfill :reprocess} mode))
+          (conj (msg/t :run/mode-invalid))
+          (not (contains? run-statuses status))
+          (conj (msg/t :run/status-invalid)))]
+    (if (empty? errors)
+      (schema/valid)
+      (schema/invalid-with-errors errors))))

--- a/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/interface.clj
+++ b/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/interface.clj
@@ -1,0 +1,37 @@
+(ns ai.miniforge.data-foundry.pipeline-runner.interface
+  (:require [ai.miniforge.data-foundry.pipeline-runner.core :as core]
+            [ai.miniforge.data-foundry.pipeline-runner.run :as run]
+            [ai.miniforge.data-foundry.pipeline-runner.transforms :as transforms]))
+
+;; -- Pipeline Run Status --
+(def run-statuses
+  "N3 §2.4 pipeline run statuses"
+  #{:pending :executing :completed :failed :cancelled})
+
+;; -- Pipeline Execution --
+(defn create-pipeline-run
+  "Create a new PipelineRun record.
+   Required: :pipeline-run/pipeline-id, :pipeline-run/version, :pipeline-run/mode
+   Returns schema/success with :pipeline-run key."
+  [opts]
+  (core/create-pipeline-run opts))
+
+(defn execute-pipeline
+  "Execute a pipeline in full-refresh mode.
+   Takes a pipeline definition, a map of connector implementations (keyed by connector-ref UUID),
+   and an optional context map.
+   Returns schema/success or schema/failure with :pipeline-run key."
+  [pipeline connectors context]
+  (run/execute-pipeline pipeline connectors context))
+
+(defn validate-pipeline-run
+  "Validate a PipelineRun record."
+  [pipeline-run]
+  (core/validate-pipeline-run pipeline-run))
+
+;; -- Built-in Transforms --
+
+(def built-in-transforms
+  "Map of built-in transform type keywords to transform functions.
+   Register these in the pipeline execution context under :transforms."
+  {:derived-ratio transforms/derived-ratio})

--- a/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/messages.clj
+++ b/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.pipeline-runner.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/pipeline-runner/messages/en-US.edn" :pipeline-runner/messages))

--- a/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/run.clj
@@ -1,0 +1,352 @@
+(ns ai.miniforge.data-foundry.pipeline-runner.run
+  (:require [ai.miniforge.data-foundry.pipeline.interface :as pipeline]
+            [ai.miniforge.data-foundry.connector.interface :as conn]
+            [ai.miniforge.data-foundry.data-quality.interface :as dq]
+            [ai.miniforge.data-foundry.pipeline-runner.core :as core]
+            [ai.miniforge.data-foundry.pipeline-runner.messages :as msg]
+            [ai.miniforge.dag-executor.interface :as dag]
+            [ai.miniforge.schema.interface :as schema])
+  (:import [java.time Instant]))
+
+(def default-config
+  "Default execution configuration. Override via stage :config map."
+  {:connector/page-size  1000
+   :publish/default-mode :append})
+
+(defn- stage-result
+  "Build a stage result map. Merges extras onto the base."
+  [id name status extras]
+  (merge {:stage/id id :stage/name name :status status :retry-count 0}
+         extras))
+
+(def ^:private auth-keys
+  "Keys that belong to auth config, extracted from stage config."
+  #{:auth/method :auth/credential-id :auth/credential-scope
+    :auth/client-id :auth/token-endpoint :auth/certificate-path :auth/vault-path})
+
+(defn- extract-auth
+  "Extract auth keys from a config map into a separate auth map."
+  [config]
+  (not-empty (select-keys config auth-keys)))
+
+(defn- resolve-schema-name
+  "Resolve the schema-name for a connector extract call.
+   Connectors use a resource key (e.g. \"issues\", \"pulls\") not the stage name.
+   Check for common resource config keys, falling back to the stage name."
+  [config stage-name]
+  (or (:github/resource config)
+      (:gitlab/resource config)
+      (:resource config)
+      stage-name))
+
+(defn- extract-cursor-map
+  [context]
+  (or (:pipeline-run/connector-cursors context)
+      (:connector-cursors context)
+      {}))
+
+(defn- cursor-entry->cursor
+  [entry]
+  (cond
+    (nil? entry) nil
+    (:cursor entry) (:cursor entry)
+    (:cursor/type entry) entry
+    :else nil))
+
+(defn- prior-cursor
+  [{:stage/keys [id connector-ref config name]} context]
+  (let [schema-name (resolve-schema-name config name)
+        cursor-map  (extract-cursor-map context)]
+    (or (some-> (get cursor-map id) cursor-entry->cursor)
+        (some-> (get cursor-map [connector-ref schema-name]) cursor-entry->cursor)
+        (some-> (get cursor-map connector-ref) cursor-entry->cursor))))
+
+(defn- cursor-entry
+  [{:stage/keys [id name connector-ref]} schema-name cursor]
+  {:stage/id            id
+   :stage/name          name
+   :stage/connector-ref connector-ref
+   :stage/schema-name   schema-name
+   :cursor              cursor
+   :cursor/updated-at   (Instant/now)})
+
+;;------------------------------------------------------------------------------ Stage executors
+
+(defn- execute-ingest-stage
+  "Execute an ingest stage using the connector's extract method."
+  [{:stage/keys [id name connector-ref config]} connectors context]
+  (let [connector (get connectors connector-ref)]
+    (if (nil? connector)
+      (stage-result id name :failed
+                    {:error-message (msg/t :run/connector-not-found {:ref connector-ref})})
+      (try
+        (let [auth   (or (extract-auth config) (get context :auth {}))
+              schema (resolve-schema-name config name)
+              cursor (prior-cursor {:stage/id id
+                                    :stage/name name
+                                    :stage/connector-ref connector-ref
+                                    :stage/config config}
+                                   context)
+              handle (:connection/handle (conn/connect connector (or config {}) auth))
+              result (conn/extract connector handle schema
+                                   (cond-> {:extract/batch-size (get config :connector/page-size
+                                                                     (:connector/page-size default-config))}
+                                     cursor (assoc :extract/cursor cursor)))]
+          (conn/close connector handle)
+          (stage-result id name :completed
+                        {:started-at (get context :started-at (Instant/now))
+                         :completed-at (Instant/now)
+                         :schema-name schema
+                         :records (:records result)
+                         :cursor (:extract/cursor result)}))
+        (catch Exception e
+          (stage-result id name :failed {:error-message (.getMessage e)}))))))
+
+(defn- execute-publish-stage
+  "Execute a publish stage using the connector's publish method."
+  [{:stage/keys [id name connector-ref config]} connectors context input-records]
+  (let [connector (get connectors connector-ref)]
+    (if (nil? connector)
+      (stage-result id name :failed
+                    {:error-message (msg/t :run/connector-not-found {:ref connector-ref})})
+      (try
+        (let [auth   (or (extract-auth config) (:auth context {}))
+              handle (:connection/handle (conn/connect connector (or config {}) auth))
+              result (conn/publish connector handle name input-records
+                                   {:publish/mode     (get config :publish-mode
+                                                          (:publish/default-mode default-config))
+                                    :publish/datasets (:publish/datasets context)})]
+          (conn/close connector handle)
+          (stage-result id name :completed {:completed-at (Instant/now)}))
+        (catch Exception e
+          (stage-result id name :failed {:error-message (.getMessage e)}))))))
+
+(defn- execute-transform-stage
+  "Execute a non-connector stage (normalize, transform, aggregate, etc.).
+   If :stage/transform config with :transform/type is present and a matching
+   transform fn exists in context :transforms, calls it with input records.
+   Otherwise passes records through unchanged."
+  [{:stage/keys [id name config]} context input-records]
+  (let [transform-type (get-in config [:stage/transform :transform/type])
+        transform-fn   (when transform-type
+                         (get-in context [:transforms transform-type]))]
+    (if transform-fn
+      (try
+        (let [result-records (transform-fn input-records config)]
+          (stage-result id name :completed
+                        {:started-at (Instant/now)
+                         :completed-at (Instant/now)
+                         :records result-records}))
+        (catch Exception e
+          (stage-result id name :failed {:error-message (.getMessage e)})))
+      (stage-result id name :completed
+                    {:started-at (Instant/now)
+                     :completed-at (Instant/now)
+                     :records input-records}))))
+
+(defn- execute-validate-stage
+  "Execute a validate stage using data-quality rules.
+   If :stage/quality-pack is present in config, evaluates records and filters.
+   Otherwise falls through to transform (pass-through)."
+  [{:stage/keys [id name config]} context input-records]
+  (if-let [quality-pack (:stage/quality-pack config)]
+    (let [evaluation (dq/evaluate-records (:pack/rules quality-pack) input-records)
+          passed     (dq/filter-passed evaluation)
+          report     (dq/generate-report (:pack/id quality-pack) evaluation)]
+      (stage-result id name :completed
+                    {:started-at (Instant/now)
+                     :completed-at (Instant/now)
+                     :records passed
+                     :quality-report report}))
+    (execute-transform-stage {:stage/id id :stage/name name :stage/config config} context input-records)))
+
+;;------------------------------------------------------------------------------ DAG scheduling helpers
+
+(defn- skip-remaining-tasks!
+  "Skip all still-pending tasks. Called when any stage fails to halt execution."
+  [run-atom]
+  (doseq [[task-id task] (:run/tasks @run-atom)
+          :when (= :pending (:task/status task))]
+    (dag/transition-task! run-atom task-id :skipped nil)))
+
+(defn- collect-inputs
+  "Collect input datasets and flattened records produced by upstream stages."
+  [stage-def stage-map stage-outputs]
+  (let [datasets (into {}
+                       (keep (fn [dep-id]
+                               (when-let [recs (get stage-outputs dep-id)]
+                                 [(get-in stage-map [dep-id :stage/name]) recs])))
+                       (:stage/dependencies stage-def))]
+    {:datasets datasets
+     :records  (vec (mapcat val datasets))}))
+
+(defn- run-stage
+  "Dispatch to the appropriate stage executor based on :stage/family."
+  [stage-def connectors context input-datasets input-records]
+  (case (:stage/family stage-def)
+    :ingest   (execute-ingest-stage stage-def connectors context)
+    :publish  (execute-publish-stage stage-def connectors
+                                     (assoc context :publish/datasets input-datasets)
+                                     input-records)
+    :validate (execute-validate-stage stage-def context input-records)
+    (execute-transform-stage stage-def context input-records)))
+
+(defn- apply-stage-result!
+  "Update run-atom based on stage result. Skips remaining tasks on failure."
+  [run-atom stage-id result]
+  (if (= :failed (:status result))
+    (do
+      (dag/mark-failed! run-atom stage-id {:reason (:error-message result)} nil)
+      (skip-remaining-tasks! run-atom))
+    (dag/mark-completed! run-atom stage-id nil)))
+
+;;------------------------------------------------------------------------------ Spawn support
+
+(defn- generate-spawns
+  "If the stage config contains :stage/spawn-fn, look up the function in
+   context [:spawn-fns] and call it with (records config) to produce spawn requests.
+   Returns a seq of spawn-request maps, or nil."
+  [stage-def context records]
+  (when-let [spawn-key (get-in stage-def [:stage/config :stage/spawn-fn])]
+    (when-let [spawn-fn (get-in context [:spawn-fns spawn-key])]
+      (seq (spawn-fn records (:stage/config stage-def))))))
+
+(defn- spawn->stage-def
+  "Convert a spawn-request map into a stage-def suitable for the stage-map.
+   Assigns a new stage id and wires the parent as a dependency.
+   Inherits :stage/connector-ref from parent when the spawn omits it."
+  [spawn parent-stage-def]
+  (let [parent-id (:stage/id parent-stage-def)]
+    {:stage/id            (random-uuid)
+     :stage/name          (:spawn/name spawn)
+     :stage/family        (or (:spawn/family spawn) :ingest)
+     :stage/connector-ref (or (:spawn/connector-ref spawn)
+                               (:stage/connector-ref parent-stage-def))
+     :stage/config        (:spawn/config spawn)
+     :stage/dependencies  [parent-id]
+     :stage/input-datasets  []
+     :stage/output-datasets (or (:spawn/output-datasets spawn) [])}))
+
+(defn- downstream-stage-ids
+  "Return the set of stage-map keys whose :stage/dependencies include parent-id."
+  [stage-map parent-id]
+  (into #{}
+        (keep (fn [[sid sd]]
+                (when (some #{parent-id} (:stage/dependencies sd)) sid)))
+        stage-map))
+
+(defn- inject-spawned-stages!
+  "Add spawned stage tasks to run-atom and return updated stage-map.
+   Each spawned task depends on the parent stage; it becomes ready once the
+   parent completes. Inherits connector-ref from parent when omitted.
+
+   Also adds each spawned stage as a dependency of any stages that already
+   depend on the parent, so those downstream stages wait for and collect
+   records from all spawned children."
+  [run-atom stage-map spawns parent-stage-def]
+  (let [parent-id (:stage/id parent-stage-def)
+        ds-ids    (downstream-stage-ids stage-map parent-id)]
+    (reduce (fn [sm spawn]
+              (let [stage-def (spawn->stage-def spawn parent-stage-def)
+                    stage-id  (:stage/id stage-def)]
+                ;; Register the spawned task — depends on parent only.
+                (swap! run-atom update :run/tasks assoc stage-id
+                       (dag/create-task-state stage-id #{parent-id}))
+                ;; Wire spawned stage into each downstream stage's dep-set so
+                ;; those stages wait for (and collect records from) all children.
+                (doseq [ds-id ds-ids]
+                  (swap! run-atom update-in [:run/tasks ds-id :task/deps] conj stage-id))
+                ;; Mirror the dep-set update in the stage-map so collect-inputs
+                ;; can look up the spawned stage's records via its UUID.
+                (reduce (fn [sm' ds-id]
+                          (update-in sm' [ds-id :stage/dependencies] conj stage-id))
+                        (assoc sm stage-id stage-def)
+                        ds-ids)))
+            stage-map
+            spawns)))
+
+;;------------------------------------------------------------------------------ Scheduling loop
+
+(defn- step-pipeline
+  "Execute the next ready stage. Returns [stage-outputs stage-runs cursors stage-map].
+   If the stage defines a :stage/spawn-fn, spawned child tasks are injected into
+   the run-atom and stage-map before the parent is marked complete."
+  [run-atom stage-map connectors context stage-outputs stage-runs cursors]
+  (let [stage-id  (first (dag/ready-tasks @run-atom))
+        stage-def (get stage-map stage-id)
+        _         (dag/transition-task! run-atom stage-id :ready nil)
+        _         (dag/transition-task! run-atom stage-id :running nil)
+        {:keys [datasets records]} (collect-inputs stage-def stage-map stage-outputs)
+        result    (run-stage stage-def connectors context datasets records)
+
+        ;; Inject spawned child stages before marking parent terminal so they
+        ;; depend on parent-id and become ready once parent completes.
+        spawns         (when (= :completed (:status result))
+                         (generate-spawns stage-def context (:records result)))
+        new-stage-map  (if (seq spawns)
+                         (inject-spawned-stages! run-atom stage-map spawns stage-def)
+                         stage-map)
+        _              (apply-stage-result! run-atom stage-id result)]
+    [(if (:records result) (assoc stage-outputs stage-id (:records result)) stage-outputs)
+     (conj stage-runs (dissoc result :records :cursor))
+     (if (:cursor result)
+       (assoc cursors stage-id (cursor-entry stage-def (:schema-name result) (:cursor result)))
+       cursors)
+     new-stage-map]))
+
+(defn- run-pipeline-dag
+  "Loop over the DAG until all stages reach a terminal state.
+   Returns {:stage-runs [...] :cursors {...} :failed? bool}."
+  [run-atom stage-map connectors context]
+  (loop [stage-outputs {}
+         stage-runs    []
+         cursors       {}
+         sm            stage-map]
+    (if (dag/all-terminal? @run-atom)
+      {:stage-runs stage-runs
+       :cursors    cursors
+       :failed?    (seq (:run/failed @run-atom))}
+      (let [[outputs' runs' cursors' sm']
+            (step-pipeline run-atom sm connectors context stage-outputs stage-runs cursors)]
+        (recur outputs' runs' cursors' sm')))))
+
+;;------------------------------------------------------------------------------ Public API
+
+(defn execute-pipeline
+  "Execute a pipeline using dag-executor for dependency scheduling.
+   Runs stages in topological order. Each stage result feeds into dependent stages.
+   Stops on first failure — skips all remaining pending stages.
+
+   context may include:
+     :transforms  — map of keyword → (fn [records config] -> records)
+     :spawn-fns   — map of keyword → (fn [records config] -> [spawn-request ...])"
+  [pipeline-def connectors context]
+  (let [validation (pipeline/validate-pipeline pipeline-def)]
+    (if-not (:success? validation)
+      (schema/failure-with-errors :pipeline-run (:errors validation))
+      (let [{:pipeline/keys [id version stages mode]} pipeline-def
+            run-result   (core/create-pipeline-run
+                          {:pipeline-run/pipeline-id id
+                           :pipeline-run/version version
+                           :pipeline-run/mode (or mode :full-refresh)})
+            pipeline-run (:pipeline-run run-result)
+            stage-map    (into {} (map (juxt :stage/id identity)) stages)
+            task-defs    (map (fn [{:stage/keys [id dependencies]}]
+                                {:task/id id :task/deps (set dependencies)})
+                              stages)
+            run-atom     (dag/create-run-atom
+                           (dag/create-dag-from-tasks (random-uuid) task-defs))
+            {:keys [stage-runs cursors failed?]}
+            (run-pipeline-dag run-atom stage-map connectors context)
+            final-run    (assoc pipeline-run
+                                :pipeline-run/status (if failed? :failed :completed)
+                                :pipeline-run/stage-runs stage-runs
+                                :pipeline-run/connector-cursors cursors
+                                :pipeline-run/started-at (:pipeline-run/created-at pipeline-run)
+                                :pipeline-run/completed-at (Instant/now))]
+        (if failed?
+          (schema/failure :pipeline-run
+                          (msg/t :run/stage-failed
+                                 {:name (:stage/name (first (filter #(= :failed (:status %)) stage-runs)))})
+                          {:pipeline-run final-run})
+          (schema/success :pipeline-run final-run))))))

--- a/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/run.clj
@@ -172,11 +172,10 @@
 (defn- collect-inputs
   "Collect input datasets and flattened records produced by upstream stages."
   [stage-def stage-map stage-outputs]
-  (let [datasets (into {}
-                       (keep (fn [dep-id]
-                               (when-let [recs (get stage-outputs dep-id)]
-                                 [(get-in stage-map [dep-id :stage/name]) recs])))
-                       (:stage/dependencies stage-def))]
+  (let [dep->dataset (fn [dep-id]
+                       (when-let [recs (get stage-outputs dep-id)]
+                         [(get-in stage-map [dep-id :stage/name]) recs]))
+        datasets    (into {} (keep dep->dataset) (:stage/dependencies stage-def))]
     {:datasets datasets
      :records  (vec (mapcat val datasets))}))
 
@@ -227,13 +226,20 @@
      :stage/input-datasets  []
      :stage/output-datasets (or (:spawn/output-datasets spawn) [])}))
 
+(defn- stage->task-def
+  "Convert a pipeline stage to a DAG task definition."
+  [{:stage/keys [id dependencies]}]
+  {:task/id id :task/deps (set dependencies)})
+
+(defn- depends-on?
+  "True when a stage-def's dependencies include the given parent-id."
+  [parent-id [_sid sd]]
+  (when (some #{parent-id} (:stage/dependencies sd)) _sid))
+
 (defn- downstream-stage-ids
   "Return the set of stage-map keys whose :stage/dependencies include parent-id."
   [stage-map parent-id]
-  (into #{}
-        (keep (fn [[sid sd]]
-                (when (some #{parent-id} (:stage/dependencies sd)) sid)))
-        stage-map))
+  (into #{} (keep #(depends-on? parent-id %)) stage-map))
 
 (defn- inject-spawned-stages!
   "Add spawned stage tasks to run-atom and return updated stage-map.
@@ -246,7 +252,9 @@
   [run-atom stage-map spawns parent-stage-def]
   (let [parent-id (:stage/id parent-stage-def)
         ds-ids    (downstream-stage-ids stage-map parent-id)]
-    (reduce (fn [sm spawn]
+    (letfn [(add-spawned-dep [sm' ds-id stage-id]
+              (update-in sm' [ds-id :stage/dependencies] conj stage-id))
+            (register-spawn [sm spawn]
               (let [stage-def (spawn->stage-def spawn parent-stage-def)
                     stage-id  (:stage/id stage-def)]
                 ;; Register the spawned task — depends on parent only.
@@ -258,12 +266,10 @@
                   (swap! run-atom update-in [:run/tasks ds-id :task/deps] conj stage-id))
                 ;; Mirror the dep-set update in the stage-map so collect-inputs
                 ;; can look up the spawned stage's records via its UUID.
-                (reduce (fn [sm' ds-id]
-                          (update-in sm' [ds-id :stage/dependencies] conj stage-id))
+                (reduce #(add-spawned-dep %1 %2 stage-id)
                         (assoc sm stage-id stage-def)
-                        ds-ids)))
-            stage-map
-            spawns)))
+                        ds-ids)))]
+      (reduce register-spawn stage-map spawns))))
 
 ;;------------------------------------------------------------------------------ Scheduling loop
 
@@ -331,9 +337,7 @@
                            :pipeline-run/mode (or mode :full-refresh)})
             pipeline-run (:pipeline-run run-result)
             stage-map    (into {} (map (juxt :stage/id identity)) stages)
-            task-defs    (map (fn [{:stage/keys [id dependencies]}]
-                                {:task/id id :task/deps (set dependencies)})
-                              stages)
+            task-defs    (map stage->task-def stages)
             run-atom     (dag/create-run-atom
                            (dag/create-dag-from-tasks (random-uuid) task-defs))
             {:keys [stage-runs cursors failed?]}

--- a/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/transforms.clj
+++ b/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/transforms.clj
@@ -1,0 +1,57 @@
+(ns ai.miniforge.data-foundry.pipeline-runner.transforms
+  "Built-in transform functions for pipeline stages.
+   Each transform fn takes [input-records stage-config] and returns output records.")
+
+(defn- parse-numeric-value
+  "Parse a record's :value to a double, skipping FRED dot-values."
+  [record]
+  (let [v (:value record)]
+    (cond
+      (number? v) v
+      (= v ".")   nil
+      (string? v) (parse-double v)
+      :else       nil)))
+
+(defn- series-values-by-date
+  "Build a date→numeric-value lookup map for a given series-id in the records."
+  [records series-id]
+  (into {}
+        (for [r records
+              :when (= (str series-id) (str (:series_id r)))
+              :let [v (parse-numeric-value r)]
+              :when v]
+          [(:date r) v])))
+
+(defn- compute-ratios
+  "Compute ratio records by joining numerator and denominator date maps."
+  [num-map denom-map num-scale out-scale output-series]
+  (vec (for [[date num-val] num-map
+             :let [denom-val (get denom-map date)]
+             :when (and denom-val (not (zero? denom-val)))]
+         {:date      date
+          :series_id (or output-series "DERIVED_RATIO")
+          :value     (format "%.2f" (* (/ (* num-val num-scale)
+                                          denom-val)
+                                       out-scale))})))
+
+(defn derived-ratio
+  "Compute a derived ratio from two series in the input records.
+   Config keys (under :stage/transform):
+     :transform/numerator-series   — series_id of the numerator
+     :transform/denominator-series — series_id of the denominator
+     :transform/numerator-scale    — multiply numerator by this (default 1.0)
+     :transform/output-scale       — multiply ratio by this (default 1.0)
+     :transform/output-series      — series_id for the output records
+   Joins numerator and denominator by :date, emits one record per matched date.
+   Passes through all input records unchanged plus the derived records."
+  [input-records stage-config]
+  (let [{:transform/keys [numerator-series denominator-series
+                           numerator-scale output-scale output-series]}
+        (:stage/transform stage-config)
+
+        num-scale (or numerator-scale 1.0)
+        out-scale (or output-scale 1.0)
+        num-map   (series-values-by-date input-records numerator-series)
+        denom-map (series-values-by-date input-records denominator-series)
+        derived   (compute-ratios num-map denom-map num-scale out-scale output-series)]
+    (into (vec input-records) derived)))

--- a/components/pipeline-runner/test/ai/miniforge/data_foundry/pipeline_runner/interface_test.clj
+++ b/components/pipeline-runner/test/ai/miniforge/data_foundry/pipeline_runner/interface_test.clj
@@ -1,0 +1,835 @@
+(ns ai.miniforge.data-foundry.pipeline-runner.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.pipeline-runner.interface :as runner]
+            [ai.miniforge.data-foundry.connector.interface :as conn]
+            [ai.miniforge.data-foundry.data-quality.interface :as dq]))
+
+;; ---------------------------------------------------------------------------
+;; Constants
+;; ---------------------------------------------------------------------------
+
+(deftest run-statuses-test
+  (testing "N3 §2.4 run statuses"
+    (is (= #{:pending :executing :completed :failed :cancelled}
+           runner/run-statuses))))
+
+;; ---------------------------------------------------------------------------
+;; Mock connectors
+;; ---------------------------------------------------------------------------
+
+(defrecord MockSourceConnector [extract-result]
+  conn/Connector
+  (connect [_ config auth]
+    {:connection/handle "mock-handle"
+     :connector/status :connected
+     :connection/opened-at (java.time.Instant/now)})
+  (close [_ handle]
+    {:connector/status :closed
+     :connection/closed-at (java.time.Instant/now)})
+
+  conn/SourceConnector
+  (discover [_ handle opts] {:schemas [] :discover/total-count 0})
+  (extract [_ handle schema-name opts]
+    (or extract-result
+        {:records [{:id "1" :value 100} {:id "2" :value 200}]
+         :extract/cursor {:cursor/type :offset :cursor/value 2}
+         :extract/has-more false
+         :extract/row-count 2
+         :extract/completed-at (java.time.Instant/now)}))
+  (checkpoint [_ handle connector-id cursor-state]
+    {:checkpoint/id (java.util.UUID/randomUUID)
+     :checkpoint/created (java.time.Instant/now)
+     :checkpoint/status :committed}))
+
+(defrecord MockSinkConnector [publish-result]
+  conn/Connector
+  (connect [_ config auth]
+    {:connection/handle "mock-sink-handle"
+     :connector/status :connected
+     :connection/opened-at (java.time.Instant/now)})
+  (close [_ handle]
+    {:connector/status :closed
+     :connection/closed-at (java.time.Instant/now)})
+
+  conn/SinkConnector
+  (publish [_ handle schema-name records opts]
+    (or publish-result
+        {:publish/records-written (count records)
+         :publish/records-failed 0})))
+
+(defrecord FailingSourceConnector []
+  conn/Connector
+  (connect [_ config auth]
+    {:connection/handle "fail-handle"
+     :connector/status :connected})
+  (close [_ handle]
+    {:connector/status :closed})
+
+  conn/SourceConnector
+  (discover [_ handle opts] {:schemas []})
+  (extract [_ handle schema-name opts]
+    (throw (ex-info "Connection refused" {:cause :network})))
+  (checkpoint [_ handle connector-id cursor-state] {}))
+
+(defrecord InspectableSourceConnector [calls extract-fn]
+  conn/Connector
+  (connect [_ _config _auth]
+    {:connection/handle "inspect-handle"
+     :connector/status :connected
+     :connection/opened-at (java.time.Instant/now)})
+  (close [_ _handle]
+    {:connector/status :closed
+     :connection/closed-at (java.time.Instant/now)})
+
+  conn/SourceConnector
+  (discover [_ _handle _opts] {:schemas [] :discover/total-count 0})
+  (extract [_ _handle schema-name opts]
+    (swap! calls conj {:schema-name schema-name :opts opts})
+    (extract-fn schema-name opts))
+  (checkpoint [_ _handle _connector-id _cursor-state]
+    {:checkpoint/status :committed}))
+
+;; ---------------------------------------------------------------------------
+;; Test fixtures
+;; ---------------------------------------------------------------------------
+
+(def ^:private ds-a (java.util.UUID/randomUUID))
+(def ^:private ds-b (java.util.UUID/randomUUID))
+(def ^:private ds-c (java.util.UUID/randomUUID))
+(def ^:private conn-src (java.util.UUID/randomUUID))
+(def ^:private conn-sink (java.util.UUID/randomUUID))
+
+(def ^:private stage-1-id (java.util.UUID/randomUUID))
+(def ^:private stage-2-id (java.util.UUID/randomUUID))
+(def ^:private stage-3-id (java.util.UUID/randomUUID))
+(def ^:private stage-5-id (java.util.UUID/randomUUID))
+(def ^:private stage-6-id (java.util.UUID/randomUUID))
+
+(def ^:private test-pipeline
+  {:pipeline/id (java.util.UUID/randomUUID)
+   :pipeline/name "Test Pipeline"
+   :pipeline/version "1.0.0"
+   :pipeline/stages
+   [{:stage/id stage-1-id
+     :stage/name "Ingest"
+     :stage/family :ingest
+     :stage/connector-ref conn-src
+     :stage/input-datasets []
+     :stage/output-datasets [ds-a]
+     :stage/dependencies []}
+    {:stage/id stage-2-id
+     :stage/name "Normalize"
+     :stage/family :normalize
+     :stage/input-datasets [ds-a]
+     :stage/output-datasets [ds-b]
+     :stage/dependencies [stage-1-id]}]
+   :pipeline/mode :full-refresh
+   :pipeline/input-datasets []
+   :pipeline/output-datasets [ds-b]
+   :pipeline/created-at (java.time.Instant/now)
+   :pipeline/updated-at (java.time.Instant/now)})
+
+(def ^:private three-stage-pipeline
+  {:pipeline/id (java.util.UUID/randomUUID)
+   :pipeline/name "Three Stage Pipeline"
+   :pipeline/version "1.0.0"
+   :pipeline/stages
+   [{:stage/id stage-1-id
+     :stage/name "Ingest"
+     :stage/family :ingest
+     :stage/connector-ref conn-src
+     :stage/input-datasets []
+     :stage/output-datasets [ds-a]
+     :stage/dependencies []}
+    {:stage/id stage-2-id
+     :stage/name "Transform"
+     :stage/family :transform
+     :stage/input-datasets [ds-a]
+     :stage/output-datasets [ds-b]
+     :stage/dependencies [stage-1-id]}
+    {:stage/id stage-3-id
+     :stage/name "Publish"
+     :stage/family :publish
+     :stage/connector-ref conn-sink
+     :stage/input-datasets [ds-b]
+     :stage/output-datasets []
+     :stage/dependencies [stage-2-id]}]
+   :pipeline/mode :full-refresh
+   :pipeline/input-datasets []
+   :pipeline/output-datasets []
+   :pipeline/created-at (java.time.Instant/now)
+   :pipeline/updated-at (java.time.Instant/now)})
+
+(def ^:private multi-ingest-pipeline
+  {:pipeline/id (java.util.UUID/randomUUID)
+   :pipeline/name "Multi Ingest Pipeline"
+   :pipeline/version "1.0.0"
+   :pipeline/stages
+   [{:stage/id stage-5-id
+     :stage/name "Ingest Issues"
+     :stage/family :ingest
+     :stage/connector-ref conn-src
+     :stage/input-datasets []
+     :stage/output-datasets [ds-a]
+     :stage/dependencies []
+     :stage/config {:gitlab/resource "issues"}}
+    {:stage/id stage-6-id
+     :stage/name "Ingest Merge Requests"
+     :stage/family :ingest
+     :stage/connector-ref conn-src
+     :stage/input-datasets []
+     :stage/output-datasets [ds-b]
+     :stage/dependencies []
+     :stage/config {:gitlab/resource "merge-requests"}}]
+   :pipeline/mode :incremental
+   :pipeline/input-datasets []
+   :pipeline/output-datasets [ds-a ds-b]
+   :pipeline/created-at (java.time.Instant/now)
+   :pipeline/updated-at (java.time.Instant/now)})
+
+;; ---------------------------------------------------------------------------
+;; create-pipeline-run
+;; ---------------------------------------------------------------------------
+
+(deftest create-pipeline-run-test
+  (testing "Create valid pipeline run"
+    (let [result (runner/create-pipeline-run
+                  {:pipeline-run/pipeline-id (java.util.UUID/randomUUID)
+                   :pipeline-run/version "1.0.0"
+                   :pipeline-run/mode :full-refresh})]
+      (is (:success? result))
+      (is (= :pending (get-in result [:pipeline-run :pipeline-run/status])))
+      (is (uuid? (get-in result [:pipeline-run :pipeline-run/id])))
+      (is (inst? (get-in result [:pipeline-run :pipeline-run/created-at])))))
+
+  (testing "Defaults mode to :full-refresh when nil"
+    (let [result (runner/create-pipeline-run
+                  {:pipeline-run/pipeline-id (java.util.UUID/randomUUID)
+                   :pipeline-run/version "1.0.0"})]
+      (is (:success? result))
+      (is (= :full-refresh (get-in result [:pipeline-run :pipeline-run/mode])))))
+
+  (testing "Initializes empty collections"
+    (let [result (runner/create-pipeline-run
+                  {:pipeline-run/pipeline-id (java.util.UUID/randomUUID)
+                   :pipeline-run/version "1.0.0"
+                   :pipeline-run/mode :full-refresh})
+          run (:pipeline-run result)]
+      (is (= [] (:pipeline-run/input-dataset-versions run)))
+      (is (= [] (:pipeline-run/output-dataset-versions run)))
+      (is (= [] (:pipeline-run/stage-runs run)))
+      (is (= {} (:pipeline-run/connector-cursors run)))
+      (is (= [] (:pipeline-run/policy-evaluations run))))))
+
+;; ---------------------------------------------------------------------------
+;; validate-pipeline-run
+;; ---------------------------------------------------------------------------
+
+(deftest validate-pipeline-run-valid-test
+  (testing "Valid pipeline run passes"
+    (let [run {:pipeline-run/id (java.util.UUID/randomUUID)
+               :pipeline-run/pipeline-id (java.util.UUID/randomUUID)
+               :pipeline-run/version "1.0.0"
+               :pipeline-run/mode :full-refresh
+               :pipeline-run/status :pending}]
+      (is (:valid? (runner/validate-pipeline-run run))))))
+
+(deftest validate-pipeline-run-missing-id-test
+  (testing "Missing id fails"
+    (let [result (runner/validate-pipeline-run
+                  {:pipeline-run/pipeline-id (java.util.UUID/randomUUID)
+                   :pipeline-run/version "1.0.0"
+                   :pipeline-run/mode :full-refresh
+                   :pipeline-run/status :pending})]
+      (is (not (:valid? result))))))
+
+(deftest validate-pipeline-run-missing-pipeline-id-test
+  (testing "Missing pipeline-id fails"
+    (let [result (runner/validate-pipeline-run
+                  {:pipeline-run/id (java.util.UUID/randomUUID)
+                   :pipeline-run/version "1.0.0"
+                   :pipeline-run/mode :full-refresh
+                   :pipeline-run/status :pending})]
+      (is (not (:valid? result))))))
+
+(deftest validate-pipeline-run-missing-version-test
+  (testing "Missing version fails"
+    (let [result (runner/validate-pipeline-run
+                  {:pipeline-run/id (java.util.UUID/randomUUID)
+                   :pipeline-run/pipeline-id (java.util.UUID/randomUUID)
+                   :pipeline-run/mode :full-refresh
+                   :pipeline-run/status :pending})]
+      (is (not (:valid? result))))))
+
+(deftest validate-pipeline-run-invalid-mode-test
+  (testing "Invalid mode fails"
+    (let [result (runner/validate-pipeline-run
+                  {:pipeline-run/id (java.util.UUID/randomUUID)
+                   :pipeline-run/pipeline-id (java.util.UUID/randomUUID)
+                   :pipeline-run/version "1.0.0"
+                   :pipeline-run/mode :invalid
+                   :pipeline-run/status :pending})]
+      (is (not (:valid? result))))))
+
+(deftest validate-pipeline-run-invalid-status-test
+  (testing "Invalid status fails"
+    (let [result (runner/validate-pipeline-run
+                  {:pipeline-run/id (java.util.UUID/randomUUID)
+                   :pipeline-run/pipeline-id (java.util.UUID/randomUUID)
+                   :pipeline-run/version "1.0.0"
+                   :pipeline-run/mode :full-refresh
+                   :pipeline-run/status :unknown})]
+      (is (not (:valid? result))))))
+
+(deftest validate-pipeline-run-multiple-errors-test
+  (testing "Multiple validation errors accumulate"
+    (let [result (runner/validate-pipeline-run {})]
+      (is (not (:valid? result)))
+      (is (>= (count (:errors result)) 3)))))
+
+;; ---------------------------------------------------------------------------
+;; execute-pipeline — success paths
+;; ---------------------------------------------------------------------------
+
+(deftest execute-pipeline-success-test
+  (testing "Execute pipeline with mock connector (full-refresh)"
+    (let [mock-conn (->MockSourceConnector nil)
+          connectors {conn-src mock-conn}
+          result (runner/execute-pipeline test-pipeline connectors {})]
+      (is (:success? result))
+      (is (= :completed (get-in result [:pipeline-run :pipeline-run/status])))
+      (is (= 2 (count (get-in result [:pipeline-run :pipeline-run/stage-runs]))))
+      (is (every? #(= :completed (:status %))
+                  (get-in result [:pipeline-run :pipeline-run/stage-runs]))))))
+
+(deftest execute-pipeline-stage-order-test
+  (testing "Stages execute in topological order"
+    (let [mock-conn (->MockSourceConnector nil)
+          result (runner/execute-pipeline test-pipeline {conn-src mock-conn} {})
+          stage-runs (get-in result [:pipeline-run :pipeline-run/stage-runs])]
+      (is (= "Ingest" (:stage/name (first stage-runs))))
+      (is (= "Normalize" (:stage/name (second stage-runs)))))))
+
+(deftest execute-pipeline-cursors-captured-test
+  (testing "Cursor from ingest stage is captured by stage id"
+    (let [mock-conn (->MockSourceConnector nil)
+          result (runner/execute-pipeline test-pipeline {conn-src mock-conn} {})
+          cursors (get-in result [:pipeline-run :pipeline-run/connector-cursors])]
+      (is (some? (get cursors stage-1-id)))
+      (is (= conn-src (get-in cursors [stage-1-id :stage/connector-ref])))
+      (is (= "Ingest" (get-in cursors [stage-1-id :stage/name])))
+      (is (= "Ingest" (get-in cursors [stage-1-id :stage/schema-name])))
+      (is (some? (get-in cursors [stage-1-id :cursor :cursor/value]))))))
+
+(deftest execute-pipeline-resumes-from-stage-cursor-test
+  (testing "Prior stage cursor is passed back into extract"
+    (let [calls (atom [])
+          prior {:cursor/type :offset :cursor/value 42}
+          connector (->InspectableSourceConnector
+                     calls
+                     (fn [_schema-name _opts]
+                       {:records [{:id "1"}]
+                        :extract/cursor {:cursor/type :offset :cursor/value 43}
+                        :extract/has-more false
+                        :extract/row-count 1}))
+          _result (runner/execute-pipeline
+                   test-pipeline
+                   {conn-src connector}
+                   {:pipeline-run/connector-cursors
+                    {stage-1-id {:cursor prior}}})]
+      (is (= prior (get-in (first @calls) [:opts :extract/cursor]))))))
+
+(deftest execute-pipeline-separates-cursors-for-shared-connector-test
+  (testing "Multiple ingest stages sharing one connector keep separate cursors"
+    (let [calls (atom [])
+          connector (->InspectableSourceConnector
+                     calls
+                     (fn [schema-name _opts]
+                       {:records [{:schema schema-name}]
+                        :extract/cursor {:cursor/type :timestamp-watermark
+                                         :cursor/value (str schema-name "-cursor")}
+                        :extract/has-more false
+                        :extract/row-count 1}))
+          result (runner/execute-pipeline multi-ingest-pipeline {conn-src connector} {})
+          cursors (get-in result [:pipeline-run :pipeline-run/connector-cursors])]
+      (is (= "issues" (get-in cursors [stage-5-id :stage/schema-name])))
+      (is (= "merge-requests" (get-in cursors [stage-6-id :stage/schema-name])))
+      (is (= "issues-cursor" (get-in cursors [stage-5-id :cursor :cursor/value])))
+      (is (= "merge-requests-cursor" (get-in cursors [stage-6-id :cursor :cursor/value]))))))
+
+(deftest execute-pipeline-timestamps-test
+  (testing "Pipeline run has start/complete timestamps"
+    (let [mock-conn (->MockSourceConnector nil)
+          result (runner/execute-pipeline test-pipeline {conn-src mock-conn} {})
+          run (:pipeline-run result)]
+      (is (inst? (:pipeline-run/started-at run)))
+      (is (inst? (:pipeline-run/completed-at run))))))
+
+;; ---------------------------------------------------------------------------
+;; execute-pipeline — three stage with publish
+;; ---------------------------------------------------------------------------
+
+(deftest execute-three-stage-pipeline-test
+  (testing "Ingest -> Transform -> Publish pipeline"
+    (let [mock-source (->MockSourceConnector nil)
+          mock-sink (->MockSinkConnector nil)
+          connectors {conn-src mock-source conn-sink mock-sink}
+          result (runner/execute-pipeline three-stage-pipeline connectors {})]
+      (is (:success? result))
+      (is (= :completed (get-in result [:pipeline-run :pipeline-run/status])))
+      (is (= 3 (count (get-in result [:pipeline-run :pipeline-run/stage-runs]))))
+      (is (every? #(= :completed (:status %))
+                  (get-in result [:pipeline-run :pipeline-run/stage-runs]))))))
+
+;; ---------------------------------------------------------------------------
+;; execute-pipeline — failure paths
+;; ---------------------------------------------------------------------------
+
+(deftest execute-pipeline-missing-connector-test
+  (testing "Pipeline fails when connector missing"
+    (let [result (runner/execute-pipeline test-pipeline {} {})]
+      (is (not (:success? result)))
+      (is (= :failed (get-in result [:pipeline-run :pipeline-run/status]))))))
+
+(deftest execute-pipeline-connector-exception-test
+  (testing "Pipeline fails when connector throws exception"
+    (let [failing-conn (->FailingSourceConnector)
+          result (runner/execute-pipeline test-pipeline {conn-src failing-conn} {})]
+      (is (not (:success? result)))
+      (is (= :failed (get-in result [:pipeline-run :pipeline-run/status])))
+      ;; First stage should be failed
+      (let [stage-runs (get-in result [:pipeline-run :pipeline-run/stage-runs])]
+        (is (= :failed (:status (first stage-runs))))
+        (is (some? (:error-message (first stage-runs))))))))
+
+(deftest execute-pipeline-stops-on-failure-test
+  (testing "Pipeline stops executing after first stage failure"
+    (let [failing-conn (->FailingSourceConnector)
+          result (runner/execute-pipeline test-pipeline {conn-src failing-conn} {})
+          stage-runs (get-in result [:pipeline-run :pipeline-run/stage-runs])]
+      ;; Only ingest stage should have run (failed); normalize should not have run
+      (is (= 1 (count stage-runs)))
+      (is (= "Ingest" (:stage/name (first stage-runs)))))))
+
+(deftest execute-pipeline-publish-missing-connector-test
+  (testing "Publish stage fails when sink connector missing"
+    (let [mock-source (->MockSourceConnector nil)
+          ;; Source exists but sink does not
+          connectors {conn-src mock-source}
+          result (runner/execute-pipeline three-stage-pipeline connectors {})]
+      (is (not (:success? result)))
+      (is (= :failed (get-in result [:pipeline-run :pipeline-run/status])))
+      ;; Ingest and transform should succeed, publish should fail
+      (let [stage-runs (get-in result [:pipeline-run :pipeline-run/stage-runs])]
+        (is (= :completed (:status (first stage-runs))))
+        (is (= :completed (:status (second stage-runs))))
+        (is (= :failed (:status (nth stage-runs 2))))))))
+
+(deftest execute-pipeline-invalid-pipeline-test
+  (testing "Invalid pipeline definition returns validation errors"
+    (let [bad-pipeline (assoc test-pipeline :pipeline/stages [])
+          result (runner/execute-pipeline bad-pipeline {} {})]
+      (is (not (:success? result)))
+      (is (seq (:errors result))))))
+
+(deftest execute-pipeline-custom-extract-result-test
+  (testing "Custom extract result flows through pipeline"
+    (let [custom-records [{:id "A"} {:id "B"} {:id "C"}]
+          mock-conn (->MockSourceConnector
+                     {:records custom-records
+                      :extract/cursor {:cursor/type :offset :cursor/value 3}
+                      :extract/has-more false
+                      :extract/row-count 3})
+          result (runner/execute-pipeline test-pipeline {conn-src mock-conn} {})]
+      (is (:success? result))
+      (is (= :completed (get-in result [:pipeline-run :pipeline-run/status]))))))
+
+;; ---------------------------------------------------------------------------
+;; execute-pipeline — validate stage
+;; ---------------------------------------------------------------------------
+
+(def ^:private stage-4-id (java.util.UUID/randomUUID))
+(def ^:private ds-d (java.util.UUID/randomUUID))
+
+(def ^:private validate-pipeline
+  {:pipeline/id (java.util.UUID/randomUUID)
+   :pipeline/name "Pipeline with Validate"
+   :pipeline/version "1.0.0"
+   :pipeline/stages
+   [{:stage/id stage-1-id
+     :stage/name "Ingest"
+     :stage/family :ingest
+     :stage/connector-ref conn-src
+     :stage/input-datasets []
+     :stage/output-datasets [ds-a]
+     :stage/dependencies []}
+    {:stage/id stage-4-id
+     :stage/name "Validate"
+     :stage/family :validate
+     :stage/input-datasets [ds-a]
+     :stage/output-datasets [ds-d]
+     :stage/dependencies [stage-1-id]
+     :stage/config {:stage/quality-pack
+                    {:pack/id :test-quality
+                     :pack/rules [(dq/required-rule :id)]}}}]
+   :pipeline/mode :full-refresh
+   :pipeline/input-datasets []
+   :pipeline/output-datasets [ds-d]
+   :pipeline/created-at (java.time.Instant/now)
+   :pipeline/updated-at (java.time.Instant/now)})
+
+(deftest execute-pipeline-validate-stage-test
+  (testing "Validate stage filters records and produces quality report"
+    (let [mock-conn (->MockSourceConnector
+                     {:records [{:id "1" :value 100}
+                                {:id nil :value 200}
+                                {:id "3" :value 300}]
+                      :extract/cursor {:cursor/type :offset :cursor/value 3}
+                      :extract/has-more false
+                      :extract/row-count 3})
+          result (runner/execute-pipeline validate-pipeline {conn-src mock-conn} {})]
+      (is (:success? result))
+      (is (= :completed (get-in result [:pipeline-run :pipeline-run/status])))
+      ;; Both stages should complete
+      (let [stage-runs (get-in result [:pipeline-run :pipeline-run/stage-runs])]
+        (is (= 2 (count stage-runs)))
+        (is (every? #(= :completed (:status %)) stage-runs))
+        ;; Validate stage should have quality-report
+        (let [validate-run (second stage-runs)]
+          (is (some? (:quality-report validate-run)))
+          (is (= :test-quality (get-in validate-run [:quality-report :report/pack-id])))
+          (is (= 3 (get-in validate-run [:quality-report :report/total])))
+          (is (= 1 (get-in validate-run [:quality-report :report/failed]))))))))
+
+(deftest execute-pipeline-validate-no-pack-test
+  (testing "Validate stage without quality pack is pass-through"
+    (let [pipeline-no-pack
+          (assoc-in validate-pipeline
+                    [:pipeline/stages 1 :stage/config] {})
+          mock-conn (->MockSourceConnector nil)
+          result (runner/execute-pipeline pipeline-no-pack {conn-src mock-conn} {})]
+      (is (:success? result))
+      (is (= :completed (get-in result [:pipeline-run :pipeline-run/status]))))))
+
+;; ---------------------------------------------------------------------------
+;; execute-pipeline — transform stage with registered function
+;; ---------------------------------------------------------------------------
+
+(def ^:private stage-t-id (java.util.UUID/randomUUID))
+(def ^:private ds-t (java.util.UUID/randomUUID))
+
+(def ^:private transform-pipeline
+  {:pipeline/id (java.util.UUID/randomUUID)
+   :pipeline/name "Pipeline with Transform"
+   :pipeline/version "1.0.0"
+   :pipeline/stages
+   [{:stage/id stage-1-id
+     :stage/name "Ingest"
+     :stage/family :ingest
+     :stage/connector-ref conn-src
+     :stage/input-datasets []
+     :stage/output-datasets [ds-a]
+     :stage/dependencies []}
+    {:stage/id stage-t-id
+     :stage/name "Derive"
+     :stage/family :transform
+     :stage/input-datasets [ds-a]
+     :stage/output-datasets [ds-t]
+     :stage/dependencies [stage-1-id]
+     :stage/config
+     {:stage/transform
+      {:transform/type :test-double}}}]
+   :pipeline/mode :full-refresh
+   :pipeline/input-datasets []
+   :pipeline/output-datasets [ds-t]
+   :pipeline/created-at (java.time.Instant/now)
+   :pipeline/updated-at (java.time.Instant/now)})
+
+(deftest execute-pipeline-transform-fn-test
+  (testing "Transform stage calls registered transform function"
+    (let [double-fn (fn [records _config]
+                      (mapv #(update % :value * 2) records))
+          mock-conn (->MockSourceConnector
+                     {:records [{:id "1" :value 10} {:id "2" :value 20}]
+                      :extract/cursor nil :extract/has-more false :extract/row-count 2})
+          result (runner/execute-pipeline
+                  transform-pipeline {conn-src mock-conn}
+                  {:transforms {:test-double double-fn}})]
+      (is (:success? result))
+      (is (= :completed (get-in result [:pipeline-run :pipeline-run/status]))))))
+
+(deftest execute-pipeline-transform-passthrough-test
+  (testing "Transform stage without matching fn is pass-through"
+    (let [mock-conn (->MockSourceConnector nil)
+          result (runner/execute-pipeline
+                  transform-pipeline {conn-src mock-conn}
+                  {:transforms {}})]
+      (is (:success? result))
+      (is (= :completed (get-in result [:pipeline-run :pipeline-run/status]))))))
+
+;; ---------------------------------------------------------------------------
+;; Built-in transforms — derived-ratio
+;; ---------------------------------------------------------------------------
+
+(deftest derived-ratio-transform-test
+  (testing "derived-ratio computes ratio from two series"
+    (let [input [{:date "2025-01-01" :series_id "NCBEILQ027S" :value "70000"}
+                 {:date "2025-01-01" :series_id "GDP" :value "28000"}
+                 {:date "2025-04-01" :series_id "NCBEILQ027S" :value "72000"}
+                 {:date "2025-04-01" :series_id "GDP" :value "28500"}]
+          config {:stage/transform
+                  {:transform/type              :derived-ratio
+                   :transform/numerator-series  "NCBEILQ027S"
+                   :transform/denominator-series "GDP"
+                   :transform/numerator-scale   0.001
+                   :transform/output-scale      100.0
+                   :transform/output-series     "BUFFETT_INDICATOR"}}
+          result ((runner/built-in-transforms :derived-ratio) input config)
+          derived (filter #(= "BUFFETT_INDICATOR" (:series_id %)) result)]
+      ;; (70000 * 0.001) / 28000 * 100 = 70/28000*100 = 0.25
+      (is (= 2 (count derived)))
+      (is (= "BUFFETT_INDICATOR" (:series_id (first derived))))
+      ;; Q1: 70000*0.001 = 70, 70/28000*100 = 0.25
+      (is (= "0.25" (:value (first (filter #(= "2025-01-01" (:date %)) derived)))))
+      ;; Q2: 72000*0.001 = 72, 72/28500*100 ≈ 0.25
+      ;; Original input records should also be present
+      (is (= 6 (count result))))))
+
+(deftest derived-ratio-handles-dot-values-test
+  (testing "derived-ratio skips FRED dot-values"
+    (let [input [{:date "2025-01-01" :series_id "A" :value "100"}
+                 {:date "2025-01-01" :series_id "B" :value "."}]
+          config {:stage/transform
+                  {:transform/type              :derived-ratio
+                   :transform/numerator-series  "A"
+                   :transform/denominator-series "B"
+                   :transform/output-series     "X"}}
+          result ((runner/built-in-transforms :derived-ratio) input config)
+          derived (filter #(= "X" (:series_id %)) result)]
+      ;; No derived records since denominator is "."
+      (is (empty? derived)))))
+
+;; ---------------------------------------------------------------------------
+;; execute-pipeline — spawn-requests (dependent ingest fan-out)
+;; ---------------------------------------------------------------------------
+
+(def ^:private spawn-parent-id (java.util.UUID/randomUUID))
+(def ^:private conn-parent (java.util.UUID/randomUUID))
+(def ^:private conn-child  (java.util.UUID/randomUUID))
+(def ^:private ds-parent   (java.util.UUID/randomUUID))
+
+(def ^:private spawn-pipeline
+  "Parent ingest stage fans out one child ingest per output record."
+  {:pipeline/id (java.util.UUID/randomUUID)
+   :pipeline/name "Spawn Pipeline"
+   :pipeline/version "1.0.0"
+   :pipeline/stages
+   [{:stage/id spawn-parent-id
+     :stage/name "Ingest Issues"
+     :stage/family :ingest
+     :stage/connector-ref conn-parent
+     :stage/input-datasets []
+     :stage/output-datasets [ds-parent]
+     :stage/dependencies []
+     :stage/config {:gitlab/resource "issues"
+                    :stage/spawn-fn :notes-per-issue}}]
+   :pipeline/mode :full-refresh
+   :pipeline/input-datasets []
+   :pipeline/output-datasets [ds-parent]
+   :pipeline/created-at (java.time.Instant/now)
+   :pipeline/updated-at (java.time.Instant/now)})
+
+(deftest execute-pipeline-spawn-creates-child-stages-test
+  (testing "Spawn fn fires for each issue record, child stages run and complete"
+    (let [issues-conn (->MockSourceConnector
+                       {:records [{:iid 1 :title "Bug 1"}
+                                  {:iid 2 :title "Bug 2"}]
+                        :extract/cursor nil
+                        :extract/has-more false
+                        :extract/row-count 2})
+          notes-conn  (->MockSourceConnector
+                       {:records [{:id "n1" :body "a note"}]
+                        :extract/cursor nil
+                        :extract/has-more false
+                        :extract/row-count 1})
+          spawn-fn    (fn [records _config]
+                        (map (fn [issue]
+                               {:spawn/name         (str "Notes for Issue #" (:iid issue))
+                                :spawn/family       :ingest
+                                :spawn/connector-ref conn-child
+                                :spawn/config       {:gitlab/resource "notes"
+                                                     :gitlab/issue-iid (:iid issue)}})
+                             records))
+          result (runner/execute-pipeline
+                  spawn-pipeline
+                  {conn-parent issues-conn conn-child notes-conn}
+                  {:spawn-fns {:notes-per-issue spawn-fn}})]
+      (is (:success? result))
+      (is (= :completed (get-in result [:pipeline-run :pipeline-run/status])))
+      ;; 1 parent + 2 spawned child stages = 3 total
+      (let [runs (get-in result [:pipeline-run :pipeline-run/stage-runs])]
+        (is (= 3 (count runs)))
+        (is (every? #(= :completed (:status %)) runs))
+        ;; Parent ran first
+        (is (= "Ingest Issues" (:stage/name (first runs))))
+        ;; Both children ran
+        (let [child-names (set (map :stage/name (rest runs)))]
+          (is (contains? child-names "Notes for Issue #1"))
+          (is (contains? child-names "Notes for Issue #2")))))))
+
+(deftest execute-pipeline-no-spawn-fn-test
+  (testing "Stage without :stage/spawn-fn runs normally — no spawning"
+    (let [mock-conn (->MockSourceConnector nil)
+          result    (runner/execute-pipeline test-pipeline {conn-src mock-conn} {})]
+      (is (:success? result))
+      (is (= 2 (count (get-in result [:pipeline-run :pipeline-run/stage-runs])))))))
+
+(deftest execute-pipeline-spawn-child-failure-test
+  (testing "Failure in a spawned child stage fails the pipeline"
+    (let [issues-conn (->MockSourceConnector
+                       {:records [{:iid 1 :title "Bug 1"}]
+                        :extract/cursor nil
+                        :extract/has-more false
+                        :extract/row-count 1})
+          failing-notes (->FailingSourceConnector)
+          spawn-fn    (fn [records _config]
+                        (map (fn [issue]
+                               {:spawn/name         (str "Notes for Issue #" (:iid issue))
+                                :spawn/family       :ingest
+                                :spawn/connector-ref conn-child
+                                :spawn/config       {:gitlab/resource "notes"
+                                                     :gitlab/issue-iid (:iid issue)}})
+                             records))
+          result (runner/execute-pipeline
+                  spawn-pipeline
+                  {conn-parent issues-conn conn-child failing-notes}
+                  {:spawn-fns {:notes-per-issue spawn-fn}})]
+      (is (not (:success? result)))
+      (is (= :failed (get-in result [:pipeline-run :pipeline-run/status]))))))
+
+;; ---------------------------------------------------------------------------
+;; execute-pipeline — spawn downstream propagation (fan-out → collect → publish)
+;; ---------------------------------------------------------------------------
+
+(def ^:private spawn-fanout-id (java.util.UUID/randomUUID))
+(def ^:private spawn-pub-id    (java.util.UUID/randomUUID))
+(def ^:private ds-fanout       (java.util.UUID/randomUUID))
+
+(def ^:private spawn-with-publish-pipeline
+  "Parent ingest spawns child stages; a publish stage collects from all of them."
+  {:pipeline/id (java.util.UUID/randomUUID)
+   :pipeline/name "Spawn With Publish"
+   :pipeline/version "1.0.0"
+   :pipeline/stages
+   [{:stage/id spawn-fanout-id
+     :stage/name "Ingest Issues"
+     :stage/family :ingest
+     :stage/connector-ref conn-parent
+     :stage/input-datasets []
+     :stage/output-datasets [ds-fanout]
+     :stage/dependencies []
+     :stage/config {:stage/spawn-fn :notes-per-issue}}
+    {:stage/id spawn-pub-id
+     :stage/name "Publish"
+     :stage/family :publish
+     :stage/connector-ref conn-sink
+     :stage/input-datasets [ds-fanout]
+     :stage/output-datasets []
+     :stage/dependencies [spawn-fanout-id]}]
+   :pipeline/mode :full-refresh
+   :pipeline/input-datasets []
+   :pipeline/output-datasets []
+   :pipeline/created-at (java.time.Instant/now)
+   :pipeline/updated-at (java.time.Instant/now)})
+
+(deftest execute-pipeline-spawn-downstream-collects-test
+  (testing "Downstream stage waits for and collects records from all spawned children"
+    (let [published-records (atom nil)
+          issues-conn  (->MockSourceConnector
+                        {:records [{:iid 1 :title "Issue A"}
+                                   {:iid 2 :title "Issue B"}]
+                         :extract/cursor nil
+                         :extract/has-more false
+                         :extract/row-count 2})
+          notes-conn   (->MockSourceConnector
+                        {:records [{:id "note-1" :body "note body"}]
+                         :extract/cursor nil
+                         :extract/has-more false
+                         :extract/row-count 1})
+          ;; Capture what the publish stage receives
+          sink-conn    (reify
+                         conn/Connector
+                         (connect [_ _ _] {:connection/handle "sink-h"
+                                           :connector/status :connected
+                                           :connection/opened-at (java.time.Instant/now)})
+                         (close [_ _] {:connector/status :closed
+                                       :connection/closed-at (java.time.Instant/now)})
+                         conn/SinkConnector
+                         (publish [_ _ _ records _]
+                           (reset! published-records records)
+                           {:publish/records-written (count records)
+                            :publish/records-failed 0}))
+          spawn-fn     (fn [records _config]
+                         (map (fn [issue]
+                                {:spawn/name         (str "Notes #" (:iid issue))
+                                 :spawn/family       :ingest
+                                 :spawn/connector-ref conn-child
+                                 :spawn/config       {:gitlab/resource "notes"
+                                                      :gitlab/noteable-iid (:iid issue)}})
+                              records))
+          result (runner/execute-pipeline
+                  spawn-with-publish-pipeline
+                  {conn-parent issues-conn conn-child notes-conn conn-sink sink-conn}
+                  {:spawn-fns {:notes-per-issue spawn-fn}})]
+      (is (:success? result))
+      (is (= :completed (get-in result [:pipeline-run :pipeline-run/status])))
+      ;; 1 parent + 2 spawned + 1 publish = 4 total stage-runs
+      (let [runs (get-in result [:pipeline-run :pipeline-run/stage-runs])]
+        (is (= 4 (count runs)))
+        (is (every? #(= :completed (:status %)) runs))
+        (is (= "Publish" (:stage/name (last runs)))))
+      ;; Publish received records from all spawned children (2 × 1 note = 2)
+      ;; plus the parent issues (2), totalling 4 records
+      (is (some? @published-records))
+      (is (= 4 (count @published-records))))))
+
+(deftest execute-pipeline-spawn-inherits-connector-ref-test
+  (testing "Spawned stage inherits parent connector-ref when spawn omits :spawn/connector-ref"
+    (let [notes-conn  (->MockSourceConnector
+                       {:records [{:id "n1" :body "a note"}]
+                        :extract/cursor nil
+                        :extract/has-more false
+                        :extract/row-count 1})
+          ;; Parent connector returns two issues
+          issues-conn (->MockSourceConnector
+                       {:records [{:iid 10 :title "Issue A"}
+                                  {:iid 11 :title "Issue B"}]
+                        :extract/cursor nil
+                        :extract/has-more false
+                        :extract/row-count 2})
+          ;; Spawn fn omits :spawn/connector-ref — should inherit conn-parent
+          spawn-fn    (fn [records _config]
+                        (map (fn [issue]
+                               {:spawn/name   (str "Notes for Issue #" (:iid issue))
+                                :spawn/family :ingest
+                                :spawn/config {:gitlab/resource     "notes"
+                                               :gitlab/noteable-kind "issues"
+                                               :gitlab/noteable-iid  (:iid issue)}})
+                             records))
+          result (runner/execute-pipeline
+                  spawn-pipeline
+                  ;; Parent connector also handles "notes" for the spawned stages
+                  {conn-parent (->MockSourceConnector
+                                {:records [{:iid 10 :title "Issue A"}
+                                           {:iid 11 :title "Issue B"}]
+                                 :extract/cursor nil
+                                 :extract/has-more false
+                                 :extract/row-count 2})}
+                  {:spawn-fns {:notes-per-issue spawn-fn}})]
+      ;; Pipeline should complete — spawned stages use the inherited connector-ref
+      (is (:success? result))
+      (is (= :completed (get-in result [:pipeline-run :pipeline-run/status])))
+      ;; 1 parent + 2 spawned = 3 total stage-runs
+      (let [runs (get-in result [:pipeline-run :pipeline-run/stage-runs])]
+        (is (= 3 (count runs)))
+        (is (every? #(= :completed (:status %)) runs))))))

--- a/components/pipeline-runner/test/ai/miniforge/data_foundry/pipeline_runner/interface_test.clj
+++ b/components/pipeline-runner/test/ai/miniforge/data_foundry/pipeline_runner/interface_test.clj
@@ -639,6 +639,33 @@
    :pipeline/created-at (java.time.Instant/now)
    :pipeline/updated-at (java.time.Instant/now)})
 
+(defn- issue->notes-spawn
+  "Build a spawn descriptor for notes-per-issue with an explicit connector-ref."
+  [issue]
+  {:spawn/name         (str "Notes for Issue #" (:iid issue))
+   :spawn/family       :ingest
+   :spawn/connector-ref conn-child
+   :spawn/config       {:gitlab/resource "notes"
+                         :gitlab/issue-iid (:iid issue)}})
+
+(defn- issue->notes-spawn-short
+  "Build a spawn descriptor with a shorter name label."
+  [issue]
+  {:spawn/name         (str "Notes #" (:iid issue))
+   :spawn/family       :ingest
+   :spawn/connector-ref conn-child
+   :spawn/config       {:gitlab/resource "notes"
+                         :gitlab/noteable-iid (:iid issue)}})
+
+(defn- issue->notes-spawn-inherit
+  "Build a spawn descriptor that omits :spawn/connector-ref (inherits from parent)."
+  [issue]
+  {:spawn/name   (str "Notes for Issue #" (:iid issue))
+   :spawn/family :ingest
+   :spawn/config {:gitlab/resource     "notes"
+                  :gitlab/noteable-kind "issues"
+                  :gitlab/noteable-iid  (:iid issue)}})
+
 (deftest execute-pipeline-spawn-creates-child-stages-test
   (testing "Spawn fn fires for each issue record, child stages run and complete"
     (let [issues-conn (->MockSourceConnector
@@ -653,13 +680,7 @@
                         :extract/has-more false
                         :extract/row-count 1})
           spawn-fn    (fn [records _config]
-                        (map (fn [issue]
-                               {:spawn/name         (str "Notes for Issue #" (:iid issue))
-                                :spawn/family       :ingest
-                                :spawn/connector-ref conn-child
-                                :spawn/config       {:gitlab/resource "notes"
-                                                     :gitlab/issue-iid (:iid issue)}})
-                             records))
+                        (map issue->notes-spawn records))
           result (runner/execute-pipeline
                   spawn-pipeline
                   {conn-parent issues-conn conn-child notes-conn}
@@ -693,13 +714,7 @@
                         :extract/row-count 1})
           failing-notes (->FailingSourceConnector)
           spawn-fn    (fn [records _config]
-                        (map (fn [issue]
-                               {:spawn/name         (str "Notes for Issue #" (:iid issue))
-                                :spawn/family       :ingest
-                                :spawn/connector-ref conn-child
-                                :spawn/config       {:gitlab/resource "notes"
-                                                     :gitlab/issue-iid (:iid issue)}})
-                             records))
+                        (map issue->notes-spawn records))
           result (runner/execute-pipeline
                   spawn-pipeline
                   {conn-parent issues-conn conn-child failing-notes}
@@ -770,13 +785,7 @@
                            {:publish/records-written (count records)
                             :publish/records-failed 0}))
           spawn-fn     (fn [records _config]
-                         (map (fn [issue]
-                                {:spawn/name         (str "Notes #" (:iid issue))
-                                 :spawn/family       :ingest
-                                 :spawn/connector-ref conn-child
-                                 :spawn/config       {:gitlab/resource "notes"
-                                                      :gitlab/noteable-iid (:iid issue)}})
-                              records))
+                         (map issue->notes-spawn-short records))
           result (runner/execute-pipeline
                   spawn-with-publish-pipeline
                   {conn-parent issues-conn conn-child notes-conn conn-sink sink-conn}
@@ -809,13 +818,7 @@
                         :extract/row-count 2})
           ;; Spawn fn omits :spawn/connector-ref — should inherit conn-parent
           spawn-fn    (fn [records _config]
-                        (map (fn [issue]
-                               {:spawn/name   (str "Notes for Issue #" (:iid issue))
-                                :spawn/family :ingest
-                                :spawn/config {:gitlab/resource     "notes"
-                                               :gitlab/noteable-kind "issues"
-                                               :gitlab/noteable-iid  (:iid issue)}})
-                             records))
+                        (map issue->notes-spawn-inherit records))
           result (runner/execute-pipeline
                   spawn-pipeline
                   ;; Parent connector also handles "notes" for the spawned stages

--- a/components/pipeline/deps.edn
+++ b/components/pipeline/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/dag-primitives {:local/root "../../../miniforge/components/dag-primitives"}
+        ai.miniforge/dag-executor   {:local/root "../../../miniforge/components/dag-executor"}
+        ai.miniforge/schema         {:local/root "../../../miniforge/components/schema"}
+        ai.miniforge/workflow       {:local/root "../../../miniforge/components/workflow"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps {}}}}

--- a/components/pipeline/deps.edn
+++ b/components/pipeline/deps.edn
@@ -1,7 +1,7 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/dag-primitives {:local/root "../../../miniforge/components/dag-primitives"}
-        ai.miniforge/dag-executor   {:local/root "../../../miniforge/components/dag-executor"}
-        ai.miniforge/schema         {:local/root "../../../miniforge/components/schema"}
-        ai.miniforge/workflow       {:local/root "../../../miniforge/components/workflow"}}
+ :deps {ai.miniforge/dag-primitives {:local/root "../dag-primitives"}
+        ai.miniforge/dag-executor   {:local/root "../dag-executor"}
+        ai.miniforge/schema         {:local/root "../schema"}
+        ai.miniforge/workflow       {:local/root "../workflow"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/pipeline/resources/config/pipeline/messages/en-US.edn
+++ b/components/pipeline/resources/config/pipeline/messages/en-US.edn
@@ -1,0 +1,25 @@
+{:pipeline/messages
+ {;; Pipeline validation (core.clj)
+  :pipeline/id-required              ":pipeline/id is required"
+  :pipeline/name-must-be-string      ":pipeline/name must be a string"
+  :pipeline/version-must-be-string   ":pipeline/version must be a string"
+  :pipeline/stages-must-be-vector    ":pipeline/stages must be a vector"
+  :pipeline/stages-must-not-be-empty ":pipeline/stages must not be empty"
+  :pipeline/mode-invalid             ":pipeline/mode must be one of {allowed}"
+  :pipeline/input-ds-must-be-vector  ":pipeline/input-datasets must be a vector"
+  :pipeline/output-ds-must-be-vector ":pipeline/output-datasets must be a vector"
+  :pipeline/stage-error              "Stage '{name}': {error}"
+  :pipeline/unknown-dependency       "Stage '{name}' references unknown dependency: {dep}"
+  :pipeline/cycle-detected           "Pipeline stages contain a cycle"
+
+  ;; Stage validation (stage.clj)
+  :stage/id-required                 ":stage/id is required"
+  :stage/name-must-be-string         ":stage/name must be a string"
+  :stage/family-invalid              ":stage/family must be one of {allowed}"
+  :stage/connector-ref-required      ":stage/connector-ref is required for {family} stages"
+  :stage/connector-ref-forbidden     ":stage/connector-ref must not be set for {family} stages"
+  :stage/ingest-no-input             "Ingest stages must not have input datasets"
+  :stage/publish-no-output           "Publish stages must not have output datasets"
+  :stage/must-have-input             "{family} stages must have at least one input dataset"
+  :stage/must-have-output            "{family} stages must have at least one output dataset"
+  :stage/deps-must-be-vector         ":stage/dependencies must be a vector"}}

--- a/components/pipeline/src/ai/miniforge/data_foundry/pipeline/core.clj
+++ b/components/pipeline/src/ai/miniforge/data_foundry/pipeline/core.clj
@@ -1,0 +1,93 @@
+(ns ai.miniforge.data-foundry.pipeline.core
+  (:require [ai.miniforge.data-foundry.pipeline.stage :as stage]
+            [ai.miniforge.data-foundry.pipeline.dag :as dag]
+            [ai.miniforge.data-foundry.pipeline.messages :as msg])
+  (:import [java.util UUID]
+           [java.time Instant]))
+
+(def execution-modes
+  "N3 §3 execution modes"
+  #{:full-refresh :incremental :backfill :reprocess})
+
+(defn- validate-pipeline-impl
+  [{:pipeline/keys [id name version stages mode input-datasets output-datasets]}]
+  (let [base-errors
+        (cond-> []
+          (nil? id)
+          (conj (msg/t :pipeline/id-required))
+
+          (not (string? name))
+          (conj (msg/t :pipeline/name-must-be-string))
+
+          (not (string? version))
+          (conj (msg/t :pipeline/version-must-be-string))
+
+          (not (vector? stages))
+          (conj (msg/t :pipeline/stages-must-be-vector))
+
+          (and (vector? stages) (empty? stages))
+          (conj (msg/t :pipeline/stages-must-not-be-empty))
+
+          (not (contains? execution-modes mode))
+          (conj (msg/t :pipeline/mode-invalid {:allowed execution-modes}))
+
+          (not (vector? input-datasets))
+          (conj (msg/t :pipeline/input-ds-must-be-vector))
+
+          (not (vector? output-datasets))
+          (conj (msg/t :pipeline/output-ds-must-be-vector)))
+
+        ;; Validate individual stages
+        stage-errors
+        (when (and (vector? stages) (seq stages))
+          (mapcat
+           (fn [s]
+             (let [v (stage/validate-stage s)]
+               (when-not (:success? v)
+                 (map #(msg/t :pipeline/stage-error {:name (:stage/name s) :error %})
+                      (:errors v)))))
+           stages))
+
+        ;; Validate DAG (no cycles, all deps exist)
+        dag-errors
+        (when (and (vector? stages) (seq stages))
+          (let [stage-ids (set (map :stage/id stages))]
+            (mapcat
+             (fn [s]
+               (for [dep (:stage/dependencies s)
+                     :when (not (contains? stage-ids dep))]
+                 (msg/t :pipeline/unknown-dependency {:name (:stage/name s) :dep dep})))
+             stages)))
+
+        ;; Check for cycles
+        cycle-errors
+        (when (and (vector? stages) (seq stages))
+          (let [order-result (dag/execution-order stages)]
+            (when (nil? order-result)
+              [(msg/t :pipeline/cycle-detected)])))]
+
+    (vec (concat base-errors stage-errors dag-errors cycle-errors))))
+
+(defn validate-pipeline
+  [pipeline]
+  (let [errors (validate-pipeline-impl pipeline)]
+    (if (empty? errors)
+      {:success? true}
+      {:success? false :errors errors})))
+
+(defn create-pipeline
+  [opts]
+  (let [now (Instant/now)
+        pipeline (cond-> opts
+                   (nil? (:pipeline/id opts))
+                   (assoc :pipeline/id (UUID/randomUUID))
+
+                   (nil? (:pipeline/created-at opts))
+                   (assoc :pipeline/created-at now)
+
+                   (nil? (:pipeline/updated-at opts))
+                   (assoc :pipeline/updated-at now))
+        validation (validate-pipeline pipeline)]
+    (if (:success? validation)
+      {:success? true :pipeline pipeline}
+      {:success? false :errors (:errors validation)})))

--- a/components/pipeline/src/ai/miniforge/data_foundry/pipeline/dag.clj
+++ b/components/pipeline/src/ai/miniforge/data_foundry/pipeline/dag.clj
@@ -2,17 +2,33 @@
   (:require [ai.miniforge.data-foundry.pipeline.messages   :as msg]
             [ai.miniforge.dag-primitives.interface :as dag]))
 
+(defn- stage->dep-entry
+  "Extract a [stage-id dependencies-set] pair from a stage."
+  [{:stage/keys [id dependencies]}]
+  [id (set dependencies)])
+
 (defn execution-order
   "Compute topological order of stages using Kahn's algorithm.
    Returns ordered vector of stage IDs, or nil if a cycle is detected."
   [stages]
-  (let [dep-map (reduce (fn [m {:stage/keys [id dependencies]}]
-                          (assoc m id (set dependencies)))
-                        {}
-                        stages)
+  (let [dep-map (into {} (map stage->dep-entry) stages)
         result  (dag/topological-sort dep-map)]
     (when (dag/ok? result)
       (:data result))))
+
+(defn- stage->task
+  "Convert a pipeline stage to a DAG task."
+  [{:stage/keys [id name family config]}]
+  {:task/id id
+   :task/name name
+   :task/type :pipeline-stage
+   :task/metadata {:stage/family family
+                   :stage/config config}})
+
+(defn- stage->edges
+  "Extract dependency edges from a stage."
+  [{:stage/keys [id dependencies]}]
+  (mapv (fn [dep] {:from dep :to id}) dependencies))
 
 (defn stages->dag
   "Convert pipeline stages to a DAG task structure.
@@ -21,17 +37,7 @@
   (let [order (execution-order stages)]
     (if (nil? order)
       {:success? false :errors [(msg/t :pipeline/cycle-detected)]}
-      (let [tasks (mapv (fn [{:stage/keys [id name family config]}]
-                          {:task/id id
-                           :task/name name
-                           :task/type :pipeline-stage
-                           :task/metadata {:stage/family family
-                                           :stage/config config}})
-                        stages)
-            edges (mapcat (fn [{:stage/keys [id dependencies]}]
-                            (map (fn [dep] {:from dep :to id}) dependencies))
-                          stages)]
-        {:success? true
-         :dag {:tasks tasks
-               :edges (vec edges)
-               :execution-order order}}))))
+      {:success? true
+       :dag {:tasks (mapv stage->task stages)
+             :edges (vec (mapcat stage->edges stages))
+             :execution-order order}})))

--- a/components/pipeline/src/ai/miniforge/data_foundry/pipeline/dag.clj
+++ b/components/pipeline/src/ai/miniforge/data_foundry/pipeline/dag.clj
@@ -1,0 +1,37 @@
+(ns ai.miniforge.data-foundry.pipeline.dag
+  (:require [ai.miniforge.data-foundry.pipeline.messages   :as msg]
+            [ai.miniforge.dag-primitives.interface :as dag]))
+
+(defn execution-order
+  "Compute topological order of stages using Kahn's algorithm.
+   Returns ordered vector of stage IDs, or nil if a cycle is detected."
+  [stages]
+  (let [dep-map (reduce (fn [m {:stage/keys [id dependencies]}]
+                          (assoc m id (set dependencies)))
+                        {}
+                        stages)
+        result  (dag/topological-sort dep-map)]
+    (when (dag/ok? result)
+      (:data result))))
+
+(defn stages->dag
+  "Convert pipeline stages to a DAG task structure.
+   Returns {:success? true :dag {:tasks [...] :edges [...]}} or error."
+  [stages]
+  (let [order (execution-order stages)]
+    (if (nil? order)
+      {:success? false :errors [(msg/t :pipeline/cycle-detected)]}
+      (let [tasks (mapv (fn [{:stage/keys [id name family config]}]
+                          {:task/id id
+                           :task/name name
+                           :task/type :pipeline-stage
+                           :task/metadata {:stage/family family
+                                           :stage/config config}})
+                        stages)
+            edges (mapcat (fn [{:stage/keys [id dependencies]}]
+                            (map (fn [dep] {:from dep :to id}) dependencies))
+                          stages)]
+        {:success? true
+         :dag {:tasks tasks
+               :edges (vec edges)
+               :execution-order order}}))))

--- a/components/pipeline/src/ai/miniforge/data_foundry/pipeline/interface.clj
+++ b/components/pipeline/src/ai/miniforge/data_foundry/pipeline/interface.clj
@@ -1,0 +1,50 @@
+(ns ai.miniforge.data-foundry.pipeline.interface
+  (:require [ai.miniforge.data-foundry.pipeline.core :as core]
+            [ai.miniforge.data-foundry.pipeline.stage :as stage]
+            [ai.miniforge.data-foundry.pipeline.dag :as dag]))
+
+;; -- Stage Families --
+(def stage-families stage/stage-families)
+
+;; -- Execution Modes --
+(def execution-modes core/execution-modes)
+
+;; -- Pipeline CRUD --
+(defn create-pipeline
+  "Create a pipeline definition.
+   Required: :pipeline/name, :pipeline/version, :pipeline/stages, :pipeline/mode,
+             :pipeline/input-datasets, :pipeline/output-datasets
+   Returns {:success? true :pipeline ...} or {:success? false :errors [...]}"
+  [opts]
+  (core/create-pipeline opts))
+
+(defn validate-pipeline
+  "Validate a pipeline definition against N3 §2.
+   Checks stage dependencies, connector refs, input/output consistency."
+  [pipeline]
+  (core/validate-pipeline pipeline))
+
+;; -- Stage Operations --
+(defn create-stage
+  "Create a stage definition.
+   Required: :stage/name, :stage/family, :stage/input-datasets, :stage/output-datasets, :stage/dependencies"
+  [opts]
+  (stage/create-stage opts))
+
+(defn validate-stage
+  "Validate a stage definition against N3 §2.2."
+  [stage-def]
+  (stage/validate-stage stage-def))
+
+;; -- DAG Conversion --
+(defn stages->dag
+  "Convert pipeline stages to a DAG task structure for Core dag-executor.
+   Returns {:success? true :dag ...} or {:success? false :errors [...]}"
+  [stages]
+  (dag/stages->dag stages))
+
+(defn execution-order
+  "Compute topological execution order for pipeline stages.
+   Returns ordered vector of stage IDs."
+  [stages]
+  (dag/execution-order stages))

--- a/components/pipeline/src/ai/miniforge/data_foundry/pipeline/messages.clj
+++ b/components/pipeline/src/ai/miniforge/data_foundry/pipeline/messages.clj
@@ -1,0 +1,7 @@
+(ns ai.miniforge.data-foundry.pipeline.messages
+  "Message catalog — delegates to ai.miniforge.messages."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a message by key, with optional param substitution."
+  (messages/create-translator "config/pipeline/messages/en-US.edn" :pipeline/messages))

--- a/components/pipeline/src/ai/miniforge/data_foundry/pipeline/stage.clj
+++ b/components/pipeline/src/ai/miniforge/data_foundry/pipeline/stage.clj
@@ -1,0 +1,78 @@
+(ns ai.miniforge.data-foundry.pipeline.stage
+  (:require [ai.miniforge.data-foundry.pipeline.messages :as msg])
+  (:import [java.util UUID]))
+
+(def stage-families
+  "N3 §2.2 stage families"
+  #{:ingest :extract :normalize :transform :aggregate :validate :enrich :publish})
+
+(def ^:private connector-required-families
+  "Stage families that REQUIRE a :stage/connector-ref"
+  #{:ingest :publish})
+
+(def ^:private connector-forbidden-families
+  "Stage families that MUST NOT have a :stage/connector-ref"
+  #{:extract :normalize :transform :aggregate :validate :enrich})
+
+(defn validate-stage
+  "Validate a stage definition against N3 §2.2."
+  [{:stage/keys [id name family connector-ref input-datasets output-datasets dependencies]}]
+  (let [errors
+        (cond-> []
+          (nil? id)
+          (conj (msg/t :stage/id-required))
+
+          (not (string? name))
+          (conj (msg/t :stage/name-must-be-string))
+
+          (not (contains? stage-families family))
+          (conj (msg/t :stage/family-invalid {:allowed stage-families}))
+
+          ;; Ingest/publish require connector
+          (and (contains? connector-required-families family) (nil? connector-ref))
+          (conj (msg/t :stage/connector-ref-required {:family family}))
+
+          ;; Other stages must not have connector
+          (and (contains? connector-forbidden-families family) (some? connector-ref))
+          (conj (msg/t :stage/connector-ref-forbidden {:family family}))
+
+          ;; Ingest must not have input datasets
+          (and (= family :ingest) (seq input-datasets))
+          (conj (msg/t :stage/ingest-no-input))
+
+          ;; Publish must not have output datasets
+          (and (= family :publish) (seq output-datasets))
+          (conj (msg/t :stage/publish-no-output))
+
+          ;; Non-ingest must have input datasets
+          (and (not= family :ingest) (empty? input-datasets))
+          (conj (msg/t :stage/must-have-input {:family family}))
+
+          ;; Non-publish must have output datasets
+          (and (not= family :publish) (empty? output-datasets))
+          (conj (msg/t :stage/must-have-output {:family family}))
+
+          (not (vector? dependencies))
+          (conj (msg/t :stage/deps-must-be-vector)))]
+    (if (empty? errors)
+      {:success? true}
+      {:success? false :errors errors})))
+
+(defn create-stage
+  [opts]
+  (let [stage (cond-> opts
+                (nil? (:stage/id opts))
+                (assoc :stage/id (UUID/randomUUID))
+
+                (nil? (:stage/dependencies opts))
+                (assoc :stage/dependencies [])
+
+                (nil? (:stage/input-datasets opts))
+                (assoc :stage/input-datasets [])
+
+                (nil? (:stage/output-datasets opts))
+                (assoc :stage/output-datasets []))
+        validation (validate-stage stage)]
+    (if (:success? validation)
+      {:success? true :stage stage}
+      {:success? false :errors (:errors validation)})))

--- a/components/pipeline/test/ai/miniforge/data_foundry/pipeline/interface_test.clj
+++ b/components/pipeline/test/ai/miniforge/data_foundry/pipeline/interface_test.clj
@@ -1,0 +1,490 @@
+(ns ai.miniforge.data-foundry.pipeline.interface-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.data-foundry.pipeline.interface :as pipe]))
+
+(def ^:private ds-a (java.util.UUID/randomUUID))
+(def ^:private ds-b (java.util.UUID/randomUUID))
+(def ^:private ds-c (java.util.UUID/randomUUID))
+(def ^:private conn-src (java.util.UUID/randomUUID))
+(def ^:private conn-sink (java.util.UUID/randomUUID))
+
+(def ^:private stage-1-id (java.util.UUID/randomUUID))
+(def ^:private stage-2-id (java.util.UUID/randomUUID))
+(def ^:private stage-3-id (java.util.UUID/randomUUID))
+
+(def ^:private valid-stages
+  [{:stage/id stage-1-id
+    :stage/name "Ingest Data"
+    :stage/family :ingest
+    :stage/connector-ref conn-src
+    :stage/input-datasets []
+    :stage/output-datasets [ds-a]
+    :stage/dependencies []}
+   {:stage/id stage-2-id
+    :stage/name "Normalize"
+    :stage/family :normalize
+    :stage/input-datasets [ds-a]
+    :stage/output-datasets [ds-b]
+    :stage/dependencies [stage-1-id]}
+   {:stage/id stage-3-id
+    :stage/name "Publish"
+    :stage/family :publish
+    :stage/connector-ref conn-sink
+    :stage/input-datasets [ds-b]
+    :stage/output-datasets []
+    :stage/dependencies [stage-2-id]}])
+
+(def ^:private valid-pipeline-opts
+  {:pipeline/name "Test Pipeline"
+   :pipeline/version "1.0.0"
+   :pipeline/stages valid-stages
+   :pipeline/mode :full-refresh
+   :pipeline/input-datasets []
+   :pipeline/output-datasets [ds-b]})
+
+;; ---------------------------------------------------------------------------
+;; Constants
+;; ---------------------------------------------------------------------------
+
+(deftest stage-families-test
+  (testing "N3 §2.2 all stage families"
+    (is (= #{:ingest :extract :normalize :transform :aggregate :validate :enrich :publish}
+           pipe/stage-families))))
+
+(deftest execution-modes-test
+  (testing "N3 §3 execution modes"
+    (is (= #{:full-refresh :incremental :backfill :reprocess}
+           pipe/execution-modes))))
+
+;; ---------------------------------------------------------------------------
+;; validate-stage (direct)
+;; ---------------------------------------------------------------------------
+
+(deftest validate-stage-valid-ingest-test
+  (testing "Valid ingest stage passes"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Ingest"
+                   :stage/family :ingest
+                   :stage/connector-ref conn-src
+                   :stage/input-datasets []
+                   :stage/output-datasets [ds-a]
+                   :stage/dependencies []})]
+      (is (:success? result)))))
+
+(deftest validate-stage-valid-transform-test
+  (testing "Valid transform stage passes"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Transform"
+                   :stage/family :transform
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets [ds-b]
+                   :stage/dependencies []})]
+      (is (:success? result)))))
+
+(deftest validate-stage-valid-publish-test
+  (testing "Valid publish stage passes"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Publish"
+                   :stage/family :publish
+                   :stage/connector-ref conn-sink
+                   :stage/input-datasets [ds-b]
+                   :stage/output-datasets []
+                   :stage/dependencies []})]
+      (is (:success? result)))))
+
+(deftest validate-stage-invalid-family-test
+  (testing "Reject unknown family"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Bad"
+                   :stage/family :unknown
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets [ds-b]
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-ingest-requires-connector-test
+  (testing "Ingest without connector-ref fails"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Ingest"
+                   :stage/family :ingest
+                   :stage/input-datasets []
+                   :stage/output-datasets [ds-a]
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-publish-requires-connector-test
+  (testing "Publish without connector-ref fails"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Publish"
+                   :stage/family :publish
+                   :stage/input-datasets [ds-b]
+                   :stage/output-datasets []
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-transform-forbids-connector-test
+  (testing "Transform with connector-ref fails"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Transform"
+                   :stage/family :transform
+                   :stage/connector-ref conn-src
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets [ds-b]
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-enrich-forbids-connector-test
+  (testing "Enrich with connector-ref fails"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Enrich"
+                   :stage/family :enrich
+                   :stage/connector-ref conn-src
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets [ds-b]
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-ingest-no-input-datasets-test
+  (testing "Ingest with input-datasets fails"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Bad Ingest"
+                   :stage/family :ingest
+                   :stage/connector-ref conn-src
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets [ds-b]
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-publish-no-output-datasets-test
+  (testing "Publish with output-datasets fails"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Bad Publish"
+                   :stage/family :publish
+                   :stage/connector-ref conn-sink
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets [ds-b]
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-transform-requires-input-test
+  (testing "Transform without input-datasets fails"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "No Input"
+                   :stage/family :transform
+                   :stage/input-datasets []
+                   :stage/output-datasets [ds-b]
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-transform-requires-output-test
+  (testing "Transform without output-datasets fails"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "No Output"
+                   :stage/family :transform
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets []
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-missing-id-test
+  (testing "Missing stage id fails"
+    (let [result (pipe/validate-stage
+                  {:stage/name "No ID"
+                   :stage/family :transform
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets [ds-b]
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-missing-name-test
+  (testing "Missing name fails"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/family :transform
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets [ds-b]
+                   :stage/dependencies []})]
+      (is (not (:success? result))))))
+
+(deftest validate-stage-missing-deps-vector-test
+  (testing "Non-vector dependencies fails"
+    (let [result (pipe/validate-stage
+                  {:stage/id (java.util.UUID/randomUUID)
+                   :stage/name "Bad Deps"
+                   :stage/family :transform
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets [ds-b]
+                   :stage/dependencies #{stage-1-id}})]
+      (is (not (:success? result))))))
+
+;; ---------------------------------------------------------------------------
+;; create-stage
+;; ---------------------------------------------------------------------------
+
+(deftest create-stage-test
+  (testing "Valid ingest stage"
+    (let [result (pipe/create-stage
+                  {:stage/name "Ingest"
+                   :stage/family :ingest
+                   :stage/connector-ref conn-src
+                   :stage/output-datasets [ds-a]})]
+      (is (:success? result))
+      (is (uuid? (get-in result [:stage :stage/id])))
+      ;; Defaults filled in
+      (is (= [] (get-in result [:stage :stage/dependencies])))
+      (is (= [] (get-in result [:stage :stage/input-datasets])))))
+
+  (testing "Reject ingest without connector"
+    (let [result (pipe/create-stage
+                  {:stage/name "Bad Ingest"
+                   :stage/family :ingest
+                   :stage/output-datasets [ds-a]})]
+      (is (not (:success? result)))))
+
+  (testing "Reject transform with connector"
+    (let [result (pipe/create-stage
+                  {:stage/name "Bad Transform"
+                   :stage/family :transform
+                   :stage/connector-ref conn-src
+                   :stage/input-datasets [ds-a]
+                   :stage/output-datasets [ds-b]})]
+      (is (not (:success? result))))))
+
+(deftest create-stage-auto-defaults-test
+  (testing "Auto-fills id, dependencies, input/output-datasets"
+    (let [result (pipe/create-stage
+                  {:stage/name "Ingest"
+                   :stage/family :ingest
+                   :stage/connector-ref conn-src
+                   :stage/output-datasets [ds-a]})]
+      (is (:success? result))
+      (is (uuid? (get-in result [:stage :stage/id])))
+      (is (= [] (get-in result [:stage :stage/dependencies])))
+      (is (= [] (get-in result [:stage :stage/input-datasets]))))))
+
+;; ---------------------------------------------------------------------------
+;; validate-pipeline (direct)
+;; ---------------------------------------------------------------------------
+
+(deftest validate-pipeline-valid-test
+  (testing "Valid pipeline passes validation"
+    (let [pipeline (assoc valid-pipeline-opts :pipeline/id (java.util.UUID/randomUUID))
+          result (pipe/validate-pipeline pipeline)]
+      (is (:success? result)))))
+
+(deftest validate-pipeline-missing-name-test
+  (testing "Missing name fails"
+    (let [result (pipe/validate-pipeline
+                  (-> valid-pipeline-opts
+                      (assoc :pipeline/id (java.util.UUID/randomUUID))
+                      (dissoc :pipeline/name)))]
+      (is (not (:success? result))))))
+
+(deftest validate-pipeline-missing-version-test
+  (testing "Missing version fails"
+    (let [result (pipe/validate-pipeline
+                  (-> valid-pipeline-opts
+                      (assoc :pipeline/id (java.util.UUID/randomUUID))
+                      (dissoc :pipeline/version)))]
+      (is (not (:success? result))))))
+
+(deftest validate-pipeline-invalid-mode-test
+  (testing "Invalid mode fails"
+    (let [result (pipe/validate-pipeline
+                  (assoc valid-pipeline-opts
+                         :pipeline/id (java.util.UUID/randomUUID)
+                         :pipeline/mode :invalid))]
+      (is (not (:success? result))))))
+
+(deftest validate-pipeline-empty-stages-test
+  (testing "Empty stages vector fails"
+    (let [result (pipe/validate-pipeline
+                  (assoc valid-pipeline-opts
+                         :pipeline/id (java.util.UUID/randomUUID)
+                         :pipeline/stages []))]
+      (is (not (:success? result))))))
+
+(deftest validate-pipeline-non-vector-stages-test
+  (testing "Non-vector stages fails"
+    (let [result (pipe/validate-pipeline
+                  (assoc valid-pipeline-opts
+                         :pipeline/id (java.util.UUID/randomUUID)
+                         :pipeline/stages #{}))]
+      (is (not (:success? result))))))
+
+(deftest validate-pipeline-non-vector-input-datasets-test
+  (testing "Non-vector input-datasets fails"
+    (let [result (pipe/validate-pipeline
+                  (assoc valid-pipeline-opts
+                         :pipeline/id (java.util.UUID/randomUUID)
+                         :pipeline/input-datasets #{}))]
+      (is (not (:success? result))))))
+
+(deftest validate-pipeline-non-vector-output-datasets-test
+  (testing "Non-vector output-datasets fails"
+    (let [result (pipe/validate-pipeline
+                  (assoc valid-pipeline-opts
+                         :pipeline/id (java.util.UUID/randomUUID)
+                         :pipeline/output-datasets nil))]
+      (is (not (:success? result))))))
+
+(deftest validate-pipeline-unknown-dependency-test
+  (testing "Stage with unknown dependency fails"
+    (let [bogus-dep (java.util.UUID/randomUUID)
+          stages [(assoc (first valid-stages) :stage/dependencies [bogus-dep])]
+          result (pipe/validate-pipeline
+                  (assoc valid-pipeline-opts
+                         :pipeline/id (java.util.UUID/randomUUID)
+                         :pipeline/stages stages))]
+      (is (not (:success? result))))))
+
+(deftest validate-pipeline-cycle-test
+  (testing "Cyclic stages fail validation"
+    (let [id-a (java.util.UUID/randomUUID)
+          id-b (java.util.UUID/randomUUID)
+          cyclic [{:stage/id id-a :stage/name "A" :stage/family :transform
+                   :stage/input-datasets [ds-a] :stage/output-datasets [ds-b]
+                   :stage/dependencies [id-b]}
+                  {:stage/id id-b :stage/name "B" :stage/family :transform
+                   :stage/input-datasets [ds-b] :stage/output-datasets [ds-a]
+                   :stage/dependencies [id-a]}]
+          result (pipe/validate-pipeline
+                  (assoc valid-pipeline-opts
+                         :pipeline/id (java.util.UUID/randomUUID)
+                         :pipeline/stages cyclic))]
+      (is (not (:success? result))))))
+
+;; ---------------------------------------------------------------------------
+;; create-pipeline
+;; ---------------------------------------------------------------------------
+
+(deftest create-pipeline-test
+  (testing "Valid pipeline"
+    (let [result (pipe/create-pipeline valid-pipeline-opts)]
+      (is (:success? result))
+      (is (some? (get-in result [:pipeline :pipeline/id])))
+      (is (some? (get-in result [:pipeline :pipeline/created-at])))
+      (is (some? (get-in result [:pipeline :pipeline/updated-at])))))
+
+  (testing "Reject invalid mode"
+    (let [result (pipe/create-pipeline
+                  (assoc valid-pipeline-opts :pipeline/mode :invalid))]
+      (is (not (:success? result))))))
+
+(deftest create-pipeline-auto-id-test
+  (testing "Auto-generates pipeline id"
+    (let [result (pipe/create-pipeline valid-pipeline-opts)]
+      (is (:success? result))
+      (is (uuid? (get-in result [:pipeline :pipeline/id]))))))
+
+(deftest create-pipeline-preserves-id-test
+  (testing "Preserves provided id"
+    (let [id (java.util.UUID/randomUUID)
+          result (pipe/create-pipeline (assoc valid-pipeline-opts :pipeline/id id))]
+      (is (:success? result))
+      (is (= id (get-in result [:pipeline :pipeline/id]))))))
+
+;; ---------------------------------------------------------------------------
+;; DAG conversion
+;; ---------------------------------------------------------------------------
+
+(deftest dag-conversion-test
+  (testing "Stages convert to DAG"
+    (let [result (pipe/stages->dag valid-stages)]
+      (is (:success? result))
+      (is (= 3 (count (get-in result [:dag :tasks]))))
+      (is (= 2 (count (get-in result [:dag :edges]))))
+      (is (= 3 (count (get-in result [:dag :execution-order]))))))
+
+  (testing "Execution order is topological"
+    (let [order (pipe/execution-order valid-stages)]
+      (is (= 3 (count order)))
+      (is (< (.indexOf order stage-1-id) (.indexOf order stage-2-id)))
+      (is (< (.indexOf order stage-2-id) (.indexOf order stage-3-id))))))
+
+(deftest dag-single-stage-test
+  (testing "Single stage DAG"
+    (let [stages [{:stage/id stage-1-id
+                   :stage/name "Solo Ingest"
+                   :stage/family :ingest
+                   :stage/connector-ref conn-src
+                   :stage/input-datasets []
+                   :stage/output-datasets [ds-a]
+                   :stage/dependencies []}]
+          result (pipe/stages->dag stages)]
+      (is (:success? result))
+      (is (= 1 (count (get-in result [:dag :tasks]))))
+      (is (= 0 (count (get-in result [:dag :edges])))))))
+
+(deftest dag-diamond-topology-test
+  (testing "Diamond DAG topology"
+    (let [id-root (java.util.UUID/randomUUID)
+          id-left (java.util.UUID/randomUUID)
+          id-right (java.util.UUID/randomUUID)
+          id-join (java.util.UUID/randomUUID)
+          stages [{:stage/id id-root :stage/name "Root" :stage/family :ingest
+                   :stage/connector-ref conn-src
+                   :stage/input-datasets [] :stage/output-datasets [ds-a]
+                   :stage/dependencies []}
+                  {:stage/id id-left :stage/name "Left" :stage/family :transform
+                   :stage/input-datasets [ds-a] :stage/output-datasets [ds-b]
+                   :stage/dependencies [id-root]}
+                  {:stage/id id-right :stage/name "Right" :stage/family :transform
+                   :stage/input-datasets [ds-a] :stage/output-datasets [ds-c]
+                   :stage/dependencies [id-root]}
+                  {:stage/id id-join :stage/name "Join" :stage/family :publish
+                   :stage/connector-ref conn-sink
+                   :stage/input-datasets [ds-b ds-c] :stage/output-datasets []
+                   :stage/dependencies [id-left id-right]}]
+          result (pipe/stages->dag stages)
+          order (pipe/execution-order stages)]
+      (is (:success? result))
+      (is (= 4 (count (get-in result [:dag :tasks]))))
+      (is (= 4 (count (get-in result [:dag :edges]))))
+      ;; Root before left and right, both before join
+      (is (< (.indexOf order id-root) (.indexOf order id-left)))
+      (is (< (.indexOf order id-root) (.indexOf order id-right)))
+      (is (< (.indexOf order id-left) (.indexOf order id-join)))
+      (is (< (.indexOf order id-right) (.indexOf order id-join))))))
+
+(deftest cycle-detection-test
+  (testing "Detect cyclic dependencies"
+    (let [id-a (java.util.UUID/randomUUID)
+          id-b (java.util.UUID/randomUUID)
+          cyclic [{:stage/id id-a :stage/name "A" :stage/family :transform
+                   :stage/input-datasets [ds-a] :stage/output-datasets [ds-b]
+                   :stage/dependencies [id-b]}
+                  {:stage/id id-b :stage/name "B" :stage/family :transform
+                   :stage/input-datasets [ds-b] :stage/output-datasets [ds-a]
+                   :stage/dependencies [id-a]}]]
+      (is (nil? (pipe/execution-order cyclic)))
+      (is (not (:success? (pipe/stages->dag cyclic)))))))
+
+(deftest cycle-detection-three-node-test
+  (testing "Detect 3-node cycle"
+    (let [id-a (java.util.UUID/randomUUID)
+          id-b (java.util.UUID/randomUUID)
+          id-c (java.util.UUID/randomUUID)
+          cyclic [{:stage/id id-a :stage/name "A" :stage/family :transform
+                   :stage/input-datasets [ds-a] :stage/output-datasets [ds-b]
+                   :stage/dependencies [id-c]}
+                  {:stage/id id-b :stage/name "B" :stage/family :transform
+                   :stage/input-datasets [ds-b] :stage/output-datasets [ds-c]
+                   :stage/dependencies [id-a]}
+                  {:stage/id id-c :stage/name "C" :stage/family :transform
+                   :stage/input-datasets [ds-c] :stage/output-datasets [ds-a]
+                   :stage/dependencies [id-b]}]]
+      (is (nil? (pipe/execution-order cyclic)))
+      (is (not (:success? (pipe/stages->dag cyclic)))))))

--- a/deps.edn
+++ b/deps.edn
@@ -318,7 +318,9 @@
                        "components/metric-registry/test"
                        "components/pipeline/test"
                        "components/pipeline-config/test"
+                       "components/pipeline-config/test/resources"
                        "components/pipeline-pack/test"
+                       "components/pipeline-pack/test/resources"
                        "components/pipeline-pack-store/test"
                        "components/pipeline-runner/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}

--- a/deps.edn
+++ b/deps.edn
@@ -113,7 +113,47 @@
                        "components/patterns/resources"
                        "bases/cli/src"
                        "bases/cli/resources"
-                       "bases/lsp-mcp-bridge/src"]
+                       "bases/lsp-mcp-bridge/src"
+                       ;; Data Foundry components
+                       "components/connector/src"
+                       "components/connector/resources"
+                       "components/connector-auth/src"
+                       "components/connector-auth/resources"
+                       "components/connector-edgar/src"
+                       "components/connector-edgar/resources"
+                       "components/connector-excel/src"
+                       "components/connector-excel/resources"
+                       "components/connector-file/src"
+                       "components/connector-file/resources"
+                       "components/connector-github/src"
+                       "components/connector-github/resources"
+                       "components/connector-gitlab/src"
+                       "components/connector-gitlab/resources"
+                       "components/connector-http/src"
+                       "components/connector-http/resources"
+                       "components/connector-jira/src"
+                       "components/connector-jira/resources"
+                       "components/connector-pipeline-output/src"
+                       "components/connector-pipeline-output/resources"
+                       "components/connector-retry/src"
+                       "components/cursor-store/src"
+                       "components/data-quality/src"
+                       "components/data-quality/resources"
+                       "components/dataset/src"
+                       "components/dataset/resources"
+                       "components/dataset-schema/src"
+                       "components/dataset-schema/resources"
+                       "components/metric-registry/src"
+                       "components/metric-registry/resources"
+                       "components/pipeline/src"
+                       "components/pipeline/resources"
+                       "components/pipeline-config/src"
+                       "components/pipeline-config/resources"
+                       "components/pipeline-pack/src"
+                       "components/pipeline-pack/resources"
+                       "components/pipeline-pack-store/src"
+                       "components/pipeline-runner/src"
+                       "components/pipeline-runner/resources"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/config {:local/root "components/config"}
                       ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}
@@ -173,7 +213,29 @@
                      ai.miniforge/phase-deployment {:local/root "components/phase-deployment"}
                      ai.miniforge/workflow-deployment {:local/root "components/workflow-deployment"}
                      ai.miniforge/workflow-chain-deployment {:local/root "components/workflow-chain-deployment"}
-                     ai.miniforge/cli {:local/root "bases/cli"}}}
+                     ai.miniforge/cli {:local/root "bases/cli"}
+                     ;; Data Foundry components
+                     ai.miniforge.data-foundry/connector {:local/root "components/connector"}
+                     ai.miniforge.data-foundry/connector-auth {:local/root "components/connector-auth"}
+                     ai.miniforge.data-foundry/connector-edgar {:local/root "components/connector-edgar"}
+                     ai.miniforge.data-foundry/connector-excel {:local/root "components/connector-excel"}
+                     ai.miniforge.data-foundry/connector-file {:local/root "components/connector-file"}
+                     ai.miniforge.data-foundry/connector-github {:local/root "components/connector-github"}
+                     ai.miniforge.data-foundry/connector-gitlab {:local/root "components/connector-gitlab"}
+                     ai.miniforge.data-foundry/connector-http {:local/root "components/connector-http"}
+                     ai.miniforge.data-foundry/connector-jira {:local/root "components/connector-jira"}
+                     ai.miniforge.data-foundry/connector-pipeline-output {:local/root "components/connector-pipeline-output"}
+                     ai.miniforge.data-foundry/connector-retry {:local/root "components/connector-retry"}
+                     ai.miniforge.data-foundry/cursor-store {:local/root "components/cursor-store"}
+                     ai.miniforge.data-foundry/data-quality {:local/root "components/data-quality"}
+                     ai.miniforge.data-foundry/dataset {:local/root "components/dataset"}
+                     ai.miniforge.data-foundry/dataset-schema {:local/root "components/dataset-schema"}
+                     ai.miniforge.data-foundry/metric-registry {:local/root "components/metric-registry"}
+                     ai.miniforge.data-foundry/pipeline {:local/root "components/pipeline"}
+                     ai.miniforge.data-foundry/pipeline-config {:local/root "components/pipeline-config"}
+                     ai.miniforge.data-foundry/pipeline-pack {:local/root "components/pipeline-pack"}
+                     ai.miniforge.data-foundry/pipeline-pack-store {:local/root "components/pipeline-pack-store"}
+                     ai.miniforge.data-foundry/pipeline-runner {:local/root "components/pipeline-runner"}}}
 
   :test {:extra-paths ["development/test"
                        "components/schema/test"
@@ -236,7 +298,29 @@
                        "components/workflow-deployment/resources"
                        "components/workflow-chain-deployment/resources"
                        "bases/cli/test"
-                       "bases/lsp-mcp-bridge/test"]
+                       "bases/lsp-mcp-bridge/test"
+                       ;; Data Foundry tests
+                       "components/connector/test"
+                       "components/connector-auth/test"
+                       "components/connector-edgar/test"
+                       "components/connector-excel/test"
+                       "components/connector-file/test"
+                       "components/connector-github/test"
+                       "components/connector-gitlab/test"
+                       "components/connector-http/test"
+                       "components/connector-jira/test"
+                       "components/connector-pipeline-output/test"
+                       "components/connector-retry/test"
+                       "components/cursor-store/test"
+                       "components/data-quality/test"
+                       "components/dataset/test"
+                       "components/dataset-schema/test"
+                       "components/metric-registry/test"
+                       "components/pipeline/test"
+                       "components/pipeline-config/test"
+                       "components/pipeline-pack/test"
+                       "components/pipeline-pack-store/test"
+                       "components/pipeline-runner/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/config {:local/root "components/config"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}

--- a/packs/data-foundry/github-data/envs/local.edn
+++ b/packs/data-foundry/github-data/envs/local.edn
@@ -1,0 +1,47 @@
+;; GitHub Data Pack — Local Environment Config
+;;
+;; Requires env vars: GITHUB_TOKEN, GITHUB_ORG, GITHUB_REPO
+;; Usage:
+;;   export GITHUB_TOKEN=ghp_... GITHUB_ORG=myorg GITHUB_REPO=myrepo
+;;   data-foundry run-pack packs/github-data --env local
+{:env/name "local"
+
+ :env/connectors
+ {:conn/github {:connector/type :github}
+  :conn/output {:connector/type :pipeline-output}}
+
+ :env/stages
+ {"Ingest PRs"
+  {:github/owner        "${GITHUB_ORG}"
+   :github/repo         "${GITHUB_REPO}"
+   :auth/method         :api-key
+   :auth/credential-id  "${GITHUB_TOKEN}"}
+
+  "Ingest Issues"
+  {:github/owner        "${GITHUB_ORG}"
+   :github/repo         "${GITHUB_REPO}"
+   :auth/method         :api-key
+   :auth/credential-id  "${GITHUB_TOKEN}"}
+
+  "Ingest Comments"
+  {:github/owner        "${GITHUB_ORG}"
+   :github/repo         "${GITHUB_REPO}"
+   :auth/method         :api-key
+   :auth/credential-id  "${GITHUB_TOKEN}"}
+
+  "Ingest Commits"
+  {:github/owner        "${GITHUB_ORG}"
+   :github/repo         "${GITHUB_REPO}"
+   :auth/method         :api-key
+   :auth/credential-id  "${GITHUB_TOKEN}"}
+
+  "Ingest Reviews"
+  {:github/owner        "${GITHUB_ORG}"
+   :github/repo         "${GITHUB_REPO}"
+   :auth/method         :api-key
+   :auth/credential-id  "${GITHUB_TOKEN}"}
+
+  "Publish"
+  {:output/dir           "output/github-data"
+   :output/format        :edn
+   :output/pipeline-name "github-extract"}}}

--- a/packs/data-foundry/github-data/pack.edn
+++ b/packs/data-foundry/github-data/pack.edn
@@ -1,0 +1,13 @@
+{:pack/id              "github-data"
+ :pack/name            "GitHub Data Pipeline Pack"
+ :pack/version         "2026.03.26"
+ :pack/description     "Extract PRs, issues, and comments from the GitHub REST API"
+ :pack/author          "miniforge.ai"
+ :pack/trust-level     :untrusted
+ :pack/authority       :authority/data
+ :pack/pipelines       ["pipelines/github-extract.edn"]
+ :pack/envs            ["envs/local.edn"]
+ :pack/connector-types #{:github :pipeline-output}
+ :pack/extends         []
+ :pack/created-at      #inst "2026-03-26T00:00:00Z"
+ :pack/updated-at      #inst "2026-03-26T00:00:00Z"}

--- a/packs/data-foundry/github-data/pipelines/github-extract.edn
+++ b/packs/data-foundry/github-data/pipelines/github-extract.edn
@@ -1,0 +1,66 @@
+;; GitHub Data Extraction Pipeline
+;;
+;; Extracts pull requests, issues, comments, commits, and reviews from a GitHub org/repo
+;; and writes raw records to the pipeline output store.
+;;
+;; Downstream consumers read the output and apply their own transforms.
+;;
+;; Usage:
+;;   export GITHUB_TOKEN=ghp_... GITHUB_ORG=myorg GITHUB_REPO=myrepo
+;;   data-foundry run-pack packs/github-data --env local
+{:pipeline/name    "GitHub Data Extract"
+ :pipeline/version "0.1.0"
+ :pipeline/mode    :incremental
+
+ :pipeline/stages
+ [{:stage/name           "Ingest PRs"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/github
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/github-prs]
+   :stage/dependencies    []
+   :stage/config          {:github/resource "pulls"}}
+
+  {:stage/name           "Ingest Issues"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/github
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/github-issues]
+   :stage/dependencies    []
+   :stage/config          {:github/resource "issues"}}
+
+  {:stage/name           "Ingest Comments"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/github
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/github-comments]
+   :stage/dependencies    []
+   :stage/config          {:github/resource "comments"}}
+
+  {:stage/name           "Ingest Commits"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/github
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/github-commits]
+   :stage/dependencies    []
+   :stage/config          {:github/resource "commits"}}
+
+  {:stage/name           "Ingest Reviews"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/github
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/github-reviews]
+   :stage/dependencies    []
+   :stage/config          {:github/resource "reviews"}}
+
+  {:stage/name           "Publish"
+   :stage/family         :publish
+   :stage/connector-ref  :conn/output
+   :stage/input-datasets  [:ds/github-prs :ds/github-issues :ds/github-comments
+                           :ds/github-commits :ds/github-reviews]
+   :stage/output-datasets []
+   :stage/dependencies    ["Ingest PRs" "Ingest Issues" "Ingest Comments"
+                           "Ingest Commits" "Ingest Reviews"]}]
+
+ :pipeline/input-datasets  []
+ :pipeline/output-datasets []}

--- a/packs/data-foundry/gitlab-data/envs/local.edn
+++ b/packs/data-foundry/gitlab-data/envs/local.edn
@@ -1,0 +1,58 @@
+;; GitLab Data Pack — Local Environment Config
+;;
+;; Requires env vars: GITLAB_TOKEN, GITLAB_PROJECT
+;; GITLAB_PROJECT can be a numeric ID or URL-encoded path (e.g., "group%2Fsubgroup%2Frepo")
+;; Usage:
+;;   export GITLAB_TOKEN=glpat-... GITLAB_PROJECT=engrammicai/ixi-services/services/ixi
+;;   data-foundry run-pack packs/gitlab-data --env local
+{:env/name "local"
+
+ :env/connectors
+ {:conn/gitlab {:connector/type :gitlab}
+  :conn/output {:connector/type :pipeline-output}}
+
+ :env/stages
+ {"Ingest Merge Requests"
+  {:gitlab/project-path  "${GITLAB_PROJECT}"
+   :auth/method          :api-key
+   :auth/credential-id   "${GITLAB_TOKEN}"}
+
+  "Ingest Issues"
+  {:gitlab/project-path  "${GITLAB_PROJECT}"
+   :auth/method          :api-key
+   :auth/credential-id   "${GITLAB_TOKEN}"}
+
+  "Ingest Pipelines"
+  {:gitlab/project-path  "${GITLAB_PROJECT}"
+   :auth/method          :api-key
+   :auth/credential-id   "${GITLAB_TOKEN}"}
+
+  "Ingest Commits"
+  {:gitlab/project-path  "${GITLAB_PROJECT}"
+   :auth/method          :api-key
+   :auth/credential-id   "${GITLAB_TOKEN}"}
+
+  "Ingest Milestones"
+  {:gitlab/project-path  "${GITLAB_PROJECT}"
+   :auth/method          :api-key
+   :auth/credential-id   "${GITLAB_TOKEN}"}
+
+  "Ingest Iterations"
+  {:gitlab/project-path  "${GITLAB_PROJECT}"
+   :auth/method          :api-key
+   :auth/credential-id   "${GITLAB_TOKEN}"}
+
+  "Ingest Boards"
+  {:gitlab/project-path  "${GITLAB_PROJECT}"
+   :auth/method          :api-key
+   :auth/credential-id   "${GITLAB_TOKEN}"}
+
+  "Ingest Notes"
+  {:gitlab/project-path  "${GITLAB_PROJECT}"
+   :auth/method          :api-key
+   :auth/credential-id   "${GITLAB_TOKEN}"}
+
+  "Publish"
+  {:output/dir           "output/gitlab-data"
+   :output/format        :edn
+   :output/pipeline-name "gitlab-extract"}}}

--- a/packs/data-foundry/gitlab-data/pack.edn
+++ b/packs/data-foundry/gitlab-data/pack.edn
@@ -1,0 +1,13 @@
+{:pack/id              "gitlab-data"
+ :pack/name            "GitLab Data Pipeline Pack"
+ :pack/version         "2026.03.26"
+ :pack/description     "Extract merge requests, issues, pipelines, and commits from the GitLab REST API"
+ :pack/author          "miniforge.ai"
+ :pack/trust-level     :untrusted
+ :pack/authority       :authority/data
+ :pack/pipelines       ["pipelines/gitlab-extract.edn"]
+ :pack/envs            ["envs/local.edn"]
+ :pack/connector-types #{:gitlab :pipeline-output}
+ :pack/extends         []
+ :pack/created-at      #inst "2026-03-26T00:00:00Z"
+ :pack/updated-at      #inst "2026-03-26T00:00:00Z"}

--- a/packs/data-foundry/gitlab-data/pipelines/gitlab-extract.edn
+++ b/packs/data-foundry/gitlab-data/pipelines/gitlab-extract.edn
@@ -1,0 +1,91 @@
+;; GitLab Data Extraction Pipeline
+;;
+;; Extracts merge requests, issues, pipelines, commits, milestones, iterations,
+;; boards, and notes from a GitLab project
+;; and writes raw records to the pipeline output store.
+;;
+;; Usage:
+;;   export GITLAB_TOKEN=glpat-... GITLAB_PROJECT=group/subgroup/repo
+;;   data-foundry run-pack packs/gitlab-data --env local
+{:pipeline/name    "GitLab Data Extract"
+ :pipeline/version "0.1.0"
+ :pipeline/mode    :incremental
+
+ :pipeline/stages
+ [{:stage/name           "Ingest Merge Requests"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/gitlab
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/gitlab-mrs]
+   :stage/dependencies    []
+   :stage/config          {:gitlab/resource "merge-requests"}}
+
+  {:stage/name           "Ingest Issues"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/gitlab
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/gitlab-issues]
+   :stage/dependencies    []
+   :stage/config          {:gitlab/resource "issues"}}
+
+  {:stage/name           "Ingest Pipelines"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/gitlab
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/gitlab-pipelines]
+   :stage/dependencies    []
+   :stage/config          {:gitlab/resource "pipelines"}}
+
+  {:stage/name           "Ingest Commits"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/gitlab
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/gitlab-commits]
+   :stage/dependencies    []
+   :stage/config          {:gitlab/resource "commits"}}
+
+  {:stage/name           "Ingest Milestones"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/gitlab
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/gitlab-milestones]
+   :stage/dependencies    []
+   :stage/config          {:gitlab/resource "milestones"}}
+
+  {:stage/name           "Ingest Iterations"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/gitlab
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/gitlab-iterations]
+   :stage/dependencies    []
+   :stage/config          {:gitlab/resource "iterations"}}
+
+  {:stage/name           "Ingest Boards"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/gitlab
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/gitlab-boards]
+   :stage/dependencies    []
+   :stage/config          {:gitlab/resource "boards"}}
+
+  {:stage/name           "Ingest Notes"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/gitlab
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/gitlab-notes]
+   :stage/dependencies    []
+   :stage/config          {:gitlab/resource "notes"}}
+
+  {:stage/name           "Publish"
+   :stage/family         :publish
+   :stage/connector-ref  :conn/output
+   :stage/input-datasets  [:ds/gitlab-mrs :ds/gitlab-issues :ds/gitlab-pipelines
+                           :ds/gitlab-commits :ds/gitlab-milestones :ds/gitlab-iterations
+                           :ds/gitlab-boards :ds/gitlab-notes]
+   :stage/output-datasets []
+   :stage/dependencies    ["Ingest Merge Requests" "Ingest Issues" "Ingest Pipelines"
+                           "Ingest Commits" "Ingest Milestones" "Ingest Iterations"
+                           "Ingest Boards" "Ingest Notes"]}]
+
+ :pipeline/input-datasets  []
+ :pipeline/output-datasets []}

--- a/packs/data-foundry/risk-data/envs/fred-local.edn
+++ b/packs/data-foundry/risk-data/envs/fred-local.edn
@@ -1,0 +1,87 @@
+;; Risk Data Pipeline — Local Environment Config
+;;
+;; Requires FRED_API_KEY env var to be set.
+;; Usage:
+;;   export FRED_API_KEY=your_key_here
+;;   clojure -M:dev -m ai.miniforge.data-foundry.pipeline-cli.core run \
+;;     pipelines/fred-risk-data.edn --env pipelines/envs/fred-local.edn
+{:env/name "fred-local"
+
+ :env/connectors
+ {:conn/fred-api  {:connector/type :http}
+  :conn/cape-src  {:connector/type :excel}
+  :conn/edgar-src {:connector/type :edgar}
+  :conn/fred-sink {:connector/type :file}}
+
+ :env/stages
+ {"Ingest FRED Latest"
+  {:http/base-url      "https://api.stlouisfed.org"
+   :http/endpoint      "/fred/series/observations"
+   :http/query-params  {:api_key "${FRED_API_KEY}"
+                        :file_type "json"
+                        :sort_order "desc"
+                        :limit "1"}
+   :http/response-path [:observations]
+   :batch/param-sets   [{:series_id "T10Y2Y"}
+                        {:series_id "T10Y3M"}
+                        {:series_id "BAMLH0A0HYM2"}
+                        {:series_id "BAA10Y"}
+                        {:series_id "ICSA"}
+                        {:series_id "UNRATE"}
+                        {:series_id "T5YIE"}
+                        {:series_id "T10YIE"}
+                        ;; SLOS — Senior Loan Officer Survey (quarterly)
+                        {:series_id "DRTSCILM"}   ; C&I Large/Middle-Market
+                        {:series_id "DRTSCIS"}     ; C&I Small Firms
+                        {:series_id "SUBLPDRCSC"}  ; CRE Construction & Land Dev
+                        {:series_id "DRTSSP"}      ; Residential (Subprime Mortgage)
+                        {:series_id "DRTSCLCC"}    ; Consumer (Credit Card)
+                        ;; Sentiment proxies
+                        {:series_id "UMCSENT"}     ; Michigan Consumer Sentiment (→ AAII proxy)
+                        {:series_id "VIXCLS"}      ; VIX (→ CBOE P/C ratio proxy)
+                        {:series_id "STLFSI4"}]}   ; St. Louis Financial Stress Index
+
+  "Ingest FRED YoY"
+  {:http/base-url      "https://api.stlouisfed.org"
+   :http/endpoint      "/fred/series/observations"
+   :http/query-params  {:api_key "${FRED_API_KEY}"
+                        :file_type "json"
+                        :sort_order "desc"
+                        :limit "400"
+                        :observation_start "2025-01-01"}
+   :http/response-path [:observations]
+   :batch/param-sets   [{:series_id "M2SL"}
+                        {:series_id "CPIAUCSL"}
+                        {:series_id "CPILFESL"}
+                        {:series_id "PCEPILFE"}
+                        {:series_id "IR"}
+                        {:series_id "ISRATIO"}
+                        {:series_id "JTSJOL"}
+                        {:series_id "FRGSHPUSM649NCIS"}
+                        {:series_id "FRGEXPUSM649NCIS"}
+                        {:series_id "BOGZ1FL663067003Q"}
+                        {:series_id "NCBEILQ027S"}
+                        {:series_id "GDP"}]}
+
+  "Ingest Shiller CAPE"
+  {:excel/url            "https://img1.wsimg.com/blobby/go/e5e77e0b-59d1-44d9-ab25-4763ac982e53/downloads/3228b83a-7bad-4e69-b405-71e3a1ca6351/ie_data.xls"
+   :excel/sheet-name     "Data"
+   :excel/data-start-row 8
+   :excel/columns        {0 :date, 12 :value}
+   :excel/min-value      2020.0
+   :excel/date-format    :decimal-year
+   :excel/series-id      "CAPE10"}
+
+  "Ingest Insider Ratio"
+  {:edgar/form-type       "4"
+   :edgar/user-agent      "DataFoundry/1.0 chris@miniforge.ai"
+   :edgar/start-date      "2025-01-01"
+   :edgar/sample-size     200
+   :edgar/transaction-codes #{"P" "S"}
+   :edgar/aggregation     :monthly-buy-sell-ratio
+   :edgar/series-id       "INSIDER_BUY_SELL_RATIO"
+   :edgar/filing-filenames ["form4.xml" "ownership.xml" "primary_doc.xml"]}
+
+  "Publish"
+  {:file/path   "output/fred-risk-data.json"
+   :file/format :json}}}

--- a/packs/data-foundry/risk-data/metric-registry.edn
+++ b/packs/data-foundry/risk-data/metric-registry.edn
@@ -1,0 +1,351 @@
+{:registry/id      "risk-metrics"
+ :registry/version "2026.03.17"
+ :registry/families
+
+ [{:family/id       :yield-curve
+   :family/name     "Yield Curve & Credit Spreads"
+   :family/metrics
+   [{:metric/id              "T10Y2Y"
+     :metric/name            "10Y-2Y Treasury Spread"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :daily
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :percent}
+    {:metric/id              "T10Y3M"
+     :metric/name            "10Y-3M Treasury Spread"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :daily
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :percent}
+    {:metric/id              "BAMLH0A0HYM2"
+     :metric/name            "ICE BofA US High Yield OAS"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :daily
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :percent}
+    {:metric/id              "BAA10Y"
+     :metric/name            "Moody's Baa-10Y Treasury Spread"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :daily
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :percent}]}
+
+  {:family/id       :labor-market
+   :family/name     "Labor Market"
+   :family/metrics
+   [{:metric/id              "ICSA"
+     :metric/name            "Initial Jobless Claims"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :weekly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :count}
+    {:metric/id              "UNRATE"
+     :metric/name            "Unemployment Rate"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :percent}
+    {:metric/id              "JTSJOL"
+     :metric/name            "Job Openings (JOLTS)"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :count}]}
+
+  {:family/id       :inflation
+   :family/name     "Inflation & Expectations"
+   :family/metrics
+   [{:metric/id              "T5YIE"
+     :metric/name            "5-Year Breakeven Inflation"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :daily
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :percent}
+    {:metric/id              "T10YIE"
+     :metric/name            "10-Year Breakeven Inflation"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :daily
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :percent}
+    {:metric/id              "CPIAUCSL"
+     :metric/name            "CPI All Urban Consumers"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :index}
+    {:metric/id              "CPILFESL"
+     :metric/name            "CPI Less Food & Energy (Core)"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :index}
+    {:metric/id              "PCEPILFE"
+     :metric/name            "PCE Less Food & Energy (Core)"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :index}]}
+
+  {:family/id       :monetary
+   :family/name     "Monetary & Liquidity"
+   :family/metrics
+   [{:metric/id              "M2SL"
+     :metric/name            "M2 Money Stock"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :level}
+    {:metric/id              "STLFSI4"
+     :metric/name            "St. Louis Financial Stress Index"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :weekly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :index}]}
+
+  {:family/id       :lending-standards
+   :family/name     "Senior Loan Officer Survey (SLOS)"
+   :family/metrics
+   [{:metric/id              "DRTSCILM"
+     :metric/name            "SLOS: C&I Large/Middle-Market"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :quarterly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :percent}
+    {:metric/id              "DRTSCIS"
+     :metric/name            "SLOS: C&I Small Firms"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :quarterly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :percent}
+    {:metric/id              "SUBLPDRCSC"
+     :metric/name            "SLOS: CRE Construction & Land Dev"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :quarterly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :percent}
+    {:metric/id              "DRTSSP"
+     :metric/name            "SLOS: Residential (Subprime Mortgage)"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :quarterly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :percent}
+    {:metric/id              "DRTSCLCC"
+     :metric/name            "SLOS: Consumer (Credit Card)"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :quarterly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :percent}]}
+
+  {:family/id       :sentiment
+   :family/name     "Sentiment & Volatility"
+   :family/metrics
+   [{:metric/id              "UMCSENT"
+     :metric/name            "Michigan Consumer Sentiment"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :index}
+    {:metric/id              "VIXCLS"
+     :metric/name            "CBOE Volatility Index (VIX)"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :daily
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :index}]}
+
+  {:family/id       :trade-shipping
+   :family/name     "Trade & Shipping"
+   :family/metrics
+   [{:metric/id              "IR"
+     :metric/name            "Import Price Index"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :index}
+    {:metric/id              "ISRATIO"
+     :metric/name            "Inventory-to-Sales Ratio"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :ratio}
+    {:metric/id              "FRGSHPUSM649NCIS"
+     :metric/name            "Global Supply Chain Pressure (Shipping)"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :index}
+    {:metric/id              "FRGEXPUSM649NCIS"
+     :metric/name            "Global Supply Chain Pressure (Export Orders)"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :index}]}
+
+  {:family/id       :corporate
+   :family/name     "Corporate & Flow of Funds"
+   :family/metrics
+   [{:metric/id              "BOGZ1FL663067003Q"
+     :metric/name            "Corporate Profits After Tax"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :quarterly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :level}
+    {:metric/id              "NCBEILQ027S"
+     :metric/name            "Nonfinancial Corporate Business Equity"
+     :metric/source-type     :public_canonical
+     :metric/source-system   "FRED"
+     :metric/refresh-cadence :quarterly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :level}]}
+
+  {:family/id       :house-factors
+   :family/name     "House Factors"
+   :family/metrics
+   [{:metric/id              "BUFFETT_INDICATOR"
+     :metric/name            "Buffett Indicator (Market Cap / GDP)"
+     :metric/source-type     :house_factor
+     :metric/source-system   "internal"
+     :metric/refresh-cadence :quarterly
+     :metric/implementation-mode :derive
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :inverse
+     :metric/unit            :ratio}
+    {:metric/id              "CAPE10"
+     :metric/name            "Shiller CAPE Ratio (P/E 10)"
+     :metric/source-type     :official_market
+     :metric/source-system   "Shiller"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :pull
+     :metric/license-required false
+     :metric/redistribution-risk :low
+     :metric/direction       :inverse
+     :metric/unit            :ratio}
+    {:metric/id              "INSIDER_BUY_SELL_RATIO"
+     :metric/name            "Insider Buy:Sell Ratio (SEC Form 4)"
+     :metric/source-type     :house_factor
+     :metric/source-system   "SEC-EDGAR"
+     :metric/refresh-cadence :monthly
+     :metric/implementation-mode :derive
+     :metric/license-required false
+     :metric/redistribution-risk :none
+     :metric/direction       :normal
+     :metric/unit            :ratio}]}]
+
+ :registry/pipeline-metric-map
+ {"fred-risk-data"
+  ["T10Y2Y" "T10Y3M" "BAMLH0A0HYM2" "BAA10Y"
+   "ICSA" "UNRATE" "JTSJOL"
+   "T5YIE" "T10YIE" "CPIAUCSL" "CPILFESL" "PCEPILFE"
+   "M2SL" "STLFSI4"
+   "DRTSCILM" "DRTSCIS" "SUBLPDRCSC" "DRTSSP" "DRTSCLCC"
+   "UMCSENT" "VIXCLS"
+   "IR" "ISRATIO" "FRGSHPUSM649NCIS" "FRGEXPUSM649NCIS"
+   "BOGZ1FL663067003Q" "NCBEILQ027S"
+   "BUFFETT_INDICATOR" "CAPE10" "INSIDER_BUY_SELL_RATIO"]}}

--- a/packs/data-foundry/risk-data/pack.edn
+++ b/packs/data-foundry/risk-data/pack.edn
@@ -1,0 +1,14 @@
+{:pack/id          "risk-data"
+ :pack/name        "Risk Data Pipeline Pack"
+ :pack/version     "2026.03.17"
+ :pack/description "Market risk indicators from FRED, Shiller, SEC EDGAR"
+ :pack/author      "miniforge.ai"
+ :pack/trust-level :untrusted
+ :pack/authority   :authority/data
+ :pack/pipelines   ["pipelines/fred-risk-data.edn"]
+ :pack/envs        ["envs/fred-local.edn"]
+ :pack/metric-registry "metric-registry.edn"
+ :pack/connector-types #{:http :file :excel :edgar}
+ :pack/extends     []
+ :pack/created-at  #inst "2026-03-17T00:00:00Z"
+ :pack/updated-at  #inst "2026-03-17T00:00:00Z"}

--- a/packs/data-foundry/risk-data/pipelines/fred-risk-data.edn
+++ b/packs/data-foundry/risk-data/pipelines/fred-risk-data.edn
@@ -1,0 +1,90 @@
+;; Risk Data Pipeline
+;;
+;; Fetches market risk indicators from multiple sources:
+;;   1. FRED Latest (16 series) — most recent observation only
+;;   2. FRED YoY (11 series) — 13 months of history for YoY calc
+;;   3. Shiller CAPE (CAPE10) — from published Excel file (monthly)
+;;   4. SEC EDGAR Insider Ratio — Form 4 buy:sell ratio (monthly)
+;;   5. Buffett Indicator — derived transform: NCBEILQ027S / GDP (quarterly)
+;;
+;; Series list sourced from risk-core fixture data.
+;; House factors: INSIDER_BUY_SELL_RATIO, BUFFETT_INDICATOR
+;;
+;; Latest:  T10Y2Y, T10Y3M, BAMLH0A0HYM2, BAA10Y, ICSA, UNRATE, T5YIE, T10YIE
+;;          DRTSCILM, DRTSCIS, SUBLPDRCSC, DRTSSP, DRTSCLCC  (SLOS)
+;;          UMCSENT, VIXCLS, STLFSI4  (sentiment proxies)
+;; YoY:    M2SL, CPIAUCSL, CPILFESL, PCEPILFE, IR, ISRATIO, JTSJOL,
+;;         FRGSHPUSM649NCIS, FRGEXPUSM649NCIS, BOGZ1FL663067003Q, NCBEILQ027S
+{:pipeline/name    "Risk Data Pipeline"
+ :pipeline/version "0.2.0"
+ :pipeline/mode    :full-refresh
+
+ :pipeline/stages
+ [{:stage/name           "Ingest FRED Latest"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/fred-api
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/fred-latest-raw]
+   :stage/dependencies    []}
+
+  {:stage/name           "Ingest FRED YoY"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/fred-api
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/fred-yoy-raw]
+   :stage/dependencies    []}
+
+  {:stage/name           "Ingest Shiller CAPE"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/cape-src
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/cape-raw]
+   :stage/dependencies    []}
+
+  {:stage/name           "Ingest Insider Ratio"
+   :stage/family         :ingest
+   :stage/connector-ref  :conn/edgar-src
+   :stage/input-datasets  []
+   :stage/output-datasets [:ds/insider-raw]
+   :stage/dependencies    []}
+
+  {:stage/name           "Derive Buffett Indicator"
+   :stage/family         :transform
+   :stage/input-datasets  [:ds/fred-yoy-raw]
+   :stage/output-datasets [:ds/buffett-derived]
+   :stage/dependencies    ["Ingest FRED YoY"]
+   :stage/config
+   {:stage/transform
+    {:transform/type              :derived-ratio
+     :transform/numerator-series  "NCBEILQ027S"
+     :transform/denominator-series "GDP"
+     :transform/numerator-scale   0.001
+     :transform/output-scale      100.0
+     :transform/output-series     "BUFFETT_INDICATOR"}}}
+
+  {:stage/name           "Normalize"
+   :stage/family         :normalize
+   :stage/input-datasets  [:ds/fred-latest-raw :ds/buffett-derived :ds/cape-raw :ds/insider-raw]
+   :stage/output-datasets [:ds/normalized]
+   :stage/dependencies    ["Ingest FRED Latest" "Derive Buffett Indicator" "Ingest Shiller CAPE" "Ingest Insider Ratio"]}
+
+  {:stage/name           "Validate Quality"
+   :stage/family         :validate
+   :stage/input-datasets  [:ds/normalized]
+   :stage/output-datasets [:ds/validated]
+   :stage/dependencies    ["Normalize"]
+   :stage/config
+   {:stage/quality-pack
+    {:pack/id :risk-data-quality
+     :pack/rules [{:rule/type :required :rule/field :date}
+                  {:rule/type :required :rule/field :value}]}}}
+
+  {:stage/name           "Publish"
+   :stage/family         :publish
+   :stage/connector-ref  :conn/fred-sink
+   :stage/input-datasets  [:ds/validated]
+   :stage/output-datasets []
+   :stage/dependencies    ["Validate Quality"]}]
+
+ :pipeline/input-datasets  []
+ :pipeline/output-datasets []}


### PR DESCRIPTION
## Summary

- Imports 21 Data Foundry components into miniforge monorepo
- Namespace rename: ai.data-foundry → ai.miniforge.data-foundry
- 194 files copied, bulk sed rename, deps.edn wired
- Verified: connector.protocol and pipeline.core load under new namespace

## Components imported

Connectors: connector (protocol), connector-auth, connector-edgar, connector-excel, connector-file, connector-github, connector-gitlab, connector-http, connector-jira, connector-pipeline-output, connector-retry

ETL: pipeline (core/stage/dag), pipeline-config, pipeline-pack, pipeline-pack-store, pipeline-runner

Data: cursor-store, data-quality, dataset, dataset-schema, metric-registry

Packs: github-data, gitlab-data, risk-data

## Test plan

- [x] Namespace loading verified (connector.protocol, pipeline.core)
- [ ] Data Foundry test suite passes under new namespace

🤖 Generated with [Claude Code](https://claude.com/claude-code)