### PR TITLE
fix: sharpen planner already-satisfied detection

### DIFF
--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -279,6 +279,36 @@
       (update :plan/tasks ensure-task-ids)
       (assoc :plan/created-at (java.util.Date.))))
 
+(defn validate-already-satisfied
+  "Check that an already-satisfied claim is backed by evidence.
+   Returns {:valid? bool :reason string}.
+
+   Rejects when:
+   - No evidence provided
+   - Evidence vector is empty
+   - Acceptance criteria reference specific function names that
+     don't appear in any evidence :proof or :satisfied-by fields"
+  [plan acceptance-criteria]
+  (let [evidence (get plan :plan/evidence [])]
+    (cond
+      (empty? evidence)
+      {:valid? false :reason "No evidence provided for already-satisfied claim"}
+
+      (and (seq acceptance-criteria)
+           (let [proofs (str/join " " (map #(str (:proof %) " " (:satisfied-by %)) evidence))
+                 ;; Extract function-like names from acceptance criteria
+                 fn-names (->> acceptance-criteria
+                               (mapcat #(re-seq #"`([a-z][a-z0-9-]*!?)`" %))
+                               (map second)
+                               (remove #{"true" "false" "nil"})
+                               seq)]
+             (when fn-names
+               (some #(not (str/includes? proofs %)) fn-names))))
+      {:valid? false :reason "Acceptance criteria reference functions not found in evidence"}
+
+      :else
+      {:valid? true})))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public API
 
@@ -363,13 +393,23 @@
                       plan-final (finalize-plan plan)]
                   ;; Check for already-satisfied response
                   (if (= :already-satisfied (:plan/status plan-final))
-                    (let [output {:plan/id (random-uuid)
-                                  :plan/name "already-satisfied"
-                                  :plan/tasks []
-                                  :plan/summary (:plan/summary plan-final)
-                                  :plan/evidence (get plan-final :plan/evidence [])}]
-                      (assoc (response/success output {:tokens tokens})
-                             :status :already-satisfied))
+                    (let [criteria (get input :spec/acceptance-criteria
+                                       (get input :acceptance-criteria []))
+                          validation (validate-already-satisfied plan-final criteria)]
+                      (if (:valid? validation)
+                        (let [output {:plan/id (random-uuid)
+                                      :plan/name "already-satisfied"
+                                      :plan/tasks []
+                                      :plan/summary (:plan/summary plan-final)
+                                      :plan/evidence (get plan-final :plan/evidence [])}]
+                          (assoc (response/success output {:tokens tokens})
+                                 :status :already-satisfied))
+                        ;; Reject false already-satisfied — force planning
+                        (do
+                          (log/info logger :planner :planner/already-satisfied-rejected
+                                    {:data {:reason (:reason validation)}})
+                          (response/error (str "Already-satisfied claim rejected: "
+                                               (:reason validation))))))
                     (response/success plan-final
                                       {:tokens tokens
                                        :metrics {:tasks-created (count (:plan/tasks plan-final))

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -20,6 +20,7 @@
   "Tests for the Planner agent."
   (:require
    [clojure.test :as test :refer [deftest testing is]]
+   [clojure.string :as str]
    [ai.miniforge.agent.core :as core]
    [ai.miniforge.agent.planner :as planner]
    [ai.miniforge.logging.interface :as log]))
@@ -120,6 +121,52 @@
       (is (not (:valid? result))))))
 
 ;------------------------------------------------------------------------------ Layer 3.5
+;; Already-satisfied validation tests
+
+(deftest validate-already-satisfied-test
+  (testing "rejects when no evidence provided"
+    (let [result (planner/validate-already-satisfied
+                  {:plan/status :already-satisfied :plan/evidence []}
+                  ["A function named `export-capsule-artifacts!` exists"])]
+      (is (not (:valid? result)))
+      (is (str/includes? (:reason result) "No evidence"))))
+
+  (testing "rejects when acceptance criteria names function not in evidence"
+    (let [result (planner/validate-already-satisfied
+                  {:plan/status :already-satisfied
+                   :plan/evidence [{:requirement "Export artifacts"
+                                    :satisfied-by "runner.clj"
+                                    :proof "release-execution-environment! in finally block"}]}
+                  ["A function named `export-capsule-artifacts!` exists in runner.clj"])]
+      (is (not (:valid? result)))
+      (is (str/includes? (:reason result) "not found in evidence"))))
+
+  (testing "accepts when evidence mentions the required function"
+    (let [result (planner/validate-already-satisfied
+                  {:plan/status :already-satisfied
+                   :plan/evidence [{:requirement "Export artifacts"
+                                    :satisfied-by "runner.clj"
+                                    :proof "export-capsule-artifacts! function at line 320"}]}
+                  ["A function named `export-capsule-artifacts!` exists in runner.clj"])]
+      (is (:valid? result))))
+
+  (testing "accepts when no acceptance criteria reference function names"
+    (let [result (planner/validate-already-satisfied
+                  {:plan/status :already-satisfied
+                   :plan/evidence [{:requirement "Feature works"
+                                    :satisfied-by "core.clj"
+                                    :proof "Implementation complete"}]}
+                  ["Feature is implemented" "Tests pass"])]
+      (is (:valid? result))))
+
+  (testing "accepts with nil acceptance criteria"
+    (let [result (planner/validate-already-satisfied
+                  {:plan/status :already-satisfied
+                   :plan/evidence [{:requirement "Done" :satisfied-by "x.clj" :proof "yes"}]}
+                  nil)]
+      (is (:valid? result)))))
+
+;------------------------------------------------------------------------------ Layer 3.75
 ;; Schema backward-compat & new-field tests
 
 (deftest validate-plan-new-fields-test


### PR DESCRIPTION
## Summary

- **Planner prompt**: added explicit instruction that related code does NOT satisfy a spec asking for new functions. Must grep/verify the exact function exists before claiming already-implemented.
- **Specs**: added "THIS IS NOT YET IMPLEMENTED" markers and function-name acceptance criteria to prevent false satisfaction
- **Kanban**: moves completed specs to `work/done/`

Fixes false-positive already-satisfied detection that caused two N11 specs to be skipped without implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)