### PR TITLE
refactor: make standard workflow phase selection machine-driven

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -571,31 +571,52 @@
 
    Returns updated context."
   [pipeline ctx callbacks merge-metrics-fn transition-to-completed-fn transition-to-failed-fn]
-  (let [phase-index (:execution/phase-index ctx)
-        interceptor (get pipeline phase-index)
+  (let [machine-entry (when-let [machine (:execution/fsm-machine ctx)]
+                        (workflow-fsm/machine-active-phase-entry machine
+                                                                 (:execution/fsm-state ctx)))
+        current-phase (:execution/current-phase ctx)
+        interceptor (cond
+                      machine-entry (get pipeline (:index machine-entry))
+                      current-phase (some #(when (= current-phase
+                                                   (get-in % [:config :phase]))
+                                         %)
+                                          pipeline)
+                      :else nil)
         phase-name (get-in interceptor [:config :phase])
         {:keys [on-phase-start on-phase-complete]} callbacks
         ctx-with-phase (assoc ctx :execution/current-phase phase-name)]
+    (if-not interceptor
+      (let [phase-label (or current-phase
+                            (:phase machine-entry)
+                            :unknown)]
+        (-> ctx
+            (update :execution/errors conj
+                    {:type :missing-current-phase
+                     :phase phase-label
+                     :message (messages/t :status/no-transition-defined
+                                          {:state phase-label
+                                           :event :phase/execute})})
+            (transition-to-failed-fn)))
+      (do
+        ;; Notify phase start
+        (when on-phase-start
+          (on-phase-start ctx-with-phase interceptor))
 
-    ;; Notify phase start
-    (when on-phase-start
-      (on-phase-start ctx-with-phase interceptor))
+        ;; Execute phase lifecycle: enter -> gates -> leave
+        (let [[ctx-after-lifecycle phase-result] (execute-phase-lifecycle interceptor ctx-with-phase)
+              ;; Process result: response chain + metrics + files + artifacts
+              ctx-processed (process-phase-result ctx-after-lifecycle phase-name phase-result merge-metrics-fn)]
 
-    ;; Execute phase lifecycle: enter -> gates -> leave
-    (let [[ctx-after-lifecycle phase-result] (execute-phase-lifecycle interceptor ctx-with-phase)
-          ;; Process result: response chain + metrics + files + artifacts
-          ctx-processed (process-phase-result ctx-after-lifecycle phase-name phase-result merge-metrics-fn)]
+          ;; Notify phase complete
+          (when on-phase-complete
+            (on-phase-complete ctx-processed interceptor phase-result))
 
-      ;; Notify phase complete
-      (when on-phase-complete
-        (on-phase-complete ctx-processed interceptor phase-result))
-
-      ;; After plan phase, attempt DAG parallelization before normal transition
-      (or (try-dag-execution ctx-processed phase-name phase-result pipeline
-                             transition-to-completed-fn transition-to-failed-fn)
-          ;; Normal transition (non-plan phases, or plan not parallelizable)
-          (let [event (determine-phase-event (:config interceptor)
-                                             phase-result)]
-            (apply-phase-transition ctx-processed event pipeline
-                                    transition-to-completed-fn
-                                    transition-to-failed-fn))))))
+          ;; After plan phase, attempt DAG parallelization before normal transition
+          (or (try-dag-execution ctx-processed phase-name phase-result pipeline
+                                 transition-to-completed-fn transition-to-failed-fn)
+              ;; Normal transition (non-plan phases, or plan not parallelizable)
+              (let [event (determine-phase-event (:config interceptor)
+                                                 phase-result)]
+                (apply-phase-transition ctx-processed event pipeline
+                                        transition-to-completed-fn
+                                        transition-to-failed-fn))))))))

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -258,6 +258,14 @@
     :index (:index entry)
     :paused? true}])
 
