### PR TITLE
feat: Docker --stop-timeout + push HTTPS fallback

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
@@ -234,9 +234,14 @@
         network-args  (if (some? execution-plan)
                         [] ; network handled inside build-security-args
                         (when network ["--network" network]))
+        ;; N11 §2.2: Set Docker stop-timeout from execution plan time limit
+        stop-timeout  (when-let [ms (get-in execution-plan [:time-limit-ms])]
+                        (max 5 (quot ms 1000)))
         cmd-args      (concat ["run" "-d"
                                "--name" container-name
                                "-w" workdir]
+                              (when stop-timeout
+                                ["--stop-timeout" (str stop-timeout)])
                               network-args
                               security-args
                               runtime-fs-args

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/docker_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/docker_test.clj
@@ -196,6 +196,41 @@
                                       (throw (ex-info "docker not installed" {})))]
       (is (nil? (docker/container-image-digest nil "myimage:latest"))))))
 
+;; ============================================================================
+;; create-container --stop-timeout (N11 §2.2)
+;; ============================================================================
+
+(deftest create-container-stop-timeout-test
+  (testing "includes --stop-timeout when execution-plan has :time-limit-ms"
+    (let [captured-args (atom nil)]
+      (with-redefs [docker/run-docker (fn [_docker-path & args]
+                                        (reset! captured-args (vec args))
+                                        {:exit 0 :out "container-id-123\n" :err ""})]
+        (docker/create-container nil "test-ctr" "alpine" "/workspace" nil nil nil
+                                :execution-plan {:time-limit-ms 120000})
+        (let [args @captured-args]
+          (is (some #(= "--stop-timeout" %) args))
+          (is (some #(= "120" %) args))))))
+
+  (testing "omits --stop-timeout when no execution-plan"
+    (let [captured-args (atom nil)]
+      (with-redefs [docker/run-docker (fn [_docker-path & args]
+                                        (reset! captured-args (vec args))
+                                        {:exit 0 :out "container-id-123\n" :err ""})]
+        (docker/create-container nil "test-ctr" "alpine" "/workspace" nil nil nil)
+        (let [args @captured-args]
+          (is (not (some #(= "--stop-timeout" %) args)))))))
+
+  (testing "enforces minimum 5s stop-timeout"
+    (let [captured-args (atom nil)]
+      (with-redefs [docker/run-docker (fn [_docker-path & args]
+                                        (reset! captured-args (vec args))
+                                        {:exit 0 :out "container-id-123\n" :err ""})]
+        (docker/create-container nil "test-ctr" "alpine" "/workspace" nil nil nil
+                                :execution-plan {:time-limit-ms 2000})
+        (let [args @captured-args]
+          (is (some #(= "5" %) args)))))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (clojure.test/run-tests 'ai.miniforge.dag-executor.protocols.impl.docker-test)

--- a/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/sandbox.clj
@@ -133,12 +133,42 @@
                                :output (:output commit-r)}))
       (result/shell-failure (:error commit-r) {:commit-sha nil}))))
 
+(defn- ssh->https-with-token
+  "Convert an SSH or HTTPS git remote URL to HTTPS with token auth.
+   Returns the authenticated URL, or nil if conversion fails."
+  [remote-url token]
+  (when remote-url
+    (if-let [[_ host path] (re-matches #"git@([^:]+):(.+)" remote-url)]
+      (str "https://x-access-token:" token "@" host "/" path)
+      (when (str/starts-with? (str remote-url) "https://")
+        (str/replace remote-url #"https://" (str "https://x-access-token:" token "@"))))))
+
+(defn- push-with-https-fallback!
+  "Push using HTTPS + token auth after SSH fails. Temporarily sets the
+   remote URL to include the token, pushes, then restores the original URL."
+  [executor env-id branch-name remote-url https-url opts]
+  (exec! executor env-id (str "git remote set-url origin " https-url) {})
+  (let [retry (exec! executor env-id (str "git push -u origin " branch-name) opts)]
+    (exec! executor env-id (str "git remote set-url origin " remote-url) {})
+    retry))
+
 (defn push-branch!
   "Push branch to origin inside the sandbox container.
-   Optional opts supports :env for credential injection."
+   Optional opts supports :env for credential injection.
+   Retries with GH_TOKEN HTTPS auth if SSH push fails."
   ([executor env-id branch-name] (push-branch! executor env-id branch-name {}))
   ([executor env-id branch-name opts]
-   (exec! executor env-id (str "git push -u origin " branch-name) opts)))
+   (let [result (exec! executor env-id (str "git push -u origin " branch-name) opts)]
+     (if (result/succeeded? result)
+       result
+       (if-let [token (get-in opts [:env "GH_TOKEN"])]
+         (let [url-r (exec! executor env-id "git remote get-url origin" {})
+               remote-url (when (result/succeeded? url-r) (str/trim (get url-r :output "")))
+               https-url (ssh->https-with-token remote-url token)]
+           (if https-url
+             (push-with-https-fallback! executor env-id branch-name remote-url https-url opts)
+             result))
+         result)))))
 
 (defn create-pr!
   "Create a pull request using gh CLI inside the sandbox container.

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -275,3 +275,53 @@
       (is (not (:success? result)))
       (is (seq (:errors result))))))
 
+;; ============================================================================
+;; push-branch! HTTPS fallback tests
+;; ============================================================================
+
+(deftest push-branch-success-test
+  (testing "push-branch! succeeds on first try without fallback"
+    (let [[exec cmds] (create-mock-executor
+                       :responses {"git push" {:exit-code 0 :stdout "" :stderr ""}})]
+      (sandbox/push-branch! exec "env-1" "feat/test" {:env {"GH_TOKEN" "tok123"}})
+      (is (= 1 (count @cmds)))
+      (is (clojure.string/includes? (first @cmds) "git push")))))
+
+(deftest push-branch-ssh-fail-https-fallback-test
+  (testing "push-branch! retries with HTTPS when SSH push fails"
+    (let [push-count (atom 0)
+          cmds (atom [])
+          tracking-exec (reify
+                            dag/TaskExecutor
+                            (executor-type [_] :mock)
+                            (available? [_] (dag/ok {:available? true}))
+                            (acquire-environment! [_ _ _] (dag/ok {}))
+                            (execute! [_ _env-id command _opts]
+                              (swap! cmds conj command)
+                              (if (clojure.string/includes? (str command) "git push")
+                                (let [n (swap! push-count inc)]
+                                  (if (= n 1)
+                                    (dag/ok {:exit-code 1 :stdout "" :stderr "signing failed"})
+                                    (dag/ok {:exit-code 0 :stdout "" :stderr ""})))
+                                (dag/ok (cond
+                                          (clojure.string/includes? (str command) "get-url")
+                                          {:exit-code 0 :stdout "git@github.com:org/repo.git" :stderr ""}
+                                          :else {:exit-code 0 :stdout "" :stderr ""}))))
+                            (copy-to! [_ _ _ _] (dag/ok {}))
+                            (copy-from! [_ _ _ _] (dag/ok {}))
+                            (release-environment! [_ _] (dag/ok {}))
+                            (environment-status [_ _] (dag/ok {:status :running})))]
+        (sandbox/push-branch! tracking-exec "env-1" "feat/test" {:env {"GH_TOKEN" "tok123"}})
+        (is (= 2 @push-count))
+        ;; Should have set-url to HTTPS, pushed, then restored original URL
+        (is (some #(clojure.string/includes? (str %) "x-access-token") @cmds))
+        (is (some #(clojure.string/includes? (str %) "git@github.com") @cmds)))))
+
+(deftest push-branch-no-token-no-fallback-test
+  (testing "push-branch! returns failure without fallback when no GH_TOKEN"
+    (let [[exec _cmds] (create-mock-executor
+                        :default-response {:exit-code 1 :stdout "" :stderr "signing failed"})
+          result (sandbox/push-branch! exec "env-1" "feat/test")]
+      (is (dag/ok? result))
+      (is (= 1 (get-in result [:data :exit-code]))))))
+


### PR DESCRIPTION
## Summary

- **docker.clj**: `--stop-timeout` flag on `create-container` from execution plan `:time-limit-ms` (N11 §2.2)
- **sandbox.clj**: `push-branch!` retries with HTTPS+token when SSH fails. Extracted `ssh->https-with-token` and `push-with-https-fallback!`.

Runner.clj artifact export and timeout wrapper deferred to full runner refactor (`work/runner-refactor.spec.edn`).

## Test plan
- [x] clj-kondo lint clean
- [ ] Push succeeds when SSH agent is unresponsive but GH_TOKEN is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)