### PR TITLE
Recover compliance refactor and green changed-brick tests

### DIFF
--- a/PR-552.md
+++ b/PR-552.md
@@ -1,0 +1,61 @@
+## Summary
+
+Prototypes the mixed mechanical/semantic compliance pipeline from #552. Three new Polylith components:
+
+- **`connector-sarif`** — data-foundry `SourceConnector` for SARIF v2.1.0 JSON and CSV scan output, with Malli schemas
+  and JSON Schema export
+- **`gate-classification`** — `Gate` protocol implementation for mixed deterministic + LLM-judgment classification with
+  configurable thresholds (confidence, severity, doc-status)
+- **`workflow-security-compliance`** — 5-phase pipeline (parse → trace → verify-docs → classify → generate-exclusions)
+  with sample SARIF fixture, e2e test, and REPL demo script
+
+### New files (24 files, ~4,300 lines)
+
+**connector-sarif** (data-foundry connector)
+
+- `interface.clj` — public API: `create-sarif-connector`, schema exports, validation
+- `core.clj` — `SarifConnector` defrecord (Connector + SourceConnector protocols)
+- `format.clj` — real SARIF v2.1.0 JSON parser + CSV parser with configurable column mapping
+- `impl.clj` — connect/discover/extract/checkpoint implementation
+- `schema.clj` — Malli schemas for config, violations, runs; JSON Schema export
+- `impl_test.clj` — unit tests
+
+**gate-classification** (Gate protocol)
+
+- `interface.clj` — `create-classification-gate` factory
+- `core.clj` — `ClassificationGate` implementing check/repair/gate-id/gate-type
+- `rules.clj` — deterministic rule engine: low-confidence escalation, documented-FP auto-exclude, TP passthrough
+- `core_test.clj` + `rules_test.clj` — 45 unit tests
+
+**workflow-security-compliance** (5-phase workflow)
+
+- `phases.clj` — all 5 phase interceptors following `workflow-compliance-scanner` patterns
+- `interface.clj` — module loader
+- `security-compliance-v1.0.0.edn` — workflow pipeline definition
+- `demo/demo_security_compliance.clj` — REPL-driven guided demo
+- `e2e_test.clj` — end-to-end pipeline smoke test
+- `phases_test.clj` — unit tests per phase
+- `test/fixtures/sample-scan.sarif` + `.csv` — realistic test data (shlwapi.dll!none, ntdll, CryptEncrypt scenarios)
+
+### Design decisions
+
+- **Phases 2 & 3 are stubs**: `:sec-trace-source` and `:sec-verify-docs` enrich violations with realistic mock data
+  (`:trace/actual-api`, `:trace/call-chain`, `:verified/documented?`). Shape is correct for LLM integration; agent
+  wiring is deferred.
+- **Gate reads LLM-enriched fields deterministically**: confidence thresholds, doc-status checks, and severity filtering
+  are all configurable. The gate never calls an LLM — it consumes upstream enrichment.
+- **SARIF connector follows `connector-pipeline-output` patterns**: Malli schemas, defrecord delegation, atom-backed
+  handle state.
+
+## Test plan
+
+- [ ] Run `clj-kondo --lint` on all new files — should pass with 0 errors
+- [ ] Run unit tests: `clj -M:test -m kaocha.runner --focus-meta :connector-sarif :gate-classification
+  :workflow-security-compliance`
+- [ ] Run REPL demo: load `demo_security_compliance.clj`, evaluate Section 3 (full pipeline)
+- [ ] Verify exclusion EDN file is written to temp dir with correct structure
+- [ ] Review gate thresholds against issue #552 requirements
+
+Closes #552
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -60,7 +60,7 @@
    [ai.miniforge.cli.main.commands.evidence :as cmd-evidence]
    [ai.miniforge.cli.main.commands.artifact-cmds :as cmd-artifact]
    [ai.miniforge.cli.main.commands.etl :as cmd-etl]
-   [ai.miniforge.agent.tool-supervisor :as tool-supervisor]
+   [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.mcp-context-server.interface :as mcp-context-server]
    [ai.miniforge.lsp-mcp-bridge.main :as lsp-bridge]
    [ai.miniforge.lsp-mcp-bridge.tasks :as lsp-tasks]
@@ -258,7 +258,7 @@
 
    Reads JSON from stdin, evaluates against policy, writes decision to stdout."
   [_m]
-  (System/exit (tool-supervisor/hook-eval-stdin!)))
+  (System/exit (agent/hook-eval-stdin!)))
 
 (defn context-server-cmd
   "Run the MCP context server (internal — spawned as subprocess by the agent).

--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/discovery.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/discovery.clj
@@ -30,7 +30,7 @@
   (:require
    [clojure.java.io :as io]
    [clojure.string :as str]
-   [ai.miniforge.control-plane.messages :as messages]))
+   [ai.miniforge.control-plane.interface :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Filesystem scanning

--- a/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/interface.clj
+++ b/components/adapter-claude-code/src/ai/miniforge/adapter_claude_code/interface.clj
@@ -27,8 +27,8 @@
   (:require
    [ai.miniforge.adapter-claude-code.discovery :as discovery]
    [ai.miniforge.config.interface :as config]
-   [ai.miniforge.control-plane.messages :as messages]
-   [ai.miniforge.control-plane-adapter.protocol :as proto]
+   [ai.miniforge.control-plane.interface :as control-plane]
+   [ai.miniforge.control-plane-adapter.interface :as proto]
    [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -103,8 +103,8 @@
             {:success? true}
             (catch Exception e
               {:success? false :error (ex-message e)}))
-          {:success? false :error (messages/t :adapter/unknown-command {:command command})})
-        {:success? false :error (messages/t :adapter/no-pid)}))))
+          {:success? false :error (control-plane/t :adapter/unknown-command {:command command})})
+        {:success? false :error (control-plane/t :adapter/no-pid)}))))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Factory

--- a/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
+++ b/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
@@ -28,8 +28,8 @@
    Layer 1: Protocol implementation
    Layer 2: Factory and subscription"
   (:require
-   [ai.miniforge.control-plane.messages :as messages]
-   [ai.miniforge.control-plane-adapter.protocol :as proto]
+   [ai.miniforge.control-plane.interface :as control-plane]
+   [ai.miniforge.control-plane-adapter.interface :as proto]
    [ai.miniforge.event-stream.interface :as es]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -52,7 +52,7 @@
   (let [wf-id (:workflow/id event)]
     {:agent/vendor :miniforge
      :agent/external-id (str wf-id)
-     :agent/name (str (messages/t :adapter/miniforge-prefix) (or (:workflow/name event)
+     :agent/name (str (control-plane/t :adapter/miniforge-prefix) (or (:workflow/name event)
                                          (:message event)
                                          wf-id))
      :agent/capabilities #{:code-generation :test-writing :code-review}
@@ -89,7 +89,7 @@
         (when-let [f (get dispatch command)]
           (f control-state))
         {:success? true})
-      {:success? false :error (messages/t :adapter/no-control-state)})))
+      {:success? false :error (control-plane/t :adapter/no-control-state)})))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Factory and subscription

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -114,13 +114,15 @@
    - {:dir <path>, :mcp-config-path <path>, :artifact-path <path>}"
   ([] (create-session! nil))
   ([{:keys [workdir]}]
-  (let [working-dir (or workdir (System/getProperty "user.dir"))
-        dir (str (Files/createTempDirectory
+  (let [dir (str (Files/createTempDirectory
                   "miniforge-artifact-"
                   (into-array FileAttribute [])))
+        working-dir (or workdir (System/getProperty "user.dir"))
         config-path (str dir "/mcp-config.json")
         artifact-path (str dir "/artifact.edn")]
     {:dir dir
+     :workdir working-dir
+     :config-root (or workdir dir)
      :mcp-config-path config-path
      :artifact-path artifact-path
      :pre-session-snapshot (try
@@ -174,9 +176,10 @@
    replaces it. Otherwise appends the block. Creates .codex/ dir if needed.
 
    Returns the path to the config file."
-  [server-cmd]
+  [config-root server-cmd]
   (let [{:keys [command args]} server-cmd
-        dir (io/file ".codex")
+        root (or config-root (System/getProperty "user.dir"))
+        dir (io/file root ".codex")
         config-file (io/file dir "config.toml")
         block-header "[mcp_servers.artifact]"
         block (str block-header "\n"
@@ -202,9 +205,10 @@
    If the file exists, merges into existing JSON. Creates .cursor/ dir if needed.
 
    Returns the path to the config file."
-  [server-cmd]
+  [config-root server-cmd]
   (let [{:keys [command args]} server-cmd
-        dir (io/file ".cursor")
+        root (or config-root (System/getProperty "user.dir"))
+        dir (io/file root ".cursor")
         config-file (io/file dir "mcp.json")
         entry {"command" command "args" args}
         existing (when (.exists config-file)
@@ -254,13 +258,14 @@
    Returns: session (for threading)"
   [session]
   (let [srv-cmd       (server-command (:dir session))
+        config-root   (:config-root session)
         mcp-config    {"mcpServers" {"context" {"command" (:command srv-cmd)
                                                 "args"    (:args srv-cmd)}}}
         _             (spit (:mcp-config-path session)
                             (json/generate-string mcp-config {:pretty true}))
         settings-path (write-claude-settings! (:dir session))
-        codex-path    (write-codex-mcp-config! srv-cmd)
-        cursor-path   (write-cursor-mcp-config! srv-cmd)
+        codex-path    (write-codex-mcp-config! config-root srv-cmd)
+        cursor-path   (write-cursor-mcp-config! config-root srv-cmd)
         [hook-cmd & hook-args] (resolve-miniforge-command)
         hook-eval-cmd (str/join " " (concat [hook-cmd] hook-args ["hook-eval"]))]
     (assoc session
@@ -645,9 +650,10 @@
           session  (-> (create-capsule-session! executor env-id workdir)
                        write-capsule-mcp-config!)]
       (run-session session body-fn read-capsule-artifact cleanup-capsule-session! :capsule))
-    (let [session (-> (create-session!
-                        {:workdir (or (:execution/worktree-path context)
-                                      (System/getProperty "user.dir"))})
+    (let [workdir (:execution/worktree-path context)
+          session (-> (if workdir
+                        (create-session! {:workdir workdir})
+                        (create-session!))
                       write-mcp-config!)]
       (run-session session body-fn read-artifact cleanup-session! :host))))
 

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -104,6 +104,39 @@
       :else
       ["bb" "miniforge"])))
 
+(def ^:private codex-artifact-table-pattern
+  #"^\[mcp_servers\.artifact(?:\..+)?\]\s*$")
+
+(def ^:private toml-table-pattern
+  #"^\[[^]]+\]\s*$")
+
+(defn- strip-codex-artifact-config
+  "Remove the full mcp_servers.artifact subtree from a Codex TOML config.
+
+   This strips both the root server block and any nested tables such as
+   [mcp_servers.artifact.tools.context_read], which newer Codex builds treat
+   as invalid if the parent server definition has already been removed."
+  [content]
+  (let [lines (str/split-lines content)]
+    (loop [remaining lines
+           cleaned []
+           skipping? false]
+      (if-let [line (first remaining)]
+        (let [trimmed (str/trim line)]
+          (cond
+            (re-matches codex-artifact-table-pattern trimmed)
+            (recur (rest remaining) cleaned true)
+
+            (and skipping? (re-matches toml-table-pattern trimmed))
+            (recur remaining cleaned false)
+
+            skipping?
+            (recur (rest remaining) cleaned true)
+
+            :else
+            (recur (rest remaining) (conj cleaned line) false)))
+        (str/join "\n" cleaned)))))
+
 (defn create-session!
   "Create a new artifact session with a temporary directory.
 
@@ -187,15 +220,12 @@
                    "args = " (json/generate-string args) "\n")]
     (.mkdirs dir)
     (if (.exists config-file)
-      (let [content (slurp config-file)]
-        (if (str/includes? content block-header)
-          ;; Replace existing block (up to next section or EOF)
-          (let [replaced (str/replace content
-                                      #"(?s)\[mcp_servers\.artifact\]\n(?:(?!\n\[).)*"
-                                      block)]
-            (spit config-file replaced))
-          ;; Append
-          (spit config-file (str content "\n" block) :append false)))
+      (let [content (slurp config-file)
+            preserved (-> content strip-codex-artifact-config str/trim)]
+        (spit config-file
+              (if (str/blank? preserved)
+                block
+                (str preserved "\n\n" block))))
       (spit config-file block))
     (str config-file)))
 
@@ -423,13 +453,10 @@
   [path]
   (let [f (io/file path)]
     (when (.exists f)
-      (let [content (slurp f)
-            cleaned (str/replace content
-                                 #"(?s)\n?\[mcp_servers\.artifact\]\n(?:(?!\n\[).)*"
-                                 "")]
-        (if (str/blank? (str/trim cleaned))
+      (let [cleaned (-> (slurp f) strip-codex-artifact-config str/trim)]
+        (if (str/blank? cleaned)
           (.delete f)
-          (spit f cleaned))))))
+          (spit f (str cleaned "\n")))))))
 
 (defn cleanup-cursor-mcp-config!
   "Remove artifact key from .cursor/mcp.json.

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -27,7 +27,7 @@
    [ai.miniforge.agent.prompts :as prompts]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.patterns.interface :as patterns]
-   [ai.miniforge.repo-index.messages :as messages]
+   [ai.miniforge.repo-index.interface :as messages]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]

--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -21,6 +21,7 @@
    Public API groups are decomposed into ai.miniforge.agent.interface.* namespaces,
    while this namespace remains the Polylith entrypoint."
   (:require
+   [ai.miniforge.agent.file-artifacts :as file-artifacts]
    [ai.miniforge.agent.interface.classification :as classification]
    [ai.miniforge.agent.interface.llm :as llm]
    [ai.miniforge.agent.interface.memory :as memory]
@@ -28,7 +29,8 @@
    [ai.miniforge.agent.interface.meta :as meta]
    [ai.miniforge.agent.interface.protocols :as protocols]
    [ai.miniforge.agent.interface.runtime :as runtime]
-   [ai.miniforge.agent.interface.specialized :as specialized]))
+   [ai.miniforge.agent.interface.specialized :as specialized]
+   [ai.miniforge.agent.tool-supervisor :as tool-supervisor]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocols and configuration
@@ -158,3 +160,26 @@
 
 (def classify-task classification/classify-task)
 (def get-task-characteristics classification/get-task-characteristics)
+
+;------------------------------------------------------------------------------ Layer 3
+;; File artifacts — working tree snapshot and fallback artifact collection
+
+(def empty-snapshot
+  "Return an empty working tree snapshot."
+  file-artifacts/empty-snapshot)
+
+(def collect-written-files
+  "Collect files written during the agent session into a synthetic code artifact."
+  file-artifacts/collect-written-files)
+
+;------------------------------------------------------------------------------ Layer 3
+;; Tool supervision
+
+(def evaluate-tool-use
+  "Evaluate a tool use request against policy.
+   Returns {:decision \"allow\"} or {:decision \"deny\" :reason string}."
+  tool-supervisor/evaluate-tool-use)
+
+(def hook-eval-stdin!
+  "CLI entry point for tool-use evaluation from stdin."
+  tool-supervisor/hook-eval-stdin!)

--- a/components/agent/src/ai/miniforge/agent/model.clj
+++ b/components/agent/src/ai/miniforge/agent/model.clj
@@ -68,21 +68,17 @@
      role           - Agent role keyword (:planner, :implementer, etc.)
      provided-client - The shared LLM client from workflow context (may be nil)"
   [role provided-client]
-  (let [model-id (default-model-for-role role)
+  (if (nil? provided-client)
+    nil
+    (let [model-id (default-model-for-role role)
         backend-for-model (requiring-resolve 'ai.miniforge.llm.interface/backend-for-model)
         client-backend (requiring-resolve 'ai.miniforge.llm.interface/client-backend)
         create-client (requiring-resolve 'ai.miniforge.llm.interface/create-client)
         needed-backend (backend-for-model model-id)
         current-backend (client-backend provided-client)]
-    (cond
-      (nil? provided-client)
-      nil
-
-      (= current-backend needed-backend)
-      (assoc-in provided-client [:config :model] model-id)
-
-      :else
-      (create-client {:backend needed-backend :model model-id}))))
+      (if (= current-backend needed-backend)
+        (assoc-in provided-client [:config :model] model-id)
+        (create-client {:backend needed-backend :model model-id})))))
 
 
 (comment

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -255,6 +255,35 @@
           (doseq [f (reverse (file-seq tmp))]
             (.delete ^java.io.File f)))))))
 
+(deftest cleanup-codex-config-removes-nested-artifact-tables-test
+  (testing "cleanup removes nested artifact tool tables as part of the same subtree"
+    (let [tmp (io/file (System/getProperty "java.io.tmpdir")
+                       (str "codex-nested-test-" (random-uuid)))
+          config-file (io/file tmp "config.toml")
+          cleanup-fn  @#'session/cleanup-codex-mcp-config!]
+      (try
+        (.mkdirs tmp)
+        (spit config-file (str "sandbox_mode = \"workspace-write\"\n"
+                               "\n"
+                               "[mcp_servers.artifact]\n"
+                               "command = \"bb\"\n"
+                               "args = [\"miniforge\",\"mcp-serve\"]\n"
+                               "\n"
+                               "[mcp_servers.artifact.tools.context_read]\n"
+                               "approval_mode = \"approve\"\n"
+                               "\n"
+                               "[sandbox_workspace_write]\n"
+                               "network_access = true\n"))
+        (cleanup-fn (str config-file))
+        (let [content (slurp config-file)]
+          (is (not (str/includes? content "[mcp_servers.artifact]")))
+          (is (not (str/includes? content "[mcp_servers.artifact.tools.context_read]")))
+          (is (str/includes? content "sandbox_mode = \"workspace-write\""))
+          (is (str/includes? content "[sandbox_workspace_write]")))
+        (finally
+          (doseq [f (reverse (file-seq tmp))]
+            (.delete ^java.io.File f)))))))
+
 (deftest cleanup-cursor-config-test
   (testing "cleanup removes artifact entry but preserves other servers"
     (let [tmp (io/file (System/getProperty "java.io.tmpdir")

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
@@ -40,6 +40,16 @@
 (def PlanTask    schema/PlanTask)
 (def Plan        schema/Plan)
 (def PlanSummary schema/PlanSummary)
+
+;------------------------------------------------------------------------------ Layer 0
+;; Factory re-exports
+
+(def ->violation factory/->violation)
+(def ->scan-result factory/->scan-result)
+(def ->plan-summary factory/->plan-summary)
+(def ->plan-task factory/->plan-task)
+(def ->plan factory/->plan)
+(def ->delta-report factory/->delta-report)
 (def DeltaReport schema/DeltaReport)
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/etl.clj
@@ -13,7 +13,7 @@
    Layer 1: Format-specific record extraction
    Layer 2: Apply mapping spec to produce violations"
   (:require
-   [ai.miniforge.compliance-scanner.factory :as factory]
+   [ai.miniforge.compliance-scanner.interface :as factory]
    [cheshire.core :as json]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
@@ -57,16 +57,17 @@
                    (if (keyword? c) (name c) (str c)))
         severity (map-severity severity-map
                                (extract-field record (get fields :severity)))]
-    (factory/->violation
-     (keyword (name linter-id) (or code "lint"))
-     "lint"
-     (str (name linter-id) "/" (or code "lint"))
-     (str file)
-     (or line 0)
-     (or message "")
-     nil
-     false
-     (str (name linter-id) ": " (or message "")))))
+    (assoc (factory/->violation
+            (keyword (name linter-id) (or code "lint"))
+            "lint"
+            (str (name linter-id) "/" (or code "lint"))
+            (str file)
+            (or line 0)
+            (or message "")
+            nil
+            false
+            (str (name linter-id) ": " (or message "")))
+           :rule/severity severity)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Format-specific record extraction

--- a/components/connector-sarif/deps.edn
+++ b/components/connector-sarif/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/connector {:local/root "../connector"}
+        cheshire/cheshire {:mvn/version "5.12.0"}
+        org.clojure/data.csv {:mvn/version "1.1.0"}
+        metosin/malli {:mvn/version "0.16.4"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps  {}}}}

--- a/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/core.clj
+++ b/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/core.clj
@@ -1,0 +1,32 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.data-foundry.connector-sarif.core
+  "SarifConnector defrecord — thin protocol wrapper delegating to impl."
+  (:require [ai.miniforge.data-foundry.connector.protocol :as proto]
+            [ai.miniforge.data-foundry.connector-sarif.impl :as impl]))
+
+(defrecord SarifConnector []
+  proto/Connector
+  (connect [_ config _auth] (impl/do-connect config))
+  (close   [_ handle]       (impl/do-close handle))
+
+  proto/SourceConnector
+  (discover    [_ handle opts]                       (impl/do-discover handle opts))
+  (extract     [_ handle schema-name opts]           (impl/do-extract handle schema-name opts))
+  (checkpoint  [_ handle connector-id cursor-state]  (impl/do-checkpoint handle connector-id cursor-state)))

--- a/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/format.clj
+++ b/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/format.clj
@@ -1,0 +1,169 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.data-foundry.connector-sarif.format
+  "SARIF JSON and CSV parsing helpers.
+   Handles SARIF v2.1.0 structure (tool -> runs[] -> results[] -> locations[]).
+   Provides pluggable CSV parsing with configurable column mapping."
+  (:require [cheshire.core :as json]
+            [clojure.java.io :as io]
+            [clojure.string :as str]
+            [clojure.data.csv :as csv]))
+
+;; --------------------------------------------------------------------------
+;; SARIF v2.1.0 Parsing
+
+(defn- normalize-severity
+  "Normalize SARIF level string to keyword."
+  [level]
+  (case (str/lower-case (or level "warning"))
+    "error"   :error
+    "warning" :warning
+    "note"    :note
+    "none"    :none
+    :warning))
+
+(defn- extract-location
+  "Extract physical location from a SARIF location object."
+  [loc]
+  (let [phys (get loc "physicalLocation")
+        artifact (get phys "artifactLocation")
+        region (get phys "region")]
+    {:file   (get artifact "uri")
+     :line   (get region "startLine")
+     :column (get region "startColumn")}))
+
+(defn- parse-sarif-result
+  "Parse a single SARIF result into a unified violation record."
+  [result tool-name run-idx result-idx]
+  (let [rule-id  (get result "ruleId" "unknown")
+        message  (get-in result ["message" "text"] "")
+        level    (get result "level" "warning")
+        locs     (get result "locations" [])
+        location (if (seq locs) (extract-location (first locs)) {})]
+    {:violation/id          (str tool-name ":" run-idx ":" result-idx)
+     :violation/rule-id     rule-id
+     :violation/message     message
+     :violation/severity    (normalize-severity level)
+     :violation/location    location
+     :violation/source-tool tool-name
+     :violation/raw         result}))
+
+(defn parse-sarif
+  "Parse a SARIF v2.1.0 JSON file into violation records.
+   Returns a vector of unified SarifViolation maps."
+  [path]
+  (let [content (json/parse-string (slurp path))
+        runs    (get content "runs" [])]
+    (into []
+          (mapcat
+           (fn [[run-idx run]]
+             (let [tool-name (get-in run ["tool" "driver" "name"] "unknown")
+                   results   (get run "results" [])]
+               (map-indexed
+                (fn [res-idx result]
+                  (parse-sarif-result result tool-name run-idx res-idx))
+                results)))
+           (map-indexed vector runs)))))
+
+;; --------------------------------------------------------------------------
+;; CSV Parsing
+
+(def default-csv-columns
+  "Default column mapping for CSV scan output."
+  {:rule-id  "Rule ID"
+   :message  "Message"
+   :severity "Severity"
+   :file     "File"
+   :line     "Line"
+   :column   "Column"})
+
+(defn- find-column-index
+  "Find column index by header name (case-insensitive)."
+  [headers col-name]
+  (let [target (str/lower-case col-name)]
+    (first (keep-indexed
+            (fn [idx h] (when (= (str/lower-case (str/trim h)) target) idx))
+            headers))))
+
+(defn- csv-row->violation
+  "Convert a CSV row to a unified violation record."
+  [row headers col-map idx]
+  (let [get-col (fn [k]
+                  (when-let [col-idx (find-column-index headers (get col-map k ""))]
+                    (nth row col-idx nil)))]
+    {:violation/id          (str "csv:" idx)
+     :violation/rule-id     (or (get-col :rule-id) "unknown")
+     :violation/message     (or (get-col :message) "")
+     :violation/severity    (normalize-severity (get-col :severity))
+     :violation/location    {:file   (get-col :file)
+                             :line   (when-let [l (get-col :line)]
+                                       (try (Integer/parseInt (str/trim l))
+                                            (catch Exception _ nil)))
+                             :column (when-let [c (get-col :column)]
+                                       (try (Integer/parseInt (str/trim c))
+                                            (catch Exception _ nil)))}
+     :violation/source-tool "csv-import"
+     :violation/raw         (zipmap headers row)}))
+
+(defn parse-csv
+  "Parse a CSV scan output file into violation records.
+   Accepts optional column mapping override."
+  ([path] (parse-csv path nil))
+  ([path col-map]
+   (let [col-map (merge default-csv-columns col-map)]
+     (with-open [reader (io/reader path)]
+       (let [rows    (doall (csv/read-csv reader))
+             headers (first rows)
+             data    (rest rows)]
+         (vec (map-indexed
+               (fn [idx row] (csv-row->violation row headers col-map idx))
+               data)))))))
+
+;; --------------------------------------------------------------------------
+;; File discovery and format detection
+
+(defn detect-format
+  "Detect file format from extension."
+  [path]
+  (cond
+    (str/ends-with? (str/lower-case path) ".sarif")     :sarif
+    (str/ends-with? (str/lower-case path) ".sarif.json") :sarif
+    (str/ends-with? (str/lower-case path) ".csv")        :csv
+    :else :unknown))
+
+(defn list-scan-files
+  "List scannable files in a path (file or directory)."
+  [source-path]
+  (let [f (io/file source-path)]
+    (cond
+      (not (.exists f)) []
+      (.isFile f)       [(.getAbsolutePath f)]
+      (.isDirectory f)  (->> (.listFiles f)
+                             (filter #(#{:sarif :csv} (detect-format (.getName %))))
+                             (mapv #(.getAbsolutePath %)))
+      :else [])))
+
+(defn parse-file
+  "Parse a single file based on format. Returns violation records."
+  [path fmt csv-columns]
+  (let [actual-fmt (if (= fmt :auto) (detect-format path) (or fmt (detect-format path)))]
+    (case actual-fmt
+      :sarif (parse-sarif path)
+      :csv   (parse-csv path csv-columns)
+      (throw (ex-info (str "Unsupported format: " actual-fmt) {:path path :format actual-fmt})))))

--- a/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/impl.clj
+++ b/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/impl.clj
@@ -1,0 +1,128 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.data-foundry.connector-sarif.impl
+  "SARIF connector implementation — connect, discover, extract, checkpoint."
+  (:require [ai.miniforge.data-foundry.connector-sarif.format :as fmt]
+            [ai.miniforge.data-foundry.connector-sarif.schema :as schema]
+            [clojure.string :as str]))
+
+;; --------------------------------------------------------------------------
+;; Handle state
+
+(defonce ^:private handles (atom {}))
+
+(defn- generate-handle [] (str "sarif-" (java.util.UUID/randomUUID)))
+
+(defn- require-handle!
+  "Look up handle state, throw if missing."
+  [handle]
+  (or (get @handles handle)
+      (throw (ex-info "Unknown handle" {:handle handle}))))
+
+;; --------------------------------------------------------------------------
+;; Connect / Close
+
+(defn do-connect
+  "Validate config and establish a connection handle."
+  [config]
+  (let [{:keys [valid? errors]} (schema/validate-config config)]
+    (when-not valid?
+      (throw (ex-info "Invalid SARIF config" {:errors errors})))
+    (let [handle (generate-handle)]
+      (swap! handles assoc handle
+             {:sarif/source-path (:sarif/source-path config)
+              :sarif/format      (get config :sarif/format :auto)
+              :sarif/csv-columns (get config :sarif/csv-columns nil)})
+      {:connection/handle handle
+       :connector/status  :connected})))
+
+(defn do-close
+  "Release a connection handle."
+  [handle]
+  (swap! handles dissoc handle)
+  {:connector/status :closed})
+
+;; --------------------------------------------------------------------------
+;; Discover
+
+(defn- build-schema-descriptor [schema-type count]
+  {:schema/name schema-type
+   :schema/record-count count})
+
+(defn do-discover
+  "Discover available schemas in the connected source."
+  [handle _opts]
+  (let [state       (require-handle! handle)
+        source-path (:sarif/source-path state)
+        scan-files  (fmt/list-scan-files source-path)]
+    (if (empty? scan-files)
+      {:schemas [] :discover/total-count 0}
+      (let [all-violations  (into []
+                                  (mapcat
+                                   (fn [file-path]
+                                     (try
+                                       (fmt/parse-file file-path
+                                                       (:sarif/format state)
+                                                       (:sarif/csv-columns state))
+                                       (catch Exception e
+                                         (println (str "Warning: Failed to parse " file-path ": " (.getMessage e)))
+                                         [])))
+                                   scan-files))
+            violation-count (count all-violations)
+            csv-count       (count (filter #(str/includes? (:violation/id %) "csv:") all-violations))
+            schemas         (if (pos? violation-count)
+                              [(build-schema-descriptor :sarif-result violation-count)
+                               (build-schema-descriptor :csv-violation csv-count)]
+                              [])]
+        {:schemas schemas :discover/total-count (count schemas)}))))
+
+;; --------------------------------------------------------------------------
+;; Extract
+
+(defn do-extract
+  "Extract records for a given schema."
+  [handle _schema-name opts]
+  (let [state           (require-handle! handle)
+        source-path     (:sarif/source-path state)
+        _limit          (get opts :extract/limit 10000)
+        scan-files      (fmt/list-scan-files source-path)
+        all-violations  (into []
+                              (mapcat
+                               (fn [file-path]
+                                 (try
+                                   (fmt/parse-file file-path
+                                                   (:sarif/format state)
+                                                   (:sarif/csv-columns state))
+                                   (catch Exception e
+                                     (println (str "Warning: Failed to parse " file-path ": " (.getMessage e)))
+                                     [])))
+                               scan-files))]
+    {:records      all-violations
+     :extract/cursor   {:extract/offset 0}
+     :extract/has-more false}))
+
+;; --------------------------------------------------------------------------
+;; Checkpoint
+
+(defn do-checkpoint
+  "Persist cursor state for resumable extraction."
+  [handle _connector-id _cursor-state]
+  (let [_state (require-handle! handle)]
+    {:checkpoint/id     (java.util.UUID/randomUUID)
+     :checkpoint/status :committed}))

--- a/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/interface.clj
+++ b/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/interface.clj
@@ -1,0 +1,48 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.data-foundry.connector-sarif.interface
+  "Public API for the SARIF/CSV connector.
+   A SourceConnector that extracts violations from SARIF v2.1.0 JSON
+   and CSV scan output files."
+  (:require [ai.miniforge.data-foundry.connector-sarif.core :as core]
+            [ai.miniforge.data-foundry.connector-sarif.schema :as schema]))
+
+(defn create-sarif-connector
+  "Create a new SarifConnector instance."
+  []
+  (core/->SarifConnector))
+
+(def connector-metadata
+  "Registration metadata for the SARIF connector."
+  {:connector/name         "SARIF/CSV Scanner Connector"
+   :connector/type         :source
+   :connector/version      "0.1.0"
+   :connector/capabilities #{:cap/batch}
+   :connector/auth-methods #{:none}
+   :connector/retry-policy {:retry/strategy :none :retry/max-attempts 1}
+   :connector/maintainer   "data-foundry"})
+
+;; Schema exports
+(def SarifViolation schema/SarifViolation)
+(def SarifConfig schema/SarifConfig)
+
+(defn validate-config [config] (schema/validate-config config))
+(defn validate-violation [v] (schema/validate-violation v))
+(defn violation-json-schema [] (schema/violation-json-schema))
+(defn config-json-schema [] (schema/config-json-schema))

--- a/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/schema.clj
+++ b/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/schema.clj
@@ -1,0 +1,101 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.data-foundry.connector-sarif.schema
+  "Malli schemas, validation, and JSON Schema export for the SARIF
+   connector contract."
+  (:require [malli.core :as m]
+            [malli.error :as me]
+            [malli.json-schema :as json-schema]))
+
+;; -------------------------------------------------------------------------- Layer 0
+;; Enums
+
+(def SeverityLevel
+  "Normalized severity levels."
+  [:enum :error :warning :note :none])
+
+(def SchemaType
+  "Available extraction schemas."
+  [:enum :sarif-result :sarif-run :csv-violation])
+
+(def SourceFormat
+  "Supported input file formats."
+  [:enum :sarif :csv :auto])
+
+;; -------------------------------------------------------------------------- Layer 1
+;; Core schemas
+
+(def Location
+  "Physical location of a violation."
+  [:map
+   [:file {:optional true} [:maybe :string]]
+   [:line {:optional true} [:maybe :int]]
+   [:column {:optional true} [:maybe :int]]])
+
+(def SarifViolation
+  "Unified violation record — normalized from both SARIF and CSV sources."
+  [:map
+   [:violation/id :string]
+   [:violation/rule-id :string]
+   [:violation/message :string]
+   [:violation/severity SeverityLevel]
+   [:violation/location Location]
+   [:violation/source-tool :string]
+   [:violation/raw :map]])
+
+(def SarifConfig
+  "Configuration for the SARIF connector."
+  [:map
+   [:sarif/source-path :string]
+   [:sarif/format {:optional true} SourceFormat]
+   [:sarif/csv-columns {:optional true} [:map-of :keyword :string]]])
+
+;; -------------------------------------------------------------------------- Layer 2
+;; Validation
+
+(defn validate
+  "Validate value against schema. Returns {:valid? bool :errors map-or-nil}."
+  [schema value]
+  (if (m/validate schema value)
+    {:valid? true :errors nil}
+    {:valid? false
+     :errors (me/humanize (m/explain schema value))}))
+
+(defn validate-config
+  "Validate a SARIF connector config map."
+  [value]
+  (validate SarifConfig value))
+
+(defn validate-violation
+  "Validate a single violation record."
+  [value]
+  (validate SarifViolation value))
+
+;; -------------------------------------------------------------------------- Layer 3
+;; JSON Schema export
+
+(defn violation-json-schema
+  "Return the SarifViolation schema as JSON Schema."
+  []
+  (json-schema/transform SarifViolation))
+
+(defn config-json-schema
+  "Return the SarifConfig schema as JSON Schema."
+  []
+  (json-schema/transform SarifConfig))

--- a/components/connector-sarif/test/ai/miniforge/data_foundry/connector_sarif/impl_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/data_foundry/connector_sarif/impl_test.clj
@@ -1,0 +1,82 @@
+(ns ai.miniforge.data-foundry.connector-sarif.impl-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [cheshire.core :as json]
+            [ai.miniforge.data-foundry.connector-sarif.impl :as impl]
+            [ai.miniforge.data-foundry.connector-sarif.format :as fmt]))
+
+;; --------------------------------------------------------------------------
+;; Test helpers
+
+(defn- create-temp-sarif-file
+  "Create a temporary SARIF file with given results."
+  [results]
+  (let [f (java.io.File/createTempFile "test-scan" ".sarif")
+        content {"$schema" "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json"
+                 "version" "2.1.0"
+                 "runs" [{"tool" {"driver" {"name" "TestScanner" "version" "1.0"}}
+                          "results" results}]}]
+    (.deleteOnExit f)
+    (spit f (json/generate-string content))
+    (.getAbsolutePath f)))
+
+(defn- create-sarif-violation
+  "Create a SARIF result object for testing."
+  [rule-id message & {:keys [level file line]
+                      :or {level "warning" file "src/test.cpp" line 1}}]
+  {"ruleId" rule-id
+   "level" level
+   "message" {"text" message}
+   "locations" [{"physicalLocation"
+                 {"artifactLocation" {"uri" file}
+                  "region" {"startLine" line "startColumn" 1}}}]})
+
+;; --------------------------------------------------------------------------
+;; Tests
+
+(deftest test-connect-and-close
+  (testing "Connect with valid config"
+    (let [temp-file (create-temp-sarif-file [])
+          result    (impl/do-connect {:sarif/source-path temp-file})]
+      (is (= :connected (:connector/status result)))
+      (is (string? (:connection/handle result)))
+      (impl/do-close (:connection/handle result))))
+
+  (testing "Connect with invalid config throws"
+    (is (thrown? Exception (impl/do-connect {})))))
+
+(deftest test-discover
+  (testing "Discover schemas from SARIF file"
+    (let [temp-file (create-temp-sarif-file [(create-sarif-violation "API-001" "Test")])
+          {:keys [connection/handle]} (impl/do-connect {:sarif/source-path temp-file})
+          result (impl/do-discover handle {})]
+      (is (seq (:schemas result)))
+      (impl/do-close handle))))
+
+(deftest test-extract
+  (testing "Extract violations from SARIF"
+    (let [temp-file (create-temp-sarif-file [(create-sarif-violation "API-001" "Undocumented call" :level "error")
+                                             (create-sarif-violation "API-002" "Dynamic load" :level "warning")])
+          {:keys [connection/handle]} (impl/do-connect {:sarif/source-path temp-file})
+          result (impl/do-extract handle :sarif-result {})]
+      (is (= 2 (count (:records result))))
+      (is (= false (:extract/has-more result)))
+      (let [v (first (:records result))]
+        (is (= "API-001" (:violation/rule-id v)))
+        (is (= :error (:violation/severity v)))
+        (is (string? (:violation/message v))))
+      (impl/do-close handle))))
+
+(deftest test-format-detection
+  (testing "Format auto-detection"
+    (is (= :sarif (fmt/detect-format "scan.sarif")))
+    (is (= :sarif (fmt/detect-format "scan.sarif.json")))
+    (is (= :csv (fmt/detect-format "results.csv")))
+    (is (= :unknown (fmt/detect-format "data.xml")))))
+
+(deftest test-empty-file
+  (testing "Empty SARIF file returns no violations"
+    (let [temp-file (create-temp-sarif-file [])
+          {:keys [connection/handle]} (impl/do-connect {:sarif/source-path temp-file})
+          result (impl/do-extract handle :sarif-result {})]
+      (is (empty? (:records result)))
+      (impl/do-close handle))))

--- a/components/context-pack/src/ai/miniforge/context_pack/interface.clj
+++ b/components/context-pack/src/ai/miniforge/context_pack/interface.clj
@@ -12,6 +12,7 @@
    Layer 1: Budget queries
    Layer 2: Pack building and auditing"
   (:require [ai.miniforge.context-pack.schema :as schema]
+            [ai.miniforge.context-pack.factory :as factory]
             [ai.miniforge.context-pack.builder :as builder]
             [ai.miniforge.context-pack.budget :as budget]
             [ai.miniforge.context-pack.config :as config]))
@@ -22,6 +23,14 @@
 (def ContextPack schema/ContextPack)
 (def BudgetAudit schema/BudgetAudit)
 (def Source schema/Source)
+
+;------------------------------------------------------------------------------ Layer 0
+;; Factory re-exports
+
+(def ->context-pack factory/->context-pack)
+(def ->budget-audit factory/->budget-audit)
+(def ->source factory/->source)
+(def ->pack-context factory/->pack-context)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Budget queries

--- a/components/control-plane/src/ai/miniforge/control_plane/interface.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/interface.clj
@@ -30,11 +30,19 @@
    Layer 3: Heartbeat watchdog (background liveness monitoring)
    Layer 4: Orchestrator (adapter coordination, full lifecycle)"
   (:require
+   [ai.miniforge.control-plane.messages :as messages]
    [ai.miniforge.control-plane.state-machine :as sm]
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.decision-queue :as dq]
    [ai.miniforge.control-plane.heartbeat :as heartbeat]
    [ai.miniforge.control-plane.orchestrator :as orch]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Messages
+
+(def t
+  "Look up a control-plane message by key, with optional param substitution."
+  messages/t)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; State machine

--- a/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
@@ -30,7 +30,7 @@
    [ai.miniforge.control-plane.registry :as registry]
    [ai.miniforge.control-plane.decision-queue :as dq]
    [ai.miniforge.control-plane.heartbeat :as heartbeat]
-   [ai.miniforge.control-plane-adapter.protocol :as adapter]
+   [ai.miniforge.control-plane-adapter.interface :as adapter]
    [ai.miniforge.event-stream.interface.events :as events]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/interface.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/interface.clj
@@ -440,6 +440,19 @@
   [exec environment-id command opts]
   (executor/execute! exec environment-id command opts))
 
+(def execute!
+  "Execute a command in an environment (alias for executor-execute!).
+   See executor-execute! for full documentation."
+  executor/execute!)
+
+(def persist-workspace!
+  "Persist workspace state from an execution environment."
+  executor/persist-workspace!)
+
+(def restore-workspace!
+  "Restore workspace state into an execution environment."
+  executor/restore-workspace!)
+
 (def with-environment
   "Execute a function within an acquired environment.
    Automatically acquires and releases the environment.

--- a/components/gate-classification/deps.edn
+++ b/components/gate-classification/deps.edn
@@ -1,0 +1,5 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/loop     {:local/root "../loop"}
+        ai.miniforge/response {:local/root "../response"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps  {}}}}

--- a/components/gate-classification/src/ai/miniforge/gate_classification/core.clj
+++ b/components/gate-classification/src/ai/miniforge/gate_classification/core.clj
@@ -1,0 +1,126 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate-classification.core
+  "Classification gate implementation.
+
+   Implements the Gate protocol for mixed deterministic + LLM-judgment
+   classification in security compliance workflow."
+  (:require
+   [ai.miniforge.loop.interface.protocols.gate :as gate-protocol]
+   [ai.miniforge.gate-classification.rules :as rules]))
+
+;;------------------------------------------------------------------------------ Layer 0
+;; Forward declarations
+
+(declare check-artifact repair-artifact)
+
+;; Record definition
+
+(defrecord ClassificationGate [gate-id config]
+  gate-protocol/Gate
+  (check [this artifact context]
+    (check-artifact this artifact context))
+  (gate-id [_this]
+    gate-id)
+  (gate-type [_this]
+    :classification)
+  (repair [this artifact violations context]
+    (repair-artifact this artifact violations context)))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Check helpers
+
+(defn extract-violations
+  "Extract classified violations from artifact."
+  [artifact]
+  (or (:classified-violations artifact) []))
+
+(defn- build-gate-error
+  "Convert an unresolved violation to a gate error."
+  [violation]
+  {:code     (keyword (:violation/rule-id violation))
+   :message  (str (:violation/rule-id violation) ": " (:violation/message violation))
+   :location (:violation/location violation)})
+
+(defn- build-gate-warnings
+  "Build warnings for needs-investigation violations."
+  [violations]
+  (vec (keep (fn [v]
+               (when (rules/needs-investigation? v)
+                 {:code    (keyword (:violation/rule-id v))
+                  :message (str "Needs investigation: " (:violation/message v))}))
+             violations)))
+
+;; Check operation
+
+(defn check-artifact
+  "Run classification gate check on artifact."
+  [this artifact _context]
+  (try
+    (let [violations      (extract-violations artifact)
+          {:keys [violations]} (rules/apply-rules-to-all violations (:config this))
+          unresolved-errors (rules/filter-unresolved-errors violations (:config this))
+          warnings         (build-gate-warnings violations)]
+      {:gate/id       (:gate-id this)
+       :gate/type     :classification
+       :gate/passed?  (empty? unresolved-errors)
+       :gate/errors   (mapv build-gate-error unresolved-errors)
+       :gate/warnings warnings})
+    (catch Exception e
+      {:gate/id       (:gate-id this)
+       :gate/type     :classification
+       :gate/passed?  false
+       :gate/errors   [{:code    :check-error
+                        :message (str "Classification gate check failed: " (ex-message e))
+                        :location {}}]
+       :gate/warnings []})))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Repair operation
+
+(defn repair-artifact
+  "Repair artifact by reclassifying low-confidence violations to needs-investigation."
+  [this artifact _violations _context]
+  (try
+    (let [current-violations (extract-violations artifact)
+          reclassified       (mapv (fn [v]
+                                     (if (and (not (rules/needs-investigation? v))
+                                              (< (rules/get-confidence v)
+                                                 (get (:config this) :confidence-threshold 0.5)))
+                                       (assoc v :classification/category :needs-investigation
+                                                :classification/repair-action :reclassified)
+                                       v))
+                                   current-violations)
+          changes            (vec (keep-indexed
+                                   (fn [idx v]
+                                     (when (:classification/repair-action v)
+                                       {:index idx
+                                        :violation-id (:violation/id v)
+                                        :action :reclassified-to-investigation}))
+                                   reclassified))
+          remaining          (rules/filter-unresolved-errors reclassified (:config this))]
+      {:repaired?             (seq changes)
+       :artifact              (assoc artifact :classified-violations reclassified)
+       :changes               changes
+       :remaining-violations  remaining})
+    (catch Exception _e
+      {:repaired?            false
+       :artifact             artifact
+       :changes              []
+       :remaining-violations []})))

