### PR TITLE
fix(agent): bump max-tokens to 32k + spec OPSV convergence for agent budgets

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -531,8 +531,10 @@
   [& [opts]]
   (let [logger (or (:logger opts)
                    (log/create-logger {:min-level :info :output (fn [_])}))
+        ;; :max-tokens bumped for structured artifact output + file-diff emission.
+        ;; OPSV convergence target — see work/n07-opsv-agent-budgets.spec.edn.
         config (->> (merge {:temperature 0.2
-                            :max-tokens 8000}
+                            :max-tokens 32000}
                            (:config opts))
                     (model/apply-default-model :implementer)
                     (budget/apply-default-budget :implementer))]

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -338,8 +338,13 @@
   [& [opts]]
   (let [logger (or (:logger opts)
                    (log/create-logger {:min-level :info :output (fn [_])}))
+        ;; :max-tokens caps output-tokens-per-response. Exploration-heavy
+        ;; planning (~70 tool calls) with small budgets truncates the final
+        ;; plan EDN to nothing. 32000 is a heuristic unblocker; OPSV (N7)
+        ;; replaces this with a converged policy per role × phase — see
+        ;; work/n07-opsv-agent-budgets.spec.edn.
         config (->> (merge {:temperature 0.3
-                            :max-tokens 4000}
+                            :max-tokens 32000}
                            (:config opts))
                     (model/apply-default-model :planner)
                     (budget/apply-default-budget :planner))]

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -504,8 +504,10 @@
                        (loop/lint-gate)
                        (loop/policy-gate :security {:policies [:no-secrets]})]
         gates (get opts :gates default-gates)
+        ;; :max-tokens bumped so structured review output isn't truncated.
+        ;; OPSV convergence target — see work/n07-opsv-agent-budgets.spec.edn.
         review-config (->> (merge {:temperature 0.1
-                                   :max-tokens 4000}
+                                   :max-tokens 16000}
                                   (:config opts))
                            (model/apply-default-model :reviewer))
         config {:strict (get opts :strict false)}]

--- a/components/config/resources/config/default-user-config-fallback.edn
+++ b/components/config/resources/config/default-user-config-fallback.edn
@@ -4,7 +4,9 @@
         :model "gpt-5.2-codex"
         :timeout-ms 300000
         :line-timeout-ms 60000
-        :max-tokens 4000}
+        ;; Keep in sync with resources/config/default-user-config.edn.
+        ;; OPSV convergence target — see work/n07-opsv-agent-budgets.spec.edn.
+        :max-tokens 32000}
   :workflow {:max-iterations 50
              :max-tokens 150000
              :failure-strategy :retry}

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -4,7 +4,11 @@
         :model "gpt-5.2-codex"
         :timeout-ms 300000
         :line-timeout-ms 60000
-        :max-tokens 4000}
+        ;; Per-response output cap. 4000 truncated planner output to 0 chars on
+        ;; exploration-heavy specs (workflow e4b88416, 2026-04-18). 32000 is a
+        ;; heuristic unblocker; OPSV (N7) replaces this with a converged policy
+        ;; — see work/n07-opsv-agent-budgets.spec.edn.
+        :max-tokens 32000}
   :workflow {:max-iterations 50
              :max-tokens 150000
              :failure-strategy :retry}

--- a/work/QUEUE.md
+++ b/work/QUEUE.md
@@ -35,6 +35,18 @@ Miniforge's DAG executor exists and is wired but never fires for
 |---|---|---|---|---|
 | blocker | ● | dag-orchestration | `plan-from-agent-dag-wiring.spec.edn` — plan-from-agent must emit :plan/id so the DAG orchestrator activates | observation+tokenconservation+dogfoodenabler |
 
+## Theme — Operational Policy Synthesis (OPSV) (`operational-policy-synthesis`, status: planned)
+
+Discover scaling + budget signals via governed experiments, synthesize
+   operational policies, verify against acceptance criteria, and emit
+   them as auditable artifacts. Any numeric knob whose optimal value we
+   currently guess — agent max-tokens, tool-call caps, timeouts, K8s
+   container CPU/memory, I/O bandwidth — is an OPSV target.
+
+| tier | r | theme | spec | axes |
+|---|---|---|---|---|
+| high | ○ | operational-policy-synthesis | `n07-opsv-agent-budgets.spec.edn` — OPSV: converge agent max-tokens + phase-iteration budgets | observation+tokenconservation+dogfoodenabler |
+
 ## Theme — unassigned (`unassigned`, status: planned)
 
 (no theme description)

