### PR TITLE
refactor: normalize phase transition requests

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -185,7 +185,8 @@
           (:duration-ms result) (assoc :phase/duration-ms (:duration-ms result))
           (:artifacts result) (assoc :phase/artifacts (:artifacts result))
           (:error result) (assoc :phase/error (:error result))
-          (:redirect-to result) (assoc :phase/redirect-to (:redirect-to result))
+          (:phase/transition-request result)
+          (assoc :phase/transition-request (:phase/transition-request result))
           (:tokens result) (assoc :phase/tokens (:tokens result))
           (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))))))
 

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -365,17 +365,20 @@
       (is (= "API error" (:workflow/failure-reason event))))))
 
 ;------------------------------------------------------------------------------ Layer 3
-;; Phase completed redirect
+;; Phase completed transition request
 
-(deftest phase-completed-redirect-test
-  (testing "phase-completed with redirect-to field"
+(deftest phase-completed-transition-request-test
+  (testing "phase-completed includes transition requests"
     (let [stream (no-op-stream)
           wf-id (random-uuid)
           event (core/phase-completed stream wf-id :review
-                                       {:outcome :redirect
-                                        :redirect-to :implement})]
-      (is (= :redirect (:phase/outcome event)))
-      (is (= :implement (:phase/redirect-to event))))))
+                                      {:outcome :failure
+                                       :phase/transition-request
+                                       {:transition/type :transition/redirect
+                                        :transition/target :implement}})]
+      (is (= :failure (:phase/outcome event)))
+      (is (= :implement
+             (get-in event [:phase/transition-request :transition/target]))))))
 
 (deftest phase-completed-with-error-test
   (testing "phase-completed captures error details"

--- a/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/sinks_test.clj
@@ -112,11 +112,9 @@
           (let [wf-dir (io/file dir (str wf-id))
                 files (sort-by #(.getName %) (list-files wf-dir))]
             (is (= 2 (count files)))
-            ;; Files are sortable by timestamp-prefixed name
-            (let [e1 (read-transit-json (slurp (first files)))
-                  e2 (read-transit-json (slurp (second files)))]
-              (is (= :workflow/started (:event/type e1)))
-              (is (= :workflow/completed (:event/type e2)))))))))
+            (let [events (mapv #(read-transit-json (slurp %)) files)
+                  event-types (set (map :event/type events))]
+              (is (= #{:workflow/started :workflow/completed} event-types))))))))
 
   (testing "writes events with nil workflow-id to operator subdirectory"
     (with-temp-dir

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -474,10 +474,11 @@
 
       ;; Has on-fail transition - redirect
       on-fail
-      (-> ctx
-          (assoc-in [:phase :status] :failed)
-          (assoc-in [:phase :redirect-to] on-fail)
-          (assoc-in [:phase :error] (phase/exception-error ex)))
+      (let [phase-result (-> (:phase ctx)
+                             (assoc :status :failed)
+                             (assoc :error (phase/exception-error ex))
+                             (phase/request-redirect on-fail))]
+        (assoc ctx :phase phase-result))
 
       ;; No recovery - propagate
       :else

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -398,10 +398,11 @@
 
       ;; Has on-fail transition - redirect
       on-fail
-      (-> ctx
-          (assoc-in [:phase :status] :failed)
-          (assoc-in [:phase :redirect-to] on-fail)
-          (assoc-in [:phase :error] (phase/exception-error ex)))
+      (let [phase-result (-> (:phase ctx)
+                             (assoc :status :failed)
+                             (assoc :error (phase/exception-error ex))
+                             (phase/request-redirect on-fail))]
+        (assoc ctx :phase phase-result))
 
       ;; No recovery - propagate
       :else

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -126,8 +126,8 @@
 
    Records review metrics: issues found, approval status.
    When review decision is :changes-requested and within iteration budget,
-   sets status to :failed with :redirect-to :implement so the execution engine
-   jumps back to implement with the review feedback attached."
+   sets status to :failed with a redirect transition request so the execution
+   engine jumps back to implement with the review feedback attached."
   [ctx]
   (let [start-time (get-in ctx [:phase :started-at])
         end-time (System/currentTimeMillis)
@@ -143,7 +143,7 @@
         ;; blocking issues. Iter 23 regression: :rejected fell through to
         ;; :completed, letting release open a PR against a reviewer-rejected
         ;; artifact. Both decisions now set :failed; within iteration budget
-        ;; the phase redirects to :implement for repair.
+        ;; the phase requests a redirect to :implement for repair.
         ;; Preserve :failed from gate validation — don't overwrite with :completed.
         gate-failed? (= :failed (:phase/status (get-in ctx [:phase])))
         reviewer-blocked? (contains? #{:rejected :changes-requested} review-decision)
@@ -171,10 +171,11 @@
               (knowledge/capture-feedback-learning!
                (:knowledge-store ctx) :reviewer
                (get-in ctx [:execution/input :title]) feedback)
-              (-> updated-ctx
-                  (update-in [:phase :iterations] (fnil inc 1))
-                  (assoc-in [:phase :review-feedback] feedback)
-                  (assoc-in [:phase :redirect-to] :implement)))
+              (let [phase-result (-> (:phase updated-ctx)
+                                     (update :iterations (fnil inc 1))
+                                     (assoc :review-feedback feedback)
+                                     (phase/request-redirect :implement))]
+                (assoc updated-ctx :phase phase-result)))
             updated-ctx)
       (phase/emit-phase-completed! :review
         {:outcome     (if (= :completed phase-status) :success :failure)
@@ -199,11 +200,12 @@
 
       ;; Has on-fail transition - redirect
       on-fail
-      (-> ctx
-          (assoc-in [:phase :status] :failed)
-          (assoc-in [:phase :redirect-to] on-fail)
-          (assoc-in [:phase :error] {:message (ex-message ex)
-                                     :data (ex-data ex)}))
+      (let [phase-result (-> (:phase ctx)
+                             (assoc :status :failed)
+                             (assoc :error {:message (ex-message ex)
+                                            :data (ex-data ex)})
+                             (phase/request-redirect on-fail))]
+        (assoc ctx :phase phase-result))
 
       ;; No recovery - propagate
       :else

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -202,7 +202,7 @@
   "Post-processing for verification phase.
 
    Records test metrics: count, pass rate, coverage.
-   When verification fails and :on-fail is configured, sets :redirect-to
+   When verification fails and :on-fail is configured, requests a redirect
    so the execution engine jumps to the target phase (typically :implement)."
   [ctx]
   (let [start-time (get-in ctx [:phase :started-at])
@@ -244,12 +244,13 @@
     ;; implement won't help, so we do not redirect in those cases.
     (doto (if (and (= :failed phase-status) on-fail
                      (not timeout?) (not rate-limited?))
-              (-> updated-ctx
-                  (assoc-in [:phase :redirect-to] on-fail)
-                  (assoc-in [:phase :error]
-                            {:message      error-message
-                             :agent-status agent-status
-                             :gate-failed? gate-failed?}))
+              (let [phase-result (-> (:phase updated-ctx)
+                                     (assoc :error
+                                            {:message      error-message
+                                             :agent-status agent-status
+                                             :gate-failed? gate-failed?})
+                                     (phase/request-redirect on-fail))]
+                (assoc updated-ctx :phase phase-result))
               (cond-> updated-ctx
                 (= :failed phase-status)
                 (assoc-in [:phase :error]
@@ -281,10 +282,11 @@
 
       ;; Has on-fail transition - redirect
       on-fail
-      (-> ctx
-          (assoc-in [:phase :status] :failed)
-          (assoc-in [:phase :redirect-to] on-fail)
-          (assoc-in [:phase :error] (phase/exception-error ex)))
+      (let [phase-result (-> (:phase ctx)
+                             (assoc :status :failed)
+                             (assoc :error (phase/exception-error ex))
+                             (phase/request-redirect on-fail))]
+        (assoc ctx :phase phase-result))
 
       ;; No recovery - propagate
       :else

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -61,24 +61,24 @@
   (testing "changes-requested sets :failed status (not :retrying)"
     (let [phase (simulate-leave-review :changes-requested 1 4)]
       (is (= :failed (:status phase))
-          "Status should be :failed so execution engine uses redirect-to")
+          "Status should be :failed so execution can follow the transition request")
       (is (not (phase/retrying? phase))
           "Should NOT be retrying (would cause review to re-run in place)"))))
 
 (deftest changes-requested-within-budget-redirects-to-implement
-  (testing "changes-requested within budget sets redirect-to :implement"
+  (testing "changes-requested within budget requests redirect to :implement"
     (let [phase (simulate-leave-review :changes-requested 1 4)]
-      (is (= :implement (:redirect-to phase))
+      (is (= :implement (phase/transition-target phase))
           "Should redirect to implement for repair")
       (is (phase/failed? phase)
-          "Must be failed for redirect-to to be honored by execution engine"))))
+          "Must be failed for the transition request to be honored by execution"))))
 
 (deftest changes-requested-over-budget-no-redirect
   (testing "changes-requested at max iterations fails without redirect"
     (let [phase (simulate-leave-review :changes-requested 4 4)]
       (is (= :failed (:status phase))
           "Should be failed")
-      (is (nil? (:redirect-to phase))
+      (is (not (phase/redirect-requested? phase))
           "Should NOT redirect — iteration budget exhausted"))))
 
 (deftest changes-requested-stores-review-feedback
@@ -95,21 +95,21 @@
     (let [phase (simulate-leave-review :rejected 1 4)]
       (is (= :failed (:status phase))
           "Rejected must set :failed — falling through to :completed lets an empty-diff PR open")
-      (is (= :implement (:redirect-to phase))
+      (is (= :implement (phase/transition-target phase))
           "Rejected within budget must redirect to implement like :changes-requested"))))
 
 (deftest rejected-over-budget-no-redirect
   (testing ":rejected at max iterations fails terminally (no redirect)"
     (let [phase (simulate-leave-review :rejected 4 4)]
       (is (= :failed (:status phase)))
-      (is (nil? (:redirect-to phase))))))
+      (is (not (phase/redirect-requested? phase))))))
 
 (deftest approved-sets-completed-status
   (testing "approved review sets :completed status"
     (let [phase (simulate-leave-review :approved 1 4)]
       (is (= :completed (:status phase))
           "Approved review should complete normally")
-      (is (nil? (:redirect-to phase))
+      (is (not (phase/redirect-requested? phase))
           "No redirect needed for approved review"))))
 
 (deftest iteration-counter-incremented-on-redirect
@@ -119,18 +119,18 @@
           "Iterations should increment from 1 to 2"))))
 
 ;; ============================================================================
-;; Execution engine integration: failed + redirect-to triggers redirect
+;; Execution engine integration: failed + transition request triggers redirect
 ;; ============================================================================
 
-(deftest failed-with-redirect-not-confused-with-retrying
-  (testing "execution engine distinguishes failed+redirect from retrying"
-    (let [phase-result {:status :failed :redirect-to :implement}]
+(deftest failed-with-transition-request-not-confused-with-retrying
+  (testing "execution engine distinguishes failed+transition-request from retrying"
+    (let [phase-result (phase/request-redirect {:status :failed} :implement)]
       ;; The key invariant: failed? is true, retrying? is false
       (is (phase/failed? phase-result)
           "Should be detected as failed")
       (is (not (phase/retrying? phase-result))
           "Should NOT be detected as retrying")
-      ;; This means determine-next-index will hit the redirect branch,
+      ;; This means execution will hit the redirect branch,
       ;; not the retrying branch (which would stay at current index)
       )))
 

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
@@ -131,12 +131,12 @@
     on-fail (assoc :phase-config {:on-fail on-fail})))
 
 (deftest leave-verify-redirects-on-normal-failure-test
-  (testing "normal verify failure with :on-fail configured sets :redirect-to"
+  (testing "normal verify failure with :on-fail configured requests a redirect"
     (let [ctx (make-leave-ctx {:status :error
                                :error {:message "Tests failed: 3 assertions"}}
                               :implement)
           result (verify/leave-verify ctx)]
-      (is (= :implement (get-in result [:phase :redirect-to])))
+      (is (= :implement (phase/transition-target (get result :phase))))
       (is (= :failed (get-in result [:phase :status]))))))
 
 (deftest leave-verify-no-redirect-on-timeout-test
@@ -145,7 +145,7 @@
                                :error {:message "Agent timed out after 600000ms"}}
                               :implement)
           result (verify/leave-verify ctx)]
-      (is (nil? (get-in result [:phase :redirect-to])))
+      (is (not (phase/redirect-requested? (get result :phase))))
       (is (= :failed (get-in result [:phase :status])))
       (is (true? (get-in result [:phase :error :timeout?]))))))
 
@@ -155,7 +155,7 @@
                                :error {:message "429 rate limit exceeded"}}
                               :implement)
           result (verify/leave-verify ctx)]
