### PR TITLE
refactor: unify workflow validator and compiler

### DIFF
--- a/components/workflow/resources/config/workflow/messages/en-US.edn
+++ b/components/workflow/resources/config/workflow/messages/en-US.edn
@@ -26,6 +26,10 @@
   :status/invalid-current-state "Invalid current state: {state}"
   :status/guard-rejected-transition "Guard function rejected transition"
   :status/no-transition-defined "No transition defined for [{state} {event}]"
+  :unknown-on-success-target
+  "Phase {phase} references unknown on-success target {target}"
+  :unknown-on-fail-target
+  "Phase {phase} references unknown on-fail target {target}"
   :status/unreachable-machine-states
   "Compiled workflow machine contains unreachable states: {states}"
   :status/unreachable-machine-phases

--- a/components/workflow/src/ai/miniforge/workflow/configurable.clj
+++ b/components/workflow/src/ai/miniforge/workflow/configurable.clj
@@ -29,6 +29,7 @@
    [ai.miniforge.workflow.configurable-defaults :as defaults]
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.workflow.dag-orchestrator :as dag-orch]
+   [ai.miniforge.workflow.definition :as definition]
    [ai.miniforge.workflow.messages :as messages]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.loop.interface :as loop]))
@@ -47,25 +48,6 @@
   [workflow phase-id]
   (first (filter #(= phase-id (:phase/id %))
                  (:workflow/phases workflow))))
-
-(defn- first-transition-target
-  [phase]
-  (get-in phase [:phase/next 0 :target]))
-
-(defn- phase->pipeline-entry
-  [phase]
-  (let [target-phase (first-transition-target phase)]
-    (cond-> {:phase (:phase/id phase)}
-      target-phase (assoc :on-success target-phase))))
-
-(defn- ensure-execution-pipeline
-  [workflow]
-  (if (:workflow/pipeline workflow)
-    workflow
-    (assoc workflow
-           :workflow/pipeline
-           (mapv phase->pipeline-entry
-                 (:workflow/phases workflow)))))
 
 (defn- merged-phase-metrics
   [metrics]
@@ -449,7 +431,7 @@
       d. Apply the outcome through the authoritative execution machine
    3. Mark as completed or failed"
   [workflow input context]
-  (let [execution-workflow (ensure-execution-pipeline workflow)
+  (let [execution-workflow (definition/ensure-execution-pipeline workflow)
         max-phases (get context :max-phases (defaults/max-phases))
         callbacks {:on-phase-start (:on-phase-start context)
                    :on-phase-complete (:on-phase-complete context)}]

--- a/components/workflow/src/ai/miniforge/workflow/definition.clj
+++ b/components/workflow/src/ai/miniforge/workflow/definition.clj
@@ -1,0 +1,46 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.definition
+  "Workflow-definition normalization helpers shared by execution and validation.")
+
+(defn first-transition-target
+  "Return the first legacy transition target for a phase, when present."
+  [phase]
+  (get-in phase [:phase/next 0 :target]))
+
+(defn phase->pipeline-entry
+  "Project a legacy phase definition into the compiled-machine pipeline shape."
+  [phase]
+  (let [target-phase (first-transition-target phase)]
+    (cond-> {:phase (:phase/id phase)}
+      target-phase (assoc :on-success target-phase))))
+
+(defn ensure-execution-pipeline
+  "Ensure a workflow has a compiled-machine pipeline projection.
+
+   Pipeline workflows are returned unchanged. Legacy phase workflows are
+   normalized into `:workflow/pipeline` so validation and execution share one
+   compiler path."
+  [workflow]
+  (if (:workflow/pipeline workflow)
+    workflow
+    (assoc workflow
+           :workflow/pipeline
+           (mapv phase->pipeline-entry
+                 (:workflow/phases workflow)))))

--- a/components/workflow/src/ai/miniforge/workflow/definition.clj
+++ b/components/workflow/src/ai/miniforge/workflow/definition.clj
@@ -44,3 +44,8 @@
            :workflow/pipeline
            (mapv phase->pipeline-entry
                  (:workflow/phases workflow)))))
