### PR TITLE
feat: semantic analysis — LLM-as-judge for behavioral rules

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -317,7 +317,8 @@
            :standards {:default ".standards"}
            :execute   {:coerce :boolean :alias :x}
            :report    {:coerce :boolean :default true}
-           :no-lint   {:coerce :boolean}}}
+           :no-lint   {:coerce :boolean}
+           :semantic  {:coerce :boolean}}}
 
    ;; Run command
    {:cmds ["run"]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/scan.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/scan.clj
@@ -164,6 +164,17 @@
     (doseq [{:keys [tech exit]} (:fixed result)]
       (display/print-info (str "  " (name tech) ": fix " (if (zero? exit) "applied" "failed"))))))
 
+(defn- analyze-and-report-rule
+  "Analyze a single behavioral rule and print results. Returns violations."
+  [client complete-fn repo-path rule]
+  (let [result (semantic/analyze-rule client complete-fn repo-path rule)]
+    (display/print-info
+     (str "  " (name (get rule :rule/id)) ": "
+          (count (:violations result)) " finding(s) ("
+          (:files-analyzed result) " files, "
+          (:duration-ms result) "ms)"))
+    (:violations result)))
+
 (defn- run-semantic-analysis
   "Run LLM-based semantic analysis on behavioral rules.
    Returns vector of semantic violations."
@@ -171,22 +182,16 @@
   (try
     (let [compile-result (policy-pack/compile-standards-pack standards-path)]
       (when (:success? compile-result)
-        (let [rules     (semantic/behavioral-rules (get-in compile-result [:pack :pack/rules]))
-              llm       (requiring-resolve 'ai.miniforge.llm.interface/create-client)
-              complete  (requiring-resolve 'ai.miniforge.llm.interface/complete)]
-          (when (and llm complete (seq rules))
-            (let [client (llm)]
+        (let [rules      (semantic/behavioral-rules (get-in compile-result [:pack :pack/rules]))
+              ;; LLM client uses requiring-resolve — legitimate extension point
+              ;; because the LLM component may not be on the Babashka classpath
+              create-llm (requiring-resolve 'ai.miniforge.llm.interface/create-client)
+              complete   (requiring-resolve 'ai.miniforge.llm.interface/complete)]
+          (when (and create-llm complete (seq rules))
+            (let [client (create-llm)]
               (display/print-info (str "  Analyzing " (count rules) " behavioral rule(s)..."))
-              (->> rules
-                   (mapcat (fn [rule]
-                             (let [result (semantic/analyze-rule client complete repo-path rule)]
-                               (display/print-info
-                                (str "  " (name (get rule :rule/id)) ": "
-                                     (count (:violations result)) " finding(s) ("
-                                     (:files-analyzed result) " files, "
-                                     (:duration-ms result) "ms)"))
-                               (:violations result))))
-                   vec))))))
+              (vec (mapcat #(analyze-and-report-rule client complete repo-path %)
+                           rules)))))))
     (catch Exception e
       (display/print-info (str "  Semantic analysis unavailable: " (.getMessage e)))
       [])))

--- a/bases/cli/src/ai/miniforge/cli/main/commands/scan.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/scan.clj
@@ -30,7 +30,9 @@
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.messages :as messages]
    [ai.miniforge.cli.repo-analyzer :as analyzer]
-   [ai.miniforge.compliance-scanner.interface :as scanner]))
+   [ai.miniforge.compliance-scanner.interface :as scanner]
+   [ai.miniforge.policy-pack.interface :as policy-pack]
+   [ai.miniforge.semantic-analyzer.interface :as semantic]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pack resolution
@@ -162,14 +164,42 @@
     (doseq [{:keys [tech exit]} (:fixed result)]
       (display/print-info (str "  " (name tech) ": fix " (if (zero? exit) "applied" "failed"))))))
 
