### PR TITLE
fix(review): remediate 9 standards violations from #529 review

### DIFF
--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -202,9 +202,7 @@
         chain
         gate-kw
         (fn [ex]
-          ;; Extract anomaly from exception data, or default to check-failed
-          (or (:anomaly/category (ex-data ex))
-              :anomalies.gate/check-failed))
+          (get (ex-data ex) :anomaly/category :anomalies.gate/check-failed))
         (fn []
           (let [result (check artifact ctx)]
             (if (passed? result)

--- a/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
+++ b/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
@@ -15,7 +15,6 @@
    [ai.miniforge.connector-linter.interface :as linter]
    [ai.miniforge.cli.repo-analyzer :as analyzer]
    [ai.miniforge.gate.registry :as registry]
-   [ai.miniforge.response.builder :as response]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -71,8 +70,7 @@
         techs      (detect-technologies artifact)
         fps        @analyzer/fingerprints
         result     (linter/run-all worktree fps techs)
-        violations (:violations result)
-        duration   (get result :total-duration-ms 0)]
+        violations (:violations result)]
     (if (empty? violations)
       {:passed? true}
       {:passed? false
@@ -80,7 +78,7 @@
 
 (defn repair-pre-verify-lint
   "Lint errors cannot be auto-repaired — return to agent."
-  [artifact errors _ctx]
+  [_artifact errors _ctx]
   {:success? false
    :errors errors})
 

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -41,7 +41,7 @@
             [ai.miniforge.workflow.runner-defaults :as defaults]
             [ai.miniforge.workflow.runner-environment :as env]
             [ai.miniforge.workflow.runner-events :as events]
-            [slingshot.slingshot :refer [try+ throw+]]))
+            [slingshot.slingshot :refer [try+]]))
 
 (defonce ^:private runner-logger
   (log/create-logger {:min-level :debug :output :human}))
