### PR TITLE
refactor: migrate all ex-info throws to throw-anomaly! (30 sites, 19 files)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -27,7 +27,8 @@
    [ai.miniforge.cli.workflow-selection-config :as selection-config]
    [ai.miniforge.cli.workflow-runner.context :as context]
    [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
-   [ai.miniforge.event-stream.interface :as es]))
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event file parsing
@@ -40,8 +41,9 @@
   [workflow-id]
   (let [path (str events-dir "/" workflow-id ".edn")]
     (when-not (fs/exists? path)
-      (throw (ex-info (str "Event file not found: " path)
-                      {:workflow-id workflow-id :path path})))
+      (response/throw-anomaly! :anomalies/not-found
+                              (str "Event file not found: " path)
+                              {:workflow-id workflow-id :path path}))
     (->> (slurp path)
          str/split-lines
          (remove str/blank?)
@@ -135,9 +137,10 @@
                           (selection-config/resolve-selection-profile :default))
         workflow-version (get workflow-spec :version "latest")]
     (when-not workflow-type
-      (throw (ex-info "Could not resolve a default workflow for resume"
-                      {:operation :resume-workflow
-                       :selection-profile :default})))
+      (response/throw-anomaly! :anomalies/not-found
+                              "Could not resolve a default workflow for resume"
+                              {:operation :resume-workflow
+                               :selection-profile :default}))
     {:workflow-type workflow-type
      :workflow-version workflow-version}))
 

