### PR TITLE
feat: formalize workflow supervision fsm

### DIFF
--- a/components/event-stream/deps.edn
+++ b/components/event-stream/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/config {:local/root "../config"}
         ai.miniforge/logging {:local/root "../logging"}
+        ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/schema {:local/root "../schema"}
         com.cognitect/transit-clj {:mvn/version "1.0.333"}}
  :aliases {:test {:extra-paths ["test"]

--- a/components/event-stream/resources/config/event-stream/messages/en-US.edn
+++ b/components/event-stream/resources/config/event-stream/messages/en-US.edn
@@ -1,0 +1,7 @@
+{:event-stream/messages
+ {;; Supervisory intervention events
+  :supervisory/intervention-requested
+  "Intervention {type} requested"
+
+  :supervisory/intervention-state-changed
+  "Intervention {intervention-id} -> {state}"}}

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.event-stream.core
   "Event bus and event constructors for workflow observability."
   (:require
+   [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.event-stream.sinks :as sinks]))
@@ -27,6 +28,22 @@
 ;; Constants
 
 (def ^:const event-version "1.0.0")
+
+(def ^:private redirect-transition-type
+  :transition/redirect)
+
+(defn- redirect-target
+  "Project a redirect target for legacy consumers.
+
+   The workflow runner now emits :phase/transition-request. This helper keeps
+   :phase/redirect-to available only when the transition request represents a
+   redirect, so older event consumers do not break while the newer event shape
+   remains authoritative."
+  [result]
+  (let [transition-request (phase/transition-request result)
+        transition-type (get transition-request :transition/type)]
+    (when (= redirect-transition-type transition-type)
+      (get transition-request :transition/target))))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Event persistence via configurable sinks
@@ -177,7 +194,9 @@
 
 (defn phase-completed [stream workflow-id phase & [result]]
   (let [outcome (get result :outcome :success)
-        transition-request (get result :phase/transition-request)]
+        transition-request (phase/transition-request result)
+        redirect-to (or (redirect-target result)
+                        (:redirect-to result))]
     (-> (create-envelope stream :workflow/phase-completed workflow-id
                          (str (name phase) " phase " (name outcome)))
         (assoc :workflow/phase phase
@@ -187,6 +206,7 @@
           (:artifacts result) (assoc :phase/artifacts (:artifacts result))
           (:error result) (assoc :phase/error (:error result))
           transition-request (assoc :phase/transition-request transition-request)
+          redirect-to (assoc :phase/redirect-to redirect-to)
           (:tokens result) (assoc :phase/tokens (:tokens result))
           (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))))))
 
@@ -585,6 +605,63 @@
                        (str "Decision " decision-id " resolved: " resolution))
       (assoc :cp/decision-id decision-id
              :cp/resolution resolution)))
+
+(defn intervention-requested
+  "Emit when a bounded supervisory intervention is created."
+  [stream workflow-id intervention]
+  (-> (create-envelope stream :supervisory/intervention-requested workflow-id
+                       (str "Intervention "
+                            (name (:intervention/type intervention))
+                            " requested"))
+      (merge intervention)))
+
+(defn intervention-state-changed
+  "Emit when an InterventionRequest changes lifecycle state."
+  [stream workflow-id intervention-id to-state & [opts]]
+  (-> (create-envelope stream :supervisory/intervention-state-changed workflow-id
+                       (str "Intervention " intervention-id " → " (name to-state)))
+      (assoc :intervention/id intervention-id
+             :intervention/state to-state)
+      (cond->
+        (:intervention/from-state opts)
+        (assoc :intervention/from-state (:intervention/from-state opts))
+
+        (:intervention/type opts)
+        (assoc :intervention/type (:intervention/type opts))
+
+        (:intervention/target-type opts)
+        (assoc :intervention/target-type (:intervention/target-type opts))
+
+        (contains? opts :intervention/target-id)
+        (assoc :intervention/target-id (:intervention/target-id opts))
+
+        (:intervention/requested-by opts)
+        (assoc :intervention/requested-by (:intervention/requested-by opts))
+
+        (:intervention/request-source opts)
+        (assoc :intervention/request-source (:intervention/request-source opts))
+
+        (:intervention/justification opts)
+        (assoc :intervention/justification (:intervention/justification opts))
+
+        (:intervention/details opts)
+        (assoc :intervention/details (:intervention/details opts))
+
+        (:intervention/reason opts)
+        (assoc :intervention/reason (:intervention/reason opts))
+
+        (:intervention/outcome opts)
+        (assoc :intervention/outcome (:intervention/outcome opts))
+
+        (:intervention/requested-at opts)
+        (assoc :intervention/requested-at (:intervention/requested-at opts))
+
+        (:intervention/updated-at opts)
+        (assoc :intervention/updated-at (:intervention/updated-at opts))
+
+        (contains? opts :intervention/approval-required?)
+        (assoc :intervention/approval-required?
+               (:intervention/approval-required? opts)))))
 
 ;------------------------------------------------------------------------------ Layer 6
 ;; PR scoring events (N5-delta-2 §4.1)

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.event-stream.core
   "Event bus and event constructors for workflow observability."
   (:require
+   [ai.miniforge.event-stream.messages :as messages]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
@@ -609,59 +610,62 @@
 (defn intervention-requested
   "Emit when a bounded supervisory intervention is created."
   [stream workflow-id intervention]
-  (-> (create-envelope stream :supervisory/intervention-requested workflow-id
-                       (str "Intervention "
-                            (name (:intervention/type intervention))
-                            " requested"))
-      (merge intervention)))
+  (let [message (messages/t :supervisory/intervention-requested
+                            {:type (name (:intervention/type intervention))})]
+    (-> (create-envelope stream :supervisory/intervention-requested workflow-id
+                         message)
+        (merge intervention))))
 
 (defn intervention-state-changed
   "Emit when an InterventionRequest changes lifecycle state."
   [stream workflow-id intervention-id to-state & [opts]]
-  (-> (create-envelope stream :supervisory/intervention-state-changed workflow-id
-                       (str "Intervention " intervention-id " → " (name to-state)))
-      (assoc :intervention/id intervention-id
-             :intervention/state to-state)
-      (cond->
-        (:intervention/from-state opts)
-        (assoc :intervention/from-state (:intervention/from-state opts))
+  (let [message (messages/t :supervisory/intervention-state-changed
+                            {:intervention-id intervention-id
+                             :state (name to-state)})]
+    (-> (create-envelope stream :supervisory/intervention-state-changed workflow-id
+                         message)
+        (assoc :intervention/id intervention-id
+               :intervention/state to-state)
+        (cond->
+          (:intervention/from-state opts)
+          (assoc :intervention/from-state (:intervention/from-state opts))
 
-        (:intervention/type opts)
-        (assoc :intervention/type (:intervention/type opts))
+          (:intervention/type opts)
+          (assoc :intervention/type (:intervention/type opts))
 
-        (:intervention/target-type opts)
-        (assoc :intervention/target-type (:intervention/target-type opts))
+          (:intervention/target-type opts)
+          (assoc :intervention/target-type (:intervention/target-type opts))
 
-        (contains? opts :intervention/target-id)
-        (assoc :intervention/target-id (:intervention/target-id opts))
+          (contains? opts :intervention/target-id)
+          (assoc :intervention/target-id (:intervention/target-id opts))
 
-        (:intervention/requested-by opts)
-        (assoc :intervention/requested-by (:intervention/requested-by opts))
+          (:intervention/requested-by opts)
+          (assoc :intervention/requested-by (:intervention/requested-by opts))
 
-        (:intervention/request-source opts)
-        (assoc :intervention/request-source (:intervention/request-source opts))
+          (:intervention/request-source opts)
+          (assoc :intervention/request-source (:intervention/request-source opts))
 
-        (:intervention/justification opts)
-        (assoc :intervention/justification (:intervention/justification opts))
+          (:intervention/justification opts)
+          (assoc :intervention/justification (:intervention/justification opts))
 
-        (:intervention/details opts)
-        (assoc :intervention/details (:intervention/details opts))
+          (:intervention/details opts)
+          (assoc :intervention/details (:intervention/details opts))
 
-        (:intervention/reason opts)
-        (assoc :intervention/reason (:intervention/reason opts))
+          (:intervention/reason opts)
+          (assoc :intervention/reason (:intervention/reason opts))
 
-        (:intervention/outcome opts)
-        (assoc :intervention/outcome (:intervention/outcome opts))
+          (:intervention/outcome opts)
+          (assoc :intervention/outcome (:intervention/outcome opts))
 
-        (:intervention/requested-at opts)
-        (assoc :intervention/requested-at (:intervention/requested-at opts))
+          (:intervention/requested-at opts)
+          (assoc :intervention/requested-at (:intervention/requested-at opts))
 
-        (:intervention/updated-at opts)
-        (assoc :intervention/updated-at (:intervention/updated-at opts))
+          (:intervention/updated-at opts)
+          (assoc :intervention/updated-at (:intervention/updated-at opts))
 
-        (contains? opts :intervention/approval-required?)
-        (assoc :intervention/approval-required?
-               (:intervention/approval-required? opts)))))
+          (contains? opts :intervention/approval-required?)
+          (assoc :intervention/approval-required?
+                 (:intervention/approval-required? opts))))))
 
 ;------------------------------------------------------------------------------ Layer 6
 ;; PR scoring events (N5-delta-2 §4.1)

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -36,8 +36,8 @@
    ## Audit verdict (2026-03-28)
 
    * NO mismatches: every browser `case` string exactly matches the server keyword.
-   * LARGE coverage gap: only 6 of 43 server-side event types are handled in
-     the browser switch; the remaining 37 silently fall through to `default: break`.
+   * LARGE coverage gap: only 6 of 45 server-side event types are handled in
+     the browser switch; the remaining 39 silently fall through to `default: break`.
    * NAMING ASYMMETRIES: 13 constructors use a function name whose implied
      namespace differs from the actual `:event/type` namespace.  See
      `naming-asymmetries` below."
@@ -297,6 +297,16 @@
     :asymmetry?  true
     :asymmetry-note "Constructor prefix 'cp-' expands to full namespace 'control-plane'"}
 