@@ -259,35 +259,35 @@
 (defn- build-initial-context
   "Build the initial execution context from workflow, input, and opts."
   [workflow input opts]
-  (when (and (= :governed (get opts :execution-mode))
-             (not (and (get opts :executor) (get opts :environment-id))))
-    (response/throw-anomaly! :anomalies.workflow/no-capsule-executor
-                             "No capsule executor available for governed mode — :executor and :environment-id required (N11 §7.4 no-silent-downgrade)"
-                             {}))
-  (let [governed? (and (= :governed (get opts :execution-mode))
+  (let [mode      (get opts :execution-mode :local)
+        governed? (and (= :governed mode)
                        (get opts :executor)
-                       (get opts :environment-id))
-        capsule-exec-fn (when governed?
-                          (llm-impl/capsule-exec-fn
-                           dag-exec/execute!
-                           (get opts :executor)
-                           (get opts :environment-id)
-                           (get opts :worktree-path (defaults/default-workdir))))]
-    (-> (ctx/create-context workflow input opts)
-        (assoc :execution/executor (get opts :executor)
-               :execution/environment-id (get opts :environment-id)
-               :execution/worktree-path (get opts :worktree-path
-                                             (get opts :sandbox-workdir))
-               :execution/mode (get opts :execution-mode :local)
-               :execution/started-at (java.time.Instant/now)
-               :execution/environment-metadata (get opts :environment-metadata)
-               :execution/execute-fn (when governed? dag-exec/execute!)
-               :execution/exec-fn capsule-exec-fn
-               :execution/task-branch (when governed?
-                                        (str (defaults/task-branch-prefix)
-                                             (get opts :environment-id
-                                                  (subs (str (random-uuid)) 0 8))))
-               :execution/run-pipeline-fn run-pipeline))))
+                       (get opts :environment-id))]
+    (when (and (= :governed mode) (not governed?))
+      (response/throw-anomaly! :anomalies.workflow/no-capsule-executor
+                               (messages/t :governed/no-capsule)
+                               {}))
+    (let [capsule-exec-fn (when governed?
+                            (llm-impl/capsule-exec-fn
+                             dag-exec/execute!
+                             (get opts :executor)
+                             (get opts :environment-id)
+                             (get opts :worktree-path (defaults/default-workdir))))]
+      (-> (ctx/create-context workflow input opts)
+          (assoc :execution/executor (get opts :executor)
+                 :execution/environment-id (get opts :environment-id)
+                 :execution/worktree-path (get opts :worktree-path
+                                               (get opts :sandbox-workdir))
+                 :execution/mode mode
+                 :execution/started-at (java.time.Instant/now)
+                 :execution/environment-metadata (get opts :environment-metadata)
+                 :execution/execute-fn (when governed? dag-exec/execute!)
+                 :execution/exec-fn capsule-exec-fn
+                 :execution/task-branch (when governed?
+                                          (str (defaults/task-branch-prefix)
+                                               (get opts :environment-id
+                                                    (subs (str (random-uuid)) 0 8))))
+                 :execution/run-pipeline-fn run-pipeline)))))
 
 (defn- execute-pipeline-loop
   "Execute the phase pipeline loop. Returns final context."

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -94,21 +94,24 @@
 ;------------------------------------------------------------------------------ Layer 1.5
 ;; Supervisory entity builders
 
+(def ^:private initial-phase "init")
+
 (defn- workflow-run-fields
   "Entity fields for WorkflowRun projection, embedded in workflow lifecycle events.
    status is a keyword (:running/:completed/:failed); current-phase is a plain string."
   [context status current-phase]
-  {:workflow-run/id            (:execution/id context)
-   :workflow-run/workflow-key  (or (some-> (get-in context [:execution/workflow :workflow/id]) name) "")
-   :workflow-run/intent        (or (get-in context [:execution/input :intent])
-                                   (get-in context [:execution/input :task])
-                                   "")
-   :workflow-run/status        status
-   :workflow-run/current-phase current-phase
-   :workflow-run/started-at    (java.util.Date.)
-   :workflow-run/updated-at    (java.util.Date.)
-   :workflow-run/trigger-source (get-in context [:execution/opts :trigger-source] :cli)
-   :workflow-run/correlation-id (:execution/id context)})
+  (let [now (java.util.Date.)]
+    {:workflow-run/id            (:execution/id context)
+     :workflow-run/workflow-key  (or (some-> (get-in context [:execution/workflow :workflow/id]) name) "")
+     :workflow-run/intent        (or (get-in context [:execution/input :intent])
+                                     (get-in context [:execution/input :task])
+                                     "")
+     :workflow-run/status        status
+     :workflow-run/current-phase current-phase
+     :workflow-run/started-at    now
+     :workflow-run/updated-at    now
+     :workflow-run/trigger-source (get-in context [:execution/opts :trigger-source] :cli)
+     :workflow-run/correlation-id (:execution/id context)}))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Lifecycle event publishers
@@ -123,7 +126,7 @@
                                                   (:execution/id context)
                                                   (select-keys (:execution/workflow context)
                                                                [:workflow/id :workflow/version]))
-                             (workflow-run-fields context :running "init")))
+                             (workflow-run-fields context :running initial-phase)))
       (catch Exception e
         (println (messages/t :warn/publish-started {:error (ex-message e)}))))))
 

