### PR TITLE
refactor(connector-sarif): fix deps.edn key, adopt retry-policy preset

### DIFF
--- a/components/connector-sarif/deps.edn
+++ b/components/connector-sarif/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector {:local/root "../connector"}
+ :deps {ai.miniforge.data-foundry/connector {:local/root "../connector"}
         cheshire/cheshire {:mvn/version "5.12.0"}
         org.clojure/data.csv {:mvn/version "1.1.0"}
         metosin/malli {:mvn/version "0.16.4"}}

--- a/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/interface.clj
+++ b/components/connector-sarif/src/ai/miniforge/data_foundry/connector_sarif/interface.clj
@@ -21,7 +21,8 @@
    A SourceConnector that extracts violations from SARIF v2.1.0 JSON
    and CSV scan output files."
   (:require [ai.miniforge.data-foundry.connector-sarif.core :as core]
-            [ai.miniforge.data-foundry.connector-sarif.schema :as schema]))
+            [ai.miniforge.data-foundry.connector-sarif.schema :as schema]
+            [ai.miniforge.data-foundry.connector.interface :as conn]))
 
 (defn create-sarif-connector
   "Create a new SarifConnector instance."
@@ -35,7 +36,7 @@
    :connector/version      "0.1.0"
    :connector/capabilities #{:cap/batch}
    :connector/auth-methods #{:none}
-   :connector/retry-policy {:retry/strategy :none :retry/max-attempts 1}
+   :connector/retry-policy (conn/retry-policy :none)
    :connector/maintainer   "data-foundry"})
 
 ;; Schema exports


### PR DESCRIPTION
## Summary

Two related cleanups, both deferred from [#596](https://github.com/miniforge-ai/miniforge/pull/596):

1. **deps.edn key fix** — sarif referenced the connector dep as `ai.miniforge/connector`; every other consumer in the workspace uses `ai.miniforge.data-foundry/connector`. The `:local/root "../connector"` path happened to resolve, so the lib loaded — but sarif was the only outlier. Fixed.

2. **Adopt `retry-policy :none` preset** — the inline `{:retry/strategy :none :retry/max-attempts 1}` map now reads `(conn/retry-policy :none)`, finishing the rollout across all 7 connectors.

## Test plan

- [x] `bb pre-commit` clean (0 failures, GraalVM compat passes)
- [x] `clj-kondo` clean
- [x] sarif's existing tests still pass

## Open punch list

- ~40 status-reaching test sites `(= :success (:status r))` — last big mechanical refactor on the original audit list

🤖 Generated with [Claude Code](https://claude.com/claude-code)