### PR TITLE
refactor(polylith): clear Error 107 + Warning 207 — project membership

### DIFF
--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -56,7 +56,10 @@ ai.miniforge/messages {:local/root "../../components/messages"}
         ai.miniforge/pr-train {:local/root "../../components/pr-train"}
         ai.miniforge/pr-sync {:local/root "../../components/pr-sync"}
         ai.miniforge/repo-dag {:local/root "../../components/repo-dag"}
-        ai.miniforge/task-executor {:local/root "../../components/task-executor"}}
+        ai.miniforge/task-executor {:local/root "../../components/task-executor"}
+        ai.miniforge/diagnosis {:local/root "../../components/diagnosis"}
+        ai.miniforge/improvement {:local/root "../../components/improvement"}
+        ai.miniforge/reliability {:local/root "../../components/reliability"}}
 
  :aliases
  {:uberjar

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -55,7 +55,19 @@
         ;; Spec parsing
         ai.miniforge/spec-parser {:local/root "../../components/spec-parser"}
         ai.miniforge/messages {:local/root "../../components/messages"}
-        ai.miniforge/patterns {:local/root "../../components/patterns"}}
+        ai.miniforge/patterns {:local/root "../../components/patterns"}
+        ai.miniforge/compliance-scanner {:local/root "../../components/compliance-scanner"}
+        ai.miniforge/connector-linter {:local/root "../../components/connector-linter"}
+        ai.miniforge/context-pack {:local/root "../../components/context-pack"}
+        ai.miniforge/dag-primitives {:local/root "../../components/dag-primitives"}
+        ai.miniforge/decision {:local/root "../../components/decision"}
+        ai.miniforge/diagnosis {:local/root "../../components/diagnosis"}
+        ai.miniforge/improvement {:local/root "../../components/improvement"}
+        ai.miniforge/reliability {:local/root "../../components/reliability"}
+        ai.miniforge/repo-index {:local/root "../../components/repo-index"}
+        ai.miniforge/semantic-analyzer {:local/root "../../components/semantic-analyzer"}
+        ai.miniforge/lsp-mcp-bridge {:local/root "../../bases/lsp-mcp-bridge"}
+        ai.miniforge/mcp-context-server {:local/root "../../bases/mcp-context-server"}}
 
  :aliases
  {:uberjar

--- a/workspace.edn
+++ b/workspace.edn
@@ -7,8 +7,70 @@
  :tag-patterns {:stable "stable/*"
                 :release "v[0-9]*"}
  :projects {"development"    {:alias "dev"}
-            "miniforge-core" {:alias "core"}
-            "miniforge"      {:alias "cli"}
-            "miniforge-tui"  {:alias "tui"}
-            ;; bb-utils (shared Babashka utilities)
-            "bb-utils"       {:alias "bb-utils"}}}
+            "miniforge-core" {:alias "core"
+                              ;; Runtime-loaded via phase/namespaces.edn resource discovery
+                              ;; (see components/phase/src/ai/miniforge/phase/loader.clj) and
+                              ;; workflow chain registration, so static analysis doesn't see
+                              ;; the dependency.
+                              :necessary ["adapter-claude-code"
+                                          "connector" "connector-auth" "connector-retry"
+                                          "evidence-bundle"
+                                          "observer" "orchestrator"
+                                          "policy"
+                                          "pr-sync"
+                                          "repo-dag"
+                                          "reporting"
+                                          "task-executor"
+                                          "tool-registry"
+                                          "workflow-compliance-scanner"]}
+            "miniforge"      {:alias "cli"
+                              ;; Same pattern: workflow-*/phase-deployment are bundled so the
+                              ;; CLI has every phase/workflow interceptor on the classpath at
+                              ;; runtime; the phase loader picks them up from resource config.
+                              :necessary ["adapter-claude-code"
+                                          "connector" "connector-auth" "connector-retry"
+                                          "evaluation"
+                                          "evidence-bundle"
+                                          "failure-classifier"
+                                          "observer" "orchestrator"
+                                          "phase-deployment"
+                                          "policy"
+                                          "repo-dag"
+                                          "reporting"
+                                          "task-executor"
+                                          "tool-registry"
+                                          "training-capture"
+                                          "tui-views"
+                                          "web-dashboard"
+                                          "workflow-chain-deployment"
+                                          "workflow-chain-software-factory"
+                                          "workflow-compliance-scanner"
+                                          "workflow-deployment"
+                                          "workflow-financial-etl"
+                                          "workflow-software-factory"]}
+            "miniforge-tui"  {:alias "tui"
+                              ;; miniforge-tui is being replaced by miniforge-console; the
+                              ;; bundled components below are still present so downstream
+                              ;; users on the tui project build today keep working.
+                              :necessary ["evidence-bundle"
+                                          "observer" "orchestrator"
+                                          "phase"
+                                          "policy"
+                                          "repo-dag"
+                                          "reporting"
+                                          "task-executor"
+                                          "tool-registry"
+                                          "tui-views"
+                                          "workflow-chain-software-factory"
+                                          "workflow-financial-etl"
+                                          "workflow-software-factory"]}
+            ;; bb-utils is an aggregator — it deliberately bundles every shared Babashka
+            ;; helper so downstream miniforge products can pull the set as a single
+            ;; :local/root. None of the bb-* components are "unnecessary" here.
+            "bb-utils"       {:alias "bb-utils"
+                              :necessary ["bb-config"
+                                          "bb-data-plane-http"
+                                          "bb-etl-runner"
+                                          "bb-generate-icon"
+                                          "bb-r2"
+                                          "bb-test-runner"]}}}


### PR DESCRIPTION
## Summary
Follow-up to #612. With unique interfaces now in place, the remaining \`poly check\` noise was project-level, not component-level.

- Error 107 (missing components per project):
  * \`miniforge-core\` was missing \`diagnosis\`, \`improvement\`, \`reliability\`. These are required transitively by \`agent\`'s meta-coordinator (\`components/agent/src/ai/miniforge/agent/meta_coordinator.clj\`) — adding them to the project's deps.edn closes the gap.
  * \`miniforge-tui\` was missing ten brick interfaces + the \`lsp-mcp-bridge\` and \`mcp-context-server\` bases. I added the deps in place rather than deleting the project, since tui is on the way out (replaced by miniforge-console) but shouldn't break in the meantime.
- Warning 207 (unnecessary components): marked bundled components as \`:necessary\` per project in \`workspace.edn\`. These aren't drift — they're real runtime dependencies that polylith can't see statically:
  * The phase loader discovers phase-interceptor namespaces from classpath resources (\`config/phase/namespaces.edn\`), so \`workflow-*\`/\`phase-deployment\` packs don't appear on any \`(:require …)\` path but still need to be on the classpath.
  * \`bb-utils\` is an aggregator project — every \`bb-*\` component is deliberately bundled so downstream miniforge products can pull the shared helpers as a single \`:local/root\`.
  The \`:necessary\` entries document the list and the reason inline so future prunes can tell intentional bundling from drift.

After this, \`poly check\` reports \`OK\` across all projects. No more errors or warnings.

## Base
Stacked on \`feat/polylith-hygiene\` (#612). Rebase to main once #612 lands.

## Test plan
- [x] \`poly check\` — OK (no errors, no warnings).
- [x] Repo-wide pre-commit gate (lint + \`bb test\` + \`bb test:graalvm\`) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)