### PR TITLE
refactor: converge DAG resume on machine snapshots

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -556,7 +556,7 @@
   :workflow-runner/workflow-type-label ":workflow/type {type}"
   :workflow-runner/list-failed "Failed to list workflows: {error}"
   :workflow-runner/spec-execution-failed "\n❌ Workflow execution failed: {error}"
-  :workflow-runner/event-file-failed "Failed to read event file: {error}"
+  :workflow-runner/event-file-failed "Failed to load resume state: {error}"
   :workflow-runner/resuming "\n🔄 Resuming workflow {workflow-id}"
 
   :resume/resuming "Resuming workflow: {workflow-id}"
@@ -574,7 +574,7 @@
   :resume/missing-workflow-id "resume requires a workflow id. Usage: miniforge resume <workflow-id>"
   :workflow-runner/previously-completed "   Previously completed: {count} tasks"
   :workflow-runner/recovered-artifacts "   Recovered artifacts: {count}"
-  :workflow-runner/no-completed-tasks "   No completed tasks found in event file. Starting fresh run."
+  :workflow-runner/no-completed-tasks "   No completed tasks found in checkpointed resume state. Starting fresh run."
   :workflow-runner/chain-header "⛓  Chain: {chain-id}"
   :workflow-runner/chain-description "   {description}"
   :workflow-runner/chain-steps "   Steps: {count}"

--- a/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/resume.clj
@@ -135,13 +135,14 @@
                                      {:llm-backend llm-client
                                       :event-stream event-stream
                                       :control-state control-state
-                                      :resume-machine-snapshot machine-snapshot
-                                      :resume-phase-results (:phase-results reconstructed)
-                                      :skip-lifecycle-events false
-                                      :pre-completed-dag-tasks (:completed-dag-tasks reconstructed)
-                                      :on-phase-start (fn [_ctx interceptor]
-                                                        (when-not quiet
-                                                          (display/print-info
+                                     :resume-machine-snapshot machine-snapshot
+                                     :resume-phase-results (:phase-results reconstructed)
+                                     :skip-lifecycle-events false
+                                     :pre-completed-dag-tasks (:completed-dag-tasks reconstructed)
+                                     :pre-completed-artifacts (:completed-dag-artifacts reconstructed)
+                                     :on-phase-start (fn [_ctx interceptor]
+                                                       (when-not quiet
+                                                         (display/print-info
                                                             (messages/t :resume/phase-starting
                                                                         {:phase (get-in interceptor [:config :phase])}))))
                                       :on-phase-complete (fn [_ctx _interceptor _result] nil)})]

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -435,9 +435,8 @@
 ;; Resume workflow from event file
 
 (defn resume-workflow-from-spec!
-  "Resume a previously failed/paused workflow by replaying its event file
-   to determine which DAG tasks already completed, then re-running the spec
-   with those tasks pre-completed.
+  "Resume a previously failed or paused workflow from checkpointed DAG state,
+   falling back to legacy event reconstruction when needed.
 
    Arguments:
    - workflow-id: UUID string of the workflow to resume
@@ -463,8 +462,12 @@
                   (messages/t :workflow-runner/recovered-artifacts {:count (count (:pre-completed-artifacts resume-ctx))})))))
     (if (and resume-ctx (seq (:pre-completed-ids resume-ctx)))
       ;; Re-run with pre-completed task IDs injected
-      (let [opts-with-resume (assoc-in opts [:execution-opts :pre-completed-dag-tasks]
-                                      (:pre-completed-ids resume-ctx))]
+      (let [execution-opts (-> (get opts :execution-opts {})
+                               (assoc :pre-completed-dag-tasks
+                                      (:pre-completed-ids resume-ctx))
+                               (assoc :pre-completed-artifacts
+                                      (:pre-completed-artifacts resume-ctx)))
+            opts-with-resume (assoc opts :execution-opts execution-opts)]
         (run-workflow-from-spec! spec opts-with-resume))
       (do
         (when-not quiet

--- a/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
+++ b/bases/cli/test/ai/miniforge/cli/main/commands/resume_test.clj
@@ -21,8 +21,14 @@
    [clojure.test :refer [deftest is testing]]
    [clojure.java.io :as io]
    [cheshire.core :as json]
+   [ai.miniforge.cli.main.display :as main-display]
+   [ai.miniforge.cli.workflow-runner.context :as context]
+   [ai.miniforge.cli.workflow-runner.dashboard :as dashboard]
    [ai.miniforge.cli.main.commands.resume :as sut]
-   [ai.miniforge.cli.workflow-selection-config :as selection-config]))
+   [ai.miniforge.cli.workflow-selection-config :as selection-config]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.supervisory-state.interface :as supervisory]
+   [ai.miniforge.workflow-resume.interface :as wr]))
 
 (deftest resolve-resume-workflow-test
   (testing "recorded workflow spec wins over configured fallback"
@@ -101,3 +107,44 @@
     (fn [base-dir]
       (with-redefs [sut/events-dir (.getPath base-dir)]
         (is (nil? (sut/read-event-file (str (random-uuid)))))))))