+   {:constructor "intervention-requested"
+    :event-type  :supervisory/intervention-requested
+    :json-string "supervisory/intervention-requested"
+    :browser?    false}
+
+   {:constructor "intervention-state-changed"
+    :event-type  :supervisory/intervention-state-changed
+    :json-string "supervisory/intervention-state-changed"
+    :browser?    false}
+
    ;; PR scoring (N5-delta-2 §4.1)
    {:constructor "pr-scored"
     :event-type  :pr/scored
@@ -316,7 +326,7 @@
 ;;     "workflow/completed" "workflow/failed" "agent/chunk"]
 
 (def browser-unhandled-events
-  "37 event types emitted server-side that the browser switch silently ignores.
+  "39 event types emitted server-side that the browser switch silently ignores.
    These are the gap items for Tasks 1–7."
   (->> event-type-registry
        (remove :browser?)
@@ -357,10 +367,10 @@
    :audit/source-browser "components/web-dashboard/resources/public/js/app.js"
    :audit/browser-switch "handleWorkflowEvent"
 
-   :total-server-events      43
-   :browser-handled-count    6
-   :browser-unhandled-count  37
-   :naming-asymmetry-count   11
+   :total-server-events      (count event-type-registry)
+   :browser-handled-count    (count browser-handled-events)
+   :browser-unhandled-count  (count browser-unhandled-events)
+   :naming-asymmetry-count   (count naming-asymmetries)
 
    ;; Verdict
    :string-mismatches []
@@ -368,7 +378,7 @@
    ;; The 6 handled events are a correct, strict subset of server events.
 
    :coverage-gaps browser-unhandled-events
-   ;; ^ 37 events silently ignored by the browser. Adding cases for these
+   ;; ^ 39 events silently ignored by the browser. Adding cases for these
    ;;   is the primary work of Tasks 1–7.
 
    :asymmetries naming-asymmetries

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -103,6 +103,8 @@
 (def cp-agent-state-changed events/cp-agent-state-changed)
 (def cp-decision-created events/cp-decision-created)
 (def cp-decision-resolved events/cp-decision-resolved)
+(def intervention-requested events/intervention-requested)
+(def intervention-state-changed events/intervention-state-changed)
 
 ;; PR scoring (N5-delta-2 §4.1)
 (def pr-scored events/pr-scored)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -82,6 +82,8 @@
 (def cp-agent-state-changed core/cp-agent-state-changed)
 (def cp-decision-created core/cp-decision-created)
 (def cp-decision-resolved core/cp-decision-resolved)
+(def intervention-requested core/intervention-requested)
+(def intervention-state-changed core/intervention-state-changed)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; PR scoring event constructors (N5-delta-2 §4.1)

--- a/components/event-stream/src/ai/miniforge/event_stream/messages.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/messages.clj
@@ -1,0 +1,27 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.event-stream.messages
+  "Component-level message catalog for event-stream.
+   Delegates to the shared messages component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up an event-stream message by key, with optional param substitution."
+  (messages/create-translator "config/event-stream/messages/en-US.edn"
+                              :event-stream/messages))

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -22,6 +22,15 @@
    See specs/normative/N3-event-stream.md for the full specification.")
 
 ;------------------------------------------------------------------------------ Layer 0
+;; Shared payload schemas
+
+(def TransitionRequest
+  "Schema for a phase transition request payload."
+  [:map
+   [:transition/type keyword?]
+   [:transition/target keyword?]])
+
+;------------------------------------------------------------------------------ Layer 0
 ;; Event envelope (base schema all events must conform to)
 
 (def EventEnvelope
@@ -82,6 +91,9 @@
    [:phase/duration-ms {:optional true} int?]
    [:phase/outcome {:optional true} [:enum :success :failure :skipped]]
    [:phase/artifacts {:optional true} [:vector uuid?]]
+   [:phase/transition-request {:optional true} TransitionRequest]
+   [:phase/redirect-to {:optional true} keyword?]
+   [:phase/error {:optional true} map?]
    [:phase/tokens {:optional true} int?]
    [:phase/cost-usd {:optional true} number?]
    [:message string?]])
@@ -284,6 +296,8 @@
    :llm/request      :internal
    :llm/response     :internal
    :supervision/tool-use-evaluated :internal
+   :supervisory/intervention-requested :confidential
+   :supervisory/intervention-state-changed :confidential
    :control-action/requested :confidential
    :control-action/executed  :confidential
    :annotation/created       :internal
@@ -340,6 +354,55 @@
    [:supervision/meta-eval? {:optional true} boolean?]
    [:supervision/confidence {:optional true} number?]
    [:workflow/phase {:optional true} keyword?]
+   [:message string?]])
+
+(def InterventionRequested
+  "Schema for supervisory/intervention-requested event."
+  [:map
+   [:event/type [:= :supervisory/intervention-requested]]
+   [:event/id uuid?]
+   [:event/timestamp inst?]
+   [:event/version string?]
+   [:event/sequence-number int?]
+   [:workflow/id {:optional true} [:maybe uuid?]]
+   [:intervention/id uuid?]
+   [:intervention/type keyword?]
+   [:intervention/target-type keyword?]
+   [:intervention/target-id any?]
+   [:intervention/requested-by string?]
+   [:intervention/request-source keyword?]
+   [:intervention/state keyword?]
+   [:intervention/justification {:optional true} string?]
+   [:intervention/details {:optional true} map?]
+   [:intervention/approval-required? {:optional true} boolean?]
+   [:intervention/requested-at inst?]
+   [:intervention/updated-at inst?]
+   [:message string?]])
+
+(def InterventionStateChanged
+  "Schema for supervisory/intervention-state-changed event."
+  [:map
+   [:event/type [:= :supervisory/intervention-state-changed]]
+   [:event/id uuid?]
+   [:event/timestamp inst?]
+   [:event/version string?]
+   [:event/sequence-number int?]
+   [:workflow/id {:optional true} [:maybe uuid?]]
+   [:intervention/id uuid?]
+   [:intervention/state keyword?]
+   [:intervention/from-state {:optional true} keyword?]
+   [:intervention/type {:optional true} keyword?]
+   [:intervention/target-type {:optional true} keyword?]
+   [:intervention/target-id {:optional true} any?]
+   [:intervention/requested-by {:optional true} string?]
+   [:intervention/request-source {:optional true} keyword?]
+   [:intervention/justification {:optional true} string?]
+   [:intervention/details {:optional true} map?]
+   [:intervention/reason {:optional true} string?]
+   [:intervention/outcome {:optional true} any?]
+   [:intervention/approval-required? {:optional true} boolean?]
+   [:intervention/requested-at {:optional true} inst?]
+   [:intervention/updated-at {:optional true} inst?]
    [:message string?]])
 
 ;; OCI container event schemas

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -20,6 +20,7 @@
   "Direct unit tests for event-stream core — chain events, error handling,
    OCI events, control-plane events, and sink integration."
   (:require
+   [ai.miniforge.event-stream.messages :as messages]
    [ai.miniforge.phase.interface :as phase]
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.event-stream.core :as core]))
@@ -361,7 +362,9 @@
       (is (= :supervisory/intervention-requested (:event/type event)))
       (is (= :pause (:intervention/type event)))
       (is (= :workflow (:intervention/target-type event)))
-      (is (= :proposed (:intervention/state event))))))
+      (is (= :proposed (:intervention/state event)))
+      (is (= (messages/t :supervisory/intervention-requested {:type "pause"})
+             (:message event))))))
 
 (deftest intervention-state-changed-test
   (testing "creates supervisory intervention lifecycle event"
@@ -379,7 +382,11 @@
       (is (= intervention-id (:intervention/id event)))
       (is (= :dispatched (:intervention/from-state event)))
       (is (= :applied (:intervention/state event)))
-      (is (= {:paused true} (:intervention/outcome event))))))
+      (is (= {:paused true} (:intervention/outcome event)))
+      (is (= (messages/t :supervisory/intervention-state-changed
+                         {:intervention-id intervention-id
+                          :state "applied"})
+             (:message event))))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Workflow failed edge cases

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -20,8 +20,8 @@
   "Direct unit tests for event-stream core — chain events, error handling,
    OCI events, control-plane events, and sink integration."
   (:require
-   [clojure.test :refer [deftest testing is]]
    [ai.miniforge.phase.interface :as phase]
+   [clojure.test :refer [deftest testing is]]
    [ai.miniforge.event-stream.core :as core]))
 
 ;------------------------------------------------------------------------------ Helpers
@@ -344,6 +344,43 @@
       (is (= decision-id (:cp/decision-id event)))
       (is (= "approved" (:cp/resolution event))))))
 
