### PR TITLE
refactor: centralize storage root + profile-based token resolution

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/control_plane.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/control_plane.clj
@@ -26,6 +26,7 @@
    Layer 1: HTTP client helpers
    Layer 2: CLI commands"
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [cheshire.core :as json]
@@ -48,7 +49,7 @@
   "Read the dashboard port from discovery file.
    Returns base URL string or nil."
   []
-  (let [discovery-file (str (System/getProperty "user.home") "/.miniforge/dashboard.port")]
+  (let [discovery-file (str (config/miniforge-home) "/dashboard.port")]
     (when (.exists (io/file discovery-file))
       (try
         (let [info (json/parse-string (slurp discovery-file) true)

--- a/components/adapter-claude-code/deps.edn
+++ b/components/adapter-claude-code/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/logging {:local/root "../logging"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/response {:local/root "../response"}
         ai.miniforge/control-plane {:local/root "../control-plane"}
         ai.miniforge/control-plane-adapter {:local/root "../control-plane-adapter"}}

--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/interface.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/interface.clj
@@ -26,6 +26,7 @@
    Layer 1: Protocol implementation"
   (:require
    [ai.miniforge.adapter-claude-code.discovery :as discovery]
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.control-plane.messages :as messages]
    [ai.miniforge.control-plane-adapter.protocol :as proto]
    [clojure.java.io :as io]))
@@ -35,7 +36,7 @@
 
 (def ^:const decisions-dir
   "Directory where decisions are dropped for Claude Code agents."
-  (str (System/getProperty "user.home") "/.miniforge/decisions"))
+  (str (config/miniforge-home) "/decisions"))
 
 (defn- ensure-decisions-dir! [agent-id]
   (let [dir (io/file decisions-dir (str agent-id))]

--- a/components/artifact/deps.edn
+++ b/components/artifact/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema {:local/root "../schema"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         datalevin/datalevin {:mvn/version "0.9.16"}
         com.cognitect/transit-clj {:mvn/version "1.0.333"}}

--- a/components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj
+++ b/components/artifact/src/ai/miniforge/artifact/protocols/impl/transit_store.clj
@@ -22,6 +22,7 @@
    These functions implement the ArtifactStore protocol for the Transit-based store.
    They are used by the TransitArtifactStore record."
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [cognitect.transit :as transit]
    [ai.miniforge.artifact.core :as core]
@@ -38,7 +39,7 @@
   ([base-dir]
    (if base-dir
      (str base-dir "/artifacts")
-     (str (System/getProperty "user.home") "/.miniforge/artifacts"))))
+     (str (config/miniforge-home) "/artifacts"))))
 
 (defn artifact-file-path
   "Get the file path for an artifact by ID."

--- a/components/config/src/ai/miniforge/config/governance.clj
+++ b/components/config/src/ai/miniforge/config/governance.clj
@@ -37,7 +37,8 @@
    [clojure.java.io :as io]
    [clojure.edn :as edn]
    [babashka.fs :as fs]
-   [ai.miniforge.config.digest :as digest]))
+   [ai.miniforge.config.digest :as digest]
+   [ai.miniforge.config.user :as user]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants and helpers
@@ -51,7 +52,7 @@
 
 (def user-config-path
   "Default path to user config file."
-  (str (fs/home) "/.miniforge/config.edn"))
+  (str (user/miniforge-home) "/config.edn"))
 
 (defn resolve-profile
   "Resolve governance profile from env var or opts.

--- a/components/config/src/ai/miniforge/config/interface.clj
+++ b/components/config/src/ai/miniforge/config/interface.clj
@@ -21,11 +21,13 @@
   (:require
    [ai.miniforge.config.user :as user]
    [ai.miniforge.config.governance :as governance]
-   [ai.miniforge.config.digest :as digest]))
+   [ai.miniforge.config.digest :as digest]
+   [ai.miniforge.config.profile :as profile]))
 
 ;; Re-export public functions
 (def default-user-config-path user/default-user-config-path)
 (def default-config user/default-config)
+(def miniforge-home user/miniforge-home)
 
 (defn load-user-config
   "Load user configuration from file."
@@ -88,3 +90,21 @@
   "Verify governance file content against digest manifest."
   [config-key content]
   (digest/verify-governance-file config-key content))
