### PR TITLE
refactor: make workflow execution machine authoritative

### DIFF
--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -13,10 +13,24 @@
   :status/gate-failed        "Gate validation failed"
   :status/no-phases          "Workflow has no phases"
   :status/max-phases         "Exceeded maximum phase count: {max-phases}"
+  :status/empty-pipeline     "Workflow pipeline is empty"
+  :status/duplicate-phases   "Duplicate phase ids make transition targets ambiguous"
   :status/paused             "⏸  Workflow paused, waiting for resume..."
   :status/stopped-dashboard  "⏹  Workflow stopped by dashboard"
   :status/stopped-control    "Workflow stopped by control plane"
   :status/empty-completion   "Workflow completed but produced no artifacts or phase results"
+  :status/max-redirects      "Redirect cycle limit exceeded ({max-redirects} redirects)"
+  :status/max-redirects-hit  "Exceeded {max-redirects} redirects"
+  :status/invalid-phase-transition-event "Invalid phase transition event: {event}"
+  :status/terminal-state-transition "Cannot transition from terminal state: {state}"
+  :status/invalid-current-state "Invalid current state: {state}"
+  :status/guard-rejected-transition "Guard function rejected transition"
+  :status/no-transition-defined "No transition defined for [{state} {event}]"
+  :status/dag-executed-summary "DAG executed {task-count} task(s) successfully"
+
+  ;; Phase result messages
+  :phase/gate-failed-phase   "Gate validation failed for phase {phase}"
+  :phase/agent-failed-phase  "Agent failed in phase {phase}"
 
   ;; Execution mode
   :governed/no-capsule      "No capsule executor available for governed workflow"

--- a/components/workflow/resources/config/workflow/runner/defaults.edn
+++ b/components/workflow/resources/config/workflow/runner/defaults.edn
@@ -1,6 +1,7 @@
 {:runner/defaults
  {;; Pipeline execution limits
   :max-phases             50
+  :max-redirects          5
   :max-backoff-ms         30000
   :backoff-base-ms        1000
   :pause-poll-interval-ms 1000

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -32,9 +32,13 @@
    :execution/workflow         — Workflow configuration map
    :execution/workflow-id      — UUID from workflow config
    :execution/workflow-version — Version string from workflow config
-   :execution/status           — FSM state: :running | :completed | :failed |
+   :execution/status           — Derived from the authoritative execution
+                                 machine snapshot:
+                                 :pending | :running | :paused | :completed |
+                                 :failed | :cancelled |
                                  :completed-with-warnings
-   :execution/fsm-state        — Raw FSM state map
+   :execution/fsm-machine      — Compiled execution machine for this run
+   :execution/fsm-state        — Authoritative machine snapshot
 
    ### Input / Output
    :execution/input            — Input data for the workflow (task spec, etc.)
@@ -59,9 +63,9 @@
 
    ### Phase Execution
    :execution/phase-results    — Map of phase-name → phase result (see below)
-   :execution/current-phase    — Currently executing phase keyword
-   :execution/phase-index      — Current position in the pipeline vector
-   :execution/redirect-count   — Phase redirect counter (guards against loops)
+   :execution/current-phase    — Derived projection of the active machine state
+   :execution/phase-index      — Derived projection of the active machine state
+   :execution/redirect-count   — Derived from machine context
 
    ### Phase Result Schema
    Entries in :execution/phase-results follow the shape:
@@ -110,6 +114,36 @@
             [ai.miniforge.workflow.monitoring :as monitoring]
             [ai.miniforge.agent.interface :as agent]))
 
+;------------------------------------------------------------------------------ Internal helpers
+
+(defn sync-machine-projections
+  "Project workflow fields from the authoritative machine snapshot."
+  [ctx]
+  (let [machine (:execution/fsm-machine ctx)
+        fsm-state (:execution/fsm-state ctx)
+        projection (when (and machine fsm-state)
+                     (fsm/execution-projection machine fsm-state))
+        ctx' (cond-> (merge ctx projection)
+               (and (= :completed (:execution/status projection))
+                    (:execution/completed-with-warnings? ctx))
+               (assoc :execution/status :completed-with-warnings))]
+    ctx'))
+
+(defn transition-execution
+  "Apply an event to the authoritative execution machine and refresh projections."
+  [ctx event]
+  (if-let [machine (:execution/fsm-machine ctx)]
+    (let [fsm-state (:execution/fsm-state ctx)
+          next-state (fsm/transition-execution machine fsm-state event)
+          next-ctx (sync-machine-projections
+                    (assoc ctx :execution/fsm-state next-state))]
+      (cond-> next-ctx
+        (and (contains? #{:completed :failed :cancelled}
+                        (:execution/status next-ctx))
+             (nil? (:execution/ended-at next-ctx)))
+        (assoc :execution/ended-at (System/currentTimeMillis))))
+    ctx))
+
 ;------------------------------------------------------------------------------ Context operations
 
 (defn create-context
@@ -122,40 +156,39 @@
 
    Returns execution context map with FSM state initialized."
   [workflow input opts]
-  (let [;; Initialize FSM and transition to running state
-        fsm-state (-> (fsm/initialize)
-                      (fsm/transition-fsm :start))
+  (let [execution-machine (fsm/compile-execution-machine workflow)
+        fsm-state (let [initial-state (fsm/initialize-execution execution-machine)]
+                    (fsm/start-execution execution-machine initial-state))
         ;; Initialize meta-agents and coordinator
         meta-agents (monitoring/create-meta-agents workflow)
         coordinator (agent/create-meta-coordinator meta-agents)]
-    (merge
-     {:execution/id (random-uuid)
-      :execution/workflow workflow
-      :execution/workflow-id (:workflow/id workflow)
-      :execution/workflow-version (:workflow/version workflow)
-      :execution/status (fsm/current-state fsm-state)
-      :execution/fsm-state fsm-state
-      :execution/input input
-      :execution/artifacts []
-      :execution/errors []  ; DEPRECATED: Use :execution/response-chain instead
-      :execution/response-chain (response/create (:workflow/id workflow))
-      :execution/phase-results {}
-      :execution/output nil
-      :execution/current-phase nil
-      :execution/phase-index 0
-      :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
-      :execution/started-at (System/currentTimeMillis)
-      :execution/opts opts
-      ;; Meta-agent coordinator for workflow health monitoring
-      :execution/meta-coordinator coordinator
-      ;; Transient state for meta-agent health checks
-      :execution/streaming-activity []
-      :execution/files-written #{}}
-     ;; Merge opts into top-level context so :llm-backend is accessible to agents
-     (select-keys opts [:llm-backend :artifact-store :knowledge-store
-                        :on-phase-start :on-phase-complete
-                        :executor :environment-id :sandbox-workdir
-                        :on-chunk :event-stream :worktree-path]))))
+    (sync-machine-projections
+     (merge
+      {:execution/id (random-uuid)
+       :execution/workflow workflow
+       :execution/workflow-id (:workflow/id workflow)
+       :execution/workflow-version (:workflow/version workflow)
+       :execution/fsm-machine execution-machine
+       :execution/fsm-state fsm-state
+       :execution/input input
+       :execution/artifacts []
+       :execution/errors []  ; DEPRECATED: Use :execution/response-chain instead
+       :execution/response-chain (response/create (:workflow/id workflow))
+       :execution/phase-results {}
+       :execution/output nil
+       :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
+       :execution/started-at (System/currentTimeMillis)
+       :execution/opts opts
+       ;; Meta-agent coordinator for workflow health monitoring
+       :execution/meta-coordinator coordinator
+       ;; Transient state for meta-agent health checks
+       :execution/streaming-activity []
+       :execution/files-written #{}}
+      ;; Merge opts into top-level context so :llm-backend is accessible to agents
+      (select-keys opts [:llm-backend :artifact-store :knowledge-store
+                         :on-phase-start :on-phase-complete
+                         :executor :environment-id :sandbox-workdir
+                         :on-chunk :event-stream :worktree-path])))))
 
 (defn merge-metrics
   "Merge phase metrics into execution metrics.
@@ -168,19 +201,15 @@
 (defn transition-to-completed
   "Transition workflow to completed state using FSM."
   [ctx]
-  (let [fsm-state (:execution/fsm-state ctx)
-        new-fsm-state (fsm/transition-fsm fsm-state :complete)]
-    (-> ctx
-        (assoc :execution/fsm-state new-fsm-state)
-        (assoc :execution/status (fsm/current-state new-fsm-state))
-        (assoc :execution/ended-at (System/currentTimeMillis)))))
+  (-> (if (:execution/fsm-machine ctx)
+        (transition-execution ctx :complete)
+        (assoc ctx :execution/status :completed))
+      (assoc :execution/ended-at (System/currentTimeMillis))))
 
 (defn transition-to-failed
   "Transition workflow to failed state using FSM."
   [ctx]
-  (let [fsm-state (:execution/fsm-state ctx)
-        new-fsm-state (fsm/transition-fsm fsm-state :fail)]
-    (-> ctx
-        (assoc :execution/fsm-state new-fsm-state)
-        (assoc :execution/status (fsm/current-state new-fsm-state))
-        (assoc :execution/ended-at (System/currentTimeMillis)))))
+  (-> (if (:execution/fsm-machine ctx)
+        (transition-execution ctx :fail)
+        (assoc ctx :execution/status :failed))
+      (assoc :execution/ended-at (System/currentTimeMillis))))

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -144,6 +144,20 @@
         (assoc :execution/ended-at (System/currentTimeMillis))))
     ctx))
 
