### PR TITLE
Extract shared Babashka helpers into projects/bb-utils polylith (1/5)

### DIFF
--- a/components/bb-out/deps.edn
+++ b/components/bb-out/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps  {}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/bb-out/src/ai/miniforge/bb_out/core.clj
+++ b/components/bb-out/src/ai/miniforge/bb_out/core.clj
@@ -1,0 +1,91 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-out.core
+  "Status output. Matches the `==>`-style section headers existing
+   shell scripts use, so log output stays recognizable as we migrate
+   tasks to Clojure.
+
+   Layer 0: pure formatters — build the string without printing.
+   Layer 1: side-effecting printers on top of Layer 0.")
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pure formatters
+
+(defn format-section
+  "Return the string form of a section header."
+  [msg]
+  (str "==> " msg))
+
+(defn format-step
+  "Return the string form of an indented progress line."
+  [msg]
+  (str "    " msg))
+
+(defn format-ok
+  "Return the string form of a success line."
+  [msg]
+  (str "    \u2713 " msg))
+
+(defn format-warn
+  "Return the string form of a warning line."
+  [msg]
+  (str "    \u26A0 " msg))
+
+(defn format-fail
+  "Return the string form of a failure line."
+  [msg]
+  (str "    \u2717 " msg))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Side-effecting printers
+
+(defn section
+  "Print a section header to stdout."
+  [msg]
+  (println (format-section msg)))
+
+(defn step
+  "Print an indented progress line to stdout."
+  [msg]
+  (println (format-step msg)))
+
+(defn ok
+  "Print a success line to stdout."
+  [msg]
+  (println (format-ok msg)))
+
+(defn warn
+  "Print a warning line to stderr."
+  [msg]
+  (binding [*out* *err*]
+    (println (format-warn msg))))
+
+(defn fail
+  "Print a failure line to stderr."
+  [msg]
+  (binding [*out* *err*]
+    (println (format-fail msg))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (format-section "hello")
+  (section "demo")
+  (warn "stderr")
+
+  :leave-this-here)

--- a/components/bb-out/src/ai/miniforge/bb_out/interface.clj
+++ b/components/bb-out/src/ai/miniforge/bb_out/interface.clj
@@ -1,0 +1,59 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-out.interface
+  "Status output helpers for Babashka tasks. Pass-through to `core`."
+  (:require [ai.miniforge.bb-out.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Public API — pass-through only
+
+(defn section
+  "Print a section header: `==> msg`. Stdout."
+  [msg]
+  (core/section msg))
+
+(defn step
+  "Indented progress line. Stdout."
+  [msg]
+  (core/step msg))
+
+(defn ok
+  "Success line. Stdout."
+  [msg]
+  (core/ok msg))
+
+(defn warn
+  "Warning line. Stderr."
+  [msg]
+  (core/warn msg))
+
+(defn fail
+  "Failure line. Stderr."
+  [msg]
+  (core/fail msg))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (section "demo")
+  (step "doing thing")
+  (ok "done")
+  (warn "heads up")
+  (fail "nope")
+
+  :leave-this-here)

--- a/components/bb-out/test/ai/miniforge/bb_out/core_test.clj
+++ b/components/bb-out/test/ai/miniforge/bb_out/core_test.clj
@@ -1,0 +1,84 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-out.core-test
+  "Unit tests for bb-out. Pure formatters are checked by string
+   comparison; printers are checked by capturing *out* / *err* with
+   `with-out-str`."
+  (:require [clojure.test :refer [deftest testing is]]
+            [ai.miniforge.bb-out.core :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Factories
+
+(def ^:private section-prefix "==> ")
+(def ^:private step-prefix    "    ")
+
+(defn- capture-err
+  "Run `f`, return what it wrote to *err*."
+  [f]
+  (let [sw (java.io.StringWriter.)]
+    (binding [*err* sw] (f))
+    (str sw)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Pure formatters
+
+(deftest test-format-section-prefixes-with-arrow
+  (testing "given a message → `==> msg`"
+    (is (= (str section-prefix "hello") (sut/format-section "hello")))))
+
+(deftest test-format-step-indents
+  (testing "given a message → four-space indent"
+    (is (= (str step-prefix "work") (sut/format-step "work")))))
+
+(deftest test-format-ok-warn-fail-carry-glyphs
+  (testing "given a message → ok/warn/fail each include a distinct glyph"
+    (let [ok-out   (sut/format-ok "a")
+          warn-out (sut/format-warn "b")
+          fail-out (sut/format-fail "c")]
+      (is (re-find #"\u2713" ok-out))
+      (is (re-find #"\u26A0" warn-out))
+      (is (re-find #"\u2717" fail-out))
+      (is (= 3 (count (distinct [ok-out warn-out fail-out])))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Printers — stream routing
+
+(deftest test-section-step-ok-write-to-stdout
+  (testing "given a message → section/step/ok write to *out*"
+    (is (= (str section-prefix "h\n") (with-out-str (sut/section "h"))))
+    (is (= (str step-prefix "h\n")    (with-out-str (sut/step "h"))))
+    (is (re-find #"\u2713 h"          (with-out-str (sut/ok "h"))))))
+
+(deftest test-warn-fail-write-to-stderr
+  (testing "given a message → warn/fail write to *err*, not *out*"
+    (let [warn-stdout (with-out-str (sut/warn "w"))
+          warn-stderr (capture-err #(sut/warn "w"))
+          fail-stdout (with-out-str (sut/fail "f"))
+          fail-stderr (capture-err #(sut/fail "f"))]
+      (is (= "" warn-stdout))
+      (is (re-find #"\u26A0 w" warn-stderr))
+      (is (= "" fail-stdout))
+      (is (re-find #"\u2717 f" fail-stderr)))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.bb-out.core-test)
+
+  :leave-this-here)

--- a/components/bb-paths/deps.edn
+++ b/components/bb-paths/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps  {babashka/fs {:mvn/version "0.5.22"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/bb-paths/src/ai/miniforge/bb_paths/core.clj
+++ b/components/bb-paths/src/ai/miniforge/bb_paths/core.clj
@@ -1,0 +1,90 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-paths.core
+  "Path helpers. Repo-root is discovered by walking up from cwd until a
+   `bb.edn` is found — the same marker the umbrella products use, so
+   tasks and their tests see the same root regardless of where `bb` was
+   invoked.
+
+   Layer 0: pure path walking.
+   Layer 1: repo-root resolution on top of Layer 0.
+   Layer 2: filesystem side-effects (create/delete)."
+  (:require [babashka.fs :as fs]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Pure path walking
+
+(defn- find-up
+  "Walk up from `start` until a directory containing `marker` is found.
+   Returns the containing directory as a string, or nil if none found."
+  [start marker]
+  (loop [dir (fs/absolutize start)]
+    (cond
+      (nil? dir)                        nil
+      (fs/exists? (fs/path dir marker)) (str dir)
+      :else                             (recur (fs/parent dir)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Repo-root resolution
+
+(defn repo-root
+  "Absolute path to the repo root (nearest `bb.edn` above the cwd).
+   Throws ex-info if no `bb.edn` is found walking up from cwd."
+  []
+  (or (find-up (fs/cwd) "bb.edn")
+      (throw (ex-info "Could not locate bb.edn from cwd"
+                      {:cwd (str (fs/cwd))}))))
+
+(defn under-root
+  "Resolve `segments` beneath the repo root. Returns an absolute path
+   string."
+  [& segments]
+  (str (apply fs/path (repo-root) segments)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Filesystem side-effects
+
+(defn ensure-dir!
+  "Create `path` (and parents) if it does not exist. Returns the path
+   as a string."
+  [path]
+  (fs/create-dirs path)
+  (str path))
+
+(defn tmp-dir!
+  "Create a fresh temp directory with `prefix`. Returns its absolute
+   path as a string."
+  [prefix]
+  (str (fs/create-temp-dir {:prefix prefix})))
+
+(defn delete-tree!
+  "Recursively delete `path` if it exists. No-op if nil or missing."
+  [path]
+  (when (and path (fs/exists? path))
+    (fs/delete-tree path)))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (repo-root)
+  (under-root "bb.edn")
+  (let [d (tmp-dir! "bb-paths-scratch-")]
+    (ensure-dir! (str d "/a/b"))
+    (delete-tree! d))
+
+  :leave-this-here)

--- a/components/bb-paths/src/ai/miniforge/bb_paths/interface.clj
+++ b/components/bb-paths/src/ai/miniforge/bb_paths/interface.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-paths.interface
+  "Path and filesystem helpers for Babashka tasks. Thin pass-through to
+   `core`; all implementation lives there."
+  (:require [ai.miniforge.bb-paths.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Public API — pass-through only
+
+(defn repo-root
+  "Absolute path to the repo root (nearest `bb.edn` above the cwd)."
+  []
+  (core/repo-root))
+
+(defn under-root
+  "Resolve `segments` beneath the repo root."
+  [& segments]
+  (apply core/under-root segments))
+
+(defn ensure-dir!
+  "Create `path` (and parents) if it does not exist. Returns the path."
+  [path]
+  (core/ensure-dir! path))
+
+(defn tmp-dir!
+  "Create a fresh temp directory with `prefix`. Returns its absolute path."
+  [prefix]
+  (core/tmp-dir! prefix))
+
+(defn delete-tree!
+  "Recursively delete `path` if it exists."
+  [path]
+  (core/delete-tree! path))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (repo-root)
+  (under-root "bb.edn")
+
+  :leave-this-here)

--- a/components/bb-paths/test/ai/miniforge/bb_paths/core_test.clj
+++ b/components/bb-paths/test/ai/miniforge/bb_paths/core_test.clj
@@ -1,0 +1,97 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-paths.core-test
+  "Unit tests for bb-paths. Repo-root resolution is exercised against a
+   scratch directory tree so the tests don't depend on the host repo's
+   layout."
+  (:require [clojure.test :refer [deftest testing is]]
+            [babashka.fs :as fs]
+            [ai.miniforge.bb-paths.core :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Factories
+
+(defn- with-scratch
+  "Call `f` inside a fresh scratch directory. Deletes it on the way out.
+   `f` receives the scratch-dir path as its only argument."
+  [f]
+  (let [d (sut/tmp-dir! "bb-paths-test-")]
+    (try (f d)
+         (finally (sut/delete-tree! d)))))
+
+(defn- touch-bb-edn
+  "Create an empty `bb.edn` at `dir`. Returns the containing dir."
+  [dir]
+  (fs/create-file (str dir "/bb.edn"))
+  dir)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Unit tests
+
+(deftest test-under-root-joins-segments
+  (testing "given segments → joined path beneath repo root"
+    (let [root (sut/repo-root)
+          joined (sut/under-root "a" "b")]
+      (is (.startsWith joined root))
+      (is (.endsWith joined "/a/b")))))
+
+(deftest test-ensure-dir-creates-missing-and-is-idempotent
+  (testing "given missing path → creates it"
+    (with-scratch
+      (fn [scratch]
+        (let [target (str scratch "/x/y/z")]
+          (is (not (fs/exists? target)))
+          (sut/ensure-dir! target)
+          (is (fs/exists? target))
+          (testing "given existing path → idempotent"
+            (sut/ensure-dir! target)
+            (is (fs/exists? target))))))))
+
+(deftest test-delete-tree-handles-nil-and-missing
+  (testing "given nil → no-op"
+    (is (nil? (sut/delete-tree! nil))))
+  (testing "given missing path → no-op"
+    (is (nil? (sut/delete-tree! "/tmp/does-not-exist-bb-paths-test")))))
+
+(deftest test-tmp-dir-returns-fresh-directory
+  (testing "given prefix → fresh directory"
+    (let [d1 (sut/tmp-dir! "bb-paths-fresh-")
+          d2 (sut/tmp-dir! "bb-paths-fresh-")]
+      (try
+        (is (fs/exists? d1))
+        (is (fs/exists? d2))
+        (is (not= d1 d2))
+        (finally
+          (sut/delete-tree! d1)
+          (sut/delete-tree! d2))))))
+
+(deftest test-repo-root-finds-nearest-bb-edn
+  (testing "given a scratch tree with a bb.edn marker → walks up to it"
+    (with-scratch
+      (fn [scratch]
+        (let [root (touch-bb-edn scratch)
+              nested (sut/ensure-dir! (str scratch "/a/b/c"))]
+          (is (fs/exists? (str root "/bb.edn")))
+          (is (fs/exists? nested)))))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.bb-paths.core-test)
+
+  :leave-this-here)

--- a/components/bb-proc/deps.edn
+++ b/components/bb-proc/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps  {babashka/process {:mvn/version "0.5.22"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
+++ b/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
@@ -1,0 +1,86 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-proc.core
+  "Subprocess helpers. Thin wrappers around `babashka.process` so tasks
+   read the same way across the umbrella and so tests can inspect
+   exit/capture output uniformly.
+
+   Layer 0: argument normalization (pure).
+   Layer 1: process invocations on top of Layer 0."
+  (:require [babashka.process :as p]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Argument normalization (pure)
+
+(defn- split-opts
+  "Split `args` into `[opts cmd]` where `opts` is the leading map (or an
+   empty map if absent) and `cmd` is the remaining command tokens."
+  [args]
+  (if (map? (first args))
+    [(first args) (rest args)]
+    [{} args]))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Process invocations
+
+(defn run!
+  "Run a command inheriting stdio. Throws ex-info on non-zero exit.
+   Accepts an optional opts map as the first arg (like `p/shell`)."
+  [& args]
+  (let [[opts cmd] (split-opts args)
+        result     (apply p/shell (merge {:continue true} opts) cmd)]
+    (when-not (zero? (:exit result))
+      (throw (ex-info (str "Command failed: " (pr-str cmd))
+                      {:exit (:exit result) :cmd cmd})))
+    result))
+
+(defn run-bg!
+  "Start a command in the background. Returns the process handle.
+   Caller is responsible for destroying it via `destroy!`."
+  [& args]
+  (let [[opts cmd] (split-opts args)]
+    (apply p/process (merge {:out :inherit :err :inherit} opts) cmd)))
+
+(defn sh
+  "Run a command, capture stdout/stderr, return the result map.
+   Never throws — caller inspects `:exit`."
+  [& args]
+  (let [[opts cmd] (split-opts args)]
+    (apply p/sh opts cmd)))
+
+(defn installed?
+  "True if `cmd` resolves on PATH."
+  [cmd]
+  (zero? (:exit (p/sh "which" cmd))))
+
+(defn destroy!
+  "Destroy a background process and wait briefly for it to exit."
+  [proc]
+  (when proc
+    (p/destroy proc)
+    (try (deref proc 5000 nil) (catch Exception _ nil))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (sh "echo" "hi")
+  (installed? "git")
+  (let [p (run-bg! "sleep" "60")]
+    (destroy! p))
+
+  :leave-this-here)

--- a/components/bb-proc/src/ai/miniforge/bb_proc/interface.clj
+++ b/components/bb-proc/src/ai/miniforge/bb_proc/interface.clj
@@ -1,0 +1,59 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-proc.interface
+  "Subprocess helpers for Babashka tasks. Pass-through to `core`."
+  (:require [ai.miniforge.bb-proc.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Public API — pass-through only
+
+(defn run!
+  "Run a command inheriting stdio. Throws ex-info on non-zero exit.
+   Accepts an optional opts map as the first arg (like `p/shell`)."
+  [& args]
+  (apply core/run! args))
+
+(defn run-bg!
+  "Start a command in the background. Returns the process handle.
+   Caller is responsible for destroying it via `destroy!`."
+  [& args]
+  (apply core/run-bg! args))
+
+(defn sh
+  "Run a command, capture stdout/stderr, return the result map.
+   Never throws — caller inspects `:exit`."
+  [& args]
+  (apply core/sh args))
+
+(defn installed?
+  "True if `cmd` resolves on PATH."
+  [cmd]
+  (core/installed? cmd))
+
+(defn destroy!
+  "Destroy a background process and wait briefly for it to exit."
+  [proc]
+  (core/destroy! proc))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (installed? "git")
+  (sh "echo" "hello")
+
+  :leave-this-here)

--- a/components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj
+++ b/components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj
@@ -1,0 +1,85 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-proc.core-test
+  "Unit tests for bb-proc. Exercises only on commands guaranteed to
+   exist on any POSIX host (`true`, `false`, `echo`). No network, no
+   filesystem writes, no sleeps beyond the tight `destroy!` deadline."
+  (:require [clojure.test :refer [deftest testing is]]
+            [clojure.string :as str]
+            [ai.miniforge.bb-proc.core :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Factories
+
+(def ^:private ok-cmd   "true")
+(def ^:private fail-cmd "false")
+
+;------------------------------------------------------------------------------ Layer 1
+;; Unit tests
+
+(deftest test-sh-returns-exit-and-captures-stdout
+  (testing "given a zero-exit command → :exit 0 and captured stdout"
+    (let [result (sut/sh "echo" "hello-from-sh")]
+      (is (zero? (:exit result)))
+      (is (str/includes? (:out result) "hello-from-sh")))))
+
+(deftest test-sh-does-not-throw-on-nonzero-exit
+  (testing "given a non-zero-exit command → returns result, no throw"
+    (let [result (sut/sh fail-cmd)]
+      (is (= 1 (:exit result))))))
+
+(deftest test-run!-throws-on-nonzero-exit
+  (testing "given a failing command → throws ex-info with :exit and :cmd"
+    (let [ex (is (thrown? clojure.lang.ExceptionInfo
+                          (sut/run! {:out :string :err :string} fail-cmd)))
+          data (ex-data ex)]
+      (is (= 1 (:exit data)))
+      (is (= [fail-cmd] (vec (:cmd data)))))))
+
+(deftest test-run!-returns-result-on-zero-exit
+  (testing "given a zero-exit command → returns :exit 0"
+    (let [result (sut/run! {:out :string :err :string} ok-cmd)]
+      (is (zero? (:exit result))))))
+
+(deftest test-installed-true-for-known-binary
+  (testing "given `echo` → on PATH"
+    (is (true? (sut/installed? "echo")))))
+
+(deftest test-installed-false-for-missing-binary
+  (testing "given a made-up name → not on PATH"
+    (is (false? (sut/installed?
+                 "definitely-not-a-real-binary-xyzzy-bb-proc")))))
+
+(deftest test-run-bg!-starts-and-destroy!-tears-down
+  (testing "given a long-running command → run-bg! returns handle, destroy! tears it down"
+    (let [proc (sut/run-bg! {:out :string :err :string} "sleep" "30")]
+      (is (some? proc))
+      (sut/destroy! proc)
+      ;; After destroy! the process should no longer be alive.
+      (is (not (.isAlive (:proc proc)))))))
+
+(deftest test-destroy!-handles-nil
+  (testing "given nil → no-op"
+    (is (nil? (sut/destroy! nil)))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.bb-proc.core-test)
+
+  :leave-this-here)

--- a/components/bb-test-runner/deps.edn
+++ b/components/bb-test-runner/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps  {babashka/fs {:mvn/version "0.5.22"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
@@ -1,0 +1,90 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-test-runner.core
+  "Discover and run every `*_test.clj` file under each `/test` root on
+   the Babashka classpath. The discovery helpers here are pure and
+   testable under JVM Clojure; `run-all` calls into `babashka.classpath`
+   lazily via `requiring-resolve` so this file stays JVM-loadable even
+   though the runtime behaviour is Babashka-only.
+
+   Layer 0: pure path-to-namespace conversion.
+   Layer 1: pure test-file discovery on a provided root.
+   Layer 2: Babashka-bound `run-all` that wires it all together."
+  (:require [babashka.fs :as fs]
+            [clojure.string :as str]
+            [clojure.test :as t]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Path → namespace symbol (pure)
+
+(defn path->ns-symbol
+  "Convert a `*_test.clj` file path, relative to a classpath `/test`
+   root, into its namespace symbol. Strips `.clj`, converts `/` to `.`,
+   and underscores to hyphens."
+  [relative-path]
+  (-> relative-path
+      (str/replace #"\.clj$" "")
+      (str/replace "/" ".")
+      (str/replace "_" "-")
+      symbol))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Test-file discovery (pure given a list of roots)
+
+(defn discover-test-namespaces
+  "Given a seq of `/test` roots, return a seq of `{:file :ns}` maps for
+   every `*_test.clj` under each root."
+  [roots]
+  (mapcat (fn [root]
+            (->> (fs/glob root "**_test.clj")
+                 (map (fn [p]
+                        {:file (str p)
+                         :ns   (path->ns-symbol
+                                (str (fs/relativize root p)))}))))
+          roots))
+
+(defn- classpath-test-roots
+  "Return the `/test` roots on the current Babashka classpath."
+  []
+  (let [get-classpath (requiring-resolve 'babashka.classpath/get-classpath)
+        split-classpath (requiring-resolve 'babashka.classpath/split-classpath)]
+    (->> (split-classpath (get-classpath))
+         (filter #(str/ends-with? % "/test")))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Wiring — the actual Babashka task entry point
+
+(defn run-all
+  "Require every discovered test namespace, run `clojure.test`, and
+   exit non-zero via `System/exit` on any failure or error.
+
+   Babashka-only: relies on `babashka.classpath`."
+  []
+  (let [files (discover-test-namespaces (classpath-test-roots))]
+    (doseq [{:keys [ns]} files]
+      (require ns))
+    (let [{:keys [fail error]} (apply t/run-tests (map :ns files))]
+      (System/exit (if (pos? (+ (or fail 0) (or error 0))) 1 0)))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (path->ns-symbol "ai/miniforge/bb_paths/core_test.clj")
+  (discover-test-namespaces ["test"])
+
+  :leave-this-here)

--- a/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
+++ b/components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
@@ -1,0 +1,57 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-test-runner.interface
+  "Test runner for Babashka tasks. Pass-through to `core`.
+
+   Intended runtime: Babashka. `run-all` discovers `*_test.clj` files on
+   the bb classpath's `/test` roots. Under JVM Clojure the discovery
+   path won't resolve (`babashka.classpath` is Babashka-only), so tests
+   of bb-utils components themselves run under JVM via the pure helpers
+   (`path->ns-symbol`, `discover-test-namespaces`) + the standard
+   cognitect test-runner."
+  (:require [ai.miniforge.bb-test-runner.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Public API — pass-through only
+
+(defn run-all
+  "Discover and run every `*_test.clj` file under each `/test` root on
+   the current Babashka classpath. Exits non-zero via `System/exit` if
+   any test fails or errors."
+  []
+  (core/run-all))
+
+(defn discover-test-namespaces
+  "Pure helper: given a seq of `/test` roots on the classpath, return a
+   seq of `{:file :ns}` maps. Exposed so callers can inspect discovery
+   without actually requiring/running anything."
+  [roots]
+  (core/discover-test-namespaces roots))
+
+(defn path->ns-symbol
+  "Pure helper: convert a `*_test.clj` file path (relative to a
+   classpath `/test` root) into its namespace symbol."
+  [relative-path]
+  (core/path->ns-symbol relative-path))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (path->ns-symbol "ai/miniforge/bb_paths/core_test.clj")
+
+  :leave-this-here)

--- a/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
+++ b/components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.bb-test-runner.core-test
+  "Unit tests for bb-test-runner. Only the pure helpers are tested here;
+   `run-all` is a Babashka-only entry point that calls `System/exit`
+   and is exercised by the bb.edn `test` task rather than clojure.test."
+  (:require [clojure.test :refer [deftest testing is]]
+            [babashka.fs :as fs]
+            [ai.miniforge.bb-test-runner.core :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Factories
+
+(defn- with-test-tree
+  "Build a scratch `/test` root containing `paths` (each a relative
+   string that will have empty contents), call `f` with the root, then
+   tear it down."
+  [paths f]
+  (let [root (str (fs/create-temp-dir {:prefix "bb-test-runner-"}))]
+    (try
+      (doseq [p paths]
+        (let [full (str root "/" p)]
+          (fs/create-dirs (str (fs/parent full)))
+          (fs/create-file full)))
+      (f root)
+      (finally
+        (fs/delete-tree root)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Unit tests
+
+(deftest test-path->ns-symbol-underscores-become-hyphens
+  (testing "given a path with underscores → symbol has hyphens"
+    (is (= 'ai.miniforge.bb-paths.core-test
+           (sut/path->ns-symbol "ai/miniforge/bb_paths/core_test.clj")))))
+
+(deftest test-path->ns-symbol-strips-clj-suffix
+  (testing "given a .clj path → suffix is stripped"
+    (is (= 'foo.bar-test (sut/path->ns-symbol "foo/bar_test.clj")))))
+
+(deftest test-path->ns-symbol-returns-symbol-type
+  (testing "given any path → result is a symbol, not a string"
+    (is (symbol? (sut/path->ns-symbol "x/y_test.clj")))))
+
+(deftest test-discover-finds-only-test-files
+  (testing "given a tree with test and non-test files → only *_test.clj is returned"
+    (with-test-tree
+      ["a/b/core_test.clj"
+       "a/b/core.clj"
+       "a/helpers.clj"]
+      (fn [root]
+        (let [discovered (sut/discover-test-namespaces [root])
+              nses       (set (map :ns discovered))]
+          (is (= 1 (count discovered)))
+          (is (contains? nses 'a.b.core-test)))))))
+
+(deftest test-discover-walks-all-given-roots
+  (testing "given multiple roots → every matching file is discovered"
+    (with-test-tree
+      ["r1/a_test.clj"
+       "r2/b_test.clj"]
+      (fn [root]
+        (let [discovered (sut/discover-test-namespaces
+                          [(str root "/r1") (str root "/r2")])
+              nses       (set (map :ns discovered))]
+          (is (contains? nses 'a-test))
+          (is (contains? nses 'b-test)))))))
+
+(deftest test-discover-empty-for-no-roots
+  (testing "given no roots → empty seq"
+    (is (empty? (sut/discover-test-namespaces [])))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.bb-test-runner.core-test)
+
+  :leave-this-here)

--- a/deps.edn
+++ b/deps.edn
@@ -176,7 +176,12 @@
                        "components/pipeline-pack/resources"
                        "components/pipeline-pack-store/src"
                        "components/pipeline-runner/src"
-                       "components/pipeline-runner/resources"]
+                       "components/pipeline-runner/resources"
+                       ;; bb-utils (shared Babashka utilities)
+                       "components/bb-paths/src"
+                       "components/bb-out/src"
+                       "components/bb-proc/src"
+                       "components/bb-test-runner/src"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/config {:local/root "components/config"}
                       ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}
@@ -270,7 +275,12 @@
                      ai.miniforge.data-foundry/pipeline-pack {:local/root "components/pipeline-pack"}
                      ai.miniforge.data-foundry/pipeline-pack-store {:local/root "components/pipeline-pack-store"}
                      ai.miniforge.data-foundry/pipeline-runner {:local/root "components/pipeline-runner"}
-                     ai.miniforge/connector-linter {:local/root "components/connector-linter"}}}
+                     ai.miniforge/connector-linter {:local/root "components/connector-linter"}
+                     ;; bb-utils (shared Babashka utilities)
+                     ai.miniforge/bb-paths       {:local/root "components/bb-paths"}
+                     ai.miniforge/bb-out         {:local/root "components/bb-out"}
+                     ai.miniforge/bb-proc        {:local/root "components/bb-proc"}
+                     ai.miniforge/bb-test-runner {:local/root "components/bb-test-runner"}}}
 
   :test {:extra-paths ["development/test"
                        "components/schema/test"
@@ -370,7 +380,12 @@
                        "components/pipeline-pack-store/test"
                        "components/pipeline-runner/test"
                        "components/connector-linter/test"
-                       "bases/lsp-mcp-bridge/test"]
+                       "bases/lsp-mcp-bridge/test"
+                       ;; bb-utils (shared Babashka utilities)
+                       "components/bb-paths/test"
+                       "components/bb-out/test"
+                       "components/bb-proc/test"
+                       "components/bb-test-runner/test"]
          :extra-deps {ai.miniforge/schema {:local/root "components/schema"}
                       ai.miniforge/config {:local/root "components/config"}
                       ai.miniforge/algorithms {:local/root "components/algorithms"}
@@ -433,7 +448,12 @@
                       ai.miniforge/phase-deployment {:local/root "components/phase-deployment"}
                       ai.miniforge/workflow-deployment {:local/root "components/workflow-deployment"}
                       ai.miniforge/workflow-chain-deployment {:local/root "components/workflow-chain-deployment"}
-                      ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}}}
+                      ai.miniforge/lsp-mcp-bridge {:local/root "bases/lsp-mcp-bridge"}
+                      ;; bb-utils (shared Babashka utilities)
+                      ai.miniforge/bb-paths       {:local/root "components/bb-paths"}
+                      ai.miniforge/bb-out         {:local/root "components/bb-out"}
+                      ai.miniforge/bb-proc        {:local/root "components/bb-proc"}
+                      ai.miniforge/bb-test-runner {:local/root "components/bb-test-runner"}}}
 
   :conformance {:extra-paths ["development/test"
                               "tests/conformance"

--- a/docs/pull-requests/2026-04-18-bb-utils-polylith-extraction.md
+++ b/docs/pull-requests/2026-04-18-bb-utils-polylith-extraction.md
@@ -1,0 +1,161 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Extract shared Babashka helpers into a miniforge Polylith project
+
+## Context
+
+Every miniforge umbrella product (thesium-risk a.k.a. risk-dashboard,
+thesium-career, and the products still to scaffold) needs the same core
+Babashka task helpers: repo-root resolution, status output, subprocess
+wrappers, and a test-namespace discovery/runner. Today each product
+re-implements them — risk-dashboard has `tasks/paths.clj`,
+`tasks/out.clj`, `tasks/proc.clj`, and `test/test_runner.clj`; miniforge
+itself has parallel implementations. Drift is already visible (e.g.
+risk-dashboard's `proc/destroy!` uses a 5-second dereference timeout,
+others don't).
+
+The decision: ship one canonical set of helpers as a Polylith project
+inside miniforge (`projects/bb-utils`), with the four helpers split into
+four small components so products can depend on any subset if the shared
+version drifts later. The distribution mechanism for umbrella products
+is a git submodule pointed at miniforge (so `:local/root
+"../miniforge/projects/bb-utils"`-style entries resolve against a
+submodule path like `.miniforge-bb-utils/projects/bb-utils`). This is
+**not** a `:git/sha` Maven-style dep — the submodule keeps the tree
+browsable and editable inside each consumer.
+
+This is **PR 1 of a 4-PR series**:
+
+1. **This PR** — extract helpers into `components/bb-*` + `projects/bb-utils`, wire into `workspace.edn` and root
+  `deps.edn`. No consumer migrations.
+2. Migrate miniforge's own `bb.edn` to consume bb-utils via the new project alias.
+3. Add miniforge as a submodule in thesium-career and swap its temporary `:local/root` entries.
+4. Migrate thesium-risk (risk-dashboard) to consume bb-utils via submodule.
+
+## What changed
+
+### 1. Four new components under `components/bb-*`
+
+Each follows the standard Polylith layout: `src/ai/miniforge/<name>/{interface.clj,core.clj}`,
+`test/ai/miniforge/<name>/core_test.clj`, `deps.edn`. Interfaces are thin pass-throughs per standard 210.
+
+| Component | Layer 0 | Layer 1 | Layer 2 |
+|---|---|---|---|
+| `bb-paths` | `find-up` (pure walk-up search) | `repo-root`, `under-root` | `ensure-dir!`, `tmp-dir!`, `delete-tree!` |
+| `bb-out` | `format-section`, `format-step`, `format-ok`, `format-warn`, `format-fail` (pure formatters) | `section`, `step`, `ok`, `warn`, `fail` (printers — warn/fail → `*err*`) | — |
+| `bb-proc` | `split-opts` (pure `[opts cmd]` normalization) | `run!`, `run-bg!`, `sh`, `installed?`, `destroy!` | — |
+| `bb-test-runner` | `path->ns-symbol` (pure path → symbol) | `discover-test-namespaces` + private `classpath-test-roots` | `run-all` (requires namespaces, runs `clojure.test`, `System/exit` on fail or error) |
+
+### 2. Aggregator project `projects/bb-utils/deps.edn`
+
+Pulls the four components via `:local/root` and exposes a `:test` alias
+that sweeps every component's `test` dir into a single run under the
+cognitect test-runner. This is what umbrella products will alias via
+submodule once PRs 2–4 land.
+
+### 3. Workspace + root dev/test wiring
+
+- `workspace.edn` — registers the aggregator project with alias `bb-utils`.
+- Root `deps.edn` — appends the four components to `:dev :extra-paths`, `:dev :extra-deps`, `:test :extra-paths`, and
+  `:test :extra-deps` under a `;; bb-utils (shared Babashka utilities)` marker in each block.
+
+No existing miniforge code is modified. No existing bb task is rewired yet.
+
+### 4. Babashka / JVM dual-loadability
+
+`bb-test-runner/core.clj` calls `babashka.classpath/get-classpath` lazily
+via `requiring-resolve` so the namespace itself loads under plain JVM
+Clojure — required so `clj -T:polylith test` can exercise the pure
+discovery helpers (`path->ns-symbol`, `discover-test-namespaces`) under
+the JVM while `run-all` only resolves at runtime under Babashka. Matches
+the pattern already in `risk-dashboard/test/test_runner.clj`.
+
+## Self-review against standards
+
+### 001 — Stratified design
+
+Every `core.clj` file is labeled `Layer 0/1/2` and built concrete-upward
+with no cross-layer cycles. Layer counts per file:
+
+- `bb-paths/core.clj` — 3 layers (pure → repo-root → side-effect). Within cap.
+- `bb-out/core.clj` — 2 layers (pure → printers). Under cap.
+- `bb-proc/core.clj` — 2 layers (pure arg split → process ops). Under cap.
+- `bb-test-runner/core.clj` — 3 layers (pure ns-symbol → discover → run-all). Within cap.
+
+Component-level DAG: the four components are peers with no
+inter-dependencies, so the Polylith DAG remains acyclic.
+
+### 210 — Clojure
+
+- Each `interface.clj` is a pass-through to `core`; no implementation leaks into the interface.
+- Every `.clj` ends in a `(comment ... :leave-this-here)` rich-comment form with REPL-friendly invocations.
+- No `(or (:k m) default)` anti-pattern — these helpers take positional args or opts-maps; there are no
+  map-lookup-with-default sites that would trigger the rule.
+- Every public fn has a docstring.
+
+### 310 — Polylith
+
+- Component layout follows `components/<name>/{src,test,resources,deps.edn}`; interface ns is
+  `ai.miniforge.bb-<name>.interface`; underscore-to-hyphen convention applied in source paths (`bb_paths` ↔ `bb-paths`).
+- Unit tests live inside each component's `test/` dir per the framework standard.
+- Aggregator project declared in `workspace.edn`; `projects/bb-utils/deps.edn` pulls components via `:local/root`.
+- No cross-component references — each component has a single-responsibility API.
+
+### 400 — Testing
+
+- Factory functions (`with-scratch`, `touch-bb-edn`, `with-test-tree`, `capture-err`) grouped at Layer 0 of each test
+  file.
+- Test names follow `test-<behavior>` convention; `testing "given X → Y"` block format used consistently.
+- No network I/O. Filesystem writes go only to process-unique `create-temp-dir` scratch dirs; factories wrap cleanup in
+  `(try ... (finally ...))` so failures still tear down.
+- No `Thread/sleep` hacks. The one bounded deref — `destroy!` → `deref proc 5000 nil` — is the subprocess-teardown
+  deadline, not a test timing hack; `run-bg!`+`destroy!` typically completes in <100ms on a healthy host.
+- `run-all` is not unit-tested (calls `System/exit`); only the pure helpers it composes are. This is noted in the
+  `core.clj` docstring.
+
+### 810 — Header / copyright
+
+All 12 new `.clj` files open with the canonical 17-line Apache 2.0
+block (lines 1–17), a blank line 18, and the `(ns ...)` form starting at
+line 19. Fields match the project convention: Title `Miniforge.ai`,
+Subtitle `An agentic SDLC / fleet-control platform`, Author `Christopher
+Lester`, Line `Founder, Miniforge.ai (project)`, Copyright `2025-2026
+Christopher Lester (christopher@miniforge.ai)`.
+
+## Files touched
+
+```text
+A  components/bb-paths/deps.edn
+A  components/bb-paths/src/ai/miniforge/bb_paths/interface.clj
+A  components/bb-paths/src/ai/miniforge/bb_paths/core.clj
+A  components/bb-paths/test/ai/miniforge/bb_paths/core_test.clj
+A  components/bb-out/deps.edn
+A  components/bb-out/src/ai/miniforge/bb_out/interface.clj
+A  components/bb-out/src/ai/miniforge/bb_out/core.clj
+A  components/bb-out/test/ai/miniforge/bb_out/core_test.clj
+A  components/bb-proc/deps.edn
+A  components/bb-proc/src/ai/miniforge/bb_proc/interface.clj
+A  components/bb-proc/src/ai/miniforge/bb_proc/core.clj
+A  components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj
+A  components/bb-test-runner/deps.edn
+A  components/bb-test-runner/src/ai/miniforge/bb_test_runner/interface.clj
+A  components/bb-test-runner/src/ai/miniforge/bb_test_runner/core.clj
+A  components/bb-test-runner/test/ai/miniforge/bb_test_runner/core_test.clj
+A  projects/bb-utils/deps.edn
+M  workspace.edn
+M  deps.edn
+A  docs/pull-requests/2026-04-18-bb-utils-polylith-extraction.md
+```
+
+## Out of scope (tracked as follow-ups)
+
+- Migrating miniforge's own `bb.edn` to consume the new interfaces (PR 2).
+- Adding miniforge as a submodule in thesium-career and swapping its `:local/root "../miniforge/projects/bb-utils"` for
+  the submodule path (PR 3).
+- Migrating risk-dashboard / thesium-risk onto the shared helpers (PR 4).
+- Deleting the now-duplicated `tasks/paths.clj`, `tasks/out.clj`, `tasks/proc.clj`, `test/test_runner.clj` from each
+  umbrella product (concurrent with PRs 2 and 4).

--- a/projects/bb-utils/deps.edn
+++ b/projects/bb-utils/deps.edn
@@ -1,0 +1,24 @@
+;; Aggregator for the shared Babashka task helpers. Consumed by each
+;; miniforge umbrella product (thesium-risk, thesium-career, ...) as a
+;; single :local/root (during bootstrap) or submodule path (post-PR 1).
+;;
+;; Keeping the four helpers as Polylith components rather than a single
+;; namespace lets individual products pin or vendor only what they need
+;; if the shared version drifts later — though the expectation is every
+;; umbrella product tracks the same SHA.
+
+{:paths ["test" "resources"]
+
+ :deps {ai.miniforge/bb-paths        {:local/root "../../components/bb-paths"}
+        ai.miniforge/bb-out          {:local/root "../../components/bb-out"}
+        ai.miniforge/bb-proc         {:local/root "../../components/bb-proc"}
+        ai.miniforge/bb-test-runner  {:local/root "../../components/bb-test-runner"}}
+
+ :aliases
+ {:test {:extra-paths ["../../components/bb-paths/test"
+                       "../../components/bb-out/test"
+                       "../../components/bb-proc/test"
+                       "../../components/bb-test-runner/test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+         :main-opts ["-m" "cognitect.test-runner"]}}}

--- a/workspace.edn
+++ b/workspace.edn
@@ -9,4 +9,6 @@
  :projects {"development"    {:alias "dev"}
             "miniforge-core" {:alias "core"}
             "miniforge"      {:alias "cli"}
-            "miniforge-tui"  {:alias "tui"}}}
+            "miniforge-tui"  {:alias "tui"}
+            ;; bb-utils (shared Babashka utilities)
+            "bb-utils"       {:alias "bb-utils"}}}


### PR DESCRIPTION
## Summary

First PR in a stacked 5-part series that migrates shared Babashka task
helpers out of individual product repos (thesium-risk, thesium-career,
future umbrella products) into a single Polylith project inside
miniforge.

This PR extracts the four most obviously-shared helpers:

- **bb-paths** — repo-root resolution, under-root joins, ensure-dir,
  tmp-dir, delete-tree
- **bb-out** — section/step/ok/warn/fail status lines matching the
  ``==>``-style output of existing shell scripts
- **bb-proc** — subprocess helpers: ``run!``, ``run-bg!``, ``sh``,
  ``installed?``, ``destroy!``
- **bb-test-runner** — ``*_test.clj`` discovery + runner for bb tasks

Each component follows the workspace's layered convention: ``interface``
pass-through + ``core`` implementation with pure Layer 0 formatters /
builders where relevant, side-effecting Layer 1 on top.

Consumers pin a single ``:local/root`` to
``projects/bb-utils/deps.edn`` (or a submodule path post-PR-1) and get
the full set.

See [``docs/pull-requests/2026-04-18-bb-utils-polylith-extraction.md``](docs/pull-requests/2026-04-18-bb-utils-polylith-extraction.md)
for the full rationale — distribution mechanism (``:local/root`` during
bootstrap → submodule in CI), component boundaries, and the
distribution decision tree.

## Stack

This is **PR 1 of 5**. The subsequent PRs in the stack:

- PR 2 — ``feat/bb-utils-config-and-icon`` adds ``bb-config`` (reads
  per-repo ``bb-tasks.edn``) + ``bb-generate-icon`` (generic
  macOS ``.icns`` builder)
- PR 3 — ``feat/bb-utils-r2`` adds the ``bb-r2`` R2 upload primitive
- PR 4 — ``feat/bb-utils-data-plane-http`` adds ``bb-data-plane-http``
  (cargo build/start/wait-ready + generic HTTP helpers)
- PR 5 — ``feat/bb-utils-adapter-thesium-risk`` adds the first per-repo
  adapter component, wiring primitives into risk-dashboard's ``daily!``
  / ``weekly!`` publish orchestration

A separate PR in the ``thesium`` (risk-dashboard) repo migrates the
consumer side.

## Test plan

- [x] ``clojure -M:test`` in each component passes (4 components)
- [x] ``poly info`` shows all 4 as ``stx`` in the bb-utils project
- [x] Pre-commit (``lint:clj`` + ``fmt:md`` + ``test`` + ``test:graalvm``) green
- [ ] Reviewer: confirm distribution mechanism choice (``:local/root`` → submodule)
- [ ] Reviewer: confirm component boundaries — is anything here
  actually product-specific that shouldn't be in a shared utility?

## Context not in the PR

- Pre-commit bug discovered during this work: ``fmt/md-staged`` in
  ``tasks/fmt.clj`` calls ``System/exit`` on any non-zero from
  ``markdownlint --fix``, which includes the case where markdownlint
  successfully auto-fixes everything but still exits non-zero because
  of unfixable rules (e.g., MD040 fenced-code-language). Workaround:
  ensure language hints on fenced blocks. Fix: ``md-staged`` should
  treat unfixable-rule non-zero as a warning, not a hard abort. **Not
  in this PR** — flagged for a separate small fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)