+(deftest intervention-requested-test
+  (testing "creates supervisory intervention requested event"
+    (let [stream (no-op-stream)
+          workflow-id (random-uuid)
+          intervention {:intervention/id (random-uuid)
+                        :intervention/type :pause
+                        :intervention/target-type :workflow
+                        :intervention/target-id workflow-id
+                        :intervention/requested-by "operator@example.com"
+                        :intervention/request-source :tui
+                        :intervention/state :proposed
+                        :intervention/requested-at (java.util.Date.)
+                        :intervention/updated-at (java.util.Date.)}
+          event (core/intervention-requested stream workflow-id intervention)]
+      (is (= :supervisory/intervention-requested (:event/type event)))
+      (is (= :pause (:intervention/type event)))
+      (is (= :workflow (:intervention/target-type event)))
+      (is (= :proposed (:intervention/state event))))))
+
+(deftest intervention-state-changed-test
+  (testing "creates supervisory intervention lifecycle event"
+    (let [stream (no-op-stream)
+          intervention-id (random-uuid)
+          event (core/intervention-state-changed
+                 stream
+                 (random-uuid)
+                 intervention-id
+                 :applied
+                 {:intervention/from-state :dispatched
+                  :intervention/type :pause
+                  :intervention/outcome {:paused true}})]
+      (is (= :supervisory/intervention-state-changed (:event/type event)))
+      (is (= intervention-id (:intervention/id event)))
+      (is (= :dispatched (:intervention/from-state event)))
+      (is (= :applied (:intervention/state event)))
+      (is (= {:paused true} (:intervention/outcome event))))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Workflow failed edge cases
 
@@ -369,16 +406,17 @@
 ;; Phase completed transition request
 
 (deftest phase-completed-transition-request-test
-  (testing "phase-completed includes transition requests"
+  (testing "phase-completed preserves transition requests and legacy redirect projection"
     (let [stream (no-op-stream)
           wf-id (random-uuid)
-          event (core/phase-completed stream wf-id :review
-                                      (phase/request-redirect
-                                       {:outcome :failure}
-                                       :implement))]
+          result (phase/request-redirect {:outcome :failure} :implement)
+          event (core/phase-completed stream wf-id :review result)]
       (is (= :failure (:phase/outcome event)))
+      (is (= :transition/redirect
+             (get-in event [:phase/transition-request :transition/type])))
       (is (= :implement
-             (get-in event [:phase/transition-request :transition/target]))))))
+             (get-in event [:phase/transition-request :transition/target])))
+      (is (= :implement (:phase/redirect-to event))))))
 
 (deftest phase-completed-with-error-test
   (testing "phase-completed captures error details"

--- a/components/operator/deps.edn
+++ b/components/operator/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/schema {:local/root "../schema"}
+ :deps {ai.miniforge/messages {:local/root "../messages"}
+        ai.miniforge/schema {:local/root "../schema"}
         ai.miniforge/logging {:local/root "../logging"}
         ai.miniforge/knowledge {:local/root "../knowledge"}
         ai.miniforge/workflow {:local/root "../workflow"}}

--- a/components/operator/resources/config/operator/intervention.edn
+++ b/components/operator/resources/config/operator/intervention.edn
@@ -1,0 +1,36 @@
+{:operator/intervention
+ {:initial-state :proposed
+  :approval-required-types
+  #{:cancel :retry-from-phase :force-safe-mode :exit-safe-mode :request-human-review}
+
+  :terminal-states
+  #{:rejected :verified :failed}
+
+  :default-target-type-by-intervention
+  {:acknowledge :attention
+   :retry :workflow
+   :retry-from-phase :workflow
+   :pause :workflow
+   :resume :workflow
+   :cancel :workflow
+   :request-replan :workflow
+   :waive :policy-eval
+   :re-evaluate :pr
+   :force-safe-mode :degradation
+   :exit-safe-mode :degradation
+   :request-human-review :supervision}
+
+  :lifecycle-transitions
+  {[:proposed :require-human] :pending-human
+   [:proposed :approve] :approved
+   [:proposed :reject] :rejected
+   [:proposed :fail] :failed
+   [:pending-human :approve] :approved
+   [:pending-human :reject] :rejected
+   [:pending-human :fail] :failed
+   [:approved :dispatch] :dispatched
+   [:approved :fail] :failed
+   [:dispatched :apply] :applied
+   [:dispatched :fail] :failed
+   [:applied :verify] :verified
+   [:applied :fail] :failed}}}

--- a/components/operator/resources/config/operator/messages/en-US.edn
+++ b/components/operator/resources/config/operator/messages/en-US.edn
@@ -1,0 +1,25 @@
+{:operator/messages
+ {;; Intervention lifecycle
+  :intervention/unknown-type
+  "Unknown intervention type"
+
+  :intervention/target-type-required
+  "Intervention target type is required"
+
+  :intervention/unknown-target-type
+  "Unknown intervention target type"
+
+  :intervention/target-id-required
+  "Intervention target id is required"
+
+  :intervention/requester-required
+  "Intervention requester identity is required"
+
+  :intervention/invalid-state
+  "Invalid intervention state: {state}"
+
+  :intervention/terminal-state
+  "Cannot transition from terminal state: {state}"
+
+  :intervention/invalid-transition
+  "No intervention transition defined for [{state} {event}]"}}

--- a/components/operator/src/ai/miniforge/operator/interface.clj
+++ b/components/operator/src/ai/miniforge/operator/interface.clj
@@ -21,6 +21,7 @@
    Manages the meta-loop: observe signals, detect patterns, propose improvements."
   (:require
    [ai.miniforge.operator.core :as core]
+   [ai.miniforge.operator.intervention :as intervention]
    [ai.miniforge.operator.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -34,6 +35,10 @@
 ;; Type definitions
 (def signal-types proto/signal-types)
 (def improvement-types proto/improvement-types)
+(def intervention-types intervention/intervention-types)
+(def intervention-target-types intervention/target-types)
+(def intervention-lifecycle-states intervention/lifecycle-states)
+(def intervention-terminal-states intervention/terminal-states)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Operator creation
@@ -67,6 +72,85 @@
   "Create a governance manager.
    Controls improvement approval policies."
   core/create-governance)
+
+;------------------------------------------------------------------------------ Layer 1a
+;; Bounded supervisory interventions
+
+(def create-intervention
+  "Create a bounded InterventionRequest map."
+  intervention/create-intervention)
+
+(def approval-required?
+  "Check whether an intervention type defaults to a pending-human step."
+  intervention/approval-required?)
+
+(def valid-intervention-type?
+  "Check if an intervention type is part of the bounded vocabulary."
+  intervention/valid-type?)
+
+(def valid-intervention-target-type?
+  "Check if an intervention target type is recognized."
+  intervention/valid-target-type?)
+
+(def valid-intervention-state?
+  "Check if an intervention lifecycle state is valid."
+  intervention/valid-state?)
+
+(def intervention-terminal-state?
+  "Check if an intervention lifecycle state is terminal."
+  intervention/terminal-state?)
+
+(def intervention-target-type
+  "Resolve the default target type for an intervention."
+  intervention/intervention-target-type)
+
+(def valid-intervention-transition?
+  "Check if an intervention lifecycle transition is valid."
+  intervention/valid-transition?)
+
+(def next-intervention-state
+  "Resolve the next lifecycle state for an intervention transition."
+  intervention/next-state)
+
+(def transition-intervention
+  "Apply a lifecycle transition to an intervention."
+  intervention/transition)
+
+(def start-intervention-approval
+  "Move an intervention into :pending-human."
+  intervention/start-approval)
+
+(def approve-intervention
+  "Approve an intervention."
+  intervention/approve)
+
+(def reject-intervention
+  "Reject an intervention."
+  intervention/reject)
+
+(def dispatch-intervention
+  "Mark an intervention as dispatched."
+  intervention/dispatch)
+
+(def apply-intervention-result
+  "Mark an intervention as applied."
+  intervention/apply-result)
+
+(def verify-intervention
+  "Mark an intervention as verified."
+  intervention/verify)
+
+(def fail-intervention
+  "Mark an intervention as failed."
+  intervention/fail)
+
+(def supported-target-types
+  "Return the supported target types for an intervention type."
+  intervention/supported-target-types)
+
+(def bounded-intervention-vocabulary?
+  "Check if a set of intervention types is within the bounded vocabulary."
+  intervention/bounded-vocabulary?)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Signal observation

--- a/components/operator/src/ai/miniforge/operator/intervention.clj
+++ b/components/operator/src/ai/miniforge/operator/intervention.clj
@@ -1,0 +1,317 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.operator.intervention
+  "Pure bounded intervention lifecycle helpers.
+
+   This namespace models supervisory intervention intent and lifecycle state
+   transitions. It does not apply control actions directly."
+  (:require
+   [clojure.set :as set]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Known vocabulary
+
+(def intervention-types
+  "Bounded v1 intervention vocabulary per N5-delta-supervisory-control-plane
+   §7.1."
+  #{:acknowledge
+    :retry
+    :retry-from-phase
+    :pause
+    :resume
+    :cancel
+    :request-replan
+    :waive
+    :re-evaluate
+    :force-safe-mode
+    :exit-safe-mode
+    :request-human-review})
+
+(def target-types
+  "Known target categories for v1 interventions."
+  #{:attention :workflow :policy-eval :pr :degradation :supervision})
+
+(def lifecycle-states
+  "Intervention lifecycle states per N5-delta-supervisory-control-plane §3.3."
+  #{:proposed :pending-human :approved :rejected :dispatched :applied :verified :failed})
+
+(def terminal-states
+  "Terminal intervention lifecycle states."
+  #{:rejected :verified :failed})
+
+(def approval-required-types
+  "Interventions that default to an explicit human approval step because the
+   requested action materially changes runtime posture or execution."
+  #{:cancel :retry-from-phase :force-safe-mode :exit-safe-mode :request-human-review})
+
+(def default-target-type-by-intervention
+  "Default target type for each intervention."
+  {:acknowledge :attention
+   :retry :workflow
+   :retry-from-phase :workflow
+   :pause :workflow
+   :resume :workflow
+   :cancel :workflow
+   :request-replan :workflow
+   :waive :policy-eval
+   :re-evaluate :pr
+   :force-safe-mode :degradation
+   :exit-safe-mode :degradation
+   :request-human-review :supervision})
+
+(def lifecycle-transitions
+  "Valid intervention lifecycle transitions. Map of [from-state event] -> to-state."
+  {[:proposed :require-human] :pending-human
+   [:proposed :approve] :approved
+   [:proposed :reject] :rejected
+   [:proposed :fail] :failed
+   [:pending-human :approve] :approved
+   [:pending-human :reject] :rejected
+   [:pending-human :fail] :failed
+   [:approved :dispatch] :dispatched
+   [:approved :fail] :failed
+   [:dispatched :apply] :applied
+   [:dispatched :fail] :failed
+   [:applied :verify] :verified
+   [:applied :fail] :failed})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Construction and validation
+
+(defn approval-required?
+  "Return true when `intervention-type` defaults to a pending-human step."
+  [intervention-type]
+  (contains? approval-required-types intervention-type))
+
+(defn valid-type?
+  "Check if an intervention type is part of the bounded vocabulary."
+  [intervention-type]
+  (contains? intervention-types intervention-type))
+
+(defn valid-target-type?
+  "Check if a target type is recognized."
+  [target-type]
+  (contains? target-types target-type))
+
+(defn valid-state?
+  "Check if an intervention lifecycle state is valid."
+  [state]
+  (contains? lifecycle-states state))
+
+(defn terminal-state?
+  "Check if an intervention lifecycle state is terminal."
+  [state]
+  (contains? terminal-states state))
+
+(defn intervention-target-type
+  "Resolve the default target type for an intervention."
+  [intervention-type]
+  (get default-target-type-by-intervention intervention-type))
+
+(defn- intervention-transition-error
+  [error message]
+  {:success? false
+   :error error
+   :message message})
+
+(defn- with-optional-intervention-attrs
+  [intervention opts]
+  (cond-> intervention
+    (:reason opts) (assoc :intervention/reason (:reason opts))
+    (:outcome opts) (assoc :intervention/outcome (:outcome opts))
+    (:details opts)
+    (update :intervention/details
+            (fn [existing]
+              (merge (or existing {}) (:details opts))))))
+
+(defn- transition-opts
+  [key value]
+  (cond-> {}
+    value (assoc key value)))
+
+(defn create-intervention
+  "Create a new InterventionRequest map.
+
+   Required keys in `request`:
+   - :intervention/type
+   - :intervention/target-id
+   - :intervention/requested-by
+   - :intervention/request-source
+
+   Optional:
+   - :intervention/target-type (defaults from the intervention vocabulary)
+   - :intervention/justification
+   - :intervention/details
+   - :intervention/approval-required?"
+  [{:intervention/keys [type target-id requested-by request-source target-type]
+    :as request}]
+  (let [resolved-target-type (or target-type (intervention-target-type type))
+        now (java.util.Date.)
+        approval-required?* (boolean (or (:intervention/approval-required? request)
+                                         (approval-required? type)))]
+     (cond
+      (not (valid-type? type))
+      (throw (ex-info "Unknown intervention type"
+                      {:intervention/type type}))
+
+      (nil? resolved-target-type)
+      (throw (ex-info "Intervention target type is required"
+                      {:intervention/type type}))
+
+      (not (valid-target-type? resolved-target-type))
+      (throw (ex-info "Unknown intervention target type"
+                      {:intervention/type type
+                       :intervention/target-type resolved-target-type}))
+
+      (nil? target-id)
+      (throw (ex-info "Intervention target id is required"
+                      {:intervention/type type}))
+
+      (or (nil? requested-by) (nil? request-source))
+      (throw (ex-info "Intervention requester identity is required"
+                      {:intervention/type type
+                       :intervention/requested-by requested-by
+                       :intervention/request-source request-source}))
+
+      :else
+      (cond-> {:intervention/id (or (:intervention/id request) (random-uuid))
+               :intervention/type type
+               :intervention/target-type resolved-target-type
+               :intervention/target-id target-id
+               :intervention/requested-by requested-by
+               :intervention/request-source request-source
+               :intervention/state :proposed
+               :intervention/requested-at now
+               :intervention/updated-at now}
+        (:intervention/justification request)
+        (assoc :intervention/justification (:intervention/justification request))
+
+        (:intervention/details request)
+        (assoc :intervention/details (:intervention/details request))
+
+        approval-required?*
+        (assoc :intervention/approval-required? true)))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Lifecycle helpers
+
+(defn valid-transition?
+  "Check if an intervention lifecycle transition is valid."
+  [current-state event]
+  (contains? lifecycle-transitions [current-state event]))
+
+(defn next-state
+  "Resolve the next intervention lifecycle state."
+  [current-state event]
+  (get lifecycle-transitions [current-state event]))
+
+(defn transition
+  "Apply a lifecycle transition to `intervention`.
+
+   `opts` may carry:
+   - :reason
+   - :outcome
+   - :details
+   - :updated-at"
+  ([intervention event]
+   (transition intervention event {}))
+
+  ([intervention event opts]
+   (let [current-state (:intervention/state intervention)
+         next (next-state current-state event)
+         updated-at (or (:updated-at opts) (java.util.Date.))]
+     (cond
+       (not (valid-state? current-state))
+       (intervention-transition-error
+        :invalid-state
+        (str "Invalid intervention state: " current-state))
+
+       (terminal-state? current-state)
+       (intervention-transition-error
+        :terminal-state
+        (str "Cannot transition from terminal state: " current-state))
+
+       (nil? next)
+       (intervention-transition-error
+        :invalid-transition
+        (str "No intervention transition defined for ["
+             current-state " " event "]"))
+
+       :else
+       {:success? true
+        :intervention (-> intervention
+                          (assoc :intervention/state next
+                                 :intervention/updated-at updated-at)
+                          (with-optional-intervention-attrs opts))}))))
+
+(defn start-approval
+  "Move an intervention into `:pending-human`."
+  [intervention]
+  (transition intervention :require-human))
+
+(defn approve
+  "Approve an intervention."
+  [intervention]
+  (transition intervention :approve))
+
+(defn reject
+  "Reject an intervention."
+  ([intervention]
+   (reject intervention nil))
+  ([intervention reason]
+   (transition intervention :reject (transition-opts :reason reason))))
+
+(defn dispatch
+  "Dispatch an approved intervention to the orchestrator."
+  [intervention]
+  (transition intervention :dispatch))
+
+(defn apply-result
+  "Mark an intervention as applied."
+  ([intervention]
+   (apply-result intervention nil))
+  ([intervention outcome]
+   (transition intervention :apply (transition-opts :outcome outcome))))
+
+(defn verify
+  "Mark an intervention as verified."
+  ([intervention]
+   (verify intervention nil))
+  ([intervention outcome]
+   (transition intervention :verify (transition-opts :outcome outcome))))
+
+(defn fail
+  "Mark an intervention as failed."
+  ([intervention]
+   (fail intervention nil))
+  ([intervention reason]
+   (transition intervention :fail (transition-opts :reason reason))))
+
+(defn supported-target-types
+  "Return the configured target types for a given intervention type."
+  [intervention-type]
+  (let [target-type (intervention-target-type intervention-type)]
+    (if target-type
+      #{target-type}
+      #{})))
+
+(defn bounded-vocabulary?
+  "Check if every requested intervention type is part of the bounded vocabulary."
+  [types]
+  (empty? (set/difference (set types) intervention-types)))

--- a/components/operator/src/ai/miniforge/operator/intervention.clj
+++ b/components/operator/src/ai/miniforge/operator/intervention.clj
@@ -22,74 +22,64 @@
    This namespace models supervisory intervention intent and lifecycle state
    transitions. It does not apply control actions directly."
   (:require
-   [clojure.set :as set]))
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [clojure.set :as set]
+   [ai.miniforge.operator.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Known vocabulary
+;; Config
 
-(def intervention-types
-  "Bounded v1 intervention vocabulary per N5-delta-supervisory-control-plane
-   §7.1."
-  #{:acknowledge
-    :retry
-    :retry-from-phase
-    :pause
-    :resume
-    :cancel
-    :request-replan
-    :waive
-    :re-evaluate
-    :force-safe-mode
-    :exit-safe-mode
-    :request-human-review})
+(def ^:private intervention-config-resource
+  "Classpath location of the intervention lifecycle config."
+  "config/operator/intervention.edn")
 
-(def target-types
-  "Known target categories for v1 interventions."
-  #{:attention :workflow :policy-eval :pr :degradation :supervision})
+(defn- load-intervention-config
+  []
+  (if-let [resource (io/resource intervention-config-resource)]
+    (:operator/intervention (edn/read-string (slurp resource)))
+    (throw (ex-info "Missing operator intervention config resource"
+                    {:resource intervention-config-resource}))))
 
-(def lifecycle-states
-  "Intervention lifecycle states per N5-delta-supervisory-control-plane §3.3."
-  #{:proposed :pending-human :approved :rejected :dispatched :applied :verified :failed})
+(def ^:private intervention-config
+  (delay (load-intervention-config)))
 
-(def terminal-states
-  "Terminal intervention lifecycle states."
-  #{:rejected :verified :failed})
+(def ^:private initial-state
+  (:initial-state @intervention-config))
 
 (def approval-required-types
   "Interventions that default to an explicit human approval step because the
    requested action materially changes runtime posture or execution."
-  #{:cancel :retry-from-phase :force-safe-mode :exit-safe-mode :request-human-review})
+  (:approval-required-types @intervention-config))
+
+(def terminal-states
+  "Terminal intervention lifecycle states."
+  (:terminal-states @intervention-config))
 
 (def default-target-type-by-intervention
   "Default target type for each intervention."
-  {:acknowledge :attention
-   :retry :workflow
-   :retry-from-phase :workflow
-   :pause :workflow
-   :resume :workflow
-   :cancel :workflow
-   :request-replan :workflow
-   :waive :policy-eval
-   :re-evaluate :pr
-   :force-safe-mode :degradation
-   :exit-safe-mode :degradation
-   :request-human-review :supervision})
+  (:default-target-type-by-intervention @intervention-config))
 
 (def lifecycle-transitions
   "Valid intervention lifecycle transitions. Map of [from-state event] -> to-state."
-  {[:proposed :require-human] :pending-human
-   [:proposed :approve] :approved
-   [:proposed :reject] :rejected
-   [:proposed :fail] :failed
-   [:pending-human :approve] :approved
-   [:pending-human :reject] :rejected
-   [:pending-human :fail] :failed
-   [:approved :dispatch] :dispatched
-   [:approved :fail] :failed
-   [:dispatched :apply] :applied
-   [:dispatched :fail] :failed
-   [:applied :verify] :verified
-   [:applied :fail] :failed})
+  (:lifecycle-transitions @intervention-config))
+
+(def intervention-types
+  "Bounded v1 intervention vocabulary per N5-delta-supervisory-control-plane
+   §7.1."
+  (set (keys default-target-type-by-intervention)))
+
+(def target-types
+  "Known target categories for v1 interventions."
+  (set (vals default-target-type-by-intervention)))
+
+(def lifecycle-states
+  "Intervention lifecycle states per N5-delta-supervisory-control-plane §3.3."
+  (-> (set (mapcat (fn [[[from-state _event] to-state]]
+                     [from-state to-state])
+                   lifecycle-transitions))
+      (conj initial-state)
+      (set/union terminal-states)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Construction and validation
@@ -167,24 +157,24 @@
                                          (approval-required? type)))]
      (cond
       (not (valid-type? type))
-      (throw (ex-info "Unknown intervention type"
+      (throw (ex-info (messages/t :intervention/unknown-type)
                       {:intervention/type type}))
 
       (nil? resolved-target-type)
-      (throw (ex-info "Intervention target type is required"
+      (throw (ex-info (messages/t :intervention/target-type-required)
                       {:intervention/type type}))
 
       (not (valid-target-type? resolved-target-type))
-      (throw (ex-info "Unknown intervention target type"
+      (throw (ex-info (messages/t :intervention/unknown-target-type)
                       {:intervention/type type
                        :intervention/target-type resolved-target-type}))
 
       (nil? target-id)
-      (throw (ex-info "Intervention target id is required"
+      (throw (ex-info (messages/t :intervention/target-id-required)
                       {:intervention/type type}))
 
       (or (nil? requested-by) (nil? request-source))
-      (throw (ex-info "Intervention requester identity is required"
+      (throw (ex-info (messages/t :intervention/requester-required)
                       {:intervention/type type
                        :intervention/requested-by requested-by
                        :intervention/request-source request-source}))
@@ -196,7 +186,7 @@
                :intervention/target-id target-id
                :intervention/requested-by requested-by
                :intervention/request-source request-source
-               :intervention/state :proposed
+               :intervention/state initial-state
                :intervention/requested-at now
                :intervention/updated-at now}
         (:intervention/justification request)
@@ -240,18 +230,19 @@
        (not (valid-state? current-state))
        (intervention-transition-error
         :invalid-state
-        (str "Invalid intervention state: " current-state))
+        (messages/t :intervention/invalid-state {:state current-state}))
 
        (terminal-state? current-state)
        (intervention-transition-error
         :terminal-state
-        (str "Cannot transition from terminal state: " current-state))
+        (messages/t :intervention/terminal-state {:state current-state}))
 
        (nil? next)
        (intervention-transition-error
         :invalid-transition
-        (str "No intervention transition defined for ["
-             current-state " " event "]"))
+        (messages/t :intervention/invalid-transition
+                    {:state current-state
+                     :event event}))
 
        :else
        {:success? true

--- a/components/operator/src/ai/miniforge/operator/messages.clj
+++ b/components/operator/src/ai/miniforge/operator/messages.clj
@@ -1,0 +1,27 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.operator.messages
+  "Component-level message catalog for operator.
+   Delegates to the shared messages component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up an operator message by key, with optional param substitution."
+  (messages/create-translator "config/operator/messages/en-US.edn"
+                              :operator/messages))

--- a/components/operator/test/ai/miniforge/operator/intervention_test.clj
+++ b/components/operator/test/ai/miniforge/operator/intervention_test.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.operator.intervention-test
+  "Tests for bounded intervention lifecycle helpers."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.operator.interface :as op]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers
+
+(defn- intervention-request
+  [intervention-type target-id & {:as extra}]
+  (merge {:intervention/type intervention-type
+          :intervention/target-id target-id
+          :intervention/requested-by "operator@example.com"
+          :intervention/request-source :tui}
+         extra))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Unit tests
+
+(deftest create-intervention-defaults-target-type-and-state
+  (testing "given a retry intervention → workflow target type and proposed state are inferred"
+    (let [request (op/create-intervention
+                   (intervention-request :retry (random-uuid)))]
+      (is (= :workflow (:intervention/target-type request)))
+      (is (= :proposed (:intervention/state request)))
+      (is (uuid? (:intervention/id request)))
+      (is (inst? (:intervention/requested-at request)))
+      (is (inst? (:intervention/updated-at request))))))
+
+(deftest risky-interventions-default-to-approval-required
+  (testing "given a cancel intervention → approval is required by default"
+    (let [request (op/create-intervention
+                   (intervention-request :cancel (random-uuid)))]
+      (is (true? (op/approval-required? :cancel)))
+      (is (true? (:intervention/approval-required? request))))))
+
+(deftest intervention-lifecycle-reaches-verified
+  (testing "given an intervention through approve, dispatch, apply, verify → it ends in verified"
+    (let [created (op/create-intervention
+                   (intervention-request :pause (random-uuid)))
+          approved (:intervention (op/approve-intervention created))
+          dispatched (:intervention (op/dispatch-intervention approved))
+          applied (:intervention (op/apply-intervention-result dispatched {:paused true}))
+          verified (:intervention (op/verify-intervention applied {:visible-state :paused-by-supervisor}))]
+      (is (= :approved (:intervention/state approved)))
+      (is (= :dispatched (:intervention/state dispatched)))
+      (is (= :applied (:intervention/state applied)))
+      (is (= :verified (:intervention/state verified)))
+      (is (= {:visible-state :paused-by-supervisor} (:intervention/outcome verified))))))
+
+(deftest intervention-can-enter-pending-human
+  (testing "given a risky intervention → the lifecycle supports an explicit pending-human step"
+    (let [created (op/create-intervention
+                   (intervention-request :request-human-review (random-uuid)))
+          pending (:intervention (op/start-intervention-approval created))
+          approved (:intervention (op/approve-intervention pending))]
+      (is (= :pending-human (:intervention/state pending)))
+      (is (= :approved (:intervention/state approved))))))
+
+(deftest invalid-intervention-operations-return-errors
+  (testing "given a terminal intervention → further transitions are rejected"
+    (let [created (op/create-intervention
+                   (intervention-request :waive (random-uuid)))
+          rejected (:intervention (op/reject-intervention created "not allowed"))
+          result (op/dispatch-intervention rejected)]
+      (is (= :rejected (:intervention/state rejected)))
+      (is (false? (:success? result)))
+      (is (= :terminal-state (:error result)))))
+
+  (testing "given an unknown intervention type → creation throws"
+    (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                          #"Unknown intervention type"
+                          (op/create-intervention
+                           (intervention-request :unknown-action (random-uuid)))))))

--- a/components/operator/test/ai/miniforge/operator/intervention_test.clj
+++ b/components/operator/test/ai/miniforge/operator/intervention_test.clj
@@ -20,6 +20,7 @@
   "Tests for bounded intervention lifecycle helpers."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.operator.messages :as messages]
    [ai.miniforge.operator.interface :as op]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -84,10 +85,13 @@
           result (op/dispatch-intervention rejected)]
       (is (= :rejected (:intervention/state rejected)))
       (is (false? (:success? result)))
-      (is (= :terminal-state (:error result)))))
+      (is (= :terminal-state (:error result)))
+      (is (= (messages/t :intervention/terminal-state {:state :rejected})
+             (:message result)))))
 
   (testing "given an unknown intervention type → creation throws"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"Unknown intervention type"
+                          (re-pattern (java.util.regex.Pattern/quote
+                                       (messages/t :intervention/unknown-type)))
                           (op/create-intervention
                            (intervention-request :unknown-action (random-uuid)))))))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -29,8 +29,7 @@
    It is a pure function from an event-stream prefix to an EntityTable."
   (:require
    [clojure.edn :as edn]
-   [clojure.java.io :as io]
-   [clojure.string :as str]))
+   [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Helpers
@@ -45,6 +44,9 @@
   [workflow-id]
   (let [s (str workflow-id)]
     (str "wf-" (subs s 0 (min 8 (count s))))))
+
+(def ^:private default-agent-heartbeat-interval-ms
+  30000)
 
 (defn- now
   "Wall-clock instant. Indirected through a fn so tests can with-redefs it."
@@ -82,7 +84,8 @@
         ts       (event-instant event)
         spec     (:workflow/spec event)
         intent   (or (some-> event :workflow/intent str)
-                     (or (:message event) ""))
+                     (:message event)
+                     "")
         wf-key   (or (:workflow/key spec)
                      (some-> spec :workflow/spec name)
                      (workflow-key-fallback id))
@@ -153,6 +156,15 @@
                    {:workflow-run/status     :failed
                     :workflow-run/updated-at ts}))))
 
+(defn workflow-cancelled
+  [table {:workflow/keys [id] :as event}]
+  (let [ts (event-instant event)]
+    (-> table
+        (ensure-workflow id ts)
+        (update-in [:workflows id] merge
+                   {:workflow-run/status     :cancelled
+                    :workflow-run/updated-at ts}))))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; AgentSession handlers
 
@@ -166,7 +178,7 @@
                :agent/name                 (or agent-name (some-> vendor name) "")
                :agent/status               :idle
                :agent/capabilities         (or capabilities [])
-               :agent/heartbeat-interval-ms 30000
+               :agent/heartbeat-interval-ms default-agent-heartbeat-interval-ms
                :agent/metadata             (or (:cp/metadata event) {})
                :agent/tags                 []
                :agent/registered-at        ts
@@ -499,6 +511,90 @@
     (cond-> table
       entity (assoc-in [:decisions (:decision/id entity)] entity))))
 