+(defn active-or-last-phase
+  "Return the active phase when present, otherwise the last completed phase in
+   workflow pipeline order."
+  [ctx]
+  (let [phase-results (:execution/phase-results ctx)
+        pipeline (:workflow/pipeline (:execution/workflow ctx))
+        last-recorded-phase (some->> pipeline
+                                     (map :phase)
+                                     (filter #(contains? phase-results %))
+                                     last)]
+    (if-some [current-phase (:execution/current-phase ctx)]
+      current-phase
+      last-recorded-phase)))
+
 ;------------------------------------------------------------------------------ Context operations
 
 (defn create-context

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -30,7 +30,9 @@
             [ai.miniforge.schema.interface :as schema]
             [ai.miniforge.workflow.context :as context]
             [ai.miniforge.workflow.dag-orchestrator :as dag-orch]
-            [ai.miniforge.workflow.fsm :as workflow-fsm]))
+            [ai.miniforge.workflow.fsm :as workflow-fsm]
+            [ai.miniforge.workflow.runner-defaults :as defaults]
+            [ai.miniforge.workflow.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0: Atomic operations
 
@@ -135,17 +137,48 @@
           anomaly (if gate-errors
                     (response/gate-anomaly
                      :anomalies.gate/validation-failed
-                     (str "Gate validation failed for phase " (name phase-name))
+                     (messages/t :phase/gate-failed-phase {:phase (name phase-name)})
                      gate-errors
                      {:anomaly/phase phase-name})
                     (response/make-anomaly
                      :anomalies.phase/agent-failed
-                     (str "Agent failed in phase " (name phase-name))
+                     (messages/t :phase/agent-failed-phase {:phase (name phase-name)})
                      {:anomaly/phase phase-name}))]
       (update ctx :execution/response-chain
               response/add-failure phase-name
               anomaly
               phase-result))))
+
+(defn- phase-transition-event-message
+  [event]
+  (messages/t :status/invalid-phase-transition-event {:event event}))
+
+(defn- invalid-phase-transition-anomaly
+  [event]
+  (response/make-anomaly
+   :anomalies.workflow/invalid-transition
+   (phase-transition-event-message event)))
+
+(defn- max-redirects-exceeded-anomaly
+  []
+  (let [max-redirects (defaults/max-redirects)]
+    (response/make-anomaly
+     :anomalies.workflow/max-redirects-exceeded
+     (messages/t :status/max-redirects {:max-redirects max-redirects}))))
+
+(defn- phase-transition-failure
+  [ctx event anomaly transition-to-failed-fn]
+  (let [message (phase-transition-event-message event)]
+    (-> ctx
+        (update :execution/errors conj
+                {:type :invalid-transition
+                 :message message
+                 :anomaly anomaly})
+        (update :execution/response-chain
+                response/add-failure :pipeline anomaly
+                {:error message
+                 :event event})
+        (transition-to-failed-fn))))
 
 (defn record-phase-metrics
   "Record phase metrics in execution context."
@@ -233,7 +266,7 @@
 
 (def max-redirects
   "Maximum number of phase redirects before failing to prevent infinite loops."
-  5)
+  (defaults/max-redirects))
 
 (defn apply-phase-transition
   "Apply a phase-outcome event through the execution machine.
@@ -241,17 +274,16 @@
    Returns updated context with refreshed machine projections or terminal failure."
   [ctx event _pipeline _transition-to-completed-fn transition-to-failed-fn]
   (let [redirect-count (get ctx :execution/redirect-count 0)
-        is-redirect? (= "workflow.event" (namespace event))]
+        is-redirect? (workflow-fsm/redirect-event? event)]
     (cond
       ;; Redirect cycle limit exceeded
       (and is-redirect? (>= redirect-count max-redirects))
-      (let [anom (response/make-anomaly
-                   :anomalies.workflow/max-redirects-exceeded
-                   (str "Redirect cycle limit exceeded (" max-redirects " redirects)"))]
+      (let [anom (max-redirects-exceeded-anomaly)]
         (-> ctx
             (update :execution/errors conj
                     {:type :max-redirects-exceeded
-                     :message (str "Exceeded " max-redirects " redirects")
+                     :message (messages/t :status/max-redirects-hit
+                                          {:max-redirects max-redirects})
                      :anomaly anom})
             (update :execution/response-chain
                     response/add-failure :pipeline anom
@@ -264,20 +296,10 @@
             state-changed? (not= prior-state (:execution/fsm-state next-ctx))]
         (if (or state-changed? (= :phase/retry event))
           next-ctx
-          (let [anom (response/make-anomaly
-                       :anomalies.workflow/invalid-transition
-                       (str "Invalid phase transition event: " event))]
-            (-> ctx
-                (update :execution/errors conj
-                        {:type :invalid-transition
-                         :message (str "Invalid phase transition event: " event)
-                         :anomaly anom})
-                (update :execution/response-chain
-                        response/add-failure :pipeline
-                        anom
-                        {:error (str "Invalid phase transition event: " event)
-                         :event event})
-                (transition-to-failed-fn))))))))
+          (phase-transition-failure ctx
+                                    event
+                                    (invalid-phase-transition-anomaly event)
+                                    transition-to-failed-fn))))))
 
 ;------------------------------------------------------------------------------ Layer 1.5: DAG integration helpers
 
@@ -463,7 +485,8 @@
          :status :completed
          :result {:status         :success
                   :environment-id (get ctx :execution/environment-id)
-                  :summary        (str "DAG executed " task-count " task(s) successfully")
+                  :summary        (messages/t :status/dag-executed-summary
+                                              {:task-count task-count})
                   :metrics        (merge {:task-count task-count}
                                          (:metrics dag-result))}}
         ctx-with-dag (-> ctx

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -21,11 +21,16 @@
 
    Handles execution of individual phase steps through the enter -> gates -> leave lifecycle.
    Processes results, tracks metrics/files/artifacts, and determines phase transitions."
-  (:require [ai.miniforge.gate.interface :as gate]
+  (:require [clojure.java.io :as io]
+            [clojure.java.shell :as shell]
+            [clojure.string :as str]
+            [ai.miniforge.gate.interface :as gate]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.schema.interface :as schema]
-            [ai.miniforge.workflow.dag-orchestrator :as dag-orch]))
+            [ai.miniforge.workflow.context :as context]
+            [ai.miniforge.workflow.dag-orchestrator :as dag-orch]
+            [ai.miniforge.workflow.fsm :as workflow-fsm]))
 
 ;------------------------------------------------------------------------------ Layer 0: Atomic operations
 
