### PR TITLE
fix(workflow): enrich :dag-considered skip events with result shape

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -355,6 +355,50 @@
               (empty? (:plan/tasks plan)) :no-tasks
               :else nil))))
 
+(defn- classify-output
+  "Describe the shape of the :output value without leaking its contents.
+   Returns a keyword suitable for event payload."
+  [output]
+  (cond
+    (nil? output) :nil
+    (map? output) :map
+    (sequential? output) :sequential
+    (string? output) :string
+    :else :other))
+
+(defn dag-skip-diagnostic
+  "Produce a structured snapshot of phase-result for :no-plan-id / :no-tasks
+   skips. Keys-only (no values) so the event stays bounded and we don't leak
+   full plan content into the log.
+
+   Returned shape:
+     {:phase-result/keys [...]
+      :result/keys       [...]
+      :result/status     <value or nil>
+      :output/type       :nil | :map | :sequential | :string | :other
+      :output/keys       [...] (only if :map)
+      :output/has-plan-id? bool (only if :map)
+      :plan/task-count   int (only when reason is :no-tasks)}"
+  [phase-result reason]
+  (let [phase-keys (when (map? phase-result) (sort (keys phase-result)))
+        result     (:result phase-result)
+        result-keys (when (map? result) (sort (keys result)))
+        result-status (when (map? result) (:status result))
+        output (when (map? result) (:output result))
+        output-type (classify-output output)
+        output-keys (when (= :map output-type) (sort (keys output)))
+        has-plan-id? (when (= :map output-type)
+                       (boolean (:plan/id output)))
+        plan (extract-plan-from-phase-result phase-result)]
+    (cond-> {:phase-result/keys (vec phase-keys)
+             :result/keys       (vec result-keys)
+             :result/status     result-status
+             :output/type       output-type}
+      (seq output-keys)       (assoc :output/keys (vec output-keys))
+      (some? has-plan-id?)    (assoc :output/has-plan-id? has-plan-id?)
+      (= :no-tasks reason)    (assoc :plan/task-count
+                                     (count (:plan/tasks plan))))))
+
 (defn dag-applicable?
   "Check whether DAG execution should be attempted for this phase result.
    Returns the plan map if applicable, nil otherwise."
@@ -468,8 +512,12 @@
     (if skip-reason
       (do
         (when (= :plan phase-name)
-          (emit-dag-considered! ctx :skipped skip-reason
-                                {:phase/name phase-name}))
+          (let [base  {:phase/name phase-name}
+                extra (if (contains? #{:no-plan-id :no-tasks} skip-reason)
+                        (assoc base :dag/diagnostic
+                               (dag-skip-diagnostic phase-result skip-reason))
+                        base)]
+            (emit-dag-considered! ctx :skipped skip-reason extra)))
         nil)
       (let [plan (extract-plan-from-phase-result phase-result)
             ctx-with-resume (assoc ctx :pre-completed-ids

--- a/components/workflow/test/ai/miniforge/workflow/dag_activation_diagnostics_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_activation_diagnostics_test.clj
@@ -84,3 +84,55 @@
     (is (nil? (exec/dag-applicable? :plan
                                     (phase-result-with-plan valid-plan)
                                     {:disable-dag-execution true})))))
+
+;;----------------------------------------------------------------------------
+;; dag-skip-diagnostic — keys-only snapshot of what the plan phase returned
+
+(deftest diagnostic-success-output-missing-plan-id
+  (testing "planner succeeded but :output lacks :plan/id (the observed case)"
+    (let [pr {:name :plan :result {:status :success :output {:some/other-key 1}}}
+          d  (exec/dag-skip-diagnostic pr :no-plan-id)]
+      (is (= :success (:result/status d)))
+      (is (= :map (:output/type d)))
+      (is (= [:some/other-key] (:output/keys d)))
+      (is (false? (:output/has-plan-id? d)))
+      (is (nil? (:plan/task-count d))
+          ":no-plan-id reason should not include :plan/task-count"))))
+
+(deftest diagnostic-output-is-nil
+  (testing "planner succeeded but :output is nil"
+    (let [pr {:name :plan :result {:status :success :output nil}}
+          d  (exec/dag-skip-diagnostic pr :no-plan-id)]
+      (is (= :nil (:output/type d)))
+      (is (nil? (:output/keys d))
+          "no :output/keys when output is not a map")
+      (is (nil? (:output/has-plan-id? d))
+          "no :output/has-plan-id? when output is not a map"))))
+
+(deftest diagnostic-result-is-failure
+  (testing "planner failed — :result has no :output at all"
+    (let [pr {:name :plan :result {:status :failure :error {:message "boom"}}}
+          d  (exec/dag-skip-diagnostic pr :no-plan-id)]
+      (is (= :failure (:result/status d)))
+      (is (= :nil (:output/type d)))
+      (is (some #{:status :error} (:result/keys d))))))
+
+(deftest diagnostic-no-tasks-includes-task-count
+  (testing ":no-tasks skip includes :plan/task-count"
+    (let [plan {:plan/id (random-uuid) :plan/tasks []}
+          pr   (phase-result-with-plan plan)
+          d    (exec/dag-skip-diagnostic pr :no-tasks)]
+      (is (= 0 (:plan/task-count d)))
+      (is (true? (:output/has-plan-id? d))))))
+
+(deftest diagnostic-bounded-no-leakage
+  (testing "diagnostic doesn't leak full plan content — only keys"
+    (let [large-plan {:plan/id (random-uuid)
+                      :plan/tasks (vec (repeat 100 {:task/id (random-uuid)
+                                                    :task/description "big string"}))}
+          pr  (phase-result-with-plan large-plan)
+          d   (exec/dag-skip-diagnostic pr :no-tasks)]
+      (is (= 100 (:plan/task-count d)))
+      ;; Values should not appear anywhere in the diagnostic except task-count.
+      (is (not (re-find #"big string" (pr-str d)))
+          "diagnostic leaked plan content"))))

--- a/docs/pull-requests/2026-04-18-dag-skip-diagnostic-shape.md
+++ b/docs/pull-requests/2026-04-18-dag-skip-diagnostic-shape.md
@@ -1,0 +1,93 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# DAG skip diagnostic — include phase-result shape when :no-plan-id fires
+
+## Context
+
+PR #571 added `:workflow/dag-considered` events so every skip of the DAG
+orchestrator is observable. The first instrumented run confirmed the
+skip fires with `:dag/reason :no-plan-id` — meaning `[:phase :result :output]`
+lacks `:plan/id` at DAG check time.
+
+That's still too coarse to act on. The `:no-plan-id` skip can happen
+because:
+
+1. Planner threw → `plan-from-agent` caught → `(response/failure e)`
+   returned → `:result {:status :failure :error ...}`, no `:output`
+2. Planner streamed → parsed LLM text into some `:output` shape that
+   doesn't have `:plan/id`
+3. Planner streamed → `:output` is `nil`
+4. Something reshapes the result between `enter-plan` and
+   `extract-phase-result`
+
+Tracing the call path by inspection (`plan.clj` → `agent/interface/invoke`
+→ `runtime/invoke` → `agent-proto/invoke` → FunctionalAgent's protocol
+impl which swaps args for `invoke-fn`) confirmed the planner does
+receive correct `(ctx, task)` args — no arg-inversion bug there. So the
+bug lives somewhere else in the pipe.
+
+This PR adds one more diagnostic layer: when `:no-plan-id` / `:no-tasks`
+fires, the event carries a keys-only snapshot of what the plan phase
+returned. Next run tells us which of the four cases above is happening.
+
+## What changed
+
+### `components/workflow/.../execution.clj`
+
+- New fn `dag-skip-diagnostic` — builds a keys-only structured snapshot
+  of `phase-result`. Top-level keys of `phase-result` and `:result`, the
+  `:result/status`, the `:output/type` (one of `:nil :map :sequential
+  :string :other`), output keys if it's a map, `:output/has-plan-id?`,
+  and `:plan/task-count` for the `:no-tasks` case.
+- New helper `classify-output` — returns a shape-type keyword without
+  leaking content.
+- `try-dag-execution` now attaches `:dag/diagnostic` to the
+  `:workflow/dag-considered` event when the skip reason is
+  `:no-plan-id` or `:no-tasks`. Other skip reasons (non-plan phase,
+  `:disable-dag-execution`) don't include the diagnostic since their
+  cause is self-evident.
+
+### `components/workflow/test/.../dag_activation_diagnostics_test.clj`
+
+- 5 new unit tests covering every observable case: success-with-wrong-
+  shape output, `:nil` output, `:failure` status, `:no-tasks` + task-
+  count, and **bounded-no-leakage** (verifies full task content doesn't
+  escape into the diagnostic).
+- All 11 tests pass (27 assertions, 0 failures).
+
+## Why keys-only
+
+Values of `:output` can include the full LLM-generated plan (100+ tasks
+with descriptions, etc.). Putting that in every event would bloat logs.
+Keys + types are enough to diagnose which code path produced the shape;
+the full content can be retrieved from the artifact store or the run's
+tmp dir when needed.
+
+## Verification
+
+```bash
+$ clojure -M:dev:test -e "(require '[clojure.test :refer [run-tests]]) \
+                          (require 'ai.miniforge.workflow.dag-activation-diagnostics-test :reload) \
+                          (run-tests 'ai.miniforge.workflow.dag-activation-diagnostics-test)"
+Ran 11 tests containing 27 assertions.
+0 failures, 0 errors.
+```
+
+## Follow-up
+
+- Re-run `work/plan-from-agent-dag-wiring.spec.edn` (or any spec) with
+  this landed. Observe the `:dag/diagnostic` in `:workflow/dag-considered`.
+- The four possible cases above each point to a different fix. Next PR
+  will be targeted, not speculative.
+
+## Broader principle
+
+`specs/normative/N3-event-stream.md` governs what counts as a legitimate
+diagnostic event. This PR opts for structured keys-only payloads that
+are meaningful at any log level — including trace/debug — rather than
+free-form strings. Future phases/stream failures should follow the same
+pattern so flipping log level surfaces useful information, not noise.


### PR DESCRIPTION
## Summary
PR #571 told us the skip reason is `:no-plan-id`. That's still too coarse to act on — there are at least four distinct causes for "plan phase output lacks `:plan/id`":

1. Planner threw → `plan-from-agent` caught → `response/failure` → `:result {:status :failure}`, no `:output`
2. Planner streamed + parsed, but `:output` doesn't have `:plan/id`
3. Planner streamed but `:output` is nil
4. Something reshapes the result between `enter-plan` and `extract-phase-result`

Tracing `plan.clj` → `agent/interface/invoke` → `runtime/invoke` → `agent-proto/invoke` → FunctionalAgent's protocol impl confirmed no arg-inversion bug. The planner receives correct `(ctx, task)`. Bug is elsewhere.

This PR adds a keys-only structured snapshot to `:workflow/dag-considered` when the reason is `:no-plan-id` / `:no-tasks`. The next run will tell us which of the four cases is firing.

### What the diagnostic carries

- `:phase-result/keys` — top-level keys of the full phase map
- `:result/keys` — top-level keys of `:result`
- `:result/status` — `:success`, `:failure`, `:error`, etc.
- `:output/type` — `:nil`, `:map`, `:sequential`, `:string`, or `:other`
- `:output/keys` — (only if `:map`)
- `:output/has-plan-id?` — (only if `:map`)
- `:plan/task-count` — (only for `:no-tasks`)

**Keys-only** by design — a 100-task plan with descriptions would bloat every event. Keys + types are enough to pinpoint the code path; full content lives in the artifact store.

## Test plan
- [x] 5 new unit tests bringing file to 11 tests / 27 assertions, all pass
- [x] Bounded-no-leakage test confirms plan task descriptions don't escape into the diagnostic
- [ ] Next miniforge run will emit the enriched `:dag/diagnostic` in the event log
- [ ] Follow-up PR will be targeted to the specific case observed, not speculative

## [BYPASS-HOOKS] note
Pre-existing 5 test failures in `environment_promotion_integration_test` still on main, unrelated to this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)