### PR TITLE
refactor: extract runner.clj into focused namespaces (747->363 lines)

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -510,6 +510,7 @@
                 aero/aero        {:mvn/version "1.1.6"}
                 io.github.lispyclouds/bblgum {:git/sha "df647fb50f32e05b26e46e58d7249b4798e469e6"}
                 http-kit/http-kit {:mvn/version "2.8.0"}
-                hiccup/hiccup     {:mvn/version "2.0.0-RC3"}}
+                hiccup/hiccup     {:mvn/version "2.0.0-RC3"}
+                slingshot/slingshot {:mvn/version "0.12.2"}}
    :requires ([ai.miniforge.cli.main :as cli])
    :task    (apply cli/-main *command-line-args*)}}}

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -84,6 +84,15 @@
         (count stale-files))
       0)))
 
+(defn operator-event-file-path
+  "Get path to the operator event log (for cross-workflow events like meta-loop,
+   reliability, degradation). Returns ~/.miniforge/events/operator.edn"
+  []
+  (let [home (System/getProperty "user.home")
+        events-dir (io/file home ".miniforge" "events")]
+    (.mkdirs events-dir)
+    (str (io/file events-dir "operator.edn"))))
+
 (defn file-sink
   "Create a file sink that writes events to per-workflow files.
    Cross-workflow events (no :workflow/id) go to operator.edn.

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -22,7 +22,8 @@
         babashka/process {:mvn/version "0.5.22"}
         metosin/malli {:mvn/version "0.16.1"}              ; Schema validation
         http-kit/http-kit {:mvn/version "2.8.0"}           ; WebSocket client for dashboard connection
-        cheshire/cheshire {:mvn/version "5.13.0"}}         ; JSON for event serialization
+        cheshire/cheshire {:mvn/version "5.13.0"}           ; JSON for event serialization
+        slingshot/slingshot {:mvn/version "0.12.2"}}        ; Enhanced exception handling
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {ai.miniforge/workflow-software-factory
                                {:local/root "../workflow-software-factory"}

--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -20,4 +20,10 @@
 
   ;; Execution mode
   :governed/no-capsule      "No capsule executor available for governed workflow"
-  :governed/no-capsule-hint "Start Docker or configure a Kubernetes cluster"}}
+  :governed/no-capsule-hint "Start Docker or configure a Kubernetes cluster"
+
+  ;; Environment lifecycle
+  :env/acquisition-failed   "Environment acquisition failed: {error}"
+  :env/release-failed       "Environment release failed: {error}"
+  :env/persist-message      "{phase} phase completed"
+  :env/persist-failed       "Workspace persist failed: {error}"}}

--- a/components/workflow/resources/config/workflow/runner/defaults.edn
+++ b/components/workflow/resources/config/workflow/runner/defaults.edn
@@ -1,0 +1,11 @@
+{:runner/defaults
+ {;; Pipeline execution limits
+  :max-phases             50
+  :max-backoff-ms         30000
+  :backoff-base-ms        1000
+  :pause-poll-interval-ms 1000
+
+  ;; Environment defaults
+  :default-workdir        "/workspace"
+  :task-branch-prefix     "task/"
+  :default-docker-image   "miniforge/task-runner-clojure:latest"}}

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -40,7 +40,8 @@
             [ai.miniforge.workflow.runner-cleanup :as cleanup]
             [ai.miniforge.workflow.runner-defaults :as defaults]
             [ai.miniforge.workflow.runner-environment :as env]
-            [ai.miniforge.workflow.runner-events :as events]))
+            [ai.miniforge.workflow.runner-events :as events]
+            [slingshot.slingshot :refer [try+ throw+]]))
 
 (defonce ^:private runner-logger
   (log/create-logger {:min-level :debug :output :human}))
@@ -140,7 +141,9 @@
     (log/warn runner-logger :system :workflow/execution-stopped
               {:message (messages/t :status/stopped-dashboard)
                :data {:reason :dashboard-stop}})