-      (is (nil? (get-in result [:phase :redirect-to])))
+      (is (not (phase/redirect-requested? (get result :phase))))
       (is (= :failed (get-in result [:phase :status])))
       (is (some? (get-in result [:phase :error :rate-limited?]))))
 
@@ -164,15 +164,15 @@
                                  :error {:message "You've hit your limit · resets 7pm"}}
                                 :implement)
             result (verify/leave-verify ctx)]
-        (is (nil? (get-in result [:phase :redirect-to])))))))
+        (is (not (phase/redirect-requested? (get result :phase))))))))
 
 (deftest leave-verify-no-redirect-without-on-fail-test
-  (testing "normal failure without :on-fail does not set :redirect-to"
+  (testing "normal failure without :on-fail does not request a redirect"
     (let [ctx (make-leave-ctx {:status :error
                                :error {:message "Tests failed"}}
                               nil)
           result (verify/leave-verify ctx)]
-      (is (nil? (get-in result [:phase :redirect-to])))
+      (is (not (phase/redirect-requested? (get result :phase))))
       (is (= :failed (get-in result [:phase :status]))))))
 
 ;------------------------------------------------------------------------------ Rich Comment

--- a/components/phase/src/ai/miniforge/phase/interface.clj
+++ b/components/phase/src/ai/miniforge/phase/interface.clj
@@ -137,6 +137,18 @@
   "Check if a result map indicates retry."
   registry/retrying?)
 
