### PR TITLE
feat(supervisory-state): TaskNode + :supervisory/task-node-upserted (N5-δ3 §2.3)

### DIFF
--- a/components/supervisory-state/resources/config/supervisory-state/task-kanban-mapping.edn
+++ b/components/supervisory-state/resources/config/supervisory-state/task-kanban-mapping.edn
@@ -1,0 +1,23 @@
+;; Maps :task/status keywords to the closed six-column Kanban column set
+;; per N5-δ3 §2.3 (DAG Kanban display contract).
+;;
+;; Any status not present here falls back to :blocked at lookup time — new
+;; state-profile statuses surface visibly rather than silently landing in
+;; :done.
+;;
+;; `:pending` maps to :blocked rather than :ready because the DAG
+;; scheduler is the authority on dependency resolution — it emits
+;; `:ready` when deps clear, so supervisory-state does not need to
+;; recompute blocked-vs-ready locally.
+{:pending         :blocked
+ :ready           :ready
+ :running         :active
+ :ci-running      :active
+ :review-pending  :in-review
+ :ready-to-merge  :merging
+ :merging         :merging
+ :merged          :done
+ :completed       :done
+ :failed          :done
+ :skipped         :done
+ :cancelled       :done}

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -28,6 +28,8 @@
    This namespace knows nothing about emission, persistence, or threading.
    It is a pure function from an event-stream prefix to an EntityTable."
   (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -276,28 +278,34 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; TaskNode handlers (N5-δ3 §2.3, §3.3)
 
-(def status->kanban-column
-  "Maps :task/status keywords to the closed six-column Kanban set per
-   N5-δ3 §2.3. Unknown statuses fall back to :blocked so they surface
-   visibly rather than silently dropping into :done."
-  {:pending         :blocked   ; conservative — producer emits :ready when deps clear
-   :ready           :ready
-   :running         :active
-   :ci-running      :active
-   :review-pending  :in-review
-   :ready-to-merge  :merging
-   :merging         :merging
-   :merged          :done
-   :completed       :done
-   :failed          :done
-   :skipped         :done
-   :cancelled       :done})
+(def task-kanban-mapping-resource
+  "Classpath location of the EDN mapping from :task/status to the closed
+   six-column Kanban set. Config is data — editing the EDN lets operators
+   adjust the status→column projection without code changes."
+  "config/supervisory-state/task-kanban-mapping.edn")
+
+(defn load-task-kanban-mapping
+  "Read the status→column map from [[task-kanban-mapping-resource]].
+   Throws if the resource is missing — the file ships with the component,
+   so its absence indicates a packaging bug worth failing fast on."
+  []
+  (if-let [r (io/resource task-kanban-mapping-resource)]
+    (edn/read-string (slurp r))
+    (throw (ex-info "supervisory-state: task-kanban mapping resource missing"
+                    {:resource task-kanban-mapping-resource}))))
+
+(def ^{:doc "Memoized status→column map loaded lazily from
+  [[task-kanban-mapping-resource]]. Tests that need to exercise a
+  different mapping `with-redefs` this var."}
+  status->kanban-column
+  (delay (load-task-kanban-mapping)))
 
 (defn- task-kanban-column
   "Derive the Kanban column from a task status per N5-δ3 §2.3. Unknown
-   statuses default to :blocked."
+   statuses default to :blocked so new state-profile values surface
+   visibly rather than silently landing in :done."
   [status]
-  (get status->kanban-column status :blocked))
+  (get @status->kanban-column status :blocked))
 
 (defn- task-merge-state
   "Merge a status transition into the task entry at `existing`. Keeps

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -274,6 +274,87 @@
     (assoc-in table [:prs k] scored)))
 
 ;------------------------------------------------------------------------------ Layer 1