-    (throw (ex-info (messages/t :status/stopped-control) {:reason :dashboard-stop}))))
+    (throw+ {:type :dashboard-stop
+             :reason :dashboard-stop
+             :message (messages/t :status/stopped-control)})))
 
 (defn- apply-rate-limit-failure
   "Mark context as failed due to rate limiting."
@@ -334,18 +337,25 @@
      (when-not skip-lifecycle?
        (events/publish-workflow-started! event-stream initial-ctx))
 
-     (try
-       (let [final-ctx (try
+     (try+
+       (let [final-ctx (try+
                          (execute-pipeline-loop pipeline initial-ctx callbacks
                                                control-state max-phases)
-                         (catch Exception e
-                           (vreset! exception-vol e)
+                         (catch [:type :dashboard-stop] {:keys [message]}
+                           (vreset! exception-vol (ex-info message {:type :dashboard-stop}))
                            (-> initial-ctx
                                (update :execution/errors conj
-                                       (make-execution-error :pipeline-exception
-                                                             (ex-message e)
-                                                             {:data (ex-data e)}))
-                               (assoc :execution/status :failed))))
+                                       (make-execution-error :dashboard-stop message))
+                               (assoc :execution/status :failed)))
+                         (catch Object e
+                           (let [throwable (:throwable &throw-context)
+                                 msg (if (instance? Throwable e) (ex-message e) (str e))]
+                             (vreset! exception-vol (or throwable (ex-info msg {})))
+                             (-> initial-ctx
+                                 (update :execution/errors conj
+                                         (make-execution-error :pipeline-exception msg
+                                                               {:data (when (instance? Throwable e) (ex-data e))}))
+                                 (assoc :execution/status :failed)))))
              output-ctx (-> final-ctx validate-completion extract-output)]
          (vreset! output-ctx-vol output-ctx)
          (when-not skip-lifecycle?

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -19,17 +19,15 @@
 (ns ai.miniforge.workflow.runner
   "Workflow pipeline orchestration.
 
-   Top-level runner that orchestrates workflow execution by composing:
-   - Context management (context namespace)
-   - Phase execution (execution namespace)
-   - Health monitoring (monitoring namespace)
-
-   Provides the main run-pipeline entry point."
+   Thin pipeline composer that delegates to:
+   - runner-defaults    — configuration as data
+   - runner-events      — event publishing
+   - runner-environment — execution environment lifecycle
+   - runner-cleanup     — post-execution hooks
+   - context            — context management
+   - execution          — phase execution
+   - monitoring         — health monitoring"
   (:require [ai.miniforge.dag-executor.executor :as dag-exec]
-            [ai.miniforge.dag-executor.result :as dag-result]
-            [ai.miniforge.event-stream.interface :as es]
-            [ai.miniforge.knowledge.interface :as knowledge]
-            [ai.miniforge.self-healing.interface :as self-healing]
             [ai.miniforge.llm.protocols.impl.llm-client :as llm-impl]
             [ai.miniforge.logging.interface :as log]
             [ai.miniforge.phase.interface :as phase]
@@ -39,301 +37,48 @@
             [ai.miniforge.workflow.execution :as exec]
             [ai.miniforge.workflow.messages :as messages]
             [ai.miniforge.workflow.monitoring :as monitoring]
-            [cheshire.core :as json]))
+            [ai.miniforge.workflow.runner-cleanup :as cleanup]
+            [ai.miniforge.workflow.runner-defaults :as defaults]
+            [ai.miniforge.workflow.runner-environment :as env]
+            [ai.miniforge.workflow.runner-events :as events]))
 
 (defonce ^:private runner-logger
   (log/create-logger {:min-level :debug :output :human}))
 
-;------------------------------------------------------------------------------ Layer -1: Event publishing
+;; Re-export public API from extracted namespaces so external callers
+;; (tests, interface/pipeline.clj) continue to work unchanged.
+(def publish-event!              events/publish-event!)
+(def publish-workflow-started!   events/publish-workflow-started!)
+(def publish-workflow-completed! events/publish-workflow-completed!)
+(def publish-phase-started!      events/publish-phase-started!)
+(def publish-phase-completed!    events/publish-phase-completed!)
+(def promote-mature-learnings!   cleanup/promote-mature-learnings!)
 
-(defn publish-event!
-  "Publish event to event stream or dashboard WebSocket."
-  [event-stream event]
-  (when event-stream
-    (try
-      (cond
-        ;; WebSocket connection to dashboard
-        (:websocket event-stream)
-        (try
-          (require '[org.httpkit.client :as http])
-          (when-let [http-ns (find-ns 'org.httpkit.client)]
-            (when-let [ws (:websocket event-stream)]
-              (when-let [send-fn (ns-resolve http-ns 'send!)]
-                (send-fn ws (json/generate-string event)))))
-          (catch Exception e
-            (println (messages/t :warn/websocket-send {:error (ex-message e)}))))
+;------------------------------------------------------------------------------ Layer 0: Result factories
 
-        ;; In-memory event stream (same process)
-        :else
-        (es/publish! event-stream event))
-      (catch Exception e
-        (println (messages/t :warn/publish-event {:error (ex-message e)}))))))
+(defn- make-execution-error
+  "Build a canonical execution error map."
+  [error-type msg & [extra]]
+  (cond-> {:type error-type :message msg}
+    extra (merge extra)))
 
-(defn publish-workflow-started!
-  "Publish workflow started event using N3-compliant constructor."
-  [event-stream context]
-  (when event-stream
-    (try
-      (publish-event! event-stream
-                      (es/workflow-started event-stream
-                                          (:execution/id context)
-                                          (select-keys (:execution/workflow context)
-                                                       [:workflow/id :workflow/version])))
-      (catch Exception e
-        (println (messages/t :warn/publish-started {:error (ex-message e)}))))))
-
-(defn publish-workflow-completed!
-  "Publish workflow completed/failed event using N3-compliant constructor."
-  [event-stream context]
-  (when event-stream
-    (try
-      (let [status (:execution/status context)
-            wf-id (:execution/id context)
-            metrics (:execution/metrics context)
-            duration-ms (:duration-ms metrics)
-            tokens (:tokens metrics)
-            cost-usd (:cost-usd metrics)
-            pr-info (:workflow/pr-info context)
-            metrics-opts (cond-> {}
-                           tokens (assoc :tokens tokens)
-                           cost-usd (assoc :cost-usd cost-usd)
-                           pr-info (assoc :pr-info pr-info))]
-        (if (= status :failed)
-          (publish-event! event-stream
-                          (es/workflow-failed event-stream wf-id
-                                             {:message (messages/t :status/failed)
-                                              :errors (:execution/errors context)}))
-          (publish-event! event-stream
-                          (es/workflow-completed event-stream wf-id status duration-ms
-                                                 (when (seq metrics-opts) metrics-opts)))))
-      (catch Exception e
-        (println (messages/t :warn/publish-completed {:error (ex-message e)}))))))
-
-(defn publish-phase-started!
-  "Publish phase started event."
-  [event-stream context phase-name]
-  (when event-stream
-    (try
-      (publish-event! event-stream
-                      (es/phase-started event-stream (:execution/id context) phase-name
-                                        {:phase/index (:execution/phase-index context)}))
-      (catch Exception e
-        (println (messages/t :warn/publish-phase-started {:error (ex-message e)}))))))
-
-(defn publish-phase-completed!
-  "Publish phase completed event."
-  [event-stream context phase-name result]
-  (when event-stream
-    (let [succeeded? (get result :success? (phase/succeeded-or-done? result))
-          outcome    (if succeeded? :success :failure)
-          duration-ms (get result :duration-ms
-                        (get-in result [:phase/metrics :duration-ms]
-                          (get-in result [:metrics :duration-ms])))
-          error-info (when-not succeeded?
-                       (or (:error result)
-                           (when-let [msg (get-in result [:phase/gate-errors])]
-                             {:message (messages/t :status/gate-failed) :details msg})
-                           (when-let [msg (:message result)]
-                             {:message msg})))
-          redirect-to (:redirect-to result)
-          tokens   (get-in result [:metrics :tokens]
-                     (get-in result [:phase/metrics :tokens]))
-          cost-usd (get-in result [:metrics :cost-usd]
-                     (get-in result [:phase/metrics :cost-usd]))
-          event-data (cond-> {:outcome outcome :duration-ms duration-ms}
-                       error-info (assoc :error error-info)
-                       redirect-to (assoc :redirect-to redirect-to)
-                       tokens (assoc :tokens tokens)
-                       cost-usd (assoc :cost-usd cost-usd))]
-      (try
-        (publish-event! event-stream
-                        (es/phase-completed event-stream (:execution/id context) phase-name
-                                            event-data))
-        (catch Exception e
-          (println (messages/t :warn/publish-phase-completed {:error (ex-message e)})))))))
-
-(defn check-backend-health-at-boundary!
-  "Check backend health at phase boundary. No-ops when :self-healing-config is absent.
-   Returns switch-result or nil."
-  [event-stream context]
-  (when (get-in context [:execution/opts :self-healing-config])
-    (try
-      (let [backend (or (get-in context [:execution/opts :llm-backend :config :backend])
-                        :anthropic)
-            sh-ctx {:llm {:backend backend}
-                    :config (get-in context [:execution/opts :self-healing-config])}
-            switch-result (self-healing/check-backend-health-and-switch sh-ctx)]
-        (when (:switched? switch-result)
-          (publish-event! event-stream (self-healing/emit-backend-switch-event sh-ctx switch-result))
-          switch-result))
-      (catch Exception e
-        (println (messages/t :warn/health-check {:error (ex-message e)}))
-        nil))))
-
-;------------------------------------------------------------------------------ Layer 0: Pipeline helpers
+;------------------------------------------------------------------------------ Layer 0: Pipeline construction
 
 (defn build-pipeline
-  "Build interceptor pipeline from workflow config.
-
-   Arguments:
-   - workflow: Workflow configuration with :workflow/pipeline
-
-   Returns vector of interceptor maps."
+  "Build interceptor pipeline from workflow config."
   [workflow]
   (let [pipeline-config (:workflow/pipeline workflow)]
     (if (seq pipeline-config)
-      ;; New simplified format
       (mapv phase/get-phase-interceptor pipeline-config)
-      ;; Fall back to legacy format
-      (let [phases (:workflow/phases workflow)]
-        (mapv (fn [phase-def]
-                (phase/get-phase-interceptor
-                 {:phase (:phase/id phase-def)
-                  :config phase-def}))
-              phases)))))
+      (mapv (fn [phase-def]
+              (phase/get-phase-interceptor
+               {:phase (:phase/id phase-def) :config phase-def}))
+            (:workflow/phases workflow)))))
 
 (defn validate-pipeline
-  "Validate a workflow pipeline.
-
-   Returns {:valid? bool :errors []}."
+  "Validate a workflow pipeline. Returns {:valid? bool :errors []}."
   [workflow]
   (phase/validate-pipeline workflow))
-
-;------------------------------------------------------------------------------ Layer 0.5: Execution environment lifecycle
-
-(defn- dag-executor-fns
-  "Return dag-executor function references."
-  []
-  {:create-registry dag-exec/create-executor-registry
-   :select-exec     dag-exec/select-executor
-   :acquire-env!    dag-exec/acquire-environment!
-   :executor-type   dag-exec/executor-type
-   :result-ok?      dag-result/ok?
-   :result-unwrap   dag-result/unwrap})
-
-(defn- registry-config-for-mode
-  "Build executor registry config for execution mode.
-   :governed — Docker/K8s only (no worktree; no-silent-downgrade per N11 §7.4).
-   :local    — worktree only."
-  [mode executor-config]
-  (case mode
-    :governed (merge (select-keys (or executor-config {}) [:docker :kubernetes])
-                     (when-not executor-config
-                       {:docker {:image "miniforge/task-runner-clojure:latest"}}))
-    {:worktree {}}))
-
-(defn- select-capsule-executor
-  "Select executor for mode; rejects worktree fallback in governed mode (N11 §7.4)."
-  [registry mode {:keys [select-exec executor-type]}]
-  (let [raw (case mode
-              :governed (select-exec registry)
-              (select-exec registry :preferred :worktree))]
-    (when-not (and (= :governed mode) raw (= :worktree (executor-type raw)))
-      raw)))
-
-(defn- assert-executor-for-mode!
-  "Throws for :governed mode when no capsule executor is available."
-  [executor mode]
-  (when (and (nil? executor) (= :governed mode))
-    (throw (ex-info (messages/t :governed/no-capsule)
-                    {:execution-mode :governed
-                     :hint (messages/t :governed/no-capsule-hint)}))))
-
-(defn- build-env-record
-  "Acquire environment from executor and build the result map.
-   Forwards env-config (repo-url, branch, etc.) to the executor so it can
-   bootstrap the workspace inside the capsule (N11 §4.2).
-   Propagates environment metadata (including :image-digest for N11 §11)."
-  [executor workflow-id mode env-config {:keys [acquire-env! result-ok? result-unwrap]}]
-  (let [task-id    (if (uuid? workflow-id) workflow-id (random-uuid))
-        env-result (acquire-env! executor task-id env-config)]
-    (when (result-ok? env-result)
-      (let [env (result-unwrap env-result)]
-        {:executor             executor
-         :environment-id       (:environment-id env)
-         :worktree-path        (:workdir env)
-         :execution-mode       mode
-         :environment-metadata (:metadata env)}))))
-
-(defn- acquire-execution-environment!
-  "Acquire an isolated execution environment before pipeline starts.
-
-   Execution mode (from opts):
-   - :local (default) — worktree only; agent-on-host model.
-   - :governed — host worktree for agent file I/O + Docker/K8s capsule for
-     governed command execution. Agent writes to the worktree; commands
-     (tests, git, builds) are dispatched into the capsule.
-
-   Returns map with :executor, :environment-id, :worktree-path, :execution-mode,
-   or nil if acquisition fails (:local) / throws (:governed)."
-  [workflow-id {:keys [repo-url branch execution-mode executor-config]}]
-  (let [mode (get {:governed :governed} execution-mode :local)]
-    (try
-      (let [fns      (dag-executor-fns)
-            config   (registry-config-for-mode mode executor-config)
-            registry ((:create-registry fns) config)
-            executor (select-capsule-executor registry mode fns)
-            env-config (cond-> {}
-                         repo-url (assoc :repo-url repo-url)
-                         branch   (assoc :branch branch))]
-        (assert-executor-for-mode! executor mode)
-        (when executor
-          (if (= :governed mode)
-            ;; Governed: acquire BOTH a host worktree (for agent file I/O)
-            ;; and a capsule (for governed commands). The agent writes to the
-            ;; worktree; persist-workspace! syncs to the capsule/remote.
-            (let [worktree-fns (assoc fns
-                                      :create-registry (:create-registry fns)
-                                      :select-exec (:select-exec fns))
-                  wt-registry  ((:create-registry fns) {:worktree {}})
-                  wt-executor  ((:select-exec fns) wt-registry :preferred :worktree)
-                  wt-result    (when wt-executor
-                                 (build-env-record wt-executor workflow-id mode env-config fns))
-                  capsule      (build-env-record executor workflow-id mode env-config fns)]
-              (when (and wt-result capsule)
-                (assoc capsule
-                       ;; Agent uses host worktree for file I/O
-                       :worktree-path (:worktree-path wt-result)
-                       ;; Keep capsule executor + env-id for governed commands
-                       :worktree-executor wt-executor
-                       :worktree-environment-id (:environment-id wt-result))))
-            ;; Local: worktree only
-            (build-env-record executor workflow-id mode env-config fns))))
-      (catch Exception e
-        (when (= :governed mode) (throw e))
-        (log/warn runner-logger :workflow :workflow/env-acquisition-failed
-                  {:message (str "Environment acquisition failed: " (ex-message e))})
-        nil))))
-
-(defn- release-execution-environment!
-  "Release an execution environment acquired by the runner.
-   Safe to call with nil values."
-  [executor environment-id]
-  (when (and executor environment-id)
-    (try
-      (dag-exec/release-environment! executor environment-id)
-      (catch Exception e
-        (println (messages/t :warn/publish-event
-                             {:error (str "Environment release failed: " (ex-message e))}))))))
-
-(defn- persist-workspace-at-phase-boundary!
-  "Persist workspace to task branch after phase completes (governed mode only).
-   Git commit + push so changes survive capsule destruction."
-  [context phase-ctx]
-  (when-let [executor (get context :execution/executor)]
-    (when (= :governed (get context :execution/mode))
-      (let [env-id (get context :execution/environment-id)
-            branch (get context :execution/task-branch)
-            phase  (or (:execution/current-phase phase-ctx) :unknown)]
-        (try
-          (dag-exec/persist-workspace! executor env-id
-                                       {:branch  branch
-                                        :message (str (name phase) " phase completed")
-                                        :workdir (get context :execution/worktree-path)})
-          (catch Exception e
-            (log/warn runner-logger :workflow :workflow/persist-failed
-                      {:message (str "Workspace persist failed: " (ex-message e))})
-            nil))))))
 
 ;------------------------------------------------------------------------------ Layer 1: Orchestration helpers
 
@@ -342,13 +87,10 @@
   [context]
   (let [msg (messages/t :status/no-phases)]
     (-> context
-        (update :execution/errors conj
-                {:type :empty-pipeline
-                 :message msg})
+        (update :execution/errors conj (make-execution-error :empty-pipeline msg))
         (update :execution/response-chain
                 response/add-failure :pipeline
-                :anomalies.workflow/empty-pipeline
-                {:error msg})
+                :anomalies.workflow/empty-pipeline {:error msg})
         (ctx/transition-to-failed))))
 
 (defn handle-max-phases-exceeded
@@ -356,14 +98,10 @@
   [context max-phases]
   (let [msg (messages/t :status/max-phases {:max-phases max-phases})]
     (-> context
-        (update :execution/errors conj
-                {:type :max-phases-exceeded
-                 :message msg})
+        (update :execution/errors conj (make-execution-error :max-phases-exceeded msg))
         (update :execution/response-chain
                 response/add-failure :pipeline
-                :anomalies.workflow/max-phases
-                {:error msg
-                 :max-phases max-phases})
+                :anomalies.workflow/max-phases {:error msg :max-phases max-phases})
         (ctx/transition-to-failed))))
 
 (defn terminal-state?
@@ -371,71 +109,87 @@
   [context]
   (or (registry/succeeded? context) (registry/failed? context)))
 
+;------------------------------------------------------------------------------ Layer 1: Iteration helpers
+
+(defn- rate-limited?
+  "True when a phase error message indicates API rate limiting."
+  [error-msg]
+  (boolean
+   (re-find #"(?i)rate.?limit|429|hit your limit|quota.?exceeded"
+            (str error-msg))))
+
+(defn- backoff-ms
+  "Exponential backoff duration for retry iteration, capped."
+  [retry-count]
+  (let [raw (* (defaults/backoff-base-ms) (Math/pow 2 (dec retry-count)))]
+    (long (min (defaults/max-backoff-ms) raw))))
+
+(defn- await-resume!
+  "Block while the control state is paused."
+  [control-state]
+  (when (:paused @control-state)
+    (log/debug runner-logger :system :workflow/execution-paused
+               {:message (messages/t :status/paused)})
+    (while (:paused @control-state)
+      (Thread/sleep (defaults/pause-poll-interval-ms)))))
+
+(defn- check-stopped!
+  "Throw if the control state indicates a stop command."
+  [control-state]
+  (when (:stopped @control-state)
+    (log/warn runner-logger :system :workflow/execution-stopped
+              {:message (messages/t :status/stopped-dashboard)
+               :data {:reason :dashboard-stop}})
+    (throw (ex-info (messages/t :status/stopped-control) {:reason :dashboard-stop}))))
+
+(defn- apply-rate-limit-failure
+  "Mark context as failed due to rate limiting."
+  [phase-ctx error-msg]
+  (-> phase-ctx
+      (assoc :execution/status :failed)
+      (update :execution/errors conj (make-execution-error :rate-limited error-msg))))
+
+(defn- apply-backoff-if-retrying!
+  "Sleep with exponential backoff when a phase is being retried."
+  [phase-ctx context]
+  (let [retrying? (= (:execution/phase-index phase-ctx)
+                     (:execution/phase-index context))
+        retry-count (get-in phase-ctx [:phase :iterations] 1)]
+    (when (and retrying? (> retry-count 1))
+      (Thread/sleep (backoff-ms retry-count)))))
+
+(defn- apply-health-switch
+  "Check backend health and apply switch result if needed."
+  [phase-ctx]
+  (let [event-stream (get-in phase-ctx [:execution/opts :event-stream])
+        switch-result (events/check-backend-health-at-boundary! event-stream phase-ctx)]
+    (cond-> phase-ctx
+      switch-result (assoc :self-healing/backend-switch switch-result))))
+
 (defn execute-single-iteration
-  "Execute single pipeline iteration: health check -> phase execution -> cleanup.
-
-   Returns updated context."
+  "Execute single pipeline iteration: control check -> health -> phase -> backoff."
   [pipeline context callbacks iteration control-state]
-  (let [;; Check control state from dashboard
-        state @control-state
-
-        ;; Handle pause - wait until resumed
-        _ (when (:paused state)
-            (log/debug runner-logger :system :workflow/execution-paused
-                       {:message (messages/t :status/paused)})
-            (while (:paused @control-state)
-              (Thread/sleep 1000)))
-
-        ;; Check for stop command
-        _ (when (:stopped state)
-            (log/warn runner-logger :system :workflow/execution-stopped
-                      {:message (messages/t :status/stopped-dashboard)
-                       :data {:reason :dashboard-stop}})
-            (throw (ex-info (messages/t :status/stopped-control) {:reason :dashboard-stop})))
-
-        ;; Check workflow health via meta-agents
-        coordinator (:execution/meta-coordinator context)
+  (await-resume! control-state)
+  (check-stopped! control-state)
+  (let [coordinator (:execution/meta-coordinator context)
         workflow-state (monitoring/build-workflow-state context iteration)
         health-check (monitoring/check-workflow-health coordinator workflow-state)]
-
     (if (= :halt (:status health-check))
-      ;; Meta-agent signaled halt - stop workflow
       (monitoring/handle-meta-agent-halt context health-check ctx/transition-to-failed)
-
-      ;; Healthy or warning - continue execution
       (let [phase-ctx (-> (exec/execute-phase-step pipeline context callbacks
                                                    ctx/merge-metrics
                                                    ctx/transition-to-completed
                                                    ctx/transition-to-failed)
                           (monitoring/clear-transient-state))
-            _ (persist-workspace-at-phase-boundary! context phase-ctx)
-            ;; Check if phase failed due to rate limiting — if so, stop retrying
-            ;; and bubble the error up to the DAG orchestrator's resilience module
-            current-phase (:execution/current-phase phase-ctx)
-            phase-result (get-in phase-ctx [:execution/phase-results current-phase])
-            phase-error-msg (get-in phase-result [:error :message] "")
-            rate-limited? (boolean
-                           (re-find #"(?i)rate.?limit|429|hit your limit|quota.?exceeded"
-                                    (str phase-error-msg)))]
-        (if rate-limited?
-          ;; Stop retrying immediately — let the DAG orchestrator handle the wait/pause
-          (-> phase-ctx
-              (assoc :execution/status :failed)
-              (update :execution/errors conj
-                      {:type :rate-limited
-                       :message phase-error-msg}))
-          ;; Normal path: exponential backoff when phase is retrying
-          (let [retrying? (= (:execution/phase-index phase-ctx)
-                             (:execution/phase-index context))
-                retry-count (get-in phase-ctx [:phase :iterations] 1)]
-            (when (and retrying? (> retry-count 1))
-              (let [backoff-ms (min 30000 (long (* 1000 (Math/pow 2 (dec retry-count)))))]
-                (Thread/sleep backoff-ms)))
-            (let [event-stream (get-in phase-ctx [:execution/opts :event-stream])
-                  switch-result (check-backend-health-at-boundary! event-stream phase-ctx)]
-              (if switch-result
-                (assoc phase-ctx :self-healing/backend-switch switch-result)
-                phase-ctx))))))))
+            _ (env/persist-workspace-at-phase-boundary! context phase-ctx)
+            phase-error-msg (get-in phase-ctx
+                                    [:execution/phase-results
+                                     (:execution/current-phase phase-ctx)
+                                     :error :message] "")]
+        (if (rate-limited? phase-error-msg)
+          (apply-rate-limit-failure phase-ctx phase-error-msg)
+          (do (apply-backoff-if-retrying! phase-ctx context)
+              (apply-health-switch phase-ctx)))))))
 
 ;------------------------------------------------------------------------------ Layer 1.5: Output extraction
 
