### PR TITLE
refactor(response): success?/error? predicates + fix pre-existing implement test failures

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/approval.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/approval.clj
@@ -33,16 +33,16 @@
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Response predicates for builder responses
+;; Local aliases that delegate to response/success? and response/error?
+;; so call sites in this namespace stay terse.
 
-(defn succeeded?
+(def succeeded?
   "Check if a builder response (from response/success) succeeded."
-  [r]
-  (= :success (:status r)))
+  response/success?)
 
-(defn failed?
+(def failed?
   "Check if a builder response (from response/failure) failed."
-  [r]
-  (false? (:success r)))
+  response/error?)
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Approval request creation

--- a/components/loop/src/ai/miniforge/loop/outer.clj
+++ b/components/loop/src/ai/miniforge/loop/outer.clj
@@ -181,7 +181,7 @@
   "Check if a phase result indicates success (supports both :success? and :status patterns)."
   [result]
   (or (:success? result)
-      (= :success (:status result))))
+      (response/success? result)))
 
 ;; Logging helpers
 

--- a/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/implement.clj
@@ -292,7 +292,7 @@
         result (cond
                  ;; Curator found files — use its artifact, even if the
                  ;; implementer reported error. Merge implementer metrics through.
-                 (= :success (:status curator-result))
+                 (phase-result/succeeded? curator-result)
                  (-> impl-result
                      (assoc :status :success)
                      (assoc :output (:output curator-result))
@@ -305,7 +305,7 @@
                  ;; Implementer errored for a non-curator reason (rate-limit,
                  ;; exception, etc.). Propagate — the phase runner classifies
                  ;; those via rate-limited? / existing branches.
-                 (not= :success (:status impl-result))
+                 (not (phase-result/succeeded? impl-result))
                  impl-result
                  ;; Implementer reported success but curator still returned
                  ;; something non-success (shouldn't happen outside no-files;

--- a/components/phase-software-factory/src/ai/miniforge/phase/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase/release.clj
@@ -321,7 +321,7 @@
 
     (-> (phase-result/enter-context ctx :release :releaser gates budget start-time result)
         ;; Store PR info at top level for easy access
-        (cond-> (= :success (:status result))
+        (cond-> (phase-result/succeeded? result)
           (assoc-in [:workflow/pr-info] (get-in (:output result) [:workflow/pr-info]))))))))
 
 (defn leave-release
@@ -333,7 +333,7 @@
         end-time (System/currentTimeMillis)
         duration-ms (if start-time (- end-time start-time) 0)
         result (get-in ctx [:phase :result])
-        release-data (when (= :success (:status result)) (:output result))
+        release-data (when (phase-result/succeeded? result) (:output result))
         release-metrics (get release-data :release/metrics {})
         metrics (merge {:tokens 0 :duration-ms duration-ms} release-metrics)
         agent-status (:status result)

--- a/components/phase-software-factory/test/ai/miniforge/phase/artifact_persistence_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/artifact_persistence_test.clj
@@ -87,6 +87,21 @@
     (assoc-in updated-ctx [:execution/phase-results phase-name]
               (:phase updated-ctx))))
 
+(defn mock-curator-success
+  "Curator mock that returns success, mirroring the implementer's output/metrics.
+   Used when tests don't need the curator's no-files-written behavior."
+  [{:keys [implementer-result]}]
+  (response/success (:output implementer-result)
+                    {:metrics (:metrics implementer-result)}))
+
+(defn mock-curator-error
+  "Curator mock that returns the same error the implementer produced.
+   Used by tests verifying retry/budget logic on agent errors."
+  [{:keys [implementer-result]}]
+  (let [err (:error implementer-result)]
+    (response/error (or (:message err) "Mock curator error")
+                    {:data (or (:data err) {})})))
+
 ;------------------------------------------------------------------------------ Tests
 
 (deftest test-verify-fails-without-environment
@@ -133,7 +148,8 @@
                                          file (io/file worktree-path "src/feature.clj")]
                                      (io/make-parents file)
                                      (spit file "(ns feature)\n(defn new-feature [] :implemented)"))
