### PR TITLE
spec: clj-xref + tree-sitter symbols for richer agent context

### DIFF
--- a/docs/pull-requests/2026-04-18-clj-xref-and-tree-sitter-context-specs.md
+++ b/docs/pull-requests/2026-04-18-clj-xref-and-tree-sitter-context-specs.md
@@ -1,0 +1,91 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Two specs for richer agent context: clj-xref + tree-sitter symbols
+
+## Summary
+
+Specs only, no code. Adds two complementary work specs in `work/`:
+
+- **`clj-xref-context-neighborhoods.spec.edn`** — integrate clj-xref as
+  a Clojure-specific context provider in `context-pack`. Dependency
+  neighborhoods (callers, callees, protocol implementors, multimethod
+  dispatch) replace the current text-only BM25 neighborhoods for
+  Clojure tasks.
+- **`tree-sitter-symbol-context.spec.edn`** — reopens Phase 2 of the
+  archived repo-context plan. Lifts the existing `policy-pack/ast.clj`
+  tree-sitter CLI wrapper into a shared `tree-sitter-bridge` component,
+  adds symbol extraction to `repo-index`, and wires symbol neighborhoods
+  into `context-pack` for all languages miniforge OSS targets (Clojure,
+  TypeScript, Python, Go, Rust, Swift).
+
+## Why both
+
+Current state verified by code audit:
+
+- `repo-index` is file-level: git-tree walk + BM25 lexical search + repo
+  maps. No symbols, no AST.
+- `context-pack` assembles on top of that, token-budgeted. Text in,
+  text out.
+- `policy-pack/src/.../ast.clj` DOES shell out to `tree-sitter query`,
+  but only for rule detection. NOT wired into the agent context pipeline.
+- `work/archive/done/repo-context-implementation-plan.md` had a Phase 2
+  (tree-sitter symbols) that was archived before implementation. Phase 1
+  (file-level) shipped; Phase 2 didn't.
+
+So when an implement agent is asked to change `process-payment`, context
+today is "files whose text contains the string `process-payment`" — not
+"files that actually call or implement `process-payment`." That's a
+real signal gap.
+
+The two specs close it at different levels:
+
+| | clj-xref | tree-sitter |
+|---|---|---|
+| Scope | Clojure only | Clojure + TS + Py + Go + Rust + Swift |
+| Basis | clj-kondo static analysis | tree-sitter grammars (CLI) |
+| Queries | who-calls/calls-who/who-implements/who-dispatches + arity-aware + protocols/multimethods | def + ref + container + same-file neighbors + imports |
+| Strength | Semantic superset for Clojure | Language-agnostic coverage |
+| Cost | ~1 week of work | ~2 weeks (per original plan) |
+
+They compose. For a Clojure task, the pack includes *both* the
+tree-sitter symbol neighborhood AND the clj-xref call graph. For a
+non-Clojure task, tree-sitter alone. For a language without a grammar
+installed, we fall back to the current BM25 behavior gracefully.
+
+## Non-goals (in both specs)
+
+- **LSP replacement** — use clojure-lsp / rust-analyzer for editor UX.
+- **Persisted xref DB** — in-memory only for v1. Persistence becomes a
+  follow-up once we measure the value.
+- **New tree-sitter grammars** — upstream grammars only, pinned
+  versions.
+
+## Recommended landing order
+
+1. **clj-xref** first — narrow, additive, fastest dogfood win for the
+   Clojure-heavy codebases miniforge currently operates on (including
+   its own source).
+2. **tree-sitter symbols** after — wider infra, needs grammar install
+   task, refactors `policy-pack/ast.clj` into a shared brick.
+3. Both should be **feature-flagged off** on first ship and turned on
+   only after a measurable win in a dogfood A/B (token usage +
+   convergence rate on identical specs).
+
+## Test plan
+
+- [x] Both specs parse as valid EDN (pre-commit clj lint pass)
+- [ ] Work item tracked for running clj-xref spec first via miniforge
+- [ ] Dogfood A/B framework wired into context-pack events for
+      measurement (small ancillary change; part of the first spec)
+
+## References
+
+- clj-xref: <https://github.com/danlentz/clj-xref>
+- policy-pack AST wrapper: `components/policy-pack/src/ai/miniforge/policy_pack/ast.clj`
+- Archived plan: `work/archive/done/repo-context-implementation-plan.md`
+- N1 architecture §2.27 onward: relevant normative context for the
+  symbol-id scheme referenced in the tree-sitter spec.