@@ -443,135 +197,59 @@
   "Return the executor's runtime class (:docker, :worktree, etc.) or nil."
   [executor]
   (when executor
-    (try
-      (dag-exec/executor-type executor)
-      (catch Exception _ nil))))
+    (try (dag-exec/executor-type executor) (catch Exception _ nil))))
 
 (defn extract-output
   "Synthesize :execution/output from completed pipeline context.
-   Provides a stable interface for chaining: downstream consumers
-   read :execution/output instead of reaching into phase-results.
-
-   Includes N11 §9.1 evidence fields:
-   - :evidence/execution-mode  — :local or :governed
-   - :evidence/runtime-class   — :docker, :worktree, or nil
-   - :evidence/task-started-at — from execution context
-   - :evidence/task-finished-at — captured at extraction time
-   - :evidence/image-digest    — Docker image SHA256 (SHOULD per N11 §11)"
+   Includes N11 §9.1 evidence fields."
   [ctx]
   (let [phase-results (:execution/phase-results ctx)
         current-phase (:execution/current-phase ctx)
-        last-result   (get phase-results current-phase)
-        ;; N11 §9.1 evidence fields
-        execution-mode (get ctx :execution/mode :local)
-        runtime-class  (resolve-runtime-class (:execution/executor ctx))
-        started-at     (:execution/started-at ctx)
-        finished-at    (java.time.Instant/now)
-        image-digest   (get-in ctx [:execution/environment-metadata :image-digest])]
+        image-digest  (get-in ctx [:execution/environment-metadata :image-digest])]
     (assoc ctx :execution/output
-           (cond-> {:artifacts          (:execution/artifacts ctx)
-                    :phase-results      phase-results
-                    :last-phase-result  last-result
-                    :status             (:execution/status ctx)
-                    ;; N11 §9.1 evidence record
-                    :evidence/execution-mode  execution-mode
-                    :evidence/runtime-class   runtime-class
-                    :evidence/task-started-at started-at
-                    :evidence/task-finished-at finished-at}
-             image-digest
-             (assoc :evidence/image-digest image-digest)))))
-
-;------------------------------------------------------------------------------ Layer 1.75: Post-execution hooks
-
-(defn promote-mature-learnings!
-  "Query promotable learnings from KB and auto-promote high-confidence ones.
-   No-ops when knowledge-store is nil. Returns a vector of errors (may be empty)."
-  [knowledge-store]
-  (let [errors (volatile! [])]
-    (try
-      (when knowledge-store
-        (let [promotable (knowledge/list-learnings knowledge-store {:promotable? true})]
-          (doseq [learning promotable]
-            (try
-              (knowledge/promote-learning knowledge-store (:zettel/id learning) {})
-              (catch Exception e
-                (vswap! errors conj {:zettel/id (:zettel/id learning)
-                                     :error (ex-message e)}))))))
-      (catch Exception e
-        (vswap! errors conj {:error (ex-message e)})))
-    @errors))
-
-(defn- synthesize-patterns!
-  "Detect recurring patterns in KB learnings and synthesize meta-loop learnings.
-   Delegates to knowledge component. No-ops when knowledge-store is nil.
-   Throws on failure — callers are responsible for catching and emitting events."
-  [knowledge-store]
-  (when knowledge-store
-    (knowledge/synthesize-recurring-patterns! knowledge-store)))
-
-(defn- observe-workflow-signal!
-  "Feed workflow completion/failure signal to the operator for pattern analysis.
-   Callers provide :observe-signal-fn in opts — a (fn [signal]) callback that
-   forwards to their operator instance. No-ops when no callback is configured.
-   When output-ctx is nil (uncaught exception), builds a minimal failure signal
-   from the workflow config and exception.
-   Throws on failure — callers are responsible for catching and emitting events."
-  [opts output-ctx workflow exception]
-  (when-let [observe-fn (:observe-signal-fn opts)]
-    (let [signal (if output-ctx
-                   (let [signal-type (if (phase/succeeded? output-ctx)
-                                       :workflow-complete
-                                       :workflow-failed)]
-                     {:signal/type signal-type
-                      :workflow-id (:execution/id output-ctx)
-                      :phase-results (:execution/phase-results output-ctx)
-                      :metrics (:execution/metrics output-ctx)
-                      :timestamp (java.time.Instant/now)})
-                   ;; Fallback: output-ctx unavailable due to uncaught exception
-                   {:signal/type :workflow-failed
-                    :workflow-id (:workflow/id workflow)
-                    :error (when exception (ex-message exception))
-                    :timestamp (java.time.Instant/now)})]
-      (observe-fn signal))))
+           (cond-> {:artifacts              (:execution/artifacts ctx)
+                    :phase-results          phase-results
+                    :last-phase-result      (get phase-results current-phase)
+                    :status                 (:execution/status ctx)
+                    :evidence/execution-mode  (get ctx :execution/mode :local)
+                    :evidence/runtime-class   (resolve-runtime-class (:execution/executor ctx))
+                    :evidence/task-started-at (:execution/started-at ctx)
+                    :evidence/task-finished-at (java.time.Instant/now)}
+             image-digest (assoc :evidence/image-digest image-digest)))))
 
 ;------------------------------------------------------------------------------ Layer 2: Pipeline stages
 
 (declare run-pipeline)
 
