### PR TITLE
fix(agent): planner defaults to claude-opus-4-6 + spec multi-backend CLI parity

### DIFF
--- a/components/agent/src/ai/miniforge/agent/model.clj
+++ b/components/agent/src/ai/miniforge/agent/model.clj
@@ -25,9 +25,14 @@
 ;; Canonical role model policy
 
 (def ^:private default-agent-models
-  "Fallback model defaults when user config does not specify agent defaults."
-  {:thinking "gpt-5.4"
-   :execution "gpt-5.2-codex"})
+  "Fallback model defaults when user config does not specify agent defaults.
+
+   Thinking defaults to Claude because non-Claude CLI backends (codex,
+   cursor-agent, gh-copilot, etc.) don't yet ship structured plans back
+   through their stream parsers. Tracked in
+   work/multi-backend-cli-parity.spec.edn."
+  {:thinking "claude-opus-4-6"
+   :execution "claude-sonnet-4-6"})
 
 
 (def ^:private thinking-roles

--- a/components/config/resources/config/default-user-config-fallback.edn
+++ b/components/config/resources/config/default-user-config-fallback.edn
@@ -14,7 +14,10 @@
   :meta-loop {:enabled true
               :max-convergence-iterations 10
               :convergence-threshold 0.95}
-  :agents {:default-models {:thinking   "gpt-5.4"
+  ;; Keep in sync with resources/config/default-user-config.edn.
+  ;; See work/multi-backend-cli-parity.spec.edn for why thinking defaults
+  ;; to Claude today rather than gpt-5.4.
+  :agents {:default-models {:thinking   "claude-opus-4-6"
                             :execution  "claude-sonnet-4-6"
                             :escalation "claude-opus-4-7"}}
   :model-selection {:enabled true

--- a/components/config/test/ai/miniforge/config/user_defaults_test.clj
+++ b/components/config/test/ai/miniforge/config/user_defaults_test.clj
@@ -32,8 +32,12 @@
       (is (= :codex (get-in cfg [:llm :backend])))
       (is (= "gpt-5.2-codex" (get-in cfg [:llm :model]))))
 
-    (testing "default agent models use GPT for thinking, Claude for execution"
-      (is (= "gpt-5.4" (get-in cfg [:agents :default-models :thinking])))
+    (testing "default agent models: Opus 4.6 for thinking, Sonnet for execution"
+      ;; Non-Claude CLI backends (codex, cursor-agent, gh-copilot) don't yet
+      ;; ship structured plans through their stream parsers (see
+      ;; work/multi-backend-cli-parity.spec.edn). Planner/architect default
+      ;; to claude-opus-4-6 until that lands.
+      (is (= "claude-opus-4-6" (get-in cfg [:agents :default-models :thinking])))
       (is (= "claude-sonnet-4-6" (get-in cfg [:agents :default-models :execution]))))
 
     (testing "default self-healing enables claude and codex failover"

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -16,7 +16,14 @@
  :meta-loop {:enabled true
               :max-convergence-iterations 10
               :convergence-threshold 0.95}
-  :agents {:default-models {:thinking   "gpt-5.4"
+  ;; Planner/architect default to Opus 4.6 (opusplan, 200K context). Codex
+  ;; and other non-Claude CLI backends don't yet ship structured plans back
+  ;; through their stream parsers (agentic-by-default; see
+  ;; work/multi-backend-cli-parity.spec.edn). Claude is the only backend
+  ;; whose :default-model-for-role :planner produces a plan artifact today.
+  ;; Override per-role in your user config if your chosen backend supports
+  ;; the same contract.
+  :agents {:default-models {:thinking   "claude-opus-4-6"
                             :execution  "claude-sonnet-4-6"
                             :escalation "claude-opus-4-7"}}
   :model-selection {:enabled true

--- a/work/QUEUE.md
+++ b/work/QUEUE.md
@@ -15,11 +15,26 @@ Make miniforge capable of running miniforge without paying for
 
 | tier | r | theme | spec | axes |
 |---|---|---|---|---|
-| blocker | ● | dogfood-resilience | `event-log-tool-visibility.spec.edn` — Event log — capture tool name / args / result on every agent tool call | observation+dogfoodenabler |
+| blocker | ● | dogfood-resilience | `agent-stream-watchdog-and-resume.spec.edn` — Agent stream watchdog + session-resume for hang recovery | tokenconservation+dogfoodenabler |
 | blocker | ● | dogfood-resilience | `worktree-persistence-scratch-branch.spec.edn` — Persist worktrees outside /tmp + scratch-branch commits on every write | dogfoodenabler |
 | high | ○ | dogfood-resilience | `workflow-dependency-declarations.spec.edn` — Workflow dependency declarations — supervisor sequencing + DAG dependencies | dogfoodenabler |
-| blocker | ○ | dogfood-resilience | `agent-stream-watchdog-and-resume.spec.edn` — Agent stream watchdog + session-resume for hang recovery | tokenconservation+dogfoodenabler |
 | blocker | ○ | dogfood-resilience | `workflow-phase-checkpoint-and-resume.spec.edn` — Workflow phase checkpoint + resume | tokenconservation+dogfoodenabler |
+
+## Theme — Multi-backend CLI parity (`multi-backend-parity`, status: planned)
+
+Miniforge is an agent-CLI-agnostic platform. Every supported CLI
+   (claude, codex, cursor-agent, gh copilot, open-codex, amp, …) MUST
+   conform to the same planner/implementer/reviewer contract: structured
+   output via MCP artifact submission, session resume, stream parser
+   coverage, error classification. Today only claude is a first-class
+   citizen; codex is registered but its stream parser ignores
+   reasoning + tool-call items, and its args builder passes no MCP
+   config. Parity is foundational for OSS adoption — users pick their
+   agent CLI, not ours.
+
+| tier | r | theme | spec | axes |
+|---|---|---|---|---|
+| blocker | ● | multi-backend-parity | `multi-backend-cli-parity.spec.edn` — Multi-backend CLI parity — make codex / cursor-agent / copilot / open-codex first-class planners and implementers | correctness+scale+dogfoodenabler |
 
 ## Theme — DAG orchestration (`dag-orchestration`, status: in-flight)
 

--- a/work/multi-backend-cli-parity.spec.edn
+++ b/work/multi-backend-cli-parity.spec.edn
@@ -1,0 +1,177 @@
+;; =============================================================================
+;; Spec: Multi-backend CLI parity — codex, cursor, copilot, open-codex
+;; =============================================================================
+;;
+;; Motivation (2026-04-18):
+;;
+;; Dogfood run 4fc8a169 failed for the third time with :llm-content-length 0
+;; after 74 tool calls. Root cause traced through the LLM client:
+;;
+;;   components/llm/src/.../protocols/impl/llm_client.clj:171-172
+;;     ;; reasoning, tool_call, etc. — ignore content
+;;     nil
+;;
+;; Codex's CLI ('codex exec --full-auto') is agentic-by-default. It emits
+;; reasoning + tool_call items, completes the task, and returns. The
+;; planner's code expects a Claude-shape final text block containing the
+;; plan EDN. Codex never produces one. The stream parser throws away
+;; tool_call and reasoning content, so we end up with an empty delta
+;; buffer and throw :anomalies.agent/invoke-failed with
+;; :llm-content-length 0.
+;;
+;; Meanwhile 'codex-args' passes no MCP configuration to the CLI at all,
+;; so even if we wanted Codex to call an MCP submit-artifact tool, it
+;; couldn't — Codex doesn't know the tool exists.
+;;
+;; This isn't just a Codex issue. Miniforge is agent-CLI-agnostic by
+;; design. cursor-agent, 'gh copilot', open-codex, amp, etc. all have
+;; their own CLI invocation conventions, stream formats, and tool-use
+;; loops. Each one needs the same treatment claude gets:
+;;
+;;   - args builder passes MCP config + tool allowlist
+;;   - stream parser extracts structured output from that backend's
+;;     native event shape
+;;   - session-resume semantics mapped to the backend's equivalent
+;;   - error classification (rate-limit, timeout, context-overflow,
+;;     provider-error) mapped to canonical anomaly keywords
+;;
+;; Today only claude is first-class. Parity is foundational for OSS
+;; adoption — users pick their agent CLI, not ours.
+
+{:spec/title "Multi-backend CLI parity — make codex / cursor-agent / copilot / open-codex first-class planners and implementers"
+
+ :spec/description
+ "Bring non-Claude CLI backends up to the same feature bar Claude has:
+  MCP tool registration, structured-artifact output extraction,
+  session-resume, anomaly classification, and streaming delta support.
+  Today Claude is the only backend whose default-model-for-role
+  :planner produces a usable plan artifact; everything else registered
+  in model-catalog.edn is a dead end.
+
+  This spec is a parent — per-backend slices land as follow-up work
+  specs under the same :multi-backend-parity theme. The parent defines
+  the shared contract all backends must meet.
+
+  GROUP 1: Define the backend conformance contract
+  A new protocol (or a schema over `components/llm/.../backends`
+  config) specifying what every backend must provide:
+    - :args-fn — takes {:prompt :system :max-tokens :mcp-config
+                        :mcp-allowed-tools :model :resume :streaming?
+                        :budget-usd :max-turns :supervision}
+                 returns CLI arg vector. MUST handle mcp-config and
+                 mcp-allowed-tools (today codex-args ignores both).
+    - :stream-parser — line-by-line parse function. MUST emit
+                       {:delta string :done? bool :usage map} for text,
+                       {:tool-call ...} for tool invocations,
+                       {:artifact ...} for structured artifact
+                       submissions. Tool-call and artifact entries
+                       count toward the response content, not the
+                       throwaway pile.
+    - :artifact-extractor — optional fn to lift structured output
+                            from native format (e.g., Codex's
+                            item.completed entries → plan EDN).
+    - :session-resume-arg — how to resume (claude uses --resume,
+                            codex's equivalent TBD per backend).
+    - :error-mapper — translates native error strings to canonical
+                      anomaly keywords.
+
+  GROUP 2: Fix codex — the observed regression
+  - codex-args takes and applies mcp-config + mcp-allowed-tools
+    (passed via Codex's --mcp-config equivalent or via a sidecar
+    config file Codex reads)
+  - parse-codex-stream-line: extract agent_message AND reasoning_text
+    when no agent_message is produced (heuristic: plan EDN embedded in
+    the final reasoning step)
+  - Add :artifact-extractor for Codex that pulls EDN out of item.completed
+    entries tagged as artifact-submit (once MCP is wired)
+  - Session-resume via codex's resume mechanism (`codex session resume
+    <id>` per Codex docs)
+  - Regression test: run today's event-log-tool-visibility fixture spec
+    with :backend :codex → plan phase produces non-empty :output with
+    :plan/id
+
+  GROUP 3: Fix / register cursor-agent
+  - cursor-agent is Cursor's CLI (renamed from cursor-cli a while back).
+    Today the backends map has :cursor with :cmd 'cursor-cli' — update
+    to 'cursor-agent' + verify args-fn + stream-parser.
+  - Wire MCP config (cursor-agent supports MCP via their own config
+    mechanism — document path)
+  - Regression test: same fixture, :backend :cursor
+
+  GROUP 4: Add gh-copilot + open-codex + amp backends
+  - Research each CLI's invocation model, stream format, MCP support
+  - Write :args-fn + :stream-parser for each
+  - Regression test per backend
+
+  GROUP 5: Conformance test suite
+  A new component `components/backend-conformance` (or test-only code in
+  llm/test) that takes a backend id + a small fixture spec and runs:
+    - plan-via-backend → assert non-empty plan EDN with :plan/id
+    - implement-via-backend → assert at least one file write
+    - resume-via-backend → kill mid-phase, resume, assert continuity
+    - error-classification → feed synthetic rate-limit / timeout /
+      parse-failure responses, assert correct anomaly keyword
+  CI runs this suite on every backend whose CLI is available in the
+  environment (optional / skippable when CLIs aren't installed).
+
+  GROUP 6: User config surfaces + documentation
+  - docs/development-guidelines.md section: 'Choosing a backend',
+    listing supported backends + their feature parity status
+  - CLI message on startup: warn when the configured :llm :backend has
+    known parity gaps (e.g., 'codex backend does not yet support
+    structured plan output; planner will fall back to <claude model> —
+    see multi-backend-cli-parity.spec.edn')
+  - Per-role backend override so users can split
+    (planner=claude-opus-4-6, implementer=codex, reviewer=sonnet)
+    without touching global :backend.
+
+  NON-GOALS
+  - HTTP API backends (Anthropic API, OpenAI API, Gemini API) — those
+    are a separate conformance surface; this spec is about CLI
+    backends.
+  - Fleet-mode remote backends — scope limited to local CLI execution.
+  - Writing new backend CLIs ourselves — we only conform to what ships
+    upstream.
+  - Per-backend prompt tuning beyond what's needed to satisfy the
+    contract."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/llm/src"
+          "components/llm/test"
+          "components/agent/src"
+          "components/agent/test"
+          "components/config/src"
+          "resources/config/default-user-config.edn"
+          "docs/development-guidelines.md"
+          "specs/normative/N1-architecture.md"]}
+
+ :spec/constraints
+ ["Conformance contract MUST be defined before per-backend implementations start — otherwise each backend drifts into bespoke shape"
+  "Stream parsers MUST preserve tool-call and reasoning content when no agent_message block is emitted (heuristic: parse EDN from final reasoning if present) — not throw it away like codex does today"
+  "MCP tool registration MUST flow through args-fn consistently; each backend's CLI-specific invocation path is an implementation detail"
+  "Session-resume semantics MUST be documented per backend; parity gaps MUST be surfaced in the config-validation warning"
+  "Conformance test suite MUST be skippable when a backend CLI is unavailable (OSS contributors without all CLIs installed)"
+  "Non-Claude backends that fail conformance at ship MUST still be usable for non-planning tasks (implement-only, review-only) with a warning"
+  "Localize all user-facing strings (msg/t + en-US.edn)"]
+
+ :spec/acceptance-criteria
+ ["Backend conformance contract defined as a schema or protocol with required fields"
+  "codex backend: 'bb miniforge run <fixture>.spec.edn' with :backend :codex produces plan phase :output with :plan/id, non-zero content length"
+  "cursor-agent backend: same fixture runs end-to-end with :backend :cursor"
+  "gh-copilot backend: same fixture runs end-to-end"
+  "open-codex backend: same fixture runs end-to-end"
+  "conformance test suite runs one fixture per supported backend in CI (or clearly skips when CLI unavailable)"
+  "Per-role :llm/backend override works — user can set planner=claude, implementer=codex independently"
+  "CLI startup warns when configured backend has parity gaps, naming the specific gap"
+  "docs/development-guidelines.md documents backend selection + parity matrix"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:correctness :scale :dogfood-enabler}
+  :theme :multi-backend-parity
+  :rationale "Dogfood is blocked on Claude by default — non-Claude backends can't produce usable plans. For OSS, this is a correctness blocker: the product promises agent-CLI-agnosticism but delivers Claude-only. Parity closes both the dogfood loop and the OSS adoption surface."
+  :blocks []
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/themes.edn
+++ b/work/themes.edn
@@ -135,4 +135,30 @@
    "At least one policy is actuated to production config via OPSV (not hand-tuned)"
    "Verification evidence bundle shows pass/fail per acceptance criterion"]
   :theme/status :planned
+  :theme/owner :christopher}
+
+ :multi-backend-parity
+ {:theme/id :multi-backend-parity
+  :theme/title "Multi-backend CLI parity"
+  :theme/description
+  "Miniforge is an agent-CLI-agnostic platform. Every supported CLI
+   (claude, codex, cursor-agent, gh copilot, open-codex, amp, …) MUST
+   conform to the same planner/implementer/reviewer contract: structured
+   output via MCP artifact submission, session resume, stream parser
+   coverage, error classification. Today only claude is a first-class
+   citizen; codex is registered but its stream parser ignores
+   reasoning + tool-call items, and its args builder passes no MCP
+   config. Parity is foundational for OSS adoption — users pick their
+   agent CLI, not ours."
+  :theme/informative-spec nil
+  :theme/normative-refs
+  [{:doc "specs/normative/N1-architecture.md" :section "§2 capsule agent-agnosticism"
+    :relation :primary}]
+  :theme/completion-criteria
+  ["claude, codex, cursor-agent, gh-copilot, open-codex all run the same fixture spec end-to-end with equivalent outputs"
+   "Each backend's args builder passes MCP config + tool allowlist"
+   "Each backend's stream parser extracts structured output (plan EDN, code artifacts) from the backend's native output shape"
+   "A conformance test suite replays one fixture spec per backend and asserts equivalent phase outcomes"
+   "Backend selection is first-class in user config and session-resume works across all supported backends"]
+  :theme/status :planned
   :theme/owner :christopher}}


### PR DESCRIPTION
Tactical unblock + strategic correctness spec.

### Tactical — planner → Opus 4.6

Dogfood runs kept failing with `:llm-content-length 0` because default thinking model was gpt-5.4 (Codex backend). Codex's CLI is agentic-by-default — it completes tasks via reasoning + tool_call items and never emits a final text block the planner can read. Root cause in `components/llm/.../llm_client.clj:171-172` (stream parser ignores reasoning + tool_call) and `codex-args` (passes no MCP config).

Switched thinking default to `claude-opus-4-6` (opusplan, 200K context). Execution stays `sonnet-4.6`, escalation stays `opus-4.7`. Three files updated with comments pointing at the parity spec.

### Strategic — multi-backend CLI parity spec

New `work/multi-backend-cli-parity.spec.edn` under a new `:multi-backend-parity` theme. Miniforge is agent-CLI-agnostic by design, so this is a correctness blocker for OSS.

Scope:
- Conformance contract (args-fn, stream-parser, artifact-extractor, session-resume-arg, error-mapper)
- Fix Codex (stream parser + codex-args MCP wiring)
- Fix cursor-agent registration (CLI was renamed from cursor-cli)
- Add gh-copilot, open-codex, amp backends
- Conformance test suite
- Per-role backend override
- CLI startup warning when backend has parity gaps

### Test fix
`components/config/test/.../user_defaults_test.clj` pinned the old `gpt-5.4` thinking default — updated to match the new Opus-4.6 default.

## Test plan
- [x] Pre-commit passes (after test update)
- [ ] Re-run event-log-tool-visibility — planner should now produce usable plan EDN
- [ ] Multi-backend conformance spec scheduled for future work under `:multi-backend-parity` theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)