--- a/work/clj-xref-context-neighborhoods.spec.edn
+++ b/work/clj-xref-context-neighborhoods.spec.edn
@@ -1,0 +1,128 @@
+;; =============================================================================
+;; Spec: Clojure dependency-neighborhood context via clj-xref
+;; =============================================================================
+;;
+;; Today miniforge's agent context pipeline (repo-index → context-pack) is
+;; text-based: BM25 lexical search over file contents + token-budgeted repo
+;; maps. For an implement agent asked to change `process-payment`, the
+;; context it gets is files that mention the string "process-payment"
+;; somewhere. That's coarse — it includes irrelevant files that happen to
+;; use the same word, and it misses callers in files that use it via a
+;; namespace alias.
+;;
+;; clj-xref (https://github.com/danlentz/clj-xref) is a clj-kondo-based
+;; cross-reference database with a public API designed explicitly for
+;; feeding LLMs precise dependency neighborhoods:
+;;
+;;   who-calls, calls-who, who-references, who-implements, who-dispatches,
+;;   ns-deps, ns-dependents, call-graph, unused-vars, apropos
+;;
+;; Built on clj-kondo static analysis. Returns plain maps/vectors. No
+;; editor UX — library for programmatic + batch + REPL use.
+;;
+;; This spec adds a thin integration: context-pack gains an optional
+;; "Clojure dependency neighborhood" section populated via clj-xref when
+;; the task's target file is Clojure. The file-level BM25 path stays as
+;; the fallback and the default for non-Clojure files.
+;;
+;; See also: work/tree-sitter-symbol-context.spec.edn — the broader
+;; language-agnostic symbol extraction that complements this. clj-xref is
+;; the Clojure-specific superset (protocols, multimethods, arities) that
+;; generic tree-sitter symbol tables can't easily express.
+
+{:spec/title "Clojure dependency-neighborhood context via clj-xref"
+
+ :spec/description
+ "Integrate clj-xref as an optional Clojure-specific context provider in
+  context-pack. When an agent's task targets a Clojure file, the context
+  pack includes the dependency neighborhood of the target var(s) —
+  callers, callees, protocol implementations, multimethod dispatch — in
+  addition to (or in place of) the file-level lexical results. For non-
+  Clojure tasks and Clojure tasks without a clear target var, behavior is
+  unchanged.
+
+  GROUP 1: Add clj-xref as a dep + thin wrapper
+  Add com.github.danlentz/clj-xref as a dep in a new shared component
+  (e.g. components/clj-xref-bridge or folded into repo-index as an
+  optional namespace). Wrap only the queries we use initially:
+    - who-calls         → 'who touches this var'
+    - calls-who         → 'what does this var touch'
+    - who-implements    → 'who implements this protocol'
+    - who-dispatches    → 'what dispatch values exist for this multimethod'
+  Use in-memory analysis (xref/analyze [paths]) rather than a persisted
+  .edn file — keeps the build footprint small and avoids the incremental
+  staleness caveat.
+
+  GROUP 2: Target-var extraction from the task
+  context-pack needs to know which var(s) are the subject of the task.
+  Sources, in priority order:
+    - explicit :task/target-vars if the planner provides them
+    - parse from :task/description / spec description via regex + a
+      validate-against-known-vars step
+    - fall back to file-level context (no var → no neighborhood)
+  Produce a vector of fully-qualified symbols that clj-xref can query.
+
+  GROUP 3: Neighborhood assembly in context-pack
+  Add a new section to the pack for Clojure tasks:
+    :context-pack/dependency-neighborhood
+      :target-vars       [fq-sym ...]
+      :callers           [{:from :to :file :line :arity} ...]  (who-calls)
+      :callees           [{:from :to :file :line :arity} ...]  (calls-who)
+      :implementors      [...]                                  (who-implements)
+      :dispatch-values   [...]                                  (who-dispatches)
+      :depth             1         ;; initially, not transitive
+  Budget this section under the existing phase budget. If including the
+  full neighborhood would blow the budget, trim by distance (direct
+  callers before transitive) and emit a warning event.
+
+  GROUP 4: Opt-out flag + feature-flag rollout
+  Add :context-pack/enable-clj-xref-neighborhood to user config, default
+  false for the first release. Agents can be A/B'd:
+    - baseline (text-only BM25)
+    - with neighborhood
+  Dogfood a dozen spec runs each, compare plan/implement convergence
+  rates and token usage. Enable by default only after measurable win.
+
+  GROUP 5: Events + observability
+  Emit :context-pack/neighborhood-emitted with:
+    {:target-vars N
+     :callers-count N
+     :callees-count N
+     :implementors-count N
+     :tokens-used N
+     :trimmed? bool}
+  Feed into the compliance-scanner or a dashboard widget for measuring
+  whether neighborhoods improve or degrade agent outcomes.
+
+  NON-GOALS
+  - Persisted xref DB — in-memory only for v1.
+  - Editor integration — use clojure-lsp for that.
+  - Transitive call graphs beyond depth 1 — may add later based on
+    measurement.
+  - Non-Clojure languages — handled by the tree-sitter symbol spec."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/context-pack/src"
+          "components/repo-index/src"
+          "components/schema/src"
+          "resources/config/default-user-config.edn"
+          "docs/development-guidelines.md"]}
+
+ :spec/constraints
+ ["In-memory analysis only — do NOT persist an xref DB in v1"
+  "Non-Clojure tasks MUST see unchanged behavior"
+  "Neighborhood inclusion MUST respect the phase token budget"
+  "Events MUST carry counts + trimmed? flag so outcomes are measurable"
+  "Integration MUST be feature-flagged and default off for the first release"
+  "Localize all user-facing strings (msg/t + en-US.edn)"]
+
+ :spec/acceptance-criteria
+ ["A test spec that modifies a well-connected Clojure fn produces a context pack whose :context-pack/dependency-neighborhood includes that fn's real callers and callees"
+  "A test spec that modifies a Python or Rust file produces a context pack with NO neighborhood section"
+  "Budget overflow trims by distance + emits :context-pack/neighborhood-trimmed event"
+  ":context-pack/enable-clj-xref-neighborhood in user config toggles the feature"
+  "Dogfood A/B: 12 runs baseline vs 12 with neighborhood — measured token-delta and convergence-rate logged to dashboard"
+  "`bb test` passes across affected bricks"]
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/tree-sitter-symbol-context.spec.edn
+++ b/work/tree-sitter-symbol-context.spec.edn
@@ -1,0 +1,150 @@
+;; =============================================================================
+;; Spec: Language-agnostic symbol extraction via tree-sitter, wired into
+;;        repo-index + context-pack
+;; =============================================================================
+;;
+;; Reopens Phase 2 of the archived 'Repository Intelligence & Context
+;; Assembly' plan (work/archive/done/repo-context-implementation-plan.md).
+;; Phase 1 (file-level index, BM25, repo maps) shipped. Phase 2
+;; (tree-sitter symbols) was archived unimplemented — the agent context
+;; pipeline has stayed text-based ever since.
+;;
+;; Tree-sitter IS already in the codebase, narrowly, at
+;; components/policy-pack/src/ai/miniforge/policy_pack/ast.clj — a CLI
+;; wrapper around `tree-sitter query` for policy-rule structural matching.
+;; It is NOT wired into repo-index or context-pack, so agents today see
+;; text neighborhoods, not symbol neighborhoods.
+;;
+;; This spec:
+;;   1. Promotes the policy-pack AST wrapper into a shared component
+;;      (tree-sitter-bridge) so both policy-pack and repo-index consume
+;;      the same substrate.
+;;   2. Adds symbol extraction to repo-index covering the languages
+;;      miniforge OSS targets: Clojure, TypeScript, Python, Go, Rust,
+;;      Swift (miniforge-fleet extends for others).
+;;   3. Wires symbol neighborhoods into context-pack so agents receive
+;;      a signature-first dependency view, not just matching text blobs.
+;;
+;; Relationship to work/clj-xref-context-neighborhoods.spec.edn: clj-xref
+;; is the Clojure-specific superset (protocols, multimethods, arity-
+;; aware calls) that pure tree-sitter can't express. This spec is
+;; language-agnostic symbol tables. Both should ship — clj-xref is a
+;; fast additive win; tree-sitter is the structural base we need for the
+;; non-Clojure codebases miniforge targets.
+
+{:spec/title "Tree-sitter symbol extraction for repo-index + context-pack"
+
+ :spec/description
+ "Lift the existing policy-pack tree-sitter wrapper into a shared brick.
+  Use it to build a per-repo symbol table. Give context-pack the ability
+  to return symbol-level neighborhoods instead of text-only hits.
+
+  GROUP 1: Promote the tree-sitter wrapper into a shared component
+  Create components/tree-sitter-bridge. Move components/policy-pack/
+  src/.../ast.clj's CLI wrapper logic into it. Update policy-pack to
+  consume tree-sitter-bridge via its interface. No behavior change in
+  policy-pack; just a dependency relocation.
+
+  GROUP 2: Grammar install + health check
+  The tree-sitter CLI needs language grammars installed on PATH. Add:
+    - `bb tree-sitter:install-grammars` — install the grammars for the
+      OSS target set (clojure, typescript, tsx, python, go, rust, swift).
+    - `tree-sitter-bridge/grammars-available?` — report the installed
+      grammars; context pipeline falls back to lexical for any language
+      whose grammar is missing.
+
+  GROUP 3: Symbol extraction in repo-index
+  Add components/repo-index/src/.../symbols.clj:
+    - `extract-symbols [file-record]` — shell to tree-sitter query, parse
+      output into a vector of symbol entries:
+      {:symbol/kind (:fn :method :class :var :macro :protocol :interface
+                    :trait :impl :type :const ...)
+       :symbol/name string
+       :symbol/fqname string   ;; module/namespace-qualified
+       :symbol/file string
+       :symbol/line-start int
+       :symbol/line-end int
+       :symbol/signature string  ;; short — first N chars of the def line
+       :symbol/container fqname-or-nil
+       :symbol/visibility (:public :private :internal)
+       :symbol/language keyword}
+    - Incremental rebuild — only re-parse files whose blob-sha changed
+      in the git tree.
+    - Schema in components/schema/ for the symbol record.
+
+  GROUP 4: repo.symbol tool
+  Register a new tool in tool-registry: `repo.symbol`.
+    - Input: symbol-id OR (file-path + line)
+    - Output: signature + docstring by default; body opt-in
+    - Budget: body content counts against the snippet budget
+    - Agent prompt update: prefer repo.symbol over repo.open for
+      structural questions.
+
+  GROUP 5: Symbol neighborhoods in context-pack
+  For a task whose target is a symbol, populate
+  :context-pack/symbol-neighborhood with:
+    - Target symbols' signatures + bodies
+    - Same-file neighbors (definitions before/after)
+    - Cross-file imports / references discovered via tree-sitter query
+      patterns (language-specific — Clojure `:require`, TS `import`,
+      Python `from ... import`, etc.)
+  For Clojure tasks, the clj-xref neighborhood (other spec) supplements
+  this with call-graph / protocol info.
+
+  GROUP 6: Dogfood A/B + measurement
+  Same as clj-xref spec — run dogfood specs with text-only vs symbol
+  neighborhoods, compare convergence + token usage. Enable by default
+  only after measurable win.
+
+  NON-GOALS
+  - LSP — use clojure-lsp / rust-analyzer etc. for editor UX.
+  - Full cross-reference DB — that's what clj-xref does for Clojure; for
+    other languages, we rely on tree-sitter's more limited cross-file
+    inference and accept that some 'who-calls' queries are imprecise.
+  - Writing new tree-sitter grammars — we use upstream grammars only.
+
+  RISKS
+  - Tree-sitter CLI availability varies by developer machine. Fallback
+    to lexical is load-bearing — must be tested.
+  - Incremental update edge cases (renamed files, merged commits). The
+    original plan flagged this. Mitigate by rebuilding the symbol index
+    as part of `bb repo-index:rebuild` and tying it to release tags.
+  - Grammar version drift. Pin grammar versions in the install task.
+
+  See work/archive/done/repo-context-implementation-plan.md §Phase 2 for
+  the original thinking — symbol-id scheme, symbol-key cross-commit
+  identity, container hierarchy. Port what still applies."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/tree-sitter-bridge/"         ;; new
+          "components/policy-pack/src"             ;; migrate consumer
+          "components/repo-index/src"
+          "components/context-pack/src"
+          "components/tool-registry/src"
+          "components/schema/src"
+          "tasks/"
+          "resources/config/default-user-config.edn"
+          "docs/development-guidelines.md"
+          "specs/normative/N1-architecture.md"]}
+
+ :spec/constraints
+ ["tree-sitter CLI MUST be optional at runtime — missing grammars fall back to lexical context without errors"
+  "policy-pack behavior MUST NOT change during the wrapper relocation (pure refactor)"
+  "Symbol extraction MUST be incremental — no full re-parse on every query"
+  "Symbol records MUST be schema-validated via components/schema"
+  "Feature-flag the symbol neighborhoods in context-pack; default off for the first release"
+  "Localize all user-facing strings (msg/t + en-US.edn)"
+  "Grammar versions MUST be pinned in the install task for reproducibility"]
+
+ :spec/acceptance-criteria
+ ["components/tree-sitter-bridge exists with a clean interface; policy-pack now consumes it"
+  "`bb tree-sitter:install-grammars` installs the OSS target grammars idempotently"
+  "repo-index includes a symbol table; `bb repo-index:dump` shows per-file symbols"
+  "repo.symbol tool is registered and returns signatures + docstrings"
+  "A test spec that modifies a TypeScript function produces a context pack whose :symbol-neighborhood names the function's same-file neighbors and imported modules"
+  "Missing grammars fall back to lexical context without error events"
+  "`bb test` passes across affected bricks"
+  "Documented in docs/development-guidelines.md + normative spec updates in N1 §2.27"]
+
+ :spec/workflow-type :canonical-sdlc}


