### PR TITLE
spec: planner convergence + pedestal interceptor chain

### DIFF
--- a/work/QUEUE.md
+++ b/work/QUEUE.md
@@ -15,9 +15,12 @@ Make miniforge capable of running miniforge without paying for
 
 | tier | r | theme | spec | axes |
 |---|---|---|---|---|
-| blocker | ● | dogfood-resilience | `agent-stream-watchdog-and-resume.spec.edn` — Agent stream watchdog + session-resume for hang recovery | tokenconservation+dogfoodenabler |
+| blocker | ● | dogfood-resilience | `event-log-tool-visibility.spec.edn` — Event log — capture tool name / args / result on every agent tool call | observation+dogfoodenabler |
+| blocker | ● | dogfood-resilience | `planner-convergence-and-artifact-submission.spec.edn` — Planner convergence — container-promoted plan artifact + forced context-MCP usage | correctness+observation+tokenconservation+dogfoodenabler |
 | blocker | ● | dogfood-resilience | `worktree-persistence-scratch-branch.spec.edn` — Persist worktrees outside /tmp + scratch-branch commits on every write | dogfoodenabler |
+| high | ● | dogfood-resilience | `pedestal-interceptor-chain.spec.edn` — Pedestal-style interceptor chain for phase lifecycle | correctness+dogfoodenabler |
 | high | ○ | dogfood-resilience | `workflow-dependency-declarations.spec.edn` — Workflow dependency declarations — supervisor sequencing + DAG dependencies | dogfoodenabler |
+| blocker | ○ | dogfood-resilience | `agent-stream-watchdog-and-resume.spec.edn` — Agent stream watchdog + session-resume for hang recovery | tokenconservation+dogfoodenabler |
 | blocker | ○ | dogfood-resilience | `workflow-phase-checkpoint-and-resume.spec.edn` — Workflow phase checkpoint + resume | tokenconservation+dogfoodenabler |
 
 ## Theme — Multi-backend CLI parity (`multi-backend-parity`, status: planned)