--- a/work/n07-opsv-agent-budgets.spec.edn
+++ b/work/n07-opsv-agent-budgets.spec.edn
@@ -1,0 +1,135 @@
+;; =============================================================================
+;; Spec: N7 OPSV applied to agent resource budgets
+;; =============================================================================
+;;
+;; Normative anchor: specs/normative/N7-Operational-Policy-Synthesis.md
+;;
+;; Motivation (2026-04-18 dogfood finding, workflow e4b88416):
+;;   :llm-content-length 0
+;;   :llm-content-preview ""
+;; Planner max-tokens=4000 was too low; 72 tool calls during exploration
+;; truncated the final plan EDN to 0 chars. The fix shipped as a
+;; heuristic bump to 32000. That's a guess. We don't know the optimal
+;; value and the optimum differs per role × phase × spec size × model.
+;;
+;; The OPSV framework (N7) was designed for exactly this: numeric knobs
+;; where the optimal value is empirically discoverable via governed
+;; experiments. Originally aimed at K8s scaling and I/O bandwidth; agent
+;; budgets are the same shape of problem.
+;;
+;; This spec is the first OPSV USE CASE. It applies the DISCOVER →
+;; CONVERGE → VERIFY → ACTUATE loop to agent budgets, producing a
+;; converged policy that lands in default-user-config.edn.
+;;
+;; Scope is bounded: agent :max-tokens and phase :iterations budgets
+;; only. Cost/token dollar caps stay manual for now.
+
+{:spec/title "OPSV: converge agent max-tokens + phase-iteration budgets"
+
+ :spec/description
+ "Apply the N7 OPSV workflow to agent resource budgets. Replace the
+  hand-tuned values in default-user-config.edn + per-agent overrides
+  with a converged policy derived from governed experiments.
+
+  GROUP 1: DISCOVER — signal candidates
+  Tag the following as OPSV signals in the event log (N3 §3.13):
+    - :phase/llm-content-length — per terminal planner/implementer/
+      reviewer response, before parsing
+    - :phase/tool-call-count   — per phase, from the tool-call events
+      PR #571/#574 introduced
+    - :phase/max-tokens-config — the :max-tokens that was in effect
+    - :phase/truncation-detected? — true when :llm-content-length
+      approaches :max-tokens (heuristic: > 0.95 × cap) OR
+      :parse-result nil with :llm-content-length == 0
+    - :phase/retry-count      — times the phase re-ran within a single
+      workflow run (once the watchdog + retry machinery lands)
+  Existing event schema gains these fields as optional.
+
+  GROUP 2: Experiment pack for agent budgets
+  Define `resources/opsv/agent-budgets-experiment.edn` describing the
+  experiment:
+    - Fixture set: N historical specs covering small/medium/large
+      exploration shapes. Start with 5 — today's 6 Tier-1 dogfood
+      specs provide good variety.
+    - Controlled variable: {:role :phase :max-tokens} tuples
+    - Sweep: planner [8K 16K 32K 64K], implementer [8K 16K 32K],
+      reviewer [4K 8K 16K]
+    - Trial count: 3 per cell (run spec 3x at each cell)
+    - Observable: truncation-detected? + plan/implement phase outcome
+      + tokens-used + wall-clock + cost-usd
+    - Abort: truncation-detected? = true on ≥2 of 3 trials at a cell
+      (that cell is unsafe, move on)
+
+  GROUP 3: CONVERGE — optimization target
+  Objective per (role, phase):
+    argmin_cap (cost-usd + 10 × truncation-rate)
+    subject to: wall-clock-p95 ≤ target-for-phase
+                truncation-detected-rate ≤ 0.01
+  Start with the smallest cap that satisfies the truncation constraint,
+  not the largest — empirically we're currently configured too LOW,
+  but the long tail of oversized caps burns budget unnecessarily.
+
+  GROUP 4: VERIFY — acceptance criteria
+  For the converged policy (candidate max-tokens per role × phase):
+    - Replay all 5 fixture specs with the candidate policy
+    - Assert: 0 truncations across all trials
+    - Assert: plan phase produces non-empty :output with :plan/id
+    - Assert: implement phase produces files OR reports :curator/no-files-written (no silent empty-output)
+    - Emit verification artifact per N6 §2.8
+
+  GROUP 5: ACTUATE — policy application
+  Write the converged values to:
+    - resources/config/default-user-config.edn :llm :max-tokens
+    - Per-agent overrides removed (planner/implementer/reviewer.clj
+      hardcoded values) in favor of role-defaults in
+      agent/core.clj :default-role-configs
+  Gated by APPLY_ALLOWED (per N7 §2.4). Dry-run emits a policy diff.
+
+  GROUP 6: Integrate with `miniforge run`
+  Every production workflow run emits the DISCOVER signals automatically
+  once this spec lands — no opt-in needed. The signals flow to the
+  event stream, and any future OPSV convergence job reads them as
+  historical evidence in addition to the controlled experiment data.
+
+  Non-goals:
+    - Dollar-cost budget caps (separate concern, manual for now)
+    - LLM max-iterations tuning (separate OPSV use case)
+    - Per-backend budget convergence (Claude vs Codex vs local — can
+      layer on once single-backend converges)"
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/agent/src"
+          "components/event-stream/src"
+          "components/workflow/src"
+          "components/phase/src"
+          "resources/config/default-user-config.edn"
+          "components/config/resources/config/default-user-config-fallback.edn"
+          "resources/opsv/"]}
+
+ :spec/constraints
+ ["MUST emit DISCOVER signals on every workflow run (not opt-in) so historical data accumulates passively"
+  "MUST respect N7 §2.4 APPLY_ALLOWED gate — actuation is not automatic"
+  "Experiment fixtures MUST be reproducible: pinned model versions, pinned spec hashes"
+  "The converged policy MUST be version-pinned in the config with provenance (experiment run id)"
+  "VERIFY MUST run on a frozen fixture set — adding fixtures mid-experiment invalidates the run"
+  "Localize all user-facing strings (msg/t + en-US.edn)"]
+
+ :spec/acceptance-criteria
+ ["DISCOVER phase produces :phase/llm-content-length + :phase/tool-call-count + :phase/max-tokens-config + :phase/truncation-detected? on every plan/implement/review phase"
+  "`miniforge opsv discover agent-budgets` enumerates candidate signals + their current values"
+  "`miniforge opsv converge agent-budgets --fixtures <ids>` runs the controlled experiment end-to-end"
+  "`miniforge opsv verify agent-budgets --policy <candidate>` replays the fixture set and emits the verification evidence bundle"
+  "`miniforge opsv actuate agent-budgets --policy <candidate>` (with APPLY_ALLOWED=true) writes the converged policy to default-user-config.edn with provenance"
+  "Converged policy for at least the planner role lands in config and replaces the hand-tuned 32000 from the unblocker PR"
+  "Experiment run is reproducible: same fixture hashes + same model version → same converged policy within ±10%"]
+
+ :spec/priority
+ {:tier :high
+  :axes #{:token-conservation :dogfood-enabler :observation}
+  :theme :operational-policy-synthesis
+  :rationale "First OPSV use case. Closes the guess-at-budget loop that produced 4000-as-default and the empty-response failure. Every numeric-budget spec after this one benefits from the same framework."
+  :blocks []
+  :blocked-by ["n07-opsv-workflow.spec.edn" "n07-opsv-converge-verify-actuate.spec.edn"]}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/themes.edn
+++ b/work/themes.edn
@@ -115,4 +115,24 @@
    "Reliability events flow through the event stream with stable schema"
    "Self-healing chooses recovery actions keyed on failure class"]
   :theme/status :planned