+;; TaskNode handlers (N5-δ3 §2.3, §3.3)
+
+(def status->kanban-column
+  "Maps :task/status keywords to the closed six-column Kanban set per
+   N5-δ3 §2.3. Unknown statuses fall back to :blocked so they surface
+   visibly rather than silently dropping into :done."
+  {:pending         :blocked   ; conservative — producer emits :ready when deps clear
+   :ready           :ready
+   :running         :active
+   :ci-running      :active
+   :review-pending  :in-review
+   :ready-to-merge  :merging
+   :merging         :merging
+   :merged          :done
+   :completed       :done
+   :failed          :done
+   :skipped         :done
+   :cancelled       :done})
+
+(defn- task-kanban-column
+  "Derive the Kanban column from a task status per N5-δ3 §2.3. Unknown
+   statuses default to :blocked."
+  [status]
+  (get status->kanban-column status :blocked))
+
+(defn- task-merge-state
+  "Merge a status transition into the task entry at `existing`. Keeps
+   timestamps monotonic: :started-at captured on first entry to an active
+   column, :completed-at captured on first entry to :done. `:elapsed-ms`
+   is recomputed from `:started-at` on every update."
+  [existing new-status ^java.util.Date now-inst]
+  (let [column        (task-kanban-column new-status)
+        started-at    (or (:task/started-at existing)
+                          (when (= column :active) now-inst))
+        completed-at  (or (:task/completed-at existing)
+                          (when (= column :done) now-inst))
+        elapsed-ms    (when started-at
+                        (- (.getTime ^java.util.Date (or completed-at now-inst))
+                           (.getTime ^java.util.Date started-at)))]
+    (cond-> (assoc existing
+                   :task/status       new-status
+                   :task/kanban-column column)
+      started-at   (assoc :task/started-at started-at)
+      completed-at (assoc :task/completed-at completed-at)
+      elapsed-ms   (assoc :task/elapsed-ms elapsed-ms))))
+
+(defn task-state-changed
+  "Handler for `:task/state-changed` (N3 §3 dag lifecycle). Produces or
+   updates a TaskNode entry keyed by `:task/id`. Description / deps /
+   type are populated opportunistically from `:task/context` when the
+   DAG scheduler includes them; otherwise left absent and filled by
+   later events.
+
+   Per N5-δ3 §3.3: dependency resolution is the scheduler's concern —
+   the accumulator trusts the `:task/to-state` it receives rather than
+   recomputing blocked-vs-ready locally. `:pending` stays in `:blocked`
+   until the scheduler emits `:ready`."
+  [table {:task/keys [id to-state context] workflow-id :workflow/id :as event}]
+  (let [task-id      id
+        wf-id        workflow-id
+        status       (or to-state :pending)
+        now-inst     (event-instant event)
+        existing     (get-in table [:tasks task-id]
+                             {:task/id              task-id
+                              :task/workflow-run-id wf-id
+                              :task/description     ""})
+        ;; Context fields from the scheduler are optional; merge any we see.
+        ctx-fields   (cond-> {}
+                       (:description context)     (assoc :task/description     (:description context))
+                       (:type context)            (assoc :task/type            (:type context))
+                       (:component context)       (assoc :task/component       (:component context))
+                       (:dependencies context)    (assoc :task/dependencies    (vec (:dependencies context)))
+                       (:dependents context)      (assoc :task/dependents      (vec (:dependents context)))
+                       (:exclusive-files? context) (assoc :task/exclusive-files? (:exclusive-files? context))
+                       (:stratum? context)        (assoc :task/stratum?        (:stratum? context)))
+        merged       (-> (merge existing ctx-fields)
+                         (task-merge-state status now-inst))]
+    (cond-> table
+      task-id (assoc-in [:tasks task-id] merged))))
+
+;------------------------------------------------------------------------------ Layer 1
 ;; PolicyEvaluation handlers
 
 (defn- normalize-violation
@@ -341,6 +422,12 @@
     (cond-> table
       entity (assoc-in [:attention (:attention/id entity)] entity))))
 
