### PR TITLE
chore: scoop bucket template — autoupdate manifest + workflow

### DIFF
--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -124,7 +124,19 @@ bb test
   elevated shell.
 - **Line endings** — set `git config --global core.autocrlf input` before
   cloning to keep LF in checked-in files; mismatched CRLF will fail
-  `bb fmt:md` and pre-commit.
+  `bb fmt:md` and pre-commit. Critically, this also affects the SHA-256
+  digests baked into governance config integrity checks — those are
+  computed on LF content and a CRLF checkout will fail
+  `ai.miniforge.config.governance/verify-and-warn` at startup.
+- **Java cannot delete `.git/objects` pack files** — integration tests
+  that create temp git repos (e.g.
+  `ai.miniforge.workflow.release-integration-test`) fail on Windows
+  with `AccessDeniedException` during cleanup. Git marks pack files
+  read-only; `java.nio.file.Files.delete` does not clear the read-only
+  flag before unlinking. Workaround in test code:
+  `setWritable(true)` recursively before deleting, or use
+  `babashka.fs/delete-tree` (which handles this). The `test-windows`
+  CI job is `continue-on-error: true` until this is fixed.
 
 ## Windows — WSL2 or Git Bash (Works Today)
 

--- a/docs/platform-support.md
+++ b/docs/platform-support.md
@@ -62,6 +62,30 @@ unmodified.
 
 ## Windows — Native (Beta)
 
