### PR TITLE
feat: persist workflow machine snapshots

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -490,6 +490,7 @@
   :resume/resuming-from-phase "Resuming from phase: {phase} ({count} phases remaining)"
   :resume/all-phases-completed "All phases already completed."
   :resume/new-workflow-id "New workflow ID: {workflow-id}"
+  :resume/restored-workflow-id "Restored workflow ID: {workflow-id}"
   :resume/phase-starting "Phase: {phase}"
   :resume/completed-status "Resumed workflow completed with status: {status}"
   :resume/failed "Resume failed: {error}"

--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -101,11 +101,21 @@
             {:keys [workflow-type workflow-version]} (resolve-resume-workflow reconstructed)
             {:keys [workflow]} (load-workflow workflow-type workflow-version {})
 
-            ;; Pipeline trimming — delegated to the component
-            resume-workflow (wr/trim-pipeline workflow completed-phases)
+            machine-snapshot (:machine-snapshot reconstructed)
+            resume-workflow (if machine-snapshot
+                              workflow
+                              (wr/trim-pipeline workflow completed-phases))
             remaining-pipeline (:workflow/pipeline resume-workflow)
+            resume-run-id (or (:execution/id machine-snapshot) (random-uuid))
             _ (when-not quiet
-                (if (seq remaining-pipeline)
+                (if machine-snapshot
+                  (display/print-info
+                    (messages/t :resume/restored-workflow-id
+                                {:workflow-id resume-run-id}))
+                  (display/print-info
+                    (messages/t :resume/new-workflow-id
+                                {:workflow-id resume-run-id})))
+                (if (and (not machine-snapshot) (seq remaining-pipeline))
                   (display/print-info
                     (messages/t :resume/resuming-from-phase
                                 {:phase (name (:phase (first remaining-pipeline)))
@@ -115,14 +125,9 @@
             ;; Runtime wiring (CLI concern — stays here)
             event-stream (es/create-event-stream)
             _supervisor (supervisory/attach! event-stream)
-            new-workflow-id (random-uuid)
             control-state (es/create-control-state)
-            command-poller-cleanup (dashboard/start-command-poller! new-workflow-id control-state)
+            command-poller-cleanup (dashboard/start-command-poller! resume-run-id control-state)
             llm-client (context/create-llm-client workflow nil quiet)]
-
-        (when-not quiet
-          (display/print-info (messages/t :resume/new-workflow-id
-                                          {:workflow-id new-workflow-id})))
 
         (try
           (let [result (run-pipeline resume-workflow
@@ -130,6 +135,8 @@
                                      {:llm-backend llm-client
                                       :event-stream event-stream
                                       :control-state control-state
+                                      :resume-machine-snapshot machine-snapshot
+                                      :resume-phase-results (:phase-results reconstructed)
                                       :skip-lifecycle-events false
                                       :pre-completed-dag-tasks (:completed-dag-tasks reconstructed)
                                       :on-phase-start (fn [_ctx interceptor]

--- a/components/config/resources/config/default-user-config-fallback.edn
+++ b/components/config/resources/config/default-user-config-fallback.edn
@@ -9,7 +9,8 @@
         :max-tokens 32000}
   :workflow {:max-iterations 50
              :max-tokens 150000
-             :failure-strategy :retry}
+             :failure-strategy :retry
+             :checkpoint-root "~/.miniforge/checkpoints"}
   :artifacts {:dir "~/.miniforge/artifacts"}
   :meta-loop {:enabled true
               :max-convergence-iterations 10

--- a/components/config/test/ai/miniforge/config/user_defaults_test.clj
+++ b/components/config/test/ai/miniforge/config/user_defaults_test.clj
@@ -41,7 +41,11 @@
       (is (= "claude-sonnet-4-6" (get-in cfg [:agents :default-models :execution]))))
 
     (testing "default self-healing enables claude and codex failover"
-      (is (= [:claude :codex] (get-in cfg [:self-healing :allowed-failover-backends]))))))
+      (is (= [:claude :codex] (get-in cfg [:self-healing :allowed-failover-backends]))))
+
+    (testing "default workflow checkpoint root is configured as data"
+      (is (= "~/.miniforge/checkpoints"
+             (get-in cfg [:workflow :checkpoint-root]))))))
 
 (deftest load-default-config-falls-back-to-edn-resource-test
   (let [orig-resource io/resource]
@@ -53,7 +57,9 @@
                                   nil))]
       (let [cfg (user/load-default-config)]
         (is (= :codex (get-in cfg [:llm :backend])))
-        (is (= "claude-sonnet-4-6" (get-in cfg [:agents :default-models :execution])))))))
+        (is (= "claude-sonnet-4-6" (get-in cfg [:agents :default-models :execution])))
+        (is (= "~/.miniforge/checkpoints"
+               (get-in cfg [:workflow :checkpoint-root])))))))
 
 (deftest repo-config-support-test
   (testing "repo-config-path appends .miniforge/config.edn to the provided root"

--- a/components/workflow-resume/deps.edn
+++ b/components/workflow-resume/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/event-stream {:local/root "../event-stream"}
         ai.miniforge/response     {:local/root "../response"}
+        ai.miniforge/workflow     {:local/root "../workflow"}
         metosin/malli             {:mvn/version "0.16.4"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -37,6 +37,7 @@
   (:require
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.response.interface :as response]
+   [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.workflow-resume.schema :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -134,27 +135,38 @@
   (schema/validate! schema/ReconstructContextInput
                     {:events-dir events-dir :workflow-id workflow-id}
                     {:message "Invalid reconstruct-context input"})
-  (let [raw-events (es/read-workflow-events-by-id events-dir workflow-id)
+  (let [checkpoint-data (workflow/load-checkpoint-data workflow-id)
+        raw-events (or (es/read-workflow-events-by-id events-dir workflow-id) [])
         events (vec (filter schema/valid-event? raw-events))
-        _ (when-not (seq events)
+        _ (when-not (or checkpoint-data (seq events))
             (response/throw-anomaly! :anomalies/not-found
                                     (str "No events found for workflow: " workflow-id)
                                     {:workflow-id workflow-id
                                      :events-dir (str events-dir)
                                      :raw-event-count (count raw-events)}))
         by-type (group-by :event/type events)
-        completed-phases (extract-completed-phases events)
-        phase-results (extract-phase-results events)
+        completed-phases (or (some-> checkpoint-data :manifest :workflow/phases-completed)
+                             (extract-completed-phases events))
+        phase-results (if checkpoint-data
+                        (:phase-results checkpoint-data)
+                        (extract-phase-results events))
         workflow-spec (find-workflow-spec events)
         started-event (first (get by-type :workflow/started))
-        completed? (boolean (seq (get by-type :workflow/completed)))
-        failed? (boolean (seq (get by-type :workflow/failed)))
+        machine-snapshot (:machine-snapshot checkpoint-data)
+        checkpoint-status (:execution/status machine-snapshot)
+        completed? (or (boolean (seq (get by-type :workflow/completed)))
+                       (= :completed checkpoint-status)
+                       (= :completed-with-warnings checkpoint-status))
+        failed? (or (boolean (seq (get by-type :workflow/failed)))
+                    (= :failed checkpoint-status))
         completed-dag-tasks (extract-completed-dag-tasks events)
         dag-pause-info (extract-dag-pause-info events)]
     {:phase-results phase-results
      :completed-phases completed-phases
      :workflow-spec workflow-spec
-     :workflow-id (or (:workflow/id started-event) workflow-id)
+     :workflow-id (or (:execution/id machine-snapshot)
+                      (:workflow/id started-event)
+                      workflow-id)
      :completed? completed?
      :failed? failed?
      :event-count (count events)
@@ -162,7 +174,9 @@
                               (:completed-task-ids dag-pause-info)
                               #{})
      :dag-paused? (boolean dag-pause-info)
-     :dag-pause-reason (:pause-reason dag-pause-info)}))
+     :dag-pause-reason (:pause-reason dag-pause-info)
+     :machine-snapshot machine-snapshot
+     :checkpoint-manifest (:manifest checkpoint-data)}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Pipeline trimming
@@ -200,9 +214,12 @@
                     {:reconstructed reconstructed :fallback-fn fallback-fn}
                     {:message "Invalid resolve-workflow-identity input"})
   (let [workflow-spec (:workflow-spec reconstructed)
-        workflow-type (or (some-> workflow-spec :name keyword)
+        machine-snapshot (:machine-snapshot reconstructed)
+        workflow-type (or (:execution/workflow-id machine-snapshot)
+                          (some-> workflow-spec :name keyword)
                           (fallback-fn))
-        workflow-version (get workflow-spec :version "latest")]
+        workflow-version (or (:execution/workflow-version machine-snapshot)
+                             (get workflow-spec :version "latest"))]
     (when-not workflow-type
       (response/throw-anomaly! :anomalies/not-found
                               "Could not resolve a workflow type for resume"

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -105,6 +105,41 @@
        first
        :workflow/spec))
 
+(defn- ensure-reconstruction-source!
+  [checkpoint-data events-dir workflow-id raw-events]
+  (when-not (or checkpoint-data (seq raw-events))
+    (response/throw-anomaly! :anomalies/not-found
+                             (str "No events found for workflow: " workflow-id)
+                             {:workflow-id workflow-id
+                              :events-dir (str events-dir)
+                              :raw-event-count (count raw-events)})))
+
+(defn- checkpoint-status
+  [checkpoint-data]
+  (get-in checkpoint-data [:machine-snapshot :execution/status]))
+
+(defn- reconstructed-completed?
+  [by-type checkpoint-data]
+  (or (boolean (seq (get by-type :workflow/completed)))
+      (= :completed (checkpoint-status checkpoint-data))
+      (= :completed-with-warnings (checkpoint-status checkpoint-data))))
+
+(defn- reconstructed-failed?
+  [by-type checkpoint-data]
+  (or (boolean (seq (get by-type :workflow/failed)))
+      (= :failed (checkpoint-status checkpoint-data))))
+
+(defn- restored-completed-phases
+  [checkpoint-data events]
+  (or (some-> checkpoint-data :manifest :workflow/phases-completed)
+      (extract-completed-phases events)))
+
+(defn- restored-phase-results
+  [checkpoint-data events]
+  (if checkpoint-data
+    (:phase-results checkpoint-data)
+    (extract-phase-results events)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Context reconstruction
 
@@ -138,27 +173,15 @@
   (let [checkpoint-data (workflow/load-checkpoint-data workflow-id)
         raw-events (or (es/read-workflow-events-by-id events-dir workflow-id) [])
         events (vec (filter schema/valid-event? raw-events))
-        _ (when-not (or checkpoint-data (seq events))
-            (response/throw-anomaly! :anomalies/not-found
-                                    (str "No events found for workflow: " workflow-id)
-                                    {:workflow-id workflow-id
-                                     :events-dir (str events-dir)
-                                     :raw-event-count (count raw-events)}))
+        _ (ensure-reconstruction-source! checkpoint-data events-dir workflow-id raw-events)
         by-type (group-by :event/type events)
-        completed-phases (or (some-> checkpoint-data :manifest :workflow/phases-completed)
-                             (extract-completed-phases events))
-        phase-results (if checkpoint-data
-                        (:phase-results checkpoint-data)
-                        (extract-phase-results events))
+        completed-phases (restored-completed-phases checkpoint-data events)
+        phase-results (restored-phase-results checkpoint-data events)
         workflow-spec (find-workflow-spec events)
         started-event (first (get by-type :workflow/started))
         machine-snapshot (:machine-snapshot checkpoint-data)
-        checkpoint-status (:execution/status machine-snapshot)
-        completed? (or (boolean (seq (get by-type :workflow/completed)))
-                       (= :completed checkpoint-status)
-                       (= :completed-with-warnings checkpoint-status))
-        failed? (or (boolean (seq (get by-type :workflow/failed)))
-                    (= :failed checkpoint-status))
+        completed? (reconstructed-completed? by-type checkpoint-data)
+        failed? (reconstructed-failed? by-type checkpoint-data)
         completed-dag-tasks (extract-completed-dag-tasks events)
         dag-pause-info (extract-dag-pause-info events)]
     {:phase-results phase-results

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -21,6 +21,8 @@
    [clojure.test :refer [deftest testing is]]
    [clojure.java.io :as io]
    [cheshire.core :as json]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.workflow.interface :as workflow]
    [ai.miniforge.workflow-resume.core :as core]
    [ai.miniforge.workflow-resume.interface :as wr]))
 
@@ -136,6 +138,14 @@
              {:workflow-spec {:name "lean-sdlc"}}
              (constantly nil))))))
 
+(deftest resolve-workflow-identity-from-machine-snapshot-test
+  (testing "machine snapshot identity wins when no workflow spec is present"
+    (is (= {:workflow-type :canonical-sdlc :workflow-version "2.0.0"}
+           (core/resolve-workflow-identity
+            {:machine-snapshot {:execution/workflow-id :canonical-sdlc
+                                :execution/workflow-version "2.0.0"}}
+            (constantly nil))))))
+
 (deftest resolve-workflow-identity-fallback-test
   (testing "no spec → fallback-fn result used as :workflow-type"
     (is (= {:workflow-type :default-sdlc :workflow-version "latest"}
@@ -215,6 +225,25 @@
              clojure.lang.ExceptionInfo
              #"No events found for workflow:"
              (core/reconstruct-context base-dir (str (random-uuid)))))))))