--- a/components/gate-classification/src/ai/miniforge/gate_classification/interface.clj
+++ b/components/gate-classification/src/ai/miniforge/gate_classification/interface.clj
@@ -1,0 +1,37 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate-classification.interface
+  "Public API for the classification gate."
+  (:require [ai.miniforge.gate-classification.core :as core]))
+
+(def default-config
+  "Default gate configuration with sensible thresholds."
+  {:confidence-threshold    0.5
+   :doc-status-threshold    0.7
+   :true-positive-threshold 0.8
+   :max-error-severity      :error})
+
+(defn create-classification-gate
+  "Create a ClassificationGate instance.
+   Accepts optional config overrides merged with defaults."
+  ([] (create-classification-gate {}))
+  ([config-overrides]
+   (core/->ClassificationGate
+    :classification-gate
+    (merge default-config config-overrides))))

--- a/components/gate-classification/src/ai/miniforge/gate_classification/rules.clj
+++ b/components/gate-classification/src/ai/miniforge/gate_classification/rules.clj
@@ -1,0 +1,131 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate-classification.rules
+  "Deterministic classification rules engine.
+
+   Three core rules applied in sequence:
+   1. Low Confidence Rule: confidence < threshold -> escalate to needs-investigation
+   2. Documented False-Positive Rule: false-positive + documented + high confidence -> auto-exclude
+   3. True-Positive Passthrough Rule: true-positive + high confidence -> confirmed")
+
+;; -------------------------------------------------------------------------- Layer 0
+;; Predicates
+
+(defn true-positive?
+  "Check if violation is classified as true-positive."
+  [violation]
+  (= :true-positive (:classification/category violation)))
+
+(defn false-positive?
+  "Check if violation is classified as false-positive."
+  [violation]
+  (= :false-positive (:classification/category violation)))
+
+(defn needs-investigation?
+  "Check if violation needs investigation."
+  [violation]
+  (= :needs-investigation (:classification/category violation)))
+
+(defn documented?
+  "Check if violation has documented status."
+  [violation]
+  (= :documented (:classification/doc-status violation)))
+
+(defn get-confidence
+  "Extract confidence from violation, defaulting to 0.5."
+  [violation]
+  (or (:classification/confidence violation) 0.5))
+
+;; -------------------------------------------------------------------------- Layer 1
+;; Individual rules
+
+(defn apply-low-confidence-rule
+  "If confidence < threshold, escalate to needs-investigation.
+   Overrides LLM judgment when confidence is too low to trust."
+  [violation config]
+  (let [threshold  (get config :confidence-threshold 0.5)
+        confidence (get-confidence violation)]
+    (if (and (< confidence threshold)
+             (not (needs-investigation? violation)))
+      (-> violation
+          (assoc :classification/category :needs-investigation)
+          (assoc :classification/rule-applied :low-confidence))
+      violation)))
+
+(defn apply-documented-fp-rule
+  "If false-positive + documented + high confidence -> confirm as auto-exclude."
+  [violation config]
+  (let [doc-threshold (get config :doc-status-threshold 0.7)
+        confidence    (get-confidence violation)]
+    (if (and (false-positive? violation)
+             (documented? violation)
+             (>= confidence doc-threshold))
+      (assoc violation :classification/rule-applied :documented-false-positive)
+      violation)))
+
+(defn apply-true-positive-rule
+  "If true-positive + high confidence -> confirmed as real violation."
+  [violation config]
+  (let [tp-threshold (get config :true-positive-threshold 0.8)
+        confidence   (get-confidence violation)]
+    (if (and (true-positive? violation)
+             (>= confidence tp-threshold))
+      (assoc violation :classification/rule-applied :confirmed-true-positive)
+      violation)))
+
+;; -------------------------------------------------------------------------- Layer 2
+;; Batch processing
+
+(defn apply-rules
+  "Apply all deterministic rules to a single violation.
+   Rules are applied in sequence: low-confidence -> documented-FP -> TP."
+  [violation config]
+  (-> violation
+      (apply-low-confidence-rule config)
+      (apply-documented-fp-rule config)
+      (apply-true-positive-rule config)))
+
+(defn apply-rules-to-all
+  "Apply rules to all violations. Returns {:violations [...] :changes [...]}."
+  [violations config]
+  (let [results (mapv #(apply-rules % config) violations)
+        changes (vec (keep-indexed
+                      (fn [idx v]
+                        (when (:classification/rule-applied v)
+                          {:index idx
+                           :violation-id (:violation/id v)
+                           :rule (:classification/rule-applied v)}))
+                      results))]
+    {:violations results :changes changes}))
+
+;; -------------------------------------------------------------------------- Layer 3
+;; Severity filtering
+
+(def severity-rank
+  {:error 3 :warning 2 :note 1 :none 0})
+
+(defn filter-unresolved-errors
+  "Return violations that are true-positive and at or above severity threshold."
+  [violations config]
+  (let [max-severity (get config :max-error-severity :error)
+        threshold    (get severity-rank max-severity 3)]
+    (filterv (fn [v]
+               (and (true-positive? v)
+                    (>= (get severity-rank (:violation/severity v) 0) threshold)))
+             violations)))

--- a/components/gate-classification/test/ai/miniforge/gate_classification/core_test.clj
+++ b/components/gate-classification/test/ai/miniforge/gate_classification/core_test.clj
@@ -1,0 +1,83 @@
+(ns ai.miniforge.gate-classification.core-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [ai.miniforge.gate-classification.interface :as iface]
+            [ai.miniforge.loop.interface.protocols.gate :as gate-protocol]))
+
+(def test-config
+  {:confidence-threshold 0.5
+   :doc-status-threshold 0.7
+   :true-positive-threshold 0.8
+   :max-error-severity :error})
+
+(defn- make-violation
+  [id rule-id category confidence & {:keys [severity doc-status]
+                                      :or {severity :warning doc-status :documented}}]
+  {:violation/id id
+   :violation/rule-id rule-id
+   :violation/message (str "Test: " rule-id)
+   :violation/severity severity
+   :violation/location {:file "test.cpp" :line 1}
+   :violation/source-tool "test"
+   :violation/raw {}
+   :classification/category category
+   :classification/confidence confidence
+   :classification/doc-status doc-status})
+
+(deftest test-gate-creation
+  (testing "Create gate with defaults"
+    (let [gate (iface/create-classification-gate)]
+      (is (= :classification-gate (gate-protocol/gate-id gate)))
+      (is (= :classification (gate-protocol/gate-type gate))))))
+
+(deftest test-gate-passes-no-violations
+  (testing "Gate passes with empty violations"
+    (let [gate   (iface/create-classification-gate)
+          result (gate-protocol/check gate {:classified-violations []} {})]
+      (is (true? (:gate/passed? result)))
+      (is (empty? (:gate/errors result))))))
+
+(deftest test-gate-passes-only-false-positives
+  (testing "Gate passes when all violations are false-positive"
+    (let [gate   (iface/create-classification-gate)
+          artifact {:classified-violations
+                    [(make-violation "v1" "API-002" :false-positive 0.9)
+                     (make-violation "v2" "API-002" :false-positive 0.8)]}
+          result (gate-protocol/check gate artifact {})]
+      (is (true? (:gate/passed? result))))))
+
+(deftest test-gate-fails-true-positive-error
+  (testing "Gate fails with true-positive error severity"
+    (let [gate   (iface/create-classification-gate)
+          artifact {:classified-violations
+                    [(make-violation "v1" "API-001" :true-positive 0.9 :severity :error)]}
+          result (gate-protocol/check gate artifact {})]
+      (is (false? (:gate/passed? result)))
+      (is (pos? (count (:gate/errors result)))))))
+
+(deftest test-gate-warns-on-needs-investigation
+  (testing "Gate emits warnings for needs-investigation"
+    (let [gate   (iface/create-classification-gate)
+          artifact {:classified-violations
+                    [(make-violation "v1" "API-003" :needs-investigation 0.4)]}
+          result (gate-protocol/check gate artifact {})]
+      (is (true? (:gate/passed? result)))
+      (is (pos? (count (:gate/warnings result)))))))
+
+(deftest test-low-confidence-reclassification
+  (testing "Low confidence violations get reclassified to needs-investigation"
+    (let [gate   (iface/create-classification-gate {:confidence-threshold 0.6})
+          artifact {:classified-violations
+                    [(make-violation "v1" "API-001" :true-positive 0.3 :severity :error)]}
+          result (gate-protocol/check gate artifact {})]
+      ;; Should pass because low-confidence TP gets reclassified
+      (is (true? (:gate/passed? result))))))
+
+(deftest test-repair
+  (testing "Repair reclassifies low-confidence violations"
+    (let [gate    (iface/create-classification-gate {:confidence-threshold 0.6})
+          artifact {:classified-violations
+                    [(make-violation "v1" "API-001" :true-positive 0.3 :severity :error)
+                     (make-violation "v2" "API-002" :false-positive 0.9)]}
+          result  (gate-protocol/repair gate artifact [] {})]
+      (is (:repaired? result))
+      (is (pos? (count (:changes result)))))))

