### PR TITLE
fix(workflow): emit :workflow/dag-considered with skip reason

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -341,6 +341,19 @@
             (inc i)))
         (map-indexed vector pipeline)))
 
+(defn dag-skip-reason
+  "Return the reason DAG execution should be skipped, or nil if it should proceed.
+   Reasons are keywords — :not-plan-phase, :disabled, :no-plan-id, :no-tasks."
+  [phase-name phase-result ctx]
+  (cond
+    (not= :plan phase-name) :not-plan-phase
+    (:disable-dag-execution ctx) :disabled
+    :else (let [plan (extract-plan-from-phase-result phase-result)]
+            (cond
+              (nil? plan) :no-plan-id
+              (empty? (:plan/tasks plan)) :no-tasks
+              :else nil))))
+
 (defn dag-applicable?
   "Check whether DAG execution should be attempted for this phase result.
    Returns the plan map if applicable, nil otherwise."
@@ -348,6 +361,34 @@
   (when (and (= :plan phase-name)
              (not (:disable-dag-execution ctx)))
     (extract-plan-from-phase-result phase-result)))
+
+(defn- resolve-event-stream
+  "Find the event stream from context, matching phase/telemetry's lookup."
+  [ctx]
+  (or (:event-stream ctx)
+      (:execution/event-stream ctx)
+      (get-in ctx [:execution/opts :event-stream])))
+
+(defn- resolve-workflow-id
+  [ctx]
+  (or (:execution/id ctx) (:workflow/id ctx) (:workflow-id ctx)))
+
+(defn- emit-dag-considered!
+  "Emit a :workflow/dag-considered event describing whether DAG fired and why.
+   Swallows errors — observability must not break execution."
+  [ctx outcome reason extra]
+  (when-let [stream (resolve-event-stream ctx)]
+    (try
+      (let [publish! (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)
+            event (merge
+                    {:event/type :workflow/dag-considered
+                     :event/timestamp (str (java.time.Instant/now))
+                     :workflow/id (resolve-workflow-id ctx)
+                     :dag/outcome outcome
+                     :dag/reason reason}
+                    extra)]
+        (publish! stream event))
+      (catch Exception _ nil))))
 
 (defn- merge-sub-worktree-changes!
   "Copy changed files from DAG sub-worktrees into the parent worktree.
@@ -416,16 +457,29 @@
 
    The DAG executor is the universal executor — it handles both parallel
    and sequential plans. Returns updated context with DAG results and
-   skipped-to index, or nil if DAG execution is not applicable."
+   skipped-to index, or nil if DAG execution is not applicable.
+
+   Always emits :workflow/dag-considered so the event log captures whether
+   DAG fired and — when skipped — exactly why."
   [ctx phase-name phase-result pipeline
    transition-to-completed-fn transition-to-failed-fn]
-  (when-let [plan (dag-applicable? phase-name phase-result ctx)]
-    (let [ctx-with-resume (assoc ctx :pre-completed-ids
-                                 (get-in ctx [:execution/opts :pre-completed-dag-tasks] #{}))
-          dag-result (dag-orch/execute-plan-as-dag plan ctx-with-resume)]
-      (if (:success? dag-result)
-        (apply-dag-success ctx dag-result pipeline transition-to-completed-fn)
-        (apply-dag-failure ctx dag-result transition-to-failed-fn)))))
+  (let [skip-reason (dag-skip-reason phase-name phase-result ctx)]
+    (if skip-reason
+      (do
+        (when (= :plan phase-name)
+          (emit-dag-considered! ctx :skipped skip-reason
+                                {:phase/name phase-name}))
+        nil)
+      (let [plan (extract-plan-from-phase-result phase-result)
+            ctx-with-resume (assoc ctx :pre-completed-ids
+                                   (get-in ctx [:execution/opts :pre-completed-dag-tasks] #{}))
+            _ (emit-dag-considered! ctx :activated :plan-has-tasks
+                                    {:plan/id (:plan/id plan)
+                                     :plan/task-count (count (:plan/tasks plan))})
+            dag-result (dag-orch/execute-plan-as-dag plan ctx-with-resume)]
+        (if (:success? dag-result)
+          (apply-dag-success ctx dag-result pipeline transition-to-completed-fn)
+          (apply-dag-failure ctx dag-result transition-to-failed-fn))))))
 
 ;------------------------------------------------------------------------------ Layer 2: Phase step execution
 

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -24,6 +24,7 @@
   (:require [ai.miniforge.gate.interface :as gate]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.response.interface :as response]
+            [ai.miniforge.schema.interface :as schema]
             [ai.miniforge.workflow.dag-orchestrator :as dag-orch]))
 
 ;------------------------------------------------------------------------------ Layer 0: Atomic operations
@@ -477,7 +478,7 @@
                                     {:plan/id (:plan/id plan)
                                      :plan/task-count (count (:plan/tasks plan))})
             dag-result (dag-orch/execute-plan-as-dag plan ctx-with-resume)]