+  :theme/owner :christopher}
+
+ :operational-policy-synthesis
+ {:theme/id :operational-policy-synthesis
+  :theme/title "Operational Policy Synthesis (OPSV)"
+  :theme/description
+  "Discover scaling + budget signals via governed experiments, synthesize
+   operational policies, verify against acceptance criteria, and emit
+   them as auditable artifacts. Any numeric knob whose optimal value we
+   currently guess — agent max-tokens, tool-call caps, timeouts, K8s
+   container CPU/memory, I/O bandwidth — is an OPSV target."
+  :theme/informative-spec nil
+  :theme/normative-refs
+  [{:doc "specs/normative/N7-Operational-Policy-Synthesis.md"
+    :relation :primary}]
+  :theme/completion-criteria
+  ["OPSV workflow (DISCOVER → CONVERGE → VERIFY → ACTUATE) runs end-to-end on at least one real budget parameter"
+   "At least one policy is actuated to production config via OPSV (not hand-tuned)"
+   "Verification evidence bundle shows pass/fail per acceptance criterion"]
+  :theme/status :planned
   :theme/owner :christopher}}


### PR DESCRIPTION
Tactical unblock + strategic convergence spec.

Workflow e4b88416 failed with `:llm-content-length 0`. Planner max-tokens 4000 truncated output to zero after 72 exploration tool calls. Bumped five locations to 32K with pointer comments to the OPSV spec.

`work/n07-opsv-agent-budgets.spec.edn` — first OPSV use case. DISCOVER (passive signal tagging on every plan/implement/review) → CONVERGE (controlled sweep over role×phase×max-tokens) → VERIFY (frozen fixtures, 0 truncations) → ACTUATE (write converged policy, gated by `APPLY_ALLOWED` per N7 §2.4).

Depends on existing N7 workflow spec + CONVERGE/VERIFY/ACTUATE phases. New `:operational-policy-synthesis` theme with N7 as normative anchor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)