--- a/components/gate-classification/test/ai/miniforge/gate_classification/rules_test.clj
+++ b/components/gate-classification/test/ai/miniforge/gate_classification/rules_test.clj
@@ -1,0 +1,97 @@
+(ns ai.miniforge.gate-classification.rules-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [ai.miniforge.gate-classification.rules :as rules]))
+
+(def test-config
+  {:confidence-threshold 0.5
+   :doc-status-threshold 0.7
+   :true-positive-threshold 0.8
+   :max-error-severity :error})
+
+(defn- make-violation
+  [category confidence & {:keys [severity doc-status rule-id]
+                          :or {severity :warning doc-status :documented rule-id "API-001"}}]
+  {:violation/id "test-v"
+   :violation/rule-id rule-id
+   :violation/message "Test violation"
+   :violation/severity severity
+   :violation/location {:file "test.cpp" :line 1}
+   :classification/category category
+   :classification/confidence confidence
+   :classification/doc-status doc-status})
+
+;; Predicates
+
+(deftest test-predicates
+  (testing "true-positive?"
+    (is (true? (rules/true-positive? (make-violation :true-positive 0.9))))
+    (is (false? (rules/true-positive? (make-violation :false-positive 0.9)))))
+  (testing "false-positive?"
+    (is (true? (rules/false-positive? (make-violation :false-positive 0.9))))
+    (is (false? (rules/false-positive? (make-violation :true-positive 0.9)))))
+  (testing "needs-investigation?"
+    (is (true? (rules/needs-investigation? (make-violation :needs-investigation 0.5))))
+    (is (false? (rules/needs-investigation? (make-violation :true-positive 0.9)))))
+  (testing "documented?"
+    (is (true? (rules/documented? (make-violation :false-positive 0.9 :doc-status :documented))))
+    (is (false? (rules/documented? (make-violation :false-positive 0.9 :doc-status :undocumented))))))
+
+;; Low confidence rule
+
+(deftest test-low-confidence-rule
+  (testing "Low confidence escalates to needs-investigation"
+    (let [v (make-violation :true-positive 0.3)
+          result (rules/apply-low-confidence-rule v test-config)]
+      (is (= :needs-investigation (:classification/category result)))
+      (is (= :low-confidence (:classification/rule-applied result)))))
+  (testing "High confidence passes through"
+    (let [v (make-violation :true-positive 0.9)
+          result (rules/apply-low-confidence-rule v test-config)]
+      (is (= :true-positive (:classification/category result)))
+      (is (nil? (:classification/rule-applied result))))))
+
+;; Documented FP rule
+
+(deftest test-documented-fp-rule
+  (testing "Documented FP with high confidence gets rule applied"
+    (let [v (make-violation :false-positive 0.9 :doc-status :documented)
+          result (rules/apply-documented-fp-rule v test-config)]
+      (is (= :documented-false-positive (:classification/rule-applied result)))))
+  (testing "Undocumented FP does not trigger"
+    (let [v (make-violation :false-positive 0.9 :doc-status :undocumented)
+          result (rules/apply-documented-fp-rule v test-config)]
+      (is (nil? (:classification/rule-applied result))))))
+
+;; True positive rule
+
+(deftest test-true-positive-rule
+  (testing "High confidence TP gets confirmed"
+    (let [v (make-violation :true-positive 0.95)
+          result (rules/apply-true-positive-rule v test-config)]
+      (is (= :confirmed-true-positive (:classification/rule-applied result)))))
+  (testing "Low confidence TP does not get confirmed"
+    (let [v (make-violation :true-positive 0.6)
+          result (rules/apply-true-positive-rule v test-config)]
+      (is (nil? (:classification/rule-applied result))))))
+
+;; Batch processing
+
+(deftest test-apply-rules-to-all
+  (testing "Batch rule application"
+    (let [violations [(make-violation :true-positive 0.9 :severity :error)
+                      (make-violation :false-positive 0.8 :doc-status :documented)
+                      (make-violation :true-positive 0.3 :severity :warning)]
+          {:keys [violations changes]} (rules/apply-rules-to-all violations test-config)]
+      (is (= 3 (count violations)))
+      (is (pos? (count changes))))))
+
+;; Severity filtering
+
+(deftest test-filter-unresolved-errors
+  (testing "Filter true-positive errors"
+    (let [violations [(make-violation :true-positive 0.9 :severity :error)
+                      (make-violation :true-positive 0.9 :severity :warning)
+                      (make-violation :false-positive 0.9 :severity :error)]
+          result (rules/filter-unresolved-errors violations test-config)]
+      (is (= 1 (count result)))
+      (is (= :error (:violation/severity (first result)))))))

--- a/components/gate/src/ai/miniforge/gate/format.clj
+++ b/components/gate/src/ai/miniforge/gate/format.clj
@@ -13,9 +13,7 @@
    Layer 2: Gate check/repair + registration"
   (:require
    [ai.miniforge.gate.registry :as registry]
-   [ai.miniforge.lsp-mcp-bridge.lsp.manager :as lsp-manager]
-   [ai.miniforge.lsp-mcp-bridge.lsp.client :as lsp-client]
-   [ai.miniforge.response.builder :as response]
+   [ai.miniforge.response.interface :as response]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]))
@@ -65,10 +63,12 @@
     (subs (str path) (inc idx))))
 
 (defn- get-or-create-lsp-manager
-  "Get LSP manager from context, or create one."
+  "Get LSP manager from context, or create one.
+   Uses requiring-resolve to avoid component-to-base dependency."
   [ctx]
   (or (get ctx :lsp-manager)
-      (lsp-manager/create-manager {} (or (get ctx :execution/worktree-path) "."))))
+      ((requiring-resolve 'ai.miniforge.lsp-mcp-bridge.lsp.manager/create-manager)
+       {} (or (get ctx :execution/worktree-path) "."))))
 
 (defn- format-single-file
   "Format a single file using LSP. Returns {:formatted? bool :path string}."
@@ -79,9 +79,11 @@
           ext       (file-extension file-path)]
       (if (.exists (io/file full-path))
         (do
-          (lsp-manager/start-server manager {:language ext})
+          ((requiring-resolve 'ai.miniforge.lsp-mcp-bridge.lsp.manager/start-server)
+           manager {:language ext})
           (when-let [server (get @(:servers manager) ext)]
-            (lsp-client/format-document server uri {}))
+            ((requiring-resolve 'ai.miniforge.lsp-mcp-bridge.lsp.client/format-document)
+             server uri {}))
           {:formatted? true :path file-path})
         {:formatted? false :path file-path}))
     (catch Exception _

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -54,6 +54,10 @@
      Gate map with :name, :check, :repair"
   registry/get-gate)
 
+(def register-gate!
+  "Track a gate as registered."
+  registry/register-gate!)
+
 (def list-gates
   "List all registered gate types.
 

--- a/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
+++ b/components/gate/src/ai/miniforge/gate/pre_verify_lint.clj
@@ -13,7 +13,6 @@
    Layer 1: Gate registration"
   (:require
    [ai.miniforge.connector-linter.interface :as linter]
-   [ai.miniforge.cli.repo-analyzer :as analyzer]
    [ai.miniforge.gate.registry :as registry]
    [clojure.string :as str]))
 
@@ -68,7 +67,7 @@
   [artifact ctx]
   (let [worktree   (resolve-worktree ctx)
         techs      (detect-technologies artifact)
-        fps        @analyzer/fingerprints
+        fps        @@(requiring-resolve 'ai.miniforge.cli.repo-analyzer/fingerprints)
         result     (linter/run-all worktree fps techs)
         violations (:violations result)]
     (if (empty? violations)

--- a/components/llm/src/ai/miniforge/llm/interface.clj
+++ b/components/llm/src/ai/miniforge/llm/interface.clj
@@ -360,6 +360,13 @@
   [selection]
   (selector/explain-selection selection))
 
+;------------------------------------------------------------------------------ Layer 5
+;; Capsule integration
+
+(def capsule-exec-fn
+  "Build a capsule-aware exec function for LLM clients running inside executors."
+  impl/capsule-exec-fn)
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Create a client with claude CLI (default)

--- a/components/phase-deployment/src/ai/miniforge/phase/deploy/gates.clj
+++ b/components/phase-deployment/src/ai/miniforge/phase/deploy/gates.clj
@@ -21,7 +21,7 @@
 
    Gate metadata is loaded from EDN so descriptions and registration stay
    declarative while checks remain focused in code."
-  (:require [ai.miniforge.gate.registry :as registry]
+  (:require [ai.miniforge.gate.interface :as gate]
             [ai.miniforge.phase.deploy.messages :as msg]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]
@@ -217,17 +217,17 @@
 ;; Registration
 
 (doseq [gate-kw (keys @gate-definitions)]
-  (registry/register-gate! gate-kw))
+  (gate/register-gate! gate-kw))
 
-(defmethod registry/get-gate :provision-validated
+(defmethod gate/get-gate :provision-validated
   [_]
   (gate-map :provision-validated check-provision-validated))
 
-(defmethod registry/get-gate :deploy-healthy
+(defmethod gate/get-gate :deploy-healthy
   [_]
   (gate-map :deploy-healthy check-deploy-healthy))
 
-(defmethod registry/get-gate :health-check
+(defmethod gate/get-gate :health-check
   [_]
   (gate-map :health-check check-health-endpoint))
 

--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -32,7 +32,6 @@
             [ai.miniforge.phase.knowledge-helpers :as kb-helpers]
             [ai.miniforge.agent.interface :as agent]
             [ai.miniforge.context-pack.interface :as context-pack]
-            [ai.miniforge.context-pack.factory :as ctx-factory]
             [ai.miniforge.knowledge.interface :as knowledge]
             [ai.miniforge.repo-index.interface :as repo-index]
             [ai.miniforge.logging.interface :as log]
@@ -87,7 +86,7 @@
                     :search-index search-index
                     :search-query (when (seq files-in-scope)
                                     (first files-in-scope))})]
-        (ctx-factory/->pack-context index pack)))
+        (context-pack/->pack-context index pack)))
     (catch Exception _e
       nil)))
 
@@ -243,7 +242,7 @@
               (assoc-in [:execution/cached-files] (:task/existing-files task))
               (and (:task/context-pack task) (not (get-in ctx [:execution/pack-context])))
               (assoc-in [:execution/pack-context]
-                        (ctx-factory/->pack-context
+                        (context-pack/->pack-context
                           (:task/repo-index task)
                           (:task/context-pack task))))
         on-chunk (create-streaming-callback ctx)

--- a/components/phase-software-factory/src/ai/miniforge/phase/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/review.clj
@@ -28,7 +28,6 @@
             [ai.miniforge.phase.phase-result :as phase-result]
             [ai.miniforge.phase.knowledge-helpers :as kb-helpers]
             [ai.miniforge.agent.interface :as agent]
-            [ai.miniforge.agent.file-artifacts :as file-artifacts]
             [ai.miniforge.knowledge.interface :as knowledge]
             [ai.miniforge.response.interface :as response]))
 
@@ -67,7 +66,7 @@
    (let [worktree-path (or (get ctx :execution/worktree-path)
                            (get ctx :worktree-path))]
      (when worktree-path
-       (file-artifacts/collect-written-files (file-artifacts/empty-snapshot)
+       (agent/collect-written-files (agent/empty-snapshot)
                                             worktree-path)))))
 
 (defn- build-review-task

--- a/components/phase-software-factory/test/ai/miniforge/phase/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/implement_test.clj
@@ -66,7 +66,7 @@
 (deftest default-config-test
   (testing "implement phase has correct default configuration"
     (is (= :implementer (:agent implement/default-config)))
-    (is (= [:syntax :lint] (:gates implement/default-config)))
+    (is (= [:syntax :format :lint] (:gates implement/default-config)))
     (is (map? (:budget implement/default-config)))
     (is (= 30000 (get-in implement/default-config [:budget :tokens])))
     (is (= 8 (get-in implement/default-config [:budget :iterations])))
@@ -77,7 +77,7 @@
     (let [defaults (registry/phase-defaults :implement)]
       (is (some? defaults))
       (is (= :implementer (:agent defaults)))
-      (is (= [:syntax :lint] (:gates defaults))))))
+      (is (= [:syntax :format :lint] (:gates defaults))))))
 
 ;------------------------------------------------------------------------------ Layer 1: Interceptor Enter Tests
 

--- a/components/phase-software-factory/test/ai/miniforge/phase/release_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/release_test.clj
@@ -27,7 +27,7 @@
   test worktree before invoking the phase, simulating what the implement
   agent would do in production."
   (:require
-   [clojure.test :refer [deftest testing is use-fixtures]]
+   [clojure.test :refer [deftest testing is]]
    [clojure.java.io :as io]
    [clojure.java.shell :as shell]
    [babashka.fs :as fs]
@@ -37,8 +37,6 @@
    [ai.miniforge.release-executor.interface :as release-executor]))
 
 ;------------------------------------------------------------------------------ Test Fixtures
-
-(def ^:dynamic *test-worktree* nil)
 
 (defn create-temp-worktree
   "Create a temporary directory initialized as a real git repository.
@@ -58,16 +56,13 @@
       (fs/delete-tree dir-path)
       (catch Exception _e nil))))
 
-(defn worktree-fixture
+(defn with-test-worktree
   [f]
   (let [worktree (create-temp-worktree)]
-    (binding [*test-worktree* worktree]
-      (try
-        (f)
-        (finally
-          (cleanup-temp-worktree worktree))))))
-
-(use-fixtures :each worktree-fixture)
+    (try
+      (f worktree)
+      (finally
+        (cleanup-temp-worktree worktree)))))
 
 ;------------------------------------------------------------------------------ Mock Data
 
@@ -93,9 +88,9 @@
   "Write mock code artifact files to the test worktree.
    Simulates what the implement phase does in production: writing code
    directly to the execution environment's working directory."
-  []
+  [worktree]
   (doseq [{:keys [path content]} (:code/files mock-code-artifact)]
-    (let [file (io/file *test-worktree* path)]
+    (let [file (io/file worktree path)]
       (io/make-parents file)
       (spit file content))))
 
@@ -103,28 +98,28 @@
   "Create a test context with mock files already written to the test worktree.
    In the new environment model, code changes are in the worktree (not phase
    results). Most tests use this context."
-  []
+  [worktree]
   ;; Write mock files to the worktree, simulating what the implement phase does
-  (write-mock-files-to-worktree!)
+  (write-mock-files-to-worktree! worktree)
   {:execution/id (random-uuid)
    :execution/input {:description "Test release"
                      :title "Add feature"
                      :intent "testing"}
    :execution/metrics {:tokens 0 :duration-ms 0}
    :execution/phase-results {:implement {:result mock-implement-result}}
-   :worktree-path *test-worktree*})
+   :worktree-path worktree})
 
 (defn create-empty-context
   "Create a test context with NO files written to the worktree.
    Used to test zero-files detection (no git dirty files in environment)."
-  []
+  [worktree]
   {:execution/id (random-uuid)
    :execution/input {:description "Test release"
                      :title "Add feature"
                      :intent "testing"}
    :execution/metrics {:tokens 0 :duration-ms 0}
    :execution/phase-results {:implement {:result mock-implement-result}}
-   :worktree-path *test-worktree*})
+   :worktree-path worktree})
 
 ;------------------------------------------------------------------------------ Layer 0: Defaults Tests
 
