### PR TITLE
fix(agent): canonical error shape + planner prompt closing contract

### DIFF
--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -206,16 +206,60 @@ If you need to explore files NOT already in your context, use these MCP tools
 - `mcp__context__context_grep` — search file contents by regex
 - `mcp__context__context_glob` — find files by glob pattern
 
-## Plan Output
+## Plan Submission — REQUIRED
 
-Output your plan as a Clojure map in your final message. The plan will be extracted
-from your response text. Wrap it in a ```clojure code fence.
+**YOUR FINAL ASSISTANT MESSAGE MUST BE THE PLAN ITSELF.** Narration about
+what you've explored is not a plan. A response that ends without either
+the EDN map or an MCP submission call is a failed turn.
+
+You have two ways to submit the plan, in order of preference:
+
+### Option A (preferred) — the artifact MCP tool
+
+If an artifact submission MCP tool is available, call it with your plan
+map as the artifact. The runtime picks this up directly. Use this
+whenever possible — it bypasses text parsing.
+
+### Option B — final message containing the plan EDN
+
+If you cannot call the MCP tool, your **final** assistant message (the
+one with no tool calls) MUST contain the plan EDN wrapped in a code
+fence labeled `clojure`. Example:
+
+    ```clojure
+    {:plan/id #uuid \"...\"
+     :plan/name \"...\"
+     :plan/tasks [...]}
+    ```
+
+**Do NOT end your turn with prose narration** (\"I've reviewed the
+files...\", \"Now I'll output the plan...\", \"Based on my exploration...\",
+followed by nothing). That is how plans get lost. If you catch yourself
+writing prose-only at the end of your turn, STOP, delete the prose,
+and output the plan EDN instead.
 
 ## Turn Budget — HARD LIMIT
 
 You have at most 40 tool calls total.
 **After 15 file reads, STOP exploring and output your plan immediately.**
-A good-enough plan submitted on time is better than a perfect plan that never arrives.
+Reserve at least 1 turn for the final submission — if you are at 14
+reads, your next move is the plan, not another read.
 
-Remember: A good plan enables parallel execution where possible while respecting
-necessary dependencies. Optimize for clarity and testability."}
+A good-enough plan submitted on time is better than a perfect plan
+that never arrives.
+
+## Failure Modes to Avoid
+
+These are documented real failures that cost real tokens:
+
+1. **Narration-only ending** — agent described its exploration and
+   then terminated without EDN. The runtime throws
+   `:anomalies.agent/invoke-failed` with message \"Plan generation
+   failed: EDN parse did not succeed\". No retry.
+2. **Code fence omitted** — EDN present but not wrapped in a
+   ` ```clojure ` fence. The parser misses it.
+3. **Top-level form is not a map** — the plan MUST be a Clojure map,
+   not a vector or list. `{:plan/id ...}`, not `[{:plan/id ...}]`.
+
+Remember: A good plan enables parallel execution where possible while
+respecting necessary dependencies. Optimize for clarity and testability."}

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -368,7 +368,14 @@
                                       "                  :satisfied-by \"path/to/file.clj\"\n"
                                       "                  :proof \"specific function/test that satisfies it\"}]}\n```\n"
                                       (format-existing-files existing-files)))
