### PR TITLE
docs: formalize workflow supervision machine specs

### DIFF
--- a/docs/pull-requests/2026-04-22-feat-formalize-workflow-supervision-specs.md
+++ b/docs/pull-requests/2026-04-22-feat-formalize-workflow-supervision-specs.md
@@ -1,0 +1,78 @@
+# feat: formalize workflow, supervision, and operator-loop specs
+
+## Overview
+
+Formalize the architectural split between workflow execution, live supervision,
+global degradation mode, the learning/meta loop, and the human supervisory
+loop. Amend the normative specs so the intended control model is explicit
+before code migration begins.
+
+## Motivation
+
+The current implementation and specs mostly imply the right separation, but the
+boundaries are not explicit enough to safely refactor toward formal state
+machines without leaving competing authorities behind. In particular:
+
+- workflow execution currently mixes execution status and phase-transition logic
+- live supervisory checks and learning/meta-loop responsibilities are blurred
+- the human supervisory role is present in the N5 control-plane material but
+  not yet tied cleanly to the orchestrator and machine model
+- resume semantics still reflect phase-index thinking rather than machine
+  snapshot restoration
+
+This PR establishes the contract that the code migration will follow.
+
+## Changes In Detail
+
+- Amend N1 to separate:
+  - control-plane orchestration
+  - workflow supervision
+  - learning/meta-loop improvement
+  - human supervisory loop
+- Amend N2 to define:
+  - a unified execution machine per workflow run
+  - a distinct supervisory machine for live governance and intervention
+  - event-driven phase outcomes instead of imperative phase steering
+  - machine-snapshot-oriented resume semantics
+- Amend the N5 supervisory control-plane delta to formalize:
+  - the human supervisory loop as a peer runtime to the orchestrator
+  - bounded intervention lifecycle semantics
+  - command/query separation against canonical supervisory state
+- Add an informative architecture note describing the target multi-machine,
+  peer-runtime model that subsequent implementation PRs will follow
+
+## Testing Plan
+
+- Read the updated spec set end to end for internal consistency:
+  - N1 core architecture
+  - N2 workflows
+  - N2 phase checkpoint/resume delta
+  - N5 supervisory control-plane delta
+- Verify terminology is consistent across:
+  - orchestrator
+  - supervisory loop
+  - meta loop
+  - degradation mode
+  - workflow execution machine
+- Run Markdown lint/format checks if needed
+
+## Deployment Plan
+
+No runtime deployment. This is a contract-first documentation PR that should
+merge before implementation PRs that migrate workflow and supervisory control
+logic onto formal machines.
+
+## Related Issues/PRs
+
+- Prepares the ground for the workflow/machine compiler refactor
+- Prepares the ground for supervisory-state and intervention lifecycle work
+- Follow-up implementation PRs should stack on this one
+
+## Checklist
+
+- [x] N1 updated with orchestrator vs supervisory vs meta-loop boundaries
+- [x] N2 updated with unified execution-machine model
+- [x] N2 resume delta updated for machine snapshot semantics
+- [x] N5 supervisory delta updated for operator supervisory loop and interventions
+- [x] Informative architecture note added
+- [x] Spec language cross-checked for consistency

--- a/specs/informative/I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE.md
+++ b/specs/informative/I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE.md
@@ -1,0 +1,228 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE
+
+**Status:** Informative
+**Date:** 2026-04-22
+**Version:** 0.1.0-draft
+
+Describes the target machine architecture behind the N1/N2/N5 amendments:
+one authoritative execution machine per workflow run, separate live supervision,
+separate degradation control, a cross-run learning loop, and a human supervisory
+loop that operates as a peer runtime to the orchestrator.
+
+---
+
+## 1. Purpose
+
+Provide an implementation-oriented mental model for the formal-machine refactor
+without introducing another normative spec. This note explains how the
+architectural pieces fit together and where future workflow-family selection and
+convergence logic belongs.
+
+## 2. Topology
+
+```text
+                    ┌──────────────────────────────┐
+                    │     Human Supervisory Loop   │
+                    │  (TUI / dashboard / UX agent)│
+                    └──────────────┬───────────────┘
+                                   │ query / bounded interventions
+                                   ▼
+┌────────────────────────────────────────────────────────────────────┐
+│                          Supervisory State                        │
+│                 canonical projections and attention               │
+└──────────────────────────────┬─────────────────────────────────────┘
+                               │
+                               ▼
+                    ┌──────────────────────────────┐
+                    │         Orchestrator         │
+                    │   sole transition authority  │
+                    └───────┬───────────┬──────────┘
+                            │           │
+                            ▼           ▼
+                 ┌────────────────┐  ┌────────────────┐
+                 │ Execution FSM  │  │ Supervision FSM│
+                 │ per workflow   │  │ per workflow   │
+                 └────────┬───────┘  └────────┬───────┘
+                          │                   │
+                          └────────┬──────────┘
+                                   ▼
+                         ┌─────────────────────┐
+                         │ Degradation Mode FSM│
+                         │ global / workspace  │
+                         └─────────────────────┘
+
+         Observe outputs, evidence bundles, outcomes
+                                   │
+                                   ▼
+                     ┌────────────────────────────┐
+                     │ Learning / Meta Loop       │
+                     │ cross-run improvement      │
+                     └────────────────────────────┘
+```
+
+## 3. Machine Responsibilities
+
+### 3.1 Execution machine
+
+The execution machine owns one workflow run from start to terminal state.
+
+Typical responsibilities:
+
+- current phase or state
+- legal next transitions
+- retry and redirect budgets
+- phase-output capture and checkpointing
+- resume snapshot state
+
+The execution machine carries the workflow graph selected for the run. For a
+software-factory run that may be `:canonical-sdlc`, `:quick-fix`, or
+`:review-first`. For ETL it may be `:financial-etl` or another ETL profile.
+
+### 3.2 Supervision machine
+
+The supervision machine tracks live governance and operational posture for a run.
+
+Typical states:
+
+- `:nominal`
+- `:warning`
+- `:paused-by-supervisor`
+- `:awaiting-operator`
+- `:halted`
+
+The supervision machine reacts to stale progress, policy escalations, watchdog
+signals, and operator interventions. It does not replace the execution machine;
+it constrains or directs it through the orchestrator.
+
+### 3.3 Degradation machine
+
+The degradation machine is global or workspace-scoped rather than per-run.
+
+Typical states:
+
+- `:normal`
+- `:degraded`
+- `:safe-mode`
+
+This machine constrains what the orchestrator is willing to do. For example,
+safe mode may disable auto-merge, block nonessential external side effects, or
+force more human approvals.
+
+### 3.4 Intervention lifecycle
+
+Interventions from humans or UX-side agents are modeled explicitly rather than
+applied directly.
+
+Typical lifecycle:
+
+```text
+:proposed → :pending-human → :approved → :dispatched → :applied → :verified
+       └──────────────→ :rejected
+                                      └──────────────→ :failed
+```
+
+This keeps operator actions auditable and makes “asked for pause” different from
+“pause actually applied.”
+
+## 4. Runtime Actors
+
+### 4.1 Orchestrator
+
+The orchestrator is the autonomous control-plane runtime.
+
+It:
+
+- selects or loads the active machine instances
+- validates incoming events and interventions
+- applies transitions
+- emits durable events for projections and evidence
+- coordinates adapters, registries, and watchdogs
+
+### 4.2 Human supervisory loop
+
+The human supervisory loop is a peer control-plane runtime exposed through the UX.
+
+It:
+
+- queries canonical projections
+- monitors health, progress, and policy state
+- requests bounded interventions
+- audits results and evidence
+
+It does not directly edit workflow state.
+
+### 4.3 Learning / meta loop
+
+The learning loop is cross-run and downstream.
+
+It:
+
+- consumes Observe outputs, evidence bundles, and outcome histories
+- evaluates heuristics and policy candidates
+- produces recommendations, not live workflow transitions
+
+This keeps live supervision separate from system learning.
+
+## 5. Workflow Families, Profiles, and Convergence
+
+The machine architecture is intended to support many workflow paradigms without
+turning execution into a single gigantic universal graph.
+
+### 5.1 Family and profile split
+
+- `:software-factory`
+  - `:canonical-sdlc`
+  - `:quick-fix`
+  - `:review-first`
+- `:etl`
+  - `:financial-etl`
+  - future ETL profiles
+
+### 5.2 Selection before execution
+
+A run begins with workflow selection:
+
+1. resolve family and profile
+2. assemble policies and graph fragments
+3. compile the execution machine
+4. persist the initial machine snapshot
+
+### 5.3 Convergence
+
+Future convergence logic can evaluate multiple candidate profiles or graph
+variants before execution starts. The selected candidate becomes the single
+compiled execution machine for that run.
+
+Mid-run re-planning can exist later, but only as an explicit transition and not
+as out-of-band graph mutation.
+
+## 6. Resume Model
+
+Resume is anchored on the execution-machine snapshot, not a phase index.
+
+The useful mental model is:
+
+1. restore machine state and machine context
+2. restore completed phase outputs and artifacts
+3. rebuild projections
+4. dispatch the next legal event
+
+This works for linear workflows, skipped states, redirected states, and future
+non-waterfall profiles without inventing a second hidden state machine in the
+runner.
+
+## 7. Suggested Implementation Sequence
+
+1. Strengthen the shared FSM utilities and validation surface
+2. Normalize workflow definitions into a canonical graph model
+3. Compile the per-run execution machine from that model
+4. Introduce the per-run supervision machine and intervention lifecycle
+5. Keep the degradation machine as a separate constraint source
+6. Move the learning loop fully out of live supervision concerns
+7. Delete legacy direct status writes as each subsystem migrates

