### PR TITLE
feat(event-stream): transit wire format

### DIFF
--- a/components/event-stream/deps.edn
+++ b/components/event-stream/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/logging {:local/root "../logging"}
-        ai.miniforge/schema {:local/root "../schema"}}
+        ai.miniforge/schema {:local/root "../schema"}
+        com.cognitect/transit-clj {:mvn/version "1.0.333"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner
                                {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -20,7 +20,7 @@
   "Configurable event sinks for different deployment scenarios.
 
    Supported sinks:
-   - :file   - Write to ~/.miniforge/events/<workflow-id>.edn (local dev)
+   - :file   - Write to ~/.miniforge/events/<workflow-id>/<timestamp>-<uuid>.json (local dev)
    - :stdout - Print to stdout (container/Docker/K8s)
    - :stderr - Print to stderr (error-only events)
    - :fleet  - Send to fleet command (org-level ops)
@@ -28,74 +28,108 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [clojure.pprint :as pprint]))
+   [clojure.pprint :as pprint]
+   [cognitect.transit :as transit])
+  (:import
+   [java.io ByteArrayOutputStream]
+   [java.time ZonedDateTime ZoneOffset]
+   [java.time.format DateTimeFormatter]))
 
-;;------------------------------------------------------------------------------ Layer 0: File Sink
-
-(defn event-file-path
-  "Get path to event file for a workflow.
-
-   Arguments:
-     workflow-id - UUID or string workflow identifier
-
-   Returns: String path to ~/.miniforge/events/<workflow-id>.edn"
-  [workflow-id]
-  (let [home (System/getProperty "user.home")
-        events-dir (io/file home ".miniforge" "events")
-        workflow-file (str workflow-id ".edn")]
-    (.mkdirs events-dir)
-    (.getPath (io/file events-dir workflow-file))))
-
-(defn operator-event-file-path
-  "Get path to the operator event log for cross-workflow events.
-   Used by meta-loop, reliability, and degradation events.
-
-   Returns: String path to ~/.miniforge/events/operator.edn"
-  []
-  (let [home (System/getProperty "user.home")
-        events-dir (io/file home ".miniforge" "events")]
-    (.mkdirs events-dir)
-    (.getPath (io/file events-dir "operator.edn"))))
+;;------------------------------------------------------------------------------ Internal helpers
 
 (defn- default-events-dir
   "Return the default events directory (~/.miniforge/events)."
   []
   (io/file (System/getProperty "user.home") ".miniforge" "events"))
 
