### PR TITLE
feat: emit workflow-owned PR and artifact projections

### DIFF
--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -254,7 +254,10 @@
       (cond-> duration-ms (assoc :workflow/duration-ms duration-ms)
               (:tokens opts) (assoc :workflow/tokens (:tokens opts))
               (:cost-usd opts) (assoc :workflow/cost-usd (:cost-usd opts))
-              (:pr-info opts) (assoc :workflow/pr-info (:pr-info opts)))))
+              (:pr-info opts) (assoc :workflow/pr-info (:pr-info opts))
+              (seq (:pr-infos opts)) (assoc :workflow/pr-infos (:pr-infos opts))
+              (:workflow/evidence-bundle-id opts)
+              (assoc :workflow/evidence-bundle-id (:workflow/evidence-bundle-id opts)))))
 
 (defn workflow-failed [stream workflow-id error & [{:keys [failure/class]}]]
   (let [;; Handle anomaly maps, Throwables, and plain error maps
@@ -669,6 +672,24 @@
 
 ;------------------------------------------------------------------------------ Layer 6
 ;; PR scoring events (N5-delta-2 §4.1)
+
+(defn pr-created
+  "Emit when a workflow-owned PR is created.
+
+   This is the canonical fine-grained event that lets `supervisory-state`
+   attach a PR back to the owning workflow run instead of forcing
+   consumers to infer that relationship from summary payloads later."
+  [stream workflow-id {:pr/keys [repo number url branch title author merge-order] :as _pr}]
+  (-> (create-envelope stream :pr/created workflow-id
+                       (str "PR " repo "#" number " created"))
+      (assoc :pr/repo repo
+             :pr/number number
+             :pr/url url
+             :pr/branch branch)
+      (cond->
+        title       (assoc :pr/title title)
+        author      (assoc :pr/author author)
+        merge-order (assoc :pr/merge-order merge-order))))
 
 (defn pr-scored
   "Emit when the pr-scoring component has computed readiness, risk, and

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -307,7 +307,12 @@
     :json-string "supervisory/intervention-state-changed"
     :browser?    false}
 
-   ;; PR scoring (N5-delta-2 §4.1)
+   ;; PR fleet + scoring (N5-delta-2 §3 / §4.1)
+   {:constructor "pr-created"
+    :event-type  :pr/created
+    :json-string "pr/created"
+    :browser?    false}
+
    {:constructor "pr-scored"
     :event-type  :pr/scored
     :json-string "pr/scored"

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -107,6 +107,7 @@
 (def intervention-state-changed events/intervention-state-changed)
 
 ;; PR scoring (N5-delta-2 §4.1)
+(def pr-created events/pr-created)
 (def pr-scored events/pr-scored)
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -88,6 +88,7 @@
 ;------------------------------------------------------------------------------ Layer 2
 ;; PR scoring event constructors (N5-delta-2 §4.1)
 
+(def pr-created core/pr-created)
 (def pr-scored core/pr-scored)
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -128,6 +128,31 @@
    [:workflow/error-details {:optional true} map?]
    [:message string?]])
 
+;------------------------------------------------------------------------------ Layer 1.5
+;; PR lifecycle event schemas
+
+(def PRCreated
+  "Schema for pr/created event.
+
+   Emitted when a workflow creates a PR that should appear in the
+   supervisory PR fleet. `:workflow/id` is the owning workflow run, which
+   lets downstream consumers correlate the PR back to the run/spec dossier."
+  [:map
+   [:event/type [:= :pr/created]]
+   [:event/id uuid?]
+   [:event/timestamp inst?]
+   [:event/version string?]
+   [:event/sequence-number int?]
+   [:workflow/id uuid?]
+   [:pr/repo string?]
+   [:pr/number int?]
+   [:pr/url string?]
+   [:pr/branch string?]
+   [:pr/title {:optional true} string?]
+   [:pr/author {:optional true} string?]
+   [:pr/merge-order {:optional true} int?]
+   [:message string?]])
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Agent lifecycle event schemas
 

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -29,7 +29,8 @@
    It is a pure function from an event-stream prefix to an EntityTable."
   (:require
    [clojure.edn :as edn]
-   [clojure.java.io :as io]))
+   [clojure.java.io :as io]
+   [clojure.string :as str]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Helpers
@@ -57,6 +58,73 @@
   "Read `:event/timestamp`, defaulting to wall clock if absent."
   [event]
   (or (:event/timestamp event) (now)))
