### PR TITLE
fix: restore dogfood and status CLI surfaces

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -112,9 +112,9 @@
         last-event (last events)]
     {:workflow-id workflow-id
      :status (cond
-               (:completed? reconstructed) :completed
-               (:failed? reconstructed) :failed
-               (:dag-paused? reconstructed) :paused
+               (wr/completed? reconstructed) :completed
+               (wr/failed? reconstructed) :failed
+               (wr/paused? reconstructed) :paused
                :else :running)
      :spec-name (some-> reconstructed :workflow-spec :name)
      :event-count (:event-count reconstructed)

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -65,7 +65,9 @@
    [ai.miniforge.cli.main.commands.artifact-cmds :as cmd-artifact]
    [ai.miniforge.cli.main.commands.etl :as cmd-etl]
    [ai.miniforge.agent.interface :as agent]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.mcp-context-server.interface :as mcp-context-server]
+   [ai.miniforge.workflow-resume.interface :as wr]
    [ai.miniforge.lsp-mcp-bridge.main :as lsp-bridge]
    [ai.miniforge.lsp-mcp-bridge.tasks :as lsp-tasks]
    [slingshot.slingshot :refer [try+]]))
@@ -101,6 +103,52 @@
   [cmd]
   (let [{:keys [exit]} (process/sh "which" cmd)]
     (zero? exit)))
+
+(defn- workflow-status-summary
+  [workflow-id]
+  (let [events-dir (app-config/events-dir)
+        events (es/read-workflow-events-by-id events-dir workflow-id)
+        reconstructed (wr/reconstruct-context events-dir workflow-id)
+        last-event (last events)]
+    {:workflow-id workflow-id
+     :status (cond
+               (:completed? reconstructed) :completed
+               (:failed? reconstructed) :failed
+               (:dag-paused? reconstructed) :paused
+               :else :running)
+     :spec-name (some-> reconstructed :workflow-spec :name)
+     :event-count (:event-count reconstructed)
+     :completed-phases (:completed-phases reconstructed)
+     :completed-dag-task-count (count (:completed-dag-tasks reconstructed))
+     :last-updated (:event/timestamp last-event)}))
+
+(defn- print-workflow-status
+  [{:keys [workflow-id status spec-name event-count completed-phases
+           completed-dag-task-count last-updated]}]
+  (display/print-info (messages/t :status/workflow {:workflow-id workflow-id}))
+  (println "  status:" (name status))
+  (println "  spec:" (or spec-name "unknown"))
+  (println "  events:" event-count)
+  (println "  last-updated:" (or last-updated "unknown"))
+  (println "  completed-phases:"
+           (if (seq completed-phases)
+             (str/join ", " (map name completed-phases))
+             "none"))
+  (println "  completed-dag-tasks:" completed-dag-task-count))
+
+(defn- all-workflow-summaries
+  []
+  (let [events-dir (app-config/events-dir)]
+    (if (fs/exists? events-dir)
+      (->> (fs/list-dir events-dir)
+           (filter fs/directory?)
+           (map #(fs/file-name %))
+           (keep (fn [workflow-id]
+                   (try
+                     (workflow-status-summary workflow-id)
+                     (catch Exception _ nil))))
+           (sort-by :last-updated #(compare %2 %1)))
+      [])))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Command implementations
@@ -141,12 +189,20 @@
   [m]
   (let [{:keys [workflow-id]} (get-opts m)]
     (if workflow-id
-      (do
-        (display/print-info (messages/t :status/workflow {:workflow-id workflow-id}))
-        (println (messages/t :status/workflow-todo)))
+      (try
+        (print-workflow-status (workflow-status-summary (str workflow-id)))
+        (catch Exception e
+          (display/print-error (str "Failed to read workflow status: " (ex-message e)))))
       (do
         (display/print-info (messages/t :status/all-workflows))
-        (println (messages/t :status/all-workflows-todo))))))
+        (if-let [summaries (seq (take 10 (all-workflow-summaries)))]
+          (doseq [{:keys [workflow-id status spec-name last-updated]} summaries]
+            (println (format "  %-36s %-10s %s"
+                             workflow-id
+                             (name status)
+                             (or spec-name "unknown")))
+            (println "    last-updated:" (or last-updated "unknown")))
+          (println "  none"))))))
 
 ;; Config commands — one-liner delegates
 (defn config-init-cmd [m] (config/cmd-init (get-opts m)))

