### PR TITLE
fix: alias :standard-sdlc to :canonical-sdlc and read :workflow/type from specs

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -135,9 +135,12 @@
       (catch Exception _))))
 
 (defn select-workflow-type
-  "Select workflow type using LLM recommendation if not explicitly specified."
+  "Select workflow type using LLM recommendation if not explicitly specified.
+   Checks :spec/workflow-type first, then :workflow/type as a fallback for
+   specs that use the shorter key."
   [spec llm-client quiet]
-  (if-let [explicit-type (:spec/workflow-type spec)]
+  (if-let [explicit-type (or (:spec/workflow-type spec)
+                             (:workflow/type spec))]
     (do
       (when-not quiet
         (println (display/colorize :cyan (messages/t :workflow-runner/user-specified {:workflow-type (name explicit-type)}))))
@@ -151,27 +154,40 @@
         (println (display/colorize :yellow (messages/t :workflow-runner/auto-selected-override))))
       (:workflow recommendation))))
 
+(def ^:private workflow-aliases
+  "Map legacy/alternate workflow type keywords to their canonical counterparts.
+   Many work specs use :standard-sdlc but the only registered workflow is
+   :canonical-sdlc."
+  {:standard-sdlc :canonical-sdlc})
+
+(defn resolve-workflow-alias
+  "Resolve a workflow type through the alias map. Returns the canonical type
+   if an alias exists, otherwise returns the type unchanged."
+  [workflow-type]
+  (get workflow-aliases workflow-type workflow-type))
+
 (defn load-or-create-workflow [load-workflow workflow-type workflow-version]
-  (try
-    (load-and-validate-workflow load-workflow workflow-type workflow-version)
-    (catch Exception e
-      (case workflow-type
-        :test-only
-        {:workflow/id :test-only
-         :workflow/version "inline"
-         :workflow/name "Test Generation"
-         :workflow/pipeline [{:phase :verify} {:phase :done}]
-         :workflow/config {:max-tokens 20000 :max-iterations 10}}
+  (let [workflow-type (resolve-workflow-alias workflow-type)]
+    (try
+      (load-and-validate-workflow load-workflow workflow-type workflow-version)
+      (catch Exception e
+        (case workflow-type
+          :test-only
+          {:workflow/id :test-only
+           :workflow/version "inline"
+           :workflow/name "Test Generation"
+           :workflow/pipeline [{:phase :verify} {:phase :done}]
+           :workflow/config {:max-tokens 20000 :max-iterations 10}}
 
-        :comment-fix
-        {:workflow/id :comment-fix
-         :workflow/version "inline"
-         :workflow/name "Comment Fix"
-         :workflow/pipeline [{:phase :implement :gates [:syntax :lint :no-secrets]}
-                             {:phase :done}]
-         :workflow/config {:max-tokens 20000 :max-iterations 5}}
+          :comment-fix
+          {:workflow/id :comment-fix
+           :workflow/version "inline"
+           :workflow/name "Comment Fix"
+           :workflow/pipeline [{:phase :implement :gates [:syntax :lint :no-secrets]}
+                               {:phase :done}]
+           :workflow/config {:max-tokens 20000 :max-iterations 5}}
 
-        (throw e)))))
+          (throw e))))))
 
 (defn execute-workflow-pipeline [run-pipeline workflow input callbacks artifact-store event-stream]
   (-> callbacks

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/alias_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/alias_test.clj
@@ -1,0 +1,63 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.workflow-runner.alias-test
+  "Tests for workflow type aliasing and spec key fallback in the workflow runner."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.workflow-runner :as sut]))
+
+;------------------------------------------------------------------------------ resolve-workflow-alias
+
+(deftest resolve-workflow-alias-test
+  (testing ":standard-sdlc resolves to :canonical-sdlc"
+    (is (= :canonical-sdlc (sut/resolve-workflow-alias :standard-sdlc))))
+
+  (testing ":canonical-sdlc passes through unchanged"
+    (is (= :canonical-sdlc (sut/resolve-workflow-alias :canonical-sdlc))))
+
+  (testing "unknown workflow types pass through unchanged"
+    (is (= :quick-fix (sut/resolve-workflow-alias :quick-fix)))
+    (is (= :test-only (sut/resolve-workflow-alias :test-only)))))
+
+;------------------------------------------------------------------------------ load-or-create-workflow alias integration
+
+(deftest load-or-create-workflow-aliases-standard-sdlc-test
+  (testing ":standard-sdlc is resolved to :canonical-sdlc before loading"
+    (let [loaded-type (atom nil)
+          fake-loader (fn [workflow-id _version _opts]
+                        (reset! loaded-type workflow-id)
+                        {:workflow {:workflow/id workflow-id}
+                         :validation {:valid? true}})]
+      (sut/load-or-create-workflow fake-loader :standard-sdlc "latest")
+      (is (= :canonical-sdlc @loaded-type)
+          ":standard-sdlc should be translated to :canonical-sdlc before the loader is called"))))
+
+;------------------------------------------------------------------------------ select-workflow-type spec key fallback
+
+(deftest select-workflow-type-reads-workflow-type-key-test
+  (testing ":spec/workflow-type takes precedence over :workflow/type"
+    (let [spec {:spec/workflow-type :explicit-type
+                :workflow/type :fallback-type}
+          result (sut/select-workflow-type spec nil true)]
+      (is (= :explicit-type result))))
+
+  (testing ":workflow/type is used when :spec/workflow-type is absent"
+    (let [spec {:workflow/type :standard-sdlc}
+          result (sut/select-workflow-type spec nil true)]
+      (is (= :standard-sdlc result)))))


### PR DESCRIPTION
## Summary

- **Spec key fallback**: `select-workflow-type` now checks `:workflow/type` as a fallback when `:spec/workflow-type` is absent. Many work specs use the shorter `:workflow/type` key.
- **Workflow alias**: Added a `workflow-aliases` map that resolves `:standard-sdlc` to `:canonical-sdlc` in `load-or-create-workflow`. The only registered workflow is `:canonical-sdlc` but ~20 specs reference `:standard-sdlc`.
- **Public helper**: Exposed `resolve-workflow-alias` so the mapping is testable and reusable.

## Test plan

- [x] New `alias-test` covering `resolve-workflow-alias`, `load-or-create-workflow` alias integration, and `select-workflow-type` key fallback (3 tests, 7 assertions)
- [x] All 104 existing CLI brick tests pass (354 assertions)
- [x] GraalVM compatibility tests pass (5 tests, 301 assertions)
- [x] Pre-commit hook (lint + format + test + graalvm) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)