### PR TITLE
fix: planner convergence — unblock plan.edn Write + surface error context

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -301,34 +301,37 @@
     path))
 
 (def mcp-tools
-  "MCP tools exposed by the context server, as generic server/tool data.
+  "Tools the inner agent is auto-approved to call, as generic data.
 
-   Each backend adapter (claude, codex, cursor-agent, …) is responsible
-   for translating this into the allowlist / approval shape its CLI
-   expects. Keep this agent-CLI-agnostic — the structured form, not a
-   backend-specific string, is the source of truth.
+   Each backend adapter (claude, codex, cursor-agent, …) translates
+   this into the allowlist / approval shape its CLI expects. Keep
+   agent-CLI-agnostic — the structured form is the source of truth.
 
-   Keywords, not strings: adapters use `(name kw)` when they need the
-   wire string, or dispatch on the value directly with `case` /
-   multimethods. The keyword is the domain identity; the string is
-   the wire encoding.
+   Two entry shapes:
+   - `{:mcp/server :mcp/tool}` — a tool exposed by an MCP server
+   - plain keyword — a native tool from the agent CLI (e.g. `:Write`,
+     needed for plan.edn / code container-promotion writes)
 
    Example wire formats per backend:
-     claude  → --allowedTools \"mcp__context__context_read,...\"
-                 (mcp__<server>__<tool> fully-qualified form)
+     claude  → --allowedTools \"mcp__context__context_read,Write,...\"
      cursor  → --approve-mcps  (blanket approve; no names needed)
      codex   → (currently unused; codex uses its own MCP config)
 
-   Iterations 5-10 of the planner-convergence dogfood lost ~30 minutes
-   of tokens to a bug where bare names (e.g. `context_read`) were
-   passed straight through to Claude's --allowedTools without the
-   required prefix — every MCP call came back denied with
-     \"Claude requested permissions to use mcp__context__context_read,
-      but you haven't granted it yet.\"
-   The fix: keep the generic keyword form here; transform in the adapter."
+   Iter-10 failure — bare names like `context_read` were passed to
+   --allowedTools without the `mcp__<server>__` prefix, so every MCP
+   call got permission-denied. Iter-15 follow-on — `Write` wasn't in
+   the allowlist at all, so the planner's `.miniforge/plan.edn`
+   Write was silently denied (model then narrated 'let me try Edit'
+   and stalled). Both fix back to keeping the structured form honest
+   and adapters translating at the CLI boundary."
   [{:mcp/server :context :mcp/tool :context_read}
    {:mcp/server :context :mcp/tool :context_grep}
-   {:mcp/server :context :mcp/tool :context_glob}])
+   {:mcp/server :context :mcp/tool :context_glob}
+   ;; Native tool: container-promotion submission path. Planner
+   ;; writes .miniforge/plan.edn; implementer writes source/tests;
+   ;; releaser writes PR-body drafts. Roles that shouldn't Write
+   ;; filter via :disallowed-tools separately.
+   :Write])
 
 (defn write-mcp-config!
   "Write session config files for all supported CLI backends.

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -355,9 +355,18 @@
         ;; sized specs (2026-04-18 dogfood). OPSV-converged target — see
         ;; work/n07-opsv-agent-budgets.spec.edn.
         max-turns (get @planner-prompt-data :prompt/max-turns 80)
-        mcp-opts (assoc (artifact-session/session->mcp-opts session budget-usd max-turns)
-                        :model (model/default-model-for-role :planner)
-                        :disallowed-tools planner-disallowed-tools)]
+        ;; Thread the session workdir into the LLM request so the Claude
+        ;; subprocess is spawned inside the task worktree. Without this,
+        ;; Write(".miniforge/plan.edn") resolves to the miniforge repo
+        ;; root — observed iter 17, where Claude Code then refused to
+        ;; overwrite a stale plan.edn left over from an earlier run:
+        ;;   <tool_use_error>File has not been read yet. Read it first
+        ;;    before writing to it.</tool_use_error>
+        ;; The implementer threads :workdir the same way.
+        mcp-opts (cond-> (artifact-session/session->mcp-opts session budget-usd max-turns)
+                   true (assoc :model (model/default-model-for-role :planner)
+                               :disallowed-tools planner-disallowed-tools)
+                   (:workdir session) (assoc :workdir (:workdir session)))]
     (if on-chunk
       (llm/chat-stream llm-client user-prompt on-chunk
                        (merge {:system @planner-system-prompt} mcp-opts))

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -482,10 +482,21 @@
                                                          :tokens tokens}
                                                   stop-reason (assoc :stop-reason stop-reason)
                                                   num-turns   (assoc :num-turns num-turns))})))
