### PR TITLE
feat(supervisory-state): DecisionCard + :supervisory/decision-upserted (N5-δ3 §2.4)

### DIFF
--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -436,6 +436,69 @@
     (cond-> table
       entity (assoc-in [:tasks (:task/id entity)] entity))))
 
+;------------------------------------------------------------------------------ Layer 1
+;; DecisionCard handlers (N5-δ3 §2.4, §3.4)
+
+(defn cp-decision-created
+  "Handler for `:control-plane/decision-created` — creates a pending
+   DecisionCard entry per N5-δ3 §2.4.
+
+   Today's event payload carries the thin (`agent-id`, `decision-id`,
+   `summary`, optional `priority`) set described in
+   event-stream.core/cp-decision-created. Richer DecisionCard fields
+   (`type`, `context`, `options`, `deadline`) are populated verbatim
+   when future control-plane emissions carry them; absent fields stay
+   off the entity per the open-map rule."
+  [table event]
+  (let [{:cp/keys [agent-id decision-id summary priority type context options deadline]
+         :workflow/keys [id] :as _e} event
+        ts (event-instant event)
+        card (cond-> {:decision/id        decision-id
+                      :decision/agent-id  agent-id
+                      :decision/status    :pending
+                      :decision/summary   (or summary "")
+                      :decision/created-at ts}
+               id       (assoc :decision/workflow-run-id id)
+               type     (assoc :decision/type type)
+               priority (assoc :decision/priority priority)
+               context  (assoc :decision/context context)
+               (seq options) (assoc :decision/options (vec options))
+               deadline (assoc :decision/deadline deadline))]
+    (cond-> table
+      decision-id (assoc-in [:decisions decision-id] card))))
+
+(defn cp-decision-resolved
+  "Handler for `:control-plane/decision-resolved`. Updates the matching
+   DecisionCard with resolution state + timestamp.
+
+   If the card does not exist (resolved event arrived before the create
+   event, e.g. replay gap), a minimal stub is created so the resolution
+   is not lost — the later create event's fields merge in via regular
+   upsert. The status transitions from `:pending` to `:resolved`;
+   `:expired` is reserved for a future `:control-plane/decision-expired`
+   event."
+  [table event]
+  (let [{:cp/keys [decision-id resolution comment] :as _e} event
+        ts (event-instant event)
+        stub {:decision/id decision-id
+              :decision/agent-id nil
+              :decision/summary ""
+              :decision/created-at ts}
+        existing (get-in table [:decisions decision-id] stub)
+        updated  (cond-> (assoc existing
+                                :decision/status      :resolved
+                                :decision/resolved-at ts)
+                   resolution (assoc :decision/resolution resolution)
+                   comment    (assoc :decision/comment comment))]
+    (cond-> table
+      decision-id (assoc-in [:decisions decision-id] updated))))
+
+(defn supervisory-decision-upserted
+  [table event]
+  (let [entity (:supervisory/entity event)]
+    (cond-> table
+      entity (assoc-in [:decisions (:decision/id entity)] entity))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Dispatch table — events not listed are no-ops at the entity-state level
 
@@ -450,6 +513,8 @@
    :control-plane/agent-state-changed      cp-agent-state-changed
    :control-plane/status-changed           cp-agent-state-changed
    :control-plane/agent-heartbeat          cp-agent-heartbeat
+   :control-plane/decision-created         cp-decision-created
+   :control-plane/decision-resolved        cp-decision-resolved
    :agent/status                           agent-status
    :pr/created                             pr-created
    :pr/merged                              pr-merged
@@ -463,6 +528,7 @@
    :supervisory/agent-upserted             supervisory-agent-upserted
    :supervisory/pr-upserted                supervisory-pr-upserted
    :supervisory/task-node-upserted         supervisory-task-node-upserted
+   :supervisory/decision-upserted          supervisory-decision-upserted
    :supervisory/policy-evaluated           supervisory-policy-evaluated
    :supervisory/attention-derived          supervisory-attention-derived})
 

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
@@ -87,7 +87,8 @@
                :supervisory/pr-upserted
                :supervisory/policy-evaluated
                :supervisory/attention-derived
-               :supervisory/task-node-upserted}
+               :supervisory/task-node-upserted
+               :supervisory/decision-upserted}
              (:event/type event))
     (swap! component tick event)))
 

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
@@ -89,6 +89,15 @@
                                " → " (name (or (:task/kanban-column task-entity) :blocked))))
       (assoc :supervisory/entity task-entity)))
 
