### PR TITLE
fix(dogfood): transit Instant serialization + tool find-tools NPE

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/sinks.clj
@@ -33,7 +33,7 @@
    [cognitect.transit :as transit])
   (:import
    [java.io ByteArrayOutputStream]
-   [java.time ZonedDateTime ZoneOffset]
+   [java.time Instant ZonedDateTime ZoneOffset]
    [java.time.format DateTimeFormatter]))
 
 ;;------------------------------------------------------------------------------ Internal helpers
@@ -50,14 +50,24 @@
   (.format (DateTimeFormatter/ofPattern "yyyyMMdd'T'HHmmssSSS'Z'")
            (ZonedDateTime/now ZoneOffset/UTC)))
 
+(def ^:private instant-write-handler
+  "Transit write handler for java.time.Instant — converts to java.util.Date
+   which Transit handles natively as ~#inst."
+  (transit/write-handler
+   (constantly "t")
+   (fn [^Instant v] (str v))))
+
 (defn- write-transit-json
   "Serialize `event` to a Transit-JSON string using the verbose writer.
    Verbose mode ensures UUIDs appear as {\"~#uuid\" \"...\"} and instants
    as {\"~#inst\" \"...\"} rather than compact ~u and ~m tag-strings,
-   so the Rust parser can decode them without millisecond arithmetic."
+   so the Rust parser can decode them without millisecond arithmetic.
+   Custom handler for java.time.Instant (not supported by Transit defaults)."
   [event]
-  (let [out (ByteArrayOutputStream.)]
-    (transit/write (transit/writer out :json-verbose) event)
+  (let [out (ByteArrayOutputStream.)
+        writer (transit/writer out :json-verbose
+                               {:handlers {Instant instant-write-handler}})]
+    (transit/write writer event)
     (.toString out "UTF-8")))
 
 (defn- new-event-file-path

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -142,7 +142,23 @@
                 files (list-files wf-dir)
                 content (slurp (first files))]
             ;; Must parse without exception
-            (is (map? (read-transit-json content)))))))))
+            (is (map? (read-transit-json content))))))))
+
+  (testing "events with java.time.Instant values serialize without error"
+    (with-temp-dir
+      (fn [dir]
+        (let [sink (sinks/file-sink {:base-dir dir})
+              wf-id (random-uuid)
+              event (sample-event {:workflow/id wf-id
+                                   :execution/started-at (java.time.Instant/now)
+                                   :timestamp (java.time.Instant/now)})]
+          (sink event)
+          (let [wf-dir (io/file dir (str wf-id))
+                files (list-files wf-dir)
+                content (slurp (first files))
+                parsed (read-transit-json content)]
+            (is (map? parsed))
+            (is (some? (:execution/started-at parsed)))))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; stdout-sink

--- a/components/tool/src/ai/miniforge/tool/core.clj
+++ b/components/tool/src/ai/miniforge/tool/core.clj
@@ -192,8 +192,8 @@
            vals
            (filter (fn [tool]
                      (let [info (tool-info tool)]
-                       (or (str/includes? (str/lower-case (get info :name "")) q)
-                           (str/includes? (str/lower-case (get info :description "")) q)))))))))
+                       (or (str/includes? (str/lower-case (or (:name info) "")) q)
+                           (str/includes? (str/lower-case (or (:description info) "")) q)))))))))
 
 (defn create-function-tool
   "Create a function-based tool.


### PR DESCRIPTION
## Summary

Two bugs found by dogfooding miniforge specs against itself:

- **Event sink `java.time.Instant` serialization** — Transit's verbose writer has no default handler for `java.time.Instant`, causing `"Not supported: class java.time.Instant"` on every event file write. This silently breaks `--resume` checkpoint persistence because no checkpoint file is written. Fix: custom Transit write handler that serializes Instant as ISO-8601 string.

- **tool/core.clj `find-tools` NPE** — `(get info :name "")` returns `nil` when the key exists with a `nil` value (get returns existing nils, not the default). `str/lower-case` then throws NPE. Fix: `(or (:name info) "")` to guard against nil.

Both bugs were discovered during dogfooding of the N3 event-type-completeness spec. The Instant bug is the root cause of `--resume` not working for any miniforge run — it prevents checkpoint files from being persisted.

## Test plan

- [x] New test: events with `java.time.Instant` values serialize and round-trip through Transit
- [x] All 2060+ tests pass (0 failures, 0 errors)
- [x] Lint clean (0 errors, 0 warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)