### PR TITLE
ci(release): fire repository_dispatch to scoop-bucket on each release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,3 +344,36 @@ jobs:
           git add Formula/miniforge.rb
           git commit -m "Update miniforge to ${{ needs.release.outputs.version }}"
           git push
+
+  # Trigger the scoop bucket's autoupdate workflow so the manifest picks
+  # up this release within seconds instead of waiting for the bucket's
+  # daily cron. The bucket workflow listens on `repository_dispatch` of
+  # type `miniforge-release`. Reuses the existing GitHub App that the
+  # homebrew job authenticates with — the app already has access to all
+  # repos in the org, so we just point at scoop-bucket here.
+  scoop:
+    name: Trigger Scoop Bucket Autoupdate
+    needs: release
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.HOMEBREW_APP_ID }}
+          private-key: ${{ secrets.HOMEBREW_APP_PRIVATE_KEY }}
+          owner: miniforge-ai
+          repositories: scoop-bucket
+
+      - name: Fire repository_dispatch
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          gh api repos/miniforge-ai/scoop-bucket/dispatches \
+            -f event_type=miniforge-release \
+            -F "client_payload[version]=$VERSION" \
+            -F "client_payload[source]=miniforge-release-${{ github.run_id }}"
+          echo "Dispatched miniforge-release event for v$VERSION"


### PR DESCRIPTION
## Summary

The scoop-bucket repo (miniforge-ai/scoop-bucket) is provisioned and
its Autoupdate workflow listens for `repository_dispatch` of type
`miniforge-release`. Without this trigger, the bucket only refreshes
on its daily 06:00 UTC cron — release-day users see up to 24h of lag.
With this dispatch, the manifest updates within ~10 seconds of the
GitHub release publishing.

Mirrors the existing `homebrew` job's GitHub-App pattern. Reuses
`HOMEBREW_APP_ID` / `HOMEBREW_APP_PRIVATE_KEY` (the app already has
access to every repo in the org per the user's note); the only
difference is `repositories: scoop-bucket` instead of `homebrew-tap`.

## Prerequisites

- [x] `miniforge-ai/scoop-bucket` repo exists (bootstrapped with
      manifest + workflow files)
- [ ] `miniforge-ai/scoop-bucket` made public (required for
      `scoop bucket add` to clone anonymously)
- [ ] Autoupdate workflow run once via `workflow_dispatch` to populate
      the manifest with real release values (placeholders right now)

## Test plan

- [ ] Cut the next release tag — verify the scoop job fires and the
      bucket's Autoupdate workflow shows a triggered run within a few
      seconds.
- [ ] After bucket is public, smoke-test from a Windows machine:
      ```powershell
      scoop bucket add miniforge https://github.com/miniforge-ai/scoop-bucket
      scoop install miniforge
      mf version
      ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)