### PR TITLE
fix: tighten phase outcome standards follow-up

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -176,7 +176,8 @@
       (cond-> context (assoc :phase/context context))))
 
 (defn phase-completed [stream workflow-id phase & [result]]
-  (let [outcome (get result :outcome :success)]
+  (let [outcome (get result :outcome :success)
+        transition-request (get result :phase/transition-request)]
     (-> (create-envelope stream :workflow/phase-completed workflow-id
                          (str (name phase) " phase " (name outcome)))
         (assoc :workflow/phase phase
@@ -185,8 +186,7 @@
           (:duration-ms result) (assoc :phase/duration-ms (:duration-ms result))
           (:artifacts result) (assoc :phase/artifacts (:artifacts result))
           (:error result) (assoc :phase/error (:error result))
-          (:phase/transition-request result)
-          (assoc :phase/transition-request (:phase/transition-request result))
+          transition-request (assoc :phase/transition-request transition-request)
           (:tokens result) (assoc :phase/tokens (:tokens result))
           (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))))))
 

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -21,6 +21,7 @@
    OCI events, control-plane events, and sink integration."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.event-stream.core :as core]))
 
 ;------------------------------------------------------------------------------ Helpers
@@ -372,10 +373,9 @@
     (let [stream (no-op-stream)
           wf-id (random-uuid)
           event (core/phase-completed stream wf-id :review
-                                      {:outcome :failure
-                                       :phase/transition-request
-                                       {:transition/type :transition/redirect
-                                        :transition/target :implement}})]
+                                      (phase/request-redirect
+                                       {:outcome :failure}
+                                       :implement))]
       (is (= :failure (:phase/outcome event)))
       (is (= :implement
              (get-in event [:phase/transition-request :transition/target]))))))

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj
@@ -463,7 +463,8 @@
   [ctx ex]
   (let [iterations (get-in ctx [:phase :iterations] 0)
         max-iterations (get-in ctx [:phase :budget :iterations] 5)
-        on-fail (get-in ctx [:phase-config :on-fail])]
+        on-fail (get-in ctx [:phase-config :on-fail])
+        error-map (phase/exception-error ex)]
     (cond
       ;; Within budget - retry
       (< iterations max-iterations)
@@ -475,16 +476,15 @@
       ;; Has on-fail transition - redirect
       on-fail
       (let [phase-result (-> (:phase ctx)
-                             (assoc :status :failed)
-                             (assoc :error (phase/exception-error ex))
-                             (phase/request-redirect on-fail))]
+                             (phase/fail-and-request-redirect
+                              error-map
+                              on-fail))]
         (assoc ctx :phase phase-result))
 
       ;; No recovery - propagate
       :else
       (-> ctx
-          (assoc-in [:phase :status] :failed)
-          (assoc-in [:phase :error] (phase/exception-error ex))))))
+          (assoc :phase (phase/fail-phase (:phase ctx) error-map))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Registry method

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/release.clj
@@ -387,7 +387,8 @@
   [ctx ex]
   (let [iterations (get-in ctx [:phase :iterations] 0)
         max-iterations (get-in ctx [:phase :budget :iterations] 2)
-        on-fail (get-in ctx [:phase-config :on-fail])]
+        on-fail (get-in ctx [:phase-config :on-fail])
+        error-map (phase/exception-error ex)]
     (cond
       ;; Within budget - retry
       (< iterations max-iterations)
@@ -399,16 +400,15 @@
       ;; Has on-fail transition - redirect
       on-fail
       (let [phase-result (-> (:phase ctx)
-                             (assoc :status :failed)
-                             (assoc :error (phase/exception-error ex))
-                             (phase/request-redirect on-fail))]
+                             (phase/fail-and-request-redirect
+                              error-map
+                              on-fail))]
         (assoc ctx :phase phase-result))
 
       ;; No recovery - propagate
       :else
       (-> ctx
-          (assoc-in [:phase :status] :failed)
-          (assoc-in [:phase :error] (phase/exception-error ex))))))
+          (assoc :phase (phase/fail-phase (:phase ctx) error-map)))))) 
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Registry methods

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/review.clj
@@ -189,7 +189,9 @@
   [ctx ex]
   (let [iterations (get-in ctx [:phase :iterations] 0)
         max-iterations (get-in ctx [:phase :budget :iterations] 2)
-        on-fail (get-in ctx [:phase-config :on-fail])]
+        on-fail (get-in ctx [:phase-config :on-fail])
+        error-map {:message (ex-message ex)
+                   :data (ex-data ex)}]
     (cond
       ;; Within budget - retry
       (< iterations max-iterations)
@@ -201,18 +203,12 @@
       ;; Has on-fail transition - redirect
       on-fail
       (let [phase-result (-> (:phase ctx)
-                             (assoc :status :failed)
-                             (assoc :error {:message (ex-message ex)
-                                            :data (ex-data ex)})
-                             (phase/request-redirect on-fail))]
+                             (phase/fail-and-request-redirect error-map on-fail))]
         (assoc ctx :phase phase-result))
 
       ;; No recovery - propagate
       :else