+
+(defn execution-pipeline
+  "Return the normalized execution pipeline for a workflow definition."
+  [workflow]
+  (:workflow/pipeline (ensure-execution-pipeline workflow)))

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -40,6 +40,7 @@
   (:require
    [clojure.set :as set]
    [ai.miniforge.fsm.interface :as fsm]
+   [ai.miniforge.workflow.definition :as definition]
    [ai.miniforge.workflow.messages :as messages]))
 
 (declare current-state first-phase-index reachable-states unreachable-states)
@@ -120,7 +121,10 @@
   [error-key phase target]
   {:error error-key
    :phase phase
-   :target target})
+   :target target
+   :message (messages/t error-key
+                        {:phase phase
+                         :target target})})
 
 (defn- unknown-success-target
   [pipeline {:keys [phase on-success]}]
@@ -317,7 +321,8 @@
    progression. Coarse lifecycle status and phase/index projections are derived
    from the resulting machine snapshot."
   [workflow]
-  (let [pipeline (:workflow/pipeline workflow)
+  (let [normalized-workflow (definition/ensure-execution-pipeline workflow)
+        pipeline (:workflow/pipeline normalized-workflow)
         phase-entries (mapv build-phase-entry (range) pipeline)
         first-active-state (some-> phase-entries first :state-id)
         no-phase-machine? (empty? phase-entries)
@@ -364,7 +369,8 @@
 (defn validate-execution-machine
   "Validate that a workflow pipeline can compile into an execution machine."
   [workflow]
-  (let [pipeline (:workflow/pipeline workflow)
+  (let [normalized-workflow (definition/ensure-execution-pipeline workflow)
+        pipeline (:workflow/pipeline normalized-workflow)
         duplicate-phases (->> pipeline
                               (map :phase)
                               frequencies
@@ -380,7 +386,7 @@
         machine (when (and (seq pipeline)
                            (empty? unresolved-success)
                            (empty? unresolved-fail))
-                  (compile-execution-machine workflow))
+                  (compile-execution-machine normalized-workflow))
         unreachable-state-set (when machine
                                 (unreachable-states machine))
         unreachable-phases (when machine

--- a/components/workflow/src/ai/miniforge/workflow/fsm.clj
+++ b/components/workflow/src/ai/miniforge/workflow/fsm.clj
@@ -321,8 +321,7 @@
    progression. Coarse lifecycle status and phase/index projections are derived
    from the resulting machine snapshot."
   [workflow]
-  (let [normalized-workflow (definition/ensure-execution-pipeline workflow)
-        pipeline (:workflow/pipeline normalized-workflow)
+  (let [pipeline (definition/execution-pipeline workflow)
         phase-entries (mapv build-phase-entry (range) pipeline)
         first-active-state (some-> phase-entries first :state-id)
         no-phase-machine? (empty? phase-entries)
@@ -370,7 +369,7 @@
   "Validate that a workflow pipeline can compile into an execution machine."
   [workflow]
   (let [normalized-workflow (definition/ensure-execution-pipeline workflow)
-        pipeline (:workflow/pipeline normalized-workflow)
+        pipeline (definition/execution-pipeline normalized-workflow)
         duplicate-phases (->> pipeline
                               (map :phase)
                               frequencies

--- a/components/workflow/src/ai/miniforge/workflow/registry.clj
+++ b/components/workflow/src/ai/miniforge/workflow/registry.clj
@@ -31,7 +31,6 @@
    [clojure.java.io :as io]
    [clojure.string :as str]
    [ai.miniforge.response.interface :as response]
-   [ai.miniforge.workflow.fsm :as workflow-fsm]
    [ai.miniforge.workflow.messages :as messages]
    [ai.miniforge.workflow.validator :as validator]
    [ai.miniforge.workflow.schemas :as schemas])
@@ -169,11 +168,7 @@
 
 (defn- registration-errors
   [workflow]
-  (let [workflow-validation (validator/validate-workflow workflow)
-        machine-validation (when (:workflow/pipeline workflow)
-                             (workflow-fsm/validate-execution-machine workflow))]
-    (vec (concat (:errors workflow-validation)
-                 (:errors machine-validation)))))
+  (:errors (validator/validate-workflow workflow)))
 
 (defn- validate-workflow-registration!
   [workflow]

--- a/components/workflow/src/ai/miniforge/workflow/validator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/validator.clj
@@ -22,7 +22,8 @@
   (:require
    [clojure.java.io :as io]
    [clojure.edn :as edn]
-   [clojure.set :as set]))
+   [ai.miniforge.workflow.definition :as definition]
+   [ai.miniforge.workflow.fsm :as workflow-fsm]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema loading
@@ -104,92 +105,22 @@
      :errors @errors}))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; DAG validation
+;; Compiled-machine validation
 
-(defn build-phase-graph
-  "Build adjacency list from phases.
-   Returns map of phase-id -> #{target-phase-ids}"
-  [phases]
-  (reduce
-   (fn [graph phase]
-     (let [phase-id (:phase/id phase)
-           next-transitions (:phase/next phase [])
-           targets (set (map :target next-transitions))]
-       (assoc graph phase-id targets)))
-   {}
-   phases))
-
-(defn reachable-phases
-  "Find all phases reachable from entry-phase.
-   Returns set of phase-ids."
-  [graph entry-phase]
-  (loop [to-visit [entry-phase]
-         visited #{}]
-    (if (empty? to-visit)
-      visited
-      (let [current (first to-visit)
-            to-visit' (rest to-visit)]
-        (if (contains? visited current)
-          (recur to-visit' visited)
-          (let [neighbors (get graph current #{})
-                new-to-visit (concat to-visit' neighbors)]
-            (recur new-to-visit (conj visited current))))))))
+(defn- machine-validation-messages
+  [workflow]
+  (let [normalized-workflow (definition/ensure-execution-pipeline workflow)
+        validation (workflow-fsm/validate-execution-machine normalized-workflow)]
+    {:valid? (:valid? validation)
+     :errors (mapv :message (:errors validation))
+     :warnings (mapv :message (:warnings validation))}))
 
 (defn validate-dag
   "Validate workflow DAG structure.
-   Checks:
-   - At least one phase exists
-   - All phases referenced in transitions exist (old format only)
-   - All phases are reachable from entry phase (old format only)
-
-   Note: Pipeline format is linear by default, so DAG validation is simpler.
-   Cycles are allowed in old format (for retry/rollback patterns).
-
-   Returns:
-   {:valid? boolean
-    :errors [string]}"
+   Delegates to the compiled execution-machine validator so legacy
+   phase workflows and pipeline workflows share one authority."
   [config]
-  (let [errors (atom [])
-        phases (:workflow/phases config)
-        pipeline (:workflow/pipeline config)]
-
-    ;; Pipeline format validation (new format)
-    (when pipeline
-      (when (empty? pipeline)
-        (swap! errors conj "Workflow must have at least one phase")))
-
-    ;; Phases format validation (old format)
-    (when phases
-      (let [phase-ids (set (map :phase/id phases))
-            entry-phase (when (seq phases) (:phase/id (first phases)))
-            graph (build-phase-graph phases)]
-
-        ;; Check we have at least one phase
-        (when (empty? phases)
-          (swap! errors conj "Workflow must have at least one phase"))
-
-        ;; Check all transition targets exist
-        (doseq [phase phases]
-          (let [phase-id (:phase/id phase)
-                next-transitions (:phase/next phase [])]
-            (doseq [transition next-transitions]
-              (when-let [target (:target transition)]
-                (when-not (contains? phase-ids target)
-                  (swap! errors conj (str "Phase " phase-id " references non-existent phase: " target)))))))
-
-        ;; Note: We don't check for cycles because workflows commonly have
-        ;; intentional cycles for retry/rollback logic (e.g., verify -> implement on failure)
-        ;; Cycles are a valid workflow pattern
-
-        ;; Check reachability (only if no errors so far)
-        (when (and entry-phase (empty? @errors))
-          (let [reachable (reachable-phases graph entry-phase)
-                unreachable (set/difference phase-ids reachable)]
-            (when (seq unreachable)
-              (swap! errors conj (str "Unreachable phases: " (vec unreachable))))))))
-
-    {:valid? (empty? @errors)
-     :errors @errors}))
+  (machine-validation-messages config))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Budget validation
@@ -228,18 +159,21 @@
   "Perform full validation of workflow config.
    Combines schema, DAG, and budget validation.
 
-   Returns:
-   {:valid? boolean
-    :errors [string]}"
+  Returns:
+  {:valid? boolean
+   :errors [string]
+   :warnings [string]}"
   [config]
   (let [schema-result (validate-schema config)
-        dag-result (validate-dag config)
+        machine-result (validate-dag config)
         budget-result (validate-budgets config)
         all-errors (concat (:errors schema-result)
-                           (:errors dag-result)
-                           (:errors budget-result))]
+                           (:errors machine-result)
+                           (:errors budget-result))
+        warnings (:warnings machine-result)]
     {:valid? (empty? all-errors)
-     :errors (vec all-errors)}))
+     :errors (vec all-errors)
+     :warnings (vec warnings)}))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/src/ai/miniforge/workflow/validator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/validator.clj
@@ -22,7 +22,6 @@
   (:require
    [clojure.java.io :as io]
    [clojure.edn :as edn]
-   [ai.miniforge.workflow.definition :as definition]
    [ai.miniforge.workflow.fsm :as workflow-fsm]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -38,6 +37,21 @@
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Schema validation
+
+(defn valid?
+  "Predicate for workflow validation result maps."
+  [validation]
+  (true? (:valid? validation)))
+
+(defn- validation-result
+  [errors]
+  {:valid? (empty? errors)
+   :errors (vec errors)})
+
+(defn- validation-result-with-warnings
+  [errors warnings]
+  (assoc (validation-result errors)
+         :warnings (vec warnings)))
 
 (defn validate-schema
   "Validate workflow config against Malli schema.
@@ -101,19 +115,17 @@
       (when-not (vector? task-types)
         (swap! errors conj ":workflow/task-types must be a vector")))
 
-    {:valid? (empty? @errors)
-     :errors @errors}))
+    (validation-result @errors)))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Compiled-machine validation
 
 (defn- machine-validation-messages
   [workflow]
-  (let [normalized-workflow (definition/ensure-execution-pipeline workflow)
-        validation (workflow-fsm/validate-execution-machine normalized-workflow)]
-    {:valid? (:valid? validation)
-     :errors (mapv :message (:errors validation))
-     :warnings (mapv :message (:warnings validation))}))
+  (let [validation (workflow-fsm/validate-execution-machine workflow)
+        errors (mapv :message (:errors validation))
+        warnings (mapv :message (:warnings validation))]
+    (validation-result-with-warnings errors warnings)))
 
 (defn validate-dag
   "Validate workflow DAG structure.
@@ -149,8 +161,7 @@
         (when-not (pos? duration)
           (swap! errors conj "Budget duration must be positive"))))
 
-    {:valid? (empty? @errors)
-     :errors @errors}))
+    (validation-result @errors)))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Combined validation
@@ -171,9 +182,7 @@
                            (:errors machine-result)
                            (:errors budget-result))
         warnings (:warnings machine-result)]
-    {:valid? (empty? all-errors)
-     :errors (vec all-errors)
-     :warnings (vec warnings)}))
+    (validation-result-with-warnings all-errors warnings)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/workflow/test/ai/miniforge/workflow/definition_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/definition_test.clj
@@ -1,0 +1,26 @@
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.workflow.definition-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.workflow.definition :as definition]))
+
+(deftest ensure-execution-pipeline-test
+  (testing "legacy phase workflows are normalized into pipeline entries"
+    (let [workflow {:workflow/phases [{:phase/id :plan
+                                       :phase/next [{:target :implement}]}
+                                      {:phase/id :implement
+                                       :phase/next [{:target :done}]}
+                                      {:phase/id :done
+                                       :phase/next []}]}
+          normalized (definition/ensure-execution-pipeline workflow)]
+      (is (= [{:phase :plan :on-success :implement}
+              {:phase :implement :on-success :done}
+              {:phase :done}]
+             (:workflow/pipeline normalized)))))
+
+  (testing "existing pipeline workflows are preserved"
+    (let [workflow {:workflow/pipeline [{:phase :plan}
+                                        {:phase :done}]}
+          normalized (definition/ensure-execution-pipeline workflow)]
+      (is (= workflow normalized)))))