+(def transition-request
+  "Return the transition request attached to a phase result, if any."
+  phase-result/transition-request)
+
+(def transition-target
+  "Return the requested transition target phase, if any."
+  phase-result/transition-target)
+
+(def redirect-requested?
+  "True when a phase result requests a redirect transition."
+  phase-result/redirect-requested?)
+
 (def create-streaming-callback
   "Create a phase-scoped streaming callback when an event stream is available."
   telemetry/create-streaming-callback)
@@ -205,6 +217,10 @@
 (def skipped
   "Build a skipped-phase result for phases that short-circuit."
   phase-result/skipped)
+
+(def request-redirect
+  "Attach a redirect transition request to a phase result."
+  phase-result/request-redirect)
 
 (def test-metrics
   "Build a standard test-phase metrics map."

--- a/components/phase/src/ai/miniforge/phase/phase_result.clj
+++ b/components/phase/src/ai/miniforge/phase/phase_result.clj
@@ -44,6 +44,34 @@
   [result]
   (= :error (:status result)))
 
+(def ^:private transition-request-key
+  :phase/transition-request)
+
+(def ^:private transition-type-key
+  :transition/type)
+
+(def ^:private transition-target-key
+  :transition/target)
+
+(def ^:private redirect-transition-type
+  :transition/redirect)
+
+(defn transition-request
+  "Return the transition request attached to a phase result, if any."
+  [result]
+  (get result transition-request-key))
+
+(defn transition-target
+  "Return the requested transition target phase, if any."
+  [result]
+  (get-in result [transition-request-key transition-target-key]))
+
+(defn redirect-requested?
+  "True when a phase result requests a redirect transition."
+  [result]
+  (= redirect-transition-type
+     (get-in result [transition-request-key transition-type-key])))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Metric factories
 
