### PR TITLE
refactor(connector): extract retry-policy presets to EDN

### DIFF
--- a/components/connector-file/src/ai/miniforge/data_foundry/connector_file/interface.clj
+++ b/components/connector-file/src/ai/miniforge/data_foundry/connector_file/interface.clj
@@ -1,6 +1,7 @@
 (ns ai.miniforge.data-foundry.connector-file.interface
   "Public API for the file connector component."
-  (:require [ai.miniforge.data-foundry.connector-file.core :as core]))
+  (:require [ai.miniforge.data-foundry.connector-file.core :as core]
+            [ai.miniforge.data-foundry.connector.interface :as conn]))
 
 (defn create-file-connector
   "Create a new FileConnector instance."
@@ -14,5 +15,5 @@
    :connector/version      "0.1.0"
    :connector/capabilities #{:cap/batch}
    :connector/auth-methods #{:none}
-   :connector/retry-policy {:retry/strategy :none :retry/max-attempts 1}
+   :connector/retry-policy (conn/retry-policy :none)
    :connector/maintainer   "data-foundry"})

--- a/components/connector-github/src/ai/miniforge/data_foundry/connector_github/interface.clj
+++ b/components/connector-github/src/ai/miniforge/data_foundry/connector_github/interface.clj
@@ -1,6 +1,7 @@
 (ns ai.miniforge.data-foundry.connector-github.interface
   "Public API for the GitHub REST API connector component."
-  (:require [ai.miniforge.data-foundry.connector-github.core :as core]))
+  (:require [ai.miniforge.data-foundry.connector-github.core :as core]
+            [ai.miniforge.data-foundry.connector.interface :as conn]))
 
 (defn create-github-connector
   "Create a new GitHubConnector instance."
@@ -14,7 +15,5 @@
    :connector/version      "0.1.0"
    :connector/capabilities #{:cap/discovery :cap/incremental :cap/pagination :cap/rate-limiting}
    :connector/auth-methods #{:api-key :oauth2}
-   :connector/retry-policy {:retry/strategy       :exponential-backoff
-                            :retry/max-attempts   3
-                            :retry/base-delay-ms  1000}
+   :connector/retry-policy (conn/retry-policy :default)
    :connector/maintainer   "data-foundry"})

--- a/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/interface.clj
+++ b/components/connector-gitlab/src/ai/miniforge/data_foundry/connector_gitlab/interface.clj
@@ -1,7 +1,8 @@
 (ns ai.miniforge.data-foundry.connector-gitlab.interface
   "Public API for the GitLab REST API connector component."
   (:require [ai.miniforge.data-foundry.connector-gitlab.core :as core]
-            [ai.miniforge.data-foundry.connector-gitlab.schema :as schema]))
+            [ai.miniforge.data-foundry.connector-gitlab.schema :as schema]
+            [ai.miniforge.data-foundry.connector.interface :as conn]))
 
 ;;------------------------------------------------------------------------------ Layer 0
 ;; Schemas (exported for consumers)
@@ -25,9 +26,7 @@
    :connector/version      "0.1.0"
    :connector/capabilities #{:cap/discovery :cap/incremental :cap/pagination :cap/rate-limiting}
    :connector/auth-methods #{:api-key :oauth2}
-   :connector/retry-policy {:retry/strategy       :exponential-backoff
-                            :retry/max-attempts   3
-                            :retry/base-delay-ms  1000}
+   :connector/retry-policy (conn/retry-policy :default)
    :connector/maintainer   "data-foundry"})
 
 (comment

--- a/components/connector-http/deps.edn
+++ b/components/connector-http/deps.edn
@@ -2,6 +2,7 @@
  :deps {ai.miniforge.data-foundry/connector      {:local/root "../connector"}
         ai.miniforge.data-foundry/connector-auth  {:local/root "../connector-auth"}
         ai.miniforge.data-foundry/connector-retry {:local/root "../connector-retry"}
+        cheshire/cheshire               {:mvn/version "5.13.0"}
         hato/hato                       {:mvn/version "1.0.0"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/impl.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/impl.clj
@@ -6,8 +6,8 @@
             [ai.miniforge.data-foundry.connector-http.pagination :as page]
             [ai.miniforge.data-foundry.connector-http.messages :as msg]
             [ai.miniforge.schema.interface :as schema]
-            [hato.client :as hc]
-            [clojure.data.json :as json])
+            [cheshire.core :as json]
+            [hato.client :as hc])
   (:import [java.util UUID]))
 
 ;; -- Handle state --
