### PR TITLE
refactor: unblock cli web coverage instrumentation

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/web/components.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components.clj
@@ -24,6 +24,7 @@
    [hiccup2.core :as h]
    [hiccup.util :refer [raw-string]]
    [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.web.components.status :as status-components]
    [ai.miniforge.cli.web.risk :as risk]
    [ai.miniforge.cli.web.fleet :as fleet]))
 
@@ -47,9 +48,6 @@
 
 (def ^:const ai-placeholder-style
   "color: var(--text-muted); font-style: italic; padding: 12px;")
-
-(def ^:const no-workflows-style
-  "color: var(--text-muted); font-size: 12px; text-align: center;")
 
 (def ^:const summary-message-style
   "margin-top: 16px;")
@@ -119,54 +117,14 @@
     [:div.chat-message.assistant
      [:pre {:style chat-response-style} response]]]))
 
-(defn- overall-status-key
-  [overall]
-  (case overall
-    :healthy :web-ui/status-healthy
-    :degraded :web-ui/status-degraded
-    :warning :web-ui/status-warning
-    :error :web-ui/status-error
-    :web-ui/status-unknown))
+(def status-indicator
+  status-components/status-indicator)
 
-(defn status-indicator [status]
-  (let [overall (get status :overall)
-        status-class (name overall)
-        status-text (t (overall-status-key overall))]
-    (h/html
-     [:div.status-indicator {:class (str "status-" status-class)
-                             :hx-get "/api/status"
-                             :hx-trigger "every 60s"
-                             :hx-swap "outerHTML"}
-      [:span.status-dot]
-      [:span status-text]])))
+(def workflow-status-icon
+  status-components/workflow-status-icon)
 
-(defn workflow-status-icon [run]
-  (let [s (:status run) c (:conclusion run)]
-    (cond
-      (= s "in_progress") "⏳"
-      (= c "success") "✓"
-      (#{"failure" "timed_out" "startup_failure"} c) "✗"
-      :else "○")))
-
-(defn workflow-status [repos]
-  (let [{:keys [running failed succeeded runs]} (fleet/get-workflow-status repos)]
-    (h/html
-     [:div.workflow-status
-      {:hx-get "/api/workflows" :hx-trigger "every 60s" :hx-swap "outerHTML"}
-      [:div.workflow-status-header [:span (t :web-ui/workflow-status-header)]]
-      [:div.workflow-stats
-       [:span.workflow-stat.workflow-stat-running [:span (str running " ⏳")]]
-       [:span.workflow-stat.workflow-stat-failed [:span (str failed " ✗")]]
-       [:span.workflow-stat.workflow-stat-passed [:span (str succeeded " ✓")]]]
-      [:div.workflow-runs
-       (if (seq runs)
-         (for [run runs]
-           [:div.workflow-run
-            [:span.workflow-run-status (workflow-status-icon run)]
-            [:span.workflow-run-name (:workflowName run)]
-            [:span.workflow-run-time (fleet/format-time-ago (:createdAt run))]])
-         [:div {:style no-workflows-style}
-          (t :web-ui/workflow-status-none)])]])))
+(def workflow-status
+  status-components/workflow-status)
 
 (defn ai-summary [summary]
   (h/html

--- a/bases/cli/src/ai/miniforge/cli/web/components/status.clj
+++ b/bases/cli/src/ai/miniforge/cli/web/components/status.clj
@@ -1,0 +1,104 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.cli.web.components.status
+  "Status-oriented dashboard fragments."
+  (:require
+   [hiccup2.core :as h]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.cli.web.fleet :as fleet]))
+
+(def ^:const no-workflows-style
+  "color: var(--text-muted); font-size: 12px; text-align: center;")
+
+(defn- t
+  ([message-key]
+   (messages/t message-key))
+  ([message-key params]
+   (messages/t message-key params)))
+
+(defn- overall-status-key
+  [overall]
+  (case overall
+    :healthy :web-ui/status-healthy
+    :degraded :web-ui/status-degraded
+    :warning :web-ui/status-warning
+    :error :web-ui/status-error
+    :web-ui/status-unknown))
+
+(defn- workflow-stat
+  [class-name value]
+  [:span {:class class-name}
+   [:span value]])
+
+(defn status-indicator
+  [status]
+  (let [overall (get status :overall)
+        status-class (name overall)
+        status-text (t (overall-status-key overall))]
+    (h/html
+     [:div.status-indicator {:class (str "status-" status-class)
+                             :hx-get "/api/status"
+                             :hx-trigger "every 60s"
+                             :hx-swap "outerHTML"}
+      [:span.status-dot]
+      [:span status-text]])))
+
+(defn workflow-status-icon
+  [run]
+  (let [status (get run :status)
+        conclusion (get run :conclusion)]
+    (cond
+      (= status "in_progress") "⏳"
+      (= conclusion "success") "✓"
+      (#{"failure" "timed_out" "startup_failure"} conclusion) "✗"
+      :else "○")))
+
+(defn- workflow-run
+  [{:keys [workflowName createdAt] :as run}]
+  [:div.workflow-run
+   [:span.workflow-run-status (workflow-status-icon run)]
+   [:span.workflow-run-name workflowName]
+   [:span.workflow-run-time (fleet/format-time-ago createdAt)]])
+
+(defn- workflow-runs
+  [runs]
+  (if (seq runs)
+    (map workflow-run runs)
+    [[:div {:style no-workflows-style}
+      (t :web-ui/workflow-status-none)]]))
+
+(defn workflow-status
+  [repos]
+  (let [{:keys [running failed succeeded runs]} (fleet/get-workflow-status repos)
+        running-value (str running " ⏳")
+        failed-value (str failed " ✗")
+        succeeded-value (str succeeded " ✓")
+        rendered-runs (workflow-runs runs)]
+    (h/html
+     [:div.workflow-status
+      {:hx-get "/api/workflows"
+       :hx-trigger "every 60s"
+       :hx-swap "outerHTML"}
+      [:div.workflow-status-header
+       [:span (t :web-ui/workflow-status-header)]]
+      [:div.workflow-stats
+       (workflow-stat "workflow-stat workflow-stat-running" running-value)
+       (workflow-stat "workflow-stat workflow-stat-failed" failed-value)
+       (workflow-stat "workflow-stat workflow-stat-passed" succeeded-value)]
+      (into [:div.workflow-runs] rendered-runs)])))

--- a/bases/cli/test/ai/miniforge/cli/web/components_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/web/components_test.clj
@@ -77,6 +77,19 @@
         (is (str/includes? html "j</kbd>/"))
         (is (str/includes? html "refresh"))))))
 