+(defn- state-entry
+  [entry state-id]
+  [state-id entry])
+
+(defn- paused-state-entry
+  [entry]
+  [(:paused-state-id entry) entry])
+
 (defn compile-execution-machine
   "Compile a per-run execution machine from a workflow pipeline.
 
@@ -290,14 +298,19 @@
         state->phase (into {}
                            (concat
                             (map #(projection-entry % false) phase-entries)
-                            (map paused-projection-entry phase-entries)))]
+                            (map paused-projection-entry phase-entries)))
+        state->entry (into {}
+                           (concat
+                            (map #(state-entry % (:state-id %)) phase-entries)
+                            (map paused-state-entry phase-entries)))]
     (assoc (fsm/define-machine
             {:fsm/id :workflow-execution
              :fsm/initial :pending
              :fsm/context {:redirect-count 0}
              :fsm/states (into {} (remove (comp nil? val)) states)})
            :workflow/phase-entries phase-entries
-           :workflow/state->phase state->phase)))
+           :workflow/state->phase state->phase
+           :workflow/state->entry state->entry)))
 
 (defn validate-execution-machine
   "Validate that a workflow pipeline can compile into an execution machine."
@@ -333,6 +346,11 @@
   "Get phase metadata for the current compiled machine state."
   [machine state]
   (get-in machine [:workflow/state->phase (current-state state)]))