@@ -53,7 +53,7 @@
         status (:status resp)]
     (cond
       (<= 200 status 299)
-      (schema/success :body (json/read-str (:body resp) :key-fn keyword))
+      (schema/success :body (json/parse-string (:body resp) keyword))
 
       (= 429 status)
       (schema/failure :body (msg/t :http/rate-limited)

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/interface.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/interface.clj
@@ -1,6 +1,7 @@
 (ns ai.miniforge.data-foundry.connector-http.interface
   "Public API for the HTTP connector component."
-  (:require [ai.miniforge.data-foundry.connector-http.core :as core]))
+  (:require [ai.miniforge.data-foundry.connector-http.core :as core]
+            [ai.miniforge.data-foundry.connector.interface :as conn]))
 
 (defn create-http-connector
   "Create a new HttpConnector instance."
@@ -14,7 +15,5 @@
    :connector/version      "0.1.0"
    :connector/capabilities #{:cap/discovery :cap/incremental :cap/pagination :cap/rate-limiting}
    :connector/auth-methods #{:api-key :basic :none}
-   :connector/retry-policy {:retry/strategy :exponential-backoff
-                            :retry/max-attempts 3
-                            :retry/base-delay-ms 1000}
+   :connector/retry-policy (conn/retry-policy :default)
    :connector/maintainer   "data-foundry"})

--- a/components/connector-http/src/ai/miniforge/data_foundry/connector_http/request.clj
+++ b/components/connector-http/src/ai/miniforge/data_foundry/connector_http/request.clj
@@ -10,7 +10,7 @@
   (:require [ai.miniforge.data-foundry.connector-http.etag :as etag]
             [ai.miniforge.data-foundry.connector-http.pagination :as page]
             [ai.miniforge.schema.interface :as schema]
-            [clojure.data.json :as json]
+            [cheshire.core :as json]
             [hato.client :as hc]))
 
 ;;------------------------------------------------------------------------------ Layer 0
@@ -36,7 +36,7 @@
   "Build a schema/success from a 2xx response. Caches the ETag for the URL."
   [url resp]
   (etag/store-etag! url (etag/extract-etag (:headers resp)))
-  (schema/success :body (json/read-str (:body resp) :key-fn keyword)
+  (schema/success :body (json/parse-string (:body resp) keyword)
                   {:headers (:headers resp)}))
 
 (defn not-modified-response

--- a/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/interface.clj
+++ b/components/connector-jira/src/ai/miniforge/data_foundry/connector_jira/interface.clj
@@ -1,7 +1,8 @@
 (ns ai.miniforge.data-foundry.connector-jira.interface
   "Public API for the Jira Cloud REST API connector component."
   (:require [ai.miniforge.data-foundry.connector-jira.core :as core]
-            [ai.miniforge.data-foundry.connector-jira.schema :as schema]))
+            [ai.miniforge.data-foundry.connector-jira.schema :as schema]
+            [ai.miniforge.data-foundry.connector.interface :as conn]))
 
 ;;------------------------------------------------------------------------------ Layer 0
 ;; Schemas (exported for consumers)
@@ -25,7 +26,5 @@
    :connector/version      "0.1.0"
    :connector/capabilities #{:cap/discovery :cap/incremental :cap/pagination}
    :connector/auth-methods #{:basic}
-   :connector/retry-policy {:retry/strategy       :exponential-backoff
-                            :retry/max-attempts   3
-                            :retry/base-delay-ms  1000}
+   :connector/retry-policy (conn/retry-policy :default)
    :connector/maintainer   "data-foundry"})