@@ -148,189 +143,185 @@
 
 (deftest release-writes-files-to-temp-directory-test
   (testing "release phase writes files to temporary worktree"
-    (with-redefs [release-executor/execute-release-phase
-                  (fn [workflow-state exec-context _opts]
-                    ;; Write files directly to temp worktree (skip git staging)
-                    (let [worktree (:worktree-path exec-context)
-                          code-artifacts (map :artifact/content (:workflow/artifacts workflow-state))
-                          files (mapcat :code/files code-artifacts)]
-                      (doseq [{:keys [path content]} files]
-                        (let [file (io/file worktree path)]
-                          (io/make-parents file)
-                          (spit file content)))
-                      {:success? true
-                       :artifacts [{:artifact/id (random-uuid)
-                                    :artifact/type :release
-                                    :artifact/content {:files-written (count files)
-                                                       :branch "test-branch"
-                                                       :commit-sha "abc123"}}]
-                       :metrics {:files-written (count files)}}))]
-      (let [ctx (create-base-context)
-            ctx-with-config (assoc ctx :phase-config {:phase :release})
-            interceptor (registry/get-phase-interceptor {:phase :release})
-            result ((:enter interceptor) ctx-with-config)]
-
-        ;; Verify phase completed successfully
-        (is (= :success (get-in result [:phase :result :status]))
-            "Release phase should succeed")
-
-        ;; Verify files exist
-        (is (.exists (io/file *test-worktree* "src/feature.clj"))
-            "Source file should exist on disk")
-
-        (is (.exists (io/file *test-worktree* "test/feature_test.clj"))
-            "Test file should exist on disk")))))
-
-(deftest release-returns-correct-files-written-count-test
-  (testing "release phase returns correct :files-written count"
-    (with-redefs [release-executor/execute-release-phase
-                  (fn [workflow-state exec-context _opts]
-                    ;; Write files directly to temp worktree (skip git staging)
-                    (let [worktree (:worktree-path exec-context)
-                          code-artifacts (map :artifact/content (:workflow/artifacts workflow-state))
-                          files (mapcat :code/files code-artifacts)]
-                      (doseq [{:keys [path content]} files]
-                        (let [file (io/file worktree path)]
-                          (io/make-parents file)
-                          (spit file content)))
-                      {:success? true
-                       :artifacts [{:artifact/id (random-uuid)
-                                  :artifact/type :release
-                                  :artifact/content {:files-written (count files)}}]
-                       :metrics {:files-written (count files)}}))]
-      (let [ctx (create-base-context)
-            ctx-with-config (assoc ctx :phase-config {:phase :release})
-            interceptor (registry/get-phase-interceptor {:phase :release})
-            result ((:enter interceptor) ctx-with-config)
-            files-written (get-in result [:phase :result :output :release/metrics :files-written])]
-        
-        (is (= 2 files-written)
-            "Should report 2 files written (src + test)")))))
-
-(deftest release-fails-when-write-fails-test
-  (testing "release phase fails when file write operation fails"
-    (with-redefs [release-executor/execute-release-phase
-                  (fn [_workflow-state _exec-context _opts]
-                    ;; Simulate write failure
-                    {:success? false
-                     :errors [{:type :file-write-failed
-                              :message "Permission denied writing to src/feature.clj"
-                              :file "src/feature.clj"}]
-                     :metrics {:files-written 0}})]
-      (let [ctx (create-base-context)
-            ctx-with-config (assoc ctx :phase-config {:phase :release})
-            interceptor (registry/get-phase-interceptor {:phase :release})
-            result ((:enter interceptor) ctx-with-config)]
-        
-        (is (false? (get-in result [:phase :result :success]))
-            "Release should fail when write fails")
-
-        (is (some? (get-in result [:phase :result :error]))
-            "Error should be present in result")))))
-
-(deftest release-verifies-files-exist-after-writing-test
-  (testing "release phase verifies files exist on disk after writing"
-    (let [verification-performed (atom false)]
+    (with-test-worktree
+      (fn [worktree]
       (with-redefs [release-executor/execute-release-phase
                     (fn [workflow-state exec-context _opts]
                       ;; Write files directly to temp worktree (skip git staging)
                       (let [worktree (:worktree-path exec-context)
                             code-artifacts (map :artifact/content (:workflow/artifacts workflow-state))
                             files (mapcat :code/files code-artifacts)]
-                        (doseq [{:keys [path content action]} files]
-                          (when (#{:create :modify} action)
-                            (let [file (io/file worktree path)]
-                              (io/make-parents file)
-                              (spit file content))))
-                        ;; Verify files exist after write
-                        (doseq [{:keys [path action]} files]
-                          (when (#{:create :modify} action)
-                            (let [file-path (io/file worktree path)]
-                              (reset! verification-performed true)
-                              (when-not (.exists file-path)
-                                (throw (ex-info "File verification failed"
-                                               {:file path}))))))
+                        (doseq [{:keys [path content]} files]
+                          (let [file (io/file worktree path)]
+                            (io/make-parents file)
+                            (spit file content)))
                         {:success? true
                          :artifacts [{:artifact/id (random-uuid)
-                                    :artifact/type :release
-                                    :artifact/content {:files-written (count files)
-                                                     :files-verified (count (filter #(#{:create :modify} (:action %)) files))}}]
+                                      :artifact/type :release
+                                      :artifact/content {:files-written (count files)
+                                                         :branch "test-branch"
+                                                         :commit-sha "abc123"}}]
                          :metrics {:files-written (count files)}}))]
-        (let [ctx (create-base-context)
+        (let [ctx (create-base-context worktree)
               ctx-with-config (assoc ctx :phase-config {:phase :release})
               interceptor (registry/get-phase-interceptor {:phase :release})
               result ((:enter interceptor) ctx-with-config)]
 
-          (is @verification-performed
-              "File verification should be performed")
-
           (is (= :success (get-in result [:phase :result :status]))
-              "Release should succeed when verification passes"))))))
+              "Release phase should succeed")
+          (is (.exists (io/file worktree "src/feature.clj"))
+              "Source file should exist on disk")
+          (is (.exists (io/file worktree "test/feature_test.clj"))
+              "Test file should exist on disk")))))))
 
-(deftest release-handles-zero-files-artifact-test
-  (testing "release phase fails fast when no files changed in the environment"
-    ;; With the new environment model, zero-file detection is via the git
-    ;; working tree rather than :code/files in phase results.
-    ;; create-empty-context does NOT write any files to the worktree.
-    (let [ctx (create-empty-context)
-          ctx-with-config (assoc ctx :phase-config {:phase :release})
-          interceptor (registry/get-phase-interceptor {:phase :release})]
-      (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Release phase received code artifact with zero files"
-                            ((:enter interceptor) ctx-with-config))
-          "Release should fail fast when environment has no changed files"))))
-
-(deftest release-includes-pr-info-test
-  (testing "release phase includes PR info in result"
-    (with-redefs [release-executor/execute-release-phase
-                  (fn [_workflow-state _exec-context _opts]
-                    {:success? true
-                     :artifacts [{:artifact/id (random-uuid)
-                                :artifact/type :release
-                                :artifact/content {:files-written 2
-                                                 :branch "feature/test-123"
-                                                 :commit-sha "def456"
-                                                 :pr-number 42
-                                                 :pr-url "https://github.com/org/repo/pull/42"}}]
-                     :metrics {:files-written 2}})]
-      (let [ctx (create-base-context)
-            ctx-with-config (assoc ctx :phase-config {:phase :release})
-            interceptor (registry/get-phase-interceptor {:phase :release})
-            result ((:enter interceptor) ctx-with-config)]
-        
-        (is (some? (get-in result [:workflow/pr-info]))
-            "PR info should be available at top level")
-        
-        (let [pr-info (get-in result [:workflow/pr-info])]
-          (is (= 42 (:pr-number pr-info))
-              "PR number should be captured")
-          (is (= "https://github.com/org/repo/pull/42" (:pr-url pr-info))
-              "PR URL should be captured")
-          (is (= "feature/test-123" (:branch pr-info))
-              "Branch name should be captured"))))))
-
-(deftest release-propagates-streaming-callback-test
-  (testing "release phase passes event-stream-backed on-chunk callback to the executor"
-    (let [stream (es/create-event-stream {:sinks []})]
+(deftest release-returns-correct-files-written-count-test
+  (testing "release phase returns correct :files-written count"
+    (with-test-worktree
+      (fn [worktree]
       (with-redefs [release-executor/execute-release-phase
-                    (fn [_workflow-state exec-context _opts]
-                      (is (fn? (:on-chunk exec-context))
-                          "Release executor should receive an on-chunk callback")
-                      ((:on-chunk exec-context) {:delta "release chunk" :done? false})
-                      {:success? true
-                       :artifacts [{:artifact/id (random-uuid)
-                                    :artifact/type :release
-                                    :artifact/content {:files-written 1}}]
-                       :metrics {:files-written 1}})]
-        (let [ctx (assoc (create-base-context) :event-stream stream)
+                    (fn [workflow-state exec-context _opts]
+                      (let [worktree (:worktree-path exec-context)
+                            code-artifacts (map :artifact/content (:workflow/artifacts workflow-state))
+                            files (mapcat :code/files code-artifacts)]
+                        (doseq [{:keys [path content]} files]
+                          (let [file (io/file worktree path)]
+                            (io/make-parents file)
+                            (spit file content)))
+                        {:success? true
+                         :artifacts [{:artifact/id (random-uuid)
+                                      :artifact/type :release
+                                      :artifact/content {:files-written (count files)}}]
+                         :metrics {:files-written (count files)}}))]
+        (let [ctx (create-base-context worktree)
               ctx-with-config (assoc ctx :phase-config {:phase :release})
               interceptor (registry/get-phase-interceptor {:phase :release})
               result ((:enter interceptor) ctx-with-config)
-              chunk-events (es/get-events stream {:event-type :agent/chunk})]
-          (is (= :success (get-in result [:phase :result :status])))
-          (is (= 1 (count chunk-events)))
-          (is (= "release chunk" (:chunk/delta (first chunk-events))))
-          (is (= :release (:agent/id (first chunk-events)))))))))
+              files-written (get-in result [:phase :result :output :release/metrics :files-written])]
+          (is (= 2 files-written)
+              "Should report 2 files written (src + test)")))))))
+
+(deftest release-fails-when-write-fails-test
+  (testing "release phase fails when file write operation fails"
+    (with-test-worktree
+      (fn [worktree]
+      (with-redefs [release-executor/execute-release-phase
+                    (fn [_workflow-state _exec-context _opts]
+                      {:success? false
+                       :errors [{:type :file-write-failed
+                                 :message "Permission denied writing to src/feature.clj"
+                                 :file "src/feature.clj"}]
+                       :metrics {:files-written 0}})]
+        (let [ctx (create-base-context worktree)
+              ctx-with-config (assoc ctx :phase-config {:phase :release})
+              interceptor (registry/get-phase-interceptor {:phase :release})
+              result ((:enter interceptor) ctx-with-config)]
+          (is (false? (get-in result [:phase :result :success]))
+              "Release should fail when write fails")
+          (is (some? (get-in result [:phase :result :error]))
+              "Error should be present in result")))))))
+
+(deftest release-verifies-files-exist-after-writing-test
+  (testing "release phase verifies files exist on disk after writing"
+    (with-test-worktree
+      (fn [worktree]
+      (let [verification-performed (atom false)]
+        (with-redefs [release-executor/execute-release-phase
+                      (fn [workflow-state exec-context _opts]
+                        (let [worktree (:worktree-path exec-context)
+                              code-artifacts (map :artifact/content (:workflow/artifacts workflow-state))
+                              files (mapcat :code/files code-artifacts)]
+                          (doseq [{:keys [path content action]} files]
+                            (when (#{:create :modify} action)
+                              (let [file (io/file worktree path)]
+                                (io/make-parents file)
+                                (spit file content))))
+                          (doseq [{:keys [path action]} files]
+                            (when (#{:create :modify} action)
+                              (let [file-path (io/file worktree path)]
+                                (reset! verification-performed true)
+                                (when-not (.exists file-path)
+                                  (throw (ex-info "File verification failed"
+                                                  {:file path}))))))
+                          {:success? true
+                           :artifacts [{:artifact/id (random-uuid)
+                                        :artifact/type :release
+                                        :artifact/content {:files-written (count files)
+                                                           :files-verified (count (filter #(#{:create :modify} (:action %)) files))}}]
+                           :metrics {:files-written (count files)}}))]
+          (let [ctx (create-base-context worktree)
+                ctx-with-config (assoc ctx :phase-config {:phase :release})
+                interceptor (registry/get-phase-interceptor {:phase :release})
+                result ((:enter interceptor) ctx-with-config)]
+            (is @verification-performed
+                "File verification should be performed")
+            (is (= :success (get-in result [:phase :result :status]))
+                "Release should succeed when verification passes"))))))))
+
+(deftest release-handles-zero-files-artifact-test
+  (testing "release phase fails fast when no files changed in the environment"
+    (with-test-worktree
+      (fn [worktree]
+      (let [ctx (create-empty-context worktree)
+            ctx-with-config (assoc ctx :phase-config {:phase :release})
+            interceptor (registry/get-phase-interceptor {:phase :release})]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Release phase received code artifact with zero files"
+                              ((:enter interceptor) ctx-with-config))
+            "Release should fail fast when environment has no changed files"))))))
+
+(deftest release-includes-pr-info-test
+  (testing "release phase includes PR info in result"
+    (with-test-worktree
+      (fn [worktree]
+      (with-redefs [release-executor/execute-release-phase
+                    (fn [_workflow-state _exec-context _opts]
+                      {:success? true
+                       :artifacts [{:artifact/id (random-uuid)
+                                    :artifact/type :release
+                                    :artifact/content {:files-written 2
+                                                       :branch "feature/test-123"
+                                                       :commit-sha "def456"
+                                                       :pr-number 42
+                                                       :pr-url "https://github.com/org/repo/pull/42"}}]
+                       :metrics {:files-written 2}})]
+        (let [ctx (create-base-context worktree)
+              ctx-with-config (assoc ctx :phase-config {:phase :release})
+              interceptor (registry/get-phase-interceptor {:phase :release})
+              result ((:enter interceptor) ctx-with-config)]
+          (is (some? (get-in result [:workflow/pr-info]))
+              "PR info should be available at top level")
+          (let [pr-info (get-in result [:workflow/pr-info])]
+            (is (= 42 (:pr-number pr-info))
+                "PR number should be captured")
+            (is (= "https://github.com/org/repo/pull/42" (:pr-url pr-info))
+                "PR URL should be captured")
+            (is (= "feature/test-123" (:branch pr-info))
+                "Branch name should be captured"))))))))
+
+(deftest release-propagates-streaming-callback-test
+  (testing "release phase passes event-stream-backed on-chunk callback to the executor"
+    (with-test-worktree
+      (fn [worktree]
+      (let [stream (es/create-event-stream {:sinks []})]
+        (with-redefs [release-executor/execute-release-phase
+                      (fn [_workflow-state exec-context _opts]
+                        (is (fn? (:on-chunk exec-context))
+                            "Release executor should receive an on-chunk callback")
+                        ((:on-chunk exec-context) {:delta "release chunk" :done? false})
+                        {:success? true
+                         :artifacts [{:artifact/id (random-uuid)
+                                      :artifact/type :release
+                                      :artifact/content {:files-written 1}}]
+                         :metrics {:files-written 1}})]
+          (let [ctx (assoc (create-base-context worktree) :event-stream stream)
+                ctx-with-config (assoc ctx :phase-config {:phase :release})
+                interceptor (registry/get-phase-interceptor {:phase :release})
+                result ((:enter interceptor) ctx-with-config)
+                chunk-events (es/get-events stream {:event-type :agent/chunk})]
+            (is (= :success (get-in result [:phase :result :status])))
+            (is (= 1 (count chunk-events)))
+            (is (= "release chunk" (:chunk/delta (first chunk-events))))
+            (is (= :release (:agent/id (first chunk-events)))))))))))
 
 ;------------------------------------------------------------------------------ Regression: already-satisfied / nil implement status
 
@@ -340,29 +331,33 @@
     ;; 0 tasks. The implement result has nil :status. The release phase must
     ;; short-circuit cleanly instead of throwing :release/zero-files and then
     ;; NPE-ing in leave-release on (- end-time nil).
-    (let [ctx {:execution/id (random-uuid)
-               :execution/input {:description "Already done" :title "Noop"}
-               :execution/metrics {:tokens 0 :duration-ms 0}
-               :execution/phase-results {:implement {:result {:status nil}}}
-               :worktree-path *test-worktree*}
-          ctx-with-config (assoc ctx :phase-config {:phase :release})
-          interceptor (registry/get-phase-interceptor {:phase :release})
-          result ((:enter interceptor) ctx-with-config)]
-      (is (= :completed (get-in result [:phase :status]))
-          "Release should complete (skip) when implement status is nil and no dirty files"))))
+    (with-test-worktree
+      (fn [worktree]
+      (let [ctx {:execution/id (random-uuid)
+                 :execution/input {:description "Already done" :title "Noop"}
+                 :execution/metrics {:tokens 0 :duration-ms 0}
+                 :execution/phase-results {:implement {:result {:status nil}}}
+                 :worktree-path worktree}
+            ctx-with-config (assoc ctx :phase-config {:phase :release})
+            interceptor (registry/get-phase-interceptor {:phase :release})
+            result ((:enter interceptor) ctx-with-config)]
+        (is (= :completed (get-in result [:phase :status]))
+            "Release should complete (skip) when implement status is nil and no dirty files"))))))
 
 (deftest release-skips-when-implement-already-implemented-test
   (testing "release phase skips when implement returned :already-implemented"
-    (let [ctx {:execution/id (random-uuid)
-               :execution/input {:description "Already done" :title "Noop"}
-               :execution/metrics {:tokens 0 :duration-ms 0}
-               :execution/phase-results {:implement {:result {:status :already-implemented}}}
-               :worktree-path *test-worktree*}
-          ctx-with-config (assoc ctx :phase-config {:phase :release})
-          interceptor (registry/get-phase-interceptor {:phase :release})
-          result ((:enter interceptor) ctx-with-config)]
-      (is (= :completed (get-in result [:phase :status]))
-          "Release should complete (skip) when implement status is :already-implemented"))))
+    (with-test-worktree
+      (fn [worktree]
+      (let [ctx {:execution/id (random-uuid)
+                 :execution/input {:description "Already done" :title "Noop"}
+                 :execution/metrics {:tokens 0 :duration-ms 0}
+                 :execution/phase-results {:implement {:result {:status :already-implemented}}}
+                 :worktree-path worktree}
+            ctx-with-config (assoc ctx :phase-config {:phase :release})
+            interceptor (registry/get-phase-interceptor {:phase :release})
+            result ((:enter interceptor) ctx-with-config)]
+        (is (= :completed (get-in result [:phase :status]))
+            "Release should complete (skip) when implement status is :already-implemented"))))))
 
 (deftest leave-release-handles-nil-start-time-test
   (testing "leave-release does not NPE when :started-at is nil"
@@ -381,30 +376,28 @@
 
 (deftest leave-release-records-metrics-test
   (testing "leave-release records duration and completion"
-    (with-redefs [release-executor/execute-release-phase
-                  (fn [_workflow-state _exec-context _opts]
-                    {:success? true
-                     :artifacts [{:artifact/id (random-uuid)
-                                :artifact/type :release
-                                :artifact/content {:files-written 2}}]
-                     :metrics {:files-written 2 :tokens 300 :duration-ms 800}})]
-      (let [ctx (create-base-context)
-            ctx-with-config (assoc ctx :phase-config {:phase :release})
-            interceptor (registry/get-phase-interceptor {:phase :release})
-            enter-result ((:enter interceptor) ctx-with-config)
-            final-result ((:leave interceptor) enter-result)]
-        
-        (is (= :completed (get-in final-result [:phase :status]))
-            "Phase status should be completed")
-        
-        (is (number? (get-in final-result [:phase :duration-ms]))
-            "Duration should be recorded")
-        
-        (is (= 300 (get-in final-result [:phase :metrics :tokens]))
-            "Token metrics should be recorded")
-        
-        (is (= :release (first (get-in final-result [:execution :phases-completed])))
-            "Release should be added to phases-completed")))))
+    (with-test-worktree
+      (fn [worktree]
+      (with-redefs [release-executor/execute-release-phase
+                    (fn [_workflow-state _exec-context _opts]
+                      {:success? true
+                       :artifacts [{:artifact/id (random-uuid)
+                                    :artifact/type :release
+                                    :artifact/content {:files-written 2}}]
+                       :metrics {:files-written 2 :tokens 300 :duration-ms 800}})]
+        (let [ctx (create-base-context worktree)
+              ctx-with-config (assoc ctx :phase-config {:phase :release})
+              interceptor (registry/get-phase-interceptor {:phase :release})
+              enter-result ((:enter interceptor) ctx-with-config)
+              final-result ((:leave interceptor) enter-result)]
+          (is (= :completed (get-in final-result [:phase :status]))
+              "Phase status should be completed")
+          (is (number? (get-in final-result [:phase :duration-ms]))
+              "Duration should be recorded")
+          (is (= 300 (get-in final-result [:phase :metrics :tokens]))
+              "Token metrics should be recorded")
+          (is (= :release (first (get-in final-result [:execution :phases-completed])))
+              "Release should be added to phases-completed")))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 

--- a/components/phase-software-factory/test/ai/miniforge/phase/review_artifact_resolution_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/review_artifact_resolution_test.clj
@@ -22,10 +22,10 @@
    Validates the three-strategy resolution:
    1. Serialized :artifact key on implement result
    2. Result itself when it contains :code/files (IS the artifact)
-   3. Worktree fallback via file-artifacts/collect-written-files"
+   3. Worktree fallback via agent/collect-written-files"
   (:require
    [clojure.test :refer [deftest is testing]]
-   [ai.miniforge.agent.file-artifacts :as file-artifacts]
+   [ai.miniforge.agent.interface :as agent]
    [ai.miniforge.phase.review]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -118,7 +118,7 @@
                          :code/summary "1 files collected from agent working directory (no MCP submit)"}
           impl-result (make-bare-result)
           ctx (make-ctx)]
-      (with-redefs [file-artifacts/collect-written-files
+      (with-redefs [agent/collect-written-files
                     (fn [_snapshot working-dir]
                       (is (= "/tmp/test-worktree" working-dir)
                           "Should pass worktree-path to collect-written-files")
@@ -135,7 +135,7 @@
           impl-result (make-bare-result)
           ctx (make-ctx {:execution/worktree-path nil
                          :worktree-path "/tmp/alt-worktree"})]
-      (with-redefs [file-artifacts/collect-written-files
+      (with-redefs [agent/collect-written-files
                     (fn [_snapshot working-dir]
                       (is (= "/tmp/alt-worktree" working-dir)
                           "Should use :worktree-path as fallback")

--- a/components/phase-software-factory/test/ai/miniforge/phase/verify_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/verify_test.clj
@@ -47,7 +47,7 @@
   (testing "default config has correct structure"
     (is (nil? (:agent verify/default-config))
         "Verify phase has no agent — runs tests directly")
-    (is (= [:tests-pass :coverage] (:gates verify/default-config)))
+    (is (= [:pre-verify-lint :tests-pass :coverage] (:gates verify/default-config)))
     (is (map? (:budget verify/default-config)))
     (is (= 3 (get-in verify/default-config [:budget :iterations])))))
 
@@ -57,7 +57,7 @@
       (is (some? defaults))
       (is (nil? (:agent defaults))
           "Verify has no agent in the new environment model")
-      (is (= [:tests-pass :coverage] (:gates defaults))))))
+      (is (= [:pre-verify-lint :tests-pass :coverage] (:gates defaults))))))
 
 ;------------------------------------------------------------------------------ Layer 1: Interceptor enter tests
 
@@ -72,7 +72,7 @@
             (is (= :verify (get-in result [:phase :name])))
             (is (nil? (get-in result [:phase :agent]))
                 "No agent in new environment model")
-            (is (= [:tests-pass :coverage] (get-in result [:phase :gates])))
+            (is (= [:pre-verify-lint :tests-pass :coverage] (get-in result [:phase :gates])))
             (is (= :running (get-in result [:phase :status])))
             (is (number? (get-in result [:phase :started-at]))))
 

--- a/components/phase/src/ai/miniforge/phase/interface.clj
+++ b/components/phase/src/ai/miniforge/phase/interface.clj
@@ -37,6 +37,20 @@
    [ai.miniforge.phase.telemetry :as telemetry]))
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Phase-result pass-throughs (loaded at runtime to avoid cross-component dep)
+
+(defn enter-context
+  "Build canonical phase result context. Delegates to phase.phase-result/enter-context."
+  [ctx phase-kw agent-kw gates budget start-time result]
+  ((requiring-resolve 'ai.miniforge.phase.phase-result/enter-context)
+   ctx phase-kw agent-kw gates budget start-time result))
+
+(defn exception-error
+  "Build error map from exception. Delegates to phase.phase-result/exception-error."
+  [ex]
+  ((requiring-resolve 'ai.miniforge.phase.phase-result/exception-error) ex))
+
+;------------------------------------------------------------------------------ Layer 0
 ;; Re-export registry functions
 
 (defn ensure-phase-implementations-loaded!
@@ -89,6 +103,15 @@
 (def merge-with-defaults
   "Merge user config with phase defaults."
   registry/merge-with-defaults)
+
+(def register-phase-defaults!
+  "Register default configuration for a phase type."
+  registry/register-phase-defaults!)
+
+(def get-phase-interceptor-method
+  "The raw multimethod for registering phase interceptor implementations.
+   Use defmethod on this for new phase types."
+  registry/get-phase-interceptor)
 
 (def extract-status
   "Extract a status keyword from a map by trying known status keys."

--- a/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
+++ b/components/policy-pack/src/ai/miniforge/policy_pack/interface.clj
@@ -30,7 +30,8 @@
    [ai.miniforge.policy-pack.interface.mapping :as mapping]
    [ai.miniforge.policy-pack.interface.prompt-template :as prompt-template]
    [ai.miniforge.policy-pack.interface.taxonomy :as taxonomy]
-   [ai.miniforge.policy-pack.mdc-compiler :as mdc-compiler]))
+   [ai.miniforge.policy-pack.mdc-compiler :as mdc-compiler]
+   [ai.miniforge.policy-pack.software-factory :as software-factory]))
 
 ;------------------------------------------------------------------------------ Schema and registry API
 
@@ -132,3 +133,13 @@
   "Export the compiler's dewey-ranges as a first-class Taxonomy artifact.
    Delegates to mdc-compiler/export-canonical-taxonomy."
   mdc-compiler/export-canonical-taxonomy)
+
+;------------------------------------------------------------------------------ Software Factory
+
+(def evaluate-external-pr
+  "Evaluate an external PR diff against policy packs in read-only mode."
+  software-factory/evaluate-external-pr)
+
+(def parse-pr-diff
+  "Parse a unified diff into artifact-like inputs for external evaluation."
+  software-factory/parse-pr-diff)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/interface.clj
@@ -43,6 +43,7 @@
    [ai.miniforge.pr-lifecycle.triage :as triage]
    [ai.miniforge.pr-lifecycle.merge :as merge]
    [ai.miniforge.pr-lifecycle.events :as events]
+   [ai.miniforge.pr-lifecycle.monitor-config :as mconfig]
    [ai.miniforge.pr-lifecycle.monitor-events :as mevents]
    [ai.miniforge.pr-lifecycle.monitor-loop :as monitor]
    [ai.miniforge.pr-lifecycle.monitor-budget :as mbudget]
@@ -618,6 +619,13 @@
 (def monitor-event-types
   "Valid PR monitor loop event types (:pr-monitor/*)."
   mevents/monitor-event-types)
+
+;------------------------------------------------------------------------------ Layer 6
+;; PR Monitor Config
+
+(def monitor-defaults
+  "Return the shared PR monitor defaults map."
+  mconfig/monitor-defaults)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/repo-index/src/ai/miniforge/repo_index/interface.clj
+++ b/components/repo-index/src/ai/miniforge/repo_index/interface.clj
@@ -24,7 +24,8 @@
    Layer 0: Schema re-exports
    Layer 1: Index building and repo map
    Layer 2: File retrieval"
-  (:require [ai.miniforge.repo-index.schema :as schema]
+  (:require [ai.miniforge.repo-index.messages :as messages]
+            [ai.miniforge.repo-index.schema :as schema]
             [ai.miniforge.repo-index.factory :as factory]
             [ai.miniforge.repo-index.scanner :as scanner]
             [ai.miniforge.repo-index.repo-map :as repo-map]
@@ -32,6 +33,13 @@
             [ai.miniforge.repo-index.storage :as storage]
             [clojure.java.io :as io]
             [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Messages
+
+(def t
+  "Look up a repo-index message by key, with optional param substitution."
+  messages/t)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports

--- a/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
+++ b/components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj
@@ -12,8 +12,8 @@
    Layer 1: LLM invocation and response parsing
    Layer 2: File selection and batch analysis"
   (:require
-   [ai.miniforge.compliance-scanner.factory :as factory]
-   [ai.miniforge.policy-pack.prompt-template :as pt]
+   [ai.miniforge.compliance-scanner.interface :as factory]
+   [ai.miniforge.policy-pack.interface :as pt]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]))

--- a/components/tui-views/src/ai/miniforge/tui_views/interface.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/interface.clj
@@ -36,7 +36,7 @@
    [ai.miniforge.tui-views.persistence.pr :as persistence-pr]
    [ai.miniforge.tui-views.persistence.pr-cache :as pr-cache]
    [ai.miniforge.response.interface :as response]
-   [ai.miniforge.policy-pack.software-factory :as policy-pack]
+   [ai.miniforge.policy-pack.interface :as policy-pack]
    [ai.miniforge.pr-train.interface :as pr-train]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.tui-views.persistence.github :as github]

--- a/components/tui-views/test/ai/miniforge/tui_views/interface_handlers_test.clj
+++ b/components/tui-views/test/ai/miniforge/tui_views/interface_handlers_test.clj
@@ -38,7 +38,7 @@
    [ai.miniforge.tui-views.persistence.pr :as persistence-pr]
    [ai.miniforge.tui-views.persistence.pr-cache :as pr-cache]
    [ai.miniforge.tui-views.persistence.github :as github]
-   [ai.miniforge.policy-pack.software-factory :as policy-pack]
+   [ai.miniforge.policy-pack.interface :as policy-pack]
    [ai.miniforge.llm.interface :as llm]))
 
 ;; ---------------------------------------------------------------------------- Helpers

--- a/components/workflow-compliance-scanner/src/ai/miniforge/workflow_compliance_scanner/phases.clj
+++ b/components/workflow-compliance-scanner/src/ai/miniforge/workflow_compliance_scanner/phases.clj
@@ -32,8 +32,7 @@
      :compliance-execute  reads plan, applies fixes, commits, creates PRs"
   (:require
    [ai.miniforge.compliance-scanner.interface :as compliance-scanner]
-   [ai.miniforge.phase.phase-result           :as phase-result]
-   [ai.miniforge.phase.registry               :as registry]))
+   [ai.miniforge.phase.interface              :as phase]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Helpers
@@ -84,10 +83,10 @@
    :budget {:tokens 5000 :iterations 1 :time-seconds 1800}})
 
 ;; Register defaults on load
-(registry/register-phase-defaults! :compliance-scan     default-scan-config)
-(registry/register-phase-defaults! :compliance-classify default-classify-config)
-(registry/register-phase-defaults! :compliance-plan     default-plan-config)
-(registry/register-phase-defaults! :compliance-execute  default-execute-config)
+(phase/register-phase-defaults! :compliance-scan     default-scan-config)
+(phase/register-phase-defaults! :compliance-classify default-classify-config)
+(phase/register-phase-defaults! :compliance-plan     default-plan-config)
+(phase/register-phase-defaults! :compliance-execute  default-execute-config)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; :compliance-scan interceptor
@@ -102,7 +101,7 @@
         standards-path (resolve-standards-path ctx)
         rules          (resolve-rules ctx)
         scan-result    (compliance-scanner/scan repo-path standards-path {:rules rules})]
-    (phase-result/enter-context ctx :compliance-scan nil [] default-scan-config start-time
+    (phase/enter-context ctx :compliance-scan nil [] default-scan-config start-time
                                 {:status :success :output scan-result})))
 
 (defn leave-compliance-scan
@@ -131,7 +130,7 @@
   [ctx ex]
   (-> ctx
       (assoc-in [:phase :status] :failed)
-      (assoc-in [:phase :error] (phase-result/exception-error ex))))
+      (assoc-in [:phase :error] (phase/exception-error ex))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; :compliance-classify interceptor
@@ -144,7 +143,7 @@
   (let [start-time  (System/currentTimeMillis)
         violations  (get-in ctx [:execution/phase-results :compliance-scan :result :output :violations] [])
         classified  (compliance-scanner/classify violations)]
-    (phase-result/enter-context ctx :compliance-classify nil [] default-classify-config start-time
+    (phase/enter-context ctx :compliance-classify nil [] default-classify-config start-time
                                 {:status :success :output {:classified-violations classified}})))
 
 (defn leave-compliance-classify
@@ -175,7 +174,7 @@
   [ctx ex]
   (-> ctx
       (assoc-in [:phase :status] :failed)
-      (assoc-in [:phase :error] (phase-result/exception-error ex))))
+      (assoc-in [:phase :error] (phase/exception-error ex))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; :compliance-plan interceptor
@@ -193,7 +192,7 @@
         the-plan       (compliance-scanner/plan classified repo-path)]
     (compliance-scanner/write-work-spec! (:work-spec the-plan) repo-path)
     (compliance-scanner/write-delta-report! repo-path standards-path classified the-plan)
-    (phase-result/enter-context ctx :compliance-plan nil [] default-plan-config start-time
+    (phase/enter-context ctx :compliance-plan nil [] default-plan-config start-time
                                 {:status :success
                                  :output {:plan       the-plan
                                           :task-count (count (:dag-tasks the-plan))}})))
@@ -223,7 +222,7 @@
   [ctx ex]
   (-> ctx
       (assoc-in [:phase :status] :failed)
-      (assoc-in [:phase :error] (phase-result/exception-error ex))))
+      (assoc-in [:phase :error] (phase/exception-error ex))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; :compliance-execute interceptor
@@ -237,7 +236,7 @@
         repo-path  (resolve-repo-path ctx)
         plan       (get-in ctx [:execution/phase-results :compliance-plan :result :output :plan])
         result     (compliance-scanner/execute! plan repo-path)]
-    (phase-result/enter-context ctx :compliance-execute nil [] default-execute-config start-time
+    (phase/enter-context ctx :compliance-execute nil [] default-execute-config start-time
                                 {:status :success :output result})))
 
 (defn leave-compliance-execute
@@ -269,41 +268,41 @@
   [ctx ex]
   (-> ctx
       (assoc-in [:phase :status] :failed)
-      (assoc-in [:phase :error] (phase-result/exception-error ex))))
+      (assoc-in [:phase :error] (phase/exception-error ex))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Registry methods
 