-                               "\n\nOutput your plan as a Clojure map following the format in your system prompt. "
+                               "\n\n## REQUIRED Output\n\n"
+                               "Your FINAL assistant message MUST be the plan. Either:\n"
+                               "  (a) call the artifact submission MCP tool with your plan map, OR\n"
+                               "  (b) end your turn with the plan EDN wrapped in a ```clojure code fence.\n\n"
+                               "Narration-only responses (e.g. \"Based on my exploration...\" with no EDN) "
+                               "are rejected by the runtime with :anomalies.agent/invoke-failed and cost "
+                               "a full turn's tokens. If the last thing you would say is prose, STOP and "
+                               "replace it with the plan EDN instead.\n\n"
                                "Use (random-uuid) for all IDs - just write #uuid \"<any-uuid>\" placeholders that I'll fill in.")]
           (if llm-client
             ;; Use the real LLM with artifact session for MCP tool support

--- a/components/agent/src/ai/miniforge/agent/protocols/impl/specialized.clj
+++ b/components/agent/src/ai/miniforge/agent/protocols/impl/specialized.clj
@@ -21,7 +21,8 @@
 
    These functions implement the logic for the FunctionalAgent record."
   (:require
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Helper functions for cycle-agent
@@ -84,13 +85,12 @@
                           :status (:status result)}})
         result)
       (catch Exception e
-        (log/error logger :agent :agent/invoke-failed
-                   {:message (ex-message e)
-                    :data {:role role
-                           :duration-ms (- (System/currentTimeMillis) start-time)}})
-        {:status :error
-         :error (ex-message e)
-         :metrics {:duration-ms (- (System/currentTimeMillis) start-time)}}))))
+        (let [duration-ms (- (System/currentTimeMillis) start-time)]
+          (log/error logger :agent :agent/invoke-failed
+                     {:message (ex-message e)
+                      :data {:role role :duration-ms duration-ms}})
+          (response/error e {:data (assoc (ex-data e) :role role)
+                             :duration-ms duration-ms}))))))
 
 (defn validate-impl
   "Implementation of validate protocol method for FunctionalAgent."

--- a/components/agent/test/ai/miniforge/agent/invoke_error_shape_test.clj
+++ b/components/agent/test/ai/miniforge/agent/invoke_error_shape_test.clj
@@ -1,0 +1,77 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.invoke-error-shape-test
+  "Regression: invoke-impl's catch branch MUST produce the canonical
+   response/error shape ({:error {:message string :data map}}), not
+   hand-rolled {:error <string>}.
+
+   Observed 2026-04-18 workflow 60cf2407: planner threw an anomaly,
+   invoke-impl caught it and returned :error as a string, and the
+   downstream DAG skip diagnostic's summarize-error couldn't pull the
+   message (because (:message 'some string') is nil). Fix the
+   producer, not the consumer."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.agent.specialized :as specialized]
+   [ai.miniforge.agent.interface :as agent]))
+
+(defn- throwing-agent [ex]
+  (specialized/create-base-agent
+    {:role :planner
+     :system-prompt "spy"
+     :invoke-fn (fn [_ctx _input] (throw ex))
+     :validate-fn (fn [_] {:valid? true})
+     :repair-fn (fn [output _ _] output)}))
+
+(deftest invoke-catch-produces-canonical-error-shape
+  (testing "invoke-impl's catch returns {:status :error :error {:message :data ...}}"
+    (let [ex (ex-info "boom" {:cause :test})
+          result (agent/invoke (throwing-agent ex) {} {})]
+      (is (= :error (:status result)))
+      (is (map? (:error result))
+          ":error MUST be a map (canonical response/error shape)")
+      (is (= "boom" (:message (:error result))))
+      (is (map? (:data (:error result)))
+          ":error :data MUST be a map"))))
+
+(deftest invoke-catch-preserves-ex-data
+  (testing "ex-data from the thrown exception is preserved on :error :data"
+    (let [ex (ex-info "llm timeout" {:provider :anthropic :retry? true})
+          result (agent/invoke (throwing-agent ex) {} {})]
+      (is (= :anthropic (get-in result [:error :data :provider])))
+      (is (true? (get-in result [:error :data :retry?]))))))
+
+(deftest invoke-catch-records-role-on-data
+  (testing ":error :data carries :role so event sinks can attribute the failure"
+    (let [ex (ex-info "boom" {})
+          result (agent/invoke (throwing-agent ex) {} {})]
+      (is (= :planner (get-in result [:error :data :role]))))))
+
+(deftest invoke-catch-records-duration-at-top-level
+  (testing ":duration-ms lives at the top level of the response (per response/error opts)"
+    (let [ex (ex-info "boom" {})
+          result (agent/invoke (throwing-agent ex) {} {})]
+      (is (integer? (get-in result [:metrics :duration-ms]))))))
+
+(deftest invoke-catch-message-not-string-under-error
+  (testing "smoke test of the observed regression: :error is NOT a string"
+    (let [ex (ex-info "some message" {})
+          result (agent/invoke (throwing-agent ex) {} {})]
+      (is (not (string? (:error result)))
+          "if :error is a string here, summarize-error can't read it"))))

