### PR TITLE
spec: 5 dogfood improvement specs from today's post-mortem

### DIFF
--- a/docs/pull-requests/2026-04-17-dogfood-improvement-specs.md
+++ b/docs/pull-requests/2026-04-17-dogfood-improvement-specs.md
@@ -1,0 +1,115 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Five specs from today's dogfood post-mortem
+
+## Context
+
+Two miniforge runs earlier today (polylith-compliance-remediation +
+polylith-workflow-gates-and-scope) both ended in failure. Investigation of
+the event logs at `~/.miniforge/events/<workflow-id>/*.json` and a code
+trace of the DAG executor surfaced five distinct problems and one root
+cause. This PR captures them as specs.
+
+The root cause was NOT "spec too broad." Miniforge is explicitly designed
+to decompose specs into a DAG of smaller parallel workflows — the DAG
+executor exists and is wired. The decomposition just isn't firing for
+LLM-generated plans.
+
+## What landed
+
+Five spec files under `work/`. All are `:workflow-type :canonical-sdlc`
+and written at a scope small enough that a single miniforge workflow
+should be able to complete each without hitting the failure modes they
+themselves describe.
+
+### 1. `plan-from-agent-dag-wiring.spec.edn` — **root-cause fix**
+
+The biggest single finding. `components/dag-executor/` and
+`workflow/dag_orchestrator.clj` are fully built; `execution.clj:344-350`
+wires `dag-applicable?` to fire when the plan phase output contains
+`:plan/id`. The `plan-from-spec-tasks` fast path (specs with
+pre-declared tasks) emits `:plan/id` correctly. The `plan-from-agent`
+LLM path (the common case) does NOT. So for any spec without
+pre-declared tasks, the DAG orchestrator never activates and the
+implementer sees the entire spec in one monolithic phase. That is what
+caused the 13-minute hang.
+
+Fix scope: `components/phase-software-factory/.../plan.clj` lines 86+
+wrap the LLM planner output with `:plan/id` + validate against a malli
+schema so invalid DAGs fail fast instead of silently falling back.
+
+### 2. `agent-stream-watchdog-and-resume.spec.edn`
+
+The direct cause of today's 11-minute silent stall: Anthropic was
+rate-limiting / slow, the agent's HTTP stream stuck open with no events,
+miniforge had no detector. The fix: per-phase event-gap watchdog that
+kills the agent when the inter-event gap exceeds ~90s, resumes via the
+backend's session-resume mechanism (Claude Code `--resume`, Codex
+equivalent), and falls over to `self-healing/backend-auto-switch` if
+resume also hangs. Emits `:phase/termination-reason :agent-stalled` so
+hangs are visible in the event log instead of mis-attributed to "no
+files written."
+
+### 3. `event-log-tool-visibility.spec.edn`
+
+Today the event log had 203 `:agent/status :tool-calling` events for
+the remediation run. None carried the tool name, args, or result. We
+could count tool calls but couldn't diagnose what the agent was doing.
+Expand the schema to `:agent/tool-call-started` + `:tool/call-completed`
+with digested args/results, add phase heartbeat events every 30s, and
+a `miniforge events show <workflow-id>` post-mortem CLI that renders a
+human-readable timeline including gaps.
+
+### 4. `worktree-persistence-scratch-branch.spec.edn`
+
+The gates workflow produced real implementation (verify + review both
+passed 3/3 gates), but the worktree lived in `/tmp/mf-wt-gates` and got
+GC'd on process restart — 8 minutes of verified work permanently lost.
+Two fixes: move worktrees out of `/tmp` (default to
+`~/.miniforge/worktrees/`), and commit every implementer file write to
+`refs/miniforge/scratch/<workflow-id>` in the parent repo. Plus a
+`miniforge recover <workflow-id>` CLI to pull uncommitted work back
+from the scratch ref after a crash.
+
+### 5. `workflow-dependency-declarations.spec.edn`
+
+Gates ran in parallel with remediation. Gates' release phase ran
+`poly check` via pre-commit, which reported the 13 structural errors
+remediation was mid-way through fixing, and gates aborted. No mechanism
+exists today for "spec B depends on spec A landing." Add
+`:spec/depends-on` with requirement types (`:succeeded`,
+`:merged-to-main`, `:structural-clean`) and have the supervisor refuse
+to schedule a dependent spec until its deps resolve. Same schema works
+for intra-DAG dependencies from spec #1's decomposition.
+
+## Proposed landing order
+
+1. **#1 (DAG wiring)** — unlocks decomposition. Any retry after this
+   benefits from the architecture miniforge already has.
+2. **#3 (event visibility)** — provides the observability #2 needs to
+   make decisions.
+3. **#2 (watchdog + resume)** — builds on #3's events.
+4. **#4 (scratch branch)** — independent; land anytime.
+5. **#5 (dep declarations)** — after #1 lands; uses the same supervisor
+   machinery as the decomposed DAG.
+
+## Related
+
+- Depends on merge of #568 (supervisory-state component + dogfood
+  diagnosis write-up) for historical context, but this PR does not
+  require #568 for functional reasons.
+- `specs/normative/N2-workflows.md §13` already documents DAG-based
+  multi-task execution as intended behavior — these specs align code
+  with that normative model.
+
+## Test plan
+
+- [x] All 5 spec files parse as EDN (implicit: pre-commit hooks green)
+- [ ] Miniforge run of spec #1 lands a PR that makes the remaining specs
+      themselves DAG-decomposable
+- [ ] After #1 lands, re-running polylith-compliance-remediation shows
+      `:workflow/dag-activated` event and parallel child workflows