--- a/specs/normative/N1-architecture.md
+++ b/specs/normative/N1-architecture.md
@@ -7,7 +7,7 @@
 # N1 — Core Architecture & Concepts
 
 **Version:** 0.5.0-draft
-**Date:** 2026-03-08
+**Date:** 2026-04-22
 **Status:** Draft
 **Conformance:** MUST
 
@@ -47,13 +47,19 @@ A **workflow** is the top-level unit of autonomous execution.
 ```clojure
 {:workflow/id uuid                  ; REQUIRED: Unique workflow identifier
  :workflow/type keyword             ; REQUIRED: :infrastructure-change, :feature, :refactor
- :workflow/status keyword           ; REQUIRED: :pending, :executing, :completed, :failed, :cancelled
+ :workflow/status keyword           ; REQUIRED derived projection: :pending, :running, :completed, :failed, :cancelled
+
+ :workflow/machine                  ; REQUIRED: authoritative execution-machine state
+ {:machine/id keyword               ; Compiled machine identity
+  :machine/state keyword            ; Current execution state
+  :machine/context {...}            ; Execution context owned by the machine
+  :machine/snapshot {...}}          ; Durable resume snapshot (see N2)
 
  :workflow/spec {...}               ; REQUIRED: Workflow specification (see N2)
  :workflow/intent {...}             ; REQUIRED: Intent declaration (see N6)
 
- :workflow/current-phase keyword    ; OPTIONAL: :plan, :design, :implement, :verify, :review, :release, :observe
- :workflow/phases {...}             ; REQUIRED: Phase execution records
+ :workflow/current-phase keyword    ; OPTIONAL derived projection from :workflow/machine
+ :workflow/phases {...}             ; REQUIRED: Phase execution records and artifacts
 
  :workflow/created-at inst          ; REQUIRED
  :workflow/started-at inst          ; OPTIONAL
@@ -67,10 +73,12 @@ A **workflow** is the top-level unit of autonomous execution.
 Implementations MUST:
 
 1. Assign unique UUID to each workflow
-2. Track workflow status through lifecycle
+2. Track workflow lifecycle through a single authoritative execution machine
 3. Record all phase executions
 4. Generate evidence bundle upon completion (success or failure)
 5. Emit events for all state transitions (see N3)
+6. Derive `:workflow/status` and `:workflow/current-phase` from machine
+   state rather than treating them as independent write targets
 
 ### 2.2 Phase
 
@@ -308,14 +316,23 @@ See N6 for detailed artifact provenance specification.
 
 #### 2.9.1 Data Foundry Extension Nouns
 
-The following nouns are defined by the Data Foundry extension (see Data Foundry N1–N4) and recognised as first-class concepts within the Core domain model:
+The following nouns are defined by the Data Foundry extension (see Data Foundry N1–N4) and recognised as first-class
+concepts within the Core domain model:
 
-- **Dataset** — A versioned, structured collection of data with a formal schema, storage location, partitioning strategy, and complete provenance chain. Datasets are artifacts (`:artifact/type :dataset`) and MUST satisfy N6 §3.1 requirements. See Data Foundry N1.
-- **Schema** — A formal, versioned definition of dataset structure including field names, types, constraints, and nullability rules. Schemas are versioned independently and MAY be shared across dataset versions. See Data Foundry N1.
-- **Connector** — A governed tool (N10) that bridges Data Foundry and external systems for data ingestion or publication. Connectors declare capabilities, authentication requirements, and configuration schemas. See Data Foundry N2.
-- **Pipeline** — A declarative DAG of stages that ingests, transforms, and publishes data. Pipelines are specialised workflows (N2) with data-specific execution semantics. See Data Foundry N3.
-- **QualityRule** — A named, versioned data validation constraint that extends Core policy rules (N4) with data-specific check types and thresholds. See Data Foundry N4.
-- **LineageGraph** — A directed acyclic graph tracking dataset dependencies and transformations, enabling impact analysis and reprocessing decisions. See Data Foundry N4.
+- **Dataset** — A versioned, structured collection of data with a formal schema, storage location, partitioning
+  strategy, and complete provenance chain. Datasets are artifacts (`:artifact/type :dataset`) and MUST satisfy N6 §3.1
+  requirements. See Data Foundry N1.
+- **Schema** — A formal, versioned definition of dataset structure including field names, types, constraints, and
+  nullability rules. Schemas are versioned independently and MAY be shared across dataset versions. See Data Foundry N1.
+- **Connector** — A governed tool (N10) that bridges Data Foundry and external systems for data ingestion or
+  publication. Connectors declare capabilities, authentication requirements, and configuration schemas. See Data Foundry
+  N2.
+- **Pipeline** — A declarative DAG of stages that ingests, transforms, and publishes data. Pipelines are specialised
+  workflows (N2) with data-specific execution semantics. See Data Foundry N3.
+- **QualityRule** — A named, versioned data validation constraint that extends Core policy rules (N4) with data-specific
+  check types and thresholds. See Data Foundry N4.
+- **LineageGraph** — A directed acyclic graph tracking dataset dependencies and transformations, enabling impact
+  analysis and reprocessing decisions. See Data Foundry N4.
 
 ### 2.10 Knowledge Base
 
@@ -1386,24 +1403,43 @@ miniforge is structured as three cooperating layers:
 
 ### 3.1 Control Plane
 
-The **Control Plane** coordinates workflow execution.
+The **Control Plane** coordinates workflow execution, live supervision, and bounded interventions.
 
 #### 3.1.1 Responsibilities
 
 The Control Plane MUST:
 
 1. Accept workflow specifications from users
-2. Initialize workflow execution context
-3. Orchestrate phase transitions
-4. Enforce policy gates
-5. Generate evidence bundles
-6. Provide operational visibility
+2. Initialize workflow execution and supervisory context
+3. Compile or load the execution machine for each workflow run
+4. Orchestrate workflow and supervisory state transitions
+5. Enforce policy gates and degradation constraints
+6. Apply bounded control actions through authoritative machines
+7. Generate evidence bundles
+8. Provide operational visibility via canonical projections
 
 #### 3.1.2 Components
 
-- **Operator Agent** - Manages workflow lifecycle
-- **Workflow Engine** - Executes phase graph (see N2)
+- **Orchestrator** - Sole authority that applies transitions to execution, supervision, and degradation machines
+- **Workflow Execution Machine** - Per-run compiled FSM that executes the workflow graph (see N2)
+- **Workflow Supervision Machine** - Per-run FSM for live governance, safety, and operator intervention state
 - **Policy Engine** - Enforces policy packs (see N4)
+- **Supervisory State Projection** - Canonical query surface for TUI, dashboard, API, and operator tooling
+- **Human Supervisory Loop** - Peer runtime that queries supervisory
+  state and submits bounded interventions through the orchestrator
+
+#### 3.1.3 Runtime Boundaries
+
+The Control Plane MUST enforce these runtime boundaries:
+
+1. The orchestrator is the only component permitted to apply control
+   actions to workflow execution, supervision, or degradation machines
+2. The human supervisory loop MUST operate through bounded intervention
+   requests and MUST NOT directly mutate workflow state
+3. Live supervision of in-flight workflows is a control-plane concern, not a learning-layer concern
+4. The supervisory-state projection is the canonical read model for
+   external consumers and MUST remain separate from orchestration
+   scratch state
 
 ### 3.2 Agent Layer
 
@@ -1438,15 +1474,26 @@ The Learning Layer MUST:
 3. Update heuristics based on performance
 4. Maintain knowledge base of learnings
 5. Provide context to agents from past executions
+6. Produce improvement proposals without directly mutating live workflow execution state
 
 #### 3.3.2 Components
 
 - **Observer Agent** - Captures execution signals
-- **Meta Loop** - Analyzes patterns, proposes improvements
+- **Meta Loop** - Cross-run learning loop that analyzes patterns and proposes improvements
 - **Heuristic Registry** - Stores and versions prompt heuristics
 - **Knowledge Base** - Zettelkasten-based learning repository
 
-#### 3.3.3 Evaluation Pipeline
+#### 3.3.3 Boundary to Control Plane
+
+The Learning Layer MUST remain downstream of workflow execution:
+
+1. The Meta Loop MAY consume execution outcomes, evidence bundles, and observation signals
+2. The Meta Loop MUST NOT directly advance, pause, resume, or cancel an in-flight workflow
+3. Any learning-derived recommendation that affects a live workflow
+   MUST be routed back through the control plane as a bounded control
+   action or future workflow selection input
+
+#### 3.3.4 Evaluation Pipeline
 
 The Learning Layer MUST support a closed-loop evaluation pipeline for detecting regressions
 and validating changes to prompts, models, policies, tool schemas, and indexes.
@@ -1719,7 +1766,7 @@ Implementations MUST:
 
 1. **Fail-safe** - Workflow failure MUST NOT corrupt state
 2. **Fail-visible** - All failures MUST emit events and create evidence bundle
-3. **Fail-recoverable** - Workflows MUST be resumable from last successful phase
+3. **Fail-recoverable** - Workflows MUST be resumable from an authoritative machine snapshot
 4. **Fail-escalatable** - Agent failures MUST escalate to human after retry budget exhausted
 
 #### 5.3.2 Retry Budget
@@ -2165,9 +2212,9 @@ Implementations MUST demonstrate:
 
 The three-layer architecture separates concerns:
 
-- **Control Plane** - Orchestration logic (workflow engine, policy enforcement)
+- **Control Plane** - Orchestration, supervision, and bounded control logic
 - **Agent Layer** - Execution logic (specialized agents, inner loop)
-- **Learning Layer** - Improvement logic (observation, meta loop, heuristics)
+- **Learning Layer** - Cross-run improvement logic (observation, meta loop, heuristics)
 
 This enables:
 

--- a/specs/normative/N2-delta-phase-checkpoint-and-resume.md
+++ b/specs/normative/N2-delta-phase-checkpoint-and-resume.md
@@ -4,16 +4,16 @@
   Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
 -->
 
-# Normative Spec Extension: Phase Checkpoint & Resume
+# Normative Spec Extension: Phase Checkpoint, Machine Snapshot & Resume
 
 ## Purpose
 
-Make miniforge workflows genuinely resumable at **phase granularity**.
+Make miniforge workflows genuinely resumable at **phase granularity** with an
+authoritative **execution-machine snapshot**.
 
-N2 §1.1 already lists **resumability** as a core design principle
-("Workflows MUST be resumable from last successful phase"). This delta
-defines what that requires of implementations and what the user-facing
-contract looks like. Without it, users who are rate-limited,
+N2 §1.1 already lists **resumability** as a core design principle. This
+delta defines what that requires of implementations and what the
+user-facing contract looks like. Without it, users who are rate-limited,
 disconnected, or hit an LLM-provider bug mid-workflow must re-run
 already-paid-for phases to make progress — a product failure.
 
@@ -41,9 +41,10 @@ back to the broken one.
 
 - `N2-workflows.md` — parent spec. §1.1 principle #5 mandates
   resumability; this delta operationalizes it.
-- `N3-event-stream.md` — checkpoint writes emit events
+- `N3-event-stream.md` — checkpoint and snapshot writes emit events
   (`:workflow/checkpoint-written`, `:workflow/checkpoint-write-failed`,
-  `:workflow/resumed`).
+  `:workflow/machine-snapshot-written`,
+  `:workflow/machine-snapshot-write-failed`, `:workflow/resumed`).
 - `workflow-phase-checkpoint-and-resume.spec.edn` — the work spec that
   implements this extension.
 - `agent-stream-watchdog-and-resume.spec.edn` — complementary
@@ -60,18 +61,22 @@ worktree from its scratch ref.
 
 ## Spec metadata
 
-- **Title:** Phase Checkpoint & Resume
+- **Title:** Phase Checkpoint, Machine Snapshot & Resume
 - **Type:** Normative extension to N2
-- **Version:** 0.1.0-draft
+- **Version:** 0.2.0-draft
 - **Status:** Draft
 - **Conformance:** MUST (on any implementation that persists to disk)
-- **Date:** 2026-04-18
+- **Date:** 2026-04-22
 
 ## Definitions
 
 - **Phase checkpoint** — A durable serialization of a phase's output
   sufficient to reconstruct that phase's contribution to the execution
   context without re-running the phase.
+- **Execution-machine snapshot** — A durable serialization of the
+  authoritative workflow machine state, machine context, and resume
+  metadata required to continue execution without rebuilding control
+  flow from ad hoc phase indexes.
 - **Workflow manifest** — A per-workflow index file describing the
   workflow's identity, spec provenance, completed phases, and resume
   metadata.
@@ -82,22 +87,25 @@ worktree from its scratch ref.
 
 ## Normative Requirements
 
-### §1. Phase checkpoint after successful `:leave`
+### §1. Phase checkpoint and machine snapshot after successful transition
 
 When a phase's `:leave` interceptor completes without error, the
-workflow runner MUST persist the phase's contribution to
-`[:execution/phase-results <phase>]` to the checkpoint store as a
-single `.edn` file.
+workflow runner MUST persist:
+
+1. The phase's contribution to `[:execution/phase-results <phase>]` as
+   a single `.edn` file
+2. The updated execution-machine snapshot for the workflow run
 
 The write MUST be atomic (write to a temp file in the same directory,
 then rename). A partial or corrupt checkpoint MUST NOT be observable by
 a later resume.
 
-If the write fails (disk full, permission denied, etc.), the workflow
-MUST NOT fail as a result. The runner MUST log the error and emit a
-`:workflow/checkpoint-write-failed` event, then continue. Loss of a
-single checkpoint degrades resumability for that run but does not
-compromise the run itself.
+If one of these writes fails (disk full, permission denied, etc.), the
+workflow MUST NOT fail as a result. The runner MUST log the error and
+emit a `:workflow/checkpoint-write-failed` or
+`:workflow/machine-snapshot-write-failed` event, then continue. Loss of
+a single checkpoint or snapshot degrades resumability for that run but
+does not compromise the run itself.
 
 ### §2. Workflow manifest
 
@@ -110,6 +118,8 @@ file containing at least:
 - `:workflow/started-at` — ISO-8601 timestamp
 - `:workflow/phases-completed` — ordered vector of phase keywords
   checkpointed so far
+- `:workflow/machine-state` — current authoritative machine state keyword
+- `:workflow/machine-snapshot-path` — path to the latest machine snapshot
 - `:workflow/last-checkpoint-at` — ISO-8601 timestamp
 - `:workflow/backend` — string identifying the LLM backend in use
   (`claude`, `codex`, `openai`, etc.)
@@ -117,7 +127,7 @@ file containing at least:
   `:cancelled`, `:paused`
 
 The manifest MUST be updated atomically after each successful phase
-checkpoint.
+checkpoint or machine snapshot write.
 
 ### §3. Checkpoint store location
 
@@ -127,7 +137,7 @@ configurable via user config (`:checkpoint/root`) and per-invocation
 flag. A host-level GC policy MUST NOT delete checkpoints under the
 default retention window (see §7).
 
-### §4. Resume from last successful phase
+### §4. Resume from authoritative machine snapshot
 
 A user-invoked `miniforge resume <workflow-id>` command MUST:
 
@@ -135,15 +145,20 @@ A user-invoked `miniforge resume <workflow-id>` command MUST:
 2. Verify the manifest's `:workflow/spec-hash` against the current spec
    file content
 3. If the hash matches (or `--force` is passed), reconstruct the
-   execution context:
+   execution context from the machine snapshot and phase checkpoints:
+   - `:execution/machine-snapshot` restored from the persisted snapshot
+   - `:execution/machine-state` restored from the authoritative snapshot
+   - `:execution/machine-context` restored from the authoritative snapshot
    - `:execution/phase-results` populated from the checkpoint files
-   - `:execution/phase-index` pointing to the first phase NOT in
-     `:workflow/phases-completed`
    - `:execution/id` set to the original workflow id (no new id, no new
      event-log directory)
-4. Continue execution from that phase
+   - derived projections such as `:workflow/status` and
+     `:workflow/current-phase` recomputed from the machine state
+4. Continue execution by dispatching the next legal machine event
 5. Emit a `:workflow/resumed` event with
-   `{:from-phase <phase> :skipping <vector-of-skipped-phases>}`
+   `{:from-state <machine-state>
+     :from-phase <phase-or-nil>
+     :skipping <vector-of-skipped-phases>}`
 
 If the hash does NOT match and `--force` is NOT passed, the command
 MUST error with a message that identifies the drift and lists the
@@ -154,9 +169,10 @@ specs.
 
 `miniforge resume <id> --from-phase <phase>` MUST discard any
 checkpoints for `<phase>` and any later phases, truncate
-`:workflow/phases-completed`, and resume from `<phase>`. This supports
-the case where a bug is discovered in a specific phase but earlier
-phases are still valid.
+`:workflow/phases-completed`, rebuild the execution-machine snapshot to
+the last state before `<phase>`, and resume from `<phase>`. This
+supports the case where a bug is discovered in a specific phase but
+earlier phases are still valid.
 
 ### §6. Resumable workflow enumeration
 
@@ -199,15 +215,20 @@ stream contract):
   - `:workflow/id`, `:phase/name`, `:checkpoint/path`, `:checkpoint/size-bytes`
 - `:workflow/checkpoint-write-failed` on write error
   - `:workflow/id`, `:phase/name`, `:error/message`
+- `:workflow/machine-snapshot-written` after each successful snapshot write
+  - `:workflow/id`, `:machine/state`, `:snapshot/path`, `:snapshot/size-bytes`
+- `:workflow/machine-snapshot-write-failed` on snapshot write error
+  - `:workflow/id`, `:machine/state`, `:error/message`
 - `:workflow/resumed` on successful resume
-  - `:workflow/id`, `:from-phase`, `:skipping`
+  - `:workflow/id`, `:from-state`, `:from-phase`, `:skipping`
 - `:workflow/spec-hash-mismatch` on detected drift
   - `:workflow/id`, `:expected-hash`, `:actual-hash`
 
 ### §10. Billing and replay semantics
 
 A resumed workflow MUST NOT re-execute phases listed in
-`:workflow/phases-completed`. In particular:
+`:workflow/phases-completed` or any machine transitions already covered
+by the restored snapshot. In particular:
 
 - LLM agents for completed phases MUST NOT be invoked on resume
 - Side-effecting operations (commits, PRs, external API calls)
@@ -218,8 +239,9 @@ for the work they lost.
 
 ## Conformance Levels
 
-- **MUST** — §1 (checkpoint after `:leave`), §2 (manifest), §4 (resume
-  from last successful phase), §9 (event emission), §10 (no re-execute).
+- **MUST** — §1 (checkpoint and machine snapshot after `:leave`), §2
+  (manifest), §4 (resume from authoritative machine snapshot), §9
+  (event emission), §10 (no re-execute).
 - **SHOULD** — §5 (`--from-phase`), §6 (`list --resumable`), §7 (GC
   policy), §8 (worktree integration).
 - **MAY** — Cross-workflow replay (`miniforge replay <old-id> --into
