### PR TITLE
feat: add workflow fsm reachability guards

### DIFF
--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -26,6 +26,13 @@
   :status/invalid-current-state "Invalid current state: {state}"
   :status/guard-rejected-transition "Guard function rejected transition"
   :status/no-transition-defined "No transition defined for [{state} {event}]"
+  :status/unreachable-machine-states
+  "Compiled workflow machine contains unreachable states: {states}"
+  :status/unreachable-machine-phases
+  "Compiled workflow machine contains unreachable phases: {phases}"
+  :status/missing-workflow-id "Workflow must have :workflow/id"
+  :status/invalid-workflow-registration
+  "Workflow {workflow-id} failed registration validation"
   :status/dag-executed-summary "DAG executed {task-count} task(s) successfully"
 
   ;; Phase result messages

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -38,10 +38,11 @@
    - :resume  - Resume paused execution
    - :cancel  - Cancel workflow"
   (:require
+   [clojure.set :as set]
    [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.workflow.messages :as messages]))
 
-(declare current-state first-phase-index)
+(declare current-state first-phase-index reachable-states unreachable-states)
 
 ;; ============================================================================
 ;; FSM Definition using clj-statecharts
@@ -162,17 +163,12 @@
   [phase-entries index]
   (some-> (get phase-entries index) :state-id))
 
-(defn- redirect-transition-entry
-  [phase-entries {:keys [phase index]}]
-  (let [target (state-target phase-entries index)]
-    [(redirect-event phase)
-     {:target target}]))
-
-(defn- redirect-transitions
-  [phase-entries]
-  (into {}
-        (map (partial redirect-transition-entry phase-entries))
-        phase-entries))
+(defn- redirect-transition
+  [phase-entries {:keys [config]}]
+  (when-let [target-phase (:on-fail config)]
+    (when-let [target-index (first-phase-index phase-entries target-phase)]
+      {(redirect-event target-phase)
+       {:target (state-target phase-entries target-index)}})))
 
 (defn redirect-event?
   "True when an event keyword represents a workflow phase redirect."
@@ -235,7 +231,7 @@
             :cancel :cancelled
             :fail :failed
             :complete :completed}
-           (redirect-transitions phase-entries))}]))
+           (redirect-transition phase-entries {:config config}))}]))
 
 (defn- build-paused-state
   [{:keys [state-id paused-state-id]}]
@@ -266,6 +262,54 @@
   [entry]
   [(:paused-state-id entry) entry])
 
+(defn- transition-target
+  [transition]
+  (cond
+    (keyword? transition) transition
+    (map? transition) (:target transition)
+    :else nil))
+
+(defn- state-transition-targets
+  [state-config]
+  (->> (get state-config :on {})
+       vals
+       (keep transition-target)
+       set))
+
+(defn- build-state-graph
+  [states]
+  (into {}
+        (map (fn [[state-id state-config]]
+               [state-id (state-transition-targets state-config)]))
+        states))
+
+(defn- bfs-reachable-states
+  [state-graph start-state]
+  (loop [to-visit [start-state]
+         visited #{}]
+    (if (empty? to-visit)
+      visited
+      (let [current-state (first to-visit)
+            remaining (rest to-visit)]
+        (if (contains? visited current-state)
+          (recur remaining visited)
+          (recur (concat remaining (get state-graph current-state #{}))
+                 (conj visited current-state)))))))
+
+(defn- unreachable-phase-error
+  [phases]
+  {:error :unreachable-phase-states
+   :phases phases
+   :message (messages/t :status/unreachable-machine-phases
+                        {:phases phases})})
+
+(defn- unreachable-state-error
+  [states]
+  {:error :unreachable-machine-states
+   :states states
+   :message (messages/t :status/unreachable-machine-states
+                        {:states states})})
+
 (defn compile-execution-machine
   "Compile a per-run execution machine from a workflow pipeline.
 
@@ -295,6 +339,8 @@
                  :cancelled {:type :final}}
                 (into {} (map (partial build-phase-state phase-entries)) phase-entries)
                 (into {} (map build-paused-state) phase-entries))
+        compiled-states (into {} (remove (comp nil? val)) states)
+        state-graph (build-state-graph compiled-states)
         state->phase (into {}
                            (concat
                             (map #(projection-entry % false) phase-entries)
@@ -307,10 +353,13 @@
             {:fsm/id :workflow-execution
              :fsm/initial :pending
              :fsm/context {:redirect-count 0}
-             :fsm/states (into {} (remove (comp nil? val)) states)})
+             :fsm/states compiled-states})
            :workflow/phase-entries phase-entries
            :workflow/state->phase state->phase
-           :workflow/state->entry state->entry)))
+           :workflow/state->entry state->entry
+           :workflow/state-graph state-graph
+           :workflow/state-ids (set (keys compiled-states))
+           :workflow/initial-state :pending)))
 
 (defn validate-execution-machine
   "Validate that a workflow pipeline can compile into an execution machine."
@@ -328,11 +377,27 @@
         unresolved-fail (->> pipeline
                              (keep (partial unknown-fail-target pipeline))
                              vec)
+        machine (when (and (seq pipeline)
+                           (empty? unresolved-success)
+                           (empty? unresolved-fail))
+                  (compile-execution-machine workflow))
+        unreachable-state-set (when machine
+                                (unreachable-states machine))
+        unreachable-phases (when machine
+                             (->> (:workflow/phase-entries machine)
+                                  (keep (fn [{:keys [phase state-id]}]
+                                          (when (contains? unreachable-state-set state-id)
+                                            phase)))
+                                  vec))
         errors (vec (concat
                      (when (empty? pipeline)
                        [(empty-pipeline-error)])
                      unresolved-success
-                     unresolved-fail))
+                     unresolved-fail
+                     (when (seq unreachable-phases)
+                       [(unreachable-phase-error unreachable-phases)])
+                     (when (seq unreachable-state-set)
+                       [(unreachable-state-error (vec unreachable-state-set))])))
         warnings (vec (concat
                        (when (seq duplicate-phases)
                          [(duplicate-phase-warning duplicate-phases)])))]
