### PR TITLE
refactor(pipeline-runner): DRY :started-at/:completed-at across stage executors

### DIFF
--- a/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/run.clj
+++ b/components/pipeline-runner/src/ai/miniforge/data_foundry/pipeline_runner/run.clj
@@ -19,6 +19,16 @@
   (merge {:stage/id id :stage/name name :status status :retry-count 0}
          extras))
 
+(defn- timestamps
+  "Build the {:started-at :completed-at} window for a just-completed stage.
+   started-at defaults to now (transform/validate stages); pass a value
+   from context to honor an existing window (ingest stage)."
+  ([] (timestamps nil))
+  ([started-at]
+   (let [now (Instant/now)]
+     {:started-at   (or started-at now)
+      :completed-at now})))
+
 (def ^:private auth-keys
   "Keys that belong to auth config, extracted from stage config."
   #{:auth/method :auth/credential-id :auth/credential-scope
@@ -94,11 +104,10 @@
                                      cursor (assoc :extract/cursor cursor)))]
           (conn/close connector handle)
           (stage-result id name :completed
-                        {:started-at (get context :started-at (Instant/now))
-                         :completed-at (Instant/now)
-                         :schema-name schema
-                         :records (:records result)
-                         :cursor (:extract/cursor result)}))
+                        (merge (timestamps (get context :started-at))
+                               {:schema-name schema
+                                :records (:records result)
+                                :cursor (:extract/cursor result)})))
         (catch Exception e
           (stage-result id name :failed {:error-message (.getMessage e)}))))))
 
@@ -134,15 +143,11 @@
       (try
         (let [result-records (transform-fn input-records config)]
           (stage-result id name :completed
-                        {:started-at (Instant/now)
-                         :completed-at (Instant/now)
-                         :records result-records}))
+                        (assoc (timestamps) :records result-records)))
         (catch Exception e
           (stage-result id name :failed {:error-message (.getMessage e)})))
       (stage-result id name :completed
-                    {:started-at (Instant/now)
-                     :completed-at (Instant/now)
-                     :records input-records}))))
+                    (assoc (timestamps) :records input-records)))))
 
 (defn- execute-validate-stage
   "Execute a validate stage using data-quality rules.
@@ -154,10 +159,9 @@
           passed     (dq/filter-passed evaluation)
           report     (dq/generate-report (:pack/id quality-pack) evaluation)]
       (stage-result id name :completed
-                    {:started-at (Instant/now)
-                     :completed-at (Instant/now)
-                     :records passed
-                     :quality-report report}))
+                    (merge (timestamps)
+                           {:records passed
+                            :quality-report report})))
     (execute-transform-stage {:stage/id id :stage/name name :stage/config config} context input-records)))
 
 ;;------------------------------------------------------------------------------ DAG scheduling helpers


### PR DESCRIPTION
## Summary

Three stage executors in `pipeline-runner/run.clj` (ingest, transform, validate) repeated the `{:started-at ... :completed-at (Instant/now) ...}` block — **five copies** total once you count the transform fn's two branches.

Extracts a `timestamps` helper:
- Stamps a single `now`-instant for both fields by default (transform/validate stages).
- Honors a passed-in `started-at` when present (ingest, which threads through `context`'s `:started-at`).

```diff
- {:started-at (get context :started-at (Instant/now))
-  :completed-at (Instant/now)
-  :schema-name schema
-  ...}
+ (merge (timestamps (get context :started-at))
+        {:schema-name schema
+         ...})
```

## Why

Direct application of: "DRY — do not duplicate functionality. Create a component for common logic." Five timestamp-blob copies → one helper.

## Test plan

- [x] `bb pre-commit` clean (995 tests, 0 failures, GraalVM compat passes)
- [x] Behavior identical: same nil-handling for ingest's context lookup, same fresh-now stamping for transform/validate
- [x] Existing tests assert `:inst?` on the fields, not specific timestamps — no test changes needed

## Branch naming note

Branch name (`claude/domain-status-predicates`) was originally scoped for a different slice that turned out not to be worth doing — see end-of-session summary in the conversation. This is a pivot to a smaller, higher-value slice in the same neighborhood.

🤖 Generated with [Claude Code](https://claude.com/claude-code)