### PR TITLE
feat(planner): container-promoted plan artifact via .miniforge/plan.edn

### DIFF
--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -5,7 +5,7 @@
 ;; creates detailed implementation plans.
 
 {:prompt/id :planner
- :prompt/version "2.1.0"
+ :prompt/version "2.2.0"
  :prompt/agent :planner
 
  ;; Hard turn cap passed to the backend CLI. Observed 2026-04-18: at 40
@@ -215,35 +215,29 @@ If you need to explore files NOT already in your context, use these MCP tools
 
 ## Plan Submission — REQUIRED
 
-**YOUR FINAL ASSISTANT MESSAGE MUST BE THE PLAN ITSELF.** Narration about
-what you've explored is not a plan. A response that ends without either
-the EDN map or an MCP submission call is a failed turn.
+**Write your plan EDN to `.miniforge/plan.edn` in the working directory
+using the Write tool. That file IS your submission.** No MCP call, no
+final-message code fence required. The runtime reads `.miniforge/plan.edn`
+after your turn ends.
 
-You have two ways to submit the plan, in order of preference:
+Example — the last thing you do is:
 
-### Option A (preferred) — the artifact MCP tool
+    Write(\".miniforge/plan.edn\", \"{:plan/id #uuid \\\"...\\\"
+                                  :plan/name \\\"...\\\"
+                                  :plan/tasks [...]}\")
 
-If an artifact submission MCP tool is available, call it with your plan
-map as the artifact. The runtime picks this up directly. Use this
-whenever possible — it bypasses text parsing.
+The content MUST be a single top-level Clojure map (not a vector, not a
+list) and MUST parse as EDN. `#uuid \"<any-uuid>\"` is fine — the runtime
+will accept any valid UUID.
 
-### Option B — final message containing the plan EDN
+**Failure fallback (do not rely on this):** if `.miniforge/plan.edn` is
+absent when your turn ends, the runtime will try to parse the plan out
+of your final text block wrapped in a ` ```clojure ` fence. Relying on
+the fallback has caused every recent plan failure. Write the file.
 
-If you cannot call the MCP tool, your **final** assistant message (the
-one with no tool calls) MUST contain the plan EDN wrapped in a code
-fence labeled `clojure`. Example:
-
-    ```clojure
-    {:plan/id #uuid \"...\"
-     :plan/name \"...\"
-     :plan/tasks [...]}
-    ```
-
-**Do NOT end your turn with prose narration** (\"I've reviewed the
-files...\", \"Now I'll output the plan...\", \"Based on my exploration...\",
-followed by nothing). That is how plans get lost. If you catch yourself
-writing prose-only at the end of your turn, STOP, delete the prose,
-and output the plan EDN instead.
+**Do NOT end your turn with prose narration** (\"Based on my exploration…\",
+\"Now I'll output the plan…\") followed by nothing. If you catch yourself
+about to, STOP and invoke Write instead.
 
 ## Turn Budget — HARD LIMIT
 
@@ -268,16 +262,18 @@ never arrives.
 
 These are documented real failures that cost real tokens:
 
-1. **Narration-only ending** — agent described its exploration and
-   then terminated without EDN (e.g., \"Let me check a few more
-   files...\" and then the turn cap hit). The runtime throws
-   `:anomalies.agent/invoke-failed` with message \"Plan generation
-   failed: EDN parse did not succeed\". No retry. Real cost observed
-   2026-04-18: 8 minutes + $$ of Opus 4.6 for zero usable output.
-2. **Code fence omitted** — EDN present but not wrapped in a
-   ` ```clojure ` fence. The parser misses it.
-3. **Top-level form is not a map** — the plan MUST be a Clojure map,
-   not a vector or list. `{:plan/id ...}`, not `[{:plan/id ...}]`.
+1. **Forgot to Write the file** — tool chain ended without ever calling
+   `Write(\".miniforge/plan.edn\", ...)`. Runtime finds no file, falls
+   back to final-message parsing, finds nothing parseable, throws
+   `:anomalies.agent/invoke-failed`. Observed 2026-04-19: ZERO chars of
+   content after 58 tool calls, $$$ of Opus 4.6 for nothing.
+2. **Exploration loop** — kept reading files instead of writing the
+   plan, hit the turn cap mid-chain. The plan you had at turn 20 was
+   good enough. Write it.
+3. **Top-level form is not a map** — plan.edn MUST contain a single
+   top-level Clojure map, not a vector or list. `{:plan/id ...}`,
+   not `[{:plan/id ...}]`.
+4. **Invalid EDN** — file must parse. Check your syntax before Write.
 
 Remember: A good plan enables parallel execution where possible while
 respecting necessary dependencies. Optimize for clarity and testability."}

--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -432,6 +432,35 @@
 
     :else m))
 