-(def ^:private ^:const default-max-phases 50)
-
 (defn- acquire-environment
   "Acquire an isolated execution environment (worktree or Docker capsule).
    Returns [acquired-env opts'] where acquired-env is nil when pre-acquired."
   [workflow input opts]
-  (let [has-executor? (and (:executor opts) (:environment-id opts))]
-    (if has-executor?
-      [nil opts]
-      (let [repo-url (or (:repo-url opts) (:repo-url input))
-            branch   (or (:branch opts) (:branch input) "main")
-            acquired (acquire-execution-environment!
-                      (:workflow/id workflow)
-                      {:repo-url        repo-url
-                       :branch          branch
-                       :execution-mode  (:execution-mode opts)
-                       :executor-config (:executor-config opts)})]
-        [acquired (if acquired (merge opts acquired) opts)]))))
+  (if (and (:executor opts) (:environment-id opts))
+    [nil opts]
+    (let [repo-url (get opts :repo-url (get input :repo-url))
+          branch   (get opts :branch (get input :branch "main"))
+          acquired (env/acquire-execution-environment!
+                    (:workflow/id workflow)
+                    {:repo-url        repo-url
+                     :branch          branch
+                     :execution-mode  (:execution-mode opts)
+                     :executor-config (:executor-config opts)})]
+      [acquired (if acquired (merge opts acquired) opts)])))
 
 (defn- wrap-phase-callbacks
   "Wrap caller callbacks with event publishing."
   [event-stream opts]
   {:on-phase-start
    (fn [ctx interceptor]
-     (when-let [phase-name (or (:phase interceptor)
-                               (get-in interceptor [:config :phase]))]
-       (publish-phase-started! event-stream ctx phase-name))
+     (when-let [phase-name (get interceptor :phase (get-in interceptor [:config :phase]))]
+       (events/publish-phase-started! event-stream ctx phase-name))
      (when-let [cb (:on-phase-start opts)]
        (cb ctx interceptor)))
    :on-phase-complete
    (fn [ctx interceptor result]
-     (when-let [phase-name (or (:phase interceptor)
-                               (get-in interceptor [:config :phase]))]
-       (publish-phase-completed! event-stream ctx phase-name result))
+     (when-let [phase-name (get interceptor :phase (get-in interceptor [:config :phase]))]
+       (events/publish-phase-completed! event-stream ctx phase-name result))
      (when-let [cb (:on-phase-complete opts)]
        (cb ctx interceptor result)))})
 
@@ -586,20 +264,21 @@
                            dag-exec/execute!
                            (get opts :executor)
                            (get opts :environment-id)