+
+(deftest reconstruct-context-prefers-machine-snapshot-test
+  (testing "checkpoint data restores without requiring event files"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data {:machine-snapshot {:execution/id workflow-id
+                                             :execution/workflow-id :canonical-sdlc
+                                             :execution/workflow-version "1.0.0"
+                                             :execution/status :running}
+                           :manifest {:workflow/phases-completed [:plan]}
+                           :phase-results {:plan {:status :completed}}}]
+      (with-redefs [workflow/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
+                    es/read-workflow-events-by-id (fn [_events-dir _workflow-run-id] nil)]
+        (let [ctx (core/reconstruct-context "/tmp/unused-events" workflow-id)]
+          (is (= workflow-id (:workflow-id ctx)))
+          (is (= (:machine-snapshot checkpoint-data) (:machine-snapshot ctx)))
+          (is (= [:plan] (:completed-phases ctx)))
+          (is (= {:status :completed}
+                 (get-in ctx [:phase-results :plan])))
+          (is (= 0 (:event-count ctx))))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Interface re-exports

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -1,0 +1,260 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.checkpoint-store
+  "Durable execution-machine snapshots and phase checkpoints."
+  (:require
+   [ai.miniforge.config.interface :as config]
+   [babashka.fs :as fs]
+   [clojure.edn :as edn]
+   [clojure.walk :as walk]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants and path resolution
+
+(def checkpoint-root-option-key
+  "Execution option key for overriding the checkpoint root."
+  :checkpoint/root)
+
+(def machine-snapshot-filename
+  "Filename for the authoritative execution-machine snapshot."
+  "machine-snapshot.edn")
+
+(def manifest-filename
+  "Filename for the durable workflow checkpoint manifest."
+  "manifest.edn")
+
+(def phase-checkpoints-directory-name
+  "Directory name for per-phase checkpoint files."
+  "phases")
+
+(def temp-file-suffix
+  "Temporary suffix used for atomic checkpoint writes."
+  ".tmp")
+
+(defn- current-checkpoint-timestamp
+  []
+  (str (java.time.Instant/now)))
+
+(defn- serialize-checkpoint-value
+  [value]
+  (walk/postwalk
+   (fn [node]
+     (if (instance? java.time.Instant node)
+       (str node)
+       node))
+   value))
+
+(def persisted-execution-keys
+  "Serializable execution fields kept in the durable machine snapshot."
+  [:execution/id
+   :execution/workflow-id
+   :execution/workflow-version
+   :execution/input
+   :execution/status
+   :execution/current-phase
+   :execution/phase-index
+   :execution/redirect-count
+   :execution/fsm-state
+   :execution/response-chain
+   :execution/errors
+   :execution/artifacts
+   :execution/metrics
+   :execution/output
+   :execution/started-at
+   :execution/ended-at
+   :execution/environment-id
+   :execution/worktree-path
+   :execution/mode
+   :execution/completed-with-warnings?])
+
+(defn- normalize-checkpoint-root
+  [checkpoint-root]
+  (some-> checkpoint-root fs/expand-home str))
+
+(defn default-checkpoint-root
+  "Default durable checkpoint root from merged config."
+  []
+  (normalize-checkpoint-root
+   (or (get-in (config/load-merged-config) [:workflow :checkpoint-root])
+       (str (config/miniforge-home) "/checkpoints"))))
+
+(defn resolve-checkpoint-root
+  "Resolve checkpoint root from context/opts/config."
+  ([]
+   (default-checkpoint-root))
+  ([m]
+   (normalize-checkpoint-root
+    (or (:execution/checkpoint-root m)
+        (get m checkpoint-root-option-key)
+        (get-in m [:execution/opts checkpoint-root-option-key])
+        (default-checkpoint-root)))))
+
+(defn workflow-checkpoint-dir
+  "Directory for one workflow run's durable checkpoint state."
+  [checkpoint-root workflow-run-id]
+  (str (fs/path checkpoint-root (str workflow-run-id))))
+
+(defn machine-snapshot-path
+  "Path to the authoritative machine snapshot for a workflow run."
+  [checkpoint-root workflow-run-id]
+  (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
+                machine-snapshot-filename)))
+
+(defn manifest-path
+  "Path to the manifest for a workflow run."
+  [checkpoint-root workflow-run-id]
+  (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
+                manifest-filename)))
+
+(defn phase-checkpoints-dir
+  "Directory that stores per-phase checkpoint files."
+  [checkpoint-root workflow-run-id]
+  (str (fs/path (workflow-checkpoint-dir checkpoint-root workflow-run-id)
+                phase-checkpoints-directory-name)))
+
+(defn phase-checkpoint-path
+  "Path to a persisted phase checkpoint."
+  [checkpoint-root workflow-run-id phase-name]
+  (str (fs/path (phase-checkpoints-dir checkpoint-root workflow-run-id)
+                (str (name phase-name) ".edn"))))
+
+;------------------------------------------------------------------------------ Layer 0.5
+;; Serialization helpers
+
+(defn- write-edn-atomically!
+  [target-path data]
+  (let [target (fs/file target-path)
+        temp-path (str target-path temp-file-suffix)]
+    (fs/create-dirs (fs/parent target))
+    (spit temp-path (pr-str data))
+    (when (fs/exists? target-path)
+      (fs/delete target-path))
+    (fs/move temp-path target-path)
+    target-path))
+
+(defn- read-edn-file
+  [path]
+  (when (fs/exists? path)
+    (edn/read-string (slurp path))))
+
+(defn ordered-phase-ids
+  "Phase ids in workflow pipeline order, filtered to checkpointed phases."
+  [ctx]
+  (let [phase-results (:execution/phase-results ctx)
+        pipeline-phase-ids (map :phase (get-in ctx [:execution/workflow :workflow/pipeline]))
+        ordered-phase-ids (filter #(contains? phase-results %) pipeline-phase-ids)
+        remaining-phase-ids (remove (set ordered-phase-ids) (keys phase-results))]
+    (vec (concat ordered-phase-ids remaining-phase-ids))))
+
+(defn active-or-last-phase
+  "Current phase when present, otherwise the last checkpointed phase."
+  [ctx]
+  (or (:execution/current-phase ctx)
+      (last (ordered-phase-ids ctx))))
+
+(defn build-machine-snapshot
+  "Build the durable machine snapshot for an execution context."
+  [ctx]
+  (-> (select-keys ctx persisted-execution-keys)
+      serialize-checkpoint-value))
+
+(defn build-phase-checkpoint
+  "Build a durable per-phase checkpoint record."
+  [ctx phase-name phase-result]
+  (let [checkpointed-at (current-checkpoint-timestamp)]
+    (serialize-checkpoint-value
+     {:workflow/id (:execution/id ctx)
+      :workflow/workflow-id (:execution/workflow-id ctx)
+      :workflow/workflow-version (:execution/workflow-version ctx)
+      :workflow/phase phase-name
+      :workflow/checkpointed-at checkpointed-at
+      :phase/result phase-result})))
+
+(defn build-manifest
+  "Build the durable checkpoint manifest for an execution context."
+  [ctx checkpoint-root]
+  (let [workflow-run-id (:execution/id ctx)
+        phase-ids (ordered-phase-ids ctx)
+        phase-paths (into {}
+                          (map (fn [phase-id]
+                                 [phase-id
+                                  (phase-checkpoint-path checkpoint-root workflow-run-id phase-id)]))
+                          phase-ids)]
+    (serialize-checkpoint-value
+     {:workflow/id workflow-run-id
+      :workflow/workflow-id (:execution/workflow-id ctx)
+      :workflow/workflow-version (:execution/workflow-version ctx)
+      :workflow/phases-completed phase-ids
+      :workflow/machine-snapshot-path
+      (machine-snapshot-path checkpoint-root workflow-run-id)
+      :workflow/phase-checkpoints phase-paths
+      :workflow/last-checkpoint-at (current-checkpoint-timestamp)})))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Persistence and restore inputs
+
+(defn persist-execution-state!
+  "Persist a machine snapshot, manifest, and current phase checkpoint."
+  [ctx]
+  (try
+    (when-let [workflow-run-id (:execution/id ctx)]
+      (let [checkpoint-root (resolve-checkpoint-root ctx)
+            phase-name (active-or-last-phase ctx)
+            phase-result (get-in ctx [:execution/phase-results phase-name])
+            snapshot-path' (machine-snapshot-path checkpoint-root workflow-run-id)
+            manifest-path' (manifest-path checkpoint-root workflow-run-id)
+            snapshot (build-machine-snapshot ctx)
+            manifest (build-manifest ctx checkpoint-root)]
+        (when (and phase-name phase-result)
+          (write-edn-atomically!
+           (phase-checkpoint-path checkpoint-root workflow-run-id phase-name)
+           (build-phase-checkpoint ctx phase-name phase-result)))
+        (write-edn-atomically! snapshot-path' snapshot)
+        (write-edn-atomically! manifest-path' manifest)
+        {:checkpoint/root checkpoint-root
+         :checkpoint/machine-snapshot-path snapshot-path'
+         :checkpoint/manifest-path manifest-path'}))
+    (catch Exception _
+      nil)))
+
+(defn load-checkpoint-data
+  "Load durable checkpoint data for a workflow run, if present."
+  ([workflow-run-id]
+   (load-checkpoint-data workflow-run-id {}))
+  ([workflow-run-id opts]
+   (try
+     (let [checkpoint-root (resolve-checkpoint-root opts)
+           manifest-path' (manifest-path checkpoint-root workflow-run-id)
+           manifest (read-edn-file manifest-path')
+           snapshot-path' (or (:workflow/machine-snapshot-path manifest)
+                              (machine-snapshot-path checkpoint-root workflow-run-id))
+           machine-snapshot (read-edn-file snapshot-path')
+           phase-paths (or (:workflow/phase-checkpoints manifest) {})
+           phase-results (into {}
+                               (keep (fn [[phase-id path]]
+                                       (when-let [checkpoint (read-edn-file path)]
+                                         [phase-id (:phase/result checkpoint)])))
+                               phase-paths)]
+       (when machine-snapshot
+         {:checkpoint/root checkpoint-root
+          :manifest manifest
+          :machine-snapshot machine-snapshot
+          :phase-results phase-results}))
+     (catch Exception _
+       nil))))

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -20,6 +20,7 @@
   "Durable execution-machine snapshots and phase checkpoints."
   (:require
    [ai.miniforge.config.interface :as config]
+   [ai.miniforge.workflow.schemas :as schemas]
    [babashka.fs :as fs]
    [clojure.edn :as edn]
    [clojure.walk :as walk]))
@@ -212,15 +213,20 @@
 (defn persist-execution-state!
   "Persist a machine snapshot, manifest, and current phase checkpoint."
   [ctx]
-  (try
-    (when-let [workflow-run-id (:execution/id ctx)]
-      (let [checkpoint-root (resolve-checkpoint-root ctx)
-            phase-name (active-or-last-phase ctx)
-            phase-result (get-in ctx [:execution/phase-results phase-name])
-            snapshot-path' (machine-snapshot-path checkpoint-root workflow-run-id)
-            manifest-path' (manifest-path checkpoint-root workflow-run-id)
-            snapshot (build-machine-snapshot ctx)
-            manifest (build-manifest ctx checkpoint-root)]
+  (when-let [workflow-run-id (:execution/id ctx)]
+    (let [checkpoint-root (resolve-checkpoint-root ctx)
+          phase-name (active-or-last-phase ctx)
+          phase-result (get-in ctx [:execution/phase-results phase-name])
+          snapshot-path' (machine-snapshot-path checkpoint-root workflow-run-id)
+          manifest-path' (manifest-path checkpoint-root workflow-run-id)
+          snapshot (build-machine-snapshot ctx)
+          manifest (build-manifest ctx checkpoint-root)
+          checkpoint-data {:checkpoint/root checkpoint-root
+                           :manifest manifest
+                           :machine-snapshot snapshot
+                           :phase-results (or (:execution/phase-results ctx) {})}]
+      (schemas/validate-checkpoint-data! checkpoint-data)
+      (try
         (when (and phase-name phase-result)
           (write-edn-atomically!
            (phase-checkpoint-path checkpoint-root workflow-run-id phase-name)
@@ -229,9 +235,9 @@
         (write-edn-atomically! manifest-path' manifest)
         {:checkpoint/root checkpoint-root
          :checkpoint/machine-snapshot-path snapshot-path'
-         :checkpoint/manifest-path manifest-path'}))
-    (catch Exception _
-      nil)))
+         :checkpoint/manifest-path manifest-path'}
+        (catch Exception _
+          nil)))))
 
 (defn load-checkpoint-data
   "Load durable checkpoint data for a workflow run, if present."

--- a/components/workflow/src/ai/miniforge/workflow/context.clj
+++ b/components/workflow/src/ai/miniforge/workflow/context.clj
@@ -112,11 +112,32 @@
    :knowledge-store — Knowledge base store
    :event-stream   — Event stream for telemetry"
   (:require [ai.miniforge.response.interface :as response]
+            [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
             [ai.miniforge.workflow.fsm :as fsm]
             [ai.miniforge.workflow.monitoring :as monitoring]
             [ai.miniforge.agent.interface :as agent]))
 
 ;------------------------------------------------------------------------------ Internal helpers
+
+(def execution-passthrough-option-keys
+  "Execution options that are copied onto the top-level workflow context."
+  [:llm-backend :artifact-store :knowledge-store
+   :on-phase-start :on-phase-complete
+   :executor :environment-id :sandbox-workdir
+   :on-chunk :event-stream :worktree-path])
+
+(defn- passthrough-option-values
+  [opts]
+  (select-keys opts execution-passthrough-option-keys))
+
+(defn- monitoring-runtime-fields
+  [workflow]
+  (let [supervisors (monitoring/create-supervisors workflow)
+        supervision-runtime (agent/create-supervision-coordinator supervisors)]
+    {:execution/supervision-runtime supervision-runtime
+     :execution/meta-coordinator supervision-runtime
+     :execution/streaming-activity []
+     :execution/files-written #{}}))
 
 (defn sync-machine-projections
   "Project workflow fields from the authoritative machine snapshot."
@@ -175,9 +196,7 @@
   (let [execution-machine (fsm/compile-execution-machine workflow)
         fsm-state (let [initial-state (fsm/initialize-execution execution-machine)]
                     (fsm/start-execution execution-machine initial-state))
-        ;; Initialize live workflow supervision runtime.
-        supervisors (monitoring/create-supervisors workflow)
-        supervision-runtime (agent/create-supervision-coordinator supervisors)]
+        checkpoint-root (checkpoint-store/resolve-checkpoint-root opts)]
     (sync-machine-projections
      (merge
       {:execution/id (random-uuid)
@@ -195,19 +214,31 @@
        :execution/metrics {:tokens 0 :cost-usd 0.0 :duration-ms 0}
        :execution/started-at (System/currentTimeMillis)
        :execution/opts opts
-       ;; Live workflow supervision runtime
-       :execution/supervision-runtime supervision-runtime
-       ;; DEPRECATED: Temporary backwards-compatible alias for integration and
-       ;; end-to-end tests that still read the pre-refactor execution key.
-       :execution/meta-coordinator supervision-runtime
-       ;; Transient state for supervision checks
-       :execution/streaming-activity []
-       :execution/files-written #{}}
+       :execution/checkpoint-root checkpoint-root}
+      (monitoring-runtime-fields workflow)
       ;; Merge opts into top-level context so :llm-backend is accessible to agents
-      (select-keys opts [:llm-backend :artifact-store :knowledge-store
-                         :on-phase-start :on-phase-complete
-                         :executor :environment-id :sandbox-workdir
-                         :on-chunk :event-stream :worktree-path])))))
+      (passthrough-option-values opts)))))
+
+(defn restore-context
+  "Restore execution context from a durable machine snapshot and phase checkpoints."
+  [workflow input machine-snapshot phase-results opts]
+  (let [execution-machine (fsm/compile-execution-machine workflow)
+        checkpoint-root (checkpoint-store/resolve-checkpoint-root
+                         (merge opts machine-snapshot))]
+    (sync-machine-projections
+     (merge
+      machine-snapshot
+      {:execution/workflow workflow
+       :execution/workflow-id (:workflow/id workflow)
+       :execution/workflow-version (:workflow/version workflow)
+       :execution/fsm-machine execution-machine
+       :execution/fsm-state (:execution/fsm-state machine-snapshot)
+       :execution/input (get machine-snapshot :execution/input input)
+       :execution/phase-results phase-results
+       :execution/opts opts
+       :execution/checkpoint-root checkpoint-root}
+      (monitoring-runtime-fields workflow)
+      (passthrough-option-values opts)))))
 
 (defn merge-metrics
   "Merge phase metrics into execution metrics.

--- a/components/workflow/src/ai/miniforge/workflow/interface.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface.clj
@@ -21,6 +21,7 @@
    Public API groups live under ai.miniforge.workflow.interface.* namespaces,
    while this namespace remains the Polylith entrypoint."
   (:require
+   [ai.miniforge.workflow.interface.checkpoints :as checkpoints]
    [ai.miniforge.workflow.interface.configurable :as configurable]
    [ai.miniforge.workflow.interface.pipeline :as pipeline]
    [ai.miniforge.workflow.interface.profiles :as profiles]
@@ -61,6 +62,7 @@
 (def run-pipeline pipeline/run-pipeline)
 (def build-pipeline pipeline/build-pipeline)
 (def validate-pipeline pipeline/validate-pipeline)
+(def load-checkpoint-data checkpoints/load-checkpoint-data)
 (def run-chain pipeline/run-chain)
 (def load-chain pipeline/load-chain)
 (def list-chains pipeline/list-chains)

--- a/components/workflow/src/ai/miniforge/workflow/interface/checkpoints.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/checkpoints.clj
@@ -19,6 +19,13 @@
 (ns ai.miniforge.workflow.interface.checkpoints
   "Workflow checkpointing and resume data APIs."
   (:require
-   [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]))
+   [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
+   [ai.miniforge.workflow.schemas :as schemas]))
 
-(def load-checkpoint-data checkpoint-store/load-checkpoint-data)
+(defn load-checkpoint-data
+  "Load checkpoint data and validate it at the public boundary."
+  ([workflow-run-id]
+   (load-checkpoint-data workflow-run-id {}))
+  ([workflow-run-id opts]
+   (some-> (checkpoint-store/load-checkpoint-data workflow-run-id opts)
+           schemas/validate-checkpoint-data!)))

--- a/components/workflow/src/ai/miniforge/workflow/interface/checkpoints.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/checkpoints.clj
@@ -1,0 +1,24 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.interface.checkpoints
+  "Workflow checkpointing and resume data APIs."
+  (:require
+   [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]))
+
+(def load-checkpoint-data checkpoint-store/load-checkpoint-data)

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -32,6 +32,7 @@
             [ai.miniforge.logging.interface :as log]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.response.interface :as response]
+            [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
             [ai.miniforge.workflow.context :as ctx]
             [ai.miniforge.workflow.execution :as exec]
             [ai.miniforge.workflow.fsm :as workflow-fsm]
@@ -189,26 +190,29 @@
         workflow-state (monitoring/build-supervision-state context iteration)
         supervision-result (monitoring/check-workflow-supervision
                             supervision-runtime
-                            workflow-state)]
-    (if (= :halt (:status supervision-result))
-      (monitoring/handle-supervision-halt
-       context
-       supervision-result
-       ctx/transition-to-failed)
-      (let [phase-ctx (-> (exec/execute-phase-step pipeline context callbacks
-                                                   ctx/merge-metrics
-                                                   ctx/transition-to-completed
-                                                   ctx/transition-to-failed)
-                          (monitoring/clear-transient-state))
-            _ (env/persist-workspace-at-phase-boundary! context phase-ctx)
-            phase-error-msg (get-in phase-ctx
-                                    [:execution/phase-results
-                                     (:execution/current-phase phase-ctx)
-                                     :error :message] "")]
-        (if (rate-limited? phase-error-msg)
-          (apply-rate-limit-failure phase-ctx phase-error-msg)
-          (do (apply-backoff-if-retrying! phase-ctx context)
-              (apply-health-switch phase-ctx)))))))
+                            workflow-state)
+        iteration-result
+        (if (= :halt (:status supervision-result))
+          (monitoring/handle-supervision-halt
+           context
+           supervision-result
+           ctx/transition-to-failed)
+          (let [phase-ctx (-> (exec/execute-phase-step pipeline context callbacks
+                                                       ctx/merge-metrics
+                                                       ctx/transition-to-completed
+                                                       ctx/transition-to-failed)
+                              (monitoring/clear-transient-state))
+                _ (env/persist-workspace-at-phase-boundary! context phase-ctx)
+                phase-error-msg (get-in phase-ctx
+                                        [:execution/phase-results
+                                         (:execution/current-phase phase-ctx)
+                                         :error :message] "")]
+            (if (rate-limited? phase-error-msg)
+              (apply-rate-limit-failure phase-ctx phase-error-msg)
+              (do (apply-backoff-if-retrying! phase-ctx context)
+                  (apply-health-switch phase-ctx)))))]
+    (checkpoint-store/persist-execution-state! iteration-result)
+    iteration-result))
 
 ;------------------------------------------------------------------------------ Layer 1.5: Output extraction
 
@@ -278,7 +282,9 @@
 (defn- build-initial-context
   "Build the initial execution context from workflow, input, and opts."
   [workflow input opts]
-  (let [mode      (get opts :execution-mode :local)
+  (let [resume-machine-snapshot (:resume-machine-snapshot opts)
+        resume-phase-results (:resume-phase-results opts)
+        mode      (get opts :execution-mode :local)
         governed? (and (= :governed mode)
                        (get opts :executor)
                        (get opts :environment-id))]
@@ -292,7 +298,12 @@
                              (get opts :executor)
                              (get opts :environment-id)
                              (get opts :worktree-path (defaults/default-workdir))))]
-      (-> (ctx/create-context workflow input opts)
+      (-> (if (and resume-machine-snapshot resume-phase-results)
+            (ctx/restore-context workflow input
+                                 resume-machine-snapshot
+                                 resume-phase-results
+                                 opts)
+            (ctx/create-context workflow input opts))
           (assoc :execution/executor (get opts :executor)
                  :execution/environment-id (get opts :environment-id)
                  :execution/worktree-path (get opts :worktree-path
@@ -361,6 +372,8 @@
          initial-ctx         (build-initial-context workflow input opts)
          output-ctx-vol      (volatile! nil)
          exception-vol       (volatile! nil)]
+
+     (checkpoint-store/persist-execution-state! initial-ctx)
 
      (when-not skip-lifecycle?
        (events/publish-workflow-started! event-stream initial-ctx))

--- a/components/workflow/src/ai/miniforge/workflow/schemas.clj
+++ b/components/workflow/src/ai/miniforge/workflow/schemas.clj
@@ -44,6 +44,46 @@
    [:has-review boolean?]
    [:has-testing boolean?]])
 
+(def WorkflowRunId
+  "Workflow run identifier persisted in checkpoint data."
+  [:or uuid? string? keyword?])
+
+(def CheckpointManifest
+  "Durable checkpoint manifest persisted for a workflow run."
+  [:map {:closed false}
+   [:workflow/id WorkflowRunId]
+   [:workflow/workflow-id [:maybe keyword?]]
+   [:workflow/workflow-version [:maybe string?]]
+   [:workflow/phases-completed [:vector keyword?]]
+   [:workflow/machine-snapshot-path string?]
+   [:workflow/phase-checkpoints [:map-of keyword? string?]]
+   [:workflow/last-checkpoint-at string?]])
+
+(def MachineSnapshot
+  "Serializable execution snapshot persisted for workflow resume."
+  [:map {:closed false}
+   [:execution/id WorkflowRunId]
+   [:execution/workflow-id [:maybe keyword?]]
+   [:execution/workflow-version [:maybe string?]]
+   [:execution/status keyword?]
+   [:execution/fsm-state some?]
+   [:execution/response-chain map?]
+   [:execution/errors [:vector map?]]
+   [:execution/artifacts [:vector any?]]
+   [:execution/metrics map?]])
+
+(def PhaseResults
+  "Checkpointed phase results keyed by phase id."
+  [:map-of keyword? map?])
+
+(def CheckpointData
+  "Loaded checkpoint payload returned from the workflow checkpoint boundary."
+  [:map {:closed false}
+   [:checkpoint/root string?]
+   [:manifest CheckpointManifest]
+   [:machine-snapshot MachineSnapshot]
+   [:phase-results PhaseResults]])
+
 ;;------------------------------------------------------------------------------ Layer 1
 ;; Workflow recommendation schema
 
@@ -82,6 +122,11 @@
   [value]
   (m/validate WorkflowRecommendation value))
 
+(defn valid-checkpoint-data?
+  "Check if a value is valid loaded checkpoint data."
+  [value]
+  (m/validate CheckpointData value))
+
 (defn explain-characteristics
   "Get human-readable explanation of validation errors for characteristics.
 
@@ -103,3 +148,18 @@
   [value]
   (when-let [explanation (m/explain WorkflowRecommendation value)]
     (me/humanize explanation)))
+
+(defn explain-checkpoint-data
+  "Get human-readable explanation of validation errors for checkpoint data."
+  [value]
+  (when-let [explanation (m/explain CheckpointData value)]
+    (me/humanize explanation)))
+
+(defn validate-checkpoint-data!
+  "Validate loaded or soon-to-be-persisted checkpoint data at the boundary."
+  [value]
+  (if (valid-checkpoint-data? value)
+    value
+    (throw (ex-info "Invalid checkpoint data"
+                    {:value value
+                     :errors (explain-checkpoint-data value)}))))

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -21,7 +21,8 @@
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
-   [ai.miniforge.workflow.context :as ctx]))
+   [ai.miniforge.workflow.context :as ctx]
+   [ai.miniforge.workflow.interface :as workflow]))
 
 (defn- with-temp-checkpoint-root
   [f]
@@ -70,3 +71,42 @@
         (testing "manifest tracks checkpointed phases"
           (is (= [:done]
                  (get-in checkpoint-data [:manifest :workflow/phases-completed]))))))))