--- a/bases/cli/src/ai/miniforge/cli/messages.clj
+++ b/bases/cli/src/ai/miniforge/cli/messages.clj
@@ -20,7 +20,8 @@
   "Resource-backed message catalog for shared CLI user-facing copy."
   (:require
    [clojure.string :as str]
-   [ai.miniforge.cli.resource-config :as resource-config]))
+   [ai.miniforge.cli.resource-config :as resource-config]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Catalog loading
@@ -85,6 +86,7 @@
   ([message-key params]
    (if-let [value (get (catalog) message-key)]
      (render-value value params)
-     (throw (ex-info "Missing CLI message key"
-                     {:message-key message-key
-                      :locale (active-locale)})))))
+     (response/throw-anomaly! :anomalies/not-found
+                             "Missing CLI message key"
+                             {:message-key message-key
+                              :locale (active-locale)})))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -33,6 +33,7 @@
    [ai.miniforge.cli.workflow-runner.sandbox :as sandbox]
    [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
    [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.response.interface :as response]
    [slingshot.slingshot :refer [try+]]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -120,11 +121,13 @@
 (defn load-and-validate-workflow [load-workflow workflow-id version]
   (let [{:keys [workflow validation]} (load-workflow workflow-id version {})]
     (when-not workflow
-      (throw (ex-info (messages/t :workflow-runner/not-found {:workflow-id workflow-id})
-                      {:workflow-id workflow-id :version version})))
+      (response/throw-anomaly! :anomalies/not-found
+                               (messages/t :workflow-runner/not-found {:workflow-id workflow-id})
+                               {:workflow-id workflow-id :version version}))
     (when (and validation (not (:valid? validation)))
-      (throw (ex-info (messages/t :workflow-runner/validation-failed {:errors (:errors validation)})
-                      {:workflow-id workflow-id :validation validation})))
+      (response/throw-anomaly! :anomalies.workflow/invalid-config
+                               (messages/t :workflow-runner/validation-failed {:errors (:errors validation)})
+                               {:workflow-id workflow-id :validation validation}))
     workflow))
 
 (defn create-artifact-store [quiet]

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -26,7 +26,8 @@
    [cheshire.core :as json]
    [ai.miniforge.cli.config :as config]
    [ai.miniforge.cli.workflow-runner.display :as display]
-   [ai.miniforge.event-stream.interface :as es]))
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Input resolution
@@ -35,22 +36,26 @@
   (when path
     (let [file (fs/file path)]
       (when-not (fs/exists? file)
-        (throw (ex-info (str "Input file not found: " path) {:path path})))
+        (response/throw-anomaly! :anomalies/not-found
+                                (str "Input file not found: " path)
+                                {:path path}))
       (let [content (slurp file)
             ext (fs/extension file)]
         (case ext
           "edn" (edn/read-string content)
           "json" (json/parse-string content true)
-          (throw (ex-info (str "Unsupported file format: " ext " (use .edn or .json)")
-                          {:path path :extension ext})))))))
+          (response/throw-anomaly! :anomalies/unsupported
+                                  (str "Unsupported file format: " ext " (use .edn or .json)")
+                                  {:path path :extension ext}))))))
 
 (defn parse-inline-json [s]
   (when s
     (try
       (json/parse-string s true)
       (catch Exception e
-        (throw (ex-info (str "Failed to parse input JSON: " (ex-message e))
-                        {:input s} e))))))
+        (response/throw-anomaly! :anomalies/fault
+                                (str "Failed to parse input JSON: " (ex-message e))
+                                {:input s}))))))
 
 (defn resolve-input [{:keys [input input-json]}]
   (cond

--- a/components/agent/src/ai/miniforge/agent/file_artifacts.clj
+++ b/components/agent/src/ai/miniforge/agent/file_artifacts.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.agent.file-artifacts
   "Fallback artifact collection from files written in the working tree."
   (:require
+   [ai.miniforge.response.interface :as response]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
@@ -160,10 +161,11 @@
       (reduce add-entry
               (empty-snapshot)
               (keep porcelain-entry (str/split-lines out)))
-      (throw (ex-info "Failed to snapshot working directory"
-                      {:working-dir working-dir
-                       :exit exit
-                       :stderr err})))))
+      (response/throw-anomaly! :anomalies/fault
+                              "Failed to snapshot working directory"
+                              {:working-dir working-dir
+                               :exit exit
+                               :stderr err})))))
 
 (defn snapshot-via-executor
   "Capture git dirty state inside a capsule via the executor.

--- a/components/agent/src/ai/miniforge/agent/meta_protocol.clj
+++ b/components/agent/src/ai/miniforge/agent/meta_protocol.clj
@@ -130,8 +130,9 @@
          enabled? true}
     :as opts}]
   (when-not (and id name)
-    (throw (ex-info "Meta-agent config requires :id and :name"
-                    {:provided opts})))
+    (response/throw-anomaly! :anomalies/incorrect
+                            "Meta-agent config requires :id and :name"
+                            {:provided opts}))
   (map->MetaAgentConfig
    {:id id
     :name name

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -385,11 +385,12 @@
                 (let [content (llm/get-content llm-response)
                       plan (or artifact
                                (parse-plan-response content)
-                               (throw (ex-info "Plan generation failed: EDN parse did not succeed"
-                                               {:phase :plan
-                                                :parse-result nil
-                                                :llm-content-length (count content)
-                                                :llm-content-preview (subs content 0 (min 500 (count content)))})))
+                               (response/throw-anomaly! :anomalies.agent/invoke-failed
+                                                       "Plan generation failed: EDN parse did not succeed"
+                                                       {:phase :plan
+                                                        :parse-result nil
+                                                        :llm-content-length (count content)
+                                                        :llm-content-preview (subs content 0 (min 500 (count content)))})))
                       plan-final (finalize-plan plan)]
                   ;; Check for already-satisfied response
                   (if (= :already-satisfied (:plan/status plan-final))
@@ -420,8 +421,9 @@
                                     "LLM call failed")]
                   (response/error error-msg))))
                ;; No LLM client — hard failure
-            (throw (ex-info "No LLM backend provided for planner agent"
-                            {:phase :plan})))))
+            (response/throw-anomaly! :anomalies.agent/llm-error
+                                    "No LLM backend provided for planner agent"
+                                    {:phase :plan})))))
 
       :validate-fn validate-plan
 

