### PR TITLE
feat(llm): add Opus 4.7 to backend config as escalation default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,6 @@ dist/
 # Tool config (local)
 .codex/
 .cursor/
-.claude/worktrees/
 
 # Checkpoints (local development snapshots)
 docs/checkpoints/

--- a/bases/cli/resources/config/cli/backends.edn
+++ b/bases/cli/resources/config/cli/backends.edn
@@ -8,7 +8,7 @@
    :command "claude"
    :installation "npm install -g @anthropic-ai/claude-cli"
    :api-key-var "ANTHROPIC_API_KEY"
-   :models ["claude-sonnet-4-6" "claude-opus-4-6" "claude-sonnet-4-5-20250929" "claude-haiku-4-5-20251001"]
+   :models ["claude-sonnet-4-6" "claude-opus-4-7" "claude-opus-4-6" "claude-sonnet-4-5-20250929" "claude-haiku-4-5-20251001"]
    :check-type :cli}
 
   :codex

--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -215,6 +215,7 @@ Output execution logs and status reports."})
                 "claude-sonnet-4-6" {:input 3.0 :output 15.0}
                 "claude-opus-4" {:input 15.0 :output 75.0}
                 "claude-opus-4-6" {:input 5.0 :output 25.0}
+                "claude-opus-4-7" {:input 5.0 :output 25.0}
                 "claude-haiku" {:input 0.25 :output 1.25}}
         {:keys [input output]} (get prices model {:input 3.0 :output 15.0})]
     (+ (* input-tokens (/ input 1000000))
@@ -476,6 +477,7 @@ Output execution logs and status reports."})
     (let [result (protocol/invoke agent task exec-context)]
       (record-backend-health! exec-context true)
       (assoc result :self-healing/workaround-applied true))
+    #_{:clj-kondo/ignore [:unresolved-symbol :unused-binding]}
     (catch Object _
       (let [retry-e (:throwable &throw-context)]
         (record-backend-health! exec-context false)

--- a/components/config/resources/config/default-user-config-fallback.edn
+++ b/components/config/resources/config/default-user-config-fallback.edn
@@ -14,7 +14,7 @@
               :convergence-threshold 0.95}
   :agents {:default-models {:thinking   "gpt-5.4"
                             :execution  "claude-sonnet-4-6"
-                            :escalation "claude-opus-4-6"}}
+                            :escalation "claude-opus-4-7"}}
   :model-selection {:enabled true
                     :strategy :automatic
                     :cost-limit-per-task 0.10

--- a/components/llm/resources/llm/model-catalog.edn
+++ b/components/llm/resources/llm/model-catalog.edn
@@ -1,5 +1,37 @@
 {:models
- {:opus-4.6
+ {:opus-4.7
+  {:model-id "claude-opus-4-7"
+   :provider :anthropic
+   :backend :claude
+   :family :claude
+   :tier :flagship
+   :capabilities
+   {:reasoning :exceptional
+    :code-generation :excellent
+    :speed :slow
+    :cost :expensive
+    :context-window 1000000
+    :output-tokens 16000
+    :streaming true}
+   :best-for
+   ["Complex reasoning and planning"
+    "Architecture decisions"
+    "Novel problem solving"
+    "Spec analysis and interpretation"
+    "Multi-step logical deduction"
+    "Design trade-off evaluation"
+    "Meta-reasoning about workflows"
+    "Large-context analysis (1M tokens)"]
+   :use-cases
+   #{:workflow-planning
+     :architecture-design
+     :spec-interpretation
+     :complex-debugging
+     :research-synthesis
+     :strategic-decisions
+     :large-context}}
+
+  :opus-4.6
   {:model-id "claude-opus-4-6"
    :provider :anthropic
    :backend :claude
@@ -483,7 +515,7 @@
 
  :task-type-recommendations
  {:thinking-heavy
-  {:tier-1 [:opus-4.6 :gpt-5.4-pro :gpt-5.4]
+  {:tier-1 [:opus-4.7 :opus-4.6 :gpt-5.4-pro :gpt-5.4]
    :tier-2 [:sonnet-4.6 :gpt-5.3-codex :gemini-2.5-pro]
    :tier-3-local [:llama-3.3-70b :glm-4-plus]
    :rationale "Exceptional reasoning needed for architecture decisions"}
@@ -501,7 +533,7 @@
    :rationale "Speed and cost efficiency for simple tasks"}
 
   :large-context
-  {:tier-1 [:gemini-2.5-pro :gpt-5.4 :gemini-2.5-flash]
+  {:tier-1 [:opus-4.7 :gemini-2.5-pro :gpt-5.4 :gemini-2.5-flash]
    :tier-2 [:opus-4.6 :sonnet-4.6 :llama-3.3-70b]
    :rationale "Need 1M+ token context windows"}
 

--- a/components/llm/test/ai/miniforge/llm/model_registry_test.clj
+++ b/components/llm/test/ai/miniforge/llm/model_registry_test.clj
@@ -167,14 +167,14 @@
 
 (deftest test-get-primary-recommendation
   (testing "Get primary recommendation"
-    (is (= :opus-4.6 (registry/get-primary-recommendation :thinking-heavy)))
+    (is (= :opus-4.7 (registry/get-primary-recommendation :thinking-heavy)))
     (is (= :sonnet-4.6 (registry/get-primary-recommendation :execution-focused)))
     (is (= :haiku-4.5 (registry/get-primary-recommendation :simple-validation)))
-    (is (= :gemini-2.5-pro (registry/get-primary-recommendation :large-context)))))
+    (is (= :opus-4.7 (registry/get-primary-recommendation :large-context)))))
 
 (deftest test-model-registry-completeness
-  (testing "All 18 models are present"
-    (is (= 18 (count registry/model-registry))))
+  (testing "All 19 models are present"
+    (is (= 19 (count registry/model-registry))))
 
   (testing "All models have required fields"
     (doseq [[model-key model-data] registry/model-registry]

--- a/components/llm/test/ai/miniforge/llm/model_selection_integration_test.clj
+++ b/components/llm/test/ai/miniforge/llm/model_selection_integration_test.clj
@@ -48,7 +48,7 @@
       (is (= :thinking-heavy (:task-type selection)))
 
       ;; Should select a flagship model for planning
-      (is (some #{(:model selection)} [:opus-4.6 :gpt-5.4-pro :gpt-5.4]))
+      (is (some #{(:model selection)} [:opus-4.7 :opus-4.6 :gpt-5.4-pro :gpt-5.4]))
 
       ;; Verify model profile
       (let [model (registry/get-model (:model selection))]
@@ -131,8 +131,8 @@
       ;; Should select a model with large context window
       (let [model (registry/get-model (:model selection))]
         (is (>= (get-in model [:capabilities :context-window]) 500000))
-        ;; Current large-context tier includes Google and OpenAI 1M+ models.
-        (is (some #{(:provider model)} [:google :openai]))))))
+        ;; Current large-context tier includes Anthropic (Opus 4.7 1M), Google and OpenAI 1M+ models.
+        (is (some #{(:provider model)} [:anthropic :google :openai]))))))
 
 (deftest test-cost-optimized-strategy
   (testing "Cost-optimized strategy prefers cheaper models"
@@ -256,7 +256,7 @@
 
       ;; Large context should use a provider with 1M+ context models
       (let [large-context (second selections)]
-        (is (#{:google :openai} (:provider large-context))))
+        (is (#{:anthropic :google :openai} (:provider large-context))))
 
       ;; Privacy should use local (Meta, Alibaba, DeepSeek, etc.)
       (let [privacy (nth selections 2)]
@@ -307,13 +307,13 @@
       (is (:model high-selection))
       (is (:model low-selection)))))
 
-(deftest test-all-18-models-accessible
-  (testing "All 18 models in registry can be selected"
+(deftest test-all-19-models-accessible
+  (testing "All 19 models in registry can be selected"
     (let [;; Get all model keys
           all-models (keys registry/model-registry)]
 
-      ;; Should have exactly 18 models
-      (is (= 18 (count all-models)))
+      ;; Should have exactly 19 models
+      (is (= 19 (count all-models)))
 
       ;; All should be queryable
       (doseq [model-key all-models]

--- a/components/llm/test/ai/miniforge/llm/model_selector_test.clj
+++ b/components/llm/test/ai/miniforge/llm/model_selector_test.clj
@@ -45,7 +45,7 @@
 (deftest test-select-by-automatic
   (testing "Automatic selection for thinking-heavy"
     (let [selected (selector/select-by-automatic :thinking-heavy {})]
-      (is (some #{selected} [:opus-4.6 :gpt-5.4-pro :gpt-5.4]))))
+      (is (some #{selected} [:opus-4.7 :opus-4.6 :gpt-5.4-pro :gpt-5.4]))))
 
   (testing "Automatic selection for execution-focused"
     (let [selected (selector/select-by-automatic :execution-focused {})]

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -14,7 +14,7 @@
               :convergence-threshold 0.95}
   :agents {:default-models {:thinking   "gpt-5.4"
                             :execution  "claude-sonnet-4-6"
-                            :escalation "claude-opus-4-6"}}
+                            :escalation "claude-opus-4-7"}}
   :model-selection {:enabled true
                     :strategy :automatic
                     :cost-limit-per-task 0.10


### PR DESCRIPTION
## Summary

Opus 4.7 is released with 1M token context window. Update the default model config so the escalation tier uses 4.7 instead of 4.6.

## Changes

- **model-catalog.edn**: add `:opus-4.7` entry with 1M context; add to `:thinking-heavy` tier-1 and `:large-context` tier-1 recommendations
- **default-user-config.edn** / **default-user-config-fallback.edn**: `:escalation "claude-opus-4-7"`
- **backends.edn**: add \`claude-opus-4-7\` to Claude models list (first after sonnet-4-6)
- **agent/core.clj**: add 4-7 pricing entry to \`estimate-cost-usd\`; add kondo-ignore for pre-existing slingshot lint noise
- **model selection tests**: update assertions (19 models, 4.7 in tiers, `:anthropic` allowed provider for large-context)
- **.gitignore**: remove \`.claude/worktrees/\` — the rule broke git operations inside worktrees placed there (files appeared ignored to their own worktree)

## Test plan

- [x] `model-registry-test`: 9 tests, 233 assertions, 0 failures
- [x] `user-defaults-test`: 3 tests, 10 assertions, 0 failures
- [ ] 11 pre-existing e2e failures in \`workflow-security-compliance\` (SARIF fixture loading) unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)