+(defn decision-upserted
+  [stream decision-entity]
+  (-> (es/create-envelope stream
+                          :supervisory/decision-upserted
+                          (:decision/workflow-run-id decision-entity)
+                          (str "Decision " (:decision/id decision-entity)
+                               " → " (name (or (:decision/status decision-entity) :pending))))
+      (assoc :supervisory/entity decision-entity)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Diff + emit — publish one event per entity that changed
 
@@ -117,4 +126,5 @@
     (emit-diff! stream policy-evaluated   (:policy-evals old-table) (:policy-evals new-table))
     (emit-diff! stream attention-derived  (:attention    old-table) (:attention    new-table))
     (emit-diff! stream task-node-upserted (:tasks         old-table) (:tasks        new-table))
+    (emit-diff! stream decision-upserted  (:decisions     old-table) (:decisions    new-table))
     (- (count (es/get-events stream)) before)))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
@@ -83,6 +83,22 @@
    This is a display contract: adding a column breaks consumers."
   [:blocked :ready :active :in-review :merging :done])
 
+(def decision-types
+  "Known decision request shapes per N5-δ3 §2.4. Open — producer may emit
+   additional types (control-plane can extend without a spec bump)."
+  [:approval :choice :input :confirmation :unknown])
+
+(def decision-priorities
+  "Known priority tiers per N5-δ3 §2.4. Open by convention."
+  [:critical :high :medium :low])
+
+(def decision-statuses
+  "Lifecycle status of a DecisionCard per N5-δ3 §2.4. `:expired` is
+   reserved for the future `:control-plane/decision-expired` event or
+   a deadline-vs-wall-clock derivation; today's producers emit only
+   `:pending` (on create) and `:resolved` (on resolve)."
+  [:pending :resolved :expired])
+
 ;------------------------------------------------------------------------------ Layer 0a
 ;; Registry extensions for supervisory v1
 
@@ -135,7 +151,15 @@
    ;; without a spec bump. `:task/kanban-column` is closed: it is the
    ;; display contract for §3.2.5.
    :task/id                      :id/uuid
-   :task/kanban-column           (into [:enum] task-kanban-columns)})
+   :task/kanban-column           (into [:enum] task-kanban-columns)
+
+   ;; DecisionCard (N5-delta-3 §2.4). Open maps on the entity — these
+   ;; registry entries document known values for display, not closed
+   ;; enums the producer must emit. Consumers MUST preserve unknowns.
+   :decision/id                  :id/uuid
+   :decision/type                (into [:enum] decision-types)
+   :decision/priority            (into [:enum] decision-priorities)
+   :decision/status              (into [:enum] decision-statuses)})
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Entity schemas — open maps, mirror N5-delta-1 §3.1
@@ -330,6 +354,32 @@
    [:task/exclusive-files? {:optional true} boolean?]
    [:task/stratum?         {:optional true} boolean?]])
 
+(def DecisionCard
+  "A pending or resolved decision request from an agent per N5-δ3 §2.4.
+
+   Today's `:control-plane/decision-created` / `-resolved` events carry a
+   thin payload (id, agent-id, summary, optional priority; resolution on
+   resolve). Richer fields — `:decision/type`, `:decision/context`,
+   `:decision/options`, `:decision/deadline`, `:decision/comment` — are
+   part of the entity shape so future control-plane extensions can
+   surface them; supervisory-state populates only what arrives on the
+   wire, per the open-map rule."
+  [:map {:registry registry}
+   [:decision/id :decision/id]
+   [:decision/agent-id :id/uuid]
+   [:decision/workflow-run-id {:optional true} [:maybe :id/uuid]]
+   [:decision/type {:optional true} [:maybe :decision/type]]
+   [:decision/priority {:optional true} [:maybe :decision/priority]]
+   [:decision/status :decision/status]
+   [:decision/summary string?]
+   [:decision/context  {:optional true} [:maybe string?]]
+   [:decision/options  {:optional true} [:vector string?]]
+   [:decision/deadline {:optional true} [:maybe :common/timestamp]]
+   [:decision/created-at :common/timestamp]
+   [:decision/resolution {:optional true} [:maybe string?]]
+   [:decision/comment    {:optional true} [:maybe string?]]
+   [:decision/resolved-at {:optional true} [:maybe :common/timestamp]]])
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Component-internal entity table
 
