### PR TITLE
refactor: classify JVM-only bricks via ns-meta; drop requiring-resolve

### DIFF
--- a/bases/etl/src/ai/miniforge/etl/main.clj
+++ b/bases/etl/src/ai/miniforge/etl/main.clj
@@ -20,6 +20,7 @@
   "JVM entry point for `mf etl` subcommands. Shelled out to from the
    Babashka CLI because the concrete source connectors depend on hato
    and Apache POI, which aren't BB-compatible."
+  {:miniforge/runtime :jvm-only}
   (:require
    [ai.miniforge.etl.registry :as registry]
    [ai.miniforge.etl.runner :as runner]

--- a/bases/etl/src/ai/miniforge/etl/registry.clj
+++ b/bases/etl/src/ai/miniforge/etl/registry.clj
@@ -20,7 +20,13 @@
   "Maps pack-declared `:connector/type` keywords to the factory that
    constructs a live connector instance. Only the type→factory mapping
    is hardcoded; everything else (which type a pack uses, which auth
-   credentials, which output destination) stays in the pack's env EDN."
+   credentials, which output destination) stays in the pack's env EDN.
+
+   JVM-only: eagerly requires every concrete connector interface, and
+   several of those (http, edgar, excel, github, gitlab, jira) pull in
+   hato/POI. The etl base is shelled out to from Babashka, never
+   loaded under it."
+  {:miniforge/runtime :jvm-only}
   (:require
    [ai.miniforge.connector-edgar.interface :as edgar]
    [ai.miniforge.connector-excel.interface :as excel]

--- a/bases/etl/src/ai/miniforge/etl/runner.clj
+++ b/bases/etl/src/ai/miniforge/etl/runner.clj
@@ -24,7 +24,11 @@
 
    Every piece of configuration (which connector type, which auth
    credential, which output destination) stays in the pack; the runner
-   just wires pack data into live instances."
+   just wires pack data into live instances.
+
+   JVM-only: transitively loads the concrete connector chain through
+   `etl.registry`."
+  {:miniforge/runtime :jvm-only}
   (:require
    [ai.miniforge.etl.registry :as registry]
    [ai.miniforge.pipeline-config.interface :as pc]

--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/interface.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/interface.clj
@@ -1,14 +1,15 @@
 (ns ai.miniforge.connector-edgar.interface
   "Public API for the EDGAR connector component.
 
-   The EdgarConnector record depends on hato, which isn't
-   Babashka-compatible — it's resolved lazily so this interface
-   stays loadable under BB.")
+   JVM-only: depends on `hato` via `connector-http` for request dispatch,
+   so this namespace is not loadable under Babashka."
+  {:miniforge/runtime :jvm-only}
+  (:require [ai.miniforge.connector-edgar.core :as core]))
 
 (defn create-edgar-connector
   "Create a new EdgarConnector instance."
   []
-  (@(requiring-resolve 'ai.miniforge.connector-edgar.core/->EdgarConnector)))
+  (core/->EdgarConnector))
 
 (def connector-metadata
   "Registration metadata for the EDGAR connector."

--- a/components/connector-excel/src/ai/miniforge/connector_excel/interface.clj
+++ b/components/connector-excel/src/ai/miniforge/connector_excel/interface.clj
@@ -1,13 +1,15 @@
 (ns ai.miniforge.connector-excel.interface
   "Public API for the Excel connector component.
 
-   The ExcelConnector record depends on Apache POI (JVM-only) —
-   it's resolved lazily so this interface stays loadable under BB.")
+   JVM-only: depends on Apache POI for .xls/.xlsx parsing, which isn't
+   Babashka-compatible."
+  {:miniforge/runtime :jvm-only}
+  (:require [ai.miniforge.connector-excel.core :as core]))
 
 (defn create-excel-connector
   "Create a new ExcelConnector instance."
   []
-  (@(requiring-resolve 'ai.miniforge.connector-excel.core/->ExcelConnector)))
+  (core/->ExcelConnector))
 
 (def connector-metadata
   "Registration metadata for the Excel connector."

--- a/components/connector-github/src/ai/miniforge/connector_github/interface.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/interface.clj
@@ -1,5 +1,8 @@
 (ns ai.miniforge.connector-github.interface
-  "Public API for the GitHub REST API connector component."
+  "Public API for the GitHub REST API connector component.
+
+   JVM-only: transitively depends on `hato` via `connector-http`."
+  {:miniforge/runtime :jvm-only}
   (:require [ai.miniforge.connector-github.core :as core]
             [ai.miniforge.connector.interface :as conn]))
 

--- a/components/connector-gitlab/src/ai/miniforge/connector_gitlab/interface.clj
+++ b/components/connector-gitlab/src/ai/miniforge/connector_gitlab/interface.clj
@@ -1,5 +1,8 @@
 (ns ai.miniforge.connector-gitlab.interface
-  "Public API for the GitLab REST API connector component."
+  "Public API for the GitLab REST API connector component.
+
+   JVM-only: transitively depends on `hato` via `connector-http`."
+  {:miniforge/runtime :jvm-only}
   (:require [ai.miniforge.connector-gitlab.core :as core]
             [ai.miniforge.connector-gitlab.schema :as schema]
             [ai.miniforge.connector.interface :as conn]))

--- a/components/connector-http/src/ai/miniforge/connector_http/interface.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/interface.clj
@@ -1,19 +1,21 @@
 (ns ai.miniforge.connector-http.interface
   "Public API for the HTTP connector component.
 
-   Only metadata and BB-safe cursor/rate-limit helpers are exposed eagerly.
-   Request utilities and the HttpConnector record depend on hato, which
-   isn't Babashka-compatible — they're resolved lazily so sibling
-   connectors can keep `connector-http.interface` in their require list
-   without breaking the GraalVM-compat gate."
-  (:require [ai.miniforge.connector-http.cursors :as cursors]
+   JVM-only: depends on `hato` (request dispatch), so this namespace is
+   not loadable under Babashka. Downstream callers that need to stay
+   BB-compatible should shell out to a JVM subprocess rather than
+   `require` this namespace."
+  {:miniforge/runtime :jvm-only}
+  (:require [ai.miniforge.connector-http.core :as core]
+            [ai.miniforge.connector-http.cursors :as cursors]
             [ai.miniforge.connector-http.rate-limit :as rate-limit]
+            [ai.miniforge.connector-http.request :as request]
             [ai.miniforge.connector.interface :as conn]))
 
 (defn create-http-connector
   "Create a new HttpConnector instance."
   []
-  (@(requiring-resolve 'ai.miniforge.connector-http.core/->HttpConnector)))
+  (core/->HttpConnector))
 
 (def connector-metadata
   "Registration metadata for the HTTP connector."
@@ -32,15 +34,12 @@
 (def sort-by-timestamp    cursors/sort-by-timestamp)
 (def parse-timestamp      cursors/parse-timestamp)
 
-;; -- Request utilities --
-;; Lazy resolution: requiring the `request` namespace at interface load
-;; time pulls in `hato.client` which is not Babashka-compatible. Source
-;; connectors only call these from JVM-resolved code paths.
-(defn coerce-records    [& args] (apply @(requiring-resolve 'ai.miniforge.connector-http.request/coerce-records) args))
-(defn do-request        [& args] (apply @(requiring-resolve 'ai.miniforge.connector-http.request/do-request) args))
-(defn error-response    [& args] (apply @(requiring-resolve 'ai.miniforge.connector-http.request/error-response) args))
-(defn next-url          [& args] (apply @(requiring-resolve 'ai.miniforge.connector-http.request/next-url) args))
-(defn throw-on-failure! [& args] (apply @(requiring-resolve 'ai.miniforge.connector-http.request/throw-on-failure!) args))
+;; -- Request utilities (shared by HTTP-based source connectors) --
+(def coerce-records    request/coerce-records)
+(def do-request        request/do-request)
+(def error-response    request/error-response)
+(def next-url          request/next-url)
+(def throw-on-failure! request/throw-on-failure!)
 
 ;; -- Rate-limit utilities --
 (def acquire-permit!     rate-limit/acquire-permit!)

--- a/components/connector-jira/src/ai/miniforge/connector_jira/interface.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/interface.clj
@@ -1,5 +1,8 @@
 (ns ai.miniforge.connector-jira.interface
-  "Public API for the Jira Cloud REST API connector component."
+  "Public API for the Jira Cloud REST API connector component.
+
+   JVM-only: transitively depends on `hato` via `connector-http`."
+  {:miniforge/runtime :jvm-only}
   (:require [ai.miniforge.connector-jira.core :as core]
             [ai.miniforge.connector-jira.schema :as schema]
             [ai.miniforge.connector.interface :as conn]))

--- a/tests/graalvm_compatibility_test.clj
+++ b/tests/graalvm_compatibility_test.clj
@@ -19,9 +19,17 @@
 (ns graalvm-compatibility-test
   "GraalVM/Babashka compatibility test suite.
 
-   Ensures ALL miniforge bricks (components + bases) can be loaded in
-   Babashka/GraalVM native image environments. New bricks are discovered
-   automatically from the filesystem — no manual list to maintain.
+   Ensures every miniforge brick (component + base) that is *intended*
+   to run under Babashka can actually be loaded there. Bricks that are
+   known JVM-only opt out of the load attempt by declaring
+   `{:miniforge/runtime :jvm-only}` in their namespace metadata; the
+   discovery below reads that marker from the file text (without
+   loading the namespace, which would otherwise pull in the BB-hostile
+   transitive deps we're trying to avoid).
+
+   Also enforces that no JVM-only brick ever ships inside
+   `projects/miniforge/deps.edn`, because the miniforge CLI runs under
+   Babashka.
 
    Run with:
      bb test:graalvm
@@ -30,30 +38,67 @@
   (:require
    [clojure.test :refer [deftest is testing run-tests]]
    [clojure.string :as str]
+   [clojure.edn :as edn]
    [clojure.java.io :as io]))
+
+;; ============================================================================
+;; Runtime classification (reads ns-meta without loading the namespace)
+;; ============================================================================
+
+(def ^:private jvm-only-meta-re
+  "Distinctive enough that the only legitimate place it can appear is a
+   brick's ns-meta marker."
+  #":miniforge/runtime\s+:jvm-only")
+
+(defn- file-marked-jvm-only?
+  [^java.io.File f]
+  (and (.exists f)
+       (boolean (re-find jvm-only-meta-re (slurp f)))))
+
+(defn- component-interface-file
+  [brick-name]
+  (io/file "components" brick-name "src" "ai" "miniforge"
+           (str/replace brick-name "-" "_") "interface.clj"))
+
+(defn jvm-only-component?
+  "True when `components/<brick-name>/…/interface.clj` self-declares
+   `{:miniforge/runtime :jvm-only}` in its ns metadata."
+  [brick-name]
+  (file-marked-jvm-only? (component-interface-file brick-name)))
+
+(defn- base-src-files
+  [base-name]
+  (let [src-dir (io/file "bases" base-name "src")]
+    (when (.exists src-dir)
+      (->> (file-seq src-dir)
+           (filter #(str/ends-with? (.getName %) ".clj"))))))
+
+(defn jvm-only-base?
+  "True when any .clj file under `bases/<base-name>/src` carries the
+   JVM-only marker — bases don't follow the single-interface convention
+   so we treat any marked file as opting the whole base out."
+  [base-name]
+  (boolean (some file-marked-jvm-only? (base-src-files base-name))))
 
 ;; ============================================================================
 ;; Discovery
 ;; ============================================================================
 
 (defn discover-interface-namespaces
-  "Scan components/ for interface.clj files and derive namespace symbols.
-   Returns a sorted seq of namespace symbols."
+  "Return one entry per component with an `interface.clj`:
+     {:brick-name …, :ns-sym …, :jvm-only? bool}"
   []
-  (let [component-dirs (-> (io/file "components") .listFiles seq)
-        interface-files (->> component-dirs
-                             (filter #(.isDirectory %))
-                             (mapcat (fn [dir]
-                                       (let [;; components/<name>/src/ai/miniforge/<name>/interface.clj
-                                             ;; Name may contain hyphens -> underscores in path
-                                             brick-name (.getName dir)
-                                             path-name (str/replace brick-name "-" "_")
-                                             iface (io/file dir "src" "ai" "miniforge" path-name "interface.clj")]
-                                         (when (.exists iface)
-                                           [(symbol (str "ai.miniforge." brick-name ".interface"))])))))]
-    (sort-by str interface-files)))
+  (->> (-> (io/file "components") .listFiles seq)
+       (filter #(.isDirectory %))
+       (keep (fn [dir]
+               (let [brick-name (.getName dir)]
+                 (when (.exists (component-interface-file brick-name))
+                   {:brick-name brick-name
+                    :ns-sym     (symbol (str "ai.miniforge." brick-name ".interface"))
+                    :jvm-only?  (jvm-only-component? brick-name)}))))
+       (sort-by :brick-name)))
 
-(defn path->namespace
+(defn- path->namespace
   "Convert a .clj file path (relative to src/) to a namespace symbol.
    e.g. ai/miniforge/cli/main.clj -> ai.miniforge.cli.main"
   [src-root clj-file]
@@ -67,19 +112,25 @@
         symbol)))
 
 (defn discover-base-namespaces
-  "Scan bases/ for all .clj source files and derive namespace symbols.
-   Returns a sorted seq of namespace symbols."
+  "Return one entry per .clj file under `bases/<base>/src/`:
+     {:ns-sym …, :file …, :jvm-only? bool}
+
+   Per-file rather than per-base because some bases mix BB-safe and
+   JVM-only source files, and the loader tests require each file
+   independently."
   []
-  (let [base-dirs (-> (io/file "bases") .listFiles seq)]
-    (->> base-dirs
-         (filter #(.isDirectory %))
-         (mapcat (fn [dir]
-                   (let [src-dir (io/file dir "src")]
-                     (when (.exists src-dir)
-                       (->> (file-seq src-dir)
-                            (filter #(str/ends-with? (.getName %) ".clj"))
-                            (map #(path->namespace src-dir %)))))))
-         (sort-by str))))
+  (->> (-> (io/file "bases") .listFiles seq)
+       (filter #(.isDirectory %))
+       (mapcat (fn [dir]
+                 (let [src-dir (io/file dir "src")]
+                   (when (.exists src-dir)
+                     (->> (file-seq src-dir)
+                          (filter #(str/ends-with? (.getName %) ".clj"))
+                          (map (fn [f]
+                                 {:ns-sym    (path->namespace src-dir f)
+                                  :file      f
+                                  :jvm-only? (file-marked-jvm-only? f)})))))))
+       (sort-by (comp str :ns-sym))))
 
 ;; ============================================================================
 ;; Helpers
@@ -119,61 +170,60 @@
 ;; ============================================================================
 
 (deftest test-all-components-load-in-babashka
-  (testing "All component interfaces should load in Babashka/GraalVM"
-    (let [all-ns (discover-interface-namespaces)]
-      ;; Ensure we actually found bricks (sanity check)
-      (is (>= (count all-ns) 20)
-          (str "Expected 20+ component interfaces, found " (count all-ns)
+  (testing "Every BB-runtime component interface loads; JVM-only bricks are skipped."
+    (let [bricks (discover-interface-namespaces)]
+      (is (>= (count bricks) 20)
+          (str "Expected 20+ component interfaces, found " (count bricks)
                ". Is the test running from the repo root?"))
 
-      (doseq [ns-sym all-ns]
-        (let [[success? error-msg] (require-namespace ns-sym)]
-          (cond
-            ;; Loaded fine
-            success?
-            (is true (str ns-sym " loaded"))
+      (doseq [{:keys [ns-sym jvm-only?]} bricks]
+        (if jvm-only?
+          (println "  SKIP:" ns-sym "- :miniforge/runtime :jvm-only")
+          (let [[success? error-msg] (require-namespace ns-sym)]
+            (cond
+              success?
+              (is true (str ns-sym " loaded"))
 
-            ;; Not on classpath — warn but don't fail
-            ;; (brick exists but not wired into workspace :dev alias yet)
-            (classpath-error? error-msg)
-            (println "  WARN:" ns-sym "- not on :dev classpath (add to deps.edn :dev alias)")
+              (classpath-error? error-msg)
+              (println "  WARN:" ns-sym "- not on :dev classpath (add to deps.edn :dev alias)")
 
-            ;; JVM-only code detected — hard failure
-            (jvm-only-error? error-msg)
-            (is false (str "JVM-ONLY DEPENDENCY DETECTED in " ns-sym ":\n"
-                           error-msg
-                           "\n\nThis blocks GraalVM native compilation."
-                           "\nFix: use Babashka-compatible alternatives."))
+              (jvm-only-error? error-msg)
+              (is false (str "JVM-ONLY DEPENDENCY DETECTED in " ns-sym ":\n"
+                             error-msg
+                             "\n\nThis blocks GraalVM native compilation."
+                             "\nFix: either use Babashka-compatible alternatives, or add"
+                             "\n     `{:miniforge/runtime :jvm-only}` to the ns metadata"
+                             "\n     if the brick is deliberately JVM-only."))
 
-            ;; Other error — fail with details
-            :else
-            (is false (str "Failed to load " ns-sym ":\n" error-msg))))))))
+              :else
+              (is false (str "Failed to load " ns-sym ":\n" error-msg)))))))))
 
 (deftest test-all-bases-load-in-babashka
-  (testing "All base namespaces should load in Babashka/GraalVM"
-    (let [all-ns (discover-base-namespaces)]
-      ;; Ensure we actually found base namespaces (sanity check)
-      (is (>= (count all-ns) 3)
-          (str "Expected 3+ base namespaces, found " (count all-ns)
+  (testing "Every BB-runtime base namespace loads; JVM-only files are skipped."
+    (let [files (discover-base-namespaces)]
+      (is (>= (count files) 3)
+          (str "Expected 3+ base namespaces, found " (count files)
                ". Is the test running from the repo root?"))
 
-      (doseq [ns-sym all-ns]
-        (let [[success? error-msg] (require-namespace ns-sym)]
-          (cond
-            success?
-            (is true (str ns-sym " loaded"))
+      (doseq [{:keys [ns-sym jvm-only?]} files]
+        (if jvm-only?
+          (println "  SKIP:" ns-sym "- :miniforge/runtime :jvm-only")
+          (let [[success? error-msg] (require-namespace ns-sym)]
+            (cond
+              success?
+              (is true (str ns-sym " loaded"))
 
-            (classpath-error? error-msg)
-            (println "  WARN:" ns-sym "- not on :dev classpath (add to deps.edn :dev alias)")
+              (classpath-error? error-msg)
+              (println "  WARN:" ns-sym "- not on :dev classpath (add to deps.edn :dev alias)")
 
-            (jvm-only-error? error-msg)
-            (is false (str "JVM-ONLY DEPENDENCY DETECTED in " ns-sym ":\n"
-                           error-msg
-                           "\n\nThis blocks GraalVM native compilation."
-                           "\nFix: use Babashka-compatible alternatives."))
+              (jvm-only-error? error-msg)
+              (is false (str "JVM-ONLY DEPENDENCY DETECTED in " ns-sym ":\n"
+                             error-msg
+                             "\n\nFix: use Babashka-compatible alternatives, or mark the"
+                             "\n     file with `{:miniforge/runtime :jvm-only}` ns-meta."))
 
-            :else
-            (is false (str "Failed to load " ns-sym ":\n" error-msg))))))))
+              :else
+              (is false (str "Failed to load " ns-sym ":\n" error-msg)))))))))
 
 (deftest test-no-forbidden-dependencies
   (testing "Forbidden JVM-only dependencies should not be present"
@@ -200,7 +250,6 @@
       (doseq [f src-files]
         (let [content (slurp f)
               rel-path (str/replace (.getPath f) (str (System/getProperty "user.dir") "/") "")]
-          ;; Check for defrecord implementing java.io.Closeable or java.lang.AutoCloseable
           (when (and (str/includes? content "defrecord")
                      (or (str/includes? content "java.io.Closeable")
                          (str/includes? content "java.lang.AutoCloseable")))
@@ -217,6 +266,69 @@
             "Should resolve load-workflow")
         (is (some? (resolve 'ai.miniforge.workflow.interface/run-pipeline))
             "Should resolve run-pipeline")))))
+
+;; ============================================================================
+;; miniforge-project BB-safety gate — no JVM-only bricks on the CLI classpath
+;; ============================================================================
+
+(defn- parse-deps-edn
+  [^java.io.File f]
+  (when (.exists f)
+    (edn/read-string (slurp f))))
+
+(defn- project-local-root-deps
+  "Return every `:local/root` dep declared in `projects/<project>/deps.edn`,
+   flattened across `:deps` and test `:extra-deps`. Each entry is
+   `{:dep-sym … :local-root …}`."
+  [project-name]
+  (let [deps-edn (parse-deps-edn (io/file "projects" project-name "deps.edn"))]
+    (for [[dep-sym dep-spec] (merge (:deps deps-edn)
+                                    (get-in deps-edn [:aliases :test :extra-deps]))
+          :let [local-root (:local/root dep-spec)]
+          :when local-root]
+      {:dep-sym    dep-sym
+       :local-root local-root})))
+
+(defn- classify-local-root
+  "Map a `local-root` like `../../components/connector-http` or
+   `../../bases/etl` to `{:kind :component|:base :name <brick-name>}`.
+   Unrecognised shapes get `:kind nil`."
+  [local-root]
+  (let [parts (vec (str/split local-root #"/"))]
+    (cond
+      (some #{"components"} parts)
+      {:kind :component
+       :name (get parts (inc (.indexOf parts "components")))}
+
+      (some #{"bases"} parts)
+      {:kind :base
+       :name (get parts (inc (.indexOf parts "bases")))}
+
+      :else
+      {:kind nil :name nil})))
+
+(defn- jvm-only-local-root?
+  [local-root]
+  (let [{:keys [kind name]} (classify-local-root local-root)]
+    (case kind
+      :component (jvm-only-component? name)
+      :base      (jvm-only-base? name)
+      false)))
+
+(deftest test-no-jvm-only-brick-in-miniforge-project
+  (testing "projects/miniforge/deps.edn must not ship JVM-only bricks"
+    (let [deps (project-local-root-deps "miniforge")]
+      (is (seq deps)
+          "Expected local-root brick deps in projects/miniforge/deps.edn")
+      (doseq [{:keys [dep-sym local-root]} deps]
+        (is (not (jvm-only-local-root? local-root))
+            (str "JVM-only brick shipped in projects/miniforge/deps.edn: "
+                 dep-sym " (" local-root ")"
+                 "\n  This brick is marked {:miniforge/runtime :jvm-only}."
+                 "\n  The miniforge CLI runs under Babashka and cannot load hato/POI/etc."
+                 "\n  Fix: remove the dep from projects/miniforge/deps.edn, or route"
+                 "\n       the feature through a JVM shell-out (see bases/etl for the"
+                 "\n       canonical pattern)."))))))
 
 ;; ============================================================================
 ;; Entry point
@@ -238,7 +350,8 @@
   ;; Discover all base namespaces
   (discover-base-namespaces)
 
-  ;; Test a specific namespace
-  (require-namespace 'ai.miniforge.dag-executor.interface)
+  ;; Check a specific brick's runtime
+  (jvm-only-component? "connector-http")
+  (jvm-only-component? "connector-file")
 
   :end)


### PR DESCRIPTION
## Summary
Replaces the \`requiring-resolve\` workarounds I added in #612 with explicit \`{:miniforge/runtime :jvm-only}\` ns-meta markers on the bricks that actually depend on hato (HTTP) or Apache POI (Excel), and teaches the GraalVM-compat gate to classify bricks *before* trying to load them.

The lazy-resolve dance sidestepped a design question rather than answering it. The real statement about those connectors is **"this code is intentionally JVM-only"** — saying so in the namespace metadata makes the classification visible to tooling and to humans reading the file.

## Changes

- **\`connector-http\`, \`connector-edgar\`, \`connector-excel\`** interfaces drop \`(@(requiring-resolve 'connector-X.core/->XConnector))\` in favour of plain \`(core/->XConnector)\` again. \`connector-http.interface\` re-exports the request utilities as direct \`def\`s instead of wrapping each in \`(apply @(requiring-resolve …) args)\`.
- **Six component interfaces** (\`connector-http\`, \`connector-edgar\`, \`connector-excel\`, plus the transitively-JVM-only \`connector-github\`/\`-gitlab\`/\`-jira\` that require \`connector-http\`) gain \`{:miniforge/runtime :jvm-only}\` ns-meta with a one-line note explaining why.
- **All three \`bases/etl/src\` files** get the same marker — the etl base transitively loads the hato/POI chain through the connector registry, and downstream consumers shell out to it rather than requiring it.
- **\`tests/graalvm_compatibility_test.clj\`** reads the marker from file text (via a narrow regex on ns-meta) before attempting to require a namespace. JVM-only bricks log \`SKIP:\` instead of being exercised under BB. This removes the need for \`jvm-only-error?\` to catch the hato reflection error post-hoc — JVM-only bricks are never loaded in the BB test process at all.
- **New test \`test-no-jvm-only-brick-in-miniforge-project\`** walks \`projects/miniforge/deps.edn\` \`:local/root\` deps, classifies each as a component or base, and fails if any carry the JVM-only marker. Protects the miniforge CLI (which runs under Babashka) from ever shipping a hato/POI brick.

## How BB-runtime is declared

A brick opts out of BB compat by adding ns-meta to a single, canonical place:

\`\`\`clojure
(ns ai.miniforge.connector-http.interface
  \"docstring\"
  {:miniforge/runtime :jvm-only}
  (:require ...))
\`\`\`

- **Components**: mark the interface.clj. Detection checks only that one file per brick.
- **Bases**: mark any .clj file under \`bases/<base>/src/\`. Bases don't follow the single-interface convention, so the any-file-marked rule keeps the declaration where the offending code actually lives.

Unmarked is the default and means "should load under Babashka". The existing \`test-no-forbidden-dependencies\` and \`test-no-java-interface-in-defrecord\` gates still catch accidental JVM-only code that hasn't been marked.

## Extending the project-level gate

The new \`test-no-jvm-only-brick-in-miniforge-project\` is parameterised by project name (\`project-local-root-deps\` + \`jvm-only-local-root?\`). Any other project that should run under Babashka can get the same gate by adding a two-line deftest pointing at its \`projects/<name>\` dir.

## Test plan
- [x] \`bb test:graalvm\` — 6 tests / 450 assertions, 0 failures. 9 JVM-only bricks (6 connectors + 3 etl base files) show \`SKIP\` in the log; everything else loads under BB.
- [x] \`clojure -M:dev:test\` for connector-github, connector-gitlab, connector-http, connector-edgar still pass (46 tests / 157 assertions).
- [x] Sanity-checked the classifier: \`jvm-only-component? "connector-http"\` → true; \`jvm-only-component? "connector-file"\` → false; \`jvm-only-base? "etl"\` → true; \`jvm-only-base? "cli"\` → false.
- [x] \`projects/miniforge/deps.edn\` passes the new gate today (the four bricks it ships — \`connector\`, \`connector-auth\`, \`connector-retry\`, \`connector-linter\` — are all BB-safe).
- [x] Pre-commit hook green (full test suite + GraalVM gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)