### PR TITLE
feat: add career-profile workflow family

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,7 @@ miniforge/
 │   ├── workflow/       # MiniForge Core — shared workflow runtime
 │   ├── workflow-software-factory/  # Miniforge product workflows
 │   ├── workflow-financial-etl/     # Data Foundry product workflows
+│   ├── workflow-career/            # Thesium Career product workflows
 │   ├── agent/          # AI agent implementations
 │   ├── loop/           # Inner loop (generate-validate-repair)
 │   └── ...

--- a/bb.edn
+++ b/bb.edn
@@ -518,6 +518,7 @@
                  "components/compliance-scanner/resources"
                  "components/workflow-compliance-scanner/src"
                  "components/workflow-compliance-scanner/resources"
+                 "components/workflow-career/resources"
                  "components/workflow-software-factory/resources"
                  "components/workflow-chain-software-factory/resources"
                  "components/pr-sync/src"

--- a/components/workflow-career/README.md
+++ b/components/workflow-career/README.md
@@ -1,0 +1,32 @@
+# Thesium Career Workflow Resources
+
+This component owns app-specific workflow resources for **Thesium Career**.
+
+The initial scope is the first agentic workflow family over the career
+knowledge-graph tool surface:
+
+- `career-profile`
+
+Later slices should add the sibling workflow resources for ranking and
+Lens generation beside this component rather than pushing product
+workflows back into the shared `workflow` component.
+
+## What This Component Owns
+
+- career workflow definitions under `resources/workflows/`
+- career-owned workflow tests under `test/`
+
+## Why This Exists
+
+The shared `workflow` component is the kernel. Product workflow
+families belong in app-owned components that compose into the kernel
+through the classpath.
+
+That keeps:
+
+- product-specific workflow ids
+- KG tool requirements
+- policy-pack references
+- phase budgets and workflow defaults
+
+in data surfaces owned by the career product layer.

--- a/components/workflow-career/deps.edn
+++ b/components/workflow-career/deps.edn
@@ -1,0 +1,4 @@
+{:paths ["src" "resources"]
+ :deps {ai.miniforge/logging {:local/root "../logging"}
+        ai.miniforge/schema  {:local/root "../schema"}}
+ :aliases {:test {:extra-paths ["test"]}}}

--- a/components/workflow-career/resources/workflows/career-profile-v1.0.0.edn
+++ b/components/workflow-career/resources/workflows/career-profile-v1.0.0.edn
@@ -1,0 +1,70 @@
+{:workflow/id :career-profile
+ :workflow/version "1.0.0"
+ :workflow/name "Career Profile Workflow"
+ :workflow/description
+ "Retrieve evidence-backed profile context from the career knowledge graph,
+  synthesize a user-facing profile packet, and surface low-confidence areas
+  as explicit open questions."
+
+ :workflow/task-types [:career :profile :knowledge-graph :agentic-synthesis]
+
+ :workflow/pipeline
+ [{:phase :career-profile-check-sufficiency}
+  {:phase :career-profile-query-kg}
+  {:phase :career-profile-synthesize}
+  {:phase :career-profile-ground}
+  {:phase :done}]
+
+ :workflow/config
+ {:max-tokens 60000
+  :max-iterations 8
+
+  :tool-surface
+  {:provider :thesium/kg-mcp-tools
+   :required-tools ["kg.entity_lookup"
+                    "kg.datalog_query"
+                    "kg.fulltext_search"]}
+
+  :policy-pack
+  {:id :career-profile-v1
+   :version "1.0.0"
+   :locale "en-US"}
+
+  :output
+  {:artifact/type :career/profile-packet
+   :persist? true
+   :surface-low-confidence-as-open-questions? true}
+
+  :quality-gates
+  {:minimum-grounding-score 0.85
+   :allow-resume-only? true
+   :require-open-questions-for-low-confidence? true}
+
+  :phase-defaults
+  {:career-profile-check-sufficiency
+   {:agent nil
+    :gates []
+    :budget {:tokens 1000
+             :iterations 1
+             :time-seconds 60}}
+
+   :career-profile-query-kg
+   {:agent :career-profile-analyst
+    :gates []
+    :budget {:tokens 12000
+             :iterations 2
+             :time-seconds 180}}
+
+   :career-profile-synthesize
+   {:agent :career-profile-analyst
+    :gates []
+    :budget {:tokens 35000
+             :iterations 3
+             :time-seconds 300}}
+
+   :career-profile-ground
+   {:agent :career-grounding-reviewer
+    :gates [:grounding-threshold]
+    :budget {:tokens 12000
+             :iterations 2
+             :time-seconds 180}}}}}