+
+;; Profile functions
+(def profile-path profile/profile-path)
+
+(defn load-profile
+  "Load user profile from ~/.miniforge/profile.edn."
+  ([] (profile/load-profile))
+  ([path] (profile/load-profile path)))
+
+(defn validate-profile
+  "Validate a profile map. Returns {:valid? bool :errors [...]}."
+  [p]
+  (profile/validate-profile p))
+
+(defn resolve-token
+  "Resolve git token for a host kind using profile + env var chain."
+  [host-kind & [opts]]
+  (profile/resolve-token host-kind opts))

--- a/components/config/src/ai/miniforge/config/profile.clj
+++ b/components/config/src/ai/miniforge/config/profile.clj
@@ -1,0 +1,125 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.config.profile
+  "User profile management (~/.miniforge/profile.edn).
+
+   Provides token storage, identity, and default preferences using Aero
+   for environment variable resolution. Profile is user-scoped — never
+   checked into a repository.
+
+   Token resolution order:
+   1. MINIFORGE_GIT_TOKEN env (universal override)
+   2. Profile token for the requested host kind
+   3. Provider-specific env var (GH_TOKEN, GITLAB_TOKEN)
+   4. CLI fallback (gh auth token)
+
+   Layer 0: Schema and path
+   Layer 1: Load and validate
+   Layer 2: Token resolution"
+  (:require
+   [aero.core :as aero]
+   [ai.miniforge.config.user :as user]
+   [clojure.java.io :as io]
+   [clojure.java.shell :as shell]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema and path
+
+(def profile-path
+  "Default location for user profile."
+  (str (user/miniforge-home) "/profile.edn"))
+
+
+;------------------------------------------------------------------------------ Layer 1
+;; Load and validate
+
+(defn load-profile
+  "Load user profile from ~/.miniforge/profile.edn using Aero.
+   Returns the profile map, or nil if file does not exist."
+  ([] (load-profile profile-path))
+  ([path]
+   (let [f (io/file path)]
+     (when (.exists f)
+       (try
+         (aero/read-config f)
+         (catch Exception _
+           nil))))))
+
+(defn validate-profile
+  "Validate a profile map. Returns {:valid? bool :errors [...]}.
+   Checks that :tokens is a map with keyword keys and string values,
+   and that :identity has :name and :email when present."
+  [profile]
+  (let [errors (cond-> []
+                 (and (:tokens profile)
+                      (not (map? (:tokens profile))))
+                 (conj ":tokens must be a map")
+
+                 (and (:identity profile)
+                      (not (map? (:identity profile))))
+                 (conj ":identity must be a map")
+
+                 (and (get-in profile [:identity :email])
+                      (not (string? (get-in profile [:identity :email]))))
+                 (conj ":identity/:email must be a string")
+
+                 (and (get-in profile [:identity :name])
+                      (not (string? (get-in profile [:identity :name]))))
+                 (conj ":identity/:name must be a string"))]
+    {:valid? (empty? errors)
+     :errors errors}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Token resolution
+
+(defn- gh-cli-token
+  "Attempt to get a GitHub token from the gh CLI.
+   Returns the token string or nil."
+  []
+  (try
+    (let [r (shell/sh "gh" "auth" "token")]
+      (when (zero? (:exit r))
+        (let [token (str/trim (:out r))]
+          (when (seq token) token))))
+    (catch Exception _ nil)))
+
+(defn resolve-token
+  "Resolve a git authentication token for a given host kind.
+
+   Resolution order:
+   1. MINIFORGE_GIT_TOKEN env var (universal override)
+   2. Profile :tokens entry for the host kind
+   3. Provider-specific env var (GH_TOKEN / GITLAB_TOKEN)
+   4. gh CLI fallback (GitHub only)
+
+   Arguments:
+   - host-kind: :github, :gitlab, :bitbucket, or :custom
+   - opts: optional map with :profile (pre-loaded profile map)
+
+   Returns: token string or nil."
+  [host-kind & [{:keys [profile]}]]
+  (let [profile (or profile (load-profile))]
+    (or (System/getenv "MINIFORGE_GIT_TOKEN")
+        (get-in profile [:tokens host-kind])
+        (case host-kind
+          :gitlab  (System/getenv "GITLAB_TOKEN")
+          :github  (or (System/getenv "GH_TOKEN") (gh-cli-token))
+          ;; bitbucket, custom — no additional fallback
+          nil))))

--- a/components/config/src/ai/miniforge/config/user.clj
+++ b/components/config/src/ai/miniforge/config/user.clj
@@ -33,9 +33,16 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Constants and utilities
 
+(defn miniforge-home
+  "Return the miniforge home directory.
+   Resolution: MINIFORGE_HOME env > ~/.miniforge"
+  []
+  (or (System/getenv "MINIFORGE_HOME")
+      (str (System/getProperty "user.home") "/.miniforge")))
+
 (def default-user-config-path
   "Default location for user config file."
-  (str (fs/home) "/.miniforge/config.edn"))
+  (str (miniforge-home) "/config.edn"))
 
 (def ^:private default-config-resource-path
   "Primary resource path for shipped user config defaults."

--- a/components/config/test/ai/miniforge/config/profile_test.clj
+++ b/components/config/test/ai/miniforge/config/profile_test.clj
@@ -1,0 +1,98 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.config.profile-test
+  "Tests for user profile loading and token resolution."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.config.profile :as profile]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; validate-profile tests
+
+(deftest validate-profile-valid-test
+  (testing "Valid profile passes validation"
+    (let [p {:tokens {:github "tok-123" :gitlab "tok-456"}
+             :identity {:name "Test User" :email "test@example.com"}
+             :defaults {:agent :claude-code}}
+          result (profile/validate-profile p)]
+      (is (:valid? result))
+      (is (empty? (:errors result))))))
+
+(deftest validate-profile-empty-test
+  (testing "Empty profile is valid (all fields optional)"
+    (let [result (profile/validate-profile {})]
+      (is (:valid? result)))))
+
+(deftest validate-profile-bad-tokens-test
+  (testing "Non-map :tokens fails"
+    (let [result (profile/validate-profile {:tokens "not-a-map"})]
+      (is (not (:valid? result)))
+      (is (some #(re-find #":tokens" %) (:errors result))))))
+
+(deftest validate-profile-bad-identity-test
+  (testing "Non-map :identity fails"
+    (let [result (profile/validate-profile {:identity "not-a-map"})]
+      (is (not (:valid? result))))))
+
+(deftest validate-profile-bad-email-test
+  (testing "Non-string email fails"
+    (let [result (profile/validate-profile {:identity {:email 123}})]
+      (is (not (:valid? result))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; load-profile tests
+
+(deftest load-profile-missing-file-test
+  (testing "Missing file returns nil"
+    (is (nil? (profile/load-profile "/tmp/nonexistent-miniforge-profile.edn")))))
+
+(deftest load-profile-roundtrip-test
+  (testing "Aero reads profile with #env tags"
+    (let [tmp (java.io.File/createTempFile "profile-test" ".edn")]
+      (try
+        (spit tmp "{:tokens {:github \"test-token\"}\n :identity {:name \"Chris\" :email \"c@m.ai\"}}")
+        (let [p (profile/load-profile (.getPath tmp))]
+          (is (= "test-token" (get-in p [:tokens :github])))
+          (is (= "Chris" (get-in p [:identity :name]))))
+        (finally
+          (.delete tmp))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; resolve-token tests
+
+(deftest resolve-token-from-profile-test
+  (testing "Token resolved from profile when no env override"
+    (let [profile {:tokens {:github "profile-gh-token"
+                            :gitlab "profile-gl-token"}}]
+      ;; Profile token should be returned when no MINIFORGE_GIT_TOKEN env
+      ;; (We can't unset env vars in tests, but we can pass profile directly)
+      (is (= "profile-gh-token"
+             (profile/resolve-token :github {:profile profile})))
+      (is (= "profile-gl-token"
+             (profile/resolve-token :gitlab {:profile profile}))))))
+
+(deftest resolve-token-nil-for-unknown-host-test
+  (testing "Unknown host kind with no profile returns nil"
+    (let [profile {:tokens {}}]
+      (is (nil? (profile/resolve-token :custom {:profile profile}))))))
+
+(deftest resolve-token-profile-nil-test
+  (testing "Nil profile with no env vars falls through"
+    ;; With empty profile and no matching env var, should return nil for :custom
+    (is (nil? (profile/resolve-token :custom {:profile {}})))))

--- a/components/dag-executor/deps.edn
+++ b/components/dag-executor/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/dag-primitives {:local/root "../dag-primitives"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/dag-primitives {:local/root "../dag-primitives"}
         ai.miniforge/task {:local/root "../task"}
         ai.miniforge/loop {:local/root "../loop"}
         ai.miniforge/logging {:local/root "../logging"}

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
@@ -26,6 +26,7 @@
    - resources/executor/docker/Dockerfile.task-runner       (minimal Alpine)
    - resources/executor/docker/Dockerfile.task-runner-clojure (with Clojure tooling)"
   (:require
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.dag-executor.result :as result]
    [ai.miniforge.dag-executor.workspace :as workspace]
    [ai.miniforge.dag-executor.protocols.executor :as proto]
@@ -514,19 +515,10 @@
 
 (defn- resolve-git-token
   "Resolve a git authentication token for capsule clone.
-   One canonical env var per provider:
-   - MINIFORGE_GIT_TOKEN — universal override (any host)
-   - GITLAB_TOKEN — GitLab hosts
-   - GH_TOKEN — GitHub hosts (fallback: `gh auth token` CLI)"
+   Delegates to config/resolve-token which uses the profile + env chain:
+   MINIFORGE_GIT_TOKEN → profile → provider env var → CLI fallback."
   [_repo-url {:keys [host-kind]}]
-  (or (System/getenv "MINIFORGE_GIT_TOKEN")
-      (case host-kind
-        :gitlab (System/getenv "GITLAB_TOKEN")
-        (or (System/getenv "GH_TOKEN")
-            (try (let [r (clojure.java.shell/sh "gh" "auth" "token")]
-                   (when (zero? (:exit r))
-                     (str/trim (:out r))))
-                 (catch Exception _ nil))))))
+  (config/resolve-token host-kind))
 
 
 (defn- authenticated-https-url

--- a/components/event-stream/deps.edn
+++ b/components/event-stream/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/logging {:local/root "../logging"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/schema {:local/root "../schema"}
         com.cognitect/transit-clj {:mvn/version "1.0.333"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -26,6 +26,7 @@
    - :fleet  - Send to fleet command (org-level ops)
    - :multi  - Combine multiple sinks"
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [clojure.pprint :as pprint]
@@ -40,7 +41,7 @@
 (defn- default-events-dir
   "Return the default events directory (~/.miniforge/events)."
   []
-  (io/file (System/getProperty "user.home") ".miniforge" "events"))
+  (io/file (config/miniforge-home) "events"))
 
 (defn- now-sortable-str
   "Return a sortable UTC timestamp string for use as a file-name prefix.

--- a/components/knowledge/deps.edn
+++ b/components/knowledge/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/algorithms {:local/root "../algorithms"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/algorithms {:local/root "../algorithms"}
         ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}

--- a/components/knowledge/src/ai/miniforge/knowledge/store.clj
+++ b/components/knowledge/src/ai/miniforge/knowledge/store.clj
@@ -23,6 +23,7 @@
    Layer 1: Query operations
    Layer 2: Agent injection"
   (:require
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.knowledge.messages :as messages]
    [ai.miniforge.knowledge.zettel :as zettel]
    [ai.miniforge.logging.interface :as log]
@@ -255,7 +256,7 @@
      (create-file-backed-store)
      (create-file-backed-store {:path \"/repo/.miniforge/knowledge\"})"
   [& [{:keys [path logger]}]]
-  (let [base-path (expand-path (or path "~/.miniforge/knowledge"))
+  (let [base-path (expand-path (or path (str (config/miniforge-home) "/knowledge")))
         _ (ensure-directory base-path)
         log (or logger (log/create-logger {:min-level :info :output (fn [_])}))
         initial (scan-directory base-path)]

--- a/components/logging/deps.edn
+++ b/components/logging/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src" "resources"]
- :deps {}
+ :deps {ai.miniforge/config {:local/root "../config"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/logging/src/ai/miniforge/logging/core.clj
+++ b/components/logging/src/ai/miniforge/logging/core.clj
@@ -21,6 +21,7 @@
    Layer 0: Pure functions for log entry creation
    Layer 1: Logger protocol and default implementation"
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -123,8 +124,7 @@
 
    Returns: String path to ~/.miniforge/logs/<workflow-id>.log"
   [workflow-id]
-  (let [home (System/getProperty "user.home")
-        logs-dir (io/file home ".miniforge" "logs")
+  (let [logs-dir (io/file (config/miniforge-home) "logs")
         log-file (str workflow-id ".log")]
     (.mkdirs logs-dir)
     (.getPath (io/file logs-dir log-file))))

--- a/components/logging/src/ai/miniforge/logging/sinks.clj
+++ b/components/logging/src/ai/miniforge/logging/sinks.clj
@@ -26,6 +26,7 @@
    - :fleet  - Send to fleet command (org-level ops)
    - :multi  - Combine multiple sinks"
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.logging.core :as core]))
@@ -40,8 +41,7 @@
 
    Returns: String path to ~/.miniforge/logs/<workflow-id>.log"
   [workflow-id]
-  (let [home (System/getProperty "user.home")
-        logs-dir (io/file home ".miniforge" "logs")
+  (let [logs-dir (io/file (config/miniforge-home) "logs")
         log-file (str workflow-id ".log")]
     (.mkdirs logs-dir)
     (.getPath (io/file logs-dir log-file))))

--- a/components/phase/deps.edn
+++ b/components/phase/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {}
+ :deps {ai.miniforge/config {:local/root "../config"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {}}}}

--- a/components/phase/src/ai/miniforge/phase/agent_behavior.clj
+++ b/components/phase/src/ai/miniforge/phase/agent_behavior.clj
@@ -31,7 +31,8 @@
    Layer 0: Behavior extraction and formatting
    Layer 1: Rule loading (built-in + standards + user packs)
    Layer 2: Full pipeline"
-  (:require [clojure.edn :as edn]
+  (:require [ai.miniforge.config.interface :as config]
+            [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.string :as str]))
 
@@ -175,7 +176,7 @@
    - Vector of rules, or empty vector on failure"
   []
   (try
-    (let [packs-dir (io/file (System/getProperty "user.home") ".miniforge" "packs")]
+    (let [packs-dir (io/file (config/miniforge-home) "packs")]
       (if (.isDirectory packs-dir)
         (when-let [load-all (requiring-resolve 'ai.miniforge.policy-pack.interface/load-all-packs)]
           (let [result (load-all (str packs-dir))]

--- a/components/pr-lifecycle/deps.edn
+++ b/components/pr-lifecycle/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/dag-executor {:local/root "../dag-executor"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/dag-executor {:local/root "../dag-executor"}
         ai.miniforge/release-executor {:local/root "../release-executor"}
         ai.miniforge/loop {:local/root "../loop"}
         ai.miniforge/agent {:local/root "../agent"}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_budget.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_budget.clj
@@ -22,6 +22,7 @@
    Budget state is persisted in ~/.miniforge/state/pr-monitor/ so that
    restarts do not reset counters."
   (:require
+   [ai.miniforge.config.interface :as mf-config]
    [ai.miniforge.pr-lifecycle.monitor-config :as config]
    [ai.miniforge.schema.interface :as schema]
    [clojure.edn :as edn]
@@ -163,7 +164,7 @@
 ;; Budget persistence
 
 (def ^:private state-dir
-  (str (System/getProperty "user.home") "/.miniforge/state/pr-monitor"))
+  (str (mf-config/miniforge-home) "/state/pr-monitor"))
 
 (defn save-budget!
   "Persist budget state to disk."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/pr_poller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/pr_poller.clj
@@ -22,6 +22,7 @@
    Uses the gh CLI for all GitHub API access — no long-lived tokens
    needed beyond the local gh auth configuration."
   (:require
+   [ai.miniforge.config.interface :as mf-config]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.schema.interface :as schema]
@@ -67,7 +68,7 @@
 
 (def ^:private state-dir
   "Base directory for PR monitor state."
-  (str (System/getProperty "user.home") "/.miniforge/state/pr-monitor"))
+  (str (mf-config/miniforge-home) "/state/pr-monitor"))
 
 (defn- ensure-state-dir!
   "Ensure the state directory exists."

--- a/components/pr-sync/deps.edn
+++ b/components/pr-sync/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/messages {:local/root "../messages"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/messages {:local/root "../messages"}
         cheshire/cheshire {:mvn/version "5.13.0"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
+++ b/components/pr-sync/src/ai/miniforge/pr_sync/core.clj
@@ -28,6 +28,7 @@
 
    Pure status mapping lives in ai.miniforge.pr-sync.status."
   (:require
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.pr-sync.messages :as messages]
    [ai.miniforge.pr-sync.status :as status]
    [clojure.edn :as edn]
@@ -40,7 +41,7 @@
 ;; Constants
 
 (def default-fleet-config-path
-  (str (System/getProperty "user.home") "/.miniforge/config.edn"))
+  (str (config/miniforge-home) "/config.edn"))
 
 (def github-repo-slug-pattern
   #"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")

--- a/components/self-healing/deps.edn
+++ b/components/self-healing/deps.edn
@@ -18,7 +18,8 @@
 
 {:paths ["src" "resources"]
 
- :deps {org.clojure/clojure {:mvn/version "1.12.0"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        org.clojure/clojure {:mvn/version "1.12.0"}
         clj-http/clj-http {:mvn/version "3.13.0"}}
 
  :aliases

--- a/components/self-healing/src/ai/miniforge/self_healing/workaround_detector.clj
+++ b/components/self-healing/src/ai/miniforge/self_healing/workaround_detector.clj
@@ -24,6 +24,7 @@
    - Tier 2 (prompt-once): sudo operations, install packages
    - Tier 3 (always-prompt): Delete files, modify system configs"
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [ai.miniforge.self-healing.workaround-registry :as registry]))
@@ -95,7 +96,7 @@
 
    Returns: String path to ~/.miniforge/workaround_approvals.edn"
   []
-  (str (System/getProperty "user.home") "/.miniforge/workaround_approvals.edn"))
+  (str (config/miniforge-home) "/workaround_approvals.edn"))
 
 (defn load-approvals
   "Load workaround approval history.

--- a/components/self-healing/test/ai/miniforge/self_healing/workaround_registry_test.clj
+++ b/components/self-healing/test/ai/miniforge/self_healing/workaround_registry_test.clj
@@ -20,12 +20,13 @@
   "Unit tests for workaround registry."
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [clojure.java.io :as io]
+            [ai.miniforge.config.interface :as config]
             [ai.miniforge.self-healing.workaround-registry :as registry]))
 
 ;;------------------------------------------------------------------------------ Test fixtures
 
 (def test-registry-path
-  (str (System/getProperty "user.home") "/.miniforge/test_workarounds.edn"))
+  (str (config/miniforge-home) "/test_workarounds.edn"))
 
 (defn cleanup-test-registry
   [f]

--- a/components/tool-registry/deps.edn
+++ b/components/tool-registry/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/logging {:local/root "../logging"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/schema {:local/root "../schema"}
         metosin/malli {:mvn/version "0.16.4"}
         org.clojure/core.async {:mvn/version "1.6.681"}

--- a/components/tool-registry/src/ai/miniforge/tool_registry/loader.clj
+++ b/components/tool-registry/src/ai/miniforge/tool_registry/loader.clj
@@ -29,6 +29,7 @@
    2. User: ~/.miniforge/tools/**/*.edn
    3. Project: .miniforge/tools/**/*.edn"
   (:require
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.tool-registry.schema :as schema]
    [ai.miniforge.logging.interface :as log]
    [clojure.java.io :as io]
@@ -41,7 +42,7 @@
 (defn user-tools-dir
   "Get the user tools directory (~/.miniforge/tools)."
   []
-  (io/file (System/getProperty "user.home") ".miniforge" "tools"))
+  (io/file (config/miniforge-home) "tools"))
 
 (defn project-tools-dir
   "Get the project tools directory (.miniforge/tools)."

--- a/components/tui-engine/deps.edn
+++ b/components/tui-engine/deps.edn
@@ -1,3 +1,4 @@
 {:paths ["src" "resources"]
- :deps {babashka/clojure-lanterna {:mvn/version "0.9.8"}}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        babashka/clojure-lanterna {:mvn/version "0.9.8"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/components/tui-engine/src/ai/miniforge/tui_engine/log.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/log.clj
@@ -33,6 +33,7 @@
 
    Layer 0: No dependencies on other tui namespaces."
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.string :as str])
   (:import
    [java.io File FileWriter BufferedWriter]
@@ -43,7 +44,7 @@
 ;; Log file setup
 
 (def ^:private log-dir
-  (str (System/getProperty "user.home") "/.miniforge/logs"))
+  (str (config/miniforge-home) "/logs"))
 
 (def ^:private log-path
   (str log-dir "/tui.log"))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/style.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/style.clj
@@ -31,6 +31,7 @@
    Custom themes can be added via ~/.miniforge/themes/*.edn.
    Themes are pure data maps — no side effects."
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [clojure.edn :as edn]))
 
@@ -182,7 +183,7 @@
   "Load custom themes from ~/.miniforge/themes/*.edn.
    Each file should contain a single map: {theme-keyword theme-map}."
   []
-  (let [dir (io/file (System/getProperty "user.home") ".miniforge" "themes")]
+  (let [dir (io/file (config/miniforge-home) "themes")]
     (if (and (.exists dir) (.isDirectory dir))
       (->> (.listFiles dir)
            (filter #(.endsWith (.getName %) ".edn"))

--- a/components/tui-views/deps.edn
+++ b/components/tui-views/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/pr-train {:local/root "../pr-train"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/pr-train {:local/root "../pr-train"}
         ai.miniforge/policy-pack {:local/root "../policy-pack"}
         ai.miniforge/orchestrator {:local/root "../orchestrator"}
         ai.miniforge/response {:local/root "../response"}

--- a/components/tui-views/src/ai/miniforge/tui_views/file_subscription.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/file_subscription.clj
@@ -24,6 +24,7 @@
    workflows without an in-memory event stream — cross-process via
    the filesystem protocol used by event-stream file-sink."
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [ai.miniforge.tui-views.persistence :as persistence]
    [ai.miniforge.tui-views.subscription :as subscription]))
@@ -34,7 +35,7 @@
 (defn events-dir
   "Returns ~/.miniforge/events/ as a java.io.File."
   []
-  (io/file (System/getProperty "user.home") ".miniforge" "events"))
+  (io/file (config/miniforge-home) "events"))
 
 (defn scan-event-files
   "Find *.edn files in dir, returns sorted list of java.io.File."

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence.clj
@@ -26,6 +26,7 @@
 
    Layer 1: Pure data loading, no side effects beyond file I/O."
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [clojure.edn :as edn]
    [ai.miniforge.tui-views.model :as model]))
@@ -454,7 +455,7 @@
 (defn events-dir
   "Get the events directory path. Returns a java.io.File."
   []
-  (io/file (System/getProperty "user.home") ".miniforge" "events"))
+  (io/file (config/miniforge-home) "events"))
 
 (defn workflow-events-file
   "Resolve the persisted event file for a workflow UUID."

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence/pr.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence/pr.clj
@@ -26,6 +26,7 @@
    Layer 1: PR loading (fleet repos, PR items)
    Layer 2: Composite loaders (load-all-into-model)"
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [ai.miniforge.tui-views.model :as model]
    [ai.miniforge.tui-views.persistence :as persistence]
@@ -40,7 +41,7 @@
 (defn packs-dir
   "Get the policy packs directory path."
   []
-  (io/file (System/getProperty "user.home") ".miniforge" "packs"))
+  (io/file (config/miniforge-home) "packs"))
 
 (defn load-policy-packs
   "Load policy packs from ~/.miniforge/packs/.

--- a/components/tui-views/src/ai/miniforge/tui_views/persistence/pr_cache.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/persistence/pr_cache.clj
@@ -30,6 +30,7 @@
    Layer 1: Read/write cache file
    Layer 2: Apply cache to model, persist from model"
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [clojure.edn :as edn]))
 
@@ -72,7 +73,7 @@
 
 (def ^:private cache-dir-path
   "Default cache directory."
-  (delay (io/file (System/getProperty "user.home") ".miniforge" "cache")))
+  (delay (io/file (config/miniforge-home) "cache")))
 
 (defn cache-file
   "Returns the cache file path."

--- a/components/web-dashboard/deps.edn
+++ b/components/web-dashboard/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/messages {:local/root "../messages"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/messages {:local/root "../messages"}
         http-kit/http-kit {:mvn/version "2.8.0"}
         hiccup/hiccup {:mvn/version "2.0.0-RC3"}
         cheshire/cheshire {:mvn/version "5.13.0"}}

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.web-dashboard.server
   "HTTP server with WebSocket support for the production web dashboard."
   (:require
+   [ai.miniforge.config.interface :as config]
    [org.httpkit.server :as http]
    [clojure.string :as str]
    [clojure.java.io :as io]
@@ -44,7 +45,7 @@
   "Write dashboard discovery file for auto-connect."
   [port]
   (try
-    (let [discovery-dir (str (System/getProperty "user.home") "/.miniforge")
+    (let [discovery-dir (config/miniforge-home)
           discovery-file (str discovery-dir "/dashboard.port")
           info {:port port
                 :pid (.pid (java.lang.ProcessHandle/current))
@@ -59,7 +60,7 @@
   "Remove dashboard discovery file on shutdown."
   []
   (try
-    (let [discovery-file (str (System/getProperty "user.home") "/.miniforge/dashboard.port")]
+    (let [discovery-file (str (config/miniforge-home) "/dashboard.port")]
       (when (.exists (io/file discovery-file))
         (.delete (io/file discovery-file))))
     (catch Exception _ nil)))
@@ -384,7 +385,7 @@
         server (http/run-server handler {:port port :legacy-return-value? false})
         actual-port (http/server-port server)
         ;; Start file watcher to tail-follow event files
-        events-dir (str (System/getProperty "user.home") "/.miniforge/events")
+        events-dir (str (config/miniforge-home) "/events")
         watcher-cleanup (watcher/start-watcher!
                          events-dir
                          (fn [event]

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/trains.clj
@@ -15,6 +15,7 @@
 (ns ai.miniforge.web-dashboard.state.trains
   "PR Train, DAG, and fleet repository onboarding/sync accessors."
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
@@ -27,7 +28,7 @@
 ;; Fleet repository config and provider helpers
 
 (def default-fleet-config-path
-  (str (System/getProperty "user.home") "/.miniforge/config.edn"))
+  (str (config/miniforge-home) "/config.edn"))
 
 (def external-train-prefix
   "External PRs: ")

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/state/workflows.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/state/workflows.clj
@@ -15,6 +15,7 @@
 (ns ai.miniforge.web-dashboard.state.workflows
   "Workflow state from live and historical event streams."
   (:require
+   [ai.miniforge.config.interface :as config]
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.web-dashboard.watcher :as watcher]))
@@ -24,7 +25,7 @@
 
 (def events-dir-path
   "Default event archive directory shared by the CLI and dashboard."
-  (str (System/getProperty "user.home") "/.miniforge/events"))
+  (str (config/miniforge-home) "/events"))
 
 (def stale-threshold-ms
   "Workflows with no events for this long are considered stale (10 minutes)."

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema {:local/root "../schema"}
+ :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/response {:local/root "../response"}  ; Response chains

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -26,6 +26,7 @@
    - Layer 2: Batch analysis + rate limit handling
    - Layer 3: Resume — reconstruct completed-ids from event file"
   (:require
+   [ai.miniforge.config.interface :as config]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
    [clojure.edn :as edn]
@@ -460,7 +461,7 @@
 
 (def default-events-dir
   "Default directory for workflow event files."
-  (delay (str (System/getProperty "user.home") "/.miniforge/events")))
+  (delay (str (config/miniforge-home) "/events")))
 
 (defn resume-context-from-event-file
   "Build resume context from a workflow's event file.


### PR DESCRIPTION
## Summary

- **MINIFORGE_HOME support**: New `config/miniforge-home` function resolves `MINIFORGE_HOME` env var → `~/.miniforge` default. Replaces 28 hardcoded `(System/getProperty "user.home") "/.miniforge"` references across 24 source files. Enables CI isolation and multi-instance deployments.
- **Profile-based token resolution**: New `config/profile.clj` loads `~/.miniforge/profile.edn` via Aero for per-host-kind token storage. 4-tier resolution: `MINIFORGE_GIT_TOKEN` → profile → provider env var → `gh` CLI fallback.
- **Docker token wiring**: `dag-executor/docker.clj` now delegates to `config/resolve-token` instead of URL-guessing heuristics.

## Test plan

- [x] 2511 tests, 0 new failures (pre-existing lsp-mcp-bridge subprocess failures excluded by not touching that brick)
- [x] New `profile_test.clj` — 10 tests covering validation, load, and token resolution
- [x] Lint clean (0 errors, 0 new warnings)
- [x] Verified `config/miniforge-home` is the sole remaining `System/getProperty "user.home" ... .miniforge` callsite

🤖 Generated with [Claude Code](https://claude.com/claude-code)