@@ -245,6 +267,13 @@ different outcome than one who resumes an identical spec. Silently
 resuming across a spec edit produces subtly wrong results. The
 explicit `--force` flag preserves the override for the cases where the
 user knows what they're doing.
+
+### Why machine snapshot, not phase index
+
+Phase indexes alone are not authoritative enough once a workflow can
+skip phases, redirect, retry, await supervision, or support multiple
+workflow profiles. The machine snapshot carries the actual control-flow
+state and eliminates a second hidden state machine in the runner.
 
 ### Why same workflow id continues
 

--- a/specs/normative/N2-workflows.md
+++ b/specs/normative/N2-workflows.md
@@ -7,7 +7,7 @@
 # N2 — Workflow Execution Model
 
 **Version:** 0.5.0-draft
-**Date:** 2026-03-08
+**Date:** 2026-04-22
 **Status:** Draft
 **Conformance:** MUST
 
@@ -20,7 +20,7 @@ This specification defines the **workflow execution model** for miniforge autono
 - **Phase graph** structure and execution order
 - **Phase responsibilities** and expected outputs
 - **Inner loop** validation and repair mechanism
-- **Outer loop** phase transition state machine
+- **Unified execution machine** for workflow progression
 - **Gate contract** for validation checkpoints
 - **Context handoff** protocol between phases
 