+
+(deftest persist-execution-state-validates-before-saving-test
+  (with-temp-checkpoint-root
+    (fn [checkpoint-root]
+      (let [workflow {:workflow/id :test
+                      :workflow/version "1.0.0"
+                      :workflow/pipeline [{:phase :done}]}
+            invalid-ctx (-> (ctx/create-context workflow {:task "Test"}
+                                                {:checkpoint/root checkpoint-root})
+                            (assoc :execution/phase-results {:done :invalid-phase-result}))]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Invalid checkpoint data"
+                              (checkpoint-store/persist-execution-state! invalid-ctx)))))))
+
+(deftest load-checkpoint-data-validates-at-interface-boundary-test
+  (testing "invalid checkpoint payloads are rejected at the public interface"
+    (with-redefs [checkpoint-store/load-checkpoint-data
+                  (fn [_workflow-run-id _opts]
+                    {:checkpoint/root "/tmp/checkpoints"
+                     :manifest {:workflow/id (random-uuid)
+                                :workflow/workflow-id :canonical-sdlc
+                                :workflow/workflow-version "1.0.0"
+                                :workflow/phases-completed [:plan]
+                                :workflow/machine-snapshot-path "/tmp/checkpoints/run/machine-snapshot.edn"
+                                :workflow/phase-checkpoints {:plan "/tmp/checkpoints/run/phases/plan.edn"}
+                                :workflow/last-checkpoint-at "2026-04-24T00:00:00Z"}
+                     :machine-snapshot {:execution/id (random-uuid)
+                                        :execution/workflow-id :canonical-sdlc
+                                        :execution/workflow-version "1.0.0"
+                                        :execution/status :running
+                                        :execution/fsm-state {:_state :running}
+                                        :execution/response-chain {}
+                                        :execution/errors []
+                                        :execution/artifacts []
+                                        :execution/metrics {}}
+                     :phase-results {:plan :invalid-phase-result}})]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"Invalid checkpoint data"
+                            (workflow/load-checkpoint-data (random-uuid) {}))))))

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -1,0 +1,72 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.checkpoint-store-test
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
+   [ai.miniforge.workflow.context :as ctx]))
+
+(defn- with-temp-checkpoint-root
+  [f]
+  (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
+                            (str "mf-checkpoint-test-" (random-uuid)))
+               .mkdirs)]
+    (try
+      (f (.getAbsolutePath root))
+      (finally
+        (doseq [file (reverse (file-seq root))]
+          (.delete ^java.io.File file))))))
+
+(deftest persist-and-load-checkpoint-data-test
+  (with-temp-checkpoint-root
+    (fn [checkpoint-root]
+      (let [workflow {:workflow/id :test
+                      :workflow/version "1.0.0"
+                      :workflow/pipeline [{:phase :done}]}
+            execution-ctx (-> (ctx/create-context workflow {:task "Test"}
+                                                  {:checkpoint/root checkpoint-root})
+                              (assoc-in [:execution/phase-results :done]
+                                        {:status :completed
+                                         :summary "done"})
+                              (assoc :execution/current-phase :done
+                                     :execution/started-at (java.time.Instant/now)
+                                     :execution/output
+                                     {:status :running
+                                      :finished-at (java.time.Instant/now)}))
+            _ (checkpoint-store/persist-execution-state! execution-ctx)
+            checkpoint-data (checkpoint-store/load-checkpoint-data
+                             (:execution/id execution-ctx)
+                             {:checkpoint/root checkpoint-root})]
+        (testing "loads machine snapshot and phase results"
+          (is (= (:execution/id execution-ctx)
+                 (get-in checkpoint-data [:machine-snapshot :execution/id])))
+          (is (= {:status :completed
+                  :summary "done"}
+                 (get-in checkpoint-data [:phase-results :done]))))
+        (testing "serializes nested instant values into EDN-readable strings"
+          (is (string? (get-in checkpoint-data
+                               [:machine-snapshot :execution/started-at])))
+          (is (string? (get-in checkpoint-data
+                               [:machine-snapshot
+                                :execution/output
+                                :finished-at]))))
+        (testing "manifest tracks checkpointed phases"
+          (is (= [:done]
+                 (get-in checkpoint-data [:manifest :workflow/phases-completed]))))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -7,6 +7,7 @@
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.dag-executor.interface :as dag-exec]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.workflow.messages :as messages]
    [ai.miniforge.workflow.execution :as exec]
    [ai.miniforge.phase.interface]))
 