+
+(deftest resume-workflow-passes-dag-recovery-data-test
+  (let [workflow-id (random-uuid)
+        run-pipeline-opts (atom nil)
+        reconstructed {:completed-phases [:plan]
+                       :event-count 0
+                       :completed-dag-tasks #{:task-a}
+                       :completed-dag-artifacts [{:artifact/id "art-1"}]
+                       :phase-results {:plan {:status :completed}}
+                       :machine-snapshot {:execution/id workflow-id}
+                       :workflow-spec {:name "canonical-sdlc"
+                                       :version "1.0.0"}}]
+    (with-redefs [wr/reconstruct-context (fn [_events-dir _workflow-id] reconstructed)
+                  sut/resolve-resume-workflow (fn [_] {:workflow-type :canonical-sdlc
+                                                       :workflow-version "1.0.0"})
+                  context/create-llm-client (fn [_workflow _provider _quiet] :llm-client)
+                  es/create-event-stream (fn [] :event-stream)
+                  supervisory/attach! (fn [_event-stream] nil)
+                  dashboard/start-command-poller! (fn [_workflow-id _control-state]
+                                                    (fn [] nil))
+                  main-display/print-info (fn [& _] nil)
+                  main-display/print-error (fn [& _] nil)
+                  clojure.core/requiring-resolve
+                  (fn [sym]
+                    (cond
+                      (= sym 'ai.miniforge.workflow.interface/load-workflow)
+                      (fn [_workflow-type _workflow-version _opts]
+                        {:workflow {:workflow/id :canonical-sdlc
+                                    :workflow/version "1.0.0"
+                                    :workflow/pipeline [{:phase :verify}]}})
+
+                      (= sym 'ai.miniforge.workflow.interface/run-pipeline)
+                      (fn [_workflow _input opts]
+                        (reset! run-pipeline-opts opts)
+                        {:execution/status :completed})))]
+      (let [result (sut/resume-workflow workflow-id {:quiet true})]
+        (is (= :completed (:execution/status result)))
+        (is (= #{:task-a}
+               (:pre-completed-dag-tasks @run-pipeline-opts)))
+        (is (= [{:artifact/id "art-1"}]
+               (:pre-completed-artifacts @run-pipeline-opts)))))))

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/core.clj
@@ -66,6 +66,14 @@
        (map :dag/task-id)
        set))
 
