### PR TITLE
fix: re-enable tests deferred from PR #661 — both real bugs resolved

### DIFF
--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -4,6 +4,7 @@
         ai.miniforge/lsp-mcp-bridge {:local/root "../../bases/lsp-mcp-bridge"}
         ai.miniforge/mcp-context-server {:local/root "../../bases/mcp-context-server"}
         ai.miniforge/workflow {:local/root "../../components/workflow"}
+        ai.miniforge/workflow-resume {:local/root "../../components/workflow-resume"}
         ai.miniforge/schema {:local/root "../../components/schema"}
         ai.miniforge/config {:local/root "../../components/config"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}

--- a/projects/miniforge/test/ai/miniforge/workflow/artifact_persistence_test.clj
+++ b/projects/miniforge/test/ai/miniforge/workflow/artifact_persistence_test.clj
@@ -317,50 +317,43 @@
                             ((:enter verify-interceptor) ctx))
           "Verify should throw when no execution environment is available"))))
 
-;; TEMPORARILY DISABLED — surfaced by PR #661 (Linux pipefail + poly install)
-;; once test failures stopped being silently masked by `cmd | tee`.
-;;
-;; The test asserts the release phase tolerates an empty :code/files artifact
-;; when the curator confirms files exist in the environment. The current
-;; phase-software-factory/release/build-release-input code path discovers
-;; files via `git-dirty-files` against the worktree BEFORE invoking the
-;; stubbed executor, and throws :release/zero-files on an empty result.
-;; Either the contract regressed (input building should defer to executor
-;; when one is provided) or this test was written against a prior shape.
-;;
-;; Re-enable once that regression is resolved. The body of the test is
-;; preserved verbatim under (comment …) so a follow-up PR can drop the
-;; comment marker and a single empty-line edit re-enables it. Tracked as
-;; a Windows-fidelity-pass follow-up.
 (deftest test-workflow-empty-artifact-handling
-  (testing "TEMPORARILY DISABLED — see comment above; pending release-phase fix"
-    (is true)))
+  (testing "Release phase accepts an empty :code/files artifact when the worktree has dirty files from earlier phases"
+    ;; Regression target: the release phase discovers files from git state,
+    ;; not from the artifact's :code/files. An implement result with empty
+    ;; :code/files MUST still reach the release executor as long as the
+    ;; environment (worktree) has the work — e.g. the agent wrote design
+    ;; docs / specs / config directly without populating :code/files, or
+    ;; the curator filtered the artifact down to []. The curator is
+    ;; stubbed here because the production implementation reads the
+    ;; worktree itself; this test isolates the release-phase contract.
+    ;;
+    ;; The release phase calls `git-dirty-files` against the worktree, so
+    ;; we simulate the "agent wrote to disk without populating :code/files"
+    ;; case by writing a real file before the pipeline runs.
+    (let [stray-file (io/file *test-worktree-path* "src" "stray.clj")]
+      (io/make-parents stray-file)
+      (spit stray-file "(ns stray)\n;; written outside :code/files — release should still find it via git\n"))
+    (with-redefs [agent/curate-implement-output
+                  (fn [_opts]
+                    (response/success mock-empty-artifact
+                                      {:tokens 0 :duration-ms 0}))]
+      (let [result-ctx (execute-phase-pipeline
+                        {:implement-agent-fn
+                         (fn [_agent _task _ctx]
+                           (response/success mock-empty-artifact
+                                             {:tokens 50 :duration-ms 300}))
 
-(comment
-  ;; Original test body — re-enable when build-release-input defers
-  ;; file discovery in test/stubbed-executor mode.
-  (deftest test-workflow-empty-artifact-handling
-    (testing "Release phase accepts an empty :code/files artifact when the curator confirms files exist in the environment"
-      (with-redefs [agent/curate-implement-output
-                    (fn [_opts]
-                      (response/success mock-empty-artifact
-                                        {:tokens 0 :duration-ms 0}))]
-        (let [result-ctx (execute-phase-pipeline
-                          {:implement-agent-fn
-                           (fn [_agent _task _ctx]
-                             (response/success mock-empty-artifact
-                                               {:tokens 50 :duration-ms 300}))
-
-                           :release-opts
-                           {:executor
-                            (fn [_workflow-state _exec-context _opts]
-                              {:success? true
-                               :artifacts []
-                               :metrics {:files-written 0}})}})]
-          (is (= :completed (get-in result-ctx [:phase :status]))
-              "Release phase should complete when executor returns success")
-          (is (= :success (get-in result-ctx [:phase :result :status]))
-              "Release result should be success"))))))
+                         :release-opts
+                         {:executor
+                          (fn [_workflow-state _exec-context _opts]
+                            {:success? true
+                             :artifacts []
+                             :metrics {:files-written 0}})}})]
+        (is (= :completed (get-in result-ctx [:phase :status]))
+            "Release phase should complete when executor returns success")
+        (is (= :success (get-in result-ctx [:phase :result :status]))
+            "Release result should be success")))))
 
 (deftest test-artifact-content-verification
   (testing "Files written to disk have correct content"

--- a/tasks/test_runner.clj
+++ b/tasks/test_runner.clj
@@ -72,24 +72,15 @@
                          "ai.miniforge.web-dashboard.fleet-onboarding-integration-test"
                          "ai.miniforge.self-healing.integration-test"
                          "ai.miniforge.governance.e2e-test"]
-        ;; TEMPORARILY EMPTY — surfaced by PR #661 (Linux pipefail). The
-        ;; miniforge-core project's classpath transitively requires
-        ;; `ai.miniforge.workflow-resume.interface` (via resume.clj) but
-        ;; the project's deps.edn is missing that component dependency
-        ;; — Polylith Error 107 has been flagging this. Loading the
-        ;; kernel-loader test explodes at require-time before any tests
-        ;; can run. Re-enable once miniforge-core's deps are corrected
-        ;; or resume.clj's coupling is broken.
-        kernel-tests []
+        kernel-tests ["ai.miniforge.workflow.kernel-loader-integration-test"]
         miniforge-exit (run-project-tests! "miniforge" miniforge-tests)]
     (when-not (zero? miniforge-exit)
       (println "❌ Integration tests failed in project: miniforge")
       (System/exit miniforge-exit))