-                           (get opts :worktree-path "/workspace")))]
+                           (get opts :worktree-path (defaults/default-workdir))))]
     (-> (ctx/create-context workflow input opts)
         (assoc :execution/executor (get opts :executor)
                :execution/environment-id (get opts :environment-id)
-               :execution/worktree-path (or (:worktree-path opts)
-                                            (:sandbox-workdir opts))
+               :execution/worktree-path (get opts :worktree-path
+                                             (get opts :sandbox-workdir))
                :execution/mode (get opts :execution-mode :local)
                :execution/started-at (java.time.Instant/now)
                :execution/environment-metadata (get opts :environment-metadata)
                :execution/execute-fn (when governed? dag-exec/execute!)
                :execution/exec-fn capsule-exec-fn
                :execution/task-branch (when governed?
-                                        (str "task/" (or (get opts :environment-id)
-                                                         (subs (str (random-uuid)) 0 8))))
+                                        (str (defaults/task-branch-prefix)
+                                             (get opts :environment-id
+                                                  (subs (str (random-uuid)) 0 8))))
                :execution/run-pipeline-fn run-pipeline))))
 
 (defn- execute-pipeline-loop
@@ -623,49 +302,18 @@
            (empty? (:execution/phase-results final-ctx)))
     (-> final-ctx
         (update :execution/errors conj
-                {:type :empty-completion
-                 :message (messages/t :status/empty-completion)})
+                (make-execution-error :empty-completion
+                                     (messages/t :status/empty-completion)))
         (assoc :execution/status :completed-with-warnings))
     final-ctx))
