### PR TITLE
feat: formalize workflow agent default contract

### DIFF
--- a/components/workflow/resources/config/workflow/observe-phase.edn
+++ b/components/workflow/resources/config/workflow/observe-phase.edn
@@ -1,5 +1,5 @@
 {:observe/phase-defaults
- {:agent nil
+ {:agent :default
   :gates []
   :budget {:tokens 0
            :iterations 1

--- a/components/workflow/src/ai/miniforge/workflow/agent_factory.clj
+++ b/components/workflow/src/ai/miniforge/workflow/agent_factory.clj
@@ -32,7 +32,7 @@
   "Agent types that require a :phase/handler or phase interceptor.
    These phases have real responsibilities (gate evaluation, release ops,
    metrics collection) that cannot be fulfilled by a stub artifact."
-  #{:reviewer :releaser :observer})
+  #{:default :reviewer :releaser :observer})
 
 (defn create-agent-for-phase
   "Create agent instance from :phase/agent keyword.
@@ -45,10 +45,11 @@
    - :spec-analyzer -> planner with spec-focus prompt
    - :designer -> planner with design-focus prompt
    - :none -> nil (skip phase)
+   - :default -> invalid here; requires :phase/handler or phase interceptor
 
-   Throws for :reviewer, :releaser, :observer — these require a :phase/handler
-   or a registered phase interceptor (see phase.registry). Using this factory
-   for them produces a silent stub that does no real work.
+   Throws for :default, :reviewer, :releaser, :observer — these require a
+   :phase/handler or a registered phase interceptor (see phase.registry).
+   Using this factory for them produces a silent stub that does no real work.
 
    Arguments:
    - phase: Phase configuration map with :phase/agent
@@ -83,7 +84,9 @@
       ;; Unknown agent type — fail loud
       (throw (ex-info (str "Unknown agent type: " agent-type
                            ". Supported: :planner :implementer :tester "
-                           ":spec-analyzer :designer :none")
+                           ":spec-analyzer :designer :none. "
+                           "Use :default only with a :phase/handler or "
+                           "phase interceptor.")
                       {:agent-type agent-type
                        :phase-id (:phase/id phase)})))))
 

--- a/components/workflow/test/ai/miniforge/workflow/agent_factory_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/agent_factory_test.clj
@@ -65,6 +65,15 @@
       (is (nil? agent-instance)
           "Should return nil for :none agent"))))
 