@@ -340,7 +405,37 @@
      :errors errors
      :warnings warnings
      :machine (when (empty? errors)
-                (compile-execution-machine workflow))}))
+                machine)}))
+
+(defn state-graph
+  "Return the compiled state graph for a workflow execution machine."
+  [machine]
+  (:workflow/state-graph machine))
+
+(defn compiled-state-ids
+  "Return the set of states defined by a compiled workflow execution machine."
+  [machine]
+  (:workflow/state-ids machine))
+
+(defn reachable-states
+  "Return the set of states reachable in a compiled workflow machine.
+
+   With one arg, traversal starts from the machine's initial state.
+   With two args, traversal starts from the provided state id."
+  ([machine]
+   (reachable-states machine (:workflow/initial-state machine)))
+  ([machine start-state]
+   (if start-state
+     (bfs-reachable-states (state-graph machine) start-state)
+     #{})))
+
+(defn unreachable-states
+  "Return the set of defined states that are not reachable in a compiled workflow machine."
+  ([machine]
+   (unreachable-states machine (:workflow/initial-state machine)))
+  ([machine start-state]
+   (set/difference (compiled-state-ids machine)
+                   (reachable-states machine start-state))))
 
 (defn machine-phase-entry
   "Get phase metadata for the current compiled machine state."

--- a/components/workflow/src/ai/miniforge/workflow/registry.clj
+++ b/components/workflow/src/ai/miniforge/workflow/registry.clj
@@ -31,6 +31,9 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.response.interface :as response]
+   [ai.miniforge.workflow.fsm :as workflow-fsm]
+   [ai.miniforge.workflow.messages :as messages]
+   [ai.miniforge.workflow.validator :as validator]
    [ai.miniforge.workflow.schemas :as schemas])
   (:import
    [java.util.jar JarFile]))
@@ -164,19 +167,41 @@
 ;;------------------------------------------------------------------------------ Layer 3
 ;; Registry operations
 
+(defn- registration-errors
+  [workflow]
+  (let [workflow-validation (validator/validate-workflow workflow)
+        machine-validation (when (:workflow/pipeline workflow)
+                             (workflow-fsm/validate-execution-machine workflow))]
+    (vec (concat (:errors workflow-validation)
+                 (:errors machine-validation)))))
+
+(defn- validate-workflow-registration!
+  [workflow]
+  (let [workflow-id (:workflow/id workflow)
+        errors (registration-errors workflow)]
+    (when (seq errors)
+      (response/throw-anomaly!
+       :anomalies.workflow/invalid-config
+       (messages/t :status/invalid-workflow-registration
+                   {:workflow-id workflow-id})
+       {:workflow-id workflow-id
+        :validation/errors errors}))
+    workflow))
+
 (defn register-workflow!
   "Register a workflow in the registry.
 
    Arguments:
      workflow - Workflow definition map
 
-   Returns: The registered workflow"
+  Returns: The registered workflow"
   [workflow]
   (let [id (:workflow/id workflow)]
     (when-not id
       (response/throw-anomaly! :anomalies/incorrect
-                              "Workflow must have :workflow/id"
+                              (messages/t :status/missing-workflow-id)
                               {:workflow workflow}))
+    (validate-workflow-registration! workflow)
     (swap! registry assoc id workflow)
     workflow))
 

--- a/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/fsm_test.clj
@@ -244,6 +244,36 @@
       (is (= :verify (fsm/current-phase-id machine s6)))
       (is (= :done (fsm/current-phase-id machine s7))))))
 