-      (-> ctx
-          (assoc-in [:phase :status] :failed)
-          (assoc-in [:phase :error] {:message (ex-message ex)
-                                     :data (ex-data ex)})))))
+      (assoc ctx :phase (phase/fail-phase (:phase ctx) error-map)))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Registry method

--- a/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
+++ b/components/phase-software-factory/src/ai/miniforge/phase_software_factory/verify.clj
@@ -271,7 +271,8 @@
   [ctx ex]
   (let [iterations (get-in ctx [:phase :iterations] 0)
         max-iterations (get-in ctx [:phase :budget :iterations] 3)
-        on-fail (get-in ctx [:phase-config :on-fail])]
+        on-fail (get-in ctx [:phase-config :on-fail])
+        error-map (phase/exception-error ex)]
     (cond
       ;; Within budget - retry
       (< iterations max-iterations)
@@ -283,16 +284,15 @@
       ;; Has on-fail transition - redirect
       on-fail
       (let [phase-result (-> (:phase ctx)
-                             (assoc :status :failed)
-                             (assoc :error (phase/exception-error ex))
-                             (phase/request-redirect on-fail))]
+                             (phase/fail-and-request-redirect
+                              error-map
+                              on-fail))]
         (assoc ctx :phase phase-result))
 
       ;; No recovery - propagate
       :else
       (-> ctx
-          (assoc-in [:phase :status] :failed)
-          (assoc-in [:phase :error] (phase/exception-error ex))))))
+          (assoc :phase (phase/fail-phase (:phase ctx) error-map))))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Registry method

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/review_repair_loop_test.clj
@@ -60,7 +60,7 @@
 (deftest changes-requested-sets-failed-status
   (testing "changes-requested sets :failed status (not :retrying)"
     (let [phase (simulate-leave-review :changes-requested 1 4)]
-      (is (= :failed (:status phase))
+      (is (phase/failed? phase)
           "Status should be :failed so execution can follow the transition request")
       (is (not (phase/retrying? phase))
           "Should NOT be retrying (would cause review to re-run in place)"))))
@@ -76,7 +76,7 @@
 (deftest changes-requested-over-budget-no-redirect
   (testing "changes-requested at max iterations fails without redirect"
     (let [phase (simulate-leave-review :changes-requested 4 4)]
-      (is (= :failed (:status phase))
+      (is (phase/failed? phase)
           "Should be failed")
       (is (not (phase/redirect-requested? phase))
           "Should NOT redirect — iteration budget exhausted"))))
@@ -93,7 +93,7 @@
 (deftest rejected-redirects-to-implement-like-changes-requested
   (testing "iter-23 regression: :rejected decision must trigger redirect, not :completed"
     (let [phase (simulate-leave-review :rejected 1 4)]
-      (is (= :failed (:status phase))
+      (is (phase/failed? phase)
           "Rejected must set :failed — falling through to :completed lets an empty-diff PR open")
       (is (= :implement (phase/transition-target phase))
           "Rejected within budget must redirect to implement like :changes-requested"))))
@@ -101,13 +101,13 @@
 (deftest rejected-over-budget-no-redirect
   (testing ":rejected at max iterations fails terminally (no redirect)"
     (let [phase (simulate-leave-review :rejected 4 4)]
-      (is (= :failed (:status phase)))
+      (is (phase/failed? phase))
       (is (not (phase/redirect-requested? phase))))))
 
 (deftest approved-sets-completed-status
   (testing "approved review sets :completed status"
     (let [phase (simulate-leave-review :approved 1 4)]
-      (is (= :completed (:status phase))
+      (is (phase/succeeded? phase)
           "Approved review should complete normally")
       (is (not (phase/redirect-requested? phase))
           "No redirect needed for approved review"))))

--- a/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
+++ b/components/phase-software-factory/test/ai/miniforge/phase_software_factory/verify_failure_modes_test.clj
@@ -137,7 +137,7 @@
                               :implement)
           result (verify/leave-verify ctx)]
       (is (= :implement (phase/transition-target (get result :phase))))
-      (is (= :failed (get-in result [:phase :status]))))))
+      (is (phase/failed? (get result :phase))))))
 
 (deftest leave-verify-no-redirect-on-timeout-test
   (testing "timeout error does NOT redirect even with :on-fail configured"
@@ -146,7 +146,7 @@
                               :implement)
           result (verify/leave-verify ctx)]
       (is (not (phase/redirect-requested? (get result :phase))))
