### PR TITLE
fix(bb): add supervisory-state to bb miniforge task classpath

### DIFF
--- a/bb.edn
+++ b/bb.edn
@@ -482,6 +482,7 @@
                  "components/self-healing/src"
                  "components/event-stream/src"
                  "components/event-stream/resources"
+                 "components/supervisory-state/src"
                  "components/dag-primitives/src"
                  "components/dag-executor/src"
                  "components/dag-executor/resources"


### PR DESCRIPTION
PRs #572/#578 registered `supervisory-state` in all three project `deps.edn` but not in `bb.edn`'s miniforge dev task. `bb miniforge run` blew up at require-time with 'Could not locate ai/miniforge/supervisory_state/interface.clj on classpath'. Added `components/supervisory-state/src` right after `event-stream/resources` (its only dep).

Unblocks dogfood runs via the dev task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)