+(deftest compiled-execution-machine-reachability-test
+  (let [workflow {:workflow/id :test
+                  :workflow/pipeline [{:phase :plan}
+                                      {:phase :implement}
+                                      {:phase :done}]}
+        machine (fsm/compile-execution-machine workflow)
+        expected-reachable
+        #{:pending
+          :phase-0-plan
+          :paused-phase-0-plan
+          :phase-1-implement
+          :paused-phase-1-implement
+          :phase-2-done
+          :paused-phase-2-done
+          :completed
+          :failed
+          :cancelled}]
+    (testing "initial reachability exactly matches the compiled machine state set"
+      (is (= expected-reachable
+             (fsm/compiled-state-ids machine)))
+      (is (= expected-reachable
+             (fsm/reachable-states machine)))
+      (is (= #{}
+             (fsm/unreachable-states machine))))
+    (testing "terminal states cannot reach active workflow states"
+      (is (= #{:completed}
+             (fsm/reachable-states machine :completed)))
+      (is (= (disj expected-reachable :completed)
+             (fsm/unreachable-states machine :completed))))))
+
 (deftest validate-execution-machine-test
   (testing "detects unresolved transition targets"
     (let [result (fsm/validate-execution-machine
@@ -257,4 +287,16 @@
                    :workflow/pipeline [{:phase :plan}
                                        {:phase :plan}]})]
       (is (true? (:valid? result)))
-      (is (= :duplicate-phase-identifiers (-> result :warnings first :warning))))))
+      (is (= :duplicate-phase-identifiers (-> result :warnings first :warning)))))
+  (testing "rejects compiled workflows with unreachable phase states"
+    (let [result (fsm/validate-execution-machine
+                  {:workflow/id :skip-impl
+                   :workflow/pipeline [{:phase :plan :on-success :verify}
+                                       {:phase :implement}
+                                       {:phase :verify :on-success :done}
+                                       {:phase :done}]})]
+      (is (false? (:valid? result)))
+      (is (some #(= :unreachable-phase-states (:error %))
+                (:errors result)))
+      (is (some #(= :unreachable-machine-states (:error %))
+                (:errors result))))))

--- a/components/workflow/test/ai/miniforge/workflow/registry_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/registry_test.clj
@@ -44,3 +44,34 @@
       (is (contains? workflow-ids :financial-etl))
       (is (contains? workflow-ids :canonical-sdlc))
       (is (contains? workflow-ids :simple)))))
+
+(deftest register-workflow!-validates-compiled-machine-test
+  (testing "valid compiled workflows register successfully"
+    (let [workflow {:workflow/id :test-fsm
+                    :workflow/version "1.0.0"
+                    :workflow/name "Test FSM"
+                    :workflow/description "Valid compiled workflow"
+                    :workflow/pipeline [{:phase :plan}
+                                        {:phase :done}]}]
+      (is (= workflow (registry/register-workflow! workflow)))
+      (is (contains? (set (registry/list-workflow-ids)) :test-fsm))))
+
+  (testing "compiled workflows with unreachable phases are rejected at registration"
+    (let [workflow {:workflow/id :invalid-fsm
+                    :workflow/version "1.0.0"
+                    :workflow/name "Invalid FSM"
+                    :workflow/description "Workflow with unreachable compiled phase"
+                    :workflow/pipeline [{:phase :plan :on-success :verify}
+                                        {:phase :implement}
+                                        {:phase :verify :on-success :done}
+                                        {:phase :done}]}]
+      (registry/clear-registry!)
+      (let [thrown (try
+                     (registry/register-workflow! workflow)
+                     nil
+                     (catch clojure.lang.ExceptionInfo ex
+                       ex))]
+        (is (instance? clojure.lang.ExceptionInfo thrown))
+        (is (re-find #"failed registration validation"
+                     (.getMessage ^clojure.lang.ExceptionInfo thrown))))
+      (is (empty? (registry/list-workflow-ids))))))