-      (is (= :failed (get-in result [:phase :status])))
+      (is (phase/failed? (get result :phase)))
       (is (true? (get-in result [:phase :error :timeout?]))))))
 
 (deftest leave-verify-no-redirect-on-rate-limit-test
@@ -156,7 +156,7 @@
                               :implement)
           result (verify/leave-verify ctx)]
       (is (not (phase/redirect-requested? (get result :phase))))
-      (is (= :failed (get-in result [:phase :status])))
+      (is (phase/failed? (get result :phase)))
       (is (some? (get-in result [:phase :error :rate-limited?]))))
 
     (testing "rate-limit variant: you've hit your limit"
@@ -173,7 +173,7 @@
                               nil)
           result (verify/leave-verify ctx)]
       (is (not (phase/redirect-requested? (get result :phase))))
-      (is (= :failed (get-in result [:phase :status]))))))
+      (is (phase/failed? (get result :phase))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 

--- a/components/phase/src/ai/miniforge/phase/interface.clj
+++ b/components/phase/src/ai/miniforge/phase/interface.clj
@@ -218,9 +218,17 @@
   "Build a skipped-phase result for phases that short-circuit."
   phase-result/skipped)
 
+(def fail-phase
+  "Mark a phase state as failed and attach the error map."
+  phase-result/fail-phase)
+
 (def request-redirect
   "Attach a redirect transition request to a phase result."
   phase-result/request-redirect)
+
+(def fail-and-request-redirect
+  "Mark a phase state as failed and request a redirect transition."
+  phase-result/fail-and-request-redirect)
 
 (def test-metrics
   "Build a standard test-phase metrics map."

--- a/components/phase/src/ai/miniforge/phase/phase_result.clj
+++ b/components/phase/src/ai/miniforge/phase/phase_result.clj
@@ -150,12 +150,26 @@
    :output  {:skipped true :reason reason}
    :metrics {:tokens 0 :duration-ms 0 :cost-usd 0.0}})
 
+(defn fail-phase
+  "Mark a phase state as failed and attach the error map."
+  [phase-state error]
+  (-> phase-state
+      (assoc :status :failed)
+      (assoc :error error)))
+
 (defn request-redirect
   "Attach a redirect transition request to a phase result."
   [result target-phase]
   (assoc result transition-request-key
          {transition-type-key   redirect-transition-type
           transition-target-key target-phase}))