-                                   (response/success nil {:tokens 1000 :duration-ms 2000}))]
+                                   (response/success nil {:tokens 1000 :duration-ms 2000}))
+                    agent/curate-implement-output mock-curator-success]
         (let [ctx (-> (create-base-context)
                       (assoc :execution/environment-id env-id))
               ctx-entered (execute-phase-enter :implement ctx)
@@ -158,7 +174,11 @@
     (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                   agent/invoke (fn [_ _ _]
                                  ;; Simulate agent returning error status
-                                 (response/error "LLM timeout" {:tokens 0 :duration-ms 5000}))]
+                                 (response/error "LLM timeout" {:tokens 0 :duration-ms 5000}))
+                  ;; Curator mirrors implementer's error WITHOUT the
+                  ;; :curator/no-files-written terminal code, so the retry
+                  ;; budget logic governs status — not the curator's verdict.
+                  agent/curate-implement-output mock-curator-error]
       (let [ctx (create-base-context)
             ctx-entered (execute-phase-enter :implement ctx)
             ctx-left (execute-phase-leave :implement ctx-entered)]
@@ -171,7 +191,8 @@
   (testing "leave-implement fails when agent returns :error and budget exhausted"
     (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                   agent/invoke (fn [_ _ _]
-                                 (response/error "LLM timeout" {:tokens 0 :duration-ms 5000}))]
+                                 (response/error "LLM timeout" {:tokens 0 :duration-ms 5000}))
+                  agent/curate-implement-output mock-curator-error]
       (let [ctx (-> (create-base-context)
                     (assoc-in [:phase :iterations] 8)) ;; At max budget (iterations=8)
             ctx-entered (execute-phase-enter :implement ctx)

--- a/components/phase-software-factory/test/ai/miniforge/phase/implement_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase/implement_test.clj
@@ -61,6 +61,24 @@
    :execution/phase-results {:plan {:result {:status :success
                                             :output mock-plan-result}}}})
 
+(defn mock-curator-success
+  "Mock for agent/curate-implement-output that returns success.
+
+   The real curator inspects the executor environment for written files;
+   tests that don't actually write files need to bypass that inspection."
+  [{:keys [implementer-result]}]
+  (response/success (:output implementer-result)
+                    {:metrics (:metrics implementer-result)}))
+
+(defn mock-curator-error
+  "Mock for agent/curate-implement-output that returns the same error
+   the implementer produced — used by tests verifying exception/error
+   propagation without coupling to the curator's no-files verdict."
+  [{:keys [implementer-result]}]
+  (let [err (:error implementer-result)]
+    (response/error (or (:message err) "Implementation failed")
+                    {:data (or (:data err) {})})))
+
 ;------------------------------------------------------------------------------ Layer 0: Defaults Tests
 
 (deftest default-config-test
@@ -99,7 +117,8 @@
   (testing "leave-implement stores environment-id in result, not serialized :code/files"
     (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                   agent/invoke (fn [_ _ _]
-                                (response/success nil {:tokens 800 :duration-ms 1500}))]
+                                (response/success nil {:tokens 800 :duration-ms 1500}))
+                  agent/curate-implement-output mock-curator-success]
       (let [env-id (random-uuid)
             ctx (-> (create-base-context)
                     (assoc :execution/environment-id env-id))
@@ -139,7 +158,8 @@
   (testing "implement phase treats nil agent output as success — code is in the environment"
     (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                   agent/invoke (fn [_ _ _]
-                                (response/success nil {:tokens 200 :duration-ms 500}))]
+                                (response/success nil {:tokens 200 :duration-ms 500}))
+                  agent/curate-implement-output mock-curator-success]
       (let [ctx (create-base-context)
             ctx-with-config (assoc ctx :phase-config {:phase :implement})
             interceptor (registry/get-phase-interceptor {:phase :implement})
@@ -156,19 +176,22 @@
     (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                   agent/invoke (fn [_ _ _]
                                 (throw (ex-info "Implementation failed"
-                                               {:reason :llm-timeout})))]
+                                               {:reason :llm-timeout})))
+                  agent/curate-implement-output mock-curator-error]
       (let [ctx (create-base-context)
             ctx-with-config (assoc ctx :phase-config {:phase :implement})
             interceptor (registry/get-phase-interceptor {:phase :implement})
             result ((:enter interceptor) ctx-with-config)]
         
+        ;; impl-result wins because curator's mock doesn't set :curator/no-files-written
+        ;; terminal code, so the cond falls through to (not (succeeded? impl-result)).
         (is (= false (get-in result [:phase :result :success]))
-            "Result should indicate failure")
-        
+            "Result should indicate failure (response/failure shape from caught exception)")
+
         (is (some? (get-in result [:phase :result :error]))
             "Error should be captured in result")
