### PR TITLE
feat(runner-events): embed workflow-run/* entity fields in lifecycle events

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/messages.clj
+++ b/bases/cli/src/ai/miniforge/cli/messages.clj
@@ -89,4 +89,4 @@
      (response/throw-anomaly! :anomalies/not-found
                              "Missing CLI message key"
                              {:message-key message-key
-                              :locale (active-locale)})))))
+                              :locale (active-locale)}))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -55,7 +55,7 @@
       (catch Exception e
         (response/throw-anomaly! :anomalies/fault
                                 (str "Failed to parse input JSON: " (ex-message e))
-                                {:input s}))))))
+                                {:input s})))))
 
 (defn resolve-input [{:keys [input input-json]}]
   (cond

--- a/components/agent/src/ai/miniforge/agent/file_artifacts.clj
+++ b/components/agent/src/ai/miniforge/agent/file_artifacts.clj
@@ -165,7 +165,7 @@
                               "Failed to snapshot working directory"
                               {:working-dir working-dir
                                :exit exit
-                               :stderr err})))))
+                               :stderr err}))))
 
 (defn snapshot-via-executor
   "Capture git dirty state inside a capsule via the executor.

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -390,7 +390,7 @@
                                                        {:phase :plan
                                                         :parse-result nil
                                                         :llm-content-length (count content)
-                                                        :llm-content-preview (subs content 0 (min 500 (count content)))})))
+                                                        :llm-content-preview (subs content 0 (min 500 (count content)))}))
                       plan-final (finalize-plan plan)]
                   ;; Check for already-satisfied response
                   (if (= :already-satisfied (:plan/status plan-final))
@@ -423,7 +423,7 @@
                ;; No LLM client — hard failure
             (response/throw-anomaly! :anomalies.agent/llm-error
                                     "No LLM backend provided for planner agent"
-                                    {:phase :plan})))))
+                                    {:phase :plan}))))
 
       :validate-fn validate-plan
 

--- a/components/agent/src/ai/miniforge/agent/prompts.clj
+++ b/components/agent/src/ai/miniforge/agent/prompts.clj
@@ -48,11 +48,11 @@
                                     "Prompt data missing :prompt/system key"
                                     {:agent-type agent-type
                                      :resource-path resource-path
-                                     :keys (keys prompt-data)}))))
+                                     :keys (keys prompt-data)})))
       (response/throw-anomaly! :anomalies/not-found
                                 "Could not find prompt resource"
                                 {:agent-type agent-type
-                                 :resource-path resource-path})))))
+                                 :resource-path resource-path}))))
 
 (defn load-prompt-data
   "Load full prompt data map from resources.
@@ -70,7 +70,7 @@
       (response/throw-anomaly! :anomalies/not-found
                                 "Could not find prompt resource"
                                 {:agent-type agent-type
-                                 :resource-path resource-path})))))
+                                 :resource-path resource-path}))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/dag-executor/src/ai/miniforge/dag_executor/execution_plan.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/execution_plan.clj
@@ -119,7 +119,7 @@
       (response/throw-anomaly! :anomalies/incorrect
                               "Invalid execution plan"
                               {:errors errors
-                               :plan   plan-map})))))
+                               :plan   plan-map}))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -203,7 +203,7 @@
         gate-kw
         (fn [ex]
           ;; Extract anomaly from exception data, or default to check-failed
-          (or (:anomaly (ex-data ex))
+          (or (:anomaly/category (ex-data ex))
               :anomalies.gate/check-failed))
         (fn []
           (let [result (check artifact ctx)]
@@ -211,7 +211,7 @@
               result
               (response/throw-anomaly! :anomalies.gate/validation-failed
                                       "Gate validation failed"
-                                      {:errors (:errors result)}))))))))
+                                      {:errors (:errors result)})))))))
    (response/create :gates)
    gate-kws))
 

--- a/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
+++ b/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
@@ -74,17 +74,15 @@
         violations (:violations result)
         duration   (get result :total-duration-ms 0)]
     (if (empty? violations)
-      (response/success {:message (str "Lint clean (" duration "ms)")}
-                        {:duration-ms duration})
-      (response/error (str (count violations) " lint error(s)")
-                      {:data {:errors (mapv violation->lint-error violations)}
-                       :duration-ms duration}))))
+      {:passed? true}
+      {:passed? false
+       :errors (mapv violation->lint-error violations)})))
 
 (defn repair-pre-verify-lint
   "Lint errors cannot be auto-repaired — return to agent."
   [artifact errors _ctx]
-  (response/failure "Lint errors require agent repair"
-                    {:data {:artifact artifact :errors errors}}))
+  {:success? false
+   :errors errors})
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Gate registration

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence/github.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence/github.clj
@@ -52,7 +52,7 @@
 
 (defn- successful-output [result]
   (when (zero? (:exit result))
-    (get result :out "")))
+    (or (get result :out) "")))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Individual fetchers

--- a/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/chain_loader.clj
@@ -126,7 +126,7 @@
       (response/throw-anomaly! :anomalies/not-found
                               (str "Chain '" (name chain-id) "' not found. "
                                    "Looked for: " versioned-path ", " base-path)
-                              {:chain-id chain-id :version version})))))
+                              {:chain-id chain-id :version version}))))
 
 (defn list-chains
   "List all available chain definitions from classpath."

--- a/components/workflow/src/ai/miniforge/workflow/loader.clj
+++ b/components/workflow/src/ai/miniforge/workflow/loader.clj
@@ -137,7 +137,7 @@
                                   "Failed to load workflow from resource"
                                   {:workflow-id workflow-id
                                    :resource-path resource-path
-                                   :error (.getMessage e)})))))))
+                                   :error (.getMessage e)}))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Heuristic store loading
@@ -193,7 +193,7 @@
                               "Workflow validation failed"
                               {:workflow-id workflow-id
                                :version version
-                               :errors (:errors validation)})))
+                               :errors (:errors validation)}))
 
     ;; Cache the validated workflow
     (swap! workflow-cache assoc [workflow-id version] workflow)
@@ -239,7 +239,7 @@
         (response/throw-anomaly! :anomalies/not-found
                                 "Workflow not found"
                                 {:workflow-id workflow-id
-                                 :version version}))))))
+                                 :version version})))))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Workflow discovery

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -69,7 +69,7 @@
     (->> res slurp edn/read-string (validate! ObservePhaseConfig))
     (response/throw-anomaly! :anomalies/not-found
                             "Missing classpath resource: config/workflow/observe-phase.edn"
-                            {:hint "Add components/workflow/resources to your classpath"}))))
+                            {:hint "Add components/workflow/resources to your classpath"})))
 
 (defn- load-monitor-defaults
   []

--- a/components/workflow/src/ai/miniforge/workflow/registry.clj
+++ b/components/workflow/src/ai/miniforge/workflow/registry.clj
@@ -97,7 +97,7 @@
         (response/throw-anomaly! :anomalies/fault
                                 (str "Failed to load workflow from " resource-path)
                                 {:resource-path resource-path
-                                 :error (ex-message e)}))))))
+                                 :error (ex-message e)})))))
 
 (defn discover-workflows-from-resources
   "Discover workflows from classpath resources.

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -259,6 +259,11 @@
 (defn- build-initial-context
   "Build the initial execution context from workflow, input, and opts."
   [workflow input opts]
+  (when (and (= :governed (get opts :execution-mode))
+             (not (and (get opts :executor) (get opts :environment-id))))
+    (response/throw-anomaly! :anomalies.workflow/no-capsule-executor
+                             "No capsule executor available for governed mode — :executor and :environment-id required (N11 §7.4 no-silent-downgrade)"
+                             {}))
   (let [governed? (and (= :governed (get opts :execution-mode))
                        (get opts :executor)
                        (get opts :environment-id))
@@ -341,6 +346,7 @@
        (let [final-ctx (try+
                          (execute-pipeline-loop pipeline initial-ctx callbacks
                                                control-state max-phases)
+                         #_{:clj-kondo/ignore [:unresolved-namespace :unresolved-symbol]}
                          (catch [:anomaly/category :anomalies.dashboard/stop]
                                 {:keys [anomaly/message]}
                            (vreset! exception-vol (ex-info message {:type :dashboard-stop}))
@@ -348,6 +354,7 @@
                                (update :execution/errors conj
                                        (make-execution-error :dashboard-stop message))
                                (assoc :execution/status :failed)))
+                         #_{:clj-kondo/ignore [:unresolved-symbol]}
                          (catch Object e
                            (let [throwable (:throwable &throw-context)
                                  msg (if (instance? Throwable e) (ex-message e) (str e))]

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -91,6 +91,25 @@
       tokens        (assoc :tokens tokens)
       cost-usd      (assoc :cost-usd cost-usd))))
 
+;------------------------------------------------------------------------------ Layer 1.5
+;; Supervisory entity builders
+
+(defn- workflow-run-fields
+  "Entity fields for WorkflowRun projection, embedded in workflow lifecycle events.
+   status is a keyword (:running/:completed/:failed); current-phase is a plain string."
+  [context status current-phase]
+  {:workflow-run/id            (:execution/id context)
+   :workflow-run/workflow-key  (or (some-> (get-in context [:execution/workflow :workflow/id]) name) "")
+   :workflow-run/intent        (or (get-in context [:execution/input :intent])
+                                   (get-in context [:execution/input :task])
+                                   "")
+   :workflow-run/status        status
+   :workflow-run/current-phase current-phase
+   :workflow-run/started-at    (java.util.Date.)
+   :workflow-run/updated-at    (java.util.Date.)
+   :workflow-run/trigger-source (get-in context [:execution/opts :trigger-source] :cli)
+   :workflow-run/correlation-id (:execution/id context)})
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Lifecycle event publishers
 
@@ -100,10 +119,11 @@
   (when event-stream
     (try
       (publish-event! event-stream
-                      (es/workflow-started event-stream
-                                          (:execution/id context)
-                                          (select-keys (:execution/workflow context)
-                                                       [:workflow/id :workflow/version])))
+                      (merge (es/workflow-started event-stream
+                                                  (:execution/id context)
+                                                  (select-keys (:execution/workflow context)
+                                                               [:workflow/id :workflow/version]))
+                             (workflow-run-fields context :running "init")))
       (catch Exception e
         (println (messages/t :warn/publish-started {:error (ex-message e)}))))))
 
@@ -112,18 +132,21 @@
   [event-stream context]
   (when event-stream
     (try
-      (let [wf-id (:execution/id context)
-            metrics-opts (build-completion-metrics context)]
+      (let [wf-id        (:execution/id context)
+            metrics-opts (build-completion-metrics context)
+            last-phase   (or (some-> (:execution/current-phase context) name) "")]
         (if (registry/failed? context)
           (publish-event! event-stream
-                          (es/workflow-failed event-stream wf-id
-                                             {:message (messages/t :status/failed)
-                                              :errors (:execution/errors context)}))
+                          (merge (es/workflow-failed event-stream wf-id
+                                                    {:message (messages/t :status/failed)
+                                                     :errors (:execution/errors context)})
+                                 (workflow-run-fields context :failed last-phase)))
           (publish-event! event-stream
-                          (es/workflow-completed event-stream wf-id
-                                                 (:execution/status context)
-                                                 (get-in context [:execution/metrics :duration-ms])
-                                                 (when (seq metrics-opts) metrics-opts)))))
+                          (merge (es/workflow-completed event-stream wf-id
+                                                       (:execution/status context)
+                                                       (get-in context [:execution/metrics :duration-ms])
+                                                       (when (seq metrics-opts) metrics-opts))
+                                 (workflow-run-fields context :completed last-phase)))))
       (catch Exception e
         (println (messages/t :warn/publish-completed {:error (ex-message e)}))))))
 
@@ -133,8 +156,9 @@
   (when event-stream
     (try
       (publish-event! event-stream
-                      (es/phase-started event-stream (:execution/id context) phase-name
-                                        {:phase/index (:execution/phase-index context)}))
+                      (merge (es/phase-started event-stream (:execution/id context) phase-name
+                                               {:phase/index (:execution/phase-index context)})
+                             (workflow-run-fields context :running (name phase-name))))
       (catch Exception e
         (println (messages/t :warn/publish-phase-started {:error (ex-message e)}))))))
 

--- a/components/workflow/src/ai/miniforge/workflow/state.clj
+++ b/components/workflow/src/ai/miniforge/workflow/state.clj
@@ -113,7 +113,7 @@
                               {:current-status current-status
                                :event event
                                :error (:error result)
-                               :message (:message result)})))))
+                               :message (:message result)}))))
 
 (defn transition-to-phase
   "Transition execution to a new phase.


### PR DESCRIPTION
## Summary

- Merges `workflow-run/*` projection fields into `workflow/started`, `workflow/completed`, `workflow/failed`, and `workflow/phase-started` events so the Rust StateManager can deserialize `WorkflowRun` entities directly from the Transit-JSON event stream
- Without this change, the StateManager counted events correctly but produced an empty supervisory view — all `WorkflowRun` deserialization attempts silently failed due to `workflow/id` vs `workflow-run/id` key mismatch
- Also fixes 17 pre-existing unmatched delimiter syntax errors from the slingshot migration (#526) and 4 additional pre-existing test failures that were masked by the linting failures

## Pre-existing fixes revealed by unblocking linting

- **gate/interface**: anomaly-fn used `:anomaly` key but slingshot exceptions use `:anomaly/category`
- **gate/pre-verify-lint**: `check` / `repair` functions returned `response/success` maps instead of the `{:passed? bool}` gate spec format
- **workflow/runner**: governed mode silently downgraded to local execution when no capsule was provided, violating N11 §7.4 no-silent-downgrade; restored throw behavior
- **tui-views/github**: `(get result :out "")` returns nil when `:out` key exists with nil value; changed to `(or (get result :out) "")`

## Test plan

- [x] Pre-commit hook passes: 1880 tests, 0 failures, 0 errors
- [ ] End-to-end: start a workflow run, open `miniforge-console`, verify workflow runs appear in the supervisory view

🤖 Generated with [Claude Code](https://claude.com/claude-code)