### PR TITLE
feat: formalize PR lifecycle controller FSM

### DIFF
--- a/components/pr-lifecycle/deps.edn
+++ b/components/pr-lifecycle/deps.edn
@@ -1,6 +1,8 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/config {:local/root "../config"}
         ai.miniforge/dag-executor {:local/root "../dag-executor"}
+        ai.miniforge/fsm {:local/root "../fsm"}
+        ai.miniforge/messages {:local/root "../messages"}
         ai.miniforge/release-executor {:local/root "../release-executor"}
         ai.miniforge/loop {:local/root "../loop"}
         ai.miniforge/agent {:local/root "../agent"}

--- a/components/pr-lifecycle/resources/config/pr-lifecycle/controller-defaults.edn
+++ b/components/pr-lifecycle/resources/config/pr-lifecycle/controller-defaults.edn
@@ -1,0 +1,6 @@
+{:pr-lifecycle/controller-defaults
+ {:max-fix-iterations 5
+  :ci-poll-interval-ms 30000
+  :review-poll-interval-ms 30000
+  :auto-resolve-comments true
+  :branch-name-prefix "task-"}}

--- a/components/pr-lifecycle/resources/config/pr-lifecycle/fsm.edn
+++ b/components/pr-lifecycle/resources/config/pr-lifecycle/fsm.edn
@@ -1,0 +1,30 @@
+{:pr-lifecycle/fsm
+ {:initial-status :pending
+  :statuses
+  [:pending
+   :creating-pr
+   :monitoring-ci
+   :monitoring-review
+   :fixing
+   :ready-to-merge
+   :merged
+   :failed]
+  :terminal-statuses
+  #{:merged :failed}
+  :status-transition-events
+  {[:pending :creating-pr] :create-pr
+   [:pending :monitoring-ci] :start-ci-monitoring
+   [:pending :failed] :fail
+   [:creating-pr :monitoring-ci] :start-ci-monitoring
+   [:creating-pr :failed] :fail
+   [:monitoring-ci :monitoring-review] :start-review-monitoring
+   [:monitoring-ci :fixing] :start-fixing
+   [:monitoring-ci :failed] :fail
+   [:monitoring-review :ready-to-merge] :mark-ready-to-merge
+   [:monitoring-review :fixing] :start-fixing
+   [:monitoring-review :failed] :fail
+   [:fixing :monitoring-ci] :start-ci-monitoring
+   [:fixing :failed] :fail
+   [:ready-to-merge :monitoring-ci] :start-ci-monitoring
+   [:ready-to-merge :merged] :merge
+   [:ready-to-merge :failed] :fail}}}

--- a/components/pr-lifecycle/resources/config/pr-lifecycle/messages/en-US.edn
+++ b/components/pr-lifecycle/resources/config/pr-lifecycle/messages/en-US.edn
@@ -1,0 +1,52 @@
+{:pr-lifecycle/messages
+ {;; Config
+  :config/missing-resource
+  "Missing classpath resource: {resource}"
+  :config/classpath-hint
+  "Add components/pr-lifecycle/resources to your classpath"
+
+  ;; Controller
+  :controller/invalid-transition
+  "Invalid PR lifecycle controller status transition"
+  :controller/creating-pr
+  "Creating PR for task"
+  :controller/pr-created
+  "PR created successfully"
+  :controller/max-fix-iterations-exceeded
+  "Max fix iterations exceeded"
+  :controller/fixing-ci
+  "Running fix loop for CI failure"
+  :controller/fixing-review
+  "Running fix loop for review feedback"
+  :controller/attempting-merge
+  "Attempting to merge PR"
+  :controller/merged
+  "PR merged successfully"
+  :controller/lifecycle-starting
+  "Starting PR lifecycle"
+  :controller/pr-creation-failed
+  "PR creation failed"
+  :controller/exception
+  "Controller exception"
+  :controller/default-commit-title
+  "implement task"
+  :controller/commit-message
+  "feat: {title}\n\nTask: {task-id}"
+  :controller/default-pr-title
+  "Task {task-fragment}"
+  :controller/default-task-description
+  "Automated task implementation"
+  :controller/pr-body-template
+  "## Task\n\n{description}\n\n## Acceptance Criteria\n\n{criteria}"
+  :controller/criterion-line
+  "- {criterion}"
+
+  ;; FSM
+  :fsm/invalid-state
+  "Invalid controller status: {status}"
+  :fsm/invalid-target-status
+  "Invalid target controller status: {status}"
+  :fsm/terminal-state
+  "Cannot transition from terminal state: {status}"
+  :fsm/invalid-transition
+  "No controller transition defined for [{from-status} -> {to-status}]"}}

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -19,21 +19,43 @@
 (ns ai.miniforge.pr-lifecycle.controller
   "PR lifecycle controller - orchestrates task→PR→merge workflow.
 
-   This is the main state machine that drives a task through its
-   PR lifecycle, coordinating CI/review monitoring, fix loops, and merge."
+   This controller uses an explicit FSM-backed status model to drive a task
+   through PR creation, CI/review monitoring, fix loops, and merge."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
-   [ai.miniforge.pr-lifecycle.events :as events]
    [ai.miniforge.pr-lifecycle.ci-monitor :as ci]
-   [ai.miniforge.pr-lifecycle.review-monitor :as review]
+   [ai.miniforge.pr-lifecycle.events :as events]
    [ai.miniforge.pr-lifecycle.fix-loop :as fix]
+   [ai.miniforge.pr-lifecycle.fsm :as controller-fsm]
    [ai.miniforge.pr-lifecycle.merge :as merge]
+   [ai.miniforge.pr-lifecycle.review-monitor :as review]
    [ai.miniforge.release-executor.interface :as release]
    [ai.miniforge.logging.interface :as log]
    [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Controller state
+
+(defn- invalid-transition-ex
+  "Create an exception describing an invalid controller status transition."
+  [current-status new-status transition-result]
+  (ex-info "Invalid PR lifecycle controller status transition"
+           {:from current-status
+            :to new-status
+            :error (:error transition-result)
+            :message (:message transition-result)
+            :valid-targets (controller-fsm/valid-targets current-status)}))
+
+(defn- transition-status
+  "Validate and apply a status transition to the current controller snapshot."
+  [controller-state new-status]
+  (let [current-status (:status controller-state)
+        transition-result (controller-fsm/transition current-status new-status)]
+    (if (:success? transition-result)
+      (assoc controller-state
+             :status (:state transition-result)
+             :updated-at (java.util.Date.))
+      (throw (invalid-transition-ex current-status new-status transition-result)))))
 
 (defn create-controller
   "Create a PR lifecycle controller for a task.
@@ -85,8 +107,9 @@
          :generate-fn generate-fn
 
          ;; State
-         :status :pending ; :pending :creating-pr :monitoring-ci :monitoring-review
-                         ; :fixing :ready-to-merge :merging :merged :failed
+         :status controller-fsm/initial-status ; :pending :creating-pr :monitoring-ci
+                                               ; :monitoring-review :fixing
+                                               ; :ready-to-merge :merged :failed
          :pr nil         ; PR info once created
          :ci-monitor nil
          :review-monitor nil
@@ -97,12 +120,14 @@
          :updated-at (java.util.Date.)}))
 
 (defn update-status!
-  "Update controller status with timestamp."
+  "Update controller status using the formal PR lifecycle FSM."
   [controller new-status]
-  (swap! controller assoc
-         :status new-status
-         :updated-at (java.util.Date.))
-  new-status)
+  (loop []
+    (let [current-state @controller
+          updated-state (transition-status current-state new-status)]
+      (if (compare-and-set! controller current-state updated-state)
+        (:status updated-state)
+        (recur)))))
 
 (defn add-history!
   "Add an event to controller history."
@@ -523,13 +548,19 @@
               (recur)))))
 
       (catch Exception e
-        (update-status! controller :failed)
+        (let [final-status (if (= :failed (:status @controller))
+                             :failed
+                             (try
+                               (update-status! controller :failed)
+                               :failed
+                               (catch clojure.lang.ExceptionInfo _
+                                 (:status @controller))))]
         (add-history! controller :exception {:message (.getMessage e)})
         (when logger
           (log/error logger :pr-lifecycle :controller/exception
                      {:message "Controller exception"
                       :data {:error (.getMessage e)}}))
-        {:status :failed :error (.getMessage e)}))))
+        {:status final-status :error (.getMessage e)})))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -45,6 +45,11 @@
 (def ^:private lifecycle-failed-status
   :failed)
 