+
+(defn- append-distinct
+  "Append values from `new-items` onto `existing-items`, preserving order and
+   removing duplicates."
+  [existing-items new-items]
+  (reduce (fn [acc item]
+            (if (some #(= item %) acc)
+              acc
+              (conj acc item)))
+          (vec (or existing-items []))
+          new-items))
+
+(defn- artifact-id
+  "Extract the UUID artifact id from a phase artifact entry.
+
+   Historical emitters have used both bare UUIDs and `{:artifact/id ...}`
+   maps in phase results; supervisory-state accepts either so replay stays
+   robust while the event contract converges."
+  [artifact]
+  (cond
+    (uuid? artifact) artifact
+    (uuid? (:artifact/id artifact)) (:artifact/id artifact)
+    (uuid? (:id artifact)) (:id artifact)
+    :else nil))
+
+(defn- event-artifact-ids
+  "Normalize :phase/artifacts from an event into a vector of UUIDs."
+  [event]
+  (->> (:phase/artifacts event)
+       (keep artifact-id)
+       vec))
+
+(defn- repo-from-pr-url
+  "Extract `owner/repo` from a GitHub pull-request URL."
+  [pr-url]
+  (when (string? pr-url)
+    (let [parts (str/split pr-url #"/")]
+      (when-let [pull-index (first (keep-indexed #(when (= %2 "pull") %1) parts))]
+        (when (>= pull-index 2)
+          (str (nth parts (- pull-index 2)) "/" (nth parts (dec pull-index))))))))
+
+(defn- normalize-workflow-pr
+  "Normalize workflow-owned PR metadata into the shared `:pr/*` shape."
+  [pr]
+  (let [repo   (or (:pr/repo pr) (repo-from-pr-url (or (:pr/url pr) (:pr-url pr))))
+        number (or (:pr/number pr) (:pr-number pr) (:pr/id pr))
+        url    (or (:pr/url pr) (:pr-url pr))]
+    (when (and repo number url)
+      (cond-> {:pr/repo repo
+               :pr/number number
+               :pr/url url
+               :pr/branch (or (:pr/branch pr) (:branch pr) "")}
+        (:pr/title pr) (assoc :pr/title (:pr/title pr))
+        (:title pr)    (assoc :pr/title (:title pr))
+        (:pr/author pr) (assoc :pr/author (:pr/author pr))
+        (:author pr)    (assoc :pr/author (:author pr))
+        (:pr/merge-order pr) (assoc :pr/merge-order (:pr/merge-order pr))
+        (:merge-order pr)    (assoc :pr/merge-order (:merge-order pr))))))
+
+(defn- event-workflow-prs
+  "Collect normalized PRs embedded on workflow lifecycle events."
+  [event]
+  (let [raw-prs (concat (get event :workflow/pr-infos [])
+                        (cond-> [] (:workflow/pr-info event) (conj (:workflow/pr-info event))))]
+    (->> raw-prs
+         (keep normalize-workflow-pr)
+         (append-distinct []))))
 
 (defn- coarse-agent-status
   "Map fine-grained `:agent/status` `status/type` keywords to the coarse
@@ -133,19 +201,32 @@
 
 (defn workflow-phase-completed
   [table {:workflow/keys [id] :as event}]
-  (let [ts (event-instant event)]
+  (let [ts (event-instant event)
+        artifact-ids (event-artifact-ids event)]
     (-> table
         (ensure-workflow id ts)
-        (assoc-in [:workflows id :workflow-run/updated-at] ts))))
+        (update-in [:workflows id]
+                   (fn [run]
+                     (cond-> (assoc run :workflow-run/updated-at ts)
+                       (seq artifact-ids)
+                       (update :workflow-run/artifact-ids append-distinct artifact-ids)))))))
 
 (defn workflow-completed
   [table {:workflow/keys [id] :as event}]
-  (let [ts (event-instant event)]
+  (let [ts (event-instant event)
+        prs (event-workflow-prs event)
+        evidence-bundle-id (:workflow/evidence-bundle-id event)]
     (-> table
         (ensure-workflow id ts)
-        (update-in [:workflows id] merge
-                   {:workflow-run/status     :completed
-                    :workflow-run/updated-at ts}))))
+        (update-in [:workflows id]
+                   (fn [run]
+                     (cond-> (merge run
+                                    {:workflow-run/status     :completed
+                                     :workflow-run/updated-at ts})
+                       (seq prs)
+                       (update :workflow-run/prs append-distinct prs)
+                       evidence-bundle-id
+                       (assoc :workflow-run/evidence-bundle-id evidence-bundle-id)))))))
 
 (defn workflow-failed
   [table {:workflow/keys [id] :as event}]
@@ -224,36 +305,49 @@
   [(:pr/repo event) (:pr/number event)])
 
 (defn pr-created
-  [table {:pr/keys [repo number url branch title author merge-order] :as event}]
-  (assoc-in table [:prs (pr-key event)]
-            {:pr/repo       (or repo "")
-             :pr/number     (or number 0)
-             :pr/url        (or url "")
-             :pr/branch     (or branch "")
-             :pr/title      (or title "")
-             :pr/status     :open
-             :pr/merge-order (or merge-order 0)
-             :pr/depends-on []
-             :pr/blocks     []
-             :pr/ci-status  :pending
-             :pr/author     author}))
+  [table {:pr/keys [repo number url branch title author merge-order] workflow-id :workflow/id :as event}]
+  (let [pr-state (merge (get-in table [:prs (pr-key event)] {})
+                        {:pr/repo        (or repo "")
+                         :pr/number      (or number 0)
+                         :pr/url         (or url "")
+                         :pr/branch      (or branch "")
+                         :pr/title       (or title "")
+                         :pr/status      :open
+                         :pr/merge-order (or merge-order 0)
+                         :pr/depends-on  []
+                         :pr/blocks      []
+                         :pr/ci-status   :pending
+                         :pr/author      author})]
+    (assoc-in table [:prs (pr-key event)]
+              (cond-> pr-state
+                workflow-id (assoc :pr/workflow-run-id workflow-id)))))
 
 (defn pr-merged
   [table event]
   (let [k (pr-key event)
-        ts (event-instant event)]
+        ts (event-instant event)
+        workflow-id (:workflow/id event)]
     (cond-> table
       (get-in table [:prs k])
-      (update-in [:prs k] merge
-                 {:pr/status :merged
-                  :pr/merged-at ts}))))
+      (update-in [:prs k]
+                 (fn [pr]
+                   (cond-> (merge pr
+                                  {:pr/status :merged
+                                   :pr/merged-at ts})
+                     (and workflow-id (nil? (:pr/workflow-run-id pr)))
+                     (assoc :pr/workflow-run-id workflow-id)))))))
 
 (defn pr-closed
   [table event]
-  (let [k (pr-key event)]
+  (let [k (pr-key event)
+        workflow-id (:workflow/id event)]
     (cond-> table
       (get-in table [:prs k])
-      (assoc-in [:prs k :pr/status] :closed))))
+      (update-in [:prs k]
+                 (fn [pr]
+                   (cond-> (assoc pr :pr/status :closed)
+                     (and workflow-id (nil? (:pr/workflow-run-id pr)))
+                     (assoc :pr/workflow-run-id workflow-id)))))))
 
 (defn pr-scored
   "Merge pre-computed readiness/risk/policy/recommendation fields from a
@@ -267,7 +361,7 @@
    `:pr/created`. The stub uses producer-canonical empties for required
    keys; a later `:pr/created` or `:supervisory/pr-upserted` will overwrite
    them while the scored keys are preserved via `merge`."
-  [table {:pr/keys [repo number readiness risk policy recommendation] :as event}]
+  [table {:pr/keys [repo number readiness risk policy recommendation] workflow-id :workflow/id :as event}]
   (let [k       (pr-key event)
         stub    {:pr/repo       (or repo "")
                  :pr/number     (or number 0)
@@ -284,7 +378,9 @@
                    readiness      (assoc :pr/readiness readiness)
                    risk           (assoc :pr/risk risk)
                    policy         (assoc :pr/policy policy)
-                   recommendation (assoc :pr/recommendation recommendation))]
+                   recommendation (assoc :pr/recommendation recommendation)
+                   (and workflow-id (nil? (:pr/workflow-run-id existing)))
+                   (assoc :pr/workflow-run-id workflow-id))]
     (assoc-in table [:prs k] scored)))
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
@@ -186,7 +186,19 @@
    [:workflow-run/started-at :common/timestamp]
    [:workflow-run/updated-at :common/timestamp]
    [:workflow-run/trigger-source :workflow-run/trigger-source]