-                ;; LLM call failed — no silent fallback
-                (let [error-msg (or (:message (llm/get-error llm-response))
-                                    "LLM call failed")]
-                  (response/error error-msg))))
+                ;; LLM call failed — preserve the full llm-error shape
+                ;; into :data so the phase-completed event carries
+                ;; :type (e.g. "cli_error" / "adaptive_timeout"),
+                ;; :stderr / :stdout / :timeout / :exit-code for
+                ;; post-mortem. Iters 11-12 lost this context and
+                ;; produced undiagnosable \"Unknown error\" / bare
+                ;; \"Process timed out\" phase errors.
+                (let [llm-err (llm/get-error llm-response)
+                      error-msg (or (:message llm-err) "LLM call failed")
+                      stop-reason (:stop-reason llm-response)
+                      num-turns   (:num-turns llm-response)]
+                  (response/error error-msg
+                                  {:data (cond-> (or llm-err {})
+                                           stop-reason (assoc :stop-reason stop-reason)
+                                           num-turns   (assoc :num-turns num-turns))}))))
                ;; No LLM client — hard failure
             (response/throw-anomaly! :anomalies.agent/llm-error
                                     "No LLM backend provided for planner agent"

--- a/components/agent/src/ai/miniforge/agent/planner.clj
+++ b/components/agent/src/ai/miniforge/agent/planner.clj
@@ -449,8 +449,16 @@
                                  (assoc :stop-reason (:stop-reason llm-response))
                                  (:num-turns llm-response)
                                  (assoc :num-turns (:num-turns llm-response)))})
