### PR TITLE
refactor: extract workflow supervision boundary

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface.clj
+++ b/components/agent/src/ai/miniforge/agent/interface.clj
@@ -30,6 +30,7 @@
    [ai.miniforge.agent.interface.protocols :as protocols]
    [ai.miniforge.agent.interface.runtime :as runtime]
    [ai.miniforge.agent.interface.specialized :as specialized]
+   [ai.miniforge.agent.interface.supervision :as supervision]
    [ai.miniforge.agent.tool-supervisor :as tool-supervisor]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -159,6 +160,11 @@
 (def reset-all-meta-agents! meta/reset-all-meta-agents!)
 (def get-meta-check-history meta/get-meta-check-history)
 (def get-meta-agent-stats meta/get-meta-agent-stats)
+(def create-supervision-coordinator supervision/create-supervision-coordinator)
+(def check-all-supervisors supervision/check-all-supervisors)
+(def reset-all-supervisors! supervision/reset-all-supervisors!)
+(def get-supervision-check-history supervision/get-supervision-check-history)
+(def get-supervisor-stats supervision/get-supervisor-stats)
 (def run-meta-loop-cycle! meta/run-meta-loop-cycle!)
 (def create-meta-loop-context meta/create-meta-loop-context)
 (def record-workflow-outcome! meta/record-workflow-outcome!)

