### PR TITLE
fix(phase): widen rate-limit classifier to catch suspicious short terminations

### DIFF
--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -316,18 +316,51 @@
         (assoc-in [:phase :rules-manifest] rules-manifest))))
 
 (def ^:private rate-limit-pattern
-  "Lightweight rate limit detection for the phase level.
-   Avoids a dependency on workflow/dag-resilience."
-  #"(?i)you've hit your limit|rate.?limit|429|quota.?exceeded|resets \d+[ap]m")
+  "Lightweight rate limit / infra-transient detection for the phase level.
+   Avoids a dependency on workflow/dag-resilience.
+
+   Widened 2026-04-17 after a dogfood failure where the LLM backend
+   returned near-empty content in ~4s (quota-exhausted-adjacent infra
+   failure) that the prior narrow regex missed. Added: HTTP 503, 'too
+   many requests', 'overloaded', 'try again', 'capacity', 'throttled',
+   and a broader apostrophe class for 'you've'."
+  #"(?i)you['\u2019]ve hit your (usage |)limit|rate.?limit|429|503|quota.?exceeded|resets? \d+[ap]m|too many requests|overloaded|try again (?:later|in)|at capacity|throttled")
+
+(def ^:private suspicious-short-duration-ms
+  "Threshold below which an implement phase is too fast to have done real
+   work. A legitimate implementer LLM call takes minutes; anything under
+   30s that ALSO failed to produce files is almost always an infra
+   failure (auth, quota, transient backend error) rather than a real
+   task failure. Routing these through the rate-limit branch lets the
+   workflow pause and resume rather than terminating permanently."
+  30000)
+
+(defn- suspicious-short-termination?
+  "Heuristic: implement phase completed in <30s AND produced no files.
+   Observed 2026-04-17 dogfood pattern — LLM stream returned immediately
+   with empty content; agent-status :error but no rate-limit keywords in
+   the error message. Almost certainly an infra failure that masqueraded
+   as a task failure."
+  [result]
+  (let [duration (get-in result [:metrics :duration-ms] 0)
+        error-code (get-in result [:error :data :code])
+        no-files? (= :curator/no-files-written error-code)]
+    (and no-files?
+         (pos? duration)
+         (< duration suspicious-short-duration-ms))))
 
 (defn- rate-limit-in-result?
-  "Check if an agent result contains rate limit indicators.
-   Scans both error message and output text."
+  "Check if an agent result indicates an infrastructure failure that
+   should pause/resume rather than terminate. Two signals:
+     1. Known rate-limit / quota / transient-backend keywords in error text.
+     2. Suspiciously short termination with no files produced (observed
+        symptom of LLM-backend failure that returned empty content fast)."
   [result]
-  (some (fn [text]
-          (and (string? text) (re-find rate-limit-pattern text)))
-        [(get-in result [:error :message])
-         (when (string? (:output result)) (:output result))]))
+  (or (some (fn [text]
+              (and (string? text) (re-find rate-limit-pattern text)))
+            [(get-in result [:error :message])
+             (when (string? (:output result)) (:output result))])
+      (suspicious-short-termination? result)))
 
 (defn- extract-error-message
   "Extract the most relevant error message from an agent result."

--- a/components/phase-software-factory/test/ai/miniforge/phase/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/implement_test.clj
@@ -257,6 +257,77 @@
       (is @capsule-called "Should have called execute-fn")
       (is (= 1 (count result))))))
 
