### PR TITLE
fix(phase): curator terminal code wins over implementer error

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -276,22 +276,42 @@
             :logger logger})
           (catch Exception e
             (response/failure e)))
+        ;; The curator's verdict is the source of truth about whether the
+        ;; implementer produced useful work (the environment is the artifact).
+        ;; Its terminal :code (e.g. :curator/no-files-written) carries
+        ;; retry-or-terminate signal the phase runner depends on, so when the
+        ;; curator returned an error we propagate IT, not the implementer's
+        ;; symptom-level error. If the implementer also errored, that context
+        ;; is preserved in the event stream separately.
+        ;; Fix for 2026-04-17 dogfood: previously impl-result won on dual-error,
+        ;; dropping the curator's :code and leaving leave-implement's retry
+        ;; gate blind — phase retried 6×.
+        curator-terminal?
+        (= :curator/no-files-written
+           (get-in curator-result [:error :data :code]))
         result (cond
-                 ;; Curator found files — trust it and use its artifact, even if
-                 ;; the implementer reported error. Merge impl metrics through.
+                 ;; Curator found files — use its artifact, even if the
+                 ;; implementer reported error. Merge implementer metrics through.
                  (= :success (:status curator-result))
                  (-> impl-result
                      (assoc :status :success)
                      (assoc :output (:output curator-result))
                      (update :metrics merge (:metrics curator-result)))
-                 ;; Curator found nothing AND implementer reported success —
-                 ;; that's the empty-diff fast-fail path (silent "wrote nothing").
-                 (= :success (:status impl-result))
+                 ;; Curator said no-files (terminal). This wins over any
+                 ;; implementer error — the implementer's error is the symptom,
+                 ;; the empty diff is the root cause the phase runner needs.
+                 curator-terminal?
                  curator-result
-                 ;; Curator found nothing AND implementer reported error —
-                 ;; propagate the original implementer error (more specific).
+                 ;; Implementer errored for a non-curator reason (rate-limit,
+                 ;; exception, etc.). Propagate — the phase runner classifies
+                 ;; those via rate-limited? / existing branches.
+                 (not= :success (:status impl-result))
+                 impl-result
+                 ;; Implementer reported success but curator still returned
+                 ;; something non-success (shouldn't happen outside no-files;
+                 ;; defensive fallback).
                  :else
-                 impl-result)]
+                 curator-result)]
     (-> (phase-result/enter-context ctx :implement :implementer gates budget start-time result)
         (assoc-in [:phase :rules-manifest] rules-manifest))))
 


### PR DESCRIPTION
## Summary

**Hotfix** — `leave-implement`'s retry-gate was blind to the curator's terminal `:curator/no-files-written` code whenever the implementer also errored. Observed in a 2026-04-17 dogfood run: despite PR #561 shipping, the run re-entered implement attempt 2 after 11.1 min, repeating the pre-curator 6× burn pattern.

## Root cause

`leave-implement`'s result-selection cond preferred `impl-result` on dual-error:

```
;; Curator found nothing AND implementer reported error —
;; propagate the original implementer error (more specific).
:else impl-result
```

The implementer's `parse-error` isn't tagged with `:curator/no-files-written`, so PR #561's terminal check (commit e339708c) never saw the code, and `registry/determine-phase-status` retried as normal.

## Fix

Curator terminal code wins over implementer symptom-level error:

```
(cond
  (= :success (:status curator-result))       curator success
  curator-terminal?                           curator terminal code (NEW priority)
  (not= :success (:status impl-result))       impl error (rate-limit etc)
  :else                                       defensive fallback)
```

## Test plan

- [x] 22/99 existing assertions pass
- [x] Compile check on `ai.miniforge.phase.implement`
- [ ] Dogfood re-run on the phase-fsm M1a spec — kicking off immediately, will comment with result

## Follow-up

This cond ladder is exactly what M1a (phase-fsm) subsumes. Spec drafted at `specs/active/phase-fsm.spec.edn`. The hotfix evaporates once M1a lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)