### PR TITLE
fix: rename all work specs from :standard-sdlc to :canonical-sdlc

### DIFF
--- a/work/archive/done/agent-rule-visibility.spec.edn
+++ b/work/archive/done/agent-rule-visibility.spec.edn
@@ -23,7 +23,7 @@
   "Existing callers of inject-knowledge must not break (backwards compatible)"
   "Pre-commit hooks must pass"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :plan/tasks

--- a/work/archive/done/algorithms-tests.spec.edn
+++ b/work/archive/done/algorithms-tests.spec.edn
@@ -16,7 +16,7 @@
   "All tests must pass with bb test"
   "Pre-commit hooks must pass"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :plan/tasks

--- a/work/archive/done/decompose-test-files.spec.edn
+++ b/work/archive/done/decompose-test-files.spec.edn
@@ -41,7 +41,7 @@
   "bb test must pass with same assertion count as before"
   "Pre-commit hooks must pass on final commit"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :plan/tasks

--- a/work/archive/done/pr-lifecycle-tests.spec.edn
+++ b/work/archive/done/pr-lifecycle-tests.spec.edn
@@ -18,7 +18,7 @@
   "All tests must pass with bb test"
   "Pre-commit hooks must pass"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :plan/tasks

--- a/work/archive/stale/finish-yc-mvp.spec.edn
+++ b/work/archive/stale/finish-yc-mvp.spec.edn
@@ -52,7 +52,7 @@
   "Keep docs and runbook in-repo and versioned"
   "A single operator must be able to run demo start-to-finish"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :plan/tasks

--- a/work/archive/stale/web-dashboard.spec.edn
+++ b/work/archive/stale/web-dashboard.spec.edn
@@ -69,7 +69,7 @@
   "bb test must pass with all existing tests"
   "Pre-commit hooks must pass on final commit"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :plan/tasks

--- a/work/backend-failover.spec.edn
+++ b/work/backend-failover.spec.edn
@@ -40,7 +40,7 @@
   "Rate limit detection must cover Claude (HTTP 429 / :rate-limit-error) and Codex (usage limit message)"
   "If all allowed backends are in cooldown, propagate the original error — do not loop"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :tasks

--- a/work/capsule-runtime-spec-wiring.spec.edn
+++ b/work/capsule-runtime-spec-wiring.spec.edn
@@ -43,4 +43,4 @@
   "Secret names (not values) are logged at debug level"
   "Local mode ignores runtime-spec (no capsule to configure)"]
 
- :workflow/type :canonical-sdlc}
+ :spec/workflow-type :canonical-sdlc}

--- a/work/control-plane-completion.spec.edn
+++ b/work/control-plane-completion.spec.edn
@@ -49,7 +49,7 @@
   "All existing control plane tests continue to pass"
   "New integration tests cover decision delivery round-trip and event emission"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :plan/tasks

--- a/work/done/finish-event-telemetry.spec.edn
+++ b/work/done/finish-event-telemetry.spec.edn
@@ -26,7 +26,7 @@
                "Do not change agent component — it already accepts on-chunk"
                "Use requiring-resolve for optional event-stream dependency"
                "Preserve backward compatibility with existing WebSocket consumers"]
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  ;; ---------------------------------------------------------------------------

--- a/work/environment-promotion-pipeline.spec.edn
+++ b/work/environment-promotion-pipeline.spec.edn
@@ -56,7 +56,7 @@
   "All existing tests must pass after refactor"
   "MCP artifact server can be removed once environment promotion works"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  ;; -------------------------------------------------------------------------

--- a/work/in-progress/capsule-artifact-export.spec.edn
+++ b/work/in-progress/capsule-artifact-export.spec.edn
@@ -39,4 +39,4 @@
   "Local mode skips export (artifacts already on host filesystem)"
   "Exported artifact paths recorded in :execution/output"]
 
- :workflow/type :canonical-sdlc}
+ :spec/workflow-type :canonical-sdlc}

--- a/work/in-progress/capsule-cleanup-reliability.spec.edn
+++ b/work/in-progress/capsule-cleanup-reliability.spec.edn
@@ -27,4 +27,4 @@
   "No lingering containers after pipeline timeout"
   "docker ps --filter name=miniforge-task returns empty after any run"]
 