--- a/components/agent/src/ai/miniforge/agent/interface/supervision.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/supervision.clj
@@ -1,0 +1,37 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.agent.interface.supervision
+  "Live workflow supervision API.
+
+   This namespace provides a workflow-facing supervision boundary over the
+   current meta-coordinator implementation, without changing the underlying
+   runtime behavior."
+  (:require
+   [ai.miniforge.agent.meta-coordinator :as meta-coord]
+   [ai.miniforge.agent.meta.progress-monitor :as progress-monitor]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Supervision runtime operations
+
+(def create-progress-monitor-agent progress-monitor/create-progress-monitor-agent)
+(def create-supervision-coordinator meta-coord/create-coordinator)
+(def check-all-supervisors meta-coord/check-all-agents)
+(def reset-all-supervisors! meta-coord/reset-all-agents!)
+(def get-supervision-check-history meta-coord/get-check-history)
+(def get-supervisor-stats meta-coord/get-agent-stats)

--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -32,6 +32,10 @@
   :phase/gate-failed-phase   "Gate validation failed for phase {phase}"
   :phase/agent-failed-phase  "Agent failed in phase {phase}"
 
+  ;; Supervision
+  :supervision/unsupported-supervisor
+  "Unsupported workflow supervisor id: {supervisor-id}"
+
   ;; Execution mode
   :governed/no-capsule      "No capsule executor available for governed workflow"
   :governed/no-capsule-hint "Start Docker or configure a Kubernetes cluster"

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -88,8 +88,8 @@
    ### Artifacts & Tracking
    :execution/artifacts        — Vector of lightweight provenance artifacts
                                  produced by phases (not serialized code)
-   :execution/files-written    — Set of file paths written (meta-agent
-                                 monitoring; populated from environment)
+   :execution/files-written    — Set of file paths written (supervision
+                                 tracking; populated from environment)
    :execution/metrics          — Accumulated metrics:
                                  {:tokens N :cost-usd N :duration-ms N}
    :execution/started-at       — System time millis at workflow start
@@ -100,8 +100,8 @@
    :execution/response-chain   — Structured response chain (per-phase
                                  success/failure tracking)
 
-   ### Meta-Agent Support
-   :execution/meta-coordinator    — Coordinator for workflow health monitoring
+   ### Supervision Support
+   :execution/supervision-runtime — Runtime for workflow health supervision
    :execution/streaming-activity  — Transient streaming activity tracking
 
    ### Pass-Through from opts
@@ -173,9 +173,9 @@
   (let [execution-machine (fsm/compile-execution-machine workflow)
         fsm-state (let [initial-state (fsm/initialize-execution execution-machine)]
                     (fsm/start-execution execution-machine initial-state))
-        ;; Initialize meta-agents and coordinator
-        meta-agents (monitoring/create-meta-agents workflow)
-        coordinator (agent/create-meta-coordinator meta-agents)]
+        ;; Initialize live workflow supervision runtime.
+        supervisors (monitoring/create-supervisors workflow)
+        supervision-runtime (agent/create-supervision-coordinator supervisors)]
     (sync-machine-projections
      (merge
       {:execution/id (random-uuid)
@@ -193,9 +193,9 @@
        :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
        :execution/started-at (System/currentTimeMillis)
        :execution/opts opts
-       ;; Meta-agent coordinator for workflow health monitoring
-       :execution/meta-coordinator coordinator
-       ;; Transient state for meta-agent health checks
+       ;; Live workflow supervision runtime
+       :execution/supervision-runtime supervision-runtime
+       ;; Transient state for supervision checks
        :execution/streaming-activity []
        :execution/files-written #{}}
       ;; Merge opts into top-level context so :llm-backend is accessible to agents

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -102,6 +102,8 @@
 
    ### Supervision Support
    :execution/supervision-runtime — Runtime for workflow health supervision
+   :execution/meta-coordinator    — DEPRECATED alias for
+                                    :execution/supervision-runtime
    :execution/streaming-activity  — Transient streaming activity tracking
 
    ### Pass-Through from opts
@@ -195,6 +197,9 @@
        :execution/opts opts
        ;; Live workflow supervision runtime
        :execution/supervision-runtime supervision-runtime
+       ;; DEPRECATED: Temporary backwards-compatible alias for integration and
+       ;; end-to-end tests that still read the pre-refactor execution key.
+       :execution/meta-coordinator supervision-runtime
        ;; Transient state for supervision checks
        :execution/streaming-activity []
        :execution/files-written #{}}

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -187,7 +187,7 @@
           (get phase-result :metrics {})))
 
 (defn track-phase-files
-  "Track files written by phase for meta-agent monitoring.
+  "Track files written by phase for workflow supervision.
 
    In the new environment model, code changes live in the execution
    environment's git working tree (:execution/worktree-path) rather than

--- a/components/workflow/src/ai/miniforge/workflow/monitoring.clj
+++ b/components/workflow/src/ai/miniforge/workflow/monitoring.clj
@@ -17,39 +17,43 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.workflow.monitoring
-  "Meta-agent health monitoring integration.
+  "Workflow supervision integration.
 
-   Provides functions for building workflow state, checking health via meta-agent
-   coordinator, and handling halt conditions."
-  (:require [ai.miniforge.agent.interface :as agent]
+   Provides functions for building workflow state, checking health via the
+   live supervision runtime, and handling halt conditions."
+  (:require [ai.miniforge.agent.interface.supervision :as supervision]
             [ai.miniforge.response.interface :as response]))
 
-;------------------------------------------------------------------------------ Meta-agent setup
+;------------------------------------------------------------------------------ Supervision setup
 
-(defn create-meta-agents
-  "Create meta-agents from workflow configuration.
+(def default-progress-monitor-config
+  "Default progress-monitor config when workflow config does not override it."
+  {:check-interval-ms 30000
+   :stagnation-threshold-ms 120000
+   :max-total-ms 600000})
 
-   Falls back to default progress monitor if no meta-agents configured."
+(defn create-supervisors
+  "Create supervisors from workflow configuration.
+
+   Falls back to the default progress monitor if no supervisors are configured."
   [workflow]
-  (let [meta-agent-configs (get workflow :workflow/meta-agents [])]
-    (if (seq meta-agent-configs)
-      ;; Use configured meta-agents
-      (for [config meta-agent-configs
+  (let [supervisor-configs (get workflow :workflow/meta-agents [])]
+    (if (seq supervisor-configs)
+      ;; Use configured supervisors from the existing workflow config key.
+      (for [config supervisor-configs
             :when (:enabled? config true)]
         (case (:id config)
           :progress-monitor
-          (agent/create-progress-monitor-agent
-           (merge {:check-interval-ms 30000
-                   :stagnation-threshold-ms 120000
-                   :max-total-ms 600000}
+          (supervision/create-progress-monitor-agent
+           (merge default-progress-monitor-config
                   (:config config)))))
       ;; Default: just progress monitor
-      [(agent/create-progress-monitor-agent)])))
+      [(supervision/create-progress-monitor-agent)])))
 
 ;------------------------------------------------------------------------------ Health monitoring
 
-(defn build-workflow-state
-  "Build workflow state map for meta-agent health checks."
+(defn build-supervision-state
+  "Build workflow state map for supervision checks."
   [ctx iteration]
   {:workflow/id (:execution/workflow-id ctx)
    :workflow/phase (:execution/current-phase ctx)
@@ -58,30 +62,36 @@
    :workflow/streaming-activity (:execution/streaming-activity ctx)
    :workflow/files-written (:execution/files-written ctx)})
 
-(defn check-workflow-health
-  "Run meta-agent health checks on workflow state.
+(defn check-workflow-supervision
+  "Run workflow supervision checks on workflow state.
 
-   Returns health check result."
-  [coordinator workflow-state]
-  (agent/check-all-meta-agents coordinator workflow-state))
+   Returns supervision result."
+  [runtime workflow-state]
+  (supervision/check-all-supervisors runtime workflow-state))
 
-(defn handle-meta-agent-halt
-  "Handle meta-agent halt signal by transitioning workflow to failed state."
-  [ctx health-check transition-to-failed-fn]
-  (-> ctx
-      (update :execution/errors conj
-              {:type :meta-agent-halt
-               :agent (:halting-agent health-check)
-               :message (:halt-reason health-check)
-               :data (:data (first (filter #(= :halt (:status %))
-                                           (:checks health-check))))})
-      (update :execution/response-chain
-              response/add-failure :meta-agent
-              :anomalies.workflow/halted-by-meta-agent
-              {:agent (:halting-agent health-check)
-               :reason (:halt-reason health-check)
-               :checks (:checks health-check)})
-      (transition-to-failed-fn)))
+(defn- halting-check
+  [supervision-result]
+  (first (filter #(= :halt (:status %))
+                 (:checks supervision-result))))
+
+(defn handle-supervision-halt
+  "Handle supervision halt signal by transitioning workflow to failed state."
+  [ctx supervision-result transition-to-failed-fn]
+  (let [halting-check (halting-check supervision-result)
+        supervisor-id (:halting-agent supervision-result)]
+    (-> ctx
+        (update :execution/errors conj
+                {:type :supervision-halt
+                 :supervisor supervisor-id
+                 :message (:halt-reason supervision-result)
+                 :data (:data halting-check)})
+        (update :execution/response-chain
+                response/add-failure :supervision
+                :anomalies.workflow/halted-by-supervision
+                {:supervisor supervisor-id
+                 :reason (:halt-reason supervision-result)
+                 :checks (:checks supervision-result)})
+        (transition-to-failed-fn))))
 
 (defn clear-transient-state
   "Clear transient state after phase execution to prevent memory buildup."

--- a/components/workflow/src/ai/miniforge/workflow/monitoring.clj
+++ b/components/workflow/src/ai/miniforge/workflow/monitoring.clj
@@ -22,6 +22,7 @@
    Provides functions for building workflow state, checking health via the
    live supervision runtime, and handling halt conditions."
   (:require [ai.miniforge.agent.interface.supervision :as supervision]
+            [ai.miniforge.workflow.messages :as messages]
             [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Supervision setup
@@ -32,6 +33,30 @@
    :stagnation-threshold-ms 120000
    :max-total-ms 600000})
 
+(defn- enabled-supervisor?
+  [config]
+  (get config :enabled? true))
+
+(defn- unsupported-supervisor-exception
+  [config]
+  (let [supervisor-id (:id config)]
+    (ex-info
+     (messages/t :supervision/unsupported-supervisor
+                 {:supervisor-id (pr-str supervisor-id)})
+     {:anomaly/category :anomalies.workflow/invalid-supervisor
+      :supervisor/id supervisor-id
+      :supervisor/config config})))
+
+(defn- create-configured-supervisor
+  [config]
+  (let [supervisor-id (:id config)
+        supervisor-config (:config config)]
+    (case supervisor-id
+      :progress-monitor
+      (supervision/create-progress-monitor-agent
+       (merge default-progress-monitor-config supervisor-config))
+      (throw (unsupported-supervisor-exception config)))))
+
 (defn create-supervisors
   "Create supervisors from workflow configuration.
 
@@ -39,14 +64,9 @@
   [workflow]
   (let [supervisor-configs (get workflow :workflow/meta-agents [])]
     (if (seq supervisor-configs)
-      ;; Use configured supervisors from the existing workflow config key.
-      (for [config supervisor-configs
-            :when (:enabled? config true)]
-        (case (:id config)
-          :progress-monitor
-          (supervision/create-progress-monitor-agent
-           (merge default-progress-monitor-config
-                  (:config config)))))
+      (->> supervisor-configs
+           (filter enabled-supervisor?)
+           (mapv create-configured-supervisor))
       ;; Default: just progress monitor
       [(supervision/create-progress-monitor-agent)])))
 

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -185,11 +185,16 @@
   [pipeline context callbacks iteration control-state]
   (await-resume! control-state)
   (check-stopped! control-state)
-  (let [coordinator (:execution/meta-coordinator context)
-        workflow-state (monitoring/build-workflow-state context iteration)
-        health-check (monitoring/check-workflow-health coordinator workflow-state)]
-    (if (= :halt (:status health-check))
-      (monitoring/handle-meta-agent-halt context health-check ctx/transition-to-failed)
+  (let [supervision-runtime (:execution/supervision-runtime context)
+        workflow-state (monitoring/build-supervision-state context iteration)
+        supervision-result (monitoring/check-workflow-supervision
+                            supervision-runtime
+                            workflow-state)]
+    (if (= :halt (:status supervision-result))
+      (monitoring/handle-supervision-halt
+       context
+       supervision-result
+       ctx/transition-to-failed)
       (let [phase-ctx (-> (exec/execute-phase-step pipeline context callbacks
                                                    ctx/merge-metrics
                                                    ctx/transition-to-completed

--- a/components/workflow/test/ai/miniforge/workflow/monitoring_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/monitoring_test.clj
@@ -1,0 +1,43 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.monitoring-test
+  (:require
+   [ai.miniforge.workflow.monitoring :as monitoring]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest create-supervisors-defaults-test
+  (testing "create-supervisors falls back to the default progress monitor"
+    (let [supervisors (monitoring/create-supervisors {:workflow/id :test})]
+      (is (= 1 (count supervisors))))))
+
+(deftest create-supervisors-invalid-id-test
+  (testing "create-supervisors fails fast on unsupported supervisor ids"
+    (let [workflow {:workflow/id :test
+                    :workflow/meta-agents [{:id :unknown-supervisor}]}
+          result (try
+                   (monitoring/create-supervisors workflow)
+                   nil
+                   (catch clojure.lang.ExceptionInfo ex
+                     ex))]
+      (is (instance? clojure.lang.ExceptionInfo result))
+      (let [data (ex-data result)]
+        (is (= :anomalies.workflow/invalid-supervisor
+               (:anomaly/category data)))
+        (is (= :unknown-supervisor
+               (:supervisor/id data)))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_iteration_test.clj
@@ -5,6 +5,8 @@
    Includes slingshot try+/throw+ bb-compatibility tests."
   (:require
    [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.workflow.context :as ctx]
+   [ai.miniforge.workflow.monitoring :as monitoring]
    [ai.miniforge.workflow.runner :as runner]
    [slingshot.slingshot :refer [try+ throw+]]))
 
@@ -12,6 +14,18 @@
 (def ^:private rate-limited? #'runner/rate-limited?)
 (defn- backoff-ms [n] (#'runner/backoff-ms n))
 (def ^:private make-execution-error #'runner/make-execution-error)
+
+(defn- running-control-state
+  []
+  (atom {:paused false :stopped false :adjustments {}}))
+
+(defn- halted-supervision-result
+  []
+  {:status :halt
+   :halt-reason "workflow stalled"
+   :halting-agent :progress-monitor
+   :checks [{:status :halt
+             :data {:elapsed-ms 120000}}]})
 
 ;; ============================================================================
 ;; rate-limited?
@@ -113,3 +127,28 @@
                      {:caught true :message message}))]
       (is (true? (:caught result)))
       (is (= "stopped" (:message result))))))
+
+;; ============================================================================
+;; execute-single-iteration
+;; ============================================================================
+
+(deftest execute-single-iteration-halts-on-supervision-test
+  (testing "supervision halt transitions the workflow to failed"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :done}]}
+          context (ctx/create-context workflow {:task "Test"} {})
+          result (with-redefs [monitoring/check-workflow-supervision
+                               (fn [_runtime _workflow-state]
+                                 (halted-supervision-result))]
+                   (runner/execute-single-iteration
+                    []
+                    context
+                    {}
+                    1
+                    (running-control-state)))]
+      (is (= :failed (:execution/status result)))
+      (is (some #(= :supervision-halt (:type %))
+                (:execution/errors result)))
+      (is (= :progress-monitor
+             (:supervisor (last (:execution/errors result))))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -40,6 +40,9 @@
       (is (= :running (:execution/status ctx)))
       (is (= {:task "Test"} (:execution/input ctx)))
       (is (contains? ctx :execution/supervision-runtime))
+      (is (contains? ctx :execution/meta-coordinator))
+      (is (identical? (:execution/supervision-runtime ctx)
+                      (:execution/meta-coordinator ctx)))
       (is (vector? (:execution/artifacts ctx)))
       (is (number? (:execution/started-at ctx))))))
 

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -39,6 +39,7 @@
       (is (= :test (:execution/workflow-id ctx)))
       (is (= :running (:execution/status ctx)))
       (is (= {:task "Test"} (:execution/input ctx)))
+      (is (contains? ctx :execution/supervision-runtime))
       (is (vector? (:execution/artifacts ctx)))
       (is (number? (:execution/started-at ctx))))))
 

--- a/docs/pull-requests/2026-04-23-refactor-workflow-supervision-boundary.md
+++ b/docs/pull-requests/2026-04-23-refactor-workflow-supervision-boundary.md
@@ -1,0 +1,73 @@
+# refactor: extract workflow supervision boundary
+
+## Overview
+
+Rename the workflow runtime's live monitoring boundary from `meta` to
+`supervision` without changing the underlying behavior. This keeps the
+workflow runner aligned with the merged architecture/spec direction while the
+existing coordinator implementation remains in place underneath.
+
+## Motivation
+
+The workflow runtime was still wired through `meta` terminology:
+
+- `:execution/meta-coordinator`
+- `workflow.monitoring/create-meta-agents`
+- `workflow.monitoring/check-workflow-health`
+- `workflow.monitoring/handle-meta-agent-halt`
+
+That conflated live workflow supervision with the learning/meta loop. This PR
+separates the runtime boundary first, without trying to move the underlying
+implementation in the same slice.
+
+## Changes In Detail
+
+- Add a workflow-facing supervision interface in
+  `agent.interface.supervision`
+- Re-export supervision operations from `agent.interface`
+  - `create-supervision-coordinator`
+  - `check-all-supervisors`
+  - `reset-all-supervisors!`
+  - `get-supervision-check-history`
+  - `get-supervisor-stats`
+- Refactor `workflow.context` to initialize and store
+  `:execution/supervision-runtime`
+- Refactor `workflow.monitoring` to expose supervision-facing helpers
+  - `create-supervisors`
+  - `build-supervision-state`
+  - `check-workflow-supervision`
+  - `handle-supervision-halt`
+- Keep the underlying coordinator implementation unchanged by adapting the
+  boundary over the existing meta-coordinator
+- Translate workflow halt reporting to supervision terminology
+  - `:supervision-halt`
+  - `:anomalies.workflow/halted-by-supervision`
+- Add workflow tests for:
+  - context initialization with `:execution/supervision-runtime`
+  - supervision halt transitioning an iteration to failed
+
+## Testing Plan
+
+- `clj-kondo --lint` on touched source and test files
+- `bb test components/agent components/workflow`
+- `bb pre-commit`
+
+## Deployment Plan
+
+No deployment step. This is a runtime-boundary refactor inside the workflow
+and agent components.
+
+## Related Issues/PRs
+
+- Follows merged `#640`
+- Prepares the next slices:
+  - supervision FSM / intervention lifecycle
+  - learning-loop ownership cleanup
+  - workflow machine snapshot persistence/resume
+
+## Checklist
+
+- [x] Workflow runtime no longer uses `meta` terminology for live supervision
+- [x] Underlying behavior preserved
+- [x] Halt path covered by tests
+- [x] `bb pre-commit` passes


### PR DESCRIPTION
# refactor: extract workflow supervision boundary

## Overview

Rename the workflow runtime's live monitoring boundary from `meta` to
`supervision` without changing the underlying behavior. This keeps the
workflow runner aligned with the merged architecture/spec direction while the
existing coordinator implementation remains in place underneath.

## Motivation

The workflow runtime was still wired through `meta` terminology:

- `:execution/meta-coordinator`
- `workflow.monitoring/create-meta-agents`
- `workflow.monitoring/check-workflow-health`
- `workflow.monitoring/handle-meta-agent-halt`

That conflated live workflow supervision with the learning/meta loop. This PR
separates the runtime boundary first, without trying to move the underlying
implementation in the same slice.

## Changes In Detail

- Add a workflow-facing supervision interface in
  `agent.interface.supervision`
- Re-export supervision operations from `agent.interface`
  - `create-supervision-coordinator`
  - `check-all-supervisors`
  - `reset-all-supervisors!`
  - `get-supervision-check-history`
  - `get-supervisor-stats`
- Refactor `workflow.context` to initialize and store
  `:execution/supervision-runtime`
- Refactor `workflow.monitoring` to expose supervision-facing helpers
  - `create-supervisors`
  - `build-supervision-state`
  - `check-workflow-supervision`
  - `handle-supervision-halt`
- Keep the underlying coordinator implementation unchanged by adapting the
  boundary over the existing meta-coordinator
- Translate workflow halt reporting to supervision terminology
  - `:supervision-halt`
  - `:anomalies.workflow/halted-by-supervision`
- Add workflow tests for:
  - context initialization with `:execution/supervision-runtime`
  - supervision halt transitioning an iteration to failed

## Testing Plan

- `clj-kondo --lint` on touched source and test files
- `bb test components/agent components/workflow`
- `bb pre-commit`

## Deployment Plan

No deployment step. This is a runtime-boundary refactor inside the workflow
and agent components.

## Related Issues/PRs

- Follows merged `#640`
- Prepares the next slices:
  - supervision FSM / intervention lifecycle
  - learning-loop ownership cleanup
  - workflow machine snapshot persistence/resume

## Checklist

- [x] Workflow runtime no longer uses `meta` terminology for live supervision
- [x] Underlying behavior preserved
- [x] Halt path covered by tests
- [x] `bb pre-commit` passes
