### PR TITLE
fix(agent): clean stale Codex MCP config subtree

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -167,6 +167,39 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; MCP config generation
 
+(def ^:private codex-artifact-table-pattern
+  #"^\[mcp_servers\.artifact(?:\..+)?\]\s*$")
+
+(def ^:private toml-table-pattern
+  #"^\[[^]]+\]\s*$")
+
+(defn- strip-codex-artifact-config
+  "Remove the full mcp_servers.artifact subtree from a Codex TOML config.
+
+   This strips both the root server block and any nested tables such as
+   [mcp_servers.artifact.tools.context_read], which newer Codex builds treat
+   as invalid if the parent server definition has already been removed."
+  [content]
+  (let [lines (str/split-lines content)]
+    (loop [remaining lines
+           cleaned []
+           skipping? false]
+      (if-let [line (first remaining)]
+        (let [trimmed (str/trim line)]
+          (cond
+            (re-matches codex-artifact-table-pattern trimmed)
+            (recur (rest remaining) cleaned true)
+
+            (and skipping? (re-matches toml-table-pattern trimmed))
+            (recur remaining cleaned false)
+
+            skipping?
+            (recur (rest remaining) cleaned true)
+
+            :else
+            (recur (rest remaining) (conj cleaned line) false)))
+        (str/join "\n" cleaned)))))
+
 (defn write-codex-mcp-config!
   "Write or update .codex/config.toml with [mcp_servers.artifact] block.
 
@@ -184,15 +217,12 @@
                    "args = " (json/generate-string args) "\n")]
     (.mkdirs dir)
     (if (.exists config-file)
-      (let [content (slurp config-file)]
-        (if (str/includes? content block-header)
-          ;; Replace existing block (up to next section or EOF)
-          (let [replaced (str/replace content
-                                      #"(?s)\[mcp_servers\.artifact\]\n(?:(?!\n\[).)*"
-                                      block)]
-            (spit config-file replaced))
-          ;; Append
-          (spit config-file (str content "\n" block) :append false)))
+      (let [content (slurp config-file)
+            preserved (-> content strip-codex-artifact-config str/trim)]
+        (spit config-file
+              (if (str/blank? preserved)
+                block
+                (str preserved "\n\n" block))))
       (spit config-file block))
     (str config-file)))
 
@@ -418,13 +448,10 @@
   [path]
   (let [f (io/file path)]
     (when (.exists f)
-      (let [content (slurp f)
-            cleaned (str/replace content
-                                 #"(?s)\n?\[mcp_servers\.artifact\]\n(?:(?!\n\[).)*"
-                                 "")]
-        (if (str/blank? (str/trim cleaned))
+      (let [cleaned (-> (slurp f) strip-codex-artifact-config str/trim)]
+        (if (str/blank? cleaned)
           (.delete f)
-          (spit f cleaned))))))
+          (spit f (str cleaned "\n")))))))
 
 (defn cleanup-cursor-mcp-config!
   "Remove artifact key from .cursor/mcp.json.

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -255,6 +255,35 @@
           (doseq [f (reverse (file-seq tmp))]
             (.delete ^java.io.File f)))))))
 
