### PR TITLE
fix: remove duplicated workflow supervision payload maps

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/monitoring.clj
+++ b/components/workflow/src/ai/miniforge/workflow/monitoring.clj
@@ -37,6 +37,16 @@
   [config]
   (get config :enabled? true))
 
+(defn- progress-monitor-config
+  [config]
+  (merge default-progress-monitor-config
+         (get config :config {})))
+
+(defn- create-progress-monitor
+  [config]
+  (supervision/create-progress-monitor-agent
+   (progress-monitor-config config)))
+
 (defn- unsupported-supervisor-exception
   [config]
   (let [supervisor-id (:id config)]
@@ -49,12 +59,10 @@
 
 (defn- create-configured-supervisor
   [config]
-  (let [supervisor-id (:id config)
-        supervisor-config (:config config)]
+  (let [supervisor-id (:id config)]
     (case supervisor-id
       :progress-monitor
-      (supervision/create-progress-monitor-agent
-       (merge default-progress-monitor-config supervisor-config))
+      (create-progress-monitor config)
       (throw (unsupported-supervisor-exception config)))))
 
 (defn create-supervisors
@@ -68,7 +76,7 @@
            (filter enabled-supervisor?)
            (mapv create-configured-supervisor))
       ;; Default: just progress monitor
-      [(supervision/create-progress-monitor-agent)])))
+      [(create-progress-monitor {})])))
 
 ;------------------------------------------------------------------------------ Health monitoring
 
@@ -94,23 +102,38 @@
   (first (filter #(= :halt (:status %))
                  (:checks supervision-result))))
 
+(defn- supervision-halt-data
+  [supervision-result]
+  (let [halting-check' (halting-check supervision-result)]
+    {:supervisor (:halting-agent supervision-result)
+     :reason (:halt-reason supervision-result)
+     :checks (:checks supervision-result)
+     :data (:data halting-check')}))
+
+(defn- supervision-halt-error
+  [halt-data]
+  {:type :supervision-halt
+   :supervisor (:supervisor halt-data)
+   :message (:reason halt-data)
+   :data (:data halt-data)})
+
+(defn- supervision-halt-response
+  [halt-data]
+  {:supervisor (:supervisor halt-data)
+   :reason (:reason halt-data)
+   :checks (:checks halt-data)})
+
 (defn handle-supervision-halt
   "Handle supervision halt signal by transitioning workflow to failed state."
   [ctx supervision-result transition-to-failed-fn]
-  (let [halting-check (halting-check supervision-result)
-        supervisor-id (:halting-agent supervision-result)]
+  (let [halt-data (supervision-halt-data supervision-result)]
     (-> ctx
         (update :execution/errors conj
-                {:type :supervision-halt
-                 :supervisor supervisor-id
-                 :message (:halt-reason supervision-result)
-                 :data (:data halting-check)})
+                (supervision-halt-error halt-data))
         (update :execution/response-chain
                 response/add-failure :supervision
                 :anomalies.workflow/halted-by-supervision
-                {:supervisor supervisor-id
-                 :reason (:halt-reason supervision-result)
-                 :checks (:checks supervision-result)})
+                (supervision-halt-response halt-data))
         (transition-to-failed-fn))))
 
 (defn clear-transient-state

--- a/components/workflow/test/ai/miniforge/workflow/monitoring_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/monitoring_test.clj
@@ -18,13 +18,39 @@
 
 (ns ai.miniforge.workflow.monitoring-test
   (:require
+   [ai.miniforge.agent.interface.supervision :as supervision]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.monitoring :as monitoring]
    [clojure.test :refer [deftest is testing]]))
 
 (deftest create-supervisors-defaults-test
   (testing "create-supervisors falls back to the default progress monitor"
-    (let [supervisors (monitoring/create-supervisors {:workflow/id :test})]
-      (is (= 1 (count supervisors))))))
+    (let [captured-config (atom nil)
+          supervisors (with-redefs [supervision/create-progress-monitor-agent
+                                    (fn [config]
+                                      (reset! captured-config config)
+                                      :progress-monitor)]
+                        (monitoring/create-supervisors {:workflow/id :test}))]
+      (is (= [:progress-monitor] supervisors))
+      (is (= monitoring/default-progress-monitor-config
+             @captured-config)))))
+
+(deftest create-supervisors-merges-configured-progress-monitor-test
+  (testing "create-supervisors merges workflow overrides into the factory config"
+    (let [captured-config (atom nil)
+          workflow {:workflow/id :test
+                    :workflow/meta-agents
+                    [{:id :progress-monitor
+                      :config {:max-total-ms 900000}}]}
+          supervisors (with-redefs [supervision/create-progress-monitor-agent
+                                    (fn [config]
+                                      (reset! captured-config config)
+                                      :progress-monitor)]
+                        (monitoring/create-supervisors workflow))]
+      (is (= [:progress-monitor] supervisors))
+      (is (= (assoc monitoring/default-progress-monitor-config
+                    :max-total-ms 900000)
+             @captured-config)))))
 
 (deftest create-supervisors-invalid-id-test
   (testing "create-supervisors fails fast on unsupported supervisor ids"
@@ -41,3 +67,27 @@
                (:anomaly/category data)))
         (is (= :unknown-supervisor
                (:supervisor/id data)))))))