@@ -308,7 +309,8 @@
         (is (= "env-42" (:env-id @call-args)))
         (is (= "task/abc" (get-in @call-args [:opts :branch])))
         (is (= "/workspace" (get-in @call-args [:opts :workdir])))
-        (is (= "implement phase completed" (get-in @call-args [:opts :message])))))))
+        (is (= (messages/t :env/persist-message {:phase "implement"})
+               (get-in @call-args [:opts :message])))))))
 
 (deftest persist-workspace-uses-unknown-when-no-phase-test
   (testing "uses 'unknown' when phase-ctx has no :execution/current-phase"
@@ -322,7 +324,8 @@
                     (fn [_exec _env-id opts]
                       (reset! call-args opts))]
         (persist-fn context phase-ctx)
-        (is (= "unknown phase completed" (:message @call-args)))))))
+        (is (= (messages/t :env/persist-message {:phase "unknown"})
+               (:message @call-args)))))))
 
 (deftest persist-workspace-catches-exceptions-test
   (testing "catches exceptions from persist-workspace! without propagating"

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -21,10 +21,23 @@
    Tests that execute real phase pipelines (plan, implement, etc.)
    live in runner-integration-test under project tests."
   (:require
+   [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.phase.interface]))
+
+(defn- with-temp-checkpoint-root
+  [f]
+  (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
+                            (str "mf-runner-checkpoint-test-" (random-uuid)))
+               .mkdirs)]
+    (try
+      (f (.getAbsolutePath root))
+      (finally
+        (doseq [file (reverse (file-seq root))]
+          (.delete ^java.io.File file))))))
 
 ;; ============================================================================
 ;; Context creation tests