+(deftest workflow-status-renders-localized-summary-test
+  (testing "workflow status renders counts and the empty-state copy"
+    (with-redefs [fleet/get-workflow-status (constantly {:running 1
+                                                         :failed 2
+                                                         :succeeded 3
+                                                         :runs []})]
+      (let [html (str (sut/workflow-status ["miniforge"]))]
+        (is (str/includes? html "Workflow Status"))
+        (is (str/includes? html "1 ⏳"))
+        (is (str/includes? html "2 ✗"))
+        (is (str/includes? html "3 ✓"))
+        (is (str/includes? html "No recent workflows"))))))
+
 (deftest empty-detail-renders-localized-empty-state-test
   (testing "empty detail renders the localized empty state copy"
     (let [html (str (sut/empty-detail))]

--- a/docs/pull-requests/2026-04-24-refactor-cli-web-coverage-unblock.md
+++ b/docs/pull-requests/2026-04-24-refactor-cli-web-coverage-unblock.md
@@ -1,0 +1,64 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# refactor: unblock CLI web coverage instrumentation
+
+## Overview
+Extracts the CLI dashboard status/workflow rendering path into a smaller
+namespace so Cloverage can instrument the web surface without tripping the
+JVM method-size limit.
+
+## Motivation
+`bb ccov` was failing before tests even ran because
+`ai.miniforge.cli.web.components/workflow-status` compiled into a method
+that was too large for Cloverage instrumentation. That made the coverage
+task unreliable for the whole repo.
+
+## Base Branch
+`main`
+
+## Changes In Detail
+- adds `bases/cli/src/ai/miniforge/cli/web/components/status.clj`
+  - moves `status-indicator`, `workflow-status-icon`, and
+    `workflow-status` into a smaller focused namespace
+  - keeps the rendering path localized through the existing CLI message
+    catalog
+- updates `bases/cli/src/ai/miniforge/cli/web/components.clj`
+  - reduces the size of the original namespace
+  - keeps the existing public vars as pass-throughs so callers do not
+    change
+- updates `bases/cli/test/ai/miniforge/cli/web/components_test.clj`
+  - adds direct coverage for the extracted workflow-status surface
+
+## Testing Plan
+Executed in `/Users/chris/ws/miniforge.ai/thesium-career/miniforge`:
+- `git diff --check`
+- `clojure -Sdeps '{:paths ["bases/cli/src" "bases/cli/resources" "bases/cli/test"]}' -M:test -e "(require 'ai.miniforge.cli.web.components-test) (let [result (clojure.test/run-tests 'ai.miniforge.cli.web.components-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`
+- `bb ccov`
+
+Results:
+- `components-test` passed: 5 tests, 17 assertions
+- `bb ccov` no longer fails on `Method code too large!` for
+  `ai.miniforge.cli.web.components`
+- `bb ccov` now completes instrumentation and writes a coverage report
+  with aggregate coverage:
+  - `% forms`: `52.61`
+  - `% lines`: `68.62`
+- the full `bb ccov` command still exits non-zero (`43`) because of
+  existing downstream failures in the broader suite; those are outside
+  this render-namespace unblock slice
+
+## Deployment Plan
+No migration is required.
+
+Consumers pick up the smaller CLI web rendering surface with the updated
+checkout.
+
+## Checklist
+- [x] Removed the CLI web method-size coverage blocker
+- [x] Preserved the existing public component API
+- [x] Added direct test coverage for the extracted status surface
+- [x] Verified full coverage instrumentation reaches report generation


### PR DESCRIPTION
<!--
  Title: Miniforge.ai
  Author: Christopher Lester (christopher@miniforge.ai)
  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
-->

# refactor: unblock CLI web coverage instrumentation

## Overview
Extracts the CLI dashboard status/workflow rendering path into a smaller
namespace so Cloverage can instrument the web surface without tripping the
JVM method-size limit.

## Motivation
`bb ccov` was failing before tests even ran because
`ai.miniforge.cli.web.components/workflow-status` compiled into a method
that was too large for Cloverage instrumentation. That made the coverage
task unreliable for the whole repo.

## Base Branch
`main`

## Changes In Detail
- adds `bases/cli/src/ai/miniforge/cli/web/components/status.clj`
  - moves `status-indicator`, `workflow-status-icon`, and
    `workflow-status` into a smaller focused namespace
  - keeps the rendering path localized through the existing CLI message
    catalog
- updates `bases/cli/src/ai/miniforge/cli/web/components.clj`
  - reduces the size of the original namespace
  - keeps the existing public vars as pass-throughs so callers do not
    change
- updates `bases/cli/test/ai/miniforge/cli/web/components_test.clj`
  - adds direct coverage for the extracted workflow-status surface

## Testing Plan
Executed in `/Users/chris/ws/miniforge.ai/thesium-career/miniforge`:
- `git diff --check`
- `clojure -Sdeps '{:paths ["bases/cli/src" "bases/cli/resources" "bases/cli/test"]}' -M:test -e "(require 'ai.miniforge.cli.web.components-test) (let [result (clojure.test/run-tests 'ai.miniforge.cli.web.components-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`
- `bb ccov`

Results:
- `components-test` passed: 5 tests, 17 assertions
- `bb ccov` no longer fails on `Method code too large!` for
  `ai.miniforge.cli.web.components`
- `bb ccov` now completes instrumentation and writes a coverage report
  with aggregate coverage:
  - `% forms`: `52.61`
  - `% lines`: `68.62`
- the full `bb ccov` command still exits non-zero (`43`) because of
  existing downstream failures in the broader suite; those are outside
  this render-namespace unblock slice

## Deployment Plan
No migration is required.

Consumers pick up the smaller CLI web rendering surface with the updated
checkout.

## Checklist
- [x] Removed the CLI web method-size coverage blocker
- [x] Preserved the existing public component API
- [x] Added direct test coverage for the extracted status surface
- [x] Verified full coverage instrumentation reaches report generation