@@ -32,39 +32,69 @@ This specification builds upon core concepts defined in N1 (Architecture).
 2. **Fail-safe** - Validation failures MUST trigger repair, not silent progression
 3. **Observable** - All phase transitions MUST emit events (see N3)
 4. **Traceable** - Complete evidence trail from intent to outcome (see N6)
-5. **Resumable** - Workflows MUST be resumable from last successful phase
+5. **Resumable** - Workflows MUST be resumable from an authoritative machine snapshot
 
 ---
 
 ## 2. Workflow Lifecycle
 
-### 2.1 Workflow States
+### 2.1 Authoritative Execution Model
+
+Each workflow run MUST execute against exactly one compiled **execution machine**.
+
+The execution machine is the authoritative source of truth for:
+
+1. Workflow lifecycle status
+2. Current phase or non-phase execution state
+3. Retry and redirect budgets
+4. Resume checkpoints and snapshots
+5. Legal next transitions
+
+Implementations MUST NOT split authority between a coarse lifecycle FSM
+and separate ad hoc phase-index or redirect logic.
+
+`:workflow/status`, `:workflow/current-phase`, and similar convenience
+fields MAY be materialized for UI, telemetry, or APIs, but they MUST be
+derived projections of the execution machine state.
+
+### 2.2 Workflow State Projections
+
+The execution machine MUST project at least these workflow lifecycle states:
 
 ```clojure
 :workflow/status
   :pending      ; Workflow created, not yet started
-  :executing    ; Workflow running (in some phase)
+  :running      ; Workflow running (in some phase or supervisory wait state)
   :completed    ; Workflow completed successfully
   :failed       ; Workflow failed (gate failure, agent error)
   :cancelled    ; Workflow cancelled by user
 ```
 