+(defn- remove-nil-values
+  "Drop entries whose values are nil."
+  [m]
+  (into {} (remove (comp nil? val)) m))
+
 (defn- format-acceptance-criteria
   [criteria]
   (->> criteria
@@ -144,9 +149,10 @@
    Returns controller state atom."
   [dag-id run-id task-id task
    & {:as opts}]
-  (let [defaults (merge (controller-config/controller-defaults)
+  (let [non-nil-opts (remove-nil-values opts)
+        defaults (merge (controller-config/controller-defaults)
                         {:merge-policy merge/default-merge-policy}
-                        opts)
+                        non-nil-opts)
         worktree-path (:worktree-path defaults)
         merge-policy (:merge-policy defaults)
         created-at (java.util.Date.)
@@ -161,9 +167,9 @@
            :config config
 
            ;; Dependencies
-           :event-bus (:event-bus opts)
-           :logger (:logger opts)
-           :generate-fn (:generate-fn opts)
+           :event-bus (:event-bus non-nil-opts)
+           :logger (:logger non-nil-opts)
+           :generate-fn (:generate-fn non-nil-opts)
 
            ;; State
            :status controller-fsm/initial-status

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -32,6 +32,7 @@
    [ai.miniforge.pr-lifecycle.merge :as merge]
    [ai.miniforge.pr-lifecycle.review-monitor :as review]
    [ai.miniforge.release-executor.interface :as release]
+   [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]
    [clojure.string :as str]))
 
@@ -40,6 +41,9 @@
 
 (def ^:private lifecycle-loop-sleep-ms
   1000)
+
+(def ^:private lifecycle-failed-status
+  :failed)
 
 (defn- format-acceptance-criteria
   [criteria]
@@ -92,18 +96,28 @@
   (ex-info (messages/t :controller/invalid-transition)
            {:from current-status
             :to new-status
-            :error (:error transition-result)
-            :message (:message transition-result)
+            :error (controller-fsm/transition-error-code transition-result)
+            :message (controller-fsm/transition-error-message transition-result)
             :valid-targets (controller-fsm/valid-targets current-status)}))
+
+(defn- result-status
+  "Return a normalized status keyword for result payloads."
+  [result]
+  (if (schema/succeeded? result) :succeeded :failed))
+
+(defn- fix-completion-data
+  "Create history payload for a completed fix attempt."
+  [fix-result]
+  {:result-status (result-status fix-result)})
 
 (defn- transition-status
   "Validate and apply a status transition to the current controller snapshot."
   [controller-state new-status]
   (let [current-status (:status controller-state)
         transition-result (controller-fsm/transition current-status new-status)]
-    (if (:success? transition-result)
+    (if (controller-fsm/succeeded? transition-result)
       (assoc controller-state
-             :status (:state transition-result)
+             :status (controller-fsm/transition-state transition-result)
              :updated-at (java.util.Date.))
       (throw (invalid-transition-ex current-status new-status transition-result)))))
 
@@ -187,7 +201,7 @@
 (defn fail-controller!
   "Mark controller as failed and return a DAG error."
   [controller error-key error-msg]
-  (update-status! controller :failed)
+  (update-status! controller lifecycle-failed-status)
   (dag/err error-key error-msg))
 
 (defn create-and-checkout-branch!
@@ -195,7 +209,7 @@
    Returns the branch result or a DAG error."
   [controller worktree-path branch-name]
   (let [branch-result (release/create-branch! worktree-path branch-name)]
-    (if (:success? branch-result)
+    (if (schema/succeeded? branch-result)
       branch-result
       (do
         (add-history! controller :pr-creation-failed {:error (:error branch-result)})
@@ -216,7 +230,7 @@
   [controller worktree-path task task-id]
   (let [commit-msg (build-commit-message task task-id)
         commit-result (release/commit-changes! worktree-path commit-msg)]
-    (if (:success? commit-result)
+    (if (schema/succeeded? commit-result)
       commit-result
       (fail-controller! controller :commit-failed (:error commit-result)))))
 
@@ -225,7 +239,7 @@
    Returns the PR info map or a DAG error."
   [controller worktree-path branch-name base-branch task task-id commit-result]
   (let [push-result (release/push-branch! worktree-path branch-name)]
-    (if-not (:success? push-result)
+    (if-not (schema/succeeded? push-result)
       (fail-controller! controller :push-failed (:error push-result))
       (let [pr-title (build-pr-title task task-id)
             pr-body (build-pr-body task)
@@ -233,7 +247,7 @@
                                           {:title pr-title
                                            :body pr-body
                                            :base-branch base-branch})]
-        (if-not (:success? pr-result)
+        (if-not (schema/succeeded? pr-result)
           (fail-controller! controller :pr-creation-failed (:error pr-result))
           {:pr/id       (:pr-number pr-result)
            :pr/url      (:pr-url pr-result)
@@ -377,7 +391,7 @@
                        :event-bus event-bus
                        :dag/id (:dag/id @controller)
                        :run/id (:run/id @controller)})]
-      (add-history! controller :ci-fix-completed {:success? (:success? fix-result)})
+      (add-history! controller :ci-fix-completed (fix-completion-data fix-result))
       fix-result)))
 
 (defn handle-review-feedback!
@@ -410,7 +424,7 @@
                        :dag/id (:dag/id @controller)
                        :run/id (:run/id @controller)
                        :auto-resolve-comments auto-resolve-comments})]
-      (add-history! controller :review-fix-completed {:success? (:success? fix-result)})
+      (add-history! controller :review-fix-completed (fix-completion-data fix-result))
       fix-result)))
 
 ;------------------------------------------------------------------------------ Layer 1
@@ -513,20 +527,20 @@
                   (:failure :timed-out)
                   ;; CI failed - run fix loop
                   (let [fix-result (handle-ci-failure! controller (:ci/logs ci-result))]
-                    (if (:success? fix-result)
+                    (if (schema/succeeded? fix-result)
                       (do
                         ;; Fix pushed - restart CI monitoring
                         (start-ci-monitoring! controller)
                         (recur))
                       (do
                         ;; Fix failed
-                        (update-status! controller :failed)
-                        {:status :failed :reason :fix-failed})))
+                        (update-status! controller lifecycle-failed-status)
+                        {:status lifecycle-failed-status :reason :fix-failed})))
 
                   ;; Unknown status
                   (do
-                    (update-status! controller :failed)
-                    {:status :failed :reason :unknown-ci-status}))))
+                    (update-status! controller lifecycle-failed-status)
+                    {:status lifecycle-failed-status :reason :unknown-ci-status}))))
 
             ;; Review monitoring
             :monitoring-review
@@ -554,15 +568,15 @@
                 ;; Run fix loop for review feedback
                 (let [fix-result (handle-review-feedback!
                                   controller (:actionable-comments review-result))]
-                  (if (:success? fix-result)
+                  (if (schema/succeeded? fix-result)
                     (do
                       ;; Fix pushed - restart CI monitoring
                       (start-ci-monitoring! controller)
                       (recur))
                     (do
                       ;; Fix failed
-                      (update-status! controller :failed)
-                      {:status :failed :reason :fix-failed})))
+                      (update-status! controller lifecycle-failed-status)
+                      {:status lifecycle-failed-status :reason :fix-failed})))
 
                 ;; Unknown/timeout
                 {:status :pending :waiting-for :review}))
@@ -578,7 +592,7 @@
             {:status :merged}
 
             :failed