+(defn extract-completed-dag-artifacts
+  "Artifacts recorded on successful `:dag/task-completed` events."
+  [events]
+  (->> events
+       (filter #(= :dag/task-completed (:event/type %)))
+       (mapcat #(get-in % [:dag/result :data :artifacts] []))
+       vec))
+
 (defn extract-dag-pause-info
   "Find the last `:dag/paused` event and extract completed task IDs + reason."
   [events]
@@ -118,6 +126,10 @@
   [checkpoint-data]
   (get-in checkpoint-data [:machine-snapshot :execution/status]))
 
+(defn- checkpoint-dag-result
+  [checkpoint-data]
+  (get-in checkpoint-data [:machine-snapshot :execution/dag-result]))
+
 (defn- reconstructed-completed?
   [by-type checkpoint-data]
   (or (boolean (seq (get by-type :workflow/completed)))
@@ -140,6 +152,34 @@
     (:phase-results checkpoint-data)
     (extract-phase-results events)))
 
+(defn- restored-dag-pause-info
+  [checkpoint-data events]
+  (let [dag-result (checkpoint-dag-result checkpoint-data)]
+    (or (when (:paused? dag-result)
+          {:completed-task-ids (set (:completed-task-ids dag-result))
+           :pause-reason (:pause-reason dag-result)})
+        (extract-dag-pause-info events))))
+
+(defn- restored-completed-dag-tasks
+  [checkpoint-data events]
+  (let [dag-result (checkpoint-dag-result checkpoint-data)
+        checkpoint-task-ids (set (:completed-task-ids dag-result))
+        event-task-ids (extract-completed-dag-tasks events)
+        pause-task-ids (:completed-task-ids (restored-dag-pause-info checkpoint-data events))]
+    (or (not-empty checkpoint-task-ids)
+        (not-empty event-task-ids)
+        pause-task-ids
+        #{})))
+
+(defn- restored-completed-dag-artifacts
+  [checkpoint-data events]
+  (let [dag-result (checkpoint-dag-result checkpoint-data)
+        checkpoint-artifacts (vec (get dag-result :artifacts []))
+        event-artifacts (extract-completed-dag-artifacts events)]
+    (if (seq checkpoint-artifacts)
+      checkpoint-artifacts
+      event-artifacts)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Context reconstruction
 
@@ -159,6 +199,7 @@
      :failed?              — true if :workflow/failed emitted
      :event-count          — int (count of events that passed shape validation)
      :completed-dag-tasks  — set of DAG task IDs that succeeded
+     :completed-dag-artifacts — recovered artifacts from completed DAG tasks
      :dag-paused?          — boolean
      :dag-pause-reason     — keyword or nil
 
@@ -182,8 +223,9 @@
         machine-snapshot (:machine-snapshot checkpoint-data)
         completed? (reconstructed-completed? by-type checkpoint-data)
         failed? (reconstructed-failed? by-type checkpoint-data)
-        completed-dag-tasks (extract-completed-dag-tasks events)
-        dag-pause-info (extract-dag-pause-info events)]
+        completed-dag-tasks (restored-completed-dag-tasks checkpoint-data events)
+        completed-dag-artifacts (restored-completed-dag-artifacts checkpoint-data events)
+        dag-pause-info (restored-dag-pause-info checkpoint-data events)]
     {:phase-results phase-results
      :completed-phases completed-phases
      :workflow-spec workflow-spec
@@ -193,9 +235,8 @@
      :completed? completed?
      :failed? failed?
      :event-count (count events)
-     :completed-dag-tasks (or (not-empty completed-dag-tasks)
-                              (:completed-task-ids dag-pause-info)
-                              #{})
+     :completed-dag-tasks completed-dag-tasks
+     :completed-dag-artifacts completed-dag-artifacts
      :dag-paused? (boolean dag-pause-info)
      :dag-pause-reason (:pause-reason dag-pause-info)
      :machine-snapshot machine-snapshot

--- a/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
+++ b/components/workflow-resume/src/ai/miniforge/workflow_resume/interface.clj
@@ -33,7 +33,8 @@
                                     (:workflow-version identity)))
        (def resumed (wr/trim-pipeline workflow (:completed-phases ctx)))
        ;; adapters call run-pipeline on `resumed` with the ctx's
-       ;; :completed-dag-tasks threaded as :pre-completed-dag-tasks"
+       ;; :completed-dag-tasks / :completed-dag-artifacts threaded into
+       ;; :pre-completed-dag-tasks / :pre-completed-artifacts"
   (:require
    [ai.miniforge.workflow-resume.core :as core]))
 
@@ -44,6 +45,7 @@
 (def failed?                     core/failed?)
 (def paused?                     core/paused?)
 (def extract-completed-dag-tasks core/extract-completed-dag-tasks)
+(def extract-completed-dag-artifacts core/extract-completed-dag-artifacts)
 (def extract-dag-pause-info      core/extract-dag-pause-info)
 (def extract-completed-phases    core/extract-completed-phases)
 (def extract-phase-results       core/extract-phase-results)

--- a/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
+++ b/components/workflow-resume/test/ai/miniforge/workflow_resume/core_test.clj
@@ -72,6 +72,18 @@
                   {:event/type :dag/task-failed    :dag/task-id "t3"}]]
       (is (= #{"t1" "t2"} (core/extract-completed-dag-tasks events))))))
 
+(deftest extract-completed-dag-artifacts-test
+  (testing "collects artifacts from :dag/task-completed events"
+    (let [events [{:event/type :dag/task-completed
+                   :dag/result {:data {:artifacts [{:artifact/id "a"}]}}}
+                  {:event/type :dag/task-completed
+                   :dag/result {:data {:artifacts [{:artifact/id "b"}
+                                                   {:artifact/id "c"}]}}}
+                  {:event/type :dag/task-failed
+                   :dag/result {:data {:artifacts [{:artifact/id "ignored"}]}}}]]
+      (is (= [{:artifact/id "a"} {:artifact/id "b"} {:artifact/id "c"}]
+             (core/extract-completed-dag-artifacts events))))))
+
 (deftest extract-dag-pause-info-last-pause-wins-test
   (testing "multiple pause events — latest one wins"
     (let [events [{:event/type :dag/paused
@@ -227,12 +239,16 @@
              (core/reconstruct-context base-dir (str (random-uuid)))))))))
 
 (deftest reconstruct-context-prefers-machine-snapshot-test
-  (testing "checkpoint data restores without requiring event files"
+  (testing "checkpoint data restores workflow and DAG resume state without requiring event files"
     (let [workflow-id (str (random-uuid))
           checkpoint-data {:machine-snapshot {:execution/id workflow-id
                                              :execution/workflow-id :canonical-sdlc
                                              :execution/workflow-version "1.0.0"
-                                             :execution/status :running}
+                                             :execution/status :running
+                                             :execution/dag-result {:paused? true
+                                                                    :completed-task-ids ["task-1" "task-2"]
+                                                                    :artifacts [{:artifact/id "art-1"}]
+                                                                    :pause-reason :rate-limit}}
                            :manifest {:workflow/phases-completed [:plan]}
                            :phase-results {:plan {:status :completed}}}]
       (with-redefs [workflow/load-checkpoint-data (fn [_workflow-run-id] checkpoint-data)
@@ -243,6 +259,10 @@
           (is (= [:plan] (:completed-phases ctx)))
           (is (= {:status :completed}
                  (get-in ctx [:phase-results :plan])))
+          (is (= #{"task-1" "task-2"} (:completed-dag-tasks ctx)))
+          (is (= [{:artifact/id "art-1"}] (:completed-dag-artifacts ctx)))
+          (is (true? (:dag-paused? ctx)))
+          (is (= :rate-limit (:dag-pause-reason ctx)))
           (is (= 0 (:event-count ctx))))))))
 
 ;------------------------------------------------------------------------------ Layer 3
@@ -253,6 +273,8 @@
     (is (= core/completed? wr/completed?))
     (is (= core/failed? wr/failed?))
     (is (= core/paused? wr/paused?))
+    (is (= core/extract-completed-dag-tasks wr/extract-completed-dag-tasks))
+    (is (= core/extract-completed-dag-artifacts wr/extract-completed-dag-artifacts))
     (is (= core/extract-completed-phases wr/extract-completed-phases))
     (is (= core/reconstruct-context wr/reconstruct-context))
     (is (= core/trim-pipeline wr/trim-pipeline))

--- a/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
+++ b/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj
@@ -75,6 +75,8 @@
    :execution/response-chain
    :execution/errors
    :execution/artifacts
+   :execution/dag-result
+   :execution/dag-pr-infos
    :execution/metrics
    :execution/output
    :execution/started-at

--- a/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj
@@ -63,14 +63,22 @@
    :metrics {}
    :error error})
 
-(defn dag-execution-paused [completed failed artifacts reason]
-  {:success? false
-   :paused? true
-   :tasks-completed completed
-   :tasks-failed failed
-   :artifacts (vec artifacts)
-   :pause-reason reason
-   :metrics {}})
+(defn dag-execution-paused
+  [completed-task-ids failed-task-ids artifacts decision]
+  (let [reset-at (:reset-at decision)
+        wait-ms (:wait-ms decision)
+        auto-resume? (= :checkpoint-and-resume (:action decision))]
+    {:success? false
+     :paused? true
+     :tasks-completed (count completed-task-ids)
+     :tasks-failed (count failed-task-ids)
+     :completed-task-ids (vec completed-task-ids)
+     :artifacts (vec artifacts)
+     :pause-reason (:reason decision)
+     :reset-at reset-at
+     :wait-ms wait-ms
+     :auto-resume? auto-resume?
+     :metrics {}}))
 
 ;--- Layer 0: Level Traversal
 
@@ -522,8 +530,8 @@
         (log-checkpoint-info logger auto-resume? reset-at
                              (:wait-ms decision 0) (count new-completed))
         {:action :pause
-         :result (dag-execution-paused (count new-completed) (count failed-ids)
-                                       artifacts (:reason decision))}))))
+         :result (dag-execution-paused new-completed failed-ids
+                                       artifacts decision)}))))
 
 (defn emit-completed-checkpoints!
   "Emit task-completed events for checkpointing."

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -29,6 +29,7 @@
    [ai.miniforge.config.interface :as config]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]))
