### PR TITLE
fix: add missing components to project classpaths for integration tests

### DIFF
--- a/components/gate/deps.edn
+++ b/components/gate/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/response {:local/root "../response"}}
+ :deps {ai.miniforge/connector-linter {:local/root "../connector-linter"}
+        ai.miniforge/response {:local/root "../response"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {}}}}

--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -35,7 +35,27 @@
 ai.miniforge/messages {:local/root "../../components/messages"}
         ai.miniforge/patterns {:local/root "../../components/patterns"}
         ai.miniforge/compliance-scanner {:local/root "../../components/compliance-scanner"}
-        ai.miniforge/workflow-compliance-scanner {:local/root "../../components/workflow-compliance-scanner"}}
+        ai.miniforge/workflow-compliance-scanner {:local/root "../../components/workflow-compliance-scanner"}
+        ;; Transitive deps needed for classpath completeness
+        ai.miniforge/connector-linter {:local/root "../../components/connector-linter"}
+        ai.miniforge/connector {:local/root "../../components/connector"}
+        ai.miniforge/connector-auth {:local/root "../../components/connector-auth"}
+        ai.miniforge/connector-retry {:local/root "../../components/connector-retry"}
+        ai.miniforge/repo-index {:local/root "../../components/repo-index"}
+        ai.miniforge/semantic-analyzer {:local/root "../../components/semantic-analyzer"}
+        ai.miniforge/context-pack {:local/root "../../components/context-pack"}
+        ai.miniforge/adapter-claude-code {:local/root "../../components/adapter-claude-code"}
+        ai.miniforge/control-plane {:local/root "../../components/control-plane"}
+        ai.miniforge/control-plane-adapter {:local/root "../../components/control-plane-adapter"}
+        ai.miniforge/dag-primitives {:local/root "../../components/dag-primitives"}
+        ai.miniforge/decision {:local/root "../../components/decision"}
+        ai.miniforge/reporting {:local/root "../../components/reporting"}
+        ai.miniforge/release-executor {:local/root "../../components/release-executor"}
+        ai.miniforge/pr-lifecycle {:local/root "../../components/pr-lifecycle"}
+        ai.miniforge/pr-train {:local/root "../../components/pr-train"}
+        ai.miniforge/pr-sync {:local/root "../../components/pr-sync"}
+        ai.miniforge/repo-dag {:local/root "../../components/repo-dag"}
+        ai.miniforge/task-executor {:local/root "../../components/task-executor"}}
 
  :aliases
  {:uberjar

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -65,6 +65,23 @@
         ai.miniforge/patterns {:local/root "../../components/patterns"}
         ;; Workflow compliance scanning (phase-level compliance checks)
         ai.miniforge/workflow-compliance-scanner {:local/root "../../components/workflow-compliance-scanner"}
+        ;; Linter connector (pre-verify lint gate)
+        ai.miniforge/connector-linter {:local/root "../../components/connector-linter"}
+        ai.miniforge/compliance-scanner {:local/root "../../components/compliance-scanner"}
+        ai.miniforge/connector {:local/root "../../components/connector"}
+        ai.miniforge/connector-auth {:local/root "../../components/connector-auth"}
+        ai.miniforge/connector-retry {:local/root "../../components/connector-retry"}
+        ai.miniforge/repo-index {:local/root "../../components/repo-index"}
+        ;; Adapter for Claude Code control plane integration
+        ai.miniforge/adapter-claude-code {:local/root "../../components/adapter-claude-code"}
+        ;; DAG primitives (shared types for dag-executor)
+        ai.miniforge/dag-primitives {:local/root "../../components/dag-primitives"}
+        ;; Decision component (control plane decisions)
+        ai.miniforge/decision {:local/root "../../components/decision"}
+        ;; Semantic analysis for code understanding
+        ai.miniforge/semantic-analyzer {:local/root "../../components/semantic-analyzer"}
+        ;; Context packing for agent prompts
+        ai.miniforge/context-pack {:local/root "../../components/context-pack"}
         ;; Meta-agent loop: learning layer (N1 §3.3)
         ai.miniforge/failure-classifier {:local/root "../../components/failure-classifier"}
         ai.miniforge/reliability {:local/root "../../components/reliability"}


### PR DESCRIPTION
## Summary

- Add `connector-linter` dependency to `gate/deps.edn` -- `pre_verify_lint.clj` requires it but it was undeclared
- Add 13 missing transitive components to `projects/miniforge/deps.edn`
- Add 20 missing components to `projects/miniforge-core/deps.edn`

These were causing `FileNotFoundException` during `bb test:integration` -- the gate's pre-verify lint gate couldn't find the connector-linter interface, and miniforge-core couldn't find semantic-analyzer.

## Test plan

- [x] `bb test:integration`: 292 tests, 1055 assertions, 0 failures (was failing before)
- [x] Pre-commit: 42 brick tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)