-            {:status :failed :history (:history @controller)}
+            {:status lifecycle-failed-status :history (:history @controller)}
 
             ;; Default
             (do
@@ -586,11 +600,11 @@
               (recur)))))
 
       (catch Exception e
-        (let [final-status (if (= :failed (:status @controller))
-                             :failed
+        (let [final-status (if (= lifecycle-failed-status (:status @controller))
+                             lifecycle-failed-status
                              (try
-                               (update-status! controller :failed)
-                               :failed
+                               (update-status! controller lifecycle-failed-status)
+                               lifecycle-failed-status
                                (catch clojure.lang.ExceptionInfo _
                                  (:status @controller))))]
         (add-history! controller :exception {:message (.getMessage e)})

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller.clj
@@ -24,9 +24,11 @@
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.pr-lifecycle.ci-monitor :as ci]
+   [ai.miniforge.pr-lifecycle.controller-config :as controller-config]
    [ai.miniforge.pr-lifecycle.events :as events]
    [ai.miniforge.pr-lifecycle.fix-loop :as fix]
    [ai.miniforge.pr-lifecycle.fsm :as controller-fsm]
+   [ai.miniforge.pr-lifecycle.messages :as messages]
    [ai.miniforge.pr-lifecycle.merge :as merge]
    [ai.miniforge.pr-lifecycle.review-monitor :as review]
    [ai.miniforge.release-executor.interface :as release]
@@ -36,10 +38,58 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Controller state
 
+(def ^:private lifecycle-loop-sleep-ms
+  1000)
+
+(defn- format-acceptance-criteria
+  [criteria]
+  (->> criteria
+       (map #(messages/t :controller/criterion-line {:criterion %}))
+       (str/join "\n")))
+
+(defn- task-id-fragment
+  [task-id]
+  (let [task-id-string (str task-id)
+        fragment-length (min 8 (count task-id-string))]
+    (subs task-id-string 0 fragment-length)))
+
+(defn- build-commit-message
+  [task task-id]
+  (let [title (get task :task/title (messages/t :controller/default-commit-title))]
+    (messages/t :controller/commit-message
+                {:title title
+                 :task-id task-id})))
+
+(defn- build-pr-title
+  [task task-id]
+  (get task :task/title
+       (messages/t :controller/default-pr-title
+                   {:task-fragment (task-id-fragment task-id)})))
+
+(defn- build-pr-body
+  [task]
+  (let [description (get task :task/description
+                         (messages/t :controller/default-task-description))
+        criteria (format-acceptance-criteria
+                  (get task :task/acceptance-criteria []))]
+    (messages/t :controller/pr-body-template
+                {:description description
+                 :criteria criteria})))
+
+(defn- controller-config-map
+  [worktree-path merge-policy controller-defaults]
+  {:worktree-path worktree-path
+   :merge-policy merge-policy
+   :max-fix-iterations (:max-fix-iterations controller-defaults)
+   :ci-poll-interval-ms (:ci-poll-interval-ms controller-defaults)
+   :review-poll-interval-ms (:review-poll-interval-ms controller-defaults)
+   :auto-resolve-comments (:auto-resolve-comments controller-defaults)
+   :branch-name-prefix (:branch-name-prefix controller-defaults)})
+
 (defn- invalid-transition-ex
   "Create an exception describing an invalid controller status transition."
   [current-status new-status transition-result]
-  (ex-info "Invalid PR lifecycle controller status transition"
+  (ex-info (messages/t :controller/invalid-transition)
            {:from current-status
             :to new-status
             :error (:error transition-result)
@@ -79,45 +129,38 @@
 
    Returns controller state atom."
   [dag-id run-id task-id task
-   & {:keys [worktree-path event-bus logger generate-fn merge-policy
-             max-fix-iterations ci-poll-interval-ms review-poll-interval-ms
-             auto-resolve-comments]
-      :or {max-fix-iterations 5
-           ci-poll-interval-ms 30000
-           review-poll-interval-ms 30000
-           merge-policy merge/default-merge-policy
-           auto-resolve-comments true}}]
-  (atom {:controller/id (random-uuid)
-         :dag/id dag-id
-         :run/id run-id
-         :task/id task-id
-         :task task
+   & {:as opts}]
+  (let [defaults (merge (controller-config/controller-defaults)
+                        {:merge-policy merge/default-merge-policy}
+                        opts)
+        worktree-path (:worktree-path defaults)
+        merge-policy (:merge-policy defaults)
+        created-at (java.util.Date.)
+        config (controller-config-map worktree-path merge-policy defaults)]
+    (atom {:controller/id (random-uuid)
+           :dag/id dag-id
+           :run/id run-id
+           :task/id task-id
+           :task task
 
-         ;; Configuration
-         :config {:worktree-path worktree-path
-                  :merge-policy merge-policy
-                  :max-fix-iterations max-fix-iterations
-                  :ci-poll-interval-ms ci-poll-interval-ms
-                  :review-poll-interval-ms review-poll-interval-ms
-                  :auto-resolve-comments auto-resolve-comments}
+           ;; Configuration
+           :config config
 
-         ;; Dependencies
-         :event-bus event-bus
-         :logger logger
-         :generate-fn generate-fn
+           ;; Dependencies
+           :event-bus (:event-bus opts)
+           :logger (:logger opts)
+           :generate-fn (:generate-fn opts)
 
-         ;; State
-         :status controller-fsm/initial-status ; :pending :creating-pr :monitoring-ci
-                                               ; :monitoring-review :fixing
-                                               ; :ready-to-merge :merged :failed
-         :pr nil         ; PR info once created
-         :ci-monitor nil
-         :review-monitor nil
-         :fix-iterations 0
-         :ci-retries 0
-         :history []
-         :created-at (java.util.Date.)
-         :updated-at (java.util.Date.)}))
+           ;; State
+           :status controller-fsm/initial-status
+           :pr nil
+           :ci-monitor nil
+           :review-monitor nil
+           :fix-iterations 0
+           :ci-retries 0
+           :history []
+           :created-at created-at
+           :updated-at created-at})))
 
 (defn update-status!
   "Update controller status using the formal PR lifecycle FSM."
@@ -171,8 +214,7 @@
   "Stage and commit all changes with the given task info.
    Returns the commit result or a DAG error."
   [controller worktree-path task task-id]
-  (let [commit-msg (str "feat: " (get task :task/title "implement task")
-                        "\n\nTask: " task-id)
+  (let [commit-msg (build-commit-message task task-id)
         commit-result (release/commit-changes! worktree-path commit-msg)]
     (if (:success? commit-result)
       commit-result
@@ -185,13 +227,8 @@
   (let [push-result (release/push-branch! worktree-path branch-name)]
     (if-not (:success? push-result)
       (fail-controller! controller :push-failed (:error push-result))
-      (let [pr-title (or (:task/title task) (str "Task " (subs (str task-id) 0 8)))
-            pr-body  (str "## Task\n\n"
-                          (get task :task/description "Automated task implementation")
-                          "\n\n"
-                          "## Acceptance Criteria\n\n"
-                          (when-let [criteria (:task/acceptance-criteria task)]
-                            (str/join "\n" (map #(str "- " %) criteria))))
+      (let [pr-title (build-pr-title task task-id)
+            pr-body (build-pr-body task)
             pr-result (release/create-pr! worktree-path
                                           {:title pr-title
                                            :body pr-body
@@ -219,7 +256,7 @@
                      logger))
   (when logger
     (log/info logger :pr-lifecycle :controller/pr-created
-              {:message "PR created successfully"
+              {:message (messages/t :controller/pr-created)
                :data {:pr-url (:pr/url pr-info)}}))
   (dag/ok pr-info))
 
@@ -237,15 +274,15 @@
   [controller code-artifact]
   (let [{dag-id :dag/id run-id :run/id task-id :task/id
          :keys [task config event-bus logger]} @controller
-        {:keys [worktree-path]} config
-        branch-name (str "task-" (subs (str task-id) 0 8))]
+        {:keys [worktree-path branch-name-prefix]} config
+        branch-name (str branch-name-prefix (task-id-fragment task-id))]
 
     (update-status! controller :creating-pr)
     (add-history! controller :pr-creation-started {:branch branch-name})
 
     (when logger
       (log/info logger :pr-lifecycle :controller/creating-pr
-                {:message "Creating PR for task"
+                {:message (messages/t :controller/creating-pr)
                  :data {:task-id task-id :branch branch-name}}))
 
     (let [branch-result (create-and-checkout-branch! controller worktree-path branch-name)]
@@ -319,9 +356,9 @@
       (add-history! controller :max-fix-iterations-exceeded {:iterations current-iterations})
       (when logger
         (log/warn logger :pr-lifecycle :controller/max-iterations
-                  {:message "Max fix iterations exceeded"
+                  {:message (messages/t :controller/max-fix-iterations-exceeded)
                    :data {:task-id task-id :iterations current-iterations}}))
-      (throw (ex-info "Max fix iterations exceeded"
+      (throw (ex-info (messages/t :controller/max-fix-iterations-exceeded)
                       {:task-id task-id :iterations current-iterations})))
 
     (update-status! controller :fixing)
@@ -330,7 +367,7 @@
 
     (when logger
       (log/info logger :pr-lifecycle :controller/fixing-ci
-                {:message "Running fix loop for CI failure"
+                {:message (messages/t :controller/fixing-ci)
                  :data {:task-id task-id :iteration (inc current-iterations)}}))
 
     (let [fix-result (fix/fix-ci-failure
@@ -353,7 +390,7 @@
     (when (>= current-iterations max-fix-iterations)
       (update-status! controller :failed)
       (add-history! controller :max-fix-iterations-exceeded {:iterations current-iterations})
-      (throw (ex-info "Max fix iterations exceeded"
+      (throw (ex-info (messages/t :controller/max-fix-iterations-exceeded)
                       {:task-id task-id :iterations current-iterations})))
 
     (update-status! controller :fixing)
@@ -362,7 +399,7 @@
 
     (when logger
       (log/info logger :pr-lifecycle :controller/fixing-review
-                {:message "Running fix loop for review feedback"
+                {:message (messages/t :controller/fixing-review)
                  :data {:task-id task-id :comment-count (count review-comments)}}))
 
     (let [fix-result (fix/fix-review-feedback
@@ -391,7 +428,7 @@
 
     (when logger
       (log/info logger :pr-lifecycle :controller/merging
-                {:message "Attempting to merge PR"
+                {:message (messages/t :controller/attempting-merge)
                  :data {:pr-id (:pr/id pr)}}))
 
     (let [merge-result (merge/attempt-merge
@@ -408,7 +445,7 @@
           (add-history! controller :merged {:pr-id (:pr/id pr)})
           (when logger
             (log/info logger :pr-lifecycle :controller/merged
-                      {:message "PR merged successfully"
+                      {:message (messages/t :controller/merged)
                        :data {:pr-id (:pr/id pr)}})))
         (add-history! controller :merge-blocked {:reason (:error merge-result)}))
       merge-result)))
@@ -440,7 +477,7 @@
 
     (when logger
       (log/info logger :pr-lifecycle :controller/lifecycle-starting
-                {:message "Starting PR lifecycle"
+                {:message (messages/t :controller/lifecycle-starting)
                  :data {:task-id (:task/id @controller)}}))
 
     (try
@@ -448,7 +485,8 @@
       (when-not skip-pr-creation?
         (let [pr-result (create-pr! controller code-artifact)]
           (when (dag/err? pr-result)
-            (throw (ex-info "PR creation failed" {:error (:error pr-result)})))))
+            (throw (ex-info (messages/t :controller/pr-creation-failed)
+                            {:error (:error pr-result)})))))
 
       ;; Step 2: CI/Review loop
       (loop []
@@ -532,7 +570,7 @@
             ;; Fixing in progress
             :fixing
             (do
-              (Thread/sleep 1000) ; Wait for fix to complete
+              (Thread/sleep lifecycle-loop-sleep-ms)
               (recur))
 
             ;; Terminal states
@@ -544,7 +582,7 @@
 
             ;; Default
             (do
-              (Thread/sleep 1000)
+              (Thread/sleep lifecycle-loop-sleep-ms)
               (recur)))))
 
       (catch Exception e
@@ -558,7 +596,7 @@
         (add-history! controller :exception {:message (.getMessage e)})
         (when logger
           (log/error logger :pr-lifecycle :controller/exception
-                     {:message "Controller exception"
+                     {:message (messages/t :controller/exception)
                       :data {:error (.getMessage e)}}))
         {:status final-status :error (.getMessage e)})))))
 

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller_config.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/controller_config.clj
@@ -1,0 +1,67 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.controller-config
+  "Load PR lifecycle controller defaults from EDN configuration."
+  (:require
+   [ai.miniforge.pr-lifecycle.messages :as messages]
+   [ai.miniforge.schema.interface :as schema]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schemas + config loading
+
+(def ControllerDefaults
+  [:map
+   [:max-fix-iterations nat-int?]
+   [:ci-poll-interval-ms nat-int?]
+   [:review-poll-interval-ms nat-int?]
+   [:auto-resolve-comments boolean?]
+   [:branch-name-prefix :string]])
+
+(def ControllerConfig
+  [:map
+   [:pr-lifecycle/controller-defaults ControllerDefaults]])
+
+(def ^:private controller-defaults-resource
+  "Classpath resource holding controller defaults."
+  "config/pr-lifecycle/controller-defaults.edn")
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
+
+(defn- load-controller-config
+  []
+  (if-let [resource (io/resource controller-defaults-resource)]
+    (->> resource slurp edn/read-string (validate! ControllerConfig))
+    (throw (ex-info (messages/t :config/missing-resource
+                                {:resource controller-defaults-resource})
+                    {:hint (messages/t :config/classpath-hint)}))))
+
+(def ^:private controller-config
+  (delay (load-controller-config)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Public helpers
+
+(defn controller-defaults
+  "Return the PR lifecycle controller defaults map."
+  []
+  (:pr-lifecycle/controller-defaults @controller-config))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj
@@ -23,44 +23,54 @@
    transition policy explicit, testable, and backed by the shared FSM
    foundation component."
   (:require
-   [ai.miniforge.fsm.interface :as fsm]))
+   [ai.miniforge.fsm.interface :as fsm]
+   [ai.miniforge.pr-lifecycle.messages :as messages]
+   [ai.miniforge.schema.interface :as schema]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; FSM definition
 
+(def PrLifecycleFsmConfig
+  [:map
+   [:pr-lifecycle/fsm
+    [:map
+     [:initial-status keyword?]
+     [:statuses [:vector keyword?]]
+     [:terminal-statuses [:set keyword?]]
+     [:status-transition-events [:map-of [:tuple keyword? keyword?] keyword?]]]]])
+
+(def ^:private fsm-config-resource
+  "Classpath resource holding the PR lifecycle FSM definition."
+  "config/pr-lifecycle/fsm.edn")
+
+(defn- validate!
+  [result-schema value]
+  (schema/validate result-schema value))
+
+(defn- load-fsm-config
+  []
+  (if-let [resource (io/resource fsm-config-resource)]
+    (->> resource slurp edn/read-string (validate! PrLifecycleFsmConfig))
+    (throw (ex-info (messages/t :config/missing-resource
+                                {:resource fsm-config-resource})
+                    {:hint (messages/t :config/classpath-hint)}))))
+
+(def ^:private fsm-config
+  (delay (load-fsm-config)))
+
 (def initial-status
   "Initial controller status."
-  :pending)
+  (get-in @fsm-config [:pr-lifecycle/fsm :initial-status]))
 
 (def controller-status-order
   "Ordered controller statuses for machine compilation."
-  [:pending
-   :creating-pr
-   :monitoring-ci
-   :monitoring-review
-   :fixing
-   :ready-to-merge
-   :merged
-   :failed])
+  (get-in @fsm-config [:pr-lifecycle/fsm :statuses]))
 
 (def status-transition-events
   "Configured controller transitions keyed by `[from-status to-status]`."
-  {[:pending :creating-pr]              :create-pr
-   [:pending :monitoring-ci]           :start-ci-monitoring
-   [:pending :failed]                  :fail
-   [:creating-pr :monitoring-ci]       :start-ci-monitoring
-   [:creating-pr :failed]              :fail
-   [:monitoring-ci :monitoring-review] :start-review-monitoring
-   [:monitoring-ci :fixing]            :start-fixing
-   [:monitoring-ci :failed]            :fail
-   [:monitoring-review :ready-to-merge] :mark-ready-to-merge
-   [:monitoring-review :fixing]        :start-fixing
-   [:monitoring-review :failed]        :fail
-   [:fixing :monitoring-ci]            :start-ci-monitoring
-   [:fixing :failed]                   :fail
-   [:ready-to-merge :monitoring-ci]    :start-ci-monitoring
-   [:ready-to-merge :merged]           :merge
-   [:ready-to-merge :failed]           :fail})
+  (get-in @fsm-config [:pr-lifecycle/fsm :status-transition-events]))
 
 (def controller-statuses
   "Valid controller statuses."
@@ -68,7 +78,7 @@
 
 (def terminal-statuses
   "Terminal controller statuses."
-  #{:merged :failed})
+  (get-in @fsm-config [:pr-lifecycle/fsm :terminal-statuses]))
 
 (defn valid-status?
   "Check whether `status` is a recognized controller status."
@@ -177,17 +187,18 @@
   [error from-status to-status]
   (let [message (case error
                   :invalid-state
-                  (str "Invalid controller status: " from-status)
+                  (messages/t :fsm/invalid-state {:status from-status})
 
                   :invalid-target-status
-                  (str "Invalid target controller status: " to-status)
+                  (messages/t :fsm/invalid-target-status {:status to-status})
 
                   :terminal-state
-                  (str "Cannot transition from terminal state: " from-status)
+                  (messages/t :fsm/terminal-state {:status from-status})
 
                   :invalid-transition
-                  (str "No controller transition defined for ["
-                       from-status " -> " to-status "]"))]
+                  (messages/t :fsm/invalid-transition
+                              {:from-status from-status
+                               :to-status to-status}))]
     {:success? false
      :error error
      :message message}))

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj
@@ -90,6 +90,16 @@
   [status]
   (contains? terminal-statuses status))
 
+(defn succeeded?
+  "Check whether a controller transition result succeeded."
+  [result]
+  (schema/succeeded? result))
+
+(defn failed?
+  "Check whether a controller transition result failed."
+  [result]
+  (schema/failed? result))
+
 (defn- transition-targets
   "Return all configured targets from `from-status`."
   [from-status]
@@ -132,7 +142,57 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; Transition execution
 
+(def ^:private transition-data-key
+  :transition)
+
 (declare transition-failure)
+
+(defn- transition-result
+  "Create a successful controller transition result."
+  [state event]
+  (let [transition {:state state
+                    :event event}]
+    (schema/success transition-data-key transition)))
+
+(defn- transition-error
+  "Create a structured controller transition error map."
+  [error-code from-status to-status]
+  (let [message (case error-code
+                  :invalid-state
+                  (messages/t :fsm/invalid-state {:status from-status})
+
+                  :invalid-target-status
+                  (messages/t :fsm/invalid-target-status {:status to-status})
+
+                  :terminal-state
+                  (messages/t :fsm/terminal-state {:status from-status})
+
+                  :invalid-transition
+                  (messages/t :fsm/invalid-transition
+                              {:from-status from-status
+                               :to-status to-status}))]
+    {:code error-code
+     :message message}))
+
+(defn transition-state
+  "Return the target controller state from a transition result."
+  [result]
+  (get-in result [transition-data-key :state]))
+
+(defn transition-event
+  "Return the transition event from a transition result."
+  [result]
+  (get-in result [transition-data-key :event]))
+
+(defn transition-error-code
+  "Return the transition error code from a failed result."
+  [result]
+  (get-in result [:error :code]))
+
+(defn transition-error-message
+  "Return the transition error message from a failed result."
+  [result]
+  (get-in result [:error :message]))
 
 (def controller-state-definitions
   "Machine state definitions keyed by controller status."
@@ -154,8 +214,8 @@
   "Attempt a controller status transition.
 
    Returns:
-   - `{:success? true :state new-status :event event-or-nil}` on success
-   - `{:success? false :error keyword :message string}` on failure"
+   - `(schema/success :transition {:state new-status :event event-or-nil})` on success
+   - `(schema/failure :transition {:code keyword :message string})` on failure"
   [from-status to-status]
   (cond
     (not (valid-status? from-status))
@@ -165,9 +225,7 @@
     (transition-failure :invalid-target-status from-status to-status)
 
     (= from-status to-status)
-    {:success? true
-     :state from-status
-     :event nil}
+    (transition-result from-status nil)
 
     (terminal-status? from-status)
     (transition-failure :terminal-state from-status to-status)
@@ -177,31 +235,14 @@
       (let [state-map {:_state from-status}
             new-state-map (fsm/transition controller-machine state-map event)
             new-state (fsm/current-state new-state-map)]
-        {:success? true
-         :state new-state
-         :event event})
+        (transition-result new-state event))
       (transition-failure :invalid-transition from-status to-status))))
 
 (defn- transition-failure
-  "Return a consistent controller transition failure map."
-  [error from-status to-status]
-  (let [message (case error
-                  :invalid-state
-                  (messages/t :fsm/invalid-state {:status from-status})
-
-                  :invalid-target-status
-                  (messages/t :fsm/invalid-target-status {:status to-status})
-
-                  :terminal-state
-                  (messages/t :fsm/terminal-state {:status from-status})
-
-                  :invalid-transition
-                  (messages/t :fsm/invalid-transition
-                              {:from-status from-status
-                               :to-status to-status}))]
-    {:success? false
-     :error error
-     :message message}))
+  "Return a consistent controller transition failure result."
+  [error-code from-status to-status]
+  (let [error (transition-error error-code from-status to-status)]
+    (schema/failure transition-data-key error)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj
@@ -1,0 +1,202 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.fsm
+  "Finite State Machine for PR lifecycle controller status transitions.
+
+   Keeps the controller's public status contract stable while making the
+   transition policy explicit, testable, and backed by the shared FSM
+   foundation component."
+  (:require
+   [ai.miniforge.fsm.interface :as fsm]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; FSM definition
+
+(def initial-status
+  "Initial controller status."
+  :pending)
+
+(def controller-status-order
+  "Ordered controller statuses for machine compilation."
+  [:pending
+   :creating-pr
+   :monitoring-ci
+   :monitoring-review
+   :fixing
+   :ready-to-merge
+   :merged
+   :failed])
+
+(def status-transition-events
+  "Configured controller transitions keyed by `[from-status to-status]`."
+  {[:pending :creating-pr]              :create-pr
+   [:pending :monitoring-ci]           :start-ci-monitoring
+   [:pending :failed]                  :fail
+   [:creating-pr :monitoring-ci]       :start-ci-monitoring
+   [:creating-pr :failed]              :fail
+   [:monitoring-ci :monitoring-review] :start-review-monitoring
+   [:monitoring-ci :fixing]            :start-fixing
+   [:monitoring-ci :failed]            :fail
+   [:monitoring-review :ready-to-merge] :mark-ready-to-merge
+   [:monitoring-review :fixing]        :start-fixing
+   [:monitoring-review :failed]        :fail
+   [:fixing :monitoring-ci]            :start-ci-monitoring
+   [:fixing :failed]                   :fail
+   [:ready-to-merge :monitoring-ci]    :start-ci-monitoring
+   [:ready-to-merge :merged]           :merge
+   [:ready-to-merge :failed]           :fail})
+
+(def controller-statuses
+  "Valid controller statuses."
+  (set controller-status-order))
+
+(def terminal-statuses
+  "Terminal controller statuses."
+  #{:merged :failed})
+
+(defn valid-status?
+  "Check whether `status` is a recognized controller status."
+  [status]
+  (contains? controller-statuses status))
+
+(defn terminal-status?
+  "Check whether `status` is terminal."
+  [status]
+  (contains? terminal-statuses status))
+
+(defn- transition-targets
+  "Return all configured targets from `from-status`."
+  [from-status]
+  (->> status-transition-events
+       (keep (fn [[[source-status target-status] _event]]
+               (when (= source-status from-status)
+                 target-status)))
+       set))
+
+(defn- machine-state-definition
+  "Return the machine state definition for a controller status."
+  [status]
+  (if (terminal-status? status)
+    {:type :final}
+    {:on (into {}
+               (for [[[source-status target-status] event] status-transition-events
+                     :when (= source-status status)]
+                 [event target-status]))}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Transition validation
+
+(defn valid-transition?
+  "Check whether the controller may move from `from-status` to `to-status`.
+
+   Same-state transitions are treated as valid idempotent updates."
+  [from-status to-status]
+  (and (valid-status? from-status)
+       (valid-status? to-status)
+       (or (= from-status to-status)
+           (contains? status-transition-events [from-status to-status]))))
+
+(defn valid-targets
+  "Return the valid target statuses from `from-status`, including itself."
+  [from-status]
+  (if (valid-status? from-status)
+    (conj (transition-targets from-status) from-status)
+    #{}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Transition execution
+
+(declare transition-failure)
+
+(def controller-state-definitions
+  "Machine state definitions keyed by controller status."
+  (zipmap controller-status-order
+          (map machine-state-definition controller-status-order)))
+
+(def controller-machine-config
+  "PR lifecycle controller machine configuration."
+  {:fsm/id :pr-lifecycle-controller
+   :fsm/initial initial-status
+   :fsm/context {}
+   :fsm/states controller-state-definitions})
+
+(def controller-machine
+  "Compiled controller machine."
+  (fsm/define-machine controller-machine-config))
+
+(defn transition
+  "Attempt a controller status transition.
+
+   Returns:
+   - `{:success? true :state new-status :event event-or-nil}` on success
+   - `{:success? false :error keyword :message string}` on failure"
+  [from-status to-status]
+  (cond
+    (not (valid-status? from-status))
+    (transition-failure :invalid-state from-status to-status)
+
+    (not (valid-status? to-status))
+    (transition-failure :invalid-target-status from-status to-status)
+
+    (= from-status to-status)
+    {:success? true
+     :state from-status
+     :event nil}
+
+    (terminal-status? from-status)
+    (transition-failure :terminal-state from-status to-status)
+
+    :else
+    (if-let [event (get status-transition-events [from-status to-status])]
+      (let [state-map {:_state from-status}
+            new-state-map (fsm/transition controller-machine state-map event)
+            new-state (fsm/current-state new-state-map)]
+        {:success? true
+         :state new-state
+         :event event})
+      (transition-failure :invalid-transition from-status to-status))))
+
+(defn- transition-failure
+  "Return a consistent controller transition failure map."
+  [error from-status to-status]
+  (let [message (case error
+                  :invalid-state
+                  (str "Invalid controller status: " from-status)
+
+                  :invalid-target-status
+                  (str "Invalid target controller status: " to-status)
+
+                  :terminal-state
+                  (str "Cannot transition from terminal state: " from-status)
+
+                  :invalid-transition
+                  (str "No controller transition defined for ["
+                       from-status " -> " to-status "]"))]
+    {:success? false
+     :error error
+     :message message}))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (valid-transition? :pending :creating-pr)
+  (valid-transition? :merged :monitoring-ci)
+  (transition :monitoring-ci :monitoring-review)
+  (transition :ready-to-merge :merged)
+  (valid-targets :fixing)
+  :end)

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj
@@ -58,19 +58,20 @@
                     {:hint (messages/t :config/classpath-hint)}))))
 
 (def ^:private fsm-config
-  (delay (load-fsm-config)))
+  "Validated PR lifecycle FSM configuration loaded eagerly at require time."
+  (load-fsm-config))
 
 (def initial-status
   "Initial controller status."
-  (get-in @fsm-config [:pr-lifecycle/fsm :initial-status]))
+  (get-in fsm-config [:pr-lifecycle/fsm :initial-status]))
 
 (def controller-status-order
   "Ordered controller statuses for machine compilation."
-  (get-in @fsm-config [:pr-lifecycle/fsm :statuses]))
+  (get-in fsm-config [:pr-lifecycle/fsm :statuses]))
 
 (def status-transition-events
   "Configured controller transitions keyed by `[from-status to-status]`."
-  (get-in @fsm-config [:pr-lifecycle/fsm :status-transition-events]))
+  (get-in fsm-config [:pr-lifecycle/fsm :status-transition-events]))
 
 (def controller-statuses
   "Valid controller statuses."
@@ -78,7 +79,7 @@
 
 (def terminal-statuses
   "Terminal controller statuses."
-  (get-in @fsm-config [:pr-lifecycle/fsm :terminal-statuses]))
+  (get-in fsm-config [:pr-lifecycle/fsm :terminal-statuses]))
 
 (defn valid-status?
   "Check whether `status` is a recognized controller status."

--- a/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/messages.clj
+++ b/components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/messages.clj
@@ -1,0 +1,27 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.messages
+  "Component-level message catalog for PR lifecycle.
+   Delegates to the shared messages component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a PR lifecycle message by key, with optional param substitution."
+  (messages/create-translator "config/pr-lifecycle/messages/en-US.edn"
+                              :pr-lifecycle/messages))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
@@ -48,6 +48,15 @@
     {:publish! (fn [event] (swap! events conj event) nil)
      :events events}))
 
+(defn transition-error-data
+  "Return ex-data for an invalid controller status transition."
+  [controller target-status]
+  (try
+    (controller/update-status! controller target-status)
+    nil
+    (catch clojure.lang.ExceptionInfo ex
+      (ex-data ex))))
+
 ;------------------------------------------------------------------------------ Controller Creation
 
 (deftest create-controller-initial-state-test
@@ -273,52 +282,60 @@
       (is (= :failed (:status @ctrl))))))
 
 ;------------------------------------------------------------------------------ Invalid / Unexpected State Transitions
-;;
-;; NOTE: The current controller uses a simple atom and does not enforce
-;; state transition guards. These tests document that arbitrary status
-;; values are stored as-is (they are NOT rejected). This is important
-;; for understanding the controller's current contract and for detecting
-;; regressions if transition guards are added in the future.
 
-(deftest invalid-status-value-stored-as-is-test
-  (testing "Controller stores arbitrary status values (no guard)"
+(deftest invalid-status-value-rejected-test
+  (testing "Controller rejects unknown statuses and preserves the current state"
+    (let [ctrl (controller/create-controller
+                 "dag" "run" "task" test-task
+                 :worktree-path "/tmp")
+          error-data (transition-error-data ctrl :bogus-status)]
+      (is (= :invalid-target-status (:error error-data)))
+      (is (= :pending (:status @ctrl))))))
+
+(deftest backward-transition-rejected-test
+  (testing "Controller rejects backward transitions that are outside the FSM"
+    (let [ctrl (controller/create-controller
+                 "dag" "run" "task" test-task
+                 :worktree-path "/tmp")
+          _ (controller/update-status! ctrl :monitoring-ci)
+          error-data (transition-error-data ctrl :pending)]
+      (is (= :invalid-transition (:error error-data)))
+      (is (= :monitoring-ci (:status @ctrl)))
+      (is (= #{:monitoring-ci :monitoring-review :fixing :failed}
+             (:valid-targets error-data))))))
+
+(deftest transition-from-terminal-state-rejected-test
+  (testing "Transitioning away from :merged is rejected"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
                  :worktree-path "/tmp")]
-      ;; An invalid status keyword is stored without rejection
-      (controller/update-status! ctrl :bogus-status)
-      (is (= :bogus-status (:status @ctrl))
-          "Controller currently accepts any keyword as status"))))
-
-(deftest backward-transition-not-rejected-test
-  (testing "Backward transitions are not rejected (no guard)"
-    (let [ctrl (controller/create-controller
-                 "dag" "run" "task" test-task
-                 :worktree-path "/tmp")]
+      (controller/update-status! ctrl :creating-pr)
       (controller/update-status! ctrl :monitoring-ci)
-      (controller/update-status! ctrl :pending)
-      (is (= :pending (:status @ctrl))
-          "Controller allows going back to :pending from :monitoring-ci"))))
-
-(deftest transition-from-terminal-state-not-rejected-test
-  (testing "Transitioning from :merged (terminal) is not rejected (no guard)"
-    (let [ctrl (controller/create-controller
-                 "dag" "run" "task" test-task
-                 :worktree-path "/tmp")]
+      (controller/update-status! ctrl :monitoring-review)
+      (controller/update-status! ctrl :ready-to-merge)
       (controller/update-status! ctrl :merged)
-      (controller/update-status! ctrl :monitoring-ci)
-      (is (= :monitoring-ci (:status @ctrl))
-          "Controller allows transition away from terminal :merged state"))))
+      (let [error-data (transition-error-data ctrl :monitoring-ci)]
+        (is (= :terminal-state (:error error-data)))
+        (is (= :merged (:status @ctrl)))))))
 
-(deftest transition-from-failed-state-not-rejected-test
-  (testing "Transitioning from :failed (terminal) is not rejected (no guard)"
+(deftest transition-from-failed-state-rejected-test
+  (testing "Transitioning away from :failed is rejected"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
                  :worktree-path "/tmp")]
       (controller/update-status! ctrl :failed)
-      (controller/update-status! ctrl :creating-pr)
-      (is (= :creating-pr (:status @ctrl))
-          "Controller allows transition away from terminal :failed state"))))
+      (let [error-data (transition-error-data ctrl :creating-pr)]
+        (is (= :terminal-state (:error error-data)))
+        (is (= :failed (:status @ctrl)))))))
+
+(deftest idempotent-transition-remains-valid-test
+  (testing "Controller allows same-state transitions for idempotent status updates"
+    (let [ctrl (controller/create-controller
+                 "dag" "run" "task" test-task
+                 :worktree-path "/tmp")]
+      (controller/update-status! ctrl :monitoring-ci)
+      (is (= :monitoring-ci (controller/update-status! ctrl :monitoring-ci)))
+      (is (= :monitoring-ci (:status @ctrl))))))
 
 ;------------------------------------------------------------------------------ add-history! Function
 
@@ -388,6 +405,7 @@
                  :generate-fn (fn [& _] nil))]
       ;; We need to set up PR info for the fix loop
       (swap! ctrl assoc
+             :status :monitoring-ci
              :pr {:pr/id 123 :pr/branch "feat/x" :pr/head-sha "abc"}
              :fix-iterations 0)
       ;; The actual fix-ci-failure call will fail because generate-fn

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
@@ -26,7 +26,9 @@
   (:require
    [clojure.test :refer [deftest testing is]]
    [ai.miniforge.pr-lifecycle.controller :as controller]
+   [ai.miniforge.pr-lifecycle.controller-config :as controller-config]
    [ai.miniforge.pr-lifecycle.merge :as merge]
+   [ai.miniforge.pr-lifecycle.messages :as messages]
    [ai.miniforge.pr-lifecycle.events :as events]
    [ai.miniforge.pr-lifecycle.fix-loop :as fix]
    [ai.miniforge.dag-executor.interface :as dag]
@@ -40,6 +42,12 @@
    :task/description "Add the feature"
    :task/acceptance-criteria ["Tests pass" "No lint errors"]
    :task/constraints ["No breaking changes"]})
+
+(defn- max-fix-iterations-exceeded-pattern
+  []
+  (re-pattern
+   (java.util.regex.Pattern/quote
+    (messages/t :controller/max-fix-iterations-exceeded))))
 
 (defn make-event-collector
   "Create a minimal event bus that collects published events."
@@ -91,15 +99,22 @@
 
 (deftest create-controller-default-config-test
   (testing "Controller uses default configuration values"
-    (let [ctrl (controller/create-controller
+    (let [defaults (controller-config/controller-defaults)
+          ctrl (controller/create-controller
                  "dag" "run" "task" test-task
                  :worktree-path "/tmp/repo")]
       (is (= "/tmp/repo" (get-in @ctrl [:config :worktree-path])))
-      (is (= 5 (get-in @ctrl [:config :max-fix-iterations])))
-      (is (= 30000 (get-in @ctrl [:config :ci-poll-interval-ms])))
-      (is (= 30000 (get-in @ctrl [:config :review-poll-interval-ms])))
+      (is (= (:max-fix-iterations defaults)
+             (get-in @ctrl [:config :max-fix-iterations])))
+      (is (= (:ci-poll-interval-ms defaults)
+             (get-in @ctrl [:config :ci-poll-interval-ms])))
+      (is (= (:review-poll-interval-ms defaults)
+             (get-in @ctrl [:config :review-poll-interval-ms])))
       (is (= merge/default-merge-policy (get-in @ctrl [:config :merge-policy])))
-      (is (true? (get-in @ctrl [:config :auto-resolve-comments]))))))
+      (is (= (:auto-resolve-comments defaults)
+             (get-in @ctrl [:config :auto-resolve-comments])))
+      (is (= (:branch-name-prefix defaults)
+             (get-in @ctrl [:config :branch-name-prefix]))))))
 
 (deftest create-controller-custom-config-test
   (testing "Controller accepts custom configuration"
@@ -117,7 +132,9 @@
       (is (= 5000 (get-in @ctrl [:config :ci-poll-interval-ms])))
       (is (= 10000 (get-in @ctrl [:config :review-poll-interval-ms])))
       (is (= custom-policy (get-in @ctrl [:config :merge-policy])))
-      (is (false? (get-in @ctrl [:config :auto-resolve-comments]))))))
+      (is (false? (get-in @ctrl [:config :auto-resolve-comments])))
+      (is (= (:branch-name-prefix (controller-config/controller-defaults))
+             (get-in @ctrl [:config :branch-name-prefix]))))))
 
 (deftest create-controller-with-dependencies-test
   (testing "Controller stores event-bus, logger, generate-fn"
@@ -166,7 +183,7 @@
                  :worktree-path "/tmp")]
       (is (= #{:worktree-path :merge-policy :max-fix-iterations
                :ci-poll-interval-ms :review-poll-interval-ms
-               :auto-resolve-comments}
+               :auto-resolve-comments :branch-name-prefix}
              (set (keys (:config @ctrl))))))))
 
 ;------------------------------------------------------------------------------ State Machine Transitions via update-status!