--- a/docs/pull-requests/2026-04-24-feat-fsm-reachability-guards.md
+++ b/docs/pull-requests/2026-04-24-feat-fsm-reachability-guards.md
@@ -1,0 +1,75 @@
+# feat: add FSM reachability guards for compiled workflows
+
+## Overview
+
+Strengthen workflow FSM validation in two places:
+
+- test coverage now asserts exact reachable and unreachable state sets for the
+  compiled workflow execution machine
+- workflow registration now rejects compiled workflows whose state graph
+  contains unreachable phases or unreachable machine states
+
+This moves reachability from an informal expectation into both the test suite
+and the workflow registration boundary.
+
+## Motivation
+
+The existing FSM tests covered selected happy-path transitions, but they did
+not prove the stronger invariant:
+
+- states we expect to be reachable are reachable
+- states we do not expect to be reachable are not reachable
+
+The registry also accepted workflows without validating the compiled execution
+machine. That meant a malformed workflow could be discovered and registered even
+if its machine graph contained unreachable states.
+
+## Changes In Detail
+
+- add compiled execution-machine graph metadata in `workflow.fsm`
+- add reachability helpers:
+  - `state-graph`
+  - `compiled-state-ids`
+  - `reachable-states`
+  - `unreachable-states`
+- tighten redirect transitions in the compiled machine so they only target the
+  current phase's configured `:on-fail` target instead of allowing redirect
+  events to every phase from every phase
+- extend `validate-execution-machine` to reject:
+  - unreachable compiled phase states
+  - unreachable machine states
+- update `workflow.registry/register-workflow!` to validate workflows at
+  registration time and reject invalid compiled machines
+- localize the new validation messages in `en-US.edn`
+
+## Testing
+
+- add exact reachability / negative-reachability assertions in
+  `workflow.fsm-test`
+- add registration-boundary coverage in `workflow.registry-test`
+- existing workflow shard remains green after tightening redirect legality
+
+## Boundary Behavior
+
+After this PR, workflows are rejected at registration when:
+
+- schema / DAG validation fails
+- compiled execution-machine targets are unresolved
+- compiled execution-machine phases are unreachable
+- compiled execution-machine states are unreachable
+
+That means workflow discovery and registration now enforce the FSM contract
+instead of relying on runtime execution to surface graph defects.
+
+## Testing Plan
+
+- `clj-kondo --lint` on touched workflow namespaces and tests
+- `bb test components/workflow`
+- `bb pre-commit`
+
+## Checklist
+
+- [x] Compiled workflow machine exposes a reachability graph
+- [x] Tests assert exact reachable and unreachable state sets
+- [x] Negative reachability is covered
+- [x] Invalid compiled workflows are rejected at registration


### PR DESCRIPTION
# feat: add FSM reachability guards for compiled workflows

## Overview

Strengthen workflow FSM validation in two places:

- test coverage now asserts exact reachable and unreachable state sets for the
  compiled workflow execution machine
- workflow registration now rejects compiled workflows whose state graph
  contains unreachable phases or unreachable machine states

This moves reachability from an informal expectation into both the test suite
and the workflow registration boundary.

## Motivation

The existing FSM tests covered selected happy-path transitions, but they did
not prove the stronger invariant:

- states we expect to be reachable are reachable
- states we do not expect to be reachable are not reachable

The registry also accepted workflows without validating the compiled execution
machine. That meant a malformed workflow could be discovered and registered even
if its machine graph contained unreachable states.

## Changes In Detail

- add compiled execution-machine graph metadata in `workflow.fsm`
- add reachability helpers:
  - `state-graph`
  - `compiled-state-ids`
  - `reachable-states`
  - `unreachable-states`
- tighten redirect transitions in the compiled machine so they only target the
  current phase's configured `:on-fail` target instead of allowing redirect
  events to every phase from every phase
- extend `validate-execution-machine` to reject:
  - unreachable compiled phase states
  - unreachable machine states
- update `workflow.registry/register-workflow!` to validate workflows at
  registration time and reject invalid compiled machines
- localize the new validation messages in `en-US.edn`

## Testing

- add exact reachability / negative-reachability assertions in
  `workflow.fsm-test`
- add registration-boundary coverage in `workflow.registry-test`
- existing workflow shard remains green after tightening redirect legality

## Boundary Behavior

After this PR, workflows are rejected at registration when:

- schema / DAG validation fails
- compiled execution-machine targets are unresolved
- compiled execution-machine phases are unreachable
- compiled execution-machine states are unreachable

That means workflow discovery and registration now enforce the FSM contract
instead of relying on runtime execution to surface graph defects.

## Testing Plan

- `clj-kondo --lint` on touched workflow namespaces and tests
- `bb test components/workflow`
- `bb pre-commit`

## Checklist

- [x] Compiled workflow machine exposes a reachability graph
- [x] Tests assert exact reachable and unreachable state sets
- [x] Negative reachability is covered
- [x] Invalid compiled workflows are rejected at registration
