### PR TITLE
fix(tests): update two integration tests out of sync with main

### DIFF
--- a/projects/miniforge/test/ai/miniforge/knowledge/interface_test.clj
+++ b/projects/miniforge/test/ai/miniforge/knowledge/interface_test.clj
@@ -204,7 +204,7 @@
   (testing "Returns manifest for known roles"
     (let [manifest (k/get-agent-manifest :planner)]
       (is (= :planner (:agent-role manifest)))
-      (is (vector? (:dewey-prefixes manifest)))
+      (is (vector? (:tags manifest)))
       (is (vector? (:types manifest)))))
 
   (testing "Returns default manifest for unknown roles"

--- a/projects/miniforge/test/ai/miniforge/workflow/artifact_persistence_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/artifact_persistence_test.clj
@@ -318,28 +318,35 @@
           "Verify should throw when no execution environment is available"))))
 
 (deftest test-workflow-empty-artifact-handling
-  (testing "Workflow handles empty implement artifact via environment model"
-    ;; In the environment model, the release phase discovers files from git status
-    ;; rather than from the artifact's :code/files. An empty artifact doesn't cause
-    ;; a release failure if the worktree has any dirty files (e.g. .miniforge/index).
-    ;; The release executor mock returns success since it receives the worktree state.
-    (let [result-ctx (execute-phase-pipeline
-                      {:implement-agent-fn
-                       (fn [_agent _task _ctx]
-                         ;; Implementer returns empty artifact (no code/files)
-                         (response/success mock-empty-artifact {:tokens 50 :duration-ms 300}))
+  (testing "Release phase accepts an empty :code/files artifact when the curator confirms files exist in the environment"
+    ;; Regression target: the release phase discovers files from git state,
+    ;; not from the artifact's :code/files. An implement result with empty
+    ;; :code/files MUST still reach the release executor as long as the
+    ;; curator has confirmed the environment has the work.
+    ;;
+    ;; The curator is stubbed here because it reads the real worktree — its
+    ;; behavior is covered by its own tests. This test isolates the release
+    ;; phase's tolerance of an empty :code/files on a successful implement.
+    (with-redefs [agent/curate-implement-output
+                  (fn [_opts]
+                    (response/success mock-empty-artifact
+                                      {:tokens 0 :duration-ms 0}))]
+      (let [result-ctx (execute-phase-pipeline
+                        {:implement-agent-fn
+                         (fn [_agent _task _ctx]
+                           (response/success mock-empty-artifact
+                                             {:tokens 50 :duration-ms 300}))
 
-                       :release-opts
-                       {:executor
-                        (fn [_workflow-state _exec-context _opts]
-                          {:success? true
-                           :artifacts []
-                           :metrics {:files-written 0}})}})]
-      ;; The release phase should complete (the executor mock returns success)
-      (is (= :completed (get-in result-ctx [:phase :status]))
-          "Release phase should complete when executor returns success")
-      (is (= :success (get-in result-ctx [:phase :result :status]))
-          "Release result should be success"))))
+                         :release-opts
+                         {:executor
+                          (fn [_workflow-state _exec-context _opts]
+                            {:success? true
+                             :artifacts []
+                             :metrics {:files-written 0}})}})]
+        (is (= :completed (get-in result-ctx [:phase :status]))
+            "Release phase should complete when executor returns success")
+        (is (= :success (get-in result-ctx [:phase :result :status]))
+            "Release result should be success")))))
 
 (deftest test-artifact-content-verification
   (testing "Files written to disk have correct content"


### PR DESCRIPTION
## Summary

- Clean the two pre-existing failures reported by `bb test:integration` on `main` (290 tests → 1 failure + 1 error → 0 / 0).
- Neither failure is in the implement/artifact-persistence path that a prior \`[BYPASS-HOOKS]\` note on the now-closed #585 misattributed; the implement + artifact-persistence brick tests pass cleanly (142 tests, 417 assertions).

## Changes

**`agent-manifest-test`** (`projects/miniforge/test/.../knowledge/interface_test.clj`)
\`default-agent-manifests\` in \`components/knowledge/store.clj\` intentionally dropped \`:dewey-prefixes\` (see docstring at store.clj:329 — phase-scoped rule injection moved to \`agent-behavior/load-and-filter-behaviors\`). The test hadn't been updated. Swapped the stale assertion for \`(vector? (:tags manifest))\`, which is the field the planner entry actually carries.

**`test-workflow-empty-artifact-handling`** (`projects/miniforge/test/.../workflow/artifact_persistence_test.clj`)
The test predates the curator added to \`enter-implement\`. With the curator in place, an empty worktree + empty \`:code/files\` now trips \`:curator/no-files-written\` and the implement phase fails before the release executor is ever reached — so the release-phase tolerance the test was designed to verify never actually runs.

The test's target is release-phase behavior, not curator behavior. Stubbed the curator via \`with-redefs\` so the test isolates what it claims to test. Curator behavior is covered by its own tests (\`components/agent/test/.../curator_test.clj\`).

## What this does not do

- No production code changes. Test-only.
- Does not touch the implement/artifact-persistence brick tests — those pass on main.
- Does not revive the closed #585 work. The replacement scope is captured in \`work/pedestal-interceptor-chain.spec.edn\` and \`work/planner-convergence-and-artifact-submission.spec.edn\` (separate PRs).

## Test plan

- [x] \`agent-manifest-test\` passes (1 test / 5 assertions)
- [x] \`test-workflow-empty-artifact-handling\` passes (1 test / 2 assertions)
- [x] \`bb test:integration\` clean: 290 tests / 1039 assertions / 0 failures / 0 errors
- [x] Pre-commit green (lint + GraalVM/Babashka)

🤖 Generated with [Claude Code](https://claude.com/claude-code)