-        
-        (is (= "Implementation failed" 
+
+        (is (= "Implementation failed"
                (get-in result [:phase :result :error :message]))
             "Error message should be preserved")))))
 
@@ -179,7 +202,8 @@
     (with-redefs [agent/create-implementer (fn [_] {:type :mock-implementer})
                   agent/invoke (fn [_ _ _]
                                 (response/success mock-code-artifact
-                                                {:tokens 1500 :duration-ms 3000}))]
+                                                {:tokens 1500 :duration-ms 3000}))
+                  agent/curate-implement-output mock-curator-success]
       (let [ctx (create-base-context)
             ctx-with-config (assoc ctx :phase-config {:phase :implement})
             interceptor (registry/get-phase-interceptor {:phase :implement})

--- a/components/response/src/ai/miniforge/response/builder.clj
+++ b/components/response/src/ai/miniforge/response/builder.clj
@@ -54,6 +54,14 @@
        artifact (assoc :artifact artifact)
        (not artifact) (assoc :artifact output)))))
 
+(defn success?
+  "True for response maps produced by `success` (have :status :success).
+
+   Use this on single result maps. For response *chains* (have :succeeded? key),
+   use `succeeded?` instead."
+  [response]
+  (= :success (:status response)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Error responses
 
@@ -115,6 +123,21 @@
               :error (error-details message data)
               :metrics merged-metrics}
        output (assoc :output output)))))
+
+(defn error?
+  "True for response maps representing failure.
+
+   Matches:
+   - `:status :error`  (output of `error`)
+   - `:status :failed` (legacy/phase shape)
+   - `:success false`  (output of `failure`)
+
+   Use this on single result maps. For response *chains*, use `failed?`."
+  [response]
+  (let [status (:status response)]
+    (or (= :error status)
+        (= :failed status)
+        (false? (:success response)))))
 
 (defn failure
   "Create a canonical failure response (alias for error with :success false).

--- a/components/response/src/ai/miniforge/response/interface.clj
+++ b/components/response/src/ai/miniforge/response/interface.clj
@@ -392,6 +392,19 @@
      (success test-artifact {:tokens 100 :duration-ms 500})"
   builder/success)
 
+(def success?
+  "True for response maps produced by `success` (have :status :success).
+
+   Use on single result maps; for response chains, use `succeeded?`."
+  builder/success?)
+
+(def error?
+  "True for response maps produced by `error` or `failure`.
+
+   Matches :status :error, :status :failed, or :success false.
+   Use on single result maps; for response chains, use `failed?`."
+  builder/error?)
+
 (def error
   "Create a canonical error response.
 

--- a/components/response/test/ai/miniforge/response/interface_test.clj
+++ b/components/response/test/ai/miniforge/response/interface_test.clj
@@ -433,6 +433,42 @@
       (is (pos? (count (get-in resp [:error :message])))))))
 
 ;; ============================================================================