+(defn supervisory-task-node-upserted
+  [table event]
+  (let [entity (:supervisory/entity event)]
+    (cond-> table
+      entity (assoc-in [:tasks (:task/id entity)] entity))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Dispatch table — events not listed are no-ops at the entity-state level
 
@@ -360,12 +447,14 @@
    :pr/merged                              pr-merged
    :pr/closed                              pr-closed
    :pr/scored                              pr-scored
+   :task/state-changed                     task-state-changed
    :gate/passed                            gate-passed
    :gate/failed                            gate-failed
    ;; Snapshot events (used during replay)
    :supervisory/workflow-upserted          supervisory-workflow-upserted
    :supervisory/agent-upserted             supervisory-agent-upserted
    :supervisory/pr-upserted                supervisory-pr-upserted
+   :supervisory/task-node-upserted         supervisory-task-node-upserted
    :supervisory/policy-evaluated           supervisory-policy-evaluated
    :supervisory/attention-derived          supervisory-attention-derived})
 

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
@@ -96,7 +96,8 @@
                :supervisory/agent-upserted
                :supervisory/pr-upserted
                :supervisory/policy-evaluated
-               :supervisory/attention-derived}
+               :supervisory/attention-derived
+               :supervisory/task-node-upserted}
              (:event/type event))
     (swap! component tick event)))
 

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
@@ -99,6 +99,15 @@
                            (:attention/summary attention-entity)))
       (assoc :supervisory/entity attention-entity)))
 
+(defn task-node-upserted
+  [stream task-entity]
+  (-> (event-envelope stream
+                      :supervisory/task-node-upserted
+                      (:task/workflow-run-id task-entity)
+                      (str "Task " (:task/id task-entity)
+                           " → " (name (or (:task/kanban-column task-entity) :blocked))))
+      (assoc :supervisory/entity task-entity)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Diff + emit — publish one event per entity that changed
 
@@ -126,4 +135,5 @@
     (emit-diff! stream pr-upserted        (:prs          old-table) (:prs          new-table))
     (emit-diff! stream policy-evaluated   (:policy-evals old-table) (:policy-evals new-table))
     (emit-diff! stream attention-derived  (:attention    old-table) (:attention    new-table))
+    (emit-diff! stream task-node-upserted (:tasks         old-table) (:tasks        new-table))
     (- (count (:events @stream)) before)))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
@@ -78,6 +78,11 @@
    the keyword verbatim."
   [:merge :approve :review :remediate :decompose :wait :escalate])
 
+(def task-kanban-columns
+  "Closed six-column set for the DAG Kanban view (N5 §3.2.5 / N5-δ3 §2.3).
+   This is a display contract: adding a column breaks consumers."
+  [:blocked :ready :active :in-review :merging :done])
+
 ;------------------------------------------------------------------------------ Layer 0a
 ;; Registry extensions for supervisory v1
 
@@ -123,7 +128,14 @@
    ;; PR scoring (N5-delta-2 §2)
    :risk/level                   (into [:enum] risk-levels)
    :policy/overall               (into [:enum] policy-overall-states)
-   :pr/recommendation            (into [:enum] pr-recommendations)})
+   :pr/recommendation            (into [:enum] pr-recommendations)
+
+   ;; TaskNode (N5-delta-3 §2.3). `:task/status` is intentionally OPEN
+   ;; — the DAG state-profile system lets workflow families add statuses
+   ;; without a spec bump. `:task/kanban-column` is closed: it is the
+   ;; display contract for §3.2.5.
+   :task/id                      :id/uuid
+   :task/kanban-column           (into [:enum] task-kanban-columns)})
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Entity schemas — open maps, mirror N5-delta-1 §3.1
@@ -294,6 +306,30 @@
    [:attention/derived-at :common/timestamp]
    [:attention/resolved? boolean?]])
 
