### PR TITLE
feat(llm): capture stop_reason + num_turns from Claude stream-json

### DIFF
--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -435,23 +435,31 @@
                   ;; don't block the migration window.
                   worktree-plan (get worktree-artifacts :plan)]
               (log/info logger :planner :planner/llm-called
-                        {:data {:success (llm/success? llm-response)
-                                :tokens tokens
-                                :streaming? (boolean on-chunk)
-                                :plan-source (cond worktree-plan :worktree
-                                                   artifact      :mcp-artifact
-                                                   :else         :final-message)}})
+                        {:data (cond-> {:success (llm/success? llm-response)
+                                        :tokens tokens
+                                        :streaming? (boolean on-chunk)
+                                        :plan-source (cond worktree-plan :worktree
+                                                           artifact      :mcp-artifact
+                                                           :else         :final-message)}
+                                 (:stop-reason llm-response)
+                                 (assoc :stop-reason (:stop-reason llm-response))
+                                 (:num-turns llm-response)
+                                 (assoc :num-turns (:num-turns llm-response)))})
               (if (llm/success? llm-response)
                 (let [content (llm/get-content llm-response)
+                      stop-reason (:stop-reason llm-response)
+                      num-turns   (:num-turns llm-response)
                       plan (or worktree-plan
                                artifact
                                (parse-plan-response content)
                                (response/throw-anomaly! :anomalies.agent/invoke-failed
                                                        "Plan generation failed: EDN parse did not succeed"
-                                                       {:phase :plan
-                                                        :parse-result nil
-                                                        :llm-content-length (count content)
-                                                        :llm-content-preview (subs content 0 (min 500 (count content)))}))
+                                                       (cond-> {:phase :plan
+                                                                :parse-result nil
+                                                                :llm-content-length (count content)
+                                                                :llm-content-preview (subs content 0 (min 500 (count content)))}
+                                                         stop-reason (assoc :stop-reason stop-reason)
+                                                         num-turns   (assoc :num-turns num-turns))))
                       plan-final (finalize-plan plan)]
                   ;; Check for already-satisfied response
                   (if (= :already-satisfied (:plan/status plan-final))
@@ -474,9 +482,11 @@
                                                (:reason validation))))))
                     (response/success plan-final
                                       {:tokens tokens
-                                       :metrics {:tasks-created (count (:plan/tasks plan-final))
-                                                 :complexity (:plan/estimated-complexity plan-final)
-                                                 :tokens tokens}})))
+                                       :metrics (cond-> {:tasks-created (count (:plan/tasks plan-final))
+                                                         :complexity (:plan/estimated-complexity plan-final)
+                                                         :tokens tokens}
+                                                  stop-reason (assoc :stop-reason stop-reason)
+                                                  num-turns   (assoc :num-turns num-turns))})))
                 ;; LLM call failed — no silent fallback
                 (let [error-msg (or (:message (llm/get-error llm-response))
                                     "LLM call failed")]

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -101,11 +101,27 @@
                                    (when (= "tool_use" (:type block))
                                      (:name block)))
                                  content-blocks)
-                text (str/join text-blocks)]
-            (if (seq tool-names)
-              {:delta (or text "") :done? false :tool-use true :tool-names tool-names}
-              (when-not (str/blank? text)
-                {:delta text :done? false})))
+                text (str/join text-blocks)
+                ;; Claude surfaces stop_reason on each assistant message.
+                ;; Values: "end_turn" | "max_tokens" | "stop_sequence" |
+                ;; "tool_use" | "max_turns" (Claude Code adds the last).
+                ;; The accumulator tracks the LATEST — that's the reason
+                ;; the overall turn ended.
+                stop-reason (get-in data [:message :stop_reason])]
+            (cond
+              (seq tool-names)
+              (cond-> {:delta (or text "") :done? false
+                       :tool-use true :tool-names tool-names}
+                stop-reason (assoc :stop-reason stop-reason))
+
+              (not (str/blank? text))
+              (cond-> {:delta text :done? false}
+                stop-reason (assoc :stop-reason stop-reason))
+
+              ;; No text + no tool calls — still carry stop-reason if
+              ;; present so "empty turn" shows a reason.
+              stop-reason
+              {:delta "" :done? false :stop-reason stop-reason}))
 
           ;; Legacy format support
           "stream_event"