+
+(defn fail-and-request-redirect
+  "Mark a phase state as failed and request a redirect transition."
+  [phase-state error target-phase]
+  (-> phase-state
+      (fail-phase error)
+      (request-redirect target-phase)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-04-22-fix-phase-outcome-standards-followup.md
+++ b/docs/pull-requests/2026-04-22-fix-phase-outcome-standards-followup.md
@@ -1,0 +1,54 @@
+# fix: tighten phase outcome standards follow-up
+
+## Overview
+
+Apply the review-driven cleanup that should have landed after `#639`:
+remove duplicated failure/redirect construction, use shared phase helpers
+more consistently in tests, and keep the event-stream tests deterministic.
+
+## Motivation
+
+`#639` landed the phase transition-request contract, but the review found a
+few standards gaps in the follow-up delta:
+
+- duplicated failure/redirect construction in phase implementations
+- tests reaching into raw status fields where predicates/factories fit better
+- a deterministic file-sink test relying on filename ordering
+
+This PR is the standards cleanup that should have followed that merge.
+
+## Changes In Detail
+
+- Add shared phase helpers in `phase.phase-result`
+  - `fail-phase`
+  - `fail-and-request-redirect`
+- Re-export those helpers in `phase.interface`
+- Refactor `implement`, `review`, `verify`, and `release` error paths to use
+  the shared helpers instead of duplicating failure/redirect map construction
+- Update tests to prefer shared predicates/factories
+  - use `phase/failed?` and `phase/succeeded?`
+  - use `phase/request-redirect` in event-stream tests
+- Keep the file-sink test order-independent by asserting on event types rather
+  than directory listing order
+
+## Testing Plan
+
+- `clj-kondo --lint` on the touched source and test files
+- `bb test components/phase-software-factory components/workflow components/event-stream`
+- `bb pre-commit`
+
+## Deployment Plan
+
+No deployment step. This is a standards follow-up on top of the merged phase
+outcome refactor.
+
+## Related Issues/PRs
+
+- Follows merged `#639`
+
+## Checklist
+
+- [x] Duplicate failure/redirect construction removed
+- [x] Tests use shared predicates/factories where appropriate
+- [x] Event-stream sink test no longer depends on file ordering
+- [x] `bb pre-commit` passes


### PR DESCRIPTION
# fix: tighten phase outcome standards follow-up

## Overview

Apply the review-driven cleanup that should have landed after `#639`:
remove duplicated failure/redirect construction, use shared phase helpers
more consistently in tests, and keep the event-stream tests deterministic.

## Motivation

`#639` landed the phase transition-request contract, but the review found a
few standards gaps in the follow-up delta:

- duplicated failure/redirect construction in phase implementations
- tests reaching into raw status fields where predicates/factories fit better
- a deterministic file-sink test relying on filename ordering

This PR is the standards cleanup that should have followed that merge.

## Changes In Detail

- Add shared phase helpers in `phase.phase-result`
  - `fail-phase`
  - `fail-and-request-redirect`
- Re-export those helpers in `phase.interface`
- Refactor `implement`, `review`, `verify`, and `release` error paths to use
  the shared helpers instead of duplicating failure/redirect map construction
- Update tests to prefer shared predicates/factories
  - use `phase/failed?` and `phase/succeeded?`
  - use `phase/request-redirect` in event-stream tests
- Keep the file-sink test order-independent by asserting on event types rather
  than directory listing order

## Testing Plan

- `clj-kondo --lint` on the touched source and test files
- `bb test components/phase-software-factory components/workflow components/event-stream`
- `bb pre-commit`

## Deployment Plan

No deployment step. This is a standards follow-up on top of the merged phase
outcome refactor.

## Related Issues/PRs

- Follows merged `#639`

## Checklist

- [x] Duplicate failure/redirect construction removed
- [x] Tests use shared predicates/factories where appropriate
- [x] Event-stream sink test no longer depends on file ordering
- [x] `bb pre-commit` passes