+;------------------------------------------------------------------------------ Layer 1
+;; InterventionRequest handlers
+
+(defn- intervention-stub
+  [event]
+  (let [ts (event-instant event)]
+    {:intervention/id (or (:intervention/id event) (random-uuid))
+     :intervention/type :request-human-review
+     :intervention/target-type :supervision
+     :intervention/target-id nil
+     :intervention/requested-by "unknown"
+     :intervention/request-source :api
+     :intervention/state :proposed
+     :intervention/requested-at ts
+     :intervention/updated-at ts}))
+
+(defn- intervention-attributes
+  [event requested-at updated-at]
+  (cond-> {:intervention/id (:intervention/id event)
+           :intervention/state (get event :intervention/state :proposed)
+           :intervention/requested-at requested-at
+           :intervention/updated-at updated-at}
+    (:intervention/type event)
+    (assoc :intervention/type (:intervention/type event))
+
+    (:intervention/target-type event)
+    (assoc :intervention/target-type (:intervention/target-type event))
+
+    (contains? event :intervention/target-id)
+    (assoc :intervention/target-id (:intervention/target-id event))
+
+    (:intervention/requested-by event)
+    (assoc :intervention/requested-by (:intervention/requested-by event))
+
+    (:intervention/request-source event)
+    (assoc :intervention/request-source (:intervention/request-source event))
+
+    (:intervention/justification event)
+    (assoc :intervention/justification (:intervention/justification event))
+
+    (:intervention/details event)
+    (assoc :intervention/details (:intervention/details event))
+
+    (:intervention/reason event)
+    (assoc :intervention/reason (:intervention/reason event))
+
+    (:intervention/outcome event)
+    (assoc :intervention/outcome (:intervention/outcome event))
+
+    (contains? event :intervention/approval-required?)
+    (assoc :intervention/approval-required?
+           (:intervention/approval-required? event))))
+
+(defn supervisory-intervention-requested
+  [table event]
+  (let [intervention-id (:intervention/id event)
+        ts (or (:intervention/requested-at event) (event-instant event))
+        request (intervention-attributes event ts (or (:intervention/updated-at event) ts))]
+    (cond-> table
+      intervention-id (assoc-in [:interventions intervention-id] request))))
+
+(defn supervisory-intervention-state-changed
+  [table event]
+  (let [intervention-id (:intervention/id event)
+        existing (get-in table [:interventions intervention-id] (intervention-stub event))
+        updated-at (or (:intervention/updated-at event) (event-instant event))
+        updated (merge existing
+                       (intervention-attributes event
+                                                (or (:intervention/requested-at event)
+                                                    (:intervention/requested-at existing))
+                                                updated-at)
+                       {:intervention/state (or (:intervention/state event)
+                                                (:intervention/state existing)
+                                                :proposed)
+                        :intervention/updated-at updated-at})]
+    (cond-> table
+      intervention-id (assoc-in [:interventions intervention-id] updated))))
+
+(defn supervisory-intervention-upserted
+  [table event]
+  (let [entity (:supervisory/entity event)]
+    (cond-> table
+      entity (assoc-in [:interventions (:intervention/id entity)] entity))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Dispatch table — events not listed are no-ops at the entity-state level
 
@@ -509,12 +605,15 @@
    :workflow/phase-completed               workflow-phase-completed
    :workflow/completed                     workflow-completed
    :workflow/failed                        workflow-failed
+   :workflow/cancelled                     workflow-cancelled
    :control-plane/agent-registered         cp-agent-registered
    :control-plane/agent-state-changed      cp-agent-state-changed
    :control-plane/status-changed           cp-agent-state-changed
    :control-plane/agent-heartbeat          cp-agent-heartbeat
    :control-plane/decision-created         cp-decision-created
    :control-plane/decision-resolved        cp-decision-resolved
+   :supervisory/intervention-requested     supervisory-intervention-requested
+   :supervisory/intervention-state-changed supervisory-intervention-state-changed
    :agent/status                           agent-status
    :pr/created                             pr-created
    :pr/merged                              pr-merged
@@ -529,6 +628,7 @@
    :supervisory/pr-upserted                supervisory-pr-upserted
    :supervisory/task-node-upserted         supervisory-task-node-upserted
    :supervisory/decision-upserted          supervisory-decision-upserted
+   :supervisory/intervention-upserted      supervisory-intervention-upserted
    :supervisory/policy-evaluated           supervisory-policy-evaluated
    :supervisory/attention-derived          supervisory-attention-derived})
 

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
@@ -88,7 +88,8 @@
                :supervisory/policy-evaluated
                :supervisory/attention-derived
                :supervisory/task-node-upserted