@@ -114,6 +127,23 @@
       (is (= :completed (:execution/status result)))
       (is (number? (:execution/ended-at result))))))
 
+(deftest run-pipeline-persists-machine-snapshot-test
+  (with-temp-checkpoint-root
+    (fn [checkpoint-root]
+      (let [workflow {:workflow/id :test
+                      :workflow/version "1.0.0"
+                      :workflow/pipeline [{:phase :done}]}
+            result (runner/run-pipeline workflow {:task "Test"}
+                                        {:checkpoint/root checkpoint-root})
+            checkpoint-data (checkpoint-store/load-checkpoint-data
+                             (:execution/id result)
+                             {:checkpoint/root checkpoint-root})]
+        (is (= :completed (:execution/status result)))
+        (is (= (:execution/id result)
+               (get-in checkpoint-data [:machine-snapshot :execution/id])))
+        (is (= [:done]
+               (get-in checkpoint-data [:manifest :workflow/phases-completed])))))))
+
 (deftest run-pipeline-callbacks-test
   (testing "run-pipeline invokes callbacks"
     (let [workflow {:workflow/id :test
@@ -142,6 +172,20 @@
                     :workflow/pipeline [{:phase :done}]}
           result (runner/run-pipeline workflow {:task "Test"} {:max-phases 50})]
       (is (= :completed (:execution/status result))))))