### PR DESCRIPTION
## Summary
Two complementary work specs. No code.

- **`clj-xref-context-neighborhoods.spec.edn`** — Clojure-specific dependency neighborhoods (callers, callees, protocol implementors, multimethod dispatch) via clj-xref in `context-pack`.
- **`tree-sitter-symbol-context.spec.edn`** — Reopens archived Phase 2: lifts `policy-pack/ast.clj`'s tree-sitter CLI wrapper into `tree-sitter-bridge`, adds symbol extraction to `repo-index` for Clojure/TS/Python/Go/Rust/Swift.

### Why
Audit of the current context pipeline: `repo-index` + `context-pack` are file-level (BM25 lexical). `policy-pack` uses tree-sitter but only for rule detection — not wired into agents. So when an agent is asked to change `process-payment`, it gets "files whose text contains that string," not "files that actually call or implement it." Real signal gap.

clj-xref gives Clojure semantic superset (arity-aware, protocols, multimethods). Tree-sitter gives language-agnostic structural coverage. They compose.

### Landing order
1. clj-xref first — narrow, additive, fastest dogfood win for the Clojure-heavy codebases miniforge operates on
2. Tree-sitter symbols after — bigger infra, grammar install task, policy-pack refactor
3. Both feature-flagged off on ship; turn on after dogfood A/B shows measurable win

See `docs/pull-requests/2026-04-18-clj-xref-and-tree-sitter-context-specs.md` for the full write-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)