### PR TITLE
refactor(agent): extract per-create-fn LLM call defaults to EDN

### DIFF
--- a/components/agent/resources/config/agent/agent-llm-defaults.edn
+++ b/components/agent/resources/config/agent/agent-llm-defaults.edn
@@ -1,0 +1,24 @@
+;; Per-LLM-call config defaults applied by each create-{role} factory fn
+;; (planner.clj, implementer.clj, releaser.clj, tester.clj, reviewer.clj).
+;;
+;; These are intentionally distinct from role-defaults.edn:
+;; - role-defaults.edn supplies system-wide defaults for the
+;;   make-base-agent code path (default-role-configs in core.clj).
+;; - This file supplies the operative LLM-call config each specialized
+;;   create-{role} factory uses when constructing its agent.
+;;
+;; OPSV (N7) will converge these two sets — see
+;; work/n07-opsv-agent-budgets.spec.edn. Until then, the values stay split.
+;;
+;; Notes:
+;; - :max-tokens caps output-tokens-per-response. Exploration-heavy planning
+;;   (~70 tool calls) with small budgets truncates the final plan EDN to
+;;   nothing — 32000 is a heuristic unblocker.
+;; - reviewer/implementer max-tokens are bumped so structured output isn't
+;;   truncated.
+
+{:planner     {:temperature 0.3 :max-tokens 32000}
+ :implementer {:temperature 0.2 :max-tokens 32000}
+ :releaser    {:temperature 0.3 :max-tokens 2000}
+ :tester      {:temperature 0.2 :max-tokens 6000}
+ :reviewer    {:temperature 0.1 :max-tokens 16000}}

--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.agent.file-artifacts :as file-artifacts]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.patterns.interface :as patterns]
    [ai.miniforge.repo-index.interface :as messages]
