### PR TITLE
feat: DAG decomposition from plan phase

### DIFF
--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -5,7 +5,7 @@
 ;; creates detailed implementation plans.
 
 {:prompt/id :planner
- :prompt/version "1.0.0"
+ :prompt/version "2.0.0"
  :prompt/agent :planner
 
  :prompt/system
@@ -39,12 +39,101 @@ You must output a structured plan as a Clojure map with:
                :task/type :implement ; or :test, :review, :design, :deploy, :configure
                :task/dependencies [<uuid>...] ; IDs of tasks that must complete first
                :task/acceptance-criteria [\"Criterion 1\" \"Criterion 2\"...]
-               :task/estimated-effort :small} ; :small, :medium, :large, :xlarge
+               :task/estimated-effort :small ; :small, :medium, :large, :xlarge
+               :task/component \"agent\" ; Polylith component name (optional)
+               :task/exclusive-files [\"components/agent/src/.../foo.clj\"] ; files this task modifies (optional)
+               :task/stratum 0} ; ordering level: 0=foundation, 1=depends on 0, etc. (optional)
               ...]
  :plan/estimated-complexity :medium ; :low, :medium, :high
  :plan/risks [\"Risk description\"...]
  :plan/assumptions [\"Assumption made\"...]}
 ```
+
+## DAG Decomposition Rules
+
+When the specification touches multiple Polylith components, source directories, or
+conceptual modules, you MUST decompose into separate tasks per boundary.
+
+### Decomposition Heuristics
+
+1. **One component = one task.** If the spec requires changes to `components/agent/`
+   AND `components/workflow/`, those are two separate :implement tasks.
+
+2. **Interface + implementation = same task.** A component's `interface.clj` and its
+   impl files belong together in one task.
+
+3. **Test tasks follow implementation tasks.** For each :implement task, create a
+   corresponding :test task that depends on it.
+
+4. **Cross-component wiring = separate task.** If components need integration glue
+   (e.g., a new function call from workflow -> agent), that is a dedicated task
+   depending on both component tasks.
+
+5. **Stratum ordering.** Assign :task/stratum starting at 0 for foundation tasks
+   (schemas, interfaces), 1 for implementations that depend on them, 2 for
+   integration/tests. Tasks at the same stratum can run in parallel.
+
+### Task Scope Fields
+
+Each task SHOULD include these additional fields when decomposing:
+
+- `:task/component` - The Polylith component name (e.g., \"agent\", \"workflow\",
+  \"dag-executor\"). Helps the executor allocate isolated worktrees.
+
+- `:task/exclusive-files` - Vector of file paths this task will modify.
+  The executor uses this to prevent two parallel tasks from writing the
+  same file. List actual file paths, not directories.
+
+- `:task/stratum` - Integer ordering level. 0 = foundation (no deps),
+  1 = depends on stratum 0, etc. When present, the executor auto-wires
+  dependencies between strata, so you can omit :task/dependencies if
+  strata are sufficient.
+
+### Example: Multi-Component Decomposition
+
+For a spec like \"Add rate limiting to the agent component and update the
+workflow orchestrator to respect it\":
+
+```clojure
+{:plan/id #uuid \"...\"
+ :plan/name \"add-rate-limiting\"
+ :plan/tasks
+ [{:task/id #uuid \"aaa...\"
+   :task/description \"Add rate-limit config schema and helpers to agent component\"
+   :task/type :implement
+   :task/component \"agent\"
+   :task/exclusive-files [\"components/agent/src/ai/miniforge/agent/rate_limit.clj\"
+                          \"components/agent/src/ai/miniforge/agent/interface.clj\"]
+   :task/stratum 0
+   :task/acceptance-criteria [\"rate_limit.clj exists with config schema\"
+                              \"interface.clj re-exports public API\"]}
+  {:task/id #uuid \"bbb...\"
+   :task/description \"Update workflow orchestrator to check rate limits before dispatch\"
+   :task/type :implement
+   :task/component \"workflow\"
+   :task/exclusive-files [\"components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj\"]
+   :task/stratum 1
+   :task/dependencies [#uuid \"aaa...\"]
+   :task/acceptance-criteria [\"dag_orchestrator calls rate-limit check\"
+                              \"Existing tests pass\"]}
+  {:task/id #uuid \"ccc...\"
+   :task/description \"Write tests for rate limiting across both components\"
+   :task/type :test
+   :task/component \"agent\"
+   :task/exclusive-files [\"components/agent/test/ai/miniforge/agent/rate_limit_test.clj\"]
+   :task/stratum 2
+   :task/dependencies [#uuid \"aaa...\" #uuid \"bbb...\"]
+   :task/acceptance-criteria [\"Unit tests pass\" \"Edge cases covered\"]}]}
+```
+
+Note: tasks aaa and bbb touch different components. If they were at the same
+stratum (and bbb did not import aaa), they could run in parallel.
+
+### Single-Component Specs
+
+If the entire spec touches only one component and a small set of files,
+a single :implement task is fine. Do NOT artificially split work that
+naturally belongs together.
 
 ## Already-Satisfied Detection
 

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -44,7 +44,10 @@
    [:task/type [:enum :implement :test :review :design :deploy :configure]]
    [:task/dependencies {:optional true} [:vector uuid?]]
    [:task/acceptance-criteria {:optional true} [:vector [:string {:min 1}]]]
-   [:task/estimated-effort {:optional true} [:enum :small :medium :large :xlarge]]])
+   [:task/estimated-effort {:optional true} [:enum :small :medium :large :xlarge]]
+   [:task/component {:optional true} [:string {:min 1}]]
+   [:task/exclusive-files {:optional true} [:vector [:string {:min 1}]]]
+   [:task/stratum {:optional true} [:int {:min 0}]]])
 
 (def Plan
   "Schema for the planner's output."

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -119,6 +119,42 @@
           result (planner/validate-plan self-dep-plan)]
       (is (not (:valid? result))))))
 
+;------------------------------------------------------------------------------ Layer 3.5
+;; Schema backward-compat & new-field tests
+
+(deftest validate-plan-new-fields-test
+  (testing "plan with task/component, exclusive-files, stratum validates"
+    (let [plan {:plan/id (random-uuid)
+                :plan/name "multi-component"
+                :plan/tasks [{:task/id (random-uuid)
+                              :task/description "Agent changes"
+                              :task/type :implement
+                              :task/component "agent"
+                              :task/exclusive-files ["components/agent/src/foo.clj"]
+                              :task/stratum 0}
+                             {:task/id (random-uuid)
+                              :task/description "Workflow changes"
+                              :task/type :implement
+                              :task/component "workflow"
+                              :task/exclusive-files ["components/workflow/src/bar.clj"]
+                              :task/stratum 0}]}
+          result (planner/validate-plan plan)]
+      (is (:valid? result))))
+
+  (testing "plan without new fields still validates (backward compat)"
+    (let [result (planner/validate-plan valid-plan)]
+      (is (:valid? result))))
+
+  (testing "invalid stratum type fails validation"
+    (let [plan {:plan/id (random-uuid)
+                :plan/name "bad-stratum"
+                :plan/tasks [{:task/id (random-uuid)
+                              :task/description "Task"
+                              :task/type :implement
+                              :task/stratum -1}]}
+          result (planner/validate-plan plan)]
+      (is (not (:valid? result))))))
+
 ;------------------------------------------------------------------------------ Layer 4
 ;; Utility tests
 

--- a/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_sandbox_test.clj
@@ -153,3 +153,44 @@
                   {:release-meta test-release-meta})]
       (is (not (:success? result)))
       (is (= :no-files-to-stage (:type (first (:errors result))))))))
+
+;; ============================================================================
+;; gh-exec-opts and governed-mode token injection
+;; ============================================================================
+
+(deftest gh-exec-opts-with-token-test
+  (testing "gh-exec-opts injects GH_TOKEN env var when github-token present"
+    (let [gh-exec-opts (var-get (ns-resolve 'ai.miniforge.release-executor.core 'gh-exec-opts))]
+      (is (= {:env {"GH_TOKEN" "my-secret-token"}}
+             (gh-exec-opts {:github-token "my-secret-token"}))))))
+
+(deftest gh-exec-opts-without-token-test
+  (testing "gh-exec-opts returns empty map when no github-token"
+    (let [gh-exec-opts (var-get (ns-resolve 'ai.miniforge.release-executor.core 'gh-exec-opts))]
+      (is (= {} (gh-exec-opts {})))
+      (is (= {} (gh-exec-opts {:github-token nil}))))))
+
+(deftest execute-release-passes-github-token-test
+  (testing "execute-release-phase threads github-token from context into state"
+    (let [opts-seen (atom [])
+          [exec _] (create-mock-executor
+                    :responses {"git symbolic-ref" {:exit-code 0 :stdout "refs/remotes/origin/main\n" :stderr ""}
+                                "git fetch"        {:exit-code 0 :stdout "" :stderr ""}
+                                "git checkout"     {:exit-code 0 :stdout "" :stderr ""}
+                                "git add"          {:exit-code 0 :stdout "" :stderr ""}
+                                "git diff"         {:exit-code 0 :stdout "M src/a.clj" :stderr ""}
+                                "git commit"       {:exit-code 0 :stdout "" :stderr ""}
+                                "gh auth"          {:exit-code 0 :stdout "Logged in" :stderr ""}
+                                "git push"         {:exit-code 0 :stdout "" :stderr ""}
+                                "gh pr create"     {:exit-code 0 :stdout "https://github.com/o/r/pull/1" :stderr ""}
+                                "git rev-parse"    {:exit-code 0 :stdout "abc123\n" :stderr ""}})
+          result (core/execute-release-phase
+                  (make-workflow-state)
+                  {:executor exec
+                   :environment-id "mock-env"
+                   :worktree-path "/tmp/wt"
+                   :create-pr? true
+                   :github-token "governed-token"}
+                  {:release-meta test-release-meta})]
+      ;; The pipeline should succeed and create a PR
+      (is (:success? result)))))

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -82,6 +82,21 @@
       (is (:available? result))
       (is (not (:authenticated? result))))))
 
+(deftest check-gh-auth-with-token-opts-test
+  (testing "check-gh-auth! accepts opts for GH_TOKEN injection"
+    (let [[exec _cmds] (create-mock-executor
+                        :responses {"gh auth status" {:exit-code 0 :stdout "Logged in" :stderr ""}})
+          result (sandbox/check-gh-auth! exec "env-1" {:env {"GH_TOKEN" "test-token"}})]
+      (is (:available? result))
+      (is (:authenticated? result)))))
+
+(deftest check-gh-auth-two-arity-backward-compatible-test
+  (testing "check-gh-auth! works with 2-arg call (no opts)"
+    (let [[exec _cmds] (create-mock-executor
+                        :responses {"gh auth status" {:exit-code 0 :stdout "Logged in" :stderr ""}})
+          result (sandbox/check-gh-auth! exec "env-1")]
+      (is (:authenticated? result)))))
+
 ;; ============================================================================
 ;; create-branch! tests
 ;; ============================================================================

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -31,7 +31,8 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.phase.interface :as phase]
-   [ai.miniforge.workflow.dag-resilience :as resilience]))
+   [ai.miniforge.workflow.dag-resilience :as resilience]
+   [clojure.set :as set]))
 
 ;--- Layer 0: Result Constructors
 
@@ -144,22 +145,43 @@
   "Convert a single plan task to a DAG task with validated deps."
   [t valid-task-ids plan-id workflow-id context]
   (let [task-id (normalize-task-id (:task/id t))]
-  {:task/id task-id
-   :task/deps (validate-deps task-id
-                             (map normalize-task-id (:task/dependencies t []))
-                             valid-task-ids)
-   :task/description (:task/description t)
-   :task/type (:task/type t :implement)
-   :task/acceptance-criteria (:task/acceptance-criteria t [])
-   :task/context (merge {:parent-plan-id plan-id
-                         :parent-workflow-id workflow-id}
-                        (select-keys context [:llm-backend :artifact-store]))}))
+    (cond-> {:task/id task-id
+             :task/deps (validate-deps task-id
+                                       (map normalize-task-id (:task/dependencies t []))
+                                       valid-task-ids)
+             :task/description (:task/description t)
+             :task/type (:task/type t :implement)
+             :task/acceptance-criteria (:task/acceptance-criteria t [])
+             :task/context (merge {:parent-plan-id plan-id
+                                   :parent-workflow-id workflow-id}
+                                  (select-keys context [:llm-backend :artifact-store]))}
+      (:task/component t)      (assoc :task/component (:task/component t))
+      (:task/exclusive-files t) (assoc :task/exclusive-files (:task/exclusive-files t))
+      (:task/stratum t)         (assoc :task/stratum (:task/stratum t)))))
+
+(defn wire-stratum-deps
+  "Auto-wire dependencies from :task/stratum when explicit deps are absent.
+   All tasks at stratum N depend on all tasks at stratum N-1.
+   No-op when no tasks have :task/stratum set."
+  [dag-tasks]
+  (if-not (some :task/stratum dag-tasks)
+    dag-tasks
+    (let [by-stratum (group-by #(:task/stratum % 0) dag-tasks)]
+      (mapv (fn [task]
+              (let [s (:task/stratum task 0)]
+                (if (and (empty? (:task/deps task #{}))
+                         (pos? s))
+                  (let [prev-ids (set (map :task/id (get by-stratum (dec s) [])))]
+                    (assoc task :task/deps prev-ids))
+                  task)))
+            dag-tasks))))
 
 (defn plan->dag-tasks [plan context]
   (let [tasks (:plan/tasks plan [])
-        valid-task-ids (set (map (comp normalize-task-id :task/id) tasks))]
-    (mapv #(plan-task->dag-task % valid-task-ids (:plan/id plan) (:workflow-id context) context)
-          tasks)))
+        valid-task-ids (set (map (comp normalize-task-id :task/id) tasks))
+        dag-tasks (mapv #(plan-task->dag-task % valid-task-ids (:plan/id plan) (:workflow-id context) context)
+                        tasks)]
+    (wire-stratum-deps dag-tasks)))
 
 ;--- Layer 1: Sub-Workflow Construction
 
@@ -192,16 +214,20 @@
    pick it up directly. Includes task title and acceptance criteria for
    use by the release phase (PR title/body)."
   [task-def]
-  {:title (:task/description task-def "Implement task")
-   :description (:task/description task-def "Implement task")
-   :task/type (:task/type task-def :implement)
-   :task/acceptance-criteria (:task/acceptance-criteria task-def [])
-   :task/id (:task/id task-def)
-   ;; Provide the task as a single-task plan so the implement phase
-   ;; receives it without needing another plan phase
-   :plan/tasks [{:task/id (random-uuid)
-                 :task/description (:task/description task-def "Implement task")
-                 :task/type (:task/type task-def :implement)}]})
+  (cond-> {:title (:task/description task-def "Implement task")
+           :description (:task/description task-def "Implement task")
+           :task/type (:task/type task-def :implement)
+           :task/acceptance-criteria (:task/acceptance-criteria task-def [])
+           :task/id (:task/id task-def)
+           ;; Provide the task as a single-task plan so the implement phase
+           ;; receives it without needing another plan phase
+           :plan/tasks [{:task/id (random-uuid)
+                         :task/description (:task/description task-def "Implement task")
+                         :task/type (:task/type task-def :implement)}]}
+    (:task/exclusive-files task-def)
+    (assoc :files-in-scope (:task/exclusive-files task-def))
+    (:task/component task-def)
+    (assoc :task/component (:task/component task-def))))
 
 (defn task-sub-opts
   "Build execution opts for a DAG task's sub-workflow.
@@ -335,6 +361,26 @@
                  (and (not (contains? completed-ids task-id))
                       (not (contains? failed-ids task-id))
                       (every? #(contains? completed-ids %) (:task/deps task #{})))))))
+
+(defn select-non-conflicting-batch
+  "Select up to max-parallel ready tasks whose exclusive-files don't overlap.
+   Falls back to (take max-parallel) when no tasks declare exclusive-files."
+  [ready-tasks max-parallel]
+  (loop [candidates (seq ready-tasks)
+         selected []
+         claimed-files #{}]
+    (cond
+      (nil? candidates)                  selected
+      (>= (count selected) max-parallel) selected
+      :else
+      (let [[_tid task] (first candidates)
+            task-files (set (:task/exclusive-files task))]
+        (if (and (seq task-files)
+                 (seq (set/intersection claimed-files task-files)))
+          (recur (next candidates) selected claimed-files)
+          (recur (next candidates)
+                 (conj selected (first candidates))
+                 (into claimed-files task-files)))))))
 
 (defn execute-tasks-batch [tasks execute-fn context]
   (->> tasks
@@ -540,7 +586,7 @@
 
           ;; Execute next batch
           :else
-          (let [batch (take max-parallel ready-tasks)
+          (let [batch (select-non-conflicting-batch ready-tasks max-parallel)
                 _ (notify-batch-start batch on-task-start)
                 ctx (cond-> context
                       current-backend (assoc :current-backend current-backend))
@@ -573,8 +619,24 @@
                      current-backend
                      (inc iteration)))))))))
 
+(defn warn-potential-monolith
+  "Log a warning when a plan may be under-decomposed — single task but
+   multiple components or many files."
+  [plan logger]
+  (let [tasks (:plan/tasks plan [])
+        components (->> tasks (keep :task/component) distinct)
+        all-files (->> tasks (mapcat :task/exclusive-files) distinct)]
+    (when (and (<= (count tasks) 1)
+               (or (> (count components) 1)
+                   (> (count all-files) 5)))
+      (log/info logger :dag-orchestrator :plan/potential-monolith
+                {:data {:task-count (count tasks)
+                        :component-count (count components)
+                        :file-count (count all-files)}}))))
+
 (defn execute-plan-as-dag [plan context]
   (let [logger (or (:logger context) (log/create-logger {:min-level :info}))
+        _ (warn-potential-monolith plan logger)
         task-defs (plan->dag-tasks plan context)
         tasks-map (->> task-defs (map (fn [t] [(:task/id t) t])) (into {}))
         pre-completed (get context :pre-completed-ids #{})

--- a/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_orchestrator_test.clj
@@ -1,0 +1,169 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.dag-orchestrator-test
+  "Tests for DAG orchestrator: stratum wiring, conflict-aware batching,
+   plan-to-DAG conversion with new decomposition fields."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.workflow.dag-orchestrator :as dag-orch]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures
+
+(def id-a (random-uuid))
+(def id-b (random-uuid))
+(def id-c (random-uuid))
+(def id-d (random-uuid))
+
+;------------------------------------------------------------------------------ Layer 1
+;; wire-stratum-deps tests
+
+(deftest wire-stratum-deps-no-strata-test
+  (testing "no-op when no tasks have :task/stratum"
+    (let [tasks [{:task/id id-a :task/deps #{}}
+                 {:task/id id-b :task/deps #{}}]]
+      (is (= tasks (dag-orch/wire-stratum-deps tasks))))))
+
+(deftest wire-stratum-deps-wires-across-strata-test
+  (testing "stratum-1 tasks auto-depend on all stratum-0 tasks"
+    (let [tasks [{:task/id id-a :task/deps #{} :task/stratum 0}
+                 {:task/id id-b :task/deps #{} :task/stratum 0}
+                 {:task/id id-c :task/deps #{} :task/stratum 1}]
+          result (dag-orch/wire-stratum-deps tasks)
+          c-deps (:task/deps (nth result 2))]
+      (is (= #{id-a id-b} c-deps)))))
+
+(deftest wire-stratum-deps-preserves-explicit-deps-test
+  (testing "tasks with explicit deps are not overwritten"
+    (let [tasks [{:task/id id-a :task/deps #{} :task/stratum 0}
+                 {:task/id id-b :task/deps #{id-a} :task/stratum 1}]
+          result (dag-orch/wire-stratum-deps tasks)
+          b-deps (:task/deps (nth result 1))]
+      (is (= #{id-a} b-deps)))))
+
+(deftest wire-stratum-deps-three-strata-test
+  (testing "stratum-2 depends on stratum-1, not stratum-0"
+    (let [tasks [{:task/id id-a :task/deps #{} :task/stratum 0}
+                 {:task/id id-b :task/deps #{} :task/stratum 1}
+                 {:task/id id-c :task/deps #{} :task/stratum 2}]
+          result (dag-orch/wire-stratum-deps tasks)]
+      (is (= #{id-a} (:task/deps (nth result 1))))
+      (is (= #{id-b} (:task/deps (nth result 2)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; select-non-conflicting-batch tests
+
+(deftest select-non-conflicting-batch-no-files-test
+  (testing "selects all when no exclusive-files declared"
+    (let [tasks [[id-a {:task/id id-a}]
+                 [id-b {:task/id id-b}]
+                 [id-c {:task/id id-c}]]
+          batch (dag-orch/select-non-conflicting-batch tasks 4)]
+      (is (= 3 (count batch))))))
+
+(deftest select-non-conflicting-batch-respects-max-test
+  (testing "respects max-parallel limit"
+    (let [tasks [[id-a {:task/id id-a}]
+                 [id-b {:task/id id-b}]
+                 [id-c {:task/id id-c}]]
+          batch (dag-orch/select-non-conflicting-batch tasks 2)]
+      (is (= 2 (count batch))))))
+
+(deftest select-non-conflicting-batch-skips-conflicts-test
+  (testing "skips tasks with overlapping exclusive-files"
+    (let [tasks [[id-a {:task/id id-a
+                        :task/exclusive-files ["src/foo.clj" "src/bar.clj"]}]
+                 [id-b {:task/id id-b
+                        :task/exclusive-files ["src/bar.clj" "src/baz.clj"]}]
+                 [id-c {:task/id id-c
+                        :task/exclusive-files ["src/qux.clj"]}]]
+          batch (dag-orch/select-non-conflicting-batch tasks 4)
+          selected-ids (set (map first batch))]
+      ;; a and c should be selected; b conflicts with a on src/bar.clj
+      (is (contains? selected-ids id-a))
+      (is (not (contains? selected-ids id-b)))
+      (is (contains? selected-ids id-c)))))
+
+(deftest select-non-conflicting-batch-mixed-declared-test
+  (testing "tasks without exclusive-files don't conflict with anything"
+    (let [tasks [[id-a {:task/id id-a
+                        :task/exclusive-files ["src/foo.clj"]}]
+                 [id-b {:task/id id-b}]
+                 [id-c {:task/id id-c
+                        :task/exclusive-files ["src/foo.clj"]}]]
+          batch (dag-orch/select-non-conflicting-batch tasks 4)
+          selected-ids (set (map first batch))]
+      ;; a and b selected; c conflicts with a
+      (is (contains? selected-ids id-a))
+      (is (contains? selected-ids id-b))
+      (is (not (contains? selected-ids id-c))))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; plan->dag-tasks integration tests
+
+(deftest plan-to-dag-tasks-forwards-new-fields-test
+  (testing "component and exclusive-files are forwarded to DAG tasks"
+    (let [plan {:plan/id (random-uuid)
+                :plan/name "test"
+                :plan/tasks [{:task/id id-a
+                              :task/description "Agent work"
+                              :task/type :implement
+                              :task/component "agent"
+                              :task/exclusive-files ["components/agent/src/foo.clj"]
+                              :task/stratum 0}]}
+          dag-tasks (dag-orch/plan->dag-tasks plan {})
+          task (first dag-tasks)]
+      (is (= "agent" (:task/component task)))
+      (is (= ["components/agent/src/foo.clj"] (:task/exclusive-files task)))
+      (is (= 0 (:task/stratum task))))))
+
+(deftest plan-to-dag-tasks-stratum-wiring-integration-test
+  (testing "stratum deps are auto-wired during plan->dag-tasks conversion"
+    (let [plan {:plan/id (random-uuid)
+                :plan/name "multi-stratum"
+                :plan/tasks [{:task/id id-a
+                              :task/description "Foundation"
+                              :task/type :implement
+                              :task/stratum 0}
+                             {:task/id id-b
+                              :task/description "Depends on foundation"
+                              :task/type :implement
+                              :task/stratum 1}]}
+          dag-tasks (dag-orch/plan->dag-tasks plan {})
+          task-b (second dag-tasks)]
+      (is (contains? (:task/deps task-b) id-a)))))
+
+(deftest plan-to-dag-tasks-backward-compat-test
+  (testing "plan without new fields still converts correctly"
+    (let [plan {:plan/id (random-uuid)
+                :plan/name "old-style"
+                :plan/tasks [{:task/id id-a
+                              :task/description "Single task"
+                              :task/type :implement}]}
+          dag-tasks (dag-orch/plan->dag-tasks plan {})
+          task (first dag-tasks)]
+      (is (= id-a (:task/id task)))
+      (is (nil? (:task/component task)))
+      (is (nil? (:task/exclusive-files task))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.workflow.dag-orchestrator-test)
+
+  :leave-this-here)


### PR DESCRIPTION
## Summary

- **Planner prompt v2.0** — teaches the LLM to decompose specs along Polylith component boundaries instead of producing monolithic single-task plans. Includes decomposition heuristics, new field descriptions, a worked multi-component example, and an over-decomposition guard.
- **PlanTask schema** — adds three optional fields: `:task/component`, `:task/exclusive-files`, `:task/stratum` for parallel coordination without breaking existing plans.
- **Stratum-based dependency wiring** — `wire-stratum-deps` auto-wires DAG edges from integer strata (simpler than UUID cross-references for LLMs). Stratum 0 tasks run in parallel; stratum 1 auto-depends on all stratum 0, etc.
- **File-conflict-aware batching** — `select-non-conflicting-batch` replaces naive `take` in the DAG loop to prevent two parallel tasks from writing the same file.
- **Monolith warning** — logs when a plan has <=1 task but references multiple components or >5 files.

Addresses convergence gap: "Plan phase produces a single implement task for 6-file changes across 3 components."

## Test plan

- [x] All 495 existing tests pass (0 failures)
- [x] 11 new DAG orchestrator tests: stratum wiring, conflict batching, field forwarding, backward compat
- [x] 3 new planner schema tests: new fields validate, old plans still validate, negative stratum rejected
- [ ] Manual: run a multi-component spec through governed mode and verify plan produces per-component tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)