--- a/docs/pull-requests/2026-04-18-planner-prompt-and-error-shape.md
+++ b/docs/pull-requests/2026-04-18-planner-prompt-and-error-shape.md
@@ -1,0 +1,126 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Fix planner prompt + canonical invoke error shape
+
+## Context
+
+PR #574 surfaced the planner's actual failure in the event log:
+
+```clojure
+:anomaly/category :anomalies.agent/invoke-failed
+:anomaly/message  "Plan generation failed: EDN parse did not succeed"
+:llm-content-preview "I need to explore the codebase... Let me look at the
+                      key files... Now let me look at the agent interface...
+                      Let me check the planner system prompt..."
+```
+
+The LLM is narrating its exploration, calling tools, then **ending the
+turn without either (a) a final EDN plan or (b) an MCP artifact
+submission call**. The runtime's `parse-plan-response` gets narrative
+prose, can't read it as EDN, and throws.
+
+## Root cause — two producer bugs
+
+### Bug 1 — planner prompt doesn't enforce the closing contract
+
+The planner's "Plan Output" section was only 2 lines:
+
+> Output your plan as a Clojure map in your final message. The plan will
+> be extracted from your response text. Wrap it in a ```clojure code fence.
+
+And the user-prompt's closing instruction was similarly soft. The LLM
+read this as a suggestion, not a hard requirement. Turns ending in
+narration are a real and recurring failure mode.
+
+### Bug 2 — `invoke-impl` returns non-canonical error shape
+
+When the planner threw, `agent.protocols.impl.specialized/invoke-impl`
+caught the exception and returned:
+
+```clojure
+{:status :error
+ :error (ex-message e)           ; ← a STRING
+ :metrics {:duration-ms ...}}
+```
+
+The canonical `response/error` shape is `{:error {:message string :data
+map}}`. Hand-rolling the catch branch produced internal shape drift.
+This is why PR #574's `summarize-error` couldn't pull the error into
+the DAG diagnostic — `(:message <string>)` is nil. Same feedback
+pattern you gave me earlier: fix the producer, don't tolerate drift at
+the consumer.
+
+## What changed
+
+### Planner prompt — hard-enforce the closing contract
+
+`components/agent/resources/prompts/planner.edn`:
+
+- Replaced the 2-line "Plan Output" section with an expanded **"Plan
+  Submission — REQUIRED"** section.
+- Two explicit options: (A) call the artifact MCP tool, (B) final
+  assistant message contains the plan EDN in a `clojure` code fence.
+- Explicit "do NOT end your turn with prose narration" with examples
+  of the phrases that trigger the failure.
+- Added a **"Failure Modes to Avoid"** section citing the real observed
+  failures (narration-only ending, missing code fence, wrong top-level
+  form).
+- Turn-budget section updated: reserve at least 1 turn for final
+  submission; if at 14 reads, next move is the plan, not another read.
+
+`components/agent/src/ai/miniforge/agent/planner.clj`:
+
+- User-prompt closing block is now explicit: "Your FINAL assistant
+  message MUST be the plan", lists both submission paths, cites the
+  anomaly name that rejections throw, and tells the LLM to stop and
+  replace prose if it catches itself writing prose-only.
+
+### `invoke-impl` uses `response/error`
+
+`components/agent/src/.../protocols/impl/specialized.clj`:
+
+- Catch branch now calls `(response/error e {:data (ex-data e) ...})`
+  instead of hand-rolling `{:error (ex-message e)}`.
+- Exception message, `ex-data`, and `:role` all end up on the
+  canonical `{:error {:message :data}}` shape. `summarize-error` can
+  pull it; event sinks and failure classifiers get a consistent shape.
+
+### Tests
+
+`components/agent/test/.../invoke_error_shape_test.clj` — 5 new tests,
+9 assertions covering:
+
+- `:error` is a map, not a string
+- `:message` matches the exception message
+- `:data` preserves `ex-data`
+- `:role` recorded on `:error :data`
+- `:duration-ms` at `:metrics`
+- explicit smoke test that `:error` is not a string (the observed
+  regression)
+
+All pre-existing tests still pass (4 env-promotion, 6 phase-outcome,
+15 dag-activation-diagnostics, 5 new invoke-error-shape).
+
+## Expected behavior on next run
+
+1. If the planner fails, `:result :error :message` carries the actual
+   error string, and `:dag/diagnostic :result/error :error/message`
+   surfaces it.
+2. With the stronger prompt, the LLM is more likely to produce a final
+   EDN plan (or call the MCP artifact tool). Fewer dead turns.
+3. If narration-only endings continue despite the prompt, the
+   diagnostic will tell us exactly which anomaly triggered and we can
+   consider a runtime retry with a constrained re-prompt.
+
+## Follow-up
+
+- If the prompt fix doesn't reduce narration-only endings, consider
+  **runtime retry**: detect `:anomalies.agent/invoke-failed` from
+  parse failure, retry once with a constrained "emit plan only"
+  prompt. That's targeted behavior, not a guess — wait for the next
+  run's data.
+- The checkpoint/resume spec (PR #574) remains a separate work stream.

--- a/work/plan-from-agent-dag-wiring.spec.edn
+++ b/work/plan-from-agent-dag-wiring.spec.edn
@@ -80,7 +80,7 @@
   reading the code. Make it observable from the event log."
 
  :spec/intent
- {:type :fix
+ {:type :bugfix
   :scope ["components/phase-software-factory/src/ai/miniforge/phase/plan.clj"
           "components/workflow/src/ai/miniforge/workflow/execution.clj"
           "components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj"


### PR DESCRIPTION
## Summary
PR #574's enriched diagnostic surfaced the actual planner failure: LLM narrates exploration, ends turn with prose, never outputs EDN or calls the MCP artifact tool → runtime throws `:anomalies.agent/invoke-failed`.

### Two producer bugs, two fixes

**1. `invoke-impl` shape drift** — hand-rolled `{:error (ex-message e)}` (string) instead of canonical `{:error {:message :data}}` (map). That's why `summarize-error` couldn't pull the error into `:result/error`. Fixed: use `response/error`.

**2. Planner prompt doesn't enforce the closing contract.** Old section was 2 lines of suggestion. New "Plan Submission — REQUIRED" section: two explicit submission paths (MCP tool OR EDN in a `clojure` fence), explicit "do NOT end with prose narration", "Failure Modes to Avoid" citing real failures, turn-budget reserves 1 turn for submission. User-prompt closing block updated to match.

### Tests
5 new `invoke_error_shape_test.clj` tests / 9 assertions covering the canonical shape. All pre-existing tests still pass. **No `[BYPASS-HOOKS]`** — pre-commit clean.

## Expected behavior on next run
1. If planner still fails, `:dag/diagnostic :result/error :error/message` surfaces the real error message.
2. Stronger prompt should reduce narration-only endings.
3. If narration-only persists despite the prompt, runtime retry (detect + re-prompt constrained) is the next lever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)