### PR TITLE
refactor: make agent meta loop authoritative

### DIFF
--- a/components/agent/src/ai/miniforge/agent/interface/meta.clj
+++ b/components/agent/src/ai/miniforge/agent/interface/meta.clj
@@ -20,6 +20,7 @@
   "Meta-agent orchestration API."
   (:require
    [ai.miniforge.agent.meta-coordinator :as meta-coord]
+   [ai.miniforge.agent.meta.loop :as meta-loop]
    [ai.miniforge.agent.meta.progress-monitor :as progress-monitor]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -46,7 +47,7 @@
 
    Returns: {:cycle/sli-count :cycle/breach-count :cycle/signal-count
              :cycle/diagnosis-count :cycle/proposal-count :cycle/degradation-mode ...}"
-  meta-coord/run-meta-loop-cycle!)
+  meta-loop/run-meta-loop-cycle!)
 
 (def create-meta-loop-context
   "Create a MetaLoopContext bundling reliability engine, degradation manager,
@@ -55,7 +56,7 @@
    Arguments:
      event-stream - event stream atom
      config       - optional {:reliability {} :degradation {}}"
-  meta-coord/create-meta-loop-context)
+  meta-loop/create-meta-loop-context)
 
 (def record-workflow-outcome!
   "Record a workflow completion for use in the next meta-loop cycle.
@@ -65,7 +66,7 @@
      workflow-id   - uuid
      status        - :completed | :failed | :escalated
      failure-class - optional :failure.class/* keyword"
-  meta-coord/record-workflow-outcome!)
+  meta-loop/record-workflow-outcome!)
 
 (def run-cycle-from-context!
   "Run one meta-loop cycle using the accumulated metrics in ctx.
@@ -75,4 +76,4 @@
      training-examples - optional vector of training records
 
    Returns: cycle result map."
-  meta-coord/run-cycle-from-context!)
+  meta-loop/run-cycle-from-context!)

--- a/components/agent/src/ai/miniforge/agent/meta/loop.clj
+++ b/components/agent/src/ai/miniforge/agent/meta/loop.clj
@@ -18,6 +18,31 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Cycle context
 
+(defn- empty-metrics-store
+  []
+  {:workflow-metrics []
+   :failure-events []
+   :phase-metrics []
+   :gate-metrics []
+   :tool-metrics []
+   :context-metrics []})
+
+(defn- context-map
+  [opts]
+  (merge {:cycle-count (atom 0)
+          :metrics-store (atom (empty-metrics-store))}
+         opts))
+
+(defn- event-stream-context
+  [event-stream config]
+  (context-map
+   {:event-stream event-stream
+    :reliability-engine (reliability/create-engine event-stream (:reliability config))
+    :degradation-manager (reliability/create-degradation-manager event-stream (:degradation config))
+    :diagnosis-config (:diagnosis config)
+    :improvement-pipeline (improvement/create-pipeline)
+    :knowledge-store (:knowledge-store config)}))
+
 (defn create-meta-loop-context
   "Create the context required to run meta-loop cycles.
 
@@ -28,8 +53,12 @@
      :improvement-pipeline  - from improvement/create-pipeline
      :event-stream          - event stream atom
      :knowledge-store       - optional knowledge store for learning capture"
-  [opts]
-  (merge {:cycle-count (atom 0)} opts))
+  ([context-or-event-stream]
+   (if (map? context-or-event-stream)
+     (context-map context-or-event-stream)
+     (event-stream-context context-or-event-stream nil)))
+  ([event-stream config]
+   (event-stream-context event-stream config)))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Pipeline stages
@@ -73,6 +102,53 @@
     (stream/publish! event-stream
                      (events/meta-loop-cycle-completed event-stream summary))))
 
+(defn- execute-cycle
+  [ctx metrics diagnosis-data]
+  (let [{:keys [reliability-engine degradation-manager
+                diagnosis-config improvement-pipeline]} ctx
+        reliability-result (compute-reliability reliability-engine metrics)
+        degradation-mode (or (evaluate-degradation degradation-manager reliability-result)
+                             :nominal)
+        diagnosis-result (run-diagnosis diagnosis-data reliability-result diagnosis-config)
+        proposals (generate-proposals (:diagnoses diagnosis-result)
+                                      degradation-mode
+                                      improvement-pipeline)]
+    {:degradation-mode degradation-mode
+     :diagnosis-result diagnosis-result
+     :proposals proposals
+     :reliability-result reliability-result}))
+
+(defn- cycle-summary
+  [cycle-number cycle-data]
+  (let [{:keys [degradation-mode diagnosis-result proposals reliability-result]} cycle-data]
+    {:cycle-number cycle-number
+     :reliability reliability-result
+     :degradation-mode degradation-mode
+     :signals (count (:signals diagnosis-result))
+     :correlations (count (:correlations diagnosis-result))
+     :diagnoses (count (:diagnoses diagnosis-result))
+     :proposals (count (or proposals []))}))
+
+(defn- cycle-result
+  [started-at duration-ms cycle-data]
+  (let [{:keys [degradation-mode diagnosis-result proposals reliability-result]} cycle-data
+        breaches (get reliability-result :breaches [])
+        recommendation (get reliability-result :recommendation)
+        slis (get reliability-result :slis [])
+        diagnoses (:diagnoses diagnosis-result)
+        signals (:signals diagnosis-result)
+        correlations (:correlations diagnosis-result)]
+    {:cycle/started-at started-at
+     :cycle/duration-ms duration-ms
+     :cycle/sli-count (count slis)
+     :cycle/breach-count (count breaches)
+     :cycle/signal-count (count signals)
+     :cycle/correlation-count (count correlations)
+     :cycle/diagnosis-count (count diagnoses)
+     :cycle/proposal-count (count (or proposals []))
+     :cycle/degradation-mode degradation-mode
+     :cycle/recommendation recommendation}))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Meta-loop cycle
 
@@ -94,28 +170,50 @@
       :signals int
       :diagnoses int
       :proposals int}"
-  [ctx metrics diagnosis-data]
-  (let [{:keys [reliability-engine degradation-manager
-                diagnosis-config improvement-pipeline
-                event-stream cycle-count]} ctx
+  ([ctx]
+   (let [started-at (java.util.Date.)
+         metrics (get ctx :metrics {})
+         diagnosis-data {:failure-events (get metrics :failure-events [])
+                         :training-examples (get ctx :training-examples [])
+                         :phase-metrics (get metrics :phase-metrics [])}
+         completed-cycle (execute-cycle ctx metrics diagnosis-data)
+         duration-ms (- (System/currentTimeMillis) (.getTime started-at))
+         result (cycle-result started-at duration-ms completed-cycle)]
+     (emit-cycle-event (:event-stream ctx) result)
+     result))
+  ([ctx metrics diagnosis-data]
+   (let [cycle-number (swap! (:cycle-count ctx) inc)
+         completed-cycle (execute-cycle ctx metrics diagnosis-data)
+         summary (cycle-summary cycle-number completed-cycle)]
+     (emit-cycle-event (:event-stream ctx) summary)
+     summary)))
 
-        cycle-num          (swap! cycle-count inc)
-        reliability-result (compute-reliability reliability-engine metrics)
-        deg-mode           (evaluate-degradation degradation-manager reliability-result)
-        diag-result        (run-diagnosis diagnosis-data reliability-result diagnosis-config)
-        proposals          (generate-proposals (:diagnoses diag-result)
-                                              (or deg-mode :nominal)
-                                              improvement-pipeline)
-        summary            {:cycle-number    cycle-num
-                            :reliability     reliability-result
-                            :degradation-mode (or deg-mode :nominal)
-                            :signals         (count (:signals diag-result))
-                            :correlations    (count (:correlations diag-result))
-                            :diagnoses       (count (:diagnoses diag-result))
-                            :proposals       (count (or proposals []))}]
+(defn record-workflow-outcome!
+  "Record a workflow completion for use in the next meta-loop cycle."
+  [ctx workflow-id status & [failure-class]]
+  (let [now (java.util.Date.)]
+    (swap! (:metrics-store ctx) update :workflow-metrics conj
+           {:workflow/id workflow-id
+            :status status
+            :timestamp now})
+    (when failure-class
+      (swap! (:metrics-store ctx) update :failure-events conj
+             {:failure/class failure-class
+              :workflow/id workflow-id
+              :timestamp now})))
+  nil)
 
-    (emit-cycle-event event-stream summary)
-    summary))
+(defn run-cycle-from-context!
+  "Run one meta-loop cycle using the accumulated metrics in `ctx`."
+  [ctx & [training-examples]]
+  (run-meta-loop-cycle!
+   {:event-stream (:event-stream ctx)
+    :reliability-engine (:reliability-engine ctx)
+    :degradation-manager (:degradation-manager ctx)
+    :diagnosis-config (:diagnosis-config ctx)
+    :improvement-pipeline (:improvement-pipeline ctx)
+    :metrics @(:metrics-store ctx)
+    :training-examples training-examples}))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/agent/src/ai/miniforge/agent/meta_coordinator.clj
+++ b/components/agent/src/ai/miniforge/agent/meta_coordinator.clj
@@ -23,12 +23,7 @@
    It routes workflow state to meta-agents and aggregates their decisions.
    Any meta-agent can halt the workflow - coordinator just enforces it."
   (:require [ai.miniforge.agent.meta-protocol :as mp]
-            [ai.miniforge.response.interface :as response]
-            [ai.miniforge.reliability.interface :as reliability]
-            [ai.miniforge.diagnosis.interface :as diagnosis]
-            [ai.miniforge.improvement.interface :as improvement]
-            [ai.miniforge.event-stream.interface.stream :as stream]
-            [ai.miniforge.event-stream.interface.events :as events]))
+            [ai.miniforge.response.interface :as response]))
 
 (defrecord MetaCoordinator
   [agents           ; Vector of MetaAgent instances
@@ -203,156 +198,6 @@
 ;;----------------------------------------------------------------------------- Learning Layer
 ;; Meta-loop cycle — N1 §3.3
 
-(defn run-meta-loop-cycle!
-  "Execute one meta-loop learning cycle per N1 §3.3.
-
-   Orchestrates:
-   1. Compute SLIs, check SLOs, update error budgets (reliability layer)
-   2. Evaluate degradation mode — may transition :nominal → :degraded → :safe-mode
-   3. Run full diagnosis pipeline: extract signals → correlate → diagnose
-   4. Generate improvement proposals from diagnoses
-   5. Store proposals in pipeline (pending operator approval)
-   6. Emit :meta-loop/cycle-completed event
-
-   Proposal generation is skipped when degradation mode is :degraded or :safe-mode
-   to avoid generating noise during active incidents.
-
-   Arguments:
-     ctx - map with keys:
-       :event-stream         - event stream atom for emitting cycle events
-       :reliability-engine   - ReliabilityEngine (reliability/create-engine)
-       :degradation-manager  - DegradationManager (reliability/create-degradation-manager)
-       :improvement-pipeline - pipeline atom (improvement/create-pipeline)
-       :metrics              - collected metrics map (see reliability/compute-all-slis):
-                                 :workflow-metrics :phase-metrics :gate-metrics
-                                 :tool-metrics :failure-events :context-metrics
-       :training-examples    - vector of training records (optional)
-
-   Returns: cycle result map with :cycle/* keys."
-  [{:keys [event-stream reliability-engine degradation-manager
-           improvement-pipeline metrics training-examples]}]
-  (let [started-at (java.util.Date.)]
-    (try
-      (let [;; 1. Compute SLIs, check SLOs, update error budgets
-            {:keys [slo-checks budgets breaches recommendation] :as cycle-result}
-            (reliability/compute-cycle! reliability-engine (or metrics {}))
-
-            ;; 2. Evaluate and possibly transition degradation mode
-            current-mode (reliability/evaluate-degradation! degradation-manager budgets)
-
-            ;; 3. Run full diagnosis: signals → correlations → diagnoses
-            {:keys [signals correlations diagnoses]}
-            (diagnosis/run-diagnosis
-             {:slo-checks        slo-checks
-              :failure-events    (get metrics :failure-events [])
-              :training-examples (or training-examples [])
-              :phase-metrics     (get metrics :phase-metrics [])})
-
-            ;; 4. Generate proposals only in nominal mode — avoid noise during incidents
-            proposals (when (= :nominal current-mode)
-                        (improvement/generate-proposals diagnoses))
-
-            ;; 5. Store proposals
-            _ (when (and improvement-pipeline (seq proposals))
-                (doseq [p proposals]
-                  (improvement/store-proposal! improvement-pipeline p)))
-
-            duration-ms (- (System/currentTimeMillis) (.getTime started-at))
-
-            result {:cycle/started-at       started-at
-                    :cycle/duration-ms      duration-ms
-                    :cycle/sli-count        (count (:slis cycle-result))
-                    :cycle/breach-count     (count breaches)
-                    :cycle/signal-count     (count signals)
-                    :cycle/correlation-count (count correlations)
-                    :cycle/diagnosis-count  (count diagnoses)
-                    :cycle/proposal-count   (count (or proposals []))
-                    :cycle/degradation-mode current-mode
-                    :cycle/recommendation   recommendation}]
-
-        ;; 6. Emit summary event
-        (when event-stream
-          (stream/publish! event-stream
-                           (events/meta-loop-cycle-completed event-stream result)))
-
-        result)
-
-      (catch Exception e
-        (when event-stream
-          (stream/publish! event-stream
-                           (events/meta-loop-cycle-failed event-stream e)))
-        (throw e)))))
-
-;;----------------------------------------------------------------------------- Meta-loop context
-
-(defrecord MetaLoopContext
-  [event-stream
-   reliability-engine
-   degradation-manager
-   improvement-pipeline
-   metrics-store])    ; atom: {:workflow-metrics [] :failure-events [] :phase-metrics []}
-
-(defn create-meta-loop-context
-  "Create a MetaLoopContext that bundles all stateful objects needed for a cycle.
-
-   Arguments:
-     event-stream - event stream atom
-     config       - optional:
-       :reliability   - config for reliability/create-engine
-       :degradation   - config for reliability/create-degradation-manager
-
-   Returns: MetaLoopContext record."
-  [event-stream & [config]]
-  (->MetaLoopContext
-   event-stream
-   (reliability/create-engine event-stream (:reliability config))
-   (reliability/create-degradation-manager event-stream (:degradation config))
-   (improvement/create-pipeline)
-   (atom {:workflow-metrics []
-          :failure-events   []
-          :phase-metrics    []
-          :gate-metrics     []
-          :tool-metrics     []
-          :context-metrics  []})))
-
-(defn record-workflow-outcome!
-  "Record a workflow completion for use in the next meta-loop cycle.
-
-   Arguments:
-     ctx           - MetaLoopContext
-     workflow-id   - uuid
-     status        - :completed | :failed | :escalated
-     failure-class - optional :failure.class/* keyword (when failed)"
-  [ctx workflow-id status & [failure-class]]
-  (let [now (java.util.Date.)]
-    (swap! (:metrics-store ctx) update :workflow-metrics conj
-           {:workflow/id workflow-id
-            :status      status
-            :timestamp   now})
-    (when failure-class
-      (swap! (:metrics-store ctx) update :failure-events conj
-             {:failure/class failure-class
-              :workflow/id   workflow-id
-              :timestamp     now})))
-  nil)
-
-(defn run-cycle-from-context!
-  "Run one meta-loop cycle using the accumulated metrics in ctx.
-
-   Arguments:
-     ctx               - MetaLoopContext
-     training-examples - optional vector of training records
-
-   Returns: cycle result map."
-  [ctx & [training-examples]]
-  (run-meta-loop-cycle!
-   {:event-stream         (:event-stream ctx)
-    :reliability-engine   (:reliability-engine ctx)
-    :degradation-manager  (:degradation-manager ctx)
-    :improvement-pipeline (:improvement-pipeline ctx)
-    :metrics              @(:metrics-store ctx)
-    :training-examples    training-examples}))
-
 (comment
   ;; Usage example
   ;; (require '[ai.miniforge.agent.meta.progress-monitor :as pm])
@@ -390,15 +235,4 @@
   ;; ;; Get history
   ;; (get-check-history coordinator {:limit 50 :agent-id :progress-monitor})
 
-  ;; Process-level meta-loop context
-  ;; (def stream (ai.miniforge.event-stream.interface/create-event-stream))
-  ;; (def ctx (create-meta-loop-context stream))
-  ;;
-  ;; ;; After workflow runs:
-  ;; (record-workflow-outcome! ctx wf-id :completed nil)
-  ;; (record-workflow-outcome! ctx wf-id :failed :failure.class/timeout)
-  ;;
-  ;; ;; Run a learning cycle:
-  ;; (run-cycle-from-context! ctx)
-  ;; ;; => {:cycle/sli-count 7 :cycle/signal-count 2 :cycle/degradation-mode :nominal ...}
   )

--- a/components/agent/test/ai/miniforge/agent/meta/loop_test.clj
+++ b/components/agent/test/ai/miniforge/agent/meta/loop_test.clj
@@ -123,3 +123,32 @@
       (is (= 1 (:cycle-number r1)))
       (is (= 2 (:cycle-number r2)))
       (is (= 3 (:cycle-number r3))))))
+
+(deftest meta-loop-context-records-workflow-outcomes-test
+  (testing "context metrics store accumulates workflow outcomes and failures"
+    (let [ctx (meta-loop/create-meta-loop-context (make-stream))]
+      (meta-loop/record-workflow-outcome! ctx #uuid "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" :completed)
+      (meta-loop/record-workflow-outcome! ctx
+                                          #uuid "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+                                          :failed
+                                          :failure.class/timeout)
+      (let [metrics-store @(:metrics-store ctx)]
+        (is (= 2 (count (:workflow-metrics metrics-store))))
+        (is (= 1 (count (:failure-events metrics-store))))))))
+
+(deftest meta-loop-context-cycle-test
+  (testing "context-backed cycle returns the public namespaced learning result"
+    (let [stream (make-stream)
+          ctx (meta-loop/create-meta-loop-context stream
+                                                  {:reliability {:windows [:7d]
+                                                                 :tiers [:standard]}})
+          _ (meta-loop/record-workflow-outcome! ctx
+                                                #uuid "cccccccc-cccc-cccc-cccc-cccccccccccc"
+                                                :failed
+                                                :failure.class/timeout)
+          result (meta-loop/run-cycle-from-context! ctx)]
+      (is (contains? result :cycle/started-at))
+      (is (contains? result :cycle/duration-ms))
+      (is (contains? result :cycle/signal-count))
+      (is (contains? result :cycle/diagnosis-count))
+      (is (contains? result :cycle/degradation-mode)))))

--- a/docs/pull-requests/2026-04-23-refactor-learning-loop-authority.md
+++ b/docs/pull-requests/2026-04-23-refactor-learning-loop-authority.md
@@ -1,0 +1,47 @@
+# refactor: make `agent.meta.loop` the learning-loop authority
+
+## Overview
+
+Remove the duplicated learning-loop implementation from `agent.meta-coordinator`
+and make `agent.meta.loop` the single source of truth for learning-cycle
+execution and context helpers.
+
+## Motivation
+
+The supervision split landed, but the agent layer still had two different
+implementations of the learning loop:
+
+- `agent.meta.loop`
+- `agent.meta-coordinator`
+
+That left duplicated ownership for the same control path and kept the public
+`agent.interface.meta` API pointed at the wrong implementation.
+
+## Changes In Detail
+
+- Move the public learning-loop authority to `agent.meta.loop`
+- Add context-backed helpers to `agent.meta.loop`:
+  - `create-meta-loop-context`
+  - `record-workflow-outcome!`
+  - `run-cycle-from-context!`
+- Add a compatibility arity on `run-meta-loop-cycle!` so the public interface
+  can keep its current shape while delegating to the real learning-loop module
+- Update `agent.interface.meta` so supervision functions still route to
+  `meta-coordinator`, but learning-loop functions route to `meta.loop`
+- Delete the duplicated learning-loop implementation from
+  `agent.meta-coordinator`
+- Extend `meta.loop` tests to cover context-backed metrics accumulation and
+  context-driven cycle execution
+
+## Testing Plan
+
+- `clj-kondo --lint` on the touched `components/agent` namespaces
+- `clojure -M:test -e "(require 'ai.miniforge.agent.meta.loop-test) ..."`
+- `bb test components/agent`
+
+## Checklist
+
+- [x] Learning-loop execution has one implementation
+- [x] Public `agent.interface.meta` learning APIs point to `agent.meta.loop`
+- [x] Supervisor coordination remains in `agent.meta-coordinator`
+- [x] Tests cover the context-backed learning-loop path


### PR DESCRIPTION
# refactor: make `agent.meta.loop` the learning-loop authority

## Overview

Remove the duplicated learning-loop implementation from `agent.meta-coordinator`
and make `agent.meta.loop` the single source of truth for learning-cycle
execution and context helpers.

## Motivation

The supervision split landed, but the agent layer still had two different
implementations of the learning loop:

- `agent.meta.loop`
- `agent.meta-coordinator`

That left duplicated ownership for the same control path and kept the public
`agent.interface.meta` API pointed at the wrong implementation.

## Changes In Detail

- Move the public learning-loop authority to `agent.meta.loop`
- Add context-backed helpers to `agent.meta.loop`:
  - `create-meta-loop-context`
  - `record-workflow-outcome!`
  - `run-cycle-from-context!`
- Add a compatibility arity on `run-meta-loop-cycle!` so the public interface
  can keep its current shape while delegating to the real learning-loop module
- Update `agent.interface.meta` so supervision functions still route to
  `meta-coordinator`, but learning-loop functions route to `meta.loop`
- Delete the duplicated learning-loop implementation from
  `agent.meta-coordinator`
- Extend `meta.loop` tests to cover context-backed metrics accumulation and
  context-driven cycle execution

## Testing Plan

- `clj-kondo --lint` on the touched `components/agent` namespaces
- `clojure -M:test -e "(require 'ai.miniforge.agent.meta.loop-test) ..."`
- `bb test components/agent`

## Checklist

- [x] Learning-loop execution has one implementation
- [x] Public `agent.interface.meta` learning APIs point to `agent.meta.loop`
- [x] Supervisor coordination remains in `agent.meta-coordinator`
- [x] Tests cover the context-backed learning-loop path