--- a/components/agent/src/ai/miniforge/agent/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/prompts.clj
@@ -20,6 +20,7 @@
   "Agent prompt loading utilities.
    Loads system prompts from EDN resources for configurability."
   (:require
+   [ai.miniforge.response.interface :as response]
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
@@ -43,13 +44,15 @@
       (let [prompt-data (with-open [rdr (io/reader resource)]
                           (edn/read (java.io.PushbackReader. rdr)))]
         (or (:prompt/system prompt-data)
-            (throw (ex-info "Prompt data missing :prompt/system key"
-                            {:agent-type agent-type
-                             :resource-path resource-path
-                             :keys (keys prompt-data)}))))
-      (throw (ex-info "Could not find prompt resource"
-                      {:agent-type agent-type
-                       :resource-path resource-path})))))
+            (response/throw-anomaly! :anomalies/not-found
+                                    "Prompt data missing :prompt/system key"
+                                    {:agent-type agent-type
+                                     :resource-path resource-path
+                                     :keys (keys prompt-data)}))))
+      (response/throw-anomaly! :anomalies/not-found
+                                "Could not find prompt resource"
+                                {:agent-type agent-type
+                                 :resource-path resource-path})))))
 
 (defn load-prompt-data
   "Load full prompt data map from resources.
@@ -64,9 +67,10 @@
     (if-let [resource (io/resource resource-path)]
       (with-open [rdr (io/reader resource)]
         (edn/read (java.io.PushbackReader. rdr)))
-      (throw (ex-info "Could not find prompt resource"
-                      {:agent-type agent-type
-                       :resource-path resource-path})))))
+      (response/throw-anomaly! :anomalies/not-found
+                                "Could not find prompt resource"
+                                {:agent-type agent-type
+                                 :resource-path resource-path})))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/impl/messaging.clj
@@ -21,6 +21,7 @@
 
    Implements N1 Architecture Specification section 6.2."
   (:require
+   [ai.miniforge.response.interface :as response]
    [malli.core :as m]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -256,9 +257,10 @@
     ;; Validate message
     (let [validation (validate-message-impl message)]
       (when-not (:valid? validation)
-        (throw (ex-info "Invalid message"
-                        {:message message
-                         :errors (:errors validation)}))))
+        (response/throw-anomaly! :anomalies/incorrect
+                                "Invalid message"
+                                {:message message
+                                 :errors (:errors validation)})))
     ;; Route message
     (let [routed-msg (route-message-impl router message)
           event (create-message-sent-event routed-msg)]

--- a/components/dag-executor/src/ai/miniforge/dag_executor/execution_plan.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/execution_plan.clj
@@ -27,6 +27,7 @@
    Layer 1: Malli schemas — mount, execution plan
    Layer 2: Constructor and validator"
   (:require
+   [ai.miniforge.response.interface :as response]
    [malli.core :as m]
    [malli.error :as me]))
 
@@ -115,8 +116,10 @@
   (let [{:keys [valid? errors]} (validate-plan plan-map)]
     (if valid?
       plan-map
-      (throw (ex-info "Invalid execution plan" {:errors errors
-                                                :plan   plan-map})))))
+      (response/throw-anomaly! :anomalies/incorrect
+                              "Invalid execution plan"
+                              {:errors errors
+                               :plan   plan-map})))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
@@ -29,6 +29,7 @@
    [ai.miniforge.dag-executor.result :as result]
    [ai.miniforge.dag-executor.workspace :as workspace]
    [ai.miniforge.dag-executor.protocols.executor :as proto]
+   [ai.miniforge.response.interface :as response]
    [clojure.java.io]
    [clojure.java.shell :as shell]
    [clojure.string :as str]))
@@ -490,10 +491,11 @@
               stderr   (if sanitize?
                          (sanitize-token (or (get-in r [:data :stderr]) ""))
                          (or (get-in r [:data :stderr]) ""))]
-          (throw (ex-info (str error-prefix ": " safe-cmd
-                               (when (seq stderr) (str "\n" stderr)))
-                          {:cmd safe-cmd :stderr stderr
-                           :exit (get-in r [:data :exit-code])}))))
+          (response/throw-anomaly! :anomalies/fault
+                                  (str error-prefix ": " safe-cmd
+                                       (when (seq stderr) (str "\n" stderr)))
+                                  {:cmd safe-cmd :stderr stderr
+                                   :exit (get-in r [:data :exit-code])})))
       r)))
 
 ;; ============================================================================

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -209,9 +209,9 @@
           (let [result (check artifact ctx)]
             (if (passed? result)
               result
-              (throw (ex-info "Gate validation failed"
-                              {:anomaly :anomalies.gate/validation-failed
-                               :errors (:errors result)}))))))))
+              (response/throw-anomaly! :anomalies.gate/validation-failed
+                                      "Gate validation failed"
+                                      {:errors (:errors result)}))))))))
    (response/create :gates)
    gate-kws))
 

--- a/components/llm/src/ai/miniforge/llm/model_registry.clj
+++ b/components/llm/src/ai/miniforge/llm/model_registry.clj
@@ -22,6 +22,7 @@
    Layer 1: Query functions (by capability, use-case, task-type)
    Layer 2: Recommendation logic"
   (:require
+   [ai.miniforge.response.interface :as response]
    [clojure.edn :as edn]
    [clojure.java.io :as io]))
 