--- a/components/workflow-career/test/ai/miniforge/workflow_career/catalog_test.clj
+++ b/components/workflow-career/test/ai/miniforge/workflow_career/catalog_test.clj
@@ -1,0 +1,50 @@
+;; Title: Miniforge.ai
+;; Subtitle: career workflow catalog composition test
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow-career.catalog-test
+  (:require [ai.miniforge.workflow.loader :as loader]
+            [ai.miniforge.workflow.registry :as registry]
+            [clojure.test :refer [deftest is testing use-fixtures]]))
+
+(use-fixtures :each
+  (fn [f]
+    (loader/clear-cache!)
+    (registry/clear-registry!)
+    (f)
+    (loader/clear-cache!)
+    (registry/clear-registry!)))
+
+(deftest test-career-profile-loads-from-resource
+  (testing "career-profile workflow resource is loadable through the shared loader"
+    (let [workflow (loader/load-from-resource :career-profile "1.0.0")]
+      (is (some? workflow))
+      (is (= :career-profile (:workflow/id workflow)))
+      (is (= "1.0.0" (:workflow/version workflow)))
+      (is (= ["kg.entity_lookup"
+              "kg.datalog_query"
+              "kg.fulltext_search"]
+             (get-in workflow [:workflow/config :tool-surface :required-tools])))
+      (is (= :career/profile-packet
+             (get-in workflow [:workflow/config :output :artifact/type]))))))
+
+(deftest test-career-profile-is-discoverable
+  (testing "registry discovery sees career-profile when the component is on the classpath"
+    (let [workflow-ids (->> (registry/discover-workflows-from-resources)
+                            (map :workflow/id)
+                            set)]
+      (is (contains? workflow-ids :career-profile)))))

--- a/deps.edn
+++ b/deps.edn
@@ -41,6 +41,7 @@
                        "components/workflow/resources"
                        "components/workflow-financial-etl/src"
                        "components/workflow-financial-etl/resources"
+                       "components/workflow-career/resources"
                        "components/workflow-chain-software-factory/resources"
                        "components/workflow-software-factory/resources"
                        "components/phase-deployment/src"
@@ -198,6 +199,7 @@
                       ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}
                       ai.miniforge/workflow-financial-etl {:local/root "components/workflow-financial-etl"}
+                      ai.miniforge/workflow-career {:local/root "components/workflow-career"}
                       ai.miniforge/workflow-chain-software-factory {:local/root "components/workflow-chain-software-factory"}
                       ai.miniforge/workflow-software-factory {:local/root "components/workflow-software-factory"}
                       ai.miniforge/release-executor {:local/root "components/release-executor"}
@@ -308,6 +310,8 @@
                        "components/workflow/test-resources"
                        "components/workflow-financial-etl/test"
                        "components/workflow-financial-etl/resources"
+                       "components/workflow-career/test"
+                       "components/workflow-career/resources"
                        "components/workflow-chain-software-factory/resources"
                        "components/workflow-software-factory/resources"
                        "components/operator/test"
@@ -417,6 +421,7 @@
                       ai.miniforge/gate {:local/root "components/gate"}
                       ai.miniforge/workflow {:local/root "components/workflow"}
                       ai.miniforge/workflow-financial-etl {:local/root "components/workflow-financial-etl"}
+                      ai.miniforge/workflow-career {:local/root "components/workflow-career"}
                       ai.miniforge/workflow-chain-software-factory {:local/root "components/workflow-chain-software-factory"}
                       ai.miniforge/workflow-software-factory {:local/root "components/workflow-software-factory"}
                       ai.miniforge/release-executor {:local/root "components/release-executor"}