-(defmethod registry/get-phase-interceptor :compliance-scan
+(defmethod phase/get-phase-interceptor-method :compliance-scan
   [config]
-  (let [merged (registry/merge-with-defaults config)]
+  (let [merged (phase/merge-with-defaults config)]
     {:name   ::compliance-scan
      :config merged
      :enter  (fn [ctx] (enter-compliance-scan (assoc ctx :phase-config merged)))
      :leave  leave-compliance-scan
      :error  error-compliance-scan}))
 
-(defmethod registry/get-phase-interceptor :compliance-classify
+(defmethod phase/get-phase-interceptor-method :compliance-classify
   [config]
-  (let [merged (registry/merge-with-defaults config)]
+  (let [merged (phase/merge-with-defaults config)]
     {:name   ::compliance-classify
      :config merged
      :enter  (fn [ctx] (enter-compliance-classify (assoc ctx :phase-config merged)))
      :leave  leave-compliance-classify
      :error  error-compliance-classify}))
 
-(defmethod registry/get-phase-interceptor :compliance-plan
+(defmethod phase/get-phase-interceptor-method :compliance-plan
   [config]
-  (let [merged (registry/merge-with-defaults config)]
+  (let [merged (phase/merge-with-defaults config)]
     {:name   ::compliance-plan
      :config merged
      :enter  (fn [ctx] (enter-compliance-plan (assoc ctx :phase-config merged)))
      :leave  leave-compliance-plan
      :error  error-compliance-plan}))
 
-(defmethod registry/get-phase-interceptor :compliance-execute
+(defmethod phase/get-phase-interceptor-method :compliance-execute
   [config]
-  (let [merged (registry/merge-with-defaults config)]
+  (let [merged (phase/merge-with-defaults config)]
     {:name   ::compliance-execute
      :config merged
      :enter  (fn [ctx] (enter-compliance-execute (assoc ctx :phase-config merged)))
@@ -313,15 +312,15 @@
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Check registered defaults
-  (registry/phase-defaults :compliance-scan)
-  (registry/phase-defaults :compliance-classify)
-  (registry/phase-defaults :compliance-plan)
-  (registry/phase-defaults :compliance-execute)
+  (phase/phase-defaults :compliance-scan)
+  (phase/phase-defaults :compliance-classify)
+  (phase/phase-defaults :compliance-plan)
+  (phase/phase-defaults :compliance-execute)
 
   ;; Get interceptors
-  (registry/get-phase-interceptor {:phase :compliance-scan})
-  (registry/get-phase-interceptor {:phase :compliance-classify})
-  (registry/get-phase-interceptor {:phase :compliance-plan})
-  (registry/get-phase-interceptor {:phase :compliance-execute})
+  (phase/get-phase-interceptor-method {:phase :compliance-scan})
+  (phase/get-phase-interceptor-method {:phase :compliance-classify})
+  (phase/get-phase-interceptor-method {:phase :compliance-plan})
+  (phase/get-phase-interceptor-method {:phase :compliance-execute})
 
   :leave-this-here)

--- a/components/workflow-financial-etl/src/ai/miniforge/workflow_financial_etl/events.clj
+++ b/components/workflow-financial-etl/src/ai/miniforge/workflow_financial_etl/events.clj
@@ -19,7 +19,7 @@
 (ns ai.miniforge.workflow-financial-etl.events
   "ETL lifecycle event schemas and emission helpers."
   (:require
-   [ai.miniforge.logging.core :as logging-core]))
+   [ai.miniforge.logging.interface :as log]))
 
 (defn make-event-base
   [event-type workflow-id]
@@ -48,13 +48,13 @@
 (defn emit-etl-completed
   [logger workflow-id duration-ms summary]
   (let [event (etl-completed-event workflow-id duration-ms summary)]
-    (logging-core/log* logger :info :etl :etl/completed
-                       {:message (:message event)
-                        :data (dissoc event :message)})))
+    (log/info logger :etl :etl/completed
+             {:message (:message event)
+              :data (dissoc event :message)})))
 
 (defn emit-etl-failed
   [logger workflow-id failure-stage failure-reason & [error-details]]
   (let [event (etl-failed-event workflow-id failure-stage failure-reason error-details)]
-    (logging-core/log* logger :error :etl :etl/failed
-                       {:message (:message event)
-                        :data (dissoc event :message)})))
+    (log/error logger :etl :etl/failed
+              {:message (:message event)
+               :data (dissoc event :message)})))

--- a/components/workflow-security-compliance/demo/demo_security_compliance.clj
+++ b/components/workflow-security-compliance/demo/demo_security_compliance.clj
@@ -1,0 +1,172 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns demo-security-compliance
+  "Demo script — runs the full security-compliance workflow against fixtures.
+
+   Usage (from the workflow-security-compliance component root):
+     clj -M -m demo-security-compliance
+
+   Or from a REPL:
+     (require 'demo-security-compliance)
+     (demo-security-compliance/-main)"
+  (:require
+   [clojure.java.io :as io]
+   [clojure.pprint :as pp]
+   [ai.miniforge.workflow-security-compliance.phases :as phases]
+   [ai.miniforge.workflow-security-compliance.interface]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- separator [label]
+  (println)
+  (println "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+  (println (str " " label))
+  (println "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+  (println))
+
+(defn- print-violation-summary [violations]
+  (doseq [v violations]
+    (println (format "  [%s] %-8s %s"
+                     (:violation/rule-id v)
+                     (name (:violation/severity v))
+                     (subs (:violation/message v) 0
+                           (min 70 (count (:violation/message v))))))))
+
+(defn- print-classified [classified]
+  (let [by-cat (group-by :classification/category classified)]
+    (doseq [[cat items] (sort-by (comp str key) by-cat)]
+      (println (format "  %-22s %d items  (confidence: %.0f%%–%.0f%%)"
+                       (name cat)
+                       (count items)
+                       (* 100.0 (apply min (map :classification/confidence items)))
+                       (* 100.0 (apply max (map :classification/confidence items)))))
+      (doseq [v items]
+        (println (format "    • %s  %s  [%s]"
+                         (:violation/rule-id v)
+                         (get-in v [:violation/location :file] "?")
+                         (name (or (:classification/doc-status v) :unknown))))))))
+
+;------------------------------------------------------------------------------ Main
+
+(defn -main
+  "Run the 5-phase security compliance workflow against sample fixtures."
+  [& _args]
+  (separator "Miniforge — Security Compliance Workflow Demo (issue #552)")
+
+  (let [output-dir (str (System/getProperty "java.io.tmpdir")
+                        "/miniforge-demo-" (System/currentTimeMillis))
+
+        ;; Build initial context
+        ctx {:execution/id            (random-uuid)
+             :execution/input         {:scan-paths  ["test/fixtures/sample-scan.sarif"
+                                                      "test/fixtures/sample-scan.csv"]
+                                        :output-dir  output-dir}
+             :execution/metrics       {:duration-ms 0}
+             :execution/phase-results {}}]
+
+    ;; ─── Phase 1: Parse Scan ───
+    (separator "Phase 1: Parse Scan (SARIF + CSV)")
+    (let [after-parse (-> ctx
+                          phases/enter-sec-parse-scan
+                          (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                          phases/leave-sec-parse-scan)
+          violations  (get-in after-parse [:execution/phase-results :sec-parse-scan
+                                           :result :output :violations])]
+      (println (format "  Parsed %d violations from %d files"
+                       (count violations)
+                       (count (get-in ctx [:execution/input :scan-paths]))))
+      (print-violation-summary violations)
+
+      ;; ─── Phase 2: Trace Source ───
+      (separator "Phase 2: Trace Source (stub — LLM-assisted in production)")
+      (let [after-trace (-> after-parse
+                            phases/enter-sec-trace-source
+                            (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                            phases/leave-sec-trace-source)
+            traced      (get-in after-trace [:execution/phase-results :sec-trace-source
+                                             :result :output :traced-violations])
+            dynamic     (filter :trace/dynamic-load? traced)]
+        (println (format "  Traced %d violations, %d involve dynamic loading"
+                         (count traced) (count dynamic)))
+
+        ;; ─── Phase 3: Verify Docs ───
+        (separator "Phase 3: Verify Docs (mechanical + stub)")
+        (let [after-verify (-> after-trace
+                               phases/enter-sec-verify-docs
+                               (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                               phases/leave-sec-verify-docs)
+              verified     (get-in after-verify [:execution/phase-results :sec-verify-docs
+                                                 :result :output :verified-violations])
+              documented   (filter :verified/documented? verified)
+              undocumented (remove :verified/documented? verified)]
+          (println (format "  Verified %d violations: %d documented, %d undocumented"
+                           (count verified) (count documented) (count undocumented)))
+
+          ;; ─── Phase 4: Classify ───
+          (separator "Phase 4: Classify (deterministic rules)")
+          (let [after-classify (-> after-verify
+                                   phases/enter-sec-classify
+                                   (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                                   phases/leave-sec-classify)
+                classified     (get-in after-classify [:execution/phase-results :sec-classify
+                                                       :result :output :classified-violations])
+                metrics        (get-in after-classify [:phase :metrics])]
+            (println "  Classification results:")
+            (println (format "    True positives:      %d" (:true-positives metrics 0)))
+            (println (format "    False positives:     %d" (:false-positives metrics 0)))
+            (println (format "    Needs investigation: %d" (:needs-review metrics 0)))
+            (println)
+            (print-classified classified)
+
+            ;; ─── Phase 5: Generate Exclusions ───
+            (separator "Phase 5: Generate Exclusions")
+            (let [after-exclusions (-> after-classify
+                                       phases/enter-sec-generate-exclusions
+                                       (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                                       phases/leave-sec-generate-exclusions)
+                  excl-output      (get-in after-exclusions [:execution/phase-results
+                                                             :sec-generate-exclusions
+                                                             :result :output])
+                  excl-file        (io/file output-dir ".security-exclusions" "exclusions.edn")]
+              (println (format "  Excluded (false positives):  %d" (:total-excluded excl-output 0)))
+              (println (format "  Flagged (needs action):      %d" (:total-flagged excl-output 0)))
+              (println)
+
+              (when (.exists excl-file)
+                (println (format "  Exclusion file written to: %s" (.getAbsolutePath excl-file)))
+                (println)
+                (println "  Exclusion list contents:")
+                (pp/pprint (:exclusion-list excl-output)))
+
+              ;; ─── Summary ───
+              (separator "Pipeline Summary")
+              (let [total-duration (get-in after-exclusions [:execution/metrics :duration-ms] 0)
+                    phases-done   (get-in after-exclusions [:execution :phases-completed])]
+                (println (format "  Phases completed: %d / 5" (count phases-done)))
+                (println (format "  Total duration:   %d ms" total-duration))
+                (println (format "  Input files:      %d" (count (get-in ctx [:execution/input :scan-paths]))))
+                (println (format "  Total violations: %d" (count classified)))
+                (println (format "  True positives:   %d (action required)"
+                                 (count (filter #(= :true-positive (:classification/category %)) classified))))
+                (println (format "  False positives:  %d (excluded)"
+                                 (count (filter #(= :false-positive (:classification/category %)) classified))))
+                (println (format "  Needs review:     %d (manual investigation)"
+                                 (count (filter #(= :needs-investigation (:classification/category %)) classified))))
+                (println)
+                (println "  ✓ Demo complete. Issue #552 vertical slice functional.")))))))))

--- a/components/workflow-security-compliance/deps.edn
+++ b/components/workflow-security-compliance/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/phase    {:local/root "../phase"}
+        ai.miniforge/response {:local/root "../response"}
+        cheshire/cheshire     {:mvn/version "5.12.0"}}
+ :aliases {:test {:extra-paths ["test"]
+                  :extra-deps  {}}}}

--- a/components/workflow-security-compliance/resources/workflows/security-compliance-v1.0.0.edn
+++ b/components/workflow-security-compliance/resources/workflows/security-compliance-v1.0.0.edn
@@ -1,0 +1,27 @@
+;; Security Compliance Workflow v1.0.0 (issue #552)
+;; ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+;;
+;; Mixed mechanical/semantic compliance pipeline:
+;;   parse SARIF/CSV → trace source (LLM) → verify docs → classify → exclusions
+;;
+;; Phases 2 & 3 are LLM-assisted (stubs in prototype).
+
+{:workflow/id      :security-compliance
+ :workflow/version "1.0.0"
+ :workflow/name    "Security Compliance Workflow"
+ :workflow/description
+ "Scan binary API violations, trace through wrappers, verify documentation
+  status, classify as true/false positive, and generate exclusion list.
+  Mixes mechanical ETL with agentic source analysis."
+
+ :workflow/pipeline
+ [{:phase :sec-parse-scan}
+  {:phase :sec-trace-source}
+  {:phase :sec-verify-docs}
+  {:phase :sec-classify}
+  {:phase :sec-generate-exclusions}
+  {:phase :done}]
+
+ :workflow/config
+ {:max-tokens     75000
+  :max-iterations 10}}

--- a/components/workflow-security-compliance/src/ai/miniforge/workflow_security_compliance/interface.clj
+++ b/components/workflow-security-compliance/src/ai/miniforge/workflow_security_compliance/interface.clj
@@ -1,0 +1,3 @@
+(ns ai.miniforge.workflow-security-compliance.interface
+  "Module loader — requires phases to register interceptors on load."
+  (:require [ai.miniforge.workflow-security-compliance.phases]))

--- a/components/workflow-security-compliance/src/ai/miniforge/workflow_security_compliance/phases.clj
+++ b/components/workflow-security-compliance/src/ai/miniforge/workflow_security_compliance/phases.clj
@@ -1,0 +1,459 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow-security-compliance.phases
+  "Phase interceptors for the 5-phase security compliance workflow (issue #552).
+
+   Pipeline:
+     :sec-parse-scan      — parse SARIF/CSV files into unified violations
+     :sec-trace-source    — trace each violation to actual API call (LLM-assisted stub)
+     :sec-verify-docs     — verify API documentation status (mixed/stub)
+     :sec-classify        — classify violations as true/false/needs-investigation
+     :sec-generate-exclusions — generate and write exclusion list
+
+   Context threading:
+     Results stored at [:execution/phase-results :phase-keyword :result :output]
+     Subsequent phases read from prior phase results at the same path."
+  (:require
+   [ai.miniforge.phase.phase-result :as phase-result]
+   [ai.miniforge.phase.registry     :as registry]
+   [cheshire.core    :as json]
+   [clojure.java.io  :as io]
+   [clojure.string   :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers — SARIF/CSV parsing (inline for prototype; production uses connector-sarif)
+
+(defn- parse-sarif-file
+  "Parse a SARIF v2.1.0 JSON file into unified violation records."
+  [path]
+  (if (.exists (io/file path))
+    (let [content (-> path slurp (json/parse-string))
+          runs    (get content "runs" [])]
+      (into []
+            (mapcat
+             (fn [[run-idx run]]
+               (let [tool-name (get-in run ["tool" "driver" "name"] "unknown")
+                     results   (get run "results" [])]
+                 (map-indexed
+                  (fn [res-idx result]
+                    (let [loc  (first (get result "locations" []))
+                          phys (get loc "physicalLocation")
+                          art  (get phys "artifactLocation")
+                          reg  (get phys "region")]
+                      {:violation/id          (str tool-name ":" run-idx ":" res-idx)
+                       :violation/rule-id     (get result "ruleId" "unknown")
+                       :violation/message     (get-in result ["message" "text"] "")
+                       :violation/severity    (keyword (get result "level" "warning"))
+                       :violation/location    {:file   (get art "uri")
+                                               :line   (get reg "startLine")
+                                               :column (get reg "startColumn")}
+                       :violation/source-tool tool-name
+                       :violation/raw         result}))
+                  results)))
+             (map-indexed vector runs))))
+    []))
+
+(defn- parse-csv-file
+  "Parse a CSV scan output file into unified violation records."
+  [path]
+  (if (.exists (io/file path))
+    (let [lines (str/split (slurp path) #"\n")]
+      (mapv (fn [[_idx line]]
+              (let [parts (str/split line #"," 6)
+                    [rule-id message severity file line-no col] parts]
+                {:violation/id          (str "csv:" rule-id ":" line-no)
+                 :violation/rule-id     (str/trim (or rule-id "unknown"))
+                 :violation/message     (str/trim (str/replace (or message "") #"\"" ""))
+                 :violation/severity    (keyword (str/lower-case (str/trim (or severity "warning"))))
+                 :violation/location    {:file   (str/trim (or file ""))
+                                         :line   (try (Integer/parseInt (str/trim (or line-no "0")))
+                                                      (catch Exception _ 0))
+                                         :column (try (Integer/parseInt (str/trim (or col "0")))
+                                                      (catch Exception _ 0))}
+                 :violation/source-tool "csv-import"
+                 :violation/raw         {:line line}}))
+            (map-indexed vector (rest lines))))
+    []))
+
+(def ^:private known-apis
+  "Default set of known/documented public APIs for verification."
+  #{"SHCreateStreamOnFileW" "CreateFileW" "ReadFile" "WriteFile"
+    "CryptEncrypt" "SetWindowPos" "CoInitializeEx" "OleInitialize"
+    "LoadLibraryW" "GetProcAddress" "FreeLibrary"})
+
+(defn- resolve-scan-path
+  "Resolve a scan path from either the filesystem or the test classpath.
+   Tests run from the repo root, so component-local fixtures need a classpath
+   fallback instead of assuming the current working directory."
+  [path]
+  (let [file (io/file path)]
+    (cond
+      (.exists file)
+      (.getPath file)
+
+      :else
+      (some-> (or (io/resource path)
+                  (io/resource (str/replace-first path #"^test/" ""))
+                  (io/resource (str/replace-first path #"^test/fixtures/" "fixtures/")))
+              io/file
+              .getPath))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Default configs
+
+(def default-parse-scan-config
+  {:agent nil :gates [] :budget {:tokens 1000 :iterations 1 :time-seconds 60}})
+
+(def default-trace-source-config
+  {:agent :security-analyst :gates [] :budget {:tokens 50000 :iterations 5 :time-seconds 600}})
+
+(def default-verify-docs-config
+  {:agent :security-analyst :gates [] :budget {:tokens 10000 :iterations 1 :time-seconds 300}})
+
+(def default-classify-config
+  {:agent nil :gates [:classification-gate] :budget {:tokens 5000 :iterations 1 :time-seconds 120}})
+
+(def default-generate-exclusions-config
+  {:agent nil :gates [] :budget {:tokens 1000 :iterations 1 :time-seconds 60}})
+
+;; Register defaults on load
+(registry/register-phase-defaults! :sec-parse-scan           default-parse-scan-config)
+(registry/register-phase-defaults! :sec-trace-source         default-trace-source-config)
+(registry/register-phase-defaults! :sec-verify-docs          default-verify-docs-config)
+(registry/register-phase-defaults! :sec-classify             default-classify-config)
+(registry/register-phase-defaults! :sec-generate-exclusions  default-generate-exclusions-config)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Phase 1: :sec-parse-scan — mechanical SARIF/CSV parsing
+
+(defn enter-sec-parse-scan
+  "Parse SARIF/CSV files from input paths into unified violations."
+  [ctx]
+  (let [start-time  (System/currentTimeMillis)
+        scan-paths  (get-in ctx [:execution/input :scan-paths] [])
+        violations  (into []
+                         (mapcat
+                          (fn [path]
+                            (let [resolved-path (or (resolve-scan-path path) path)]
+                              (cond
+                                (str/ends-with? resolved-path ".sarif") (parse-sarif-file resolved-path)
+                                (str/ends-with? resolved-path ".csv")   (parse-csv-file resolved-path)
+                                :else [])))
+                          scan-paths))]
+    (phase-result/enter-context ctx :sec-parse-scan nil [] default-parse-scan-config start-time
+                                {:status :success :output {:violations violations}})))
+
+(defn leave-sec-parse-scan [ctx]
+  (let [start-time      (get-in ctx [:phase :started-at])
+        end-time        (System/currentTimeMillis)
+        duration-ms     (- end-time start-time)
+        violations      (get-in ctx [:phase :result :output :violations] [])
+        violation-count (count violations)]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (assoc-in [:phase :metrics] {:violation-count violation-count :duration-ms duration-ms})
+        (assoc-in [:execution/phase-results :sec-parse-scan :result] (get-in ctx [:phase :result]))
+        (update-in [:execution :phases-completed] (fnil conj []) :sec-parse-scan)
+        (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
+
+(defn error-sec-parse-scan [ctx ex]
+  (-> ctx
+      (assoc-in [:phase :status] :failed)
+      (assoc-in [:phase :error] (phase-result/exception-error ex))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Phase 2: :sec-trace-source — LLM-assisted source tracing (stub)
+
+(defn- stub-trace-violation
+  "Stub: enrich a violation with mock trace data.
+   In production, this calls the :security-analyst agent to trace
+   through wrapper functions and identify the actual API call."
+  [violation]
+  (let [msg (:violation/message violation)
+        dynamic-load? (boolean (re-find #"(?i)loadlibrary|getprocaddress|dynamic.load" (or msg "")))
+        actual-api (or (second (re-find #"!([A-Za-z0-9_]+)" (or msg "")))
+                       (:violation/rule-id violation))]
+    (assoc violation
+           :trace/actual-api     actual-api
+           :trace/call-chain     [(get-in violation [:violation/location :file] "unknown")]
+           :trace/dynamic-load?  dynamic-load?)))
+
+(defn enter-sec-trace-source [ctx]
+  (let [start-time  (System/currentTimeMillis)
+        violations  (get-in ctx [:execution/phase-results :sec-parse-scan :result :output :violations] [])
+        traced      (mapv stub-trace-violation violations)]
+    (phase-result/enter-context ctx :sec-trace-source :security-analyst [] default-trace-source-config start-time
+                                {:status :success :output {:traced-violations traced}})))
+
+(defn leave-sec-trace-source [ctx]
+  (let [start-time  (get-in ctx [:phase :started-at])
+        end-time    (System/currentTimeMillis)
+        duration-ms (- end-time start-time)
+        traced      (get-in ctx [:phase :result :output :traced-violations] [])]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (assoc-in [:phase :metrics] {:traced-count (count traced) :duration-ms duration-ms})
+        (assoc-in [:execution/phase-results :sec-trace-source :result] (get-in ctx [:phase :result]))
+        (update-in [:execution :phases-completed] (fnil conj []) :sec-trace-source)
+        (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
+
+(defn error-sec-trace-source [ctx ex]
+  (-> ctx
+      (assoc-in [:phase :status] :failed)
+      (assoc-in [:phase :error] (phase-result/exception-error ex))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Phase 3: :sec-verify-docs — mixed mechanical/semantic doc verification (stub)
+
+(defn- verify-violation-docs
+  "Verify whether a traced API is documented/public.
+   Mechanical: check against known-apis set.
+   Semantic (stub): would call agent for ambiguous cases."
+  [violation apis]
+  (let [actual-api (:trace/actual-api violation "")
+        is-known   (boolean (some #(str/includes? actual-api %) apis))]
+    (assoc violation
+           :verified/documented? is-known
+           :verified/public?     is-known
+           :verified/by          (if is-known :known-apis-registry :stub-agent))))
+
+(defn enter-sec-verify-docs [ctx]
+  (let [start-time (System/currentTimeMillis)
+        traced     (get-in ctx [:execution/phase-results :sec-trace-source :result :output :traced-violations] [])
+        apis       (get-in ctx [:execution/input :known-apis] known-apis)
+        verified   (mapv #(verify-violation-docs % apis) traced)]
+    (phase-result/enter-context ctx :sec-verify-docs :security-analyst [] default-verify-docs-config start-time
+                                {:status :success :output {:verified-violations verified}})))
+
+(defn leave-sec-verify-docs [ctx]
+  (let [start-time  (get-in ctx [:phase :started-at])
+        end-time    (System/currentTimeMillis)
+        duration-ms (- end-time start-time)
+        verified    (get-in ctx [:phase :result :output :verified-violations] [])
+        documented  (count (filter :verified/documented? verified))]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (assoc-in [:phase :metrics] {:verified-count (count verified)
+                                     :documented-count documented
+                                     :duration-ms duration-ms})
+        (assoc-in [:execution/phase-results :sec-verify-docs :result] (get-in ctx [:phase :result]))
+        (update-in [:execution :phases-completed] (fnil conj []) :sec-verify-docs)
+        (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
+
+(defn error-sec-verify-docs [ctx ex]
+  (-> ctx
+      (assoc-in [:phase :status] :failed)
+      (assoc-in [:phase :error] (phase-result/exception-error ex))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Phase 4: :sec-classify — deterministic classification
+
+(defn- classify-violation
+  "Classify a verified violation using deterministic rules.
+   Uses doc-status, dynamic-load flag, and severity to determine category."
+  [violation]
+  (let [is-documented? (get violation :verified/documented? false)
+        dynamic-load?  (get violation :trace/dynamic-load? false)
+        severity       (:violation/severity violation)]
+    (assoc violation
+           :classification/category
+           (cond
+             ;; Documented, non-dynamic → likely false positive
+             (and is-documented? (not dynamic-load?))
+             :false-positive
+
+             ;; Undocumented + error severity → true positive
+             (and (not is-documented?) (= severity :error))
+             :true-positive
+
+             ;; Dynamic load with documentation → needs investigation
+             (and dynamic-load? is-documented?)
+             :needs-investigation
+
+             ;; Default: needs investigation
+             :else :needs-investigation)
+
+           :classification/confidence
+           (cond
+             (and is-documented? (not dynamic-load?)) 0.9
+             (and (not is-documented?) (= severity :error)) 0.85
+             :else 0.5)
+
+           :classification/doc-status
+           (if is-documented? :documented :undocumented)
+
+           :classification/reasoning
+           (cond
+             (and is-documented? (not dynamic-load?))
+             "Documented public API, no dynamic loading — benign"
+
+             (and (not is-documented?) (= severity :error))
+             "Undocumented API with error severity — real violation"
+
+             :else
+             "Ambiguous — requires manual review"))))
+
+(defn enter-sec-classify [ctx]
+  (let [start-time (System/currentTimeMillis)
+        verified   (get-in ctx [:execution/phase-results :sec-verify-docs :result :output :verified-violations] [])
+        classified (mapv classify-violation verified)]
+    (phase-result/enter-context ctx :sec-classify nil [:classification-gate] default-classify-config start-time
+                                {:status :success :output {:classified-violations classified}})))
+
+(defn leave-sec-classify [ctx]
+  (let [start-time      (get-in ctx [:phase :started-at])
+        end-time        (System/currentTimeMillis)
+        duration-ms     (- end-time start-time)
+        classified      (get-in ctx [:phase :result :output :classified-violations] [])
+        true-positives  (count (filter #(= :true-positive (:classification/category %)) classified))
+        false-positives (count (filter #(= :false-positive (:classification/category %)) classified))
+        needs-review    (count (filter #(= :needs-investigation (:classification/category %)) classified))]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (assoc-in [:phase :metrics] {:true-positives  true-positives
+                                     :false-positives false-positives
+                                     :needs-review    needs-review
+                                     :duration-ms     duration-ms})
+        (assoc-in [:execution/phase-results :sec-classify :result] (get-in ctx [:phase :result]))
+        (update-in [:execution :phases-completed] (fnil conj []) :sec-classify)
+        (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
+
+(defn error-sec-classify [ctx ex]
+  (-> ctx
+      (assoc-in [:phase :status] :failed)
+      (assoc-in [:phase :error] (phase-result/exception-error ex))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Phase 5: :sec-generate-exclusions — mechanical output
+
+(defn enter-sec-generate-exclusions [ctx]
+  (let [start-time  (System/currentTimeMillis)
+        classified  (get-in ctx [:execution/phase-results :sec-classify :result :output :classified-violations] [])
+        excluded    (filter #(= :false-positive (:classification/category %)) classified)
+        flagged     (filter #(not= :false-positive (:classification/category %)) classified)
+        excl-map    (reduce (fn [acc v]
+                              (update acc (:violation/rule-id v)
+                                      (fnil conj [])
+                                      {:file           (get-in v [:violation/location :file])
+                                       :line           (get-in v [:violation/location :line])
+                                       :classification (:classification/category v)
+                                       :justification  (:classification/reasoning v)
+                                       :api            (:trace/actual-api v)
+                                       :documented?    (:verified/documented? v)}))
+                            {}
+                            excluded)
+        output-dir  (get-in ctx [:execution/input :output-dir] ".")
+        excl-dir    (io/file output-dir ".security-exclusions")]
+    ;; Write exclusion file
+    (.mkdirs excl-dir)
+    (spit (io/file excl-dir "exclusions.edn")
+          (pr-str {:generated-at (str (java.time.Instant/now))
+                   :exclusions   excl-map
+                   :summary      {:total-excluded (count excluded)
+                                  :total-flagged  (count flagged)}}))
+    (phase-result/enter-context ctx :sec-generate-exclusions nil [] default-generate-exclusions-config start-time
+                                {:status :success
+                                 :output {:exclusion-list  excl-map
+                                          :total-excluded  (count excluded)
+                                          :total-flagged   (count flagged)}})))
+
+(defn leave-sec-generate-exclusions [ctx]
+  (let [start-time  (get-in ctx [:phase :started-at])
+        end-time    (System/currentTimeMillis)
+        duration-ms (- end-time start-time)
+        output      (get-in ctx [:phase :result :output])]
+    (-> ctx
+        (assoc-in [:phase :ended-at] end-time)
+        (assoc-in [:phase :duration-ms] duration-ms)
+        (assoc-in [:phase :status] :completed)
+        (assoc-in [:phase :metrics] {:excluded  (:total-excluded output 0)
+                                     :flagged   (:total-flagged output 0)
+                                     :duration-ms duration-ms})
+        (assoc-in [:execution/phase-results :sec-generate-exclusions :result] (get-in ctx [:phase :result]))
+        (update-in [:execution :phases-completed] (fnil conj []) :sec-generate-exclusions)
+        (update-in [:execution/metrics :duration-ms] (fnil + 0) duration-ms))))
+
+(defn error-sec-generate-exclusions [ctx ex]
+  (-> ctx
+      (assoc-in [:phase :status] :failed)
+      (assoc-in [:phase :error] (phase-result/exception-error ex))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Registry methods
+
+(defmethod registry/get-phase-interceptor :sec-parse-scan
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name   ::sec-parse-scan
+     :config merged
+     :enter  (fn [ctx] (enter-sec-parse-scan (assoc ctx :phase-config merged)))
+     :leave  leave-sec-parse-scan
+     :error  error-sec-parse-scan}))
+
+(defmethod registry/get-phase-interceptor :sec-trace-source
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name   ::sec-trace-source
+     :config merged
+     :enter  (fn [ctx] (enter-sec-trace-source (assoc ctx :phase-config merged)))
+     :leave  leave-sec-trace-source
+     :error  error-sec-trace-source}))
+
+(defmethod registry/get-phase-interceptor :sec-verify-docs
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name   ::sec-verify-docs
+     :config merged
+     :enter  (fn [ctx] (enter-sec-verify-docs (assoc ctx :phase-config merged)))
+     :leave  leave-sec-verify-docs
+     :error  error-sec-verify-docs}))
+
+(defmethod registry/get-phase-interceptor :sec-classify
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name   ::sec-classify
+     :config merged
+     :enter  (fn [ctx] (enter-sec-classify (assoc ctx :phase-config merged)))
+     :leave  leave-sec-classify
+     :error  error-sec-classify}))
+
+(defmethod registry/get-phase-interceptor :sec-generate-exclusions
+  [config]
+  (let [merged (registry/merge-with-defaults config)]
+    {:name   ::sec-generate-exclusions
+     :config merged
+     :enter  (fn [ctx] (enter-sec-generate-exclusions (assoc ctx :phase-config merged)))
+     :leave  leave-sec-generate-exclusions
+     :error  error-sec-generate-exclusions}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (registry/phase-defaults :sec-parse-scan)
+  (registry/phase-defaults :sec-trace-source)
+  (registry/phase-defaults :sec-verify-docs)
+  (registry/phase-defaults :sec-classify)
+  (registry/phase-defaults :sec-generate-exclusions))

--- a/components/workflow-security-compliance/test/ai/miniforge/workflow_security_compliance/e2e_test.clj
+++ b/components/workflow-security-compliance/test/ai/miniforge/workflow_security_compliance/e2e_test.clj
@@ -1,0 +1,153 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow-security-compliance.e2e-test
+  "End-to-end integration test for the security compliance workflow (issue #552).
+
+   Threads a context through all 5 phases in order, verifying:
+     1. SARIF + CSV parsing yields unified violations
+     2. Trace enrichment adds API/call-chain metadata
+     3. Doc verification marks known/unknown APIs
+     4. Classification produces correct category distribution
+     5. Exclusion generation writes a valid EDN file"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.java.io :as io]
+   [clojure.edn :as edn]
+   [ai.miniforge.workflow-security-compliance.phases :as phases]
+   [ai.miniforge.workflow-security-compliance.interface]))
+
+;------------------------------------------------------------------------------ E2E Pipeline
+
+(deftest full-pipeline-e2e-test
+  (testing "full 5-phase pipeline from parse through exclusion generation"
+    (let [output-dir (str (System/getProperty "java.io.tmpdir")
+                          "/miniforge-e2e-" (System/currentTimeMillis))
+          ctx {:execution/id            (random-uuid)
+               :execution/input         {:scan-paths  ["test/fixtures/sample-scan.sarif"
+                                                        "test/fixtures/sample-scan.csv"]
+                                          :output-dir  output-dir}
+               :execution/metrics       {:duration-ms 0}
+               :execution/phase-results {}}
+
+          ;; Phase 1: Parse
+          after-parse (-> ctx
+                          phases/enter-sec-parse-scan
+                          (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                          phases/leave-sec-parse-scan)
+          violations  (get-in after-parse [:execution/phase-results :sec-parse-scan
+                                           :result :output :violations])
+
+          ;; Phase 2: Trace
+          after-trace (-> after-parse
+                          phases/enter-sec-trace-source
+                          (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                          phases/leave-sec-trace-source)
+          traced      (get-in after-trace [:execution/phase-results :sec-trace-source
+                                           :result :output :traced-violations])
+
+          ;; Phase 3: Verify Docs
+          after-verify (-> after-trace
+                           phases/enter-sec-verify-docs
+                           (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                           phases/leave-sec-verify-docs)
+          verified     (get-in after-verify [:execution/phase-results :sec-verify-docs
+                                             :result :output :verified-violations])
+
+          ;; Phase 4: Classify
+          after-classify (-> after-verify
+                             phases/enter-sec-classify
+                             (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                             phases/leave-sec-classify)
+          classified     (get-in after-classify [:execution/phase-results :sec-classify
+                                                 :result :output :classified-violations])
+
+          ;; Phase 5: Generate Exclusions
+          after-exclusions (-> after-classify
+                               phases/enter-sec-generate-exclusions
+                               (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                               phases/leave-sec-generate-exclusions)
+          excl-output      (get-in after-exclusions [:execution/phase-results :sec-generate-exclusions
+                                                     :result :output])]
+
+      ;; ── Phase 1 assertions ──
+      (testing "Phase 1: parse-scan"
+        (is (= 7 (count violations))
+            "5 SARIF + 2 CSV = 7 total violations")
+        (is (every? :violation/id violations))
+        (is (some #(= "BinaryAPIScanner" (:violation/source-tool %)) violations)
+            "SARIF violations should have tool name"))
+
+      ;; ── Phase 2 assertions ──
+      (testing "Phase 2: trace-source"
+        (is (= 7 (count traced)))
+        (is (every? :trace/actual-api traced))
+        (let [dynamic (filter :trace/dynamic-load? traced)]
+          (is (pos? (count dynamic))
+              "dynamic loads from SARIF should be detected")))
+
+      ;; ── Phase 3 assertions ──
+      (testing "Phase 3: verify-docs"
+        (is (= 7 (count verified)))
+        (is (every? #(contains? % :verified/documented?) verified))
+        (let [documented (filter :verified/documented? verified)]
+          (is (pos? (count documented))
+              "at least one known API should be marked documented")))
+
+      ;; ── Phase 4 assertions ──
+      (testing "Phase 4: classify"
+        (is (= 7 (count classified)))
+        (let [by-cat (group-by :classification/category classified)]
+          (is (pos? (count (get by-cat :true-positive [])))
+              "undocumented error APIs should be true-positive")
+          (is (= #{:true-positive :false-positive :needs-investigation}
+                 (set (keys by-cat)))
+              "all three categories should be represented")))
+
+      ;; ── Phase 5 assertions ──
+      (testing "Phase 5: generate-exclusions"
+        (is (some? excl-output))
+        (is (pos? (+ (:total-excluded excl-output 0)
+                     (:total-flagged excl-output 0)))
+            "should have some excluded or flagged items")
+        (let [excl-file (io/file output-dir ".security-exclusions" "exclusions.edn")]
+          (is (.exists excl-file)
+              "exclusions.edn should be written to disk")
+          (when (.exists excl-file)
+            (let [parsed (edn/read-string (slurp excl-file))]
+              (is (string? (:generated-at parsed)))
+              (is (map? (:exclusions parsed)))
+              (is (map? (:summary parsed)))))))
+
+      ;; ── Cross-phase assertions ──
+      (testing "context threading: all phases completed"
+        (is (= #{:sec-parse-scan :sec-trace-source :sec-verify-docs
+                 :sec-classify :sec-generate-exclusions}
+               (set (get-in after-exclusions [:execution :phases-completed])))
+            "all 5 phases should be in phases-completed"))
+
+      (testing "context threading: cumulative metrics"
+        (is (number? (get-in after-exclusions [:execution/metrics :duration-ms] 0))
+            "cumulative duration should be recorded as a number"))
+
+      ;; Clean up temp files
+      (let [excl-file (io/file output-dir ".security-exclusions" "exclusions.edn")]
+        (when (.exists excl-file)
+          (.delete excl-file)
+          (.delete (io/file output-dir ".security-exclusions"))
+          (.delete (io/file output-dir)))))))

--- a/components/workflow-security-compliance/test/ai/miniforge/workflow_security_compliance/phases_test.clj
+++ b/components/workflow-security-compliance/test/ai/miniforge/workflow_security_compliance/phases_test.clj
@@ -1,0 +1,281 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow-security-compliance.phases-test
+  "Unit tests for the 5-phase security compliance workflow (issue #552).
+
+   Tests phase interceptors individually:
+     :sec-parse-scan           — SARIF/CSV parsing
+     :sec-trace-source         — source tracing (stub)
+     :sec-verify-docs          — documentation verification (mixed/stub)
+     :sec-classify             — deterministic classification
+     :sec-generate-exclusions  — exclusion file generation"
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [clojure.java.io :as io]
+   [ai.miniforge.phase.registry :as registry]
+   [ai.miniforge.workflow-security-compliance.phases :as phases]
+   [ai.miniforge.workflow-security-compliance.interface]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(def ^:private test-fixtures-dir
+  "test/fixtures")
+
+(defn- fixture-path [filename]
+  (str test-fixtures-dir "/" filename))
+
+(defn base-ctx
+  "Minimal execution context for testing."
+  []
+  {:execution/id            (random-uuid)
+   :execution/input         {:scan-paths  [(fixture-path "sample-scan.sarif")
+                                           (fixture-path "sample-scan.csv")]
+                             :output-dir  (str (System/getProperty "java.io.tmpdir")
+                                               "/miniforge-test-" (System/currentTimeMillis))}
+   :execution/metrics       {:duration-ms 0}
+   :execution/phase-results {}})
+
+;------------------------------------------------------------------------------ Registry Tests
+
+(deftest phases-registered-in-registry-test
+  (testing "all five security compliance phases are registered after namespace load"
+    (is (some? (registry/phase-defaults :sec-parse-scan))
+        ":sec-parse-scan defaults should be registered")
+    (is (some? (registry/phase-defaults :sec-trace-source))
+        ":sec-trace-source defaults should be registered")
+    (is (some? (registry/phase-defaults :sec-verify-docs))
+        ":sec-verify-docs defaults should be registered")
+    (is (some? (registry/phase-defaults :sec-classify))
+        ":sec-classify defaults should be registered")
+    (is (some? (registry/phase-defaults :sec-generate-exclusions))
+        ":sec-generate-exclusions defaults should be registered")))
+
+(deftest phase-interceptors-are-retrievable-test
+  (testing "get-phase-interceptor returns valid interceptor maps for each phase"
+    (doseq [phase-kw [:sec-parse-scan :sec-trace-source :sec-verify-docs
+                       :sec-classify :sec-generate-exclusions]]
+      (let [interceptor (registry/get-phase-interceptor {:phase phase-kw})]
+        (is (map? interceptor) (str phase-kw " should return a map"))
+        (is (fn? (:enter interceptor)) (str phase-kw " should have an :enter fn"))
+        (is (fn? (:leave interceptor)) (str phase-kw " should have a :leave fn"))
+        (is (fn? (:error interceptor)) (str phase-kw " should have an :error fn"))))))
+
+;------------------------------------------------------------------------------ Phase 1: Parse Scan
+
+(deftest enter-sec-parse-scan-with-sarif-test
+  (testing "parse-scan phase extracts violations from SARIF fixture"
+    (let [ctx      (assoc-in (base-ctx) [:execution/input :scan-paths]
+                             [(fixture-path "sample-scan.sarif")])
+          result   (phases/enter-sec-parse-scan ctx)
+          violations (get-in result [:phase :result :output :violations])]
+      (is (= 5 (count violations))
+          "SARIF fixture has 5 results")
+      (is (every? :violation/id violations)
+          "every violation should have an id")
+      (is (every? :violation/rule-id violations)
+          "every violation should have a rule-id")
+      (is (every? :violation/severity violations)
+          "every violation should have a severity"))))
+
+(deftest enter-sec-parse-scan-with-csv-test
+  (testing "parse-scan phase extracts violations from CSV fixture"
+    (let [ctx      (assoc-in (base-ctx) [:execution/input :scan-paths]
+                             [(fixture-path "sample-scan.csv")])
+          result   (phases/enter-sec-parse-scan ctx)
+          violations (get-in result [:phase :result :output :violations])]
+      (is (= 2 (count violations))
+          "CSV fixture has 2 data rows")
+      (is (every? :violation/id violations))
+      (is (every? #(= "csv-import" (:violation/source-tool %)) violations)))))
+
+(deftest enter-sec-parse-scan-mixed-formats-test
+  (testing "parse-scan handles both SARIF and CSV in a single pass"
+    (let [ctx    (base-ctx)
+          result (phases/enter-sec-parse-scan ctx)
+          violations (get-in result [:phase :result :output :violations])]
+      (is (= 7 (count violations))
+          "5 SARIF + 2 CSV = 7 total violations"))))
+
+(deftest enter-sec-parse-scan-no-files-test
+  (testing "parse-scan returns empty when no scan paths given"
+    (let [ctx    (assoc-in (base-ctx) [:execution/input :scan-paths] [])
+          result (phases/enter-sec-parse-scan ctx)
+          violations (get-in result [:phase :result :output :violations])]
+      (is (empty? violations)))))
+
+(deftest leave-sec-parse-scan-stores-metrics-test
+  (testing "leave-sec-parse-scan populates metrics and phase-results"
+    (let [ctx    (-> (base-ctx)
+                     phases/enter-sec-parse-scan
+                     (assoc-in [:phase :started-at] (- (System/currentTimeMillis) 100)))
+          result (phases/leave-sec-parse-scan ctx)]
+      (is (= :completed (get-in result [:phase :status])))
+      (is (pos? (get-in result [:phase :metrics :violation-count])))
+      (is (some? (get-in result [:execution/phase-results :sec-parse-scan :result]))))))
+
+;------------------------------------------------------------------------------ Phase 2: Trace Source
+
+(deftest enter-sec-trace-source-enriches-violations-test
+  (testing "trace-source stub enriches each violation with trace fields"
+    (let [ctx    (-> (base-ctx)
+                     phases/enter-sec-parse-scan
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-parse-scan)
+          result (phases/enter-sec-trace-source ctx)
+          traced (get-in result [:phase :result :output :traced-violations])]
+      (is (= 7 (count traced)))
+      (is (every? :trace/actual-api traced))
+      (is (every? :trace/call-chain traced))
+      (is (every? #(contains? % :trace/dynamic-load?) traced)))))
+
+(deftest trace-source-detects-dynamic-loads-test
+  (testing "dynamic load patterns are flagged in trace"
+    (let [ctx    (-> (base-ctx)
+                     (assoc-in [:execution/input :scan-paths]
+                               [(fixture-path "sample-scan.sarif")])
+                     phases/enter-sec-parse-scan
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-parse-scan)
+          result (phases/enter-sec-trace-source ctx)
+          traced (get-in result [:phase :result :output :traced-violations])
+          dynamic (filter :trace/dynamic-load? traced)]
+      (is (pos? (count dynamic))
+          "at least one SARIF violation involves dynamic loading"))))
+
+;------------------------------------------------------------------------------ Phase 3: Verify Docs
+
+(deftest enter-sec-verify-docs-marks-known-apis-test
+  (testing "known APIs are marked as documented"
+    (let [ctx    (-> (base-ctx)
+                     phases/enter-sec-parse-scan
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-parse-scan
+                     phases/enter-sec-trace-source
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-trace-source)
+          result (phases/enter-sec-verify-docs ctx)
+          verified (get-in result [:phase :result :output :verified-violations])]
+      (is (= 7 (count verified)))
+      (is (every? #(contains? % :verified/documented?) verified))
+      (is (every? #(contains? % :verified/public?) verified))
+      ;; CryptEncrypt is in known-apis, so at least one should be documented
+      (is (pos? (count (filter :verified/documented? verified)))
+          "at least one API from known-apis set should be documented"))))
+
+;------------------------------------------------------------------------------ Phase 4: Classify
+
+(deftest enter-sec-classify-categorizes-violations-test
+  (testing "classify assigns categories to all violations"
+    (let [ctx    (-> (base-ctx)
+                     phases/enter-sec-parse-scan
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-parse-scan
+                     phases/enter-sec-trace-source
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-trace-source
+                     phases/enter-sec-verify-docs
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-verify-docs)
+          result (phases/enter-sec-classify ctx)
+          classified (get-in result [:phase :result :output :classified-violations])]
+      (is (= 7 (count classified)))
+      (is (every? :classification/category classified))
+      (is (every? :classification/confidence classified))
+      (is (every? #(#{:true-positive :false-positive :needs-investigation}
+                     (:classification/category %))
+                  classified)
+          "all categories must be in the expected set"))))
+
+(deftest classify-assigns-correct-categories-test
+  (testing "classification rules produce correct categories"
+    ;; Documented + non-dynamic → false-positive
+    ;; Undocumented + error → true-positive
+    ;; Otherwise → needs-investigation
+    (let [ctx    (-> (base-ctx)
+                     (assoc-in [:execution/input :scan-paths]
+                               [(fixture-path "sample-scan.sarif")])
+                     phases/enter-sec-parse-scan
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-parse-scan
+                     phases/enter-sec-trace-source
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-trace-source
+                     phases/enter-sec-verify-docs
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-verify-docs)
+          result (phases/enter-sec-classify ctx)
+          classified (get-in result [:phase :result :output :classified-violations])
+          by-category (group-by :classification/category classified)]
+      ;; The SARIF has API-001 (error, undocumented ntdll/user32) → true-positive
+      (is (pos? (count (get by-category :true-positive [])))
+          "should have at least one true-positive")
+      ;; CryptEncrypt is in known-apis, error but documented → false-positive
+      ;; (documented + non-dynamic = false-positive)
+      (is (some #(or (= :false-positive (:classification/category %))
+                     (= :needs-investigation (:classification/category %)))
+                classified)
+          "should have documented items classified as FP or needs-investigation"))))
+
+;------------------------------------------------------------------------------ Phase 5: Generate Exclusions
+
+(deftest enter-sec-generate-exclusions-writes-file-test
+  (testing "generate-exclusions writes EDN exclusion file and produces output"
+    (let [output-dir (str (System/getProperty "java.io.tmpdir")
+                          "/miniforge-excl-test-" (System/currentTimeMillis))
+          ctx    (-> (base-ctx)
+                     (assoc-in [:execution/input :output-dir] output-dir)
+                     phases/enter-sec-parse-scan
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-parse-scan
+                     phases/enter-sec-trace-source
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-trace-source
+                     phases/enter-sec-verify-docs
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-verify-docs
+                     phases/enter-sec-classify
+                     (assoc-in [:phase :started-at] (System/currentTimeMillis))
+                     phases/leave-sec-classify)
+          result (phases/enter-sec-generate-exclusions ctx)
+          output (get-in result [:phase :result :output])
+          excl-file (io/file output-dir ".security-exclusions" "exclusions.edn")]
+      (is (some? output))
+      (is (number? (:total-excluded output)))
+      (is (number? (:total-flagged output)))
+      (is (.exists excl-file)
+          "exclusions.edn should be written to disk")
+      ;; Clean up
+      (.delete excl-file)
+      (.delete (io/file output-dir ".security-exclusions"))
+      (.delete (io/file output-dir)))))
+
+;------------------------------------------------------------------------------ Error Handling
+
+(deftest error-handlers-capture-exception-test
+  (testing "error handlers set :failed status and store error info"
+    (let [ctx (base-ctx)
+          ex  (Exception. "test failure")]
+      (doseq [error-fn [phases/error-sec-parse-scan
+                         phases/error-sec-trace-source
+                         phases/error-sec-verify-docs
+                         phases/error-sec-classify
+                         phases/error-sec-generate-exclusions]]
+        (let [result (error-fn ctx ex)]
+          (is (= :failed (get-in result [:phase :status])))
+          (is (some? (get-in result [:phase :error]))))))))

--- a/components/workflow-security-compliance/test/fixtures/sample-scan.csv
+++ b/components/workflow-security-compliance/test/fixtures/sample-scan.csv
@@ -1,0 +1,3 @@
+Rule ID,Message,Severity,File,Line,Column
+API-002,"Dynamic load via LoadLibrary/GetProcAddress: ole32.dll!none — cannot resolve target symbol",warning,src/com/ole_wrapper.cpp,67,4
+API-001,"Call to undocumented API: gdi32.dll!GdiDllInitialize",error,src/graphics/gdi_init.cpp,12,1

--- a/components/workflow-security-compliance/test/fixtures/sample-scan.sarif
+++ b/components/workflow-security-compliance/test/fixtures/sample-scan.sarif
@@ -1,0 +1,46 @@
+{
+  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/master/Schemata/sarif-schema-2.1.0.json",
+  "version": "2.1.0",
+  "runs": [
+    {
+      "tool": {
+        "driver": {
+          "name": "BinaryAPIScanner",
+          "version": "3.2.1",
+          "rules": [
+            { "id": "API-001", "shortDescription": { "text": "Undocumented API call detected" }, "defaultConfiguration": { "level": "error" } },
+            { "id": "API-002", "shortDescription": { "text": "Dynamic loading pattern detected" }, "defaultConfiguration": { "level": "warning" } },
+            { "id": "API-003", "shortDescription": { "text": "Deprecated API usage" }, "defaultConfiguration": { "level": "error" } }
+          ]
+        }
+      },
+      "results": [
+        {
+          "ruleId": "API-002", "level": "warning",
+          "message": { "text": "Dynamic load via LoadLibrary/GetProcAddress: shlwapi.dll!none — cannot resolve target symbol" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/win32/shell_utils.cpp" }, "region": { "startLine": 142, "startColumn": 5 } } }]
+        },
+        {
+          "ruleId": "API-001", "level": "error",
+          "message": { "text": "Call to undocumented API: ntdll.dll!RtlAdjustPrivilege" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/core/privilege_escalation.cpp" }, "region": { "startLine": 87, "startColumn": 12 } } }]
+        },
+        {
+          "ruleId": "API-002", "level": "warning",
+          "message": { "text": "Dynamic load via LoadLibrary/GetProcAddress: kernel32.dll!none — cannot resolve target symbol" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/io/async_file_ops.cpp" }, "region": { "startLine": 223, "startColumn": 8 } } }]
+        },
+        {
+          "ruleId": "API-001", "level": "error",
+          "message": { "text": "Call to undocumented API: user32.dll!NtUserSetWindowPos" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/ui/window_manager.cpp" }, "region": { "startLine": 456, "startColumn": 3 } } }]
+        },
+        {
+          "ruleId": "API-003", "level": "error",
+          "message": { "text": "Deprecated API: advapi32.dll!CryptEncrypt — use BCrypt* APIs instead" },
+          "locations": [{ "physicalLocation": { "artifactLocation": { "uri": "src/crypto/legacy_encrypt.cpp" }, "region": { "startLine": 34, "startColumn": 1 } } }]
+        }
+      ]
+    }
+  ]
+}

--- a/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
+++ b/components/workflow/src/ai/miniforge/workflow/observe_phase.clj
@@ -23,9 +23,8 @@
    This is the N2 §7 implementation. The Observe phase is the final
    phase of the standard SDLC workflow: plan → implement → verify →
    review → release → observe."
-  (:require [ai.miniforge.phase.registry :as registry]
-            [ai.miniforge.pr-lifecycle.monitor-config :as monitor-config]
-            [ai.miniforge.pr-lifecycle.monitor-loop :as monitor-loop]
+  (:require [ai.miniforge.phase.interface :as phase]
+            [ai.miniforge.pr-lifecycle.interface :as pr-lifecycle]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]
             [clojure.edn :as edn]
@@ -73,7 +72,7 @@
 
 (defn- load-monitor-defaults
   []
-  (monitor-config/monitor-defaults))
+  (pr-lifecycle/monitor-defaults))
 
 (defn- present-overrides
   [overrides]
@@ -84,7 +83,7 @@
   (:observe/phase-defaults (load-observe-phase-config)))
 
 ;; Register defaults on load
-(registry/register-phase-defaults! :observe default-config)
+(phase/register-phase-defaults! :observe default-config)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Interceptor implementation
@@ -146,8 +145,8 @@
             monitor-config (resolve-monitor-config ctx logger generate-fn event-bus)
             self-author (:self-author monitor-config)
 
-            monitor (monitor-loop/create-monitor monitor-config)
-            evidence (monitor-loop/run-monitor-loop monitor self-author)
+            monitor (pr-lifecycle/create-pr-monitor monitor-config)
+            evidence (pr-lifecycle/run-pr-monitor-loop monitor self-author)
 
             result-data {:observe/status :completed
                          :observe/evidence evidence
@@ -189,9 +188,9 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Registry method
 
-(defmethod registry/get-phase-interceptor :observe
+(defmethod phase/get-phase-interceptor-method :observe
   [config]
-  (let [merged (registry/merge-with-defaults config)]
+  (let [merged (phase/merge-with-defaults config)]
     {:name ::observe
      :config merged
      :enter (fn [ctx]
@@ -202,10 +201,10 @@
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   ;; Get interceptor
-  (registry/get-phase-interceptor {:phase :observe})
+  (phase/get-phase-interceptor-method {:phase :observe})
 
   ;; Check defaults
-  (registry/phase-defaults :observe)
+  (phase/phase-defaults :observe)
 
   ;; Typical execution context keys the Observe phase reads:
   ;; :execution/dag-pr-infos — vector of PR info maps from Release phase

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -27,11 +27,10 @@
    - context            — context management
    - execution          — phase execution
    - monitoring         — health monitoring"
-  (:require [ai.miniforge.dag-executor.executor :as dag-exec]
-            [ai.miniforge.llm.protocols.impl.llm-client :as llm-impl]
+  (:require [ai.miniforge.dag-executor.interface :as dag-exec]
+            [ai.miniforge.llm.interface :as llm-impl]
             [ai.miniforge.logging.interface :as log]
             [ai.miniforge.phase.interface :as phase]
-            [ai.miniforge.phase.registry :as registry]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.workflow.context :as ctx]
             [ai.miniforge.workflow.execution :as exec]
@@ -108,7 +107,7 @@
 (defn terminal-state?
   "Check if workflow is in terminal state."
   [context]
-  (or (registry/succeeded? context) (registry/failed? context)))
+  (or (phase/succeeded? context) (phase/failed? context)))
 
 ;------------------------------------------------------------------------------ Layer 1: Iteration helpers
 

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -22,8 +22,7 @@
    Manages worktree and Docker capsule acquisition, release, and
    workspace persistence at phase boundaries. Extracted from runner.clj."
   (:require
-   [ai.miniforge.dag-executor.executor :as dag-exec]
-   [ai.miniforge.dag-executor.result :as dag-result]
+   [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.messages :as messages]
@@ -38,12 +37,12 @@
 (defn dag-executor-fns
   "DAG executor function references — resolved at call time so with-redefs works."
   []
-  {:create-registry dag-exec/create-executor-registry
-   :select-exec     dag-exec/select-executor
-   :acquire-env!    dag-exec/acquire-environment!
-   :executor-type   dag-exec/executor-type
-   :result-ok?      dag-result/ok?
-   :result-unwrap   dag-result/unwrap})
+  {:create-registry dag/create-executor-registry
+   :select-exec     dag/select-executor
+   :acquire-env!    dag/acquire-environment!
+   :executor-type   dag/executor-type
+   :result-ok?      dag/ok?
+   :result-unwrap   dag/unwrap})
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Configuration
@@ -139,7 +138,7 @@
   [executor environment-id]
   (when (and executor environment-id)
     (try
-      (dag-exec/release-environment! executor environment-id)
+      (dag/release-environment! executor environment-id)
       (catch Exception e
         (println (messages/t :env/release-failed {:error (ex-message e)}))))))
 
@@ -152,7 +151,7 @@
             branch (get context :execution/task-branch)
             phase  (get phase-ctx :execution/current-phase :unknown)]
         (try
-          (dag-exec/persist-workspace! executor env-id
+          (dag/persist-workspace! executor env-id
                                        {:branch  branch
                                         :message (messages/t :env/persist-message {:phase (name phase)})
                                         :workdir (get context :execution/worktree-path)})

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -23,7 +23,7 @@
    All functions are safe to call with nil event-stream (no-op)."
   (:require
    [ai.miniforge.event-stream.interface :as es]
-   [ai.miniforge.phase.registry :as registry]
+   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.self-healing.interface :as self-healing]
    [ai.miniforge.workflow.messages :as messages]
    [cheshire.core :as json]))
@@ -70,7 +70,7 @@
 (defn- build-phase-event-data
   "Build event data map for a phase completion event."
   [result]
-  (let [succeeded? (get result :success? (registry/succeeded-or-done? result))
+  (let [succeeded? (get result :success? (phase/succeeded-or-done? result))
         outcome    (if succeeded? :success :failure)
         duration-ms (get result :duration-ms
                       (get-in result [:phase/metrics :duration-ms]
@@ -138,7 +138,7 @@
       (let [wf-id        (:execution/id context)
             metrics-opts (build-completion-metrics context)
             last-phase   (or (some-> (:execution/current-phase context) name) "")]
-        (if (registry/failed? context)
+        (if (phase/failed? context)
           (publish-event! event-stream
                           (merge (es/workflow-failed event-stream wf-id
                                                     {:message (messages/t :status/failed)

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -5,7 +5,7 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]
-   [ai.miniforge.dag-executor.executor :as dag-exec]
+   [ai.miniforge.dag-executor.interface :as dag-exec]
    [ai.miniforge.phase.interface]))
 
 ;; ---------------------------------------------------------------------------- extract-output

--- a/deps.edn
+++ b/deps.edn
@@ -108,6 +108,9 @@
                        "components/compliance-scanner/resources"
                        "components/workflow-compliance-scanner/src"
                        "components/workflow-compliance-scanner/resources"
+                       "components/workflow-security-compliance/src"
+                       "components/workflow-security-compliance/resources"
+                       "components/gate-classification/src"
                        "components/repo-index/src"
                        "components/repo-index/resources"
                        "components/context-pack/src"
@@ -151,6 +154,8 @@
                        "components/connector-jira/resources"
                        "components/connector-pipeline-output/src"
                        "components/connector-pipeline-output/resources"
+                       "components/connector-sarif/src"
+                       "components/connector-sarif/resources"
                        "components/connector-retry/src"
                        "components/cursor-store/src"
                        "components/data-quality/src"
@@ -223,6 +228,8 @@
                      ai.miniforge/spec-parser {:local/root "components/spec-parser"}
                      ai.miniforge/compliance-scanner {:local/root "components/compliance-scanner"}
                      ai.miniforge/workflow-compliance-scanner {:local/root "components/workflow-compliance-scanner"}
+                     ai.miniforge/workflow-security-compliance {:local/root "components/workflow-security-compliance"}
+                     ai.miniforge/gate-classification {:local/root "components/gate-classification"}
                      ai.miniforge/repo-index {:local/root "components/repo-index"}
                      ai.miniforge/context-pack {:local/root "components/context-pack"}
                      ai.miniforge/mcp-context-server {:local/root "bases/mcp-context-server"}
@@ -248,6 +255,7 @@
                      ai.miniforge.data-foundry/connector-http {:local/root "components/connector-http"}
                      ai.miniforge.data-foundry/connector-jira {:local/root "components/connector-jira"}
                      ai.miniforge.data-foundry/connector-pipeline-output {:local/root "components/connector-pipeline-output"}
+                     ai.miniforge.data-foundry/connector-sarif {:local/root "components/connector-sarif"}
                      ai.miniforge.data-foundry/connector-retry {:local/root "components/connector-retry"}
                      ai.miniforge.data-foundry/cursor-store {:local/root "components/cursor-store"}
                      ai.miniforge.data-foundry/data-quality {:local/root "components/data-quality"}
@@ -316,6 +324,8 @@
                        "components/spec-parser/test"
                        "components/compliance-scanner/test"
                        "components/workflow-compliance-scanner/test"
+                       "components/workflow-security-compliance/test"
+                       "components/gate-classification/test"
                        "components/repo-index/test"
                        "components/context-pack/test"
                        "bases/mcp-context-server/test"
@@ -341,6 +351,7 @@
                        "components/connector-http/test"
                        "components/connector-jira/test"
                        "components/connector-pipeline-output/test"
+                       "components/connector-sarif/test"
                        "components/connector-retry/test"
                        "components/cursor-store/test"
                        "components/data-quality/test"
@@ -404,6 +415,8 @@
                       ai.miniforge/spec-parser {:local/root "components/spec-parser"}
                       ai.miniforge/compliance-scanner {:local/root "components/compliance-scanner"}
                       ai.miniforge/workflow-compliance-scanner {:local/root "components/workflow-compliance-scanner"}
+                      ai.miniforge/workflow-security-compliance {:local/root "components/workflow-security-compliance"}
+                      ai.miniforge/gate-classification {:local/root "components/gate-classification"}
                       ai.miniforge/repo-index {:local/root "components/repo-index"}
                       ai.miniforge/context-pack {:local/root "components/context-pack"}
                       ai.miniforge/mcp-context-server {:local/root "bases/mcp-context-server"}

--- a/docs/pull-requests/2026-04-15-codex-recover-compliance-refactor-tests.md
+++ b/docs/pull-requests/2026-04-15-codex-recover-compliance-refactor-tests.md
@@ -1,0 +1,106 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Recover compliance refactor and green changed-brick tests
+
+**Branch:** `codex/recover-compliance-refactor-tests`
+**Base Branch:** `main`
+**Recovered From:** `worktree-agent-ac127be3`
+**Depends On:** none
+
+## Overview
+
+Recover the in-progress Claude work around the mixed security compliance
+pipeline, related Polylith cleanup, and storage/test isolation work, then bring
+ the changed-brick suite back to green so the branch can be reviewed as a PR.
+
+## Motivation
+
+The worktree contained a large staged and unstaged refactor spanning new
+compliance components, workflow additions, interface cleanup, and execution
+environment handling. Before it could be reviewed or merged, the branch needed:
+
+- a durable commit instead of temporary worktree state
+- the changed-brick test runner stabilized for linked-worktree git envs
+- stale and broken tests repaired so `bb test` and the pre-commit hook pass
+
+## Changes In Detail
+
+### New Compliance Pipeline
+
+- add `connector-sarif` for SARIF v2.1.0 and CSV ingestion
+- add `gate-classification` for deterministic violation categorization
+- add `workflow-security-compliance` with parse, trace, verify-docs,
+  classify, and exclusion-generation phases
+- add fixtures, e2e coverage, and a demo workflow entrypoint
+
+### Polylith And Interface Cleanup
+
+- continue interface pass-through remediation across workflow, phase,
+  control-plane, llm, repo-index, policy-pack, dag-executor, and related
+  components
+- continue phase/result movement and wiring needed for the broader
+  Polylith compliance cleanup
+- capture the associated recovery and remediation specs under `work/`
+
+### Test And Runtime Fixes
+
+- isolate Codex/Cursor MCP config writes to per-session roots so parallel tests
+  do not fight over repo-local config files
+- clean nested `mcp_servers.artifact.*` Codex config tables during session
+  cleanup so newer Codex TOML layouts do not retain invalid orphaned sections
+- preserve `:rule/severity` in connector-linter ETL output
+- align verify and implement tests with the current default gate sets
+- rewrite `phase.release-test` worktree setup so lint and parallel execution are
+  stable
+- group `workflow`, `phase`, `agent`, and `phase-software-factory` in one
+  sequential changed-brick affinity bucket to avoid shared `with-redefs`
+  collisions
+- prevent `GIT_DIR` / `GIT_WORK_TREE` leakage into the test JVM so git commands
+  inside temp repos resolve correctly
+- restore planner behavior when no LLM backend is provided
+- resolve workflow-security-compliance fixture paths from the classpath and
+  improve stub trace API extraction so doc verification/classification tests
+  reflect the intended sample data
+
+## Testing Plan
+
+- run `bb test`
+- run pre-commit hook checks during `git commit`
+- verify targeted namespaces while fixing regressions:
+  - `ai.miniforge.phase.release-test`
+  - `ai.miniforge.phase.verify-test`
+  - `ai.miniforge.phase.artifact-persistence-test`
+  - `ai.miniforge.workflow-security-compliance.phases-test`
+  - `ai.miniforge.workflow-security-compliance.e2e-test`
+  - `ai.miniforge.agent.planner-test`
+
+## Deployment Plan
+
+No deployment-specific rollout is required. This is codebase, workflow, and
+test infrastructure work. Merge behind normal review once the PR is accepted.
+
+## Related Issues/PRs
+
+- `PR-552.md`
+- `work/polylith-compliance-remediation.spec.edn`
+- `work/storage-root-configuration.spec.edn`
+
+## Test Results
+
+- `bb test` passed: `2386 tests, 13178 passes, 0 failures, 0 errors`
+- pre-commit hook passed during commit, including:
+  - staged Clojure lint
+  - changed-brick tests
+  - GraalVM/Babashka compatibility tests
+
+## Checklist
+
+- [x] Recover the in-progress work into a durable commit
+- [x] Fix changed-brick test failures
+- [x] Add PR documentation to the repo
+- [ ] Push branch
+- [ ] Open PR

--- a/scripts/test-changed-bricks.bb
+++ b/scripts/test-changed-bricks.bb
@@ -97,14 +97,12 @@
 
 (def affinity-groups
   "Bricks that share with-redefs targets and must NOT run in parallel.
-   phase-software-factory tests redefine agent/invoke, agent/create-implementer,
-   etc., so they must run in the same sequential group as the agent brick."
-  {;; phase-software-factory tests redefine agent/invoke etc.
-   "agent+phases" #{"agent" "phase-software-factory"}
-   ;; workflow and phase tests both dynamically require context_pack via
-   ;; ensure-phase-implementations-loaded! — concurrent pmap loading causes
-   ;; Compiler$CompilerException races on context_pack/interface.clj.
-   "workflow+phase" #{"workflow" "phase"}})
+   workflow, phase, agent, and phase-software-factory all exercise the same
+   phase pipeline and redefine shared globals such as agent/invoke,
+   agent/create-implementer, verify/run-tests!, and
+   release-executor/execute-release-phase. Running them in separate pmap
+   groups causes intermittent cross-brick test pollution."
+  {"workflow+agent+phases" #{"workflow" "phase" "agent" "phase-software-factory"}})
 
 (defn coalesce-by-affinity
   "Merge brick-groups that belong to the same affinity group into a single
@@ -152,12 +150,17 @@
           (println (str "    " brick " (" (count nses) " namespaces)"))
           (doseq [ns nses] (println (str "      " ns))))
         (let [expr (build-test-expr brick-groups)
-              ;; Strip GIT_INDEX_FILE from the test JVM's environment.
-              ;; When committing from a git worktree, GIT_INDEX_FILE points to
-              ;; the worktree-specific index. Test subprocesses that run git
-              ;; commands (e.g., create-worktree in runner tests) can corrupt
-              ;; this index, causing the commit to produce an empty tree.
-              test-env (dissoc (into {} (System/getenv)) "GIT_INDEX_FILE")
+              ;; Strip git worktree vars from the test JVM's environment.
+              ;; Changed-brick detection may need the caller's GIT_DIR /
+              ;; GIT_WORK_TREE, but test namespaces shell out to git against
+              ;; temp repos and worktrees. If those vars leak into the test
+              ;; JVM, git commands inside tests resolve against the committing
+              ;; repo instead of the test fixture repo, causing false failures.
+              test-env (dissoc (into {} (System/getenv))
+                               "GIT_INDEX_FILE"
+                               "GIT_DIR"
+                               "GIT_WORK_TREE"
+                               "GIT_COMMON_DIR")
               {:keys [exit]} (deref (p/process {:out :inherit :err :inherit
                                                 :env test-env}
                                                "clojure" "-M:dev:test" "-e" expr))]

--- a/work/artifact-extraction-agent.spec.edn
+++ b/work/artifact-extraction-agent.spec.edn
@@ -1,0 +1,127 @@
+;; =============================================================================
+;; Spec: Deterministic Artifact Extraction from Container/Worktree
+;; =============================================================================
+;;
+;; Problem:
+;;
+;;   The implement phase depends on the LLM calling a save-artifact MCP tool
+;;   to emit structured code artifacts. The LLM frequently fails to call the
+;;   tool, causing the implement phase to fail after ~11 minutes of code
+;;   generation. The code IS written to the container/worktree filesystem,
+;;   but the artifact session can't find it because the MCP tool was never
+;;   invoked. The file-artifact fallback exists but unreliably detects files
+;;   across worktree boundaries.
+;;
+;;   This is the #1 blocker for reliable autonomous pipeline execution,
+;;   documented in project_dogfood_findings_2026_03_25.md.
+;;
+;; Insight:
+;;
+;;   The container/worktree IS the artifact. The implementer agent's job is
+;;   pure code generation — write files, run tests, iterate. When it exits,
+;;   the filesystem delta is the deliverable. Artifact extraction should be
+;;   deterministic, not dependent on LLM tool-calling behavior.
+;;
+;; Solution:
+;;
+;;   Replace the MCP-dependent artifact capture with a post-implementation
+;;   extraction step:
+;;
+;;   1. Implementer agent writes code in container/worktree → exits
+;;   2. Extraction function diffs container against base (git diff)
+;;   3. Changed/added files are collected into a structured artifact
+;;   4. Artifact conforms to the existing artifact schema
+;;   5. Next phase receives the artifact through the normal handoff
+;;
+;;   The extraction step is deterministic — no LLM, no MCP, just filesystem
+;;   inspection. It replaces the fragile save-artifact path with a reliable
+;;   git-diff-based one.
+;;
+;; Relationship to specs:
+;;
+;;   - N11 (Task Capsule Isolation) — N11.CP.5 requires artifact export before
+;;     capsule destruction. This makes export deterministic.
+;;   - N2 (Workflows) — phase-to-phase handoff contract unchanged; inner
+;;     mechanism changes.
+;;   - capsule-artifact-export.spec.edn — the "how" of export changes from
+;;     MCP-tool-dependent to git-diff-deterministic.
+
+{:spec/title "Deterministic artifact extraction from container/worktree"
+
+ :spec/description
+ "Replace the MCP-dependent artifact capture in the implement phase with a
+  deterministic post-implementation extraction step. The container/worktree
+  filesystem delta IS the artifact.
+
+  CURRENT FLOW (fragile):
+    Implementer agent → (should call save-artifact MCP tool) → artifact session
+    Problem: LLM frequently doesn't call the tool → phase fails
+
+  NEW FLOW (deterministic):
+    Implementer agent → writes code in worktree → exits
+                                    │
+    extract-artifact (deterministic) │
+      1. git diff --name-status against base commit
+      2. Collect all changed/added files with content
+      3. Build structured artifact map conforming to existing schema
+      4. Return artifact to phase pipeline
+                                    │
+    Next phase receives artifact normally
+
+  IMPLEMENTATION:
+
+  1. Extract function (components/agent/src/.../artifact_extraction.clj):
+     - extract-worktree-artifact [worktree-path base-ref]
+       Returns {:code/files [{:path ... :content ... :status :added|:modified}]
+                :code/summary {:files-changed N :additions N :deletions N}}
+     - Uses git diff --name-status + file reads (no LLM, no MCP)
+     - Respects .gitignore (no build artifacts, node_modules, etc.)
+     - Filters by known source extensions (configurable)
+
+  2. Phase interceptor change (implement phase leave handler):
+     - After implementer agent exits, invoke extract-worktree-artifact
+     - If extraction finds changes → build artifact → proceed to verify
+     - If extraction finds NO changes → mark phase failed (no output)
+     - Remove dependency on MCP artifact file existence
+
+  3. Fallback removal:
+     - Remove file-artifact-fallback logic from artifact_session.clj
+     - Remove the ERROR log about 'artifact file not found -- MCP tool was
+       likely not called by the LLM'
+     - The MCP save-artifact tool can remain available but is no longer
+       required for phase success
+
+  4. Retry improvement:
+     - Currently retries re-run the full implement phase (~11 min each)
+     - With extraction, the artifact is always captured if code was written
+     - Retries only needed when NO code was written (actual failure)"
+
+ :spec/intent {:type :refactor
+               :scope ["components/agent/src"
+                       "components/phase/src"
+                       "components/workflow/src"]}
+
+ :spec/constraints
+ ["Extraction must be deterministic — no LLM calls, no MCP dependency"
+  "Output artifact must conform to existing artifact schema"
+  "Must handle both worktree and Docker container filesystems"
+  "Must respect .gitignore and configurable extension filters"
+  "Must not break existing phase-to-phase handoff contract"
+  "MCP save-artifact tool may remain available as optional enhancement"
+  "Extraction must complete in under 10 seconds for typical code changes"
+  "Must handle binary files gracefully (skip content, include path)"]
+
+ :spec/acceptance-criteria
+ ["extract-worktree-artifact produces a valid artifact from a worktree with changes"
+  "extract-worktree-artifact returns empty artifact (not nil) when no changes exist"
+  "Implement phase succeeds when LLM writes code but does NOT call save-artifact"
+  "Implement phase fails cleanly when LLM writes NO code (actual failure)"
+  "Artifact schema is identical whether produced by extraction or MCP tool"
+  "Extraction completes in under 10 seconds for 50-file changesets"
+  "Binary files are listed in artifact but content is not included"
+  ".gitignore patterns are respected (no node_modules, build outputs)"
+  "git diff against base ref correctly identifies added, modified, and deleted files"
+  "Existing tests continue to pass"
+  "End-to-end: bb miniforge run completes implement phase without MCP artifact"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/capsule-artifact-export.spec.edn
+++ b/work/done/capsule-artifact-export.spec.edn
@@ -1,0 +1,42 @@
+{:spec/title "Export declared artifacts before capsule DESTROY"
+
+ :spec/description
+ "Per N11 §4.3 and §9.2, the executor must copy declared artifacts out of the
+  capsule before destroying it. Currently capsule cleanup (release-execution-
+  environment!) destroys the container without an explicit export phase.
+
+  Implementation:
+  1. In runner.clj, before calling release-execution-environment! in the finally
+     block, call a new `export-capsule-artifacts!` function that:
+     - Reads the artifact manifest from the execution context (if any)
+     - For each declared artifact, calls `copy-from!` on the executor to copy
+       it from the capsule to a local staging directory
+     - Verifies all :required? true artifacts were successfully copied
+     - Fails the workflow if a required artifact is missing
+  2. The artifact manifest should be built during the pipeline from phase results.
+     Each phase that produces artifacts (implement, verify, release) appends to
+     :execution/artifact-manifest on the context.
+  3. The copy-from! protocol method already exists on the TaskExecutor protocol.
+     The Docker implementation uses `docker cp`. Use it.
+  4. Store exported artifacts in a temp directory, then merge paths into the
+     workflow output for downstream consumers."
+
+ :spec/intent {:type :feature
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj"]}
+
+ :spec/constraints
+ ["Only applies when :execution/mode is :governed"
+  "Uses existing copy-from! protocol method — no new executor methods"
+  "Must not fail silently — log warnings for optional artifacts, throw for required"
+  "Cleanup must still happen even if export fails (export in try, cleanup in finally)"
+  "Existing tests must pass"]
+
+ :spec/acceptance-criteria
+ ["Declared artifacts are copied from capsule before container removal"
+  "Required artifacts that fail to export cause workflow failure"
+  "Optional artifacts that fail to export log a warning but don't fail"
+  "Local mode skips export (artifacts already on host filesystem)"
+  "Exported artifact paths recorded in :execution/output"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/capsule-cleanup-reliability.spec.edn
+++ b/work/done/capsule-cleanup-reliability.spec.edn
@@ -1,0 +1,30 @@
+{:spec/title "Reliable capsule cleanup on failure"
+
+ :spec/description
+ "Docker containers from governed-mode runs linger after pipeline errors or
+  timeouts. The runner's release-execution-environment! must be called in all
+  exit paths — success, failure, exception, and timeout.
+
+  Currently the runner has a try/finally but the environment release may not
+  cover all DAG sub-workflow capsules. Each capsule created by the DAG
+  orchestrator must also be cleaned up."
+
+ :spec/intent {:type :bugfix
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj"
+                       "components/workflow/src/ai/miniforge/workflow/dag_task_runner.clj"]}
+
+ :spec/constraints
+ ["release-execution-environment! must be called in finally blocks"
+  "DAG sub-workflow capsules must be tracked and cleaned up"
+  "Cleanup must not throw — wrap in try/catch"
+  "Log cleanup actions at debug level"
+  "Do not change the public API of run-pipeline"]
+
+ :spec/acceptance-criteria
+ ["No lingering miniforge-task-* containers after pipeline success"
+  "No lingering containers after pipeline failure"
+  "No lingering containers after pipeline timeout"
+  "docker ps --filter name=miniforge-task returns empty after any run"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/capsule-timeout-enforcement.spec.edn
+++ b/work/done/capsule-timeout-enforcement.spec.edn
@@ -1,0 +1,40 @@
+{:spec/title "Capsule self-terminates on timeout expiry"
+
+ :spec/description
+ "Per N11 §2.2, capsules must be self-terminating on timeout expiry. Currently
+  the timeout is passed to Docker resource config but there is no enforcement
+  mechanism — a runaway container will not be killed.
+
+  Implementation:
+  1. In docker.clj create-container, add --stop-timeout flag to set Docker's
+     built-in stop timeout. This handles ungraceful shutdown.
+  2. In runner.clj, wrap the pipeline execution loop in a future with
+     deref timeout. If the timeout fires:
+     - Log a warning with the workflow-id and elapsed time
+     - Call release-execution-environment! to kill the capsule
+     - Return a :timeout failure result
+  3. The timeout value should come from the workflow config or phase budget:
+     - (:budget :time-seconds) from phase config, or
+     - A global default of 30 minutes for the full pipeline
+  4. For DAG sub-workflows, each task inherits the parent timeout budget
+     divided by task count (floor), with a minimum of 5 minutes."
+
+ :spec/intent {:type :feature
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj"]}
+
+ :spec/constraints
+ ["Only enforce timeout in governed mode — local mode relies on user interrupt"
+  "Timeout must not leave orphan containers"
+  "Use future + deref-with-timeout, not Thread/sleep"
+  "Log elapsed time and timeout value on expiry"
+  "Existing tests must pass"]
+
+ :spec/acceptance-criteria
+ ["Governed pipeline that exceeds timeout returns :timeout failure"
+  "Container is killed when timeout fires"
+  "Timeout value comes from workflow/phase config"
+  "DAG sub-workflows respect timeout budget"
+  "Local mode is unaffected"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/evidence-execution-mode.spec.edn
+++ b/work/done/evidence-execution-mode.spec.edn
@@ -1,0 +1,46 @@
+{:spec/title "Evidence bundle records execution mode and runtime class"
+
+ :spec/description
+ "Per N11 §9.1, each task capsule must produce an evidence record containing
+  :evidence/execution-mode #{:local :governed}. Currently no execution mode
+  is recorded in evidence bundles or workflow output.
+
+  Implementation:
+  1. In the `extract-output` function in runner.clj, add evidence fields to
+     the :execution/output map by reading from the execution context:
+     - :evidence/execution-mode from (:execution/mode ctx) — defaults to :local
+     - :evidence/runtime-class from the executor-type of (:execution/executor ctx)
+       — :docker, :worktree, or nil if no executor
+     - :evidence/task-started-at from (:execution/started-at ctx)
+     - :evidence/task-finished-at — capture current time at extract-output
+  2. In the `create-bundle-impl` function in evidence_bundle.clj (or collector.clj),
+     accept and merge these evidence fields from the workflow result into the
+     evidence bundle map.
+  3. For image-digest (SHOULD per N11 §11): in docker.clj acquire-environment!,
+     after create-container, run `docker inspect <container> --format '{{.Image}}'`
+     to capture the image SHA256. Store it in the environment metadata. Then in
+     extract-output, read it from context and include as :evidence/image-digest."
+
+ :spec/intent {:type :feature
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/evidence-bundle/src/ai/miniforge/evidence_bundle"
+                       "components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj"]}
+
+ :spec/constraints
+ ["Evidence fields added to the workflow :execution/output map, not a new store"
+  ":evidence/execution-mode comes from (:execution/mode ctx), default :local"
+  ":evidence/runtime-class comes from (executor-type (:execution/executor ctx))"
+  ":evidence/image-digest is optional (SHOULD) — only for Docker executor"
+  "Use the governed? predicate from artifact-session when checking mode"
+  "Existing tests must pass"
+  "Do not add fields to context — read from existing keys at extract-output time"]
+
+ :spec/acceptance-criteria
+ [":evidence/execution-mode present in workflow :execution/output when pipeline completes"
+  ":evidence/runtime-class present when executor is available"
+  "Local mode records :local, governed records :governed"
+  ":evidence/task-started-at and :evidence/task-finished-at present in output"
+  "Evidence bundle includes execution-mode and runtime-class when created from workflow result"
+  "Image digest captured and recorded for Docker-based governed runs"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/n05-cli-command-wiring.spec.edn
+++ b/work/done/n05-cli-command-wiring.spec.edn
@@ -1,0 +1,68 @@
+;; =============================================================================
+;; Spec: N5 — CLI Command Wiring Audit and Completion
+;; =============================================================================
+;;
+;; Normative ref: specs/normative/N5-cli-tui-api.md
+;;
+;; Many components exist but lack CLI exposure. N5 specifies a full command
+;; taxonomy (miniforge <ns> <cmd>) that is only partially wired. No work spec
+;; previously existed to close this gap.
+
+{:spec/title "N5: Audit and wire all N5-specified CLI commands to components"
+
+ :spec/description
+ "Audit every CLI command specified in N5 against the actual CLI implementation
+  in bases/cli/. For each missing or partially wired command, connect it to the
+  existing component. Commands to verify/wire:
+
+  Workflow commands:
+  - miniforge workflow execute <spec>
+  - miniforge workflow status <id>
+  - miniforge workflow list
+  - miniforge workflow cancel <id>
+
+  Policy commands:
+  - miniforge policy list
+  - miniforge policy show <pack-id>
+  - miniforge policy install <path>
+
+  Evidence commands:
+  - miniforge evidence show <id>
+  - miniforge evidence export <id> <format>
+  - miniforge evidence list
+
+  Artifact commands:
+  - miniforge artifact provenance <id>
+  - miniforge artifact list
+
+  ETL commands:
+  - miniforge etl repo <url>
+
+  Fleet commands:
+  - miniforge fleet watch (TUI)
+  - miniforge fleet prs
+
+  Produce a wiring report as part of the PR showing: command, status before,
+  status after, component connected."
+
+ :spec/intent {:type :feature
+               :scope ["bases/cli/src"
+                       "components/workflow/src"
+                       "components/policy-pack/src"
+                       "components/evidence-bundle/src"
+                       "components/artifact/src"]}
+
+ :spec/constraints
+ ["Do not change existing working commands — only add missing wiring"
+  "Each command must validate args and print usage on invalid input"
+  "Commands must exit with appropriate exit codes (0 success, 1 error)"
+  "Output format should be human-readable by default, --json flag for machine output"]
+
+ :spec/acceptance-criteria
+ ["All N5-specified commands are callable from the CLI"
+  "miniforge help shows all available commands grouped by namespace"
+  "Each command connects to the correct component interface function"
+  "Invalid command arguments produce helpful error messages"
+  "Wiring report documents before/after status for each command"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/release-pr-quality.spec.edn
+++ b/work/done/release-pr-quality.spec.edn
@@ -1,0 +1,61 @@
+{:spec/title "Release Phase — PR Description and PR Doc Generation"
+ :spec/description
+ "The release phase creates PRs with empty descriptions and no PR doc.
+  Extend the release pipeline to:
+  1. Generate a concise PR title (< 70 chars) from the task description
+  2. Generate a structured PR body (summary, changes, test plan)
+  3. Generate a PR doc in docs/pull-requests/ with the standard format
+  All without requiring a releaser LLM agent — use deterministic templates
+  enriched with data from the workflow (files changed, tests run, review results)."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/release-executor/src/ai/miniforge/release_executor/metadata.clj"
+          "components/release-executor/src/ai/miniforge/release_executor/core.clj"
+          "docs/pull-requests/"]}
+
+ :spec/constraints
+ ["PR title must be < 70 characters"
+  "PR body must include ## Summary, ## Changes, ## Test plan sections"
+  "PR doc must follow existing format in docs/pull-requests/"
+  "Must work without LLM (deterministic fallback) but use LLM when available"
+  "PR doc filename: YYYY-MM-DD-<slug>.md"
+  "Pre-commit hooks must pass"]
+
+ :spec/workflow-type :canonical-sdlc
+ :workflow/version "2.0.0"
+
+ :plan/tasks
+ [{:task/id :improve-fallback-metadata
+   :task/description
+   "Improve fallback-release-metadata in metadata.clj:
+    - Generate concise title (truncate task description to 70 chars, smart split)
+    - Generate structured PR body with ## Summary, ## Changes (file list),
+      ## Test plan sections
+    - Use workflow data: file paths from code artifacts, gate results,
+      review summary if available
+    Read source: components/release-executor/src/ai/miniforge/release_executor/metadata.clj"
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :add-pr-doc-generation
+   :task/description
+   "Add a new step to the release pipeline that generates a PR doc file:
+    - step-generate-pr-doc between step-create-pr and step-build-artifact
+    - Writes to docs/pull-requests/YYYY-MM-DD-<slug>.md
+    - Include: title, summary, files changed, test results, review decision
+    - Commit the doc as part of the release commit (before push)
+    Read source: components/release-executor/src/ai/miniforge/release_executor/core.clj
+    Read examples: docs/pull-requests/ (any recent file for format)"
+   :task/type :implement
+   :task/dependencies [:improve-fallback-metadata]}
+
+  {:task/id :test-pr-quality
+   :task/description
+   "Add tests for PR description and doc generation:
+    - Test fallback metadata produces valid title/body
+    - Test PR doc generation creates correct file with expected sections
+    - Test integration: metadata flows through to gh pr create
+    Read source: components/release-executor/test/"
+   :task/type :test
+   :task/dependencies [:add-pr-doc-generation]}]}

--- a/work/done/runner-refactor.spec.edn
+++ b/work/done/runner-refactor.spec.edn
@@ -1,0 +1,53 @@
+{:spec/title "Refactor workflow runner.clj to standards compliance"
+
+ :spec/description
+ "runner.clj has accumulated technical debt from multiple agents and sessions.
+  Full refactor required to comply with miniforge engineering standards.
+
+  Issues:
+  - Nested conditionals instead of composed pipelines
+  - Hand-built maps instead of factory functions / anomaly constructors
+  - Raw strings instead of messages/t localization
+  - Magic numbers (max-phases, timeouts) instead of named constants
+  - Mixed concerns (output extraction, artifact export, timeout enforcement,
+    monitoring, promotion all in one 700+ line file)
+  - No schemas at boundaries
+  - Reaching into data structures for status instead of predicates
+
+  Approach:
+  - Extract to focused namespaces: context.clj (exists), execution.clj (exists),
+    monitoring.clj (exists), artifact-export.clj (new), timeout.clj (new)
+  - runner.clj becomes a thin pipeline composer (~200 lines)
+  - All constants to config/runner/defaults.edn
+  - All strings to messages/en-US.edn
+  - Factory functions for result maps
+  - Predicates for status checks
+  - Tests updated to match
+
+  NOTE: This should be decomposed into a DAG of component-level PRs,
+  not one giant PR."
+
+ :spec/intent {:type :refactor
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/workflow/src/ai/miniforge/workflow"]}
+
+ :spec/constraints
+ ["Follow stratified design — dependencies flow downward only"
+  "Configuration is data (.edn), not code"
+  "Localize all strings via messages/t"
+  "Factory functions over duplicate maps"
+  "Predicates (succeeded? failed?) over status keyword checks"
+  "No nested conditionals — compose pipelines"
+  "PR DAG — one PR per extracted namespace"
+  "Code changes require test changes"]
+
+ :spec/acceptance-criteria
+ ["runner.clj is under 250 lines"
+  "No raw strings — all localized"
+  "No magic numbers — all named constants in defaults.edn"
+  "No hand-built result maps — factory functions"
+  "No nested conditionals — pipeline composition"
+  "All existing tests pass"
+  "New tests for extracted functions"]
+
+ :workflow/type :canonical-sdlc}

--- a/work/done/slingshot-adoption.spec.edn
+++ b/work/done/slingshot-adoption.spec.edn
@@ -1,0 +1,68 @@
+{:spec/title "Adopt slingshot try+/throw+ across the codebase"
+
+ :spec/description
+ "slingshot/slingshot 0.12.2 is verified bb-compatible.
+
+  Phase 1 (DONE — PRs #519, #521, #523):
+  - try+ at catch sites in workflow/runner, CLI base, agent component
+  - catch Object as universal fallback (ex-info maps bypass catch Exception)
+
+  Phase 2 (THIS SPEC):
+  Create an anomaly component with throw-anomaly! function that standardizes
+  the throw shape. All throw sites migrate from ad-hoc ex-info to
+  throw-anomaly! with canonical :type keywords. Catch sites destructure
+  directly from the thrown map.
+
+  throw-anomaly! is a function (not a macro) that:
+  1. Builds a canonical map {:type :message :timestamp :data}
+  2. Calls slingshot throw+ with the map
+  3. Provides a single extension point for cross-cutting concerns
+
+  Anomaly type taxonomy (namespaced keywords):
+  - :llm/rate-limited     {:backend :status :retry-after-ms}
+  - :llm/context-exceeded {:backend :tokens :limit}
+  - :llm/timeout          {:backend :duration-ms}
+  - :llm/unavailable      {:backend :error}
+  - :gate/failed          {:gate :errors}
+  - :gate/skipped         {:gate :reason}
+  - :executor/unavailable {:execution-mode :hint}
+  - :executor/timeout     {:environment-id :duration-ms}
+  - :dashboard/stop       {:reason}
+  - :pipeline/max-phases  {:max-phases :iteration}
+  - :pipeline/empty       {}
+  - :agent/execution-failed {:agent-id :task-id :error}
+  - :agent/validation-failed {:agent-id :errors}
+
+  Convergence with response/make-anomaly:
+  The response component's anomaly codes (:anomalies/fault, :anomalies/unavailable,
+  etc.) map to slingshot :type keywords. throw-anomaly! should accept an optional
+  :anomaly/category that bridges the two systems."
+
+ :spec/intent {:type :feature
+               :scope ["components/anomaly"
+                       "components/llm/src"
+                       "components/agent/src"
+                       "components/workflow/src"
+                       "components/gate/src"
+                       "components/dag-executor/src"
+                       "bases/cli/src"]}
+
+ :spec/constraints
+ ["throw-anomaly! is a function, not a macro"
+  "Canonical map shape: {:type :message :timestamp} + caller data"
+  "Anomaly types are namespaced keywords (component/error-kind)"
+  "Converge with response/make-anomaly anomaly codes"
+  "bb-compatible (slingshot verified)"
+  "PR DAG: anomaly component first, then migrate throw sites per component"
+  "catch Object as universal fallback in try+ blocks"]
+
+ :spec/acceptance-criteria
+ ["components/anomaly exists with throw-anomaly! and anomaly type registry"
+  "Zero ad-hoc (throw (ex-info ...)) in migrated components"
+  "All catch sites use slingshot key-value selectors for known types"
+  "Anomaly type taxonomy documented in anomaly component EDN"
+  "throw-anomaly! accepts :anomaly/category for response chain convergence"
+  "All existing tests pass"
+  "New tests for throw-anomaly! and each anomaly type"]
+
+ :workflow/type :canonical-sdlc}

--- a/work/done/standards-pass.spec.edn
+++ b/work/done/standards-pass.spec.edn
@@ -1,0 +1,239 @@
+;; =============================================================================
+;; Spec: Standards Pass — Apply Always-Apply Rules to Miniforge Codebase
+;; =============================================================================
+;;
+;; Goal: Fix all known violations of the newly-added always-apply standards
+;; across the miniforge codebase. Three independent concerns → three PRs.
+;;
+;; Audit findings (2026-03-29):
+;;   - 20 map-access pattern violations (or (:k m) default) across 12 files
+;;   - 11 localization violations (raw strings) in web-dashboard views
+;;   -  2 code-quality violations in tui-views (nested if-let, long fn)
+;;
+;; PR plan (bottom-up, all independent):
+;;   PR A: Map access pattern  — pure style, no behavior change
+;;   PR B: Localization        — web-dashboard views + en-US.edn keys
+;;   PR C: Code quality        — tui-views nested conditional + long fn
+;;
+;; All three PRs can be reviewed and merged independently.
+
+{:spec/title "Standards pass: map access, localization, code quality"
+ :spec/description
+ "Fix all audit-identified violations of the always-apply engineering standards.
+  Three independent PRs: map access pattern, localization, code quality."
+
+ :spec/intent {:type  :refactor
+               :scope ["components/repo-index/src"
+                       "components/loop/src"
+                       "components/tui-engine/src"
+                       "components/llm/src"
+                       "components/agent/src"
+                       "components/dag-executor/src"
+                       "components/web-dashboard/src"
+                       "components/knowledge/src"
+                       "components/tui-views/src"]}
+
+ :spec/constraints
+ ["No behavior changes — all fixes are mechanical style corrections"
+  "Each PR must pass bb pre-commit (lint + tests) before opening"
+  "Do not change any test files in PR A or B — test files are not the target here"
+  "Do not introduce new raw strings while fixing existing ones"]
+
+ :spec/workflow-type :canonical-sdlc
+ :workflow/version "2.0.0"
+
+ :tasks
+
+ ;; ── Task A ──────────────────────────────────────────────────────────────────
+ [{:task/id    :map-access-pattern
+   :task/title "PR A: Replace (or (:k m) default) with (get m :k default)"
+   :task/phase :implement
+   :task/description
+   "Fix all 20 map-access pattern violations identified in the audit.
+    Rule: (get m k default) over (or (:key m) default).
+    Exception: dual-key coalesces like (or (:a m) (:b m)) are acceptable — leave them.
+
+    Files and specific fixes:
+
+    components/repo-index/src/ai/miniforge/repo_index/interface.clj
+      Line ~163: (or (:max-lines opts) 500) → (get opts :max-lines 500)
+
+    components/repo-index/src/ai/miniforge/repo_index/repo_map.clj
+      Line ~171: (or (:token-budget opts) default-token-budget) → (get opts :token-budget default-token-budget)
+
+    components/loop/src/ai/miniforge/loop/outer.clj
+      Line ~299: (or (:output result) result) → (get result :output result)
+
+    components/loop/src/ai/miniforge/loop/repair.clj
+      Line ~82: (or (:errors result) errors) → (get result :errors errors)
+
+    components/tui-engine/src/ai/miniforge/tui_engine/widget/tree.clj
+      Line ~36: (or (:fg node) fg) → (get node :fg fg)
+
+    components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+      Line ~38: (or (:input-tokens usage) 0) → (get usage :input-tokens 0)
+               (or (:output-tokens usage) 0) → (get usage :output-tokens 0)
+
+    components/agent/src/ai/miniforge/agent/tester.clj
+      Line ~287: (or (:code input) input) → (get input :code input)
+
+    components/agent/src/ai/miniforge/agent/reviewer.clj
+      Line ~488: (or (:gates opts) default-gates) → (get opts :gates default-gates)
+
+    components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+      Line ~489: (or (:image config) default-image) → (get config :image default-image)
+
+    components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/kubernetes.clj
+      Line ~359: (or (:namespace config) default-namespace) → (get config :namespace default-namespace)
+      Line ~360: (or (:image config) default-image) → (get config :image default-image)
+
+    components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+      Line ~223: (or (:workdir opts) worktree-path) → (get opts :workdir worktree-path)
+      Line ~261: (or (:base-path config) default-base-path) → (get config :base-path default-base-path)
+      Line ~262: (or (:max-concurrent config) default-max-concurrent) → (get config :max-concurrent default-max-concurrent)
+
+    components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
+      Line ~175: (or (:image config) default-image) → (get config :image default-image)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/server/control_plane.clj
+      Line ~87: (or (:heartbeat_interval_ms body) 30000) → (get body :heartbeat_interval_ms 30000)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/server/auth.clj
+      Line ~50: (or (:username entry) username) → (get entry :username username)
+      Line ~54: (or (:display-name entry) uname) → (get entry :display-name uname)
+
+    components/knowledge/src/ai/miniforge/knowledge/learning.clj
+      Line ~60: (or (:confidence learning) 0.7) → (get learning :confidence 0.7)
+
+    components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+      Line ~179: (or (:name spec) name) → (get spec :name name)
+
+    Acceptance:
+    - All 20 (or (:k m) literal-default) forms replaced
+    - bb pre-commit passes
+    - Open PR with title 'fix: replace (or (:k m) default) with (get m :k default)'"
+
+   :task/constraints
+   ["Read each file before editing — do not guess line numbers"
+    "Do not change (or (:a m) (:b m)) dual-key coalesces — they are not violations"
+    "Do not change (or (get m :k) fallback) forms — those are fine"]}
+
+  ;; ── Task B ──────────────────────────────────────────────────────────────────
+  {:task/id    :localization
+   :task/title "PR B: Replace raw string literals in web-dashboard views"
+   :task/phase :implement
+   :task/description
+   "Fix 11 localization violations in web-dashboard view files.
+    Rule: no raw string literals in view/template namespaces — use (msg/t :key).
+
+    Step 1: Add missing keys to en-US.edn
+    File: components/web-dashboard/resources/config/web-dashboard/messages/en-US.edn
+
+    Add under :web-dashboard/messages:
+      ;; shared UI actions
+      :action/filter              'Filter'
+      :action/delete              'Delete'
+      :action/close               'Close'
+      :action/done                'Done'
+
+      ;; generic status/error labels
+      :status/error               'Error'
+      :status/failed-label        'Failed'
+
+      ;; table headers
+      :table/status-header        'Status'
+
+    Step 2: Replace raw strings in view files
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/views/workflows.clj
+      'Filter'  → (msg/t :action/filter)
+      'Error'   → (msg/t :status/error)   (if present — verify context first)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/views/archived.clj
+      'Failed'  → (msg/t :status/failed-label)
+      'Delete'  → (msg/t :action/delete)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/views/fleet.clj
+      'Status'  → (msg/t :table/status-header)
+      'Filter'  → (msg/t :action/filter)
+      'Error'   → (msg/t :status/error)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/views/dag.clj
+      'Close'   → (msg/t :action/close)
+      'Done'    → (msg/t :action/done)
+      'Filter'  → (msg/t :action/filter)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/views/evidence.clj
+      'Filter'  → (msg/t :action/filter)
+
+    Each view file already requires [ai.miniforge.web-dashboard.messages :as msg] —
+    verify the require is present before using msg/t. If absent, add it.
+
+    Acceptance:
+    - grep for string literals in views/ files returns only code strings (CSS classes,
+      hiccup attribute values like 'innerHTML', script strings) — no user-visible copy
+    - bb pre-commit passes
+    - Open PR with title 'fix: localize raw string literals in web-dashboard views'"
+
+   :task/constraints
+   ["Read each view file before editing to verify the exact string and context"
+    "Do not localize CSS class names, hx-* attribute values, or JavaScript strings"
+    "Add all new keys to en-US.edn in the same commit as the view changes"]}
+
+  ;; ── Task C ──────────────────────────────────────────────────────────────────
+  {:task/id    :code-quality
+   :task/title "PR C: Fix nested conditional and long function in tui-views"
+   :task/phase :implement
+   :task/description
+   "Fix 2 code-quality violations in tui-views.
+
+    File: components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
+
+    Fix 1 — Nested if-let (~line 299):
+    Replace nested (if-let [started ...] (if-let [wf-date ...] ...)) with a flat
+    cond or some-> chain. The goal is at most one level of conditional nesting.
+
+    Suggested refactor:
+      (defn- workflow-started-date [wf]
+        (some-> wf :started event-ts ->instant))
+
+      ;; Then flatten:
+      (let [started-date (workflow-started-date wf)]
+        (cond
+          (nil? started-date) fallback-value
+          ... => result))
+
+    Fix 2 — Long function derive-recommendation (~line 474, ~73 lines):
+    Extract the large cond branches into named private helper functions.
+    Each branch should become a call to a descriptively-named fn.
+
+    Example approach:
+      (defn- stale-recommendation [wf] ...)
+      (defn- failing-ci-recommendation [wf] ...)
+      (defn- blocked-recommendation [wf] ...)
+
+      (defn derive-recommendation [wf]
+        (cond
+          (stale? wf)      (stale-recommendation wf)
+          (ci-failing? wf) (failing-ci-recommendation wf)
+          (blocked? wf)    (blocked-recommendation wf)
+          :else            default-recommendation))
+
+    Read the file first to understand the actual structure before refactoring.
+
+    Acceptance:
+    - No nested conditionals deeper than one level in the refactored code
+    - derive-recommendation body is < 20 lines (delegates to named fns)
+    - All extracted fns are at Layer 0 (pure helpers)
+    - bb pre-commit passes
+    - Open PR with title 'refactor: flatten nested conditional and extract pipeline stages in tui-views'"
+
+   :task/constraints
+   ["Read the full file before editing — do not guess at structure"
+    "Do not change the public API of any functions"
+    "Preserve all existing behavior exactly"]}]
+
+ :dependencies
+ {:map-access-pattern []
+  :localization       []
+  :code-quality       []}}

--- a/work/polylith-compliance-remediation.spec.edn
+++ b/work/polylith-compliance-remediation.spec.edn
@@ -1,0 +1,76 @@
+;; =============================================================================
+;; Spec: Polylith Compliance Remediation
+;; =============================================================================
+;;
+;; `poly check` reports 41 errors. Components bypass interfaces, circular
+;; dependencies exist, project deps are incomplete. Must fix.
+;;
+;; Fix groups in dependency order:
+;;
+;; GROUP 1: Break circular dependency (Error 104)
+;;   gate > cli > workflow > gate
+;;
+;; GROUP 2: Fix 31 interface bypass violations (Error 101)
+;;   Components reaching into internal namespaces instead of .interface
+;;
+;; GROUP 3: Fix missing interface definitions (Error 103)
+;;   phase-deployment and phase-software-factory
+;;
+;; GROUP 4: Fix multi-implementation interfaces (Error 106/108)
+;;   data-foundry and phase multi-impl need profiles
+;;
+;; GROUP 5: Fix project completeness (Error 107, 112)
+;;
+;; GROUP 6: Clean up warnings (202, 207)
+
+{:spec/title "Polylith compliance remediation — fix all poly check errors"
+
+ :spec/description
+ "Fix all 41 errors from `poly check`. Every component must depend only on
+  interfaces, circular dependencies must be broken, and project configs must
+  be complete.
+
+  GROUP 1: Break circular dependency (Error 104)
+  gate > cli > workflow > gate. Use requiring-resolve or extract shared
+  concern to break the cycle.
+
+  GROUP 2: Fix interface bypass violations (Error 101 — 31 sites)
+  For each: change require to .interface, add pass-through if missing.
+  Key components: workflow (5), gate (3), control-plane cluster (4),
+  phase-software-factory (2), semantic-analyzer (2), remaining singles.
+
+  GROUP 3: Fix missing interface definitions (Error 103 — 2 sites)
+  phase-deployment and phase-software-factory missing many phase interface fns.
+
+  GROUP 4: Fix multi-impl interfaces (Error 106/108 — 7 sites)
+  data-foundry and phase need Polylith profiles.
+
+  GROUP 5: Fix project completeness (Error 107, 112 — 4 sites)
+  Add missing components to project deps.edn. Fix mcp-context-server
+  base direct brick dependency.
+
+  GROUP 6: Clean up warnings (202, 207)
+  Missing resource paths, unnecessary components in projects."
+
+ :spec/intent {:type :refactor
+               :scope ["components/*/src"
+                       "components/*/deps.edn"
+                       "bases/*/deps.edn"
+                       "projects/*/deps.edn"
+                       "workspace.edn"]}
+
+ :spec/constraints
+ ["Do not change component behavior — only dependency wiring"
+  "Interface pass-throughs must preserve existing function signatures"
+  "Run poly check after each group to verify progress"
+  "Run bb test after each group to verify no regressions"
+  "Each group should be a separate commit for reviewability"]
+
+ :spec/acceptance-criteria
+ ["poly check reports 0 errors"
+  "No circular dependencies in the component graph"
+  "All cross-component requires use .interface namespaces"
+  "All existing tests pass"
+  "Project deps.edn files are complete per poly check"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/storage-root-configuration.spec.edn
+++ b/work/storage-root-configuration.spec.edn
@@ -1,0 +1,56 @@
+{:spec/title "Configurable storage root — MINIFORGE_HOME for all state directories"
+
+ :spec/description
+ "All miniforge state (events, artifacts, cache, config, packs, tools, themes,
+  logs, decisions, workaround approvals) is hardcoded to ~/.miniforge/<subdir>
+  across ~20 call sites in 15+ components. This causes:
+
+  1. Tests that touch real user state (cleanup-stale-events! with {:ttl-ms 0}
+     deleted all event files, destroying resume checkpoints — PR #516 patch)
+  2. No way to run multiple miniforge instances with isolated state
+  3. No CI-friendly configuration (everything goes to ~/.miniforge)
+
+  Solution: a storage component (protocol + filesystem impl) that resolves
+  paths from a configurable root. Pattern from storage-proxy: protocol-based
+  with config-driven selection.
+
+  Protocol: StoragePaths — named path accessors (events-dir, artifacts-dir, etc.)
+  Impl: FilesystemStorage record backed by root dir
+  Root resolution: MINIFORGE_HOME env > config file > ~/.miniforge default
+  Test support: create-storage {:root temp-dir} for full isolation
+
+  All ~20 hardcoded (System/getProperty \"user.home\") \".miniforge\" sites
+  migrate to use the storage component's interface."
+
+ :spec/intent {:type :refactor
+               :scope ["components/storage"
+                       "components/event-stream/src"
+                       "components/artifact/src"
+                       "components/tool-registry/src"
+                       "components/self-healing/src"
+                       "components/tui-engine/src"
+                       "components/pr-lifecycle/src"
+                       "components/pr-sync/src"
+                       "components/web-dashboard/src"
+                       "components/workflow/src"
+                       "components/phase/src"
+                       "components/adapter-claude-code/src"
+                       "bases/cli/src"]}
+
+ :spec/constraints
+ ["Protocol + impl in components/storage (Polylith pattern)"
+  "Root resolution: MINIFORGE_HOME env > config > ~/.miniforge"
+  "Tests create isolated storage via {:root temp-dir}"
+  "Backward compatible — existing ~/.miniforge layout preserved"
+  "No functional changes — pure path resolution refactor"
+  "PR DAG — storage component first, then migrate callers in batches"]
+
+ :spec/acceptance-criteria
+ ["components/storage exists with protocol and filesystem impl"
+  "MINIFORGE_HOME env var overrides default root"
+  "Zero hardcoded ~/.miniforge paths remain in src/ (grep verification)"
+  "All existing tests pass"
+  "New tests verify path resolution, env override, and test isolation"
+  "bb test does not modify ~/.miniforge (full test isolation)"]
+
+ :workflow/type :canonical-sdlc}


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# Recover compliance refactor and green changed-brick tests

**Branch:** `codex/recover-compliance-refactor-tests`
**Base Branch:** `main`
**Recovered From:** `worktree-agent-ac127be3`
**Depends On:** none

## Overview

Recover the in-progress Claude work around the mixed security compliance
pipeline, related Polylith cleanup, and storage/test isolation work, then bring
 the changed-brick suite back to green so the branch can be reviewed as a PR.

## Motivation

The worktree contained a large staged and unstaged refactor spanning new
compliance components, workflow additions, interface cleanup, and execution
environment handling. Before it could be reviewed or merged, the branch needed:

- a durable commit instead of temporary worktree state
- the changed-brick test runner stabilized for linked-worktree git envs
- stale and broken tests repaired so `bb test` and the pre-commit hook pass

## Changes In Detail

### New Compliance Pipeline

- add `connector-sarif` for SARIF v2.1.0 and CSV ingestion
- add `gate-classification` for deterministic violation categorization
- add `workflow-security-compliance` with parse, trace, verify-docs,
  classify, and exclusion-generation phases
- add fixtures, e2e coverage, and a demo workflow entrypoint

### Polylith And Interface Cleanup

- continue interface pass-through remediation across workflow, phase,
  control-plane, llm, repo-index, policy-pack, dag-executor, and related
  components
- continue phase/result movement and wiring needed for the broader
  Polylith compliance cleanup
- capture the associated recovery and remediation specs under `work/`

### Test And Runtime Fixes

- isolate Codex/Cursor MCP config writes to per-session roots so parallel tests
  do not fight over repo-local config files
- clean nested `mcp_servers.artifact.*` Codex config tables during session
  cleanup so newer Codex TOML layouts do not retain invalid orphaned sections
- preserve `:rule/severity` in connector-linter ETL output
- align verify and implement tests with the current default gate sets
- rewrite `phase.release-test` worktree setup so lint and parallel execution are
  stable
- group `workflow`, `phase`, `agent`, and `phase-software-factory` in one
  sequential changed-brick affinity bucket to avoid shared `with-redefs`
  collisions
- prevent `GIT_DIR` / `GIT_WORK_TREE` leakage into the test JVM so git commands
  inside temp repos resolve correctly
- restore planner behavior when no LLM backend is provided
- resolve workflow-security-compliance fixture paths from the classpath and
  improve stub trace API extraction so doc verification/classification tests
  reflect the intended sample data

## Testing Plan

- run `bb test`
- run pre-commit hook checks during `git commit`
- verify targeted namespaces while fixing regressions:
  - `ai.miniforge.phase.release-test`
  - `ai.miniforge.phase.verify-test`
  - `ai.miniforge.phase.artifact-persistence-test`
  - `ai.miniforge.workflow-security-compliance.phases-test`
  - `ai.miniforge.workflow-security-compliance.e2e-test`
  - `ai.miniforge.agent.planner-test`

## Deployment Plan

No deployment-specific rollout is required. This is codebase, workflow, and
test infrastructure work. Merge behind normal review once the PR is accepted.

## Related Issues/PRs

- `PR-552.md`
- `work/polylith-compliance-remediation.spec.edn`
- `work/storage-root-configuration.spec.edn`

## Test Results

- `bb test` passed: `2386 tests, 13178 passes, 0 failures, 0 errors`
- pre-commit hook passed during commit, including:
  - staged Clojure lint
  - changed-brick tests
  - GraalVM/Babashka compatibility tests

## Checklist

- [x] Recover the in-progress work into a durable commit
- [x] Fix changed-brick test failures
- [x] Add PR documentation to the repo
- [ ] Push branch
- [ ] Open PR
