### PR TITLE
feat: adopt slingshot try+/throw+ in CLI base

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -52,7 +52,8 @@
    [ai.miniforge.agent.tool-supervisor :as tool-supervisor]
    [ai.miniforge.mcp-context-server.interface :as mcp-context-server]
    [ai.miniforge.lsp-mcp-bridge.main :as lsp-bridge]
-   [ai.miniforge.lsp-mcp-bridge.tasks :as lsp-tasks]))
+   [ai.miniforge.lsp-mcp-bridge.tasks :as lsp-tasks]
+   [slingshot.slingshot :refer [try+]]))
 
 ;; TUI components loaded conditionally (only in JVM/jlink bundled runtime)
 (def tui-available?
@@ -429,44 +430,36 @@
    {:cmds ["control-plane" "terminate"] :fn cp-terminate-cmd
     :args->opts [:agent-id]}])
 
+(defn- handle-unknown-command
+  "Print help for an unrecognized CLI command."
+  [{:keys [wrong-input dispatch all-commands]}]
+  (display/print-error (messages/t :main/unknown-command
+                                   {:command (str/join " " (conj (vec dispatch) wrong-input))}))
+  (println)
+  (when (and (= (first dispatch) "fleet")
+             (contains? #{"web" "dashboard" "tui"} wrong-input))
+    (println (messages/t :main/did-you-mean))
+    (println (str "  " (app-config/command-string (if (= wrong-input "dashboard") "web" wrong-input))))
+    (println))
+  (when (seq all-commands)
+    (println (messages/t :main/available-commands
+                         {:scope (if (seq dispatch)
+                                   (str "'" (str/join " " dispatch) "' ")
+                                   "")}))
+    (doseq [cmd all-commands]
+      (println (str "  " (app-config/command-string (str/join " " (conj (vec dispatch) cmd))))))
+    (println))
+  (println (messages/t :main/run-help
+                       {:command (app-config/command-string "help")}))
+  (System/exit 1))
+
 (defn -main
   "CLI entry point."
   [& args]
-  (try
+  (try+
     (cli/dispatch dispatch-table args)
-    (catch clojure.lang.ExceptionInfo e
-      (let [data (ex-data e)]
-        (if (and (= (:type data) :org.babashka/cli)
-                 (= (:cause data) :no-match))
-          (let [wrong-input (:wrong-input data)
-                dispatch (:dispatch data)
-                all-commands (:all-commands data)]
-            (display/print-error (messages/t :main/unknown-command
-                                             {:command (str/join " " (conj (vec dispatch)
-                                                                           wrong-input))}))
-            (println)
-
-            ;; Special case: suggest alternatives for moved commands
-            (when (and (= (first dispatch) "fleet")
-                       (contains? #{"web" "dashboard" "tui"} wrong-input))
-              (println (messages/t :main/did-you-mean))
-              (println (str "  " (app-config/command-string (if (= wrong-input "dashboard") "web" wrong-input))))
-              (println))
-
-            (when (seq all-commands)
-              (println (messages/t :main/available-commands
-                                   {:scope (if (seq dispatch)
-                                             (str "'" (str/join " " dispatch) "' ")
-                                             "")}))
-              (doseq [cmd all-commands]
-                (println (str "  " (app-config/command-string (str/join " " (conj (vec dispatch) cmd))))))
-              (println))
-
-            (println (messages/t :main/run-help
-                                 {:command (app-config/command-string "help")}))
-            (System/exit 1))
-          ;; Re-throw if not a no-match error
-          (throw e))))))
+    (catch [:type :org.babashka/cli :cause :no-match] data
+      (handle-unknown-command data))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/run.clj
@@ -27,7 +27,32 @@
    [ai.miniforge.cli.spec-parser :as spec-parser]
    [ai.miniforge.cli.workflow-runner :as workflow-runner]
    [ai.miniforge.cli.main.commands.plan-executor :as plan-executor]
-   [ai.miniforge.cli.main.commands.resume :as resume]))
+   [ai.miniforge.cli.main.commands.resume :as resume]
+   [slingshot.slingshot :refer [try+]]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Error handling
+
+(defn- classify-error
+  "Attempt runtime error classification. Returns classification or nil."
+  [e]
+  (try
+    (when-let [classifier (requiring-resolve 'ai.miniforge.agent-runtime.interface/classify-error)]
+      (classifier e (ex-data e)))
+    (catch Exception _ nil)))
+
+(defn- print-run-error-and-exit!
+  "Print error details and exit with code 1."
+  [e]
+  (let [classification (classify-error e)]
+    (if classification
+      (display/print-classified-error classification)
+      (do
+        (display/print-error (messages/t :run/failed {:error (ex-message e)}))
+        (when-let [data (ex-data e)]
+          (println (messages/t :run/error-details {:details (pr-str data)}))))))
+  (flush)
+  (System/exit 1))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Input type detection
@@ -116,45 +141,18 @@
 
       ;; Markdown spec — route directly through spec-parser (no EDN pre-read)
       (markdown-spec? spec)
-      (try
+      (try+
         (run-spec-workflow spec opts)
-        (catch Exception e
-          (display/print-error (messages/t :run/failed {:error (ex-message e)}))
-          (when-let [data (ex-data e)]
-            (println (messages/t :run/error-details {:details (pr-str data)})))
-          (flush)
-          (System/exit 1)))
+        (catch Object e (print-run-error-and-exit! (:throwable &throw-context))))
 
       ;; EDN/JSON — dispatch based on file content
       :else
-      (try
+      (try+
         (let [parsed     (read-edn-file spec)
               input-type (detect-input-type parsed)]
           (case input-type
-            ;; Spec file
-            :spec
-            (run-spec-workflow spec opts)
-
-            ;; DAG or Plan file — execute directly
-            (:dag :plan)
-            (do
-              (display/print-info (messages/t :run/detected-format {:format (name input-type) :path spec}))
-              (plan-executor/execute-plan parsed opts))
-
-            ;; Unrecognized format
-            (display/print-error
-             (messages/t :run/unrecognized-format {:path spec}))))
-        (catch Exception e
-          (let [error-classification (try
-                                       (let [classifier (requiring-resolve 'ai.miniforge.agent-runtime.interface/classify-error)]
-                                         (when classifier
-                                           (classifier e (ex-data e))))
-                                       (catch Exception _ nil))]
-            (if error-classification
-              (display/print-classified-error error-classification)
-              (do
-                (display/print-error (messages/t :run/failed {:error (ex-message e)}))
-                (when-let [data (ex-data e)]
-                  (println (messages/t :run/error-details {:details (pr-str data)}))))))
-          (flush)
-          (System/exit 1))))))
+            :spec      (run-spec-workflow spec opts)
+            (:dag :plan) (do (display/print-info (messages/t :run/detected-format {:format (name input-type) :path spec}))
+                             (plan-executor/execute-plan parsed opts))
+            (display/print-error (messages/t :run/unrecognized-format {:path spec}))))
+        (catch Object e (print-run-error-and-exit! (:throwable &throw-context)))))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -32,7 +32,8 @@
    [ai.miniforge.cli.workflow-runner.context :as context]
    [ai.miniforge.cli.workflow-runner.sandbox :as sandbox]
    [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
-   [ai.miniforge.phase.interface :as phase]))
+   [ai.miniforge.phase.interface :as phase]
+   [slingshot.slingshot :refer [try+]]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Work spec kanban lifecycle
@@ -226,10 +227,20 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Execution orchestration
 