-### 2.2 State Transition Diagram
+The machine MAY use more specific internal state identifiers such as `:phase/plan`,
+`:phase/verify`, `:awaiting-operator`, or `:releasing`, but those states MUST map
+deterministically onto the lifecycle projection above.
+
+### 2.3 State Transition Diagram
 
 ```text
-pending ──[start]──► executing ──[complete all phases]──► completed
-                         │
-                         │ [gate failure, agent error]
-                         ▼
-                       failed
-                         ▲
-                         │
-                   [user action]
-                         │
-                     cancelled
+pending ──[start]──► running ──[complete machine]──► completed
+                        │
+                        │ [terminal failure]
+                        ▼
+                      failed
+                        ▲
+                        │
+                  [cancel action]
+                        │
+                    cancelled
 ```
 
-### 2.3 Workflow Lifecycle Events
+Within `:running`, the execution machine MAY move through workflow-defined states,
+including phase states, retry states, review or release states, and temporary
+awaiting-supervision states, provided those transitions are encoded in the same
+authoritative machine.
+
+### 2.4 Workflow Lifecycle Events
 
 Implementations MUST emit these events (see N3):
 
@@ -77,13 +107,59 @@ Implementations MUST emit these events (see N3):
 
 ---
 
-## 3. Phase Graph
+## 3. Workflow Graph and Phase Model
 
-### 3.1 Standard Phase Sequence
+### 3.1 Workflow Definition Model
+
+A workflow definition is a graph that is compiled into the per-run execution machine.
+
+Implementations MUST support workflow definitions that declare:
+
+1. Workflow family (for example `:software-factory` or `:etl`)
+2. Workflow profile (for example `:canonical-sdlc`, `:quick-fix`, `:review-first`, `:financial-etl`)
+3. Nodes or states
+4. Transitions and terminal states
+5. Retry, rollback, or redirect budgets
+6. Optional skip or policy-gated edges
+
+### 3.1.1 Canonical SDLC Profile
 
 ```text
 Plan → Design → Implement → Verify → Review → Release → Observe
 ```
+
+The sequence above defines the **canonical SDLC** profile for software-factory workflows.
+It is not the only valid workflow shape. ETL workflows and future SDLC paradigms MAY
+compile different graphs so long as they satisfy this specification's machine,
+gate, evidence, and observability requirements.
+
+### 3.1.2 Workflow Family and Profile Selection
+
+Implementations MUST separate **workflow selection** from **workflow execution**:
+
+1. Selection chooses a workflow family, profile, and policy set for the run
+2. Execution runs the compiled machine for that chosen definition
+
+The selected definition MAY be static, policy-driven, or later learned by convergence logic,
+but once execution begins, the run MUST have one authoritative compiled machine snapshot.
+Mid-run re-planning MAY be supported only as an explicit machine transition or intervention,
+not by mutating the workflow graph out-of-band.
+
+### 3.1.3 Phase Outcome Semantics
+
+Phases MUST NOT imperatively choose the next phase by mutating execution indexes,
+redirect targets, or other control-flow fields.
+
+Instead, a phase MUST emit one or more outcome events, such as:
+
+- `:phase/succeeded`
+- `:phase/failed`
+- `:phase/retry-requested`
+- `:phase/rollback-requested`
+- `:phase/escalated`
+
+The compiled execution machine MUST determine the legal next transition from those events,
+its current state, guards, and configured budgets.
 
 ### 3.2 Phase Definitions
 
@@ -450,7 +526,11 @@ Implementations MUST:
 1. Extract signals from workflow execution (duration, iterations, outcomes)
 2. Update knowledge base with learnings
 3. Propose heuristic improvements (if patterns detected)
