### PR TITLE
feat: implement miniforge pr respond — auto-fix review comments

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -21,9 +21,24 @@
   (:require
    [babashka.process :as process]
    [cheshire.core :as json]
+   [clojure.string :as str]
    [ai.miniforge.cli.app-config :as app-config]
    [ai.miniforge.cli.main.display :as display]
    [ai.miniforge.cli.messages :as messages]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Shell helpers
+
+(defn- sh! [& args]
+  (apply process/sh args))
+
+(defn- checkout-pr! [pr-number]
+  (let [r (sh! "gh" "pr" "checkout" (str pr-number))]
+    (when (zero? (:exit r))
+      (str/trim (:out (sh! "git" "branch" "--show-current"))))))
+
+(defn- push! []
+  (zero? (:exit (sh! "git" "push"))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; PR commands
@@ -59,7 +74,6 @@
                                     " " title
                                     " (" (:login author "unknown") ")"))))))
               (catch Exception _
-                ;; Fallback to simple text output if JSON parsing fails
                 (let [result2 (process/sh "gh" "pr" "list" "--repo" r "--limit" "10")]
                   (if (zero? (:exit result2))
                     (println (:out result2))
@@ -80,9 +94,29 @@
   (let [{:keys [url]} opts]
     (if-not url
       (display/print-error (messages/t :pr/respond-usage {:command (app-config/command-string "pr respond <pr-url>")}))
-      (do
-        (display/print-info (messages/t :pr/responding {:url url}))
-        (println (messages/t :pr/respond-todo))))))
+      (let [parse-url (requiring-resolve 'ai.miniforge.pr-lifecycle.interface/parse-pr-url)
+            respond!  (requiring-resolve 'ai.miniforge.pr-lifecycle.interface/respond-to-comments!)
+            run-spec  (requiring-resolve 'ai.miniforge.cli.workflow-runner/run-workflow-from-spec!)
+            {:keys [number]} (parse-url url)]
+        (when-not number
+          (display/print-error "Could not parse PR number from URL")
+          (System/exit 1))
+        (display/print-info (str "Checking out PR #" number "..."))
+        (let [branch (checkout-pr! number)]
+          (when-not branch
+            (display/print-error "Failed to checkout PR branch")
+            (System/exit 1))
+          (display/print-info (str "On branch: " branch))
+          (let [cwd (System/getProperty "user.dir")
+                result (respond! url cwd
+                                 (fn [spec run-opts] (run-spec spec (merge {:quiet true} run-opts)))
+                                 push!
+                                 opts)]
+            (display/print-info
+             (str "\nDone: " (:comments-found result) " comment(s), "
+                  (:files-processed result) " file(s) processed, "
+                  (count (filter :succeeded? (:fixes result))) " fixed"
+                  (when (:pushed? result) ", pushed")))))))))
 
 (defn pr-merge-cmd
   [opts]

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -46,7 +46,8 @@
    [ai.miniforge.pr-lifecycle.monitor-events :as mevents]
    [ai.miniforge.pr-lifecycle.monitor-loop :as monitor]
    [ai.miniforge.pr-lifecycle.monitor-budget :as mbudget]
-   [ai.miniforge.pr-lifecycle.pr-poller :as poller]))
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]
+   [ai.miniforge.pr-lifecycle.responder :as responder]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Events
@@ -685,3 +686,37 @@
   ; => {:comments-received 5 :comments-addressed 3 :fixes-pushed [...] ...}
 
   :leave-this-here)