+
+(deftest handle-supervision-halt-builds-canonical-payloads-test
+  (testing "handle-supervision-halt reuses canonical halt payload builders"
+    (let [ctx {:execution/errors []
+               :execution/response-chain (response/create :workflow)}
+          supervision-result {:halt-reason "workflow stalled"
+                              :halting-agent :progress-monitor
+                              :checks [{:status :halt
+                                        :data {:elapsed-ms 120000}}]}
+          result (monitoring/handle-supervision-halt ctx
+                                                     supervision-result
+                                                     identity)]
+      (is (= {:type :supervision-halt
+              :supervisor :progress-monitor
+              :message "workflow stalled"
+              :data {:elapsed-ms 120000}}
+             (last (:execution/errors result))))
+      (is (= :anomalies.workflow/halted-by-supervision
+             (response/last-anomaly (:execution/response-chain result))))
+      (is (= {:supervisor :progress-monitor
+              :reason "workflow stalled"
+              :checks [{:status :halt
+                        :data {:elapsed-ms 120000}}]}
+             (response/last-response (:execution/response-chain result)))))))

--- a/docs/pull-requests/2026-04-23-fix-workflow-supervision-dry-factories.md
+++ b/docs/pull-requests/2026-04-23-fix-workflow-supervision-dry-factories.md
@@ -1,0 +1,47 @@
+# fix: remove ad hoc supervision payload duplication
+
+## Overview
+
+Tighten the merged workflow supervision boundary by replacing duplicated
+hand-built monitoring payload maps with small factory helpers in
+`workflow.monitoring`.
+
+## Motivation
+
+The supervision-boundary refactor landed the right architecture, but
+`workflow.monitoring` still had two regressions against the standards:
+
+- progress-monitor creation was split across ad hoc call sites
+- supervision halt payloads were hand-built inline in multiple shapes
+
+This keeps the slice small while restoring the factory/predicate style the
+repo expects.
+
+## Changes In Detail
+
+- Add `progress-monitor-config` and `create-progress-monitor`
+  - default and configured supervisor creation now share one factory path
+- Add `supervision-halt-data`, `supervision-halt-error`, and
+  `supervision-halt-response`
+  - `handle-supervision-halt` now consumes those factories instead of
+    hand-constructing duplicate maps inline
+- Extend `monitoring_test`
+  - default progress-monitor creation uses canonical config
+  - workflow overrides merge through the same factory
+  - halt handling emits the expected canonical error/response payloads
+
+## Testing Plan
+
+- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/monitoring.clj
+  components/workflow/test/ai/miniforge/workflow/monitoring_test.clj`
+- `bb test components/workflow`
+
+## Deployment Plan
+
+No deployment step. Internal workflow runtime cleanup only.
+
+## Checklist
+
+- [x] Removed duplicated ad hoc progress-monitor construction
+- [x] Removed duplicated ad hoc supervision halt payload maps
+- [x] Added direct tests for the new factories


### PR DESCRIPTION
# fix: remove ad hoc supervision payload duplication

## Overview

Tighten the merged workflow supervision boundary by replacing duplicated
hand-built monitoring payload maps with small factory helpers in
`workflow.monitoring`.

## Motivation

The supervision-boundary refactor landed the right architecture, but
`workflow.monitoring` still had two regressions against the standards:

- progress-monitor creation was split across ad hoc call sites
- supervision halt payloads were hand-built inline in multiple shapes

This keeps the slice small while restoring the factory/predicate style the
repo expects.

## Changes In Detail

- Add `progress-monitor-config` and `create-progress-monitor`
  - default and configured supervisor creation now share one factory path
- Add `supervision-halt-data`, `supervision-halt-error`, and
  `supervision-halt-response`
  - `handle-supervision-halt` now consumes those factories instead of
    hand-constructing duplicate maps inline
- Extend `monitoring_test`
  - default progress-monitor creation uses canonical config
  - workflow overrides merge through the same factory
  - halt handling emits the expected canonical error/response payloads

## Testing Plan

- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/monitoring.clj
  components/workflow/test/ai/miniforge/workflow/monitoring_test.clj`
- `bb test components/workflow`

## Deployment Plan

No deployment step. Internal workflow runtime cleanup only.

## Checklist

- [x] Removed duplicated ad hoc progress-monitor construction
- [x] Removed duplicated ad hoc supervision halt payload maps
- [x] Added direct tests for the new factories
