### PR TITLE
fix(submodule): .standards URL from SSH to HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,8 @@
 [submodule ".standards"]
 	path = .standards
-	url = git@github.com:miniforge-ai/miniforge-standards.git
+	# HTTPS (not SSH, not relative) so the submodule clones in every
+	# environment: local SSH dev, GitHub Actions with GITHUB_TOKEN,
+	# and Cloudflare Workers Builds via the "Cloudflare Workers and
+	# Pages" GitHub App. miniforge-standards is public, so no auth
+	# is required.
+	url = https://github.com/miniforge-ai/miniforge-standards.git


### PR DESCRIPTION
## Summary

Switch the nested \`.standards\` submodule URL from SSH to HTTPS so it clones in CI and build environments that don't have SSH keys.

\`\`\`diff
-url = git@github.com:miniforge-ai/miniforge-standards.git
+url = https://github.com/miniforge-ai/miniforge-standards.git
\`\`\`

## Why

Any parent repo that vendors \`miniforge\` as a submodule and is built in an HTTPS-only environment fails on recursive submodule init. Concrete example: Cloudflare Workers Builds deploying thesium surfaces this as the generic \`Failed: error occurred while updating repository submodules\` — the outer submodules (top-level \`miniforge\` + \`miniforge-standards\`) clone fine over HTTPS+App-token, then recursion tries \`git@github.com:…\` for \`miniforge/.standards\` and hits \`Permission denied (publickey)\`.

HTTPS works everywhere:

- **Local SSH dev** — git resolves \`https://github.com/…\` as-is; existing credential helpers or anonymous fetch handle it.
- **GitHub Actions** — uses \`GITHUB_TOKEN\` automatically.
- **Cloudflare Workers Builds** — uses the Cloudflare Workers & Pages GitHub App token.

\`miniforge-standards\` is public, so no auth is required in any path.

## Test plan

- [x] Local: \`git submodule sync .standards && rm -rf .standards && git submodule update --init .standards\` — clones successfully over HTTPS.
- [ ] After merge, bump the \`miniforge\` submodule pointer in thesium and confirm Cloudflare Workers Builds deploys of \`thesium.app\` succeed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)