-   [:workflow-run/correlation-id :id/uuid]])
+   [:workflow-run/correlation-id :id/uuid]
+   [:workflow-run/artifact-ids {:optional true} [:vector :id/uuid]]
+   [:workflow-run/evidence-bundle-id {:optional true} [:maybe :id/uuid]]
+   [:workflow-run/prs {:optional true}
+    [:vector
+     [:map
+      [:pr/repo [:string {:min 1}]]
+      [:pr/number :common/non-neg-int]
+      [:pr/url string?]
+      [:pr/branch string?]
+      [:pr/title {:optional true} [:maybe string?]]
+      [:pr/author {:optional true} [:maybe string?]]
+      [:pr/merge-order {:optional true} [:maybe :common/non-neg-int]]]]]])
 
 (def AgentSession
   "An external or internal agent observable to the supervisory plane.
@@ -299,6 +311,7 @@
    [:pr/changed-files-count {:optional true} [:maybe :common/non-neg-int]]
    [:pr/behind-main {:optional true} [:maybe boolean?]]
    [:pr/merged-at {:optional true} [:maybe :common/timestamp]]
+   [:pr/workflow-run-id {:optional true} [:maybe :id/uuid]]
    [:pr/readiness {:optional true} [:maybe PrReadiness]]
    [:pr/risk {:optional true} [:maybe PrRisk]]
    [:pr/policy {:optional true} [:maybe PrPolicy]]

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -78,6 +78,38 @@
                   (acc/apply-event (ev :workflow/completed {:workflow/id wf-id})))]
     (is (= :completed (get-in table [:workflows wf-id :workflow-run/status])))))
 