+
+(defn machine-active-phase-entry
+  "Get the active workflow phase entry for the current compiled machine state."
+  [machine state]
+  (get-in machine [:workflow/state->entry (current-state state)]))
 
 (defn execution-status
   "Project coarse execution status from a compiled machine snapshot."

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -166,9 +166,10 @@
 
 (defn- apply-backoff-if-retrying!
   "Sleep with exponential backoff when a phase is being retried."
-  [phase-ctx context]
-  (let [retrying? (= (:execution/phase-index phase-ctx)
-                     (:execution/phase-index context))
+  [phase-ctx _context]
+  (let [current-phase (:execution/current-phase phase-ctx)
+        retrying? (phase/retrying?
+                   (get-in phase-ctx [:execution/phase-results current-phase]))
         retry-count (get-in phase-ctx [:phase :iterations] 1)]
     (when (and retrying? (> retry-count 1))
       (Thread/sleep (backoff-ms retry-count)))))

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -206,7 +206,14 @@
     (testing "start enters the first pipeline phase"
       (is (= :running (fsm/execution-status machine running-state)))
       (is (= :plan (fsm/current-phase-id machine running-state)))
-      (is (= 0 (fsm/current-phase-index machine running-state))))))
+      (is (= 0 (fsm/current-phase-index machine running-state))))
+    (testing "active machine entry includes the phase config and index"
+      (is (= {:index 0
+              :phase :plan
+              :config {:phase :plan}
+              :state-id :phase-0-plan
+              :paused-state-id :paused-phase-0-plan}
+             (fsm/machine-active-phase-entry machine running-state))))))
 
 (deftest compiled-execution-machine-follows-phase-transitions-test
   (let [workflow {:workflow/id :test

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -134,6 +134,23 @@
       (is (= :verify (:execution/current-phase result)))
       (is (= 0 (:execution/redirect-count result))))))
 
+(deftest execute-phase-step-uses-machine-state-over-phase-index-test
+  (testing "standard execution selects the active phase from the machine snapshot"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :done}]}
+          pipeline (runner/build-pipeline workflow)
+          context (-> (ctx/create-context workflow {:task "Test"} {})
+                      (assoc :execution/phase-index 99))
+          result (exec/execute-phase-step pipeline
+                                          context
+                                          {}
+                                          ctx/merge-metrics
+                                          ctx/transition-to-completed
+                                          ctx/transition-to-failed)]
+      (is (= :completed (:execution/status result)))
+      (is (contains? (:execution/phase-results result) :done)))))
+
 ;; ---------------------------------------------------------------------------- publish-event edge cases
 
 (deftest publish-event-nil-stream-test

--- a/docs/pull-requests/2026-04-24-refactor-standard-workflow-machine-phase-authority.md
+++ b/docs/pull-requests/2026-04-24-refactor-standard-workflow-machine-phase-authority.md
@@ -1,0 +1,59 @@
+# refactor: make standard workflow phase selection machine-driven
+
+## Overview
+
+Remove the remaining standard-runner dependence on `:execution/phase-index` as
+the authority for phase selection and retry behavior.
+
+The compiled workflow execution machine already owns the active phase. This PR
+makes the standard interceptor runner read that authority directly from the
+machine snapshot instead of selecting interceptors from a mutable phase index in
+context.
+
+## Motivation
+
+The workflow FSM work already made the execution machine authoritative for
+status and phase progression, but the standard runner still had two lingering
+control paths:
+
+- `workflow.execution/execute-phase-step` selected the current interceptor from
+  `:execution/phase-index`
+- `workflow.runner/apply-backoff-if-retrying!` inferred retries by comparing
+  pre/post `:execution/phase-index`
+
+That meant the standard path still relied on an index projection as a live
+control input instead of treating it as derived state.
+
+## Changes In Detail
+
+- add `workflow.fsm/machine-active-phase-entry` so the runner can ask the
+  compiled machine for the active phase entry directly
+- update `workflow.execution/execute-phase-step` to select the interceptor from
+  the machine snapshot, with `:execution/current-phase` only as a fallback for
+  non-machine test contexts
+- stop using `:execution/phase-index` as the retry signal in
+  `workflow.runner/apply-backoff-if-retrying!`
+- add tests proving:
+  - the compiled machine exposes the active phase entry
+  - tampering with `:execution/phase-index` does not break the standard runner
+
+## Scope
+
+This PR is intentionally limited to the standard workflow runner.
+
+It does **not** yet convert the configurable workflow path in
+`workflow.configurable`, which still uses ad hoc `select-next-phase` logic and
+needs its own compiler-backed follow-up.
+
+## Testing Plan
+
+- `clj-kondo --lint` on the touched workflow namespaces and tests
+- `bb test components/workflow`
+- `bb pre-commit`
+
+## Checklist
+
+- [x] Standard runner phase selection reads from machine state
+- [x] `:execution/phase-index` is no longer standard-runner phase authority
+- [x] Retry backoff no longer depends on phase-index comparison
+- [x] Tests cover machine-backed phase selection


### PR DESCRIPTION
# refactor: make standard workflow phase selection machine-driven

## Overview

Remove the remaining standard-runner dependence on `:execution/phase-index` as
the authority for phase selection and retry behavior.

The compiled workflow execution machine already owns the active phase. This PR
makes the standard interceptor runner read that authority directly from the
machine snapshot instead of selecting interceptors from a mutable phase index in
context.

## Motivation

The workflow FSM work already made the execution machine authoritative for
status and phase progression, but the standard runner still had two lingering
control paths:

- `workflow.execution/execute-phase-step` selected the current interceptor from
  `:execution/phase-index`
- `workflow.runner/apply-backoff-if-retrying!` inferred retries by comparing
  pre/post `:execution/phase-index`

That meant the standard path still relied on an index projection as a live
control input instead of treating it as derived state.

## Changes In Detail

- add `workflow.fsm/machine-active-phase-entry` so the runner can ask the
  compiled machine for the active phase entry directly
- update `workflow.execution/execute-phase-step` to select the interceptor from
  the machine snapshot, with `:execution/current-phase` only as a fallback for
  non-machine test contexts
- stop using `:execution/phase-index` as the retry signal in
  `workflow.runner/apply-backoff-if-retrying!`
- add tests proving:
  - the compiled machine exposes the active phase entry
  - tampering with `:execution/phase-index` does not break the standard runner

## Scope

This PR is intentionally limited to the standard workflow runner.

It does **not** yet convert the configurable workflow path in
`workflow.configurable`, which still uses ad hoc `select-next-phase` logic and
needs its own compiler-backed follow-up.

## Testing Plan

- `clj-kondo --lint` on the touched workflow namespaces and tests
- `bb test components/workflow`
- `bb pre-commit`

## Checklist

- [x] Standard runner phase selection reads from machine state
- [x] `:execution/phase-index` is no longer standard-runner phase authority
- [x] Retry backoff no longer depends on phase-index comparison
- [x] Tests cover machine-backed phase selection
