### PR TITLE
refactor(supervisory-state): materialized-view framing, remove replay, drop stream-atom peek

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -41,6 +41,7 @@
 (def cancelled? control-state/cancelled?)
 
 (def create-event-stream stream/create-event-stream)
+(def create-envelope stream/create-envelope)
 (def publish! stream/publish!)
 (def subscribe! stream/subscribe!)
 (def unsubscribe! stream/unsubscribe!)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/stream.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/stream.clj
@@ -25,6 +25,7 @@
 ;; Event stream lifecycle and queries
 
 (def create-event-stream core/create-event-stream)
+(def create-envelope core/create-envelope)
 (def publish! core/publish!)
 (def subscribe! core/subscribe!)
 (def unsubscribe! core/unsubscribe!)

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
@@ -17,20 +17,23 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.supervisory-state.core
-  "Supervisory-state component lifecycle and runtime.
+  "Supervisory-state — materialized view of the event log with change
+   notifications.
 
-   The component owns an atom of form:
+   The component maintains an in-memory entity table derived from events
+   flowing through the event stream. When the table changes, the emitter
+   publishes `:supervisory/*-upserted` events on the same stream so that
+   downstream consumers (dashboard, TUI, file sink) can subscribe to
+   canonical entity snapshots instead of folding source events themselves.
 
-     {:table <EntityTable>     ; canonical entity snapshot
-      :last-seq long            ; highest sequence number observed
-      :subscriber-id keyword    ; event-stream subscription handle
-      :stream <event-stream>}   ; back-reference to the stream we emit into
+   The runtime atom is not a store — it's a view cache. No persistence
+   across process restarts; the view is rebuilt by normal live event
+   flow after attach.
 
-   On `start!` it first replays the stream's in-memory event log to rebuild
-   the entity table (N5-delta-1 §3.4), then subscribes live. Each live event
-   is passed through the accumulator; if the entity table changes, the
-   emitter publishes one `:supervisory/*-upserted` event per changed entity
-   back into the same stream."
+   Shape:
+     {:table       <EntityTable>  — current view
+      :stream      <event-stream> — the stream we subscribe to + emit into
+      :subscribed? boolean        — idempotent-start latch}"
   (:require
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.supervisory-state.accumulator :as accumulator]
@@ -66,19 +69,6 @@
     (assoc state :table next-table)))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Startup replay
-
-(defn- replay
-  "Walk the stream's in-memory event log and fold it through the accumulator.
-   Returns a fresh entity table. Attention is derived once at the end rather
-   than on every step, to avoid emitting thousands of intermediate items
-   during replay."
-  [stream]
-  (let [events (es/get-events stream)]
-    (-> (accumulator/apply-events schema/empty-table events)
-        with-attention)))
-
-;------------------------------------------------------------------------------ Layer 3
 ;; Lifecycle
 
 (defn create
@@ -102,13 +92,15 @@
     (swap! component tick event)))
 
 (defn start!
-  "Replay the stream's history into the entity table, then subscribe live.
-   Idempotent — subsequent calls are no-ops."
+  "Subscribe to the stream. Idempotent — subsequent calls are no-ops.
+
+   The materialized view starts empty and accumulates as events flow
+   live. No startup replay of the in-memory event log (YAGNI — no
+   production caller attached to a pre-populated stream)."
   [component]
   (let [{:keys [stream subscribed?]} @component]
     (when-not subscribed?
-      (let [initial (replay stream)]
-        (swap! component assoc :table initial :subscribed? true))
+      (swap! component assoc :subscribed? true)
       (es/subscribe! stream subscriber-id
                      (fn [event] (handle-event! component event))))
     component))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
@@ -17,95 +17,76 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.supervisory-state.emitter
-  "Construct and publish `:supervisory/*-upserted` snapshot events.
+  "Construct and publish `:supervisory/*-upserted` snapshot events — the
+   change-notification output of the materialized view built in
+   `accumulator.clj`.
 