-               :supervisory/decision-upserted}
+               :supervisory/decision-upserted
+               :supervisory/intervention-upserted}
              (:event/type event))
     (swap! component tick event)))
 
@@ -138,3 +139,6 @@
 (defn prs         [component] (vals (get-in @component [:table :prs])))
 (defn policy-evals [component] (vals (get-in @component [:table :policy-evals])))
 (defn attention   [component] (vals (get-in @component [:table :attention])))
+(defn tasks       [component] (vals (get-in @component [:table :tasks])))
+(defn decisions   [component] (vals (get-in @component [:table :decisions])))
+(defn interventions [component] (vals (get-in @component [:table :interventions])))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/emitter.clj
@@ -98,6 +98,16 @@
                                " → " (name (or (:decision/status decision-entity) :pending))))
       (assoc :supervisory/entity decision-entity)))
 
+(defn intervention-upserted
+  [stream intervention-entity]
+  (-> (es/create-envelope stream
+                          :supervisory/intervention-upserted
+                          nil
+                          (str "Intervention " (:intervention/id intervention-entity)
+                               " → "
+                               (name (or (:intervention/state intervention-entity) :proposed))))
+      (assoc :supervisory/entity intervention-entity)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Diff + emit — publish one event per entity that changed
 
@@ -127,4 +137,5 @@
     (emit-diff! stream attention-derived  (:attention    old-table) (:attention    new-table))
     (emit-diff! stream task-node-upserted (:tasks         old-table) (:tasks        new-table))
     (emit-diff! stream decision-upserted  (:decisions     old-table) (:decisions    new-table))
+    (emit-diff! stream intervention-upserted (:interventions old-table) (:interventions new-table))
     (- (count (es/get-events stream)) before)))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
@@ -37,6 +37,7 @@
 (def PolicyEvaluation schema/PolicyEvaluation)
 (def PolicyViolation  schema/PolicyViolation)
 (def AttentionItem    schema/AttentionItem)
+(def InterventionRequest schema/InterventionRequest)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Lifecycle
@@ -56,6 +57,9 @@
 (def prs           core/prs)
 (def policy-evals  core/policy-evals)
 (def attention     core/attention)
+(def tasks         core/tasks)
+(def decisions     core/decisions)
+(def interventions core/interventions)
 
 (comment
   (require '[ai.miniforge.event-stream.interface :as es])

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
@@ -99,6 +99,11 @@
    `:pending` (on create) and `:resolved` (on resolve)."
   [:pending :resolved :expired])
 
+(def intervention-states
+  "Lifecycle states of an InterventionRequest per
+   N5-delta-supervisory-control-plane §3.3."
+  [:proposed :pending-human :approved :rejected :dispatched :applied :verified :failed])
+
 ;------------------------------------------------------------------------------ Layer 0a
 ;; Registry extensions for supervisory v1
 
@@ -159,7 +164,11 @@
    :decision/id                  :id/uuid
    :decision/type                (into [:enum] decision-types)
    :decision/priority            (into [:enum] decision-priorities)
-   :decision/status              (into [:enum] decision-statuses)})
+   :decision/status              (into [:enum] decision-statuses)
+
+   ;; InterventionRequest (N5 supervisory delta §3.1 / §3.3)
+   :intervention/id              :id/uuid
+   :intervention/state           (into [:enum] intervention-states)})
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Entity schemas — open maps, mirror N5-delta-1 §3.1
@@ -380,6 +389,27 @@
    [:decision/comment    {:optional true} [:maybe string?]]
    [:decision/resolved-at {:optional true} [:maybe :common/timestamp]]])
 
+(def InterventionRequest
+  "A bounded supervisory control request per N5 supervisory delta §3.1.
+
+   The type and target-type stay open keywords at this boundary so replay and
+   downstream consumers preserve future spec-aligned additions."
+  [:map {:registry registry}
+   [:intervention/id :intervention/id]
+   [:intervention/type keyword?]
+   [:intervention/target-type keyword?]
+   [:intervention/target-id any?]
+   [:intervention/requested-by [:string {:min 1}]]
+   [:intervention/request-source keyword?]
+   [:intervention/state :intervention/state]
+   [:intervention/requested-at :common/timestamp]
+   [:intervention/updated-at :common/timestamp]
+   [:intervention/justification {:optional true} [:maybe string?]]
+   [:intervention/details {:optional true} [:maybe map?]]
+   [:intervention/approval-required? {:optional true} boolean?]
+   [:intervention/reason {:optional true} [:maybe string?]]
+   [:intervention/outcome {:optional true} any?]])
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Component-internal entity table
 
@@ -392,7 +422,8 @@
    [:policy-evals  [:map-of :id/uuid PolicyEvaluation]]
    [:attention     [:map-of :id/uuid AttentionItem]]
    [:tasks         [:map-of :id/uuid TaskNode]]
