### PR TITLE
feat(implementer): port planner-convergence fixes — artifact wins on CLI error

### DIFF
--- a/components/agent/src/ai/miniforge/agent/implementer.clj
+++ b/components/agent/src/ai/miniforge/agent/implementer.clj
@@ -508,16 +508,41 @@
                 {:data {:file-count (count (:code/files file-artifact))
                         :tools-called (get response :tools-called [])}}))
     (log/info logger :implementer :implementer/llm-called
-              {:data {:success (llm/success? response)
-                      :tokens tokens
-                      :streaming? (boolean on-chunk)
-                      :file-artifact-fallback? (= :file-fallback artifact-source)
-                      :tools-called (get response :tools-called [])}})
-    (if (llm/success? response)
+              {:data (cond-> {:success (llm/success? response)
+                              :tokens tokens
+                              :streaming? (boolean on-chunk)
+                              :artifact-source (or artifact-source :none)
+                              :tools-called (get response :tools-called [])}
+                       (:stop-reason response)
+                       (assoc :stop-reason (:stop-reason response))
+                       (:num-turns response)
+                       (assoc :num-turns (:num-turns response)))})
+    ;; Container-promotion precedence: if the agent wrote files into
+    ;; the worktree (file-artifact via collect-written-files) or
+    ;; submitted via the MCP artifact path, honor that even when the
+    ;; CLI itself terminated with a timeout/error. Iter-20 of the
+    ;; planner-convergence dogfood showed Claude stalling AFTER a
+    ;; successful stream of edits; the old path discarded a real
+    ;; artifact because the LLM response was classified as failure.
+    ;; Mirrors the planner fix in `(or worktree-plan (llm/success? …))`.
+    (if (or effective-artifact (llm/success? response))
       (process-llm-response response effective-artifact artifact-source
                             context logger tokens cost-usd)
-      (response/error (or (:message (llm/get-error response))
-                          (messages/t :error/llm-failed))))))
+      ;; LLM call failed, no artifact — preserve the full llm-error
+      ;; shape into :data so the phase-completed event carries
+      ;; :type (e.g. "cli_error" / "adaptive_timeout"), :stderr /
+      ;; :stdout / :timeout / :exit-code for post-mortem. Iters
+      ;; 11-12 of planner-convergence lost this context and produced
+      ;; undiagnosable "Unknown error" phase errors; same trap here.
+      (let [llm-err (llm/get-error response)
+            error-msg (or (:message llm-err)
+                          (messages/t :error/llm-failed))
+            stop-reason (:stop-reason response)
+            num-turns   (:num-turns response)]
+        (response/error error-msg
+                        {:data (cond-> (or llm-err {})
+                                 stop-reason (assoc :stop-reason stop-reason)
+                                 num-turns   (assoc :num-turns num-turns))})))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Public API

--- a/components/agent/test/ai/miniforge/agent/implementer_test.clj
+++ b/components/agent/test/ai/miniforge/agent/implementer_test.clj
@@ -153,7 +153,85 @@
       (is (= "Collected from working tree"
              (get-in result [:output :code/summary])))
       (is (= :warn (:log/level fallback-log)))