-4. Record in learning layer for meta loop (see N1, Section 3.3)
+4. Record signals for the learning layer and meta loop (see N1, Section 3.3)
+
+The Observe phase remains part of the per-run execution machine. The cross-run learning
+meta loop consumes Observe outputs and other evidence after or alongside workflow execution,
+but it is not itself the live supervisory mechanism for phase transitions.
 
 ```clojure
 ;; Observe output schema
@@ -492,23 +572,26 @@ Before executing a phase, implementations MUST verify:
 
 For each phase, implementations MUST:
 
-1. **Emit phase-started event** (see N3)
-2. **Initialize agent** with context
-3. **Execute agent** (invoke method)
-4. **Run inner loop** validation and repair (see Section 5)
-5. **Execute gates** (see Section 6)
-6. **Store artifacts** with provenance (see N6)
-7. **Update phase context** for next phase
-8. **Emit phase-completed event** (see N3)
+1. **Confirm the current machine state** permits entering that phase
+2. **Emit phase-started event** (see N3)
+3. **Initialize agent** with context
+4. **Execute agent** (invoke method)
+5. **Run inner loop** validation and repair (see Section 5)
+6. **Execute gates** (see Section 6)
+7. **Emit phase outcome event(s)** for the execution machine
+8. **Persist machine snapshot and artifacts** with provenance (see N6)
+9. **Update derived phase context** for downstream consumers
+10. **Emit phase-completed or phase-failed event** (see N3)
 
 ### 4.3 Phase Failure Handling
 
 If a phase fails, implementations MUST:
 
-1. **Emit phase-failed event** with reason
+1. **Emit phase-failed and machine-transition events** with reason
 2. **Record partial evidence** (even for incomplete phase)
-3. **Halt workflow** (do not proceed to next phase)
-4. **Escalate to human** with failure details and remediation options
+3. **Apply the failure transition defined by the execution machine**
+4. **Notify the supervisory machine** so live governance state reflects the failure
+5. **Escalate to human** with failure details and remediation options when machine policy requires it
 
 Options for user:
 
@@ -516,6 +599,10 @@ Options for user:
 - Skip phase (if safe)
 - Cancel workflow
 - Override gate (if permitted by policy)
+
+Human or automated intervention MUST flow through bounded supervisory control actions.
+The workflow runner MUST NOT accept direct phase-index manipulation or uncontrolled
+state mutation as a substitute for those actions.
 
 ### 4.4 Phase Context Handoff
 
@@ -525,6 +612,9 @@ Each phase MUST receive a complete context:
 {:workflow/id uuid
  :workflow/spec {...}              ; Original specification
  :workflow/intent {...}            ; Intent declaration
+
+ :execution/machine-state keyword  ; Current authoritative execution state
+ :execution/machine-snapshot {...} ; Durable snapshot for resume and supervision
 
  :phase/name keyword               ; Current phase
  :phase/input-context
@@ -895,7 +985,7 @@ If phase skipped, implementations MUST emit:
 
 ### 8.1 Resume Requirements
 
-Implementations MUST support resuming workflows from last successful phase if:
+Implementations MUST support resuming workflows from an authoritative machine snapshot if:
 
 - Workflow failed due to transient error (LLM timeout, network issue)
 - User cancelled workflow and wants to restart
@@ -905,15 +995,16 @@ Implementations MUST support resuming workflows from last successful phase if:
 
 To resume workflow:
 
-1. **Load workflow state** from persistent storage
-2. **Identify last successful phase**
-3. **Restore context** from that phase
-4. **Resume execution** from next phase
+1. **Load the most recent machine snapshot** from persistent storage
+2. **Verify the snapshot and workflow definition** are compatible
+3. **Restore machine state, machine context, and completed phase artifacts**
+4. **Rebuild derived projections** such as `:workflow/status` and `:workflow/current-phase`
+5. **Resume execution** by dispatching the next legal machine event
 
 ```clojure
 ;; Resume workflow
 (workflow/resume engine workflow-id)
-;; → Resumes from phase after last completed phase
+;; → Restores the execution machine and continues from its next legal transition
 ```
 
 ### 8.3 Resume Constraints
@@ -921,7 +1012,7 @@ To resume workflow:
 Implementations MUST NOT resume if:
 
 - Workflow already completed
-- Workflow state is corrupted
+- Machine snapshot or workflow state is corrupted
 - Too much time has passed (state may be stale)
 
 ---
@@ -949,16 +1040,24 @@ Implementations MUST NOT resume if:
 
  :workflow/context {...}           ; OPTIONAL: Domain-specific context (AWS region, etc.)
 
+ :workflow/definition
+ {:workflow/family keyword         ; REQUIRED: :software-factory | :etl | future families
+  :workflow/profile keyword        ; REQUIRED: :canonical-sdlc | :quick-fix | :review-first | :financial-etl | ...
+  :workflow/graph {...}            ; OPTIONAL: inline graph or reference-resolved graph
+  :workflow/policies
+  {:skip-phases #{keyword}         ; OPTIONAL: phases or states that may be skipped
+   :retry-budgets map              ; OPTIONAL: per-state or per-transition budgets
+   :auto-merge? boolean}}          ; OPTIONAL: release policy for eligible workflows
+
  :workflow/validation
  {:policy-packs [string ...]       ; REQUIRED: Policy packs to enforce
   :require-evidence? boolean       ; REQUIRED: Generate evidence bundle?
   :semantic-intent-check? boolean  ; REQUIRED: Validate semantic intent?
   :slo-overrides map}              ; OPTIONAL: Per-workflow SLO target overrides (see N1 §5.5.3)
-
- :workflow/phases
- {:skip-design? boolean            ; OPTIONAL: Skip design phase if true
-  :auto-merge? boolean             ; OPTIONAL: Auto-merge PR if gates pass
-  :max-inner-loop-iterations long}} ; OPTIONAL: Override default retry budget
+ 
+ :workflow/runtime
+ {:max-inner-loop-iterations long  ; OPTIONAL: Override default retry budget
+  :checkpoint-policy map}}         ; OPTIONAL: Snapshot/checkpoint configuration
 ```
 
 #### 9.1.1 ETL Workflow Type
@@ -975,9 +1074,10 @@ ETL workflows SHOULD emit:
 ETL workflows MUST default generated packs to `:untrusted` unless explicitly promoted under policy.
 
 **Custom Phase Sequence:** ETL workflows use a fundamentally different process than
-standard infrastructure change workflows. While the standard phase sequence is
+standard software-factory workflows. While the canonical SDLC sequence is
 (Plan → Design → Implement → Verify → Review → Release → Observe), ETL workflows
-MAY define custom phases appropriate to the ingestion and normalization process
+MAY define custom phases appropriate to the ingestion and normalization process,
+provided those phases are still compiled into a single authoritative execution machine.
 (e.g., Inventory → Classify → Scan → Extract → Validate → Index). The workflow
 extensibility model treats ETL as just another workflow type with its own phase graph.
 
@@ -1194,6 +1294,10 @@ Implementations MUST support these transitions:
 | `:ready-to-merge` | `:merging` | Merge initiated |
 | `:merging` | `:merged` | Merge successful |
 | Any non-terminal | `:failed` | Max retries exceeded, unrecoverable error |