-   Each entity family has a constructor that produces an N3 §3.19-compliant
-   event map and a diff-and-emit function that publishes one event per
-   entity that differs between the previous and current table."
+   Each entity family has a constructor that produces an N3 §3.19-
+   compliant event map and a diff-and-emit function that publishes one
+   event per entity that differs between the previous and current table.
+
+   Envelope + sequence numbering is delegated to `event-stream/create-envelope`;
+   the emitter does not reach into the stream's internal state."
   (:require
    [ai.miniforge.event-stream.interface :as es]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event constructors (match N3 §3.19 schemas)
-;;
-;; `create-envelope` in `event-stream.core` is not on the interface, so this
-;; component builds its own envelope inline. The `publish!` path only reads
-;; the N3 §2.1 required fields and the `:event/type` for routing.
-
-(def ^:const event-version "1.0.0")
-
-(defn- next-seq!
-  "Increment and return the sequence number for a given scope id."
-  [stream scope-id]
-  (let [new-val (-> (swap! stream update-in [:sequence-numbers scope-id]
-                           (fn [v] (inc (or v -1))))
-                    (get-in [:sequence-numbers scope-id]))]
-    new-val))
-
-(defn- event-envelope
-  [stream event-type scope-id message]
-  {:event/type             event-type
-   :event/id               (random-uuid)
-   :event/timestamp        (java.util.Date.)
-   :event/version          event-version
-   :event/sequence-number  (next-seq! stream scope-id)
-   :workflow/id            scope-id
-   :message                message})
 
 (defn workflow-upserted
   [stream workflow-entity]
-  (-> (event-envelope stream
-                      :supervisory/workflow-upserted
-                      (:workflow-run/id workflow-entity)
-                      (str "Workflow " (:workflow-run/workflow-key workflow-entity)
-                           " upserted"))
+  (-> (es/create-envelope stream
+                          :supervisory/workflow-upserted
+                          (:workflow-run/id workflow-entity)
+                          (str "Workflow " (:workflow-run/workflow-key workflow-entity)
+                               " upserted"))
       (assoc :supervisory/entity workflow-entity)))
 
 (defn agent-upserted
   [stream agent-entity]
-  (-> (event-envelope stream
-                      :supervisory/agent-upserted
-                      nil
-                      (str "Agent " (:agent/name agent-entity) " upserted"))
+  (-> (es/create-envelope stream
+                          :supervisory/agent-upserted
+                          nil
+                          (str "Agent " (:agent/name agent-entity) " upserted"))
       (assoc :supervisory/entity agent-entity)))
 
 (defn pr-upserted
   [stream pr-entity]
-  (-> (event-envelope stream
-                      :supervisory/pr-upserted
-                      nil
-                      (str "PR " (:pr/repo pr-entity) "#" (:pr/number pr-entity)
-                           " upserted"))
+  (-> (es/create-envelope stream
+                          :supervisory/pr-upserted
+                          nil
+                          (str "PR " (:pr/repo pr-entity) "#" (:pr/number pr-entity)
+                               " upserted"))
       (assoc :supervisory/entity pr-entity)))
 
 (defn policy-evaluated
   [stream policy-entity]
-  (-> (event-envelope stream
-                      :supervisory/policy-evaluated
-                      nil
-                      (str "Policy evaluation "
-                           (:policy-eval/id policy-entity)
-                           ": "
-                           (:policy-eval/passed? policy-entity)))
+  (-> (es/create-envelope stream
+                          :supervisory/policy-evaluated
+                          nil
+                          (str "Policy evaluation "
+                               (:policy-eval/id policy-entity)
+                               ": "
+                               (:policy-eval/passed? policy-entity)))
       (assoc :supervisory/entity policy-entity)))
 
 (defn attention-derived
   [stream attention-entity]
-  (-> (event-envelope stream
-                      :supervisory/attention-derived
-                      nil
-                      (str "Attention "
-                           (name (:attention/severity attention-entity)) ": "
-                           (:attention/summary attention-entity)))
+  (-> (es/create-envelope stream
+                          :supervisory/attention-derived
+                          nil
+                          (str "Attention "
+                               (name (:attention/severity attention-entity)) ": "
+                               (:attention/summary attention-entity)))
       (assoc :supervisory/entity attention-entity)))
 
 (defn task-node-upserted
   [stream task-entity]
-  (-> (event-envelope stream
-                      :supervisory/task-node-upserted
-                      (:task/workflow-run-id task-entity)
-                      (str "Task " (:task/id task-entity)
-                           " → " (name (or (:task/kanban-column task-entity) :blocked))))
+  (-> (es/create-envelope stream
+                          :supervisory/task-node-upserted
+                          (:task/workflow-run-id task-entity)
+                          (str "Task " (:task/id task-entity)
+                               " → " (name (or (:task/kanban-column task-entity) :blocked))))
       (assoc :supervisory/entity task-entity)))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -129,11 +110,11 @@
 
    Returns the number of events published, mainly for testing."
   [stream old-table new-table]
-  (let [before (count (:events @stream))]
+  (let [before (count (es/get-events stream))]
     (emit-diff! stream workflow-upserted  (:workflows    old-table) (:workflows    new-table))
     (emit-diff! stream agent-upserted     (:agents       old-table) (:agents       new-table))
     (emit-diff! stream pr-upserted        (:prs          old-table) (:prs          new-table))
     (emit-diff! stream policy-evaluated   (:policy-evals old-table) (:policy-evals new-table))
     (emit-diff! stream attention-derived  (:attention    old-table) (:attention    new-table))
     (emit-diff! stream task-node-upserted (:tasks         old-table) (:tasks        new-table))
-    (- (count (:events @stream)) before)))
+    (- (count (es/get-events stream)) before)))

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
@@ -113,20 +113,22 @@
         (is (= (inc before) after)
             "only the synthetic event should be added; no re-emission loop")))))
 
-;------------------------------------------------------------------------------ Replay
+;------------------------------------------------------------------------------ Live view build-up
 
-(deftest startup-replay-reconstructs-table-from-history
+(deftest live-events-build-the-view-incrementally
+  ;; Covers the production attach order: component attaches first, then
+  ;; events flow. Replaces the former startup-replay test after YAGNI-
+  ;; removing `replay` (no production caller ever populated the stream
+  ;; before the component subscribed).
   (let [stream (no-sink-stream)
-        wf-id  (random-uuid)]
-    ;; Events exist in the stream before the component starts.
+        wf-id  (random-uuid)
+        comp   (iface/start! (iface/create stream))]
     (es/publish! stream (workflow-started wf-id))
     (es/publish! stream (workflow-completed wf-id))
-    (let [comp (iface/create stream)]
-      (iface/start! comp)
-      (let [runs (iface/workflows comp)]
-        (is (= 1 (count runs)))
-        (is (= :completed (:workflow-run/status (first runs)))
-            "replay must apply all historic events, ending in :completed")))))
+    (let [runs (iface/workflows comp)]
+      (is (= 1 (count runs)))
+      (is (= :completed (:workflow-run/status (first runs)))
+          "live subscription must see all events, ending in :completed"))))
 
 ;------------------------------------------------------------------------------ TaskNode (N5-δ3 §3.3)
 