--- a/components/workflow/test/ai/miniforge/workflow/registry_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/registry_test.clj
@@ -56,6 +56,38 @@
       (is (= workflow (registry/register-workflow! workflow)))
       (is (contains? (set (registry/list-workflow-ids)) :test-fsm))))
 
+  (testing "legacy phase workflows are validated through the compiled machine path"
+    (let [workflow {:workflow/id :legacy-invalid-fsm
+                    :workflow/version "1.0.0"
+                    :workflow/name "Legacy Invalid FSM"
+                    :workflow/description "Legacy workflow with unreachable phase"
+                    :workflow/phases [{:phase/id :plan
+                                       :phase/name "Plan"
+                                       :phase/agent :planner
+                                       :phase/next [{:target :verify}]}
+                                      {:phase/id :implement
+                                       :phase/name "Implement"
+                                       :phase/agent :implementer
+                                       :phase/next [{:target :done}]}
+                                      {:phase/id :verify
+                                       :phase/name "Verify"
+                                       :phase/agent :tester
+                                       :phase/next [{:target :done}]}
+                                      {:phase/id :done
+                                       :phase/name "Done"
+                                       :phase/agent :none
+                                       :phase/next []}]}]
+      (let [thrown (try
+                     (registry/register-workflow! workflow)
+                     nil
+                     (catch clojure.lang.ExceptionInfo ex
+                       ex))]
+        (is (instance? clojure.lang.ExceptionInfo thrown))
+        (is (re-find #"failed registration validation"
+                     (.getMessage ^clojure.lang.ExceptionInfo thrown))))
+      (is (not (contains? (set (registry/list-workflow-ids))
+                          :legacy-invalid-fsm)))))
+
   (testing "compiled workflows with unreachable phases are rejected at registration"
     (let [workflow {:workflow/id :invalid-fsm
                     :workflow/version "1.0.0"

--- a/components/workflow/test/ai/miniforge/workflow/validator_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/validator_test.clj
@@ -148,8 +148,8 @@
                   :workflow/exit-phases [:end]}
           result (validator/validate-dag config)]
       (is (not (:valid? result)) "Non-existent phase reference should fail")
-      (is (some #(re-find #"non-existent" %) (:errors result))
-          "Should report non-existent phase")))
+      (is (some #(re-find #"unknown on-success target" %) (:errors result))
+          "Should report unknown target")))
 
   ;; TODO: Validator doesn't currently validate :workflow/entry-phase
   ;; It just uses first phase by default. Uncomment when implemented.
