### PR TITLE
fix: pr respond treats DAG partial success as success

### DIFF
--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
@@ -108,11 +108,15 @@
 ;; Orchestration
 
 (defn- fix-succeeded?
-  "True when a workflow result indicates success."
+  "True when a workflow result indicates success or partial success.
+   A DAG workflow may fail overall but still produce PRs for completed tasks.
+   We consider it a success if the status is not :failed OR if the DAG
+   produced at least one PR (partial success)."
   [result]
   (and (map? result)
        (not (:error result))
-       (not= :failed (get result :execution/status))))
+       (or (not= :failed (get result :execution/status))
+           (seq (get-in result [:execution/dag-result :pr-infos])))))
 
 (defn- run-fix-for-group
   "Run a fix workflow for a comment group. Returns result map or {:error msg}."

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/responder_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/responder_test.clj
@@ -184,6 +184,41 @@
         (is (nil? (get-in result [:fixes 0 :replied?])))
         (is (false? (:pushed? result)))))))
 
+(deftest respond-to-comments-partial-success-test
+  (testing "treats DAG partial success (failed status but PRs produced) as success"
+    (with-redefs [poller/fetch-pr-comments
+                  (fn [_ _] (dag/ok {:comments [review-comment]}))
+                  github/reply-to-comment
+                  (fn [_ _ _ _] (dag/ok {:reply-id 1}))
+                  github/get-thread-id
+                  (fn [_ _ _] (dag/ok {:thread-id "PRRT_123"}))
+                  github/resolve-conversation
+                  (fn [_ _] (dag/ok {:resolved true}))]
+      (let [result (responder/respond-to-comments!
+                    "https://github.com/org/repo/pull/1"
+                    "/tmp/worktree"
+                    (fn [_ _] {:execution/status :failed
+                               :execution/dag-result {:pr-infos [{:pr-number 491}]}})
+                    (fn [] true)
+                    {})]
+        (is (true? (get-in result [:fixes 0 :succeeded?])))
+        (is (true? (get-in result [:fixes 0 :replied?])))
+        (is (true? (:pushed? result)))))))
+
+(deftest respond-to-comments-total-failure-test
+  (testing "treats DAG failure with no PRs as failure"
+    (with-redefs [poller/fetch-pr-comments
+                  (fn [_ _] (dag/ok {:comments [review-comment]}))]
+      (let [result (responder/respond-to-comments!
+                    "https://github.com/org/repo/pull/1"
+                    "/tmp/worktree"
+                    (fn [_ _] {:execution/status :failed
+                               :execution/dag-result {:pr-infos []}})
+                    (fn [] true)
+                    {})]
+        (is (false? (get-in result [:fixes 0 :succeeded?])))
+        (is (false? (:pushed? result)))))))
+
 (deftest respond-to-comments-invalid-url-test
   (testing "throws on unparseable PR URL"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo #"Could not parse"


### PR DESCRIPTION
## Summary

- `fix-succeeded?` now checks for `:pr-infos` in the DAG result when overall status is `:failed`
- A DAG workflow that fails (e.g., test task can't run in sandbox) but produces PRs for completed implement tasks is treated as a success for reply/resolve purposes
- Adds 2 tests: partial success (failed + PRs = reply) and total failure (failed + no PRs = skip)

Fixes the issue where `pr respond` reported "0 fixed" despite producing 5 PRs from the DAG decomposition.

## Test plan

- [x] clj-kondo lint clean
- [x] New test: partial success triggers reply+resolve
- [x] New test: total failure still skips reply
- [x] Existing tests unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)