--- a/work/agent-stream-watchdog-and-resume.spec.edn
+++ b/work/agent-stream-watchdog-and-resume.spec.edn
@@ -1,0 +1,84 @@
+;; =============================================================================
+;; Spec: Agent stream watchdog + session resume
+;; =============================================================================
+;;
+;; Observed failure mode (remediation run 2026-04-17, workflow b86fdfba):
+;;   :implement phase started at 16:46:47
+;;   86 read-tool calls fired in 98 seconds (steady ~1/sec cadence)
+;;   Last tool call at 16:48:51
+;;   THEN 11 MINUTES of total event silence
+;;   Curator finally terminated at 16:59:52 with "no files written"
+;;   Terminal event: :rate-limited? false, :iterations 1, :phase/tokens 0
+;;
+;; Cause (per user): Anthropic was silently rate-limiting / slow today.
+;; The backend HTTP stream stalled without returning a usable error. The
+;; agent was blocked waiting on its next response for 11 minutes. Miniforge
+;; had no detector for this — it kept the phase alive until some much-longer
+;; timeout fired and the curator grabbed the failure flag.
+;;
+;; We can't shim between the agent and its LLM. We CAN detect at the event
+;; boundary: every tool call emits a status event. A gap in that stream
+;; beyond a threshold IS the signal.
+
+{:spec/title "Agent stream watchdog + session-resume for hang recovery"
+
+ :spec/description
+ "Detect agent-stream hangs via event-emission gap, kill the agent, and
+  resume on the same backend (via session-resume) or fail over to another
+  backend. Integrate with the existing self-healing/backend-auto-switch
+  machinery.
+
+  GROUP 1: Per-phase event-gap watchdog
+  A background timer runs during each agent-driven phase. Every time the
+  agent emits any event (tool-calling, chunk, status, etc.), the timer
+  resets. If the timer exceeds :agent/stream-gap-threshold-ms (default
+  90000 = 90s, configurable per backend), send a kill signal to the agent
+  subprocess and emit :agent/stream-stalled event with the gap duration.
+
+  GROUP 2: Session ID persistence
+  When a Claude Code or Codex agent starts, capture its session ID from
+  the initial handshake (both backends expose this). Persist as part of
+  the phase state in /events and in the workflow run table. This is the
+  payload for resume.
+
+  GROUP 3: Resume-on-kill
+  After a watchdog-kill, consult self-healing policy. If this is the first
+  hang for this phase and the backend is still healthy, restart the agent
+  with backend's `--resume <session-id>` equivalent. The resumed session
+  preserves context and tool-call history; the agent picks up where it
+  stopped. If resume also hangs (second watchdog fire), escalate to
+  backend-auto-switch: mark the current backend unhealthy and retry on
+  the next backend in :allowed-failover-backends.
+
+  GROUP 4: Emit richer terminal events
+  Current terminal event on hang shows :rate-limited? false, :iterations 1,
+  :phase/tokens 0 — misleading because all three are true but don't surface
+  the real cause. Add :phase/termination-reason (one of :agent-stalled,
+  :curator-rejected, :tool-error, :normal). On watchdog kills,
+  termination-reason is :agent-stalled with the gap duration embedded."
+
+ :spec/intent {:type :refactor
+               :scope ["components/agent/src"
+                       "components/workflow-runner/src"
+                       "components/self-healing/src"
+                       "components/event-stream/src"
+                       "resources/config/default-user-config.edn"]}
+
+ :spec/constraints
+ ["Watchdog must not block event emission — run on a separate scheduler"
+  "Default gap threshold 90s; per-backend override in config"
+  "Session IDs must be persisted synchronously before the first tool call, otherwise resume is impossible"
+  "Failover must respect :allowed-failover-backends config — no silent backend switches"
+  "All watchdog actions MUST emit events; no silent retries"
+  "Tests must include a simulated-hang backend that ignores messages for >90s"]
+
+ :spec/acceptance-criteria
+ ["A synthetic backend that stops responding triggers a watchdog kill within 90s of the last event"
+  "Kill emits :agent/stream-stalled with accurate gap duration"
+  "Session ID is persisted per phase and visible in the event log"
+  "Resume path restarts the agent with the correct session ID"
+  "Second hang on the same phase triggers backend failover per self-healing config"
+  "Terminal :workflow/phase-completed on hang carries :phase/termination-reason :agent-stalled"
+  "Existing passing workflows do not regress (watchdog is observe-only when no hang)"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/event-log-tool-visibility.spec.edn
+++ b/work/event-log-tool-visibility.spec.edn
@@ -1,0 +1,81 @@
+;; =============================================================================
+;; Spec: Event log — tool-call visibility
+;; =============================================================================
+;;
+;; Today's dogfood post-mortem discovered a significant observability gap.
+;; The remediation run emitted 203 :agent/status events during implement,
+;; all with the generic payload:
+;;
+;;   {:event/type :agent/status
+;;    :status/type :tool-calling
+;;    :message "Agent calling tool"}
+;;
+;; No tool name, no args, no result, no duration. From the event log
+;; alone we can count tool calls but cannot diagnose what the agent was
+;; doing or why it stopped writing. The only deeper signal was reading
+;; the live process stdout — which was lost on restart.
+;;
+;; Self-improvement requires visibility. Miniforge cannot improve what it
+;; cannot see.
+
+{:spec/title "Event log — capture tool name / args / result on every agent tool call"
+
+ :spec/description
+ "Expand the event schema so every agent tool call emits a richer event
+  with enough context for post-mortem diagnosis without needing the
+  live stdout. Add phase-level heartbeat events and a derived event-gap
+  metric so watchdogs (and humans) can spot stalls.
+
+  GROUP 1: Tool-call event schema
+  Replace the single :agent/status :tool-calling event with two:
+    :agent/tool-call-started — fields: :tool/name, :tool/args-digest,
+        :tool/call-id, :agent/id
+    :tool/call-completed    — fields: :tool/call-id, :tool/result-digest,
+        :tool/duration-ms, :tool/success?, :tool/error (optional)
+  Args and result are digested (first 1 KB + sha256) to keep event size
+  bounded; full content goes to /artifacts if needed.
+
+  GROUP 2: Phase heartbeat events
+  Every N seconds (default 30s) during an active phase, emit
+  :workflow/phase-heartbeat with :phase/active-since, :phase/events-emitted,
+  :phase/last-event-at, :phase/gap-since-last-event-ms. Watchdog uses this
+  to sanity-check its own timer against wall clock.
+
+  GROUP 3: Post-mortem CLI
+  `miniforge events show <workflow-id>` renders a human-readable timeline:
+    16:47:13  implement  read  bases/mcp-context-server/deps.edn
+    16:47:15  implement  grep  'data-foundry' components/**
+    ...
+    16:48:51  implement  grep  'phase' components/**
+    16:48:51→16:59:52 — 11m0s event-stream gap (stalled)
+    16:59:52  implement  TERMINATED  :agent-stalled
+
+  GROUP 4: Rule-based alerts
+  Config-driven alerts: 'if phase-heartbeat gap > X', 'if no tool-call-
+  completed in Y seconds', 'if tool-call error rate > Z%'. Alerts route
+  to observability/event-sinks. Enables the watchdog spec to subscribe
+  rather than polling."
+
+ :spec/intent {:type :feature
+               :scope ["components/event-stream/src"
+                       "components/agent/src"
+                       "components/observer/src"
+                       "bases/cli/src/ai/miniforge/cli/main/commands/"
+                       "components/schema/src"]}
+
+ :spec/constraints
+ ["Event size must stay bounded — digest large args/results, link to artifacts"
+  "Heartbeat cadence configurable; default 30s to balance detail vs noise"
+  "Schema changes must be backward-compatible — consumers reading old events still work"
+  "Tool-call events must preserve causality: started → completed pairs"
+  "`miniforge events show` must work offline against the local event log"]
+
+ :spec/acceptance-criteria
+ ["Every agent tool call produces started+completed events with tool name and digests"
+  "Phase heartbeat fires every 30s with accurate gap metric"
+  "`miniforge events show <id>` renders a full phase timeline including gaps"
+  "Rule-based alert triggers :stream-stalled event when phase-heartbeat gap > threshold"
+  "A dogfood replay of today's hang shows exactly where the 11m gap started"
+  "Existing event consumers (dashboard, attention component) still work"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/plan-from-agent-dag-wiring.spec.edn
+++ b/work/plan-from-agent-dag-wiring.spec.edn
@@ -1,0 +1,106 @@
+;; =============================================================================
+;; Spec: Wire `plan-from-agent` output into the DAG orchestrator
+;; =============================================================================
+;;
+;; **This is the biggest single fix of today's dogfood findings.**
+;;
+;; Investigation of why the polylith-compliance-remediation run collapsed
+;; into one monolithic implement phase (13 min stall, zero files written)
+;; revealed that the DAG decomposition scaffolding is fully built but the
+;; trigger never fires for LLM-generated plans.
+;;
+;; Code paths:
+;;   components/dag-executor/        — full DAG executor, wired
+;;   components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+;;     — sub-workflow spawner, wired
+;;   components/workflow/src/ai/miniforge/workflow/execution.clj
+;;     line 344 — (dag-applicable? phase-name phase-result ctx)
+;;                checks for (get-in phase-result [:result :output :plan/id])
+;;     line 414 — (try-dag-execution ...) invokes the orchestrator
+;;
+;; Plan paths in components/phase-software-factory/src/ai/miniforge/phase/plan.clj:
+;;   plan-from-spec-tasks  line 46+  returns plan wrapped with :plan/id ✓
+;;   plan-from-agent       line 86+  does NOT wrap output with :plan/id ✗
+;;
+;; When a spec doesn't pre-declare tasks (the common case — e.g., today's
+;; remediation spec), plan-from-agent fires, extract-plan-from-phase-result
+;; returns nil, dag-applicable? returns nil, and execution falls back to
+;; one-phase-does-everything. The agent then has to tackle the full spec
+;; in a single implement iteration, which today caused the 13-minute hang.
+;;
+;; Also referenced: specs/normative/N2-workflows.md §13 documents
+;; DAG-based multi-task execution as the intended model.
+
+{:spec/title "plan-from-agent must emit :plan/id so the DAG orchestrator activates"
+
+ :spec/description
+ "Make the LLM-generated plan path produce the same output shape as the
+  spec-task plan path so the DAG orchestrator can pick it up. Without
+  this, miniforge's entire parallel-workflow capability is unreachable
+  for any spec that doesn't pre-declare tasks.
+
+  GROUP 1: Fix plan-from-agent output shape
+  File: components/phase-software-factory/src/ai/miniforge/phase/plan.clj
+  In plan-from-agent (line 86) and enter-plan (the interceptor that calls
+  it), ensure the returned phase result has:
+    {:result {:output {:plan/id <uuid>
+                       :plan/tasks [...]
+                       :plan/edges [...]   ;; DAG edges, may be empty for
+                                            ;; linear plans
+                       ...}}}
+  Match the schema used by plan-from-spec-tasks. :plan/id is a fresh UUID
+  per plan. :plan/tasks is the decomposed task list. :plan/edges encodes
+  dependencies between tasks for the DAG orchestrator.
+
+  GROUP 2: Instruct the planner agent to emit tasks, not just a prose plan
+  The planner's system prompt currently elicits a descriptive plan. Update
+  the prompt so the LLM returns a structured task graph:
+    - Each task has: id, title, scope (files/bricks), acceptance criteria
+    - Dependencies between tasks where they exist (e.g., Group 2 requires
+      Group 1)
+  Use tool_use with a plan-producing tool rather than parsing free-form
+  text.
+
+  GROUP 3: Guardrail — validate DAG shape before acceptance
+  extract-plan-from-phase-result should validate the plan against a
+  malli schema. If the planner produces an invalid DAG (cycles, unknown
+  task refs, empty task list), the phase fails with a clear error rather
+  than silently falling back to monolithic execution.
+
+  GROUP 4: Tests covering the DAG activation path
+  Add an integration test: given a spec without pre-declared tasks,
+  plan-from-agent runs, returns a valid plan, dag-applicable? returns
+  non-nil, the orchestrator spawns N sub-workflows. Currently no test
+  exercises this end-to-end.
+
+  GROUP 5: Metric / event for DAG activation
+  Emit :workflow/dag-activated event when the orchestrator takes over,
+  and :workflow/dag-skipped {:reason ...} when it doesn't. Today we have
+  no visibility into which path fired — the diagnosis required grep-
+  reading the code. Make it observable from the event log."
+
+ :spec/intent
+ {:type :fix
+  :scope ["components/phase-software-factory/src/ai/miniforge/phase/plan.clj"
+          "components/workflow/src/ai/miniforge/workflow/execution.clj"
+          "components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj"
+          "components/agent/src"
+          "components/schema/src"]}
+
+ :spec/constraints
+ ["Preserve the plan-from-spec-tasks fast path — specs that pre-declare tasks must continue to work"
+  "Plan schema must be malli-validated; invalid plans fail-fast, not silently"
+  "Planner prompt changes must still produce human-readable output for review in the plan artifact"
+  "Do not change the DAG orchestrator — the fix is upstream of it"
+  "Event types :workflow/dag-activated and :workflow/dag-skipped must be added to the event schema, not overloaded onto existing events"]
+
+ :spec/acceptance-criteria
+ ["plan-from-agent returns a phase result with :plan/id in {:result :output}"
+  "Running a spec without pre-declared tasks (e.g., polylith-compliance-remediation) triggers the DAG orchestrator"
+  "`miniforge events show <workflow-id>` shows :workflow/dag-activated when decomposition fires"
+  "Invalid plans (cycles / empty task lists / unknown refs) fail with a clear error, not silent fallback"
+  "Re-running today's remediation spec produces N child workflows (one per error class group) running in parallel where dependencies allow"
+  "Existing plan-from-spec-tasks tests still pass"
+  "An integration test asserts dag-applicable? fires on an LLM-generated plan"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/workflow-dependency-declarations.spec.edn
+++ b/work/workflow-dependency-declarations.spec.edn
@@ -1,0 +1,80 @@
+;; =============================================================================
+;; Spec: Workflow dependency declarations
+;; =============================================================================
+;;
+;; Observed failure (gates workflow e60f987a, 2026-04-17):
+;;   Gates and remediation ran in parallel. Gates' release phase tried
+;;   to commit its changes; pre-commit ran `poly check`; poly check
+;;   reported the 13 existing structural errors (which the parallel
+;;   remediation was mid-way through fixing); commit rejected; gates
+;;   aborted.
+;;
+;; No coordination existed to say "gates must wait for remediation."
+;; The supervisor scheduled both because there was no declared dependency.
+
+{:spec/title "Workflow dependency declarations — supervisor sequencing + DAG dependencies"
+
+ :spec/description
+ "Allow specs to declare dependencies on other specs. Supervisor refuses
+  to schedule a spec until its declared deps have successfully landed.
+  Applies to both cross-spec (polylith-gates depends on polylith-remediation)
+  and intra-DAG dependencies (child workflows within one spec's DAG).
+
+  GROUP 1: Schema
+  Add :spec/depends-on to the spec schema:
+    :spec/depends-on [{:dep/spec 'work/polylith-compliance-remediation.spec.edn'
+                       :dep/requirement :merged-to-main}
+                      {:dep/spec :workflow/some-earlier-run
+                       :dep/requirement :succeeded}]
+  Requirement types:
+    :succeeded     — dep workflow has :status/succeeded
+    :merged-to-main — dep's PR has been merged (uses git tag / commit check)
+    :structural-clean — `poly check` passes (or equivalent external gate)
+
+  GROUP 2: Supervisor scheduling check
+  Before transitioning a spec from :pending to :running, the supervisor
+  checks each :spec/depends-on entry. If any is unsatisfied, the spec
+  stays in :pending with :spec/blocked-by reason. Supervisor re-evaluates
+  on every workflow state change or every :heartbeat-interval-ms.
+
+  GROUP 3: Clear blocked-on status in UI
+  `miniforge list` (or equivalent) shows blocked workflows with their
+  unsatisfied deps:
+    pending  polylith-workflow-gates-and-scope  blocked-by: polylith-compliance-remediation (:merged-to-main not yet satisfied)
+
+  GROUP 4: CLI override
+  `miniforge run --ignore-deps <spec>` bypasses the check for forced runs
+  (explicit opt-in, logs a warning). Useful when human knows deps are
+  satisfied but automation can't verify.
+
+  GROUP 5: DAG-internal dependencies
+  When a spec's plan phase emits a DAG of child workflows (see
+  spec-decomposition-into-dag-workflows.spec.edn), the plan declares
+  child-to-child :depends-on relationships. Same supervisor mechanism
+  enforces them. The schema and machinery are identical whether
+  dependencies are cross-spec or intra-DAG."
+
+ :spec/intent {:type :feature
+               :scope ["components/spec-parser/src"
+                       "components/workflow-runner/src"
+                       "components/orchestrator/src"
+                       "bases/cli/src/ai/miniforge/cli/main/commands/"
+                       "components/schema/src"]}
+
+ :spec/constraints
+ ["Dep satisfaction must be observable, not inferred — each requirement type has a concrete check"
+  ":merged-to-main requires a git remote call; cache results for a configurable window (default 60s)"
+  ":structural-clean needs a pluggable gate interface — don't hardcode poly check"
+  "Circular deps must be detected at schedule time, not runtime"
+  "Override flag must emit a warning event; never silent"
+  "Default behavior for specs without :spec/depends-on must be unchanged (schedule immediately)"]
+
+ :spec/acceptance-criteria
+ ["Two specs with :depends-on relationship: dependent waits for dependency to succeed before scheduling"
+  ":merged-to-main resolves by checking the current main branch commit against the declared PR"
+  "`miniforge list` shows blocked workflows with readable :blocked-by reason"
+  "Circular dep detection rejects at spec-load time with a helpful error"
+  "--ignore-deps override works, emits warning event, runs the spec"
+  "Existing specs without :depends-on still schedule and run unchanged"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/worktree-persistence-scratch-branch.spec.edn
+++ b/work/worktree-persistence-scratch-branch.spec.edn
@@ -1,0 +1,81 @@
+;; =============================================================================
+;; Spec: Worktree persistence + scratch-branch safety
+;; =============================================================================
+;;
+;; Observed failure (gates workflow e60f987a, 2026-04-17):
+;;   :implement → :verify → :review (3/3 gates passed, 8 min of real work)
+;;   :release failed because pre-commit's poly check rejected the commit
+;;   Worktree at /tmp/mf-wt-gates was GC'd on next process-tree restart
+;;   All 8+ minutes of working code: permanently lost
+;;
+;; Two root causes:
+;; 1. Worktrees live under /tmp — tmpfs on macOS, volatile across reboots
+;; 2. Miniforge only "commits" in the release phase. A crash mid-phase
+;;    means uncommitted file edits vanish with the worktree.
+
+{:spec/title "Persist worktrees outside /tmp + scratch-branch commits on every write"
+
+ :spec/description
+ "Two independent-but-related fixes that together make miniforge resilient
+  to process-tree death mid-workflow.
+
+  GROUP 1: Move worktree root out of /tmp
+  Current code places worktrees under /tmp/miniforge-worktrees/. Move to
+  `~/.miniforge/worktrees/<workflow-id>/` by default. Configurable via
+  :workflow/worktree-root in user config. /tmp location remains available
+  as an explicit opt-in (useful for CI ephemeral runs).
+
+  GROUP 2: Scratch-branch commit on every file write
+  Each implementer file write in a worktree triggers a mirrored commit
+  on refs/miniforge/scratch/<workflow-id> in the *parent* repo (not the
+  worktree — avoids the known empty-tree bug). Commits are small, fast,
+  not pushed. Supervisor can recover in-flight work from the scratch ref
+  after a crash.
+
+  Commit message format:
+    scratch: <workflow-id> <phase> <file-path>
+
+  Scratch refs are auto-garbage-collected 7 days after workflow-run/finished.
+
+  GROUP 3: Recovery CLI
+  `miniforge recover <workflow-id>` lists all scratch commits for that
+  workflow, shows diff stats, and offers to:
+    (a) squash them into a recovery branch for manual review
+    (b) discard them (with confirmation)
+  Example:
+    $ miniforge recover 40a8f167-2b48-4324-a2ed-fcd18b7fa9b7
+    Found 14 scratch commits (2026-04-17 16:35:17 → 16:42:40)
+    Summary: 11 files written, 847 insertions, 23 deletions
+    Phases: implement (14 commits)
+    [1] Create recovery branch `recover/40a8f167` with squashed commits
+    [2] Show diff
+    [3] Discard
+
+  GROUP 4: Worktree lifecycle hooks
+  Extend the existing worktree-lifecycle component: on worktree-create
+  register the scratch-ref, on worktree-destroy preserve the scratch ref
+  until GC time."
+
+ :spec/intent {:type :refactor
+               :scope ["components/workflow-runner/src"
+                       "components/worktree-lifecycle/src"
+                       "components/implementer/src"
+                       "bases/cli/src/ai/miniforge/cli/main/commands/"
+                       "resources/config/default-user-config.edn"]}
+
+ :spec/constraints
+ ["Scratch commits must go to the PARENT repo directory — worktree commits produce empty trees (documented prior-art bug)"
+  "Scratch commits must not pollute `git log` on tracked branches — use refs/miniforge/scratch/* namespace"
+  "Scratch-commit overhead must stay under 200ms per file write to avoid slowing implementers"
+  "Worktree-root migration must handle existing /tmp worktrees gracefully (detect + warn, don't error)"
+  "Recovery CLI must require explicit confirmation before discarding work"]
+
+ :spec/acceptance-criteria
+ ["Default worktree-root is `~/.miniforge/worktrees/` — surviving across reboots"
+  "Every file write in a worktree produces a scratch commit on refs/miniforge/scratch/<workflow-id>"
+  "Scratch commits are visible via `git show refs/miniforge/scratch/<workflow-id>` and have correct trees (not empty)"
+  "`miniforge recover <workflow-id>` succeeds on today's gates workflow if re-simulated"
+  "7-day GC removes scratch refs for completed workflows"
+  "Existing test suite passes; new tests cover crash-recovery path"]
+
+ :spec/workflow-type :canonical-sdlc}


### PR DESCRIPTION
## Summary
Five specs derived from today's two failed miniforge runs, ordered by landing priority:

1. **`plan-from-agent-dag-wiring`** — root cause. DAG executor is fully wired but LLM plans don't emit `:plan/id`, so `dag-applicable?` returns nil and every non-pre-declared-task spec runs as one monolithic workflow. The 13-min hang we saw was this architecture gap in action.
2. **`event-log-tool-visibility`** — 203 tool-call events with no tool name / args / result. Expand schema + heartbeats + `miniforge events show` post-mortem CLI.
3. **`agent-stream-watchdog-and-resume`** — per-phase event-gap watchdog + session resume + backend failover. Catches silent stalls (today Anthropic was slow for 11 minutes with zero events).
4. **`worktree-persistence-scratch-branch`** — `/tmp/` worktrees + commit-only-at-release = data loss. Scratch ref + recovery CLI.
5. **`workflow-dependency-declarations`** — `:spec/depends-on` so gates doesn't race remediation.

See `docs/pull-requests/2026-04-17-dogfood-improvement-specs.md` for the full write-up and code trace.

## Next
Kicking off `plan-from-agent-dag-wiring.spec.edn` in miniforge right after this lands. That's the root-cause fix — every spec after it benefits from proper DAG decomposition.

## Test plan
- [x] All 5 spec files parse as EDN, pre-commit green
- [ ] Run of spec #1 produces a merged PR; verify `:workflow/dag-activated` event appears in subsequent runs
- [ ] Re-run today's polylith-compliance-remediation after #1 lands → should decompose into parallel child workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)