### PR TITLE
refactor: flatten nested conditionals + DRY readiness factors

### DIFF
--- a/components/config/src/ai/miniforge/config/digest.clj
+++ b/components/config/src/ai/miniforge/config/digest.clj
@@ -78,11 +78,11 @@
    For :knowledge-safety, a :mismatch is a hard failure.
    For other configs, :mismatch is a warning."
   [config-key content]
-  (if-let [manifest (load-digest-manifest)]
-    (if-let [expected (get manifest config-key)]
-      (let [actual (sha256-hex content)]
-        (if (= expected actual)
-          :ok
-          :mismatch))
-      :no-entry)
-    :no-manifest))
+  (let [manifest (load-digest-manifest)
+        expected (when manifest (get manifest config-key))
+        actual   (when expected (sha256-hex content))]
+    (cond
+      (nil? manifest)     :no-manifest
+      (nil? expected)     :no-entry
+      (= expected actual) :ok
+      :else               :mismatch)))

--- a/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
+++ b/components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj
@@ -187,37 +187,78 @@
            :blocker/message "PR is in draft"
            :blocker/source "author"})))
 
+(def factor-weights
+  "Per-factor weights for the readiness score. Must sum to 1.0."
+  {:deps-merged  0.25
+   :ci-passed    0.25
+   :approved     0.20
+   :gates-passed 0.15
+   :behind-main  0.15})
+
+(def review-score-by-status
+  "PR status → review-score in [0.0, 1.0]."
+  {:merged            1.0
+   :merge-ready       1.0
+   :approved          1.0
+   :reviewing         0.5
+   :changes-requested 0.25
+   :open              0.3
+   :draft             0.0
+   :closed            0.0})
+
+(def ^:const default-factor-score
+  "Score used for factors that aren't yet derived from real signals
+   (e.g. :deps-merged, :gates-passed in naive mode without train context)."
+  1.0)
+
+(def ^:const ci-passing-score 1.0)
+(def ^:const ci-failing-score 0.0)
+(def ^:const ci-pending-score 0.5)
+
+(defn- ci-status-score
+  "Map CI status booleans to a [0.0, 1.0] score."
+  [ci-ok? ci-fail?]
+  (cond
+    ci-ok?   ci-passing-score
+    ci-fail? ci-failing-score
+    :else    ci-pending-score))
+
+(defn- behind-status-score
+  "Map behind-main flag to a [0.0, 1.0] score."
+  [behind?]
+  (if behind? 0.0 default-factor-score))
+
+(defn- factor
+  "Build one {:factor :weight :score} entry from the weights table."
+  [factor-key score]
+  {:factor factor-key
+   :weight (get factor-weights factor-key)
+   :score  score})
+
+(defn- weighted-sum
+  "Sum each factor's :weight × :score."
+  [factors]
+  (reduce + 0.0 (map (fn [{:keys [weight score]}] (* weight score)) factors)))
+
 (defn readiness-factors
   "Compute weighted readiness factors and score.
-   Weights: deps=0.25 ci=0.25 approved=0.20 gates=0.15 behind-main=0.15.
    Deps and gates default to 1.0 in naive derivation (no train context).
    Returns {:weighted float :factors [...]
             :ci-score float :review-score float :behind-score float}."
   [status ci-ok? ci-fail? behind?]
-  (let [ci-score     (if ci-ok? 1.0 (if ci-fail? 0.0 0.5))
-        review-score (case status
-                       (:merged :merge-ready :approved) 1.0
-                       :reviewing 0.5
-                       :changes-requested 0.25
-                       :open 0.3
-                       :draft 0.0
-                       :closed 0.0
-                       0.0)
-        behind-score (if behind? 0.0 1.0)
-        weighted     (+ (* 0.25 1.0)
-                       (* 0.25 ci-score)
-                       (* 0.20 review-score)
-                       (* 0.15 1.0)
-                       (* 0.15 behind-score))]
-    {:weighted     weighted
+  (let [ci-score     (ci-status-score ci-ok? ci-fail?)
+        review-score (get review-score-by-status status 0.0)
+        behind-score (behind-status-score behind?)
+        factors      [(factor :deps-merged  default-factor-score)
+                      (factor :ci-passed    ci-score)
+                      (factor :approved     review-score)
+                      (factor :gates-passed default-factor-score)
+                      (factor :behind-main  behind-score)]]
+    {:weighted     (weighted-sum factors)
      :ci-score     ci-score
      :review-score review-score
      :behind-score behind-score
-     :factors      [{:factor :deps-merged  :weight 0.25 :score 1.0}
-                    {:factor :ci-passed    :weight 0.25 :score ci-score}
-                    {:factor :approved     :weight 0.20 :score review-score}
-                    {:factor :gates-passed :weight 0.15 :score 1.0}
-                    {:factor :behind-main  :weight 0.15 :score behind-score}]}))
+     :factors      factors}))
 
 (defn derive-readiness
   "Derive N9 readiness state from provider signals.


### PR DESCRIPTION
## Summary

Two small but high-clarity cleanups identified in the original audit:

### `config/digest.clj/verify-governance-file`
Triple-nested `if-let` pyramid → flat `cond`. Same four return values, but the decision table now reads top-to-bottom instead of inside-out.

```diff
- (if-let [manifest (load-digest-manifest)]
-   (if-let [expected (get manifest config-key)]
-     (let [actual (sha256-hex content)]
-       (if (= expected actual) :ok :mismatch))
-     :no-entry)
-   :no-manifest)
+ (let [manifest (load-digest-manifest)
+       expected (when manifest (get manifest config-key))
+       actual   (when expected (sha256-hex content))]
+   (cond
+     (nil? manifest)     :no-manifest
+     (nil? expected)     :no-entry
+     (= expected actual) :ok
+     :else               :mismatch))
```

### `tui-views/view/project/helpers.clj/readiness-factors`
Multiple violations cleaned up:
- Nested ternary `(if ci-ok? 1.0 (if ci-fail? 0.0 0.5))` → named `ci-status-score` fn with `cond`
- Magic weights `0.25/0.25/0.20/0.15/0.15` were duplicated across the `weighted` calculation **and** the `:factors` vector. Now live in one `factor-weights` map; the weighted score is *derived from the factors* via `weighted-sum` rather than recomputed in parallel
- Inline `case` for review score → `review-score-by-status` lookup map (data over syntax)
- Magic 1.0/0.5/0.0 → named constants where intent wasn't obvious

## Test plan

- [x] `bb pre-commit` clean (995 tests, 3719 passes, 0 failures, 0 errors, GraalVM compat passes)
- [x] `clj-kondo` clean
- [x] Existing `readiness-factors-*` tests in `project_test.clj` pass without modification (intentional — refactor preserves behavior, including the `weights-sum-to-one` invariant)

## Out of scope (remaining punch list)

- connector-sarif's stale deps.edn key + retry-policy adoption
- ~40 status-reaching test sites `(= :success (:status r))`

🤖 Generated with [Claude Code](https://claude.com/claude-code)