### PR TITLE
fix: clear persistent clj-kondo warnings

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -21,7 +21,10 @@
 
    Handles execution of individual phase steps through the enter -> gates -> leave lifecycle.
    Processes results, tracks metrics/files/artifacts, and determines phase transitions."
-  (:require [ai.miniforge.gate.interface :as gate]
+  (:require [clojure.java.io :as io]
+            [clojure.java.shell :as shell]
+            [clojure.string :as str]
+            [ai.miniforge.gate.interface :as gate]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]
@@ -475,17 +478,17 @@
   [parent-worktree sub-worktree-paths]
   (doseq [sub-wt sub-worktree-paths]
     (try
-      (let [{:keys [out]} (clojure.java.shell/sh
+      (let [{:keys [out]} (shell/sh
                             "git" "diff" "--name-only" "HEAD"
                             :dir sub-wt)
-            changed-files (remove clojure.string/blank?
-                                  (clojure.string/split-lines (or out "")))]
+            changed-files (remove str/blank?
+                                  (str/split-lines (or out "")))]
         (doseq [f changed-files]
-          (let [src (clojure.java.io/file sub-wt f)
-                dst (clojure.java.io/file parent-worktree f)]
+          (let [src (io/file sub-wt f)
+                dst (io/file parent-worktree f)]
             (when (.exists src)
-              (clojure.java.io/make-parents dst)
-              (clojure.java.io/copy src dst)))))
+              (io/make-parents dst)
+              (io/copy src dst)))))
       (catch Exception _e nil))))
 
 (defn apply-dag-success

--- a/docs/pull-requests/2026-04-22-fix-precommit-kondo-warnings.md
+++ b/docs/pull-requests/2026-04-22-fix-precommit-kondo-warnings.md
@@ -1,0 +1,45 @@
+# fix: clear persistent clj-kondo warnings from workflow execution
+
+## Overview
+
+Remove the persistent `clj-kondo` warnings from the pre-commit path by fixing
+the namespace declarations in `workflow.execution`.
+
+## Motivation
+
+The pre-commit hook has been warning on every commit because
+`components/workflow/src/ai/miniforge/workflow/execution.clj` used
+`clojure.java.shell`, `clojure.string`, and `clojure.java.io` without requiring
+them. That makes the hook noisy and easy to ignore, even though the warning is a
+real source issue in the repo.
+
+## Changes In Detail
+
+- Add explicit requires for:
+  - `clojure.java.io`
+  - `clojure.java.shell`
+  - `clojure.string`
+- Switch the fully qualified calls in `merge-sub-worktree-changes!` to the new
+  aliases so lint resolves them correctly
+- Keep behavior unchanged; this is a source/lint cleanup only
+
+## Testing Plan
+
+- Run `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/execution.clj`
+- Run `bb test components/workflow`
+
+## Deployment Plan
+
+No runtime deployment. Merge normally; this only removes persistent lint noise
+from the commit path.
+
+## Related Issues/PRs
+
+- Follow-up hygiene fix after `#636`, which surfaced the warning during
+  pre-commit validation
+
+## Checklist
+
+- [x] `workflow.execution` requires the namespaces it uses
+- [x] `clj-kondo` warning is gone for the file
+- [x] Workflow brick tests pass


### PR DESCRIPTION
# fix: clear persistent clj-kondo warnings from workflow execution

## Overview

Remove the persistent `clj-kondo` warnings from the pre-commit path by fixing
the namespace declarations in `workflow.execution`.

## Motivation

The pre-commit hook has been warning on every commit because
`components/workflow/src/ai/miniforge/workflow/execution.clj` used
`clojure.java.shell`, `clojure.string`, and `clojure.java.io` without requiring
them. That makes the hook noisy and easy to ignore, even though the warning is a
real source issue in the repo.

## Changes In Detail

- Add explicit requires for:
  - `clojure.java.io`
  - `clojure.java.shell`
  - `clojure.string`
- Switch the fully qualified calls in `merge-sub-worktree-changes!` to the new
  aliases so lint resolves them correctly
- Keep behavior unchanged; this is a source/lint cleanup only

## Testing Plan

- Run `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/execution.clj`
- Run `bb test components/workflow`

## Deployment Plan

No runtime deployment. Merge normally; this only removes persistent lint noise
from the commit path.

## Related Issues/PRs

- Follow-up hygiene fix after `#636`, which surfaced the warning during
  pre-commit validation

## Checklist

- [x] `workflow.execution` requires the namespaces it uses
- [x] `clj-kondo` warning is gone for the file
- [x] Workflow brick tests pass