--- a/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/interface.clj
+++ b/components/connector-pipeline-output/src/ai/miniforge/data_foundry/connector_pipeline_output/interface.clj
@@ -6,7 +6,8 @@
    Exposes Malli and JSON Schema definitions for the output contract so
    consumers can validate manifests and configure pipelines correctly."
   (:require [ai.miniforge.data-foundry.connector-pipeline-output.core :as core]
-            [ai.miniforge.data-foundry.connector-pipeline-output.schema :as schema]))
+            [ai.miniforge.data-foundry.connector-pipeline-output.schema :as schema]
+            [ai.miniforge.data-foundry.connector.interface :as conn]))
 
 (defn create-pipeline-output-connector
   "Create a new PipelineOutputConnector instance."
@@ -20,7 +21,7 @@
    :connector/version      "0.1.0"
    :connector/capabilities #{:cap/batch}
    :connector/auth-methods #{:none}
-   :connector/retry-policy {:retry/strategy :none :retry/max-attempts 1}
+   :connector/retry-policy (conn/retry-policy :none)
    :connector/maintainer   "data-foundry"})
 
 ;; -- Public Contract Schemas (Malli) --

--- a/components/connector/resources/config/connector/retry-policies.edn
+++ b/components/connector/resources/config/connector/retry-policies.edn
@@ -1,0 +1,14 @@
+;; Connector retry policy presets.
+;;
+;; Connector registrations reference these by key
+;; (see connector/retry-policy in the interface).
+;;
+;; Adding a preset here is preferred over inlining a one-off policy in a
+;; connector's metadata — keeps policies discoverable and consistent.
+
+{:default {:retry/strategy      :exponential-backoff
+           :retry/max-attempts  3
+           :retry/base-delay-ms 1000}
+
+ :none    {:retry/strategy     :none
+           :retry/max-attempts 1}}

--- a/components/connector/src/ai/miniforge/data_foundry/connector/interface.clj
+++ b/components/connector/src/ai/miniforge/data_foundry/connector/interface.clj
@@ -1,9 +1,10 @@
 (ns ai.miniforge.data-foundry.connector.interface
   (:require [ai.miniforge.data-foundry.connector.core :as core]
-            [ai.miniforge.data-foundry.connector.state :as state]
             [ai.miniforge.data-foundry.connector.cursor :as cursor]
             [ai.miniforge.data-foundry.connector.protocol :as protocol]
-            [ai.miniforge.data-foundry.connector.result :as result]))
+            [ai.miniforge.data-foundry.connector.result :as result]
+            [ai.miniforge.data-foundry.connector.retry :as retry]
+            [ai.miniforge.data-foundry.connector.state :as state]))
 
 ;; -- Connector Protocol --
 (def Connector protocol/Connector)
@@ -44,6 +45,17 @@
 ;; -- Connector Types --
 (def connector-types core/connector-types)
 (def connector-capabilities core/connector-capabilities)
+
+;; -- Retry Policy Presets --
+(def retry-policies
+  "Map of preset-key → retry-policy-map (loaded from EDN)."
+  retry/retry-policies)
+
+(defn retry-policy
+  "Return the retry policy preset for `policy-key` (e.g. `:default`, `:none`).
+   Throws when the key is unknown."
+  [policy-key]
+  (retry/retry-policy policy-key))
 
 ;; -- Registration --
 (defn create-connector

--- a/components/connector/src/ai/miniforge/data_foundry/connector/retry.clj
+++ b/components/connector/src/ai/miniforge/data_foundry/connector/retry.clj
@@ -1,0 +1,30 @@
+(ns ai.miniforge.data-foundry.connector.retry
+  "Connector retry policy presets.
+
+   Loads named retry policies from
+   resources/config/connector/retry-policies.edn so individual connector
+   registrations can reference a preset (`:default`, `:none`, ...) instead
+   of inlining the same map in every interface.clj."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+(def ^:private retry-policies-resource
+  "config/connector/retry-policies.edn")
+
+(def retry-policies
+  "Map of preset-key → retry-policy-map, loaded from EDN at namespace load."
+  (-> retry-policies-resource
+      io/resource
+      slurp
+      edn/read-string))
+
+(defn retry-policy
+  "Return the retry policy preset for `policy-key`.
+
+   Throws ex-info when the key is unknown so misconfiguration is caught at
+   namespace load time, not on the first request."
+  [policy-key]
+  (or (get retry-policies policy-key)
+      (throw (ex-info "Unknown connector retry policy preset"
+                      {:policy-key policy-key
+                       :known-keys (set (keys retry-policies))}))))

--- a/components/connector/test/ai/miniforge/data_foundry/connector/interface_test.clj
+++ b/components/connector/test/ai/miniforge/data_foundry/connector/interface_test.clj
@@ -18,6 +18,50 @@
     (is (contains? conn/connector-capabilities :cap/pagination))))
 
 ;; ---------------------------------------------------------------------------