--- a/work/pedestal-interceptor-chain.spec.edn
+++ b/work/pedestal-interceptor-chain.spec.edn
@@ -1,0 +1,122 @@
+;; =============================================================================
+;; Spec: Pedestal-style interceptor chain for phase lifecycle
+;; =============================================================================
+;;
+;; Context:
+;;   PR #585 added an :exit lifecycle slot to phases as a band-aid for
+;;   curator placement. That shape (:enter, :leave, :exit, :error as
+;;   flat keys on the interceptor map) cannot express ordered,
+;;   composable interceptor stacks — which is what we actually need
+;;   for curators, telemetry wrappers, rate limiters, and future
+;;   policy-pack-injected interceptors.
+;;
+;;   This spec replaces the flat shape with a Pedestal-style
+;;   interceptor chain: each phase registers a vector of named
+;;   interceptors with :enter / :leave / :error fns. The runtime
+;;   folds :enter forward across the vector, then :leave in reverse.
+;;   Ordering is stable and explicit, composition is the default
+;;   case, and curators are just interceptors appended after the
+;;   main phase logic.
+;;
+;; Why this, not :exit:
+;;   :exit works for exactly one curator per phase. The moment we want
+;;   (curator + telemetry wrapper + rate-limit guard + policy-injected
+;;   pre-flight check) on a phase, flat slots break down. Pedestal's
+;;   chain model has been production-grade for a decade; adopting its
+;;   shape here costs us little and buys the composition property for
+;;   everything downstream (OPSV policy injection, N10 governed
+;;   execution, supervisory interceptors).
+
+{:spec/title "Pedestal-style interceptor chain for phase lifecycle"
+
+ :spec/description
+ "Replace the flat :enter/:leave/:exit/:error interceptor shape
+  introduced in PR #585 with a Pedestal-style interceptor chain. A
+  phase registers a vector of named interceptors; the runtime folds
+  :enter forward across the vector, then :leave in reverse (matching
+  Pedestal's contract). :error is per-interceptor and bubbles up the
+  chain in reverse until handled.
+
+  GROUP 1 — Core shape change (this PR)
+  - components/workflow/.../execution.clj
+    - Replace execute-enter / execute-leave / execute-exit with
+      execute-chain-forward + execute-chain-reverse helpers.
+    - execute-phase-lifecycle folds :enter forward over the chain,
+      applies gate validation on the main interceptor's output,
+      then folds :leave in reverse.
+    - Backward-compat: a legacy flat interceptor (no :interceptors
+      key) is lifted to a single-element chain with :enter/:leave/
+      :error inherited from the top-level keys. Existing phase
+      registrations keep working.
+  - components/phase/src/ai/miniforge/phase/registry.clj (and
+    any registry consumer) accepts both shapes without branching at
+    the call site.
+  - Remove the :exit slot entirely. Curators that lived in :exit
+    become the last :leave in the chain.
+
+  GROUP 2 — Migrate existing phases to the chain shape
+  - plan.clj: [{:name ::plan-main :enter :leave :error}
+               {:name ::plan-curator :leave curate-plan}]
+  - implement.clj: move the inline curator call from enter-implement
+    into a ::implement-curator interceptor whose :leave runs
+    curate-implement-output. Preserve the feedback loop into
+    leave-implement's retry decisions by having the curator write to
+    [:phase :curator-result] and leave-implement read it.
+  - verify / review / release: single-element chains today; ready
+    for curator interceptors from the adjacent curator spec.
+
+  GROUP 3 — Policy-pack-injected interceptors (follow-up)
+  - Policy packs register interceptors by phase id. At phase
+    construction time, the registry concats packed interceptors
+    into the chain at a declared position (::before-curator,
+    ::after-main, etc.). This is how OPSV (N7) and N10 governed
+    execution attach without every phase coding them in manually.
+
+  NON-GOALS
+  - Changing phase semantics. Every existing test must still pass.
+  - Introducing a full Pedestal dependency. We adopt the shape, not
+    the library.
+  - Async interceptor support. Chain is synchronous; an async
+    variant is a separate spec if ever needed.
+  - Changing what curate-plan / curate-implement-output check.
+    Their validation logic stays identical; only invocation site
+    moves."
+
+ :spec/intent
+ {:type :refactor
+  :scope ["components/workflow/src"
+          "components/workflow/test"
+          "components/phase/src"
+          "components/phase-software-factory/src"
+          "components/phase-software-factory/test"
+          "specs/normative/N2-workflows.md"]}
+
+ :spec/constraints
+ ["Chain is synchronous; no async/defer semantics in Group 1"
+  "Legacy flat interceptor shape MUST continue to work during the migration window (Group 1 lands before Group 2)"
+  "Interceptor execution order MUST be deterministic — :enter in registered order, :leave in reverse"
+  ":error on an interceptor catches exceptions from that interceptor's :enter only; uncaught errors bubble and run :leave in reverse from the failing point (Pedestal contract)"
+  "Gate validation runs after the main phase interceptor's :enter completes, BEFORE the chain's :leave fold — same observable point as today"
+  "Curators MUST remain deterministic (no LLM, no I/O) — same rule as the adjacent phase-exit-curator spec"
+  "No new public surface on the phase interface beyond the :interceptors key"]
+
+ :spec/acceptance-criteria
+ ["A phase registered with :interceptors [{:name ... :enter :leave}...] executes all :enter fns in order then all :leave fns in reverse"
+  "A phase registered with legacy flat {:enter :leave :error} keys (no :interceptors vector) still executes correctly"
+  "Throwing in the N-th interceptor's :enter runs :leave for interceptors 0..N-1 in reverse before surfacing the error"
+  "Gate validation still fires between the main interceptor's :enter and the chain's :leave fold"
+  "Existing phase_exit_slot_test assertions port cleanly to the chain shape — curator-as-last-leave preserves observable behavior"
+  "plan-curator as the second interceptor in the plan chain rejects malformed plans at the same observable boundary as the :exit slot did"
+  "Policy-pack-injected interceptors (stubbed test) can be appended to a phase's chain without modifying phase code"
+  "`poly test` green on workflow + phase-software-factory after the migration"
+  "No reference to :exit remains in components/workflow or components/phase-software-factory after GROUP 2 lands"]
+
+ :spec/priority
+ {:tier :high
+  :axes #{:correctness :dogfood-enabler}
+  :theme :dogfood-resilience
+  :rationale "Flat :exit is a band-aid. A proper chain is the substrate for every future curator, OPSV policy interceptor, and supervisory pre-flight. Landing it now means every follow-up theme (curators, policy packs, governed execution) plugs in without re-opening phase registration code."
+  :blocks ["phase-exit-curator-interceptor.spec.edn"]
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}

--- a/work/planner-convergence-and-artifact-submission.spec.edn
+++ b/work/planner-convergence-and-artifact-submission.spec.edn
@@ -1,0 +1,193 @@
+;; =============================================================================
+;; Spec: Planner convergence — container-promoted plan artifact + context-MCP
+;;       enforcement + stop-reason visibility
+;; =============================================================================
+;;
+;; Iteration 5 evidence (workflow 59b62101, 2026-04-19, 4:11 elapsed):
+;;   - 84 planner tool calls: Read×47, Bash×21, Grep×11, Glob×3, Agent×2
+;;   - ZERO mcp__context__context_{read,grep,glob} calls — model ignored
+;;     the pre-loaded cache from the explore phase and used Claude Code's
+;;     native filesystem tools directly.
+;;   - ONE assistant text block: 85 chars at seq 136, mid-chain:
+;;     "Let me check a few specific files for precise file paths and
+;;      current implementations."
+;;     Followed by ~37 more tool calls. Never produced plan EDN.
+;;   - Final error: :llm-content-length 85, "Plan generation failed:
+;;     EDN parse did not succeed". The runtime does not capture
+;;     stop_reason — we can't tell end_turn vs max_turns vs stop_sequence.
+;;
+;; What's actually happening:
+;;   The planner has access to native Read/Bash/Grep/Glob/Agent tools,
+;;   so it uses them. It ignores the context MCP cache and ignores the
+;;   prompt's "after 15 reads STOP" guidance. It emits exactly one
+;;   assistant text block per run — early, as an exploration-intent
+;;   narration — then turn-cap terminates it mid tool chain.
+;;
+;; Prior art to respect:
+;;   - A `submit_artifact` MCP tool was previously considered and REMOVED
+;;     because agents did not reliably call it. Do not re-introduce it.
+;;   - Implementer already uses container promotion via
+;;     file-artifacts/collect-written-files — the worktree delta IS the
+;;     artifact. Same pattern applies to the planner: write plan.edn
+;;     into the worktree, runtime reads it after the LLM terminates.
+
+{:spec/title "Planner convergence — container-promoted plan artifact + forced context-MCP usage"
+
+ :spec/description
+ "Three interventions that make the planner converge. The artifact
+  submission path becomes container promotion (same model implementer
+  already uses). Context reads are forced through the MCP cache by
+  disallowing native filesystem tools. Observability gaps that kept us
+  guessing across five iterations are closed. Ordered by leverage.
+
+  GROUP 1 — Plan artifact as a worktree file (container promotion)
+  The planner writes `.miniforge/plan.edn` into the session worktree
+  using the Write tool. Runtime reads that file after the LLM
+  terminates via the same `file-artifacts/collect-written-files`
+  path the implementer uses. No submit_artifact MCP tool. No
+  text-parsing heuristics. The container (worktree delta) IS the
+  artifact; its presence and shape ARE the submission.
+
+  - components/agent/.../planner.clj: after invocation, look for
+    `<workdir>/.miniforge/plan.edn`. If present, parse and return.
+    If absent, fall through to the existing final-message EDN parser
+    (staged removal, see GROUP 4).
+  - components/agent/resources/prompts/planner.edn: replace the
+    'Option A / Option B' submission section with a single
+    directive: `Write .miniforge/plan.edn with the plan EDN as your
+    final act.` No ambiguity. One submission path.
+  - Plan shape validation (curate-plan, PR #585) still fires — it
+    already reads from :phase :result :output regardless of source.
+
+  GROUP 2 — Disallow native filesystem tools for the planner
+  The planner has no reason to call Bash. Read/Grep/Glob on the
+  filesystem bypass the explore-phase context cache entirely —
+  defeating the whole purpose of the cache. Force the convergence.
+
+  - components/agent/.../planner.clj passes
+    :disallowed-tools [\"Read\" \"Grep\" \"Glob\" \"Bash\"
+                       \"Agent\" \"WebSearch\" \"WebFetch\" \"LS\"]
+    to the LLM client. This is identical in form to tester.clj's
+    existing disallow-list — role-scoped tool allowlists are already
+    the precedent.
+  - Write stays allowed (required for GROUP 1).
+  - context_read / context_grep / context_glob MCP tools remain
+    allowed — these become the only way for the planner to inspect
+    source that was not already pre-loaded.
+  - Planner prompt is updated to stop referencing native tools; the
+    MCP context_* tools become the documented exploration path.
+
+  GROUP 2B — Cached web surface (required to disable WebSearch/WebFetch)
+  Disabling WebSearch/WebFetch without a replacement takes away a
+  legitimate capability (fetching docs, looking up APIs, reading
+  specifications). Mirror the context-MCP pattern: an MCP server
+  that provides cached web read + search with the same cache-first
+  semantics as the context file cache.
+
+  - bases/mcp-context-server (or a new bases/mcp-web-cache) gains
+    `web_fetch` + `web_search` tools. Reads go through a content-
+    addressed on-disk cache (sha256 of URL + params -> response).
+    Cache hits are free. Cache misses hit the real network and
+    populate the cache.
+  - The cache is session-scoped by default, with a knob to promote
+    entries into a long-lived workspace cache for reuse across
+    runs — critical for dogfood cost control (repeated planner
+    runs should not re-fetch the same docs N times).
+  - Planner + every other role that currently has WebSearch/WebFetch
+    (implementer, reviewer) picks up the cached MCP tools in its
+    allowlist and gets WebSearch/WebFetch disallowed the same way.
+  - This MUST land alongside GROUP 2 — disabling the native web
+    tools without the cached replacement regresses capability.
+
+  GROUP 3 — stop_reason + final-message capture (diagnostic)
+  Claude Code stream-json surfaces stop_reason on its terminal event
+  (end_turn, max_turns, stop_sequence, tool_use). Codex surfaces a
+  finish reason on turn.completed. We drop both.
+
+  - components/llm/.../llm_client.clj captures the terminal stop
+    reason + the raw final assistant message block.
+  - Runtime records them on :phase :result :meta
+    {:stop-reason :max_turns :final-message-preview \"...\"
+     :turn-count N :tool-call-count M}.
+  - runner_events.clj includes them in phase-completed on failure.
+    `mf events show <wf-id>` displays 'stop_reason max_turns' so the
+    next post-mortem does not require guessing.
+  - Diagnostic only — no behavior change. Lands with GROUP 1/2 for
+    observability of their effect.
+
+  GROUP 3B — Web cache promotion + invalidation (follow-up)
+  Session-cache of web fetches becomes long-lived once we have a
+  working session-scoped version. Document here; implement in its
+  own spec.
+
+  GROUP 4 — Remove final-message EDN parser (follow-up)
+  Once GROUP 1 lands and one dogfood iteration confirms plan.edn
+  submissions work, delete the text-parsing fallback. One submission
+  path in prod, not two. This is a separate spec — ship GROUP 1-3
+  first, confirm, then remove the fallback.
+
+  NON-GOALS
+  - Re-introducing a submit_artifact MCP tool. Already tried;
+    agents did not reliably call it. Container promotion is the
+    replacement, not a parallel path.
+  - Disabling WebSearch/WebFetch without a cached MCP replacement.
+    That would regress capability. The replacement lands in the
+    same PR as the disable (GROUP 2 + GROUP 2B ship together).
+  - Adding a forced-finalize re-prompt (\"you ran out of budget,
+    emit the plan now\"). That is a band-aid over the real bug
+    (agents over-exploring). GROUP 2 removes the exploration
+    affordances that cause the over-exploration; a re-prompt
+    would paper over the symptom rather than eliminate the cause.
+  - Changing the LLM backend default, turn cap, or max-tokens.
+    These were tuned across iterations 1-4. The bug is tool
+    access + submission shape, not budget size.
+  - Applying this pattern to implementer / verifier / reviewer /
+    releaser. Implementer already does container promotion.
+    Verifier/reviewer/releaser get their own specs when we see
+    their convergence problems — do not pre-generalize."
+
+ :spec/intent
+ {:type :feature
+  :scope ["components/agent/src"
+          "components/agent/resources/prompts/planner.edn"
+          "components/llm/src"
+          "components/event-stream/src"
+          "components/workflow-runner/src"
+          "bases/mcp-context-server/src"
+          "bases/mcp-context-server/resources"]}
+
+ :spec/constraints
+ ["Plan artifact path is `.miniforge/plan.edn` within the session worktree — stable, discoverable, colocated with other phase artifacts"
+  "File-based artifact read uses existing file-artifacts/collect-written-files path — no new snapshot mechanism"
+  "Planner disallow-list includes Read/Grep/Glob/Bash/Agent/WebSearch/WebFetch/LS; Write remains allowed for artifact emission"
+  "Role-scoped disallow-list — other agent roles keep their existing tool access (implementer needs Read/Grep, tester disallows Read, etc.)"
+  "stop_reason capture MUST be per-backend; claude + codex covered here, cursor-agent/copilot/open-codex parity deferred to multi-backend-cli-parity spec"
+  "No LLM-based self-supervision, no re-prompting, no heuristic retry. Deterministic tool allow/disallow + deterministic file read only."
+  "Final-message EDN fallback stays in place through GROUP 3; removal is GROUP 4 / follow-up spec"
+  "Pre-commit + poly check green before merge"]
+
+ :spec/acceptance-criteria
+ ["A planner run that writes `.miniforge/plan.edn` to the worktree yields the plan from that file — final-message parser is not invoked"
+  "A planner run that does NOT write `.miniforge/plan.edn` still falls back to final-message parsing (backward compat through GROUP 3)"
+  "Planner LLM invocation is launched with :disallowed-tools including \"Read\" \"Bash\" \"Grep\" \"Glob\" \"Agent\""
+  "A dogfood run shows ZERO Read/Bash/Grep/Glob/Agent/WebSearch/WebFetch tool-call events on the planner; only context_read/context_grep/context_glob + web_fetch/web_search + Write"
+  "web_fetch MCP tool returns cached content on second fetch of the same URL within a session (content-addressed hit) — no network call on the second read"
+  "web_search MCP tool returns cached results on an identical query within a session"
+  ":phase :result :meta carries :stop-reason, :final-message-preview, :turn-count, :tool-call-count after every planner invocation (success or failure)"
+  "phase-completed event on failure carries :stop-reason; `mf events show <wf-id>` displays it"
+  "Planner prompt no longer references 'Option A/Option B' — a single Write .miniforge/plan.edn directive"
+  "Unit test: parse-plan-from-worktree reads a plan.edn file and returns it; curate-plan validates it identically to final-message plans"
+  "Unit test: planner disallow-tools list is asserted in create-planner / invoke-planner-session"
+  "Integration test: a stubbed planner session that writes plan.edn yields that plan; one that only emits text yields the final-message path"
+  "Iteration 6 dogfood run against an unblocked queue spec produces a successful plan OR fails with a clearly-typed diagnostic (stop_reason surfaced, file absent, shape invalid) — no more 'mystery 85 char failure'"]
+
+ :spec/priority
+ {:tier :blocker
+  :axes #{:dogfood-enabler :token-conservation :observation :correctness}
+  :theme :dogfood-resilience
+  :rationale "Every dogfood run currently risks 4+ minutes and real tokens on a planner that wanders through native filesystem tools and terminates without an artifact. Container promotion is already the model for implementer; extending it to planner + removing the native-tool escape hatches is the single largest convergence lever we have."
+  :blocks ["pedestal-interceptor-chain.spec.edn"
+           "n07-opsv-agent-budgets.spec.edn"]
+  :blocked-by []}
+
+ :spec/workflow-type :canonical-sdlc}


### PR DESCRIPTION
## Summary

- Land two work specs under the \`:dogfood-resilience\` theme capturing iteration-5 findings (workflow \`59b62101\`).
- **\`planner-convergence-and-artifact-submission.spec.edn\`** (tier \`:blocker\`) — container-promoted plan artifact, native-tool disallow for planner, cached web-MCP replacement, stop_reason visibility. Replaces the failed \`submit_artifact\` MCP approach with the same container-promotion model implementer already uses.
- **\`pedestal-interceptor-chain.spec.edn\`** (tier \`:high\`) — pure Pedestal-style interceptor chain per phase. Replaces the \`:exit\` slot band-aid from the closed #585.

## Iteration 5 evidence (referenced in both specs)

From workflow \`59b62101-e92e-4cec-bc1b-c8243b3e2221\`:

- 84 planner tool calls: Read×47, Bash×21, Grep×11, Glob×3, Agent×2
- **Zero** \`mcp__context__context_*\` calls despite the prompt directing to use them
- One 85-char text block at seq 136, mid-chain: \"Let me check a few specific files for precise file paths and current implementations.\"
- Final error \`:llm-content-length 85\` / \"Plan generation failed: EDN parse did not succeed\"
- Runtime does not capture \`stop_reason\` — can't tell end_turn vs max_turns vs stop_sequence

## Key design calls captured

**Container promotion, not a submission tool.** Previously tried \`submit_artifact\` MCP tool; agents didn't call it. Planner writes \`.miniforge/plan.edn\` to the worktree; runtime reads it via \`file-artifacts/collect-written-files\`. One submission path.

**Web-cache MCP lands with the WebSearch/WebFetch disable.** Disabling the native web tools without a replacement would regress capability. Cached \`web_fetch\` + \`web_search\` mirrors the context-MCP cache pattern; non-goal to ship one without the other.

**No forced-finalize re-prompt.** Explicitly non-goal — band-aid over over-exploration. The fix is disallowing the exploration affordances, not re-prompting at the end.

**Chain, not slot.** The interceptor-chain spec carries the \`:blocks [\"phase-exit-curator-interceptor.spec.edn\"]\` annotation so the queue reflects that landing the chain obsoletes the \`:exit\` approach (#585 closed for the same reason).

## Test plan

- [x] \`bb work:queue\` regenerates cleanly with both specs appearing under \`dogfood-resilience\` at their declared tiers
- [x] Pre-commit green (lint + GraalVM compat)
- [ ] Post-merge: kick off a miniforge run against \`planner-convergence-and-artifact-submission.spec.edn\` as the next dogfood target

🤖 Generated with [Claude Code](https://claude.com/claude-code)