@@ -43,7 +48,7 @@
             (error-fn ctx ex)
             (let [anom (response/from-exception ex)]
               (-> ctx
-                  (assoc :execution/status :failed)
+                  (context/transition-to-failed)
                   (update :execution/errors conj
                           {:type :phase-error
                            :phase phase-name
@@ -203,84 +208,40 @@
       (record-phase-artifacts phase-result)
       (track-phase-files phase-result)))
 
-(defn determine-next-index
-  "Determine next phase index based on result and config.
-
-   Arguments:
-   - pipeline: Vector of phase interceptors
-   - current-index: Current phase index
-   - phase-config: Current phase configuration
-   - phase-result: Result from phase execution
-
-   Returns next index or :done/:error."
-  [pipeline current-index phase-config phase-result]
-  (let [on-fail (:on-fail phase-config)
-        on-success (:on-success phase-config)
-        redirect-to (:redirect-to phase-result)]
+(defn determine-phase-event
+  "Translate a phase result into an execution-machine event."
+  [_phase-config phase-result]
+  (let [redirect-to (:redirect-to phase-result)]
     (cond
-      ;; Phase retrying (transient error, stay at current index)
       (phase/retrying? phase-result)
-      current-index
+      :phase/retry
 
-      ;; Phase already done — skip to done
       (phase/already-done? phase-result)
-      (let [done-index (->> pipeline
-                            (map-indexed vector)
-                            (filter #(= :done (get-in (second %) [:config :phase])))
-                            (first))]
-        (if done-index (first done-index) :done))
+      :phase/already-done
 
-      ;; Phase completed successfully
       (phase/succeeded? phase-result)
-      (if on-success
-        ;; Find target phase by name
-        (let [target-index (->> pipeline
-                                (map-indexed vector)
-                                (filter #(= on-success (get-in (second %) [:config :phase])))
-                                (first))]
-          (if target-index (first target-index) (inc current-index)))
-        ;; Default: next phase
-        (let [next-idx (inc current-index)]
-          (if (< next-idx (count pipeline))
-            next-idx
-            :done)))
+      :phase/succeed
 
-      ;; Phase failed with redirect — jump to target phase
       (and (phase/failed? phase-result) redirect-to)
-      (let [target-index (->> pipeline
-                              (map-indexed vector)
-                              (filter #(= redirect-to (get-in (second %) [:config :phase])))
-                              (first))]
-        (if target-index (first target-index) :error))
+      (workflow-fsm/redirect-event redirect-to)
 
-      ;; Phase failed
       (phase/failed? phase-result)
-      (if on-fail
-        ;; Find target phase by name
-        (let [target-index (->> pipeline
-                                (map-indexed vector)
-                                (filter #(= on-fail (get-in (second %) [:config :phase])))
-                                (first))]
-          (if target-index
-            (first target-index)
-            :error))
-        :error)
+      :phase/fail
 
-      ;; Default: move to next
-      :else (inc current-index))))
+      :else
+      :phase/succeed)))
 
 (def max-redirects
   "Maximum number of phase redirects before failing to prevent infinite loops."
   5)
 
 (defn apply-phase-transition
-  "Apply phase transition based on next-index.
+  "Apply a phase-outcome event through the execution machine.
 
-   Returns context with updated status/phase-index or terminal state."
-  [ctx next-index pipeline transition-to-completed-fn transition-to-failed-fn]
-  (let [current-index (:execution/phase-index ctx)
-        is-redirect? (and (number? next-index) (not= next-index (inc current-index)))
-        redirect-count (get ctx :execution/redirect-count 0)]
+   Returns updated context with refreshed machine projections or terminal failure."
+  [ctx event _pipeline _transition-to-completed-fn transition-to-failed-fn]
+  (let [redirect-count (get ctx :execution/redirect-count 0)
+        is-redirect? (= "workflow.event" (namespace event))]
     (cond
       ;; Redirect cycle limit exceeded
       (and is-redirect? (>= redirect-count max-redirects))
@@ -297,33 +258,26 @@
                     {:redirect-count redirect-count})
             (transition-to-failed-fn)))
 
-      (= :done next-index)
-      (transition-to-completed-fn ctx)
-
-      (= :error next-index)
-      (transition-to-failed-fn ctx)
-
-      (number? next-index)
-      (if (< next-index (count pipeline))
-        (cond-> (assoc ctx :execution/phase-index next-index)
-          is-redirect? (update :execution/redirect-count (fnil inc 0)))
-        (transition-to-completed-fn ctx))
-
       :else
-      (let [anom (response/make-anomaly
-                   :anomalies.workflow/invalid-transition
-                   (str "Invalid next index: " next-index))]
-        (-> ctx
-            (update :execution/errors conj
-                    {:type :invalid-transition
-                     :message (str "Invalid next index: " next-index)
-                     :anomaly anom})
-            (update :execution/response-chain
-                    response/add-failure :pipeline
-                    anom
-                    {:error (str "Invalid next index: " next-index)
-                     :next-index next-index})
-            (transition-to-failed-fn))))))
+      (let [prior-state (:execution/fsm-state ctx)
+            next-ctx (context/transition-execution ctx event)
+            state-changed? (not= prior-state (:execution/fsm-state next-ctx))]
+        (if (or state-changed? (= :phase/retry event))
+          next-ctx
+          (let [anom (response/make-anomaly
+                       :anomalies.workflow/invalid-transition
+                       (str "Invalid phase transition event: " event))]
+            (-> ctx
+                (update :execution/errors conj
+                        {:type :invalid-transition
+                         :message (str "Invalid phase transition event: " event)
+                         :anomaly anom})
+                (update :execution/response-chain
+                        response/add-failure :pipeline
+                        anom
+                        {:error (str "Invalid phase transition event: " event)
+                         :event event})
+                (transition-to-failed-fn))))))))
 
 ;------------------------------------------------------------------------------ Layer 1.5: DAG integration helpers
 
@@ -475,17 +429,17 @@
   [parent-worktree sub-worktree-paths]
   (doseq [sub-wt sub-worktree-paths]
     (try
-      (let [{:keys [out]} (clojure.java.shell/sh
+      (let [{:keys [out]} (shell/sh
                             "git" "diff" "--name-only" "HEAD"
                             :dir sub-wt)
-            changed-files (remove clojure.string/blank?
-                                  (clojure.string/split-lines (or out "")))]
+            changed-files (remove str/blank?
+                                  (str/split-lines (or out "")))]
         (doseq [f changed-files]
-          (let [src (clojure.java.io/file sub-wt f)
-                dst (clojure.java.io/file parent-worktree f)]
+          (let [src (io/file sub-wt f)
+                dst (io/file parent-worktree f)]
             (when (.exists src)
-              (clojure.java.io/make-parents dst)
-              (clojure.java.io/copy src dst)))))
+              (io/make-parents dst)
+              (io/copy src dst)))))
       (catch Exception _e nil))))
 
 (defn apply-dag-success
@@ -493,7 +447,7 @@
    Merges artifact provenance, copies sub-worktree file changes into the
    parent worktree, synthesizes an :implement phase result, and advances
    past implement to verify → review → release."
-  [ctx dag-result pipeline transition-to-completed-fn]
+  [ctx dag-result pipeline transition-to-completed-fn transition-to-failed-fn]
   (let [artifacts  (:artifacts dag-result)
         task-count (count artifacts)
         ;; Merge sub-worktree changes into parent worktree so the release
@@ -517,9 +471,14 @@
                          (assoc :execution/dag-result dag-result)
                          (assoc-in [:execution/phase-results :implement]
                                    synthesized-implement-result))
-        post-impl-idx (index-after-phase pipeline :implement)]
+        post-impl-idx (index-after-phase pipeline :implement)
+        next-phase (some-> (get pipeline post-impl-idx) :config :phase)]
     (if (and post-impl-idx (< post-impl-idx (count pipeline)))
-      (assoc ctx-with-dag :execution/phase-index post-impl-idx)
+      (apply-phase-transition ctx-with-dag
+                              (workflow-fsm/redirect-event next-phase)
+                              pipeline
+                              transition-to-completed-fn
+                              transition-to-failed-fn)
       (transition-to-completed-fn ctx-with-dag))))
 
 (defn apply-dag-failure
@@ -560,7 +519,9 @@
                                      :plan/task-count (count (:plan/tasks plan))})
             dag-result (dag-orch/execute-plan-as-dag plan ctx-with-resume)]
         (if (schema/succeeded? dag-result)
-          (apply-dag-success ctx dag-result pipeline transition-to-completed-fn)
+          (apply-dag-success ctx dag-result pipeline
+                             transition-to-completed-fn
+                             transition-to-failed-fn)
           (apply-dag-failure ctx dag-result transition-to-failed-fn))))))
 
 ;------------------------------------------------------------------------------ Layer 2: Phase step execution
@@ -601,9 +562,8 @@
       (or (try-dag-execution ctx-processed phase-name phase-result pipeline
                              transition-to-completed-fn transition-to-failed-fn)
           ;; Normal transition (non-plan phases, or plan not parallelizable)
-          (let [next-index (determine-next-index pipeline phase-index
-                                                 (:config interceptor)
-                                                 phase-result)]
-            (apply-phase-transition ctx-processed next-index pipeline
+          (let [event (determine-phase-event (:config interceptor)
+                                             phase-result)]
+            (apply-phase-transition ctx-processed event pipeline
                                     transition-to-completed-fn
                                     transition-to-failed-fn))))))

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -494,15 +494,19 @@
                          (assoc :execution/dag-result dag-result)
                          (assoc-in [:execution/phase-results :implement]
                                    synthesized-implement-result))
-        post-impl-idx (index-after-phase pipeline :implement)
-        next-phase (some-> (get pipeline post-impl-idx) :config :phase)]
-    (if (and post-impl-idx (< post-impl-idx (count pipeline)))
-      (apply-phase-transition ctx-with-dag
-                              (workflow-fsm/redirect-event next-phase)
+        ctx-after-plan
+        (apply-phase-transition ctx-with-dag
+                                :phase/succeed
+                                pipeline
+                                transition-to-completed-fn
+                                transition-to-failed-fn)]
+    (if (phase/failed? ctx-after-plan)
+      ctx-after-plan
+      (apply-phase-transition ctx-after-plan
+                              :phase/succeed
                               pipeline
                               transition-to-completed-fn
-                              transition-to-failed-fn)
-      (transition-to-completed-fn ctx-with-dag))))
+                              transition-to-failed-fn))))
 
 (defn apply-dag-failure
   "Apply a failed DAG result to the execution context."

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -40,6 +40,8 @@
   (:require
    [ai.miniforge.fsm.interface :as fsm]))
 
+(declare current-state)
+
 ;; ============================================================================
 ;; FSM Definition using clj-statecharts
 ;; ============================================================================
@@ -64,6 +66,243 @@
 (def workflow-machine
   "Compiled workflow state machine."
   (fsm/define-machine workflow-machine-config))