- :workflow/type :canonical-sdlc}
+ :spec/workflow-type :canonical-sdlc}

--- a/work/in-progress/capsule-timeout-enforcement.spec.edn
+++ b/work/in-progress/capsule-timeout-enforcement.spec.edn
@@ -37,4 +37,4 @@
   "DAG sub-workflows respect timeout budget"
   "Local mode is unaffected"]
 
- :workflow/type :canonical-sdlc}
+ :spec/workflow-type :canonical-sdlc}

--- a/work/in-progress/evidence-execution-mode.spec.edn
+++ b/work/in-progress/evidence-execution-mode.spec.edn
@@ -43,4 +43,4 @@
   "Evidence bundle includes execution-mode and runtime-class when created from workflow result"
   "Image digest captured and recorded for Docker-based governed runs"]
 
- :workflow/type :canonical-sdlc}
+ :spec/workflow-type :canonical-sdlc}

--- a/work/knowledge-mcp-query.spec.edn
+++ b/work/knowledge-mcp-query.spec.edn
@@ -69,7 +69,7 @@
   "Do not require agents to call lookup_policy — it is available, not mandatory"
   "Tool response must be valid even when no rules match (return empty array, not error)"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :tasks

--- a/work/policy-pack-configuration.spec.edn
+++ b/work/policy-pack-configuration.spec.edn
@@ -86,7 +86,7 @@
   "An absent .miniforge/config.edn is not an error — silently treated as {}"
   "agent-behavior.clj must remain fail-safe — exceptions cannot bubble up to the agent"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :tasks

--- a/work/policy-pack-extensibility.spec.edn
+++ b/work/policy-pack-extensibility.spec.edn
@@ -58,7 +58,7 @@
   "Phase behavior must be identical before and after (same rules in agent context)"
   "The knowledge store (zettels) may remain as a caching layer if needed; removing it is out of scope"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :tasks

--- a/work/pr-monitor-loop.spec.edn
+++ b/work/pr-monitor-loop.spec.edn
@@ -2,7 +2,7 @@
  :spec/version "0.1.0"
  :spec/created "2026-03-30"
  :spec/status "active"
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
 
  :spec/title "PR Monitor Loop: Autonomous Comment Resolution and Change Iteration"
 

--- a/work/release-pr-quality.spec.edn
+++ b/work/release-pr-quality.spec.edn
@@ -22,7 +22,7 @@
   "PR doc filename: YYYY-MM-DD-<slug>.md"
   "Pre-commit hooks must pass"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :plan/tasks

--- a/work/repo-config-profile.spec.edn
+++ b/work/repo-config-profile.spec.edn
@@ -65,7 +65,7 @@
   "Profile tokens are validated on save (gh auth status / glab auth status)"
   "Repo config supports :repo/agent for agent CLI selection"]
 
- :workflow/type :canonical-sdlc
+ :spec/workflow-type :canonical-sdlc
 
  :plan/tasks
  [{:task/id :profile-schema-and-reader

--- a/work/standards-pass.spec.edn
+++ b/work/standards-pass.spec.edn
@@ -39,7 +39,7 @@
   "Do not change any test files in PR A or B — test files are not the target here"
   "Do not introduce new raw strings while fixing existing ones"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :tasks

--- a/work/wire-self-repair-chain.spec.edn
+++ b/work/wire-self-repair-chain.spec.edn
@@ -58,7 +58,7 @@
   "Add tests for each connection point — no silent regressions"
   "Prefer additive changes over rewrites of existing components"]
 
- :workflow/type :standard-sdlc
+ :spec/workflow-type :canonical-sdlc
  :workflow/version "2.0.0"
 
  :plan/tasks


### PR DESCRIPTION
## Summary
- Rename `:workflow/type :standard-sdlc` → `:spec/workflow-type :canonical-sdlc` in all 23 work spec files
- Fixes both the key name (`:workflow/type` → `:spec/workflow-type`) and the value (`:standard-sdlc` → `:canonical-sdlc`)
- No code changes — data only

## Test plan
- [x] `grep -rn "standard-sdlc" work/` returns 0 matches
- [x] All specs now use the correct key and value that the runner reads

🤖 Generated with [Claude Code](https://claude.com/claude-code)