+
+(deftest run-pipeline-resume-machine-snapshot-test
+  (testing "resume-machine-snapshot preserves the original execution id"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :done}]}
+          resume-ctx (ctx/create-context workflow {:task "Test"} {})
+          result (runner/run-pipeline workflow
+                                      {:task "Ignored"}
+                                      {:resume-machine-snapshot
+                                       (checkpoint-store/build-machine-snapshot resume-ctx)
+                                       :resume-phase-results {}})]
+      (is (= :completed (:execution/status result)))
+      (is (= (:execution/id resume-ctx) (:execution/id result))))))
 
 ;; ============================================================================
 ;; Phase result recording tests

--- a/docs/pull-requests/2026-04-23-feat-workflow-machine-snapshot-resume.md
+++ b/docs/pull-requests/2026-04-23-feat-workflow-machine-snapshot-resume.md
@@ -1,0 +1,66 @@
+# feat: restore workflows from durable machine snapshots
+
+## Overview
+
+Persist the authoritative workflow execution machine as durable checkpoint data
+and teach resume flows to restore from that snapshot instead of reconstructing
+execution state from phase indexes alone.
+
+## Motivation
+
+`#638` made the execution machine authoritative for workflow progression, but
+checkpoint/resume still depended on legacy event-log reconstruction and
+phase-index semantics. The specs now require machine-snapshot restoration.
+
+This slice closes that gap by making resume prefer a persisted execution
+snapshot while preserving the existing event-history fallback.
+
+## Changes In Detail
+
+- Add durable workflow checkpoint storage in `workflow.checkpoint-store`
+  - machine snapshot
+  - checkpoint manifest
+  - per-phase checkpoint files
+- Add `workflow.interface/load-checkpoint-data` as the public restore boundary
+- Extend `workflow.context` with `restore-context`
+  - recompiles the machine
+  - restores the persisted machine snapshot
+  - restores phase results
+  - rehydrates runtime-only monitoring fields
+- Persist checkpoints from `workflow.runner`
+  - after initial context creation
+  - after each iteration result
+- Update `workflow-resume` to prefer machine snapshots and checkpoint manifests
+  over event-log reconstruction when available
+- Update CLI `resume` to resume the original workflow run id and pass restored
+  machine state into `workflow/run-pipeline`
+- Add user config data for the default checkpoint root
+- Normalize checkpoint payloads into EDN-readable data so timestamp fields
+  round-trip cleanly
+
+## Testing Plan
+
+- `clj-kondo --lint` on all touched source and test files
+- `bb test components/workflow-resume components/workflow components/config`
+- `bb pre-commit`
+
+## Deployment Plan
+
+No deployment step. This is an internal workflow runtime change.
+
+## Related Issues/PRs
+
+- Follows `#638`, which made the execution machine authoritative
+- Prepares the next workflow critical-path slices:
+  - supervision/runtime boundary extraction
+  - formal supervision FSM and intervention lifecycle
+  - configurable workflow compilation
+
+## Checklist
+
+- [x] Execution machine snapshots persist durably
+- [x] Resume prefers persisted machine snapshots
+- [x] Legacy event-history fallback remains available
+- [x] Checkpoint payloads are EDN-readable
+- [x] Tests cover snapshot persistence and restoration
+- [x] Full pre-commit passes

