### PR TITLE
refactor(agent): extract per-role static defaults to EDN

### DIFF
--- a/components/agent/resources/config/agent/role-defaults.edn
+++ b/components/agent/resources/config/agent/role-defaults.edn
@@ -1,0 +1,19 @@
+;; Per-role static defaults for agent execution.
+;;
+;; Loaded by ai.miniforge.agent.role-config; merged with the role's
+;; default model in core.clj/default-role-configs.
+;;
+;; Temperature ranges: 0.0 (deterministic) → 1.0 (creative)
+;; Tokens: appropriate context window for the role's task type.
+;; Budget caps an entire agent run, not a single LLM call.
+
+{:planner     {:temperature 0.7 :max-tokens 16000 :budget {:tokens 100000 :cost-usd 5.0}}
+ :architect   {:temperature 0.5 :max-tokens 16000 :budget {:tokens 80000  :cost-usd 4.0}}
+ :implementer {:temperature 0.3 :max-tokens 16000 :budget {:tokens 100000 :cost-usd 5.0}}
+ :tester      {:temperature 0.2 :max-tokens 8000  :budget {:tokens 40000  :cost-usd 2.0}}
+ :reviewer    {:temperature 0.4 :max-tokens 12000 :budget {:tokens 60000  :cost-usd 3.0}}
+ :sre         {:temperature 0.2 :max-tokens 8000  :budget {:tokens 40000  :cost-usd 2.0}}
+ :security    {:temperature 0.1 :max-tokens 8000  :budget {:tokens 40000  :cost-usd 2.0}}
+ :release     {:temperature 0.1 :max-tokens 4000  :budget {:tokens 20000  :cost-usd 1.0}}
+ :historian   {:temperature 0.3 :max-tokens 8000  :budget {:tokens 30000  :cost-usd 1.5}}
+ :operator    {:temperature 0.1 :max-tokens 4000  :budget {:tokens 20000  :cost-usd 1.0}}}

--- a/components/agent/src/ai/miniforge/agent/core.clj
+++ b/components/agent/src/ai/miniforge/agent/core.clj
@@ -27,6 +27,7 @@
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.protocol :as protocol]
    [ai.miniforge.agent.memory :as memory]
+   [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.task-classifier :as classifier]
    [ai.miniforge.llm.interface :as llm]
    [ai.miniforge.response.interface :as response]
@@ -42,59 +43,21 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Role configurations and defaults
 
+(defn- assemble-role-config
+  "Compose a role's full config: static defaults from EDN + dynamically
+   selected model. Pulled out as a named fn to keep `default-role-configs`
+   reading as data, not as a calculation."
+  [role]
+  (assoc (role-config/role-default role)
+         :model (model/default-model-for-role role)))
+
 (def default-role-configs
   "Default configurations for each agent role.
-   Temperature ranges: 0.0 (deterministic) to 1.0 (creative)
-   Tokens: appropriate context window for task type."
-  {:planner     {:model (model/default-model-for-role :planner)
-                 :temperature 0.7
-                 :max-tokens 16000
-                 :budget {:tokens 100000 :cost-usd 5.0}}
 
-   :architect   {:model (model/default-model-for-role :architect)
-                 :temperature 0.5
-                 :max-tokens 16000
-                 :budget {:tokens 80000 :cost-usd 4.0}}
-
-   :implementer {:model (model/default-model-for-role :implementer)
-                 :temperature 0.3
-                 :max-tokens 16000
-                 :budget {:tokens 100000 :cost-usd 5.0}}
-
-   :tester      {:model (model/default-model-for-role :tester)
-                 :temperature 0.2
-                 :max-tokens 8000
-                 :budget {:tokens 40000 :cost-usd 2.0}}
-
-   :reviewer    {:model (model/default-model-for-role :reviewer)
-                 :temperature 0.4
-                 :max-tokens 12000
-                 :budget {:tokens 60000 :cost-usd 3.0}}
-
-   :sre         {:model (model/default-model-for-role :sre)
-                 :temperature 0.2
-                 :max-tokens 8000
-                 :budget {:tokens 40000 :cost-usd 2.0}}
-
-   :security    {:model (model/default-model-for-role :security)
-                 :temperature 0.1
-                 :max-tokens 8000
-                 :budget {:tokens 40000 :cost-usd 2.0}}
-
-   :release     {:model (model/default-model-for-role :release)
-                 :temperature 0.1
-                 :max-tokens 4000
-                 :budget {:tokens 20000 :cost-usd 1.0}}
-
-   :historian   {:model (model/default-model-for-role :historian)
-                 :temperature 0.3
-                 :max-tokens 8000
-                 :budget {:tokens 30000 :cost-usd 1.5}}
-
-   :operator    {:model (model/default-model-for-role :operator)
-                 :temperature 0.1
-                 :max-tokens 4000
-                 :budget {:tokens 20000 :cost-usd 1.0}}})
+   Static fields (temperature, max-tokens, budget) live in
+   resources/config/agent/role-defaults.edn. The :model is selected
+   dynamically by `model/default-model-for-role` and merged in here."
+  (into {} (map (juxt identity assemble-role-config) (role-config/roles))))
 
 (def role-capabilities
   "Default capabilities for each agent role."

--- a/components/agent/src/ai/miniforge/agent/role_config.clj
+++ b/components/agent/src/ai/miniforge/agent/role_config.clj
@@ -1,0 +1,56 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.role-config
+  "Per-role static defaults (temperature, max-tokens, budget) for agents.
+
+   Loaded from resources/config/agent/role-defaults.edn so tweaking a
+   role's token/cost budget happens in one place rather than across
+   inlined Clojure literals. The dynamic per-role :model selection lives
+   in agent/core.clj, which composes it with `role-default` to produce
+   the full role config."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+(def ^:private role-defaults-resource
+  "config/agent/role-defaults.edn")
+
+(def role-defaults
+  "Map of role-keyword → static defaults map (loaded from EDN at ns load).
+
+   Each value carries :temperature, :max-tokens, and :budget."
+  (-> role-defaults-resource
+      io/resource
+      slurp
+      edn/read-string))
+
+(defn role-default
+  "Return the static defaults for `role`.
+
+   Throws ex-info on unknown roles so misconfiguration fails loud at the
+   first lookup rather than producing a nil-merge surprise downstream."
+  [role]
+  (or (get role-defaults role)
+      (throw (ex-info "Unknown agent role"
+                      {:role role
+                       :known-roles (set (keys role-defaults))}))))
+
+(defn roles
+  "Return the set of roles for which static defaults are defined."
+  []
+  (set (keys role-defaults)))