+
+;------------------------------------------------------------------------------
+; Layer 0.5: Compiled execution machine
+
+(defn phase-state-id
+  "Build the active execution-machine state id for a pipeline phase."
+  [index phase]
+  (keyword (str "phase-" index "-" (name phase))))
+
+(defn paused-phase-state-id
+  "Build the paused execution-machine state id for a pipeline phase."
+  [index phase]
+  (keyword (str "paused-phase-" index "-" (name phase))))
+
+(defn redirect-event
+  "Build the event keyword used to redirect to a named phase."
+  [phase]
+  (keyword "workflow.event" (str "redirect-to-" (name phase))))
+
+(defn- first-phase-index
+  [pipeline phase]
+  (some (fn [[index config]]
+          (when (= phase (:phase config))
+            index))
+        (map-indexed vector pipeline)))
+
+(defn- build-phase-entry
+  [index config]
+  (let [phase (:phase config)]
+    {:index index
+     :phase phase
+     :config config
+     :state-id (phase-state-id index phase)
+     :paused-state-id (paused-phase-state-id index phase)}))
+
+(defn- state-target
+  [phase-entries index]
+  (some-> (get phase-entries index) :state-id))
+
+(defn- redirect-transitions
+  [phase-entries]
+  (into {}
+        (map (fn [{:keys [phase index]}]
+               [(redirect-event phase)
+                {:target (state-target phase-entries index)
+                 :actions [(fsm/assign {:redirect-count (fn [ctx _event]
+                                                          (inc (get ctx :redirect-count 0)))})]}]))
+        phase-entries))
+
+(defn- build-phase-state
+  [phase-entries {:keys [index config state-id paused-state-id]}]
+  (let [next-index (when (< (inc index) (count phase-entries))
+                     (inc index))
+        on-success-index (or (when-let [target-phase (:on-success config)]
+                               (first-phase-index phase-entries target-phase))
+                             next-index)
+        on-fail-index (when-let [target-phase (:on-fail config)]
+                        (first-phase-index phase-entries target-phase))
+        done-index (first-phase-index phase-entries :done)
+        success-target (or (state-target phase-entries on-success-index)
+                           :completed)
+        failure-target (or (state-target phase-entries on-fail-index)
+                           :failed)
+        already-done-target (or (state-target phase-entries done-index)
+                                :completed)]
+    [state-id
+     {:on (merge
+           {:phase/retry state-id
+            :phase/succeed success-target
+            :phase/already-done already-done-target
+            :phase/fail failure-target
+            :pause paused-state-id
+            :cancel :cancelled
+            :fail :failed
+            :complete :completed}
+           (redirect-transitions phase-entries))}]))
+
+(defn- build-paused-state
+  [{:keys [state-id paused-state-id]}]
+  [paused-state-id
+   {:on {:resume state-id
+         :cancel :cancelled
+         :fail :failed
+         :complete :completed}}])
+
+(defn- projection-entry
+  [entry paused?]
+  [(:state-id entry) {:phase (:phase entry)
+                      :index (:index entry)
+                      :paused? paused?}])
+
+(defn compile-execution-machine
+  "Compile a per-run execution machine from a workflow pipeline.
+
+   The compiled machine is the authoritative source of truth for workflow
+   progression. Coarse lifecycle status and phase/index projections are derived
+   from the resulting machine snapshot."
+  [workflow]
+  (let [pipeline (:workflow/pipeline workflow)
+        phase-entries (mapv build-phase-entry (range) pipeline)
+        first-active-state (some-> phase-entries first :state-id)
+        no-phase-machine? (empty? phase-entries)
+        states (merge
+                {:pending {:on (cond-> {:fail :failed
+                                        :cancel :cancelled}
+                                 no-phase-machine? (assoc :start :running)
+                                 first-active-state (assoc :start first-active-state))}
+                 :running (when no-phase-machine?
+                            {:on {:complete :completed
+                                  :fail :failed
+                                  :pause :paused
+                                  :cancel :cancelled}})
+                 :paused (when no-phase-machine?
+                           {:on {:resume :running
+                                 :cancel :cancelled}})
+                 :completed {:type :final}
+                 :failed {:type :final}
+                 :cancelled {:type :final}}
+                (into {} (map (partial build-phase-state phase-entries)) phase-entries)
+                (into {} (map build-paused-state) phase-entries))
+        state->phase (into {}
+                           (concat
+                            (map #(projection-entry % false) phase-entries)
+                            (map (fn [entry]
+                                   [(:paused-state-id entry)
+                                    {:phase (:phase entry)
+                                     :index (:index entry)
+                                     :paused? true}])
+                                 phase-entries)))]
+    (assoc (fsm/define-machine
+            {:fsm/id :workflow-execution
+             :fsm/initial :pending
+             :fsm/context {:redirect-count 0}
+             :fsm/states (into {} (remove (comp nil? val)) states)})
+           :workflow/phase-entries phase-entries
+           :workflow/state->phase state->phase)))
+
+(defn validate-execution-machine
+  "Validate that a workflow pipeline can compile into an execution machine."
+  [workflow]
+  (let [pipeline (:workflow/pipeline workflow)
+        duplicate-phases (->> pipeline
+                              (map :phase)
+                              frequencies
+                              (filter (fn [[_ count]] (> count 1)))
+                              (map first)
+                              vec)
+        unresolved-success (->> pipeline
+                                (keep (fn [{:keys [phase on-success]}]
+                                        (when (and on-success
+                                                   (nil? (first-phase-index pipeline on-success)))
+                                          {:error :unknown-on-success-target
+                                           :phase phase
+                                           :target on-success})))
+                                vec)
+        unresolved-fail (->> pipeline
+                             (keep (fn [{:keys [phase on-fail]}]
+                                     (when (and on-fail
+                                                (nil? (first-phase-index pipeline on-fail)))
+                                       {:error :unknown-on-fail-target
+                                        :phase phase
+                                        :target on-fail})))
+                             vec)
+        errors (vec (concat
+                     (when (empty? pipeline)
+                       [{:error :empty-pipeline
+                         :message "Workflow pipeline is empty"}])
+                     unresolved-success
+                     unresolved-fail))
+        warnings (vec (concat
+                       (when (seq duplicate-phases)
+                         [{:warning :duplicate-phase-identifiers
+                           :phases duplicate-phases
+                           :message "Duplicate phase ids make transition targets ambiguous"}])))]
+    {:valid? (empty? errors)
+     :errors errors
+     :warnings warnings
+     :machine (when (empty? errors)
+                (compile-execution-machine workflow))}))
+
+(defn machine-phase-entry
+  "Get phase metadata for the current compiled machine state."
+  [machine state]
+  (get-in machine [:workflow/state->phase (current-state state)]))
+
+(defn execution-status
+  "Project coarse execution status from a compiled machine snapshot."
+  [machine state]
+  (let [state-id (current-state state)]
+    (cond
+      (= :pending state-id) :pending
+      (= :completed state-id) :completed
+      (= :failed state-id) :failed
+      (= :cancelled state-id) :cancelled
+      (:paused? (machine-phase-entry machine state)) :paused
+      :else :running)))
+
+(defn current-phase-id
+  "Project the current phase keyword from a compiled machine snapshot."
+  [machine state]
+  (:phase (machine-phase-entry machine state)))
+
+(defn current-phase-index
+  "Project the current phase index from a compiled machine snapshot."
+  [machine state]
+  (:index (machine-phase-entry machine state)))
+
+(defn execution-projection
+  "Project execution fields from a compiled machine snapshot."
+  [machine state]
+  (let [ctx (fsm/context state)]
+    {:execution/status (execution-status machine state)
+     :execution/current-phase (current-phase-id machine state)
+     :execution/phase-index (current-phase-index machine state)
+     :execution/redirect-count (get ctx :redirect-count 0)}))
+
+(defn initialize-execution
+  "Initialize a compiled execution machine."
+  [machine]
+  (fsm/initialize machine))
+
+(defn start-execution
+  "Start a compiled execution machine from :pending."
+  [machine state]
+  (fsm/transition machine state :start))
+
+(defn transition-execution
+  "Apply an event to a compiled execution machine snapshot."
+  [machine state event]
+  (let [event-key (if (keyword? event) event (:type event))
+        transition-defined? (contains? (get-in machine [:states (current-state state) :on] {})
+                                       event-key)
+        next-state (fsm/transition machine state event)]
+    (if (and transition-defined?
+             (= "workflow.event" (namespace event-key)))
+      (fsm/update-context next-state update :redirect-count (fnil inc 0))
+      next-state)))
 
 ;; ============================================================================
 ;; Legacy API - for backward compatibility with state.clj

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -38,13 +38,30 @@
    - :resume  - Resume paused execution
    - :cancel  - Cancel workflow"
   (:require
-   [ai.miniforge.fsm.interface :as fsm]))
+   [ai.miniforge.fsm.interface :as fsm]
+   [ai.miniforge.workflow.messages :as messages]))
 
-(declare current-state)
+(declare current-state first-phase-index)
 
 ;; ============================================================================
 ;; FSM Definition using clj-statecharts
 ;; ============================================================================