@@ -463,8 +464,22 @@
   "Default directory for workflow event files."
   (delay (str (config/miniforge-home) "/events")))
 
+(defn checkpoint-resume-context
+  "Build resume context from authoritative checkpoint data when available."
+  [workflow-id opts]
+  (when-let [checkpoint-data (checkpoint-store/load-checkpoint-data workflow-id opts)]
+    (let [dag-result (get-in checkpoint-data [:machine-snapshot :execution/dag-result])
+          completed-task-ids (set (:completed-task-ids dag-result))
+          artifacts (vec (get dag-result :artifacts []))]
+      (when (or (seq completed-task-ids) (seq artifacts))
+        {:pre-completed-ids completed-task-ids
+         :pre-completed-artifacts artifacts
+         :resumed? true
+         :resume-source :checkpoint}))))
+
 (defn resume-context-from-event-file
-  "Build resume context from a workflow's event file.
+  "Build resume context from durable checkpoint data, falling back to
+   legacy event-file reconstruction when checkpoint DAG state is absent.
 
    Arguments:
    - workflow-id: UUID of the workflow to resume
@@ -476,16 +491,17 @@
     :resumed? true}"
   ([workflow-id] (resume-context-from-event-file workflow-id {}))
   ([workflow-id opts]
-   (let [events-dir (or (:events-dir opts) @default-events-dir)
-         file-path (str events-dir "/" workflow-id ".edn")
-         events (read-event-file file-path)]
-     (if (seq events)
-       (let [completed-ids (extract-completed-task-ids events)
-             artifacts (extract-completed-artifacts events)]
-         {:pre-completed-ids completed-ids
-          :pre-completed-artifacts artifacts
-          :resumed? true
-          :resume-source file-path})
-       {:pre-completed-ids #{}
-        :pre-completed-artifacts []
-        :resumed? false}))))
+   (or (checkpoint-resume-context workflow-id opts)
+       (let [events-dir (or (:events-dir opts) @default-events-dir)
+             file-path (str events-dir "/" workflow-id ".edn")
+             events (read-event-file file-path)]
+         (if (seq events)
+           (let [completed-ids (extract-completed-task-ids events)
+                 artifacts (extract-completed-artifacts events)]
+             {:pre-completed-ids completed-ids
+              :pre-completed-artifacts artifacts
+              :resumed? true
+              :resume-source file-path})
+           {:pre-completed-ids #{}
+            :pre-completed-artifacts []
+            :resumed? false})))))

