### PR TITLE
feat(events): :agent/tool-call events with named tools + mf events show CLI

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -210,6 +210,7 @@
 (defn logs-list-cmd [_m] (observability/handle-logs {:subcommand "list"}))
 (defn events-tail-cmd [m] (observability/handle-events (assoc (get-opts m) :subcommand "tail")))
 (defn events-list-cmd [_m] (observability/handle-events {:subcommand "list"}))
+(defn events-show-cmd [m] (observability/handle-events (assoc (get-opts m) :subcommand "show")))
 
 ;; Delegated commands
 (defn run-cmd [m] (cmd-run/run-cmd (get-opts m)))
@@ -469,6 +470,13 @@
 
    {:cmds ["events" "list"]
     :fn events-list-cmd}
+
+   {:cmds ["events" "show"]
+    :fn events-show-cmd
+    :args->opts [:workflow-id]
+    :spec {:filter {:coerce :keyword}
+           :no-chunks {:coerce :boolean :default true}
+           :no-status {:coerce :boolean :default false}}}
 
    ;; Fleet subcommands (daemon management + watch/prs — N5)
    {:cmds ["fleet" "start"]  :fn fleet-start-cmd}

--- a/bases/cli/src/ai/miniforge/cli/observability.clj
+++ b/bases/cli/src/ai/miniforge/cli/observability.clj
@@ -419,18 +419,159 @@
                   (println (colorize :yellow (messages/t :observability/cleanup-not-available)))))
     (println (colorize :red (messages/t :observability/unknown-subcommand {:subcommand subcommand})))))
 
