### PR TITLE
feat(supervisory-state): core + emitter + interface + tests

### DIFF
--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/attention.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/attention.clj
@@ -40,22 +40,30 @@
   (UUID/fromString "6ba7b810-9dad-11d1-80b4-00c04fd430c8"))
 
 (defn- uuid-v5
-  "Derive a deterministic UUID v5 from a namespace and a byte string."
+  "Derive a deterministic UUID v5 from a namespace UUID and a string key.
+
+   Uses SHA-1 per RFC-4122 §4.3. The bit-math constants are encoded as
+   signed longs because Clojure parses `0xFFFFFFFFFFFF0FFF` (>Long.MAX_VALUE)
+   as BigInt, which breaks `bit-and`."
   [^UUID ns-uuid ^String key]
-  (let [md   (MessageDigest/getInstance "SHA-1")
-        _    (let [buf (ByteBuffer/wrap (byte-array 16))]
-               (.putLong buf (.getMostSignificantBits ns-uuid))
-               (.putLong buf (.getLeastSignificantBits ns-uuid))
-               (.update md (.array buf)))
-        _    (.update md (.getBytes key "UTF-8"))
-        hash (.digest md)
-        msb  (ByteBuffer/wrap hash 0 8)
-        lsb  (ByteBuffer/wrap hash 8 8)
-        hi   (bit-or (bit-and (.getLong msb) 0xFFFFFFFFFFFF0FFF)
-                     0x0000000000005000)                        ; version 5
-        lo   (bit-or (bit-and (.getLong lsb) 0x3FFFFFFFFFFFFFFF)
-                     (bit-shift-left 0x8 60))]                  ; RFC-4122 variant
-    (UUID. hi lo)))
+  (let [md (MessageDigest/getInstance "SHA-1")
+        ns-buf (ByteBuffer/wrap (byte-array 16))]
+    (.putLong ns-buf (.getMostSignificantBits ns-uuid))
+    (.putLong ns-buf (.getLeastSignificantBits ns-uuid))
+    (.update md (.array ns-buf))
+    (.update md (.getBytes key "UTF-8"))
+    (let [hash    (.digest md)
+          msb-raw (.getLong (ByteBuffer/wrap hash 0 8))
+          lsb-raw (.getLong (ByteBuffer/wrap hash 8 8))
+          ;; 0xFFFFFFFFFFFF0FFF as signed long = -61441.
+          ;; Clears the 4-bit version nibble (bits 48-51), then OR in 0x5000
+          ;; to set UUID version = 5 (SHA-1 name-based).
+          hi      (bit-or (bit-and msb-raw (unchecked-long -61441)) 0x5000)
+          ;; Clear the top two bits (variant field, 62-63), then set to 10
+          ;; (RFC-4122). Long/MIN_VALUE == 0x8000000000000000.
+          lo      (bit-or (bit-and lsb-raw 0x3FFFFFFFFFFFFFFF)
+                          Long/MIN_VALUE)]
+      (UUID. hi lo))))
 
 (defn- attention-id
   "Stable ID derived from source-type and source-id so the same logical
@@ -178,13 +186,14 @@
    pr-behind-main-rule
    policy-violation-rule])
 