--- a/bb.edn
+++ b/bb.edn
@@ -375,20 +375,17 @@
   dogfood:check
   {:doc "Check dogfooding prerequisites"
    :requires ([dogfood])
-   :task (dogfood/check)}
+   :task (apply dogfood/check *command-line-args*)}
 
   dogfood:dry-run
-  {:doc "Dry run - show what would be executed"
-   :task (p/shell "bb" "scripts/dogfood-dag.clj" "dogfood-tasks.edn")}
+  {:doc "Show the dogfood command that would run (usage: bb dogfood:dry-run [spec-path])"
+   :requires ([dogfood])
+   :task (apply dogfood/dry-run *command-line-args*)}
 
   dogfood
-  {:doc "Run dogfooding session - miniforge works on itself"
-   :task (do
-           (println "🤖 Starting miniforge dogfooding...")
-           (println "📖 See DOGFOODING.md for full guide")
-           (println "\n⚠️  Note: Full execution requires task-1 completion")
-           (println "   (wiring LLM backend into generate.clj)")
-           (p/shell "bb" "dogfood:dry-run"))}
+  {:doc "Run dogfooding via the development CLI (usage: bb dogfood [spec-path])"
+   :requires ([dogfood])
+   :task (apply dogfood/run *command-line-args*)}
 
   ;; ──────────────────────────────────────────────────────────────────────────
   ;; MCP Context Server
@@ -483,6 +480,7 @@
                  "components/event-stream/src"
                  "components/event-stream/resources"
                  "components/supervisory-state/src"