+;; retry-policy presets
+;; ---------------------------------------------------------------------------
+
+(deftest retry-policy-default-test
+  (testing ":default preset is exponential-backoff with 3 attempts"
+    (let [policy (conn/retry-policy :default)]
+      (is (= :exponential-backoff (:retry/strategy policy)))
+      (is (= 3 (:retry/max-attempts policy)))
+      (is (pos? (:retry/base-delay-ms policy))))))
+
+(deftest retry-policy-none-test
+  (testing ":none preset disables retries"
+    (let [policy (conn/retry-policy :none)]
+      (is (= :none (:retry/strategy policy)))
+      (is (= 1 (:retry/max-attempts policy))))))
+
+(deftest retry-policy-unknown-test
+  (testing "unknown preset throws ex-info with known-keys context"
+    (try
+      (conn/retry-policy :nope)
+      (is false "Should have thrown")
+      (catch clojure.lang.ExceptionInfo e
+        (let [data (ex-data e)]
+          (is (= :nope (:policy-key data)))
+          (is (contains? (:known-keys data) :default))
+          (is (contains? (:known-keys data) :none)))))))
+
+(deftest retry-policy-presets-pass-validation-test
+  (testing "Each preset, when used in a connector registration, validates clean"
+    (let [base {:connector/id (java.util.UUID/randomUUID)
+                :connector/name "Preset Test"
+                :connector/type :source
+                :connector/version "1.0.0"
+                :connector/capabilities #{:cap/batch}
+                :connector/auth-methods #{:none}
+                :connector/maintainer "test-team"}]
+      (doseq [preset-key (keys conn/retry-policies)]
+        (let [connector (assoc base
+                               :connector/retry-policy (conn/retry-policy preset-key))
+              result (conn/validate-connector connector)]
+          (is (:success? result)
+              (str "preset " preset-key " should validate")))))))
+
+;; ---------------------------------------------------------------------------
 ;; validate-connector
 ;; ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Six connector interfaces (http, gitlab, jira, github, pipeline-output, file) inlined the same retry-policy maps. Two commits, distinct concerns:

1. **035aa252** `fix(connector-http): swap clojure.data.json for cheshire` — pre-existing latent bug surfaced by my refactor: connector-http's source required `clojure.data.json` (not in `deps.edn`, also forbidden by the GraalVM-compat check). Two `read-str` → `parse-string` swaps + dep add.
2. **5ccb4ec3** `refactor(connector): extract retry-policy presets to EDN, replace duplicates` — moves the duplicated maps into `resources/config/connector/retry-policies.edn`, exposes `connector/retry-policy` lookup, replaces the inline maps with `(conn/retry-policy :default)` / `(:none)`.

## Why

- **Configuration is data, pull it to `.edn`** — direct application of the standards principle.
- **DRY / factory over duplicate maps** — single source of truth for retry policy; tweaks land in one file.
- **Intent over shape** — `(conn/retry-policy :default)` reads as intent; the inlined map didn't.

## Test plan

- [x] `bb pre-commit` passes on each commit (lint + 830/3557 tests + GraalVM compat — 0 failures)
- [x] New tests in `connector.interface-test`: `retry-policy-default-test`, `retry-policy-none-test`, `retry-policy-unknown-test`, `retry-policy-presets-pass-validation-test`
- [x] `clj-kondo` clean on every changed file

## Out of scope

- `connector-sarif` also has the inline map but its `deps.edn` key is stale (`ai.miniforge/connector` vs the real `ai.miniforge.data-foundry/connector`) — touching it crosses the scope of this PR. Follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)