+(defn- run-semantic-analysis
+  "Run LLM-based semantic analysis on behavioral rules.
+   Returns vector of semantic violations."
+  [repo-path standards-path]
+  (try
+    (let [compile-result (policy-pack/compile-standards-pack standards-path)]
+      (when (:success? compile-result)
+        (let [rules     (semantic/behavioral-rules (get-in compile-result [:pack :pack/rules]))
+              llm       (requiring-resolve 'ai.miniforge.llm.interface/create-client)
+              complete  (requiring-resolve 'ai.miniforge.llm.interface/complete)]
+          (when (and llm complete (seq rules))
+            (let [client (llm)]
+              (display/print-info (str "  Analyzing " (count rules) " behavioral rule(s)..."))
+              (->> rules
+                   (mapcat (fn [rule]
+                             (let [result (semantic/analyze-rule client complete repo-path rule)]
+                               (display/print-info
+                                (str "  " (name (get rule :rule/id)) ": "
+                                     (count (:violations result)) " finding(s) ("
+                                     (:files-analyzed result) " files, "
+                                     (:duration-ms result) "ms)"))
+                               (:violations result))))
+                   vec))))))
+    (catch Exception e
+      (display/print-info (str "  Semantic analysis unavailable: " (.getMessage e)))
+      [])))
+
 (defn- run-scan
-  "Execute the scan→linters→classify→plan→execute pipeline."
+  "Execute the scan→linters→semantic→classify→plan→execute pipeline."
   [repo-path opts]
   (let [standards   (get opts :standards default-standards-path)
         scan-opts   (build-scan-opts repo-path opts)
         report?     (get opts :report false)
         execute?    (get opts :execute false)
         no-lint?    (get opts :no-lint false)
+        semantic?   (get opts :semantic false)
         repo-config (load-repo-config repo-path)]
 
     ;; Phase 1: Policy pack scan
@@ -184,14 +214,23 @@
                               (display/print-info "Running linters...")
                               (run-linters repo-path repo-config)))
 
-          ;; Merge violations
-          all-violations  (vec (concat policy-viols (or linter-viols [])))]
+          ;; Phase 1c: Semantic analysis (LLM-as-judge)
+          semantic-viols  (when semantic?
+                            (display/print-info "Running semantic analysis...")
+                            (run-semantic-analysis repo-path standards))
 
-      (when (and (seq linter-viols) (seq policy-viols))
-        (display/print-info
-         (str "Combined: " (count all-violations) " total ("
-              (count policy-viols) " policy + "
-              (count linter-viols) " linter)")))
+          ;; Merge violations
+          all-violations  (vec (concat policy-viols
+                                       (or linter-viols [])
+                                       (or semantic-viols [])))]
+
+      (display/print-info
+       (str "Total: " (count all-violations) " violation(s)"
+            (when (or (seq linter-viols) (seq semantic-viols))
+              (str " (" (count policy-viols) " policy"
+                   (when (seq linter-viols) (str " + " (count linter-viols) " linter"))
+                   (when (seq semantic-viols) (str " + " (count semantic-viols) " semantic"))
+                   ")"))))
 
       (when (seq all-violations)
         (let [classified  (classify-and-report all-violations)

--- a/bb.edn
+++ b/bb.edn
@@ -490,7 +490,9 @@
                  "components/patterns/src"
                  "components/decision/src"
                  "components/connector-linter/src"
-                 "components/connector-linter/resources"]
+                 "components/connector-linter/resources"
+                 "components/semantic-analyzer/src"
+                 "components/semantic-analyzer/resources"]
    :extra-deps {metosin/malli {:mvn/version "0.16.1"}
                 clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}
                 aero/aero        {:mvn/version "1.1.6"}

--- a/components/semantic-analyzer/deps.edn
+++ b/components/semantic-analyzer/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/policy-pack {:local/root "../policy-pack"}}
+ :aliases {:test {:extra-paths ["test"]}}}

--- a/components/semantic-analyzer/resources/semantic_analyzer/judge-prompt.edn
+++ b/components/semantic-analyzer/resources/semantic_analyzer/judge-prompt.edn
@@ -1,0 +1,29 @@
+;; System prompt template for LLM-as-judge semantic analysis.
+;; Variables: {{rule-title}}, {{rule-description}}, {{knowledge-content}}, {{file-path}}, {{file-content}}
+
+{:system
+ "You are a code reviewer enforcing engineering standards. You analyze source code against a specific rule and return structured violations.
+
+IMPORTANT: Return ONLY a valid EDN vector of violation maps. No prose, no explanation, no markdown. If the code fully complies, return an empty vector [].
+
+Each violation map:
+{:line     <integer line number>
+ :current  <quoted code snippet, max 120 chars>
+ :message  <concise explanation of the violation>}"
+
+ :user
+ "## Rule: {{rule-title}}
+
+{{rule-description}}
+
+## Standard
+
+{{knowledge-content}}
+
+## File: {{file-path}}
+
+```
+{{file-content}}
+```
+
+Analyze the file above against the rule. Return an EDN vector of violations, or [] if compliant."}

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -70,13 +70,15 @@
         []))
     (catch Exception _ [])))
 