@@ -381,7 +398,7 @@
       (swap! ctrl assoc :fix-iterations 3)
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
-            #"Max fix iterations exceeded"
+            (max-fix-iterations-exceeded-pattern)
             (controller/handle-ci-failure! ctrl "some ci logs"))))))
 
 (deftest handle-review-feedback-max-iterations-test
@@ -393,7 +410,7 @@
       (swap! ctrl assoc :fix-iterations 2)
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
-            #"Max fix iterations exceeded"
+            (max-fix-iterations-exceeded-pattern)
             (controller/handle-review-feedback! ctrl [{:body "Fix"}]))))))
 
 (deftest handle-ci-failure-increments-iteration-before-max-test
@@ -451,7 +468,7 @@
                  :max-fix-iterations 0)]
       (is (thrown-with-msg?
             clojure.lang.ExceptionInfo
-            #"Max fix iterations exceeded"
+            (max-fix-iterations-exceeded-pattern)
             (controller/handle-ci-failure! ctrl "logs"))))))
 
 ;------------------------------------------------------------------------------ State Manipulation (via atom)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
@@ -155,6 +155,22 @@
       (is (= (:branch-name-prefix (controller-config/controller-defaults))
              (get-in @ctrl [:config :branch-name-prefix]))))))
 
+(deftest create-controller-nil-options-preserve-defaults-test
+  (testing "Nil options do not overwrite configured defaults"
+    (let [defaults (controller-config/controller-defaults)
+          ctrl (controller/create-controller
+                 "dag" "run" "task" test-task
+                 :worktree-path "/tmp/repo"
+                 :ci-poll-interval-ms nil
+                 :review-poll-interval-ms nil
+                 :auto-resolve-comments nil)]
+      (is (= (:ci-poll-interval-ms defaults)
+             (get-in @ctrl [:config :ci-poll-interval-ms])))
+      (is (= (:review-poll-interval-ms defaults)
+             (get-in @ctrl [:config :review-poll-interval-ms])))
+      (is (= (:auto-resolve-comments defaults)
+             (get-in @ctrl [:config :auto-resolve-comments]))))))
+
 (deftest create-controller-with-dependencies-test
   (testing "Controller stores event-bus, logger, generate-fn"
     (let [bus (make-event-collector)

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
@@ -32,7 +32,8 @@
    [ai.miniforge.pr-lifecycle.events :as events]
    [ai.miniforge.pr-lifecycle.fix-loop :as fix]
    [ai.miniforge.dag-executor.interface :as dag]
-   [ai.miniforge.release-executor.interface :as release]))
+   [ai.miniforge.release-executor.interface :as release]
+   [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Test Data
 
@@ -48,6 +49,24 @@
   (re-pattern
    (java.util.regex.Pattern/quote
     (messages/t :controller/max-fix-iterations-exceeded))))
+
+(defn- release-success
+  [data]
+  (merge {:success? true} data))
+
+(defn- release-failure
+  [error]
+  {:success? false
+   :error error})
+
+(defn- fix-success
+  [data]
+  (merge {:success? true} data))
+
+(defn- fix-failure
+  [reason]
+  {:success? false
+   :reason reason})
 
 (defn make-event-collector
   "Create a minimal event bus that collects published events."
@@ -471,6 +490,38 @@
             (max-fix-iterations-exceeded-pattern)
             (controller/handle-ci-failure! ctrl "logs"))))))
 
