### PR TITLE
feat(planner): disallow native Read/Bash/Grep/Glob/Agent/LS

### DIFF
--- a/components/agent/resources/prompts/planner.edn
+++ b/components/agent/resources/prompts/planner.edn
@@ -5,7 +5,7 @@
 ;; creates detailed implementation plans.
 
 {:prompt/id :planner
- :prompt/version "2.2.0"
+ :prompt/version "2.3.0"
  :prompt/agent :planner
 
  ;; Hard turn cap passed to the backend CLI. Observed 2026-04-18: at 40
@@ -198,20 +198,23 @@ work is needed, proceed with normal plan generation.
 9. **Review Points**: Include :review tasks at natural checkpoints, especially after
    significant implementation milestones.
 
-## CRITICAL: Do NOT Re-Read Files Already In This Prompt
+## Tools Available to the Planner
 
-The 'Existing Files in Scope' section in your input contains source code that was loaded
-during the explore phase. **Do NOT use Read, mcp__context__context_read, or any tool to re-read files
-whose content is already provided.** Use the provided files to understand the codebase.
-Only read additional files if they are NOT already in your context.
+**Filesystem reads go through the context MCP, not native tools.**
+Read/Bash/Grep/Glob/Agent/LS are DISABLED for this role — calling them
+returns an error. Use these three tools for exploration:
 
-## MCP Context Tools
-
-If you need to explore files NOT already in your context, use these MCP tools
-(they check a pre-loaded cache first for instant lookup):
 - `mcp__context__context_read` — read a file by path
 - `mcp__context__context_grep` — search file contents by regex
 - `mcp__context__context_glob` — find files by glob pattern
+
+They hit a pre-loaded cache populated by the explore phase. The 'Existing
+Files in Scope' section below already contains the files the explore
+phase loaded for you — **do NOT re-read those via the MCP tools either.**
+Only fetch files that are not already in your context.
+
+**Write IS enabled** — that is how you submit the plan
+(`.miniforge/plan.edn`, see below). Do not use Write for anything else.
 
 ## Plan Submission — REQUIRED
 
@@ -245,9 +248,9 @@ The backend CLI caps your turns at `:prompt/max-turns` (currently 80).
 **Your plan MUST be submitted before that cap.** The cap is a ceiling, not
 a target — most specs should land well under it.
 
-**After 15 file reads, STOP exploring and output your plan immediately.**
-Reserve at least 2 turns for the final submission — if you are at 13
-reads, your next move is the plan, not another read.
+**After 15 context_read/grep/glob calls, STOP exploring and Write the
+plan immediately.** Reserve at least 2 turns for the final submission —
+if you are at 13 MCP reads, your next move is Write, not another read.
 
 Before every additional tool call, ask yourself:
 - Can I draft a plausible plan with what I already know? If yes, STOP.

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -317,6 +317,33 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public API
 
+(def ^:private planner-disallowed-tools
+  "Native Claude Code tools the planner MUST NOT call.
+
+   Rationale (iteration 5 + 6 dogfood evidence): the planner had access
+   to Read/Bash/Grep/Glob/Agent and used them exclusively — 140+ tool
+   calls across two iterations, zero plan artifacts produced. The MCP
+   context cache (context_read/context_grep/context_glob) — which the
+   explore phase pre-populates with the scoped files the planner
+   actually needs — was consulted once in 140 tool calls.
+
+   Forcing the MCP path achieves two things:
+     1. The planner works off a curated, pre-loaded file set instead
+        of flailing through the whole filesystem. Fewer noisy reads,
+        faster convergence.
+     2. Cache-miss events land in the session :context-misses file,
+        so we learn what the planner actually wanted that the explore
+        phase didn't provide. Signal the context-quality theme needs.
+
+   Write stays allowed — that's the container-promotion submission
+   path (.miniforge/plan.edn, landed in GROUP 1). WebSearch/WebFetch
+   are NOT in this list because disallowing them without a cached MCP
+   replacement would regress capability; they ship with GROUP 2B /
+   2c of the planner-convergence spec.
+
+   Matches the role-scoped disallow-list pattern tester.clj uses."
+  ["Read" "Bash" "Grep" "Glob" "Agent" "LS"])
+
 (defn- invoke-planner-session
   "Session body for the planner: build mcp-opts with model hint, call LLM."
   [session llm-client user-prompt config context on-chunk]
@@ -328,7 +355,8 @@
         ;; work/n07-opsv-agent-budgets.spec.edn.
         max-turns (get @planner-prompt-data :prompt/max-turns 80)
         mcp-opts (assoc (artifact-session/session->mcp-opts session budget-usd max-turns)
-                        :model (model/default-model-for-role :planner))]
+                        :model (model/default-model-for-role :planner)
+                        :disallowed-tools planner-disallowed-tools)]
     (if on-chunk
       (llm/chat-stream llm-client user-prompt on-chunk
                        (merge {:system @planner-system-prompt} mcp-opts))

--- a/components/agent/test/ai/miniforge/agent/planner_test.clj
+++ b/components/agent/test/ai/miniforge/agent/planner_test.clj
@@ -23,6 +23,9 @@
    [clojure.string :as str]
    [ai.miniforge.agent.core :as core]
    [ai.miniforge.agent.planner :as planner]
+   [ai.miniforge.agent.artifact-session :as artifact-session]
+   [ai.miniforge.agent.model :as model]
+   [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -256,6 +259,93 @@
     (let [agent (planner/create-planner)]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo #"No LLM backend"
             (core/cycle-agent agent {} "Create a REST API endpoint"))))))
