### PR TITLE
fix: silent exit dogfood — kanban provenance, exit code, flush, failure events

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
@@ -57,7 +57,8 @@
 
 (defn- run-spec-workflow
   "Parse, validate, and execute a workflow spec from path.
-   Used by both the markdown and EDN code paths."
+   Used by both the markdown and EDN code paths.
+   Returns the workflow result map, or nil on validation failure."
   [spec-path opts]
   (display/print-info (messages/t :run/parsing-spec {:path spec-path}))
   (let [parsed-spec (spec-parser/parse-spec-file spec-path)
@@ -66,7 +67,8 @@
       (do
         (display/print-error (messages/t :run/invalid-spec))
         (doseq [error (:errors validation)]
-          (println (messages/t :run/validation-error {:error error}))))
+          (println (messages/t :run/validation-error {:error error})))
+        nil)
       (do
         (display/print-info (messages/t :run/running-workflow {:title (:spec/title parsed-spec)}))
         (workflow-runner/run-workflow-from-spec!
@@ -115,7 +117,9 @@
         (catch Exception e
           (display/print-error (messages/t :run/failed {:error (ex-message e)}))
           (when-let [data (ex-data e)]
-            (println (messages/t :run/error-details {:details (pr-str data)})))))
+            (println (messages/t :run/error-details {:details (pr-str data)})))
+          (flush)
+          (System/exit 1)))
 
       ;; EDN/JSON — dispatch based on file content
       :else
@@ -147,4 +151,6 @@
               (do
                 (display/print-error (messages/t :run/failed {:error (ex-message e)}))
                 (when-let [data (ex-data e)]
-                  (println (messages/t :run/error-details {:details (pr-str data)})))))))))))
+                  (println (messages/t :run/error-details {:details (pr-str data)}))))))
+          (flush)
+          (System/exit 1))))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -60,9 +60,13 @@
           target)))))
 
 (defn move-spec-to-in-progress!
-  "Move a work spec to in-progress when execution starts."
+  "Move a work spec to in-progress when execution starts.
+   Returns updated provenance with new source-file path,
+   or the original provenance if the move was a no-op."
   [provenance]
-  (move-spec! provenance :in-progress))
+  (if-let [new-path (move-spec! provenance :in-progress)]
+    (assoc provenance :source-file new-path)
+    provenance))
 
 (defn move-spec-on-completion!
   "Move a work spec to done or failed based on workflow result."
@@ -195,6 +199,16 @@
       (cond-> event-stream (assoc :event-stream event-stream))
       (->> (run-pipeline workflow input))))
 
+(defn- failure-message
+  "Build a meaningful failure message from a workflow result.
+   Falls back to execution status when no explicit errors exist."
+  [result]
+  (let [errors (:execution/errors result)
+        status (get result :execution/status :unknown)]
+    (if (seq errors)
+      (str (first errors))
+      (str "Workflow ended with status: " (name status)))))
+
 (defn publish-completion-event [event-stream workflow-id result]
   (let [status (if (phase/succeeded? result) :success :failure)
         duration-ms (get-in result [:execution/metrics :duration-ms])]
@@ -202,8 +216,10 @@
                  (if (= status :success)
                    (es/workflow-completed event-stream workflow-id status duration-ms)
                    (es/workflow-failed event-stream workflow-id
-                                       {:message (str (first (:execution/errors result)))
-                                        :errors (:execution/errors result)})))))
+                                       {:message (failure-message result)
+                                        :errors (or (seq (:execution/errors result))
+                                                    [{:type :unknown-failure
+                                                      :message (failure-message result)}])})))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Execution orchestration
@@ -426,8 +442,7 @@
       (when-not quiet
         (display/print-workflow-header (keyword (str "adhoc-" (hash spec))) "adhoc" quiet))
       (dashboard/print-dashboard-status! quiet)
-      (let [provenance (:spec/provenance enriched-spec)]
-        (move-spec-to-in-progress! provenance)
+      (let [provenance (move-spec-to-in-progress! (:spec/provenance enriched-spec))]
         (try
           (let [result (execute-with-events {:run-pipeline run-pipeline
                                              :workflow workflow
@@ -445,7 +460,8 @@
             (when command-poller-cleanup (command-poller-cleanup))))))
     (catch Exception e
       (when-not quiet
-        (println (display/colorize :red (messages/t :workflow-runner/spec-execution-failed {:error (ex-message e)}))))
+        (println (display/colorize :red (messages/t :workflow-runner/spec-execution-failed {:error (ex-message e)})))
+        (flush))
       (throw e))))
 
 ;------------------------------------------------------------------------------ Layer 2b

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
@@ -58,7 +58,8 @@
                                          {:workflow-id (name workflow-id)})))
     (println (colorize :cyan (messages/t :workflow-runner/version
                                          {:version version})))