@@ -531,10 +532,7 @@
   [& [opts]]
   (let [logger (or (:logger opts)
                    (log/create-logger {:min-level :info :output (fn [_])}))
-        ;; :max-tokens bumped for structured artifact output + file-diff emission.
-        ;; OPSV convergence target — see work/n07-opsv-agent-budgets.spec.edn.
-        config (->> (merge {:temperature 0.2
-                            :max-tokens 32000}
+        config (->> (merge (role-config/agent-llm-default :implementer)
                            (:config opts))
                     (model/apply-default-model :implementer)
                     (budget/apply-default-budget :implementer))]

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -24,6 +24,7 @@
    [ai.miniforge.agent.budget :as budget]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
@@ -377,13 +378,7 @@
   [& [opts]]
   (let [logger (or (:logger opts)
                    (log/create-logger {:min-level :info :output (fn [_])}))
-        ;; :max-tokens caps output-tokens-per-response. Exploration-heavy
-        ;; planning (~70 tool calls) with small budgets truncates the final
-        ;; plan EDN to nothing. 32000 is a heuristic unblocker; OPSV (N7)
-        ;; replaces this with a converged policy per role × phase — see
-        ;; work/n07-opsv-agent-budgets.spec.edn.
-        config (->> (merge {:temperature 0.3
-                            :max-tokens 32000}
+        config (->> (merge (role-config/agent-llm-default :planner)
                            (:config opts))
                     (model/apply-default-model :planner)
                     (budget/apply-default-budget :planner))]

--- a/components/agent/src/ai/miniforge/agent/releaser.clj
+++ b/components/agent/src/ai/miniforge/agent/releaser.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.agent.budget :as budget]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
@@ -221,8 +222,7 @@
   [& [opts]]
   (let [logger (or (:logger opts)
                    (log/create-logger {:min-level :info :output (fn [_])}))
-        config (->> (merge {:temperature 0.3
-                            :max-tokens 2000}
+        config (->> (merge (role-config/agent-llm-default :releaser)
                            (:config opts))
                     (model/apply-default-model :releaser)
                     (budget/apply-default-budget :releaser))]

--- a/components/agent/src/ai/miniforge/agent/reviewer.clj
+++ b/components/agent/src/ai/miniforge/agent/reviewer.clj
@@ -23,6 +23,7 @@
   (:require
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
@@ -504,10 +505,7 @@
                        (loop/lint-gate)
                        (loop/policy-gate :security {:policies [:no-secrets]})]
         gates (get opts :gates default-gates)
-        ;; :max-tokens bumped so structured review output isn't truncated.
-        ;; OPSV convergence target — see work/n07-opsv-agent-budgets.spec.edn.
-        review-config (->> (merge {:temperature 0.1
-                                   :max-tokens 16000}
+        review-config (->> (merge (role-config/agent-llm-default :reviewer)
                                   (:config opts))
                            (model/apply-default-model :reviewer))
         config {:strict (get opts :strict false)}]

--- a/components/agent/src/ai/miniforge/agent/role_config.clj
+++ b/components/agent/src/ai/miniforge/agent/role_config.clj
@@ -17,27 +17,45 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.agent.role-config
-  "Per-role static defaults (temperature, max-tokens, budget) for agents.
+  "Per-role agent defaults loaded from EDN.
 
-   Loaded from resources/config/agent/role-defaults.edn so tweaking a
-   role's token/cost budget happens in one place rather than across
-   inlined Clojure literals. The dynamic per-role :model selection lives
-   in agent/core.clj, which composes it with `role-default` to produce
-   the full role config."
+   Two distinct sets of defaults live here, with different consumers:
+
+   - role-defaults (config/agent/role-defaults.edn): system-wide
+     temperature/max-tokens/budget used by core.clj's
+     default-role-configs (the make-base-agent code path).
+
+   - agent-llm-defaults (config/agent/agent-llm-defaults.edn):
+     operative LLM-call config used by each specialized create-{role}
+     factory fn (planner.clj, implementer.clj, etc.).
+
+   OPSV (N7) will eventually converge these — see
+   work/n07-opsv-agent-budgets.spec.edn."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]))
 
-(def ^:private role-defaults-resource
-  "config/agent/role-defaults.edn")
+(defn- load-edn
+  "Read an EDN resource by classpath path."
+  [resource-path]
+  (-> resource-path io/resource slurp edn/read-string))
+
+(defn- lookup-or-throw
+  "Return (get m k); throw ex-info with `kind` context on miss."
+  [m k kind]
+  (or (get m k)
+      (throw (ex-info (str "Unknown agent role for " kind)
+                      {:role k
+                       :kind kind
+                       :known-roles (set (keys m))}))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; System-wide role defaults (consumed by core.clj/default-role-configs)
 
 (def role-defaults
   "Map of role-keyword → static defaults map (loaded from EDN at ns load).
 
    Each value carries :temperature, :max-tokens, and :budget."
-  (-> role-defaults-resource
-      io/resource
-      slurp
-      edn/read-string))
+  (load-edn "config/agent/role-defaults.edn"))
 
 (defn role-default
   "Return the static defaults for `role`.
@@ -45,12 +63,27 @@
    Throws ex-info on unknown roles so misconfiguration fails loud at the
    first lookup rather than producing a nil-merge surprise downstream."
   [role]
-  (or (get role-defaults role)
-      (throw (ex-info "Unknown agent role"
-                      {:role role
-                       :known-roles (set (keys role-defaults))}))))
+  (lookup-or-throw role-defaults role "role-default"))
 
 (defn roles
   "Return the set of roles for which static defaults are defined."
   []
   (set (keys role-defaults)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Per-LLM-call defaults (consumed by each specialized create-{role} factory)
+
+(def agent-llm-defaults
+  "Map of role-keyword → per-LLM-call config (loaded from EDN at ns load).
+
+   Each value carries :temperature and :max-tokens. These are the
+   operative defaults applied by each create-{role} factory fn before
+   merging in the caller's :config opts."
+  (load-edn "config/agent/agent-llm-defaults.edn"))
+
+(defn agent-llm-default
+  "Return the per-LLM-call config defaults for `role`.
+
+   Throws ex-info on unknown roles."
+  [role]
+  (lookup-or-throw agent-llm-defaults role "agent-llm-default"))

--- a/components/agent/src/ai/miniforge/agent/tester.clj
+++ b/components/agent/src/ai/miniforge/agent/tester.clj
@@ -24,6 +24,7 @@
    [ai.miniforge.agent.budget :as budget]
    [ai.miniforge.agent.model :as model]
    [ai.miniforge.agent.prompts :as prompts]
+   [ai.miniforge.agent.role-config :as role-config]
    [ai.miniforge.agent.specialized :as specialized]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.schema.interface :as schema]
@@ -301,8 +302,7 @@
   [& [opts]]
   (let [logger (or (:logger opts)
                    (log/create-logger {:min-level :info :output (fn [_])}))
-        config (->> (merge {:temperature 0.2
-                            :max-tokens 6000}
+        config (->> (merge (role-config/agent-llm-default :tester)
                            (:config opts))
                     (model/apply-default-model :tester)
                     (budget/apply-default-budget :tester))]

--- a/components/agent/test/ai/miniforge/agent/role_config_test.clj
+++ b/components/agent/test/ai/miniforge/agent/role_config_test.clj
@@ -58,3 +58,36 @@
   (testing "roles returns the set of declared roles"
     (is (= (set (keys role-config/role-defaults))
            (role-config/roles)))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; agent-llm-defaults (per-LLM-call config consumed by create-{role} factories)
+
+(deftest agent-llm-defaults-loaded-test
+  (testing "EDN config loads and contains every specialized role"
+    (is (map? role-config/agent-llm-defaults))
+    (doseq [role [:planner :implementer :releaser :tester :reviewer]]
+      (is (contains? role-config/agent-llm-defaults role)
+          (str "missing role: " role)))))
+
+(deftest agent-llm-defaults-shape-test
+  (testing "every entry carries :temperature and :max-tokens"
+    (doseq [[role defaults] role-config/agent-llm-defaults]
+      (is (number? (:temperature defaults)) (str role " :temperature"))
+      (is (<= 0.0 (:temperature defaults) 1.0) (str role " temperature in [0,1]"))
+      (is (pos-int? (:max-tokens defaults)) (str role " :max-tokens")))))
+
+(deftest agent-llm-default-lookup-test
+  (testing "agent-llm-default returns the same map as direct lookup"
+    (is (= (get role-config/agent-llm-defaults :planner)
+           (role-config/agent-llm-default :planner)))))
+
+(deftest agent-llm-default-unknown-test
+  (testing "unknown role throws ex-info with known-roles in data"
+    (try
+      (role-config/agent-llm-default :nope)
+      (is false "Should have thrown")
+      (catch clojure.lang.ExceptionInfo e
+        (let [data (ex-data e)]
+          (is (= :nope (:role data)))
+          (is (= "agent-llm-default" (:kind data)))
+          (is (contains? (:known-roles data) :planner)))))))


### PR DESCRIPTION
## Summary

Companion to the just-merged [#599](https://github.com/miniforge-ai/miniforge/pull/599). Five specialized `create-{role}` factory fns (planner, implementer, releaser, tester, reviewer) each inlined the same `{:temperature N :max-tokens N}` shape with magic numbers. This PR pulls those into [components/agent/resources/config/agent/agent-llm-defaults.edn](components/agent/resources/config/agent/agent-llm-defaults.edn) and exposes `role-config/agent-llm-default` for lookup.

Each call site now reads:
```clojure
(merge (role-config/agent-llm-default :planner) (:config opts))
```

The two EDN-loaded sets in `role-config.clj` (system-wide `role-defaults` from #599 vs operative `agent-llm-defaults` here) are intentionally kept distinct — they have different consumers, documented in the ns docstring. OPSV (N7) will eventually converge them.

## Why

- **Configuration is data, pull it to `.edn`** — direct application of the standards principle.
- **Single source of truth** — tweaking the planner's `:max-tokens` is one EDN change instead of finding it in `planner.clj`.
- **DRY** — the duplicated "load EDN + fail-loud lookup" pattern in `role-config.clj` collapsed into two private helpers (`load-edn`, `lookup-or-throw`).

## Test plan

- [x] `bb pre-commit` clean (0 failures, GraalVM compat passes)
- [x] New tests in [role_config_test.clj](components/agent/test/ai/miniforge/agent/role_config_test.clj): EDN loads, every role has the expected shape, fail-loud lookup, ex-data carries `:kind`
- [x] Existing role-defaults tests still pass (the helper extraction kept ex-data shape compatible)
- [x] `clj-kondo` clean

## Out of scope

Still on the punch list (each its own slice):
- `meta/progress_monitor.clj` stagnation/total/check-interval ms constants
- `task_classifier.clj` `(* file-count 500)` tokens-per-file multiplier
- connector-sarif's stale deps.edn key + retry-policy adoption
- ~40 test sites still status-reaching `(= :success (:status r))`
- Nested `if-let` chains in `config/digest.clj` and `tui-views/view/project/helpers.clj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)