### PR TITLE
feat(cli): add worktree resolution for nested checkout safety

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -10,6 +10,10 @@
    "    --worktree <path> Custom worktree path"
    "    --resume <id>     Resume a workflow from its last checkpoint"
    ""
+   "  worktree <subcommand>  Resolve or run inside the active git worktree"
+   "    path              Print the resolved git worktree root"
+   "    run -- <cmd...>   Run a command inside that worktree root"
+   ""
    "  scan [repo-path]    Run compliance scanner against a repository"
    "    -p, --pack <name> Policy pack to use (e.g., foundations-1.0.0)"
    "    -r, --rules <sel> Rule selector: all, always-apply, or rule ID"
@@ -209,6 +213,11 @@
   :run/unrecognized-format "Unrecognized file format in: {path}\nExpected :spec/title (spec), :dag-id (DAG), or :plan/id (plan)"
   :run/failed "Failed to run workflow: {error}"
   :run/error-details "  Details: {details}"
+
+  ;; ── Worktree ──────────────────────────────────────────────────────────
+  :worktree/root-not-found "No git worktree found from: {path}"
+  :worktree/usage "Usage: {command}"
+  :worktree/run-usage "Usage: {command}"
 
   ;; ── Recommender ───────────────────────────────────────────────────────
   :recommender/parse-warning "Warning: Failed to parse LLM response: {error}"

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -54,6 +54,7 @@
    [ai.miniforge.cli.main.commands.control-plane :as cmd-cp]
    [ai.miniforge.cli.main.commands.scan :as cmd-scan]
    [ai.miniforge.cli.main.commands.init :as cmd-init]
+   [ai.miniforge.cli.main.commands.worktree :as cmd-worktree]
    ;; N5 command modules
    [ai.miniforge.cli.main.commands.workflow-commands :as cmd-workflow]
    [ai.miniforge.cli.main.commands.policy :as cmd-policy]
@@ -212,6 +213,7 @@
 (defn run-cmd [m] (cmd-run/run-cmd (get-opts m)))
 (defn scan-cmd [m] (cmd-scan/scan-cmd (get-opts m)))
 (defn init-cmd [m] (cmd-init/init-cmd (get-opts m)))
+(defn worktree-cmd [m] (cmd-worktree/worktree-cmd m))
 (defn web-cmd [m] (cmd-monitoring/web-cmd (get-opts m)))
 (defn tui-cmd [m] (cmd-monitoring/tui-cmd (get-opts m)))
 (defn fleet-start-cmd [m] (cmd-fleet/fleet-start-cmd (get-opts m)))
@@ -343,6 +345,11 @@
    {:cmds ["init"]
     :fn init-cmd
     :args->opts [:repo]}