@@ -341,7 +391,8 @@
    [:prs           [:map-of [:tuple string? :common/non-neg-int] PrFleetEntry]]
    [:policy-evals  [:map-of :id/uuid PolicyEvaluation]]
    [:attention     [:map-of :id/uuid AttentionItem]]
-   [:tasks         [:map-of :id/uuid TaskNode]]])
+   [:tasks         [:map-of :id/uuid TaskNode]]
+   [:decisions     [:map-of :id/uuid DecisionCard]]])
 
 (def empty-table
   "Initial empty entity table."
@@ -350,4 +401,5 @@
    :prs {}
    :policy-evals {}
    :attention {}
-   :tasks {}})
+   :tasks {}
+   :decisions {}})

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -354,6 +354,105 @@
     (is (= entity (get-in table [:tasks tid]))
         "snapshot replay trusts the carried entity verbatim")))
 
+;------------------------------------------------------------------------------ DecisionCard (N5-δ3 §2.4)
+
+(defn- decision-created-event
+  [decision-id agent-id summary & [extras]]
+  (ev :control-plane/decision-created
+      (merge {:cp/agent-id    agent-id
+              :cp/decision-id decision-id
+              :cp/summary     summary}
+             extras)))
+
+(defn- decision-resolved-event
+  [decision-id resolution & [extras]]
+  (ev :control-plane/decision-resolved
+      (merge {:cp/decision-id decision-id
+              :cp/resolution  resolution}
+             extras)))
+
+(deftest cp-decision-created-makes-pending-card
+  (let [did   (random-uuid)
+        aid   (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (decision-created-event did aid "Approve the merge"
+                                                       {:cp/priority :high}))
+        card  (get-in table [:decisions did])]
+    (is (some? card))
+    (is (= did (:decision/id card)))
+    (is (= aid (:decision/agent-id card)))
+    (is (= "Approve the merge" (:decision/summary card)))
+    (is (= :high (:decision/priority card)))
+    (is (= :pending (:decision/status card)))
+    (is (some? (:decision/created-at card)))
+    (is (nil? (:decision/resolved-at card)) "not resolved until a resolve event arrives")))
+
+(deftest cp-decision-created-attaches-workflow-run-id-when-present
+  (let [did   (random-uuid)
+        wf    (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (ev :control-plane/decision-created
+                                   {:cp/agent-id    (random-uuid)
+                                    :cp/decision-id did
+                                    :cp/summary     "x"
+                                    :workflow/id    wf}))
+        card  (get-in table [:decisions did])]
+    (is (= wf (:decision/workflow-run-id card)))))
+
+(deftest cp-decision-resolved-updates-existing-card
+  (let [did   (random-uuid)
+        aid   (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (decision-created-event did aid "Choose target"))
+                  (acc/apply-event (decision-resolved-event did "approve"
+                                                            {:cp/comment "lgtm"})))
+        card  (get-in table [:decisions did])]
+    (is (= :resolved (:decision/status card)))
+    (is (= "approve" (:decision/resolution card)))
+    (is (= "lgtm" (:decision/comment card)))
+    (is (some? (:decision/resolved-at card)))
+    ;; Creation fields must survive the resolve update.
+    (is (= aid (:decision/agent-id card)))
+    (is (= "Choose target" (:decision/summary card)))))
+
+(deftest cp-decision-resolved-before-created-stubs-minimal-card
+  (let [did   (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (decision-resolved-event did "approve"))
+        card  (get-in table [:decisions did])]
+    (is (some? card) "resolve-before-create must not drop the resolution")
+    (is (= did (:decision/id card)))
+    (is (= :resolved (:decision/status card)))
+    (is (= "approve" (:decision/resolution card)))
+    (is (nil? (:decision/agent-id card))
+        "stub agent-id is nil until the create event arrives")))
+
+(deftest cp-decision-resolved-into-nonexistent-then-created-merges
+  ;; Resolve arrives first (replay gap), then create — both fields survive.
+  (let [did   (random-uuid)
+        aid   (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (decision-resolved-event did "approve"))
+                  (acc/apply-event (decision-created-event did aid "x")))
+        card  (get-in table [:decisions did])]
+    ;; The later create event overwrote the stub — that's acceptable
+    ;; behaviour (create always reflects initial state; consumers get a
+    ;; pending entry, then see resolved on the next resolve event).
+    (is (= :pending (:decision/status card)))
+    (is (= aid (:decision/agent-id card)))))
+
+(deftest supervisory-decision-upserted-applies-baseline
+  (let [did    (random-uuid)
+        entity {:decision/id        did
+                :decision/agent-id  (random-uuid)
+                :decision/status    :pending
+                :decision/summary   "test"
+                :decision/created-at (java.util.Date.)}
+        table  (acc/apply-event schema/empty-table
+                                (ev :supervisory/decision-upserted
+                                    {:supervisory/entity entity}))]
+    (is (= entity (get-in table [:decisions did])))))
+
 ;------------------------------------------------------------------------------ PolicyEvaluation
 
 (deftest gate-passed-creates-evaluation

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
@@ -179,3 +179,45 @@
       (is (= :done (:task/kanban-column (:supervisory/entity final))))
       (is (some? (:task/completed-at (:supervisory/entity final))))
       (is (some? (:task/elapsed-ms (:supervisory/entity final)))))))
