### PR TITLE
feat: adopt slingshot try+/throw+ in agent component

### DIFF
--- a/components/agent/deps.edn
+++ b/components/agent/deps.edn
@@ -6,7 +6,8 @@
         ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/reliability {:local/root "../reliability"}
         ai.miniforge/diagnosis {:local/root "../diagnosis"}
-        ai.miniforge/improvement {:local/root "../improvement"}}
+        ai.miniforge/improvement {:local/root "../improvement"}
+        slingshot/slingshot {:mvn/version "0.12.2"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -463,6 +463,27 @@ Output execution logs and status reports."})
       (classifier exception {:task-id task-id}))
     (catch Exception _ nil)))
 
+(defn- retry?
+  "True when self-healing produced a viable workaround to retry."
+  [healing-result]
+  (boolean (:retry? healing-result)))
+
+(defn- invoke-with-retry
+  "Retry agent invocation after a successful workaround.
+   Returns the retry result or an execution-failure on second failure."
+  [agent task exec-context classification]
+  (try+
+    (let [result (protocol/invoke agent task exec-context)]
+      (record-backend-health! exec-context true)
+      (assoc result :self-healing/workaround-applied true))
+    (catch Object _
+      (let [retry-e (:throwable &throw-context)]
+        (record-backend-health! exec-context false)
+        (execution-failure retry-e
+                           {:error-classification classification
+                            :self-healing/workaround-applied true
+                            :self-healing/retry-failed true})))))
+
 (defn try-self-healing-on-failure
   "Attempt workaround when agent execution fails. Returns {:retry? bool} or nil."
   [exception]
@@ -501,23 +522,13 @@ Output execution logs and status reports."})
                      (record-backend-health! exec-context true)
                      invoke-result)
                    (catch Object _
-                     (let [e (:throwable &throw-context)]
+                     (let [e (:throwable &throw-context)
+                           classification (classify-execution-error e task-id)
+                           healing (try-self-healing-on-failure e)]
                        (record-backend-health! exec-context false)
-                       (let [classification (classify-execution-error e task-id)
-                             healing (try-self-healing-on-failure e)]
-                         (if (:retry? healing)
-                           (try+
-                             (let [retry-result (protocol/invoke initialized-agent task exec-context)]
-                               (record-backend-health! exec-context true)
-                               (assoc retry-result :self-healing/workaround-applied true))
-                             (catch Object _
-                               (let [retry-e (:throwable &throw-context)]
-                                 (record-backend-health! exec-context false)
-                                 (execution-failure retry-e
-                                                    {:error-classification classification
-                                                     :self-healing/workaround-applied true
-                                                     :self-healing/retry-failed true}))))
-                           (execution-failure e {:error-classification classification}))))))
+                       (if (retry? healing)
+                         (invoke-with-retry initialized-agent task exec-context classification)
+                         (execution-failure e {:error-classification classification})))))
 
           ;; Validate output
           validation (protocol/validate agent result exec-context)

--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -31,7 +31,8 @@
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.tool.interface :as tool]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [slingshot.slingshot :refer [try+ throw+]]))
 
 ;; Module-level logger for agent operations
 (def default-logger
@@ -454,6 +455,14 @@ Output execution logs and status reports."})
         (record-fn backend success?)))
     (catch Exception _ nil)))
 
+(defn- classify-execution-error
+  "Try to classify an execution error via agent-runtime. Returns classification or nil."
+  [exception task-id]
+  (try
+    (when-let [classifier (requiring-resolve 'ai.miniforge.agent-runtime.interface/classify-error)]
+      (classifier exception {:task-id task-id}))
+    (catch Exception _ nil)))
+
 (defn try-self-healing-on-failure
   "Attempt workaround when agent execution fails. Returns {:retry? bool} or nil."
   [exception]
@@ -486,35 +495,29 @@ Output execution logs and status reports."})
           ;; Initialize agent
           initialized-agent (protocol/init agent (:config agent))
 
-          ;; Execute
-          result (try
+          ;; Execute with self-healing retry
+          result (try+
                    (let [invoke-result (protocol/invoke initialized-agent task exec-context)]
                      (record-backend-health! exec-context true)
                      invoke-result)
-                   (catch Exception e
-                     (record-backend-health! exec-context false)
-                     (let [;; Try to classify the error if agent-runtime is available
-                           error-classification (try
-                                                 (let [classifier (requiring-resolve 'ai.miniforge.agent-runtime.interface/classify-error)]
-                                                   (when classifier
-                                                     (classifier e {:task-id task-id})))
-                                                 (catch Exception _ nil))
-                           healing (try-self-healing-on-failure e)]
-                       (if (:retry? healing)
-                         ;; Workaround applied — retry once
-                         (try
-                           (let [retry-result (protocol/invoke initialized-agent task exec-context)]
-                             (record-backend-health! exec-context true)
-                             (assoc retry-result :self-healing/workaround-applied true))
-                           (catch Exception retry-e
-                             (record-backend-health! exec-context false)
-                             (execution-failure retry-e
-                                                {:error-classification error-classification
-                                                 :self-healing/workaround-applied true
-                                                 :self-healing/retry-failed true})))
-                         ;; No workaround — return error (existing behavior)
-                         (execution-failure e
-                                            {:error-classification error-classification})))))
+                   (catch Object _
+                     (let [e (:throwable &throw-context)]
+                       (record-backend-health! exec-context false)
+                       (let [classification (classify-execution-error e task-id)
+                             healing (try-self-healing-on-failure e)]
+                         (if (:retry? healing)
+                           (try+
+                             (let [retry-result (protocol/invoke initialized-agent task exec-context)]
+                               (record-backend-health! exec-context true)
+                               (assoc retry-result :self-healing/workaround-applied true))
+                             (catch Object _
+                               (let [retry-e (:throwable &throw-context)]
+                                 (record-backend-health! exec-context false)
+                                 (execution-failure retry-e
+                                                    {:error-classification classification
+                                                     :self-healing/workaround-applied true
+                                                     :self-healing/retry-failed true}))))
+                           (execution-failure e {:error-classification classification}))))))
 
           ;; Validate output
           validation (protocol/validate agent result exec-context)


### PR DESCRIPTION
## Summary

Second PR in the slingshot adoption DAG (per work/slingshot-adoption.spec.edn).

- **agent/core.clj**: `DefaultExecutor.execute` uses `try+` with `(catch Object _)` + `&throw-context` — replaces nested `catch Exception` with inline error classification
- Extracted `classify-execution-error` helper from duplicated inline `try/catch` + `requiring-resolve` pattern
- Self-healing retry path uses `try+` for symmetry

## Test plan

- [x] 263 agent tests pass, 0 failures, 0 errors
- [x] bb-compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)