+;; Result map predicates (success?/error?)
+;; ============================================================================
+
+(deftest success?-test
+  (testing "true for builder success outputs"
+    (is (true? (r/success? (r/success {:foo 1}))))
+    (is (true? (r/success? (r/success {} {:tokens 10})))))
+
+  (testing "false for error/failure builder outputs"
+    (is (false? (r/success? (r/error "boom"))))
+    (is (false? (r/success? (r/failure "boom")))))
+
+  (testing "false for nil and arbitrary maps"
+    (is (false? (r/success? nil)))
+    (is (false? (r/success? {})))
+    (is (false? (r/success? {:status :pending})))))
+
+(deftest error?-test
+  (testing "true for error builder output (:status :error)"
+    (is (true? (r/error? (r/error "boom")))))
+
+  (testing "true for failure builder output (:success false)"
+    (is (true? (r/error? (r/failure "boom")))))
+
+  (testing "true for legacy :status :failed shape"
+    (is (true? (r/error? {:status :failed :error {:message "x"}}))))
+
+  (testing "false for success builder output"
+    (is (false? (r/error? (r/success {:foo 1})))))
+
+  (testing "false for nil and arbitrary maps"
+    (is (false? (r/error? nil)))
+    (is (false? (r/error? {})))
+    (is (false? (r/error? {:status :pending})))))
+
+;; ============================================================================
 ;; Boundary translator tests
 ;; ============================================================================
 

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -39,6 +39,12 @@
   [^Throwable e]
   ((requiring-resolve 'ai.miniforge.response.interface/from-exception) e))
 
+(defn response-success?
+  "Check if a response builder result represents success.
+   Wraps response/success? via requiring-resolve to keep the soft dep."
+  [response]
+  ((requiring-resolve 'ai.miniforge.response.interface/success?) response))
+
 (defn anomaly-http-response
   "Translate an anomaly map to a Ring HTTP response.
    Body is JSON-encoded for wire transport."
@@ -655,7 +661,7 @@
                                 (:signer data)
                                 (keyword (:decision data))
                                 {:reason (:reason data)})]
-          (if (= :success (:status result))
+          (if (response-success? result)
             (do
               (update-fn mgr (:output result))
               (responses/json-response


### PR DESCRIPTION
## Summary

Adds `success?`/`error?` predicates to the `response` component and refactors production call sites to use them instead of reaching into result-map internals with `(= :success (:status r))`. Along the way, fixes 13 pre-existing failures in the implement phase tests that were masked because the affected component wasn't in the change set.

Three commits, one per logical step (PR DAG over giant PRs):

1. **730e8b0b** `refactor(response): add success?/error? predicates, replace status reaching` — adds the predicates + refactors loop, event-stream/approval, web-dashboard handlers to use them.
2. **b2f67082** `test(phase): mock agent/curate-implement-output in implement tests` — fixes 13 pre-existing failures (9 in `implement-test`, 4 in `artifact-persistence-test`) caused by tests not mocking the curator added in the 2026-04-17 dogfood fix.
3. **326267b9** `refactor(phase): replace status reaching with phase-result/succeeded?` — completes the predicate rollout in `phase-software-factory` (was deferred from #1 until the test failures were fixed).

## Why

Three principles from the engineering standards:
- **Predicates over reaching** — `success?` instead of `(= :success (:status r))` reads as intent, not implementation.
- **Factory + predicate symmetry** — the `success` builder already existed; `success?` closes the loop.
- **Tests at the same standard** — pre-existing failures couldn't keep being shrugged off.

## Test plan

- [x] `bb pre-commit` passes on each commit (756/3353 → 824/3532, both 0 failures, 0 errors)
- [x] Lint clean on all touched files (the `redefined var retryable?` warning in `response.interface.clj` is pre-existing)
- [x] Production call sites covered: `loop/outer.clj`, `event-stream/approval.clj`, `web-dashboard/server/handlers.clj`, `phase/release.clj` (×2), `phase/implement.clj` (×2)
- [x] New tests in `response.interface-test`: `success?-test`, `error?-test`

## Out of scope

- ~40 test sites still using `(= :success (:status …))` — separate PR. Not refactored here because each test should own its assertion shape decisions.
- `release-executor/metadata.clj` — would require adding a new component dependency on `response`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)