-      (is (= 1 (get-in fallback-log [:data :file-count]))))))
+      (is (= 1 (get-in fallback-log [:data :file-count])))))
+
+  (testing "file artifact wins when LLM call failed (CLI timeout with files on disk)"
+    ;; Iter 20 parity: Claude stalled after successful writes. The file-
+    ;; artifact container-promotion must preempt the CLI-error branch
+    ;; just like the planner's worktree-plan precedence.
+    (let [[logger _] (log/collecting-logger {:min-level :trace})
+          fallback-artifact {:code/files [{:path "src/partial.clj"
+                                           :content "(ns partial)"
+                                           :action :create}]
+                             :code/summary "written before stall"
+                             :code/language "clojure"
+                             :code/tests-needed? true}
+          error-response {:success false
+                          :error {:type "adaptive_timeout"
+                                  :message "Adaptive timeout: stream-idle"
+                                  :timeout {:type :stream-idle :elapsed-ms 180000}}
+                          :anomaly {}}
+          result (with-redefs [artifact-session/create-session!
+                               (fn [& _] (session-map))
+                               artifact-session/write-mcp-config!
+                               identity
+                               artifact-session/read-artifact
+                               (constantly nil)
+                               artifact-session/read-context-misses
+                               (constantly nil)
+                               artifact-session/cleanup-session!
+                               (constantly nil)
+                               budget/resolve-cost-budget-usd
+                               (fn [& _] 1.0)
+                               llm/chat
+                               (fn [& _] error-response)
+                               file-artifacts/collect-written-files
+                               (fn [_ _] fallback-artifact)]
+                   (@#'implementer/invoke-with-llm
+                    nil "prompt" "system" {} {} nil logger []))]
+      (is (response/success? result)
+          "file artifact container-promotion honors the work even on CLI error")
+      (is (= [{:path "src/partial.clj"
+               :content "(ns partial)"
+               :action :create}]
+             (get-in result [:output :code/files])))))
+
+  (testing "LLM error preserves :type + timeout shape in :data for diagnostics"
+    ;; Iter 20 parity: the planner error path forwards llm-error as
+    ;; :data. Same here so mf events show names the real failure
+    ;; class instead of a bare message.
+    (let [[logger _] (log/collecting-logger {:min-level :trace})
+          error-response {:success false
+                          :error {:type "adaptive_timeout"
+                                  :message "Adaptive timeout: stream-idle"
+                                  :timeout {:type :stream-idle :elapsed-ms 180000}
+                                  :exit-code -1}
+                          :stop-reason "max_turns"
+                          :num-turns 10}
+          result (with-redefs [artifact-session/create-session!
+                               (fn [& _] (session-map))
+                               artifact-session/write-mcp-config!
+                               identity
+                               artifact-session/read-artifact
+                               (constantly nil)
+                               artifact-session/read-context-misses
+                               (constantly nil)
+                               artifact-session/cleanup-session!
+                               (constantly nil)
+                               budget/resolve-cost-budget-usd
+                               (fn [& _] 1.0)
+                               llm/chat
+                               (fn [& _] error-response)
+                               file-artifacts/collect-written-files
+                               (fn [_ _] nil)]
+                   (@#'implementer/invoke-with-llm
+                    nil "prompt" "system" {} {} nil logger []))]
+      (is (response/error? result))
+      (is (= "Adaptive timeout: stream-idle" (get-in result [:error :message])))
+      (is (= "adaptive_timeout" (get-in result [:error :data :type])))
+      (is (= :stream-idle (get-in result [:error :data :timeout :type])))
+      (is (= "max_turns" (get-in result [:error :data :stop-reason])))
+      (is (= 10 (get-in result [:error :data :num-turns]))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation tests


### PR DESCRIPTION
## Summary

Iter-20 of the planner-convergence dogfood landed plan phase green, then both spawned implement sub-workflows failed. The implementer had two of the same bugs the planner just got fixed in #610:

1. File-artifact container promotion was only honored when \`(llm/success? response)\` — CLI timeout AFTER the agent wrote files to the worktree discarded the work.
2. The error branch extracted only \`:message\` from llm-error, losing \`:type\`, \`:timeout\`, \`:stderr\`, \`:stdout\`, \`:exit-code\` — same undiagnosable bare-message shape.

## Fix

- \`(if (or effective-artifact (llm/success? response)) …)\` — container-promotion result preempts CLI classification. Mirrors the planner's \`(or worktree-plan (llm/success? …))\`.
- Error path forwards the full llm-error as \`:data\` with \`:stop-reason\` + \`:num-turns\` merged.
- \`:implementer/llm-called\` log event gets \`:stop-reason\` / \`:num-turns\` / \`:artifact-source\` for parity with the planner.

## Already in place (from #610)

Global fixes applied to every role; implementer inherits them:

- \`:workdir\` threading into Claude subprocess (implementer was already correct)
- \`:Write\` in \`--allowedTools\`
- stream-idle fast-fail + \`.destroyForcibly\` on hung subprocess
- 180s line-timeout for Opus reasoning pauses

## Test plan

- [x] Existing invoke/fallback tests green
- [x] **NEW**: \"file artifact wins when LLM call failed\" — iter-20 regression guard
- [x] **NEW**: \"LLM error preserves :type + timeout shape in :data\" — stop-reason, num-turns, timeout type all flow through
- [x] 11 / 66 assertions on implementer-test green
- [x] Pre-commit + GraalVM
- [ ] Post-merge: iter 21 against planner-convergence spec — expect sub-workflow implement phases to succeed (or fail with structured, diagnosable error data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)