+(def TaskNode
+  "A single DAG task observable in the Kanban view (N5 §3.2.5 / N5-δ3 §2.3).
+
+   `:task/status` is an OPEN keyword — workflow families may add their own
+   statuses via the DAG state-profile system. `:task/kanban-column` is the
+   closed display contract derived from status + dependency resolution per
+   N5-δ3 §2.3's status→column table; unknown statuses fall back to
+   `:blocked` so they surface visibly."
+  [:map {:registry registry}
+   [:task/id :task/id]
+   [:task/workflow-run-id :id/uuid]
+   [:task/description string?]
+   [:task/type {:optional true} [:maybe keyword?]]
+   [:task/component {:optional true} [:maybe string?]]
+   [:task/status keyword?]
+   [:task/kanban-column :task/kanban-column]
+   [:task/dependencies {:optional true} [:vector :id/uuid]]
+   [:task/dependents   {:optional true} [:vector :id/uuid]]
+   [:task/started-at   {:optional true} [:maybe :common/timestamp]]
+   [:task/completed-at {:optional true} [:maybe :common/timestamp]]
+   [:task/elapsed-ms   {:optional true} [:maybe :common/non-neg-int]]
+   [:task/exclusive-files? {:optional true} boolean?]
+   [:task/stratum?         {:optional true} boolean?]])
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Component-internal entity table
 
@@ -304,7 +340,8 @@
    [:agents        [:map-of :id/uuid AgentSession]]
    [:prs           [:map-of [:tuple string? :common/non-neg-int] PrFleetEntry]]
    [:policy-evals  [:map-of :id/uuid PolicyEvaluation]]
-   [:attention     [:map-of :id/uuid AttentionItem]]])
+   [:attention     [:map-of :id/uuid AttentionItem]]
+   [:tasks         [:map-of :id/uuid TaskNode]]])
 
 (def empty-table
   "Initial empty entity table."
@@ -312,4 +349,5 @@
    :agents {}
    :prs {}
    :policy-evals {}
-   :attention {}})
+   :attention {}
+   :tasks {}})

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -275,6 +275,14 @@
           (str "status " status " should map to column " column
                ", got " (:task/kanban-column task))))))
 