--- a/components/workflow/src/ai/miniforge/workflow/execution.clj
+++ b/components/workflow/src/ai/miniforge/workflow/execution.clj
@@ -517,9 +517,11 @@
   "Apply a failed DAG result to the execution context."
   [ctx dag-result transition-to-failed-fn]
   (transition-to-failed-fn
-   (update ctx :execution/errors conj
-           {:type :dag-execution-failed
-            :dag-result dag-result})))
+   (-> ctx
+       (assoc :execution/dag-result dag-result)
+       (update :execution/errors conj
+               {:type :dag-execution-failed
+                :dag-result dag-result}))))
 
 (defn try-dag-execution
   "After plan phase, execute all plans via the DAG executor.

--- a/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/checkpoint_store_test.clj
@@ -46,6 +46,11 @@
                               (assoc-in [:execution/phase-results :done]
                                         {:status :completed
                                          :summary "done"})
+                              (assoc :execution/dag-result
+                                     {:paused? true
+                                      :completed-task-ids [:task-a]
+                                      :artifacts [{:artifact/id "art-1"}]
+                                      :pause-reason :rate-limit})
                               (assoc :execution/current-phase :done
                                      :execution/started-at (java.time.Instant/now)
                                      :execution/output
@@ -60,7 +65,12 @@
                  (get-in checkpoint-data [:machine-snapshot :execution/id])))
           (is (= {:status :completed
                   :summary "done"}
-                 (get-in checkpoint-data [:phase-results :done]))))
+                 (get-in checkpoint-data [:phase-results :done])))
+          (is (= {:paused? true
+                  :completed-task-ids [:task-a]
+                  :artifacts [{:artifact/id "art-1"}]
+                  :pause-reason :rate-limit}
+                 (get-in checkpoint-data [:machine-snapshot :execution/dag-result]))))
         (testing "serializes nested instant values into EDN-readable strings"
           (is (string? (get-in checkpoint-data
                                [:machine-snapshot :execution/started-at])))

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_execution_test.clj
@@ -66,7 +66,8 @@
                       plan {:logger logger})]
           (is (not (:success? result)))
           (is (true? (:paused? result)))