+(deftest cleanup-codex-config-removes-nested-artifact-tables-test
+  (testing "cleanup removes nested artifact tool tables as part of the same subtree"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "codex-nested-test-" (random-uuid)))
+          config-file (io/file tmp "config.toml")
+          cleanup-fn  @#'session/cleanup-codex-mcp-config!]
+      (try
+        (.mkdirs tmp)
+        (spit config-file (str "sandbox_mode = \"workspace-write\"\n"
+                               "\n"
+                               "[mcp_servers.artifact]\n"
+                               "command = \"bb\"\n"
+                               "args = [\"miniforge\",\"mcp-serve\"]\n"
+                               "\n"
+                               "[mcp_servers.artifact.tools.context_read]\n"
+                               "approval_mode = \"approve\"\n"
+                               "\n"
+                               "[sandbox_workspace_write]\n"
+                               "network_access = true\n"))
+        (cleanup-fn (str config-file))
+        (let [content (slurp config-file)]
+          (is (not (str/includes? content "[mcp_servers.artifact]")))
+          (is (not (str/includes? content "[mcp_servers.artifact.tools.context_read]")))
+          (is (str/includes? content "sandbox_mode = \"workspace-write\""))
+          (is (str/includes? content "[sandbox_workspace_write]")))
+        (finally
+          (doseq [f (reverse (file-seq tmp))]
+            (.delete ^java.io.File f)))))))
+
 (deftest cleanup-cursor-config-test
   (testing "cleanup removes artifact entry but preserves other servers"
     (let [tmp (io/file (System/getProperty "java.io.tmpdir")

--- a/docs/pull-requests/2026-04-15-fix-codex-invalid-transport-cleanup.md
+++ b/docs/pull-requests/2026-04-15-fix-codex-invalid-transport-cleanup.md
@@ -1,0 +1,57 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix stale Codex MCP cleanup leaving invalid transport config
+
+**PR:** [#554](https://github.com/miniforge-ai/miniforge/pull/554)
+**Branch:** `fix/codex-invalid-transport-cleanup`
+
+## Context
+
+Miniforge writes a project-local `.codex/config.toml` during MCP-backed agent
+sessions. Cleanup was only removing the root `[mcp_servers.artifact]` block,
+not nested tables under the same subtree.
+
+That leaves behind config fragments such as:
+
+- `[mcp_servers.artifact.tools.context_read]`
+
+Current Codex builds reject that orphaned nested table at startup with:
+
+- `Error loading config.toml: invalid transport in mcp_servers.artifact`
+
+The effect is that opening Codex or the Codex desktop app from a Miniforge repo
+can fail until the broken local config is manually repaired.
+
+## What changed
+
+- Added `strip-codex-artifact-config` in `artifact_session.clj` to remove the
+  full `mcp_servers.artifact` TOML subtree, including nested tables.
+- Updated `write-codex-mcp-config!` to rewrite the config from preserved
+  non-artifact content plus a fresh artifact block, instead of replacing only
+  the top-level server table via regex.
+- Updated `cleanup-codex-mcp-config!` to remove nested artifact tables and keep
+  unrelated project config intact.
+- Added a regression test covering cleanup of a config file that contains both
+  `[mcp_servers.artifact]` and
+  `[mcp_servers.artifact.tools.context_read]`.
+
+## Verification
+
+- `codex mcp list` succeeds from the repaired local repo after removing the
+  stale nested artifact table
+- `clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.agent.artifact-session-test) ..."`
+  runs the focused artifact session test namespace successfully
+
+## Risk
+
+This change is intentionally narrow:
+
+- It only affects Codex project-local MCP config generation and cleanup
+- It preserves unrelated TOML sections outside the `mcp_servers.artifact`
+  subtree
+- It adds a regression test for the exact stale-config shape that caused the
+  startup failure


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Fix stale Codex MCP cleanup leaving invalid transport config

**PR:** [#554](https://github.com/miniforge-ai/miniforge/pull/554)
**Branch:** `fix/codex-invalid-transport-cleanup`

## Context

Miniforge writes a project-local `.codex/config.toml` during MCP-backed agent
sessions. Cleanup was only removing the root `[mcp_servers.artifact]` block,
not nested tables under the same subtree.

That leaves behind config fragments such as:

- `[mcp_servers.artifact.tools.context_read]`

Current Codex builds reject that orphaned nested table at startup with:

- `Error loading config.toml: invalid transport in mcp_servers.artifact`

The effect is that opening Codex or the Codex desktop app from a Miniforge repo
can fail until the broken local config is manually repaired.

## What changed

- Added `strip-codex-artifact-config` in `artifact_session.clj` to remove the
  full `mcp_servers.artifact` TOML subtree, including nested tables.
- Updated `write-codex-mcp-config!` to rewrite the config from preserved
  non-artifact content plus a fresh artifact block, instead of replacing only
  the top-level server table via regex.
- Updated `cleanup-codex-mcp-config!` to remove nested artifact tables and keep
  unrelated project config intact.
- Added a regression test covering cleanup of a config file that contains both
  `[mcp_servers.artifact]` and
  `[mcp_servers.artifact.tools.context_read]`.

## Verification

- `codex mcp list` succeeds from the repaired local repo after removing the
  stale nested artifact table
- `clojure -M:dev:test -e "(require 'clojure.test 'ai.miniforge.agent.artifact-session-test) ..."`
  runs the focused artifact session test namespace successfully

## Risk

This change is intentionally narrow:

- It only affects Codex project-local MCP config generation and cleanup
- It preserves unrelated TOML sections outside the `mcp_servers.artifact`
  subtree
- It adds a regression test for the exact stale-config shape that caused the
  startup failure