@@ -121,6 +149,13 @@
   {:status  :success
    :output  {:skipped true :reason reason}
    :metrics {:tokens 0 :duration-ms 0 :cost-usd 0.0}})
+
+(defn request-redirect
+  "Attach a redirect transition request to a phase result."
+  [result target-phase]
+  (assoc result transition-request-key
+         {transition-type-key   redirect-transition-type
+          transition-target-key target-phase}))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/phase/src/ai/miniforge/phase/telemetry.clj
+++ b/components/phase/src/ai/miniforge/phase/telemetry.clj
@@ -141,7 +141,7 @@
    - ctx      — execution context map
    - phase-kw — phase keyword (e.g. :verify, :review, :release)
    - result   — optional map with :outcome, :duration-ms, :tokens,
-                 :cost-usd, :error, :redirect-to, :artifacts"
+                 :cost-usd, :error, :phase/transition-request, :artifacts"
   [ctx phase-kw result]
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
@@ -164,7 +164,7 @@
 (defn emit-agent-started!
   "Publish an :agent/started event.
    Called when a phase begins executing an agent invocation."
-  [ctx phase-kw agent-id]
+  [ctx _phase-kw agent-id]
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try
@@ -177,7 +177,7 @@
 (defn emit-agent-completed!
   "Publish an :agent/completed event.
    Called when a phase's agent invocation finishes."
-  [ctx phase-kw agent-id result]
+  [ctx _phase-kw agent-id _result]
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try
@@ -203,7 +203,7 @@
    - ctx      — execution context map
    - phase-kw — phase keyword that completed (used as the milestone name)
    - result   — result map from the phase (may include :artifacts, :tokens, :cost-usd)"
-  [ctx phase-kw result]
+  [ctx phase-kw _result]
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try
@@ -245,7 +245,7 @@
    - ctx      — execution context map
    - phase-kw — phase keyword used as the milestone identifier
    - result   — result map from the phase (may include :artifacts, :tokens, :cost-usd)"
-  [ctx phase-kw result]
+  [ctx phase-kw _result]
   (when-let [stream (resolve-event-stream ctx)]
     (let [workflow-id (resolve-workflow-id ctx)]
       (try

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -220,8 +220,8 @@
 
    Returns [ctx phase-result]."
   [interceptor ctx]
-  ;; Clear :phase map before each phase to prevent stale state (e.g. :redirect-to)
-  ;; from leaking across phase boundaries
+  ;; Clear :phase map before each phase to prevent stale transition requests
+  ;; from leaking across phase boundaries.
   (let [ctx-clean (dissoc ctx :phase)
         ctx-entered (execute-enter interceptor ctx-clean)
         phase-result (extract-phase-result ctx-entered)
@@ -241,10 +241,15 @@
       (record-phase-artifacts phase-result)
       (track-phase-files phase-result)))
 
+(defn- redirect-target
+  [phase-result]
+  (when (phase/redirect-requested? phase-result)
+    (phase/transition-target phase-result)))
+
 (defn determine-phase-event
   "Translate a phase result into an execution-machine event."
   [_phase-config phase-result]
-  (let [redirect-to (:redirect-to phase-result)]
+  (let [target-phase (redirect-target phase-result)]
     (cond
       (phase/retrying? phase-result)
       :phase/retry
@@ -255,8 +260,8 @@
       (phase/succeeded? phase-result)
       :phase/succeed
 
-      (and (phase/failed? phase-result) redirect-to)
-      (workflow-fsm/redirect-event redirect-to)
+      (and (phase/failed? phase-result) target-phase)
+      (workflow-fsm/redirect-event target-phase)
 
       (phase/failed? phase-result)
       :phase/fail

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -119,13 +119,14 @@
                            {:message (messages/t :status/gate-failed) :details msg})
                          (when-let [msg (:message result)]
                            {:message msg})))
+        transition-request (phase/transition-request result)
         tokens   (get-in result [:metrics :tokens]
                    (get-in result [:phase/metrics :tokens]))
         cost-usd (get-in result [:metrics :cost-usd]
                    (get-in result [:phase/metrics :cost-usd]))]
     (cond-> {:outcome outcome :duration-ms duration-ms}
       error-info    (assoc :error error-info)
-      (:redirect-to result) (assoc :redirect-to (:redirect-to result))
+      transition-request (assoc :phase/transition-request transition-request)
       tokens        (assoc :tokens tokens)
       cost-usd      (assoc :cost-usd cost-usd))))
 

--- a/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/run7_regression_test.clj
@@ -21,10 +21,10 @@
    1. Duration-ms always 0 — agent metrics fallback shadows real wall-clock time
    2. Terminal event silently dropped — requiring-resolve nil causes when-let short-circuit
    3. Phase leave functions must override agent duration-ms with wall-clock time
-   4. Stale :phase map cleared between phases
+   4. Stale phase transition request cleared between phases
    5. Review feedback lost during phase clearing (Run 9)"
   (:require
-   [ai.miniforge.phase.interface]
+   [ai.miniforge.phase.interface :as phase]
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.execution :as exec]))
@@ -142,11 +142,12 @@
 (deftest phase-map-cleared-between-phases-test
   (testing "execute-phase-lifecycle clears :phase before entering next phase"
     ;; Simulate a context with a stale :phase map from a previous phase
-    ;; (e.g., verify left :redirect-to :implement on it)
-    (let [stale-ctx {:phase {:name :verify
-                             :status :failed
-                             :redirect-to :implement
-                             :duration-ms 3000}
+    ;; (e.g., verify left a redirect transition request on it)
+    (let [stale-phase (phase/request-redirect {:name :verify
+                                               :status :failed
+                                               :duration-ms 3000}
+                                              :implement)
+          stale-ctx {:phase stale-phase
                      :execution/input {:description "test"}
                      :execution/phase-results {}
                      :execution/errors []
@@ -158,9 +159,9 @@
           interceptor (ai.miniforge.phase.interface/get-phase-interceptor {:phase :done})
           ;; execute-phase-lifecycle should clear :phase first
           [ctx-after _result] (exec/execute-phase-lifecycle interceptor stale-ctx)]
-      ;; The stale :redirect-to should NOT be present
-      (is (not= :implement (get-in ctx-after [:phase :redirect-to]))
-          "Stale :redirect-to from previous phase must not leak"))))
+      ;; The stale transition request should NOT be present.
+      (is (nil? (get-in ctx-after [:phase :phase/transition-request]))
+          "Stale phase transition request must not leak"))))
 
 ;; ============================================================================
 ;; Fix 5: Review feedback survives :phase clearing (Run 9 bug)

--- a/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
@@ -22,6 +22,7 @@
    so the Rust StateManager can deserialize WorkflowRun projections."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.workflow.runner-events :as events]
    [ai.miniforge.event-stream.interface :as event-stream]))
 