-    (when (seq kernel-tests)
-      (let [kernel-exit (run-project-tests! "miniforge-core" kernel-tests)]
-        (when-not (zero? kernel-exit)
-          (println "❌ Integration tests failed in project: miniforge-core")
-          (System/exit kernel-exit))))))
+    (let [kernel-exit (run-project-tests! "miniforge-core" kernel-tests)]
+      (when-not (zero? kernel-exit)
+        (println "❌ Integration tests failed in project: miniforge-core")
+        (System/exit kernel-exit)))))
 
 (defn conformance []
   (println "🧪 Running N1 conformance tests...")


### PR DESCRIPTION
## Summary

Two tests were disabled with TODO markers in PR #661 when Linux
pipefail surfaced previously-masked failures. Both root causes
identified and fixed.

### Bug 1: `miniforge-core` missing `workflow-resume` component dep

`bases/cli/commands/resume.clj` requires
`ai.miniforge.workflow-resume.interface`, but
`projects/miniforge-core/deps.edn` never pulled in the component.
Any classpath that touches the CLI exploded at require-time with
`FileNotFoundException`. Polylith Error 107 had been flagging this
all along.

**Fix:** add `ai.miniforge/workflow-resume` to `miniforge-core/deps.edn`
(it's already in `projects/miniforge`). Re-enabled
`kernel-loader-integration-test` in `tasks/test_runner.clj`.

### Bug 2: `test-workflow-empty-artifact-handling` — incomplete test setup

The test asserted the release phase tolerates an empty `:code/files`
artifact "when the environment has the work" — but the test stubbed
`agent/curate-implement-output` without writing any actual files to
`*test-worktree-path*`. The release phase calls `git-dirty-files`
against the worktree (its production contract: files are discovered
from git state, not from the artifact's `:code/files`), got nothing,
and threw `:release/zero-files`. Production behavior was correct;
the test setup was incomplete.

**Fix:** write a "stray" file to the worktree before the pipeline
runs. That simulates exactly the scenario the test docstring
describes — the agent wrote files but the `:code/files` artifact
came back empty (e.g. the curator filter dropped them).

## Verification

```
bb test:integration
…
miniforge:       Ran 290 tests, 1039 assertions, 0 failures, 0 errors
miniforge-core:  Ran 2 tests, 16 assertions, 0 failures, 0 errors
```

## Test plan

- [ ] CI Linux Test job runs the full integration suite green.
- [ ] CI Lint passes.
- [ ] Polylith Error 107 (`Missing components in the miniforge-core
      project for these interfaces: workflow-resume`) is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)