@@ -185,20 +185,20 @@
                   [{:phase/id :start
                     :phase/name "Start"
                     :phase/agent :planner
-                    :phase/next [{:target :end}]}
-                   {:phase/id :end
-                    :phase/name "End"
-                    :phase/agent :none
-                    :phase/next []}
+                    :phase/next [{:target :done}]}
                    {:phase/id :orphan
                     :phase/name "Orphan"
                     :phase/agent :implementer
-                    :phase/next []}]  ; No path to this phase
+                    :phase/next [{:target :done}]}
+                   {:phase/id :done
+                    :phase/name "Done"
+                    :phase/agent :none
+                    :phase/next []}]  ; start skips orphan in compiled-machine path
                   :workflow/entry-phase :start
-                  :workflow/exit-phases [:end]}
+                  :workflow/exit-phases [:done]}
           result (validator/validate-dag config)]
       (is (not (:valid? result)) "Unreachable phases should fail")
-      (is (some #(re-find #"Unreachable" %) (:errors result))
+      (is (some #(re-find #"unreachable phases" %) (:errors result))
           "Should report unreachable phases"))))
 
 (deftest validate-budgets-test
@@ -297,8 +297,8 @@
           result (validator/validate-workflow config)]
       (is (not (:valid? result)) "Invalid workflow should fail")
       (is (>= (count (:errors result)) 2) "Should report multiple errors")
