### PR TITLE
spec: add TUI workstream specs and retire Phase 0 spec to done

### DIFF
--- a/work/done/tui-meta-control-plane.spec.edn
+++ b/work/done/tui-meta-control-plane.spec.edn
@@ -1,0 +1,103 @@
+;; Miniforge Control Console — Phase 0: Rust Core + TUI
+;;
+;; Normative contract: specs/normative/N5-delta-2-meta-control-plane.md
+;; Scope: Rust workspace, supervisory state, event client, ratatui monitor
+;; Out of scope: macOS native app, embedded agent CLI, decision resolution UX
+;;   (these are future phases, spec'd after Phase 0 validates the core)
+
+{:spec/id "control-console-phase-0"
+ :spec/version "0.1.0"
+ :spec/created "2026-04-10"
+ :spec/status "draft"
+ :spec/type :work-spec
+ :spec/depends-on ["N5-delta-2-meta-control-plane-v1"]
+
+ :title "Control Console Phase 0 — Rust Core + TUI"
+
+ :problem
+ "Miniforge needs a control surface that is not the Clojure TUI (JVM startup,
+  limited rendering, dual-model risk) and not the web dashboard (high latency,
+  OBSERVE-only). The architecture is Rust core + platform renderers (Thesium
+  pattern). Phase 0 builds the Rust core and a ratatui terminal renderer,
+  shipping a single binary (miniforge-console) that replaces the Clojure TUI."
+
+ :architecture
+ "miniforge-control/
+    Cargo.toml                     workspace root
+    crates/
+      contracts/                   supervisory entity types (serde structs)
+      state/                       state manager + projection builders
+      event-client/                subscribe to miniforge event stream
+      ffi/                         C-ABI facade (for future native shells)
+      tui/                         ratatui monitor (binary target)
+
+  The tui crate uses state/ and event-client/ as direct dependencies
+  (in-process, no FFI). ffi/ exists so the native app (Phase 1) can
+  load the core as a dylib — but Phase 0 only validates that it compiles."
+
+ :plan/tasks
+
+ [{:task/id :workspace-and-contracts
+   :task/description
+   "Create Rust workspace. Define supervisory entity structs in contracts/:
+    WorkflowRun, PolicyEvaluation, AttentionItem, AgentSession, PrFleetEntry.
+    Derive Serialize/Deserialize. Test against JSON fixtures from the Clojure
+    event stream (sample event files from ~/.miniforge/events/)."
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :event-client
+   :task/description
+   "Rust event stream client in event-client/. Watches ~/.miniforge/events/
+    for new .edn files (notify crate for file watching). Parses events into
+    contract types. On startup, replays recent events for durable state.
+    Emits parsed events to a channel (crossbeam or tokio mpsc)."
+   :task/type :implement
+   :task/dependencies [:workspace-and-contracts]}
+
+  {:task/id :state-manager
+   :task/description
+   "State manager in state/. Consumes events from event-client channel.
+    Maintains canonical supervisory state. Computes projections:
+    - workflow_ticker() -> active/recent workflow rows
+    - agent_sessions() -> agent status rows
+    - pr_fleet() -> PR summary
+    - attention() -> derived attention items
+    Projections are pure functions of state. Notify subscribers on change."
+   :task/type :implement
+   :task/dependencies [:workspace-and-contracts]}
+
+  {:task/id :tui-monitor
+   :task/description
+   "ratatui monitor screen in tui/. Renders projections from state manager:
+    - Agent sessions zone
+    - Workflow ticker zone
+    - PR fleet zone
+    - Attention bar
+    Keyboard: j/k navigate, Enter drill-down (placeholder), Esc back, q quit.
+    Responsive: 60-col stacked, 80-col split, 120+ full.
+    Binary: miniforge-console [--headless] (headless prints JSON projections)."
+   :task/type :implement
+   :task/dependencies [:state-manager :event-client]}
+
+  {:task/id :ffi-scaffold
+   :task/description
+   "C-ABI facade in ffi/. Expose init/dispatch/subscribe/string_free symbols.
+    Phase 0 scope: symbols compile and export correctly. Dispatch handles
+    a :status command returning state summary as JSON. Subscribe delivers
+    events via callback. This validates the boundary for Phase 1 (native app)
+    without building the Swift side."
+   :task/type :implement
+   :task/dependencies [:state-manager]}]
+
+ :spec/acceptance-criteria
+ ["miniforge-console launches in under 200ms"
+  "Start a workflow from Claude Code → monitor shows it within 2s"
+  "Attention items derive automatically from supervisory state"
+  "Works at 60 columns in a tmux pane"
+  "cargo build --release produces a single binary under 20MB"
+  "--headless mode prints JSON projections to stdout"
+  "FFI symbols export and basic dispatch round-trips JSON"]
+
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"}

--- a/work/tui-ws1-supervisory-domain.spec.edn
+++ b/work/tui-ws1-supervisory-domain.spec.edn
@@ -1,0 +1,166 @@
+;; WS1 — Supervisory Domain Formalization
+;;
+;; Phase 1 of the TUI Supervisory Control Plane work spec.
+;; Introduces Malli schemas for v1 supervisory entities, projection builders
+;; for monitor zones, and PR governance state derivation.
+;;
+;; Parent work spec: work/tui-supervisory-control-plane.spec.edn
+;; Normative contract: specs/normative/N5-delta-supervisory-control-plane.md
+
+{:spec/id "tui-ws1-supervisory-domain"
+ :spec/version "0.1.0"
+ :spec/created "2026-04-02"
+ :spec/status "active"
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :spec/title "WS1: Supervisory Domain Formalization"
+
+ :spec/description
+ "Make supervisory entities explicit so the monitor renders from canonical
+  data, not ad-hoc model keys. Introduces open Malli schemas for the v1
+  entities (WorkflowRun, PolicyEvaluation, PolicyViolation, AttentionItem,
+  Waiver, EvidenceBundle), pure projection builders for each monitor zone,
+  and explicit PR governance state derivation.
+
+  This is foundation work — without it the monitor will be visually improved
+  but architecturally brittle."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/tui-views"
+          "components/policy-pack"
+          "components/evidence-bundle"]}
+
+ :spec/constraints
+ ["Schemas MUST be open Malli :map — validate required keys, extra keys pass through"
+  "Projection builders MUST be pure functions with stable input/output contracts"
+  "PR governance state MUST be derived from PolicyEvaluation + Waiver records, never hardcoded"
+  "Prefer placing schemas in existing components over creating new ones to avoid circular deps"
+  "All tests must pass with bb test"]
+
+ :spec/acceptance-criteria
+ ["Monitor zones can be described in terms of projection builders"
+  "No view depends on hidden ad-hoc state for supervisory meaning"
+  "PR governance state is always derivable, never hardcoded"
+  "Malli schema validates a well-formed WorkflowRun with open keys"
+  "Missing required keys fail validation"]
+
+ :title "WS1: Supervisory Domain Formalization"
+
+ :description
+ "Formalize the supervisory entities that the TUI monitor will render.
+  Today the TUI model has raw data maps with implicit business logic
+  scattered across view code. This workstream introduces canonical schemas,
+  projection builders, and governance state derivation so the monitor
+  surface operates on well-defined data."
+
+ :context
+ {:normative-refs
+  ["N5-delta-supervisory-control-plane §3 — v1 supervisory entities"
+   "N5-delta-supervisory-control-plane §4 — PR governance states"
+   "N5-delta-supervisory-control-plane §5 — attention derivation rules"]
+
+  :current-state
+  ["TUI model has :workflows, :pr-items, :trains as raw data vectors"
+   "View code in project.clj does ad-hoc projections with implicit logic"
+   "No formal schema for workflow runs or policy evaluations"
+   "PR governance state (passing/failing/waived) is implicit"]
+
+  :existing-components
+  ["tui-views/model.clj — TUI state shape and init-model"
+   "tui-views/view/project.clj — current ad-hoc data projections"
+   "policy-pack/schema.clj — existing policy schema definitions"
+   "evidence-bundle — evidence storage and retrieval"
+   "control-plane/registry.clj — agent session model (AgentSession already exists)"]}
+
+ :plan/tasks
+ [{:task/id :supervisory-entity-schemas
+   :task/description
+   "Define open Malli schemas for the 6 v1 supervisory entities in a new
+    namespace (or extend existing schema namespaces). Each schema validates
+    required keys but allows extra keys to pass through.
+
+    Entities and their minimum required keys:
+    - WorkflowRun: :workflow/id, :workflow/key, :workflow/status, :workflow/phase, :workflow/started-at
+    - PolicyEvaluation: :eval/id, :eval/pr-id, :eval/result, :eval/rules-applied, :eval/evaluated-at
+    - PolicyViolation: :violation/id, :violation/eval-id, :violation/rule, :violation/category, :violation/severity
+    - AttentionItem: :attention/id, :attention/severity, :attention/summary, :attention/source-type, :attention/source-id
+    - Waiver: :waiver/id, :waiver/eval-id, :waiver/actor, :waiver/reason, :waiver/created-at
+    - EvidenceBundle: :evidence/id, :evidence/workflow-id, :evidence/entries
+
+    Place schemas where they avoid circular dependencies. The tui-views
+    component or a shared schema component are good candidates.
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/schema.clj (extend)
+           OR new namespace depending on dependency analysis
+    Tests: Malli validates well-formed entities, extra keys pass, missing required keys fail"
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :projection-builders
+   :task/description
+   "Define pure projection functions with stable input/output contracts for
+    each monitor zone. These replace the ad-hoc pattern where views reach
+    into raw model keys with implicit business logic.
+
+    Required projections:
+    - workflow-ticker: [supervisory-state] -> [{:run ... :status ... :phase ... :duration ...}]
+      Sorted active-first, then by started-at descending.
+    - pr-train-strip: [supervisory-state] -> {:train-progress ... :fleet-summary ...}
+      Shows train completion ratio and fleet aggregate counts.
+    - policy-health: [supervisory-state] -> {:pass-rate ... :violations-by-category ... :governance-counts ...}
+      Computes pass rate from evaluations, groups violations by category.
+    - attention: [supervisory-state] -> [{:severity ... :summary ... :source-type ... :source-id ... :created-at ...}]
+      Derives attention items from model state per normative delta §5.
+
+    Each projection must return a stable shape when the model is empty
+    (no nil, no crash — empty collections and zero counts).
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/view/project.clj (refactor)
+           OR new projection namespace
+    Tests: Each projection returns correct shape for populated and empty state"
+   :task/type :implement
+   :task/dependencies [:supervisory-entity-schemas]}
+
+  {:task/id :governance-state-derivation
+   :task/description
+   "Implement PR governance state derivation per normative delta §4.
+    A PR's governance state is one of:
+    - :not-evaluated — no PolicyEvaluation exists for this PR
+    - :policy-passing — latest evaluation result is :pass
+    - :policy-failing — latest evaluation result is :fail, no Waiver exists
+    - :waived — latest evaluation result is :fail, but a Waiver record exists
+    - :escalated — PR has been explicitly escalated
+
+    Implement as a pure function:
+    (derive-governance-state pr-id evaluations waivers) -> keyword
+
+    This function is used by the policy-health projection builder and the
+    PR fleet/train views. It must never be hardcoded per PR — always derived
+    from the evaluation and waiver records.
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+           OR the projection namespace from :projection-builders
+    Tests: Each governance state transition tested (no eval, passing, failing, waived)"
+   :task/type :implement
+   :task/dependencies [:supervisory-entity-schemas]}
+
+  {:task/id :ws1-tests
+   :task/description
+   "Verify all WS1 deliverables:
+    1. Malli schema validates well-formed WorkflowRun, PolicyEvaluation, etc.
+    2. Extra keys pass validation without error (open schema)
+    3. Missing required keys fail validation
+    4. Workflow ticker projection returns sorted active-first list
+    5. Policy health projection computes correct pass rate
+    6. Attention projection derives items from model state
+    7. All projections return stable shapes when model is empty
+    8. PR governance state derivation handles all 4 states correctly
+
+    Run: bb test
+    Files: components/tui-views/test/..."
+   :task/type :test
+   :task/dependencies [:supervisory-entity-schemas
+                       :projection-builders
+                       :governance-state-derivation]}]}

