### PR TITLE
refactor(agent): extract magic numbers to named constants

### DIFF
--- a/components/agent/src/ai/miniforge/agent/meta/progress_monitor.clj
+++ b/components/agent/src/ai/miniforge/agent/meta/progress_monitor.clj
@@ -23,6 +23,27 @@
   (:require [ai.miniforge.agent.meta-protocol :as mp]
             [ai.miniforge.llm.interface :as llm]))
 
+;------------------------------------------------------------------------------ Layer 0
+;; Default monitoring intervals
+;;
+;; All values are milliseconds. Operationally tuned: kept as named
+;; constants here (vs an EDN file) since callers can override via the
+;; create-progress-monitor-agent options map and there are only three
+;; numbers to track.
+
+(def ^:const default-check-interval-ms
+  "How often the meta-agent runs its health check."
+  30000)                                ; 30 seconds
+
+(def ^:const default-stagnation-threshold-ms
+  "Time without streaming activity or file writes that triggers a
+   stagnation halt."
+  120000)                               ; 2 minutes
+
+(def ^:const default-max-total-ms
+  "Hard upper bound on a single workflow run before forced halt."
+  600000)                               ; 10 minutes
+
 (defrecord ProgressMonitorMetaAgent [monitor-state config]
   mp/MetaAgent
 
@@ -73,24 +94,24 @@
     (reset! monitor-state
             (llm/create-progress-monitor
              (or (:monitor-options config)
-                 {:stagnation-threshold-ms 120000  ; 2 minutes
-                  :max-total-ms 600000})))))       ; 10 minutes
+                 {:stagnation-threshold-ms default-stagnation-threshold-ms
+                  :max-total-ms            default-max-total-ms})))))
 
 (defn create-progress-monitor-agent
   "Create a Progress Monitor meta-agent.
 
    Options:
-   - :check-interval-ms (default: 30000) - How often to check
-   - :priority (default: :high) - Check priority
-   - :stagnation-threshold-ms (default: 120000) - Stagnation timeout
-   - :max-total-ms (default: 600000) - Hard timeout limit"
+   - :check-interval-ms        (default: default-check-interval-ms)        - How often to check
+   - :priority                 (default: :high)                             - Check priority
+   - :stagnation-threshold-ms  (default: default-stagnation-threshold-ms)   - Stagnation timeout
+   - :max-total-ms             (default: default-max-total-ms)              - Hard timeout limit"
   ([]
    (create-progress-monitor-agent {}))
   ([{:keys [check-interval-ms priority stagnation-threshold-ms max-total-ms]
-     :or {check-interval-ms 30000
-          priority :high
-          stagnation-threshold-ms 120000
-          max-total-ms 600000}}]
+     :or {check-interval-ms       default-check-interval-ms
+          priority                :high
+          stagnation-threshold-ms default-stagnation-threshold-ms
+          max-total-ms            default-max-total-ms}}]
    (let [monitor-options {:stagnation-threshold-ms stagnation-threshold-ms
                           :max-total-ms max-total-ms}
          config (mp/create-meta-config

--- a/components/agent/src/ai/miniforge/agent/task_classifier.clj
+++ b/components/agent/src/ai/miniforge/agent/task_classifier.clj
@@ -92,6 +92,15 @@
    :formatter-agent :simple-validation
    :linter-agent :simple-validation})
 
+;------------------------------------------------------------------------------ Layer 0.5
+;; Heuristic constants
+
+(def ^:const default-tokens-per-file
+  "Heuristic estimate of tokens per source file when only :file-count is
+   available. Used by extract-context-size as a coarse proxy for true
+   token counts; refine to a real tokenizer count if precision matters."
+  500)
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Feature extraction
 
@@ -117,7 +126,7 @@
   (cond
     context-tokens context-tokens
     estimated-loc estimated-loc
-    file-count (* file-count 500) ; Estimate 500 tokens per file
+    file-count (* file-count default-tokens-per-file)
     :else 0))
 
 (defn extract-privacy-requirements

--- a/components/agent/test/ai/miniforge/agent/task_classifier_test.clj
+++ b/components/agent/test/ai/miniforge/agent/task_classifier_test.clj
@@ -185,7 +185,8 @@
     (is (= 10000 (classifier/extract-context-size {:estimated-loc 10000}))))
 
   (testing "Extract from file-count"
-    (is (= 5000 (classifier/extract-context-size {:file-count 10}))))
+    (is (= (* 10 classifier/default-tokens-per-file)
+           (classifier/extract-context-size {:file-count 10}))))
 
   (testing "Default to 0"
     (is (= 0 (classifier/extract-context-size {})))))


### PR DESCRIPTION
## Summary

Two small clusters of remaining magic numbers in the agent component:

- **[meta/progress_monitor.clj](components/agent/src/ai/miniforge/agent/meta/progress_monitor.clj)** — `30000`/`120000`/`600000` ms duplicated across the `:keys :or` defaults map, the `reset-state!` impl, and the docstring. Now three named constants (`default-check-interval-ms`, `default-stagnation-threshold-ms`, `default-max-total-ms`) referenced from one place.
- **[task_classifier.clj](components/agent/src/ai/miniforge/agent/task_classifier.clj)** — bare `(* file-count 500)` becomes `(* file-count default-tokens-per-file)`. The corresponding test that asserted `5000` is updated to compose the constant rather than re-encode the magic.

## Why

Direct application of "no magic numbers, use well named constants that demonstrate intent." Constants chosen over EDN here because each value has exactly one caller, and tuning happens via the agent's options map — no operator-tunable config story would benefit from EDN extraction at this size.

## Test plan

- [x] `bb pre-commit` clean (0 failures, GraalVM compat passes)
- [x] `clj-kondo` clean
- [x] Updated `test-extract-context-size` references the constant rather than the literal `5000`

## Out of scope

- connector-sarif's stale deps.edn key + retry-policy adoption
- ~40 test sites still status-reaching `(= :success (:status r))`
- Nested `if-let` chains in `config/digest.clj` and `tui-views/view/project/helpers.clj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)