--- a/components/agent/test/ai/miniforge/agent/role_config_test.clj
+++ b/components/agent/test/ai/miniforge/agent/role_config_test.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.role-config-test
+  (:require [clojure.test :refer [deftest is testing]]
+            [ai.miniforge.agent.role-config :as role-config]))
+
+(deftest role-defaults-loaded-test
+  (testing "EDN config loads at namespace load and contains expected roles"
+    (is (map? role-config/role-defaults))
+    (doseq [role [:planner :architect :implementer :tester :reviewer
+                  :sre :security :release :historian :operator]]
+      (is (contains? role-config/role-defaults role)
+          (str "missing role: " role)))))
+
+(deftest role-default-shape-test
+  (testing "every role default carries :temperature, :max-tokens, :budget"
+    (doseq [[role defaults] role-config/role-defaults]
+      (is (number? (:temperature defaults)) (str role " :temperature"))
+      (is (<= 0.0 (:temperature defaults) 1.0) (str role " temperature in [0,1]"))
+      (is (pos-int? (:max-tokens defaults)) (str role " :max-tokens"))
+      (let [budget (:budget defaults)]
+        (is (map? budget) (str role " :budget map"))
+        (is (pos-int? (:tokens budget)) (str role " budget :tokens"))
+        (is (pos? (:cost-usd budget)) (str role " budget :cost-usd"))))))
+
+(deftest role-default-lookup-test
+  (testing "role-default returns the same map as direct lookup"
+    (is (= (get role-config/role-defaults :planner)
+           (role-config/role-default :planner)))))
+
+(deftest role-default-unknown-test
+  (testing "unknown role throws ex-info with known-roles in data"
+    (try
+      (role-config/role-default :nope)
+      (is false "Should have thrown")
+      (catch clojure.lang.ExceptionInfo e
+        (let [data (ex-data e)]
+          (is (= :nope (:role data)))
+          (is (contains? (:known-roles data) :planner)))))))
+
+(deftest roles-fn-test
+  (testing "roles returns the set of declared roles"
+    (is (= (set (keys role-config/role-defaults))
+           (role-config/roles)))))


### PR DESCRIPTION
## Summary

Extracts the 10-role static defaults map in `agent/core.clj` (`{:temperature ... :max-tokens ... :budget {...}}` × 10 roles, ~50 lines of inlined numerics) into [components/agent/resources/config/agent/role-defaults.edn](components/agent/resources/config/agent/role-defaults.edn) with a small loader at [agent/role_config.clj](components/agent/src/ai/miniforge/agent/role_config.clj).

`core.clj/default-role-configs` now composes EDN-loaded static defaults with the dynamic `:model` selection. The shape consumers see is identical — only the location of the numbers changed.

## Why

- **Configuration is data, pull it to `.edn`** — direct application of the standards principle. Tweaking a budget for `:planner` is now a 1-line change in EDN, not a hunt through a literal.
- **One source of truth** — same role appearing in 10 inlined entries → one EDN row.
- **Prior art in same component** — `resources/prompts/*.edn` already follows this pattern.

## Test plan

- [x] `bb pre-commit` clean (756/3353 → 832/3565, 0 failures, 0 errors, GraalVM compat passes)
- [x] New tests in [role_config_test.clj](components/agent/test/ai/miniforge/agent/role_config_test.clj): EDN loads, every role has the expected shape, fail-loud lookup, `roles` set
- [x] Existing `core_test/role-config-test` still passes (iterates over `default-role-configs` shape)
- [x] `clj-kondo` clean

## Out of scope (future slices)

The original audit identified more agent-component magic-number clusters; each gets its own focused PR rather than a sweeping change:

- per-LLM-call `:max-tokens` overrides (32000/2000/6000/16000) inlined in `planner.clj`, `implementer.clj`, `releaser.clj`, `tester.clj`, `reviewer.clj`
- `meta/progress_monitor.clj` stagnation/total/check-interval ms constants
- `task_classifier.clj` `(* file-count 500)` tokens-per-file multiplier

🤖 Generated with [Claude Code](https://claude.com/claude-code)