+                 "components/workflow-resume/src"
                  "components/dag-primitives/src"
                  "components/dag-executor/src"
                  "components/dag-executor/resources"

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -45,17 +45,17 @@
 (defn completed?
   "True when a reconstructed workflow context has completed successfully."
   [reconstructed]
-  (boolean (:completed? reconstructed)))
+  (true? (:completed? reconstructed)))
 
 (defn failed?
   "True when a reconstructed workflow context has failed."
   [reconstructed]
-  (boolean (:failed? reconstructed)))
+  (true? (:failed? reconstructed)))
 
 (defn paused?
   "True when a reconstructed workflow context reflects a paused DAG."
   [reconstructed]
-  (boolean (:dag-paused? reconstructed)))
+  (true? (:dag-paused? reconstructed)))
 
 (defn extract-completed-dag-tasks
   "Task IDs that finished successfully as `:dag/task-completed` events."

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -42,6 +42,21 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pure extractors over an event sequence
 
+(defn completed?
+  "True when a reconstructed workflow context has completed successfully."
+  [reconstructed]
+  (boolean (:completed? reconstructed)))
+
+(defn failed?
+  "True when a reconstructed workflow context has failed."
+  [reconstructed]
+  (boolean (:failed? reconstructed)))
+
+(defn paused?
+  "True when a reconstructed workflow context reflects a paused DAG."
+  [reconstructed]
+  (boolean (:dag-paused? reconstructed)))
+
 (defn extract-completed-dag-tasks
   "Task IDs that finished successfully as `:dag/task-completed` events."
   [events]

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
@@ -40,6 +40,9 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pure extractors
 
+(def completed?                  core/completed?)
+(def failed?                     core/failed?)
+(def paused?                     core/paused?)
 (def extract-completed-dag-tasks core/extract-completed-dag-tasks)
 (def extract-dag-pause-info      core/extract-dag-pause-info)
 (def extract-completed-phases    core/extract-completed-phases)

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -27,6 +27,19 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pure extractors
 
+(deftest reconstructed-status-predicates-test
+  (testing "predicates read the reconstructed status flags"
+    (let [completed {:completed? true}
+          failed {:failed? true}
+          paused {:dag-paused? true}
+          running {}]
+      (is (true? (core/completed? completed)))
+      (is (false? (core/completed? running)))
+      (is (true? (core/failed? failed)))
+      (is (false? (core/failed? running)))
+      (is (true? (core/paused? paused)))
+      (is (false? (core/paused? running))))))
+
 (deftest extract-completed-phases-test
   (testing "only :phase-completed events with :success outcome are collected"
     (let [events [{:event/type :workflow/started}
@@ -208,6 +221,9 @@
 
 (deftest interface-reexports-test
   (testing "interface exposes the domain API"
+    (is (= core/completed? wr/completed?))
+    (is (= core/failed? wr/failed?))
+    (is (= core/paused? wr/paused?))
     (is (= core/extract-completed-phases wr/extract-completed-phases))
     (is (= core/reconstruct-context wr/reconstruct-context))
     (is (= core/trim-pipeline wr/trim-pipeline))

--- a/docs/pull-requests/2026-04-22-fix-dogfood-cli-surface.md
+++ b/docs/pull-requests/2026-04-22-fix-dogfood-cli-surface.md
@@ -1,0 +1,120 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# fix: restore dogfood and workflow-status CLI surfaces
+
+## Overview
+
+This PR repairs three stale CLI surfaces that were blocking the current
+dogfooding loop:
+
+- `bb miniforge ...` was missing the `workflow-resume` component on its
+  Babashka classpath, so `run --resume` and `resume` blew up at load time.
+- `bb dogfood:check`, `bb dogfood:dry-run`, and `bb dogfood` were still
+  wired to an obsolete DAG helper path instead of the current
+  `bb miniforge run <spec>` workflow.
+- `bb miniforge status` still printed a TODO instead of reporting real
+  workflow state from the local event log.
+
+## Motivation
+
+The immediate need is the dogfooding iteration on
+`work/planner-convergence-and-artifact-submission.spec.edn`. During that
+work we found that the documented commands no longer matched the current
+repo. If we keep those commands in the surface area, they need to work
+well enough to support the checkpoint/resume loop we use to avoid
+replaying already-debugged phases.
+
+## Layer
+
+Adapter / CLI
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+None.
+
+## Changes In Detail
+
+### Babashka CLI wiring
+
+- Add `components/workflow-resume/src` to the `bb miniforge` task
+  classpath so the resume command family loads in development mode.
+
+### Dogfood tasks
+
+- Replace the stale `dogfood-tasks.edn` / `scripts/dogfood-dag.clj`
+  shell-out path with task functions that target the current spec-runner
+  flow.
+- Make `bb dogfood:check` accept either `GITHUB_TOKEN` or an authenticated
+  `gh` session as valid GitHub auth.
+- Default dogfood targeting to
+  `work/planner-convergence-and-artifact-submission.spec.edn`, while still
+  allowing an explicit spec path override.
+- Make `bb dogfood:dry-run` print the exact command that would run.
+- Make `bb dogfood` execute `bb miniforge run <spec>` directly with
+  `GITHUB_TOKEN` injected from `gh auth token` when needed.
+
+### Workflow status command
+
+- Replace the TODO-only `status` implementation with a real event-log
+  summary:
+  - workflow status (`running` / `paused` / `failed` / `completed`)
+  - recorded spec name
+  - event count
+  - last update timestamp
+  - completed phases
+  - completed DAG task count
+- Add an all-workflows summary view for the no-arg `bb miniforge status`
+  path.
+
+## Standards Review
+
+- Branch created from updated `main` in a dedicated worktree:
+  `/private/tmp/mf-dogfood-cli-surface`
+- PR scope kept to one concern: stale CLI surface repair for dogfooding
+  and workflow inspection
+- Code follows adapter-layer boundaries:
+  - Babashka task wiring in `bb.edn`
+  - task logic in `tasks/dogfood.clj`
+  - CLI status adapter in `bases/cli/.../main.clj`
+- No hook bypass planned; validation runs before commit
+
+## Testing Plan
+
+- [x] `bb miniforge help`
+- [x] `bb miniforge status`
+- [x] `bb miniforge status ad37c6d1-1ca5-444b-9397-11e69be21e25`
+- [x] `bb dogfood:check work/planner-convergence-and-artifact-submission.spec.edn`
+- [x] `bb dogfood:dry-run work/planner-convergence-and-artifact-submission.spec.edn`
+- [x] `bb pre-commit`
+
+Notes:
+
+- `bb pre-commit` passed on the staged set.
+- `bb lint:clj:all` still reports unrelated pre-existing repo issues outside
+  this PR's scope, so the authoritative gate for this branch is the staged
+  pre-commit run rather than repo-wide lint cleanliness.
+
+## Deployment Plan
+
+Merge normally. No config migration or rollout steps required.
+
+## Related Issues/PRs
+
+- Dogfooding follow-up after PR #634
+- Target spec:
+  `work/planner-convergence-and-artifact-submission.spec.edn`
+
+## Checklist
+
+- [x] Standards review completed
+- [x] Validation commands completed
+- [ ] Changes staged and committed
+- [ ] PR opened for review

--- a/docs/pull-requests/2026-04-22-fix-dogfood-cli-surface.md
+++ b/docs/pull-requests/2026-04-22-fix-dogfood-cli-surface.md
@@ -6,6 +6,9 @@
 
 # fix: restore dogfood and workflow-status CLI surfaces
 
+**PR:** [#635](https://github.com/miniforge-ai/miniforge/pull/635)
+**Branch:** `fix/dogfood-cli-surface`
+
 ## Overview
 
 This PR repairs three stale CLI surfaces that were blocking the current
@@ -116,5 +119,5 @@ Merge normally. No config migration or rollout steps required.
 
 - [x] Standards review completed
 - [x] Validation commands completed
-- [ ] Changes staged and committed
-- [ ] PR opened for review
+- [x] Changes staged and committed
+- [x] PR opened for review

--- a/tasks/dogfood.clj
+++ b/tasks/dogfood.clj
@@ -18,33 +18,134 @@
 
 (ns dogfood
   (:require
-   [babashka.process :as p]))
+   [babashka.fs :as fs]
+   [babashka.process :as p]
+   [clojure.string :as str]))
+
+(def ^:private default-spec-path
+  "Default dogfood target when no explicit spec path is supplied."
+  "work/planner-convergence-and-artifact-submission.spec.edn")
 
 (defn command-available? [cmd]
   (zero? (:exit (p/sh {:continue true :out :discard :err :discard} "which" cmd))))
 
-(defn check []
-  (println "🔍 Checking dogfooding prerequisites...")
-  (let [github-token (System/getenv "GITHUB_TOKEN")
+(defn- gh-authenticated? []
+  (and (command-available? "gh")
+       (zero? (:exit (p/sh {:continue true :out :discard :err :discard}
+                           "gh" "auth" "status")))))
+
+(defn- resolve-github-auth []
+  (let [env-token (System/getenv "GITHUB_TOKEN")]
+    (cond
+      (some? env-token)
+      {:source :env
+       :token env-token}
+
+      (gh-authenticated?)
+      (let [{:keys [exit out]} (p/sh {:continue true :out :string :err :discard}
+                                     "gh" "auth" "token")
+            token (some-> out str/trim not-empty)]
+        (when (and (zero? exit) token)
+          {:source :gh-auth
+           :token token}))
+
+      :else
+      nil)))
+
+(defn- resolve-spec-path [args]
+  (or (first args) default-spec-path))
+
+(defn- git-clean? []
+  (and (zero? (:exit (p/sh {:continue true :out :discard :err :discard}
+                           "git" "diff" "--quiet")))
+       (zero? (:exit (p/sh {:continue true :out :discard :err :discard}
+                           "git" "diff" "--cached" "--quiet")))))
+
+(defn- prerequisite-status [args]
+  (let [spec-path (resolve-spec-path args)
+        github-auth (resolve-github-auth)
         anthropic-key (System/getenv "ANTHROPIC_API_KEY")
         openai-key (System/getenv "OPENAI_API_KEY")
         codex-cli (command-available? "codex")
-        git-clean (zero? (:exit (p/sh {:continue true} "git" "diff" "--quiet")))
-        checks {:github-token (some? github-token)
+        checks {:spec-exists (fs/exists? spec-path)
+                :github-auth (some? github-auth)
                 :llm-backend (or codex-cli (some? anthropic-key) (some? openai-key))
-                :git-clean git-clean}]
+                :git-clean (git-clean?)}]
+    {:spec-path spec-path
+     :github-auth github-auth
+     :checks checks
+     :backend-source (cond
+                       codex-cli :codex-cli
+                       anthropic-key :anthropic-api-key
+                       openai-key :openai-api-key
+                       :else :none)}))
+
+(defn check
+  "Validate dogfooding prerequisites. Usage: bb dogfood:check [spec-path]"
+  [& args]
+  (println "🔍 Checking dogfooding prerequisites...")
+  (let [{:keys [spec-path github-auth checks backend-source]}
+        (prerequisite-status args)]
+    (println "  target-spec:" spec-path)
     (doseq [[check passed?] checks]
       (println (format "  %s %s"
                        (if passed? "✅" "❌")
                        (name check))))
     (println (format "  %s backend-source"
-                     (cond
-                       codex-cli "✅ codex-cli"
-                       anthropic-key "✅ anthropic-api-key"
-                       openai-key "✅ openai-api-key"
-                       :else "❌ none")))
+                     (case backend-source
+                       :codex-cli "✅ codex-cli"
+                       :anthropic-api-key "✅ anthropic-api-key"
+                       :openai-api-key "✅ openai-api-key"
+                       "❌ none")))
+    (println (format "  %s github-auth-source"
+                     (case (:source github-auth)
+                       :env "✅ env:GITHUB_TOKEN"
+                       :gh-auth "✅ gh auth token"
+                       "❌ none")))
     (if (every? val checks)
       (do (println "\n✅ Ready for dogfooding!")
           (System/exit 0))
       (do (println "\n⚠️  Fix issues above before dogfooding")
           (System/exit 1)))))
+
+(defn dry-run
+  "Show the exact command that dogfood would execute.
+   Usage: bb dogfood:dry-run [spec-path]"
+  [& args]
+  (let [{:keys [spec-path github-auth checks backend-source]}
+        (prerequisite-status args)
+        command (if (= :gh-auth (:source github-auth))
+                  (str "env GITHUB_TOKEN=$(gh auth token) bb miniforge run "
+                       spec-path)
+                  (str "bb miniforge run " spec-path))]
+    (println "🤖 Dogfood dry run")
+    (println "  spec:" spec-path)
+    (println "  backend:" (name backend-source))
+    (println "  github-auth:" (or (some-> github-auth :source name) "none"))
+    (println)
+    (println "Command:")
+    (println command)
+    (when-not (every? val checks)
+      (println)
+      (println "Prerequisite failures:")
+      (doseq [[check passed?] checks
+              :when (not passed?)]
+        (println " -" (name check))))))
+
+(defn run
+  "Run dogfooding via the development CLI.
+   Usage: bb dogfood [spec-path]"
+  [& args]
+  (let [{:keys [spec-path github-auth checks]}
+        (prerequisite-status args)]
+    (if (every? val checks)
+      (let [proc (p/process (cond-> {:out :inherit
+                                     :err :inherit}
+                              (:token github-auth)
+                              (assoc :extra-env {"GITHUB_TOKEN" (:token github-auth)}))
+                            "bb" "miniforge" "run" spec-path)
+            {:keys [exit]} @proc]
+        (System/exit exit))
+      (do
+        (check spec-path)
+        (System/exit 1)))))


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# fix: restore dogfood and workflow-status CLI surfaces

## Overview

This PR repairs three stale CLI surfaces that were blocking the current
dogfooding loop:

- `bb miniforge ...` was missing the `workflow-resume` component on its
  Babashka classpath, so `run --resume` and `resume` blew up at load time.
- `bb dogfood:check`, `bb dogfood:dry-run`, and `bb dogfood` were still
  wired to an obsolete DAG helper path instead of the current
  `bb miniforge run <spec>` workflow.
- `bb miniforge status` still printed a TODO instead of reporting real
  workflow state from the local event log.

## Motivation

The immediate need is the dogfooding iteration on
`work/planner-convergence-and-artifact-submission.spec.edn`. During that
work we found that the documented commands no longer matched the current
repo. If we keep those commands in the surface area, they need to work
well enough to support the checkpoint/resume loop we use to avoid
replaying already-debugged phases.

## Layer

Adapter / CLI

## Base Branch

`main`

## Depends On

None.

## Changes In Detail

### Babashka CLI wiring

- Add `components/workflow-resume/src` to the `bb miniforge` task
  classpath so the resume command family loads in development mode.

### Dogfood tasks

- Replace the stale `dogfood-tasks.edn` / `scripts/dogfood-dag.clj`
  shell-out path with task functions that target the current spec-runner
  flow.
- Make `bb dogfood:check` accept either `GITHUB_TOKEN` or an authenticated
  `gh` session as valid GitHub auth.
- Default dogfood targeting to
  `work/planner-convergence-and-artifact-submission.spec.edn`, while still
  allowing an explicit spec path override.
- Make `bb dogfood:dry-run` print the exact command that would run.
- Make `bb dogfood` execute `bb miniforge run <spec>` directly with
  `GITHUB_TOKEN` injected from `gh auth token` when needed.

### Workflow status command

- Replace the TODO-only `status` implementation with a real event-log
  summary:
  - workflow status (`running` / `paused` / `failed` / `completed`)
  - recorded spec name
  - event count
  - last update timestamp
  - completed phases
  - completed DAG task count
- Add an all-workflows summary view for the no-arg `bb miniforge status`
  path.

## Standards Review

- Branch created from updated `main` in a dedicated worktree:
  `/private/tmp/mf-dogfood-cli-surface`
- PR scope kept to one concern: stale CLI surface repair for dogfooding
  and workflow inspection
- Code follows adapter-layer boundaries:
  - Babashka task wiring in `bb.edn`
  - task logic in `tasks/dogfood.clj`
  - CLI status adapter in `bases/cli/.../main.clj`
- No hook bypass planned; validation runs before commit

## Testing Plan

- [x] `bb miniforge help`
- [x] `bb miniforge status`
- [x] `bb miniforge status ad37c6d1-1ca5-444b-9397-11e69be21e25`
- [x] `bb dogfood:check work/planner-convergence-and-artifact-submission.spec.edn`
- [x] `bb dogfood:dry-run work/planner-convergence-and-artifact-submission.spec.edn`
- [x] `bb pre-commit`

Notes:

- `bb pre-commit` passed on the staged set.
- `bb lint:clj:all` still reports unrelated pre-existing repo issues outside
  this PR's scope, so the authoritative gate for this branch is the staged
  pre-commit run rather than repo-wide lint cleanliness.

## Deployment Plan

Merge normally. No config migration or rollout steps required.

## Related Issues/PRs

- Dogfooding follow-up after PR #634
- Target spec:
  `work/planner-convergence-and-artifact-submission.spec.edn`

## Checklist

- [x] Standards review completed
- [x] Validation commands completed
- [ ] Changes staged and committed
- [ ] PR opened for review