@@ -41,7 +42,8 @@
   []
   (if-let [resource (io/resource "llm/model-catalog.edn")]
     (edn/read-string (slurp resource))
-    (throw (ex-info "Missing llm/model-catalog.edn resource" {}))))
+    (response/throw-anomaly! :anomalies/not-found
+                            "Missing llm/model-catalog.edn resource")))
 
 (def ^:private model-catalog
   "Resource-backed model catalog and task-type recommendations."

--- a/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/records/llm_client.clj
@@ -22,7 +22,8 @@
    CLIClient - LLM client using CLI backends (claude, cursor, etc.)"
   (:require
    [ai.miniforge.llm.interface.protocols.llm-client :as p]
-   [ai.miniforge.llm.protocols.impl.llm-client :as impl]))
+   [ai.miniforge.llm.protocols.impl.llm-client :as impl]
+   [ai.miniforge.response.interface :as response]))
 
 (defrecord CLIClient [config logger exec-fn stream-exec-fn]
   p/LLMClient
@@ -53,9 +54,10 @@
   ([] (create-client {}))
   ([{:keys [backend logger exec-fn stream-exec-fn model] :or {backend :codex}}]
    (when-not (contains? impl/backends backend)
-     (throw (ex-info (str "Unknown backend: " backend)
-                     {:backend backend
-                      :available (keys impl/backends)})))
+     (response/throw-anomaly! :anomalies/incorrect
+                             (str "Unknown backend: " backend)
+                             {:backend backend
+                              :available (keys impl/backends)}))
    (->CLIClient (cond-> {:backend backend}
                   model (assoc :model model))
                 logger

--- a/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
@@ -23,7 +23,8 @@
   (:require
    [clojure.java.io :as io]
    [clojure.edn :as edn]
-   [clojure.string :as str])
+   [clojure.string :as str]
+   [ai.miniforge.response.interface :as response])
   (:import
    [java.util.jar JarFile]))
 
@@ -122,9 +123,10 @@
         chain-def (when resource-path (load-chain-resource resource-path))]
     (if chain-def
       {:chain chain-def :source :resource :path resource-path}
-      (throw (ex-info (str "Chain '" (name chain-id) "' not found. "
-                           "Looked for: " versioned-path ", " base-path)
-                      {:chain-id chain-id :version version})))))
+      (response/throw-anomaly! :anomalies/not-found
+                              (str "Chain '" (name chain-id) "' not found. "
+                                   "Looked for: " versioned-path ", " base-path)
+                              {:chain-id chain-id :version version})))))
 
 (defn list-chains
   "List all available chain definitions from classpath."

--- a/components/workflow/src/ai/miniforge/workflow/loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/loader.clj
@@ -23,6 +23,7 @@
    [clojure.java.io :as io]
    [clojure.edn :as edn]
    [clojure.string :as str]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.validator :as validator]
    [ai.miniforge.heuristic.interface :as heuristic])
   (:import
@@ -132,11 +133,11 @@
         (with-open [rdr (io/reader resource)]
           (edn/read (java.io.PushbackReader. rdr)))
         (catch Exception e
-          (throw (ex-info "Failed to load workflow from resource"
-                          {:workflow-id workflow-id
-                           :resource-path resource-path
-                           :error (.getMessage e)}
-                          e)))))))
+          (response/throw-anomaly! :anomalies/fault
+                                  "Failed to load workflow from resource"
+                                  {:workflow-id workflow-id
+                                   :resource-path resource-path
+                                   :error (.getMessage e)})))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Heuristic store loading
@@ -188,10 +189,11 @@
                     {:valid? true :errors []}
                     (validator/validate-workflow workflow))]
     (when-not (:valid? validation)
-      (throw (ex-info "Workflow validation failed"
-                      {:workflow-id workflow-id
-                       :version version
-                       :errors (:errors validation)})))
+      (response/throw-anomaly! :anomalies.workflow/invalid-config
+                              "Workflow validation failed"
+                              {:workflow-id workflow-id
+                               :version version
+                               :errors (:errors validation)})))
 
     ;; Cache the validated workflow
     (swap! workflow-cache assoc [workflow-id version] workflow)
@@ -234,9 +236,10 @@
         (validate-and-cache-workflow workflow workflow-id version skip-validation?)
 
         ;; Not found anywhere