-      ;; Should have errors from DAG and budget validation
-      (is (some #(re-find #"non-existent" %) (:errors result))
-          "Should report non-existent phase")
+      ;; Should have errors from compiled-machine and budget validation
+      (is (some #(re-find #"unknown on-success target" %) (:errors result))
+          "Should report unknown target")
       (is (some #(re-find #"positive" %) (:errors result))
           "Should report negative budget"))))

--- a/docs/pull-requests/2026-04-25-refactor-workflow-validator-compiler-unification.md
+++ b/docs/pull-requests/2026-04-25-refactor-workflow-validator-compiler-unification.md
@@ -1,0 +1,43 @@
+# Refactor Workflow Validator And Compiler Unification
+
+## Summary
+
+- move legacy workflow normalization into shared
+  [components/workflow/src/ai/miniforge/workflow/definition.clj](/components/workflow/src/ai/miniforge/workflow/definition.clj)
+  so configurable execution and validation use the same
+  `:workflow/phases -> :workflow/pipeline` projection
+- make the execution-machine compiler normalize workflows directly, then
+  surface localized validation messages for unknown transition targets
+- replace the old hand-rolled DAG validation in
+  [components/workflow/src/ai/miniforge/workflow/validator.clj](/components/workflow/src/ai/miniforge/workflow/validator.clj)
+  with compiled-machine validation, and remove the extra machine-validation
+  pass from
+  [components/workflow/src/ai/miniforge/workflow/registry.clj](/components/workflow/src/ai/miniforge/workflow/registry.clj)
+
+## Why
+
+- registration, loading, and configurable execution were still using two
+  different authorities for workflow validity
+- legacy phase workflows could execute through the compiled machine path
+  while validation still reasoned about a separate graph model
+- this slice makes registration and loading validate the same machine shape
+  the runtime actually executes
+
+## Validation
+
+- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/definition.clj`
+  `components/workflow/src/ai/miniforge/workflow/configurable.clj`
+  `components/workflow/src/ai/miniforge/workflow/fsm.clj`
+  `components/workflow/src/ai/miniforge/workflow/validator.clj`
+  `components/workflow/src/ai/miniforge/workflow/registry.clj`
+  `components/workflow/test/ai/miniforge/workflow/definition_test.clj`
+  `components/workflow/test/ai/miniforge/workflow/validator_test.clj`
+  `components/workflow/test/ai/miniforge/workflow/registry_test.clj`
+- `clojure -M:dev:test -e "(require '[clojure.test :as t]`
+  `'ai.miniforge.workflow.definition-test`
+  `'ai.miniforge.workflow.validator-test`
+  `'ai.miniforge.workflow.registry-test`
+  `'ai.miniforge.workflow.configurable-test`
+  `'ai.miniforge.workflow.fsm-test) ..."`
+- `bb test components/workflow`
+- `bb pre-commit`