+
+This task lifecycle MUST itself be implemented as an explicit machine or transition table
+with legal-state validation. Implementations MUST NOT permit unconstrained direct writes
+to task status fields.
 
 ### 13.3 Automated CI/Review Fix Iteration
 
@@ -1426,7 +1530,7 @@ Chained execution MUST preserve provenance across workflow boundaries:
    :edge/from-workflow-id uuid         ; Upstream workflow
    :edge/to-workflow-id uuid           ; Downstream workflow
    :edge/bindings [...]                ; Input bindings (§14.2)
-   :edge/status keyword                ; :pending, :executing, :completed, :failed
+   :edge/status keyword                ; :pending, :running, :completed, :failed
    :edge/started-at inst
    :edge/completed-at inst}]}
 ```

--- a/specs/normative/N5-delta-supervisory-control-plane.md
+++ b/specs/normative/N5-delta-supervisory-control-plane.md
@@ -7,9 +7,9 @@
 # N5 Delta — Supervisory Control Plane
 
 - **Spec ID:** `N5-delta-supervisory-control-plane-v1`
-- **Version:** `0.2.0-draft`
+- **Version:** `0.3.0-draft`
 - **Status:** Draft
-- **Date:** 2026-04-17
+- **Date:** 2026-04-22
 - **Amends:** N5 — Interface Standard: CLI/TUI/API
 - **Related:** N3 (event stream), N4 (policy packs), N6 (evidence), N8 (observability control), N9 (external PR
   integration), pr-monitor-loop-v1 (autonomous PR comment resolution)
@@ -30,6 +30,8 @@ model, governance states, and bounded interventions that the TUI must support.
 - Attention items as a first-class supervisory concept (§5)
 - Waiver semantics for policy overrides (§6)
 - Bounded intervention vocabulary (§7)
+- Intervention request lifecycle semantics (§7)
+- Command/query separation against canonical supervisory state (§7)
 - Monitor mode as default TUI posture (§8)
 - Durable startup and stale-read requirements (§9)
 
@@ -60,6 +62,32 @@ The human's role in the supervisory model is:
 - **Auditor** — reviews evidence bundles and governance dispositions
 
 The TUI MUST be optimized for these roles, not for direct workflow operation.
+
+### 2.3 Human supervisory loop
+
+The supervisory UX runtime is a **human supervisory loop** that operates as a
+peer to the orchestrator within the control plane.
+
+The human supervisory loop MUST:
+
+1. Query canonical supervisory state through the supervisory-state projection
+2. Submit bounded intervention requests rather than mutating workflow state directly
+3. Receive durable intervention results and evidence after the orchestrator applies an action
+
+The human supervisory loop MAY be exposed through a TUI, dashboard, API-backed
+operator agent, or other UX surfaces, but all such surfaces MUST share the same
+canonical intervention model.
+
+### 2.4 Boundary to orchestrator and learning loop
+
+The orchestrator and the human supervisory loop are separate actors with different
+authority boundaries:
+
+1. The orchestrator is the only component permitted to apply transitions to the execution, supervision, or degradation
+  machines
+2. The human supervisory loop is a peer control surface, not an alternate source of truth
+3. The learning/meta loop remains a learning-layer concern and MUST NOT
+   be treated as the live supervisory mechanism for in-flight workflows
 
 ## 3. Supervisory entities — v1
 
@@ -175,6 +203,29 @@ Minimum required keys for supervisory display:
  :evidence/gate-summary  map?}      ;; {:passed N :failed N :skipped N}
 ```
 
+#### InterventionRequest
+
+A durable request to perform a bounded supervisory action against the system.
+
+Minimum required keys:
+
+```clojure
+{:intervention/id            uuid?
+ :intervention/type          keyword?   ;; see §7.1
+ :intervention/target-type   keyword?   ;; :workflow, :policy-eval, :degradation, :supervision
+ :intervention/target-id     any?
+ :intervention/requested-by  string?
+ :intervention/request-source keyword?  ;; :tui, :dashboard, :api, :ux-agent
+ :intervention/state         keyword?   ;; see §3.3
+ :intervention/justification string?
+ :intervention/requested-at  inst?
+ :intervention/updated-at    inst?}
+```
+
+InterventionRequests MUST be the canonical representation of supervisory control
+intent. UI actions, operator-agent actions, and API commands MUST all materialize
+as InterventionRequests before they are applied.
+
 ### 3.2 Workflow execution states
 
 WorkflowRun `:workflow-run/status` MUST distinguish at least:
@@ -192,7 +243,27 @@ WorkflowRun `:workflow-run/status` MUST distinguish at least:
 Terminal states (`:completed`, `:failed`, `:cancelled`) MUST NOT transition back to active states. A retry MUST produce
 a new WorkflowRun.
 
-### 3.3 Existing entities carried forward
+WorkflowRun state is a supervisory projection over the authoritative execution and
+supervision machines. It MUST NOT be mutated directly by the UI.
+
+### 3.3 Intervention lifecycle states
+
+InterventionRequest `:intervention/state` MUST distinguish at least:
+
+| State | Meaning |
+|-------|---------|
+| `:proposed` | Intervention created but not yet validated |
+| `:pending-human` | Waiting on explicit human approval or confirmation |
+| `:approved` | Approved and ready for dispatch |
+| `:rejected` | Explicitly denied |
+| `:dispatched` | Submitted to the orchestrator for execution |
+| `:applied` | Target machine transition or side effect applied |
+| `:verified` | Post-application verification succeeded |
+| `:failed` | Dispatch or post-application verification failed |
+
+Terminal states are `:rejected`, `:verified`, and `:failed`.
+
+### 3.4 Existing entities carried forward
 
 The following entities already exist in sufficient form across N1, N4, N9, and existing components. They do not require
 new formalization for v1 but MUST be correlatable to v1 entities:
@@ -207,7 +278,7 @@ new formalization for v1 but MUST be correlatable to v1 entities:
 - **PRTrain** — defined in N9 and the pr-train component
 - **WorkflowPhase** — defined in N2; tracked in events
 
-### 3.4 Materialization — the supervisory-state component
+### 3.5 Materialization — the supervisory-state component
 
 The entities defined in §3.1 MUST be materialized by a dedicated component,
 `components/supervisory-state`, which is the canonical source of supervisory
@@ -238,7 +309,8 @@ control console).
    derived inside this component and emitted as `:supervisory/attention-derived`
    (N3 §3.19). No other component MAY emit attention snapshots.
 6. **One source per entity family.** For each of WorkflowRun, AgentSession,
-   PrFleetEntry, PolicyEvaluation, AttentionItem the component MUST be the
+   PrFleetEntry, PolicyEvaluation, AttentionItem, and InterventionRequest the
+   component MUST be the
    sole emitter of the corresponding `:supervisory/*-upserted` event.
    Other components MAY and SHOULD continue emitting their own fine-grained
    lifecycle events, but MUST NOT produce snapshot events directly.