+### End users (`scoop install miniforge`)
+
+Once `miniforge-ai/scoop-bucket` is provisioned (template lives at
+[`scoop/`](../scoop/) — see its README for bootstrap steps), end users
+install with:
+
+```powershell
+# One-time scoop install (skip if already present)
+# If you hit an execution-policy error first:
+#   Set-ExecutionPolicy RemoteSigned -Scope CurrentUser
+Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+
+# Add buckets and install. Babashka is pulled automatically as a dep.
+scoop bucket add scoop-clojure https://github.com/littleli/scoop-clojure
+scoop bucket add miniforge https://github.com/miniforge-ai/scoop-bucket
+scoop install miniforge
+
+mf version
+```
+
+Upgrade later with `scoop update miniforge`.
+
+### Contributors (cloning and running from source)
+
 ```powershell
 # 1. Install scoop (skip if already installed)
 # If you hit an execution-policy error first:

--- a/scoop/.github/workflows/autoupdate.yml
+++ b/scoop/.github/workflows/autoupdate.yml
@@ -1,0 +1,51 @@
+name: Autoupdate
+
+# Refreshes bucket/miniforge.json when miniforge cuts a new release.
+# Three triggers, in priority order:
+#   1. repository_dispatch — fired from miniforge's release.yml on tag push
+#      (instant, ~10s after release publishes the artifact).
+#   2. workflow_dispatch — manual run from the Actions UI.
+#   3. schedule — daily safety net at 06:00 UTC in case (1) is ever missed.
+#
+# Public-repo runners are free, so the daily cron costs nothing.
+
+on:
+  repository_dispatch:
+    types: [miniforge-release]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+permissions:
+  contents: write
+
+jobs:
+  excavate:
+    name: Refresh manifest from latest miniforge release
+    runs-on: windows-latest
+    steps:
+      - name: Checkout bucket
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run scoop excavator
+        uses: Ash258/Scoop-GithubActions@stable
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_UPDATED: '1'
+        with:
+          run: excavator
+
+      - name: Commit and push
+        shell: pwsh
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add bucket/
+          if (git diff --cached --quiet) {
+            Write-Host "No manifest changes — already up to date."
+          } else {
+            git commit -m "chore(autoupdate): refresh miniforge manifest"
+            git push
+          }

--- a/scoop/README.md
+++ b/scoop/README.md
@@ -1,0 +1,71 @@
+<!--
+  This is the contents of the miniforge-ai/scoop-bucket repository,
+  staged here in the main miniforge repo as a template. It is NOT used
+  from this location — copy these files into the new bucket repo when
+  provisioning. See provisioning notes at the bottom.
+-->
+
+# miniforge-ai/scoop-bucket
+
+[Scoop](https://scoop.sh) bucket for installing
+[Miniforge](https://github.com/miniforge-ai/miniforge) on Windows.
+
+## Install
+
+```powershell
+# One-time bucket setup
+scoop bucket add scoop-clojure https://github.com/littleli/scoop-clojure
+scoop bucket add miniforge https://github.com/miniforge-ai/scoop-bucket
+
+# Install miniforge (pulls babashka automatically as a dependency)
+scoop install miniforge
+
+mf version
+```
+
+## Update
+
+```powershell
+scoop update miniforge
+```
+
+## How autoupdate works
+
+`bucket/miniforge.json` declares `checkver` and `autoupdate` blocks
+pointing at the miniforge release feed. The `Autoupdate` workflow
+(`.github/workflows/autoupdate.yml`) refreshes the manifest on three
+triggers:
+
+1. **`repository_dispatch`** — fired by miniforge's release.yml on each
+   `v*` tag (instant — within ~10s of the release publishing).
+2. **`workflow_dispatch`** — manual via the Actions UI.
+3. **`schedule`** — daily at 06:00 UTC as a safety net.
+
+Public-repo Actions runners are free, so neither the cron nor the
+dispatch run costs anything against any minute budget.
+
+## Provisioning notes (delete this section after first commit)
+
+This bucket repo was bootstrapped from the template at
+`scoop/` in [`miniforge-ai/miniforge`](https://github.com/miniforge-ai/miniforge).
+To bring it online:
+
+1. **Create the public repo** on GitHub:
+   `gh repo create miniforge-ai/scoop-bucket --public --description "Scoop bucket for miniforge"`
+2. **Copy** `scoop/bucket/miniforge.json` and `scoop/.github/workflows/autoupdate.yml`
+   from miniforge's main branch into the new repo. The `bucket/` and
+   `.github/workflows/` paths must be at the bucket repo's root.
+3. **Manual first-run**: in the new repo's Actions tab, run the
+   `Autoupdate` workflow via `workflow_dispatch`. This populates
+   `bucket/miniforge.json` with the latest release version and SHA256.
+4. (Optional) **Wire up `repository_dispatch`** in miniforge's
+   `release.yml` so the bucket updates instantly on each release —
+   one-line follow-up, not blocking.
+5. Once the manifest has a real version (not `0.0.0-template`), test
+   end-to-end on a Windows machine:
+
+   ```powershell
+   scoop bucket add miniforge https://github.com/miniforge-ai/scoop-bucket
+   scoop install miniforge
+   mf version
+   ```

--- a/scoop/bucket/miniforge.json
+++ b/scoop/bucket/miniforge.json
@@ -1,0 +1,24 @@
+{
+  "version": "0.0.0-template",
+  "description": "Autonomous software factory — built on MiniForge Core",
+  "homepage": "https://miniforge.ai",
+  "license": "Apache-2.0",
+  "url": "https://github.com/miniforge-ai/miniforge/releases/download/v0.0.0-template/miniforge-windows-x86_64.zip",
+  "hash": "0000000000000000000000000000000000000000000000000000000000000000",
+  "bin": "mf.cmd",
+  "depends": "scoop-clojure/babashka",
+  "checkver": {
+    "github": "https://github.com/miniforge-ai/miniforge"
+  },
+  "autoupdate": {
+    "url": "https://github.com/miniforge-ai/miniforge/releases/download/v$version/miniforge-windows-x86_64.zip",
+    "hash": {
+      "url": "$url.sha256"
+    }
+  },
+  "notes": [
+    "Miniforge requires Babashka. Scoop should pull it automatically via the 'depends' field.",
+    "If 'scoop install' reports the bucket missing, run: scoop bucket add scoop-clojure https://github.com/littleli/scoop-clojure",
+    "Run 'mf check:platform' (when invoked through bb against the miniforge repo) to verify your install."
+  ]
+}


### PR DESCRIPTION
## Summary

Phase B+ of the Windows fidelity pass — the scoop bucket contents staged
as a template at `scoop/` so the future `miniforge-ai/scoop-bucket` repo
can be provisioned by copy. **Stacked on #658** (Windows CI/release);
re-target to `main` after #657 and #658 merge.

- `scoop/bucket/miniforge.json` — manifest with `checkver`/`autoupdate`
  pointing at the miniforge release feed. Placeholder version + hash get
  rewritten by the excavator on first run.
- `scoop/.github/workflows/autoupdate.yml` — triggers on
  `repository_dispatch` (future, instant), `workflow_dispatch` (manual),
  and a daily 06:00 UTC `schedule` (safety net). Public-repo runners
  are free, so the cron is zero-cost.
- `scoop/README.md` — end-user install snippet + provisioning notes for
  the new bucket repo (delete after first commit there).
- `docs/platform-support.md` — splits the Windows section into
  end-user (`scoop install miniforge`) and contributor flows.

## Why a template directory and not just the new repo?

Two reasons:

1. **You don't have a Windows machine** to verify the manifest end-to-end,
   so review-by-PR is the safer path.
2. The bucket repo doesn't exist yet — staging here lets us iterate on
   the manifest format before any of it is publicly addressable.

## Provisioning checklist (after merge)

1. `gh repo create miniforge-ai/scoop-bucket --public --description "Scoop bucket for miniforge"`
2. Copy `scoop/bucket/miniforge.json` and `scoop/.github/workflows/autoupdate.yml`
   from this repo into the bucket repo (must be at the bucket's root —
   `bucket/…` and `.github/workflows/…`).
3. Adapt `scoop/README.md` to the new repo, then drop the
   "Provisioning notes" section.
4. In the bucket repo's Actions tab, manually run `Autoupdate` via
   `workflow_dispatch`. This populates `bucket/miniforge.json` with the
   real version + SHA256 from the latest miniforge release.
5. End-to-end smoke test on a Windows machine:
   ```powershell
   scoop bucket add miniforge https://github.com/miniforge-ai/scoop-bucket
   scoop install miniforge
   mf version
   ```

## Follow-up (one line, deferred)

Add a `repository_dispatch` POST step to miniforge's `release.yml` so
the bucket updates within ~10s of each release tag instead of within
24h. Defers because:

- The bucket repo doesn't exist yet — the POST would 404.
- It needs a GitHub App with write on the bucket repo (mirror the
  existing `HOMEBREW_APP_*` setup but installed on `scoop-bucket`).
- The daily cron is sufficient for the first few releases.

The bucket workflow already listens for the dispatch event, so the
miniforge side is the only piece left when you're ready to flip it on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)