+
+(def redirect-event-namespace
+  "Namespace used for redirect events in the compiled execution machine."
+  "workflow.event")
+
+(def phase-state-prefix
+  "Prefix used for active phase state identifiers."
+  "phase")
+
+(def paused-phase-state-prefix
+  "Prefix used for paused phase state identifiers."
+  "paused-phase")
+
+(defn- phase-state-name
+  [prefix index phase]
+  (str prefix "-" index "-" (name phase)))
 
 (def workflow-machine-config
   "Workflow execution state machine configuration."
@@ -73,23 +90,63 @@
 (defn phase-state-id
   "Build the active execution-machine state id for a pipeline phase."
   [index phase]
-  (keyword (str "phase-" index "-" (name phase))))
+  (keyword (phase-state-name phase-state-prefix index phase)))
 
 (defn paused-phase-state-id
   "Build the paused execution-machine state id for a pipeline phase."
   [index phase]
-  (keyword (str "paused-phase-" index "-" (name phase))))
+  (keyword (phase-state-name paused-phase-state-prefix index phase)))
 
 (defn redirect-event
   "Build the event keyword used to redirect to a named phase."
   [phase]
-  (keyword "workflow.event" (str "redirect-to-" (name phase))))
+  (keyword redirect-event-namespace (str "redirect-to-" (name phase))))
+
+(defn- increment-redirect-count
+  [redirect-count]
+  (inc (or redirect-count 0)))
+
+(defn- matching-phase-index
+  [phase [index config]]
+  (when (= phase (:phase config))
+    index))
+
+(defn- duplicate-phase?
+  [[_phase count]]
+  (> count 1))
+
+(defn- unresolved-target-error
+  [error-key phase target]
+  {:error error-key
+   :phase phase
+   :target target})
+
+(defn- unknown-success-target
+  [pipeline {:keys [phase on-success]}]
+  (when (and on-success
+             (nil? (first-phase-index pipeline on-success)))
+    (unresolved-target-error :unknown-on-success-target phase on-success)))
+
+(defn- unknown-fail-target
+  [pipeline {:keys [phase on-fail]}]
+  (when (and on-fail
+             (nil? (first-phase-index pipeline on-fail)))
+    (unresolved-target-error :unknown-on-fail-target phase on-fail)))
+
+(defn- duplicate-phase-warning
+  [duplicate-phases]
+  {:warning :duplicate-phase-identifiers
+   :phases duplicate-phases
+   :message (messages/t :status/duplicate-phases)})
+
+(defn- empty-pipeline-error
+  []
+  {:error :empty-pipeline
+   :message (messages/t :status/empty-pipeline)})
 
 (defn- first-phase-index
   [pipeline phase]
-  (some (fn [[index config]]
-          (when (= phase (:phase config))
-            index))
+  (some (partial matching-phase-index phase)
         (map-indexed vector pipeline)))
 
 (defn- build-phase-entry
@@ -105,15 +162,52 @@
   [phase-entries index]
   (some-> (get phase-entries index) :state-id))
 
+(defn- redirect-transition-entry
+  [phase-entries {:keys [phase index]}]
+  (let [target (state-target phase-entries index)]
+    [(redirect-event phase)
+     {:target target}]))
+
 (defn- redirect-transitions
   [phase-entries]
   (into {}
-        (map (fn [{:keys [phase index]}]
-               [(redirect-event phase)
-                {:target (state-target phase-entries index)
-                 :actions [(fsm/assign {:redirect-count (fn [ctx _event]
-                                                          (inc (get ctx :redirect-count 0)))})]}]))
+        (map (partial redirect-transition-entry phase-entries))
         phase-entries))
+
+(defn redirect-event?
+  "True when an event keyword represents a workflow phase redirect."
+  [event-key]
+  (= redirect-event-namespace (namespace event-key)))
+
+(defn- machine-transition-defined?
+  [machine state event-key]
+  (contains? (get-in machine [:states (current-state state) :on] {})
+             event-key))
+
+(defn transition-execution
+  "Apply an event to a compiled execution machine snapshot."
+  [machine state event]
+  (let [event-key (if (keyword? event) event (:type event))
+        transition-defined? (machine-transition-defined? machine state event-key)
+        next-state (fsm/transition machine state event)]
+    (if (and transition-defined?
+             (redirect-event? event-key))
+      (fsm/update-context next-state update :redirect-count increment-redirect-count)
+      next-state)))
+
+(defn- terminal-state-message
+  [current-state]
+  (messages/t :status/terminal-state-transition {:state current-state}))
+
+(defn- invalid-state-message
+  [current-state]
+  (messages/t :status/invalid-current-state {:state current-state}))
+
+(defn- no-transition-message
+  [current-state event]
+  (messages/t :status/no-transition-defined
+              {:state current-state
+               :event event}))
 
 (defn- build-phase-state
   [phase-entries {:keys [index config state-id paused-state-id]}]
@@ -157,6 +251,13 @@
                       :index (:index entry)
                       :paused? paused?}])
 
+(defn- paused-projection-entry
+  [entry]
+  [(:paused-state-id entry)
+   {:phase (:phase entry)
+    :index (:index entry)
+    :paused? true}])
+
 (defn compile-execution-machine
   "Compile a per-run execution machine from a workflow pipeline.
 
@@ -189,12 +290,7 @@
         state->phase (into {}
                            (concat
                             (map #(projection-entry % false) phase-entries)
-                            (map (fn [entry]
-                                   [(:paused-state-id entry)
-                                    {:phase (:phase entry)
-                                     :index (:index entry)
-                                     :paused? true}])
-                                 phase-entries)))]
+                            (map paused-projection-entry phase-entries)))]
     (assoc (fsm/define-machine
             {:fsm/id :workflow-execution
              :fsm/initial :pending
@@ -210,36 +306,23 @@
         duplicate-phases (->> pipeline
                               (map :phase)
                               frequencies
-                              (filter (fn [[_ count]] (> count 1)))
+                              (filter duplicate-phase?)
                               (map first)
                               vec)
         unresolved-success (->> pipeline
-                                (keep (fn [{:keys [phase on-success]}]
-                                        (when (and on-success
-                                                   (nil? (first-phase-index pipeline on-success)))
-                                          {:error :unknown-on-success-target
-                                           :phase phase
-                                           :target on-success})))
+                                (keep (partial unknown-success-target pipeline))
                                 vec)
         unresolved-fail (->> pipeline
-                             (keep (fn [{:keys [phase on-fail]}]
-                                     (when (and on-fail
-                                                (nil? (first-phase-index pipeline on-fail)))
-                                       {:error :unknown-on-fail-target
-                                        :phase phase
-                                        :target on-fail})))
+                             (keep (partial unknown-fail-target pipeline))
                              vec)
         errors (vec (concat
                      (when (empty? pipeline)
-                       [{:error :empty-pipeline
-                         :message "Workflow pipeline is empty"}])
+                       [(empty-pipeline-error)])
                      unresolved-success
                      unresolved-fail))
         warnings (vec (concat
                        (when (seq duplicate-phases)
-                         [{:warning :duplicate-phase-identifiers
-                           :phases duplicate-phases
-                           :message "Duplicate phase ids make transition targets ambiguous"}])))]
+                         [(duplicate-phase-warning duplicate-phases)])))]
     {:valid? (empty? errors)
      :errors errors
      :warnings warnings
@@ -291,18 +374,6 @@
   "Start a compiled execution machine from :pending."
   [machine state]
   (fsm/transition machine state :start))
-
-(defn transition-execution
-  "Apply an event to a compiled execution machine snapshot."
-  [machine state event]
-  (let [event-key (if (keyword? event) event (:type event))
-        transition-defined? (contains? (get-in machine [:states (current-state state) :on] {})
-                                       event-key)
-        next-state (fsm/transition machine state event)]
-    (if (and transition-defined?
-             (= "workflow.event" (namespace event-key)))
-      (fsm/update-context next-state update :redirect-count (fnil inc 0))
-      next-state)))
 
 ;; ============================================================================
 ;; Legacy API - for backward compatibility with state.clj
@@ -389,25 +460,25 @@
      (terminal-state? current-state)
      {:success? false
       :error :terminal-state
-      :message (str "Cannot transition from terminal state: " current-state)}
+      :message (terminal-state-message current-state)}
 
      ;; Invalid state
      (not (contains? workflow-states current-state))
      {:success? false
       :error :invalid-state
-      :message (str "Invalid current state: " current-state)}
+      :message (invalid-state-message current-state)}
 
      ;; Guard function failed
      (not (guard-fn current-state event))
      {:success? false
       :error :guard-failed
-      :message "Guard function rejected transition"}
+      :message (messages/t :status/guard-rejected-transition)}
 
      ;; Invalid transition
      (not (valid-transition? current-state event))
      {:success? false
       :error :invalid-transition
-      :message (str "No transition defined for [" current-state " " event "]")}
+      :message (no-transition-message current-state event)}
 
      ;; Valid transition - use clj-statecharts for actual transition
      :else

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -65,15 +65,19 @@
 
 ;------------------------------------------------------------------------------ Layer 0: Pipeline construction
 
