### PR TITLE
fix(deps): register supervisory-state + mcp-context-server in CLI projects

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -33,9 +33,11 @@
    - doctor   : System health check
    - version  : Version information
 
-   Note: This is designed to run in Babashka. Components that require
-   JVM-only libraries (malli, etc.) are not directly required here.
-   Instead, we use lightweight implementations suitable for CLI."
+   Note: This is designed to run in Babashka. Malli is bundled with
+   Babashka, so schema validation is available here; what we avoid in
+   this ns are requires that pull in components with truly BB-hostile
+   transitive deps (e.g. native JNI), preferring lightweight dispatch
+   to fuller JVM code paths when the CLI only needs thin orchestration."
   (:require
    [babashka.cli :as cli]
    [babashka.fs :as fs]

--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -31,6 +31,7 @@
         ai.miniforge/operator {:local/root "../../components/operator"}
         ai.miniforge/orchestrator {:local/root "../../components/orchestrator"}
         ai.miniforge/event-stream {:local/root "../../components/event-stream"}
+        ai.miniforge/supervisory-state {:local/root "../../components/supervisory-state"}
         ai.miniforge/self-healing {:local/root "../../components/self-healing"}
 ai.miniforge/messages {:local/root "../../components/messages"}
         ai.miniforge/patterns {:local/root "../../components/patterns"}

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -7,6 +7,7 @@
         ai.miniforge/tui-views {:local/root "../../components/tui-views"}
         ;; Event streaming (TUI subscribes to workflow events)
         ai.miniforge/event-stream {:local/root "../../components/event-stream"}
+        ai.miniforge/supervisory-state {:local/root "../../components/supervisory-state"}
         ;; Core domain components needed by CLI
         ai.miniforge/schema {:local/root "../../components/schema"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["test" "integration" "e2e"]
 
  :deps {ai.miniforge/cli {:local/root "../../bases/cli"}
+        ai.miniforge/mcp-context-server {:local/root "../../bases/mcp-context-server"}
         ;; Workflow and all its transitive dependencies
         ai.miniforge/workflow {:local/root "../../components/workflow"}
         ai.miniforge/workflow-chain-software-factory {:local/root "../../components/workflow-chain-software-factory"}
@@ -49,6 +50,7 @@
         ai.miniforge/reporting {:local/root "../../components/reporting"}
         ;; Event streaming and observability
         ai.miniforge/event-stream {:local/root "../../components/event-stream"}
+        ai.miniforge/supervisory-state {:local/root "../../components/supervisory-state"}
         ;; Self-healing: workaround detection, backend health tracking
         ai.miniforge/self-healing {:local/root "../../components/self-healing"}
         ;; TUI framework and views


### PR DESCRIPTION
## Summary

Two project-deps misses that surfaced the moment I tried \`bb install:local\` against main:

1. **supervisory-state** was added as a require in \`workflow_runner.clj\` via #572 but never listed as a dep in the three project deps.edn files (\`projects/miniforge/\`, \`projects/miniforge-core/\`, \`projects/miniforge-tui/\`). The top-level \`deps.edn\` \`:dev\` alias pulls every component, so \`clojure -M:dev\` worked — but the install-time uberjar build uses the project deps only, and blew up with \`FileNotFoundException: supervisory_state/interface.clj\`.

2. **mcp-context-server** has been required from \`bases/cli/src/.../main.clj:65\` for a while but was never listed in \`projects/miniforge/deps.edn\`. The old installed jar predates that require; any rebuild since would have hit \`FileNotFoundException: mcp_context_server/interface.clj\` as soon as the supervisory-state miss was fixed.

Also corrects a misleading docstring in \`bases/cli/.../main.clj\`: the old comment cited **malli** as an example of a "JVM-only library" we avoid — but malli IS bundled with Babashka. Rewrote to describe what we actually avoid (requires that pull in truly BB-hostile transitive deps).

## Verification

After this PR:
- \`bb install:local\` produces a working uberjar.
- \`mf version\` runs cleanly.
- A workflow stream published with \`ss/attach!\` writes \`:supervisory/*-upserted\` events to \`~/.miniforge/events/<wf>/\`.
- \`cargo mfc --headless\` (miniforge-control) deserializes them and renders the populated entity tables — full end-to-end pipeline verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)