+
+;------------------------------------------------------------------------------ DecisionCard (N5-δ3 §3.4)
+
+(defn- cp-decision-created-event [decision-id agent-id summary]
+  {:event/type :control-plane/decision-created
+   :event/id (random-uuid)
+   :event/timestamp (java.util.Date.)
+   :event/version "1.0.0"
+   :event/sequence-number 0
+   :workflow/id (random-uuid)
+   :cp/agent-id agent-id
+   :cp/decision-id decision-id
+   :cp/summary summary
+   :message (str "Decision needed from " agent-id ": " summary)})
+
+(defn- cp-decision-resolved-event [decision-id resolution]
+  {:event/type :control-plane/decision-resolved
+   :event/id (random-uuid)
+   :event/timestamp (java.util.Date.)
+   :event/version "1.0.0"
+   :event/sequence-number 0
+   :workflow/id (random-uuid)
+   :cp/decision-id decision-id
+   :cp/resolution resolution
+   :message (str "Decision " decision-id " resolved: " resolution)})
+
+(deftest decision-created-then-resolved-produces-two-snapshots
+  (let [stream (no-sink-stream)
+        comp   (iface/create stream)
+        did    (random-uuid)
+        aid    (random-uuid)]
+    (iface/start! comp)
+    (es/publish! stream (cp-decision-created-event  did aid "Approve the merge"))
+    (es/publish! stream (cp-decision-resolved-event did "approve"))
+    (let [snaps (->> (supervisory-events stream)
+                     (filter #(= :supervisory/decision-upserted (:event/type %))))
+          final (last snaps)]
+      (is (= 2 (count snaps)) "pending + resolved = two snapshots")
+      (is (= :resolved (:decision/status (:supervisory/entity final))))
+      (is (= "approve"   (:decision/resolution (:supervisory/entity final))))
+      (is (= aid         (:decision/agent-id (:supervisory/entity final)))
+          "resolve event must preserve the agent-id from the create event"))))


### PR DESCRIPTION
## Summary

Second of the N5-δ3 producer-side implementation PRs (follows miniforge#616 TaskNode). Projects the existing \`:control-plane/decision-created\` / \`-resolved\` events into a \`DecisionCard\` entity on the supervisory snapshot path so the Rust TUI can render N5 §3.2.7 Decision Queue without recomputing decision state locally.

- **No new producer hooks required** — consumes events that already flow through \`control-plane\`.
- **Open-map entity**: thin payload populated from what the wire events carry; \`:decision/type\`, \`:decision/context\`, \`:decision/options\`, \`:decision/deadline\`, \`:decision/comment\` are part of the entity shape per spec but remain absent until control-plane emissions are extended. Consumers preserve unknowns per the open-map rule.
- **Resolve-before-create resilience**: if a resolve event arrives before its create (replay gap), a minimal stub is created so the resolution is not lost.
- **Invariant 6 preserved**: supervisory-state is still the sole emitter of \`:supervisory/decision-upserted\`; control-plane keeps emitting its own fine-grained events for other consumers.

## What's not here (follow-ups)

- Extending the \`:control-plane/decision-created\` event to carry richer fields (type, context, options, deadline) — separate PR
- Rust consumer side (\`DecisionCard\` struct + \`SupervisoryState.decisions\` + \`StateManager\` dispatch + TUI §3.2.7 Decision Queue) — separate PR in miniforge-control

## Test plan

- [x] 8 new unit/integration tests; 48 supervisory-state tests total / 135 assertions — all green
- [x] Pre-commit (clj-kondo, markdown format, GraalVM/Babashka) — pass

Refs: N5-δ3 §2.4, §3.4, §4.4 (merged in #611 + #614); follows #616 TaskNode pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)