### PR TITLE
feat: lightweight :comment-fix workflow for pr respond

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -155,12 +155,22 @@
   (try
     (load-and-validate-workflow load-workflow workflow-type workflow-version)
     (catch Exception e
-      (if (= workflow-type :test-only)
+      (case workflow-type
+        :test-only
         {:workflow/id :test-only
          :workflow/version "inline"
          :workflow/name "Test Generation"
          :workflow/pipeline [{:phase :verify} {:phase :done}]
          :workflow/config {:max-tokens 20000 :max-iterations 10}}
+
+        :comment-fix
+        {:workflow/id :comment-fix
+         :workflow/version "inline"
+         :workflow/name "Comment Fix"
+         :workflow/pipeline [{:phase :implement :gates [:syntax :lint :no-secrets]}
+                             {:phase :done}]
+         :workflow/config {:max-tokens 20000 :max-iterations 5}}
+
         (throw e)))))
 
 (defn execute-workflow-pipeline [run-pipeline workflow input callbacks artifact-store event-stream]

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/responder.clj
@@ -102,8 +102,9 @@
 ;; Fix spec generation
 
 (defn build-fix-spec
-  "Build a workflow spec from a group of review comments on a file.
-   Includes pre-gathered file contents so the explore phase can skip."
+  "Build a lightweight workflow spec from review comments on a file.
+   Uses :comment-fix workflow (implement + gates only) instead of full SDLC.
+   Includes pre-gathered file contents so the explore phase is skipped."
   [{:keys [path description]} context]
   (let [file-content (some #(when (= path (:path %)) (:content %)) (:files context))]
     (cond-> {:spec/title (str "Fix review comments on " path)
@@ -114,7 +115,7 @@
              :spec/constraints ["Only modify the specific code referenced by the review comments"
                                 "Do not change unrelated code"
                                 "Maintain existing tests"]
-             :workflow/type :canonical-sdlc}
+             :workflow/type :comment-fix}
       file-content
       (assoc :task/existing-files [{:path path :content file-content}]))))
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/responder_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/responder_test.clj
@@ -121,7 +121,7 @@
                  :comment-ids [123]}
           context {:diff "diff content" :files [{:path "src/foo.clj" :content "(ns foo)"}]}
           spec (responder/build-fix-spec group context)]
-      (is (= :canonical-sdlc (:workflow/type spec)))
+      (is (= :comment-fix (:workflow/type spec)))
       (is (= :fix (get-in spec [:spec/intent :type])))
       (is (= ["src/foo.clj"] (get-in spec [:spec/intent :scope])))
       (is (str/includes? (:spec/description spec) "Extract this function"))

--- a/dev/test.clj
+++ b/dev/test.clj
@@ -1,0 +1,80 @@
+
+(ns test
+  (:require [schema :as schema]))
+
+(declare validate-no-rule-id-collisions)
+(declare validate-taxonomy-refs)
+(declare apply-overrides)
+
+(defn- resolved-pack [inherited-rules overlay-rules overlay-pack base-packs]
+  (let [;; Combine: inherited + overlay rules
+        combined-rules (into inherited-rules overlay-rules)
+
+        ;; Apply overrides last
+        overrides      (:pack/overrides overlay-pack [])
+        final-rules    (apply-overrides combined-rules overrides)
+
+        ;; Inherit taxonomy-ref from base if overlay doesn't have one
+        base-tax-ref   (some :pack/taxonomy-ref (filterv some? base-packs))
+        final-tax-ref  (or (:pack/taxonomy-ref overlay-pack) base-tax-ref)
+
+        resolved-pack  (cond-> (assoc overlay-pack :pack/rules final-rules)
+                         final-tax-ref (assoc :pack/taxonomy-ref final-tax-ref))]
+
+    (schema/success :pack resolved-pack {})))
+
+(defn- pack-id [extends]
+  (fn [i bp]
+    (when (nil? bp)
+      (str "Base pack not found: "
+           (:pack-id (nth extends i))))))
+
+(defn resolve-overlay
+  "Resolve an overlay pack by merging inherited rules from base packs.
+
+   Resolution order (per N4 §2.5):
+   1. Inherited rules merged from all :pack/extends entries in declaration order
+   2. Overlay :pack/rules appended (IDs MUST NOT collide with inherited)
+   3. :pack/overrides apply last (only :rule/severity and :rule/enabled?)
+   4. Taxonomy ref inherited from base pack(s); conflicting refs invalid
+
+   Arguments:
+   - overlay-pack - The overlay pack with :pack/extends
+   - pack-store   - Map of pack-id -> PackManifest for base pack resolution
+
+   Returns:
+   - {:success? true :pack <resolved PackManifest>}
+   - {:success? false :errors [...]}"
+  [overlay-pack pack-store]
+  (let [extends (:pack/extends overlay-pack [])
+
+        ;; Load base packs in declaration order
+        base-packs (mapv (fn [{:keys [pack-id]}]
+                           (get pack-store pack-id))
+                         extends)
+        missing    (keep-indexed (pack-id extends) base-packs)]
+
+    (cond 
+      (seq missing) (schema/failure-with-errors :pack (vec missing))
+      )
+    
+    (if (seq missing)
+      (schema/failure-with-errors :pack (vec missing))
+
+      (let [;; Taxonomy ref validation
+            tax-errors (validate-taxonomy-refs (filterv some? base-packs) overlay-pack)]
+
+        (if (seq tax-errors)
+          (schema/failure-with-errors :pack tax-errors)
+
+          (let [;; Merge inherited rules (declaration order)
+                inherited-rules (vec (mapcat :pack/rules (filterv some? base-packs)))
+                inherited-ids   (set (map :rule/id inherited-rules))
+
+                ;; Check for collisions with overlay's own rules
+                overlay-rules   (:pack/rules overlay-pack [])
+                collision-errors (validate-no-rule-id-collisions inherited-ids overlay-rules)]
+
+            (if (seq collision-errors)
+              (schema/failure-with-errors :pack collision-errors)
+              (resolved-pack inherited-rules overlay-rules overlay-pack base-packs))))))))


### PR DESCRIPTION
## Summary

Comment fixes via `pr respond` now use a `:comment-fix` inline workflow instead of full `:canonical-sdlc`. The pipeline is:

```
[{:phase :implement :gates [:syntax :lint :no-secrets]}
 {:phase :done}]
```

This maintains the governed stance (gates enforced) while cutting ~10min of overhead per comment by skipping plan, explore, review, and release phases.

## Rationale

A "extract this to a function" review comment should take 1-3 minutes, not 30. The current full SDLC pipeline re-explores, re-plans, decomposes into DAG sub-tasks, runs review, and creates separate PRs — all unnecessary for a focused refactor the reviewer already specified.

## Test plan

- [x] clj-kondo lint clean
- [x] Test updated for `:comment-fix` workflow type
- [ ] Manual: `bb miniforge pr respond <url>` completes in ~3min per comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)