### PR TITLE
test: use response/success? predicate across response-builder test sites

### DIFF
--- a/components/agent/test/ai/miniforge/agent/curator_test.clj
+++ b/components/agent/test/ai/miniforge/agent/curator_test.clj
@@ -22,6 +22,7 @@
    tested via injected stub clients, never a real LLM backend."
   (:require
    [ai.miniforge.agent.curator :as sut]
+   [ai.miniforge.response.interface :as response]
    [clojure.test :refer [deftest is testing]]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -65,7 +66,7 @@
                    :worktree-path "/tmp/ignored"
                    :intent-scope [(:path src-file) (:path test-file)]
                    :spec-description "Add retry-budget state machine"})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (let [art (:output result)]
         (is (uuid? (:code/id art)))
         (is (= 2 (count (:code/files art))))
@@ -90,7 +91,7 @@
                    :intent-scope [(:path src-file)]
                    :spec-description "Add retry-budget"})
           art (:output result)]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (= ["docs/unrelated.md"] (:code/scope-deviations art))
           "path not in scope should appear in deviations"))))
 
@@ -102,7 +103,7 @@
                      :worktree-path "/tmp/ignored"
                      :intent-scope scope})
             art (:output result)]
-        (is (= :success (:status result)))
+        (is (response/success? result))
         (is (= [] (:code/scope-deviations art))
             (str "scope=" (pr-str scope)))))))
 

--- a/components/agent/test/ai/miniforge/agent/implementer_extended_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_extended_test.clj
@@ -21,6 +21,7 @@
    language detection, artifact repair edge cases, formatting, and prior-attempts."
   (:require
    [ai.miniforge.agent.implementer :as impl]
+   [ai.miniforge.response.interface :as response]
    [clojure.string :as str]
    [clojure.test :refer [deftest testing is]]))
 
@@ -214,14 +215,14 @@
   (testing "adds UUID when :code/id is missing"
     (let [artifact {:code/files [{:path "a.clj" :content "(ns a)" :action :create}]}
           result (impl/repair-code-artifact artifact {:code/id "missing"} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (uuid? (get-in result [:output :code/id]))))))
 
 (deftest repair-adds-missing-files-vector-test
   (testing "adds empty files vector when nil"
     (let [artifact {:code/id (random-uuid) :code/files nil}
           result (impl/repair-code-artifact artifact {} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (vector? (get-in result [:output :code/files]))))))
 
 (deftest repair-fills-empty-create-content-test
@@ -229,7 +230,7 @@
     (let [artifact {:code/id (random-uuid)
                     :code/files [{:path "a.clj" :content "" :action :create}]}
           result (impl/repair-code-artifact artifact {:files "empty"} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (seq (get-in result [:output :code/files 0 :content]))))))
 
 (deftest repair-deduplicates-files-test
@@ -239,7 +240,7 @@
                                  {:path "b.clj" :content "(ns b)" :action :create}
                                  {:path "a.clj" :content "(ns a-v2)" :action :modify}]}
           result (impl/repair-code-artifact artifact {} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (let [files (get-in result [:output :code/files])
             paths (map :path files)]
         (is (= (count (distinct paths)) (count paths)))))))