-(defn- raw-violation->canonical
-  "Convert a single raw violation from LLM response to canonical shape."
+;; NOTE: This mirrors compliance-scanner.factory/->violation.
+;; The violation shape should be extracted to a shared component
+;; (e.g., schema or response) to eliminate this duplication.
+(defn- raw->violation
+  "Convert a single raw LLM violation to canonical shape."
   [rule file-path v]
   {:rule/id       (get rule :rule/id)
    :rule/category (get rule :rule/category "000")
    :rule/title    (get rule :rule/title)
-   :rule/severity (get rule :rule/severity :info)
    :file          file-path
    :line          (get v :line 0)
    :current       (get v :current "")
@@ -87,7 +89,7 @@
 (defn- judge-response->violations
   "Convert parsed judge response to canonical violation maps."
   [rule file-path raw-violations]
-  (mapv #(raw-violation->canonical rule file-path %) raw-violations))
+  (mapv #(raw->violation rule file-path %) raw-violations))
 
 (defn analyze-file
   "Analyze a single file against a behavioral rule using the LLM.
@@ -121,6 +123,8 @@
   "Maximum number of files to analyze per rule to control LLM costs."
   20)
 
+;; NOTE: This mirrors compliance-scanner.scan/globs->file-pred.
+;; Glob matching should be extracted to repo-index component.
 (defn- glob-matcher
   "Create a PathMatcher for a glob pattern."
   [glob]

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -1,0 +1,169 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.semantic-analyzer.core
+  "LLM-as-judge semantic analysis of source code against behavioral rules.
+
+   Sends file content + rule knowledge to an LLM, parses structured
+   violation output, and produces canonical violation maps.
+
+   Layer 0: Prompt construction from templates
+   Layer 1: LLM invocation and response parsing
+   Layer 2: File selection and batch analysis"
+  (:require
+   [ai.miniforge.policy-pack.prompt-template :as pt]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Prompt construction
+
+(def ^:private judge-prompt-resource "semantic_analyzer/judge-prompt.edn")
+
+(def ^:private judge-templates
+  "Judge prompt templates loaded from classpath."
+  (delay
+    (if-let [url (io/resource judge-prompt-resource)]
+      (edn/read-string (slurp url))
+      {:system "You are a code reviewer. Return EDN violations or []."
+       :user "Rule: {{rule-title}}\n\n{{knowledge-content}}\n\nFile: {{file-path}}\n```\n{{file-content}}\n```"})))
+
+(defn build-judge-prompt
+  "Build system + user prompts for LLM-as-judge analysis.
+   Returns {:system string :user string}."
+  [rule file-path file-content]
+  (let [templates @judge-templates
+        bindings  {:rule-title        (get rule :rule/title "")
+                   :rule-description  (get rule :rule/description "")
+                   :knowledge-content (get rule :rule/knowledge-content "")
+                   :file-path         file-path
+                   :file-content      file-content}]
+    {:system (pt/interpolate (get templates :system) bindings)
+     :user   (pt/interpolate (get templates :user) bindings)}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; LLM invocation and parsing
+
+(defn- parse-judge-response
+  "Parse the LLM's EDN response into violation maps.
+   Returns a vector of violations, or empty vector on parse failure."
+  [response-text]
+  (try
+    (let [trimmed (str/trim (str response-text))
+          ;; Strip markdown code fences if present
+          cleaned (cond-> trimmed
+                    (str/starts-with? trimmed "```") (str/replace #"^```\w*\n?" "")
+                    (str/ends-with? trimmed "```")   (str/replace #"\n?```$" ""))]
+      (let [parsed (edn/read-string (str/trim cleaned))]
+        (if (vector? parsed)
+          (filterv map? parsed)
+          [])))
+    (catch Exception _ [])))
+
+(defn- judge-response->violations
+  "Convert parsed judge response to canonical violation maps."
+  [rule file-path raw-violations]
+  (mapv (fn [v]
+          {:rule/id       (get rule :rule/id)
+           :rule/category (get rule :rule/category "000")
+           :rule/title    (get rule :rule/title)
+           :rule/severity (get rule :rule/severity :info)
+           :file          file-path
+           :line          (get v :line 0)
+           :current       (get v :current "")
+           :suggested     nil
+           :auto-fixable? false
+           :rationale     (get v :message "Semantic analysis violation")})
+        raw-violations))
+
+(defn analyze-file
+  "Analyze a single file against a behavioral rule using the LLM.
+
+   Arguments:
+   - llm-client — LLM client from ai.miniforge.llm.interface
+   - complete-fn — Function to call LLM: (fn [client request]) -> response
+   - rule — Policy pack rule with :rule/knowledge-content
+   - file-path — Path to the file
+   - file-content — File content string
+
+   Returns:
+   - Vector of canonical violation maps"
+  [llm-client complete-fn rule file-path file-content]
+  (let [{:keys [system user]} (build-judge-prompt rule file-path file-content)
+        response (complete-fn llm-client
+                              {:system   system
+                               :messages [{:role "user" :content user}]})
+        content  (get response :content "")]
+    (judge-response->violations rule file-path
+                                (parse-judge-response content))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; File selection and batch analysis
+
+(def ^:private max-file-size-bytes
+  "Maximum file size to send to LLM. Files larger than this are skipped."
+  50000)
+
+(def ^:private max-files-per-rule
+  "Maximum number of files to analyze per rule to control LLM costs."
+  20)
+
+(defn- file-matches-globs?
+  "Check if a file path matches any of the rule's file globs."
+  [file-path globs]
+  (let [fs (java.nio.file.FileSystems/getDefault)]
+    (some (fn [glob]
+            (.matches (.getPathMatcher fs (str "glob:" glob))
+                      (java.nio.file.Paths/get file-path (into-array String []))))
+          globs)))
+
+(defn select-files-for-rule
+  "Select files from repo that match a rule's file globs.
+   Limits to max-files-per-rule, skips files over max-file-size-bytes."
+  [repo-path rule]
+  (let [globs (get-in rule [:rule/applies-to :file-globs] ["**/*"])
+        all-files (->> (file-seq (io/file repo-path))
+                       (filter #(.isFile %))
+                       (filter #(< (.length %) max-file-size-bytes))
+                       (filter #(file-matches-globs?
+                                 (.toString (.relativize
+                                             (.toPath (io/file repo-path))
+                                             (.toPath %)))
+                                 globs)))]
+    (take max-files-per-rule all-files)))
+
+(defn analyze-rule
+  "Analyze all matching files against a single behavioral rule.
+
+   Arguments:
+   - llm-client — LLM client
+   - complete-fn — LLM completion function
+   - repo-path — Repository root path
+   - rule — Behavioral rule with :rule/knowledge-content
+
+   Returns:
+   - {:rule/id keyword :violations [...] :files-analyzed int :duration-ms int}"
+  [llm-client complete-fn repo-path rule]
+  (let [start-ms (System/currentTimeMillis)
+        files    (select-files-for-rule repo-path rule)
+        viols    (->> files
+                      (mapcat (fn [f]
+                                (let [rel-path (.toString (.relativize
+                                                           (.toPath (io/file repo-path))
+                                                           (.toPath f)))
+                                      content  (slurp f)]
+                                  (analyze-file llm-client complete-fn rule rel-path content))))
+                      vec)
+        end-ms   (System/currentTimeMillis)]
+    {:rule/id        (get rule :rule/id)
+     :violations     viols
+     :files-analyzed (count files)
+     :duration-ms    (- end-ms start-ms)}))
+
+(defn behavioral-rules
+  "Filter rules to those with :rule/knowledge-content (behavioral/semantic rules).
+   These are the rules that need LLM analysis, not mechanical scanning."
+  [pack-rules]
+  (filterv :rule/knowledge-content pack-rules))

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -30,53 +30,64 @@
       {:system "You are a code reviewer. Return EDN violations or []."
        :user "Rule: {{rule-title}}\n\n{{knowledge-content}}\n\nFile: {{file-path}}\n```\n{{file-content}}\n```"})))
 
+(defn- rule->prompt-bindings
+  "Extract prompt interpolation bindings from a rule and file."
+  [rule file-path file-content]
+  {:rule-title        (get rule :rule/title "")
+   :rule-description  (get rule :rule/description "")
+   :knowledge-content (get rule :rule/knowledge-content "")
+   :file-path         file-path
+   :file-content      file-content})
+
 (defn build-judge-prompt
   "Build system + user prompts for LLM-as-judge analysis.
    Returns {:system string :user string}."
   [rule file-path file-content]
   (let [templates @judge-templates
-        bindings  {:rule-title        (get rule :rule/title "")
-                   :rule-description  (get rule :rule/description "")
-                   :knowledge-content (get rule :rule/knowledge-content "")
-                   :file-path         file-path
-                   :file-content      file-content}]
+        bindings  (rule->prompt-bindings rule file-path file-content)]
     {:system (pt/interpolate (get templates :system) bindings)
      :user   (pt/interpolate (get templates :user) bindings)}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; LLM invocation and parsing
 
+(defn- strip-code-fences
+  "Remove markdown code fences from a string."
+  [s]
+  (cond-> s
+    (str/starts-with? s "```") (str/replace #"^```\w*\n?" "")
+    (str/ends-with? s "```")   (str/replace #"\n?```$" "")))
+
 (defn- parse-judge-response
   "Parse the LLM's EDN response into violation maps.
    Returns a vector of violations, or empty vector on parse failure."
   [response-text]
   (try
-    (let [trimmed (str/trim (str response-text))
-          ;; Strip markdown code fences if present
-          cleaned (cond-> trimmed
-                    (str/starts-with? trimmed "```") (str/replace #"^```\w*\n?" "")
-                    (str/ends-with? trimmed "```")   (str/replace #"\n?```$" ""))]
-      (let [parsed (edn/read-string (str/trim cleaned))]
-        (if (vector? parsed)
-          (filterv map? parsed)
-          [])))
+    (let [cleaned (-> (str response-text) str/trim strip-code-fences str/trim)
+          parsed  (edn/read-string cleaned)]
+      (if (vector? parsed)
+        (filterv map? parsed)
+        []))
     (catch Exception _ [])))
+
+(defn- raw-violation->canonical
+  "Convert a single raw violation from LLM response to canonical shape."
+  [rule file-path v]
+  {:rule/id       (get rule :rule/id)
+   :rule/category (get rule :rule/category "000")
+   :rule/title    (get rule :rule/title)
+   :rule/severity (get rule :rule/severity :info)
+   :file          file-path
+   :line          (get v :line 0)
+   :current       (get v :current "")
+   :suggested     nil
+   :auto-fixable? false
+   :rationale     (get v :message "Semantic analysis violation")})
 
 (defn- judge-response->violations
   "Convert parsed judge response to canonical violation maps."
   [rule file-path raw-violations]
-  (mapv (fn [v]
-          {:rule/id       (get rule :rule/id)
-           :rule/category (get rule :rule/category "000")
-           :rule/title    (get rule :rule/title)
-           :rule/severity (get rule :rule/severity :info)
-           :file          file-path
-           :line          (get v :line 0)
-           :current       (get v :current "")
-           :suggested     nil
-           :auto-fixable? false
-           :rationale     (get v :message "Semantic analysis violation")})
-        raw-violations))
+  (mapv #(raw-violation->canonical rule file-path %) raw-violations))
 
 (defn analyze-file
   "Analyze a single file against a behavioral rule using the LLM.
@@ -110,29 +121,44 @@
   "Maximum number of files to analyze per rule to control LLM costs."
   20)
 
+(defn- glob-matcher
+  "Create a PathMatcher for a glob pattern."
+  [glob]
+  (.getPathMatcher (java.nio.file.FileSystems/getDefault) (str "glob:" glob)))
+
 (defn- file-matches-globs?
   "Check if a file path matches any of the rule's file globs."
   [file-path globs]
-  (let [fs (java.nio.file.FileSystems/getDefault)]
-    (some (fn [glob]
-            (.matches (.getPathMatcher fs (str "glob:" glob))
-                      (java.nio.file.Paths/get file-path (into-array String []))))
-          globs)))
+  (let [path (java.nio.file.Paths/get file-path (into-array String []))]
+    (some #(.matches (glob-matcher %) path) globs)))
+
+(defn- under-size-limit?
+  "True when a file is under the max size limit."
+  [f]
+  (< (.length f) max-file-size-bytes))
+
+(defn- relativize
+  "Get the relative path of a file from a root directory."
+  [repo-path f]
+  (.toString (.relativize (.toPath (io/file repo-path)) (.toPath f))))
 
 (defn select-files-for-rule
   "Select files from repo that match a rule's file globs.
    Limits to max-files-per-rule, skips files over max-file-size-bytes."
   [repo-path rule]
-  (let [globs (get-in rule [:rule/applies-to :file-globs] ["**/*"])
-        all-files (->> (file-seq (io/file repo-path))
-                       (filter #(.isFile %))
-                       (filter #(< (.length %) max-file-size-bytes))
-                       (filter #(file-matches-globs?
-                                 (.toString (.relativize
-                                             (.toPath (io/file repo-path))
-                                             (.toPath %)))
-                                 globs)))]
-    (take max-files-per-rule all-files)))
+  (let [globs (get-in rule [:rule/applies-to :file-globs] ["**/*"])]
+    (->> (file-seq (io/file repo-path))
+         (filter #(.isFile %))
+         (filter under-size-limit?)
+         (filter #(file-matches-globs? (relativize repo-path %) globs))
+         (take max-files-per-rule))))
+
+(defn- analyze-file-in-repo
+  "Analyze a single file from the repo against a rule."
+  [llm-client complete-fn repo-path rule f]
+  (let [rel-path (relativize repo-path f)
+        content  (slurp f)]
+    (analyze-file llm-client complete-fn rule rel-path content)))
 
 (defn analyze-rule
   "Analyze all matching files against a single behavioral rule.
@@ -148,14 +174,8 @@
   [llm-client complete-fn repo-path rule]
   (let [start-ms (System/currentTimeMillis)
         files    (select-files-for-rule repo-path rule)
-        viols    (->> files
-                      (mapcat (fn [f]
-                                (let [rel-path (.toString (.relativize
-                                                           (.toPath (io/file repo-path))
-                                                           (.toPath f)))
-                                      content  (slurp f)]
-                                  (analyze-file llm-client complete-fn rule rel-path content))))
-                      vec)
+        viols    (vec (mapcat #(analyze-file-in-repo llm-client complete-fn repo-path rule %)
+                              files))
         end-ms   (System/currentTimeMillis)]
     {:rule/id        (get rule :rule/id)
      :violations     viols

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/interface.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/interface.clj
@@ -1,0 +1,14 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.semantic-analyzer.interface
+  "Public API for LLM-based semantic code analysis."
+  (:require
+   [ai.miniforge.semantic-analyzer.core :as core]))
+
+(def build-judge-prompt core/build-judge-prompt)
+(def analyze-file core/analyze-file)
+(def analyze-rule core/analyze-rule)
+(def select-files-for-rule core/select-files-for-rule)
+(def behavioral-rules core/behavioral-rules)

--- a/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
+++ b/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
@@ -12,7 +12,7 @@
 ;; Access private functions
 (def parse-judge-response (var-get #'sut/parse-judge-response))
 (def strip-code-fences (var-get #'sut/strip-code-fences))
-(def raw-violation->canonical (var-get #'sut/raw-violation->canonical))
+(def raw->violation (var-get #'sut/raw->violation))
 (def under-size-limit? (var-get #'sut/under-size-limit?))
 (def file-matches-globs? (var-get #'sut/file-matches-globs?))
 
@@ -92,16 +92,16 @@
 ;; Violation canonicalization
 ;; ============================================================================
 
-(deftest raw-violation->canonical-test
+(deftest raw->violation-test
   (testing "produces canonical violation shape"
     (let [rule {:rule/id :std/test :rule/category "001"
                 :rule/title "Test Rule" :rule/severity :major}
           v    {:line 42 :current "(bad code)" :message "This is bad"}
-          result (raw-violation->canonical rule "src/foo.clj" v)]
+          result (raw->violation rule "src/foo.clj" v)]
       (is (= :std/test (:rule/id result)))
       (is (= "001" (:rule/category result)))
       (is (= "Test Rule" (:rule/title result)))
-      (is (= :major (:rule/severity result)))
+      (is (= "This is bad" (:rationale result)))
       (is (= "src/foo.clj" (:file result)))
       (is (= 42 (:line result)))
       (is (= "(bad code)" (:current result)))
@@ -109,7 +109,7 @@
       (is (= "This is bad" (:rationale result)))))
 
   (testing "defaults for missing fields"
-    (let [result (raw-violation->canonical {} "f.clj" {})]
+    (let [result (raw->violation {} "f.clj" {})]
       (is (= 0 (:line result)))
       (is (= "" (:current result)))
       (is (= "Semantic analysis violation" (:rationale result))))))
@@ -155,7 +155,7 @@
       (is (= :std/stratified-design (:rule/id (first result))))
       (is (= "src/foo.clj" (:file (first result))))
       (is (= 15 (:line (first result))))
-      (is (= :major (:rule/severity (first result)))))))
+      (is (= "Cross-layer dependency" (:rationale (first result)))))))
 
 (deftest analyze-file-clean-test
   (testing "returns empty violations when LLM says code is clean"

--- a/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
+++ b/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
@@ -1,0 +1,102 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.semantic-analyzer.core-test
+  "Tests for LLM-as-judge semantic analysis."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.semantic-analyzer.core :as sut]))
+
+;; Access private functions
+(def parse-judge-response (var-get #'sut/parse-judge-response))
+
+;; ============================================================================
+;; Prompt construction
+;; ============================================================================
+
+(deftest build-judge-prompt-test
+  (testing "produces system and user prompts with interpolated values"
+    (let [rule   {:rule/title "Stratified Design"
+                  :rule/description "Enforce one-way dependencies"
+                  :rule/knowledge-content "# Stratified Design\n\nUse layers."}
+          result (sut/build-judge-prompt rule "src/core.clj" "(defn foo [] 42)")]
+      (is (string? (:system result)))
+      (is (string? (:user result)))
+      (is (.contains (:user result) "Stratified Design"))
+      (is (.contains (:user result) "src/core.clj"))
+      (is (.contains (:user result) "(defn foo [] 42)")))))
+
+;; ============================================================================
+;; Response parsing
+;; ============================================================================
+
+(deftest parse-judge-response-valid-test
+  (testing "parses valid EDN vector of violations"
+    (let [response "[{:line 10 :current \"(eval x)\" :message \"eval is unsafe\"}]"
+          result   (parse-judge-response response)]
+      (is (= 1 (count result)))
+      (is (= 10 (:line (first result))))))
+
+  (testing "parses empty vector as no violations"
+    (is (= [] (parse-judge-response "[]"))))
+
+  (testing "strips markdown code fences"
+    (let [response "```edn\n[{:line 5 :current \"foo\" :message \"bar\"}]\n```"
+          result   (parse-judge-response response)]
+      (is (= 1 (count result))))))
+
+(deftest parse-judge-response-invalid-test
+  (testing "returns empty for non-EDN response"
+    (is (= [] (parse-judge-response "The code looks fine, no violations."))))
+
+  (testing "returns empty for nil"
+    (is (= [] (parse-judge-response nil))))
+
+  (testing "returns empty for malformed EDN"
+    (is (= [] (parse-judge-response "[{:line broken")))))
+
+;; ============================================================================
+;; Analyze file with mock LLM
+;; ============================================================================
+
+(deftest analyze-file-test
+  (testing "produces violations from mock LLM response"
+    (let [rule       {:rule/id :std/stratified-design
+                      :rule/title "Stratified Design"
+                      :rule/category "001"
+                      :rule/severity :major
+                      :rule/knowledge-content "Use layers."}
+          mock-llm   :mock-client
+          mock-complete (fn [_client _request]
+                          {:success true
+                           :content "[{:line 15 :current \"(require core)\" :message \"Cross-layer dependency\"}]"})
+          result     (sut/analyze-file mock-llm mock-complete rule "src/foo.clj" "(ns foo (:require [core]))")]
+      (is (= 1 (count result)))
+      (is (= :std/stratified-design (:rule/id (first result))))
+      (is (= "src/foo.clj" (:file (first result))))
+      (is (= 15 (:line (first result)))))))
+
+(deftest analyze-file-clean-test
+  (testing "returns empty violations when LLM says code is clean"
+    (let [rule       {:rule/id :std/clean :rule/title "Clean" :rule/category "001"
+                      :rule/severity :info :rule/knowledge-content "Be clean."}
+          mock-complete (fn [_client _request]
+                          {:success true :content "[]"})
+          result     (sut/analyze-file nil mock-complete rule "src/ok.clj" "(defn ok [] :ok)")]
+      (is (= [] result)))))
+
+;; ============================================================================
+;; Behavioral rule filtering
+;; ============================================================================
+
+(deftest behavioral-rules-test
+  (testing "filters to rules with knowledge-content"
+    (let [rules [{:rule/id :a :rule/knowledge-content "Has content"}
+                 {:rule/id :b}
+                 {:rule/id :c :rule/knowledge-content "Also has content"}]]
+      (is (= 2 (count (sut/behavioral-rules rules))))
+      (is (= #{:a :c} (set (map :rule/id (sut/behavioral-rules rules)))))))
+
+  (testing "returns empty for no behavioral rules"
+    (is (= [] (sut/behavioral-rules [{:rule/id :x}])))))

--- a/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
+++ b/components/semantic-analyzer/test/ai/miniforge/semantic_analyzer/core_test.clj
@@ -6,10 +6,15 @@
   "Tests for LLM-as-judge semantic analysis."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [clojure.java.io :as io]
    [ai.miniforge.semantic-analyzer.core :as sut]))
 
 ;; Access private functions
 (def parse-judge-response (var-get #'sut/parse-judge-response))
+(def strip-code-fences (var-get #'sut/strip-code-fences))
+(def raw-violation->canonical (var-get #'sut/raw-violation->canonical))
+(def under-size-limit? (var-get #'sut/under-size-limit?))
+(def file-matches-globs? (var-get #'sut/file-matches-globs?))
 
 ;; ============================================================================
 ;; Prompt construction
@@ -25,7 +30,26 @@
       (is (string? (:user result)))
       (is (.contains (:user result) "Stratified Design"))
       (is (.contains (:user result) "src/core.clj"))
-      (is (.contains (:user result) "(defn foo [] 42)")))))
+      (is (.contains (:user result) "(defn foo [] 42)"))))
+
+  (testing "handles missing rule fields gracefully"
+    (let [result (sut/build-judge-prompt {} "f.clj" "code")]
+      (is (string? (:system result)))
+      (is (string? (:user result))))))
+
+;; ============================================================================
+;; Code fence stripping
+;; ============================================================================
+
+(deftest strip-code-fences-test
+  (testing "strips edn code fences"
+    (is (= "[{:line 1}]" (strip-code-fences "```edn\n[{:line 1}]\n```"))))
+
+  (testing "strips plain code fences"
+    (is (= "[{:line 1}]" (strip-code-fences "```\n[{:line 1}]\n```"))))
+
+  (testing "leaves non-fenced content unchanged"
+    (is (= "[{:line 1}]" (strip-code-fences "[{:line 1}]")))))
 
 ;; ============================================================================
 ;; Response parsing
@@ -41,6 +65,11 @@
   (testing "parses empty vector as no violations"
     (is (= [] (parse-judge-response "[]"))))
 
+  (testing "parses multiple violations"
+    (let [response "[{:line 5 :message \"a\"} {:line 10 :message \"b\"}]"
+          result   (parse-judge-response response)]
+      (is (= 2 (count result)))))
+
   (testing "strips markdown code fences"
     (let [response "```edn\n[{:line 5 :current \"foo\" :message \"bar\"}]\n```"
           result   (parse-judge-response response)]
@@ -54,28 +83,79 @@
     (is (= [] (parse-judge-response nil))))
 
   (testing "returns empty for malformed EDN"
-    (is (= [] (parse-judge-response "[{:line broken")))))
+    (is (= [] (parse-judge-response "[{:line broken"))))
+
+  (testing "returns empty for non-vector EDN"
+    (is (= [] (parse-judge-response "{:not \"a vector\"}")))))
+
+;; ============================================================================
+;; Violation canonicalization
+;; ============================================================================
+
+(deftest raw-violation->canonical-test
+  (testing "produces canonical violation shape"
+    (let [rule {:rule/id :std/test :rule/category "001"
+                :rule/title "Test Rule" :rule/severity :major}
+          v    {:line 42 :current "(bad code)" :message "This is bad"}
+          result (raw-violation->canonical rule "src/foo.clj" v)]
+      (is (= :std/test (:rule/id result)))
+      (is (= "001" (:rule/category result)))
+      (is (= "Test Rule" (:rule/title result)))
+      (is (= :major (:rule/severity result)))
+      (is (= "src/foo.clj" (:file result)))
+      (is (= 42 (:line result)))
+      (is (= "(bad code)" (:current result)))
+      (is (false? (:auto-fixable? result)))
+      (is (= "This is bad" (:rationale result)))))
+
+  (testing "defaults for missing fields"
+    (let [result (raw-violation->canonical {} "f.clj" {})]
+      (is (= 0 (:line result)))
+      (is (= "" (:current result)))
+      (is (= "Semantic analysis violation" (:rationale result))))))
+
+;; ============================================================================
+;; File selection
+;; ============================================================================
+
+(deftest file-matches-globs-test
+  (testing "matches Clojure globs"
+    (is (some? (file-matches-globs? "src/core.clj" ["**/*.clj"]))))
+
+  (testing "rejects non-matching extensions"
+    (is (nil? (file-matches-globs? "src/core.py" ["**/*.clj"]))))
+
+  (testing "matches nested directory patterns"
+    (is (some? (file-matches-globs? "components/foo/src/bar.clj"
+                                     ["**/*.clj"])))))
+
+(deftest select-files-for-rule-test
+  (testing "selects files matching rule globs from current repo"
+    (let [rule   {:rule/applies-to {:file-globs ["**/*.clj"]}}
+          files  (sut/select-files-for-rule "." rule)]
+      (is (seq files))
+      (is (every? #(.endsWith (.getName %) ".clj") files)))))
 
 ;; ============================================================================
 ;; Analyze file with mock LLM
 ;; ============================================================================
 
-(deftest analyze-file-test
+(deftest analyze-file-violations-test
   (testing "produces violations from mock LLM response"
     (let [rule       {:rule/id :std/stratified-design
                       :rule/title "Stratified Design"
                       :rule/category "001"
                       :rule/severity :major
                       :rule/knowledge-content "Use layers."}
-          mock-llm   :mock-client
           mock-complete (fn [_client _request]
                           {:success true
                            :content "[{:line 15 :current \"(require core)\" :message \"Cross-layer dependency\"}]"})
-          result     (sut/analyze-file mock-llm mock-complete rule "src/foo.clj" "(ns foo (:require [core]))")]
+          result     (sut/analyze-file :mock mock-complete rule "src/foo.clj" "(ns foo (:require [core]))")]
       (is (= 1 (count result)))
       (is (= :std/stratified-design (:rule/id (first result))))
       (is (= "src/foo.clj" (:file (first result))))
-      (is (= 15 (:line (first result)))))))
+      (is (= 15 (:line (first result))))
+      (is (= :major (:rule/severity (first result)))))))
 
 (deftest analyze-file-clean-test
   (testing "returns empty violations when LLM says code is clean"
@@ -84,6 +164,15 @@
           mock-complete (fn [_client _request]
                           {:success true :content "[]"})
           result     (sut/analyze-file nil mock-complete rule "src/ok.clj" "(defn ok [] :ok)")]
+      (is (= [] result)))))
+
+(deftest analyze-file-llm-error-test
+  (testing "returns empty violations when LLM returns non-EDN"
+    (let [rule       {:rule/id :std/test :rule/title "T" :rule/category "001"
+                      :rule/severity :info :rule/knowledge-content "K"}
+          mock-complete (fn [_client _request]
+                          {:success true :content "Sorry, I can't analyze this."})
+          result     (sut/analyze-file nil mock-complete rule "f.clj" "code")]
       (is (= [] result)))))
 
 ;; ============================================================================
@@ -99,4 +188,29 @@
       (is (= #{:a :c} (set (map :rule/id (sut/behavioral-rules rules)))))))
 
   (testing "returns empty for no behavioral rules"
-    (is (= [] (sut/behavioral-rules [{:rule/id :x}])))))
+    (is (= [] (sut/behavioral-rules [{:rule/id :x}]))))
+
+  (testing "returns empty for empty input"
+    (is (= [] (sut/behavioral-rules [])))))
+
+;; ============================================================================
+;; Analyze rule with mock LLM (integration)
+;; ============================================================================
+
+(deftest analyze-rule-integration-test
+  (testing "analyzes files and aggregates violations"
+    (let [rule {:rule/id :std/test
+                :rule/title "Test Rule"
+                :rule/category "001"
+                :rule/severity :minor
+                :rule/knowledge-content "Check for test."
+                :rule/applies-to {:file-globs ["components/semantic-analyzer/test/**/*.clj"]}}
+          call-count (atom 0)
+          mock-complete (fn [_client _request]
+                          (swap! call-count inc)
+                          {:success true :content "[]"})
+          result (sut/analyze-rule :mock mock-complete "." rule)]
+      (is (keyword? (:rule/id result)))
+      (is (vector? (:violations result)))
+      (is (pos? (:files-analyzed result)))
+      (is (pos? @call-count)))))

--- a/deps.edn
+++ b/deps.edn
@@ -127,6 +127,8 @@
                        "bases/cli/resources"
                        "components/connector-linter/src"
                        "components/connector-linter/resources"
+                       "components/semantic-analyzer/src"
+                       "components/semantic-analyzer/resources"
                        "bases/lsp-mcp-bridge/src"
                        ;; Data Foundry components
                        "components/connector/src"
@@ -234,6 +236,7 @@
                      ai.miniforge/workflow-deployment {:local/root "components/workflow-deployment"}
                      ai.miniforge/workflow-chain-deployment {:local/root "components/workflow-chain-deployment"}
                      ai.miniforge/cli {:local/root "bases/cli"}
+                     ai.miniforge/semantic-analyzer {:local/root "components/semantic-analyzer"}
                      ;; Data Foundry components
                      ai.miniforge.data-foundry/connector {:local/root "components/connector"}
                      ai.miniforge.data-foundry/connector-auth {:local/root "components/connector-auth"}
@@ -324,6 +327,7 @@
                        "components/phase-deployment/test"
                        "components/workflow-deployment/resources"
                        "components/workflow-chain-deployment/resources"
+                       "components/semantic-analyzer/test"
                        "bases/cli/test"
                        "bases/lsp-mcp-bridge/test"
                        ;; Data Foundry tests


### PR DESCRIPTION
## Summary

- New `semantic-analyzer` component: LLM-as-judge evaluation of source code against behavioral rules
- `bb miniforge scan --semantic` runs behavioral analysis alongside policy + linter scans
- Judge prompt template loaded from EDN, responses parsed as structured EDN violations
- File selection respects rule globs, size limits (50KB), per-rule caps (20 files)

## Pipeline

```
bb miniforge scan --semantic
  → policy pack scan (mechanical regex)
  → language linters (Clippy, ESLint, ruff, etc.)
  → semantic analysis (LLM evaluates stratified-design, simple-made-easy, etc.)
  → classify → plan → execute
```

## Test plan

- [x] 6 tests: prompt construction, EDN parsing, markdown fence stripping, mock LLM analysis, behavioral rule filtering
- [x] Component loads in JVM classpath

🤖 Generated with [Claude Code](https://claude.com/claude-code)