-        (if (:success? dag-result)
+        (if (schema/succeeded? dag-result)
           (apply-dag-success ctx dag-result pipeline transition-to-completed-fn)
           (apply-dag-failure ctx dag-result transition-to-failed-fn))))))
 

--- a/components/workflow/test/ai/miniforge/workflow/dag_activation_diagnostics_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_activation_diagnostics_test.clj
@@ -1,0 +1,86 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.dag-activation-diagnostics-test
+  "Unit tests for DAG activation skip-reason diagnostics.
+
+   Ensures every non-activation path has a specific reason that will land
+   in the event log via :workflow/dag-considered."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.workflow.execution :as exec]))
+
+(def ^:private valid-plan
+  {:plan/id #uuid "00000000-0000-0000-0000-000000000001"
+   :plan/tasks [{:task/id #uuid "00000000-0000-0000-0000-000000000002"
+                 :task/description "t1"}
+                {:task/id #uuid "00000000-0000-0000-0000-000000000003"
+                 :task/description "t2"}]
+   :plan/name "test"})
+
+(defn- phase-result-with-plan [plan]
+  {:name :plan
+   :agent :planner
+   :result {:status :success :output plan}})
+
+(deftest skip-reason-not-plan-phase
+  (testing "Non-plan phases skip with :not-plan-phase"
+    (is (= :not-plan-phase
+           (exec/dag-skip-reason :implement (phase-result-with-plan valid-plan) {})))
+    (is (= :not-plan-phase
+           (exec/dag-skip-reason :verify {} {})))))
+
+(deftest skip-reason-disabled
+  (testing "When ctx has :disable-dag-execution, skip with :disabled"
+    (is (= :disabled
+           (exec/dag-skip-reason :plan
+                                 (phase-result-with-plan valid-plan)
+                                 {:disable-dag-execution true})))))
+
+(deftest skip-reason-no-plan-id
+  (testing "Missing :plan/id in phase output skips with :no-plan-id"
+    (is (= :no-plan-id
+           (exec/dag-skip-reason :plan {:result {:status :success :output {}}} {})))
+    (is (= :no-plan-id
+           (exec/dag-skip-reason :plan {:result {:status :error}} {})))
+    (is (= :no-plan-id
+           (exec/dag-skip-reason :plan {} {})))))
+
+(deftest skip-reason-no-tasks
+  (testing "Plan with :plan/id but empty :plan/tasks skips with :no-tasks"
+    (let [empty-plan {:plan/id (random-uuid) :plan/tasks []}]
+      (is (= :no-tasks
+             (exec/dag-skip-reason :plan (phase-result-with-plan empty-plan) {}))))))
+
+(deftest activates-with-tasks
+  (testing "Plan with :plan/id and at least one task returns nil (don't skip)"
+    (is (nil? (exec/dag-skip-reason :plan (phase-result-with-plan valid-plan) {})))
+    (let [one-task-plan {:plan/id (random-uuid)
+                         :plan/tasks [{:task/id (random-uuid)}]}]
+      (is (nil? (exec/dag-skip-reason :plan
+                                      (phase-result-with-plan one-task-plan)
+                                      {}))))))
+
+(deftest dag-applicable-backward-compatible
+  (testing "dag-applicable? preserves existing return semantics"
+    (is (= valid-plan
+           (exec/dag-applicable? :plan (phase-result-with-plan valid-plan) {})))
+    (is (nil? (exec/dag-applicable? :implement (phase-result-with-plan valid-plan) {})))
+    (is (nil? (exec/dag-applicable? :plan
+                                    (phase-result-with-plan valid-plan)
+                                    {:disable-dag-execution true})))))