@@ -250,7 +251,7 @@
                     :code/files [{:path "a.clj" :content "(ns a)" :action :create}
                                  {:path nil :content "orphan" :action :create}]}
           result (impl/repair-code-artifact artifact {} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (= 1 (count (get-in result [:output :code/files])))))))
 
 (deftest repair-adds-default-action-test
@@ -258,7 +259,7 @@
     (let [artifact {:code/id (random-uuid)
                     :code/files [{:path "a.clj" :content "(ns a)"}]}
           result (impl/repair-code-artifact artifact {} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (= :create (get-in result [:output :code/files 0 :action]))))))
 
 (deftest repair-adds-empty-content-when-nil-test
@@ -266,7 +267,7 @@
     (let [artifact {:code/id (random-uuid)
                     :code/files [{:path "a.clj" :content nil :action :delete}]}
           result (impl/repair-code-artifact artifact {} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (= "" (get-in result [:output :code/files 0 :content]))))))
 
 (deftest repair-records-repairs-made-test

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -27,7 +27,8 @@
    [ai.miniforge.agent.file-artifacts :as file-artifacts]
    [ai.miniforge.agent.implementer :as implementer]
    [ai.miniforge.llm.interface :as llm]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures
@@ -144,7 +145,7 @@
                    (@#'implementer/invoke-with-llm
                     nil "prompt" "system" {} {} nil logger []))
           fallback-log (find-log-entry entries :implementer/file-artifact-fallback)]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (= [{:path "src/generated.clj"
                :content "(ns generated)"
                :action :create}]
@@ -320,7 +321,7 @@
                                       :content "(ns test)"
                                       :action :create}]}
           result (core/repair agent bad-artifact {:code/id ["required"]} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (uuid? (get-in result [:output :code/id])))))
 
   (testing "adds content to empty :create files"
@@ -330,7 +331,7 @@
                                       :content ""
                                       :action :create}]}
           result (core/repair agent bad-artifact {:files ["empty content"]} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (seq (get-in result [:output :code/files 0 :content]))))))
 
 ;------------------------------------------------------------------------------ Layer 6

--- a/components/agent/test/ai/miniforge/agent/releaser_test.clj
+++ b/components/agent/test/ai/miniforge/agent/releaser_test.clj
@@ -22,7 +22,8 @@
    [clojure.test :as test :refer [deftest testing is]]
    [ai.miniforge.agent.core :as core]
    [ai.miniforge.agent.releaser :as releaser]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures
@@ -135,7 +136,7 @@
           bad-artifact (assoc valid-release-artifact
                               :release/branch-name "feature/bad branch")
           result (core/repair agent bad-artifact {:branch-name ["spaces"]} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (not (re-find #" " (get-in result [:output :release/branch-name]))))))
 
   (testing "truncates long PR title"
@@ -143,14 +144,14 @@
           long-title (apply str (repeat 80 "x"))
           bad-artifact (assoc valid-release-artifact :release/pr-title long-title)
           result (core/repair agent bad-artifact {:pr-title ["too long"]} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (<= (count (get-in result [:output :release/pr-title])) 70))))
 
   (testing "adds missing ID"
     (let [agent (releaser/create-releaser)
           bad-artifact (dissoc valid-release-artifact :release/id)
           result (core/repair agent bad-artifact {:release/id ["required"]} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (uuid? (get-in result [:output :release/id]))))))
 
 ;------------------------------------------------------------------------------ Layer 6

--- a/components/agent/test/ai/miniforge/agent/response_parsing_test.clj
+++ b/components/agent/test/ai/miniforge/agent/response_parsing_test.clj
@@ -274,7 +274,7 @@
           ;; Simulate what a phase does with the response
           phase-result (response/success parsed {:tokens 1000 :duration-ms 5000})]
 
-      (is (= :success (:status phase-result))
+      (is (response/success? phase-result)
           "Phase should successfully process agent response")
       (is (= parsed (:output phase-result))
           "Phase should extract parsed artifact")
@@ -289,7 +289,7 @@
           failure-response (response/failure (ex-info "Test error" {}))]
 
       ;; Test success response structure
-      (is (= :success (:status success-response))
+      (is (response/success? success-response)
           "Success response should have :success status")
       (is (= artifact (:output success-response))
           "Success response should contain artifact")

--- a/components/agent/test/ai/miniforge/agent/reviewer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/reviewer_test.clj
@@ -22,7 +22,8 @@
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.agent.reviewer :as reviewer]
    [ai.miniforge.agent.core :as core]
-   [ai.miniforge.loop.interface :as loop]))
+   [ai.miniforge.loop.interface :as loop]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Test fixtures
 
@@ -87,7 +88,7 @@
           reviewer (reviewer/create-reviewer {:gates gates})
           result (core/invoke reviewer {} sample-artifact)]
 