--- a/work/tui-ws2-durable-startup.spec.edn
+++ b/work/tui-ws2-durable-startup.spec.edn
@@ -1,0 +1,191 @@
+;; WS2 — Durable Startup, Replay, and Live Subscription
+;;
+;; Phase 1 of the TUI Supervisory Control Plane work spec.
+;; Ensures the TUI is useful immediately on startup and stays current
+;; via live event subscription across three event families.
+;;
+;; Parent work spec: work/tui-supervisory-control-plane.spec.edn
+;; Normative contract: specs/normative/N5-delta-supervisory-control-plane.md
+
+{:spec/id "tui-ws2-durable-startup"
+ :spec/version "0.1.0"
+ :spec/created "2026-04-02"
+ :spec/status "active"
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :spec/title "WS2: Durable Startup, Replay, and Live Subscription"
+
+ :spec/description
+ "The TUI must be useful immediately on startup and stay current during
+  active runs. This is the #1 functional gap today. Covers startup load of
+  recent supervisory state from disk, live event subscription across three
+  event families (:workflow/*, :pr-monitor/*, :control-plane/*), and
+  graceful degradation when live subscription is unavailable."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/tui-views"
+          "components/event-stream"]}
+
+ :spec/constraints
+ ["Startup must load from existing persistence paths (~/.miniforge/workflows/, PR sync cache)"
+  "Event handlers must translate domain events into TUI model updates via the Elm update loop"
+  "Stale state must never appear indistinguishable from live state"
+  "Empty disk state must produce a valid empty model, not nil or crash"
+  "All tests must pass with bb test"]
+
+ :spec/acceptance-criteria
+ ["Launching TUI with no active workflow shows recent runs and PR state"
+  "Starting a workflow from Claude Code updates TUI in real time"
+  "Restarting TUI reconstructs state without requiring fresh activity"
+  "Subscription outage does not yield empty screen"
+  "PR monitor loop events update PR monitoring status in model"
+  "Control plane agent discovery events update agent display"]
+
+ :title "WS2: Durable Startup, Replay, and Live Subscription"
+
+ :description
+ "Fix startup state loading and wire live event subscription so the TUI
+  always has something to show and stays current. The standalone TUI already
+  calls persistence/load-workflows-into-model on startup, but PR state,
+  policy evaluations, and agent sessions are not loaded. Live event handling
+  exists for :workflow/* events but is incomplete, and :pr-monitor/* and
+  :control-plane/* event families are not wired at all."
+
+ :context
+ {:normative-refs
+  ["N5-delta-supervisory-control-plane §7 — durability and replay"
+   "N5-delta-supervisory-control-plane §5 — event families"
+   "N3 §3.x — :pr-monitor/* event types"]
+
+  :current-state
+  ["Standalone TUI startup loads workflows from disk via persistence/load-workflows-into-model"
+   "PR state and policy evaluations not loaded on startup"
+   "subscription.clj translates :workflow/* events to TUI messages"
+   "No handlers for :pr-monitor/* events (13 event types in monitor_events.clj)"
+   "No handlers for :control-plane/* events (agent discovery, status, decisions)"
+   "No stale-state indicator when subscription is unavailable"]
+
+  :existing-components
+  ["tui-views/subscription.clj — event-stream subscription bridge"
+   "tui-views/persistence.clj — workflow loading from disk"
+   "tui-views/interface.clj — start-tui!, start-standalone-tui!"
+   "pr-lifecycle/monitor_events.clj — 13 :pr-monitor/* event constructors"
+   "control-plane/orchestrator.clj — emits :control-plane/* events"
+   "control-plane/registry.clj — agent session CRUD"]}
+
+ :plan/tasks
+ [{:task/id :startup-load
+   :task/description
+   "Extend the TUI startup path to load recent supervisory state from disk.
+
+    Currently: start-standalone-tui! calls persistence/load-workflows-into-model
+    to populate :workflows from ~/.miniforge/workflows/.
+
+    Add:
+    1. Load PR state from the GitHub sync cache (pr-items, train state)
+    2. Load policy evaluation results from pr-cache if present
+    3. Derive governance states for loaded PRs using the derivation fn from WS1
+    4. Load agent sessions from control-plane registry if control-plane is active
+    5. Derive initial attention items from loaded state
+
+    The startup path must handle missing/empty data gracefully — each load
+    step that finds no data should produce an empty collection, not fail.
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/persistence.clj
+           components/tui-views/src/ai/miniforge/tui_views/interface.clj
+    Tests: Model populated after init with disk data, empty disk = valid empty model"
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :live-event-subscription
+   :task/description
+   "Wire event-stream subscription to update supervisory projections during
+    active runs. Extend subscription.clj translate-event to handle all three
+    event families.
+
+    :workflow/* events (extend existing handlers):
+    - :workflow/started → add WorkflowRun to model :workflows
+    - :workflow/phase-changed → update :workflow/phase and :workflow/status
+    - :agent/status → update agent activity text for the workflow
+    - :gate/evaluated → append gate result, re-derive governance state
+    - :workflow/completed → set terminal status :completed
+    - :workflow/failed → set terminal status :failed with error info
+    - :pr/synced → update PR data in :pr-items, re-derive governance state
+
+    :pr-monitor/* events (NEW — from pr-lifecycle/monitor_events.clj):
+    - :pr-monitor/loop-started → mark PR as actively monitored in model
+    - :pr-monitor/comment-received → increment pending comment count on PR
+    - :pr-monitor/comment-classified → update comment classification
+    - :pr-monitor/fix-started → show fix-in-progress for PR
+    - :pr-monitor/fix-pushed → update PR with new commit SHA
+    - :pr-monitor/reply-posted → decrement pending count, update last action
+    - :pr-monitor/budget-warning → derive warning attention item
+    - :pr-monitor/budget-exhausted → derive critical attention item
+    - :pr-monitor/escalated → derive critical attention item
+    - :pr-monitor/cycle-completed → update cycle stats on PR
+    - :pr-monitor/loop-stopped → mark PR monitoring as inactive
+
+    :control-plane/* events (NEW — from control-plane/orchestrator.clj):
+    - :control-plane/agent-discovered → add agent session to model
+    - :control-plane/status-changed → update agent status/task display
+    - :control-plane/decision-submitted → add pending decision, mark agent blocked
+    - :control-plane/decision-resolved → clear pending decision, unblock agent
+
+    Each handler translates the domain event into a TUI msg for the Elm
+    update loop. Use the existing msg/make-msg pattern.
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/subscription.clj
+           components/tui-views/src/ai/miniforge/tui_views/msg.clj (new msg types)
+           components/tui-views/src/ai/miniforge/tui_views/update.clj (new handlers)
+    Tests: Each event family produces correct model updates"
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :stale-read-degradation
+   :task/description
+   "When live subscription is unavailable, display stale state from the
+    most recent startup load with a visible indicator.
+
+    Implementation:
+    1. Track :subscription/status in the model (:connected, :disconnected, :stale)
+    2. Track :subscription/last-event-at timestamp
+    3. After N seconds (configurable, default 30) with no events while a
+       workflow is expected to be active, set status to :stale
+    4. Render a stale indicator in the status bar: '⊘ stale (last: 2m ago)'
+    5. When events resume, clear the stale indicator
+
+    The stale indicator must be visible but not alarming — it's informational,
+    not an error. Use a dim/muted color from the palette.
+
+    Do NOT show an empty screen when stale. Show the last-known state.
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/model.clj (add keys)
+           components/tui-views/src/ai/miniforge/tui_views/subscription.clj
+           components/tui-views/src/ai/miniforge/tui_views/view.clj (status bar)
+    Tests: Stale indicator appears after timeout, disappears on event resume"
+   :task/type :implement
+   :task/dependencies [:live-event-subscription]}
+
+  {:task/id :ws2-tests
+   :task/description
+   "Integration tests for WS2:
+    1. Workflows from disk appear in model after init
+    2. PR state loaded from cache on startup
+    3. Empty disk state produces valid empty model, not nil/crash
+    4. Model updates when workflow phase changes during active run
+    5. Gate results accumulate in real time
+    6. Completed/failed events set terminal status
+    7. PR monitor events update PR monitoring state in model
+    8. Budget exhaustion from monitor loop creates attention item
+    9. Agent discovered event adds agent session to model
+    10. Stale indicator visible when subscription disconnected
+    11. Stale indicator clears when live events resume
+
+    Run: bb test
+    Files: components/tui-views/test/..."
+   :task/type :test
+   :task/dependencies [:startup-load
+                       :live-event-subscription
+                       :stale-read-degradation]}]}

--- a/work/tui-ws3-monitor-mode.spec.edn
+++ b/work/tui-ws3-monitor-mode.spec.edn
@@ -1,0 +1,177 @@
+;; WS3 — Monitor Mode
+;;
+;; Phase 2 of the TUI Supervisory Control Plane work spec.
+;; The default supervisory surface — a single-screen dashboard answering
+;; "what are my agents doing?" at a glance.
+;;
+;; Parent work spec: work/tui-supervisory-control-plane.spec.edn
+;; Normative contract: specs/normative/N5-delta-supervisory-control-plane.md
+;; Depends on: tui-ws1-supervisory-domain, tui-ws2-durable-startup
+
+{:spec/id "tui-ws3-monitor-mode"
+ :spec/version "0.1.0"
+ :spec/created "2026-04-02"
+ :spec/status "active"
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :spec/title "WS3: Monitor Mode"
+
+ :spec/description
+ "Build the default :monitor screen — a single-screen dashboard with zones
+  for agent sessions, workflow ticker, PR train/fleet, attention bar, and
+  policy health. Responsive from 60 to 200+ columns for tmux side-pane use.
+  This is the first dogfooding milestone."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/tui-views"
+          "components/tui-engine"]}
+
+ :spec/constraints
+ ["Monitor must be legible at 60 columns (tmux right pane)"
+  "Monitor must be the default view on startup (replaces :pr-fleet)"
+  "Selection and drill-down must use existing view navigation patterns"
+  "Zones must render from projection builders (WS1), not raw model keys"
+  "Empty state must show guidance, not blank screen"
+  "All tests must pass with bb test"]
+
+ :spec/acceptance-criteria
+ ["Monitor mode useful in a tmux right pane at 60 columns"
+  "Active workflows and PR disposition visible without navigation"
+  "Attention items visible without drilling in"
+  "Monitor is the default view on startup"
+  "Enter drills into selected item, Esc returns"]
+
+ :title "WS3: Monitor Mode"
+
+ :description
+ "The monitor screen is the first genuinely useful dogfooding milestone.
+  It replaces :pr-fleet as the default view and provides a single-screen
+  dashboard that the user can keep in a tmux right pane while agents work
+  in Claude Code or Codex. No navigation required to see what's happening."
+
+ :context
+ {:normative-refs
+  ["N5-delta-supervisory-control-plane §6 — monitor mode requirements"
+   "N5-delta-supervisory-control-plane §6.2 — responsive layout"]
+
+  :current-state
+  ["Default view is :pr-fleet"
+   "No :monitor view exists"
+   "Existing views are full-screen single-purpose (workflow-list, pr-fleet, etc.)"
+   "screens.edn defines 10 view configurations"
+   "model/init-model sets :view to :pr-fleet"
+   "tui-engine handles terminal width detection"]
+
+  :existing-components
+  ["tui-views/model.clj — model shape, init-model, top-level-views"
+   "tui-views/view.clj — view dispatch and rendering"
+   "tui-views/views/ — existing view implementations (11 files)"
+   "tui-views/resources/config/tui/screens.edn — declarative view config"
+   "tui-engine — Lanterna-based terminal renderer with width detection"]}
+
+ :plan/tasks
+ [{:task/id :monitor-screen
+   :task/description
+   "Create the :monitor view — a new single-screen dashboard with zones.
+
+    Layout (vertical stack):
+    ┌─ Agent Sessions (when control plane active) ─────────────┐
+    │ [icon] agent-name  status  task  heartbeat                │
+    ├─ Workflow Ticker ─────────────────────────────────────────┤
+    │ [status] name  phase  duration  agent-status              │
+    ├─ PR Train / Fleet ────────────────────────────────────────┤
+    │ Train: ▓▓▓░░ 3/5 merged  or  Fleet: 12 open │ 3 ready   │
+    │ Per-PR monitor status when active                         │
+    ├─ Policy Health (when width permits) ──────────────────────┤
+    │ Pass rate: 87%  Top violations: missing-tests (3)         │
+    ├─ Attention Bar ───────────────────────────────────────────┤
+    │ ● workflow failed: fix-login  ▲ PR blocked: #247          │
+    └───────────────────────────────────────────────────────────┘
+
+    Each zone renders from its corresponding projection builder (WS1).
+    Selection: arrow keys move between zones/items, Enter drills into
+    the selected workflow/PR/agent detail view, Esc returns to monitor.
+
+    Empty zones show a single-line placeholder (e.g., 'No active workflows').
+
+    Create the view implementation following the pattern of existing views
+    (workflow_list.clj, pr_fleet.clj). Register in screens.edn.
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/views/monitor.clj (new)
+           components/tui-views/resources/config/tui/screens.edn (add :monitor)
+           components/tui-views/src/ai/miniforge/tui_views/view.clj (add dispatch)
+    Tests: Monitor renders with all zones populated, empty state shows guidance"
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :narrow-width-rendering
+   :task/description
+   "Make the monitor mode responsive from 60 to 200+ columns.
+
+    At 60-80 cols (tmux right pane):
+    - Workflow rows: status-icon + name (truncated to 15 chars) + phase + duration
+    - PR rows: #number + governance-icon
+    - Attention: icon + truncated summary
+    - Drop box borders (save 2 columns)
+    - Abbreviated footer keybindings
+
+    At 80-120 cols:
+    - Add agent status column to workflow rows
+    - Add PR title column (truncated)
+    - Full footer with keybindings
+
+    At 120+ cols:
+    - Full-width tables matching existing layout conventions
+    - Policy health zone always visible
+
+    Width detection: use terminal cols from tui-engine on startup and
+    on resize events. Store in model as :terminal/cols.
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/views/monitor.clj
+    Tests: Table renders without overflow at 60 columns, text truncation with ellipsis"
+   :task/type :implement
+   :task/dependencies [:monitor-screen]}
+
+  {:task/id :monitor-as-default
+   :task/description
+   "Make :monitor the default view on TUI startup.
+
+    Changes:
+    1. model/init-model: change :view from :pr-fleet to :monitor
+    2. model/top-level-views: add :monitor as first entry
+    3. screens.edn: add :monitor view configuration
+    4. Ensure Tab cycles through views with :monitor first
+    5. Ensure Esc from any detail view returns to :monitor (not :workflow-list)
+
+    Existing views remain accessible — this only changes the default.
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/model.clj
+           components/tui-views/resources/config/tui/screens.edn
+    Tests: TUI starts in :monitor view, Tab cycles to existing views,
+           Esc from detail returns to :monitor"
+   :task/type :implement
+   :task/dependencies [:monitor-screen]}
+
+  {:task/id :ws3-tests
+   :task/description
+   "Verify all WS3 deliverables:
+    1. Monitor renders with all zones populated
+    2. Workflow ticker shows active workflows with correct status characters
+    3. PR zone shows train progress or fleet summary
+    4. Attention bar surfaces derived items
+    5. Enter drills into selected item
+    6. Esc returns to monitor from any detail view
+    7. Empty state shows guidance, not blank screen
+    8. Table renders without overflow at 60 columns
+    9. Text truncation with ellipsis for long names
+    10. TUI starts in :monitor view
+    11. Tab cycles to existing views
+
+    Run: bb test
+    Files: components/tui-views/test/..."
+   :task/type :test
+   :task/dependencies [:monitor-screen
+                       :narrow-width-rendering
+                       :monitor-as-default]}]}

--- a/work/tui-ws4-governance-surface.spec.edn
+++ b/work/tui-ws4-governance-surface.spec.edn
@@ -1,0 +1,168 @@
+;; WS4 — Governance Surface
+;;
+;; Phase 3 of the TUI Supervisory Control Plane work spec.
+;; Answers "are my review policies working?" from the monitor.
+;;
+;; Parent work spec: work/tui-supervisory-control-plane.spec.edn
+;; Normative contract: specs/normative/N5-delta-supervisory-control-plane.md
+;; Depends on: tui-ws1-supervisory-domain, tui-ws3-monitor-mode
+
+{:spec/id "tui-ws4-governance-surface"
+ :spec/version "0.1.0"
+ :spec/created "2026-04-02"
+ :spec/status "active"
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :spec/title "WS4: Governance Surface"
+
+ :spec/description
+ "Expose policy-governed review as a first-class supervisory concern.
+  Aggregate policy health in the monitor, implement Waiver entity persistence,
+  and build governance drill-down from violations to evidence. This is where
+  the TUI becomes more than a workflow progress screen."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/tui-views"
+          "components/policy-pack"
+          "components/evidence-bundle"]}
+
+ :spec/constraints
+ ["Waiver records MUST be separate durable records — never mutate original PolicyEvaluation"
+  "Governance state MUST be derived from evaluations + waivers (WS1 derivation fn)"
+  "Waived PRs MUST remain visibly waived, not appear as passing"
+  "Drill-down must use existing view navigation patterns (Enter/Esc)"
+  "All tests must pass with bb test"]
+
+ :spec/acceptance-criteria
+ ["User can answer 'are my review policies working?' from monitor"
+  "Failing/waived/passing states visually distinct"
+  "Drill-down shows evidence behind governance disposition"
+  "Waiver recorded with reason, loaded on startup, does not modify evaluation"]
+
+ :title "WS4: Governance Surface"
+
+ :description
+ "Policy health aggregation, waiver recording, and governance drill-down.
+  The monitor's policy health zone (from WS3) is backed by the policy-health
+  projection builder (from WS1). This workstream fills in the interactive
+  governance features: full policy health rendering, waiver persistence, and
+  drill-down from aggregate violations to individual PR evidence."
+
+ :context
+ {:normative-refs
+  ["N5-delta-supervisory-control-plane §4 — PR governance states"
+   "N5-delta-supervisory-control-plane §8 — governance and audit requirements"
+   "N5-delta-supervisory-control-plane §8.2 — waiver requirements"]
+
+  :current-state
+  ["Policy health zone exists as a placeholder in monitor (from WS3)"
+   "No Waiver entity or persistence"
+   "No governance drill-down view"
+   "Policy evaluation results stored per-PR in sync cache"
+   "evidence-bundle component exists for evidence storage"]
+
+  :existing-components
+  ["tui-views/views/monitor.clj — monitor screen (from WS3)"
+   "tui-views/view/project.clj — policy-health projection builder (from WS1)"
+   "tui-views/views/evidence.clj — existing evidence detail view"
+   "policy-pack/ — policy rule definitions and evaluation"
+   "evidence-bundle/ — evidence storage and retrieval"]}
+
+ :plan/tasks
+ [{:task/id :policy-health-zone
+   :task/description
+   "Fully render the policy health zone in the monitor screen.
+
+    Display:
+    - Pass rate as percentage: 'Pass rate: 87% (26/30)'
+    - Top violation categories with counts: 'Top: missing-tests (3), no-changelog (2)'
+    - PRs in each governance state: '✓ 26 passing │ ✗ 3 failing │ ⊘ 1 waived'
+    - Zero-violation state: 'All PRs passing policy ✓'
+
+    Backed by the policy-health projection builder from WS1.
+    Render at different widths:
+    - 60-80 cols: pass rate only, single line
+    - 80-120 cols: pass rate + top violations
+    - 120+ cols: full display with governance counts
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/views/monitor.clj
+    Tests: Pass rate computed correctly, violations grouped, zero-violation state"
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :waiver-recording
+   :task/description
+   "Implement the Waiver entity persistence and the :waive action.
+
+    When a user selects a failing PR in the monitor or governance drill-down
+    and invokes 'waive' (w key), prompt for a reason using the existing
+    confirm overlay pattern, then:
+    1. Create a Waiver record (matching the WS1 schema)
+    2. Persist to ~/.miniforge/waivers/{eval-id}.edn
+    3. Re-derive the PR's governance state (should become :waived)
+    4. Update the model and re-render
+
+    Waiver loading on startup:
+    - Scan ~/.miniforge/waivers/ for .edn files
+    - Load and apply to governance state derivation
+    - Include in the startup-load path (extend WS2 :startup-load)
+
+    Waiver record fields: :waiver/id, :waiver/eval-id, :waiver/actor,
+    :waiver/reason, :waiver/created-at, optional :waiver/expires-at
+
+    The original PolicyEvaluation MUST remain unchanged after waiver.
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/views/monitor.clj
+           components/tui-views/src/ai/miniforge/tui_views/persistence.clj (waiver I/O)
+           components/tui-views/src/ai/miniforge/tui_views/update.clj (waive handler)
+    Tests: Waiver persisted and loaded, governance changes to :waived,
+           original evaluation unchanged, waived PR visually distinct"
+   :task/type :implement
+   :task/dependencies [:policy-health-zone]}
+
+  {:task/id :governance-drill-down
+   :task/description
+   "Build governance drill-down navigation from the policy health zone.
+
+    Drill-down flow:
+    1. From policy health zone, select a violation category → shows all PRs
+       with that violation category, grouped by governance state
+    2. Select a PR → shows full policy evaluation detail: rules applied,
+       violations with severity and category, evidence references
+    3. Waived violations show waiver reason and actor
+    4. Select evidence reference → drills into existing evidence detail view
+
+    Implementation: create a :governance-detail view (or extend the existing
+    evidence.clj view). Register in screens.edn. Wire Enter/Esc navigation.
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/views/governance.clj (new)
+           components/tui-views/resources/config/tui/screens.edn
+           components/tui-views/src/ai/miniforge/tui_views/view.clj (dispatch)
+    Tests: Drill from category to PR list, drill from PR to evaluation detail,
+           waiver reason visible in drill-down"
+   :task/type :implement
+   :task/dependencies [:policy-health-zone :waiver-recording]}
+
+  {:task/id :ws4-tests
+   :task/description
+   "Verify all WS4 deliverables:
+    1. Pass rate computed correctly from evaluations
+    2. Violation categories grouped and counted
+    3. Governance states shown with correct counts
+    4. Zero-violation state shows 'All PRs passing policy'
+    5. Waiver record persisted to disk and loaded on startup
+    6. PR governance state changes from :policy-failing to :waived
+    7. Waived PR displays distinctly from passing PR
+    8. Original PolicyEvaluation unchanged after waiver
+    9. Drill from violation category to PR list works
+    10. Drill from PR to policy evaluation detail works
+    11. Waiver reason visible in drill-down
+
+    Run: bb test
+    Files: components/tui-views/test/..."
+   :task/type :test
+   :task/dependencies [:policy-health-zone
+                       :waiver-recording
+                       :governance-drill-down]}]}

--- a/work/tui-ws5-attention-intervention.spec.edn
+++ b/work/tui-ws5-attention-intervention.spec.edn
@@ -1,0 +1,189 @@
+;; WS5 — Attention and Bounded Intervention
+;;
+;; Phase 4 of the TUI Supervisory Control Plane work spec.
+;; Compresses the system into actionable exceptions and allows limited
+;; supervisory action. Completes the shift from passive visibility to
+;; supervisory control.
+;;
+;; Parent work spec: work/tui-supervisory-control-plane.spec.edn
+;; Normative contract: specs/normative/N5-delta-supervisory-control-plane.md
+;; Depends on: tui-ws1-supervisory-domain, tui-ws2-durable-startup, tui-ws3-monitor-mode
+
+{:spec/id "tui-ws5-attention-intervention"
+ :spec/version "0.1.0"
+ :spec/created "2026-04-02"
+ :spec/status "active"
+ :workflow/type :standard-sdlc
+ :workflow/version "2.0.0"
+
+ :spec/title "WS5: Attention and Bounded Intervention"
+
+ :spec/description
+ "Derive attention items from supervisory state and provide bounded
+  intervention actions. Attention surfaces failures, blocks, and escalations
+  automatically. Interventions (retry, pause, resume, waive, resolve decision)
+  let the human act without the TUI becoming a general command shell."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/tui-views"
+          "components/control-plane"
+          "components/workflow"]}
+
+ :spec/constraints
+ ["Attention items MUST be derived from canonical supervisory state, not manually created"
+  "Interventions MUST be bounded — the UI must NOT become a general command shell"
+  "Every intervention MUST produce a durable record (per N5 §6.2)"
+  "Decision resolution MUST use control-plane/resolve-and-deliver! to deliver back to agent"
+  "All tests must pass with bb test"]
+
+ :spec/acceptance-criteria
+ ["Failed workflows, blocked trains, policy failures surface automatically"
+  "Interventions are durable and bounded"
+  "UI does not expand into a general command shell"
+  "Decision resolution delivers result back to blocked agent"
+  "Intervention audit trail is queryable"]
+
+ :title "WS5: Attention and Bounded Intervention"
+
+ :description
+ "Attention derivation recomputes on every model change, surfacing items
+  the human needs to see. Interventions are a bounded set of supervisory
+  actions (retry, pause, resume, cancel, waive, re-evaluate, resolve decision,
+  acknowledge) that let the human act on exceptions without leaving the
+  monitor. Every intervention is recorded for auditability."
+
+ :context
+ {:normative-refs
+  ["N5-delta-supervisory-control-plane §5 — attention derivation rules"
+   "N5-delta-supervisory-control-plane §6 — bounded intervention vocabulary"
+   "N5-delta-supervisory-control-plane §6.2 — intervention auditability"]
+
+  :current-state
+  ["No attention derivation system"
+   "No intervention menu or action dispatch"
+   "Monitor attention bar zone exists (from WS3) but renders static items"
+   "control-plane/decision-queue exists for agent decisions"
+   "Existing confirm overlay pattern for user confirmations"
+   "event-stream/approval exists for decision resolution"]
+
+  :existing-components
+  ["tui-views/views/monitor.clj — monitor screen with attention bar"
+   "tui-views/view/project.clj — attention projection builder (from WS1)"
+   "control-plane/decision_queue.clj — pending decision management"
+   "control-plane/orchestrator.clj — resolve-and-deliver!"
+   "event-stream/approval.clj — approval request/resolution"
+   "workflow/ — workflow state machine (pause, resume, cancel)"]}
+
+ :plan/tasks
+ [{:task/id :attention-derivation
+   :task/description
+   "Implement the attention derivation rules from the normative delta §5.
+
+    On every model change (after update functions run), recompute attention
+    items from supervisory state and store in model as :attention-items.
+    The attention projection builder from WS1 provides the pure derivation
+    function — this task wires it into the update loop.
+
+    Required attention rules:
+
+    Workflow rules:
+    - :workflow/failed → critical (workflow crashed, human must decide retry/cancel)
+    - :workflow/stale → warning (no progress for >5 min while status is :running)
+    - :workflow/completed → info (workflow finished successfully)
+
+    PR rules:
+    - PR :policy-failing → warning (policy failed, may need waiver)
+    - PR conflicts → warning (PR has merge conflicts)
+    - PR merged → info (PR successfully merged)
+
+    PR train rules:
+    - Train :blocked → critical (train cannot progress)
+    - Train policy violation → warning (a PR in the train failed policy)
+
+    PR monitor loop rules (from :pr-monitor/* events):
+    - :pr-monitor/budget-exhausted → critical (monitor gave up, human must act)
+    - :pr-monitor/escalated → critical (monitor explicitly escalated)
+    - :pr-monitor/budget-warning → warning (approaching budget limit)
+    - :pr-monitor/fix-pushed → info (autonomous fix landed)
+
+    Control plane rules (from :control-plane/* events):
+    - Agent :blocked on pending decision → critical (human must resolve)
+    - Agent heartbeat stale (>2 min) → warning (agent may be dead)
+    - Agent :failed → critical (agent session crashed)
+    - Agent :completed → info (session finished)
+
+    Items auto-resolve when the underlying condition resolves (e.g., workflow
+    retried and now running clears the :failed attention item).
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/update.clj
+           components/tui-views/src/ai/miniforge/tui_views/view/project.clj
+    Tests: Each rule generates correct severity, items auto-resolve,
+           empty model produces empty attention list"
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :intervention-menu
+   :task/description
+   "Bounded intervention actions from the monitor and detail views.
+
+    When an attention item or entity is selected and the user presses 'i'
+    (intervene), show a context menu of applicable interventions:
+
+    Context-dependent interventions:
+    - Failed workflow: [r]etry, [c]ancel
+    - Running workflow: [p]ause
+    - Paused workflow: [r]esume, [c]ancel
+    - Failing PR: [w]aive (→ WS4 waiver flow), [e] re-evaluate policy
+    - Blocked agent (pending decision): [d] resolve decision
+    - Stale/failed agent: [t]erminate
+    - Any attention item: [a]cknowledge (marks as seen, keeps in history)
+
+    Decision resolution flow:
+    When an agent is :blocked on a pending decision, the intervention menu
+    shows the decision's summary and available options (from decision-queue).
+    The human selects an option or provides free-form resolution. This calls
+    control-plane/resolve-and-deliver! which delivers the result back to the
+    agent and transitions it to :running.
+
+    UI pattern: use the existing confirm overlay ({:confirm {:action ...}})
+    extended with a multi-option variant for decision resolution.
+
+    Intervention recording:
+    Every intervention produces a durable record persisted to
+    ~/.miniforge/interventions/{timestamp}-{type}.edn with fields:
+    :intervention/id, :intervention/type, :intervention/target-type,
+    :intervention/target-id, :intervention/actor, :intervention/timestamp,
+    :intervention/details
+
+    Files: components/tui-views/src/ai/miniforge/tui_views/views/monitor.clj
+           components/tui-views/src/ai/miniforge/tui_views/update.clj
+           components/tui-views/src/ai/miniforge/tui_views/persistence.clj
+    Tests: Each intervention type dispatches correctly, intervention recorded,
+           decision resolution delivers to agent and unblocks"
+   :task/type :implement
+   :task/dependencies [:attention-derivation]}
+
+  {:task/id :ws5-tests
+   :task/description
+   "Verify all WS5 deliverables:
+    1. Failed workflow generates critical attention item
+    2. Stale workflow generates warning after threshold
+    3. Completed workflow generates info item
+    4. Items auto-resolve when underlying condition resolves
+    5. Empty model produces empty attention list, not error
+    6. Retry creates new workflow run from failed run's spec
+    7. Pause/resume change workflow status correctly
+    8. Waive creates Waiver record and updates governance state
+    9. Re-evaluate triggers new PolicyEvaluation
+    10. Resolve decision delivers result and unblocks agent
+    11. Acknowledge marks attention item as seen
+    12. Intervention recorded in ~/.miniforge/interventions/
+    13. Budget exhaustion from PR monitor creates critical attention item
+    14. Blocked agent decision surfaces as critical and is resolvable
+
+    Run: bb test
+    Files: components/tui-views/test/..."
+   :task/type :test
+   :task/dependencies [:attention-derivation
+                       :intervention-menu]}]}


### PR DESCRIPTION
## Summary

- Phase 0 (Rust core + ratatui TUI, implemented in miniforge-control) is complete — moves `tui-meta-control-plane.spec.edn` to `work/done/`
- Adds TUI workstream specs `tui-ws1` through `tui-ws5` that were authored in the `tui-control-plane-spec` worktree but were never committed to main

## Test plan
- [ ] Verify spec files are well-formed EDN
- [ ] Confirm `tui-meta-control-plane` no longer appears in active work queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)