--- a/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
@@ -1,0 +1,114 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.runner-events-test
+  "Tests for workflow lifecycle event publishing.
+   Verifies that workflow-run/* entity fields are merged into lifecycle events
+   so the Rust StateManager can deserialize WorkflowRun projections."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.workflow.runner-events :as events]
+   [ai.miniforge.event-stream.interface :as event-stream]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- test-context
+  "Minimal execution context for event publishing tests."
+  []
+  {:execution/id            (random-uuid)
+   :execution/workflow      {:workflow/id :test-wf :workflow/version "1.0.0"}
+   :execution/input         {:intent "Test task"}
+   :execution/opts          {:trigger-source :api}
+   :execution/status        :running
+   :execution/errors        []
+   :execution/metrics       {:duration-ms 100}
+   :execution/current-phase :plan
+   :execution/phase-index   0})
+
+(defn- create-stream []
+  (event-stream/create-event-stream {:sinks []}))
+
+(defn- first-event [stream]
+  (first (:events @stream)))
+
+;------------------------------------------------------------------------------ publish-workflow-started!
+
+(deftest publish-workflow-started-includes-entity-fields-test
+  (testing "publish-workflow-started! merges workflow-run/* fields"
+    (let [stream (create-stream)
+          ctx    (test-context)]
+      (events/publish-workflow-started! stream ctx)
+      (let [ev (first-event stream)]
+        (is (= (:execution/id ctx) (:workflow-run/id ev)))
+        (is (= "test-wf" (:workflow-run/workflow-key ev)))
+        (is (= "Test task" (:workflow-run/intent ev)))
+        (is (= :running (:workflow-run/status ev)))
+        (is (= "init" (:workflow-run/current-phase ev)))
+        (is (= :api (:workflow-run/trigger-source ev)))
+        (is (inst? (:workflow-run/started-at ev)))
+        (is (inst? (:workflow-run/updated-at ev)))))))
+
+(deftest publish-workflow-started-timestamps-same-instant-test
+  (testing "started-at and updated-at are bound to the same instant"
+    (let [stream (create-stream)
+          ctx    (test-context)]
+      (events/publish-workflow-started! stream ctx)
+      (let [ev (first-event stream)]
+        (is (= (:workflow-run/started-at ev)
+               (:workflow-run/updated-at ev)))))))
+
+(deftest publish-workflow-started-nil-stream-is-noop-test
+  (testing "nil event-stream does not throw"
+    (is (nil? (events/publish-workflow-started! nil (test-context))))))
+
+;------------------------------------------------------------------------------ publish-workflow-completed!
+
+(deftest publish-workflow-completed-success-entity-fields-test
+  (testing "publish-workflow-completed! merges workflow-run/* on success"
+    (let [stream (create-stream)
+          ctx    (assoc (test-context) :execution/status :completed)]
+      (events/publish-workflow-completed! stream ctx)
+      (let [ev (first-event stream)]
+        (is (= (:execution/id ctx) (:workflow-run/id ev)))
+        (is (= :completed (:workflow-run/status ev)))
+        (is (= "plan" (:workflow-run/current-phase ev)))))))
+
+(deftest publish-workflow-completed-failed-entity-fields-test
+  (testing "publish-workflow-completed! merges workflow-run/* on failure"
+    (let [stream (create-stream)
+          ctx    (assoc (test-context) :execution/status :failed)]
+      (events/publish-workflow-completed! stream ctx)
+      (let [ev (first-event stream)]
+        (is (= (:execution/id ctx) (:workflow-run/id ev)))
+        (is (= :failed (:workflow-run/status ev)))))))
+
+;------------------------------------------------------------------------------ publish-phase-started!
+
+(deftest publish-phase-started-includes-entity-fields-test
+  (testing "publish-phase-started! merges workflow-run/* fields with phase as current-phase"
+    (let [stream (create-stream)
+          ctx    (test-context)]
+      (events/publish-phase-started! stream ctx :implement)
+      (let [ev (first-event stream)]
+        (is (= (:execution/id ctx) (:workflow-run/id ev)))
+        (is (= :running (:workflow-run/status ev)))
+        (is (= "implement" (:workflow-run/current-phase ev)))))))
+
+(deftest publish-phase-started-nil-stream-is-noop-test
+  (testing "nil event-stream does not throw"
+    (is (nil? (events/publish-phase-started! nil (test-context) :plan)))))


### PR DESCRIPTION
## Summary

Post-merge cleanup of standards violations found in code review of #529.

- **`gate/interface.clj`**: `(get ex-data :anomaly/category :default)` instead of `(or (:anomaly/category ...) :default)` — prefers 3-arg `get` over `or`-form for default values
- **`pre-verify-lint.clj`**: Remove unused `response.builder` require; remove unused `duration` binding; rename `artifact` → `_artifact` in `repair-pre-verify-lint`
- **`runner-events.clj`**: Bind `(java.util.Date.)` once as `now` (DRY — both `started-at` and `updated-at` now guaranteed the same instant); extract `initial-phase "init"` constant
- **`runner.clj`**: Extract `mode` binding, compute `governed?` once; use `(messages/t :governed/no-capsule)` instead of raw string; remove unused `throw+` refer from slingshot import
- **New**: `runner_events_test.clj` — 7 tests covering `workflow-run/*` field merge for `publish-workflow-started!`, `publish-workflow-completed!`, and `publish-phase-started!`

## Test plan

- [ ] All 1887 tests pass (pre-commit verified — 0 failures, 0 errors)
- [ ] `runner_events_test.clj`: 7 tests, 19 assertions — verifies entity fields appear in lifecycle events

🤖 Generated with [Claude Code](https://claude.com/claude-code)