-      (is (= :success (:status result))
+      (is (response/success? result)
           "Invocation should succeed")
 
       (let [review (:artifact result)]
@@ -117,7 +118,7 @@
           reviewer (reviewer/create-reviewer {:gates gates})
           result (core/invoke reviewer {} sample-artifact)]
 
-      (is (= :success (:status result))
+      (is (response/success? result)
           "Invocation should succeed")
 
       (let [review (:artifact result)]
@@ -277,7 +278,7 @@
                                                            :action :create}]}}
           result (core/invoke reviewer {} valid-artifact)]
 
-      (is (= :success (:status result)))
+      (is (response/success? result))
       ;; Note: actual gate behavior depends on loop implementation
       (is (some? (:artifact result))
           "Should return review artifact")))
@@ -289,7 +290,7 @@
           reviewer (reviewer/create-reviewer {:gates gates})
           result (core/invoke reviewer {} sample-artifact)]
 
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (= 3 (get-in result [:artifact :review/gates-total]))
           "Should run all 3 gates"))))
 
@@ -313,7 +314,7 @@
           reviewer (reviewer/create-reviewer {:gates [error-gate]})
           result (core/invoke reviewer {} sample-artifact)]
 
-      (is (= :success (:status result))
+      (is (response/success? result)
           "Should succeed even when gate throws")
 
       (let [review (:artifact result)]

--- a/components/agent/test/ai/miniforge/agent/tester_test.clj
+++ b/components/agent/test/ai/miniforge/agent/tester_test.clj
@@ -22,7 +22,8 @@
    [clojure.test :as test :refer [deftest testing is]]
    [ai.miniforge.agent.core :as core]
    [ai.miniforge.agent.tester :as tester]
-   [ai.miniforge.logging.interface :as log]))
+   [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test fixtures
@@ -231,7 +232,7 @@
                                       :content "(ns example-test (:require [clojure.test :refer :all]))\n(deftest t (is true))"}]
                         :test/type :unit}
           result (core/repair agent bad-artifact {:test/id ["required"]} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (uuid? (get-in result [:output :test/id])))))
 
   (testing "repairs non-test file paths"
@@ -241,7 +242,7 @@
                                       :content "(ns not-test)"}]
                         :test/type :unit}
           result (core/repair agent bad-artifact {:files ["naming"]} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       ;; Path should be fixed to include _test
       (let [repaired-path (get-in result [:output :test/files 0 :path])]
         (is (re-find #"_test" repaired-path)))))
@@ -253,7 +254,7 @@
                                       :content "(ns example-test)\n(is true)\n(is false)\n(is (= 1 1))"}]
                         :test/type :unit}
           result (core/repair agent bad-artifact {} {})]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (pos? (get-in result [:output :test/assertions-count]))))))
 
 ;------------------------------------------------------------------------------ Layer 6

--- a/components/event-stream/test/ai/miniforge/event_stream/approval_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/approval_test.clj
@@ -20,7 +20,8 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.event-stream.interface :as es]
-   [ai.miniforge.event-stream.approval :as approval]))
+   [ai.miniforge.event-stream.approval :as approval]
+   [ai.miniforge.response.interface :as response]))
 
 ;; ============================================================================
 ;; Quorum approval tests
@@ -221,4 +222,4 @@
           result (es/execute-control-action-with-approval!
                   stream action
                   (fn [_] {:paused true}))]
-      (is (= :success (:status result))))))
+      (is (response/success? result)))))