@@ -118,7 +134,12 @@
                      :usage {:input-tokens (:input_tokens usage)
                              :output-tokens (:output_tokens usage)}
                      :cost-usd (:total_cost_usd data)}
-              (:session_id data) (assoc :session-id (:session_id data))))
+              (:session_id data) (assoc :session-id (:session_id data))
+              (:num_turns data)  (assoc :num-turns (:num_turns data))
+              ;; Claude Code surfaces a top-level stop_reason on the
+              ;; final result event too — prefer it over the per-message
+              ;; stop_reason when both are present.
+              (:stop_reason data) (assoc :stop-reason (:stop_reason data))))
 
           ;; Tool use events — capture tool name for diagnostics
           "tool_use"
@@ -591,7 +612,7 @@
                  :content (:content result)}))
     result))
 
-(defn stream-with-parser [stream-parser on-chunk accumulated-content accumulated-usage accumulated-cost accumulated-tools accumulated-session-id]
+(defn stream-with-parser [stream-parser on-chunk accumulated-content accumulated-usage accumulated-cost accumulated-tools accumulated-session-id accumulated-stop-reason accumulated-turns]
   (fn [line]
     (when-let [parsed (stream-parser line)]
       (when-let [usage (:usage parsed)]
@@ -600,6 +621,10 @@
         (reset! accumulated-cost cost))
       (when-let [session-id (:session-id parsed)]
         (reset! accumulated-session-id session-id))
+      (when-let [sr (:stop-reason parsed)]
+        (reset! accumulated-stop-reason sr))
+      (when-let [nt (:num-turns parsed)]
+        (reset! accumulated-turns nt))
       (if (or (:tool-use parsed) (:heartbeat parsed))
         ;; Tool-use and heartbeat events: track tool names and fire on-chunk
         (do
@@ -624,22 +649,27 @@
       (log/debug logger :system :agent/streaming-complete
                  {:data {:response-length content-length}}))))
 
-(defn streaming-success-response [content exit-code usage cost-usd]
+(defn streaming-success-response [content exit-code usage cost-usd stop-reason num-turns]
   (if (rate-limited? content)
     (llm-error :anomalies.agent/rate-limited "rate_limit"
                (str "Claude CLI rate limited: " (str/trim content))
-               {:exit-code exit-code :stdout content})
+               {:exit-code exit-code :stdout content
+                :stop-reason stop-reason :num-turns num-turns})
     (cond-> (llm-success content {:exit-code exit-code :usage usage})
-      cost-usd (assoc :cost-usd cost-usd))))
+      cost-usd    (assoc :cost-usd cost-usd)
+      stop-reason (assoc :stop-reason stop-reason)
+      num-turns   (assoc :num-turns num-turns))))
 
