### PR TITLE
fix(compiler): alwaysApply rules → :major/:warn + spec housekeeping

### DIFF
--- a/work/artifact-extraction-agent.spec.edn
+++ b/work/artifact-extraction-agent.spec.edn
@@ -1,0 +1,127 @@
+;; =============================================================================
+;; Spec: Deterministic Artifact Extraction from Container/Worktree
+;; =============================================================================
+;;
+;; Problem:
+;;
+;;   The implement phase depends on the LLM calling a save-artifact MCP tool
+;;   to emit structured code artifacts. The LLM frequently fails to call the
+;;   tool, causing the implement phase to fail after ~11 minutes of code
+;;   generation. The code IS written to the container/worktree filesystem,
+;;   but the artifact session can't find it because the MCP tool was never
+;;   invoked. The file-artifact fallback exists but unreliably detects files
+;;   across worktree boundaries.
+;;
+;;   This is the #1 blocker for reliable autonomous pipeline execution,
+;;   documented in project_dogfood_findings_2026_03_25.md.
+;;
+;; Insight:
+;;
+;;   The container/worktree IS the artifact. The implementer agent's job is
+;;   pure code generation — write files, run tests, iterate. When it exits,
+;;   the filesystem delta is the deliverable. Artifact extraction should be
+;;   deterministic, not dependent on LLM tool-calling behavior.
+;;
+;; Solution:
+;;
+;;   Replace the MCP-dependent artifact capture with a post-implementation
+;;   extraction step:
+;;
+;;   1. Implementer agent writes code in container/worktree → exits
+;;   2. Extraction function diffs container against base (git diff)
+;;   3. Changed/added files are collected into a structured artifact
+;;   4. Artifact conforms to the existing artifact schema
+;;   5. Next phase receives the artifact through the normal handoff
+;;
+;;   The extraction step is deterministic — no LLM, no MCP, just filesystem
+;;   inspection. It replaces the fragile save-artifact path with a reliable
+;;   git-diff-based one.
+;;
+;; Relationship to specs:
+;;
+;;   - N11 (Task Capsule Isolation) — N11.CP.5 requires artifact export before
+;;     capsule destruction. This makes export deterministic.
+;;   - N2 (Workflows) — phase-to-phase handoff contract unchanged; inner
+;;     mechanism changes.
+;;   - capsule-artifact-export.spec.edn — the "how" of export changes from
+;;     MCP-tool-dependent to git-diff-deterministic.
+
+{:spec/title "Deterministic artifact extraction from container/worktree"
+
+ :spec/description
+ "Replace the MCP-dependent artifact capture in the implement phase with a
+  deterministic post-implementation extraction step. The container/worktree
+  filesystem delta IS the artifact.
+
+  CURRENT FLOW (fragile):
+    Implementer agent → (should call save-artifact MCP tool) → artifact session
+    Problem: LLM frequently doesn't call the tool → phase fails
+
+  NEW FLOW (deterministic):
+    Implementer agent → writes code in worktree → exits
+                                    │
+    extract-artifact (deterministic) │
+      1. git diff --name-status against base commit
+      2. Collect all changed/added files with content
+      3. Build structured artifact map conforming to existing schema
+      4. Return artifact to phase pipeline
+                                    │
+    Next phase receives artifact normally
+
+  IMPLEMENTATION:
+
+  1. Extract function (components/agent/src/.../artifact_extraction.clj):
+     - extract-worktree-artifact [worktree-path base-ref]
+       Returns {:code/files [{:path ... :content ... :status :added|:modified}]
+                :code/summary {:files-changed N :additions N :deletions N}}
+     - Uses git diff --name-status + file reads (no LLM, no MCP)
+     - Respects .gitignore (no build artifacts, node_modules, etc.)
+     - Filters by known source extensions (configurable)
+
+  2. Phase interceptor change (implement phase leave handler):
+     - After implementer agent exits, invoke extract-worktree-artifact
+     - If extraction finds changes → build artifact → proceed to verify
+     - If extraction finds NO changes → mark phase failed (no output)
+     - Remove dependency on MCP artifact file existence
+
+  3. Fallback removal:
+     - Remove file-artifact-fallback logic from artifact_session.clj
+     - Remove the ERROR log about 'artifact file not found -- MCP tool was
+       likely not called by the LLM'
+     - The MCP save-artifact tool can remain available but is no longer
+       required for phase success
+
+  4. Retry improvement:
+     - Currently retries re-run the full implement phase (~11 min each)
+     - With extraction, the artifact is always captured if code was written
+     - Retries only needed when NO code was written (actual failure)"
+
+ :spec/intent {:type :refactor
+               :scope ["components/agent/src"
+                       "components/phase/src"
+                       "components/workflow/src"]}
+
+ :spec/constraints
+ ["Extraction must be deterministic — no LLM calls, no MCP dependency"
+  "Output artifact must conform to existing artifact schema"
+  "Must handle both worktree and Docker container filesystems"
+  "Must respect .gitignore and configurable extension filters"
+  "Must not break existing phase-to-phase handoff contract"
+  "MCP save-artifact tool may remain available as optional enhancement"
+  "Extraction must complete in under 10 seconds for typical code changes"
+  "Must handle binary files gracefully (skip content, include path)"]
+
+ :spec/acceptance-criteria
+ ["extract-worktree-artifact produces a valid artifact from a worktree with changes"
+  "extract-worktree-artifact returns empty artifact (not nil) when no changes exist"
+  "Implement phase succeeds when LLM writes code but does NOT call save-artifact"
+  "Implement phase fails cleanly when LLM writes NO code (actual failure)"
+  "Artifact schema is identical whether produced by extraction or MCP tool"
+  "Extraction completes in under 10 seconds for 50-file changesets"
+  "Binary files are listed in artifact but content is not included"
+  ".gitignore patterns are respected (no node_modules, build outputs)"
+  "git diff against base ref correctly identifies added, modified, and deleted files"
+  "Existing tests continue to pass"
+  "End-to-end: bb miniforge run completes implement phase without MCP artifact"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/capsule-artifact-export.spec.edn
+++ b/work/done/capsule-artifact-export.spec.edn
@@ -1,0 +1,42 @@
+{:spec/title "Export declared artifacts before capsule DESTROY"
+
+ :spec/description
+ "Per N11 §4.3 and §9.2, the executor must copy declared artifacts out of the
+  capsule before destroying it. Currently capsule cleanup (release-execution-
+  environment!) destroys the container without an explicit export phase.
+
+  Implementation:
+  1. In runner.clj, before calling release-execution-environment! in the finally
+     block, call a new `export-capsule-artifacts!` function that:
+     - Reads the artifact manifest from the execution context (if any)
+     - For each declared artifact, calls `copy-from!` on the executor to copy
+       it from the capsule to a local staging directory
+     - Verifies all :required? true artifacts were successfully copied
+     - Fails the workflow if a required artifact is missing
+  2. The artifact manifest should be built during the pipeline from phase results.
+     Each phase that produces artifacts (implement, verify, release) appends to
+     :execution/artifact-manifest on the context.
+  3. The copy-from! protocol method already exists on the TaskExecutor protocol.
+     The Docker implementation uses `docker cp`. Use it.
+  4. Store exported artifacts in a temp directory, then merge paths into the
+     workflow output for downstream consumers."
+
+ :spec/intent {:type :feature
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj"]}
+
+ :spec/constraints
+ ["Only applies when :execution/mode is :governed"
+  "Uses existing copy-from! protocol method — no new executor methods"
+  "Must not fail silently — log warnings for optional artifacts, throw for required"
+  "Cleanup must still happen even if export fails (export in try, cleanup in finally)"
+  "Existing tests must pass"]
+
+ :spec/acceptance-criteria
+ ["Declared artifacts are copied from capsule before container removal"
+  "Required artifacts that fail to export cause workflow failure"
+  "Optional artifacts that fail to export log a warning but don't fail"
+  "Local mode skips export (artifacts already on host filesystem)"
+  "Exported artifact paths recorded in :execution/output"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/capsule-cleanup-reliability.spec.edn
+++ b/work/done/capsule-cleanup-reliability.spec.edn
@@ -1,0 +1,30 @@
+{:spec/title "Reliable capsule cleanup on failure"
+
+ :spec/description
+ "Docker containers from governed-mode runs linger after pipeline errors or
+  timeouts. The runner's release-execution-environment! must be called in all
+  exit paths — success, failure, exception, and timeout.
+
+  Currently the runner has a try/finally but the environment release may not
+  cover all DAG sub-workflow capsules. Each capsule created by the DAG
+  orchestrator must also be cleaned up."
+
+ :spec/intent {:type :bugfix
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj"
+                       "components/workflow/src/ai/miniforge/workflow/dag_task_runner.clj"]}
+
+ :spec/constraints
+ ["release-execution-environment! must be called in finally blocks"
+  "DAG sub-workflow capsules must be tracked and cleaned up"
+  "Cleanup must not throw — wrap in try/catch"
+  "Log cleanup actions at debug level"
+  "Do not change the public API of run-pipeline"]
+
+ :spec/acceptance-criteria
+ ["No lingering miniforge-task-* containers after pipeline success"
+  "No lingering containers after pipeline failure"
+  "No lingering containers after pipeline timeout"
+  "docker ps --filter name=miniforge-task returns empty after any run"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/capsule-timeout-enforcement.spec.edn
+++ b/work/done/capsule-timeout-enforcement.spec.edn
@@ -1,0 +1,40 @@
+{:spec/title "Capsule self-terminates on timeout expiry"
+
+ :spec/description
+ "Per N11 §2.2, capsules must be self-terminating on timeout expiry. Currently
+  the timeout is passed to Docker resource config but there is no enforcement
+  mechanism — a runaway container will not be killed.
+
+  Implementation:
+  1. In docker.clj create-container, add --stop-timeout flag to set Docker's
+     built-in stop timeout. This handles ungraceful shutdown.
+  2. In runner.clj, wrap the pipeline execution loop in a future with
+     deref timeout. If the timeout fires:
+     - Log a warning with the workflow-id and elapsed time
+     - Call release-execution-environment! to kill the capsule
+     - Return a :timeout failure result
+  3. The timeout value should come from the workflow config or phase budget:
+     - (:budget :time-seconds) from phase config, or
+     - A global default of 30 minutes for the full pipeline
+  4. For DAG sub-workflows, each task inherits the parent timeout budget
+     divided by task count (floor), with a minimum of 5 minutes."
+
+ :spec/intent {:type :feature
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj"]}
+
+ :spec/constraints
+ ["Only enforce timeout in governed mode — local mode relies on user interrupt"
+  "Timeout must not leave orphan containers"
+  "Use future + deref-with-timeout, not Thread/sleep"
+  "Log elapsed time and timeout value on expiry"
+  "Existing tests must pass"]
+
+ :spec/acceptance-criteria
+ ["Governed pipeline that exceeds timeout returns :timeout failure"
+  "Container is killed when timeout fires"
+  "Timeout value comes from workflow/phase config"
+  "DAG sub-workflows respect timeout budget"
+  "Local mode is unaffected"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/evidence-execution-mode.spec.edn
+++ b/work/done/evidence-execution-mode.spec.edn
@@ -1,0 +1,46 @@
+{:spec/title "Evidence bundle records execution mode and runtime class"
+
+ :spec/description
+ "Per N11 §9.1, each task capsule must produce an evidence record containing
+  :evidence/execution-mode #{:local :governed}. Currently no execution mode
+  is recorded in evidence bundles or workflow output.
+
+  Implementation:
+  1. In the `extract-output` function in runner.clj, add evidence fields to
+     the :execution/output map by reading from the execution context:
+     - :evidence/execution-mode from (:execution/mode ctx) — defaults to :local
+     - :evidence/runtime-class from the executor-type of (:execution/executor ctx)
+       — :docker, :worktree, or nil if no executor
+     - :evidence/task-started-at from (:execution/started-at ctx)
+     - :evidence/task-finished-at — capture current time at extract-output
+  2. In the `create-bundle-impl` function in evidence_bundle.clj (or collector.clj),
+     accept and merge these evidence fields from the workflow result into the
+     evidence bundle map.
+  3. For image-digest (SHOULD per N11 §11): in docker.clj acquire-environment!,
+     after create-container, run `docker inspect <container> --format '{{.Image}}'`
+     to capture the image SHA256. Store it in the environment metadata. Then in
+     extract-output, read it from context and include as :evidence/image-digest."
+
+ :spec/intent {:type :feature
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/evidence-bundle/src/ai/miniforge/evidence_bundle"
+                       "components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj"]}
+
+ :spec/constraints
+ ["Evidence fields added to the workflow :execution/output map, not a new store"
+  ":evidence/execution-mode comes from (:execution/mode ctx), default :local"
+  ":evidence/runtime-class comes from (executor-type (:execution/executor ctx))"
+  ":evidence/image-digest is optional (SHOULD) — only for Docker executor"
+  "Use the governed? predicate from artifact-session when checking mode"
+  "Existing tests must pass"
+  "Do not add fields to context — read from existing keys at extract-output time"]
+
+ :spec/acceptance-criteria
+ [":evidence/execution-mode present in workflow :execution/output when pipeline completes"
+  ":evidence/runtime-class present when executor is available"
+  "Local mode records :local, governed records :governed"
+  ":evidence/task-started-at and :evidence/task-finished-at present in output"
+  "Evidence bundle includes execution-mode and runtime-class when created from workflow result"
+  "Image digest captured and recorded for Docker-based governed runs"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/n05-cli-command-wiring.spec.edn
+++ b/work/done/n05-cli-command-wiring.spec.edn
@@ -1,0 +1,68 @@
+;; =============================================================================
+;; Spec: N5 — CLI Command Wiring Audit and Completion
+;; =============================================================================
+;;
+;; Normative ref: specs/normative/N5-cli-tui-api.md
+;;
+;; Many components exist but lack CLI exposure. N5 specifies a full command
+;; taxonomy (miniforge <ns> <cmd>) that is only partially wired. No work spec
+;; previously existed to close this gap.
+
+{:spec/title "N5: Audit and wire all N5-specified CLI commands to components"
+
+ :spec/description
+ "Audit every CLI command specified in N5 against the actual CLI implementation
+  in bases/cli/. For each missing or partially wired command, connect it to the
+  existing component. Commands to verify/wire:
+
+  Workflow commands:
+  - miniforge workflow execute <spec>
+  - miniforge workflow status <id>
+  - miniforge workflow list
+  - miniforge workflow cancel <id>
+
+  Policy commands:
+  - miniforge policy list
+  - miniforge policy show <pack-id>
+  - miniforge policy install <path>
+
+  Evidence commands:
+  - miniforge evidence show <id>
+  - miniforge evidence export <id> <format>
+  - miniforge evidence list
+
+  Artifact commands:
+  - miniforge artifact provenance <id>
+  - miniforge artifact list
+
+  ETL commands:
+  - miniforge etl repo <url>
+
+  Fleet commands:
+  - miniforge fleet watch (TUI)
+  - miniforge fleet prs
+
+  Produce a wiring report as part of the PR showing: command, status before,
+  status after, component connected."
+
+ :spec/intent {:type :feature
+               :scope ["bases/cli/src"
+                       "components/workflow/src"
+                       "components/policy-pack/src"
+                       "components/evidence-bundle/src"
+                       "components/artifact/src"]}
+
+ :spec/constraints
+ ["Do not change existing working commands — only add missing wiring"
+  "Each command must validate args and print usage on invalid input"
+  "Commands must exit with appropriate exit codes (0 success, 1 error)"
+  "Output format should be human-readable by default, --json flag for machine output"]
+
+ :spec/acceptance-criteria
+ ["All N5-specified commands are callable from the CLI"
+  "miniforge help shows all available commands grouped by namespace"
+  "Each command connects to the correct component interface function"
+  "Invalid command arguments produce helpful error messages"
+  "Wiring report documents before/after status for each command"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/done/release-pr-quality.spec.edn
+++ b/work/done/release-pr-quality.spec.edn
@@ -1,0 +1,61 @@
+{:spec/title "Release Phase — PR Description and PR Doc Generation"
+ :spec/description
+ "The release phase creates PRs with empty descriptions and no PR doc.
+  Extend the release pipeline to:
+  1. Generate a concise PR title (< 70 chars) from the task description
+  2. Generate a structured PR body (summary, changes, test plan)
+  3. Generate a PR doc in docs/pull-requests/ with the standard format
+  All without requiring a releaser LLM agent — use deterministic templates
+  enriched with data from the workflow (files changed, tests run, review results)."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/release-executor/src/ai/miniforge/release_executor/metadata.clj"
+          "components/release-executor/src/ai/miniforge/release_executor/core.clj"
+          "docs/pull-requests/"]}
+
+ :spec/constraints
+ ["PR title must be < 70 characters"
+  "PR body must include ## Summary, ## Changes, ## Test plan sections"
+  "PR doc must follow existing format in docs/pull-requests/"
+  "Must work without LLM (deterministic fallback) but use LLM when available"
+  "PR doc filename: YYYY-MM-DD-<slug>.md"
+  "Pre-commit hooks must pass"]
+
+ :spec/workflow-type :canonical-sdlc
+ :workflow/version "2.0.0"
+
+ :plan/tasks
+ [{:task/id :improve-fallback-metadata
+   :task/description
+   "Improve fallback-release-metadata in metadata.clj:
+    - Generate concise title (truncate task description to 70 chars, smart split)
+    - Generate structured PR body with ## Summary, ## Changes (file list),
+      ## Test plan sections
+    - Use workflow data: file paths from code artifacts, gate results,
+      review summary if available
+    Read source: components/release-executor/src/ai/miniforge/release_executor/metadata.clj"
+   :task/type :implement
+   :task/dependencies []}
+
+  {:task/id :add-pr-doc-generation
+   :task/description
+   "Add a new step to the release pipeline that generates a PR doc file:
+    - step-generate-pr-doc between step-create-pr and step-build-artifact
+    - Writes to docs/pull-requests/YYYY-MM-DD-<slug>.md
+    - Include: title, summary, files changed, test results, review decision
+    - Commit the doc as part of the release commit (before push)
+    Read source: components/release-executor/src/ai/miniforge/release_executor/core.clj
+    Read examples: docs/pull-requests/ (any recent file for format)"
+   :task/type :implement
+   :task/dependencies [:improve-fallback-metadata]}
+
+  {:task/id :test-pr-quality
+   :task/description
+   "Add tests for PR description and doc generation:
+    - Test fallback metadata produces valid title/body
+    - Test PR doc generation creates correct file with expected sections
+    - Test integration: metadata flows through to gh pr create
+    Read source: components/release-executor/test/"
+   :task/type :test
+   :task/dependencies [:add-pr-doc-generation]}]}

--- a/work/done/runner-refactor.spec.edn
+++ b/work/done/runner-refactor.spec.edn
@@ -1,0 +1,53 @@
+{:spec/title "Refactor workflow runner.clj to standards compliance"
+
+ :spec/description
+ "runner.clj has accumulated technical debt from multiple agents and sessions.
+  Full refactor required to comply with miniforge engineering standards.
+
+  Issues:
+  - Nested conditionals instead of composed pipelines
+  - Hand-built maps instead of factory functions / anomaly constructors
+  - Raw strings instead of messages/t localization
+  - Magic numbers (max-phases, timeouts) instead of named constants
+  - Mixed concerns (output extraction, artifact export, timeout enforcement,
+    monitoring, promotion all in one 700+ line file)
+  - No schemas at boundaries
+  - Reaching into data structures for status instead of predicates
+
+  Approach:
+  - Extract to focused namespaces: context.clj (exists), execution.clj (exists),
+    monitoring.clj (exists), artifact-export.clj (new), timeout.clj (new)
+  - runner.clj becomes a thin pipeline composer (~200 lines)
+  - All constants to config/runner/defaults.edn
+  - All strings to messages/en-US.edn
+  - Factory functions for result maps
+  - Predicates for status checks
+  - Tests updated to match
+
+  NOTE: This should be decomposed into a DAG of component-level PRs,
+  not one giant PR."
+
+ :spec/intent {:type :refactor
+               :scope ["components/workflow/src/ai/miniforge/workflow/runner.clj"
+                       "components/workflow/src/ai/miniforge/workflow"]}
+
+ :spec/constraints
+ ["Follow stratified design — dependencies flow downward only"
+  "Configuration is data (.edn), not code"
+  "Localize all strings via messages/t"
+  "Factory functions over duplicate maps"
+  "Predicates (succeeded? failed?) over status keyword checks"
+  "No nested conditionals — compose pipelines"
+  "PR DAG — one PR per extracted namespace"
+  "Code changes require test changes"]
+
+ :spec/acceptance-criteria
+ ["runner.clj is under 250 lines"
+  "No raw strings — all localized"
+  "No magic numbers — all named constants in defaults.edn"
+  "No hand-built result maps — factory functions"
+  "No nested conditionals — pipeline composition"
+  "All existing tests pass"
+  "New tests for extracted functions"]
+
+ :workflow/type :canonical-sdlc}

--- a/work/done/slingshot-adoption.spec.edn
+++ b/work/done/slingshot-adoption.spec.edn
@@ -1,0 +1,68 @@
+{:spec/title "Adopt slingshot try+/throw+ across the codebase"
+
+ :spec/description
+ "slingshot/slingshot 0.12.2 is verified bb-compatible.
+
+  Phase 1 (DONE — PRs #519, #521, #523):
+  - try+ at catch sites in workflow/runner, CLI base, agent component
+  - catch Object as universal fallback (ex-info maps bypass catch Exception)
+
+  Phase 2 (THIS SPEC):
+  Create an anomaly component with throw-anomaly! function that standardizes
+  the throw shape. All throw sites migrate from ad-hoc ex-info to
+  throw-anomaly! with canonical :type keywords. Catch sites destructure
+  directly from the thrown map.
+
+  throw-anomaly! is a function (not a macro) that:
+  1. Builds a canonical map {:type :message :timestamp :data}
+  2. Calls slingshot throw+ with the map
+  3. Provides a single extension point for cross-cutting concerns
+
+  Anomaly type taxonomy (namespaced keywords):
+  - :llm/rate-limited     {:backend :status :retry-after-ms}
+  - :llm/context-exceeded {:backend :tokens :limit}
+  - :llm/timeout          {:backend :duration-ms}
+  - :llm/unavailable      {:backend :error}
+  - :gate/failed          {:gate :errors}
+  - :gate/skipped         {:gate :reason}
+  - :executor/unavailable {:execution-mode :hint}
+  - :executor/timeout     {:environment-id :duration-ms}
+  - :dashboard/stop       {:reason}
+  - :pipeline/max-phases  {:max-phases :iteration}
+  - :pipeline/empty       {}
+  - :agent/execution-failed {:agent-id :task-id :error}
+  - :agent/validation-failed {:agent-id :errors}
+
+  Convergence with response/make-anomaly:
+  The response component's anomaly codes (:anomalies/fault, :anomalies/unavailable,
+  etc.) map to slingshot :type keywords. throw-anomaly! should accept an optional
+  :anomaly/category that bridges the two systems."
+
+ :spec/intent {:type :feature
+               :scope ["components/anomaly"
+                       "components/llm/src"
+                       "components/agent/src"
+                       "components/workflow/src"
+                       "components/gate/src"
+                       "components/dag-executor/src"
+                       "bases/cli/src"]}
+
+ :spec/constraints
+ ["throw-anomaly! is a function, not a macro"
+  "Canonical map shape: {:type :message :timestamp} + caller data"
+  "Anomaly types are namespaced keywords (component/error-kind)"
+  "Converge with response/make-anomaly anomaly codes"
+  "bb-compatible (slingshot verified)"
+  "PR DAG: anomaly component first, then migrate throw sites per component"
+  "catch Object as universal fallback in try+ blocks"]
+
+ :spec/acceptance-criteria
+ ["components/anomaly exists with throw-anomaly! and anomaly type registry"
+  "Zero ad-hoc (throw (ex-info ...)) in migrated components"
+  "All catch sites use slingshot key-value selectors for known types"
+  "Anomaly type taxonomy documented in anomaly component EDN"
+  "throw-anomaly! accepts :anomaly/category for response chain convergence"
+  "All existing tests pass"
+  "New tests for throw-anomaly! and each anomaly type"]
+
+ :workflow/type :canonical-sdlc}

--- a/work/done/standards-pass.spec.edn
+++ b/work/done/standards-pass.spec.edn
@@ -1,0 +1,239 @@
+;; =============================================================================
+;; Spec: Standards Pass — Apply Always-Apply Rules to Miniforge Codebase
+;; =============================================================================
+;;
+;; Goal: Fix all known violations of the newly-added always-apply standards
+;; across the miniforge codebase. Three independent concerns → three PRs.
+;;
+;; Audit findings (2026-03-29):
+;;   - 20 map-access pattern violations (or (:k m) default) across 12 files
+;;   - 11 localization violations (raw strings) in web-dashboard views
+;;   -  2 code-quality violations in tui-views (nested if-let, long fn)
+;;
+;; PR plan (bottom-up, all independent):
+;;   PR A: Map access pattern  — pure style, no behavior change
+;;   PR B: Localization        — web-dashboard views + en-US.edn keys
+;;   PR C: Code quality        — tui-views nested conditional + long fn
+;;
+;; All three PRs can be reviewed and merged independently.
+
+{:spec/title "Standards pass: map access, localization, code quality"
+ :spec/description
+ "Fix all audit-identified violations of the always-apply engineering standards.
+  Three independent PRs: map access pattern, localization, code quality."
+
+ :spec/intent {:type  :refactor
+               :scope ["components/repo-index/src"
+                       "components/loop/src"
+                       "components/tui-engine/src"
+                       "components/llm/src"
+                       "components/agent/src"
+                       "components/dag-executor/src"
+                       "components/web-dashboard/src"
+                       "components/knowledge/src"
+                       "components/tui-views/src"]}
+
+ :spec/constraints
+ ["No behavior changes — all fixes are mechanical style corrections"
+  "Each PR must pass bb pre-commit (lint + tests) before opening"
+  "Do not change any test files in PR A or B — test files are not the target here"
+  "Do not introduce new raw strings while fixing existing ones"]
+
+ :spec/workflow-type :canonical-sdlc
+ :workflow/version "2.0.0"
+
+ :tasks
+
+ ;; ── Task A ──────────────────────────────────────────────────────────────────
+ [{:task/id    :map-access-pattern
+   :task/title "PR A: Replace (or (:k m) default) with (get m :k default)"
+   :task/phase :implement
+   :task/description
+   "Fix all 20 map-access pattern violations identified in the audit.
+    Rule: (get m k default) over (or (:key m) default).
+    Exception: dual-key coalesces like (or (:a m) (:b m)) are acceptable — leave them.
+
+    Files and specific fixes:
+
+    components/repo-index/src/ai/miniforge/repo_index/interface.clj
+      Line ~163: (or (:max-lines opts) 500) → (get opts :max-lines 500)
+
+    components/repo-index/src/ai/miniforge/repo_index/repo_map.clj
+      Line ~171: (or (:token-budget opts) default-token-budget) → (get opts :token-budget default-token-budget)
+
+    components/loop/src/ai/miniforge/loop/outer.clj
+      Line ~299: (or (:output result) result) → (get result :output result)
+
+    components/loop/src/ai/miniforge/loop/repair.clj
+      Line ~82: (or (:errors result) errors) → (get result :errors errors)
+
+    components/tui-engine/src/ai/miniforge/tui_engine/widget/tree.clj
+      Line ~36: (or (:fg node) fg) → (get node :fg fg)
+
+    components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+      Line ~38: (or (:input-tokens usage) 0) → (get usage :input-tokens 0)
+               (or (:output-tokens usage) 0) → (get usage :output-tokens 0)
+
+    components/agent/src/ai/miniforge/agent/tester.clj
+      Line ~287: (or (:code input) input) → (get input :code input)
+
+    components/agent/src/ai/miniforge/agent/reviewer.clj
+      Line ~488: (or (:gates opts) default-gates) → (get opts :gates default-gates)
+
+    components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/docker.clj
+      Line ~489: (or (:image config) default-image) → (get config :image default-image)
+
+    components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/kubernetes.clj
+      Line ~359: (or (:namespace config) default-namespace) → (get config :namespace default-namespace)
+      Line ~360: (or (:image config) default-image) → (get config :image default-image)
+
+    components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+      Line ~223: (or (:workdir opts) worktree-path) → (get opts :workdir worktree-path)
+      Line ~261: (or (:base-path config) default-base-path) → (get config :base-path default-base-path)
+      Line ~262: (or (:max-concurrent config) default-max-concurrent) → (get config :max-concurrent default-max-concurrent)
+
+    components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
+      Line ~175: (or (:image config) default-image) → (get config :image default-image)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/server/control_plane.clj
+      Line ~87: (or (:heartbeat_interval_ms body) 30000) → (get body :heartbeat_interval_ms 30000)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/server/auth.clj
+      Line ~50: (or (:username entry) username) → (get entry :username username)
+      Line ~54: (or (:display-name entry) uname) → (get entry :display-name uname)
+
+    components/knowledge/src/ai/miniforge/knowledge/learning.clj
+      Line ~60: (or (:confidence learning) 0.7) → (get learning :confidence 0.7)
+
+    components/tui-views/src/ai/miniforge/tui_views/update/events.clj
+      Line ~179: (or (:name spec) name) → (get spec :name name)
+
+    Acceptance:
+    - All 20 (or (:k m) literal-default) forms replaced
+    - bb pre-commit passes
+    - Open PR with title 'fix: replace (or (:k m) default) with (get m :k default)'"
+
+   :task/constraints
+   ["Read each file before editing — do not guess line numbers"
+    "Do not change (or (:a m) (:b m)) dual-key coalesces — they are not violations"
+    "Do not change (or (get m :k) fallback) forms — those are fine"]}
+
+  ;; ── Task B ──────────────────────────────────────────────────────────────────
+  {:task/id    :localization
+   :task/title "PR B: Replace raw string literals in web-dashboard views"
+   :task/phase :implement
+   :task/description
+   "Fix 11 localization violations in web-dashboard view files.
+    Rule: no raw string literals in view/template namespaces — use (msg/t :key).
+
+    Step 1: Add missing keys to en-US.edn
+    File: components/web-dashboard/resources/config/web-dashboard/messages/en-US.edn
+
+    Add under :web-dashboard/messages:
+      ;; shared UI actions
+      :action/filter              'Filter'
+      :action/delete              'Delete'
+      :action/close               'Close'
+      :action/done                'Done'
+
+      ;; generic status/error labels
+      :status/error               'Error'
+      :status/failed-label        'Failed'
+
+      ;; table headers
+      :table/status-header        'Status'
+
+    Step 2: Replace raw strings in view files
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/views/workflows.clj
+      'Filter'  → (msg/t :action/filter)
+      'Error'   → (msg/t :status/error)   (if present — verify context first)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/views/archived.clj
+      'Failed'  → (msg/t :status/failed-label)
+      'Delete'  → (msg/t :action/delete)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/views/fleet.clj
+      'Status'  → (msg/t :table/status-header)
+      'Filter'  → (msg/t :action/filter)
+      'Error'   → (msg/t :status/error)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/views/dag.clj
+      'Close'   → (msg/t :action/close)
+      'Done'    → (msg/t :action/done)
+      'Filter'  → (msg/t :action/filter)
+
+    components/web-dashboard/src/ai/miniforge/web_dashboard/views/evidence.clj
+      'Filter'  → (msg/t :action/filter)
+
+    Each view file already requires [ai.miniforge.web-dashboard.messages :as msg] —
+    verify the require is present before using msg/t. If absent, add it.
+
+    Acceptance:
+    - grep for string literals in views/ files returns only code strings (CSS classes,
+      hiccup attribute values like 'innerHTML', script strings) — no user-visible copy
+    - bb pre-commit passes
+    - Open PR with title 'fix: localize raw string literals in web-dashboard views'"
+
+   :task/constraints
+   ["Read each view file before editing to verify the exact string and context"
+    "Do not localize CSS class names, hx-* attribute values, or JavaScript strings"
+    "Add all new keys to en-US.edn in the same commit as the view changes"]}
+
+  ;; ── Task C ──────────────────────────────────────────────────────────────────
+  {:task/id    :code-quality
+   :task/title "PR C: Fix nested conditional and long function in tui-views"
+   :task/phase :implement
+   :task/description
+   "Fix 2 code-quality violations in tui-views.
+
+    File: components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
+
+    Fix 1 — Nested if-let (~line 299):
+    Replace nested (if-let [started ...] (if-let [wf-date ...] ...)) with a flat
+    cond or some-> chain. The goal is at most one level of conditional nesting.
+
+    Suggested refactor:
+      (defn- workflow-started-date [wf]
+        (some-> wf :started event-ts ->instant))
+
+      ;; Then flatten:
+      (let [started-date (workflow-started-date wf)]
+        (cond
+          (nil? started-date) fallback-value
+          ... => result))
+
+    Fix 2 — Long function derive-recommendation (~line 474, ~73 lines):
+    Extract the large cond branches into named private helper functions.
+    Each branch should become a call to a descriptively-named fn.
+
+    Example approach:
+      (defn- stale-recommendation [wf] ...)
+      (defn- failing-ci-recommendation [wf] ...)
+      (defn- blocked-recommendation [wf] ...)
+
+      (defn derive-recommendation [wf]
+        (cond
+          (stale? wf)      (stale-recommendation wf)
+          (ci-failing? wf) (failing-ci-recommendation wf)
+          (blocked? wf)    (blocked-recommendation wf)
+          :else            default-recommendation))
+
+    Read the file first to understand the actual structure before refactoring.
+
+    Acceptance:
+    - No nested conditionals deeper than one level in the refactored code
+    - derive-recommendation body is < 20 lines (delegates to named fns)
+    - All extracted fns are at Layer 0 (pure helpers)
+    - bb pre-commit passes
+    - Open PR with title 'refactor: flatten nested conditional and extract pipeline stages in tui-views'"
+
+   :task/constraints
+   ["Read the full file before editing — do not guess at structure"
+    "Do not change the public API of any functions"
+    "Preserve all existing behavior exactly"]}]
+
+ :dependencies
+ {:map-access-pattern []
+  :localization       []
+  :code-quality       []}}

--- a/work/polylith-compliance-remediation.spec.edn
+++ b/work/polylith-compliance-remediation.spec.edn
@@ -1,0 +1,76 @@
+;; =============================================================================
+;; Spec: Polylith Compliance Remediation
+;; =============================================================================
+;;
+;; `poly check` reports 41 errors. Components bypass interfaces, circular
+;; dependencies exist, project deps are incomplete. Must fix.
+;;
+;; Fix groups in dependency order:
+;;
+;; GROUP 1: Break circular dependency (Error 104)
+;;   gate > cli > workflow > gate
+;;
+;; GROUP 2: Fix 31 interface bypass violations (Error 101)
+;;   Components reaching into internal namespaces instead of .interface
+;;
+;; GROUP 3: Fix missing interface definitions (Error 103)
+;;   phase-deployment and phase-software-factory
+;;
+;; GROUP 4: Fix multi-implementation interfaces (Error 106/108)
+;;   data-foundry and phase multi-impl need profiles
+;;
+;; GROUP 5: Fix project completeness (Error 107, 112)
+;;
+;; GROUP 6: Clean up warnings (202, 207)
+
+{:spec/title "Polylith compliance remediation — fix all poly check errors"
+
+ :spec/description
+ "Fix all 41 errors from `poly check`. Every component must depend only on
+  interfaces, circular dependencies must be broken, and project configs must
+  be complete.
+
+  GROUP 1: Break circular dependency (Error 104)
+  gate > cli > workflow > gate. Use requiring-resolve or extract shared
+  concern to break the cycle.
+
+  GROUP 2: Fix interface bypass violations (Error 101 — 31 sites)
+  For each: change require to .interface, add pass-through if missing.
+  Key components: workflow (5), gate (3), control-plane cluster (4),
+  phase-software-factory (2), semantic-analyzer (2), remaining singles.
+
+  GROUP 3: Fix missing interface definitions (Error 103 — 2 sites)
+  phase-deployment and phase-software-factory missing many phase interface fns.
+
+  GROUP 4: Fix multi-impl interfaces (Error 106/108 — 7 sites)
+  data-foundry and phase need Polylith profiles.
+
+  GROUP 5: Fix project completeness (Error 107, 112 — 4 sites)
+  Add missing components to project deps.edn. Fix mcp-context-server
+  base direct brick dependency.
+
+  GROUP 6: Clean up warnings (202, 207)
+  Missing resource paths, unnecessary components in projects."
+
+ :spec/intent {:type :refactor
+               :scope ["components/*/src"
+                       "components/*/deps.edn"
+                       "bases/*/deps.edn"
+                       "projects/*/deps.edn"
+                       "workspace.edn"]}
+
+ :spec/constraints
+ ["Do not change component behavior — only dependency wiring"
+  "Interface pass-throughs must preserve existing function signatures"
+  "Run poly check after each group to verify progress"
+  "Run bb test after each group to verify no regressions"
+  "Each group should be a separate commit for reviewability"]
+
+ :spec/acceptance-criteria
+ ["poly check reports 0 errors"
+  "No circular dependencies in the component graph"
+  "All cross-component requires use .interface namespaces"
+  "All existing tests pass"
+  "Project deps.edn files are complete per poly check"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/storage-root-configuration.spec.edn
+++ b/work/storage-root-configuration.spec.edn
@@ -1,0 +1,56 @@
+{:spec/title "Configurable storage root — MINIFORGE_HOME for all state directories"
+
+ :spec/description
+ "All miniforge state (events, artifacts, cache, config, packs, tools, themes,
+  logs, decisions, workaround approvals) is hardcoded to ~/.miniforge/<subdir>
+  across ~20 call sites in 15+ components. This causes:
+
+  1. Tests that touch real user state (cleanup-stale-events! with {:ttl-ms 0}
+     deleted all event files, destroying resume checkpoints — PR #516 patch)
+  2. No way to run multiple miniforge instances with isolated state
+  3. No CI-friendly configuration (everything goes to ~/.miniforge)
+
+  Solution: a storage component (protocol + filesystem impl) that resolves
+  paths from a configurable root. Pattern from storage-proxy: protocol-based
+  with config-driven selection.
+
+  Protocol: StoragePaths — named path accessors (events-dir, artifacts-dir, etc.)
+  Impl: FilesystemStorage record backed by root dir
+  Root resolution: MINIFORGE_HOME env > config file > ~/.miniforge default
+  Test support: create-storage {:root temp-dir} for full isolation
+
+  All ~20 hardcoded (System/getProperty \"user.home\") \".miniforge\" sites
+  migrate to use the storage component's interface."
+
+ :spec/intent {:type :refactor
+               :scope ["components/storage"
+                       "components/event-stream/src"
+                       "components/artifact/src"
+                       "components/tool-registry/src"
+                       "components/self-healing/src"
+                       "components/tui-engine/src"
+                       "components/pr-lifecycle/src"
+                       "components/pr-sync/src"
+                       "components/web-dashboard/src"
+                       "components/workflow/src"
+                       "components/phase/src"
+                       "components/adapter-claude-code/src"
+                       "bases/cli/src"]}
+
+ :spec/constraints
+ ["Protocol + impl in components/storage (Polylith pattern)"
+  "Root resolution: MINIFORGE_HOME env > config > ~/.miniforge"
+  "Tests create isolated storage via {:root temp-dir}"
+  "Backward compatible — existing ~/.miniforge layout preserved"
+  "No functional changes — pure path resolution refactor"
+  "PR DAG — storage component first, then migrate callers in batches"]
+
+ :spec/acceptance-criteria
+ ["components/storage exists with protocol and filesystem impl"
+  "MINIFORGE_HOME env var overrides default root"
+  "Zero hardcoded ~/.miniforge paths remain in src/ (grep verification)"
+  "All existing tests pass"
+  "New tests verify path resolution, env override, and test isolation"
+  "bb test does not modify ~/.miniforge (full test isolation)"]
+
+ :workflow/type :canonical-sdlc}


### PR DESCRIPTION
## Summary

- **Compiler severity fix** — MDC compiler hardcoded all rules to :info/:audit. alwaysApply rules now compile to :major/:warn (mandatory). Non-always rules compile to :minor/:audit (advisory). 12 rules at :major/:warn, 11 at :minor/:audit.
- **Spec housekeeping** — 9 completed specs moved to work/done/. 3 new specs filed: artifact-extraction-agent, polylith-compliance-remediation, storage-root-configuration.

## Test plan

- [x] 3 test files updated to match new severity/enforcement values
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)