+
+;------------------------------------------------------------------------------ Layer 6
+;; Tool-disallow-list — role-scoped restriction so the planner cannot
+;; bypass the context MCP by using native filesystem tools.
+
+(deftest planner-disallowed-tools-contents-test
+  (testing "planner-disallowed-tools names the native file/shell tools"
+    (let [dt @#'planner/planner-disallowed-tools]
+      (is (vector? dt))
+      (is (every? string? dt))
+      (doseq [t ["Read" "Bash" "Grep" "Glob" "Agent" "LS"]]
+        (is (some #{t} dt)
+            (str "expected " t " in disallowed-tools")))))
+
+  (testing "planner-disallowed-tools does NOT include Write"
+    ;; Write is the container-promotion submission path — .miniforge/plan.edn.
+    (is (nil? (some #{"Write"} @#'planner/planner-disallowed-tools))))
+
+  (testing "planner-disallowed-tools does NOT include the MCP context tools"
+    ;; Those are the replacement for the native tools. Disallowing them
+    ;; would leave the planner with no way to read files at all.
+    (doseq [t ["mcp__context__context_read"
+               "mcp__context__context_grep"
+               "mcp__context__context_glob"]]
+      (is (nil? (some #{t} @#'planner/planner-disallowed-tools))
+          (str "MCP context tool " t " must NOT be disallowed"))))
+
+  (testing "planner-disallowed-tools does NOT (yet) include WebSearch/WebFetch"
+    ;; Disabling these without a cached-MCP replacement regresses
+    ;; capability — see work/planner-convergence-and-artifact-submission
+    ;; GROUP 2B. They ship with the web-cache MCP base, not here.
+    (doseq [t ["WebSearch" "WebFetch"]]
+      (is (nil? (some #{t} @#'planner/planner-disallowed-tools))
+          (str t " should not be disallowed until GROUP 2B ships")))))
+
+(deftest planner-passes-disallowed-tools-to-llm-test
+  (testing ":disallowed-tools reaches the LLM client via mcp-opts"
+    (let [captured (atom nil)
+          fake-llm-client {:type :fake}
+          fake-plan {:plan/id (random-uuid)
+                     :plan/name "stub"
+                     :plan/tasks [{:task/id (random-uuid)
+                                   :task/description "t"
+                                   :task/type :implement
+                                   :task/acceptance-criteria ["ok"]
+                                   :task/estimated-effort :small}]}]
+      (with-redefs [llm/success? (constantly true)
+                    llm/get-content (constantly (str "```clojure\n"
+                                                     (pr-str fake-plan)
+                                                     "\n```"))
+                    llm/chat (fn [_client _prompt opts]
+                               (reset! captured opts)
+                               {:status :success})
+                    llm/chat-stream (fn [_client _prompt _on-chunk opts]
+                                      (reset! captured opts)
+                                      {:status :success})
+                    model/resolve-llm-client-for-role
+                    (fn [_role provided] provided)
+                    artifact-session/with-session
+                    (fn [_context body-fn]
+                      ;; Minimal session stub — just enough for body-fn to
+                      ;; produce mcp-opts and call the (redefd) llm fns.
+                      (let [result (body-fn {:dir "/tmp/fake-session"
+                                             :workdir "/tmp/fake-workdir"
+                                             :mcp-config-path "/tmp/fake-session/mcp-config.json"
+                                             :mcp-allowed-tools []
+                                             :supervision {}
+                                             :pre-session-snapshot {}})]
+                        {:llm-result result
+                         :artifact nil
+                         :worktree-artifacts {}
+                         :context-misses nil
+                         :pre-session-snapshot {}
+                         :session-mode :host}))]
+        (let [agent (planner/create-planner {:llm-backend fake-llm-client})]
+          (try
+            (core/invoke agent {:llm-backend fake-llm-client
+                                :title "t"
+                                :description "t"
+                                :intent "t"}
+                         "build a thing")
+            (catch Exception _))
+          (is (some? @captured) "LLM client should have been called")
+          (is (vector? (:disallowed-tools @captured)))
+          (is (= @#'planner/planner-disallowed-tools
+                 (:disallowed-tools @captured))
+              ":disallowed-tools opt must equal the planner's role-scoped list"))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment


### PR DESCRIPTION
## Summary

GROUP 2a of \`work/planner-convergence-and-artifact-submission.spec.edn\` (PR #587). Builds on #593 (container-promoted plan artifact).

- Planner role now passes \`:disallowed-tools ["Read" "Bash" "Grep" "Glob" "Agent" "LS"]\` to the LLM client.
- File exploration MUST go through the MCP context cache (\`context_read\` / \`context_grep\` / \`context_glob\`).
- Write stays allowed — that's the container-promotion submission path (\`.miniforge/plan.edn\`).

## Why

Iters 5 + 6 dogfood evidence:

| iter | workflow | tool calls | MCP calls | plan |
| --- | --- | --- | --- | --- |
| 5 | \`59b62101\` | 84 | 0 | 85 chars narration |
| 6 | \`f6b9390d\` | 58 | 1 | zero chars |

The planner had native tools available and used them exclusively, bypassing the context cache the explore phase pre-populates. Disallowing the natives forces the model to use the curated, pre-loaded file set.

Second-order benefit: cache misses land in the session \`:context-misses\` file, giving the context-quality theme signal about what the planner actually wanted that explore didn't provide.

## Why not WebSearch/WebFetch?

The spec groups them in the same disallow-list, but the spec constraint explicitly requires a cached-MCP replacement to ship in the same PR as the web-tool disable. That's GROUP 2B (cached \`web_fetch\` / \`web_search\` MCP) + GROUP 2c (disable the natives) — not this PR.

This PR is file-system tools only. Web tools stay available pending GROUP 2B.

## Test plan

- [x] Unit: \`planner-disallowed-tools-contents-test\` (14 assertions) — asserts the list shape + what's NOT in it (Write / context_* / web tools)
- [x] Integration: \`planner-passes-disallowed-tools-to-llm-test\` (3 assertions) — spies through \`llm/chat-stream\` + \`llm/chat\` to confirm \`:disallowed-tools\` reaches the LLM opts
- [x] Full pre-commit: 287 tests / 1222 assertions / 0 failures
- [x] GraalVM/Babashka: 5 tests / 347 assertions green
- [ ] Post-merge: dogfood iter 7 — expect zero native Read/Bash/Grep/Glob tool-call events + \`:plan-source :worktree\` on success

## Follow-up specs

- GROUP 2B + 2c — cached web-MCP + WebSearch/WebFetch disable
- GROUP 3 — stop_reason + final-message capture for diagnosis

🤖 Generated with [Claude Code](https://claude.com/claude-code)