+(deftest task-kanban-mapping-is-loaded-from-edn-not-compiled-in
+  (testing "status→column mapping is data, not a compiled-in literal"
+    (let [m (acc/load-task-kanban-mapping)]
+      (is (map? m))
+      (is (= :blocked (get m :pending)))
+      (is (= :active  (get m :running)))
+      (is (= :done    (get m :completed))))))
+
 (deftest task-unknown-status-falls-back-to-blocked
   (let [tid   (random-uuid)
         table (acc/apply-event schema/empty-table

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -230,6 +230,122 @@
     (is (= sample-readiness (:pr/readiness pr)) "readiness preserved across partial re-score")
     (is (= sample-policy (:pr/policy pr)) "policy preserved across partial re-score")))
 
+;------------------------------------------------------------------------------ TaskNode (N5-δ3 §2.3)
+
+(defn- task-event
+  "Build a `:task/state-changed` event for tests."
+  [task-id wf-id to-state & [context]]
+  (ev :task/state-changed
+      (cond-> {:task/id       task-id
+               :workflow/id   wf-id
+               :task/to-state to-state}
+        context (assoc :task/context context))))
+
+(deftest task-state-changed-creates-entry-with-kanban-column
+  (let [tid (random-uuid)
+        wf  (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (task-event tid wf :pending))
+        task  (get-in table [:tasks tid])]
+    (is (some? task))
+    (is (= tid (:task/id task)))
+    (is (= wf (:task/workflow-run-id task)))
+    (is (= :pending (:task/status task)))
+    (is (= :blocked (:task/kanban-column task))
+        ":pending must map to :blocked column (conservative default)")))
+
+(deftest task-kanban-column-derives-from-each-known-status
+  (doseq [[status column] {:pending         :blocked
+                           :ready           :ready
+                           :running         :active
+                           :ci-running      :active
+                           :review-pending  :in-review
+                           :ready-to-merge  :merging
+                           :merging         :merging
+                           :merged          :done
+                           :completed       :done
+                           :failed          :done
+                           :skipped         :done
+                           :cancelled       :done}]
+    (let [tid   (random-uuid)
+          table (acc/apply-event schema/empty-table
+                                 (task-event tid (random-uuid) status))
+          task  (get-in table [:tasks tid])]
+      (is (= column (:task/kanban-column task))
+          (str "status " status " should map to column " column
+               ", got " (:task/kanban-column task))))))
+
+(deftest task-unknown-status-falls-back-to-blocked
+  (let [tid   (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (task-event tid (random-uuid) :some-new-profile-status))
+        task  (get-in table [:tasks tid])]
+    (is (= :some-new-profile-status (:task/status task))
+        "producer's status keyword is preserved verbatim")
+    (is (= :blocked (:task/kanban-column task))
+        "unknown status must fall back to :blocked so it surfaces visibly")))
+
+(deftest task-context-fields-populate-opportunistically
+  (let [tid   (random-uuid)
+        deps  [(random-uuid) (random-uuid)]
+        table (acc/apply-event schema/empty-table
+                               (task-event tid (random-uuid) :running
+                                           {:description "Implement widget"
+                                            :type :implement
+                                            :component "widget"
+                                            :dependencies deps}))
+        task  (get-in table [:tasks tid])]
+    (is (= "Implement widget" (:task/description task)))
+    (is (= :implement (:task/type task)))
+    (is (= "widget" (:task/component task)))
+    (is (= deps (:task/dependencies task)))))
+
+(deftest task-started-at-captured-on-entry-to-active-column
+  (let [tid   (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (task-event tid (random-uuid) :pending))
+                  (acc/apply-event (task-event tid (random-uuid) :running)))
+        task  (get-in table [:tasks tid])]
+    (is (some? (:task/started-at task))
+        ":task/started-at should be set when task first enters :active column")
+    (is (nil? (:task/completed-at task)))))
+
+(deftest task-completed-at-and-elapsed-ms-on-terminal
+  (let [tid   (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (task-event tid (random-uuid) :running))
+                  (acc/apply-event (task-event tid (random-uuid) :completed)))
+        task  (get-in table [:tasks tid])]
+    (is (some? (:task/completed-at task)))
+    (is (some? (:task/elapsed-ms task)))
+    (is (>= (:task/elapsed-ms task) 0))))
+
+(deftest task-state-changed-preserves-context-across-transitions
+  (let [tid   (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (task-event tid (random-uuid) :pending
+                                               {:description "do the thing"
+                                                :type :implement}))
+                  ;; Second event with no context — description must be preserved.
+                  (acc/apply-event (task-event tid (random-uuid) :running)))
+        task  (get-in table [:tasks tid])]
+    (is (= "do the thing" (:task/description task)))
+    (is (= :implement (:task/type task)))
+    (is (= :running (:task/status task)))))
+
+(deftest supervisory-task-node-upserted-applies-baseline
+  (let [tid   (random-uuid)
+        entity {:task/id              tid
+                :task/workflow-run-id (random-uuid)
+                :task/description     "pre-scored task"
+                :task/status          :running
+                :task/kanban-column   :active}
+        table (acc/apply-event schema/empty-table
+                               (ev :supervisory/task-node-upserted
+                                   {:supervisory/entity entity}))]
+    (is (= entity (get-in table [:tasks tid]))
+        "snapshot replay trusts the carried entity verbatim")))
+
 ;------------------------------------------------------------------------------ PolicyEvaluation
 
 (deftest gate-passed-creates-evaluation

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
@@ -127,3 +127,53 @@
         (is (= 1 (count runs)))
         (is (= :completed (:workflow-run/status (first runs)))
             "replay must apply all historic events, ending in :completed")))))