-   [:decisions     [:map-of :id/uuid DecisionCard]]])
+   [:decisions     [:map-of :id/uuid DecisionCard]]
+   [:interventions [:map-of :id/uuid InterventionRequest]]])
 
 (def empty-table
   "Initial empty entity table."
@@ -402,4 +433,5 @@
    :policy-evals {}
    :attention {}
    :tasks {}
-   :decisions {}})
+   :decisions {}
+   :interventions {}})

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -85,6 +85,13 @@
                   (acc/apply-event (ev :workflow/failed  {:workflow/id wf-id})))]
     (is (= :failed (get-in table [:workflows wf-id :workflow-run/status])))))
 
+(deftest workflow-cancelled-sets-cancelled-status
+  (let [wf-id (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :workflow/started {:workflow/id wf-id}))
+                  (acc/apply-event (ev :workflow/cancelled {:workflow/id wf-id})))]
+    (is (= :cancelled (get-in table [:workflows wf-id :workflow-run/status])))))
+
 ;------------------------------------------------------------------------------ AgentSession
 
 (deftest cp-agent-registered-inserts-session
@@ -452,6 +459,78 @@
                                 (ev :supervisory/decision-upserted
                                     {:supervisory/entity entity}))]
     (is (= entity (get-in table [:decisions did])))))
+
+;------------------------------------------------------------------------------ InterventionRequest
+
+(defn- intervention-requested-event
+  [intervention-id intervention-type target-type target-id & [extra]]
+  (ev :supervisory/intervention-requested
+      (merge {:intervention/id intervention-id
+              :intervention/type intervention-type
+              :intervention/target-type target-type
+              :intervention/target-id target-id
+              :intervention/requested-by "operator@example.com"
+              :intervention/request-source :tui
+              :intervention/state :proposed
+              :intervention/requested-at (java.util.Date.)
+              :intervention/updated-at (java.util.Date.)}
+             extra)))
+
+(defn- intervention-state-changed-event
+  [intervention-id next-state & [extra]]
+  (ev :supervisory/intervention-state-changed
+      (merge {:intervention/id intervention-id
+              :intervention/state next-state}
+             extra)))
+
+(deftest intervention-requested-creates-record
+  (let [intervention-id (random-uuid)
+        workflow-id (random-uuid)
+        table (acc/apply-event schema/empty-table
+                               (intervention-requested-event intervention-id
+                                                             :pause
+                                                             :workflow
+                                                             workflow-id))
+        request (get-in table [:interventions intervention-id])]
+    (is (= :pause (:intervention/type request)))
+    (is (= :workflow (:intervention/target-type request)))
+    (is (= workflow-id (:intervention/target-id request)))
+    (is (= :proposed (:intervention/state request)))))
+
+(deftest intervention-state-change-merges-onto-existing-record
+  (let [intervention-id (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (intervention-requested-event intervention-id
+                                                                :pause
+                                                                :workflow
+                                                                (random-uuid)))
+                  (acc/apply-event (intervention-state-changed-event
+                                    intervention-id
+                                    :applied
+                                    {:intervention/outcome {:paused true}
+                                     :intervention/reason "operator confirmed"})))
+        request (get-in table [:interventions intervention-id])]
+    (is (= :applied (:intervention/state request)))
+    (is (= {:paused true} (:intervention/outcome request)))
+    (is (= "operator confirmed" (:intervention/reason request)))
+    (is (= :pause (:intervention/type request))
+        "state-change events preserve creation fields from the request record")))
+
+(deftest intervention-upserted-applies-baseline
+  (let [intervention-id (random-uuid)
+        entity {:intervention/id intervention-id
+                :intervention/type :waive
+                :intervention/target-type :policy-eval
+                :intervention/target-id (random-uuid)
+                :intervention/requested-by "operator@example.com"
+                :intervention/request-source :dashboard
+                :intervention/state :verified
+                :intervention/requested-at (java.util.Date.)
+                :intervention/updated-at (java.util.Date.)}
+        table (acc/apply-event schema/empty-table
+                               (ev :supervisory/intervention-upserted
+                                   {:supervisory/entity entity}))]
+    (is (= entity (get-in table [:interventions intervention-id])))))
 
 ;------------------------------------------------------------------------------ PolicyEvaluation
 

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
@@ -20,7 +20,7 @@
   "End-to-end tests for the supervisory-state component lifecycle:
    replay, live subscription, snapshot emission, and re-emit prevention."
   (:require
-   [clojure.test :refer [deftest testing is]]
+   [clojure.test :refer [deftest is]]
    [ai.miniforge.event-stream.core :as es-core]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.supervisory-state.core :as core]
@@ -221,3 +221,53 @@
       (is (= "approve"   (:decision/resolution (:supervisory/entity final))))
       (is (= aid         (:decision/agent-id (:supervisory/entity final)))
           "resolve event must preserve the agent-id from the create event"))))
+
+;------------------------------------------------------------------------------ InterventionRequest
+
+(defn- intervention-requested-event [workflow-id intervention-id]
+  {:event/type :supervisory/intervention-requested
+   :event/id (random-uuid)
+   :event/timestamp (java.util.Date.)
+   :event/version "1.0.0"
+   :event/sequence-number 0
+   :workflow/id workflow-id
+   :intervention/id intervention-id
+   :intervention/type :pause
+   :intervention/target-type :workflow
+   :intervention/target-id workflow-id
+   :intervention/requested-by "operator@example.com"
+   :intervention/request-source :tui
+   :intervention/state :proposed
+   :intervention/requested-at (java.util.Date.)
+   :intervention/updated-at (java.util.Date.)
+   :message "Pause requested"})
+
+(defn- intervention-state-changed-event [workflow-id intervention-id next-state]
+  {:event/type :supervisory/intervention-state-changed
+   :event/id (random-uuid)
+   :event/timestamp (java.util.Date.)
+   :event/version "1.0.0"
+   :event/sequence-number 0
+   :workflow/id workflow-id
+   :intervention/id intervention-id
+   :intervention/state next-state
+   :intervention/outcome {:paused true}
+   :message (str "Intervention " intervention-id " → " (name next-state))})
+
+(deftest intervention-events-produce-supervisory-intervention-snapshots
+  (let [stream (no-sink-stream)
+        comp   (iface/create stream)
+        workflow-id (random-uuid)
+        intervention-id (random-uuid)]
+    (iface/start! comp)
+    (es/publish! stream (intervention-requested-event workflow-id intervention-id))
+    (es/publish! stream (intervention-state-changed-event workflow-id intervention-id :applied))
+    (let [snaps (->> (supervisory-events stream)
+                     (filter #(= :supervisory/intervention-upserted (:event/type %))))
+          final (last snaps)]
+      (is (= 2 (count snaps)) "request + applied state change should each emit a snapshot")
+      (is (= :applied (get-in final [:supervisory/entity :intervention/state])))
+      (is (= {:paused true} (get-in final [:supervisory/entity :intervention/outcome])))
+      (is (= intervention-id (->> (iface/interventions comp)
+                                  first
+                                  :intervention/id))))))

--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -35,6 +35,14 @@
   ;; Supervision
   :supervision/unsupported-supervisor
   "Unsupported workflow supervisor id: {supervisor-id}"
+  :supervision/terminal-state
+  "Cannot transition from terminal state: {state}"
+  :supervision/invalid-state
+  "Invalid supervision state: {state}"
+  :supervision/guard-rejected
+  "Guard function rejected supervision transition"
+  :supervision/invalid-transition
+  "No supervision transition defined for [{state} {event}]"
 
   ;; Execution mode
   :governed/no-capsule      "No capsule executor available for governed workflow"

--- a/components/workflow/resources/config/workflow/supervision.edn
+++ b/components/workflow/resources/config/workflow/supervision.edn
@@ -1,0 +1,36 @@
+{:workflow/supervision
+ {:fsm/id :workflow-supervision
+  :fsm/initial :nominal
+  :fsm/context {}
+  :fsm/states
+  {:nominal
+   {:on {:warning-detected :warning
+         :operator-paused :paused-by-supervisor
+         :operator-escalated :awaiting-operator
+         :execution-failed :awaiting-operator
+         :execution-completed :halted
+         :execution-cancelled :halted}}
+
+   :warning
+   {:on {:warning-cleared :nominal
+         :operator-paused :paused-by-supervisor
+         :operator-escalated :awaiting-operator
+         :execution-failed :awaiting-operator
+         :execution-completed :halted
+         :execution-cancelled :halted}}
+
+   :paused-by-supervisor
+   {:on {:operator-resumed :nominal
+         :operator-escalated :awaiting-operator
+         :execution-failed :awaiting-operator
+         :execution-completed :halted
+         :execution-cancelled :halted}}
+
+   :awaiting-operator
+   {:on {:operator-cleared :nominal
+         :operator-paused :paused-by-supervisor
+         :execution-completed :halted
+         :execution-cancelled :halted}}
+
+   :halted
+   {:type :final}}}}

--- a/components/workflow/src/ai/miniforge/workflow/interface.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface.clj
@@ -26,7 +26,8 @@
    [ai.miniforge.workflow.interface.profiles :as profiles]
    [ai.miniforge.workflow.interface.protocols :as protocols]
    [ai.miniforge.workflow.interface.registry :as registry]
-   [ai.miniforge.workflow.interface.runtime :as runtime]))
+   [ai.miniforge.workflow.interface.runtime :as runtime]
+   [ai.miniforge.workflow.interface.supervision :as supervision]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Protocols and workflow topology
@@ -56,6 +57,24 @@
 (def run-workflow runtime/run-workflow)
 
 ;------------------------------------------------------------------------------ Layer 2
+;; Supervision machine
+
+(def supervision-states supervision/supervision-states)
+(def supervision-terminal-states supervision/terminal-states)
+(def supervision-transitions supervision/supervision-transitions)
+(def valid-supervision-state? supervision/valid-state?)
+(def supervision-terminal-state? supervision/terminal-state?)
+(def valid-supervision-transition? supervision/valid-transition?)
+(def next-supervision-state supervision/next-state)
+(def transition-supervision supervision/transition)
+(def get-supervision-events supervision/get-available-events)
+(def supervision-machine-graph supervision/machine-graph)
+(def initialize-supervision supervision/initialize)
+(def transition-supervision-fsm supervision/transition-fsm)
+(def current-supervision-state supervision/current-state)
+(def final-supervision-state? supervision/is-final?)
+
+;------------------------------------------------------------------------------ Layer 3
 ;; Pipeline, configurable workflows, persistence, and registry helpers
 
 (def run-pipeline pipeline/run-pipeline)