+(defn read-worktree-artifact
+  "Read a role artifact from <workdir>/.miniforge/<role>.edn if present.
+
+   Container-promotion pattern: an agent submits its phase artifact by
+   writing a file into the worktree, and the runtime reads that file
+   after the LLM invocation. This lives alongside the MCP-based
+   artifact path (`read-artifact`) — the caller decides precedence.
+
+   Arguments:
+   - workdir — absolute path to the worktree (may be nil)
+   - role    — keyword or string naming the artifact (e.g. :plan → plan.edn)
+
+   Returns: parsed artifact map with UUID types, or nil (missing,
+   unreadable, or parse failure — all logged to stderr, never thrown)."
+  [workdir role]
+  (when (and workdir role)
+    (let [filename (str (name role) ".edn")
+          f (io/file workdir ".miniforge" filename)]
+      (when (.exists f)
+        (try
+          (-> (slurp f)
+              edn/read-string
+              parse-uuid-strings)
+          (catch Exception e
+            (binding [*out* *err*]
+              (println "WARN: failed to parse worktree artifact at"
+                       (.getPath f) "—" (ex-message e)))
+            nil))))))
+
 (defn read-artifact
   "Read the artifact EDN file from a session directory.
 
@@ -676,12 +705,26 @@
 
 (defn- run-session
   "Execute body-fn with session, read artifacts, and clean up.
-   Shared lifecycle for both host and capsule sessions."
+   Shared lifecycle for both host and capsule sessions.
+
+   `:worktree-artifacts` is a map from role keyword to parsed artifact,
+   read from <workdir>/.miniforge/<role>.edn. Container-promotion pattern —
+   agents write their artifact into the worktree and the runtime picks it
+   up here. Empty when no worktree is available (e.g. capsule mode) or no
+   files were written."
   [session body-fn read-artifact-fn cleanup-fn mode]
   (try
-    (let [result (body-fn session)]
+    (let [result (body-fn session)
+          workdir (:workdir session)
+          worktree-artifacts (when (and (= :host mode) workdir)
+                               (into {}
+                                     (keep (fn [role]
+                                             (when-let [a (read-worktree-artifact workdir role)]
+                                               [role a])))
+                                     [:plan :implement :verify :review :release]))]
       {:llm-result result
        :artifact (read-artifact-fn session)
+       :worktree-artifacts worktree-artifacts
        :context-misses (when (= :host mode) (read-context-misses session))
        :pre-session-snapshot (:pre-session-snapshot session)
        :session-mode mode})

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -395,18 +395,28 @@
                                "Use (random-uuid) for all IDs - just write #uuid \"<any-uuid>\" placeholders that I'll fill in.")]
           (if llm-client
             ;; Use the real LLM with artifact session for MCP tool support
-            (let [{:keys [llm-result artifact]}
+            (let [{:keys [llm-result artifact worktree-artifacts]}
                   (artifact-session/with-session context
                     #(invoke-planner-session % llm-client user-prompt config context on-chunk))
                   llm-response llm-result
-                  tokens (get llm-response :tokens 0)]
+                  tokens (get llm-response :tokens 0)
+                  ;; Container promotion: prefer the plan the agent wrote into
+                  ;; the worktree at .miniforge/plan.edn — that is how the
+                  ;; implementer already submits, now the planner too.
+                  ;; Fallbacks preserved so backend-specific regressions
+                  ;; don't block the migration window.
+                  worktree-plan (get worktree-artifacts :plan)]
               (log/info logger :planner :planner/llm-called
                         {:data {:success (llm/success? llm-response)
                                 :tokens tokens
-                                :streaming? (boolean on-chunk)}})
+                                :streaming? (boolean on-chunk)
+                                :plan-source (cond worktree-plan :worktree
+                                                   artifact      :mcp-artifact
+                                                   :else         :final-message)}})
               (if (llm/success? llm-response)
                 (let [content (llm/get-content llm-response)
-                      plan (or artifact
+                      plan (or worktree-plan
+                               artifact
                                (parse-plan-response content)
                                (response/throw-anomaly! :anomalies.agent/invoke-failed
                                                        "Plan generation failed: EDN parse did not succeed"

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -130,6 +130,59 @@
         (finally
           (session/cleanup-session! s))))))
 
+;------------------------------------------------------------------------------ Layer 2.1
+;; Worktree artifact tests — container-promotion submission path
+
+(defn- make-worktree-with-plan [plan-edn-str]
+  (let [wt (io/file (System/getProperty "java.io.tmpdir")
+                    (str "mf-wt-test-" (random-uuid)))
+        _  (.mkdirs (io/file wt ".miniforge"))]
+    (when plan-edn-str
+      (spit (io/file wt ".miniforge" "plan.edn") plan-edn-str))
+    (.getPath wt)))
+
+(deftest read-worktree-artifact-reads-plan-edn-test
+  (testing "reads .miniforge/<role>.edn from the worktree"
+    (let [wt (make-worktree-with-plan
+              (pr-str {:plan/id "550e8400-e29b-41d4-a716-446655440000"
+                       :plan/name "t"
+                       :plan/tasks []}))]
+      (try
+        (let [result (session/read-worktree-artifact wt :plan)]
+          (is (map? result))
+          (is (= "t" (:plan/name result)))
+          (is (instance? java.util.UUID (:plan/id result))
+              "UUID strings should be parsed through parse-uuid-strings"))
+        (finally
+          (io/delete-file (io/file wt ".miniforge" "plan.edn") true)
+          (io/delete-file (io/file wt ".miniforge") true)
+          (io/delete-file (io/file wt) true))))))
+
+(deftest read-worktree-artifact-missing-file-test
+  (testing "returns nil when .miniforge/<role>.edn is absent"
+    (let [wt (make-worktree-with-plan nil)]
+      (try
+        (is (nil? (session/read-worktree-artifact wt :plan)))
+        (finally
+          (io/delete-file (io/file wt ".miniforge") true)
+          (io/delete-file (io/file wt) true))))))
+
+(deftest read-worktree-artifact-nil-args-test
+  (testing "returns nil for nil workdir or nil role (no throw)"
+    (is (nil? (session/read-worktree-artifact nil :plan)))
+    (is (nil? (session/read-worktree-artifact "/tmp" nil)))
+    (is (nil? (session/read-worktree-artifact nil nil)))))
+
+(deftest read-worktree-artifact-invalid-edn-test
+  (testing "returns nil for unparseable file (no throw)"
+    (let [wt (make-worktree-with-plan "{{{ not edn")]
+      (try
+        (is (nil? (session/read-worktree-artifact wt :plan)))
+        (finally
+          (io/delete-file (io/file wt ".miniforge" "plan.edn") true)
+          (io/delete-file (io/file wt ".miniforge") true)
+          (io/delete-file (io/file wt) true))))))
+
 ;------------------------------------------------------------------------------ Layer 2.5
 ;; UUID/instant parsing tests (via read-artifact round-trip)
 


### PR DESCRIPTION
## Summary

GROUP 1 of \`work/planner-convergence-and-artifact-submission.spec.edn\` (PR #587).

- Planner submits its plan by writing \`.miniforge/plan.edn\` into the worktree — same container-promotion pattern the implementer already uses.
- Runtime reads it after the LLM terminates via new \`artifact-session/read-worktree-artifact\`.
- Prompt collapses from Option A / Option B ambiguity to a single Write directive.

## Why

Iters 1–6 of the dogfood loop each lost 4+ minutes of planner tokens to a submission path the model wouldn't reliably take:

- **Iter 5** (workflow \`59b62101\`): 85 chars of narration, 84 tool calls, zero plan EDN over 4:11.
- **Iter 6** (workflow \`f6b9390d\`, today): ZERO chars of content, 58 tool calls, zero plan EDN over 5:13.

The prompt's "Option A" pointed at a \`submit_artifact\` MCP tool that does not exist. "Option B" (EDN in final text block) depended on the model choosing to stop tool-calling and emit prose, which it doesn't reliably do.

Container promotion removes the ambiguity. Write the file; the runtime picks it up. Same pattern proven for implementer output.

## Submission precedence

| priority | source | how |
| --- | --- | --- |
| 1 | \`.miniforge/plan.edn\` in worktree | GROUP 1 (this PR) — planner writes via Write tool |
| 2 | MCP artifact file | legacy path, retained for capsule mode + regression safety |
| 3 | final-message EDN | fallback, logged as \`:plan-source :final-message\` so we see when the fallback fires |
| — | throw \`:anomalies.agent/invoke-failed\` | all three absent |

\`:plan-source\` logged on every planner invocation so the next dogfood run reveals which path is winning.

## What this PR does NOT do

- Does not disallow native filesystem tools for the planner (GROUP 2) — separate PR.
- Does not add stop_reason capture (GROUP 3) — separate PR.
- Does not remove the final-message EDN fallback (GROUP 4) — one dogfood run on the worktree path must go green first.
- Does not add a cached web-MCP (GROUP 2B) — lands with GROUP 2 when WebSearch/WebFetch get disallowed.

## Test plan

- [x] Unit: \`read-worktree-artifact\` — 4 new tests (happy path, missing file, nil args, invalid EDN)
- [x] \`bb test\` full pre-commit suite: 285 tests / 1205 assertions / 0 failures / 0 errors
- [x] GraalVM/Babashka compat: 5 tests / 332 assertions green
- [ ] Post-merge: dogfood iter 7 against \`work/planner-convergence-and-artifact-submission.spec.edn\` — expect \`:plan-source :worktree\` on success

🤖 Generated with [Claude Code](https://claude.com/claude-code)