-        (throw (ex-info "Workflow not found"
-                        {:workflow-id workflow-id
-                         :version version}))))))
+        (response/throw-anomaly! :anomalies/not-found
+                                "Workflow not found"
+                                {:workflow-id workflow-id
+                                 :version version}))))))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Workflow discovery

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -67,8 +67,9 @@
   []
   (if-let [res (io/resource "config/workflow/observe-phase.edn")]
     (->> res slurp edn/read-string (validate! ObservePhaseConfig))
-    (throw (ex-info "Missing classpath resource: config/workflow/observe-phase.edn"
-                    {:hint "Add components/workflow/resources to your classpath"}))))
+    (response/throw-anomaly! :anomalies/not-found
+                            "Missing classpath resource: config/workflow/observe-phase.edn"
+                            {:hint "Add components/workflow/resources to your classpath"}))))
 
 (defn- load-monitor-defaults
   []

--- a/components/workflow/src/ai/miniforge/workflow/registry.clj
+++ b/components/workflow/src/ai/miniforge/workflow/registry.clj
@@ -30,6 +30,7 @@
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.schemas :as schemas])
   (:import
    [java.util.jar JarFile]))
@@ -93,9 +94,10 @@
     (try
       (edn/read-string (slurp resource))
       (catch Exception e
-        (throw (ex-info (str "Failed to load workflow from " resource-path)
-                        {:resource-path resource-path
-                         :error (ex-message e)} e))))))
+        (response/throw-anomaly! :anomalies/fault
+                                (str "Failed to load workflow from " resource-path)
+                                {:resource-path resource-path
+                                 :error (ex-message e)}))))))
 
 (defn discover-workflows-from-resources
   "Discover workflows from classpath resources.
@@ -153,9 +155,10 @@
                          :has-testing has-testing?}]
     ;; Validate against schema
     (when-not (schemas/valid-characteristics? characteristics)
-      (throw (ex-info "Invalid workflow characteristics"
-                      {:characteristics characteristics
-                       :errors (schemas/explain-characteristics characteristics)})))
+      (response/throw-anomaly! :anomalies.workflow/invalid-config
+                              "Invalid workflow characteristics"
+                              {:characteristics characteristics
+                               :errors (schemas/explain-characteristics characteristics)}))
     characteristics))
 
 ;;------------------------------------------------------------------------------ Layer 3
@@ -171,7 +174,9 @@
   [workflow]
   (let [id (:workflow/id workflow)]
     (when-not id
-      (throw (ex-info "Workflow must have :workflow/id" {:workflow workflow})))
+      (response/throw-anomaly! :anomalies/incorrect
+                              "Workflow must have :workflow/id"
+                              {:workflow workflow}))
     (swap! registry assoc id workflow)
     workflow))
 

--- a/components/workflow/src/ai/miniforge/workflow/state.clj
+++ b/components/workflow/src/ai/miniforge/workflow/state.clj
@@ -23,6 +23,7 @@
    Tracks runtime state separately from workflow configuration."
   (:require
    [ai.miniforge.phase.interface :as phase]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.fsm :as fsm]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -107,11 +108,12 @@
       (-> state
           (assoc :execution/status (:state result))
           (record-fsm-transition current-status (:state result) event))
-      (throw (ex-info "Invalid state transition"
-                     {:current-status current-status
-                      :event event
-                      :error (:error result)
-                      :message (:message result)})))))
+      (response/throw-anomaly! :anomalies.workflow/invalid-transition
+                              "Invalid state transition"
+                              {:current-status current-status
+                               :event event
+                               :error (:error result)
+                               :message (:message result)})))))
 
 (defn transition-to-phase
   "Transition execution to a new phase.


### PR DESCRIPTION
## Summary

Completes the slingshot adoption spec — zero ad-hoc `(throw (ex-info ...))` remaining in target components. All 30 throw sites now use `response/throw-anomaly!` with canonical anomaly categories.

**19 files across 6 components:**

| Component | Files | Sites | Categories Used |
|-----------|-------|-------|-----------------|
| workflow | 5 | 10 | invalid-transition, not-found, fault, invalid-config, incorrect |
| agent | 5 | 8 | invoke-failed, llm-error, incorrect, not-found, fault |
| cli | 4 | 7 | not-found, unsupported, fault, invalid-config |
| llm | 2 | 2 | not-found, incorrect |
| gate | 1 | 1 | validation-failed |
| dag-executor | 2 | 2 | incorrect, fault |

Every throw site is now catchable via slingshot `(catch [:anomaly/category :anomalies.llm/rate-limited] ...)` selectors.

## Test plan

- [x] 444 tests, 0 errors, 0 new failures
- [x] Zero `(throw (ex-info ...))` remaining in target components (verified via grep)
- [x] bb-compatible

🤖 Generated with [Claude Code](https://claude.com/claude-code)