+
+   ;; Worktree helpers
+   {:cmds ["worktree"]
+    :fn worktree-cmd
+    :spec {:path {:alias :p}}}
 
    ;; Scan command — compliance scanner
    {:cmds ["scan"]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/worktree.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/worktree.clj
@@ -1,0 +1,100 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.main.commands.worktree
+  "User-facing helpers for resolving and executing inside the correct worktree."
+  (:require
+   [babashka.process :as process]
+   [ai.miniforge.cli.app-config :as app-config]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.worktree :as worktree]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pure helpers
+
+(defn command-args
+  [m]
+  (vec (get m :args [])))
+
+(defn command-target
+  [opts]
+  (get opts :path (System/getProperty "user.dir")))
+
+(defn resolve-root
+  [opts]
+  (worktree/worktree-root (command-target opts)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Execution
+
+(defn path-cmd
+  [opts]
+  (let [root (resolve-root opts)
+        target (command-target opts)]
+    (if root
+      (println root)
+      (do
+        (display/print-error
+         (messages/t :worktree/root-not-found {:path target}))
+        (System/exit 1)))))
+
+(defn run-cmd
+  [opts args]
+  (let [root (resolve-root opts)
+        target (command-target opts)
+        normalized-args (->> args
+                             (remove #{"--"})
+                             vec)]
+    (cond
+      (nil? root)
+      (do
+        (display/print-error
+         (messages/t :worktree/root-not-found {:path target}))
+        (System/exit 1))
+
+      (empty? normalized-args)
+      (do
+        (display/print-error
+         (messages/t :worktree/run-usage
+                     {:command (app-config/command-string "worktree run -- <cmd> [args...]")}))
+        (System/exit 1))
+
+      :else
+      (let [[cmd & cmd-args] normalized-args
+            proc (apply process/process
+                        {:out :inherit :err :inherit :dir root}
+                        cmd
+                        cmd-args)
+            exit (get @proc :exit 1)]
+        (System/exit exit)))))
+
+(defn worktree-cmd
+  [m]
+  (let [opts (if (contains? m :opts) (:opts m) m)
+        args (command-args m)
+        subcommand (first args)
+        remaining (vec (rest args))]
+    (case subcommand
+      "path" (path-cmd opts)
+      "run" (run-cmd opts remaining)
+      (do
+        (display/print-error
+         (messages/t :worktree/usage
+                     {:command (app-config/command-string "worktree <path|run> [options]")}))
+        (System/exit 1)))))

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/context.clj
@@ -25,6 +25,7 @@
    [babashka.process :as p]
    [cheshire.core :as json]
    [ai.miniforge.cli.config :as config]
+   [ai.miniforge.cli.worktree :as worktree]
    [ai.miniforge.cli.workflow-runner.display :as display]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.response.interface :as response]))
@@ -65,14 +66,19 @@
 
 (defn get-git-info []
   (try
-    (let [branch-result (p/shell {:out :string :err :string :continue true}
-                                 "git" "rev-parse" "--abbrev-ref" "HEAD")
-          commit-result (p/shell {:out :string :err :string :continue true}
-                                 "git" "rev-parse" "--short" "HEAD")]
-      (when (and (zero? (:exit branch-result))
-                 (zero? (:exit commit-result)))
-        {:git-branch (str/trim (:out branch-result))
-         :git-commit (str/trim (:out commit-result))}))
+    (when-let [root (worktree/worktree-root)]
+      (let [branch-result (p/shell {:out :string :err :string :continue true :dir root}
+                                   "git" "rev-parse" "--abbrev-ref" "HEAD")
+            commit-result (p/shell {:out :string :err :string :continue true :dir root}
+                                   "git" "rev-parse" "--short" "HEAD")
+            branch (some-> branch-result :out str/trim not-empty)
+            commit (some-> commit-result :out str/trim not-empty)
+            branch-exit (get branch-result :exit 1)
+            commit-exit (get commit-result :exit 1)]
+        (when (and (zero? branch-exit)
+                   (zero? commit-exit))
+          {:git-branch branch
+           :git-commit commit})))
     (catch Exception _ nil)))
 
 (defn get-files-in-scope
@@ -118,11 +124,12 @@
 ;; Context decoration
 
 (defn decorate-spec-with-runtime-context [spec {:keys [iteration parent-task-id] :or {iteration 1}}]
-  (let [git-info (get-git-info)
+  (let [cwd (or (worktree/worktree-root) (str (fs/cwd)))
+        git-info (get-git-info)
         files-in-scope (get-files-in-scope (:spec/intent spec))]
     (assoc spec
            :spec/context
-           (cond-> {:cwd (str (fs/cwd))
+           (cond-> {:cwd cwd
                     :files-in-scope files-in-scope
                     :environment :development}
              git-info (merge git-info))
@@ -171,4 +178,5 @@
       control-state (assoc :control-state control-state)
       skip-lifecycle-events (assoc :skip-lifecycle-events true)
       execution-opts (assoc :execution/opts execution-opts)
-      true (assoc :worktree-path (System/getProperty "user.dir")))))
+      true (assoc :worktree-path (or (worktree/worktree-root)
+                                     (System/getProperty "user.dir"))))))

--- a/bases/cli/src/ai/miniforge/cli/worktree.clj
+++ b/bases/cli/src/ai/miniforge/cli/worktree.clj
@@ -1,0 +1,103 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.worktree
+  "Resolve the nearest checkout root, preferring the nearest .git marker.
+
+   This makes nested linked worktrees safe: if an agent is launched inside a
+   child worktree under a larger repository, we bind tooling to the child
+   checkout instead of accidentally drifting up to the parent repo."
+  (:require
+   [babashka.fs :as fs]
+   [babashka.process :as process]
+   [clojure.string :as str]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Path resolution
+
+(def ^:private git-marker-name
+  ".git")
+
+(defn- file->dir
+  [path]
+  (let [file (fs/file path)]
+    (if (fs/directory? file)
+      file
+      (fs/parent file))))
+
+(defn- canonical-dir
+  [path]
+  (some-> path file->dir fs/canonicalize str))
+
+(defn- git-marker-path
+  [dir]
+  (fs/path dir git-marker-name))
+
+(defn nearest-git-root
+  "Walk upward from start-path and return the nearest directory containing
+   a .git file or directory. Returns nil when no checkout is found."
+  ([] (nearest-git-root (System/getProperty "user.dir")))
+  ([start-path]
+   (loop [dir (canonical-dir start-path)]
+     (when dir
+       (let [git-path (git-marker-path dir)
+             parent (some-> dir fs/parent str)]
+         (cond
+           (fs/exists? git-path) dir
+           (or (nil? parent) (= dir parent)) nil
+           :else (recur parent)))))))
+
+(defn worktree-root
+  "Return the canonical checkout root for start-path.
+
+   Prefers the nearest .git marker. Falls back to git rev-parse only when
+   directory walking does not find a marker."
+  ([] (worktree-root (System/getProperty "user.dir")))
+  ([start-path]
+   (or (nearest-git-root start-path)
+       (let [dir (or (canonical-dir start-path)
+                     (System/getProperty "user.dir"))
+             result (process/shell {:out :string :err :string :continue true :dir dir}
+                                   "git" "rev-parse" "--show-toplevel")
+             exit (get result :exit 1)]
+         (when (zero? exit)
+           (some-> result :out str/trim not-empty))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Git metadata
+
+(defn git-info
+  "Return basic git metadata for the resolved worktree root.
+
+   Returns nil when start-path is not inside a git checkout."
+  ([] (git-info (System/getProperty "user.dir")))
+  ([start-path]
+   (when-let [root (worktree-root start-path)]
+     (let [branch-result (process/shell {:out :string :err :string :continue true :dir root}
+                                        "git" "rev-parse" "--abbrev-ref" "HEAD")
+           commit-result (process/shell {:out :string :err :string :continue true :dir root}
+                                        "git" "rev-parse" "--short" "HEAD")
+           git-dir-result (process/shell {:out :string :err :string :continue true :dir root}
+                                         "git" "rev-parse" "--absolute-git-dir")
+           branch (some-> branch-result :out str/trim not-empty)
+           commit (some-> commit-result :out str/trim not-empty)
+           git-dir (some-> git-dir-result :out str/trim not-empty)]
+       {:worktree-path root
+        :git-branch branch
+        :git-commit commit
+        :git-dir git-dir}))))

--- a/bases/cli/test/ai/miniforge/cli/worktree_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/worktree_test.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.worktree-test
+  (:require
+   [babashka.fs :as fs]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.cli.worktree :as sut]))
+
+(defn- delete-tree!
+  [path]
+  (when (fs/exists? path)
+    (doseq [entry (reverse (file-seq (fs/file path)))]
+      (fs/delete entry))))
+
+(deftest worktree-root-prefers-nearest-git-marker-test
+  (let [tmp (fs/create-temp-dir {:prefix "miniforge-worktree-root-"})
+        repo-root (fs/path tmp "repo")
+        nested-worktree (fs/path repo-root ".claude" "worktrees" "agent-123")
+        nested-src (fs/path nested-worktree "components" "sample")]
+    (try
+      (fs/create-dirs repo-root)
+      (fs/create-dirs nested-src)
+      (spit (str (fs/path repo-root ".git")) "gitdir: /tmp/repo.git\n")
+      (spit (str (fs/path nested-worktree ".git")) "gitdir: /tmp/worktree.git\n")
+      (is (= (str (fs/canonicalize nested-worktree))
+             (sut/worktree-root (str nested-src))))
+      (finally
+        (delete-tree! tmp)))))
+
+(deftest worktree-root-finds-parent-repo-when-no-child-marker-test
+  (let [tmp (fs/create-temp-dir {:prefix "miniforge-worktree-parent-"})
+        repo-root (fs/path tmp "repo")
+        nested-src (fs/path repo-root "components" "sample")]
+    (try
+      (fs/create-dirs repo-root)
+      (fs/create-dirs nested-src)
+      (spit (str (fs/path repo-root ".git")) "gitdir: /tmp/repo.git\n")
+      (is (= (str (fs/canonicalize repo-root))
+             (sut/worktree-root (str nested-src))))
+      (finally
+        (delete-tree! tmp)))))


### PR DESCRIPTION
## Summary

- **New `ai.miniforge.cli.worktree` namespace** — `nearest-git-root` walks upward to find the nearest `.git` marker; `worktree-root` resolves the correct checkout for any path. Prevents agents in nested worktrees from drifting to the parent repo.
- **New `mf worktree path|run` commands** — `path` prints the resolved root; `run -- <cmd>` executes inside it.
- **Fixed `workflow_runner/context.clj`** — `get-git-info` now uses `worktree-root` and passes `:dir` to all git commands.

This is the root cause fix for the `core.worktree` confusion that required manual unset after agent sessions.

## Test plan

- [x] 2 unit tests for worktree root resolution (nested marker, parent fallback)
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)