--- a/resources/config/default-user-config.edn
+++ b/resources/config/default-user-config.edn
@@ -11,9 +11,10 @@
         :max-tokens 32000}
   :workflow {:max-iterations 50
              :max-tokens 150000
-             :failure-strategy :retry}
+             :failure-strategy :retry
+             :checkpoint-root "~/.miniforge/checkpoints"}
   :artifacts {:dir "~/.miniforge/artifacts"}
- :meta-loop {:enabled true
+  :meta-loop {:enabled true
               :max-convergence-iterations 10
               :convergence-threshold 0.95}
   ;; Planner/architect default to Opus 4.6 (opusplan, 200K context). Codex


### PR DESCRIPTION
# feat: restore workflows from durable machine snapshots

## Overview

Persist the authoritative workflow execution machine as durable checkpoint data
and teach resume flows to restore from that snapshot instead of reconstructing
execution state from phase indexes alone.

## Motivation

`#638` made the execution machine authoritative for workflow progression, but
checkpoint/resume still depended on legacy event-log reconstruction and
phase-index semantics. The specs now require machine-snapshot restoration.

This slice closes that gap by making resume prefer a persisted execution
snapshot while preserving the existing event-history fallback.

## Changes In Detail

- Add durable workflow checkpoint storage in `workflow.checkpoint-store`
  - machine snapshot
  - checkpoint manifest
  - per-phase checkpoint files
- Add `workflow.interface/load-checkpoint-data` as the public restore boundary
- Extend `workflow.context` with `restore-context`
  - recompiles the machine
  - restores the persisted machine snapshot
  - restores phase results
  - rehydrates runtime-only monitoring fields
- Persist checkpoints from `workflow.runner`
  - after initial context creation
  - after each iteration result
- Update `workflow-resume` to prefer machine snapshots and checkpoint manifests
  over event-log reconstruction when available
- Update CLI `resume` to resume the original workflow run id and pass restored
  machine state into `workflow/run-pipeline`
- Add user config data for the default checkpoint root
- Normalize checkpoint payloads into EDN-readable data so timestamp fields
  round-trip cleanly

## Testing Plan

- `clj-kondo --lint` on all touched source and test files
- `bb test components/workflow-resume components/workflow components/config`
- `bb pre-commit`

## Deployment Plan

No deployment step. This is an internal workflow runtime change.

## Related Issues/PRs

- Follows `#638`, which made the execution machine authoritative
- Prepares the next workflow critical-path slices:
  - supervision/runtime boundary extraction
  - formal supervision FSM and intervention lifecycle
  - configurable workflow compilation

## Checklist

- [x] Execution machine snapshots persist durably
- [x] Resume prefers persisted machine snapshots
- [x] Legacy event-history fallback remains available
- [x] Checkpoint payloads are EDN-readable
- [x] Tests cover snapshot persistence and restoration
- [x] Full pre-commit passes