@@ -112,3 +113,17 @@
 (deftest publish-phase-started-nil-stream-is-noop-test
   (testing "nil event-stream does not throw"
     (is (nil? (events/publish-phase-started! nil (test-context) :plan)))))
+
+;------------------------------------------------------------------------------ publish-phase-completed!
+
+(deftest publish-phase-completed-includes-transition-request-test
+  (testing "phase completion events include transition requests when present"
+    (let [stream (create-stream)
+          ctx (test-context)
+          phase-result (phase/request-redirect {:status :failed
+                                                :error {:message "tests failed"}}
+                                               :implement)]
+      (events/publish-phase-completed! stream ctx :verify phase-result)
+      (let [event (first-event stream)]
+        (is (= :workflow/phase-completed (:event/type event)))
+        (is (= :implement (get-in event [:phase/transition-request :transition/target])))))))

--- a/docs/pull-requests/2026-04-22-feat-phase-outcome-events.md
+++ b/docs/pull-requests/2026-04-22-feat-phase-outcome-events.md
@@ -1,0 +1,68 @@
+# feat: normalize phase transition requests into explicit outcomes
+
+## Overview
+
+Remove phase-owned workflow steering via `:redirect-to` and replace it with
+an explicit transition-request contract owned by the `phase` component.
+Workflow execution now translates that semantic request into machine events.
+
+## Motivation
+
+`#638` made the execution machine authoritative for workflow progression, but
+software-factory phases were still steering control flow directly by writing
+`:redirect-to` into phase results. That left workflow semantics leaking upward
+from phase implementations into the runner contract.
+
+This slice makes the boundary explicit:
+
+- phases request transitions semantically
+- workflow execution translates requests into machine events
+- event payloads publish the same request shape end-to-end
+
+## Changes In Detail
+
+- Add shared phase outcome helpers in `phase.phase-result`
+  - `transition-request`
+  - `transition-target`
+  - `redirect-requested?`
+  - `request-redirect`
+- Re-export those helpers in `phase.interface`
+- Refactor software-factory phases to request redirects explicitly
+  - `implement`
+  - `review`
+  - `verify`
+  - `release`
+- Refactor `workflow.execution/determine-phase-event` to consume transition
+  requests instead of reading `:redirect-to`
+- Update workflow phase-completion event publishing to include
+  `:phase/transition-request`
+- Update `event-stream.core` so emitted events preserve the new request shape
+- Update regression and phase-behavior tests to assert predicates/helpers
+  instead of reaching into the old `:redirect-to` field
+
+## Testing Plan
+
+- `clj-kondo --lint` on all touched source and test files
+- `bb test components/phase components/phase-software-factory components/workflow components/event-stream`
+- `bb pre-commit`
+
+## Deployment Plan
+
+No deployment step. This is an internal contract cleanup within the workflow
+execution stack.
+
+## Related Issues/PRs
+
+- Follows `#638`, which made the execution machine authoritative
+- Prepares the next slices:
+  - workflow snapshot persistence/resume from machine state
+  - supervision boundary extraction from `meta` terminology
+  - PR lifecycle FSM formalization
+
+## Checklist
+
+- [x] Phase redirect semantics moved into shared phase helpers
+- [x] Workflow execution consumes explicit transition requests
+- [x] Event payloads preserve transition requests
+- [x] Redirect-specific tests updated to the new contract
+- [x] Full pre-commit passes