-    (println (colorize :cyan (str (apply str (repeat 65 "━")) "\n")))))
+    (println (colorize :cyan (str (apply str (repeat 65 "━")) "\n")))
+    (flush)))
 
 (defn format-event-line
   "Format a concise progress line for a lifecycle event. Returns nil for unknown events."
@@ -182,7 +183,8 @@
                          ;; Deduplicate back-to-back duplicates from layered emitters.
                          (when-not (= line @last-line)
                            (reset! last-line line)
-                           (println line)))))
+                           (println line)
+                           (flush)))))
       (fn []
         (es/unsubscribe! event-stream sub-id)))))
 
@@ -213,7 +215,8 @@
   (case output
     :json (println (json/generate-string result {:pretty true}))
     :pretty (when-not quiet (print-pretty-result result))
-    (clojure.pprint/pprint result)))
+    (clojure.pprint/pprint result))
+  (flush))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Error help output

--- a/bases/cli/test/ai/miniforge/cli/workflow_runner/kanban_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/workflow_runner/kanban_test.clj
@@ -1,0 +1,127 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.workflow-runner.kanban-test
+  "Tests for work spec kanban lifecycle — provenance tracking and file moves."
+  (:require
+   [clojure.test :refer [deftest testing is use-fixtures]]
+   [clojure.string :as str]
+   [babashka.fs :as fs]
+   [ai.miniforge.cli.workflow-runner :as sut]))
+
+;; ============================================================================
+;; Helpers
+;; ============================================================================
+
+(def ^:dynamic *test-dir* nil)
+
+(defn with-temp-work-dir [f]
+  (let [dir (str (fs/create-temp-dir {:prefix "kanban-test-"}))]
+    (binding [*test-dir* dir]
+      (try
+        (f)
+        (finally
+          (fs/delete-tree dir))))))
+
+(use-fixtures :each with-temp-work-dir)
+
+(defn create-work-spec!
+  "Create a dummy spec file at work/<name> inside the test dir."
+  [name]
+  (let [work-dir (str *test-dir* "/work")
+        path (str work-dir "/" name)]
+    (fs/create-dirs work-dir)
+    (spit path "{:spec/title \"test\"}")
+    path))
+
+(defmacro with-test-kanban
+  "Redirect kanban dirs and work-spec? predicate to use the temp test dir."
+  [& body]
+  `(let [prefix# (str *test-dir* "/work/")]
+     (with-redefs [sut/work-dirs {:in-progress (str *test-dir* "/work/in-progress")
+                                  :done (str *test-dir* "/work/done")
+                                  :failed (str *test-dir* "/work/failed")}
+                   sut/work-spec? (fn [provenance#]
+                                    (when-let [src# (:source-file provenance#)]
+                                      (str/starts-with? (str src#) prefix#)))]
+       ~@body)))
+
+;; ============================================================================
+;; move-spec-to-in-progress! returns updated provenance
+;; ============================================================================
+
+(deftest move-spec-to-in-progress-returns-updated-provenance-test
+  (testing "provenance source-file is updated to the new in-progress path"
+    (let [spec-path (create-work-spec! "test.spec.edn")
+          provenance {:source-file spec-path}]
+      (with-test-kanban
+        (let [updated (sut/move-spec-to-in-progress! provenance)]
+          (is (= (str *test-dir* "/work/in-progress/test.spec.edn")
+                 (:source-file updated)))
+          (is (fs/exists? (:source-file updated)))
+          (is (not (fs/exists? spec-path))))))))
+
+(deftest move-spec-on-completion-uses-updated-provenance-test
+  (testing "after move-to-in-progress, move-on-completion finds the file"
+    (let [spec-path (create-work-spec! "lifecycle.spec.edn")
+          provenance {:source-file spec-path}]
+      (with-test-kanban
+        (let [updated (sut/move-spec-to-in-progress! provenance)]
+          ;; Simulate successful completion
+          (sut/move-spec-on-completion! updated {:execution/status :completed})
+          (is (fs/exists? (str *test-dir* "/work/done/lifecycle.spec.edn")))
+          (is (not (fs/exists? (:source-file updated)))))))))
+
+(deftest move-spec-on-failure-uses-updated-provenance-test
+  (testing "failed workflow moves spec to failed directory"
+    (let [spec-path (create-work-spec! "broken.spec.edn")
+          provenance {:source-file spec-path}]
+      (with-test-kanban
+        (let [updated (sut/move-spec-to-in-progress! provenance)]
+          (sut/move-spec-on-completion! updated {:execution/status :failed})
+          (is (fs/exists? (str *test-dir* "/work/failed/broken.spec.edn")))
+          (is (not (fs/exists? (:source-file updated)))))))))
+
+(deftest move-spec-to-in-progress-non-work-spec-test
+  (testing "non-work spec provenance is returned unchanged"
+    (let [provenance {:source-file "/tmp/not-a-work-spec.edn"}]
+      (is (= provenance (sut/move-spec-to-in-progress! provenance))))))
+
+;; ============================================================================
+;; failure-message
+;; ============================================================================
+
+(deftest failure-message-with-errors-test
+  (testing "uses first error entry when errors exist"
+    (let [result {:execution/errors [{:type :gate-failed :message "lint failed"}]
+                  :execution/status :failed}
+          msg (#'sut/failure-message result)]
+      (is (str/includes? msg "lint failed")))))
+
+(deftest failure-message-without-errors-test
+  (testing "includes execution status when no errors"
+    (let [result {:execution/errors []
+                  :execution/status :failed}
+          msg (#'sut/failure-message result)]
+      (is (str/includes? msg "failed")))))
+
+(deftest failure-message-nil-errors-test
+  (testing "handles nil errors gracefully"
+    (let [result {:execution/status :timeout}
+          msg (#'sut/failure-message result)]
+      (is (str/includes? msg "timeout")))))

--- a/bb.edn
+++ b/bb.edn
@@ -492,7 +492,19 @@
                  "components/connector-linter/src"
                  "components/connector-linter/resources"
                  "components/semantic-analyzer/src"
-                 "components/semantic-analyzer/resources"]
+                 "components/semantic-analyzer/resources"
+                 "components/failure-classifier/src"
+                 "components/failure-classifier/resources"
+                 "components/reliability/src"
+                 "components/reliability/resources"
+                 "components/training-capture/src"
+                 "components/training-capture/resources"
+                 "components/diagnosis/src"
+                 "components/diagnosis/resources"
+                 "components/improvement/src"
+                 "components/improvement/resources"
+                 "components/evaluation/src"
+                 "components/evaluation/resources"]
    :extra-deps {metosin/malli {:mvn/version "0.16.1"}
                 clj-statecharts/clj-statecharts {:mvn/version "0.1.5"}
                 aero/aero        {:mvn/version "1.1.6"}

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -90,8 +90,10 @@
             (.write writer (pr-str event))
             (.write writer "\n")
             (.flush writer)))
-        (catch Exception _e
-          ;; Silently fail - don't break event stream
+        (catch Exception e
+          ;; Log to stderr so failures are visible without breaking the event stream
+          (binding [*out* *err*]
+            (println (str "WARNING: Event sink write failed: " (ex-message e))))
           nil)))))
 
 ;;------------------------------------------------------------------------------ Layer 1: Stream Sinks

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -264,6 +264,21 @@
       ;; but verify it doesn't throw
       (is true))))
 
+;------------------------------------------------------------------------------ Layer 1b
+;; file-sink error reporting
+
+(deftest file-sink-reports-write-errors-to-stderr-test
+  (testing "file-sink logs write failures to stderr instead of swallowing"
+    (let [sink (sinks/file-sink)
+          event (sample-event {:workflow/id (random-uuid)})
+          stderr-output (let [w (java.io.StringWriter.)]
+                          (binding [*err* (java.io.PrintWriter. w)]
+                            (with-redefs [sinks/event-file-path
+                                          (fn [_] "/nonexistent/path/that/will/fail.edn")]
+                              (sink event)))
+                          (str w))]
+      (is (clojure.string/includes? stderr-output "WARNING")))))
+
 ;------------------------------------------------------------------------------ Layer 0
 ;; cleanup-stale-events!
 


### PR DESCRIPTION
## Summary

Fixes five bugs contributing to the "silent exit" dogfood issue where `bb miniforge run` produces 3-6 lines of output then exits with code 0, appearing to succeed while doing no work:

- **Kanban provenance stale after move**: `move-spec-to-in-progress!` moved the file but provenance kept the old path, so `move-spec-on-completion!` could never find it — specs stuck in `in-progress` forever. Now returns updated provenance.
- **Exit code 0 on failure**: `run.clj` caught workflow exceptions, printed errors, returned normally. Background runners saw "success". Now flushes and exits with code 1.
- **Stdout not flushed**: `println` is buffered; background tasks only capture what's flushed before exit. Added `flush` after header, event lines, result output, and error messages.
- **Empty failure events**: `publish-completion-event` produced `{:message "" :errors []}` when `execution/errors` was nil. Now falls back to execution status description.
- **Event sink errors silently swallowed**: `file-sink` caught all exceptions with nil body. Now logs to stderr so failures are visible.

## Test plan

- [x] All 236 existing tests pass
- [x] 5 GraalVM compatibility tests pass
- [x] New `kanban_test.clj` covers provenance lifecycle (in-progress → done, in-progress → failed, non-work-spec passthrough)
- [x] New `failure-message` tests cover errors/empty/nil paths
- [x] New `sinks_test.clj` test verifies stderr warning on write failure
- [ ] Manual: `bb miniforge run work/some.spec.edn` in background — verify exit code 1 on failure, full output captured

🤖 Generated with [Claude Code](https://claude.com/claude-code)