+(defn- publish-failure-event!
+  "Publish a workflow failure event, swallowing exceptions."
+  [event-stream workflow-id error-type message]
+  (try
+    (es/publish! event-stream
+                 (es/workflow-failed event-stream workflow-id
+                                     {:message message
+                                      :errors [{:type error-type :message message}]}))
+    (catch Exception _ nil)))
+
 (defn execute-with-events [{:keys [run-pipeline workflow workflow-input context artifact-store
                                      event-stream workflow-id sandbox-cleanup opts]}]
   (let [completed? (atom false)]
-    (try
+    (try+
       (if-let [sandbox-error (:sandbox-error context)]
         (let [result {:success? false
                       :errors [{:type :sandbox-setup-failed
@@ -244,25 +255,17 @@
           (close-artifact-store artifact-store)
           (display/print-result result opts)
           result))
-      (catch Exception e
-        (when-not @completed?
-          (try
-            (es/publish! event-stream
-                         (es/workflow-failed event-stream workflow-id
-                                             {:message (messages/t :workflow-runner/stopped {:error (ex-message e)})
-                                              :errors [{:type :interrupted :message (ex-message e)}]}))
-            (reset! completed? true)
-            (catch Exception _ nil)))
-        (throw e))
+      (catch Object _
+        (let [e (:throwable &throw-context)]
+          (when-not @completed?
+            (publish-failure-event! event-stream workflow-id :interrupted
+                                   (messages/t :workflow-runner/stopped {:error (ex-message e)}))
+            (reset! completed? true))
+          (throw e)))
       (finally
-        ;; Publish cancelled event if workflow was interrupted without completion
         (when-not @completed?
-          (try
-            (es/publish! event-stream
-                         (es/workflow-failed event-stream workflow-id
-                                             {:message (messages/t :workflow-runner/cancelled)
-                                              :errors [{:type :cancelled :message (messages/t :workflow-runner/process-terminated)}]}))
-            (catch Exception _ nil)))
+          (publish-failure-event! event-stream workflow-id :cancelled
+                                 (messages/t :workflow-runner/cancelled)))
         (when sandbox-cleanup
           (sandbox-cleanup)
           (when-not (:quiet opts)
@@ -343,7 +346,7 @@
 ;; Spec-driven execution
 
 (defn run-workflow-from-spec! [spec {:keys [quiet] :or {quiet false} :as opts}]
-  (try
+  (try+
     (let [{:keys [load-workflow run-pipeline]} (resolve-workflow-interface)
           ;; Create initial LLM client for workflow selection
           backend-override (:backend opts)
@@ -415,11 +418,12 @@
           (finally
             (progress-cleanup)
             (when command-poller-cleanup (command-poller-cleanup))))))
-    (catch Exception e
-      (when-not quiet
-        (println (display/colorize :red (messages/t :workflow-runner/spec-execution-failed {:error (ex-message e)})))
-        (flush))
-      (throw e))))
+    (catch Object _
+      (let [e (:throwable &throw-context)]
+        (when-not quiet
+          (println (display/colorize :red (messages/t :workflow-runner/spec-execution-failed {:error (ex-message e)})))
+          (flush))
+        (throw e)))))
 
 ;------------------------------------------------------------------------------ Layer 2b
 ;; Resume workflow from event file


### PR DESCRIPTION
## Summary

First PR in the slingshot adoption DAG (per work/slingshot-adoption.spec.edn).

Converts nested try/catch + ex-data inspection patterns to slingshot key-value selectors in the CLI base:

- **main.clj**: `(catch [:type :org.babashka/cli :cause :no-match] data ...)` replaces manual `(catch ExceptionInfo)` + `(if (= (:type (ex-data e)) ...))` — eliminates nested conditional
- **run.clj**: Extracted `classify-error` and `print-run-error-and-exit!` — two duplicated catch blocks become `(catch Object e (print-run-error-and-exit! ...))`
- **workflow_runner.clj**: `execute-with-events` uses `try+` with `(catch Object _)` and `&throw-context` — extracted `publish-failure-event!` (was duplicated)

Net: -5 lines, 3 fewer nested try/catch blocks, 2 extracted helpers (DRY).

## Test plan

- [x] 105 CLI brick tests pass, 0 failures, 0 errors
- [x] bb-compatible (tested via `bb test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)