@@ -254,6 +326,7 @@ control console).
 | `:control-plane/agent-registered` / `:agent-discovered` | Inserts `AgentSession` |
 | `:control-plane/agent-state-changed` / `:control-plane/status-changed` | Updates status |
 | `:control-plane/agent-heartbeat` | Advances `:agent/last-heartbeat` |
+| `:supervisory/intervention-requested` / `:supervisory/intervention-state-changed` | Upserts `InterventionRequest` |
 | `:pr/created` / `:pr/merged` / `:pr/closed` / `:pr-monitor/*` | Upserts `PrFleetEntry` |
 | `:gate/passed` / `:gate/failed` | Emits new immutable `PolicyEvaluation` |
 
@@ -351,18 +424,39 @@ The TUI MUST support a bounded set of supervisory interventions. These extend N5
 |-------------|--------|--------|
 | `acknowledge` | AttentionItem | Marks item as seen; does not resolve |
 | `retry` | WorkflowRun (failed) | Creates a new run from the same spec |
+| `retry-from-phase` | WorkflowRun | Rebuilds resume state and requests restart from a specific phase |
 | `pause` | WorkflowRun (running) | Suspends execution |
 | `resume` | WorkflowRun (paused) | Resumes execution |
 | `cancel` | WorkflowRun (active) | Terminates execution |
+| `request-replan` | WorkflowRun | Requests a new planning pass or workflow-selection pass |
 | `waive` | PolicyEvaluation | Creates a Waiver record with reason |
 | `re-evaluate` | PullRequest | Triggers a new PolicyEvaluation |
+| `force-safe-mode` | DegradationScope | Requests transition into a stricter degradation posture |
+| `exit-safe-mode` | DegradationScope | Requests return to a less restrictive degradation posture |
+| `request-human-review` | WorkflowRun or PullRequest | Escalates the target for explicit human review |
 
-### 7.2 Intervention recording
+### 7.2 Intervention lifecycle and recording
 
-Interventions MUST produce a durable record per N5 §6.2. The existing override logging schema in N5 §6.2 is sufficient;
-this delta does not add new fields.
+Every intervention MUST produce:
 
-### 7.3 Boundary constraint
+1. A durable `InterventionRequest` record in the lifecycle defined by §3.3
+2. Audit logging per N5 §6.2
+3. A resulting success, rejection, or failure state after orchestrator handling
+
+Human-triggered interventions that carry material risk MAY require a
+`pending-human` approval step before dispatch, even when the request was created
+from a UX surface.
+
+### 7.3 Command/query separation
+
+The supervisory surface MUST separate read and write paths:
+
+1. Queries MUST resolve from canonical supervisory-state projections
+2. Commands MUST materialize as InterventionRequests
+3. The orchestrator MUST validate, dispatch, and apply approved interventions
+4. External supervisory clients MUST NOT write execution or supervision state directly
+
+### 7.4 Boundary constraint
 
 The supervisory surface MUST NOT expand beyond the intervention vocabulary defined here without a spec amendment. It
 MUST NOT become a general-purpose command shell.
@@ -447,6 +541,11 @@ The TUI monitor MUST display control plane state:
 Control plane events (`:control-plane/*`) MUST be handled by the TUI event subscription alongside `:workflow/*` and
 `:pr-monitor/*` events.
 
+The orchestrator MUST be treated as the sole transition authority for execution,
+supervision, and degradation machines. The TUI and other supervisory surfaces
+render projection state and submit interventions; they do not apply transitions
+themselves.
+
 The `control-plane-completion.spec.edn` work spec covers wiring decision delivery and event emission from the
 orchestrator. The TUI work (this delta + companion work spec) covers rendering that data in monitor mode.
 
@@ -464,7 +563,6 @@ The following concepts are recognized as architecturally important but deferred 
 | Concept | Reason for deferral |
 |---------|-------------------|
 | `Lens` abstraction | Extract after monitor patterns stabilize |
-| Full `Intervention` audit trail | Simple recording (N5 §6.2) sufficient for v1 |
 | Event versioning | Existing event envelope sufficient for v1 |
 | Cross-entity correlation IDs | Add incrementally where missing |
 | Multi-project fleet aggregation | Single-project dogfooding is current scope |
@@ -483,6 +581,8 @@ through without error. Required keys MUST be present and correctly typed.
 3. Waivers MUST be separate records, not mutations of evaluations
 4. AttentionItems MUST be derivable from canonical state
 5. Terminal WorkflowRun states MUST NOT transition to active states
+6. Every supervisory write action MUST materialize as an InterventionRequest before application
+7. External supervisory clients MUST NOT directly mutate execution or supervision state
 
 ### 12.3 Monitor mode conformance
 


### PR DESCRIPTION
# feat: formalize workflow, supervision, and operator-loop specs

## Overview

Formalize the architectural split between workflow execution, live supervision,
global degradation mode, the learning/meta loop, and the human supervisory
loop. Amend the normative specs so the intended control model is explicit
before code migration begins.

## Motivation

The current implementation and specs mostly imply the right separation, but the
boundaries are not explicit enough to safely refactor toward formal state
machines without leaving competing authorities behind. In particular:

- workflow execution currently mixes execution status and phase-transition logic
- live supervisory checks and learning/meta-loop responsibilities are blurred
- the human supervisory role is present in the N5 control-plane material but
  not yet tied cleanly to the orchestrator and machine model
- resume semantics still reflect phase-index thinking rather than machine
  snapshot restoration

This PR establishes the contract that the code migration will follow.

## Changes In Detail

- Amend N1 to separate:
  - control-plane orchestration
  - workflow supervision
  - learning/meta-loop improvement
  - human supervisory loop
- Amend N2 to define:
  - a unified execution machine per workflow run
  - a distinct supervisory machine for live governance and intervention
  - event-driven phase outcomes instead of imperative phase steering
  - machine-snapshot-oriented resume semantics
- Amend the N5 supervisory control-plane delta to formalize:
  - the human supervisory loop as a peer runtime to the orchestrator
  - bounded intervention lifecycle semantics
  - command/query separation against canonical supervisory state
- Add an informative architecture note describing the target multi-machine,
  peer-runtime model that subsequent implementation PRs will follow

## Testing Plan

- Read the updated spec set end to end for internal consistency:
  - N1 core architecture
  - N2 workflows
  - N2 phase checkpoint/resume delta
  - N5 supervisory control-plane delta
- Verify terminology is consistent across:
  - orchestrator
  - supervisory loop
  - meta loop
  - degradation mode
  - workflow execution machine
- Run Markdown lint/format checks if needed

## Deployment Plan

No runtime deployment. This is a contract-first documentation PR that should
merge before implementation PRs that migrate workflow and supervisory control
logic onto formal machines.

## Related Issues/PRs

- Prepares the ground for the workflow/machine compiler refactor
- Prepares the ground for supervisory-state and intervention lifecycle work
- Follow-up implementation PRs should stack on this one

## Checklist

- [x] N1 updated with orchestrator vs supervisory vs meta-loop boundaries
- [x] N2 updated with unified execution-machine model
- [x] N2 resume delta updated for machine snapshot semantics
- [x] N5 supervisory delta updated for operator supervisory loop and interventions
- [x] Informative architecture note added
- [x] Spec language cross-checked for consistency