+
+;------------------------------------------------------------------------------ TaskNode (N5-δ3 §3.3)
+
+(defn- task-state-changed [tid wf-id to-state & [context]]
+  (cond-> {:event/type :task/state-changed
+           :event/id (random-uuid)
+           :event/timestamp (java.util.Date.)
+           :event/version "1.0.0"
+           :event/sequence-number 0
+           :workflow/id wf-id
+           :task/id tid
+           :task/to-state to-state
+           :message (str "Task " tid " → " (name to-state))}
+    context (assoc :task/context context)))
+
+(deftest task-state-changed-produces-supervisory-task-node-upserted
+  (let [stream (no-sink-stream)
+        comp   (iface/create stream)
+        tid    (random-uuid)
+        wf-id  (random-uuid)]
+    (iface/start! comp)
+    (es/publish! stream (task-state-changed tid wf-id :running
+                                            {:description "Implement X" :type :implement}))
+    (let [snaps (->> (supervisory-events stream)
+                     (filter #(= :supervisory/task-node-upserted (:event/type %))))]
+      (is (= 1 (count snaps)))
+      (let [entity (:supervisory/entity (first snaps))]
+        (is (= tid (:task/id entity)))
+        (is (= wf-id (:task/workflow-run-id entity)))
+        (is (= :running (:task/status entity)))
+        (is (= :active (:task/kanban-column entity)))
+        (is (= "Implement X" (:task/description entity)))))))
+
+(deftest task-transitions-emit-one-snapshot-per-change
+  (let [stream (no-sink-stream)
+        comp   (iface/create stream)
+        tid    (random-uuid)
+        wf-id  (random-uuid)]
+    (iface/start! comp)
+    (doseq [state [:pending :ready :running :completed]]
+      (es/publish! stream (task-state-changed tid wf-id state)))
+    (let [snaps (->> (supervisory-events stream)
+                     (filter #(= :supervisory/task-node-upserted (:event/type %))))
+          final (last snaps)]
+      ;; One snapshot per distinct status transition (diff-based emit).
+      (is (= 4 (count snaps)) "four transitions → four snapshots")
+      (is (= :completed (:task/status (:supervisory/entity final))))
+      (is (= :done (:task/kanban-column (:supervisory/entity final))))
+      (is (some? (:task/completed-at (:supervisory/entity final))))
+      (is (some? (:task/elapsed-ms (:supervisory/entity final)))))))


### PR DESCRIPTION
## Summary

First of the N5-δ3 producer-side implementation PRs. Projects DAG task state from the existing \`:task/state-changed\` fine-grained events into a TaskNode entity, emitted on the supervisory snapshot path so the Rust TUI (and any other consumer) can render N5 §3.2.5 DAG Kanban without recomputing state locally.

- **TaskNode** open map added to \`schema.clj\` with open \`:task/status\` (state-profile system can add statuses without a spec bump) and closed \`:task/kanban-column\` (display contract).
- **Status → Kanban column** mapping per spec table; unknown statuses fall back to \`:blocked\` so they surface visibly rather than silently landing in \`:done\`.
- **Opportunistic context fields** (description / type / component / dependencies) populated from \`:task/context\` when the scheduler emits them; later events preserve prior values.
- **Timestamps**: \`:started-at\` on first entry to \`:active\`, \`:completed-at\` on first entry to \`:done\`, \`:elapsed-ms\` recomputed each update.
- Emitter + \`diff-and-emit!\` extended; \`handle-event!\` ignore set widened to break re-emit loops; replay handler trusts snapshot carry.

## What's not here (follow-ups)

- Rust consumer side (\`TaskNode\` struct + \`SupervisoryState.tasks\` + \`StateManager\` dispatch) — separate PR in miniforge-control
- TUI DAG Kanban view rendering the six columns — separate PR in miniforge-control

## Test plan

- [x] 11 new unit tests in \`accumulator_test.clj\` / \`core_test.clj\` — all 12 known statuses mapped, unknown-status fallback, context preservation, timestamps, live-emit, snapshot-replay
- [x] 40 supervisory-state tests total / 104 assertions — all green
- [x] Pre-commit (clj-kondo, markdown format, GraalVM/Babashka) — pass

Refs: N5-δ3 §2.3, §3.3, §4.3 (merged in #611 + #614)

🤖 Generated with [Claude Code](https://claude.com/claude-code)