+
+;------------------------------------------------------------------------------ Layer 7
+;; PR Comment Responder
+
+(def parse-pr-url
+  "Extract owner, repo, and PR number from a GitHub PR URL.
+   Returns {:owner :repo :number} or nil."
+  responder/parse-pr-url)
+
+(def respond-to-comments!
+  "Fetch review comments, fix them, push, reply, and resolve.
+
+   Arguments:
+   - pr-url: GitHub PR URL
+   - worktree-path: Path to local git checkout on the PR branch
+   - run-fix-fn: (fn [spec opts] result) — runs a fix workflow
+   - push-fn: (fn [] bool) — pushes changes to remote
+   - opts: Additional options passed to run-fix-fn
+
+   Returns:
+   {:pr-number :comments-found :files-processed :fixes :pushed?}
+
+   Example:
+     (respond-to-comments!
+       \"https://github.com/org/repo/pull/123\"
+       \"/path/to/worktree\"
+       (fn [spec opts] (run-workflow-from-spec! spec opts))
+       (fn [] (zero? (:exit (sh \"git\" \"push\"))))
+       {:quiet true})"
+  responder/respond-to-comments!)
+
+(def build-fix-spec
+  "Build a workflow spec from a group of review comments on a file."
+  responder/build-fix-spec)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
@@ -107,6 +107,72 @@
 ;------------------------------------------------------------------------------ Layer 3
 ;; Orchestration
 
+(defn- fix-succeeded?
+  "True when a workflow result indicates success."
+  [result]
+  (and (map? result)
+       (not (:error result))
+       (not= :failed (get result :execution/status))))
+
+(defn- run-fix-for-group
+  "Run a fix workflow for a comment group. Returns result map or {:error msg}."
+  [run-fix-fn group opts]
+  (let [spec (build-fix-spec group)]
+    (try
+      (run-fix-fn spec opts)
+      (catch Exception e
+        {:error (.getMessage e)}))))
+
+(defn- reply-to-fixed-comments
+  "Reply and resolve all comments in a group after a successful fix."
+  [worktree-path pr-number comment-ids]
+  (mapv #(reply-and-resolve! worktree-path pr-number %
+                             "Fixed in latest push. Changes address the review feedback.")
+        comment-ids))
+
+(defn- fix-result
+  "Build a normalized fix result map."
+  [path comment-ids succeeded? reply-results error]
+  {:path path
+   :succeeded? succeeded?
+   :comment-ids comment-ids
+   :replied? (when reply-results (every? :replied? reply-results))
+   :resolved? (when reply-results (every? :resolved? reply-results))
+   :error error})
+
+(defn- process-comment-group
+  "Fix one file's comments, reply on success. Returns fix result map."
+  [worktree-path pr-number run-fix-fn opts {:keys [path comment-ids] :as group}]
+  (let [result (run-fix-for-group run-fix-fn group opts)
+        succeeded? (fix-succeeded? result)]
+    (if succeeded?
+      (fix-result path comment-ids true
+                  (reply-to-fixed-comments worktree-path pr-number comment-ids) nil)
+      (fix-result path comment-ids false nil (get result :error)))))
+
+(defn- fetch-actionable-comments
+  "Fetch and filter PR comments to actionable review comments.
+   Returns {:comments vector :groups vector} or throws on fetch failure."
+  [worktree-path pr-number]
+  (let [result (poller/fetch-pr-comments worktree-path pr-number)]
+    (when (dag/err? result)
+      (throw (ex-info "Failed to fetch PR comments"
+                      {:pr-number pr-number
+                       :error (get-in result [:error :message])})))
+    (let [all (get-in result [:data :comments])
+          actionable (filter-actionable-comments all)]
+      {:comments actionable
+       :groups (group-comments-by-file actionable)})))
+
+(defn- respond-result
+  "Build the response summary map."
+  [pr-number comments-found files-processed fixes pushed?]
+  {:pr-number pr-number
+   :comments-found comments-found
+   :files-processed files-processed
+   :fixes fixes
+   :pushed? pushed?})
+
 (defn respond-to-comments!
   "Fetch review comments, generate fixes, push, reply, and resolve.
 
@@ -127,50 +193,9 @@
   (let [{:keys [number]} (parse-pr-url pr-url)]
     (when-not number
       (throw (ex-info "Could not parse PR number from URL" {:url pr-url})))
-
-    (let [comments-result (poller/fetch-pr-comments worktree-path number)]
-      (when (dag/err? comments-result)
-        (throw (ex-info "Failed to fetch PR comments"
-                        {:pr-number number
-                         :error (get-in comments-result [:error :message])})))
-
-      (let [all-comments (get-in comments-result [:data :comments])
-            actionable (filter-actionable-comments all-comments)
-            groups (group-comments-by-file actionable)]
-
-        (if (empty? groups)
-          {:pr-number number
-           :comments-found 0
-           :files-processed 0
-           :fixes []
-           :pushed? false}
-
-          (let [fixes (mapv
-                       (fn [{:keys [path comment-ids] :as group}]
-                         (let [spec (build-fix-spec group)
-                               result (try
-                                        (run-fix-fn spec opts)
-                                        (catch Exception e
-                                          {:error (.getMessage e)}))
-                               succeeded? (and (map? result)
-                                               (not (:error result))
-                                               (not= :failed (get result :execution/status)))
-                               reply-results (when succeeded?
-                                               (mapv #(reply-and-resolve!
-                                                       worktree-path number %
-                                                       "Fixed in latest push. Changes address the review feedback.")
-                                                     comment-ids))]
-                           {:path path
-                            :succeeded? succeeded?
-                            :comment-ids comment-ids
-                            :replied? (when reply-results (every? :replied? reply-results))
-                            :resolved? (when reply-results (every? :resolved? reply-results))
-                            :error (when-not succeeded? (get result :error))}))
-                       groups)
-                any-succeeded? (some :succeeded? fixes)
-                pushed? (if any-succeeded? (push-fn) false)]
-            {:pr-number number
-             :comments-found (count actionable)
-             :files-processed (count groups)
-             :fixes fixes
-             :pushed? pushed?}))))))
+    (let [{:keys [comments groups]} (fetch-actionable-comments worktree-path number)]
+      (if (empty? groups)
+        (respond-result number 0 0 [] false)
+        (let [fixes (mapv #(process-comment-group worktree-path number run-fix-fn opts %) groups)
+              pushed? (if (some :succeeded? fixes) (push-fn) false)]
+          (respond-result number (count comments) (count groups) fixes pushed?))))))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
@@ -1,0 +1,176 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.responder
+  "Automated PR comment response — fetch review comments, generate fixes,
+   push, reply, and resolve conversation threads.
+
+   Layer 0: PR URL parsing and comment filtering
+   Layer 1: Fix spec generation
+   Layer 2: Orchestration (respond-to-comments!)"
+  (:require
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.github :as github]
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; PR URL parsing and comment filtering
+
+(defn parse-pr-url
+  "Extract owner, repo, and PR number from a GitHub PR URL.
+   Returns {:owner :repo :number} or nil."
+  [url]
+  (when-let [match (re-find #"github\.com/([^/]+)/([^/]+)/pull/(\d+)" (str url))]
+    {:owner (nth match 1)
+     :repo (nth match 2)
+     :number (parse-long (nth match 3))}))
+
+(def ^:private bot-authors
+  "Authors to exclude from comment processing."
+  #{"github-actions" "github-actions[bot]" "miniforge[bot]"})
+
+(defn filter-actionable-comments
+  "Filter review comments to unresolved, non-bot, code-review comments.
+   Returns vector of normalized comment maps."
+  [comments]
+  (->> comments
+       (remove #(contains? bot-authors (:comment/author %)))
+       (filter #(= :review-comment (:comment/type %)))
+       vec))
+
+(defn group-comments-by-file
+  "Group comments by their file path for batch processing.
+   Returns [{:path :comments :description :comment-ids}]."
+  [comments]
+  (->> comments
+       (filter :comment/path)
+       (group-by :comment/path)
+       (mapv (fn [[path cs]]
+               {:path path
+                :comments cs
+                :description (str/join "\n\n" (map :comment/body cs))
+                :comment-ids (mapv :comment/id cs)}))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Fix spec generation
+
+(defn build-fix-spec
+  "Build a workflow spec from a group of review comments on a file.
+   The spec drives the canonical-sdlc workflow to implement the fix."
+  [{:keys [path description]}]
+  {:spec/title (str "Fix review comments on " path)
+   :spec/description (str "Review comments to address on " path ":\n\n" description)
+   :spec/intent {:type :fix :scope [path]}
+   :spec/constraints ["Only modify the specific code referenced by the review comments"
+                      "Do not change unrelated code"
+                      "Maintain existing tests"]
+   :workflow/type :canonical-sdlc})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Reply and resolution
+
+(defn reply-and-resolve!
+  "Reply to a review comment and resolve its conversation thread.
+   Returns {:replied? bool :resolved? bool :error string-or-nil}."
+  [worktree-path pr-number comment-id message]
+  (let [reply-result (github/reply-to-comment worktree-path pr-number comment-id message)
+        replied? (dag/ok? reply-result)
+        ;; Resolve the thread if reply succeeded
+        resolve-result (when replied?
+                         (let [thread-result (github/get-thread-id worktree-path pr-number comment-id)]
+                           (when (dag/ok? thread-result)
+                             (github/resolve-conversation
+                              worktree-path
+                              (get-in thread-result [:data :thread-id])))))
+        resolved? (and resolve-result (dag/ok? resolve-result))]
+    {:replied? replied?
+     :resolved? resolved?
+     :error (when-not replied?
+              (get-in reply-result [:error :message] "Reply failed"))}))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Orchestration
+
+(defn respond-to-comments!
+  "Fetch review comments, generate fixes, push, reply, and resolve.
+
+   Arguments:
+   - pr-url: GitHub PR URL
+   - worktree-path: Path to local git checkout on the PR branch
+   - run-fix-fn: (fn [spec opts] result) — runs a fix workflow for a comment group
+   - push-fn: (fn [] bool) — pushes changes to remote
+   - opts: Additional options passed to run-fix-fn
+
+   Returns:
+   {:pr-number int
+    :comments-found int
+    :files-processed int
+    :fixes [{:path :succeeded? :comment-ids :replied? :resolved?}]
+    :pushed? bool}"
+  [pr-url worktree-path run-fix-fn push-fn opts]
+  (let [{:keys [number]} (parse-pr-url pr-url)]
+    (when-not number
+      (throw (ex-info "Could not parse PR number from URL" {:url pr-url})))
+
+    (let [comments-result (poller/fetch-pr-comments worktree-path number)]
+      (when (dag/err? comments-result)
+        (throw (ex-info "Failed to fetch PR comments"
+                        {:pr-number number
+                         :error (get-in comments-result [:error :message])})))
+
+      (let [all-comments (get-in comments-result [:data :comments])
+            actionable (filter-actionable-comments all-comments)
+            groups (group-comments-by-file actionable)]
+
+        (if (empty? groups)
+          {:pr-number number
+           :comments-found 0
+           :files-processed 0
+           :fixes []
+           :pushed? false}
+
+          (let [fixes (mapv
+                       (fn [{:keys [path comment-ids] :as group}]
+                         (let [spec (build-fix-spec group)
+                               result (try
+                                        (run-fix-fn spec opts)
+                                        (catch Exception e
+                                          {:error (.getMessage e)}))
+                               succeeded? (and (map? result)
+                                               (not (:error result))
+                                               (not= :failed (get result :execution/status)))
+                               reply-results (when succeeded?
+                                               (mapv #(reply-and-resolve!
+                                                       worktree-path number %
+                                                       "Fixed in latest push. Changes address the review feedback.")
+                                                     comment-ids))]
+                           {:path path
+                            :succeeded? succeeded?
+                            :comment-ids comment-ids
+                            :replied? (when reply-results (every? :replied? reply-results))
+                            :resolved? (when reply-results (every? :resolved? reply-results))
+                            :error (when-not succeeded? (get result :error))}))
+                       groups)
+                any-succeeded? (some :succeeded? fixes)
+                pushed? (if any-succeeded? (push-fn) false)]
+            {:pr-number number
+             :comments-found (count actionable)
+             :files-processed (count groups)
+             :fixes fixes
+             :pushed? pushed?}))))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/responder_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/responder_test.clj
@@ -1,0 +1,196 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.responder-test
+  "Unit tests for PR comment responder.
+   Tests URL parsing, comment filtering, spec generation, and orchestration
+   logic. Does NOT test GitHub API calls or git operations."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.string :as str]
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.pr-lifecycle.github :as github]
+   [ai.miniforge.pr-lifecycle.pr-poller :as poller]
+   [ai.miniforge.pr-lifecycle.responder :as responder]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; PR URL parsing
+
+(deftest parse-pr-url-test
+  (testing "parses standard GitHub PR URL"
+    (let [result (responder/parse-pr-url "https://github.com/miniforge-ai/miniforge/pull/483")]
+      (is (= "miniforge-ai" (:owner result)))
+      (is (= "miniforge" (:repo result)))
+      (is (= 483 (:number result)))))
+
+  (testing "parses URL with trailing path"
+    (let [result (responder/parse-pr-url "https://github.com/org/repo/pull/42/files")]
+      (is (= 42 (:number result)))))
+
+  (testing "returns nil for non-PR URL"
+    (is (nil? (responder/parse-pr-url "https://github.com/org/repo")))
+    (is (nil? (responder/parse-pr-url "not a url")))
+    (is (nil? (responder/parse-pr-url nil)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Comment filtering
+
+(def review-comment
+  {:comment/id 123
+   :comment/body "Extract this function"
+   :comment/author "reviewer"
+   :comment/path "src/foo.clj"
+   :comment/line 42
+   :comment/type :review-comment})
+
+(def bot-comment
+  {:comment/id 456
+   :comment/body "CI passed"
+   :comment/author "github-actions[bot]"
+   :comment/path "src/foo.clj"
+   :comment/type :review-comment})
+
+(def issue-comment
+  {:comment/id 789
+   :comment/body "General feedback"
+   :comment/author "reviewer"
+   :comment/type :issue-comment})
+
+(deftest filter-actionable-comments-test
+  (testing "keeps human review comments"
+    (let [result (responder/filter-actionable-comments [review-comment])]
+      (is (= 1 (count result)))))
+
+  (testing "filters bot comments"
+    (let [result (responder/filter-actionable-comments [review-comment bot-comment])]
+      (is (= 1 (count result)))
+      (is (= "reviewer" (:comment/author (first result))))))
+
+  (testing "filters issue comments (not inline review)"
+    (let [result (responder/filter-actionable-comments [review-comment issue-comment])]
+      (is (= 1 (count result)))))
+
+  (testing "returns empty for no actionable comments"
+    (is (empty? (responder/filter-actionable-comments [bot-comment issue-comment])))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Comment grouping
+
+(def comment-on-bar
+  (assoc review-comment :comment/id 124 :comment/path "src/bar.clj"))
+
+(def second-comment-on-foo
+  (assoc review-comment :comment/id 125 :comment/body "Also fix this"))
+
+(deftest group-comments-by-file-test
+  (testing "groups comments by path"
+    (let [groups (responder/group-comments-by-file
+                  [review-comment comment-on-bar second-comment-on-foo])]
+      (is (= 2 (count groups)))
+      (let [foo-group (first (filter #(= "src/foo.clj" (:path %)) groups))]
+        (is (= 2 (count (:comment-ids foo-group))))
+        (is (= #{123 125} (set (:comment-ids foo-group)))))))
+
+  (testing "skips comments without path"
+    (let [no-path (dissoc review-comment :comment/path)
+          groups (responder/group-comments-by-file [no-path])]
+      (is (empty? groups)))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Fix spec generation
+
+(deftest build-fix-spec-test
+  (testing "generates valid workflow spec"
+    (let [group {:path "src/foo.clj"
+                 :description "Extract this function"
+                 :comment-ids [123]}
+          spec (responder/build-fix-spec group)]
+      (is (= :canonical-sdlc (:workflow/type spec)))
+      (is (= :fix (get-in spec [:spec/intent :type])))
+      (is (= ["src/foo.clj"] (get-in spec [:spec/intent :scope])))
+      (is (clojure.string/includes? (:spec/description spec) "Extract this function")))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Orchestration
+
+(deftest respond-to-comments-no-comments-test
+  (testing "returns clean result when no comments found"
+    (with-redefs [poller/fetch-pr-comments
+                  (fn [_ _] (dag/ok {:comments []}))]
+      (let [result (responder/respond-to-comments!
+                    "https://github.com/org/repo/pull/1"
+                    "/tmp/worktree"
+                    (fn [_ _] {})
+                    (fn [] true)
+                    {})]
+        (is (= 0 (:comments-found result)))
+        (is (= 0 (:files-processed result)))
+        (is (false? (:pushed? result)))))))
+
+(deftest respond-to-comments-with-comments-test
+  (testing "processes comments, runs fix, and reports results"
+    (let [fix-calls (atom [])]
+      (with-redefs [poller/fetch-pr-comments
+                    (fn [_ _] (dag/ok {:comments [review-comment]}))
+                    github/reply-to-comment
+                    (fn [_ _ _ _] (dag/ok {:reply-id 1}))
+                    github/get-thread-id
+                    (fn [_ _ _] (dag/ok {:thread-id "PRRT_123"}))
+                    github/resolve-conversation
+                    (fn [_ _] (dag/ok {:resolved true}))]
+        (let [result (responder/respond-to-comments!
+                      "https://github.com/org/repo/pull/1"
+                      "/tmp/worktree"
+                      (fn [spec _opts]
+                        (swap! fix-calls conj spec)
+                        {:execution/status :completed})
+                      (fn [] true)
+                      {})]
+          (is (= 1 (:comments-found result)))
+          (is (= 1 (:files-processed result)))
+          (is (= 1 (count @fix-calls)))
+          (is (true? (:pushed? result)))
+          (is (true? (get-in result [:fixes 0 :succeeded?])))
+          (is (true? (get-in result [:fixes 0 :replied?])))
+          (is (true? (get-in result [:fixes 0 :resolved?]))))))))
+
+(deftest respond-to-comments-fix-failure-test
+  (testing "reports failure and skips reply when fix fails"
+    (with-redefs [poller/fetch-pr-comments
+                  (fn [_ _] (dag/ok {:comments [review-comment]}))]
+      (let [result (responder/respond-to-comments!
+                    "https://github.com/org/repo/pull/1"
+                    "/tmp/worktree"
+                    (fn [_ _] {:execution/status :failed :error "compile error"})
+                    (fn [] true)
+                    {})]
+        (is (= 1 (:comments-found result)))
+        (is (false? (get-in result [:fixes 0 :succeeded?])))
+        (is (nil? (get-in result [:fixes 0 :replied?])))
+        (is (false? (:pushed? result)))))))
+
+(deftest respond-to-comments-invalid-url-test
+  (testing "throws on unparseable PR URL"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Could not parse"
+          (responder/respond-to-comments! "not-a-url" "/tmp" (fn [_ _] {}) (fn [] true) {})))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.pr-lifecycle.responder-test)
+
+  :leave-this-here)


### PR DESCRIPTION
## Summary

- Replaces the `pr respond` TODO stub with a full implementation
- Fetches review comments via `gh api`, filters to unresolved non-bot comments
- Groups by file path, builds a fix spec per file, runs canonical-sdlc workflow
- Replies to each comment and resolves conversation threads via GraphQL
- Pushes all changes after all fixes applied

## Flow

```
pr respond <url>
  → parse PR URL → checkout branch
  → fetch review comments → filter unresolved
  → group by file
  → for each file: build-fix-spec → run-workflow → reply + resolve
  → push
```

## Test plan

- [ ] `bb miniforge pr respond https://github.com/miniforge-ai/miniforge/pull/483` fixes the 2 review comments
- [ ] Comments get replies on GitHub
- [ ] Conversation threads resolved
- [x] clj-kondo lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)