+(defn- legacy-phase-interceptor
+  [phase-def]
+  (phase/get-phase-interceptor
+   {:phase (:phase/id phase-def)
+    :config phase-def}))
+
 (defn build-pipeline
   "Build interceptor pipeline from workflow config."
   [workflow]
   (let [pipeline-config (:workflow/pipeline workflow)]
     (if (seq pipeline-config)
       (mapv phase/get-phase-interceptor pipeline-config)
-      (mapv (fn [phase-def]
-              (phase/get-phase-interceptor
-               {:phase (:phase/id phase-def) :config phase-def}))
+      (mapv legacy-phase-interceptor
             (:workflow/phases workflow)))))
 
 (defn validate-pipeline
@@ -214,8 +218,7 @@
    Includes N11 §9.1 evidence fields."
   [ctx]
   (let [phase-results (:execution/phase-results ctx)
-        current-phase (or (:execution/current-phase ctx)
-                          (some-> phase-results keys last))
+        current-phase (ctx/active-or-last-phase ctx)
         image-digest  (get-in ctx [:execution/environment-metadata :image-digest])]
     (assoc ctx :execution/output
            (cond-> {:artifacts              (:execution/artifacts ctx)
@@ -251,18 +254,21 @@
 (defn- wrap-phase-callbacks
   "Wrap caller callbacks with event publishing."
   [event-stream opts]
-  {:on-phase-start
-   (fn [ctx interceptor]
-     (when-let [phase-name (get interceptor :phase (get-in interceptor [:config :phase]))]
-       (events/publish-phase-started! event-stream ctx phase-name))
-     (when-let [cb (:on-phase-start opts)]
-       (cb ctx interceptor)))
-   :on-phase-complete
-   (fn [ctx interceptor result]
-     (when-let [phase-name (get interceptor :phase (get-in interceptor [:config :phase]))]
-       (events/publish-phase-completed! event-stream ctx phase-name result))
-     (when-let [cb (:on-phase-complete opts)]
-       (cb ctx interceptor result)))})
+  (letfn [(phase-name [interceptor]
+            (get interceptor :phase
+                 (get-in interceptor [:config :phase])))
+          (on-phase-start [ctx interceptor]
+            (when-let [phase-name' (phase-name interceptor)]
+              (events/publish-phase-started! event-stream ctx phase-name'))
+            (when-let [callback (:on-phase-start opts)]
+              (callback ctx interceptor)))
+          (on-phase-complete [ctx interceptor result]
+            (when-let [phase-name' (phase-name interceptor)]
+              (events/publish-phase-completed! event-stream ctx phase-name' result))
+            (when-let [callback (:on-phase-complete opts)]
+              (callback ctx interceptor result)))]
+    {:on-phase-start on-phase-start
+     :on-phase-complete on-phase-complete}))
 
 (defn- build-initial-context
   "Build the initial execution context from workflow, input, and opts."

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -34,6 +34,7 @@
             [ai.miniforge.response.interface :as response]
             [ai.miniforge.workflow.context :as ctx]
             [ai.miniforge.workflow.execution :as exec]
+            [ai.miniforge.workflow.fsm :as workflow-fsm]
             [ai.miniforge.workflow.messages :as messages]
             [ai.miniforge.workflow.monitoring :as monitoring]
             [ai.miniforge.workflow.runner-cleanup :as cleanup]
@@ -78,7 +79,14 @@
 (defn validate-pipeline
   "Validate a workflow pipeline. Returns {:valid? bool :errors []}."
   [workflow]
-  (phase/validate-pipeline workflow))
+  (let [phase-validation (phase/validate-pipeline workflow)
+        machine-validation (workflow-fsm/validate-execution-machine workflow)]
+    {:valid? (and (:valid? phase-validation)
+                  (:valid? machine-validation))
+     :errors (vec (concat (:errors phase-validation)
+                          (:errors machine-validation)))
+     :warnings (vec (concat (:warnings phase-validation)
+                            (:warnings machine-validation)))}))
 
 ;------------------------------------------------------------------------------ Layer 1: Orchestration helpers
 
@@ -148,7 +156,7 @@
   "Mark context as failed due to rate limiting."
   [phase-ctx error-msg]
   (-> phase-ctx
-      (assoc :execution/status :failed)
+      (ctx/transition-to-failed)
       (update :execution/errors conj (make-execution-error :rate-limited error-msg))))
 
 (defn- apply-backoff-if-retrying!
@@ -206,7 +214,8 @@
    Includes N11 §9.1 evidence fields."
   [ctx]
   (let [phase-results (:execution/phase-results ctx)
-        current-phase (:execution/current-phase ctx)
+        current-phase (or (:execution/current-phase ctx)
+                          (some-> phase-results keys last))
         image-digest  (get-in ctx [:execution/environment-metadata :image-digest])]
     (assoc ctx :execution/output
            (cond-> {:artifacts              (:execution/artifacts ctx)
@@ -307,11 +316,15 @@
   (if (and (phase/succeeded? final-ctx)
            (empty? (:execution/artifacts final-ctx))
            (empty? (:execution/phase-results final-ctx)))
-    (-> final-ctx
-        (update :execution/errors conj
-                (make-execution-error :empty-completion
-                                     (messages/t :status/empty-completion)))
-        (assoc :execution/status :completed-with-warnings))
+    (let [ctx' (-> final-ctx
+                   (update :execution/errors conj
+                           (make-execution-error :empty-completion
+                                                (messages/t :status/empty-completion))))]
+      (if (:execution/fsm-machine ctx')
+        (-> ctx'
+            (assoc :execution/completed-with-warnings? true)
+            (ctx/sync-machine-projections))
+        (assoc ctx' :execution/status :completed-with-warnings)))
     final-ctx))
 
 ;------------------------------------------------------------------------------ Layer 3: Main entry point
@@ -352,7 +365,7 @@
                            (-> initial-ctx
                                (update :execution/errors conj
                                        (make-execution-error :dashboard-stop message))
-                               (assoc :execution/status :failed)))
+                               (ctx/transition-to-failed)))
                          #_{:clj-kondo/ignore [:unresolved-symbol]}
                          (catch Object e
                            (let [throwable (:throwable &throw-context)
@@ -362,7 +375,7 @@
                                  (update :execution/errors conj
                                          (make-execution-error :pipeline-exception msg
                                                                {:data (when (instance? Throwable e) (ex-data e))}))
-                                 (assoc :execution/status :failed)))))
+                                 (ctx/transition-to-failed)))))
              output-ctx (-> final-ctx validate-completion extract-output)]
          (vreset! output-ctx-vol output-ctx)
          (when-not skip-lifecycle?

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -81,7 +81,7 @@
             (:workflow/phases workflow)))))
 
 (defn validate-pipeline
-  "Validate a workflow pipeline. Returns {:valid? bool :errors []}."
+  "Validate a workflow pipeline. Returns {:valid? bool :errors [] :warnings []}."
   [workflow]
   (let [phase-validation (phase/validate-pipeline workflow)
         machine-validation (workflow-fsm/validate-execution-machine workflow)]

--- a/components/workflow/src/ai/miniforge/workflow/runner_defaults.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_defaults.clj
@@ -30,6 +30,7 @@
       {})))
 
 (defn max-phases           [] (get @defaults :max-phases 50))
+(defn max-redirects        [] (get @defaults :max-redirects 5))
 (defn max-backoff-ms       [] (get @defaults :max-backoff-ms 30000))
 (defn backoff-base-ms      [] (get @defaults :backoff-base-ms 1000))
 (defn pause-poll-interval-ms [] (get @defaults :pause-poll-interval-ms 1000))

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -25,6 +25,7 @@
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
+   [ai.miniforge.workflow.context :as context]
    [ai.miniforge.workflow.messages :as messages]
    [ai.miniforge.workflow.runner-defaults :as defaults]))
 
@@ -142,6 +143,14 @@
       (catch Exception e
         (println (messages/t :env/release-failed {:error (ex-message e)}))))))
 