--- a/docs/pull-requests/2026-04-23-feat-workflow-career-profile.md
+++ b/docs/pull-requests/2026-04-23-feat-workflow-career-profile.md
@@ -1,0 +1,85 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# feat: add career-profile workflow family
+
+## Overview
+Adds the first Thesium Career workflow family component to Miniforge:
+`workflow-career`.
+
+This slice ships the initial `career-profile` workflow as data, wires the
+component into Miniforge classpath composition, and adds a composition
+test that proves the shared workflow loader and registry can discover it.
+
+## Motivation
+The career stack now has:
+- ETL and KG storage in `thesium-workflows`
+- a retrieval surface in `kg-retrieval`
+- an MCP-style KG tool adapter in `kg-mcp-tools`
+
+What was still missing was the first Miniforge workflow definition that
+consumes that tool boundary. Per the Thesium Career architecture, agentic
+profile/rank/lens flows belong in Miniforge workflows rather than inside
+the workflows repo or the product app.
+
+This PR starts that layer with the first workflow: `career-profile`.
+
+## Base Branch
+`main`
+
+## Depends On
+None.
+
+## Changes In Detail
+- Adds new component:
+  `components/workflow-career`
+- Adds `career-profile-v1.0.0.edn` under:
+  `components/workflow-career/resources/workflows/`
+- Encodes the workflow as data:
+  KG tool requirements,
+  policy-pack identity,
+  output contract hints, and
+  phase budgets/defaults
+- Adds composition tests in:
+  `components/workflow-career/test/ai/miniforge/workflow_career/catalog_test.clj`
+- Wires the component into:
+  root `deps.edn`,
+  `bb.edn`, and
+  `CONTRIBUTING.md`
+
+## Testing Plan
+Executed in `/tmp/cc-miniforge-workflow-career-profile`:
+- `clojure -M:test -n ai.miniforge.workflow-career.catalog-test -n ai.miniforge.workflow.loader-test -n ai.miniforge.workflow.registry-test`
+
+Coverage added:
+- workflow resource loads through the shared loader
+- workflow registry discovery sees `career-profile` on the classpath
+
+## Deployment Plan
+No migration is required.
+
+Consumers pick up the workflow family through classpath composition:
+1. include `workflow-career`
+2. the shared loader/registry now see `career-profile`
+3. later slices can add execution handlers and sibling career workflows
+   without changing the kernel
+
+## Architecture Notes
+- This PR intentionally adds only the first workflow definition, not the
+  full career workflow family.
+- It also does not yet add the `career-rank` or Lens workflows.
+- The workflow is data-only in this slice; execution handlers and
+  chaining can land in follow-on PRs.
+
+## Related Issues/PRs
+- `thesium-career` PR #15
+- `thesium-workflows` PR #8
+
+## Checklist
+- [x] Added `workflow-career` component
+- [x] Added data-backed `career-profile` workflow
+- [x] Added composition tests for loader and registry discovery
+- [x] Wired the component into Miniforge classpath composition


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# feat: add career-profile workflow family

## Overview
Adds the first Thesium Career workflow family component to Miniforge:
`workflow-career`.

This slice ships the initial `career-profile` workflow as data, wires the
component into Miniforge classpath composition, and adds a composition
test that proves the shared workflow loader and registry can discover it.

## Motivation
The career stack now has:
- ETL and KG storage in `thesium-workflows`
- a retrieval surface in `kg-retrieval`
- an MCP-style KG tool adapter in `kg-mcp-tools`

What was still missing was the first Miniforge workflow definition that
consumes that tool boundary. Per the Thesium Career architecture, agentic
profile/rank/lens flows belong in Miniforge workflows rather than inside
the workflows repo or the product app.

This PR starts that layer with the first workflow: `career-profile`.

## Base Branch
`main`

## Depends On
None.

## Changes In Detail
- Adds new component:
  `components/workflow-career`
- Adds `career-profile-v1.0.0.edn` under:
  `components/workflow-career/resources/workflows/`
- Encodes the workflow as data:
  KG tool requirements,
  policy-pack identity,
  output contract hints, and
  phase budgets/defaults
- Adds composition tests in:
  `components/workflow-career/test/ai/miniforge/workflow_career/catalog_test.clj`
- Wires the component into:
  root `deps.edn`,
  `bb.edn`, and
  `CONTRIBUTING.md`

## Testing Plan
Executed in `/tmp/cc-miniforge-workflow-career-profile`:
- `clojure -M:test -n ai.miniforge.workflow-career.catalog-test -n ai.miniforge.workflow.loader-test -n ai.miniforge.workflow.registry-test`

Coverage added:
- workflow resource loads through the shared loader
- workflow registry discovery sees `career-profile` on the classpath

## Deployment Plan
No migration is required.

Consumers pick up the workflow family through classpath composition:
1. include `workflow-career`
2. the shared loader/registry now see `career-profile`
3. later slices can add execution handlers and sibling career workflows
   without changing the kernel

## Architecture Notes
- This PR intentionally adds only the first workflow definition, not the
  full career workflow family.
- It also does not yet add the `career-rank` or Lens workflows.
- The workflow is data-only in this slice; execution handlers and
  chaining can land in follow-on PRs.

## Related Issues/PRs
- `thesium-career` PR #15
- `thesium-workflows` PR #8

## Checklist
- [x] Added `workflow-career` component
- [x] Added data-backed `career-profile` workflow
- [x] Added composition tests for loader and registry discovery
- [x] Wired the component into Miniforge classpath composition