-(defn derive
+(defn derive-items
   "Run all rules against the entity table and return a map `{id → item}`.
 
    Using a map keyed by attention/id guarantees deduplication: if two rules
    would produce the same logical signal (same source-type + source-id) the
    later rule's entry wins — in practice they produce identical items so
-   this is idempotent."
+   this is idempotent. Named `derive-items` rather than `derive` to avoid
+   shadowing `clojure.core/derive`."
   [table]
   (->> rules
        (mapcat #(% table))
@@ -192,11 +201,11 @@
        (into {})))
 
 (defn derive-seq
-  "Same as `derive` but returns a sorted sequence suitable for display.
+  "Same as `derive-items` but returns a sorted sequence suitable for display.
 
    Sort: severity rank (critical → warning → info), then summary ascending."
   [table]
   (let [rank {:critical 0 :warning 1 :info 2}]
-    (->> (derive table)
+    (->> (derive-items table)
          vals
          (sort-by (juxt #(rank (:attention/severity %)) :attention/summary)))))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
@@ -1,0 +1,137 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.supervisory-state.core
+  "Supervisory-state component lifecycle and runtime.
+
+   The component owns an atom of form:
+
+     {:table <EntityTable>     ; canonical entity snapshot
+      :last-seq long            ; highest sequence number observed
+      :subscriber-id keyword    ; event-stream subscription handle
+      :stream <event-stream>}   ; back-reference to the stream we emit into
+
+   On `start!` it first replays the stream's in-memory event log to rebuild
+   the entity table (N5-delta-1 §3.4), then subscribes live. Each live event
+   is passed through the accumulator; if the entity table changes, the
+   emitter publishes one `:supervisory/*-upserted` event per changed entity
+   back into the same stream."
+  (:require
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.supervisory-state.accumulator :as accumulator]
+   [ai.miniforge.supervisory-state.attention :as attention]
+   [ai.miniforge.supervisory-state.emitter :as emitter]
+   [ai.miniforge.supervisory-state.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Subscriber id
+
+(def ^:const subscriber-id ::supervisory-state)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Tick — process a single event; derive attention; emit diffs
+
+(defn- with-attention
+  "Attach derived AttentionItems into the table so the emitter can diff/emit
+   them alongside entity upserts."
+  [table]
+  (assoc table :attention (attention/derive-items table)))
+
+(defn tick
+  "Apply one event to `state`, emit diffs. Pure at the entity-table level;
+   side-effects are limited to `es/publish!` calls on the stream.
+
+   Returns the updated state."
+  [{:keys [table stream] :as state} event]
+  (let [next-table (-> table
+                       (accumulator/apply-event event)
+                       with-attention)]
+    (when (not= table next-table)
+      (emitter/diff-and-emit! stream table next-table))
+    (assoc state :table next-table)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Startup replay
+
+(defn- replay
+  "Walk the stream's in-memory event log and fold it through the accumulator.
+   Returns a fresh entity table. Attention is derived once at the end rather
+   than on every step, to avoid emitting thousands of intermediate items
+   during replay."
+  [stream]
+  (let [events (es/get-events stream)]
+    (-> (accumulator/apply-events schema/empty-table events)
+        with-attention)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Lifecycle
+
+(defn create
+  "Build a fresh supervisory-state component instance bound to `stream`.
+   Does not subscribe yet — call `start!` to begin consuming events."
+  [stream]
+  (atom {:table  schema/empty-table
+         :stream stream
+         :subscribed? false}))
+
+(defn- handle-event!
+  [component event]
+  ;; Ignore our own snapshot events to prevent re-emit loops.
+  (when-not (#{:supervisory/workflow-upserted
+               :supervisory/agent-upserted
+               :supervisory/pr-upserted
+               :supervisory/policy-evaluated
+               :supervisory/attention-derived}
+             (:event/type event))
+    (swap! component tick event)))
+
+(defn start!
+  "Replay the stream's history into the entity table, then subscribe live.
+   Idempotent — subsequent calls are no-ops."
+  [component]
+  (let [{:keys [stream subscribed?]} @component]
+    (when-not subscribed?
+      (let [initial (replay stream)]
+        (swap! component assoc :table initial :subscribed? true))
+      (es/subscribe! stream subscriber-id
+                     (fn [event] (handle-event! component event))))
+    component))
+
+(defn stop!
+  "Unsubscribe from the stream. The entity table is retained so it can be
+   queried post-shutdown."
+  [component]
+  (let [{:keys [stream subscribed?]} @component]
+    (when subscribed?
+      (es/unsubscribe! stream subscriber-id)
+      (swap! component assoc :subscribed? false))
+    component))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Query API
+
+(defn table
+  "Current entity table snapshot (pure read)."
+  [component]
+  (:table @component))
+
+(defn workflows   [component] (vals (get-in @component [:table :workflows])))
+(defn agents      [component] (vals (get-in @component [:table :agents])))
+(defn prs         [component] (vals (get-in @component [:table :prs])))
+(defn policy-evals [component] (vals (get-in @component [:table :policy-evals])))
+(defn attention   [component] (vals (get-in @component [:table :attention])))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
@@ -1,0 +1,129 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.supervisory-state.emitter
+  "Construct and publish `:supervisory/*-upserted` snapshot events.
+
+   Each entity family has a constructor that produces an N3 §3.19-compliant
+   event map and a diff-and-emit function that publishes one event per
+   entity that differs between the previous and current table."
+  (:require
+   [ai.miniforge.event-stream.interface :as es]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Event constructors (match N3 §3.19 schemas)
+;;
+;; `create-envelope` in `event-stream.core` is not on the interface, so this
+;; component builds its own envelope inline. The `publish!` path only reads
+;; the N3 §2.1 required fields and the `:event/type` for routing.
+
+(def ^:const event-version "1.0.0")
+
+(defn- next-seq!
+  "Increment and return the sequence number for a given scope id."
+  [stream scope-id]
+  (let [new-val (-> (swap! stream update-in [:sequence-numbers scope-id]
+                           (fn [v] (inc (or v -1))))
+                    (get-in [:sequence-numbers scope-id]))]
+    new-val))
+
+(defn- event-envelope
+  [stream event-type scope-id message]
+  {:event/type             event-type
+   :event/id               (random-uuid)
+   :event/timestamp        (java.util.Date.)
+   :event/version          event-version
+   :event/sequence-number  (next-seq! stream scope-id)
+   :workflow/id            scope-id
+   :message                message})
+
+(defn workflow-upserted
+  [stream workflow-entity]
+  (-> (event-envelope stream
+                      :supervisory/workflow-upserted
+                      (:workflow-run/id workflow-entity)
+                      (str "Workflow " (:workflow-run/workflow-key workflow-entity)
+                           " upserted"))
+      (assoc :supervisory/entity workflow-entity)))
+
+(defn agent-upserted
+  [stream agent-entity]
+  (-> (event-envelope stream
+                      :supervisory/agent-upserted
+                      nil
+                      (str "Agent " (:agent/name agent-entity) " upserted"))
+      (assoc :supervisory/entity agent-entity)))
+
+(defn pr-upserted
+  [stream pr-entity]
+  (-> (event-envelope stream
+                      :supervisory/pr-upserted
+                      nil
+                      (str "PR " (:pr/repo pr-entity) "#" (:pr/number pr-entity)
+                           " upserted"))
+      (assoc :supervisory/entity pr-entity)))
+
+(defn policy-evaluated
+  [stream policy-entity]
+  (-> (event-envelope stream
+                      :supervisory/policy-evaluated
+                      nil
+                      (str "Policy evaluation "
+                           (:policy-eval/id policy-entity)
+                           ": "
+                           (:policy-eval/passed? policy-entity)))
+      (assoc :supervisory/entity policy-entity)))
+
+(defn attention-derived
+  [stream attention-entity]
+  (-> (event-envelope stream
+                      :supervisory/attention-derived
+                      nil
+                      (str "Attention "
+                           (name (:attention/severity attention-entity)) ": "
+                           (:attention/summary attention-entity)))
+      (assoc :supervisory/entity attention-entity)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Diff + emit — publish one event per entity that changed
+
+(defn- diff-entries
+  "Return keys in `new-m` whose values differ from `old-m`."
+  [old-m new-m]
+  (for [[k v] new-m
+        :when (not= v (get old-m k))]
+    k))
+
+(defn- emit-diff!
+  [stream ctor old-m new-m]
+  (doseq [k (diff-entries old-m new-m)]
+    (es/publish! stream (ctor stream (get new-m k)))))
+
+(defn diff-and-emit!
+  "Compare `old-table` and `new-table`; publish a snapshot event for each
+   entity that was inserted or updated.
+
+   Returns the number of events published, mainly for testing."
+  [stream old-table new-table]
+  (let [before (count (:events @stream))]
+    (emit-diff! stream workflow-upserted  (:workflows    old-table) (:workflows    new-table))
+    (emit-diff! stream agent-upserted     (:agents       old-table) (:agents       new-table))
+    (emit-diff! stream pr-upserted        (:prs          old-table) (:prs          new-table))
+    (emit-diff! stream policy-evaluated   (:policy-evals old-table) (:policy-evals new-table))
+    (emit-diff! stream attention-derived  (:attention    old-table) (:attention    new-table))
+    (- (count (:events @stream)) before)))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.supervisory-state.interface
+  "Public API for the supervisory-state component.
+
+   Materializes the five canonical supervisory entities from
+   N5-delta-supervisory-control-plane §3 out of the fine-grained event
+   stream (N3 §3.1–§3.16) and emits `:supervisory/*-upserted` snapshot events
+   (N3 §3.19) for consumers — the Rust control console, native app, and web
+   dashboard."
+  (:require
+   [ai.miniforge.supervisory-state.core :as core]
+   [ai.miniforge.supervisory-state.schema :as schema]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schemas (re-exports)
+
+(def WorkflowRun      schema/WorkflowRun)
+(def AgentSession     schema/AgentSession)
+(def PrFleetEntry     schema/PrFleetEntry)
+(def PolicyEvaluation schema/PolicyEvaluation)
+(def PolicyViolation  schema/PolicyViolation)
+(def AttentionItem    schema/AttentionItem)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Lifecycle
+
+(def create core/create)
+(def start! core/start!)
+(def stop!  core/stop!)
+
+;------------------------------------------------------------------------------ Layer 2
+;; Query API (reads only; consumers should prefer subscribing to
+;; `:supervisory/*-upserted` events on the event stream)
+
+(def table         core/table)
+(def workflows     core/workflows)
+(def agents        core/agents)
+(def prs           core/prs)
+(def policy-evals  core/policy-evals)
+(def attention     core/attention)

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
@@ -28,9 +28,7 @@
    producer.
 
    All maps are open (additional keys pass through) per
-   N5-delta-1 §12.4."
-  (:require
-   [ai.miniforge.schema.interface :as schema-core]))
+   N5-delta-1 §12.4.")
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Enums — match the Rust enum variants in supervisory-entities
@@ -69,33 +67,43 @@
 ;; Registry extensions for supervisory v1
 
 (def registry
-  "Malli registry extending core registry with supervisory v1 keyword types."
-  (merge
-   schema-core/registry
-   {;; WorkflowRun
-    :workflow-run/id              :id/uuid
-    :workflow-run/status          (into [:enum] workflow-run-statuses)
-    :workflow-run/trigger-source  (into [:enum] trigger-sources)
+  "Malli registry for supervisory v1 keyword types.
 
-    ;; AgentSession (overlaps with :agent/id from core; supervisory expects UUID)
-    :agent/status                 (into [:enum] agent-statuses)
+   Inlines the few base keyword types the supervisory entities need
+   (`:id/uuid`, `:common/timestamp`, `:common/non-neg-int`) rather than
+   depending on `ai.miniforge.schema.core/registry`. That registry is
+   intentionally not on the schema component's public interface, and
+   duplicating 3 lines here keeps supervisory-state from reaching across
+   a Polylith boundary."
+  {;; Primitives
+   :id/uuid            uuid?
+   :common/timestamp   inst?
+   :common/non-neg-int [:int {:min 0}]
 
-    ;; PrFleetEntry
-    :pr/status                    (into [:enum] pr-statuses)
-    :pr/ci-status                 (into [:enum] ci-statuses)
+   ;; WorkflowRun
+   :workflow-run/id              :id/uuid
+   :workflow-run/status          (into [:enum] workflow-run-statuses)
+   :workflow-run/trigger-source  (into [:enum] trigger-sources)
 
-    ;; PolicyEvaluation
-    :policy-eval/id               :id/uuid
-    :policy-eval/target-type      (into [:enum] policy-target-types)
+   ;; AgentSession
+   :agent/status                 (into [:enum] agent-statuses)
 
-    ;; PolicyViolation
-    :violation/severity           (into [:enum] violation-severities)
-    :violation/category           (into [:enum] violation-categories)
+   ;; PrFleetEntry
+   :pr/status                    (into [:enum] pr-statuses)
+   :pr/ci-status                 (into [:enum] ci-statuses)
 
-    ;; AttentionItem
-    :attention/id                 :id/uuid
-    :attention/severity           (into [:enum] attention-severities)
-    :attention/source-type        (into [:enum] attention-source-types)}))
+   ;; PolicyEvaluation
+   :policy-eval/id               :id/uuid
+   :policy-eval/target-type      (into [:enum] policy-target-types)
+
+   ;; PolicyViolation
+   :violation/severity           (into [:enum] violation-severities)
+   :violation/category           (into [:enum] violation-categories)
+
+   ;; AttentionItem
+   :attention/id                 :id/uuid
+   :attention/severity           (into [:enum] attention-severities)
+   :attention/source-type        (into [:enum] attention-source-types)})
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Entity schemas — open maps, mirror N5-delta-1 §3.1

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -1,0 +1,208 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.supervisory-state.accumulator-test
+  "Unit tests for the supervisory-state event → entity accumulator."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.supervisory-state.accumulator :as acc]
+   [ai.miniforge.supervisory-state.schema :as schema]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn ev
+  "Construct an event matching N3 §2.1's required envelope shape, merging
+   in any extras. `:workflow/id` defaults to a random UUID."
+  [event-type extras]
+  (merge {:event/type            event-type
+          :event/id              (random-uuid)
+          :event/timestamp       (java.util.Date.)
+          :event/version         "1.0.0"
+          :event/sequence-number 0
+          :workflow/id           (random-uuid)
+          :message               "test"}
+         extras))
+
+;------------------------------------------------------------------------------ WorkflowRun
+
+(deftest workflow-started-inserts-minimal-run
+  (let [wf-id (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :workflow/started {:workflow/id wf-id}))
+        run   (get-in table [:workflows wf-id])]
+    (is (= wf-id (:workflow-run/id run)))
+    (is (= :running (:workflow-run/status run)))
+    (is (= :unknown (:workflow-run/current-phase run)))
+    (is (some? (:workflow-run/started-at run)))
+    (is (string? (:workflow-run/workflow-key run))
+        "synthesized key is a string when event carries no spec")))
+
+(deftest workflow-phase-started-updates-phase
+  (let [wf-id (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :workflow/started {:workflow/id wf-id}))
+                  (acc/apply-event (ev :workflow/phase-started
+                                       {:workflow/id wf-id
+                                        :workflow/phase :implement})))]
+    (is (= :implement (get-in table [:workflows wf-id :workflow-run/current-phase])))))
+
+(deftest workflow-phase-started-before-workflow-started-inserts-placeholder
+  (let [wf-id (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :workflow/phase-started
+                                   {:workflow/id wf-id
+                                    :workflow/phase :plan}))]
+    (is (= :plan (get-in table [:workflows wf-id :workflow-run/current-phase]))
+        "phase-started creates a placeholder when no prior workflow/started")
+    (is (= :running (get-in table [:workflows wf-id :workflow-run/status])))))
+
+(deftest workflow-completed-sets-terminal-status
+  (let [wf-id (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :workflow/started  {:workflow/id wf-id}))
+                  (acc/apply-event (ev :workflow/completed {:workflow/id wf-id})))]
+    (is (= :completed (get-in table [:workflows wf-id :workflow-run/status])))))
+
+(deftest workflow-failed-sets-failed-status
+  (let [wf-id (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :workflow/started {:workflow/id wf-id}))
+                  (acc/apply-event (ev :workflow/failed  {:workflow/id wf-id})))]
+    (is (= :failed (get-in table [:workflows wf-id :workflow-run/status])))))
+
+;------------------------------------------------------------------------------ AgentSession
+
+(deftest cp-agent-registered-inserts-session
+  (let [ag-id (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :control-plane/agent-registered
+                                   {:cp/agent-id   ag-id
+                                    :cp/vendor     :claude-code
+                                    :cp/agent-name "impl-1"}))
+        a     (get-in table [:agents ag-id])]
+    (is (= ag-id (:agent/id a)))
+    (is (= "claude-code" (:agent/vendor a)))
+    (is (= "impl-1" (:agent/name a)))
+    (is (= :idle (:agent/status a)))))
+
+(deftest cp-agent-state-changed-updates-status
+  (let [ag-id (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :control-plane/agent-registered
+                                       {:cp/agent-id ag-id
+                                        :cp/vendor   :claude-code
+                                        :cp/agent-name "impl-1"}))
+                  (acc/apply-event (ev :control-plane/agent-state-changed
+                                       {:cp/agent-id   ag-id
+                                        :cp/from-status :idle
+                                        :cp/to-status   :executing})))]
+    (is (= :executing (get-in table [:agents ag-id :agent/status])))))
+
+(deftest cp-agent-heartbeat-touches-last-heartbeat
+  (let [ag-id (random-uuid)
+        t0    (java.util.Date. (long 1000000))
+        t1    (java.util.Date. (long 2000000))
+        table (-> schema/empty-table
+                  (acc/apply-event (merge (ev :control-plane/agent-registered
+                                              {:cp/agent-id ag-id
+                                               :cp/vendor :claude-code
+                                               :cp/agent-name "impl-1"})
+                                          {:event/timestamp t0}))
+                  (acc/apply-event (merge (ev :control-plane/agent-heartbeat
+                                              {:cp/agent-id ag-id
+                                               :cp/status :executing})
+                                          {:event/timestamp t1})))]
+    (is (= t1 (get-in table [:agents ag-id :agent/last-heartbeat])))))
+
+(deftest unknown-agent-heartbeat-is-ignored
+  (let [table (acc/apply-event schema/empty-table
+                               (ev :control-plane/agent-heartbeat
+                                   {:cp/agent-id (random-uuid)}))]
+    (is (empty? (:agents table)))))
+
+;------------------------------------------------------------------------------ PR
+
+(deftest pr-created-then-merged
+  (let [table (-> schema/empty-table
+                  (acc/apply-event (ev :pr/created
+                                       {:pr/repo "acme/widget"
+                                        :pr/number 42
+                                        :pr/title "Add thing"}))
+                  (acc/apply-event (ev :pr/merged
+                                       {:pr/repo "acme/widget"
+                                        :pr/number 42})))
+        pr    (get-in table [:prs ["acme/widget" 42]])]
+    (is (= :merged (:pr/status pr)))
+    (is (some? (:pr/merged-at pr)))))
+
+;------------------------------------------------------------------------------ PolicyEvaluation
+
+(deftest gate-passed-creates-evaluation
+  (let [id    (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :gate/passed
+                                   {:gate/id id
+                                    :gate/target-type :pr
+                                    :gate/target-id   ["acme/widget" 42]
+                                    :gate/packs       ["core"]}))
+        ev*   (get-in table [:policy-evals id])]
+    (is (true? (:policy-eval/passed? ev*)))
+    (is (= :pr (:policy-eval/target-type ev*)))
+    (is (= ["core"] (:policy-eval/packs-applied ev*)))))
+
+(deftest gate-failed-captures-violations
+  (let [id    (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :gate/failed
+                                   {:gate/id id
+                                    :gate/violations [{:rule-id :no-force-push
+                                                       :severity :critical
+                                                       :category :security
+                                                       :message "force push detected"
+                                                       :remediable? false}]}))
+        ev*   (get-in table [:policy-evals id])]
+    (is (false? (:policy-eval/passed? ev*)))
+    (is (= 1 (count (:policy-eval/violations ev*))))
+    (is (= :no-force-push
+           (-> ev* :policy-eval/violations first :violation/rule-id)))))
+
+;------------------------------------------------------------------------------ Supervisory snapshot replay
+
+(deftest supervisory-workflow-upserted-applies-baseline
+  (let [wf-id  (random-uuid)
+        entity {:workflow-run/id              wf-id
+                :workflow-run/workflow-key    "auth-flow"
+                :workflow-run/intent          "add login"
+                :workflow-run/status          :completed
+                :workflow-run/current-phase   :release
+                :workflow-run/started-at      (java.util.Date.)
+                :workflow-run/updated-at      (java.util.Date.)
+                :workflow-run/trigger-source  :cli
+                :workflow-run/correlation-id  wf-id}
+        table  (acc/apply-event schema/empty-table
+                                (ev :supervisory/workflow-upserted
+                                    {:supervisory/entity entity}))]
+    (is (= entity (get-in table [:workflows wf-id]))
+        "snapshot events set the entity as an authoritative baseline")))
+
+;------------------------------------------------------------------------------ Unknown event
+
+(deftest unknown-event-type-is-noop
+  (is (= schema/empty-table
+         (acc/apply-event schema/empty-table
+                          (ev :custom/frobnicated {})))))

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/attention_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/attention_test.clj
@@ -1,0 +1,115 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.supervisory-state.attention-test
+  "Tests for attention derivation (N5-delta-1 §5.1)."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.supervisory-state.attention :as attention]
+   [ai.miniforge.supervisory-state.schema :as schema]))
+
+(defn- workflow
+  ([id status] (workflow id status (java.util.Date.)))
+  ([id status updated-at]
+   {:workflow-run/id             id
+    :workflow-run/workflow-key   (str "wf-" id)
+    :workflow-run/intent         "test"
+    :workflow-run/status         status
+    :workflow-run/current-phase  :implement
+    :workflow-run/started-at     updated-at
+    :workflow-run/updated-at     updated-at
+    :workflow-run/trigger-source :cli
+    :workflow-run/correlation-id id}))
+
+(defn- mk-agent
+  [id status]
+  {:agent/id id
+   :agent/vendor "claude-code"
+   :agent/external-id ""
+   :agent/name "a"
+   :agent/status status
+   :agent/capabilities []
+   :agent/heartbeat-interval-ms 30000
+   :agent/metadata {}
+   :agent/tags []
+   :agent/registered-at (java.util.Date.)
+   :agent/last-heartbeat (java.util.Date.)})
+
+;------------------------------------------------------------------------------ Individual rules
+
+(deftest failed-workflow-yields-critical
+  (let [id (random-uuid)
+        table (assoc-in schema/empty-table [:workflows id] (workflow id :failed))
+        items (attention/derive-seq table)]
+    (is (= 1 (count items)))
+    (is (= :critical (:attention/severity (first items))))))
+
+(deftest completed-workflow-yields-info
+  (let [id (random-uuid)
+        table (assoc-in schema/empty-table [:workflows id] (workflow id :completed))
+        items (attention/derive-seq table)]
+    (is (some #(= :info (:attention/severity %)) items))))
+
+(deftest stale-running-workflow-yields-warning
+  (let [id    (random-uuid)
+        stale (java.util.Date. (long 0))  ; epoch → definitely stale
+        table (assoc-in schema/empty-table [:workflows id]
+                        (workflow id :running stale))
+        items (attention/derive-seq table)]
+    (is (some #(and (= :warning (:attention/severity %))
+                    (= :workflow (:attention/source-type %)))
+              items))))
+
+(deftest blocked-agent-yields-warning
+  (let [id (random-uuid)
+        table (assoc-in schema/empty-table [:agents id] (mk-agent id :blocked))
+        items (attention/derive-seq table)]
+    (is (some #(and (= :warning (:attention/severity %))
+                    (= :agent (:attention/source-type %)))
+              items))))
+
+(deftest failed-agent-yields-critical
+  (let [id (random-uuid)
+        table (assoc-in schema/empty-table [:agents id] (mk-agent id :failed))
+        items (attention/derive-seq table)]
+    (is (some #(and (= :critical (:attention/severity %))
+                    (= :agent (:attention/source-type %)))
+              items))))
+
+;------------------------------------------------------------------------------ Determinism
+
+(deftest attention-id-is-stable-across-derivations
+  (let [id (random-uuid)
+        table (assoc-in schema/empty-table [:workflows id] (workflow id :failed))
+        derive-id #(-> table attention/derive-seq first :attention/id)]
+    (is (= (derive-id) (derive-id))
+        "same signal must yield same id to prevent flicker in consumers")))
+
+;------------------------------------------------------------------------------ Ordering
+
+(deftest items-sorted-critical-warning-info
+  (let [table (-> schema/empty-table
+                  (assoc-in [:workflows (random-uuid)] (workflow (random-uuid) :failed))
+                  (assoc-in [:workflows (random-uuid)] (workflow (random-uuid) :completed))
+                  (assoc-in [:agents (random-uuid)] (mk-agent (random-uuid) :blocked)))
+        sevs  (map :attention/severity (attention/derive-seq table))]
+    (is (= [:critical :warning :info] (distinct sevs))
+        "critical before warning before info")))
+
+(deftest empty-table-yields-no-items
+  (is (empty? (attention/derive-seq schema/empty-table))))

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
@@ -1,0 +1,120 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.supervisory-state.core-test
+  "End-to-end tests for the supervisory-state component lifecycle:
+   replay, live subscription, snapshot emission, and re-emit prevention."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.event-stream.core :as es-core]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.supervisory-state.core :as core]
+   [ai.miniforge.supervisory-state.interface :as iface]))
+
+;------------------------------------------------------------------------------ Helpers
+
+(defn- no-sink-stream []
+  (es-core/create-event-stream {:sinks []}))
+
+(defn- supervisory-events
+  "Events on the stream with type in the `:supervisory/*` family."
+  [stream]
+  (->> (es/get-events stream)
+       (filter #(some-> % :event/type namespace (= "supervisory")))))
+
+(defn- workflow-started [wf-id]
+  {:event/type :workflow/started
+   :event/id (random-uuid)
+   :event/timestamp (java.util.Date.)
+   :event/version "1.0.0"
+   :event/sequence-number 0
+   :workflow/id wf-id
+   :message "Workflow started"})
+
+(defn- workflow-completed [wf-id]
+  {:event/type :workflow/completed
+   :event/id (random-uuid)
+   :event/timestamp (java.util.Date.)
+   :event/version "1.0.0"
+   :event/sequence-number 1
+   :workflow/id wf-id
+   :message "Workflow completed"})
+
+;------------------------------------------------------------------------------ Lifecycle
+
+(deftest start-then-stop-subscribes-and-unsubscribes
+  (let [stream (no-sink-stream)
+        comp   (iface/create stream)]
+    (iface/start! comp)
+    (is (true? (:subscribed? @comp)))
+    (is (contains? (:subscribers @stream) core/subscriber-id))
+    (iface/stop! comp)
+    (is (false? (:subscribed? @comp)))
+    (is (not (contains? (:subscribers @stream) core/subscriber-id)))))
+
+;------------------------------------------------------------------------------ Emission
+
+(deftest live-workflow-events-produce-supervisory-snapshots
+  (let [stream (no-sink-stream)
+        comp   (iface/create stream)
+        wf-id  (random-uuid)]
+    (iface/start! comp)
+    (es/publish! stream (workflow-started wf-id))
+    (es/publish! stream (workflow-completed wf-id))
+    (let [snaps   (supervisory-events stream)
+          kinds   (frequencies (map :event/type snaps))]
+      (is (>= (count snaps) 2)
+          "at least one supervisory/workflow-upserted per entity change")
+      (is (some #{:supervisory/workflow-upserted} (keys kinds)))
+      ;; attention may also fire (workflow completed → :info item)
+      )))
+
+(deftest supervisory-events-are-not-re-emitted
+  (let [stream (no-sink-stream)
+        comp   (iface/create stream)]
+    (iface/start! comp)
+    (es/publish! stream (workflow-started (random-uuid)))
+    (let [before (count (supervisory-events stream))]
+      ;; Publish a synthetic supervisory event directly; handle-event! must
+      ;; ignore it so the component doesn't recurse.
+      (es/publish! stream {:event/type :supervisory/workflow-upserted
+                           :event/id (random-uuid)
+                           :event/timestamp (java.util.Date.)
+                           :event/version "1.0.0"
+                           :event/sequence-number 99
+                           :workflow/id (random-uuid)
+                           :message "synthetic"
+                           :supervisory/entity {:workflow-run/id (random-uuid)}})
+      (let [after (count (supervisory-events stream))]
+        (is (= (inc before) after)
+            "only the synthetic event should be added; no re-emission loop")))))
+
+;------------------------------------------------------------------------------ Replay
+
+(deftest startup-replay-reconstructs-table-from-history
+  (let [stream (no-sink-stream)
+        wf-id  (random-uuid)]
+    ;; Events exist in the stream before the component starts.
+    (es/publish! stream (workflow-started wf-id))
+    (es/publish! stream (workflow-completed wf-id))
+    (let [comp (iface/create stream)]
+      (iface/start! comp)
+      (let [runs (iface/workflows comp)]
+        (is (= 1 (count runs)))
+        (is (= :completed (:workflow-run/status (first runs)))
+            "replay must apply all historic events, ending in :completed")))))

--- a/deps.edn
+++ b/deps.edn
@@ -81,6 +81,8 @@
                        "components/repo-dag/resources"
                        "components/event-stream/src"
                        "components/event-stream/resources"
+                       "components/supervisory-state/src"
+                       "components/supervisory-state/resources"
                        "components/tui-engine/src"
                        "components/tui-engine/resources"
                        "components/tui-views/src"
@@ -214,6 +216,7 @@
                      ai.miniforge/pr-train {:local/root "components/pr-train"}
                      ai.miniforge/repo-dag {:local/root "components/repo-dag"}
                      ai.miniforge/event-stream {:local/root "components/event-stream"}
+                     ai.miniforge/supervisory-state {:local/root "components/supervisory-state"}
                      ai.miniforge/tui-engine {:local/root "components/tui-engine"}
                      ai.miniforge/tui-views {:local/root "components/tui-views"}
                      ai.miniforge/web-dashboard {:local/root "components/web-dashboard"}
@@ -310,6 +313,7 @@
                        "components/pr-train/test"
                        "components/repo-dag/test"
                        "components/event-stream/test"
+                       "components/supervisory-state/test"
                        "components/tui-engine/test"
                        "components/tui-views/test"
                        "components/web-dashboard/test"
@@ -404,6 +408,7 @@
                       ai.miniforge/pr-train {:local/root "components/pr-train"}
                       ai.miniforge/repo-dag {:local/root "components/repo-dag"}
                       ai.miniforge/event-stream {:local/root "components/event-stream"}
+                      ai.miniforge/supervisory-state {:local/root "components/supervisory-state"}
                       ai.miniforge/tui-engine {:local/root "components/tui-engine"}
                       ai.miniforge/tui-views {:local/root "components/tui-views"}
                       ai.miniforge/web-dashboard {:local/root "components/web-dashboard"}


### PR DESCRIPTION
## Summary

Extends the supervisory-state WIP component landed in #568 with the runtime pieces needed to make it actually produce `:supervisory/*-upserted` events (N3 §3.19) from the fine-grained event stream:

- **core.clj** — component lifecycle. Replay-then-subscribe pipeline; `handle-event!` filters out the component's own snapshot events to prevent re-emit loops; `start!` / `stop!` are idempotent.
- **emitter.clj** — N3 §3.19 event constructors plus `diff-and-emit!` that publishes one event per entity that changed between the prior and current table.
- **interface.clj** — public API: entity schemas, lifecycle, and a small query surface.
- **accumulator.clj** — adds `:supervisory/*-upserted` handlers so snapshot events apply as authoritative baselines during replay; event → entity update is a dispatch-table (`handlers` map) rather than a giant case.
- **attention.clj** — renames `derive` → `derive-items` (avoids shadowing `clojure.core/derive`); fixes UUID v5 bit-math to use signed-long literals (Clojure parses `0xFFFFFFFFFFFF0FFF` as BigInt, which breaks `bit-and`).
- **schema.clj** — registry becomes self-contained (inlines `:id/uuid`, `:common/timestamp`, `:common/non-neg-int`) rather than reaching through `ai.miniforge.schema.core/registry` (not on the schema component's public interface).

## Test plan

- [x] `clojure -M:dev:test … accumulator-test attention-test core-test` — **26 tests, 45 assertions, 0 failures**
  - accumulator: per-event-type unit tests (workflow-started, phase-started-before-started-placeholder, completed/failed, cp-agent-registered, cp-agent-state-changed, heartbeat, gate-passed, gate-failed, supervisory-upserted replay)
  - attention: every §5.1 rule, `attention-id` stability across derivations, critical→warning→info ordering
  - core: subscribe/unsubscribe lifecycle; live events produce snapshot events; supervisory events are not re-emitted; startup replay reconstructs state from history
- [x] Workspace deps.edn paths added (`dev` alias + tests).

## Not in scope (intentional)

- **Wiring** `supervisory-state` into `workflow_runner.clj` (and other `create-event-stream` call sites) — that's the next change; keeping it separate so this PR stays focused on the component itself.
- Rust consumer-side changes (`miniforge-control/event-client` + `state/manager` + fixture replacement) — separate PR in the other repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)