+;;------------------------------------------------------------------------------ Layer 2.5: Workflow timeline (show)
+
+(defn- workflow-events-dir
+  "Path to the per-workflow event directory for a given workflow id."
+  [workflow-id]
+  (io/file (app-config/events-dir) (str workflow-id)))
+
+(defn- strip-transit-prefix
+  "Transit-json keys arrive as '~:foo/bar'. Strip the prefix so our code
+   can use keyword accessors. Recursive walk over maps + vectors."
+  [x]
+  (cond
+    (map? x)
+    (reduce-kv (fn [acc k v]
+                 (let [k' (if (and (string? k) (.startsWith ^String k "~:"))
+                            (keyword (subs k 2))
+                            k)]
+                   (assoc acc k' (strip-transit-prefix v))))
+               {}
+               x)
+
+    (vector? x)
+    (mapv strip-transit-prefix x)
+
+    (and (string? x) (.startsWith ^String x "~:"))
+    (keyword (subs x 2))
+
+    (and (string? x) (.startsWith ^String x "~t"))
+    (subs x 2)
+
+    (and (string? x) (.startsWith ^String x "~u"))
+    (subs x 2)
+
+    :else x))
+
+(defn- read-workflow-events
+  "Read + parse every .json event file under the workflow directory, sorted
+   by filename (which is timestamp-prefixed)."
+  [dir]
+  (when (.exists ^java.io.File dir)
+    (let [json-parse (requiring-resolve 'cheshire.core/parse-string)]
+      (->> (.listFiles ^java.io.File dir)
+           (filter #(.endsWith (.getName ^java.io.File %) ".json"))
+           (sort-by #(.getName ^java.io.File %))
+           (keep (fn [f]
+                   (try
+                     (let [raw (json-parse (slurp f) false)]
+                       (strip-transit-prefix raw))
+                     (catch Exception _e nil))))))))
+
+(defn- ts-short
+  "Render the :event/timestamp field (may be a plain string after transit
+   stripping) as HH:MM:SS."
+  [ts]
+  (let [s (str ts)]
+    (cond
+      (re-find #"\d\d:\d\d:\d\d" s)
+      (first (re-find #"(\d\d:\d\d:\d\d)" s))
+      :else
+      (subs s 0 (min 8 (count s))))))
+
+(defn- summarize-event
+  "One-line summary for a single event. Emphasizes tool names, phase
+   outcomes, DAG decisions."
+  [ev]
+  (let [t (:event/type ev)
+        phase (:workflow/phase ev)
+        tool (:tool/name ev)
+        tool-names (:tool/names ev)
+        dag-outcome (:dag/outcome ev)
+        dag-reason (:dag/reason ev)
+        outcome (:phase/outcome ev)
+        duration (:phase/duration-ms ev)
+        err (or (:phase/error ev)
+                (get-in ev [:dag/diagnostic :result/error :error/message]))]
+    (cond
+      (= :workflow/phase-started t)
+      (str "→ " (some-> phase name) " started")
+
+      (= :workflow/phase-completed t)
+      (str "✓ " (some-> phase name) " " (some-> outcome name)
+           (when duration (format " (%.1fs)" (/ duration 1000.0)))
+           (when err (str " — " (subs (str err) 0 (min 160 (count (str err)))))))
+
+      (= :agent/tool-call t)
+      (str "  • tool " (or tool
+                           (when (seq tool-names) (str/join "," (map str tool-names)))
+                           "(unnamed)"))
+
+      (= :agent/status t)
+      (str "  · " (or (:status/type ev) "status") " — " (:message ev ""))
+
+      (= :agent/chunk t)
+      (str "  … chunk "
+           (if (:chunk/done? ev) "done" "streaming"))
+
+      (= :workflow/dag-considered t)
+      (str "⇒ DAG " (some-> dag-outcome name)
+           (when dag-reason (str " — " (name dag-reason))))
+
+      (= :workflow/started t) "▶ workflow started"
+      (= :workflow/completed t) (str "■ workflow completed — " (some-> (:workflow/status ev) name))
+      (= :workflow/failed t) (str "✗ workflow failed — " (:workflow/failure-reason ev ""))
+
+      :else (str (some-> t name)))))
+
+(defn show-events
+  "Render a human-readable timeline for a specific workflow.
+
+   Output per line: HH:MM:SS  summary. Filters are available via opts.
+
+   Opts:
+     :filter     — keyword event-type to include (default: show all)
+     :no-chunks  — drop :agent/chunk events (default: true; too noisy)
+     :no-status  — drop :agent/status events (default: false)"
+  [{:keys [workflow-id filter no-chunks no-status]
+    :or {no-chunks true no-status false}}]
+  (if-not workflow-id
+    (do (println (colorize :red "error: workflow-id is required"))
+        (println "usage: mf events show <workflow-id>"))
+    (let [dir (workflow-events-dir workflow-id)
+          events (read-workflow-events dir)]
+      (if (empty? events)
+        (println (colorize :yellow (str "No events found for workflow " workflow-id
+                                        " (looked in " (.getPath dir) ")")))
+        (let [kept (cond->> events
+                     filter     (clojure.core/filter #(= filter (:event/type %)))
+                     no-chunks  (remove #(= :agent/chunk (:event/type %)))
+                     no-status  (remove #(= :agent/status (:event/type %))))]
+          (println (colorize :cyan (str "Timeline for workflow " workflow-id
+                                        " — " (count kept) " event(s)")))
+          (println (colorize :gray (apply str (repeat 80 "─"))))
+          (doseq [ev kept]
+            (println (colorize :gray (ts-short (:event/timestamp ev)))
+                     (summarize-event ev))))))))
+
 (defn events-command
   "Handle 'mf events' command.
 
    Subcommands:
      tail [workflow-id] [options]  - Tail events (default)
      list                          - List available event files
-     cat <file>                    - Display event file"
-  [{:keys [subcommand workflow-id file lines follow filter all] :or {subcommand "tail" lines 20 follow true}}]
+     cat <file>                    - Display event file
+     show <workflow-id>            - Render a human-readable timeline for a workflow"
+  [{:keys [subcommand workflow-id file lines follow filter all no-chunks no-status]
+    :or {subcommand "tail" lines 20 follow true}}]
   (case subcommand
     "tail" (tail-events {:workflow-id workflow-id :all all :file file :lines lines :follow follow :filter filter})
     "list" (list-files-command find-event-stream-files "event files")
     "cat" (cat-file-command file)
+    "show" (show-events {:workflow-id workflow-id :filter filter
+                         :no-chunks (if (nil? no-chunks) true no-chunks)
+                         :no-status no-status})
     (println (colorize :red (messages/t :observability/unknown-subcommand {:subcommand subcommand})))))
 
 ;;------------------------------------------------------------------------------ Public API

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -201,6 +201,30 @@
       (assoc :agent/id agent-id
              :status/type status-type)))
 
+(defn agent-tool-call
+  "Publish a :agent/tool-call event carrying the tool name(s) the agent
+   just invoked, per N3 §3.x. Replaces the generic :agent/status
+   :tool-calling emission for consumers that want structured tool data.
+
+   Fields:
+     :tool/name            — single tool name when one tool fired in the block
+     :tool/names           — vector of names when a single assistant block
+                             included multiple tool_use items
+     :tool/call-id         — provider-supplied id (Claude tool_use.id /
+                             codex item id) when available
+     :tool/args-preview    — truncated/digested args for diagnosis (bounded
+                             to keep events small)"
+  [stream workflow-id agent-id
+   {:keys [tool-name tool-names tool-call-id tool-args-preview]}]
+  (cond-> (create-envelope stream :agent/tool-call workflow-id
+                           (str "Agent called tool"
+                                (when tool-name (str ": " tool-name))))
+    true                (assoc :agent/id agent-id)
+    tool-name           (assoc :tool/name tool-name)
+    (seq tool-names)    (assoc :tool/names (vec tool-names))
+    tool-call-id        (assoc :tool/call-id tool-call-id)
+    tool-args-preview   (assoc :tool/args-preview tool-args-preview)))
+
 (defn workflow-completed [stream workflow-id status & [duration-ms opts]]
   (-> (create-envelope stream :workflow/completed workflow-id
                        (str "Workflow " (name status)))

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -54,6 +54,7 @@
 (def phase-completed events/phase-completed)
 (def agent-chunk events/agent-chunk)
 (def agent-status events/agent-status)
+(def agent-tool-call events/agent-tool-call)
 (def workflow-completed events/workflow-completed)
 (def workflow-failed events/workflow-failed)
 (def llm-request events/llm-request)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/callbacks.clj
@@ -26,15 +26,44 @@
 ;; Convenience callbacks
 
 (defn create-streaming-callback
+  "Callback invoked by the LLM client for each parsed stream event.
+
+   Expected parsed-event keys:
+     :delta       — text content produced in this block
+     :done?       — terminal block
+     :tool-use    — boolean, true when this block invoked one or more tools
+     :tool-name   — single tool name when available (Claude / codex)
+     :tool-names  — vector of tool names (Claude multi-tool blocks)
+     :tool-call-id — provider-supplied id when available
+     :tool-args-preview — bounded args digest when the parser can safely
+                          expose it
+     :heartbeat   — keepalive, ignored for diagnostic emission
+
+   For tool-use events emits BOTH:
+     :agent/tool-call  — structured, carries :tool/name / :tool/names /
+                          :tool/call-id / :tool/args-preview
+     :agent/status     — legacy generic 'Agent calling tool' status-type
+                          :tool-calling, preserved so existing consumers
+                          (dashboard, TUI, tests) keep working during the
+                          migration."
   [stream-atom workflow-id agent-id & [opts]]
   (let [{:keys [print? quiet?]} opts]
-    (fn [{:keys [delta done? tool-use heartbeat]}]
+    (fn [{:keys [delta done? tool-use heartbeat
+                 tool-name tool-names tool-call-id tool-args-preview]}]
       (cond
         tool-use
         (when stream-atom
-          (stream/publish! stream-atom
-                           (events/agent-status stream-atom workflow-id agent-id
-                                                :tool-calling "Agent calling tool")))
+          (stream/publish!
+            stream-atom
+            (events/agent-tool-call stream-atom workflow-id agent-id
+                                    {:tool-name tool-name
+                                     :tool-names tool-names
+                                     :tool-call-id tool-call-id
+                                     :tool-args-preview tool-args-preview}))
+          (stream/publish!
+            stream-atom
+            (events/agent-status stream-atom workflow-id agent-id
+                                 :tool-calling "Agent calling tool")))
 
         heartbeat
         nil

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -29,6 +29,7 @@
 (def phase-completed core/phase-completed)
 (def agent-chunk core/agent-chunk)
 (def agent-status core/agent-status)
+(def agent-tool-call core/agent-tool-call)
 (def workflow-completed core/workflow-completed)
 (def workflow-failed core/workflow-failed)
 (def llm-request core/llm-request)

--- a/components/event-stream/test/ai/miniforge/event_stream/agent_tool_call_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/agent_tool_call_test.clj
@@ -1,0 +1,79 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.agent-tool-call-test
+  "Structured :agent/tool-call events carry the tool name(s) the agent
+   just invoked. Replaces the opaque :agent/status :tool-calling pings
+   that previously gave us no diagnostic information."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.event-stream.interface :as es]))
+
+(defn- stream [] (es/create-event-stream))
+
+(deftest single-tool-call-carries-name
+  (testing "single tool name from a Claude-style tool_use block"
+    (let [s (stream)
+          wf-id (random-uuid)
+          ev (es/agent-tool-call s wf-id :planner
+                                 {:tool-name "mcp__context__context_read"
+                                  :tool-call-id "tu_abc123"})]
+      (is (= :agent/tool-call (:event/type ev)))
+      (is (= "mcp__context__context_read" (:tool/name ev)))
+      (is (= "tu_abc123" (:tool/call-id ev)))
+      (is (= :planner (:agent/id ev))))))
+
+(deftest multi-tool-block-carries-names-vector
+  (testing "Claude assistant block containing multiple tool_use items"
+    (let [s (stream)
+          ev (es/agent-tool-call s (random-uuid) :planner
+                                 {:tool-names ["Read" "Grep" "Glob"]})]
+      (is (= :agent/tool-call (:event/type ev)))
+      (is (= ["Read" "Grep" "Glob"] (:tool/names ev)))
+      (is (nil? (:tool/name ev))
+          "prefer :tool/names for the multi case"))))
+
+(deftest empty-tool-info-does-not-leak-nil-keys
+  (testing "missing tool name/id/args do not emit nil-valued keys"
+    (let [s (stream)
+          ev (es/agent-tool-call s (random-uuid) :planner {})]
+      (is (= :agent/tool-call (:event/type ev)))
+      (is (not (contains? ev :tool/name)))
+      (is (not (contains? ev :tool/names)))
+      (is (not (contains? ev :tool/call-id)))
+      (is (not (contains? ev :tool/args-preview))))))
+
+(deftest args-preview-is-bounded
+  (testing "callers pass a pre-truncated args preview; fn stores it as-is"
+    (let [s (stream)
+          preview "{:path \"components/agent/src/core.clj\"}"
+          ev (es/agent-tool-call s (random-uuid) :planner
+                                 {:tool-name "Read" :tool-args-preview preview})]
+      (is (= preview (:tool/args-preview ev)))
+      (is (< (count (:tool/args-preview ev)) 1024)
+          "preview string stays under 1KB per event-sizing convention"))))
+
+(deftest distinct-event-type-from-agent-status
+  (testing ":agent/tool-call is a new event type, NOT :agent/status"
+    (let [s (stream)
+          wf-id (random-uuid)
+          tc (es/agent-tool-call s wf-id :planner {:tool-name "Read"})
+          st (es/agent-status s wf-id :planner :tool-calling "Agent calling tool")]
+      (is (= :agent/tool-call (:event/type tc)))
+      (is (= :agent/status (:event/type st)))
+      (is (not= (:event/type tc) (:event/type st))))))

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -165,10 +165,23 @@
               "agent_message"
               {:delta (str (:text item) "\n") :done? false}
 
+              ;; MCP tool invocation — emit a tool-use signal so the
+              ;; callback can publish :agent/tool-call with the real name
               "mcp_tool_call"
-              {:delta "" :done? false}
+              {:delta "" :done? false :tool-use true
+               :tool-name (or (get-in item [:tool :name])
+                              (:tool_name item)
+                              (:name item))
+               :tool-call-id (:id item)}
 
-              ;; reasoning, tool_call, etc. — ignore content
+              ;; Native tool call (pre-MCP) — same treatment
+              "tool_call"
+              {:delta "" :done? false :tool-use true
+               :tool-name (or (:name item) (:tool_name item))
+               :tool-call-id (:id item)}
+
+              ;; reasoning — ignored for content but could be surfaced
+              ;; later as :agent/reasoning events if useful
               nil))
 
           ;; Turn completed carries usage

--- a/docs/pull-requests/2026-04-19-agent-tool-call-visibility.md
+++ b/docs/pull-requests/2026-04-19-agent-tool-call-visibility.md
@@ -1,0 +1,116 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Agent tool-call visibility — named `:agent/tool-call` events + `mf events show`
+
+## Context
+
+Four dogfood iterations of `work/event-log-tool-visibility.spec.edn`
+have failed (Codex empty-stream, Codex+32K empty, Opus 4.6 cut off
+mid-exploration, Opus+80 turns back to empty). Each iteration produced
+a different shape of failure, and we couldn't diagnose them because
+**the spec we were iterating on is itself the spec that would give us
+the visibility to diagnose**. Per the meta-meta-loop principle:
+when miniforge can't self-improve, a human steps in.
+
+This PR ships the minimum viable subset of the spec needed to unblock
+all future dogfood diagnosis — Groups 1 + 3 of the spec. Groups 2
+(phase heartbeats) and 4 (rule-based alerts) follow in separate PRs.
+
+## What changed
+
+### Event schema
+
+- **New event type `:agent/tool-call`** (`components/event-stream/.../core.clj`).
+  Fields: `:tool/name`, `:tool/names` (vector for Claude's multi-tool
+  blocks), `:tool/call-id`, `:tool/args-preview` (bounded).
+- Exported from `event-stream.interface` and
+  `event-stream.interface.events`.
+- **Preserves `:agent/status :tool-calling`** for backward compat —
+  consumers of the legacy event keep working while observers migrate.
+
+### Stream parser enrichment
+
+- **Codex parser** (`components/llm/.../llm_client.clj`) — `item.completed`
+  with `mcp_tool_call` or `tool_call` type now emits
+  `{:tool-use true :tool-name ... :tool-call-id ...}` instead of the
+  previous `nil` / empty-delta. Codex's reasoning items are still
+  ignored but tool names are now visible.
+- **Claude parser** was already extracting `:tool-name` + `:tool-names`
+  — the data was flowing through but the callback threw them away.
+
+### Callback wiring
+
+- `event-stream.interface.callbacks/create-streaming-callback` now
+  publishes BOTH the new `:agent/tool-call` and the legacy
+  `:agent/status :tool-calling` when `:tool-use` fires. Moves args-
+  preview / call-id / names from the parsed event into the event
+  envelope.
+
+### CLI — `mf events show <workflow-id>`
+
+New subcommand in `bases/cli/.../observability.clj`:
+
+```bash
+mf events show <workflow-id>             # filtered timeline (no chunks, with status)
+mf events show <workflow-id> --no-status # tight timeline, phase+DAG+errors only
+mf events show <workflow-id> --filter :agent/tool-call
+```
+
+Reads `~/.miniforge/events/<workflow-id>/*.json`, strips Transit-style
+key prefixes, sorts chronologically, renders one event per line with
+the right summary: tool name for tool calls, phase outcomes with
+duration + error, DAG decisions with reason, workflow transitions.
+
+Sample output on a recently-failed workflow:
+
+```text
+Timeline for workflow 06e4a9b7-… — 13 event(s)
+────────────────────────────────────────────────────────────────
+08:04:57  → explore started
+08:04:57  ✓ explore success (0.0s)
+08:04:57  → plan started
+08:10:19  ✓ plan failure (321.3s) — :llm-content-length 0 …
+08:10:19  ⇒ DAG skipped — no-plan-id
+08:10:19  → implement started
+08:21:26  ✓ implement failure (667.6s) — Curator: implementer wrote no files
+```
+
+Post-mortem on a dogfood failure is now seconds of reading, not hours
+of grepping JSON.
+
+## What next dogfood runs will tell us
+
+Once this lands, the next event-log-tool-visibility re-run will emit
+`:agent/tool-call` events with real tool names. We'll finally see
+whether the planner is calling `Read`/`Grep`/`Glob` over and over,
+whether it ever invokes the MCP `submit-artifact` tool, and what
+specific files it's reading. The three ambiguous root causes for
+iteration 4's empty stream (MCP path mismatch / turn-end without text
+block / stream drop) become distinguishable from the log alone.
+
+## Tests
+
+- `components/event-stream/test/.../agent_tool_call_test.clj` — 5
+  tests, 17 assertions. Covers single + multi-tool, empty-info, args-
+  preview bounding, distinctness from legacy `:agent/status`.
+- All pass; pre-commit suite green.
+
+## Non-goals (follow-ups)
+
+- **`:tool/call-completed` pair events** — requires matching tool
+  invocation to its result across stream chunks, which is a bigger
+  refactor. Deferred to Group 2's heartbeat spec.
+- **Phase-level heartbeats** — every N seconds regardless of activity.
+  Group 2 of the spec.
+- **Rule-based alerts** — `:stream-stalled` when heartbeat gap >
+  threshold. Group 4; depends on heartbeats first.
+
+## References
+
+- `work/event-log-tool-visibility.spec.edn` — parent spec
+- Four prior failed dogfood iterations documented in this thread
+- The meta-meta-loop principle: when miniforge can't, we do.


### PR DESCRIPTION
Meta-meta-loop invocation. Four iterations of `work/event-log-tool-visibility.spec.edn` failed; we couldn't diagnose because the spec we were trying to land is itself the visibility. Human steps in per the principle.

Ships the minimum-viable subset (Groups 1 + 3 of the spec) so all future dogfood runs are diagnosable from the log alone.

### What changed
- **New `:agent/tool-call` event** with `:tool/name`, `:tool/names`, `:tool/call-id`, `:tool/args-preview`. `:agent/status :tool-calling` preserved for backward compat.
- **Codex parser** — `mcp_tool_call` + `tool_call` items now emit `{:tool-use true :tool-name ...}`; tool names finally visible on Codex runs.
- **Claude stream flow** — parser was already extracting names; callback was dropping them. Plumbed through.
- **`mf events show <workflow-id>`** — reads per-workflow event dir, renders chronological timeline. Flags `--filter`, `--no-chunks` (default), `--no-status`.

5 new tests / 17 assertions. Pre-commit green (no `[BYPASS-HOOKS]`).

### Follow-ups
Groups 2 (phase heartbeats) + 4 (rule-based alerts) as separate PRs. `:tool/call-completed` pair events deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)