### PR DESCRIPTION
## Summary

Per review follow-up (H31MDALLR): supervisory-state read like a store but actually builds a materialized view; the replay at startup was dead code in production; and the emitter reached into the event stream's private atom to bump sequence numbers. Three small fixes — not a structural restructure.

## Changes

**1. Framing** — \`core.clj\` docstring no longer describes the component as \"owning an atom\" like storage. New wording reflects what it actually is: a materialized view with change-notification output. The runtime atom is a view cache, not a store.

**2. Remove startup replay** (YAGNI). \`core/replay\` folded \`(es/get-events stream)\` at attach time to pre-populate the view from the in-memory event log. No production caller ever attaches to a pre-populated stream — the only exercise was one test that wrote events before \`start!\`. Rewrote the test as \`live-events-build-the-view-incrementally\` with the production attach order.

**3. Emitter stops peeking at stream internals**. \`emitter.clj\` had a private \`next-seq!\` that \`swap!\`ed directly into the stream atom's \`:sequence-numbers\` map, plus an inline \`event-envelope\` that duplicated \`event-stream/core/create-envelope\`. Exposed \`create-envelope\` on the \`event-stream\` interface; emitter now uses it. Diff-counter switched from \`(count (:events @stream))\` to \`(count (es/get-events stream))\`.

## Why it matters

- **Correctness**: component stops touching a private key of another component. Polylith interface boundary is honored.
- **Clarity**: docstring no longer misleads readers into thinking supervisory-state is a store; it's a projection.
- **Less code**: \`-22\` LOC in emitter, \`-12\` LOC in core.

## Test plan

- [x] \`live-events-build-the-view-incrementally\` replaces the former \`startup-replay-reconstructs-table-from-history\` — same coverage, production attach order
- [x] Existing 49 supervisory-state + event-stream interface tests green
- [x] 50 / 233 assertions / 0 failures
- [x] Pre-commit + GraalVM green

## Not in this PR

Review also suggested \"collapse into an event-stream subscriber.\" The diff-and-emit work legitimately needs previous-state to compare against, so some view must be kept in memory. The rename + dead-code removal address the actual incidental complexity; the structural question (split accumulator vs emitter into separate components, or move the change-notifier into event-stream itself) is a larger refactor worth its own design pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)