-(defn streaming-error-response [content exit-code err-result timeout-info]
+(defn streaming-error-response [content exit-code err-result timeout-info stop-reason num-turns]
   (let [error-message (or err-result
                           (when (str/blank? content) "Process failed with no output")
                           "Process failed")
         category (if timeout-info :anomalies/timeout :anomalies.agent/llm-error)
         error-type (if timeout-info "adaptive_timeout" "cli_error")]
     (llm-error category error-type (str/trim error-message)
-               {:exit-code exit-code :stderr err-result :stdout content :timeout timeout-info})))
+               (cond-> {:exit-code exit-code :stderr err-result :stdout content :timeout timeout-info}
+                 stop-reason (assoc :stop-reason stop-reason)
+                 num-turns   (assoc :num-turns num-turns)))))
 
 (defn handle-streaming [client request on-chunk backend-config progress-monitor]
   (let [{:keys [logger config]} client
@@ -654,21 +684,29 @@
         accumulated-usage (atom nil)
         accumulated-cost (atom nil)
         accumulated-tools (atom [])
-        accumulated-session-id (atom nil)]
+        accumulated-session-id (atom nil)
+        accumulated-stop-reason (atom nil)
+        accumulated-turns (atom nil)]
     (when logger
       (log/debug logger :system :agent/streaming-prompt-sent
                  {:data {:backend backend
                          :prompt-length (count prompt)}}))
     (let [result (stream-fn
                   full-cmd
-                  (stream-with-parser stream-parser on-chunk accumulated-content accumulated-usage accumulated-cost accumulated-tools accumulated-session-id)
+                  (stream-with-parser stream-parser on-chunk
+                                      accumulated-content accumulated-usage
+                                      accumulated-cost accumulated-tools
+                                      accumulated-session-id
+                                      accumulated-stop-reason accumulated-turns)
                   {:progress-monitor progress-monitor
                    :workdir (:workdir request)})
           exit-code (:exit result)
           timeout-info (:timeout result)
           final-content @accumulated-content
           tools @accumulated-tools
-          session-id @accumulated-session-id]
+          session-id @accumulated-session-id
+          stop-reason @accumulated-stop-reason
+          num-turns @accumulated-turns]
       (on-chunk {:delta ""
                  :done? true
                  :content final-content
@@ -677,11 +715,18 @@
       (when (and logger (seq tools))
         (log/info logger :system :agent/tools-called
                   {:data {:tools tools :count (count tools)}}))
+      (when (and logger stop-reason)
+        (log/info logger :system :agent/stop-reason
+                  {:data {:stop-reason stop-reason :num-turns num-turns
+                          :content-length (count final-content)}}))
       (if (zero? exit-code)
-        (cond-> (streaming-success-response final-content exit-code @accumulated-usage @accumulated-cost)
+        (cond-> (streaming-success-response final-content exit-code
+                                            @accumulated-usage @accumulated-cost
+                                            stop-reason num-turns)
           (seq tools) (assoc :tools-called tools)
           session-id   (assoc :session-id session-id))
-        (cond-> (streaming-error-response final-content exit-code (:err result) timeout-info)
+        (cond-> (streaming-error-response final-content exit-code (:err result)
+                                          timeout-info stop-reason num-turns)
           session-id (assoc :session-id session-id))))))
 
 (defn complete-stream-impl [client request on-chunk]

--- a/components/llm/test/ai/miniforge/llm/interface_test.clj
+++ b/components/llm/test/ai/miniforge/llm/interface_test.clj
@@ -157,7 +157,53 @@
     (let [line (json/generate-string {:type "result" :result {}})
           parsed (impl/parse-claude-stream-line line)]
       (is (true? (:done? parsed)))
-      (is (nil? (get-in parsed [:usage :input-tokens]))))))
+      (is (nil? (get-in parsed [:usage :input-tokens])))))
+
+  (testing "result event captures num_turns and top-level stop_reason"
+    (let [line (json/generate-string
+                 {:type "result"
+                  :num_turns 42
+                  :stop_reason "max_turns"
+                  :result {:usage {:input_tokens 1 :output_tokens 2}}})
+          parsed (impl/parse-claude-stream-line line)]
+      (is (= 42 (:num-turns parsed)))
+      (is (= "max_turns" (:stop-reason parsed))))))
+
+(deftest parse-claude-stream-assistant-stop-reason-test
+  (testing "assistant message with text carries stop_reason"
+    (let [line (json/generate-string
+                 {:type "assistant"
+                  :message {:content [{:type "text" :text "hello"}]
+                            :stop_reason "end_turn"}})
+          parsed (impl/parse-claude-stream-line line)]
+      (is (= "hello" (:delta parsed)))
+      (is (= "end_turn" (:stop-reason parsed)))))
+
+  (testing "assistant message with tool_use carries stop_reason"
+    (let [line (json/generate-string
+                 {:type "assistant"
+                  :message {:content [{:type "tool_use" :name "Read"}]
+                            :stop_reason "tool_use"}})
+          parsed (impl/parse-claude-stream-line line)]
+      (is (true? (:tool-use parsed)))
+      (is (= ["Read"] (:tool-names parsed)))
+      (is (= "tool_use" (:stop-reason parsed)))))
+
+  (testing "assistant message with empty text + no tools + stop_reason still surfaces"
+    (let [line (json/generate-string
+                 {:type "assistant"
+                  :message {:content [] :stop_reason "max_tokens"}})
+          parsed (impl/parse-claude-stream-line line)]
+      (is (= "" (:delta parsed)))
+      (is (= "max_tokens" (:stop-reason parsed)))))
+
+  (testing "assistant message without stop_reason has no :stop-reason key"
+    (let [line (json/generate-string
+                 {:type "assistant"
+                  :message {:content [{:type "text" :text "partial"}]}})
+          parsed (impl/parse-claude-stream-line line)]
+      (is (= "partial" (:delta parsed)))
+      (is (nil? (:stop-reason parsed))))))
 
 (deftest parse-codex-stream-line-test
   (testing "agent_message item extracts text delta"
@@ -246,6 +292,8 @@
           chunks (atom [])
           tools (atom [])
           session-id (atom nil)
+          stop-reason (atom nil)
+          turns (atom nil)
           handler (impl/stream-with-parser
                     #'impl/parse-claude-stream-line
                     (fn [chunk] (swap! chunks conj chunk))
@@ -253,7 +301,9 @@
                     usage
                     cost
                     tools
-                    session-id)]
+                    session-id
+                    stop-reason
+                    turns)]
       ;; Feed an assistant event
       (handler (json/generate-string
                  {:type "assistant"
@@ -268,6 +318,41 @@
                   :total_cost_usd 0.0045}))
       (is (= {:input-tokens 100 :output-tokens 50} @usage))
       (is (= 0.0045 @cost)))))