-              (if (llm/success? llm-response)
-                (let [content (llm/get-content llm-response)
+              ;; Container-promotion preempts CLI error classification:
+              ;; if the agent wrote a valid plan.edn into the worktree,
+              ;; that IS the submission and we honor it regardless of
+              ;; whether Claude CLI emitted a clean result event
+              ;; afterwards. Iter 18 hit a stream-idle timeout AFTER a
+              ;; successful Write — the plan existed, but the old
+              ;; success-branch-only logic ignored it because the LLM
+              ;; response was classified as failure.
+              (if (or worktree-plan (llm/success? llm-response))
+                (let [content (or (llm/get-content llm-response) "")
                       stop-reason (:stop-reason llm-response)
                       num-turns   (:num-turns llm-response)
                       plan (or worktree-plan

--- a/components/agent/test/ai/miniforge/agent/artifact_session_extended_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_extended_test.clj
@@ -267,29 +267,38 @@
 ;; mcp-tools tests
 
 (deftest mcp-tools-test
-  (testing "carries generic, agent-CLI-agnostic server/tool data"
+  (testing "carries generic, agent-CLI-agnostic tool data"
     ;; Structured form is the canonical representation. Each backend
     ;; adapter (claude/codex/cursor/…) maps it to its own wire format.
     ;; Do NOT put backend-specific strings here.
     (is (vector? session/mcp-tools))
-    (is (every? map? session/mcp-tools))
-    (is (every? #(and (:mcp/server %) (:mcp/tool %)) session/mcp-tools)))
+    (is (every? #(or (map? %) (keyword? %)) session/mcp-tools)
+        "entries are either keyword maps (MCP) or bare keywords (native)"))
 
-  (testing "server and tool are keywords — adapters (name kw) for the wire"
-    (is (every? #(keyword? (:mcp/server %)) session/mcp-tools))
-    (is (every? #(keyword? (:mcp/tool %)) session/mcp-tools)))
+  (testing "MCP entries use keyword :mcp/server + :mcp/tool"
+    (let [mcp-entries (filter map? session/mcp-tools)]
+      (is (every? #(keyword? (:mcp/server %)) mcp-entries))
+      (is (every? #(keyword? (:mcp/tool %)) mcp-entries))))
 
-  (testing "contains the expected context-server tools"
-    (is (every? #(= :context (:mcp/server %)) session/mcp-tools))
-    (is (= #{:context_read :context_grep :context_glob}
-           (into #{} (map :mcp/tool) session/mcp-tools))))
+  (testing "context-server MCP tools are present"
+    (let [mcp-entries (filter map? session/mcp-tools)]
+      (is (every? #(= :context (:mcp/server %)) mcp-entries))
+      (is (= #{:context_read :context_grep :context_glob}
+             (into #{} (map :mcp/tool) mcp-entries)))))
+
+  (testing "native Write is auto-approved — plan.edn submission path"
+    ;; Iter 15 dogfood regression — Write wasn't in --allowedTools,
+    ;; Claude CLI silently denied the planner's plan.edn Write, model
+    ;; narrated 'let me try Edit' and stalled. Keep Write.
+    (is (some #{:Write} session/mcp-tools)
+        "Write must stay auto-approved for container-promotion submissions"))
 
   (testing "never contains backend-specific wire strings (regression guard)"
     ;; Claude's `mcp__<server>__<tool>` form belongs in the Claude
-    ;; adapter, not here. Guard against drift that previously cost us
-    ;; six dogfood iterations.
+    ;; adapter, not here. Native tools go through (name kw).
     (doseq [t session/mcp-tools]
-      (is (not (string? t)) "mcp-tools entries should be maps, not strings"))))
+      (is (not (string? t))
+          "mcp-tools entries should be maps or keywords, not strings"))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; write-claude-settings! tests

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -90,10 +90,9 @@
           (is (= (:mcp-config-path s) (:mcp-config-path result)))
           (is (= (:artifact-path s) (:artifact-path result)))
           (is (vector? (:mcp-allowed-tools result)))
-          ;; Generic server/tool data — backend adapters translate.
-          (is (every? map? (:mcp-allowed-tools result)))
-          (is (every? #(and (:mcp/server %) (:mcp/tool %))
-                      (:mcp-allowed-tools result))))
+          ;; Mixed-shape: MCP entries are {:mcp/server :mcp/tool} maps;
+          ;; native entries are bare keywords. Adapters translate.
+          (is (every? #(or (map? %) (keyword? %)) (:mcp-allowed-tools result))))
         (finally
           (session/cleanup-session! s))))))
 

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -546,7 +546,11 @@
         ;; and the 60s cap tripped on ordinary thinking time). The
         ;; progress-monitor's stagnation-threshold (120s) is separately
         ;; the upper bound on activity silence.
-        line-timeout-ms 180000]
+        line-timeout-ms 180000
+        dump-path (System/getenv "MF_STREAM_DUMP")
+        dump-writer (when dump-path
+                      (java.io.PrintWriter.
+                        (java.io.FileWriter. dump-path true)))]
     (loop []
       (if-let [t (pm/check-timeout monitor)]
         ;; Progress-monitor timeout (stagnation or total-max)
@@ -554,6 +558,7 @@
         (if-let [line (read-line-with-timeout out-reader line-timeout-ms)]
           (do (swap! out-lines conj line)
               (pm/record-chunk! monitor line)
+              (when dump-writer (.println dump-writer line) (.flush dump-writer))
               (on-line line)
               (recur))
           ;; Line-timeout: reader produced nothing for line-timeout-ms.
@@ -566,6 +571,7 @@
                    :message (str "No stream output for " line-timeout-ms "ms")
                    :elapsed-ms line-timeout-ms
                    :stats {:lines-read (count @out-lines)}}))))
+    (when dump-writer (.close dump-writer))
     {:lines @out-lines
      :timeout @timeout-reason}))
 

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -535,13 +535,24 @@
         timeout-reason (atom nil)
         line-timeout-ms 60000]
     (loop []
-      (if-let [timeout-check (pm/check-timeout monitor)]
-        (reset! timeout-reason timeout-check)
-        (when-let [line (read-line-with-timeout out-reader line-timeout-ms)]
-          (swap! out-lines conj line)
-          (pm/record-chunk! monitor line)
-          (on-line line)
-          (recur))))
+      (if-let [t (pm/check-timeout monitor)]
+        ;; Progress-monitor timeout (stagnation or total-max)
+        (reset! timeout-reason t)
+        (if-let [line (read-line-with-timeout out-reader line-timeout-ms)]
+          (do (swap! out-lines conj line)
+              (pm/record-chunk! monitor line)
+              (on-line line)
+              (recur))
+          ;; Line-timeout: reader produced nothing for line-timeout-ms.
+          ;; Treat as stream-idle — a stalled stream, not clean EOF.
+          ;; Set an explicit reason so the caller reports it instead of
+          ;; waiting on `deref process` for the full 10 min and then
+          ;; reporting a bare "Process timed out" with no context.
+          (reset! timeout-reason
+                  {:type :stream-idle
+                   :message (str "No stream output for " line-timeout-ms "ms")
+                   :elapsed-ms line-timeout-ms
+                   :stats {:lines-read (count @out-lines)}}))))
     {:lines @out-lines
      :timeout @timeout-reason}))
 
@@ -564,6 +575,15 @@
          out-reader (java.io.BufferedReader.
                      (java.io.InputStreamReader. (:out process)))
          {:keys [lines timeout]} (process-stream-lines out-reader monitor on-line)
+         ;; Stream ended with a timeout reason (stream-idle,
+         ;; stagnation, or total-max) — the subprocess is hung or
+         ;; silent. Kill it so `deref` returns immediately instead of
+         ;; waiting 10 min for a process that will not exit.
+         _ (when timeout
+             (try
+               (when-let [^Process jp (:proc process)]
+                 (.destroyForcibly jp))
+               (catch Exception _ nil)))
          result (deref process 600000 {:exit -1 :err "Process timed out"})]
      (if timeout
        (timeout-result lines timeout)

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -533,7 +533,13 @@
 (defn process-stream-lines [out-reader monitor on-line]
   (let [out-lines (atom [])
         timeout-reason (atom nil)
-        line-timeout-ms 60000]
+        ;; 180s — Opus 4.6 can be silent for 60-90s while reasoning
+        ;; between tool-call batches (observed iter 14: 20 tool calls,
+        ;; 0 text chunks, stream went quiet after the 20th tool result
+        ;; and the 60s cap tripped on ordinary thinking time). The
+        ;; progress-monitor's stagnation-threshold (120s) is separately
+        ;; the upper bound on activity silence.
+        line-timeout-ms 180000]
     (loop []
       (if-let [t (pm/check-timeout monitor)]
         ;; Progress-monitor timeout (stagnation or total-max)

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -230,14 +230,21 @@
 (defn claude-mcp-allowlist-string
   "Claude CLI's --allowedTools wire format.
 
-   `mcp-allowed-tools` is a vector of `{:mcp/server :mcp/tool}` keyword
-   maps. Each entry becomes `mcp__<server>__<tool>`; all joined with
-   commas. A malformed entry throws via `(name nil)` at the call site
-   — the canonical shape is the only accepted shape."
+   Accepts two entry shapes:
+   - `{:mcp/server :mcp/tool}` keyword map → `mcp__<server>__<tool>`
+     (MCP tool; server name comes from the mcp-config.json key)
+   - Keyword by itself → `(name kw)` (native Claude Code tool,
+     e.g. `:Write`)
+
+   Entries are joined with commas. A malformed entry throws via
+   `(name nil)` at the call site."
   [mcp-allowed-tools]
   (->> mcp-allowed-tools
-       (mapv (fn [{:mcp/keys [server tool]}]
-               (str "mcp__" (name server) "__" (name tool))))
+       (mapv (fn [t]
+               (if (keyword? t)
+                 (name t)
+                 (let [{:mcp/keys [server tool]} t]
+                   (str "mcp__" (name server) "__" (name tool))))))
        (str/join ",")))
 
 (defn- claude-args

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -53,14 +53,28 @@
       (is (some #(= "/tmp/mcp.json" %) args)))))
 
 (deftest claude-args-allowed-tools-test
-  (testing "mcp-allowed-tools format as mcp__<server>__<tool>, joined with commas"
+  (testing "mcp maps format as mcp__<server>__<tool>, joined with commas"
     (let [args ((private-fn 'claude-args)
                 {:prompt "p"
                  :mcp-allowed-tools
                  [{:mcp/server :context :mcp/tool :context_read}
                   {:mcp/server :context :mcp/tool :context_grep}]})]
       (is (some #(= "--allowedTools" %) args))
-      (is (some #(= "mcp__context__context_read,mcp__context__context_grep" %) args)))))
+      (is (some #(= "mcp__context__context_read,mcp__context__context_grep" %) args))))
+
+  (testing "bare keywords format as the native tool name"
+    (let [args ((private-fn 'claude-args)
+                {:prompt "p"
+                 :mcp-allowed-tools [:Write :Edit]})]
+      (is (some #(= "Write,Edit" %) args))))
+
+  (testing "mixed maps + keywords format correctly"
+    (let [args ((private-fn 'claude-args)
+                {:prompt "p"
+                 :mcp-allowed-tools
+                 [{:mcp/server :context :mcp/tool :context_read}
+                  :Write]})]
+      (is (some #(= "mcp__context__context_read,Write" %) args)))))
 
 (deftest claude-mcp-allowlist-string-test
   (testing "keyword server + tool → mcp__<server>__<tool>"
@@ -68,11 +82,22 @@
            (impl/claude-mcp-allowlist-string
              [{:mcp/server :context :mcp/tool :context_read}]))))
 
-  (testing "multiple entries joined with commas"
+  (testing "bare keyword → (name kw) — native tools"
+    (is (= "Write" (impl/claude-mcp-allowlist-string [:Write])))
+    (is (= "Write,Edit" (impl/claude-mcp-allowlist-string [:Write :Edit]))))
+
+  (testing "multiple mcp entries joined with commas"
     (is (= "mcp__ctx__a,mcp__ctx__b"
            (impl/claude-mcp-allowlist-string
              [{:mcp/server :ctx :mcp/tool :a}
               {:mcp/server :ctx :mcp/tool :b}]))))
+
+  (testing "mixed mcp maps + native keywords"
+    (is (= "mcp__ctx__read,Write,mcp__ctx__grep"
+           (impl/claude-mcp-allowlist-string
+             [{:mcp/server :ctx :mcp/tool :read}
+              :Write
+              {:mcp/server :ctx :mcp/tool :grep}]))))
 
   (testing "empty vector produces empty string"
     (is (= "" (impl/claude-mcp-allowlist-string [])))))

--- a/components/response/src/ai/miniforge/response/builder.clj
+++ b/components/response/src/ai/miniforge/response/builder.clj
@@ -65,6 +65,29 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Error responses
 
+(defn- format-stack-frame
+  "Render one StackTraceElement as ClassName.methodName (File:line)."
+  [^StackTraceElement e]
+  (str (.getClassName e) "." (.getMethodName e)
+       " (" (.getFileName e) ":" (.getLineNumber e) ")"))
+
+(defn- stack-preview
+  "Render the top N frames of a stack trace as short strings. Returns
+   nil when the exception has no stack (e.g. doto-constructed Throwable)."
+  [^Throwable ex n]
+  (when-let [st (seq (.getStackTrace ex))]
+    (mapv format-stack-frame (take n st))))
+
+(defn- exception->data
+  "Exception → :data map with :exception/class and (when available)
+   :exception/stack-preview. Kept short so failures like NPE — which
+   carry no getMessage or ex-data — still name the exception class
+   and top frames in the phase-completed event."
+  [^Throwable ex]
+  (let [preview (stack-preview ex 8)]
+    (cond-> {:exception/class (.getName (class ex))}
+      preview (assoc :exception/stack-preview preview))))
+
 (defn error-details
   "Create canonical error details map.
 
@@ -97,16 +120,7 @@
          ;; through as {:message "Unknown error" :data {}} — that empty
          ;; shape is what made iter-11 planner failure un-diagnosable.
          exception-data (when exception?
-                          (let [st (seq (.getStackTrace ^Exception message))]
-                            (cond-> {:exception/class (.getName (class message))}
-                              st (assoc :exception/stack-preview
-                                        (->> st
-                                             (take 8)
-                                             (mapv (fn [^StackTraceElement e]
-                                                     (str (.getClassName e) "."
-                                                          (.getMethodName e)
-                                                          " (" (.getFileName e)
-                                                          ":" (.getLineNumber e) ")"))))))))
+                          (exception->data message))
          err-data (merge (when exception? exception-data)
                          (when exception? (ex-data message))
                          data)]

--- a/components/response/src/ai/miniforge/response/builder.clj
+++ b/components/response/src/ai/miniforge/response/builder.clj
@@ -81,21 +81,37 @@
   ([message]
    (error-details message nil))
   ([message data]
-   (let [raw-msg (if (instance? Exception message)
+   (let [exception? (instance? Exception message)
+         raw-msg (if exception?
                    (.getMessage ^Exception message)
                    (str message))
          ;; Ensure message is never nil or empty — downstream (or msg fallback)
          ;; treats "" as truthy, masking useful defaults
          msg (if (or (nil? raw-msg) (clojure.string/blank? raw-msg))
-               (if (instance? Exception message)
+               (if exception?
                  (str (class message))
                  "Unknown error")
                raw-msg)
-         err-data (if (instance? Exception message)
-                   (or data (ex-data message) {})
-                   (or data {}))]
+         ;; For Exception messages, attach class + optional stack preview
+         ;; so failures like NPE (no getMessage, no ex-data) don't come
+         ;; through as {:message "Unknown error" :data {}} — that empty
+         ;; shape is what made iter-11 planner failure un-diagnosable.
+         exception-data (when exception?
+                          (let [st (seq (.getStackTrace ^Exception message))]
+                            (cond-> {:exception/class (.getName (class message))}
+                              st (assoc :exception/stack-preview
+                                        (->> st
+                                             (take 8)
+                                             (mapv (fn [^StackTraceElement e]
+                                                     (str (.getClassName e) "."
+                                                          (.getMethodName e)
+                                                          " (" (.getFileName e)
+                                                          ":" (.getLineNumber e) ")"))))))))
+         err-data (merge (when exception? exception-data)
+                         (when exception? (ex-data message))
+                         data)]
      {:message msg
-      :data err-data})))
+      :data (or err-data {})})))
 
 (defn error
   "Create a canonical error response.

--- a/components/response/test/ai/miniforge/response/interface_test.clj
+++ b/components/response/test/ai/miniforge/response/interface_test.clj
@@ -432,6 +432,45 @@
       (is (some? (get-in resp [:error :message])))
       (is (pos? (count (get-in resp [:error :message])))))))
 
+(deftest error-details-exception-class-test
+  (testing "exception class is attached to :data — no more empty error data on NPE"
+    ;; Iter 11 of planner-convergence dogfood produced {:message "Unknown
+    ;; error" :data {}} which was undiagnosable. Whatever the exception is,
+    ;; its class MUST land in :data.
+    (let [resp (r/error (NullPointerException.))]
+      (is (= "java.lang.NullPointerException"
+             (get-in resp [:error :data :exception/class])))))
+
+  (testing "exception stack preview is attached (first 8 frames)"
+    (let [resp (r/error (Exception. "boom"))
+          preview (get-in resp [:error :data :exception/stack-preview])]
+      (is (vector? preview))
+      (is (<= (count preview) 8))
+      (is (every? string? preview))))
+
+  (testing "ex-data from ex-info is merged with the class/stack preview"
+    (let [ex (ex-info "boom" {:phase :plan :llm-content-length 42})
+          resp (r/error ex)]
+      (is (= "clojure.lang.ExceptionInfo"
+             (get-in resp [:error :data :exception/class])))
+      (is (= :plan (get-in resp [:error :data :phase])))
+      (is (= 42 (get-in resp [:error :data :llm-content-length])))))
+
+  (testing "explicit :data opt takes precedence over ex-data keys of same name"
+    (let [ex (ex-info "boom" {:phase :plan})
+          resp (r/error ex {:data {:phase :override}})]
+      (is (= :override (get-in resp [:error :data :phase])))))
+
+  (testing "non-exception messages: no exception-class key, data stays clean"
+    (let [resp (r/error "plain string")]
+      (is (nil? (get-in resp [:error :data :exception/class])))
+      (is (nil? (get-in resp [:error :data :exception/stack-preview])))))
+
+  (testing "failure preserves the same exception shape"
+    (let [resp (r/failure (NullPointerException.))]
+      (is (= "java.lang.NullPointerException"
+             (get-in resp [:error :data :exception/class]))))))
+
 ;; ============================================================================
 ;; Result map predicates (success?/error?)
 ;; ============================================================================


### PR DESCRIPTION
## Summary

Landed iteration 19 of the planner-convergence dogfood loop as the first **plan phase green**. Eight commits, each a distinct failure mode that iters 11–18 surfaced. The ordering here is also the order of root causes peeled off — each uncovered the next.

## Iter-by-iter chain

| commit | iter surfaced it | what was broken |
| --- | --- | --- |
| `1bef7ea1` | iter 11 | `error-details` flattened exceptions with nil `.getMessage` + no `ex-data` into `{:message "Unknown error" :data {}}`. Now attaches `:exception/class` + 8-frame stack preview. |
| `280455e4` | iter 12 | Planner's error branch extracted only `:message` from `llm-error` — discarded `:type`, `:stderr`, `:stdout`, `:timeout`. Now forwards the full llm-error shape as `:data`. |
| `b34f1ccc` | iter 13 | `process-stream-lines` exited silently on line-timeout, letting `deref process 600000` add 10 min of wall time before reporting. Now tags `:type :stream-idle` and `.destroyForcibly`s the subprocess. |
| `27bf71b3` | iter 14 | 60s line-timeout tripped on legitimate Opus 4.6 silent-reasoning pauses. Raised to 180s; progress-monitor's 120s stagnation threshold remains. |
| `9b8a94c2` | iter 15 | `Write` wasn't in `--allowedTools` — Claude CLI silently denied the planner's plan.edn Write. `mcp-tools` now carries `:Write` as a keyword; adapter transform accepts `{:mcp/server :mcp/tool}` maps AND bare keywords. |
| `d7c52ca2` | iter 16 diagnostic | `MF_STREAM_DUMP` env var appends the raw Claude stream-json to a file. Left in place — zero-cost when unset, invaluable when a new failure mode appears. |
| `405dd351` | iter 17 | Planner's Claude subprocess cwd was the miniforge repo instead of the task worktree. Write(".miniforge/plan.edn") resolved to `/Users/chris/.../miniforge/.miniforge/plan.edn` where a 20K stale plan.edn blocked Claude Code's "Read-before-Write" safety. Planner now threads session `:workdir` into the LLM request. |
| `0bcf4f4a` | iter 18 | Write succeeded (15K plan.edn in the correct worktree), but Claude CLI stalled AFTER the Write emitting no result event → runtime timeout → planner's error branch ignored the worktree artifact. Container-promotion semantics fix: `(or worktree-plan (llm/success? llm-response))` — the artifact is the submission, independent of CLI termination. |

## Iter 19 result

\`\`\`
workflow/phase-completed phase=:plan out=:success dur=183135ms (3:03)
\`\`\`

\`/private/tmp/miniforge-worktrees/task-b7c68424/.miniforge/plan.edn\` — 14,156 bytes, 8 well-scoped tasks:

1. Web-cache MCP tools (`web_fetch` + `web_search` with sha256-addressed cache) — GROUP 2B
2. Codex stop_reason capture
3. Extend PhaseCompleted schema with diagnostic metadata
4. Add WebSearch/WebFetch to planner disallow (after 2B)
5. Wire stop-reason through phase-completed events
6. Web cache tests
7. Codex + planner-disallow tests
8. Review checkpoint

The planner correctly identified what this PR already did (GROUP 1/2/3 mostly landed) and produced a plan for the remaining GROUP 2B + Codex work.

## Test plan

- [x] `error-details-exception-class-test` (5 sub-cases, 11 asserts)
- [x] `mcp-tools-test` with `:Write` regression guard (4 sub-cases)
- [x] `claude-mcp-allowlist-string-test` with keyword + mixed shapes (6 asserts)
- [x] `claude-args-allowed-tools-test` end-to-end into CLI args
- [x] 30 / 129 assertions across planner + artifact-session suites
- [x] 64 / 348 assertions across llm + planner + response suites
- [x] Pre-commit + GraalVM green on every commit
- [x] **Iter 19 dogfood run: plan phase SUCCESS**

## What remains

The plan.edn for iter 19 names the follow-up specs itself:

- GROUP 2B: web cache MCP (web_fetch, web_search with content-addressed caching)
- GROUP 2c: WebSearch/WebFetch disallow (after 2B provides replacements)
- Codex stop_reason parity
- Phase-completed event schema extensions

Implementer phase convergence is likely to uncover similar classes of failures — but now we have the diagnostic infrastructure to chase them fast (stop_reason, stream-idle fail-fast, stream dump, proper error preservation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)