+(defn- boundary-phase
+  [phase-ctx]
+  (if-some [current-phase (get phase-ctx :execution/current-phase)]
+    current-phase
+    (if-some [last-phase (context/active-or-last-phase phase-ctx)]
+      last-phase
+      :unknown)))
+
 (defn persist-workspace-at-phase-boundary!
   "Persist workspace to task branch after phase completes (governed mode only)."
   [context phase-ctx]
@@ -149,9 +158,7 @@
     (when (= :governed (get context :execution/mode))
       (let [env-id (get context :execution/environment-id)
             branch (get context :execution/task-branch)
-            phase  (or (get phase-ctx :execution/current-phase)
-                       (some-> phase-ctx :execution/phase-results keys last)
-                       :unknown)]
+            phase  (boundary-phase phase-ctx)]
         (try
           (dag/persist-workspace! executor env-id
                                        {:branch  branch

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -149,7 +149,9 @@
     (when (= :governed (get context :execution/mode))
       (let [env-id (get context :execution/environment-id)
             branch (get context :execution/task-branch)
-            phase  (get phase-ctx :execution/current-phase :unknown)]
+            phase  (or (get phase-ctx :execution/current-phase)
+                       (some-> phase-ctx :execution/phase-results keys last)
+                       :unknown)]
         (try
           (dag/persist-workspace! executor env-id
                                        {:branch  branch

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -43,15 +43,34 @@
     (catch Exception e
       (println (messages/t :warn/websocket-send {:error (ex-message e)})))))
 
+(defn- websocket-stream?
+  [event-stream]
+  (boolean (:websocket event-stream)))
+
+(defn- durable-event-stream?
+  [event-stream]
+  (instance? clojure.lang.IDeref event-stream))
+
+(defn- dispatchable-event-stream?
+  [event-stream]
+  (or (websocket-stream? event-stream)
+      (durable-event-stream? event-stream)))
+
 (defn publish-event!
   "Publish event to event stream or dashboard WebSocket.
    Safe to call with nil event-stream (no-op)."
   [event-stream event]
-  (when event-stream
+  (when (dispatchable-event-stream? event-stream)
     (try
-      (if (:websocket event-stream)
+      (cond
+        (websocket-stream? event-stream)
         (publish-via-websocket! event-stream event)
-        (es/publish! event-stream event))
+
+        (durable-event-stream? event-stream)
+        (es/publish! event-stream event)
+
+        :else
+        nil)
       (catch Exception e
         (println (messages/t :warn/publish-event {:error (ex-message e)}))))))
 
@@ -138,7 +157,7 @@
 (defn publish-workflow-started!
   "Publish workflow started event."
   [event-stream context]
-  (when event-stream
+  (when (dispatchable-event-stream? event-stream)
     (try
       (publish-event! event-stream
                       (merge (es/workflow-started event-stream
@@ -152,7 +171,7 @@
 (defn publish-workflow-completed!
   "Publish workflow completed/failed event."
   [event-stream context]
-  (when event-stream
+  (when (dispatchable-event-stream? event-stream)
     (try
       (let [wf-id        (:execution/id context)
             metrics-opts (build-completion-metrics context)
@@ -175,7 +194,7 @@
 (defn publish-phase-started!
   "Publish phase started event."
   [event-stream context phase-name]
-  (when event-stream
+  (when (dispatchable-event-stream? event-stream)
     (try
       (publish-event! event-stream
                       (merge (es/phase-started event-stream (:execution/id context) phase-name
@@ -187,7 +206,7 @@
 (defn publish-phase-completed!
   "Publish phase completed event."
   [event-stream context phase-name result]
-  (when event-stream
+  (when (dispatchable-event-stream? event-stream)
     (try
       (publish-event! event-stream
                       (es/phase-completed event-stream (:execution/id context) phase-name
@@ -209,7 +228,8 @@
                     :config (get-in context [:execution/opts :self-healing-config])}
             switch-result (self-healing/check-backend-health-and-switch sh-ctx)]
         (when (:switched? switch-result)
-          (publish-event! event-stream (self-healing/emit-backend-switch-event sh-ctx switch-result))
+          (when (dispatchable-event-stream? event-stream)
+            (publish-event! event-stream (self-healing/emit-backend-switch-event sh-ctx switch-result)))
           switch-result))
       (catch Exception e
         (println (messages/t :warn/health-check {:error (ex-message e)}))

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
@@ -158,12 +158,13 @@
                              {:task/id task-b
                               :task/description "Task B"
                               :task/type :implement
-                              :task/dependencies [task-a phantom]}]}
-          dag-tasks (dag-orch/plan->dag-tasks plan {})]
-      ;; Task B should only have task-a as a dep; phantom is dropped
-      (is (= #{task-a} (:task/deps (second dag-tasks))))
-      ;; Task A has no deps
-      (is (empty? (:task/deps (first dag-tasks)))))))
+                              :task/dependencies [task-a phantom]}]}]
+      (with-redefs [println (fn [& _] nil)]
+        (let [dag-tasks (dag-orch/plan->dag-tasks plan {})]
+          ;; Task B should only have task-a as a dep; phantom is dropped
+          (is (= #{task-a} (:task/deps (second dag-tasks))))
+          ;; Task A has no deps
+          (is (empty? (:task/deps (first dag-tasks)))))))))
 
 (deftest test-plan->dag-tasks-drops-string-phantom-deps
   (testing "string UUID dependencies to non-existent tasks are also dropped"
@@ -178,10 +179,11 @@
                              {:task/id task-b
                               :task/description "Task B"
                               :task/type :implement
-                              :task/dependencies [(str task-a) phantom-str]}]}
-          dag-tasks (dag-orch/plan->dag-tasks plan {})]
-      ;; task-a string should resolve; phantom string should be dropped
-      (is (= #{task-a} (:task/deps (second dag-tasks)))))))
+                              :task/dependencies [(str task-a) phantom-str]}]}]
+      (with-redefs [println (fn [& _] nil)]
+        (let [dag-tasks (dag-orch/plan->dag-tasks plan {})]
+          ;; task-a string should resolve; phantom string should be dropped
+          (is (= #{task-a} (:task/deps (second dag-tasks)))))))))
 
 (deftest test-plan->dag-tasks-all-deps-valid
   (testing "valid dependencies are preserved unchanged"
@@ -300,7 +302,9 @@
                       (dag/ok {:task-id (:task/id task-def)
                                :status :implemented
                                :artifacts []
-                               :metrics {:tokens 0 :cost-usd 0.0}}))]
+                               :metrics {:tokens 0 :cost-usd 0.0}}))
+                    println
+                    (fn [& _] nil)]
         (let [result (dag-orch/execute-plan-as-dag plan {:logger logger})]
           ;; All 3 tasks should complete — phantom dep dropped at plan conversion
           (is (:success? result))

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -188,3 +188,66 @@
           (let [r4 (fsm/transition (:state r3) :complete)]
             (is (:success? r4))
             (is (= :completed (:state r4)))))))))
+
+(deftest compiled-execution-machine-projects-phase-state-test
+  (let [workflow {:workflow/id :test
+                  :workflow/pipeline [{:phase :plan}
+                                      {:phase :implement}
+                                      {:phase :done}]}
+        machine (fsm/compile-execution-machine workflow)
+        pending-state (fsm/initialize-execution machine)
+        running-state (fsm/start-execution machine pending-state)]
+    (testing "pending state projects no active phase"
+      (is (= {:execution/status :pending
+              :execution/current-phase nil
+              :execution/phase-index nil
+              :execution/redirect-count 0}
+             (fsm/execution-projection machine pending-state))))
+    (testing "start enters the first pipeline phase"
+      (is (= :running (fsm/execution-status machine running-state)))
+      (is (= :plan (fsm/current-phase-id machine running-state)))
+      (is (= 0 (fsm/current-phase-index machine running-state))))))
+
+(deftest compiled-execution-machine-follows-phase-transitions-test
+  (let [workflow {:workflow/id :test
+                  :workflow/pipeline [{:phase :plan}
+                                      {:phase :implement}
+                                      {:phase :verify :on-fail :implement}
+                                      {:phase :done}]}
+        machine (fsm/compile-execution-machine workflow)
+        s0 (fsm/start-execution machine (fsm/initialize-execution machine))
+        s1 (fsm/transition-execution machine s0 :phase/succeed)
+        s2 (fsm/transition-execution machine s1 :phase/succeed)
+        s3 (fsm/transition-execution machine s2 (fsm/redirect-event :implement))
+        s4 (fsm/transition-execution machine s3 :pause)
+        s5 (fsm/transition-execution machine s4 :resume)
+        s6 (fsm/transition-execution machine s5 :phase/succeed)
+        s7 (fsm/transition-execution machine s6 :phase/already-done)]
+    (testing "success transitions advance through the compiled phase graph"
+      (is (= :implement (fsm/current-phase-id machine s1)))
+      (is (= :verify (fsm/current-phase-id machine s2))))
+    (testing "redirect transitions return to the configured phase and increment redirect count"
+      (is (= :implement (fsm/current-phase-id machine s3)))
+      (is (= 1 (:execution/redirect-count (fsm/execution-projection machine s3)))))
+    (testing "pause and resume are phase-local machine states"
+      (is (= :paused (fsm/execution-status machine s4)))
+      (is (= :implement (fsm/current-phase-id machine s4)))
+      (is (= :running (fsm/execution-status machine s5))))
+    (testing "already-done transitions jump to :done and then completion"
+      (is (= :verify (fsm/current-phase-id machine s6)))
+      (is (= :done (fsm/current-phase-id machine s7))))))
+
+(deftest validate-execution-machine-test
+  (testing "detects unresolved transition targets"
+    (let [result (fsm/validate-execution-machine
+                  {:workflow/id :bad
+                   :workflow/pipeline [{:phase :plan :on-success :missing}]})]
+      (is (false? (:valid? result)))
+      (is (= :unknown-on-success-target (-> result :errors first :error)))))
+  (testing "warns on duplicate phase ids because target resolution becomes ambiguous"
+    (let [result (fsm/validate-execution-machine
+                  {:workflow/id :dup
+                   :workflow/pipeline [{:phase :plan}
+                                       {:phase :plan}]})]
+      (is (true? (:valid? result)))
+      (is (= :duplicate-phase-identifiers (-> result :warnings first :warning))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -7,6 +7,7 @@
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.dag-executor.interface :as dag-exec]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.workflow.execution :as exec]
    [ai.miniforge.phase.interface]))
 
 ;; ---------------------------------------------------------------------------- extract-output
@@ -109,6 +110,28 @@
               :workflow/pipeline [{:phase :done}]}
           result (runner/run-pipeline wf {:task "Test"} {:max-phases 1})]
       (is (= :completed (:execution/status result))))))
+
+(deftest apply-dag-success-does-not-consume-redirect-budget-test
+  (testing "DAG fast-path advances with normal success events"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :plan}
+                                        {:phase :implement}
+                                        {:phase :verify}
+                                        {:phase :done}]}
+          pipeline (runner/build-pipeline workflow)
+          context (ctx/create-context workflow {:task "Test"} {})
+          dag-result {:artifacts []
+                      :worktree-paths []
+                      :metrics {:tokens 0 :cost-usd 0.0}}
+          result (exec/apply-dag-success context
+                                         dag-result
+                                         pipeline
+                                         ctx/transition-to-completed
+                                         ctx/transition-to-failed)]
+      (is (= :running (:execution/status result)))
+      (is (= :verify (:execution/current-phase result)))
+      (is (= 0 (:execution/redirect-count result))))))
 
 ;; ---------------------------------------------------------------------------- publish-event edge cases
 

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -6,6 +6,7 @@
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.dag-executor.interface :as dag-exec]
+   [ai.miniforge.logging.interface :as log]
    [ai.miniforge.phase.interface]))
 
 ;; ---------------------------------------------------------------------------- extract-output
@@ -117,8 +118,7 @@
     (is (nil? (runner/publish-event! nil {:event/type :test})))))
 
 (deftest publish-event-in-memory-stream-test
-  (testing "publish-event with in-memory stream dispatches to event-stream ns"
-    ;; This tests the fallback path - it should not throw even if ns not found
+  (testing "publish-event no-ops for non-stream maps"
     (is (nil? (runner/publish-event! {} {:event/type :test})))))
 
 ;; ---------------------------------------------------------------------------- terminal-state?
@@ -309,6 +309,8 @@
                    :execution/task-branch "b"}
           phase-ctx {:execution/current-phase :release}]
       (with-redefs [dag-exec/persist-workspace!
-                    (fn [& _] (throw (ex-info "Docker gone" {})))]
+                    (fn [& _] (throw (ex-info "Docker gone" {})))
+                    log/warn
+                    (fn [& _] nil)]
         ;; Should not throw
         (is (nil? (persist-fn context phase-ctx)))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -33,6 +33,21 @@
       (is (= :failed (:status output)))
       (is (= {:phase/status :failed} (:last-phase-result output))))))
 