+(deftest workflow-phase-completed-accumulates-artifact-ids
+  (let [wf-id (random-uuid)
+        artifact-a (random-uuid)
+        artifact-b (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :workflow/started {:workflow/id wf-id}))
+                  (acc/apply-event (ev :workflow/phase-completed
+                                       {:workflow/id wf-id
+                                        :phase/artifacts [artifact-a {:artifact/id artifact-b}]}))
+                  (acc/apply-event (ev :workflow/phase-completed
+                                       {:workflow/id wf-id
+                                        :phase/artifacts [{:artifact/id artifact-a}]})))]
+    (is (= [artifact-a artifact-b]
+           (get-in table [:workflows wf-id :workflow-run/artifact-ids])))))
+
+(deftest workflow-completed-captures-owned-prs
+  (let [wf-id (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :workflow/started {:workflow/id wf-id}))
+                  (acc/apply-event (ev :workflow/completed
+                                       {:workflow/id wf-id
+                                        :workflow/pr-info {:pr-number 42
+                                                           :pr-url "https://github.com/acme/widget/pull/42"
+                                                           :branch "feature/widget"}})))
+        prs   (get-in table [:workflows wf-id :workflow-run/prs])]
+    (is (= 1 (count prs)))
+    (is (= {:pr/repo "acme/widget"
+            :pr/number 42
+            :pr/url "https://github.com/acme/widget/pull/42"
+            :pr/branch "feature/widget"}
+           (select-keys (first prs) [:pr/repo :pr/number :pr/url :pr/branch])))))
+
 (deftest workflow-failed-sets-failed-status
   (let [wf-id (random-uuid)
         table (-> schema/empty-table
@@ -145,9 +177,11 @@
 ;------------------------------------------------------------------------------ PR
 
 (deftest pr-created-then-merged
-  (let [table (-> schema/empty-table
+  (let [wf-id (random-uuid)
+        table (-> schema/empty-table
                   (acc/apply-event (ev :pr/created
                                        {:pr/repo "acme/widget"
+                                        :workflow/id wf-id
                                         :pr/number 42
                                         :pr/title "Add thing"}))
                   (acc/apply-event (ev :pr/merged
@@ -155,7 +189,8 @@
                                         :pr/number 42})))
         pr    (get-in table [:prs ["acme/widget" 42]])]
     (is (= :merged (:pr/status pr)))
-    (is (some? (:pr/merged-at pr)))))
+    (is (some? (:pr/merged-at pr)))
+    (is (= wf-id (:pr/workflow-run-id pr)))))
 
 ;------------------------------------------------------------------------------ :pr/scored
 

--- a/components/workflow/src/ai/miniforge/workflow/runner_events.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_events.clj
@@ -22,6 +22,7 @@
    Extracted from runner.clj for single-responsibility.
    All functions are safe to call with nil event-stream (no-op)."
   (:require
+   [clojure.string :as str]
    [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.phase.interface :as phase]
    [ai.miniforge.self-healing.interface :as self-healing]
@@ -84,7 +85,10 @@
     (cond-> {}
       (:tokens metrics)   (assoc :tokens (:tokens metrics))
       (:cost-usd metrics) (assoc :cost-usd (:cost-usd metrics))
-      (:workflow/pr-info context) (assoc :pr-info (:workflow/pr-info context)))))
+      (:workflow/pr-info context) (assoc :pr-info (:workflow/pr-info context))
+      (seq (:execution/dag-pr-infos context)) (assoc :pr-infos (:execution/dag-pr-infos context))
+      (:workflow/evidence-bundle-id context)
+      (assoc :workflow/evidence-bundle-id (:workflow/evidence-bundle-id context)))))
 
 (def ^:private inner-failure-statuses
   #{:error :failed :failure})
@@ -152,6 +156,58 @@
      :workflow-run/trigger-source (get-in context [:execution/opts :trigger-source] :cli)
      :workflow-run/correlation-id (:execution/id context)}))
 