+(deftest handle-ci-failure-records-normalized-result-status-test
+  (testing "handle-ci-failure! records normalized result status in history"
+    (let [ctrl (controller/create-controller
+                 "dag" "run" "task" test-task
+                 :worktree-path "/tmp"
+                 :generate-fn (fn [& _] nil))]
+      (swap! ctrl assoc
+             :status :monitoring-ci
+             :pr {:pr/id 123 :pr/branch "feat/x" :pr/head-sha "abc"}
+             :fix-iterations 0)
+      (with-redefs [fix/fix-ci-failure (fn [& _]
+                                         (fix-success {:commit-sha "abc123"}))]
+        (controller/handle-ci-failure! ctrl "logs")
+        (is (= {:result-status :succeeded}
+               (:data (last (:history @ctrl)))))))))
+
+(deftest handle-review-feedback-records-normalized-result-status-test
+  (testing "handle-review-feedback! records normalized result status in history"
+    (let [ctrl (controller/create-controller
+                 "dag" "run" "task" test-task
+                 :worktree-path "/tmp"
+                 :generate-fn (fn [& _] nil))]
+      (swap! ctrl assoc
+             :status :monitoring-review
+             :pr {:pr/id 123 :pr/branch "feat/x" :pr/head-sha "abc"}
+             :fix-iterations 0)
+      (with-redefs [fix/fix-review-feedback (fn [& _]
+                                              (fix-failure :fix-failed))]
+        (controller/handle-review-feedback! ctrl [{:body "Fix"}])
+        (is (= {:result-status :failed}
+               (:data (last (:history @ctrl)))))))))
+
 ;------------------------------------------------------------------------------ State Manipulation (via atom)
 
 (deftest controller-status-transitions-test
@@ -573,16 +624,16 @@
   (testing "Returns branch result on success"
     (let [ctrl (make-controller)]
       (with-redefs [release/create-branch! (fn [_path _name]
-                                              {:success? true :base-branch "main"})]
+                                              (release-success {:base-branch "main"}))]
         (let [result (controller/create-and-checkout-branch! ctrl "/tmp" "feat/x")]
-          (is (:success? result))
+          (is (schema/succeeded? result))
           (is (= "main" (:base-branch result))))))))
 
 (deftest create-and-checkout-branch-failure
   (testing "Returns DAG error on failure and adds history"
     (let [ctrl (make-controller)]
       (with-redefs [release/create-branch! (fn [_path _name]
-                                              {:success? false :error "git error"})]
+                                              (release-failure "git error"))]
         (let [result (controller/create-and-checkout-branch! ctrl "/tmp" "feat/x")]
           (is (dag/err? result))
           (is (= :failed (:status @ctrl)))
@@ -614,16 +665,16 @@
     (let [ctrl (make-controller)
           task-id "task-00000001"]
       (with-redefs [release/commit-changes! (fn [_path _msg]
-                                               {:success? true :commit-sha "abc123"})]
+                                               (release-success {:commit-sha "abc123"}))]
         (let [result (controller/commit-changes! ctrl "/tmp" test-task task-id)]
-          (is (:success? result))
+          (is (schema/succeeded? result))
           (is (= "abc123" (:commit-sha result))))))))
 
 (deftest commit-changes-failure
   (testing "Returns DAG error on commit failure"
     (let [ctrl (make-controller)]
       (with-redefs [release/commit-changes! (fn [_path _msg]
-                                               {:success? false :error "nothing to commit"})]
+                                               (release-failure "nothing to commit"))]
         (let [result (controller/commit-changes! ctrl "/tmp" test-task "t-1")]
           (is (dag/err? result))
           (is (= :failed (:status @ctrl))))))))