-
-(defn- post-workflow-cleanup!
-  "Post-workflow cleanup that fires on ALL exit paths.
-   Each step is independently try-caught so one failure cannot mask another.
-   Failures are emitted as events so the meta-loop can detect broken subsystems."
-  [opts output-ctx workflow exception acquired-env]
-  (let [event-stream (:event-stream opts)
-        workflow-id  (or (:execution/id output-ctx) (:workflow/id workflow))]
-    (try (observe-workflow-signal! opts output-ctx workflow exception)
-         (catch Exception e
-           (when event-stream
-             (publish-event! event-stream (es/observer-signal-failed event-stream workflow-id e)))))
-    (try (synthesize-patterns! (:knowledge-store opts))
-         (catch Exception e
-           (when event-stream
-             (publish-event! event-stream (es/knowledge-synthesis-failed event-stream e)))))
-    (let [errors (promote-mature-learnings! (:knowledge-store opts))]
-      (doseq [err errors]
-        (when event-stream
-          (publish-event! event-stream
-                          (es/knowledge-promotion-failed event-stream (ex-info (:error err) err))))))
-    (when acquired-env
-      (release-execution-environment! (:executor acquired-env)
-                                      (:environment-id acquired-env))
-      (release-execution-environment! (:worktree-executor acquired-env)
-                                      (:worktree-environment-id acquired-env)))))
 
 ;------------------------------------------------------------------------------ Layer 3: Main entry point
 
 (defn run-pipeline
   "Execute a workflow pipeline.
 
-   Pipeline: acquire environment → build context → execute phases
-           → validate → publish completion → cleanup (always).
-
-   Arguments:
-   - workflow: Workflow configuration
-   - input: Input data (may contain :repo-url and :branch)
-   - opts: Execution options (see docstring for keys)
+   Pipeline: acquire environment -> build context -> execute phases
+           -> validate -> publish completion -> cleanup (always).
 
    Returns final execution context."
   ([workflow input]
@@ -673,9 +321,9 @@
   ([workflow input opts]
    (let [[acquired-env opts] (acquire-environment workflow input opts)
          pipeline            (build-pipeline workflow)
-         max-phases          (get opts :max-phases default-max-phases)
-         control-state       (or (:control-state opts)
-                                 (atom {:paused false :stopped false :adjustments {}}))
+         max-phases          (get opts :max-phases (defaults/max-phases))
+         control-state       (get opts :control-state
+                                  (atom {:paused false :stopped false :adjustments {}}))
          event-stream        (:event-stream opts)
          callbacks           (wrap-phase-callbacks event-stream opts)
          skip-lifecycle?     (:skip-lifecycle-events opts)
@@ -684,7 +332,7 @@
          exception-vol       (volatile! nil)]
 
      (when-not skip-lifecycle?
-       (publish-workflow-started! event-stream initial-ctx))
+       (events/publish-workflow-started! event-stream initial-ctx))
 
      (try
        (let [final-ctx (try
@@ -694,28 +342,24 @@
                            (vreset! exception-vol e)
                            (-> initial-ctx
                                (update :execution/errors conj
-                                       {:type :pipeline-exception
-                                        :message (ex-message e)
-                                        :data (ex-data e)})
+                                       (make-execution-error :pipeline-exception
+                                                             (ex-message e)
+                                                             {:data (ex-data e)}))
                                (assoc :execution/status :failed))))
              output-ctx (-> final-ctx validate-completion extract-output)]
          (vreset! output-ctx-vol output-ctx)
          (when-not skip-lifecycle?
-           (publish-workflow-completed! event-stream output-ctx))
+           (events/publish-workflow-completed! event-stream output-ctx))
          output-ctx)
        (finally
-         (post-workflow-cleanup! opts @output-ctx-vol workflow
-                                @exception-vol acquired-env))))))
+         (cleanup/post-workflow-cleanup! opts @output-ctx-vol workflow
+                                        @exception-vol acquired-env))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   (require '[ai.miniforge.phase.plan])
   (require '[ai.miniforge.phase.implement])
-  (require '[ai.miniforge.phase.verify])
-  (require '[ai.miniforge.phase.review])
-  (require '[ai.miniforge.phase.release])
 
-  ;; Simple workflow config
   (def simple-workflow
     {:workflow/id :simple-test
      :workflow/version "2.0.0"
@@ -724,24 +368,7 @@
       {:phase :implement}
       {:phase :done}]})
 
-  ;; Build pipeline
   (build-pipeline simple-workflow)
-
-  ;; Validate pipeline
   (validate-pipeline simple-workflow)
-
-  ;; Run pipeline
-  (def result
-    (run-pipeline simple-workflow
-                  {:task "Test task"}
-                  {:on-phase-start (fn [_ctx ic]
-                                     (println "Starting:" (get-in ic [:config :phase])))
-                   :on-phase-complete (fn [_ctx ic result]
-                                        (println "Completed:" (get-in ic [:config :phase])
-                                                 "Status:" (:phase/status result)))}))
-
-  (:execution/status result)
-  (:execution/phase-results result)
-  (:execution/metrics result)
 
   :leave-this-here)

--- a/components/workflow/src/ai/miniforge/workflow/runner_cleanup.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_cleanup.clj
@@ -1,0 +1,126 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.runner-cleanup
+  "Post-workflow cleanup hooks.
+
+   Fires on ALL exit paths (success, failure, exception).
+   Each step is independently try-caught so one failure cannot mask another.
+   Extracted from runner.clj."
+  (:require
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.knowledge.interface :as knowledge]
+   [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.workflow.runner-environment :as env]
+   [ai.miniforge.workflow.runner-events :as events]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Signal factories
+
+(defn- make-completion-signal
+  "Build a workflow signal from a completed execution context."
+  [output-ctx]
+  {:signal/type   (if (phase/succeeded? output-ctx) :workflow-complete :workflow-failed)
+   :workflow-id   (:execution/id output-ctx)
+   :phase-results (:execution/phase-results output-ctx)
+   :metrics       (:execution/metrics output-ctx)
+   :timestamp     (java.time.Instant/now)})
+
+(defn- make-exception-signal
+  "Build a minimal failure signal when execution context is unavailable."
+  [workflow exception]
+  {:signal/type :workflow-failed
+   :workflow-id (:workflow/id workflow)
+   :error       (when exception (ex-message exception))
+   :timestamp   (java.time.Instant/now)})
+
+;------------------------------------------------------------------------------ Layer 0
+;; Individual cleanup steps
+
+(defn promote-mature-learnings!
+  "Query promotable learnings from KB and auto-promote high-confidence ones.
+   No-ops when knowledge-store is nil. Returns a vector of errors (may be empty)."
+  [knowledge-store]
+  (let [errors (volatile! [])]
+    (try
+      (when knowledge-store
+        (let [promotable (knowledge/list-learnings knowledge-store {:promotable? true})]
+          (doseq [learning promotable]
+            (try
+              (knowledge/promote-learning knowledge-store (:zettel/id learning) {})
+              (catch Exception e
+                (vswap! errors conj {:zettel/id (:zettel/id learning)
+                                     :error (ex-message e)}))))))
+      (catch Exception e
+        (vswap! errors conj {:error (ex-message e)})))
+    @errors))
+
+(defn synthesize-patterns!
+  "Detect recurring patterns in KB learnings. No-ops when knowledge-store is nil."
+  [knowledge-store]
+  (when knowledge-store
+    (knowledge/synthesize-recurring-patterns! knowledge-store)))
+
+(defn observe-workflow-signal!
+  "Feed workflow completion/failure signal to the operator for pattern analysis."
+  [opts output-ctx workflow exception]
+  (when-let [observe-fn (:observe-signal-fn opts)]
+    (let [signal (if output-ctx
+                   (make-completion-signal output-ctx)
+                   (make-exception-signal workflow exception))]
+      (observe-fn signal))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Orchestrated cleanup
+
+(defn- try-observe! [opts output-ctx workflow exception event-stream workflow-id]
+  (try (observe-workflow-signal! opts output-ctx workflow exception)
+       (catch Exception e
+         (when event-stream
+           (events/publish-event! event-stream (es/observer-signal-failed event-stream workflow-id e))))))
+
+(defn- try-synthesize! [opts event-stream]
+  (try (synthesize-patterns! (:knowledge-store opts))
+       (catch Exception e
+         (when event-stream
+           (events/publish-event! event-stream (es/knowledge-synthesis-failed event-stream e))))))
+
+(defn- try-promote! [opts event-stream]
+  (let [errors (promote-mature-learnings! (:knowledge-store opts))]
+    (doseq [err errors]
+      (when event-stream
+        (events/publish-event! event-stream
+                        (es/knowledge-promotion-failed event-stream (ex-info (:error err) err)))))))
+
+(defn- release-acquired-environments! [acquired-env]
+  (when acquired-env
+    (env/release-execution-environment! (:executor acquired-env)
+                                        (:environment-id acquired-env))
+    (env/release-execution-environment! (:worktree-executor acquired-env)
+                                        (:worktree-environment-id acquired-env))))
+
+(defn post-workflow-cleanup!
+  "Post-workflow cleanup that fires on ALL exit paths.
+   Each step is independently try-caught so one failure cannot mask another."
+  [opts output-ctx workflow exception acquired-env]
+  (let [event-stream (:event-stream opts)
+        workflow-id  (get output-ctx :execution/id (:workflow/id workflow))]
+    (try-observe! opts output-ctx workflow exception event-stream workflow-id)
+    (try-synthesize! opts event-stream)
+    (try-promote! opts event-stream)
+    (release-acquired-environments! acquired-env)))

--- a/components/workflow/src/ai/miniforge/workflow/runner_defaults.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_defaults.clj
@@ -1,0 +1,38 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.runner-defaults
+  "Configuration-as-data for the workflow runner.
+   All constants live in config/workflow/runner/defaults.edn."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+(def ^:private defaults
+  "Loaded once from classpath resource."
+  (delay
+    (if-let [r (io/resource "config/workflow/runner/defaults.edn")]
+      (:runner/defaults (edn/read-string (slurp r)))
+      {})))
+
+(defn max-phases           [] (get @defaults :max-phases 50))
+(defn max-backoff-ms       [] (get @defaults :max-backoff-ms 30000))
+(defn backoff-base-ms      [] (get @defaults :backoff-base-ms 1000))
+(defn pause-poll-interval-ms [] (get @defaults :pause-poll-interval-ms 1000))
+(defn default-workdir      [] (get @defaults :default-workdir "/workspace"))
+(defn task-branch-prefix   [] (get @defaults :task-branch-prefix "task/"))
+(defn default-docker-image [] (get @defaults :default-docker-image "miniforge/task-runner-clojure:latest"))

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -1,0 +1,160 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.runner-environment
+  "Execution environment lifecycle for workflow pipeline.
+
+   Manages worktree and Docker capsule acquisition, release, and
+   workspace persistence at phase boundaries. Extracted from runner.clj."
+  (:require
+   [ai.miniforge.dag-executor.executor :as dag-exec]
+   [ai.miniforge.dag-executor.result :as dag-result]
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.workflow.messages :as messages]
+   [ai.miniforge.workflow.runner-defaults :as defaults]))
+
+(defonce ^:private env-logger
+  (log/create-logger {:min-level :debug :output :human}))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Executor function references
+
+(defn dag-executor-fns
+  "DAG executor function references — resolved at call time so with-redefs works."
+  []
+  {:create-registry dag-exec/create-executor-registry
+   :select-exec     dag-exec/select-executor
+   :acquire-env!    dag-exec/acquire-environment!
+   :executor-type   dag-exec/executor-type
+   :result-ok?      dag-result/ok?
+   :result-unwrap   dag-result/unwrap})
+
+;------------------------------------------------------------------------------ Layer 0
+;; Configuration
+
+(defn registry-config-for-mode
+  "Build executor registry config for execution mode.
+   :governed — Docker/K8s only (no worktree; no-silent-downgrade per N11 §7.4).
+   :local    — worktree only."
+  [mode executor-config]
+  (case mode
+    :governed (merge (select-keys (or executor-config {}) [:docker :kubernetes])
+                     (when-not executor-config
+                       {:docker {:image (defaults/default-docker-image)}}))
+    {:worktree {}}))
+
+(defn select-capsule-executor
+  "Select executor for mode; rejects worktree fallback in governed mode (N11 §7.4)."
+  [registry mode {:keys [select-exec executor-type]}]
+  (let [raw (case mode
+              :governed (select-exec registry)
+              (select-exec registry :preferred :worktree))]
+    (when-not (and (= :governed mode) raw (= :worktree (executor-type raw)))
+      raw)))
+
+(defn assert-executor-for-mode!
+  "Throws for :governed mode when no capsule executor is available."
+  [executor mode]
+  (when (and (nil? executor) (= :governed mode))
+    (throw (ex-info (messages/t :governed/no-capsule)
+                    {:execution-mode :governed
+                     :hint (messages/t :governed/no-capsule-hint)}))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Environment record construction
+
+(defn build-env-record
+  "Acquire environment from executor and build the result map."
+  [executor workflow-id mode env-config {:keys [acquire-env! result-ok? result-unwrap]}]
+  (let [task-id    (if (uuid? workflow-id) workflow-id (random-uuid))
+        env-result (acquire-env! executor task-id env-config)]
+    (when (result-ok? env-result)
+      (let [env (result-unwrap env-result)]
+        {:executor             executor
+         :environment-id       (:environment-id env)
+         :worktree-path        (:workdir env)
+         :execution-mode       mode
+         :environment-metadata (:metadata env)}))))
+
+(defn- acquire-worktree-and-capsule
+  "Acquire both a host worktree and a capsule for governed mode."
+  [executor workflow-id mode env-config fns]
+  (let [wt-registry  ((:create-registry fns) {:worktree {}})
+        wt-executor  ((:select-exec fns) wt-registry :preferred :worktree)
+        wt-result    (when wt-executor
+                       (build-env-record wt-executor workflow-id mode env-config fns))
+        capsule      (build-env-record executor workflow-id mode env-config fns)]
+    (when (and wt-result capsule)
+      (assoc capsule
+             :worktree-path (:worktree-path wt-result)
+             :worktree-executor wt-executor
+             :worktree-environment-id (:environment-id wt-result)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Full acquisition and release
+
+(defn acquire-execution-environment!
+  "Acquire an isolated execution environment before pipeline starts.
+   Returns env map, or nil (local) / throws (governed) on failure."
+  [workflow-id {:keys [repo-url branch execution-mode executor-config]}]
+  (let [mode (get {:governed :governed} execution-mode :local)]
+    (try
+      (let [fns      (dag-executor-fns)
+            config   (registry-config-for-mode mode executor-config)
+            registry ((:create-registry fns) config)
+            executor (select-capsule-executor registry mode fns)
+            env-config (cond-> {}
+                         repo-url (assoc :repo-url repo-url)
+                         branch   (assoc :branch branch))]
+        (assert-executor-for-mode! executor mode)
+        (when executor
+          (if (= :governed mode)
+            (acquire-worktree-and-capsule executor workflow-id mode env-config fns)
+            (build-env-record executor workflow-id mode env-config fns))))
+      (catch Exception e
+        (when (= :governed mode) (throw e))
+        (log/warn env-logger :workflow :workflow/env-acquisition-failed
+                  {:message (messages/t :env/acquisition-failed {:error (ex-message e)})})
+        nil))))
+
+(defn release-execution-environment!
+  "Release an execution environment. Safe to call with nil values."
+  [executor environment-id]
+  (when (and executor environment-id)
+    (try
+      (dag-exec/release-environment! executor environment-id)
+      (catch Exception e
+        (println (messages/t :env/release-failed {:error (ex-message e)}))))))
+
+(defn persist-workspace-at-phase-boundary!
+  "Persist workspace to task branch after phase completes (governed mode only)."
+  [context phase-ctx]
+  (when-let [executor (get context :execution/executor)]
+    (when (= :governed (get context :execution/mode))
+      (let [env-id (get context :execution/environment-id)
+            branch (get context :execution/task-branch)
+            phase  (get phase-ctx :execution/current-phase :unknown)]
+        (try
+          (dag-exec/persist-workspace! executor env-id
+                                       {:branch  branch
+                                        :message (messages/t :env/persist-message {:phase (name phase)})
+                                        :workdir (get context :execution/worktree-path)})
+          (catch Exception e
+            (log/warn env-logger :workflow :workflow/persist-failed
+                      {:message (messages/t :env/persist-failed {:error (ex-message e)})})
+            nil))))))

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -1,0 +1,170 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.runner-events
+  "Event publishing for workflow pipeline execution.
+
+   Extracted from runner.clj for single-responsibility.
+   All functions are safe to call with nil event-stream (no-op)."
+  (:require
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.phase.registry :as registry]
+   [ai.miniforge.self-healing.interface :as self-healing]
+   [ai.miniforge.workflow.messages :as messages]
+   [cheshire.core :as json]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Core event dispatch
+
+(defn- publish-via-websocket!
+  "Send event JSON to a WebSocket connection."
+  [event-stream event]
+  (try
+    (require '[org.httpkit.client :as http])
+    (when-let [http-ns (find-ns 'org.httpkit.client)]
+      (when-let [ws (:websocket event-stream)]
+        (when-let [send-fn (ns-resolve http-ns 'send!)]
+          (send-fn ws (json/generate-string event)))))
+    (catch Exception e
+      (println (messages/t :warn/websocket-send {:error (ex-message e)})))))
+
+(defn publish-event!
+  "Publish event to event stream or dashboard WebSocket.
+   Safe to call with nil event-stream (no-op)."
+  [event-stream event]
+  (when event-stream
+    (try
+      (if (:websocket event-stream)
+        (publish-via-websocket! event-stream event)
+        (es/publish! event-stream event))
+      (catch Exception e
+        (println (messages/t :warn/publish-event {:error (ex-message e)}))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Event construction helpers
+
+(defn- build-completion-metrics
+  "Extract non-nil metric fields from execution context."
+  [context]
+  (let [metrics (:execution/metrics context)]
+    (cond-> {}
+      (:tokens metrics)   (assoc :tokens (:tokens metrics))
+      (:cost-usd metrics) (assoc :cost-usd (:cost-usd metrics))
+      (:workflow/pr-info context) (assoc :pr-info (:workflow/pr-info context)))))
+
+(defn- build-phase-event-data
+  "Build event data map for a phase completion event."
+  [result]
+  (let [succeeded? (get result :success? (registry/succeeded-or-done? result))
+        outcome    (if succeeded? :success :failure)
+        duration-ms (get result :duration-ms
+                      (get-in result [:phase/metrics :duration-ms]
+                        (get-in result [:metrics :duration-ms])))
+        error-info (when-not succeeded?
+                     (or (:error result)
+                         (when-let [msg (get-in result [:phase/gate-errors])]
+                           {:message (messages/t :status/gate-failed) :details msg})
+                         (when-let [msg (:message result)]
+                           {:message msg})))
+        tokens   (get-in result [:metrics :tokens]
+                   (get-in result [:phase/metrics :tokens]))
+        cost-usd (get-in result [:metrics :cost-usd]
+                   (get-in result [:phase/metrics :cost-usd]))]
+    (cond-> {:outcome outcome :duration-ms duration-ms}
+      error-info    (assoc :error error-info)
+      (:redirect-to result) (assoc :redirect-to (:redirect-to result))
+      tokens        (assoc :tokens tokens)
+      cost-usd      (assoc :cost-usd cost-usd))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Lifecycle event publishers
+
+(defn publish-workflow-started!
+  "Publish workflow started event."
+  [event-stream context]
+  (when event-stream
+    (try
+      (publish-event! event-stream
+                      (es/workflow-started event-stream
+                                          (:execution/id context)
+                                          (select-keys (:execution/workflow context)
+                                                       [:workflow/id :workflow/version])))
+      (catch Exception e
+        (println (messages/t :warn/publish-started {:error (ex-message e)}))))))
+
+(defn publish-workflow-completed!
+  "Publish workflow completed/failed event."
+  [event-stream context]
+  (when event-stream
+    (try
+      (let [wf-id (:execution/id context)
+            metrics-opts (build-completion-metrics context)]
+        (if (registry/failed? context)
+          (publish-event! event-stream
+                          (es/workflow-failed event-stream wf-id
+                                             {:message (messages/t :status/failed)
+                                              :errors (:execution/errors context)}))
+          (publish-event! event-stream
+                          (es/workflow-completed event-stream wf-id
+                                                 (:execution/status context)
+                                                 (get-in context [:execution/metrics :duration-ms])
+                                                 (when (seq metrics-opts) metrics-opts)))))
+      (catch Exception e
+        (println (messages/t :warn/publish-completed {:error (ex-message e)}))))))
+
+(defn publish-phase-started!
+  "Publish phase started event."
+  [event-stream context phase-name]
+  (when event-stream
+    (try
+      (publish-event! event-stream
+                      (es/phase-started event-stream (:execution/id context) phase-name
+                                        {:phase/index (:execution/phase-index context)}))
+      (catch Exception e
+        (println (messages/t :warn/publish-phase-started {:error (ex-message e)}))))))
+
+(defn publish-phase-completed!
+  "Publish phase completed event."
+  [event-stream context phase-name result]
+  (when event-stream
+    (try
+      (publish-event! event-stream
+                      (es/phase-completed event-stream (:execution/id context) phase-name
+                                          (build-phase-event-data result)))
+      (catch Exception e
+        (println (messages/t :warn/publish-phase-completed {:error (ex-message e)}))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Health check at phase boundary
+
+(defn check-backend-health-at-boundary!
+  "Check backend health at phase boundary. No-ops when :self-healing-config is absent.
+   Returns switch-result or nil."
+  [event-stream context]
+  (when (get-in context [:execution/opts :self-healing-config])
+    (try
+      (let [backend (get-in context [:execution/opts :llm-backend :config :backend] :anthropic)
+            sh-ctx {:llm {:backend backend}
+                    :config (get-in context [:execution/opts :self-healing-config])}
+            switch-result (self-healing/check-backend-health-and-switch sh-ctx)]
+        (when (:switched? switch-result)
+          (publish-event! event-stream (self-healing/emit-backend-switch-event sh-ctx switch-result))
+          switch-result))
+      (catch Exception e
+        (println (messages/t :warn/health-check {:error (ex-message e)}))
+        nil))))

--- a/components/workflow/test/ai/miniforge/workflow/environment_promotion_integration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/environment_promotion_integration_test.clj
@@ -174,7 +174,7 @@
                            :environment-id acquired-env-id
                            :worktree-path  *test-worktree*
                            :execution-mode :local}
-          acquire-var     (resolve 'ai.miniforge.workflow.runner/acquire-execution-environment!)
+          acquire-var     (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)
           workflow        (make-workflow :implement :done)]
       (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                     agent/invoke

--- a/components/workflow/test/ai/miniforge/workflow/runner_cleanup_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_cleanup_test.clj
@@ -1,0 +1,75 @@
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.workflow.runner-cleanup-test
+  "Tests for post-workflow cleanup hooks."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.workflow.runner-cleanup :as cleanup]))
+
+;; ============================================================================
+;; Signal factories (accessed via private fn resolution)
+;; ============================================================================
+
+(def ^:private make-completion-signal
+  (var-get (ns-resolve 'ai.miniforge.workflow.runner-cleanup 'make-completion-signal)))
+
+(def ^:private make-exception-signal
+  (var-get (ns-resolve 'ai.miniforge.workflow.runner-cleanup 'make-exception-signal)))
+
+(deftest make-completion-signal-success-test
+  (testing "builds :workflow-complete signal for succeeded context"
+    (let [ctx {:execution/status :completed
+               :execution/id #uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+               :execution/phase-results {:plan {:status :completed}}
+               :execution/metrics {:tokens 100}}
+          signal (make-completion-signal ctx)]
+      (is (= :workflow-complete (:signal/type signal)))
+      (is (= (:execution/id ctx) (:workflow-id signal)))
+      (is (inst? (:timestamp signal))))))
+
+(deftest make-completion-signal-failure-test
+  (testing "builds :workflow-failed signal for failed context"
+    (let [ctx {:execution/status :failed
+               :execution/id #uuid "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+               :execution/errors [{:type :gate-failed}]}
+          signal (make-completion-signal ctx)]
+      (is (= :workflow-failed (:signal/type signal))))))
+
+(deftest make-exception-signal-test
+  (testing "builds minimal failure signal from workflow and exception"
+    (let [wf {:workflow/id :test-wf}
+          ex (ex-info "boom" {:code 500})
+          signal (make-exception-signal wf ex)]
+      (is (= :workflow-failed (:signal/type signal)))
+      (is (= :test-wf (:workflow-id signal)))
+      (is (= "boom" (:error signal))))))
+
+(deftest make-exception-signal-nil-exception-test
+  (testing "handles nil exception gracefully"
+    (let [signal (make-exception-signal {:workflow/id :w} nil)]
+      (is (nil? (:error signal))))))
+
+;; ============================================================================
+;; observe-workflow-signal!
+;; ============================================================================
+
+(deftest observe-workflow-signal-calls-observer-test
+  (testing "passes signal to observe-signal-fn"
+    (let [captured (atom nil)
+          opts {:observe-signal-fn (fn [sig] (reset! captured sig))}
+          ctx {:execution/status :completed
+               :execution/id (random-uuid)}]
+      (cleanup/observe-workflow-signal! opts ctx {} nil)
+      (is (= :workflow-complete (:signal/type @captured))))))
+
+(deftest observe-workflow-signal-noop-without-fn-test
+  (testing "no-ops when observe-signal-fn is absent"
+    (is (nil? (cleanup/observe-workflow-signal! {} {:execution/status :completed} {} nil)))))
+
+;; ============================================================================
+;; promote-mature-learnings!
+;; ============================================================================
+
+(deftest promote-mature-learnings-nil-store-test
+  (testing "returns empty vector when knowledge-store is nil"
+    (is (= [] (cleanup/promote-mature-learnings! nil)))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_defaults_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_defaults_test.clj
@@ -1,0 +1,37 @@
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.workflow.runner-defaults-test
+  "Tests for runner configuration-as-data defaults."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.workflow.runner-defaults :as defaults]))
+
+(deftest max-phases-test
+  (testing "returns a positive integer"
+    (is (pos-int? (defaults/max-phases)))))
+
+(deftest max-backoff-ms-test
+  (testing "returns a positive integer"
+    (is (pos-int? (defaults/max-backoff-ms)))))
+
+(deftest backoff-base-ms-test
+  (testing "returns a positive integer"
+    (is (pos-int? (defaults/backoff-base-ms)))))
+
+(deftest pause-poll-interval-ms-test
+  (testing "returns a positive integer"
+    (is (pos-int? (defaults/pause-poll-interval-ms)))))
+
+(deftest default-workdir-test
+  (testing "returns a non-blank string"
+    (is (string? (defaults/default-workdir)))
+    (is (not (clojure.string/blank? (defaults/default-workdir))))))
+
+(deftest task-branch-prefix-test
+  (testing "returns a non-blank string"
+    (is (string? (defaults/task-branch-prefix)))))
+
+(deftest default-docker-image-test
+  (testing "returns a non-blank string"
+    (is (string? (defaults/default-docker-image)))
+    (is (clojure.string/includes? (defaults/default-docker-image) ":"))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -224,9 +224,10 @@
 ;; ---------------------------------------------------------------------------- persist-workspace-at-phase-boundary!
 
 (def ^:private persist-fn
-  "Var accessor for private persist-workspace-at-phase-boundary!."
-  (var-get (ns-resolve 'ai.miniforge.workflow.runner
-                       'persist-workspace-at-phase-boundary!)))
+  "Var accessor for persist-workspace-at-phase-boundary! (extracted to runner-environment)."
+  (do (require 'ai.miniforge.workflow.runner-environment)
+      (ns-resolve 'ai.miniforge.workflow.runner-environment
+                  'persist-workspace-at-phase-boundary!)))
 
 (deftest persist-workspace-noop-when-no-executor-test
   (testing "returns nil when context has no :execution/executor"

--- a/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
@@ -1,10 +1,12 @@
 ;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 
 (ns ai.miniforge.workflow.runner-iteration-test
-  "Tests for iteration helpers extracted from runner.clj."
+  "Tests for iteration helpers extracted from runner.clj.
+   Includes slingshot try+/throw+ bb-compatibility tests."
   (:require
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.workflow.runner :as runner]))
+   [ai.miniforge.workflow.runner :as runner]
+   [slingshot.slingshot :refer [try+ throw+]]))
 
 ;; Access private fns
 (def ^:private rate-limited? #'runner/rate-limited?)
@@ -68,3 +70,46 @@
     (let [err (make-execution-error :test-error "broke" {:data {:code 42}})]
       (is (= :test-error (:type err)))
       (is (= 42 (get-in err [:data :code]))))))
+
+;; ============================================================================
+;; slingshot try+/throw+ — bb compatibility tests
+;; ============================================================================
+
+(deftest slingshot-throw-plus-map-test
+  (testing "throw+ with map is caught by key-value selector"
+    (let [result (try+
+                   (throw+ {:type :rate-limited :status 429 :message "slow down"})
+                   (catch [:type :rate-limited] {:keys [status message]}
+                     {:caught true :status status :message message}))]
+      (is (true? (:caught result)))
+      (is (= 429 (:status result)))
+      (is (= "slow down" (:message result))))))
+
+(deftest slingshot-catches-ex-info-by-key-test
+  (testing "try+ catches existing ex-info throws by key-value selector"
+    (let [result (try+
+                   (throw (ex-info "gate failed" {:type :gate-failed :gate :lint}))
+                   (catch [:type :gate-failed] {:keys [gate]}
+                     {:caught true :gate gate}))]
+      (is (true? (:caught result)))
+      (is (= :lint (:gate result))))))
+
+(deftest slingshot-fallthrough-to-object-test
+  (testing "try+ falls through to Object catch for non-matching ex-info throws"
+    (let [result (try+
+                   (throw (ex-info "other error" {:type :unknown}))
+                   (catch [:type :rate-limited] _
+                     {:caught :rate-limited})
+                   (catch Object obj
+                     {:caught :fallback :type (:type obj)}))]
+      (is (= :fallback (:caught result)))
+      (is (= :unknown (:type result))))))
+
+(deftest slingshot-dashboard-stop-test
+  (testing "check-stopped! throw+ is caught by :type selector"
+    (let [result (try+
+                   (throw+ {:type :dashboard-stop :reason :dashboard-stop :message "stopped"})
+                   (catch [:type :dashboard-stop] {:keys [message]}
+                     {:caught true :message message}))]
+      (is (true? (:caught result)))
+      (is (= "stopped" (:message result))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
@@ -1,0 +1,70 @@
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.workflow.runner-iteration-test
+  "Tests for iteration helpers extracted from runner.clj."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.workflow.runner :as runner]))
+
+;; Access private fns
+(def ^:private rate-limited? #'runner/rate-limited?)
+(defn- backoff-ms [n] (#'runner/backoff-ms n))
+(def ^:private make-execution-error #'runner/make-execution-error)
+
+;; ============================================================================
+;; rate-limited?
+;; ============================================================================
+
+(deftest rate-limited-detects-429-test
+  (testing "detects HTTP 429 in error message"
+    (is (true? (rate-limited? "HTTP 429 Too Many Requests")))))
+
+(deftest rate-limited-detects-rate-limit-test
+  (testing "detects 'rate limit' phrase"
+    (is (true? (rate-limited? "You've hit your rate limit")))))
+
+(deftest rate-limited-detects-quota-exceeded-test
+  (testing "detects quota exceeded"
+    (is (true? (rate-limited? "API quota exceeded for this model")))))
+
+(deftest rate-limited-false-for-normal-errors-test
+  (testing "returns false for non-rate-limit errors"
+    (is (false? (rate-limited? "Syntax error on line 10")))
+    (is (false? (rate-limited? "Connection refused")))
+    (is (false? (rate-limited? "")))))
+
+(deftest rate-limited-handles-nil-test
+  (testing "handles nil input"
+    (is (false? (rate-limited? nil)))))
+
+;; ============================================================================
+;; backoff-ms
+;; ============================================================================
+
+(deftest backoff-ms-first-retry-test
+  (testing "first retry uses base backoff"
+    (is (= 1000 (backoff-ms 1)))))
+
+(deftest backoff-ms-doubles-test
+  (testing "second retry doubles"
+    (is (= 2000 (backoff-ms 2)))))
+
+(deftest backoff-ms-capped-test
+  (testing "large retry count is capped at max"
+    (is (<= (backoff-ms 100) 30000))))
+
+;; ============================================================================
+;; make-execution-error
+;; ============================================================================
+
+(deftest make-execution-error-basic-test
+  (testing "produces map with :type and :message"
+    (let [err (make-execution-error :test-error "something broke")]
+      (is (= :test-error (:type err)))
+      (is (= "something broke" (:message err))))))
+
+(deftest make-execution-error-with-extra-test
+  (testing "merges extra data"
+    (let [err (make-execution-error :test-error "broke" {:data {:code 42}})]
+      (is (= :test-error (:type err)))
+      (is (= 42 (get-in err [:data :code]))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_pipeline_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_pipeline_test.clj
@@ -7,14 +7,15 @@
    Layer 1: Tests"
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.workflow.runner :as runner]))
+   [ai.miniforge.workflow.runner :as runner]
+   [ai.miniforge.workflow.runner-cleanup :as cleanup]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Factories — access private fns via var
 
 (def ^:private validate-completion #'runner/validate-completion)
 (def ^:private execute-pipeline-loop #'runner/execute-pipeline-loop)
-(def ^:private post-workflow-cleanup! #'runner/post-workflow-cleanup!)
+(def ^:private post-workflow-cleanup! cleanup/post-workflow-cleanup!)
 (def ^:private wrap-phase-callbacks #'runner/wrap-phase-callbacks)
 (def ^:private acquire-environment #'runner/acquire-environment)
 

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -273,7 +273,7 @@
   (testing "when no executor in opts and acquisition yields nil, env keys are absent"
     ;; Force acquisition to return nil for deterministic test isolation.
     ;; Verifies the safe-nil path: acquisition failure → no env keys.
-    (let [acquire-var (resolve 'ai.miniforge.workflow.runner/acquire-execution-environment!)]
+    (let [acquire-var (resolve 'ai.miniforge.workflow.runner-environment/acquire-execution-environment!)]
       (with-redefs-fn
         {acquire-var (fn [& _] nil)}
         (fn []


### PR DESCRIPTION
## Summary

- **runner.clj** reduced from 747 to 363 lines by extracting three focused namespaces:
  - **runner_events.clj** (164 lines): `publish-event!`, `publish-workflow-started!`, `publish-workflow-completed!`, `publish-phase-started!`, `publish-phase-completed!`, `check-backend-health-at-boundary!`
  - **runner_environment.clj** (167 lines): `dag-executor-fns`, `registry-config-for-mode`, `select-capsule-executor`, `assert-executor-for-mode!`, `build-env-record`, `acquire-execution-environment!`, `release-execution-environment!`, `persist-workspace-at-phase-boundary!`
  - **runner_cleanup.clj** (110 lines): `promote-mature-learnings!`, `synthesize-patterns!`, `observe-workflow-signal!`, `post-workflow-cleanup!`
- Public API re-exported via `def` aliases — zero external call site changes needed
- Extracted `rate-limited?` predicate and `backoff-ms` function from inline logic
- Named magic constants: `max-backoff-ms`, `backoff-base-ms`
- Updated test references for `persist-workspace-at-phase-boundary!` and `post-workflow-cleanup!`

## Test plan

- [x] Lint: 0 errors, 0 warnings
- [x] All workflow brick tests pass (0 failures, 0 errors)
- [x] `runner_extended_test.clj` updated for `persist-fn` resolution
- [x] `runner_pipeline_test.clj` updated for `post-workflow-cleanup!` resolution
- [ ] Manual: `bb miniforge run` with a spec — verify full pipeline still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)