+(defn- now-sortable-str
+  "Return a sortable UTC timestamp string for use as a file-name prefix.
+   Format: yyyyMMdd'T'HHmmss'Z', e.g. 20260411T100000Z."
+  []
+  (.format (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmssSSS'Z'")
+           (ZonedDateTime/now ZoneOffset/UTC)))
+
+(defn- write-transit-json
+  "Serialize `event` to a Transit-JSON string using the verbose writer.
+   Verbose mode ensures UUIDs appear as {\"~#uuid\" \"...\"} and instants
+   as {\"~#inst\" \"...\"} rather than compact ~u and ~m tag-strings,
+   so the Rust parser can decode them without millisecond arithmetic."
+  [event]
+  (let [out (ByteArrayOutputStream.)]
+    (transit/write (transit/writer out :json-verbose) event)
+    (.toString out "UTF-8")))
+
+(defn- new-event-file-path
+  "Return a java.io.File for a new event file in `parent-dir`.
+   The filename is {timestamp}-{uuid}.json, sortable by creation time.
+   Creates `parent-dir` if it does not already exist."
+  [parent-dir]
+  (let [dir (io/file parent-dir)]
+    (.mkdirs dir)
+    (io/file dir (str (now-sortable-str) "-" (random-uuid) ".json"))))
+
+;;------------------------------------------------------------------------------ Layer 0: File Sink paths
+
+(defn event-file-path
+  "Return a java.io.File for a new event file in the per-workflow subdirectory.
+   Creates the subdirectory if needed.
+
+   File layout: {base-dir}/{workflow-id}/{timestamp}-{uuid}.json
+
+   Arguments:
+     workflow-id - UUID or string workflow identifier
+     base-dir    - Optional base directory (default: ~/.miniforge/events)"
+  ([workflow-id]
+   (event-file-path (default-events-dir) workflow-id))
+  ([base-dir workflow-id]
+   (new-event-file-path (io/file base-dir (str workflow-id)))))
+
+(defn operator-event-file-path
+  "Return a java.io.File for a new event file in the operator subdirectory.
+   Used by meta-loop, reliability, and degradation events (no :workflow/id).
+
+   File layout: {base-dir}/operator/{timestamp}-{uuid}.json
+
+   Arguments:
+     base-dir - Optional base directory (default: ~/.miniforge/events)"
+  ([]
+   (operator-event-file-path (default-events-dir)))
+  ([base-dir]
+   (new-event-file-path (io/file base-dir "operator"))))
+
 (defn cleanup-stale-events!
   "Delete event files older than TTL from the events directory.
+   Walks all subdirectories (per-workflow and operator).
 
    Arguments:
      opts - Map with optional:
        :events-dir - Directory to clean (default: ~/.miniforge/events)
-       :ttl-ms - Max age in milliseconds (default: 7 days)
+       :base-dir   - Alias for :events-dir
+       :ttl-ms     - Max age in milliseconds (default: 7 days)
 
    Returns: Number of files deleted"
   [& [opts]]
   (let [ttl-ms (get opts :ttl-ms (* 7 24 60 60 1000))
-        events-dir (or (:events-dir opts) (default-events-dir))
+        events-dir (or (:events-dir opts) (:base-dir opts) (default-events-dir))
         cutoff (- (System/currentTimeMillis) ttl-ms)]
     (if (.isDirectory events-dir)
-      (let [stale-files (->> (.listFiles events-dir)
+      (let [stale-files (->> (file-seq events-dir)
                              (filter #(and (.isFile %)
-                                           (str/ends-with? (.getName %) ".edn")
+                                           (str/ends-with? (.getName %) ".json")
                                            (< (.lastModified %) cutoff))))]
         (doseq [f stale-files] (.delete f))
         (count stale-files))
       0)))
 
-(defn operator-event-file-path
-  "Get path to the operator event log (for cross-workflow events like meta-loop,
-   reliability, degradation). Returns ~/.miniforge/events/operator.edn"
-  []
-  (let [home (System/getProperty "user.home")
-        events-dir (io/file home ".miniforge" "events")]
-    (.mkdirs events-dir)
-    (str (io/file events-dir "operator.edn"))))
-
 (defn file-sink
-  "Create a file sink that writes events to per-workflow files.
-   Cross-workflow events (no :workflow/id) go to operator.edn.
+  "Create a file sink that writes each event as a Transit-JSON file.
+
+   File layout:
+     per-workflow:  {base-dir}/{workflow-id}/{timestamp}-{uuid}.json
+     cross-workflow: {base-dir}/operator/{timestamp}-{uuid}.json
+
+   Each event gets its own file (no append). Files are sortable by creation
+   time via the timestamp prefix.
 
    Performs lazy cleanup of stale event files (older than 7 days) on creation.
 
@@ -110,13 +144,11 @@
   (future (try (cleanup-stale-events! opts) (catch Exception _ nil)))
   (fn [event]
     (try
-      (let [file-path (if-let [workflow-id (:workflow/id event)]
-                        (event-file-path workflow-id)
-                        (operator-event-file-path))]
-        (with-open [writer (io/writer file-path :append true)]
-          (.write writer (pr-str event))
-          (.write writer "\n")
-          (.flush writer)))
+      (let [base-dir (or (:base-dir opts) (default-events-dir))
+            file-path (if-let [workflow-id (:workflow/id event)]
+                        (event-file-path base-dir workflow-id)
+                        (operator-event-file-path base-dir))]
+        (spit file-path (write-transit-json event)))
       (catch Exception e
         ;; Log to stderr so failures are visible without breaking the event stream
         (binding [*out* *err*]

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -21,20 +21,20 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [clojure.java.io :as io]
-   [clojure.edn :as edn]
-   [clojure.string]
+   [clojure.string :as str]
+   [cognitect.transit :as transit]
    [ai.miniforge.event-stream.sinks :as sinks]))
 
 ;------------------------------------------------------------------------------ Helpers
 
 (defn with-temp-dir [f]
-  (let [dir (str (java.nio.file.Files/createTempDirectory
-                   "sinks-test-"
-                   (into-array java.nio.file.attribute.FileAttribute [])))]
+  (let [dir (java.nio.file.Files/createTempDirectory
+              "sinks-test-"
+              (into-array java.nio.file.attribute.FileAttribute []))]
     (try
-      (f dir)
+      (f (.toFile dir))
       (finally
-        (doseq [file (reverse (file-seq (io/file dir)))]
+        (doseq [file (reverse (file-seq (.toFile dir)))]
           (.delete ^java.io.File file))))))
 
 (defn sample-event [& [overrides]]
@@ -47,63 +47,101 @@
           :message "Test event"}
          overrides))
 
+(defn read-transit-json [s]
+  (transit/read
+   (transit/reader
+    (java.io.ByteArrayInputStream. (.getBytes ^String s "UTF-8"))
+    :json-verbose)))
+
+(defn list-files [^java.io.File dir]
+  (when (.isDirectory dir)
+    (vec (.listFiles dir))))
+
 ;------------------------------------------------------------------------------ Layer 0
 ;; event-file-path
 
 (deftest event-file-path-test
-  (testing "returns a string path ending in .edn"
+  (testing "returns a File path ending in .json"
     (let [wf-id (random-uuid)
           path (sinks/event-file-path wf-id)]
-      (is (string? path))
-      (is (clojure.string/ends-with? path (str wf-id ".edn")))
-      (is (clojure.string/includes? path ".miniforge"))))
+      (is (instance? java.io.File path))
+      (is (str/ends-with? (.getName path) ".json"))
+      (is (str/includes? (.getPath path) (str wf-id)))))
 
-  (testing "creates events directory if it does not exist"
-    (let [path (sinks/event-file-path (random-uuid))
-          parent (io/file (.getParent (io/file path)))]
-      (is (.isDirectory parent)))))
+  (testing "creates the workflow subdirectory"
+    (let [wf-id (random-uuid)
+          path (sinks/event-file-path wf-id)
+          parent (.getParentFile path)]
+      (is (.isDirectory parent))
+      (is (str/ends-with? (.getName parent) (str wf-id)))))
+
+  (testing "accepts an explicit base-dir"
+    (with-temp-dir
+      (fn [dir]
+        (let [wf-id (random-uuid)
+              path (sinks/event-file-path dir wf-id)]
+          (is (str/includes? (.getPath path) (.getPath dir)))
+          (is (str/ends-with? (.getName path) ".json")))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; file-sink
 
 (deftest file-sink-test
-  (testing "writes event to per-workflow file"
-    (let [sink (sinks/file-sink)
-          wf-id (random-uuid)
-          event (sample-event {:workflow/id wf-id})]
-      (sink event)
-      ;; Read back
-      (let [path (sinks/event-file-path wf-id)
-            content (slurp path)
-            parsed (edn/read-string content)]
-        (is (= :workflow/started (:event/type parsed)))
-        (is (= wf-id (:workflow/id parsed)))
-        ;; Cleanup
-        (.delete (io/file path)))))
+  (testing "writes event to per-workflow file as Transit-JSON"
+    (with-temp-dir
+      (fn [dir]
+        (let [sink (sinks/file-sink {:base-dir dir})
+              wf-id (random-uuid)
+              event (sample-event {:workflow/id wf-id})]
+          (sink event)
+          (let [wf-dir (io/file dir (str wf-id))
+                files (list-files wf-dir)]
+            (is (= 1 (count files)))
+            (let [parsed (read-transit-json (slurp (first files)))]
+              (is (= :workflow/started (:event/type parsed)))
+              (is (= wf-id (:workflow/id parsed)))))))))
 
-  (testing "appends multiple events to same file"
-    (let [sink (sinks/file-sink)
-          wf-id (random-uuid)
-          e1 (sample-event {:workflow/id wf-id :event/sequence-number 0})
-          e2 (sample-event {:workflow/id wf-id :event/sequence-number 1
-                            :event/type :workflow/phase-started})]
-      (sink e1)
-      (sink e2)
-      (let [path (sinks/event-file-path wf-id)
-            lines (clojure.string/split-lines (slurp path))]
-        (is (= 2 (count lines)))
-        (is (= :workflow/started (:event/type (edn/read-string (first lines)))))
-        (is (= :workflow/phase-started (:event/type (edn/read-string (second lines)))))
-        (.delete (io/file path)))))
+  (testing "writes one file per event in the workflow subdirectory"
+    (with-temp-dir
+      (fn [dir]
+        (let [sink (sinks/file-sink {:base-dir dir})
+              wf-id (random-uuid)]
+          (sink (sample-event {:workflow/id wf-id}))
+          (sink (sample-event {:workflow/id wf-id :event/type :workflow/completed}))
+          (let [wf-dir (io/file dir (str wf-id))
+                files (sort-by #(.getName %) (list-files wf-dir))]
+            (is (= 2 (count files)))
+            ;; Files are sortable by timestamp-prefixed name
+            (let [e1 (read-transit-json (slurp (first files)))
+                  e2 (read-transit-json (slurp (second files)))]
+              (is (= :workflow/started (:event/type e1)))
+              (is (= :workflow/completed (:event/type e2)))))))))
 
-  (testing "writes events with nil workflow-id to operator.edn"
-    (let [sink (sinks/file-sink)
-          unique-type (keyword (str "test/meta-loop-" (random-uuid)))
-          event (sample-event {:workflow/id nil :event/type unique-type})]
-      (sink event)
-      (let [path (sinks/operator-event-file-path)
-            content (slurp path)]
-        (is (clojure.string/includes? content (name unique-type)))))))
+  (testing "writes events with nil workflow-id to operator subdirectory"
+    (with-temp-dir
+      (fn [dir]
+        (let [sink (sinks/file-sink {:base-dir dir})
+              unique-type (keyword (str "test/op-" (random-uuid)))
+              event (sample-event {:workflow/id nil :event/type unique-type})]
+          (sink event)
+          (let [op-dir (io/file dir "operator")
+                files (list-files op-dir)]
+            (is (= 1 (count files)))
+            (let [parsed (read-transit-json (slurp (first files)))]
+              (is (= unique-type (:event/type parsed)))))))))
+
+  (testing "output files are valid Transit-JSON readable by cognitect/transit-clj reader"
+    (with-temp-dir
+      (fn [dir]
+        (let [sink (sinks/file-sink {:base-dir dir})
+              wf-id (random-uuid)
+              event (sample-event {:workflow/id wf-id})]
+          (sink event)
+          (let [wf-dir (io/file dir (str wf-id))
+                files (list-files wf-dir)
+                content (slurp (first files))]
+            ;; Must parse without exception
+            (is (map? (read-transit-json content)))))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; stdout-sink
@@ -113,17 +151,17 @@
     (let [sink (sinks/stdout-sink {:compact true})
           event (sample-event)
           output (with-out-str (sink event))]
-      (is (not (clojure.string/blank? output)))
+      (is (not (str/blank? output)))
       ;; Should be parseable EDN
-      (let [parsed (edn/read-string output)]
+      (let [parsed (clojure.edn/read-string output)]
         (is (= :workflow/started (:event/type parsed))))))
 
   (testing "compact mode produces single-line output"
     (let [sink (sinks/stdout-sink {:compact true})
           event (sample-event)
-          output (clojure.string/trim (with-out-str (sink event)))]
+          output (str/trim (with-out-str (sink event)))]
       ;; Compact EDN should be a single line (no internal newlines before the closing brace)
-      (is (clojure.string/starts-with? output "{")))))
+      (is (str/starts-with? output "{")))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; stderr-sink
@@ -151,7 +189,7 @@
                    (binding [*err* (java.io.PrintWriter. w)]
                      (sink (sample-event)))
                    (str w))]
-      (is (not (clojure.string/blank? output))))))
+      (is (not (str/blank? output))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; multi-sink
@@ -272,15 +310,21 @@
 
 (deftest file-sink-reports-write-errors-to-stderr-test
   (testing "file-sink logs write failures to stderr instead of swallowing"
-    (let [sink (sinks/file-sink)
-          event (sample-event {:workflow/id (random-uuid)})
-          stderr-output (let [w (java.io.StringWriter.)]
-                          (binding [*err* (java.io.PrintWriter. w)]
-                            (with-redefs [sinks/event-file-path
-                                          (fn [_] "/nonexistent/path/that/will/fail.edn")]
-                              (sink event)))
-                          (str w))]
-      (is (clojure.string/includes? stderr-output "WARNING")))))
+    (with-temp-dir
+      (fn [dir]
+        ;; Create a regular file at {dir}/{wf-id} so that when the sink tries to
+        ;; create a subdirectory there (.mkdirs returns false), spit throws an
+        ;; IOException trying to write a child path of a regular file.
+        (let [wf-id (random-uuid)
+              collision (io/file dir (str wf-id))]
+          (spit (str collision) "not a dir")
+          (let [sink (sinks/file-sink {:base-dir dir})
+                event (sample-event {:workflow/id wf-id})
+                stderr-output (let [w (java.io.StringWriter.)]
+                                (binding [*err* (java.io.PrintWriter. w)]
+                                  (sink event))
+                                (str w))]
+            (is (str/includes? stderr-output "WARNING"))))))))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; cleanup-stale-events!
@@ -289,20 +333,24 @@
   (testing "returns 0 when events directory is empty"
     (with-temp-dir
       (fn [dir]
-        (is (= 0 (sinks/cleanup-stale-events! {:ttl-ms 0 :events-dir (io/file dir)}))))))
+        (is (= 0 (sinks/cleanup-stale-events! {:ttl-ms 0 :events-dir dir}))))))
 
-  (testing "deletes old files and preserves recent ones"
+  (testing "deletes old event files and preserves recent ones"
     (with-temp-dir
       (fn [dir]
-        (let [old-file (io/file dir "old-workflow.edn")
-              new-file (io/file dir "new-workflow.edn")]
-          (spit old-file "{:event/type :workflow/started}")
-          (spit new-file "{:event/type :workflow/started}")
-          (.setLastModified old-file (- (System/currentTimeMillis) (* 8 24 60 60 1000)))
-          (let [deleted (sinks/cleanup-stale-events! {:events-dir (io/file dir)})]
-            (is (= 1 deleted))
-            (is (not (.exists old-file)))
-            (is (.exists new-file)))))))
+        (let [old-dir (io/file dir "workflow-old")
+              new-dir (io/file dir "workflow-new")]
+          (.mkdirs old-dir)
+          (.mkdirs new-dir)
+          (let [old-file (io/file old-dir "20200101T000000Z-abc.json")
+                new-file (io/file new-dir "20260411T000000Z-def.json")]
+            (spit (str old-file) "{}")
+            (spit (str new-file) "{}")
+            (.setLastModified old-file (- (System/currentTimeMillis) (* 8 24 60 60 1000)))
+            (let [deleted (sinks/cleanup-stale-events! {:events-dir dir})]
+              (is (= 1 deleted))
+              (is (not (.exists old-file)))
+              (is (.exists new-file))))))))
 
   (testing "returns 0 when directory does not exist"
     (is (= 0 (sinks/cleanup-stale-events!

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -22,6 +22,7 @@
    [clojure.test :refer [deftest testing is]]
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [clojure.edn :as edn]
    [cognitect.transit :as transit]
    [ai.miniforge.event-stream.sinks :as sinks]))
 
@@ -153,7 +154,7 @@
           output (with-out-str (sink event))]
       (is (not (str/blank? output)))
       ;; Should be parseable EDN
-      (let [parsed (clojure.edn/read-string output)]
+      (let [parsed (edn/read-string output)]
         (is (= :workflow/started (:event/type parsed))))))
 
   (testing "compact mode produces single-line output"


### PR DESCRIPTION
## Summary

- Replaces `pr-str` + `:append true` in `file-sink` with Transit-JSON serialization, one file per event
- New layout: `{events-dir}/{workflow-id}/{yyyyMMddTHHmmssSSS'Z'}-{uuid}.json`
- Operator events (no `:workflow/id`): `{events-dir}/operator/{timestamp}-{uuid}.json`
- Adds `cognitect/transit-clj 1.0.333` to event-stream deps
- Uses `:json-verbose` writer so UUIDs → `{"~#uuid": "…"}` and instants → `{"~#inst": "…"}`, making the Rust parser straightforward
- File names are sortable by creation time (millisecond-precision timestamp prefix)
- `cleanup-stale-events!` now walks subdirectories for `.json` files
- `event-file-path` and `operator-event-file-path` accept optional `base-dir` for isolated testing

## Fixes

Resolves the silent multi-event-per-file bug: the old `file-sink` appended all workflow events to a single `.edn` file; the Rust `event-client` only handled `Create` events and parsed each file as a single EDN value — every event after the first was silently dropped.

## Test plan

- [x] `sinks_test.clj` updated: EDN `read-string` → `read-transit-json`; "appends multiple events" → "writes one file per event"
- [x] All 125 event-stream tests pass (pre-commit hook verified)
- [x] Linter: 0 errors, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)