### PR TITLE
refactor: swap hato for org.babashka/http-client; drop 4 jvm-only markers

### DIFF
--- a/components/connector-edgar/deps.edn
+++ b/components/connector-edgar/deps.edn
@@ -3,7 +3,7 @@
         ai.miniforge/connector-auth  {:local/root "../connector-auth"}
         ai.miniforge/connector-http  {:local/root "../connector-http"}
         ai.miniforge/connector-retry {:local/root "../connector-retry"}
-        cheshire/cheshire               {:mvn/version "5.13.0"}
-        hato/hato                       {:mvn/version "1.0.0"}}
+        cheshire/cheshire        {:mvn/version "5.13.0"}
+        org.babashka/http-client {:mvn/version "0.4.22"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
@@ -6,8 +6,8 @@
             [ai.miniforge.connector-edgar.messages :as msg]
             [ai.miniforge.connector-http.interface :as http]
             [ai.miniforge.schema.interface :as schema]
-            [cheshire.core :as cheshire]
-            [hato.client :as hc])
+            [babashka.http-client :as bb-http]
+            [cheshire.core :as cheshire])
   (:import [java.io ByteArrayInputStream]
            [java.time LocalDate]
            [java.time.format DateTimeFormatter]
@@ -39,11 +39,10 @@
   "Fetch a URL with the SEC-required User-Agent header."
   [url user-agent]
   (rate-limit! 8)
-  (let [resp (hc/get url {:headers          {"User-Agent" user-agent}
-                           :as               :byte-array
-                           :throw-exceptions false
-                           :connect-timeout  30000
-                           :timeout          30000})
+  (let [resp (bb-http/get url {:headers {"User-Agent" user-agent}
+                               :as      :bytes
+                               :throw   false
+                               :timeout 30000})
         status (:status resp)]
     (when (<= 200 status 299)
       (:body resp))))

--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/interface.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/interface.clj
@@ -1,8 +1,9 @@
 (ns ai.miniforge.connector-edgar.interface
   "Public API for the EDGAR connector component.
 
-   JVM-only: depends on `hato` via `connector-http` for request dispatch,
-   so this namespace is not loadable under Babashka."
+   JVM-only: EDGAR filings are XML, and the impl parses them with
+   `javax.xml.parsers.DocumentBuilderFactory`, which isn't available
+   under Babashka."
   {:miniforge/runtime :jvm-only}
   (:require [ai.miniforge.connector-edgar.core :as core]))
 

--- a/components/connector-excel/deps.edn
+++ b/components/connector-excel/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector      {:local/root "../connector"}
+ :deps {ai.miniforge/connector       {:local/root "../connector"}
         ai.miniforge/connector-auth  {:local/root "../connector-auth"}
         ai.miniforge/connector-retry {:local/root "../connector-retry"}
-        hato/hato                       {:mvn/version "1.0.0"}
-        dk.ative/docjure                {:mvn/version "1.19.0"}}
+        dk.ative/docjure         {:mvn/version "1.19.0"}
+        org.babashka/http-client {:mvn/version "0.4.22"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
+++ b/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
@@ -2,10 +2,9 @@
   "Implementation functions for the Excel connector.
    Downloads a remote Excel file and extracts records using column mappings."
   (:require [ai.miniforge.connector.interface :as connector]
-            [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-excel.messages :as msg]
             [ai.miniforge.schema.interface :as schema]
-            [hato.client :as hc])
+            [babashka.http-client :as http])
   (:import [java.io File FileOutputStream]
            [java.util UUID]
            [org.apache.poi.ss.usermodel WorkbookFactory Cell CellType DateUtil]))
@@ -103,9 +102,9 @@
 (defn- download-to-temp
   "Download a URL to a temporary file. Returns the File."
   [url]
-  (let [resp (hc/get url {:as               :byte-array
-                          :headers           {"User-Agent" "Mozilla/5.0"}
-                          :throw-exceptions  false})
+  (let [resp (http/get url {:as      :bytes
+                            :headers {"User-Agent" "Mozilla/5.0"}
+                            :throw   false})
         status (:status resp)]
     (when-not (<= 200 status 299)
       (throw (ex-info (msg/t :excel/download-failed {:error (str "HTTP " status)})

--- a/components/connector-github/deps.edn
+++ b/components/connector-github/deps.edn
@@ -1,8 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/connector      {:local/root "../connector"}
-        ai.miniforge/connector-auth  {:local/root "../connector-auth"}
-        ai.miniforge/connector-http  {:local/root "../connector-http"}
-        ai.miniforge/schema             {:local/root "../schema"}
-        hato/hato                       {:mvn/version "1.0.0"}}
+        ai.miniforge/connector-auth {:local/root "../connector-auth"}
+        ai.miniforge/connector-http {:local/root "../connector-http"}
+        ai.miniforge/schema         {:local/root "../schema"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector-github/src/ai/miniforge/connector_github/interface.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/interface.clj
@@ -1,8 +1,5 @@
 (ns ai.miniforge.connector-github.interface
-  "Public API for the GitHub REST API connector component.
-
-   JVM-only: transitively depends on `hato` via `connector-http`."
-  {:miniforge/runtime :jvm-only}
+  "Public API for the GitHub REST API connector component."
   (:require [ai.miniforge.connector-github.core :as core]
             [ai.miniforge.connector.interface :as conn]))
 

--- a/components/connector-gitlab/deps.edn
+++ b/components/connector-gitlab/deps.edn
@@ -1,8 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/connector      {:local/root "../connector"}
-        ai.miniforge/connector-auth  {:local/root "../connector-auth"}
-        ai.miniforge/connector-http  {:local/root "../connector-http"}
-        hato/hato                       {:mvn/version "1.0.0"}
-        metosin/malli                   {:mvn/version "0.16.4"}}
+        ai.miniforge/connector-auth {:local/root "../connector-auth"}
+        ai.miniforge/connector-http {:local/root "../connector-http"}
+        metosin/malli               {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector-gitlab/src/ai/miniforge/connector_gitlab/interface.clj
+++ b/components/connector-gitlab/src/ai/miniforge/connector_gitlab/interface.clj
@@ -1,8 +1,5 @@
 (ns ai.miniforge.connector-gitlab.interface
-  "Public API for the GitLab REST API connector component.
-
-   JVM-only: transitively depends on `hato` via `connector-http`."
-  {:miniforge/runtime :jvm-only}
+  "Public API for the GitLab REST API connector component."
   (:require [ai.miniforge.connector-gitlab.core :as core]
             [ai.miniforge.connector-gitlab.schema :as schema]
             [ai.miniforge.connector.interface :as conn]))

--- a/components/connector-http/deps.edn
+++ b/components/connector-http/deps.edn
@@ -1,8 +1,8 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/connector      {:local/root "../connector"}
+ :deps {ai.miniforge/connector       {:local/root "../connector"}
         ai.miniforge/connector-auth  {:local/root "../connector-auth"}
         ai.miniforge/connector-retry {:local/root "../connector-retry"}
-        cheshire/cheshire               {:mvn/version "5.13.0"}
-        hato/hato                       {:mvn/version "1.0.0"}}
+        cheshire/cheshire        {:mvn/version "5.13.0"}
+        org.babashka/http-client {:mvn/version "0.4.22"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector-http/src/ai/miniforge/connector_http/impl.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/impl.clj
@@ -2,12 +2,11 @@
   "Implementation functions for the HTTP connector.
    Pure logic separated from protocol wiring."
   (:require [ai.miniforge.connector.interface :as connector]
-            [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-http.pagination :as page]
             [ai.miniforge.connector-http.messages :as msg]
             [ai.miniforge.schema.interface :as schema]
-            [cheshire.core :as json]
-            [hato.client :as hc])
+            [babashka.http-client :as http]
+            [cheshire.core :as json])
   (:import [java.util UUID]))
 
 ;; -- Handle state --
@@ -46,10 +45,10 @@
 (defn do-request
   "Execute an HTTP GET request. Returns schema/success or schema/failure."
   [url headers query-params]
-  (let [resp (hc/get url {:headers          headers
-                          :query-params     query-params
-                          :as               :string
-                          :throw-exceptions false})
+  (let [resp (http/get url {:headers      headers
+                            :query-params query-params
+                            :as           :string
+                            :throw        false})
         status (:status resp)]
     (cond
       (<= 200 status 299)

--- a/components/connector-http/src/ai/miniforge/connector_http/interface.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/interface.clj
@@ -1,11 +1,5 @@
 (ns ai.miniforge.connector-http.interface
-  "Public API for the HTTP connector component.
-
-   JVM-only: depends on `hato` (request dispatch), so this namespace is
-   not loadable under Babashka. Downstream callers that need to stay
-   BB-compatible should shell out to a JVM subprocess rather than
-   `require` this namespace."
-  {:miniforge/runtime :jvm-only}
+  "Public API for the HTTP connector component."
   (:require [ai.miniforge.connector-http.core :as core]
             [ai.miniforge.connector-http.cursors :as cursors]
             [ai.miniforge.connector-http.rate-limit :as rate-limit]

--- a/components/connector-http/src/ai/miniforge/connector_http/request.clj
+++ b/components/connector-http/src/ai/miniforge/connector_http/request.clj
@@ -10,8 +10,8 @@
   (:require [ai.miniforge.connector-http.etag :as etag]
             [ai.miniforge.connector-http.pagination :as page]
             [ai.miniforge.schema.interface :as schema]
-            [cheshire.core :as json]
-            [hato.client :as hc]))
+            [babashka.http-client :as http]
+            [cheshire.core :as json]))
 
 ;;------------------------------------------------------------------------------ Layer 0
 ;; Predicates and classifiers
@@ -62,10 +62,10 @@
    Supports ETag conditional requests via If-None-Match header.
    error-fn: (fn [status resp] schema/failure) — supplies connector-specific messages."
   [url headers query-params error-fn]
-  (let [resp   (hc/get url {:headers          (etag/add-etag-header headers url)
-                             :query-params     query-params
-                             :as               :string
-                             :throw-exceptions false})
+  (let [resp   (http/get url {:headers      (etag/add-etag-header headers url)
+                              :query-params query-params
+                              :as           :string
+                              :throw        false})
         status (:status resp)]
     (cond
       (etag/not-modified? status) (not-modified-response resp)

--- a/components/connector-http/test/ai/miniforge/connector_http/request_test.clj
+++ b/components/connector-http/test/ai/miniforge/connector_http/request_test.clj
@@ -2,7 +2,7 @@
   (:require [clojure.test :refer [deftest is testing use-fixtures]]
             [ai.miniforge.connector-http.etag :as etag]
             [ai.miniforge.connector-http.request :as request]
-            [hato.client :as hc]))
+            [babashka.http-client :as http]))
 
 ;;------------------------------------------------------------------------------ Layer 0
 ;; Fixtures
@@ -90,20 +90,20 @@
 
 (deftest do-request-test
   (testing "returns success for 2xx"
-    (with-redefs [hc/get (fn [_ _] {:status 200 :body "[{\"id\":1}]" :headers {}})]
+    (with-redefs [http/get (fn [_ _] {:status 200 :body "[{\"id\":1}]" :headers {}})]
       (let [result (request/do-request "https://example.com" {} {} (fn [_ _] nil))]
         (is (true? (:success? result)))
         (is (= [{:id 1}] (:body result))))))
 
   (testing "returns not-modified for 304"
-    (with-redefs [hc/get (fn [_ _] {:status 304 :body "" :headers {}})]
+    (with-redefs [http/get (fn [_ _] {:status 304 :body "" :headers {}})]
       (let [result (request/do-request "https://example.com" {} {} (fn [_ _] nil))]
         (is (true? (:success? result)))
         (is (nil? (:body result)))
         (is (true? (:not-modified result))))))
 
   (testing "delegates non-2xx non-304 to error-fn"
-    (with-redefs [hc/get (fn [_ _] {:status 429 :body "" :headers {}})]
+    (with-redefs [http/get (fn [_ _] {:status 429 :body "" :headers {}})]
       (let [called (atom nil)]
         (request/do-request "https://example.com" {} {}
                             (fn [s r] (reset! called s) {:success? false :error-type :rate-limited}))
@@ -112,7 +112,7 @@
   (testing "adds If-None-Match when ETag is cached"
     (etag/store-etag! "https://example.com/cached" "W/\"xyz\"")
     (let [received-headers (atom nil)]
-      (with-redefs [hc/get (fn [_ opts] (reset! received-headers (:headers opts))
+      (with-redefs [http/get (fn [_ opts] (reset! received-headers (:headers opts))
                               {:status 200 :body "[]" :headers {}})]
         (request/do-request "https://example.com/cached" {} {} (fn [_ _] nil))
         (is (= "W/\"xyz\"" (get @received-headers "If-None-Match")))))))

--- a/components/connector-jira/deps.edn
+++ b/components/connector-jira/deps.edn
@@ -1,8 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/connector      {:local/root "../connector"}
-        ai.miniforge/connector-auth  {:local/root "../connector-auth"}
-        ai.miniforge/connector-http  {:local/root "../connector-http"}
-        hato/hato                       {:mvn/version "1.0.0"}
-        metosin/malli                   {:mvn/version "0.16.4"}}
+        ai.miniforge/connector-auth {:local/root "../connector-auth"}
+        ai.miniforge/connector-http {:local/root "../connector-http"}
+        metosin/malli               {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector-jira/src/ai/miniforge/connector_jira/interface.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/interface.clj
@@ -1,8 +1,5 @@
 (ns ai.miniforge.connector-jira.interface
-  "Public API for the Jira Cloud REST API connector component.
-
-   JVM-only: transitively depends on `hato` via `connector-http`."
-  {:miniforge/runtime :jvm-only}
+  "Public API for the Jira Cloud REST API connector component."
   (:require [ai.miniforge.connector-jira.core :as core]
             [ai.miniforge.connector-jira.schema :as schema]
             [ai.miniforge.connector.interface :as conn]))


### PR DESCRIPTION
## Summary
Follow-up to #630 — hato was an incidental choice inherited from the Data Foundry import (#474). \`org.babashka/http-client\` (already used in \`bases/cli\` and \`components/bb-data-plane-http\`) wraps the same \`java.net.http\` underneath, runs under both Babashka and the JVM, and is BB-native. The JVM-shell-out architecture we built for HTTP-backed connectors was solving a problem we didn't actually have.

## Changes

**Connector implementations (HTTP call sites):**
- \`connector-http\` (\`impl.clj\`, \`request.clj\`): \`hato.client/get\` → \`babashka.http-client/get\`. Options translate: \`:throw-exceptions false\` → \`:throw false\`; redundant separate \`:connect-timeout\` collapses into the single \`:timeout\` that \`bb.http-client\` takes. \`request_test\`'s \`with-redefs [hc/get …]\` renamed to match the new alias.
- \`connector-edgar\` (\`impl.clj\`): same swap. \`:as :byte-array\` → \`:as :bytes\`. Aliased as \`bb-http\` because the ns already has \`http\` bound to \`connector-http.interface\`.
- \`connector-excel\` (\`impl.clj\`): same swap for the XLS-download call. Also drops a duplicate \`connector.interface\` require that was there before.

**\`deps.edn\` cleanup:**
- \`connector-http\`, \`connector-edgar\`, \`connector-excel\`: remove \`hato/hato\`, add \`org.babashka/http-client 0.4.22\` (pinned to the version bases/cli already uses).
- \`connector-github\`, \`connector-gitlab\`, \`connector-jira\`: remove the dead \`hato/hato\` dep — none of them actually \`require\`d hato; it was transitive noise.

**ns-meta cleanup (drops :jvm-only markers that are no longer warranted):**
- \`connector-http\`, \`connector-github\`, \`connector-gitlab\`, \`connector-jira\` interfaces are now BB-compatible — markers removed.
- \`connector-edgar\` stays marked, but the reason changes: it's JVM-only because the impl parses SEC XML via \`javax.xml.parsers.DocumentBuilderFactory\`, which isn't available under Babashka. Docstring updated accordingly.
- \`connector-excel\` stays marked (Apache POI).
- \`bases/etl/*\` stays marked (transitively loads edgar + excel via the connector registry).

## Why this is worth doing

- **Simpler execution model**: 4 connectors (http, github, gitlab, jira) that previously required the etl JVM shell-out now run under Babashka directly. Only edgar and excel still need the JVM path — that's an accurate reflection of what's actually JVM-specific (XML parsing, POI).
- **Smaller dep graph**: hato is out of the tree entirely. \`org.babashka/http-client\` was already in the workspace; no new transitive weight.
- **Marker story holds up**: the \`:miniforge/runtime :jvm-only\` framework from #630 is still useful — edgar and excel genuinely are JVM-only for real reasons (javax.xml.parsers, POI), not because of an http-client choice.

## Test plan
- [x] \`bb test:graalvm\` — 6 tests / 454 assertions, 0 failures. 5 SKIPs (down from 9): etl.main, etl.registry, etl.runner, connector-edgar, connector-excel.
- [x] Manual BB-load check: \`connector-http\`, \`connector-github\`, \`connector-gitlab\`, \`connector-jira\` all \`require\` cleanly under Babashka.
- [x] JVM connector tests (\`connector-http.request-test\`, \`-.interface-test\`, \`connector-github.impl-test\`, \`connector-gitlab.impl-test\`, \`connector-edgar.interface-test\`): 55 tests / 202 assertions, 0 failures.
- [x] \`mf etl validate\` against all three shipped packs (github-data, gitlab-data, risk-data) still succeeds.
- [x] \`poly check\` clean (residual pre-existing Error 107 on \`workflow-resume\` is unrelated).
- [x] Pre-commit hook green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)