-          (is (string? (:pause-reason result))))))))
+          (is (string? (:pause-reason result)))
+          (is (= [] (:completed-task-ids result))))))))
 
 (deftest test-dag-execution-partial-rate-limit
   (testing "DAG pauses when some tasks succeed and others hit rate limits"
@@ -102,7 +103,10 @@
           (is (not (:success? result)))
           (is (true? (:paused? result)))
           ;; One task completed, one rate-limited
-          (is (= 1 (:tasks-completed result))))))))
+          (is (= 1 (:tasks-completed result)))
+          (is (= 1 (count (:completed-task-ids result))))
+          (is (contains? #{task-a task-b}
+                         (first (:completed-task-ids result)))))))))
 
 (deftest test-dag-execution-pre-completed-ids
   (testing "DAG skips tasks in pre-completed-ids set"

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_resume_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_resume_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.workflow.dag-resilience-resume-test
   "Tests for resume helpers: safe-read-edn, read-event-file, extract functions, and resume context."
   (:require
+   [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
    [clojure.test :refer [deftest testing is]]
    [clojure.java.io :as io]
    [ai.miniforge.workflow.dag-resilience :as resilience]))
@@ -149,6 +150,19 @@
 ;------------------------------------------------------------------------------ Layer 3: Resume context end-to-end
 
 (deftest test-resume-context-end-to-end
+  (testing "checkpoint data is authoritative when persisted DAG resume state exists"
+    (let [workflow-id (str (random-uuid))
+          checkpoint-data {:machine-snapshot {:execution/dag-result
+                                             {:completed-task-ids [:task-a :task-c]
+                                              :artifacts [{:code/id "art-1"}]
+                                              :pause-reason :rate-limit}}}]
+      (with-redefs [checkpoint-store/load-checkpoint-data
+                    (fn [_workflow-run-id _opts] checkpoint-data)]
+        (let [ctx (resilience/resume-context-from-event-file workflow-id)]
+          (is (= #{:task-a :task-c} (:pre-completed-ids ctx)))
+          (is (= [{:code/id "art-1"}] (:pre-completed-artifacts ctx)))
+          (is (true? (:resumed? ctx)))
+          (is (= :checkpoint (:resume-source ctx)))))))
   (testing "builds full resume context from event file"
     (let [dir (temp-dir)]
       (try
@@ -171,7 +185,8 @@
           (is (= 2 (count artifacts))))
         (finally (cleanup! dir)))))
   (testing "resume-context-from-event-file returns non-resumed for missing file"
-    (let [ctx (resilience/resume-context-from-event-file "nonexistent-workflow-id")]
-      (is (= #{} (:pre-completed-ids ctx)))
-      (is (= [] (:pre-completed-artifacts ctx)))
-      (is (false? (:resumed? ctx))))))
+    (with-redefs [checkpoint-store/load-checkpoint-data (fn [_workflow-run-id _opts] nil)]
+      (let [ctx (resilience/resume-context-from-event-file "nonexistent-workflow-id")]
+        (is (= #{} (:pre-completed-ids ctx)))
+        (is (= [] (:pre-completed-artifacts ctx)))
+        (is (false? (:resumed? ctx)))))))

--- a/docs/pull-requests/2026-04-25-refactor-dag-resume-machine-snapshot-convergence.md
+++ b/docs/pull-requests/2026-04-25-refactor-dag-resume-machine-snapshot-convergence.md
@@ -1,0 +1,42 @@
+# Refactor DAG Resume To Machine Snapshot Convergence
+
+## Summary
+
+- make checkpointed machine snapshots carry the DAG pause/resume state
+  needed for resume, instead of depending on event replay as the primary
+  source of truth
+- reconstruct completed DAG task ids, recovered DAG artifacts, and DAG
+  pause metadata from checkpointed machine state in
+  `workflow-resume`
+- thread recovered DAG artifacts through the CLI resume path so resumed
+  configurable workflows preserve prior DAG outputs
+- keep legacy event-file reconstruction only as a fallback compatibility
+  path
+
+## Implementation Notes
+
+- paused DAG results now record completed task ids, pause reason,
+  wait metadata, and recovered artifacts in
+  [components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj](/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj)
+- failed DAG execution stores the DAG result on the execution context so
+  checkpoint persistence can capture it in
+  [components/workflow/src/ai/miniforge/workflow/execution.clj](/components/workflow/src/ai/miniforge/workflow/execution.clj)
+- checkpoint persistence now keeps `:execution/dag-result` in the durable
+  machine snapshot in
+  [components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj](/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj)
+- `workflow-resume` prefers checkpointed DAG state and only falls back to
+  event replay when the snapshot lacks DAG resume data
+- the CLI resume command now passes recovered DAG artifacts through
+  `:pre-completed-artifacts`
+
+## Validation
+
+- `clj-kondo --lint` on the touched workflow, workflow-resume, and CLI files
+- `clojure -M:dev:test -e "(require '[clojure.test :as t]`
+  `'ai.miniforge.workflow.dag-resilience-execution-test`
+  `'ai.miniforge.workflow.dag-resilience-resume-test`
+  `'ai.miniforge.workflow.checkpoint-store-test`
+  `'ai.miniforge.workflow-resume.core-test`
+  `'ai.miniforge.cli.main.commands.resume-test) ..."`
+- `bb test components/workflow components/workflow-resume bases/cli`
+- `bb pre-commit`


### PR DESCRIPTION
# Refactor DAG Resume To Machine Snapshot Convergence

## Summary

- make checkpointed machine snapshots carry the DAG pause/resume state
  needed for resume, instead of depending on event replay as the primary
  source of truth
- reconstruct completed DAG task ids, recovered DAG artifacts, and DAG
  pause metadata from checkpointed machine state in
  `workflow-resume`
- thread recovered DAG artifacts through the CLI resume path so resumed
  configurable workflows preserve prior DAG outputs
- keep legacy event-file reconstruction only as a fallback compatibility
  path

## Implementation Notes

- paused DAG results now record completed task ids, pause reason,
  wait metadata, and recovered artifacts in
  [components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj](/components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj)
- failed DAG execution stores the DAG result on the execution context so
  checkpoint persistence can capture it in
  [components/workflow/src/ai/miniforge/workflow/execution.clj](/components/workflow/src/ai/miniforge/workflow/execution.clj)
- checkpoint persistence now keeps `:execution/dag-result` in the durable
  machine snapshot in
  [components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj](/components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj)
- `workflow-resume` prefers checkpointed DAG state and only falls back to
  event replay when the snapshot lacks DAG resume data
- the CLI resume command now passes recovered DAG artifacts through
  `:pre-completed-artifacts`

## Validation

- `clj-kondo --lint` on the touched workflow, workflow-resume, and CLI files
- `clojure -M:dev:test -e "(require '[clojure.test :as t]`
  `'ai.miniforge.workflow.dag-resilience-execution-test`
  `'ai.miniforge.workflow.dag-resilience-resume-test`
  `'ai.miniforge.workflow.checkpoint-store-test`
  `'ai.miniforge.workflow-resume.core-test`
  `'ai.miniforge.cli.main.commands.resume-test) ..."`
- `bb test components/workflow components/workflow-resume bases/cli`
- `bb pre-commit`