--- a/components/event-stream/test/ai/miniforge/event_stream/control_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/control_test.clj
@@ -182,7 +182,7 @@
           result (es/execute-control-action!
                   stream action
                   (fn [_act] {:paused true}))]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (= {:paused true} (:output result)))
       ;; Should have emitted requested + executed events
       (let [action-events (filter #(#{:control-action/requested :control-action/executed}

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/ci_monitor_property_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/ci_monitor_property_test.clj
@@ -28,7 +28,8 @@
    - All-success input yields :success"
   (:require
    [clojure.test :refer [deftest testing is]]
-   [ai.miniforge.pr-lifecycle.ci-monitor :as ci]))
+   [ai.miniforge.pr-lifecycle.ci-monitor :as ci]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Helpers
 
@@ -112,7 +113,7 @@
     (doseq [n (range 1 20)]
       (let [checks (vec (repeat n {:name "test" :state "COMPLETED" :conclusion "SUCCESS"}))
             result (ci/compute-ci-status checks)]
-        (is (= :success (:status result))
+        (is (response/success? result)
             (str n " SUCCESS checks should yield :success"))))))
 
 ;------------------------------------------------------------------------------ Property: Empty yields :unknown

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/ci_monitor_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/ci_monitor_test.clj
@@ -27,7 +27,8 @@
    [clojure.test :refer [deftest testing is are]]
    [ai.miniforge.pr-lifecycle.ci-monitor :as ci]
    [ai.miniforge.pr-lifecycle.events :as events]
-   [ai.miniforge.dag-executor.interface :as dag]))
+   [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Status Types
 
@@ -52,7 +53,7 @@
                   {:name "lint" :state "COMPLETED" :conclusion "SUCCESS"}
                   {:name "build" :state "COMPLETED" :conclusion "SUCCESS"}]
           result (ci/compute-ci-status checks)]
-      (is (= :success (:status result)))
+      (is (response/success? result))
       (is (= 3 (count (:passed result))))
       (is (empty? (:failed result)))
       (is (empty? (:pending result)))
@@ -78,7 +79,7 @@
     (let [checks [{:name "tests" :state "IN_PROGRESS" :conclusion nil}
                   {:name "lint" :state "COMPLETED" :conclusion "SUCCESS"}]
           result (ci/compute-ci-status checks)]
-      (is (= :success (:status result))
+      (is (response/success? result)
           "IN_PROGRESS maps to :in_progress (underscore), not :in-progress (hyphen), so it falls to :unknown"))))
 
 (deftest compute-ci-status-failure-takes-precedence-over-pending-test
@@ -127,7 +128,7 @@
     (let [checks [{:name "optional" :state "COMPLETED" :conclusion "SKIPPED"}
                   {:name "tests" :state "COMPLETED" :conclusion "SUCCESS"}]
           result (ci/compute-ci-status checks)]
-      (is (= :success (:status result))
+      (is (response/success? result)
           "Success should take precedence over neutral"))))
 
 (deftest compute-ci-status-waiting-test
@@ -272,7 +273,7 @@
                       (random-uuid) (random-uuid) (random-uuid)
                       42 "/tmp/repo")
             result (ci/poll-ci-status monitor nil)]
-        (is (= :success (:status result)))
+        (is (response/success? result))
         (is (= 2 (count (:passed (:checks result)))))
         (is (empty? (:failed (:checks result))))))))
 
@@ -363,7 +364,7 @@
                       42 "/tmp/repo")]
         (is (= :pending (:status @monitor)))
         (ci/poll-ci-status monitor nil)
-        (is (= :success (:status @monitor)))))))
+        (is (response/success? @monitor))))))
 
 ;------------------------------------------------------------------------------ Status Change Detection
 
@@ -483,7 +484,7 @@
                           ;; Third call succeeds with passing checks
                           (dag/ok {:checks [{:name "tests" :state "COMPLETED" :conclusion "SUCCESS"}]}))))]
         (let [result (ci/run-ci-monitor monitor nil)]
-          (is (= :success (:status result))
+          (is (response/success? result)
               "Monitor should eventually reach success after retries")
           (is (>= @call-count 3)
               "Should have polled at least 3 times (2 failures + 1 success)"))))))