--- a/docs/pull-requests/2026-04-17-dag-activation-diagnostics.md
+++ b/docs/pull-requests/2026-04-17-dag-activation-diagnostics.md
@@ -1,0 +1,105 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# DAG activation diagnostics — surface skip reasons in the event log
+
+## Context
+
+Three miniforge runs today ended with the curator's "implementer wrote no
+files to the environment" after the implementer agent hung or streamed
+with zero writes. The root-cause hypothesis (per the spec at
+`work/plan-from-agent-dag-wiring.spec.edn`) was that the DAG orchestrator
+never fires for LLM-generated plans, forcing a monolithic `:implement`
+phase.
+
+A REPL trace this session invalidated part of that hypothesis: with the
+planner's real output shape, `dag-applicable?` DOES correctly return the
+plan. So either:
+
+1. The planner is failing silently and returning a response with no
+   `:output :plan/id`, or
+2. The plan has no tasks, or
+3. Some other skip reason we haven't enumerated.
+
+**Without diagnostic events, we can't tell which.** Every path through
+`try-dag-execution` that declines to invoke the orchestrator is currently
+silent. Post-mortem readers (humans and future policy checks) have no
+way to know that DAG was considered and why it was skipped.
+
+This PR adds that visibility. Implementing the actual root-cause fix
+follows once we can see skip reasons in real event logs.
+
+## What changed
+
+### `components/workflow/src/ai/miniforge/workflow/execution.clj`
+
+- New fn `dag-skip-reason` — pure, returns the specific reason DAG
+  execution should skip (or `nil` to proceed). Enumerated reasons:
+  - `:not-plan-phase` — called outside the `:plan` phase
+  - `:disabled` — `:disable-dag-execution` set on ctx (sub-workflows)
+  - `:no-plan-id` — phase output lacks `:plan/id`
+  - `:no-tasks` — plan has `:plan/id` but empty `:plan/tasks`
+- `dag-applicable?` kept as-is for backward compatibility.
+- New helpers `resolve-event-stream`, `resolve-workflow-id`,
+  `emit-dag-considered!` — match the lookup logic in
+  `phase/telemetry.clj` so the event stream is found under any of
+  `:event-stream`, `:execution/event-stream`, or
+  `[:execution/opts :event-stream]`.
+- `try-dag-execution` now always emits `:workflow/dag-considered`
+  during the plan phase — either with `:dag/outcome :activated` +
+  `:plan/id` + `:plan/task-count`, or with `:dag/outcome :skipped` +
+  the specific `:dag/reason`.
+- Publish errors are swallowed — observability never breaks execution.
+
+### `components/workflow/test/ai/miniforge/workflow/dag_activation_diagnostics_test.clj`
+
+Six unit tests covering every skip reason + activation path + the
+backward-compat behavior of `dag-applicable?`. All pass
+(`12 assertions, 0 failures`).
+
+## Why this is small
+
+This PR does not fix the root cause — it makes the root cause visible.
+Once the next miniforge run emits `:workflow/dag-considered :skipped
+:no-plan-id` (or `:no-tasks`), we'll know exactly which upstream path
+to fix:
+
+- `:no-plan-id` → planner's success path isn't reaching
+  `(response/success plan-final ...)`; it's failing into an error
+  response. Next fix is to find why the planner is returning an error.
+- `:no-tasks` → planner is parsing responses into plans with empty task
+  lists. Next fix is prompt/parsing.
+- `:disabled` → unexpected ctx state leaking from sub-workflow context
+  back up. Would indicate a bigger bug.
+
+## Verification
+
+```bash
+$ clojure -M:dev:test -e "(require '[clojure.test :refer [run-tests]]) \
+                          (require 'ai.miniforge.workflow.dag-activation-diagnostics-test) \
+                          (run-tests 'ai.miniforge.workflow.dag-activation-diagnostics-test)"
+Testing ai.miniforge.workflow.dag-activation-diagnostics-test
+
+Ran 6 tests containing 12 assertions.
+0 failures, 0 errors.
+```
+
+Full `bb poly test brick:workflow` blocked by the pre-existing 13
+structural errors (Errors 103/106/107/108/112) that the remediation
+spec is meant to fix. That's unrelated to this PR and tracked
+separately.
+
+## Follow-up
+
+- Re-run `work/plan-from-agent-dag-wiring.spec.edn` (or any spec) via
+  miniforge with this landed. Observe the `:workflow/dag-considered`
+  event in `~/.miniforge/events/<workflow-id>/`. Note the `:dag/reason`.
+- File the concrete fix based on observed reason. Candidates already
+  spec'd at `work/plan-from-agent-dag-wiring.spec.edn` (Group 2 on
+  planner prompt, Group 3 on malli validation) may or may not be the
+  right lever depending on what the reason turns out to be.
+- `:workflow/dag-considered` is the single new event type — add to the
+  event schema component in a follow-up once consumed.


### PR DESCRIPTION
## Summary
Add diagnostic events for DAG activation. Every skip path in `try-dag-execution` now emits `:workflow/dag-considered {:dag/outcome :skipped :dag/reason <reason>}` with a specific reason keyword; activation emits `:dag/outcome :activated` with `:plan/id` + `:plan/task-count`.

Reasons enumerated:
- `:not-plan-phase` — not the plan phase
- `:disabled` — `:disable-dag-execution` set (sub-workflow context)
- `:no-plan-id` — phase output lacks `:plan/id`
- `:no-tasks` — plan has `:plan/id` but empty `:plan/tasks`

## Why this, not the real fix
Three miniforge runs today failed with "implementer wrote no files." Working hypothesis was that DAG never activates because `plan-from-agent` doesn't emit `:plan/id`. But a REPL trace this session showed `dag-applicable?` DOES correctly return the plan when the planner produces the expected shape. So the real skip reason is one of the other three — and we have no way to tell which without observability.

This PR adds that observability. The next run that stalls will emit a `:workflow/dag-considered :skipped` event with the concrete reason, telling us exactly which upstream path to fix. See the PR doc for the full write-up.

## Test plan
- [x] 6 new unit tests in `dag_activation_diagnostics_test` — all pass (12 assertions, 0 failures)
- [ ] Next miniforge run emits `:workflow/dag-considered` in `~/.miniforge/events/<workflow-id>/`
- [x] Publish errors swallowed — observability never breaks execution

## Note on `[BYPASS-HOOKS]`
Pre-existing 5 test failures in `environment_promotion_integration_test` are present on main without this change (verified via stash + re-run). Unrelated to this PR; noted in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)