### PR TITLE
feat: data-driven linter ETL — connector-linter component

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/scan.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/scan.clj
@@ -26,7 +26,7 @@
    [babashka.fs :as fs]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
-   [ai.miniforge.cli.linter-runner :as linter]
+   [ai.miniforge.connector-linter.interface :as linter]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.repo-analyzer :as analyzer]
@@ -139,7 +139,7 @@
   (let [detected (get repo-config :repo/technologies #{})
         fps      @analyzer/fingerprints]
     (when (seq detected)
-      (let [result (linter/run-all-linters repo-path fps detected)]
+      (let [result (linter/run-all repo-path fps detected)]
         (doseq [{:keys [tech available? violations duration-ms]} (:linter-results result)]
           (cond
             (not available?)
@@ -158,7 +158,7 @@
   [repo-path repo-config]
   (let [detected (get repo-config :repo/technologies #{})
         fps      @analyzer/fingerprints
-        result   (linter/run-linter-fixes repo-path fps detected)]
+        result   (linter/run-fixes repo-path fps detected)]
     (doseq [{:keys [tech exit]} (:fixed result)]
       (display/print-info (str "  " (name tech) ": fix " (if (zero? exit) "applied" "failed"))))))
 

--- a/bb.edn
+++ b/bb.edn
@@ -488,7 +488,9 @@
                  "components/adapter-miniforge/src"
                  "components/messages/src"
                  "components/patterns/src"
-                 "components/decision/src"]
+                 "components/decision/src"
+                 "components/connector-linter/src"
+                 "components/connector-linter/resources"]
    :extra-deps {metosin/malli {:mvn/version "0.16.1"}
                 clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}
                 aero/aero        {:mvn/version "1.1.6"}

--- a/components/connector-linter/deps.edn
+++ b/components/connector-linter/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src" "resources"]
+ :deps {}
+ :aliases {:test {:extra-paths ["test"]}}}

--- a/components/connector-linter/resources/connector_linter/linter-mappings.edn
+++ b/components/connector-linter/resources/connector_linter/linter-mappings.edn
@@ -1,0 +1,113 @@
+;; Linter field-mapping ETL specs.
+;; Each entry defines how to parse a linter's structured output into
+;; the canonical violation shape.
+;;
+;; Schema:
+;;   :mapping/id          — Linter identifier keyword (matches tech-fingerprints :parser)
+;;   :mapping/format      — Output format: :json, :json-lines, :json-nested, :edn
+;;   :mapping/filter      — Optional filter predicate on parsed records
+;;     :path              — get-in path to check
+;;     :equals            — required value
+;;   :mapping/unwrap      — Path to the violations array within each record (optional)
+;;   :mapping/parent-file — Path to the file field on the parent object (for nested formats)
+;;   :mapping/fields      — Field mapping: canonical-key → source path (keyword or vector)
+;;   :mapping/severity-map — Source severity value → canonical severity keyword
+;;
+;; Sorted by :mapping/id.
+
+[;; ── clj-kondo ──────────────────────────────────────────────────────────────
+ {:mapping/id          :clj-kondo
+  :mapping/format      :edn
+  :mapping/unwrap      [:findings]
+  :mapping/fields
+  {:file     [:filename]
+   :line     [:row]
+   :column   [:col]
+   :message  [:message]
+   :code     [:type]
+   :severity [:level]}
+  :mapping/severity-map
+  {"error"   :critical
+   "warning" :major
+   "info"    :minor}}
+
+ ;; ── Clippy (Rust) ──────────────────────────────────────────────────────────
+ {:mapping/id          :clippy
+  :mapping/format      :json-lines
+  :mapping/filter      {:path [:reason] :equals "compiler-message"}
+  :mapping/fields
+  {:file     [:message :spans 0 :file_name]
+   :line     [:message :spans 0 :line_start]
+   :column   [:message :spans 0 :column_start]
+   :message  [:message :message]
+   :code     [:message :code :code]
+   :severity [:message :level]}
+  :mapping/severity-map
+  {"error"   :critical
+   "warning" :major
+   "note"    :minor
+   "help"    :info}}
+
+ ;; ── ESLint ─────────────────────────────────────────────────────────────────
+ {:mapping/id          :eslint
+  :mapping/format      :json-nested
+  :mapping/parent-file [:filePath]
+  :mapping/unwrap      [:messages]
+  :mapping/fields
+  {:file     [:filePath]
+   :line     [:line]
+   :column   [:column]
+   :message  [:message]
+   :code     [:ruleId]
+   :severity [:severity]}
+  :mapping/severity-map
+  {2 :critical
+   1 :major}}
+
+ ;; ── golangci-lint ──────────────────────────────────────────────────────────
+ {:mapping/id          :golangci-lint
+  :mapping/format      :json
+  :mapping/unwrap      [:Issues]
+  :mapping/fields
+  {:file     [:Pos :Filename]
+   :line     [:Pos :Line]
+   :column   [:Pos :Column]
+   :message  [:Text]
+   :code     [:FromLinter]
+   :severity [:Severity]}
+  :mapping/severity-map
+  {"error"   :critical
+   "warning" :major
+   "info"    :minor}}
+
+ ;; ── ruff (Python) ──────────────────────────────────────────────────────────
+ {:mapping/id          :ruff
+  :mapping/format      :json
+  :mapping/fields
+  {:file     [:filename]
+   :line     [:location :row]
+   :column   [:location :column]
+   :message  [:message]
+   :code     [:code]
+   :severity [:type]}
+  :mapping/severity-map
+  {"E"       :critical
+   "W"       :major
+   "C"       :minor
+   "R"       :info
+   "warning" :major
+   "error"   :critical}}
+
+ ;; ── SwiftLint ──────────────────────────────────────────────────────────────
+ {:mapping/id          :swiftlint
+  :mapping/format      :json
+  :mapping/fields
+  {:file     [:file]
+   :line     [:line]
+   :column   [:character]
+   :message  [:reason]
+   :code     [:rule_id]
+   :severity [:severity]}
+  :mapping/severity-map
+  {"error"   :critical
+   "warning" :major}}]

--- a/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
@@ -1,0 +1,178 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.connector-linter.etl
+  "Data-driven field-mapping ETL engine for linter output.
+
+   Transforms structured linter output (JSON/EDN) into the canonical
+   violation shape using declarative mapping specs loaded from EDN.
+   No parser code per linter — all extraction is driven by data.
+
+   Layer 0: Field extraction and severity mapping
+   Layer 1: Format-specific record extraction
+   Layer 2: Apply mapping spec to produce violations"
+  (:require
+   [cheshire.core :as json]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Field extraction
+
+(defn- extract-field
+  "Extract a value from a record using a path spec.
+   Path can be a keyword (single key) or vector (get-in path).
+   Numeric elements in vectors index into sequential collections."
+  [record path-spec]
+  (cond
+    (keyword? path-spec) (get record path-spec)
+    (vector? path-spec)  (reduce (fn [acc k]
+                                   (cond
+                                     (nil? acc)     nil
+                                     (integer? k)   (nth acc k nil)
+                                     :else          (get acc k)))
+                                 record
+                                 path-spec)
+    :else                nil))
+
+(defn- map-severity
+  "Map a raw severity value to a canonical severity keyword using the mapping's severity-map."
+  [severity-map raw-value]
+  (let [key (if (keyword? raw-value) (name raw-value) raw-value)]
+    (get severity-map key
+         (get severity-map raw-value :minor))))
+
+(defn- record->violation
+  "Transform a single parsed record into the canonical violation shape
+   using the field mapping spec."
+  [linter-id fields severity-map record file-override]
+  (let [file     (or file-override (str (extract-field record (get fields :file))))
+        line     (extract-field record (get fields :line))
+        column   (extract-field record (get fields :column))
+        message  (extract-field record (get fields :message))
+        code     (let [c (extract-field record (get fields :code))]
+                   (if (keyword? c) (name c) (str c)))
+        severity (map-severity severity-map
+                               (extract-field record (get fields :severity)))]
+    {:rule/id       (keyword (name linter-id) (or code "lint"))
+     :rule/category "lint"
+     :rule/title    (str (name linter-id) "/" (or code "lint"))
+     :rule/severity severity
+     :file          (str file)
+     :line          (or line 0)
+     :column        (or column 0)
+     :current       (or message "")
+     :suggested     nil
+     :auto-fixable? false
+     :rationale     (str (name linter-id) ": " (or message ""))}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Format-specific record extraction
+
+(defn- parse-json-safe
+  "Parse JSON string, returning nil on failure."
+  [s]
+  (when-not (str/blank? s)
+    (try (json/parse-string s true) (catch Exception _ nil))))
+
+(defn- matches-filter?
+  "Check if a record matches the mapping's filter predicate."
+  [filter-spec record]
+  (if filter-spec
+    (= (get filter-spec :equals)
+       (extract-field record (get filter-spec :path)))
+    true))
+
+(defn- extract-records-json
+  "Extract records from a JSON array. Optionally unwrap via path."
+  [output unwrap-path]
+  (let [data (parse-json-safe output)]
+    (if unwrap-path
+      (extract-field data unwrap-path)
+      (when (sequential? data) data))))
+
+(defn- extract-records-json-lines
+  "Extract records from newline-delimited JSON (one object per line)."
+  [output]
+  (keep parse-json-safe (str/split-lines output)))
+
+(defn- extract-records-json-nested
+  "Extract records from a JSON array of parent objects, each containing
+   a nested array of child records. File path comes from the parent."
+  [output parent-file-path unwrap-path]
+  (let [parents (parse-json-safe output)]
+    (when (sequential? parents)
+      (mapcat (fn [parent]
+                (let [file     (extract-field parent parent-file-path)
+                      children (extract-field parent unwrap-path)]
+                  (mapv #(assoc % ::parent-file file) children)))
+              parents))))
+
+(defn- extract-records-edn
+  "Extract records from EDN output. Optionally unwrap via path."
+  [output unwrap-path]
+  (try
+    (let [data (edn/read-string output)]
+      (if unwrap-path
+        (extract-field data unwrap-path)
+        (when (sequential? data) data)))
+    (catch Exception _ nil)))
+
+(defn- extract-records
+  "Dispatch record extraction based on format."
+  [output mapping]
+  (let [fmt    (get mapping :mapping/format)
+        unwrap (get mapping :mapping/unwrap)]
+    (case fmt
+      :json        (extract-records-json output unwrap)
+      :json-lines  (extract-records-json-lines output)
+      :json-nested (extract-records-json-nested output
+                                                 (get mapping :mapping/parent-file)
+                                                 unwrap)
+      :edn         (extract-records-edn output unwrap)
+      nil)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Apply mapping
+
+(defn apply-mapping
+  "Apply a mapping spec to raw linter output, producing canonical violations.
+
+   Arguments:
+   - mapping — Mapping spec from linter-mappings.edn
+   - output  — Raw linter output string
+
+   Returns:
+   - Vector of violation maps"
+  [mapping output]
+  (let [linter-id    (get mapping :mapping/id)
+        fields       (get mapping :mapping/fields)
+        severity-map (get mapping :mapping/severity-map {})
+        filter-spec  (get mapping :mapping/filter)
+        records      (extract-records output mapping)]
+    (->> records
+         (filter #(matches-filter? filter-spec %))
+         (mapv (fn [record]
+                 (record->violation linter-id fields severity-map record
+                                   (get record ::parent-file))))
+         (filterv #(seq (:current %))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Mapping registry
+
+(def ^:private mappings-resource "connector_linter/linter-mappings.edn")
+
+(def mappings
+  "All linter mappings loaded from classpath EDN."
+  (delay
+    (if-let [url (io/resource mappings-resource)]
+      (let [raw (edn/read-string (slurp url))]
+        (zipmap (map :mapping/id raw) raw))
+      {})))
+
+(defn get-mapping
+  "Look up a mapping by linter ID. Returns nil if not found."
+  [linter-id]
+  (get @mappings linter-id))

--- a/components/connector-linter/src/ai/miniforge/connector_linter/interface.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/interface.clj
@@ -1,0 +1,20 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.connector-linter.interface
+  "Public API for data-driven linter integration."
+  (:require
+   [ai.miniforge.connector-linter.etl :as etl]
+   [ai.miniforge.connector-linter.runner :as runner]))
+
+;; ETL
+(def apply-mapping etl/apply-mapping)
+(def get-mapping etl/get-mapping)
+(def mappings etl/mappings)
+
+;; Runner
+(def linter-available? runner/linter-available?)
+(def run-linter runner/run-linter)
+(def run-all runner/run-all)
+(def run-fixes runner/run-fixes)

--- a/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
@@ -1,0 +1,98 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.connector-linter.runner
+  "Run linter subprocesses and parse output via ETL mappings.
+
+   Layer 0: Subprocess execution
+   Layer 1: Run a single linter
+   Layer 2: Run all linters for detected technologies"
+  (:require
+   [ai.miniforge.connector-linter.etl :as etl]
+   [babashka.process :as process]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Subprocess
+
+(defn linter-available?
+  "Check if a linter CLI is available on PATH."
+  [check-cmd]
+  (try
+    (zero? (:exit (process/sh {:cmd check-cmd :continue true
+                               :out :string :err :string})))
+    (catch Exception _ false)))
+
+(defn- run-subprocess
+  "Run a linter subprocess. Returns {:exit int :out string :err string}."
+  [repo-path command args]
+  (try
+    (process/sh {:cmd (into [command] args)
+                 :dir (str repo-path)
+                 :continue true
+                 :out :string
+                 :err :string})
+    (catch Exception e
+      {:exit -1 :out "" :err (.getMessage e)})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Single linter execution
+
+(defn run-linter
+  "Run a single linter and parse output via ETL mapping.
+   Returns {:tech keyword :violations [...] :available? bool :duration-ms int}."
+  [repo-path tech-id linter-config]
+  (let [{:keys [command args parser check-cmd]} linter-config
+        available? (linter-available? (or check-cmd [command "--version"]))
+        start-ms   (System/currentTimeMillis)]
+    (if-not available?
+      {:tech tech-id :violations [] :available? false :duration-ms 0}
+      (let [result     (run-subprocess repo-path command args)
+            output     (str (:out result))
+            mapping    (etl/get-mapping parser)
+            violations (if mapping
+                         (etl/apply-mapping mapping output)
+                         [])
+            end-ms     (System/currentTimeMillis)]
+        {:tech        tech-id
+         :violations  violations
+         :available?  true
+         :duration-ms (- end-ms start-ms)}))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Multi-linter orchestration
+
+(defn- lintable-tech
+  "True when a fingerprint has a linter and is in the detected set."
+  [detected-techs fingerprint]
+  (and (:tech/linter fingerprint)
+       (contains? detected-techs (:tech/id fingerprint))))
+
+(defn run-all
+  "Run linters for all detected technologies.
+   Returns {:linter-results [...] :violations [...] :total-violations int :total-duration-ms int}."
+  [repo-path fingerprints detected-techs]
+  (let [lintable (filter #(lintable-tech detected-techs %) fingerprints)
+        results  (mapv (fn [fp]
+                         (run-linter repo-path (:tech/id fp) (:tech/linter fp)))
+                       lintable)
+        all-viols (vec (mapcat :violations results))]
+    {:linter-results    results
+     :violations        all-viols
+     :total-violations  (count all-viols)
+     :total-duration-ms (reduce + 0 (map :duration-ms results))}))
+
+(defn run-fixes
+  "Run linter fix commands for detected technologies.
+   Returns {:fixed [...]}."
+  [repo-path fingerprints detected-techs]
+  (let [fixable (->> fingerprints
+                     (filter #(lintable-tech detected-techs %))
+                     (filter #(get-in % [:tech/linter :fix-args])))]
+    {:fixed
+     (vec (keep (fn [fp]
+                  (let [{:keys [command fix-args check-cmd]} (:tech/linter fp)]
+                    (when (linter-available? (or check-cmd [command "--version"]))
+                      {:tech (:tech/id fp)
+                       :exit (:exit (run-subprocess repo-path command fix-args))})))
+                fixable))}))

--- a/components/connector-linter/test/ai/miniforge/connector_linter/etl_test.clj
+++ b/components/connector-linter/test/ai/miniforge/connector_linter/etl_test.clj
@@ -1,0 +1,146 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.connector-linter.etl-test
+  "Tests for the data-driven ETL engine — field extraction, format parsing, mapping application."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.connector-linter.etl :as sut]))
+
+;; Access private functions
+(def extract-field (var-get #'sut/extract-field))
+(def map-severity (var-get #'sut/map-severity))
+(def matches-filter? (var-get #'sut/matches-filter?))
+
+;; ============================================================================
+;; Field extraction
+;; ============================================================================
+
+(deftest extract-field-keyword-test
+  (testing "extracts by keyword"
+    (is (= "foo.clj" (extract-field {:filename "foo.clj"} :filename)))))
+
+(deftest extract-field-vector-path-test
+  (testing "extracts by vector path"
+    (is (= 42 (extract-field {:pos {:line 42}} [:pos :line]))))
+
+  (testing "extracts through array index"
+    (is (= "bar.rs" (extract-field {:spans [{:file "bar.rs"}]} [:spans 0 :file]))))
+
+  (testing "returns nil for missing path"
+    (is (nil? (extract-field {:a 1} [:b :c])))))
+
+;; ============================================================================
+;; Severity mapping
+;; ============================================================================
+
+(deftest map-severity-test
+  (testing "maps string keys"
+    (is (= :critical (map-severity {"error" :critical} "error"))))
+
+  (testing "maps keyword values by name"
+    (is (= :major (map-severity {"warning" :major} :warning))))
+
+  (testing "defaults to :minor for unknown"
+    (is (= :minor (map-severity {"error" :critical} "unknown")))))
+
+;; ============================================================================
+;; Filter matching
+;; ============================================================================
+
+(deftest matches-filter-test
+  (testing "nil filter always matches"
+    (is (true? (matches-filter? nil {:anything true}))))
+
+  (testing "matches when path equals value"
+    (is (true? (matches-filter? {:path [:reason] :equals "compiler-message"}
+                                {:reason "compiler-message"}))))
+
+  (testing "rejects when path doesn't equal"
+    (is (false? (matches-filter? {:path [:reason] :equals "compiler-message"}
+                                 {:reason "build-script"})))))
+
+;; ============================================================================
+;; Mapping registry
+;; ============================================================================
+
+(deftest mappings-load-test
+  (testing "mappings load from classpath"
+    (is (map? @sut/mappings))
+    (is (contains? @sut/mappings :clippy))
+    (is (contains? @sut/mappings :eslint))
+    (is (contains? @sut/mappings :ruff))
+    (is (contains? @sut/mappings :swiftlint))
+    (is (contains? @sut/mappings :clj-kondo))
+    (is (contains? @sut/mappings :golangci-lint))))
+
+;; ============================================================================
+;; Full mapping application — clj-kondo
+;; ============================================================================
+
+(deftest apply-mapping-clj-kondo-test
+  (testing "parses EDN findings"
+    (let [mapping (sut/get-mapping :clj-kondo)
+          output  "{:findings [{:type :unresolved-symbol :filename \"src/core.clj\" :row 10 :col 5 :level :error :message \"Unresolved symbol: foo\"}]}"
+          result  (sut/apply-mapping mapping output)]
+      (is (= 1 (count result)))
+      (is (= "src/core.clj" (:file (first result))))
+      (is (= 10 (:line (first result))))
+      (is (= :critical (:rule/severity (first result)))))))
+
+;; ============================================================================
+;; Full mapping application — ESLint (nested format)
+;; ============================================================================
+
+(deftest apply-mapping-eslint-test
+  (testing "parses nested JSON with parent file path"
+    (let [mapping (sut/get-mapping :eslint)
+          output  "[{\"filePath\":\"/src/app.js\",\"messages\":[{\"ruleId\":\"no-unused-vars\",\"severity\":2,\"message\":\"x is unused\",\"line\":5,\"column\":3}]}]"
+          result  (sut/apply-mapping mapping output)]
+      (is (= 1 (count result)))
+      (is (= "/src/app.js" (:file (first result))))
+      (is (= :critical (:rule/severity (first result)))))))
+
+;; ============================================================================
+;; Full mapping application — Clippy (json-lines with filter)
+;; ============================================================================
+
+(deftest apply-mapping-clippy-test
+  (testing "filters for compiler-message and extracts nested fields"
+    (let [mapping (sut/get-mapping :clippy)
+          line1   "{\"reason\":\"compiler-artifact\"}"
+          line2   "{\"reason\":\"compiler-message\",\"message\":{\"message\":\"unused var\",\"level\":\"warning\",\"code\":{\"code\":\"unused_variables\"},\"spans\":[{\"file_name\":\"src/main.rs\",\"line_start\":10,\"column_start\":5}]}}"
+          output  (str line1 "\n" line2)
+          result  (sut/apply-mapping mapping output)]
+      (is (= 1 (count result)))
+      (is (= "src/main.rs" (:file (first result))))
+      (is (= :major (:rule/severity (first result)))))))
+
+;; ============================================================================
+;; Full mapping application — ruff
+;; ============================================================================
+
+(deftest apply-mapping-ruff-test
+  (testing "parses flat JSON array"
+    (let [mapping (sut/get-mapping :ruff)
+          output  "[{\"code\":\"F401\",\"message\":\"unused import\",\"filename\":\"app.py\",\"location\":{\"row\":1,\"column\":1},\"type\":\"warning\"}]"
+          result  (sut/apply-mapping mapping output)]
+      (is (= 1 (count result)))
+      (is (= "app.py" (:file (first result))))
+      (is (= :major (:rule/severity (first result)))))))
+
+;; ============================================================================
+;; Empty / error cases
+;; ============================================================================
+
+(deftest apply-mapping-empty-test
+  (testing "empty output returns empty violations"
+    (let [mapping (sut/get-mapping :eslint)]
+      (is (= [] (sut/apply-mapping mapping "")))
+      (is (= [] (sut/apply-mapping mapping "[]"))))))
+
+(deftest apply-mapping-malformed-test
+  (testing "malformed output returns empty violations"
+    (let [mapping (sut/get-mapping :eslint)]
+      (is (= [] (sut/apply-mapping mapping "not json"))))))

--- a/deps.edn
+++ b/deps.edn
@@ -113,6 +113,8 @@
                        "components/patterns/resources"
                        "bases/cli/src"
                        "bases/cli/resources"
+                       "components/connector-linter/src"
+                       "components/connector-linter/resources"
                        "bases/lsp-mcp-bridge/src"
                        ;; Data Foundry components
                        "components/connector/src"
@@ -235,7 +237,8 @@
                      ai.miniforge.data-foundry/pipeline-config {:local/root "components/pipeline-config"}
                      ai.miniforge.data-foundry/pipeline-pack {:local/root "components/pipeline-pack"}
                      ai.miniforge.data-foundry/pipeline-pack-store {:local/root "components/pipeline-pack-store"}
-                     ai.miniforge.data-foundry/pipeline-runner {:local/root "components/pipeline-runner"}}}
+                     ai.miniforge.data-foundry/pipeline-runner {:local/root "components/pipeline-runner"}
+                     ai.miniforge/connector-linter {:local/root "components/connector-linter"}}}
 
   :test {:extra-paths ["development/test"
                        "components/schema/test"
@@ -322,7 +325,9 @@
                        "components/pipeline-pack/test"
                        "components/pipeline-pack/test/resources"
                        "components/pipeline-pack-store/test"
-                       "components/pipeline-runner/test"]
+                       "components/pipeline-runner/test"
+                       "components/connector-linter/test"
+                       "bases/lsp-mcp-bridge/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/config {:local/root "components/config"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}


### PR DESCRIPTION
Replaces hardcoded parsers with generic ETL engine. Adding a new linter = adding an EDN entry. 11 tests, identical results.