@@ -634,7 +685,7 @@
           captured-msg (atom nil)]
       (with-redefs [release/commit-changes! (fn [_path msg]
                                                (reset! captured-msg msg)
-                                               {:success? true :commit-sha "x"})]
+                                               (release-success {:commit-sha "x"}))]
         (controller/commit-changes! ctrl "/tmp" test-task "t-1")
         (is (.contains @captured-msg "Implement feature X"))))))
 
@@ -644,11 +695,11 @@
   (testing "Returns PR info map on success"
     (let [ctrl (make-controller)]
       (with-redefs [release/push-branch! (fn [_path _branch]
-                                            {:success? true})
+                                            (release-success {}))
                     release/create-pr! (fn [_path _opts]
-                                         {:success? true
-                                          :pr-number 42
-                                          :pr-url "https://github.com/org/repo/pull/42"})]
+                                         (release-success
+                                          {:pr-number 42
+                                           :pr-url "https://github.com/org/repo/pull/42"}))]
         (let [commit {:commit-sha "abc123"}
               result (controller/push-and-create-pr! ctrl "/tmp" "feat/x" "main"
                                                       test-task "t-1" commit)]
@@ -662,7 +713,7 @@
   (testing "Returns DAG error when push fails"
     (let [ctrl (make-controller)]
       (with-redefs [release/push-branch! (fn [_path _branch]
-                                            {:success? false :error "remote rejected"})]
+                                            (release-failure "remote rejected"))]
         (let [result (controller/push-and-create-pr! ctrl "/tmp" "feat/x" "main"
                                                       test-task "t-1" {:commit-sha "x"})]
           (is (dag/err? result))
@@ -672,9 +723,9 @@
   (testing "Returns DAG error when PR creation fails"
     (let [ctrl (make-controller)]
       (with-redefs [release/push-branch! (fn [_path _branch]
-                                            {:success? true})
+                                            (release-success {}))
                     release/create-pr! (fn [_path _opts]
-                                         {:success? false :error "repo not found"})]
+                                         (release-failure "repo not found"))]
         (let [result (controller/push-and-create-pr! ctrl "/tmp" "feat/x" "main"
                                                       test-task "t-1" {:commit-sha "x"})]
           (is (dag/err? result)))))))