+;------------------------------------------------------------------------------ Rate-limit classifier (2026-04-17 widening)
+;; Tests for `rate-limit-in-result?` — it's private so we access via #'.
+
+(defn- rate-limit? [result]
+  (#'implement/rate-limit-in-result? result))
+
+(deftest rate-limit-classifier-detects-classic-keywords-test
+  (testing "classic patterns from the narrow regex still match"
+    (doseq [msg ["You've hit your limit"
+                 "Rate-limit exceeded"
+                 "Got HTTP 429 from backend"
+                 "Quota exceeded"
+                 "Your quota resets 2pm EST"]]
+      (is (rate-limit? {:error {:message msg}})
+          (str "should classify as rate-limit: " msg)))))
+
+(deftest rate-limit-classifier-detects-widened-patterns-test
+  (testing "patterns added 2026-04-17 after dogfood observation"
+    (doseq [msg ["HTTP 503 Service Unavailable"
+                 "Too Many Requests"
+                 "Model is overloaded, please try again later"
+                 "Backend at capacity"
+                 "Request was throttled"
+                 "You\u2019ve hit your usage limit"       ; curly apostrophe
+                 "Please try again in 30 seconds"]]
+      (is (rate-limit? {:error {:message msg}})
+          (str "should classify as rate-limit: " msg)))))
+
+(deftest rate-limit-classifier-ignores-unrelated-errors-test
+  (testing "ordinary task errors do NOT match rate-limit patterns"
+    (doseq [msg ["Syntax error at line 5"
+                 "File not found: src/foo.clj"
+                 "Test failed: expected 1 got 2"
+                 nil]]
+      (is (not (rate-limit? {:error {:message msg}}))
+          (str "should NOT classify as rate-limit: " (pr-str msg))))))
+
+(deftest rate-limit-classifier-flags-suspicious-short-termination-test
+  (testing "curator no-files + <30s duration = infra failure (observed 2026-04-17)"
+    ;; The motivating case: LLM backend returned empty content in ~4s; the
+    ;; curator fast-failed with :curator/no-files-written. Classifier should
+    ;; now route this through rate-limit handling (pause/resume), not terminate.
+    (is (rate-limit?
+         {:status :error
+          :error {:message "Curator: implementer wrote no files to the environment"
+                  :data {:code :curator/no-files-written}}
+          :metrics {:duration-ms 4567}}))))
+
+(deftest rate-limit-classifier-does-not-flag-legitimate-curator-failures-test
+  (testing "curator no-files after a full-length attempt is a real task failure"
+    ;; If the implementer ran for the full ~11 min and still wrote nothing,
+    ;; that's a real task problem (prompt, scope, tooling) — not an infra hiccup.
+    ;; Should NOT be classified as rate-limit; should fall through to terminal.
+    (is (not (rate-limit?
+              {:status :error
+               :error {:message "Curator: implementer wrote no files to the environment"
+                       :data {:code :curator/no-files-written}}
+               :metrics {:duration-ms 660000}})))))  ; 11 min
+
+(deftest rate-limit-classifier-does-not-flag-short-but-successful-test
+  (testing "fast completion WITHOUT the curator no-files signal is not infra-suspect"
+    (is (not (rate-limit? {:status :success
+                           :metrics {:duration-ms 1000}})))))
+
+(deftest rate-limit-classifier-zero-duration-does-not-flag-test
+  (testing "missing/zero duration does not satisfy the short-termination heuristic"
+    (is (not (rate-limit?
+              {:status :error
+               :error {:message "x" :data {:code :curator/no-files-written}}
+               :metrics {:duration-ms 0}})))))
+
 ;------------------------------------------------------------------------------ Rich Comment
 
 (comment


### PR DESCRIPTION
## Summary

Widens `rate-limit-in-result?` to catch a dogfood failure shape the narrow regex missed. Observed 2026-04-17: after a successful plan phase, the implementer LLM call returned near-empty streaming content in ~4s, then the curator correctly fast-failed with `:curator/no-files-written`. The narrow regex didn't match that error shape, so the workflow terminated as a task failure instead of pausing as infra failure.

## Changes

**1. Regex widening.** Adds HTTP 503, \"too many requests\", \"overloaded\", \"try again\", \"at capacity\", \"throttled\", curly-apostrophe class.

**2. New heuristic: `suspicious-short-termination?`.** If the implement phase completed in <30s AND curator reported `:curator/no-files-written`, classify as rate-limit-adjacent (infra), not task-terminal. Legitimate implementer LLM calls take minutes; sub-30s termination with no files is almost always a backend issue where the workflow should pause+resume, not terminate.

The curator's terminal code still correctly terminates legitimate task failures — a new test asserts the \"curator no-files after 11-min full attempt\" case falls through to terminal as before.

## Test plan

- [x] 7 new tests / 20 new assertions pass
- [x] Classic regex patterns still match (regression check)
- [x] Widened patterns match
- [x] Short-duration + no-files → infra (rate-limit)
- [x] Full-duration + no-files → NOT infra (task terminal preserved)
- [x] Unrelated task errors don't false-positive
- [x] Zero-duration doesn't satisfy heuristic (guard against uninstrumented paths)

Note: 9 pre-existing failures in `leave-implement-records-metrics-test` etc. are on `main` and unrelated to this change (same 9 before and after).

## Follow-up

M1a's phase-fsm will subsume this regex-based classifier into a table-driven classification map. Spec at `specs/active/phase-fsm.spec.edn` (merged via PR #564). Until M1a lands, this heuristic catches the most painful observed infra-shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)