### PR DESCRIPTION
# feat: normalize phase transition requests into explicit outcomes

## Overview

Remove phase-owned workflow steering via `:redirect-to` and replace it with
an explicit transition-request contract owned by the `phase` component.
Workflow execution now translates that semantic request into machine events.

## Motivation

`#638` made the execution machine authoritative for workflow progression, but
software-factory phases were still steering control flow directly by writing
`:redirect-to` into phase results. That left workflow semantics leaking upward
from phase implementations into the runner contract.

This slice makes the boundary explicit:

- phases request transitions semantically
- workflow execution translates requests into machine events
- event payloads publish the same request shape end-to-end

## Changes In Detail

- Add shared phase outcome helpers in `phase.phase-result`
  - `transition-request`
  - `transition-target`
  - `redirect-requested?`
  - `request-redirect`
- Re-export those helpers in `phase.interface`
- Refactor software-factory phases to request redirects explicitly
  - `implement`
  - `review`
  - `verify`
  - `release`
- Refactor `workflow.execution/determine-phase-event` to consume transition
  requests instead of reading `:redirect-to`
- Update workflow phase-completion event publishing to include
  `:phase/transition-request`
- Update `event-stream.core` so emitted events preserve the new request shape
- Update regression and phase-behavior tests to assert predicates/helpers
  instead of reaching into the old `:redirect-to` field

## Testing Plan

- `clj-kondo --lint` on all touched source and test files
- `bb test components/phase components/phase-software-factory components/workflow components/event-stream`
- `bb pre-commit`

## Deployment Plan

No deployment step. This is an internal contract cleanup within the workflow
execution stack.

## Related Issues/PRs

- Follows `#638`, which made the execution machine authoritative
- Prepares the next slices:
  - workflow snapshot persistence/resume from machine state
  - supervision boundary extraction from `meta` terminology
  - PR lifecycle FSM formalization

## Checklist

- [x] Phase redirect semantics moved into shared phase helpers
- [x] Workflow execution consumes explicit transition requests
- [x] Event payloads preserve transition requests
- [x] Redirect-specific tests updated to the new contract
- [x] Full pre-commit passes