@@ -683,10 +734,10 @@
   (testing "PR body includes acceptance criteria from task"
     (let [ctrl (make-controller)
           captured-opts (atom nil)]
-      (with-redefs [release/push-branch! (fn [_path _branch] {:success? true})
+      (with-redefs [release/push-branch! (fn [_path _branch] (release-success {}))
                     release/create-pr! (fn [_path opts]
                                          (reset! captured-opts opts)
-                                         {:success? true :pr-number 1 :pr-url "url"})]
+                                         (release-success {:pr-number 1 :pr-url "url"}))]
         (controller/push-and-create-pr! ctrl "/tmp" "feat/x" "main"
                                          test-task "t-1" {:commit-sha "x"})
         (is (.contains (:body @captured-opts) "Tests pass"))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fsm_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fsm_test.clj
@@ -1,0 +1,90 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.pr-lifecycle.fsm-test
+  "Unit tests for the PR lifecycle controller FSM."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.pr-lifecycle.fsm :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test helpers
+
+(defn- transition-result
+  "Apply a controller FSM transition and return the result map."
+  [from-status to-status]
+  (sut/transition from-status to-status))
+
+;------------------------------------------------------------------------------ Layer 1
+;; FSM validation
+
+(deftest valid-transition-happy-path-test
+  (testing "happy path transitions succeed through merge"
+    (is (= {:success? true :state :creating-pr :event :create-pr}
+           (transition-result :pending :creating-pr)))
+    (is (= {:success? true :state :monitoring-ci :event :start-ci-monitoring}
+           (transition-result :creating-pr :monitoring-ci)))
+    (is (= {:success? true :state :monitoring-review :event :start-review-monitoring}
+           (transition-result :monitoring-ci :monitoring-review)))
+    (is (= {:success? true :state :ready-to-merge :event :mark-ready-to-merge}
+           (transition-result :monitoring-review :ready-to-merge)))
+    (is (= {:success? true :state :merged :event :merge}
+           (transition-result :ready-to-merge :merged)))))
+
+(deftest valid-transition-fix-loop-test
+  (testing "fix loop transitions return to CI monitoring"
+    (is (= {:success? true :state :fixing :event :start-fixing}
+           (transition-result :monitoring-ci :fixing)))
+    (is (= {:success? true :state :monitoring-ci :event :start-ci-monitoring}
+           (transition-result :fixing :monitoring-ci)))
+    (is (= {:success? true :state :fixing :event :start-fixing}
+           (transition-result :monitoring-review :fixing)))))
+
+(deftest invalid-status-and-transition-test
+  (testing "invalid statuses and undefined transitions are rejected"
+    (is (= :invalid-state (:error (transition-result :bogus-status :creating-pr))))
+    (is (= :invalid-target-status (:error (transition-result :pending :bogus-status))))
+    (is (= :invalid-transition (:error (transition-result :monitoring-ci :pending))))))
+
+(deftest terminal-state-rejected-test
+  (testing "terminal statuses reject further transitions"
+    (is (= :terminal-state (:error (transition-result :merged :monitoring-ci))))
+    (is (= :terminal-state (:error (transition-result :failed :creating-pr))))))
+
+(deftest same-state-transition-remains-idempotent-test
+  (testing "same-state transitions are allowed as idempotent updates"
+    (is (= {:success? true :state :monitoring-ci :event nil}
+           (transition-result :monitoring-ci :monitoring-ci)))
+    (is (= {:success? true :state :merged :event nil}
+           (transition-result :merged :merged)))))
+
+(deftest valid-transition-predicate-test
+  (testing "valid-transition? requires recognized statuses"
+    (is (true? (sut/valid-transition? :monitoring-ci :monitoring-ci)))
+    (is (true? (sut/valid-transition? :monitoring-ci :monitoring-review)))
+    (is (false? (sut/valid-transition? :bogus-status :bogus-status)))
+    (is (false? (sut/valid-transition? :bogus-status :creating-pr)))))
+
+(deftest valid-targets-test
+  (testing "valid targets reflect the configured transition graph"
+    (is (= #{:pending :creating-pr :monitoring-ci :failed}
+           (sut/valid-targets :pending)))
+    (is (= #{:ready-to-merge :monitoring-ci :merged :failed}
+           (sut/valid-targets :ready-to-merge)))
+    (is (= #{}
+           (sut/valid-targets :bogus-status)))))

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fsm_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fsm_test.clj
@@ -21,7 +21,8 @@
   (:require
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.pr-lifecycle.messages :as messages]
-   [ai.miniforge.pr-lifecycle.fsm :as sut]))
+   [ai.miniforge.pr-lifecycle.fsm :as sut]
+   [ai.miniforge.schema.interface :as schema]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Test helpers
@@ -36,54 +37,71 @@
 
 (deftest valid-transition-happy-path-test
   (testing "happy path transitions succeed through merge"
-    (is (= {:success? true :state :creating-pr :event :create-pr}
-           (transition-result :pending :creating-pr)))
-    (is (= {:success? true :state :monitoring-ci :event :start-ci-monitoring}
-           (transition-result :creating-pr :monitoring-ci)))
-    (is (= {:success? true :state :monitoring-review :event :start-review-monitoring}
-           (transition-result :monitoring-ci :monitoring-review)))
-    (is (= {:success? true :state :ready-to-merge :event :mark-ready-to-merge}
-           (transition-result :monitoring-review :ready-to-merge)))
-    (is (= {:success? true :state :merged :event :merge}
-           (transition-result :ready-to-merge :merged)))))
+    (let [creating-pr (transition-result :pending :creating-pr)
+          monitoring-ci (transition-result :creating-pr :monitoring-ci)
+          monitoring-review (transition-result :monitoring-ci :monitoring-review)
+          ready-to-merge (transition-result :monitoring-review :ready-to-merge)
+          merged (transition-result :ready-to-merge :merged)]
+      (is (schema/succeeded? creating-pr))
+      (is (= {:state :creating-pr :event :create-pr} (:transition creating-pr)))
+      (is (schema/succeeded? monitoring-ci))
+      (is (= {:state :monitoring-ci :event :start-ci-monitoring} (:transition monitoring-ci)))
+      (is (schema/succeeded? monitoring-review))
+      (is (= {:state :monitoring-review :event :start-review-monitoring}
+             (:transition monitoring-review)))
+      (is (schema/succeeded? ready-to-merge))
+      (is (= {:state :ready-to-merge :event :mark-ready-to-merge}
+             (:transition ready-to-merge)))
+      (is (schema/succeeded? merged))
+      (is (= {:state :merged :event :merge} (:transition merged))))))
 
 (deftest valid-transition-fix-loop-test
   (testing "fix loop transitions return to CI monitoring"
-    (is (= {:success? true :state :fixing :event :start-fixing}
-           (transition-result :monitoring-ci :fixing)))
-    (is (= {:success? true :state :monitoring-ci :event :start-ci-monitoring}
-           (transition-result :fixing :monitoring-ci)))
-    (is (= {:success? true :state :fixing :event :start-fixing}
-           (transition-result :monitoring-review :fixing)))))
+    (let [start-fixing (transition-result :monitoring-ci :fixing)
+          restart-ci (transition-result :fixing :monitoring-ci)
+          restart-fixing (transition-result :monitoring-review :fixing)]
+      (is (schema/succeeded? start-fixing))
+      (is (= {:state :fixing :event :start-fixing} (:transition start-fixing)))
+      (is (schema/succeeded? restart-ci))
+      (is (= {:state :monitoring-ci :event :start-ci-monitoring} (:transition restart-ci)))
+      (is (schema/succeeded? restart-fixing))
+      (is (= {:state :fixing :event :start-fixing} (:transition restart-fixing))))))
 
 (deftest invalid-status-and-transition-test
   (testing "invalid statuses and undefined transitions are rejected"
     (let [invalid-state-result (transition-result :bogus-status :creating-pr)
           invalid-target-result (transition-result :pending :bogus-status)
           invalid-transition-result (transition-result :monitoring-ci :pending)]
-      (is (= :invalid-state (:error invalid-state-result)))
-      (is (= :invalid-target-status (:error invalid-target-result)))
-      (is (= :invalid-transition (:error invalid-transition-result)))
+      (is (schema/failed? invalid-state-result))
+      (is (= :invalid-state (sut/transition-error-code invalid-state-result)))
+      (is (schema/failed? invalid-target-result))
+      (is (= :invalid-target-status (sut/transition-error-code invalid-target-result)))
+      (is (schema/failed? invalid-transition-result))
+      (is (= :invalid-transition (sut/transition-error-code invalid-transition-result)))
       (is (= (messages/t :fsm/invalid-state {:status :bogus-status})
-             (:message invalid-state-result)))
+             (sut/transition-error-message invalid-state-result)))
       (is (= (messages/t :fsm/invalid-target-status {:status :bogus-status})
-             (:message invalid-target-result)))
+             (sut/transition-error-message invalid-target-result)))
       (is (= (messages/t :fsm/invalid-transition
                          {:from-status :monitoring-ci
                           :to-status :pending})
-             (:message invalid-transition-result))))))
+             (sut/transition-error-message invalid-transition-result))))))
 
 (deftest terminal-state-rejected-test
   (testing "terminal statuses reject further transitions"
-    (is (= :terminal-state (:error (transition-result :merged :monitoring-ci))))
-    (is (= :terminal-state (:error (transition-result :failed :creating-pr))))))
+    (is (= :terminal-state
+           (sut/transition-error-code (transition-result :merged :monitoring-ci))))
+    (is (= :terminal-state
+           (sut/transition-error-code (transition-result :failed :creating-pr))))))
 
 (deftest same-state-transition-remains-idempotent-test
   (testing "same-state transitions are allowed as idempotent updates"
-    (is (= {:success? true :state :monitoring-ci :event nil}
-           (transition-result :monitoring-ci :monitoring-ci)))
-    (is (= {:success? true :state :merged :event nil}
-           (transition-result :merged :merged)))))
+    (let [monitoring-ci (transition-result :monitoring-ci :monitoring-ci)
+          merged (transition-result :merged :merged)]
+      (is (schema/succeeded? monitoring-ci))
+      (is (= {:state :monitoring-ci :event nil} (:transition monitoring-ci)))
+      (is (schema/succeeded? merged))
+      (is (= {:state :merged :event nil} (:transition merged))))))
 
 (deftest valid-transition-predicate-test
   (testing "valid-transition? requires recognized statuses"

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fsm_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/fsm_test.clj
@@ -20,6 +20,7 @@
   "Unit tests for the PR lifecycle controller FSM."
   (:require
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.pr-lifecycle.messages :as messages]
    [ai.miniforge.pr-lifecycle.fsm :as sut]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -57,9 +58,20 @@
 
 (deftest invalid-status-and-transition-test
   (testing "invalid statuses and undefined transitions are rejected"
-    (is (= :invalid-state (:error (transition-result :bogus-status :creating-pr))))
-    (is (= :invalid-target-status (:error (transition-result :pending :bogus-status))))
-    (is (= :invalid-transition (:error (transition-result :monitoring-ci :pending))))))
+    (let [invalid-state-result (transition-result :bogus-status :creating-pr)
+          invalid-target-result (transition-result :pending :bogus-status)
+          invalid-transition-result (transition-result :monitoring-ci :pending)]
+      (is (= :invalid-state (:error invalid-state-result)))
+      (is (= :invalid-target-status (:error invalid-target-result)))
+      (is (= :invalid-transition (:error invalid-transition-result)))
+      (is (= (messages/t :fsm/invalid-state {:status :bogus-status})
+             (:message invalid-state-result)))
+      (is (= (messages/t :fsm/invalid-target-status {:status :bogus-status})
+             (:message invalid-target-result)))
+      (is (= (messages/t :fsm/invalid-transition
+                         {:from-status :monitoring-ci
+                          :to-status :pending})
+             (:message invalid-transition-result))))))
 
 (deftest terminal-state-rejected-test
   (testing "terminal statuses reject further transitions"

--- a/docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md
+++ b/docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md
@@ -15,12 +15,17 @@ explicit, testable, and reusable through the shared FSM foundation.
 ## Changes In Detail
 
 - Add `pr_lifecycle.fsm` with:
-  - controller status order and valid-status predicates
-  - transition graph and valid-target helpers
+  - controller status order and transition graph loaded from
+    `config/pr-lifecycle/fsm.edn`
+  - valid-status predicates and valid-target helpers
   - explicit transition execution with structured failure maps
   - compiled controller machine config backed by `fsm/define-machine`
 - Refactor `pr_lifecycle.controller` to route `update-status!` through the FSM
   and preserve the existing exception/reporting contract
+- Load controller defaults from
+  `config/pr-lifecycle/controller-defaults.edn`
+- Localize controller/FSM emitted text through
+  `config/pr-lifecycle/messages/en-US.edn`
 - Update controller tests to assert rejected invalid transitions, terminal
   behavior, and idempotent same-state updates
 - Add focused FSM tests for the happy path, fix loop, invalid inputs, terminal

--- a/docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md
+++ b/docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md
@@ -1,0 +1,41 @@
+# feat: formalize PR lifecycle controller FSM
+
+## Overview
+
+Extract the PR lifecycle controller status contract into a dedicated FSM
+module and wire the controller through that contract for status validation and
+transition execution.
+
+## Motivation
+
+The controller already behaved like a state machine, but the transition policy
+was embedded in controller code. This slice makes the lifecycle contract
+explicit, testable, and reusable through the shared FSM foundation.
+
+## Changes In Detail
+
+- Add `pr_lifecycle.fsm` with:
+  - controller status order and valid-status predicates
+  - transition graph and valid-target helpers
+  - explicit transition execution with structured failure maps
+  - compiled controller machine config backed by `fsm/define-machine`
+- Refactor `pr_lifecycle.controller` to route `update-status!` through the FSM
+  and preserve the existing exception/reporting contract
+- Update controller tests to assert rejected invalid transitions, terminal
+  behavior, and idempotent same-state updates
+- Add focused FSM tests for the happy path, fix loop, invalid inputs, terminal
+  states, and valid-target predicates
+
+## Testing Plan
+
+- `clojure -M:test -e '(require ... ) (clojure.test/run-tests ...)'` for the
+  `pr-lifecycle.fsm-test` and `pr-lifecycle.controller-test` namespaces
+- `clj-kondo --lint` on the touched `pr-lifecycle` source and test files
+
+## Checklist
+
+- [x] PR lifecycle status transitions are FSM-backed
+- [x] Invalid transitions are rejected with structured errors
+- [x] Tests updated alongside the controller change
+- [x] Targeted lint passes
+- [x] Targeted namespace tests pass


### PR DESCRIPTION
# feat: formalize PR lifecycle controller FSM

## Overview

Extract the PR lifecycle controller status contract into a dedicated FSM
module and wire the controller through that contract for status validation and
transition execution.

## Motivation

The controller already behaved like a state machine, but the transition policy
was embedded in controller code. This slice makes the lifecycle contract
explicit, testable, and reusable through the shared FSM foundation.

## Changes In Detail

- Add `pr_lifecycle.fsm` with:
  - controller status order and transition graph loaded from
    `config/pr-lifecycle/fsm.edn`
  - valid-status predicates and valid-target helpers
  - explicit transition execution with structured failure maps
  - compiled controller machine config backed by `fsm/define-machine`
- Refactor `pr_lifecycle.controller` to route `update-status!` through the FSM
  and preserve the existing exception/reporting contract
- Load controller defaults from
  `config/pr-lifecycle/controller-defaults.edn`
- Localize controller/FSM emitted text through
  `config/pr-lifecycle/messages/en-US.edn`
- Update controller tests to assert rejected invalid transitions, terminal
  behavior, and idempotent same-state updates
- Add focused FSM tests for the happy path, fix loop, invalid inputs, terminal
  states, and valid-target predicates

## Testing Plan

- `clojure -M:test -e '(require ... ) (clojure.test/run-tests ...)'` for the
  `pr-lifecycle.fsm-test` and `pr-lifecycle.controller-test` namespaces
- `clj-kondo --lint` on the touched `pr-lifecycle` source and test files

## Checklist

- [x] PR lifecycle status transitions are FSM-backed
- [x] Invalid transitions are rejected with structured errors
- [x] Tests updated alongside the controller change
- [x] Targeted lint passes
- [x] Targeted namespace tests pass
