### PR TITLE
refactor(connector-edgar): XML parsing via clojure.data.xml; drops last non-POI jvm-only marker

### DIFF
--- a/components/connector-edgar/deps.edn
+++ b/components/connector-edgar/deps.edn
@@ -4,6 +4,7 @@
         ai.miniforge/connector-http  {:local/root "../connector-http"}
         ai.miniforge/connector-retry {:local/root "../connector-retry"}
         cheshire/cheshire        {:mvn/version "5.13.0"}
-        org.babashka/http-client {:mvn/version "0.4.22"}}
+        org.babashka/http-client {:mvn/version "0.4.22"}
+        org.clojure/data.xml     {:mvn/version "0.2.0-alpha9"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
@@ -7,14 +7,13 @@
             [ai.miniforge.connector-http.interface :as http]
             [ai.miniforge.schema.interface :as schema]
             [babashka.http-client :as bb-http]
-            [cheshire.core :as cheshire])
+            [cheshire.core :as cheshire]
+            [clojure.data.xml :as xml])
   (:import [java.io ByteArrayInputStream]
            [java.time LocalDate]
            [java.time.format DateTimeFormatter]
            [java.time.temporal TemporalAdjusters]
-           [java.util UUID]
-           [javax.xml.parsers DocumentBuilderFactory]
-           [org.w3c.dom Element NodeList]))
+           [java.util UUID]))
 
 ;; -- Handle state --
 
@@ -56,25 +55,30 @@
 ;; -- XML parsing --
 
 (defn- parse-xml
-  "Parse a byte array as XML, return the Document root Element."
+  "Parse a byte-array as XML, return the root element. `clojure.data.xml`
+   elements are records shaped `{:tag :attrs :content}` with content
+   being a seq of child elements and text strings."
   [^bytes xml-bytes]
-  (let [factory (DocumentBuilderFactory/newInstance)
-        builder (.newDocumentBuilder factory)
-        doc     (.parse builder (ByteArrayInputStream. xml-bytes))]
-    (.getDocumentElement doc)))
+  (xml/parse (ByteArrayInputStream. xml-bytes)))
 
 (defn- elements-by-tag
-  "Get all descendant elements with a given tag name."
-  [^Element el ^String tag]
-  (let [^NodeList nl (.getElementsByTagName el tag)]
-    (for [i (range (.getLength nl))]
-      (.item nl i))))
+  "Return every descendant element whose `:tag` matches `tag-kw`.
+   Depth-first, excluding `el` itself — matches the javax.xml
+   `getElementsByTagName` it replaces. `(rest (tree-seq …))` drops the
+   root; `tree-seq` is otherwise self-inclusive."
+  [el tag-kw]
+  (filter (fn [n] (and (map? n) (= tag-kw (:tag n))))
+          (rest (tree-seq :content :content el))))
 
 (defn- text-content
-  "Get text content of the first child element matching tag, or nil."
-  [^Element el ^String tag]
-  (when-let [children (seq (elements-by-tag el tag))]
-    (let [text (.getTextContent ^Element (first children))]
+  "Concatenated text content of the first descendant element with
+   `tag-kw`, or nil when empty. Matches the javax.xml
+   `getTextContent` behaviour the caller expects."
+  [el tag-kw]
+  (when-let [match (first (elements-by-tag el tag-kw))]
+    (let [text (->> (tree-seq :content :content match)
+                    (filter string?)
+                    (apply str))]
       (when-not (empty? text) text))))
 
 ;; -- EDGAR EFTS API --
@@ -113,10 +117,10 @@
   [^bytes xml-bytes transaction-codes]
   (try
     (let [root (parse-xml xml-bytes)]
-      (for [^Element txn (elements-by-tag root "nonDerivativeTransaction")
-            :let [code   (text-content txn "transactionCode")
-                  shares (text-content txn "transactionShares")
-                  price  (text-content txn "transactionPricePerShare")]
+      (for [txn (elements-by-tag root :nonDerivativeTransaction)
+            :let [code   (text-content txn :transactionCode)
+                  shares (text-content txn :transactionShares)
+                  price  (text-content txn :transactionPricePerShare)]
             :when (and code (contains? transaction-codes code))]
         {:code   code
          :shares (when shares (parse-double shares))

--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/interface.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/interface.clj
@@ -1,10 +1,5 @@
 (ns ai.miniforge.connector-edgar.interface
-  "Public API for the EDGAR connector component.
-
-   JVM-only: EDGAR filings are XML, and the impl parses them with
-   `javax.xml.parsers.DocumentBuilderFactory`, which isn't available
-   under Babashka."
-  {:miniforge/runtime :jvm-only}
+  "Public API for the EDGAR connector component."
   (:require [ai.miniforge.connector-edgar.core :as core]))
 
 (defn create-edgar-connector


### PR DESCRIPTION
## Summary
Stacked on #632. [\`org.clojure/data.xml\`](https://github.com/clojure/data.xml) is BB-compatible, so EDGAR has no reason to stay on the javax.xml path.

## Changes
- \`parse-xml\` uses \`xml/parse\` on a \`ByteArrayInputStream\` instead of \`DocumentBuilderFactory\`.
- \`elements-by-tag\` is a \`tree-seq\` walk filtered by \`:tag\` — same depth-first self-inclusive semantics as \`getElementsByTagName\`. Tag args are keywords now.
- \`text-content\` grabs the first matching element and concatenates every string leaf in its subtree, which preserves javax's \`getTextContent\` behaviour (Form 4 filings wrap values in nested \`<value>…</value>\` elements).
- Dropped imports: \`javax.xml.parsers.DocumentBuilderFactory\`, \`org.w3c.dom.{Element,NodeList}\`. Added: \`clojure.data.xml\`.
- \`deps.edn\`: \`org.clojure/data.xml 0.2.0-alpha9\`.
- \`connector-edgar.interface\` drops \`{:miniforge/runtime :jvm-only}\`.

## Result
Only \`connector-excel\` (Apache POI) and the \`bases/etl/*\` files (which transitively load excel via the registry) remain JVM-only. Every HTTP-backed connector plus EDGAR now loads under Babashka directly.

## Test plan
- [x] \`connector-edgar.interface-test\`: 6 tests / 24 assertions pass under JVM.
- [x] \`bb test:graalvm\` — 455 assertions, 0 failures; 4 SKIPs (down from 5); \`connector-edgar.interface\` loads under BB.
- [x] Spot-checked the \`tree-seq + filter string?\` text extraction on a nested Form 4 \`<transactionShares><value>100</value></transactionShares>\` shape — returns \`"100"\` same as \`.getTextContent\` would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)