+
+(deftest stream-parser-accumulates-stop-reason-and-turns-test
+  (testing "latest stop_reason wins, num_turns captured from result event"
+    (let [content (atom "")
+          usage (atom nil)
+          cost (atom nil)
+          chunks (atom [])
+          tools (atom [])
+          session-id (atom nil)
+          stop-reason (atom nil)
+          turns (atom nil)
+          handler (impl/stream-with-parser
+                    #'impl/parse-claude-stream-line
+                    (fn [chunk] (swap! chunks conj chunk))
+                    content usage cost tools session-id stop-reason turns)]
+      ;; First assistant message with tool_use (not the final stop)
+      (handler (json/generate-string
+                 {:type "assistant"
+                  :message {:content [{:type "tool_use" :name "Grep"}]
+                            :stop_reason "tool_use"}}))
+      (is (= "tool_use" @stop-reason))
+      ;; Final assistant message — end_turn should overwrite tool_use
+      (handler (json/generate-string
+                 {:type "assistant"
+                  :message {:content [{:type "text" :text "done"}]
+                            :stop_reason "end_turn"}}))
+      (is (= "end_turn" @stop-reason))
+      ;; Result event — top-level stop_reason + num_turns take precedence
+      (handler (json/generate-string
+                 {:type "result"
+                  :num_turns 7
+                  :stop_reason "end_turn"
+                  :usage {:input_tokens 100 :output_tokens 50}}))
+      (is (= "end_turn" @stop-reason))
+      (is (= 7 @turns)))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Rate limit detection tests
@@ -300,13 +385,20 @@
 (deftest rate-limited-streaming-success-response-test
   (testing "rate limit content in streaming-success-response returns error"
     (let [resp (impl/streaming-success-response
-                 "You've hit your limit · resets 7pm (America/Los_Angeles)" 0 nil nil)]
+                 "You've hit your limit · resets 7pm (America/Los_Angeles)" 0 nil nil nil nil)]
       (is (not (:success resp)))
       (is (some? (:error resp)))))
 
   (testing "normal content in streaming-success-response returns success"
-    (let [resp (impl/streaming-success-response "(defn foo [] 42)" 0 nil nil)]
-      (is (:success resp)))))
+    (let [resp (impl/streaming-success-response "(defn foo [] 42)" 0 nil nil nil nil)]
+      (is (:success resp))))
+
+  (testing "stop-reason and num-turns flow through to success response"
+    (let [resp (impl/streaming-success-response "ok" 0 {:input-tokens 1 :output-tokens 2}
+                                                 nil "max_turns" 80)]
+      (is (:success resp))
+      (is (= "max_turns" (:stop-reason resp)))
+      (is (= 80 (:num-turns resp))))))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Claude backend args-fn budget tests (PR #288)


### PR DESCRIPTION
## Summary

GROUP 3 of \`work/planner-convergence-and-artifact-submission.spec.edn\` (PR #587). Claude backend only — codex parity follow-up.

- Capture \`stop_reason\` from each assistant message and from the terminal \`result\` event.
- Capture \`num_turns\` from the terminal result event.
- Flow both through the existing response/metrics plumbing. Surfaced in planner log events, \`:phase/metrics\` on success, and \`:phase/error :data\` on failure — which \`mf events show <wf-id>\` already renders.

## Why

Iters 5–7 post-mortems all had to guess at termination cause:

| iter | content | the unknown we had to guess |
| --- | --- | --- |
| 5 | 85 chars | end_turn? max_turns? stop_sequence? |
| 6 | zero chars | empty turn, or refused turn, or max_tokens-at-zero? |
| 7 | 420 chars across 3 narration blocks | did it voluntarily stop or hit the cap? |

Claude Code's stream-json has \`stop_reason\` on every assistant message and \`num_turns\` on the result event. We were dropping both. This PR captures them.

The next failure has a named cause in \`:phase/error :data\` and in the \`mf events show\` output. Diagnostic moves from forensic log-diving to a grep.

## Flow

\`\`\`
stream parser      (parse-claude-stream-line extracts stop_reason + num_turns)
    ↓
accumulator atoms  (stream-with-parser tracks latest stop_reason, first num_turns)
    ↓
handle-streaming   (reads atoms after stream-fn exits)
    ↓
streaming-{success,error}-response   (attaches :stop-reason + :num-turns to response)
    ↓
planner invoke     (logs :planner/llm-called with :stop-reason/:num-turns;
                    attaches to :metrics on success; to :anomaly :data on failure)
\`\`\`

## What this does NOT do

- **No codex parity.** Codex's \`turn.completed\` has a finish_reason field we also drop. Claude-only here to keep the change focused.
- **No dedicated \`:agent/stop-reason\` event.** Rides on \`:phase/metrics\` (success) or \`:phase/error :data\` (failure) — both already in phase-completed.
- **No behavior change on stop_reason.** Diagnostic only. Forced-finalize re-prompt on \`max_turns\` is an explicit non-goal per the parent spec.

## Test plan

- [x] \`parse-claude-stream-assistant-stop-reason-test\` (9 assertions) — text/tool_use/empty-turn/missing-reason cases
- [x] \`parse-claude-stream-result-event-test\` extended (8 assertions) — num_turns + top-level stop_reason
- [x] \`stream-parser-accumulates-stop-reason-and-turns-test\` (4 assertions) — latest-wins across multi-event streams
- [x] \`rate-limited-streaming-success-response-test\` extended (3 assertions) — stop_reason/num_turns flow to success
- [x] Full pre-commit: 359 tests / 1787 assertions / 0 failures
- [x] GraalVM/Babashka: 5 tests / 347 assertions green
- [ ] Post-merge: iter 8 — expect \`:stop-reason :end_turn\` (or \`:max_turns\`) visible in \`mf events show\` against whatever it fails on

## Follow-ups

- Codex turn.completed finish_reason capture
- Once classification data accumulates across iterations, decide if a dedicated \`:agent/stop-reason\` event is worth it
- Context-MCP behavior spec (under-populated cache → model interprets as \"tool unavailable\") — separate diagnostic spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)