@@ -562,7 +563,7 @@
                     (fn [_path _pr]
                       (dag/ok {:checks [{:name "tests" :state "COMPLETED" :conclusion "SUCCESS"}]}))]
         (let [result (ci/run-ci-monitor monitor nil)]
-          (is (= :success (:status result)))
+          (is (response/success? result))
           (is (false? (:running? @monitor))))))))
 
 (deftest run-ci-monitor-failure-completes-immediately-test
@@ -598,7 +599,7 @@
                           :on-poll (fn [r] (swap! poll-results conj r)))
         (is (>= (count @poll-results) 3)
             "on-poll should be called for each poll cycle")
-        (is (= :success (:status (last @poll-results)))
+        (is (response/success? (last @poll-results))
             "Last poll result should be the terminal one")))))
 
 (deftest run-ci-monitor-on-complete-callback-test
@@ -614,7 +615,7 @@
         (ci/run-ci-monitor monitor nil
                           :on-complete (fn [r] (reset! complete-result r)))
         (is (some? @complete-result))
-        (is (= :success (:status @complete-result)))))))
+        (is (response/success? @complete-result))))))
 
 ;------------------------------------------------------------------------------ run-ci-monitor: Event Bus Integration
 

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/integration_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/integration_test.clj
@@ -208,7 +208,7 @@
       (simulate-pr-creation! controller mock-pr-info)
       (simulate-ci-result! controller mock-ci-success)
 
-      (is (= :success (:status mock-ci-success))
+      (is (response/success? mock-ci-success)
           "CI should report success")
       (is (every? #(= "success" (:conclusion %))
                   (:checks mock-ci-success))
@@ -410,5 +410,5 @@
 
       ;; After fix, second CI check passes
       (simulate-ci-result! controller mock-ci-success)
-      (is (= :success (:status mock-ci-success))
+      (is (response/success? mock-ci-success)
           "CI should pass after fix"))))


### PR DESCRIPTION
## Summary

Last big mechanical sweep on the original audit's punch list: replaces `(= :success (:status x))` with `(response/success? x)` across test files where `x` is a response-builder output. Three commits, one per component:

1. **bc5568de** `test(agent): use response/success?` — 22 sites across 7 agent test files (reviewer/implementer/tester/curator/releaser/implementer-extended/response-parsing).
2. **f03ec7dd** `test(pr-lifecycle): use response/success?` — 13 sites across 3 pr-lifecycle test files.
3. **a6d15f87** `test(event-stream): use response/success?` — 2 sites in control/approval tests where the result of `execute-control-action!` is a response-builder map.

Reads as intent (`succeeded?`) instead of implementation (`:status equals :success`). The `[ai.miniforge.response.interface :as response]` require is added where missing.

## Why

Direct application of "success?/failed? predicates instead of reaching into data structures for status." Closes the loop on the predicate slice from #595.

## Out of scope (intentional)

A handful of sites *look* like the same pattern but check **domain status enums**, not response-builder outputs:

- [tui-views/test/.../persistence_test.clj:170,212,311](components/tui-views/test/ai/miniforge/tui_views/persistence_test.clj) — workflow/phase status
- [tui-views/test/.../msg_test.clj:232](components/tui-views/test/ai/miniforge/tui_views/msg_test.clj) and `msg_extended_test.clj:150` — message-payload domain status
- [tui-views/test/.../events_test.clj:466](components/tui-views/test/ai/miniforge/tui_views/events_test.clj) and `subscription_test.clj:135` — same
- [web-dashboard/test/.../trains_test.clj:664,710](components/web-dashboard/test/ai/miniforge/web_dashboard/state/trains_test.clj) — `sync-status`'s domain `:status` enum (`:success`/`:partial`/`:failed`)

For those, the right cleanup is a per-domain predicate (`workflow/succeeded?`, `sync-status/successful?`) rather than misuse of `response/success?`. That's its own follow-up — flagged but not done here.

## Test plan

- [x] `bb pre-commit` clean on each commit (0 failures, GraalVM compat passes)
- [x] No assertion semantics changed — `response/success?` is `(= :success (:status r))` literally

🤖 Generated with [Claude Code](https://claude.com/claude-code)