--- a/components/workflow/src/ai/miniforge/workflow/interface/supervision.clj
+++ b/components/workflow/src/ai/miniforge/workflow/interface/supervision.clj
@@ -1,0 +1,48 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.interface.supervision
+  "Public API for the per-run workflow supervision machine."
+  (:require
+   [ai.miniforge.workflow.supervision :as supervision]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; State and transition definitions
+
+(def supervision-states supervision/supervision-states)
+(def terminal-states supervision/terminal-states)
+(def supervision-transitions supervision/supervision-transitions)
+
+;------------------------------------------------------------------------------ Layer 1
+;; State helpers
+
+(def valid-state? supervision/valid-state?)
+(def terminal-state? supervision/terminal-state?)
+(def valid-transition? supervision/valid-transition?)
+(def next-state supervision/next-state)
+(def transition supervision/transition)
+(def get-available-events supervision/get-available-events)
+(def machine-graph supervision/machine-graph)
+
+;------------------------------------------------------------------------------ Layer 2
+;; Shared FSM surface
+
+(def initialize supervision/initialize)
+(def transition-fsm supervision/transition-fsm)
+(def current-state supervision/current-state)
+(def is-final? supervision/is-final?)

--- a/components/workflow/src/ai/miniforge/workflow/supervision.clj
+++ b/components/workflow/src/ai/miniforge/workflow/supervision.clj
@@ -1,0 +1,202 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.supervision
+  "Per-run supervision machine for live governance and operator posture.
+
+   This machine is intentionally separate from the execution machine in
+   `workflow.fsm`. It models the runtime supervisory stance around a run,
+   not the workflow graph itself."
+  (:require
+   [ai.miniforge.fsm.interface :as fsm]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Machine definition
+
+(def supervision-states
+  "Known per-run supervision states per
+   I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE §3.2."
+  #{:nominal :warning :paused-by-supervisor :awaiting-operator :halted})
+
+(def terminal-states
+  "Supervision terminal states."
+  #{:halted})
+
+(def supervision-transitions
+  "Valid supervision transitions. Map of [from-state event] -> to-state."
+  {[:nominal :warning-detected]              :warning
+   [:nominal :operator-paused]               :paused-by-supervisor
+   [:nominal :operator-escalated]            :awaiting-operator
+   [:nominal :execution-failed]              :awaiting-operator
+   [:nominal :execution-completed]           :halted
+   [:nominal :execution-cancelled]           :halted
+
+   [:warning :warning-cleared]               :nominal
+   [:warning :operator-paused]               :paused-by-supervisor
+   [:warning :operator-escalated]            :awaiting-operator
+   [:warning :execution-failed]              :awaiting-operator
+   [:warning :execution-completed]           :halted
+   [:warning :execution-cancelled]           :halted
+
+   [:paused-by-supervisor :operator-resumed] :nominal
+   [:paused-by-supervisor :operator-escalated] :awaiting-operator
+   [:paused-by-supervisor :execution-failed] :awaiting-operator
+   [:paused-by-supervisor :execution-completed] :halted
+   [:paused-by-supervisor :execution-cancelled] :halted
+
+   [:awaiting-operator :operator-cleared]    :nominal
+   [:awaiting-operator :operator-paused]     :paused-by-supervisor
+   [:awaiting-operator :execution-completed] :halted
+   [:awaiting-operator :execution-cancelled] :halted})
+
+(def supervision-machine-config
+  "Data-driven machine config used by the shared fsm component."
+  {:fsm/id :workflow-supervision
+   :fsm/initial :nominal
+   :fsm/context {}
+   :fsm/states
+   {:nominal              {:on {:warning-detected :warning
+                                :operator-paused :paused-by-supervisor
+                                :operator-escalated :awaiting-operator
+                                :execution-failed :awaiting-operator
+                                :execution-completed :halted
+                                :execution-cancelled :halted}}
+    :warning              {:on {:warning-cleared :nominal
+                                :operator-paused :paused-by-supervisor
+                                :operator-escalated :awaiting-operator
+                                :execution-failed :awaiting-operator
+                                :execution-completed :halted
+                                :execution-cancelled :halted}}
+    :paused-by-supervisor {:on {:operator-resumed :nominal
+                                :operator-escalated :awaiting-operator
+                                :execution-failed :awaiting-operator
+                                :execution-completed :halted
+                                :execution-cancelled :halted}}
+    :awaiting-operator    {:on {:operator-cleared :nominal
+                                :operator-paused :paused-by-supervisor
+                                :execution-completed :halted
+                                :execution-cancelled :halted}}
+    :halted               {:type :final}}})
+
+(def supervision-machine
+  "Compiled supervision state machine."
+  (fsm/define-machine supervision-machine-config))
+
+(defn- transition-error
+  [error message]
+  {:success? false
+   :error error
+   :message message})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Legacy-style helper API
+
+(defn valid-state?
+  "Check if a supervision state keyword is valid."
+  [state]
+  (contains? supervision-states state))
+
+(defn terminal-state?
+  "Check if a supervision state is terminal."
+  [state]
+  (contains? terminal-states state))
+
+(defn valid-transition?
+  "Check if a supervision transition is valid."
+  [current-state event]
+  (contains? supervision-transitions [current-state event]))
+
+(defn next-state
+  "Get the next state for a supervision transition."
+  [current-state event]
+  (get supervision-transitions [current-state event]))
+
+(defn transition
+  "Attempt a pure supervision transition.
+
+   Returns:
+   - {:success? true :state new-state}
+   - {:success? false :error keyword :message string}"
+  ([current-state event]
+   (transition current-state event (constantly true)))
+
+  ([current-state event guard-fn]
+   (cond
+     (terminal-state? current-state)
+     (transition-error
+      :terminal-state
+      (str "Cannot transition from terminal state: " current-state))
+
+     (not (valid-state? current-state))
+     (transition-error
+      :invalid-state
+      (str "Invalid supervision state: " current-state))
+
+     (not (guard-fn current-state event))
+     (transition-error
+      :guard-failed
+      "Guard function rejected supervision transition")
+
+     (not (valid-transition? current-state event))
+     (transition-error
+      :invalid-transition
+      (str "No supervision transition defined for ["
+           current-state " " event "]"))
+
+     :else
+     (let [state-map {:_state current-state}
+           new-state-map (fsm/transition supervision-machine state-map event)]
+       {:success? true
+        :state (fsm/current-state new-state-map)}))))
+
+(defn initialize
+  "Initialize supervision state."
+  []
+  (fsm/initialize supervision-machine))
+
+(defn transition-fsm
+  "Transition supervision state using the compiled shared FSM."
+  [state event]
+  (fsm/transition supervision-machine state event))
+
+(defn current-state
+  "Read the current supervision state keyword."
+  [state]
+  (fsm/current-state state))
+
+(defn is-final?
+  "Check if the compiled machine state is final."
+  [state]
+  (fsm/final? supervision-machine state))
+
+(defn get-available-events
+  "List valid events from `current-state`."
+  [current-state]
+  (vec (keep (fn [[[from-state event] _to-state]]
+               (when (= from-state current-state)
+                 event))
+             supervision-transitions)))
+
+(defn machine-graph
+  "Return a graph-style view of the supervision machine."
+  []
+  {:states supervision-states
+   :transitions (vec (map (fn [[[from event] to]]
+                           {:from from :event event :to to})
+                         supervision-transitions))
+   :terminal-states terminal-states})

--- a/components/workflow/src/ai/miniforge/workflow/supervision.clj
+++ b/components/workflow/src/ai/miniforge/workflow/supervision.clj
@@ -21,77 +21,56 @@
 
    This machine is intentionally separate from the execution machine in
    `workflow.fsm`. It models the runtime supervisory stance around a run,
-   not the workflow graph itself."
+  not the workflow graph itself."
   (:require
-   [ai.miniforge.fsm.interface :as fsm]))
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]
+   [ai.miniforge.fsm.interface :as fsm]
+   [ai.miniforge.workflow.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Machine definition
 
-(def supervision-states
-  "Known per-run supervision states per
-   I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE §3.2."
-  #{:nominal :warning :paused-by-supervisor :awaiting-operator :halted})
+(def ^:private supervision-config-resource
+  "Classpath location of the per-run supervision machine config."
+  "config/workflow/supervision.edn")
 
-(def terminal-states
-  "Supervision terminal states."
-  #{:halted})
-
-(def supervision-transitions
-  "Valid supervision transitions. Map of [from-state event] -> to-state."
-  {[:nominal :warning-detected]              :warning
-   [:nominal :operator-paused]               :paused-by-supervisor
-   [:nominal :operator-escalated]            :awaiting-operator
-   [:nominal :execution-failed]              :awaiting-operator
-   [:nominal :execution-completed]           :halted
-   [:nominal :execution-cancelled]           :halted
-
-   [:warning :warning-cleared]               :nominal
-   [:warning :operator-paused]               :paused-by-supervisor
-   [:warning :operator-escalated]            :awaiting-operator
-   [:warning :execution-failed]              :awaiting-operator
-   [:warning :execution-completed]           :halted
-   [:warning :execution-cancelled]           :halted
-
-   [:paused-by-supervisor :operator-resumed] :nominal
-   [:paused-by-supervisor :operator-escalated] :awaiting-operator
-   [:paused-by-supervisor :execution-failed] :awaiting-operator
-   [:paused-by-supervisor :execution-completed] :halted
-   [:paused-by-supervisor :execution-cancelled] :halted
-
-   [:awaiting-operator :operator-cleared]    :nominal
-   [:awaiting-operator :operator-paused]     :paused-by-supervisor
-   [:awaiting-operator :execution-completed] :halted
-   [:awaiting-operator :execution-cancelled] :halted})
+(defn- load-supervision-machine-config
+  []
+  (if-let [resource (io/resource supervision-config-resource)]
+    (:workflow/supervision (edn/read-string (slurp resource)))
+    (throw (ex-info "Missing workflow supervision config resource"
+                    {:resource supervision-config-resource}))))
 
 (def supervision-machine-config
   "Data-driven machine config used by the shared fsm component."
-  {:fsm/id :workflow-supervision
-   :fsm/initial :nominal
-   :fsm/context {}
-   :fsm/states
-   {:nominal              {:on {:warning-detected :warning
-                                :operator-paused :paused-by-supervisor
-                                :operator-escalated :awaiting-operator
-                                :execution-failed :awaiting-operator
-                                :execution-completed :halted
-                                :execution-cancelled :halted}}
-    :warning              {:on {:warning-cleared :nominal
-                                :operator-paused :paused-by-supervisor
-                                :operator-escalated :awaiting-operator
-                                :execution-failed :awaiting-operator
-                                :execution-completed :halted
-                                :execution-cancelled :halted}}
-    :paused-by-supervisor {:on {:operator-resumed :nominal
-                                :operator-escalated :awaiting-operator
-                                :execution-failed :awaiting-operator
-                                :execution-completed :halted
-                                :execution-cancelled :halted}}
-    :awaiting-operator    {:on {:operator-cleared :nominal
-                                :operator-paused :paused-by-supervisor
-                                :execution-completed :halted
-                                :execution-cancelled :halted}}
-    :halted               {:type :final}}})
+  (load-supervision-machine-config))
+
+(defn- state-definitions
+  []
+  (:fsm/states supervision-machine-config))
+
+(def supervision-states
+  "Known per-run supervision states per
+   I-WORKFLOW-SUPERVISION-MACHINE-ARCHITECTURE §3.2."
+  (set (keys (state-definitions))))
+
+(def terminal-states
+  "Supervision terminal states."
+  (->> (state-definitions)
+       (keep (fn [[state definition]]
+               (when (= :final (:type definition))
+                 state)))
+       set))
+
+(def supervision-transitions
+  "Valid supervision transitions. Map of [from-state event] -> to-state."
+  (->> (state-definitions)
+       (mapcat (fn [[from-state definition]]
+                 (map (fn [[event to-state]]
+                        [[from-state event] to-state])
+                      (:on definition))))
+       (into {})))
 
 (def supervision-machine
   "Compiled supervision state machine."
@@ -140,23 +119,24 @@
      (terminal-state? current-state)
      (transition-error
       :terminal-state
-      (str "Cannot transition from terminal state: " current-state))
+      (messages/t :supervision/terminal-state {:state current-state}))
 
      (not (valid-state? current-state))
      (transition-error
       :invalid-state
-      (str "Invalid supervision state: " current-state))
+      (messages/t :supervision/invalid-state {:state current-state}))
 
      (not (guard-fn current-state event))
      (transition-error
       :guard-failed
-      "Guard function rejected supervision transition")
+      (messages/t :supervision/guard-rejected))
 
      (not (valid-transition? current-state event))
      (transition-error
       :invalid-transition
-      (str "No supervision transition defined for ["
-           current-state " " event "]"))
+      (messages/t :supervision/invalid-transition
+                  {:state current-state
+                   :event event}))
 
      :else
      (let [state-map {:_state current-state}

--- a/components/workflow/test/ai/miniforge/workflow/supervision_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/supervision_test.clj
@@ -1,0 +1,87 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.supervision-test
+  "Tests for the per-run workflow supervision machine."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.workflow.supervision :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Helpers
+
+(def ^:private expected-states
+  #{:nominal :warning :paused-by-supervisor :awaiting-operator :halted})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Unit tests
+
+(deftest supervision-states-match-spec
+  (testing "given the supervision machine → the expected states are present"
+    (is (= expected-states sut/supervision-states))
+    (is (= #{:halted} sut/terminal-states))))
+
+(deftest valid-supervision-transitions-are-recognized
+  (testing "given nominal supervision → warning, pause, escalate, and execution failure are valid"
+    (is (sut/valid-transition? :nominal :warning-detected))
+    (is (sut/valid-transition? :nominal :operator-paused))
+    (is (sut/valid-transition? :nominal :operator-escalated))
+    (is (sut/valid-transition? :nominal :execution-failed)))
+
+  (testing "given paused supervision → resume and escalate are valid"
+    (is (sut/valid-transition? :paused-by-supervisor :operator-resumed))
+    (is (sut/valid-transition? :paused-by-supervisor :operator-escalated))))
+
+(deftest invalid-supervision-transitions-are-rejected
+  (testing "given an invalid event from nominal → transition returns a failure result"
+    (let [result (sut/transition :nominal :operator-resumed)]
+      (is (false? (:success? result)))
+      (is (= :invalid-transition (:error result)))))
+
+  (testing "given a terminal state → no further transitions are allowed"
+    (let [result (sut/transition :halted :operator-cleared)]
+      (is (false? (:success? result)))
+      (is (= :terminal-state (:error result))))))
+
+(deftest supervision-lifecycle-covers-live-governance-path
+  (testing "given a warning, escalation, and operator clear → the machine returns to nominal"
+    (let [warning (sut/transition :nominal :warning-detected)
+          escalated (sut/transition (:state warning) :operator-escalated)
+          cleared (sut/transition (:state escalated) :operator-cleared)]
+      (is (:success? warning))
+      (is (= :warning (:state warning)))
+      (is (:success? escalated))
+      (is (= :awaiting-operator (:state escalated)))
+      (is (:success? cleared))
+      (is (= :nominal (:state cleared)))))
+
+  (testing "given a completed execution → the supervision machine halts"
+    (let [halted (sut/transition :nominal :execution-completed)]
+      (is (:success? halted))
+      (is (= :halted (:state halted)))
+      (is (sut/terminal-state? (:state halted))))))
+
+(deftest compiled-supervision-fsm-matches-helper-api
+  (testing "given the compiled FSM path → transitions land in the same states"
+    (let [s0 (sut/initialize)
+          s1 (sut/transition-fsm s0 :warning-detected)
+          s2 (sut/transition-fsm s1 :execution-cancelled)]
+      (is (= :nominal (sut/current-state s0)))
+      (is (= :warning (sut/current-state s1)))
+      (is (= :halted (sut/current-state s2)))
+      (is (true? (sut/is-final? s2))))))

--- a/components/workflow/test/ai/miniforge/workflow/supervision_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/supervision_test.clj
@@ -20,6 +20,7 @@
   "Tests for the per-run workflow supervision machine."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.workflow.messages :as messages]
    [ai.miniforge.workflow.supervision :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -51,12 +52,18 @@
   (testing "given an invalid event from nominal → transition returns a failure result"
     (let [result (sut/transition :nominal :operator-resumed)]
       (is (false? (:success? result)))
-      (is (= :invalid-transition (:error result)))))
+      (is (= :invalid-transition (:error result)))
+      (is (= (messages/t :supervision/invalid-transition
+                         {:state :nominal
+                          :event :operator-resumed})
+             (:message result)))))
 
   (testing "given a terminal state → no further transitions are allowed"
     (let [result (sut/transition :halted :operator-cleared)]
       (is (false? (:success? result)))
-      (is (= :terminal-state (:error result))))))
+      (is (= :terminal-state (:error result)))
+      (is (= (messages/t :supervision/terminal-state {:state :halted})
+             (:message result))))))
 
 (deftest supervision-lifecycle-covers-live-governance-path
   (testing "given a warning, escalation, and operator clear → the machine returns to nominal"

--- a/docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md
+++ b/docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md
@@ -33,6 +33,8 @@ Without that, live control remained too implicit and too hard to reason about.
     - `:paused-by-supervisor`
     - `:awaiting-operator`
     - `:halted`
+  - move the supervision machine definition into
+    `config/workflow/supervision.edn`
   - expose both the compiled FSM path and a small legacy-style helper API
 - Add `operator.intervention`
   - bounded intervention vocabulary
@@ -46,6 +48,8 @@ Without that, live control remained too implicit and too hard to reason about.
     - `:applied`
     - `:verified`
     - `:failed`
+  - move intervention lifecycle configuration into
+    `config/operator/intervention.edn`
 - Extend `supervisory-state`
   - accumulate intervention events into the entity table
   - emit intervention upserts alongside existing supervisory entities
@@ -53,9 +57,16 @@ Without that, live control remained too implicit and too hard to reason about.
 - Extend `event-stream`
   - register the supervision/intervention event types
   - add schemas for intervention payloads
+  - localize the new supervisory intervention event messages in
+    `config/event-stream/messages/en-US.edn`
   - preserve `:phase/transition-request` on phase-completed events
   - keep `:phase/redirect-to` as a derived compatibility projection for older
     consumers while the new transition-request shape remains authoritative
+- Localize new runtime failure messages
+  - operator intervention validation/transition errors now come from
+    `config/operator/messages/en-US.edn`
+  - workflow supervision transition errors now come from
+    `config/workflow/messages/en-US.edn`
 - Extend workflow interface surface
   - export supervision helpers without reintroducing `meta` terminology
 
@@ -81,6 +92,8 @@ No deployment step. Internal control-plane and projection refactor only.
 
 - [x] Workflow supervision has a formal per-run FSM
 - [x] Intervention intent/lifecycle is bounded and explicit
+- [x] New configuration in this slice is loaded from EDN resources
+- [x] New user-facing messages in this slice are localized through `en-US.edn`
 - [x] Supervisory-state projects intervention entities
 - [x] Event-stream carries the authoritative transition-request payload shape
 - [x] Tests cover the new FSM/projection paths

--- a/docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md
+++ b/docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md
@@ -1,0 +1,86 @@
+# feat: formalize workflow supervision and intervention lifecycle
+
+## Overview
+
+Add the first formal runtime pieces for live workflow governance:
+
+- a per-run workflow supervision FSM
+- a bounded intervention lifecycle model
+- supervisory-state projection support for interventions
+
+This slice keeps the orchestrator/application boundary stable while moving the
+live supervision lane onto explicit state-machine semantics and evented
+projection paths.
+
+## Motivation
+
+The architecture/spec work established that live supervision is separate from
+both workflow execution and the learning loop. The codebase still needed a
+formal runtime model for:
+
+- per-run supervision posture
+- bounded intervention intent and lifecycle
+- supervisory projections for those interventions
+
+Without that, live control remained too implicit and too hard to reason about.
+
+## Changes In Detail
+
+- Add `workflow.supervision`
+  - formal per-run supervision states:
+    - `:nominal`
+    - `:warning`
+    - `:paused-by-supervisor`
+    - `:awaiting-operator`
+    - `:halted`
+  - expose both the compiled FSM path and a small legacy-style helper API
+- Add `operator.intervention`
+  - bounded intervention vocabulary
+  - intervention target-type resolution
+  - intervention lifecycle transitions:
+    - `:proposed`
+    - `:pending-human`
+    - `:approved`
+    - `:rejected`
+    - `:dispatched`
+    - `:applied`
+    - `:verified`
+    - `:failed`
+- Extend `supervisory-state`
+  - accumulate intervention events into the entity table
+  - emit intervention upserts alongside existing supervisory entities
+  - cover the new reducer/emitter behavior with direct tests
+- Extend `event-stream`
+  - register the supervision/intervention event types
+  - add schemas for intervention payloads
+  - preserve `:phase/transition-request` on phase-completed events
+  - keep `:phase/redirect-to` as a derived compatibility projection for older
+    consumers while the new transition-request shape remains authoritative
+- Extend workflow interface surface
+  - export supervision helpers without reintroducing `meta` terminology
+
+## Testing Plan
+
+- `clj-kondo --lint` on touched source and test files
+- `bb test components/event-stream components/operator components/supervisory-state components/workflow`
+- `bb pre-commit`
+
+## Deployment Plan
+
+No deployment step. Internal control-plane and projection refactor only.
+
+## Related Issues/PRs
+
+- Follows merged `#641`, `#642`, and `#644`
+- Unblocks the next runtime slices:
+  - orchestrator integration over supervision/intervention events
+  - PR lifecycle FSM
+  - configurable workflow compiler/selection work
+
+## Checklist
+
+- [x] Workflow supervision has a formal per-run FSM
+- [x] Intervention intent/lifecycle is bounded and explicit
+- [x] Supervisory-state projects intervention entities
+- [x] Event-stream carries the authoritative transition-request payload shape
+- [x] Tests cover the new FSM/projection paths


### PR DESCRIPTION
# feat: formalize workflow supervision and intervention lifecycle

## Overview

Add the first formal runtime pieces for live workflow governance:

- a per-run workflow supervision FSM
- a bounded intervention lifecycle model
- supervisory-state projection support for interventions

This slice keeps the orchestrator/application boundary stable while moving the
live supervision lane onto explicit state-machine semantics and evented
projection paths.

## Motivation

The architecture/spec work established that live supervision is separate from
both workflow execution and the learning loop. The codebase still needed a
formal runtime model for:

- per-run supervision posture
- bounded intervention intent and lifecycle
- supervisory projections for those interventions

Without that, live control remained too implicit and too hard to reason about.

## Changes In Detail

- Add `workflow.supervision`
  - formal per-run supervision states:
    - `:nominal`
    - `:warning`
    - `:paused-by-supervisor`
    - `:awaiting-operator`
    - `:halted`
  - expose both the compiled FSM path and a small legacy-style helper API
- Add `operator.intervention`
  - bounded intervention vocabulary
  - intervention target-type resolution
  - intervention lifecycle transitions:
    - `:proposed`
    - `:pending-human`
    - `:approved`
    - `:rejected`
    - `:dispatched`
    - `:applied`
    - `:verified`
    - `:failed`
- Extend `supervisory-state`
  - accumulate intervention events into the entity table
  - emit intervention upserts alongside existing supervisory entities
  - cover the new reducer/emitter behavior with direct tests
- Extend `event-stream`
  - register the supervision/intervention event types
  - add schemas for intervention payloads
  - preserve `:phase/transition-request` on phase-completed events
  - keep `:phase/redirect-to` as a derived compatibility projection for older
    consumers while the new transition-request shape remains authoritative
- Extend workflow interface surface
  - export supervision helpers without reintroducing `meta` terminology

## Testing Plan

- `clj-kondo --lint` on touched source and test files
- `bb test components/event-stream components/operator components/supervisory-state components/workflow`
- `bb pre-commit`

## Deployment Plan

No deployment step. Internal control-plane and projection refactor only.

## Related Issues/PRs

- Follows merged `#641`, `#642`, and `#644`
- Unblocks the next runtime slices:
  - orchestrator integration over supervision/intervention events
  - PR lifecycle FSM
  - configurable workflow compiler/selection work

## Checklist

- [x] Workflow supervision has a formal per-run FSM
- [x] Intervention intent/lifecycle is bounded and explicit
- [x] Supervisory-state projects intervention entities
- [x] Event-stream carries the authoritative transition-request payload shape
- [x] Tests cover the new FSM/projection paths