+(defn- repo-from-pr-url
+  "Extract `owner/repo` from a GitHub-style PR URL.
+
+   Returns nil when the URL does not look like a GitHub pull URL."
+  [pr-url]
+  (when (string? pr-url)
+    (let [parts (str/split pr-url #"/")]
+      (when-let [pull-index (some #(when (= "pull" (nth parts % nil)) %) (range (count parts)))]
+        (when (>= pull-index 2)
+          (str (nth parts (- pull-index 2)) "/" (nth parts (dec pull-index))))))))
+
+(defn- normalize-pr-info
+  "Normalize release / DAG PR info into the canonical `:pr/*` event payload."
+  [pr-info]
+  (let [number (or (:pr-number pr-info) (:pr/id pr-info))
+        url    (or (:pr-url pr-info) (:pr/url pr-info))
+        repo   (or (:pr/repo pr-info) (repo-from-pr-url url))]
+    (when (and repo number url)
+      {:pr/repo repo
+       :pr/number number
+       :pr/url url
+       :pr/branch (or (:branch pr-info) (:pr/branch pr-info))
+       :pr/title (or (:title pr-info) (:pr/title pr-info))
+       :pr/author (or (:author pr-info) (:pr/author pr-info))
+       :pr/merge-order (:merge-order pr-info)})))
+
+(defn- completion-prs
+  "Collect normalized PR payloads from workflow context.
+
+   The release phase produces a single `:workflow/pr-info`; DAG runs may also
+   accumulate `:execution/dag-pr-infos`. We preserve order and de-duplicate
+   by repo+number so `workflow/completed` and emitted `pr/created` events are
+   stable even when both sources describe the same PR."
+  [context]
+  (let [raw-prs (concat (get context :execution/dag-pr-infos [])
+                        (cond-> [] (:workflow/pr-info context) (conj (:workflow/pr-info context))))]
+    (->> raw-prs
+         (keep normalize-pr-info)
+         (reduce (fn [acc pr]
+                   (let [pr-key [(:pr/repo pr) (:pr/number pr)]]
+                     (if (some #(= pr-key [(:pr/repo %) (:pr/number %)]) acc)
+                       acc
+                       (conj acc pr))))
+                 []))))
+
+(defn- publish-pr-created-events!
+  "Publish canonical `:pr/created` events for workflow-owned PRs."
+  [event-stream context]
+  (doseq [pr (completion-prs context)]
+    (publish-event! event-stream
+                    (es/pr-created event-stream (:execution/id context) pr))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Lifecycle event publishers
 
@@ -183,12 +239,14 @@
                                                     {:message (messages/t :status/failed)
                                                      :errors (:execution/errors context)})
                                  (workflow-run-fields context :failed last-phase)))
-          (publish-event! event-stream
-                          (merge (es/workflow-completed event-stream wf-id
-                                                       (:execution/status context)
-                                                       (get-in context [:execution/metrics :duration-ms])
-                                                       (when (seq metrics-opts) metrics-opts))
-                                 (workflow-run-fields context :completed last-phase)))))
+          (do
+            (publish-event! event-stream
+                            (merge (es/workflow-completed event-stream wf-id
+                                                         (:execution/status context)
+                                                         (get-in context [:execution/metrics :duration-ms])
+                                                         (when (seq metrics-opts) metrics-opts))
+                                   (workflow-run-fields context :completed last-phase)))
+            (publish-pr-created-events! event-stream context))))
       (catch Exception e
         (println (messages/t :warn/publish-completed {:error (ex-message e)}))))))
 