### PR DESCRIPTION
# Refactor Workflow Validator And Compiler Unification

## Summary

- move legacy workflow normalization into shared
  [components/workflow/src/ai/miniforge/workflow/definition.clj](/components/workflow/src/ai/miniforge/workflow/definition.clj)
  so configurable execution and validation use the same
  `:workflow/phases -> :workflow/pipeline` projection
- make the execution-machine compiler normalize workflows directly, then
  surface localized validation messages for unknown transition targets
- replace the old hand-rolled DAG validation in
  [components/workflow/src/ai/miniforge/workflow/validator.clj](/components/workflow/src/ai/miniforge/workflow/validator.clj)
  with compiled-machine validation, and remove the extra machine-validation
  pass from
  [components/workflow/src/ai/miniforge/workflow/registry.clj](/components/workflow/src/ai/miniforge/workflow/registry.clj)

## Why

- registration, loading, and configurable execution were still using two
  different authorities for workflow validity
- legacy phase workflows could execute through the compiled machine path
  while validation still reasoned about a separate graph model
- this slice makes registration and loading validate the same machine shape
  the runtime actually executes

## Validation

- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/definition.clj`
  `components/workflow/src/ai/miniforge/workflow/configurable.clj`
  `components/workflow/src/ai/miniforge/workflow/fsm.clj`
  `components/workflow/src/ai/miniforge/workflow/validator.clj`
  `components/workflow/src/ai/miniforge/workflow/registry.clj`
  `components/workflow/test/ai/miniforge/workflow/definition_test.clj`
  `components/workflow/test/ai/miniforge/workflow/validator_test.clj`
  `components/workflow/test/ai/miniforge/workflow/registry_test.clj`
- `clojure -M:dev:test -e "(require '[clojure.test :as t]`
  `'ai.miniforge.workflow.definition-test`
  `'ai.miniforge.workflow.validator-test`
  `'ai.miniforge.workflow.registry-test`
  `'ai.miniforge.workflow.configurable-test`
  `'ai.miniforge.workflow.fsm-test) ..."`
- `bb test components/workflow`
- `bb pre-commit`