+(deftest test-create-agent-for-phase-default-throws
+  (testing "Throw for :default — requires :phase/handler or interceptor"
+    (let [phase {:phase/id :observe
+                 :phase/agent :default}
+          context {}]
+      (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                            #"requires a :phase/handler"
+                            (factory/create-agent-for-phase phase context))))))
+
 (deftest test-create-agent-for-phase-reviewer-throws
   (testing "Throw for :reviewer — requires :phase/handler or interceptor"
     (let [phase {:phase/id :review

--- a/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/observe_phase_test.clj
@@ -19,6 +19,7 @@
 
 (deftest default-config-loaded-from-edn-test
   (testing "observe phase defaults come from resource config"
+    (is (= :default (:agent sut/default-config)))
     (is (= 259200 (get-in sut/default-config [:budget :time-seconds])))
     (is (= [] (:gates sut/default-config)))))
 

--- a/docs/pull-requests/2026-04-23-feat-workflow-agent-default-contract.md
+++ b/docs/pull-requests/2026-04-23-feat-workflow-agent-default-contract.md
@@ -1,0 +1,80 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+  Licensed under Apache 2.0.
+-->
+
+# feat: formalize workflow agent default contract
+
+## Overview
+Formalizes the workflow `:phase/agent` contract so `nil` is no longer
+used as a meaningful value in shipped workflow defaults.
+
+This slice introduces an explicit `:default` contract for
+handler/interceptor-owned phases and keeps `:none` as the only value
+that means "this phase has no agent."
+
+## Motivation
+Using `nil` as a meaningful workflow enum value makes the execution
+contract ambiguous:
+
+- `nil` should mean absence or unspecified
+- `:none` should mean an intentional no-agent phase
+- handler/interceptor-owned phases should be explicit instead of relying
+  on `nil`
+
+The Observe phase shipped with `:agent nil` in its defaults, which made
+the data contract weaker than the execution model. This PR makes that
+contract explicit before downstream product workflows depend on it.
+
+## Base Branch
+`main`
+
+## Changes In Detail
+- Changes `components/workflow/resources/config/workflow/observe-phase.edn`
+  from `:agent nil` to `:agent :default`
+- Updates `agent_factory.clj` so `:default` is treated as a
+  handler/interceptor-owned contract and throws if it reaches raw agent
+  construction
+- Expands `agent_factory_test.clj` with a direct `:default` failure-path
+  test
+- Expands `observe_phase_test.clj` to assert the shipped default config
+  uses `:default`
+
+## Testing Plan
+Executed in `/tmp/cc-miniforge-agent-default`:
+
+```sh
+git diff --check
+clojure -M:test -e "(require 'ai.miniforge.workflow.agent-factory-test 'ai.miniforge.workflow.observe-phase-test) (let [result (clojure.test/run-tests 'ai.miniforge.workflow.agent-factory-test 'ai.miniforge.workflow.observe-phase-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"
+```
+
+Result:
+- `20` tests
+- `42` assertions
+- `0` failures
+- `0` errors
+
+## Deployment Plan
+No migration step is required.
+
+Downstream workflow packs can now normalize on:
+- `:none` for true no-agent phases
+- `:default` for handler/interceptor-owned phases
+- missing `:agent` for unspecified/absent
+
+## Architecture Notes
+- This is an execution-contract cleanup, not a behavior expansion.
+- It intentionally fails loud if `:default` is routed into raw agent
+  creation without a handler or interceptor. That preserves the semantic
+  distinction from `:none`.
+
+## Related PRs
+- `thesium-workflows` follow-on to replace private workflow `nil` agent
+  values with `:none`
+
+## Checklist
+- [x] Removed shipped `:agent nil` usage from Miniforge workflow defaults
+- [x] Added explicit `:default` semantics at the runtime boundary
+- [x] Added regression tests for the contract


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
  Licensed under Apache 2.0.
-->

# feat: formalize workflow agent default contract

## Overview
Formalizes the workflow `:phase/agent` contract so `nil` is no longer
used as a meaningful value in shipped workflow defaults.

This slice introduces an explicit `:default` contract for
handler/interceptor-owned phases and keeps `:none` as the only value
that means "this phase has no agent."

## Motivation
Using `nil` as a meaningful workflow enum value makes the execution
contract ambiguous:

- `nil` should mean absence or unspecified
- `:none` should mean an intentional no-agent phase
- handler/interceptor-owned phases should be explicit instead of relying
  on `nil`

The Observe phase shipped with `:agent nil` in its defaults, which made
the data contract weaker than the execution model. This PR makes that
contract explicit before downstream product workflows depend on it.

## Base Branch
`main`

## Changes In Detail
- Changes `components/workflow/resources/config/workflow/observe-phase.edn`
  from `:agent nil` to `:agent :default`
- Updates `agent_factory.clj` so `:default` is treated as a
  handler/interceptor-owned contract and throws if it reaches raw agent
  construction
- Expands `agent_factory_test.clj` with a direct `:default` failure-path
  test
- Expands `observe_phase_test.clj` to assert the shipped default config
  uses `:default`

## Testing Plan
Executed in `/tmp/cc-miniforge-agent-default`:

```sh
git diff --check
clojure -M:test -e "(require 'ai.miniforge.workflow.agent-factory-test 'ai.miniforge.workflow.observe-phase-test) (let [result (clojure.test/run-tests 'ai.miniforge.workflow.agent-factory-test 'ai.miniforge.workflow.observe-phase-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"
```

Result:
- `20` tests
- `42` assertions
- `0` failures
- `0` errors

## Deployment Plan
No migration step is required.

Downstream workflow packs can now normalize on:
- `:none` for true no-agent phases
- `:default` for handler/interceptor-owned phases
- missing `:agent` for unspecified/absent

## Architecture Notes
- This is an execution-contract cleanup, not a behavior expansion.
- It intentionally fails loud if `:default` is routed into raw agent
  creation without a handler or interceptor. That preserves the semantic
  distinction from `:none`.

## Related PRs
- `thesium-workflows` follow-on to replace private workflow `nil` agent
  values with `:none`

## Checklist
- [x] Removed shipped `:agent nil` usage from Miniforge workflow defaults
- [x] Added explicit `:default` semantics at the runtime boundary
- [x] Added regression tests for the contract