+(deftest extract-output-falls-back-to-pipeline-phase-order-test
+  (testing "extract-output chooses the last recorded phase using workflow pipeline order"
+    (let [ctx {:execution/workflow {:workflow/pipeline [{:phase :plan}
+                                                       {:phase :implement}
+                                                       {:phase :done}]}
+               :execution/artifacts []
+               :execution/phase-results {:done {:phase/status :succeeded}
+                                         :plan {:phase/status :succeeded}}
+               :execution/current-phase nil
+               :execution/status :completed}
+          output (:execution/output (runner/extract-output ctx))]
+      (is (= {:phase/status :succeeded} (:last-phase-result output)))
+      (is (= {:phase/status :succeeded}
+             (get-in output [:phase-results :done]))))))
+
 ;; ---------------------------------------------------------------------------- build-pipeline edge cases
 
 (deftest build-pipeline-nil-pipeline-falls-back-to-legacy-test
@@ -297,4 +312,3 @@
                     (fn [& _] (throw (ex-info "Docker gone" {})))]
         ;; Should not throw
         (is (nil? (persist-fn context phase-ctx)))))))
-

--- a/docs/pull-requests/2026-04-22-feat-unified-workflow-machine.md
+++ b/docs/pull-requests/2026-04-22-feat-unified-workflow-machine.md
@@ -1,0 +1,81 @@
+# feat: make the workflow execution machine authoritative
+
+## Overview
+
+Replace the workflow runner's split transition authority with a compiled
+per-run execution machine. Phase execution still uses the existing
+interceptor enter/leave/error lifecycle, but phase advancement now flows
+through machine events instead of direct phase-index arithmetic.
+
+## Motivation
+
+The repo already had a coarse workflow FSM, but real workflow progression was
+still controlled by:
+
+- `:execution/phase-index`
+- `:execution/current-phase`
+- `:on-success`
+- `:on-fail`
+- `:redirect-to`
+
+That left two sources of truth: a lifecycle FSM for status, and an informal
+phase-transition engine for the actual run graph. This PR makes the compiled
+execution machine the authority for the active workflow run while preserving
+current phase semantics.
+
+## Changes In Detail
+
+- Add a compiled execution-machine model in `workflow.fsm`
+  - per-phase active states
+  - per-phase paused states
+  - terminal states
+  - event translation for success, failure, retry, already-done, and redirect
+- Refactor `workflow.context` so:
+  - `:execution/fsm-machine` stores the compiled machine
+  - `:execution/fsm-state` stores the authoritative machine snapshot
+  - `:execution/status`, `:execution/current-phase`, `:execution/phase-index`,
+    and `:execution/redirect-count` are projected from that snapshot
+- Refactor `workflow.execution` so phase results become machine events rather
+  than direct next-index writes
+- Keep existing phase implementations intact for now by translating their
+  current result contract into machine events
+- Extend workflow validation so the runner validates the machine compilation
+  path, not just known phase names
+- Add focused FSM tests for:
+  - compiled machine projection
+  - redirect/retry/pause behavior
+  - machine validation
+
+## Testing Plan
+
+- `bb test components/workflow`
+- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/fsm.clj
+  components/workflow/src/ai/miniforge/workflow/context.clj components/workflow/src/ai/miniforge/workflow/execution.clj
+  components/workflow/src/ai/miniforge/workflow/runner.clj
+  components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+  components/workflow/test/ai/miniforge/workflow/fsm_test.clj`
+- `clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.review-repair-loop-test
+  'ai.miniforge.phase-software-factory.verify-failure-modes-test) ..."`
+
+## Deployment Plan
+
+No deployment step. This is a workflow-engine refactor behind the existing
+public pipeline API.
+
+## Related Issues/PRs
+
+- Follows `#636`, which formalized the unified execution-machine contract in
+  the specs
+- Prepares the next slice:
+  - phase implementations emitting explicit outcome events instead of steering
+    control flow directly
+  - supervision/orchestrator integration against the execution machine
+
+## Checklist
+
+- [x] Compiled per-run execution machine added
+- [x] Workflow context projections derive from machine snapshot
+- [x] Phase transitions run through machine events
+- [x] Existing redirect/retry semantics preserved
+- [x] Workflow validation covers machine compilation
+- [x] Workflow tests pass


### PR DESCRIPTION
# feat: make the workflow execution machine authoritative

## Overview

Replace the workflow runner's split transition authority with a compiled
per-run execution machine. Phase execution still uses the existing
interceptor enter/leave/error lifecycle, but phase advancement now flows
through machine events instead of direct phase-index arithmetic.

## Motivation

The repo already had a coarse workflow FSM, but real workflow progression was
still controlled by:

- `:execution/phase-index`
- `:execution/current-phase`
- `:on-success`
- `:on-fail`
- `:redirect-to`

That left two sources of truth: a lifecycle FSM for status, and an informal
phase-transition engine for the actual run graph. This PR makes the compiled
execution machine the authority for the active workflow run while preserving
current phase semantics.

## Changes In Detail

- Add a compiled execution-machine model in `workflow.fsm`
  - per-phase active states
  - per-phase paused states
  - terminal states
  - event translation for success, failure, retry, already-done, and redirect
- Refactor `workflow.context` so:
  - `:execution/fsm-machine` stores the compiled machine
  - `:execution/fsm-state` stores the authoritative machine snapshot
  - `:execution/status`, `:execution/current-phase`, `:execution/phase-index`,
    and `:execution/redirect-count` are projected from that snapshot
- Refactor `workflow.execution` so phase results become machine events rather
  than direct next-index writes
- Keep existing phase implementations intact for now by translating their
  current result contract into machine events
- Extend workflow validation so the runner validates the machine compilation
  path, not just known phase names
- Add focused FSM tests for:
  - compiled machine projection
  - redirect/retry/pause behavior
  - machine validation

## Testing Plan

- `bb test components/workflow`
- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/fsm.clj
  components/workflow/src/ai/miniforge/workflow/context.clj components/workflow/src/ai/miniforge/workflow/execution.clj
  components/workflow/src/ai/miniforge/workflow/runner.clj
  components/workflow/src/ai/miniforge/workflow/runner_environment.clj
  components/workflow/test/ai/miniforge/workflow/fsm_test.clj`
- `clojure -M:dev:test -e "(require 'ai.miniforge.phase-software-factory.review-repair-loop-test
  'ai.miniforge.phase-software-factory.verify-failure-modes-test) ..."`

## Deployment Plan

No deployment step. This is a workflow-engine refactor behind the existing
public pipeline API.

## Related Issues/PRs

- Follows `#636`, which formalized the unified execution-machine contract in
  the specs
- Prepares the next slice:
  - phase implementations emitting explicit outcome events instead of steering
    control flow directly
  - supervision/orchestrator integration against the execution machine

## Checklist

- [x] Compiled per-run execution machine added
- [x] Workflow context projections derive from machine snapshot
- [x] Phase transitions run through machine events
- [x] Existing redirect/retry semantics preserved
- [x] Workflow validation covers machine compilation
- [x] Workflow tests pass