--- a/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_events_test.clj
@@ -47,6 +47,9 @@
 (defn- first-event [stream]
   (first (:events @stream)))
 
+(defn- all-events [stream]
+  (:events @stream))
+
 ;------------------------------------------------------------------------------ publish-workflow-started!
 
 (deftest publish-workflow-started-includes-entity-fields-test
@@ -88,6 +91,26 @@
         (is (= (:execution/id ctx) (:workflow-run/id ev)))
         (is (= :completed (:workflow-run/status ev)))
         (is (= "plan" (:workflow-run/current-phase ev)))))))
+
+(deftest publish-workflow-completed-emits-pr-created-for-owned-prs-test
+  (testing "workflow completion emits canonical pr/created events for workflow-owned PRs"
+    (let [stream (create-stream)
+          ctx    (assoc (test-context)
+                        :execution/status :completed
+                        :workflow/pr-info {:pr-number 42
+                                           :pr-url "https://github.com/acme/widget/pull/42"
+                                           :branch "feature/widget"})]
+      (events/publish-workflow-completed! stream ctx)
+      (let [emitted (all-events stream)
+            completion (first emitted)
+            pr-created (second emitted)]
+        (is (= 2 (count emitted)))
+        (is (= :workflow/completed (:event/type completion)))
+        (is (= :pr/created (:event/type pr-created)))
+        (is (= (:execution/id ctx) (:workflow/id pr-created)))
+        (is (= "acme/widget" (:pr/repo pr-created)))
+        (is (= 42 (:pr/number pr-created)))
+        (is (= "feature/widget" (:pr/branch pr-created)))))))
 
 (deftest publish-workflow-completed-failed-entity-fields-test
   (testing "publish-workflow-completed! merges workflow-run/* on failure"

--- a/docs/pull-requests/2026-04-24-feat-run-pr-and-artifact-projections.md
+++ b/docs/pull-requests/2026-04-24-feat-run-pr-and-artifact-projections.md
@@ -1,0 +1,92 @@
+# feat: emit workflow-owned PRs and run artifact inventory
+
+## Overview
+
+Add the producer-side event and supervisory-state hooks that let downstream
+consumers correlate workflow runs to their owned pull requests and emitted
+artifacts.
+
+This PR stays at the event and projection boundary. It does not change the
+workflow FSM or phase-transition authority.
+
+## Motivation
+
+`miniforge-control` can now render a run dossier, but two remaining views were
+still producer-limited:
+
+- workflow runs could expose a summary `:workflow/pr-info`, but there was no
+  canonical event stream entry that attached owned PRs back to the workflow run
+- phase artifact output was emitted on workflow events, but supervisory-state
+  did not retain a run-local inventory of those artifact ids
+
+Without those producer hooks, the control-plane TUI had to fall back to honest
+placeholders instead of real run-scoped PR and evidence context.
+
+## Changes In Detail
+
+- add canonical `:pr/created` event support to `event-stream`
+- extend `workflow/completed` emission so workflow completion can carry:
+  - a normalized collection of owned PRs
+  - an optional workflow evidence-bundle id
+- update `workflow.runner-events` to emit `:pr/created` for workflow-owned PRs
+  inferred from release-phase and DAG completion context
+- extend `supervisory-state` workflow runs with:
+  - `:workflow-run/prs`
+  - `:workflow-run/artifact-ids`
+  - `:workflow-run/evidence-bundle-id`
+- attach `:pr/workflow-run-id` to PR fleet entries when the producer knows the
+  owning workflow run
+- preserve that ownership on later `:pr/merged`, `:pr/closed`, and `:pr/scored`
+  events so downstream correlation remains stable
+
+## Scope And Non-Goals
+
+This PR intentionally does not:
+
+- modify the compiled workflow machine or phase-selection logic
+- introduce evidence-bundle entity emission beyond the existing workflow-owned
+  evidence-bundle id field
+- attempt to infer run ownership for external PRs that were not produced by the
+  workflow run
+
+## Why This Shape
+
+The producer already had summary-level PR data at workflow completion time. The
+missing piece was a canonical fine-grained event and stable projection fields
+that consumers could trust.
+
+That makes the system cleaner in two ways:
+
+- event producers remain the source of truth for workflow-owned PR correlation
+- consumers no longer need to guess run ownership from global PR fleet rows
+
+## Enabled Follow-On Work
+
+This producer slice is meant to unlock two smaller PRs in `miniforge-control`:
+
+1. tighten dossier and monitor PR correlation around `:pr/workflow-run-id`
+2. surface run artifact and evidence inventory from workflow-owned artifact ids
+   and evidence-bundle ids
+
+## Testing Plan
+
+Executed in `/tmp/miniforge-producer-hooks`:
+
+```sh
+git diff --check
+bb test components/event-stream components/workflow components/supervisory-state
+```
+
+Result:
+
+- `539` tests
+- `2237` assertions
+- `0` failures
+- `0` errors
+
+## Checklist
+
+- [x] Producer emits canonical workflow-owned `:pr/created` events
+- [x] Workflow runs retain artifact ids and owned PR summaries
+- [x] PR fleet entries retain workflow ownership when known
+- [x] Projection tests cover the new ownership and artifact inventory behavior


### PR DESCRIPTION
## Summary
- emit canonical workflow-owned pr-created events from workflow completion context
- project workflow-owned PRs, artifact ids, and evidence bundle ids into supervisory state
- preserve pr/workflow-run-id across later PR lifecycle events so downstream run correlation stays stable

## Testing
- git diff --check
- bb test components/event-stream components/workflow components/supervisory-state
- commit hook pre-commit suite passed during git commit

## PR Doc
- docs/pull-requests/2026-04-24-feat-run-pr-and-artifact-projections.md

## Follow-ons Enabled
1. tighten run-scoped PR correlation in miniforge-control
2. surface workflow-owned artifact and evidence inventory in miniforge-control