### PR TITLE
refactor: align loop and task lifecycles with fsm defs

### DIFF
--- a/components/loop/resources/config/loop/inner.edn
+++ b/components/loop/resources/config/loop/inner.edn
@@ -1,0 +1,30 @@
+{:loop/inner
+ {:default-max-iterations 5
+  :initial-loop-state :pending
+  :default-loop-metrics
+  {:tokens 0
+   :cost-usd 0.0
+   :duration-ms 0
+   :generate-calls 0
+   :repair-calls 0}
+  :machine-definition
+  {:fsm/id :loop/inner
+   :fsm/initial :pending
+   :fsm/states
+   {:pending
+    {:on {:generate-requested :generating}}
+    :generating
+    {:on {:generation-completed :validating
+          :generation-failed :failed}}
+    :validating
+    {:on {:validation-passed :complete
+          :validation-failed :repairing
+          :validation-failed-unrecoverably :failed
+          :validation-escalated :escalated}}
+    :repairing
+    {:on {:repair-succeeded :generating
+          :repair-failed :failed
+          :repair-escalated :escalated}}
+    :complete {:type :final}
+    :failed {:type :final}
+    :escalated {:type :final}}}}}

--- a/components/loop/resources/config/loop/messages/en-US.edn
+++ b/components/loop/resources/config/loop/messages/en-US.edn
@@ -15,4 +15,25 @@
   ;; Repair messages
   :repair/max-attempts-exceeded   "Maximum repair attempts exceeded"
   :repair/strategies-exhausted    "All repair strategies exhausted"
-  :repair/escalated               "Repair escalated to outer loop"}}
+  :repair/escalated               "Repair escalated to outer loop"
+
+  ;; Inner loop lifecycle
+  :inner/invalid-transition       "Invalid state transition"
+  :inner/starting-generation      "Starting generation"
+  :inner/generation-complete      "Generation complete"
+  :inner/generation-failed        "Generation failed"
+  :inner/starting-validation      "Starting validation"
+  :inner/all-gates-passed         "All gates passed"
+  :inner/validation-failed        "Validation failed"
+  :inner/attempting-repair        "Attempting repair"
+  :inner/escalating-termination   "Escalating due to termination condition"
+  :inner/repair-successful        "Repair successful"
+  :inner/repair-requested-escalation "Repair requested escalation"
+  :inner/repair-strategies-exhausted "Repair strategies exhausted"
+  :inner/repair-failed            "Repair failed"
+  :inner/completed-successfully   "Inner loop completed successfully"
+  :inner/terminated               "Inner loop terminated"
+  :inner/escalation-already-handled "Escalation already handled"
+  :inner/resuming-after-escalation "Resuming after escalation"
+  :inner/starting-loop            "Starting inner loop"
+  :inner/unknown-state            "Unknown loop state"}}

--- a/components/loop/src/ai/miniforge/loop/inner.clj
+++ b/components/loop/src/ai/miniforge/loop/inner.clj
@@ -27,7 +27,9 @@
    [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.loop.escalation :as escalation]
+   [ai.miniforge.loop.inner-config :as inner-config]
    [ai.miniforge.loop.gates :as gates]
+   [ai.miniforge.loop.messages :as loop-messages]
    [ai.miniforge.loop.repair :as repair]
    [ai.miniforge.response.interface :as response]))
 
@@ -35,42 +37,19 @@
 ;; State machine definition and derived transition helpers
 
 (def default-max-iterations
-  5)
+  (inner-config/default-max-iterations))
 
 (def initial-loop-state
-  :pending)
+  (inner-config/initial-loop-state))
 
 (def default-loop-metrics
-  {:tokens 0
-   :cost-usd 0.0
-   :duration-ms 0
-   :generate-calls 0
-   :repair-calls 0})
+  (inner-config/default-loop-metrics))
 
 (def invalid-transition-message
-  "Invalid state transition")
+  (loop-messages/t :inner/invalid-transition))
 
 (def inner-loop-machine-definition
-  {:fsm/id :loop/inner
-   :fsm/initial initial-loop-state
-   :fsm/states
-   {:pending
-    {:on {:generate-requested :generating}}
-    :generating
-    {:on {:generation-completed :validating
-          :generation-failed :failed}}
-    :validating
-    {:on {:validation-passed :complete
-          :validation-failed :repairing
-          :validation-failed-unrecoverably :failed
-          :validation-escalated :escalated}}
-    :repairing
-    {:on {:repair-succeeded :generating
-          :repair-failed :failed
-          :repair-escalated :escalated}}
-    :complete {:type :final}
-    :failed {:type :final}
-    :escalated {:type :final}}})
+  (inner-config/machine-definition))
 
 (def inner-loop-machine
   (fsm/define-machine inner-loop-machine-definition))
@@ -285,7 +264,7 @@
         start (System/currentTimeMillis)]
     (when logger
       (log/info logger :loop :inner/iteration-started
-                {:message "Starting generation"
+                {:message (loop-messages/t :inner/starting-generation)
                  :data {:iteration (:loop/iteration loop-state)
                         :task-id (get-in loop-state [:loop/task :task/id])}}))
 
@@ -300,7 +279,7 @@
               artifact (:artifact result)]
           (when logger
             (log/debug logger :loop :inner/iteration-started
-                       {:message "Generation complete"
+                       {:message (loop-messages/t :inner/generation-complete)
                         :data {:tokens (:tokens result 0)
                                :duration-ms duration}}))
           (-> loop-state
@@ -312,7 +291,7 @@
         (catch Exception e
           (when logger
             (log/error logger :loop :inner/validation-failed
-                       {:message "Generation failed"
+                       {:message (loop-messages/t :inner/generation-failed)
                         :data {:error (.getMessage e)}}))
           (let [anom (response/from-exception e)]
             (-> loop-state
@@ -337,7 +316,7 @@
         artifact (:loop/artifact loop-state)]
     (when logger
       (log/debug logger :loop :inner/validation-passed
-                 {:message "Starting validation"
+                 {:message (loop-messages/t :inner/starting-validation)
                   :data {:gate-count (count gates)}}))
 
     (let [results (gates/run-gates gates artifact context)
@@ -347,7 +326,7 @@
         (do
           (when logger
             (log/info logger :loop :inner/validation-passed
-                      {:message "All gates passed"
+                      {:message (loop-messages/t :inner/all-gates-passed)
                        :data {:iteration (:loop/iteration loop-state)}}))
           (-> loop-state
               (set-termination :gates-passed)
@@ -356,7 +335,7 @@
         (do
           (when logger
             (log/warn logger :loop :inner/validation-failed
-                      {:message "Validation failed"
+                      {:message (loop-messages/t :inner/validation-failed)
                        :data {:failed-gates (:failed-gates results)
                               :error-count (count (:errors results))}}))
           (-> loop-state
@@ -380,7 +359,7 @@
         iteration (:loop/iteration loop-state)]
     (when logger
       (log/info logger :loop :inner/repair-attempted
-                {:message "Attempting repair"
+                {:message (loop-messages/t :inner/attempting-repair)
                  :data {:iteration iteration
                         :error-count (count errors)}}))
 
@@ -390,7 +369,7 @@
       (do
         (when logger
           (log/warn logger :loop :inner/escalated
-                    {:message "Escalating due to termination condition"
+                    {:message (loop-messages/t :inner/escalating-termination)
                      :data {:reason (:reason termination)}}))
         (-> loop-state
             (set-termination (:reason termination))
@@ -413,7 +392,7 @@
           (do
             (when logger
               (log/info logger :loop :inner/repair-attempted
-                        {:message "Repair successful"
+                        {:message (loop-messages/t :inner/repair-successful)
                          :data {:strategy (:strategy result)}}))
             (-> loop-state
                 (set-artifact (:artifact result))
@@ -424,10 +403,10 @@
           (do
             (when logger
               (log/warn logger :loop :inner/escalated
-                        {:message "Repair requested escalation"}))
+                        {:message (loop-messages/t :inner/repair-requested-escalation)}))
             (-> loop-state
                 (set-termination :max-iterations
-                                 :message "Repair strategies exhausted")
+                                 :message (loop-messages/t :inner/repair-strategies-exhausted))
                 (transition :escalated)))
 
           ;; Repair failed, try again or escalate
@@ -435,7 +414,7 @@
           (do
             (when logger
               (log/warn logger :loop :inner/validation-failed
-                        {:message "Repair failed"
+                        {:message (loop-messages/t :inner/repair-failed)
                          :data {:attempts (:attempts result)}}))
             ;; Check if we should escalate
             (if (max-iterations-exceeded? loop-state)
@@ -457,10 +436,10 @@
     (when logger
       (if success?
         (log/info logger :loop :inner/validation-passed
-                  {:message "Inner loop completed successfully"
+                  {:message (loop-messages/t :inner/completed-successfully)
                    :data {:iterations (:loop/iteration state)}})
         (log/warn logger :loop :inner/escalated
-                  {:message "Inner loop terminated"
+                  {:message (loop-messages/t :inner/terminated)
                    :data {:state current-state
                           :reason (get-in state [:loop/termination :reason])}})))
     {:success success?
@@ -531,7 +510,7 @@
     (if (>= escalation-count 1)
       {:terminal (handle-terminal-state
                   (set-termination state :max-iterations
-                                   :message "Escalation already handled")
+                                   :message (loop-messages/t :inner/escalation-already-handled))
                   logger)}
       (let [result (escalation/handle-escalation state ctx)]
         (if (= :continue (:action result))
@@ -540,7 +519,7 @@
                 next-ctx (assoc ctx :escalation-hints hints)]
             (when logger
               (log/info logger :loop :inner/escalated
-                        {:message "Resuming after escalation"
+                        {:message (loop-messages/t :inner/resuming-after-escalation)
                          :data {:hints-provided? (boolean (seq hints))}}))
             {:next-state resumed-state
              :next-ctx next-ctx})
@@ -576,7 +555,7 @@
   (let [logger (:logger context)]
     (when logger
       (log/info logger :loop :inner/iteration-started
-                {:message "Starting inner loop"
+                {:message (loop-messages/t :inner/starting-loop)
                  :data {:task-id (get-in loop-state [:loop/task :task/id])
                         :max-iterations (get-in loop-state [:loop/config :max-iterations])}}))
 
@@ -622,7 +601,7 @@
 
           ;; Unknown state (shouldn't happen)
           :else
-          (throw (ex-info "Unknown loop state"
+          (throw (ex-info (loop-messages/t :inner/unknown-state)
                           {:state current-state
                            :loop-state state})))))))
 

--- a/components/loop/src/ai/miniforge/loop/inner.clj
+++ b/components/loop/src/ai/miniforge/loop/inner.clj
@@ -24,6 +24,7 @@
    Layer 1: Step functions (generate, validate, repair)
    Layer 2: Loop runner"
   (:require
+   [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.loop.escalation :as escalation]
    [ai.miniforge.loop.gates :as gates]
@@ -31,17 +32,113 @@
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; State machine transitions (pure functions)
+;; State machine definition and derived transition helpers
+
+(def default-max-iterations
+  5)
+
+(def initial-loop-state
+  :pending)
+
+(def default-loop-metrics
+  {:tokens 0
+   :cost-usd 0.0
+   :duration-ms 0
+   :generate-calls 0
+   :repair-calls 0})
+
+(def invalid-transition-message
+  "Invalid state transition")
+
+(def inner-loop-machine-definition
+  {:fsm/id :loop/inner
+   :fsm/initial initial-loop-state
+   :fsm/states
+   {:pending
+    {:on {:generate-requested :generating}}
+    :generating
+    {:on {:generation-completed :validating
+          :generation-failed :failed}}
+    :validating
+    {:on {:validation-passed :complete
+          :validation-failed :repairing
+          :validation-failed-unrecoverably :failed
+          :validation-escalated :escalated}}
+    :repairing
+    {:on {:repair-succeeded :generating
+          :repair-failed :failed
+          :repair-escalated :escalated}}
+    :complete {:type :final}
+    :failed {:type :final}
+    :escalated {:type :final}}})
+
+(def inner-loop-machine
+  (fsm/define-machine inner-loop-machine-definition))
+
+(defn- final-state-definition?
+  [[_ state-definition]]
+  (= :final (:type state-definition)))
+
+(defn- transition-targets
+  [state-definition]
+  (->> (get state-definition :on {})
+       vals
+       (map (fn transition-target [target-or-config]
+              (if (keyword? target-or-config)
+                target-or-config
+                (:target target-or-config))))
+       set))
+
+(defn- derive-valid-transitions
+  [machine-definition]
+  (reduce-kv
+   (fn [transitions state state-definition]
+     (assoc transitions state (transition-targets state-definition)))
+   {}
+   (:fsm/states machine-definition)))
+
+(defn- derive-transition-events
+  [machine-definition]
+  (reduce-kv
+   (fn [event-map state state-definition]
+     (reduce-kv
+      (fn [state-events event target-or-config]
+        (let [target-state (if (keyword? target-or-config)
+                             target-or-config
+                             (:target target-or-config))]
+          (assoc state-events [state target-state] event)))
+      event-map
+      (get state-definition :on {})))
+   {}
+   (:fsm/states machine-definition)))
 
 (def valid-transitions
   "Valid state transitions in the inner loop state machine."
-  {:pending     #{:generating}
-   :generating  #{:validating :failed}
-   :validating  #{:complete :repairing :failed :escalated}
-   :repairing   #{:generating :escalated :failed}
-   :complete    #{}  ; terminal state
-   :failed      #{}  ; terminal state
-   :escalated   #{}}) ; terminal state
+  (derive-valid-transitions inner-loop-machine-definition))
+
+(def transition-events
+  (derive-transition-events inner-loop-machine-definition))
+
+(def terminal-states
+  (into #{}
+        (comp (filter final-state-definition?)
+              (map first))
+        (:fsm/states inner-loop-machine-definition)))
+
+(defn- invalid-transition-data
+  [from-state to-state]
+  {:from from-state
+   :to to-state
+   :valid-targets (get valid-transitions from-state #{})})
+
+(defn- add-metric-values
+  [metrics metric-updates]
+  (merge-with (fn sum-metric-values [old new]
+                (if (number? old)
+                  (+ old new)
+                  new))
+              metrics
+              metric-updates))
 
 (defn valid-transition?
   "Check if a state transition is valid."
@@ -51,20 +148,19 @@
 (defn terminal-state?
   "Check if a state is terminal (no further transitions possible)."
   [state]
-  (empty? (get valid-transitions state)))
+  (contains? terminal-states state))
 
 (defn transition
   "Attempt a state transition. Returns updated loop state or throws if invalid."
   [loop-state new-state]
-  (let [current-state (:loop/state loop-state)]
-    (if (valid-transition? current-state new-state)
-      (-> loop-state
-          (assoc :loop/state new-state)
-          (assoc :loop/updated-at (java.util.Date.)))
-      (throw (ex-info "Invalid state transition"
-                      {:from current-state
-                       :to new-state
-                       :valid-targets (get valid-transitions current-state)})))))
+  (let [current-state (:loop/state loop-state)
+        transition-event (get transition-events [current-state new-state])]
+    (when-not transition-event
+      (throw (ex-info invalid-transition-message
+                      (invalid-transition-data current-state new-state))))
+    (assoc loop-state
+           :loop/state new-state
+           :loop/updated-at (java.util.Date.))))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Loop state constructors (pure functions)
@@ -76,40 +172,29 @@
    - task - Map with :task/id and :task/type
    - context - Optional context map
 
-   Options (via context):
-   - :max-iterations - Maximum generate/repair cycles (default 5)
-   - :budget - Budget constraints map"
+  Options (via context):
+  - :max-iterations - Maximum generate/repair cycles (default 5)
+  - :budget - Budget constraints map"
   [task context]
-  (let [max-iterations (get context :max-iterations 5)
+  (let [max-iterations (get context :max-iterations default-max-iterations)
         budget (:budget context)]
     {:loop/id (random-uuid)
      :loop/type :inner
-     :loop/state :pending
+     :loop/state initial-loop-state
      :loop/iteration 0
      :loop/task task
      :loop/config (cond-> {:max-iterations max-iterations}
                     budget (assoc :budget budget))
      :loop/gate-results []
      :loop/repair-history []
-     :loop/metrics {:tokens 0
-                    :cost-usd 0.0
-                    :duration-ms 0
-                    :generate-calls 0
-                    :repair-calls 0}
+     :loop/metrics default-loop-metrics
      :loop/created-at (java.util.Date.)
      :loop/updated-at (java.util.Date.)}))
 
 (defn update-metrics
   "Update loop metrics with new values."
   [loop-state metric-updates]
-  (update loop-state :loop/metrics
-          (fn [metrics]
-            (merge-with (fn [old new]
-                          (if (number? old)
-                            (+ old new)
-                            new))
-                        metrics
-                        metric-updates))))
+  (update loop-state :loop/metrics add-metric-values metric-updates))
 
 (defn add-gate-results
   "Add gate results to loop state."
@@ -149,7 +234,8 @@
 (defn max-iterations-exceeded?
   "Check if maximum iterations have been exceeded."
   [loop-state]
-  (let [max-iter (get-in loop-state [:loop/config :max-iterations] 5)
+  (let [max-iter (get-in loop-state [:loop/config :max-iterations]
+                         default-max-iterations)
         current (get loop-state :loop/iteration 0)]
     (>= current max-iter)))
 
@@ -399,7 +485,8 @@
   "Resume the loop after human escalation with provided hints."
   [state hints]
   (let [current-iter (:loop/iteration state)
-        current-max (get-in state [:loop/config :max-iterations] 5)
+        current-max (get-in state [:loop/config :max-iterations]
+                            default-max-iterations)
         current-count (get-in state [:loop/escalation :count] 0)
         target-max (max (inc current-max) (inc current-iter))]
     (-> state

--- a/components/loop/src/ai/miniforge/loop/inner_config.clj
+++ b/components/loop/src/ai/miniforge/loop/inner_config.clj
@@ -1,0 +1,50 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.loop.inner-config
+  "Configuration-as-data for the inner loop lifecycle."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+(def ^:private defaults
+  (delay
+    (if-let [resource (io/resource "config/loop/inner.edn")]
+      (:loop/inner (edn/read-string (slurp resource)))
+      {})))
+
+(defn default-max-iterations
+  []
+  (get @defaults :default-max-iterations 5))
+
+(defn initial-loop-state
+  []
+  (get @defaults :initial-loop-state :pending))
+
+(defn default-loop-metrics
+  []
+  (get @defaults
+       :default-loop-metrics
+       {:tokens 0
+        :cost-usd 0.0
+        :duration-ms 0
+        :generate-calls 0
+        :repair-calls 0}))
+
+(defn machine-definition
+  []
+  (get @defaults :machine-definition {}))

--- a/components/loop/test/ai/miniforge/loop/inner_test.clj
+++ b/components/loop/test/ai/miniforge/loop/inner_test.clj
@@ -21,6 +21,7 @@
             [ai.miniforge.fsm.interface :as fsm]
             [ai.miniforge.loop.inner :as inner]
             [ai.miniforge.loop.gates :as gates]
+            [ai.miniforge.loop.messages :as loop-messages]
             [ai.miniforge.loop.repair :as repair]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -125,13 +126,15 @@
 
     (testing "invalid transition throws"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Invalid state transition"
+                            (re-pattern (java.util.regex.Pattern/quote
+                                         (loop-messages/t :inner/invalid-transition)))
                             (inner/transition loop-state :complete))))
 
     (testing "terminal states reject additional transitions"
       (let [terminal-state (assoc loop-state :loop/state :complete)]
         (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                              #"Invalid state transition"
+                              (re-pattern (java.util.regex.Pattern/quote
+                                           (loop-messages/t :inner/invalid-transition)))
                               (inner/transition terminal-state :generating)))))))
 
 ;------------------------------------------------------------------------------ Layer 1

--- a/components/loop/test/ai/miniforge/loop/inner_test.clj
+++ b/components/loop/test/ai/miniforge/loop/inner_test.clj
@@ -18,6 +18,7 @@
 
 (ns ai.miniforge.loop.inner-test
   (:require [clojure.test :as test :refer [deftest testing is]]
+            [ai.miniforge.fsm.interface :as fsm]
             [ai.miniforge.loop.inner :as inner]
             [ai.miniforge.loop.gates :as gates]
             [ai.miniforge.loop.repair :as repair]))
@@ -45,6 +46,18 @@
   {:artifact/id (random-uuid)
    :artifact/type :code
    :artifact/content "(defn broken ["})
+
+(defn reachable-states
+  [initial-state transitions]
+  (loop [visited #{}
+         pending [initial-state]]
+    (if-let [state (peek pending)]
+      (if (contains? visited state)
+        (recur visited (pop pending))
+        (let [next-states (seq (get transitions state #{}))]
+          (recur (conj visited state)
+                 (into (pop pending) next-states))))
+      visited)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; State transition tests
@@ -91,6 +104,19 @@
   (testing ":generating is not terminal"
     (is (not (inner/terminal-state? :generating)))))
 
+(deftest inner-loop-machine-reachability-test
+  (let [reachable (reachable-states inner/initial-loop-state
+                                    inner/valid-transitions)
+        expected-states #{:pending :generating :validating
+                          :repairing :complete :failed :escalated}]
+    (testing "all machine states are reachable from the initial state"
+      (is (= expected-states reachable)))
+    (testing "shared FSM marks terminal states as final"
+      (is (true? (fsm/final? inner/inner-loop-machine {:_state :complete})))
+      (is (true? (fsm/final? inner/inner-loop-machine {:_state :failed})))
+      (is (true? (fsm/final? inner/inner-loop-machine {:_state :escalated})))
+      (is (false? (fsm/final? inner/inner-loop-machine {:_state :generating}))))))
+
 (deftest transition-test
   (let [loop-state (inner/create-inner-loop test-task {})]
     (testing "valid transition updates state"
@@ -100,7 +126,13 @@
     (testing "invalid transition throws"
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
                             #"Invalid state transition"
-                            (inner/transition loop-state :complete))))))
+                            (inner/transition loop-state :complete))))
+
+    (testing "terminal states reject additional transitions"
+      (let [terminal-state (assoc loop-state :loop/state :complete)]
+        (is (thrown-with-msg? clojure.lang.ExceptionInfo
+                              #"Invalid state transition"
+                              (inner/transition terminal-state :generating)))))))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Loop state creation tests

--- a/components/task/deps.edn
+++ b/components/task/deps.edn
@@ -1,5 +1,5 @@
 {:paths ["src" "resources"]
- :deps {}
+ :deps {ai.miniforge/messages {:local/root "../messages"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/task/resources/config/task/lifecycle.edn
+++ b/components/task/resources/config/task/lifecycle.edn
@@ -1,0 +1,13 @@
+{:task/lifecycle
+ {:initial-task-status :pending
+  :machine-definition
+  {:fsm/id :task/lifecycle
+   :fsm/initial :pending
+   :fsm/states
+   {:pending {:on {:start :running
+                   :block :blocked}}
+    :running {:on {:complete :completed
+                   :fail :failed}}
+    :blocked {:on {:unblock :pending}}
+    :completed {:type :final}
+    :failed {:type :final}}}}}

--- a/components/task/resources/config/task/messages/en-US.edn
+++ b/components/task/resources/config/task/messages/en-US.edn
@@ -1,0 +1,13 @@
+{:task/messages
+ {:task/invalid-transition "Invalid state transition"
+  :task/not-found "Task not found"
+  :task/parent-not-found "Parent task not found"
+  :task/created "Task created"
+  :task/updated "Task updated"
+  :task/deleted "Task deleted"
+  :task/started "Task started"
+  :task/completed "Task completed"
+  :task/failed "Task failed"
+  :task/blocked "Task blocked"
+  :task/unblocked "Task unblocked"
+  :task/decomposed "Task decomposed into sub-tasks"}}

--- a/components/task/src/ai/miniforge/task/core.clj
+++ b/components/task/src/ai/miniforge/task/core.clj
@@ -22,20 +22,105 @@
    Layer 1: Task store operations (CRUD)
    Layer 2: Orchestration (queries, decomposition, state transitions)"
   (:require
+   [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; State machine definitions and pure utilities
 
+(def initial-task-status
+  :pending)
+
+(def invalid-transition-message
+  "Invalid state transition")
+
+(def task-not-found-message
+  "Task not found")
+
+(def parent-task-not-found-message
+  "Parent task not found")
+
+(def task-machine-definition
+  {:fsm/id :task/lifecycle
+   :fsm/initial initial-task-status
+   :fsm/states
+   {:pending {:on {:start :running
+                   :block :blocked}}
+    :running {:on {:complete :completed
+                   :fail :failed}}
+    :blocked {:on {:unblock :pending}}
+    :completed {:type :final}
+    :failed {:type :final}}})
+
+(def task-machine
+  (fsm/define-machine task-machine-definition))
+
+(defn- final-state-definition?
+  [[_ state-definition]]
+  (= :final (:type state-definition)))
+
+(defn- transition-targets
+  [state-definition]
+  (->> (get state-definition :on {})
+       vals
+       (map (fn transition-target [target-or-config]
+              (if (keyword? target-or-config)
+                target-or-config
+                (:target target-or-config))))
+       set))
+
+(defn- derive-valid-transitions
+  [machine-definition]
+  (reduce-kv
+   (fn [transitions state state-definition]
+     (assoc transitions state (transition-targets state-definition)))
+   {}
+   (:fsm/states machine-definition)))
+
+(defn- derive-transition-events
+  [machine-definition]
+  (reduce-kv
+   (fn [event-map state state-definition]
+     (reduce-kv
+      (fn [state-events event target-or-config]
+        (let [target-state (if (keyword? target-or-config)
+                             target-or-config
+                             (:target target-or-config))]
+          (assoc state-events [state target-state] event)))
+      event-map
+      (get state-definition :on {})))
+   {}
+   (:fsm/states machine-definition)))
+
 (def valid-transitions
   "Valid state transitions for tasks.
    Maps from-state to set of allowed to-states."
-  {:pending   #{:running :blocked}
-   :running   #{:completed :failed}
-   :blocked   #{:pending}
-   :completed #{}
-   :failed    #{}})
+  (derive-valid-transitions task-machine-definition))
+
+(def transition-events
+  (derive-transition-events task-machine-definition))
+
+(def terminal-task-statuses
+  (into #{}
+        (comp (filter final-state-definition?)
+              (map first))
+        (:fsm/states task-machine-definition)))
+
+(defn- invalid-transition-data
+  [from-state to-state]
+  {:from from-state
+   :to to-state
+   :valid-targets (get valid-transitions from-state #{})})
+
+(defn- success-task-result
+  [result]
+  (merge {:outcome :success} result))
+
+(defn- failed-task-result
+  [error]
+  {:outcome :failure
+   :error (if (string? error) error (str error))})
 
 (defn valid-transition?
   "Check if a state transition is valid according to the state machine."
@@ -45,25 +130,29 @@
 (defn validate-transition
   "Validate a state transition, throwing if invalid."
   [from-state to-state]
-  (when-not (valid-transition? from-state to-state)
-    (throw (ex-info "Invalid state transition"
-                    {:from from-state
-                     :to to-state
-                     :valid-targets (get valid-transitions from-state #{})})))
+  (let [transition-event (get transition-events [from-state to-state])]
+    (when-not transition-event
+      (throw (ex-info invalid-transition-message
+                      (invalid-transition-data from-state to-state)))))
   to-state)
 
 (defn make-task
   "Create a new task map with required fields.
    Generates a UUID if not provided."
   [{:keys [task/id task/type task/status task/constraints]
-    :or {status :pending}
+    :or {status initial-task-status}
     :as task-data}]
   (let [task-id (or id (random-uuid))
-        task (merge {:task/id task-id
-                     :task/type type
-                     :task/status status}
-                    (when constraints {:task/constraints constraints})
-                    (dissoc task-data :task/id :task/type :task/status :task/constraints))]
+        base-task {:task/id task-id
+                   :task/type type
+                   :task/status status}
+        constraint-data (when constraints {:task/constraints constraints})
+        additional-task-data (dissoc task-data
+                                     :task/id
+                                     :task/type
+                                     :task/status
+                                     :task/constraints)
+        task (merge base-task constraint-data additional-task-data)]
     (schema/validate schema/Task task)))
 
 (defn compute-child-tasks
@@ -124,7 +213,7 @@
                      :data {:task-id task-id
                             :changes (keys changes)}}))
        validated)
-     (throw (ex-info "Task not found" {:task-id task-id})))))
+     (throw (ex-info task-not-found-message {:task-id task-id})))))
 
 (defn delete-task!
   "Delete a task by ID.
@@ -139,7 +228,7 @@
                    {:message "Task deleted"
                     :data {:task-id task-id}}))
        task)
-     (throw (ex-info "Task not found" {:task-id task-id})))))
+     (throw (ex-info task-not-found-message {:task-id task-id})))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Orchestration (state transitions, queries, decomposition)
@@ -151,7 +240,7 @@
   [task-id to-state additional-changes logger event-key message]
   (let [task (get-task task-id)]
     (when-not task
-      (throw (ex-info "Task not found" {:task-id task-id})))
+      (throw (ex-info task-not-found-message {:task-id task-id})))
     (validate-transition (:task/status task) to-state)
     (let [changes (merge {:task/status to-state} additional-changes)
           updated (update-task! task-id changes)]
@@ -177,8 +266,7 @@
    Stores the result in :task/result."
   ([task-id result] (complete-task! task-id result nil))
   ([task-id result logger]
-   (let [task-result {:outcome :success}
-         full-result (merge task-result result)]
+   (let [full-result (success-task-result result)]
      (transition-task! task-id :completed
                        {:task/result full-result}
                        logger :task/completed "Task completed"))))
@@ -188,8 +276,7 @@
    Stores the error information in :task/result."
   ([task-id error] (fail-task! task-id error nil))
   ([task-id error logger]
-   (let [task-result {:outcome :failure
-                      :error (if (string? error) error (str error))}]
+   (let [task-result (failed-task-result error)]
      (transition-task! task-id :failed
                        {:task/result task-result}
                        logger :task/failed "Task failed"))))
@@ -259,7 +346,8 @@
   ([parent-task-id sub-tasks logger]
    (let [parent (get-task parent-task-id)]
      (when-not parent
-       (throw (ex-info "Parent task not found" {:task-id parent-task-id})))
+       (throw (ex-info parent-task-not-found-message
+                       {:task-id parent-task-id})))
      ;; Compute child task specs with parent references (pure)
      (let [child-specs (compute-child-tasks parent-task-id sub-tasks)
            ;; Create all child tasks (side effects)

--- a/components/task/src/ai/miniforge/task/core.clj
+++ b/components/task/src/ai/miniforge/task/core.clj
@@ -23,6 +23,8 @@
    Layer 2: Orchestration (queries, decomposition, state transitions)"
   (:require
    [ai.miniforge.fsm.interface :as fsm]
+   [ai.miniforge.task.lifecycle-config :as lifecycle-config]
+   [ai.miniforge.task.messages :as messages]
    [ai.miniforge.schema.interface :as schema]
    [ai.miniforge.logging.interface :as log]))
 
@@ -30,28 +32,19 @@
 ;; State machine definitions and pure utilities
 
 (def initial-task-status
-  :pending)
+  (lifecycle-config/initial-task-status))
 
 (def invalid-transition-message
-  "Invalid state transition")
+  (messages/t :task/invalid-transition))
 
 (def task-not-found-message
-  "Task not found")
+  (messages/t :task/not-found))
 
 (def parent-task-not-found-message
-  "Parent task not found")
+  (messages/t :task/parent-not-found))
 
 (def task-machine-definition
-  {:fsm/id :task/lifecycle
-   :fsm/initial initial-task-status
-   :fsm/states
-   {:pending {:on {:start :running
-                   :block :blocked}}
-    :running {:on {:complete :completed
-                   :fail :failed}}
-    :blocked {:on {:unblock :pending}}
-    :completed {:type :final}
-    :failed {:type :final}}})
+  (lifecycle-config/machine-definition))
 
 (def task-machine
   (fsm/define-machine task-machine-definition))
@@ -70,6 +63,20 @@
                 (:target target-or-config))))
        set))
 
+(defn- target-state
+  [target-or-config]
+  (if (keyword? target-or-config)
+    target-or-config
+    (:target target-or-config)))
+
+(defn- state-transition-events
+  [state state-definition]
+  (reduce-kv
+   (fn [events event target-or-config]
+     (assoc events [state (target-state target-or-config)] event))
+   {}
+   (get state-definition :on {})))
+
 (defn- derive-valid-transitions
   [machine-definition]
   (reduce-kv
@@ -82,14 +89,7 @@
   [machine-definition]
   (reduce-kv
    (fn [event-map state state-definition]
-     (reduce-kv
-      (fn [state-events event target-or-config]
-        (let [target-state (if (keyword? target-or-config)
-                             target-or-config
-                             (:target target-or-config))]
-          (assoc state-events [state target-state] event)))
-      event-map
-      (get state-definition :on {})))
+     (merge event-map (state-transition-events state state-definition)))
    {}
    (:fsm/states machine-definition)))
 
@@ -139,14 +139,15 @@
 (defn make-task
   "Create a new task map with required fields.
    Generates a UUID if not provided."
-  [{:keys [task/id task/type task/status task/constraints]
+  [{:keys [task/type task/status task/constraints]
     :or {status initial-task-status}
     :as task-data}]
-  (let [task-id (or id (random-uuid))
+  (let [task-id (get task-data :task/id (random-uuid))
         base-task {:task/id task-id
                    :task/type type
                    :task/status status}
-        constraint-data (when constraints {:task/constraints constraints})
+        constraint-data (when constraints
+                          {:task/constraints constraints})
         additional-task-data (dissoc task-data
                                      :task/id
                                      :task/type
@@ -187,7 +188,7 @@
      (swap! task-store assoc (:task/id task) task)
      (when logger
        (log/info logger :agent :task/created
-                 {:message "Task created"
+                 {:message (messages/t :task/created)
                   :data {:task-id (:task/id task)
                          :task-type (:task/type task)}}))
      task)))
@@ -209,7 +210,7 @@
        (swap! task-store assoc task-id validated)
        (when logger
          (log/debug logger :agent :task/updated
-                    {:message "Task updated"
+                    {:message (messages/t :task/updated)
                      :data {:task-id task-id
                             :changes (keys changes)}}))
        validated)
@@ -225,7 +226,7 @@
        (swap! task-store dissoc task-id)
        (when logger
          (log/info logger :agent :task/deleted
-                   {:message "Task deleted"
+                   {:message (messages/t :task/deleted)
                     :data {:task-id task-id}}))
        task)
      (throw (ex-info task-not-found-message {:task-id task-id})))))
@@ -259,7 +260,7 @@
   ([task-id agent-id logger]
    (transition-task! task-id :running
                      {:task/agent agent-id}
-                     logger :task/started "Task started")))
+                     logger :task/started (messages/t :task/started))))
 
 (defn complete-task!
   "Transition a task from :running to :completed.
@@ -269,7 +270,7 @@
    (let [full-result (success-task-result result)]
      (transition-task! task-id :completed
                        {:task/result full-result}
-                       logger :task/completed "Task completed"))))
+                       logger :task/completed (messages/t :task/completed)))))
 
 (defn fail-task!
   "Transition a task from :running to :failed.
@@ -279,7 +280,7 @@
    (let [task-result (failed-task-result error)]
      (transition-task! task-id :failed
                        {:task/result task-result}
-                       logger :task/failed "Task failed"))))
+                       logger :task/failed (messages/t :task/failed)))))
 
 (defn block-task!
   "Transition a task from :pending to :blocked.
@@ -288,7 +289,7 @@
   ([task-id reason logger]
    (transition-task! task-id :blocked
                      {:task/blocked-reason reason}
-                     logger :task/blocked "Task blocked")))
+                     logger :task/blocked (messages/t :task/blocked))))
 
 (defn unblock-task!
   "Transition a task from :blocked to :pending.
@@ -297,7 +298,7 @@
   ([task-id logger]
    (let [updated (transition-task! task-id :pending
                                    {}
-                                   logger :task/unblocked "Task unblocked")]
+                                   logger :task/unblocked (messages/t :task/unblocked))]
      ;; Remove the blocked-reason key
      (update-task! (:task/id updated) (dissoc updated :task/blocked-reason))
      updated)))
@@ -360,7 +361,7 @@
                                         logger)]
        (when logger
          (log/info logger :agent :task/decomposed
-                   {:message "Task decomposed into sub-tasks"
+                   {:message (messages/t :task/decomposed)
                     :data {:parent-id parent-task-id
                            :child-count (count child-ids)
                            :child-ids child-ids}}))

--- a/components/task/src/ai/miniforge/task/lifecycle_config.clj
+++ b/components/task/src/ai/miniforge/task/lifecycle_config.clj
@@ -1,0 +1,36 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.task.lifecycle-config
+  "Configuration-as-data for task lifecycle state handling."
+  (:require [clojure.edn :as edn]
+            [clojure.java.io :as io]))
+
+(def ^:private defaults
+  (delay
+    (if-let [resource (io/resource "config/task/lifecycle.edn")]
+      (:task/lifecycle (edn/read-string (slurp resource)))
+      {})))
+
+(defn initial-task-status
+  []
+  (get @defaults :initial-task-status :pending))
+
+(defn machine-definition
+  []
+  (get @defaults :machine-definition {}))

--- a/components/task/src/ai/miniforge/task/messages.clj
+++ b/components/task/src/ai/miniforge/task/messages.clj
@@ -1,0 +1,26 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.task.messages
+  "Component-level message catalog for task lifecycle."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a task message by key, with optional param substitution."
+  (messages/create-translator "config/task/messages/en-US.edn"
+                              :task/messages))

--- a/components/task/test/ai/miniforge/task/core_test.clj
+++ b/components/task/test/ai/miniforge/task/core_test.clj
@@ -19,7 +19,13 @@
 (ns ai.miniforge.task.core-test
   (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
             [ai.miniforge.fsm.interface :as fsm]
-            [ai.miniforge.task.core :as core]))
+            [ai.miniforge.task.core :as core]
+            [ai.miniforge.task.messages :as task-messages]))
+
+(defn message-pattern
+  [message-key]
+  (re-pattern (java.util.regex.Pattern/quote
+               (task-messages/t message-key))))
 
 ;------------------------------------------------------------------------------ Fixtures
 
@@ -72,7 +78,7 @@
 
   (testing "invalid transition throws"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"Invalid state transition"
+                          (message-pattern :task/invalid-transition)
                           (core/validate-transition :pending :completed)))))
 
 (deftest task-machine-reachability-test
@@ -137,7 +143,7 @@
 
   (testing "throws for non-existent task"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"Task not found"
+                          (message-pattern :task/not-found)
                           (core/update-task! (random-uuid) {:task/status :running})))))
 
 (deftest delete-task!-test
@@ -149,7 +155,7 @@
 
   (testing "throws for non-existent task"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"Task not found"
+                          (message-pattern :task/not-found)
                           (core/delete-task! (random-uuid))))))
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -168,7 +174,7 @@
           agent-id (random-uuid)]
       (core/start-task! (:task/id task) agent-id)
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Invalid state transition"
+                            (message-pattern :task/invalid-transition)
                             (core/start-task! (:task/id task) agent-id))))))
 
 (deftest complete-task!-test
@@ -182,7 +188,7 @@
   (testing "throws for non-running task"
     (let [task (core/create-task! {:task/type :implement})]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Invalid state transition"
+                            (message-pattern :task/invalid-transition)
                             (core/complete-task! (:task/id task) {}))))))
 
 (deftest fail-task!-test
@@ -197,7 +203,7 @@
   (testing "throws for non-running task"
     (let [task (core/create-task! {:task/type :implement})]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Invalid state transition"
+                            (message-pattern :task/invalid-transition)
                             (core/fail-task! (:task/id task) "error"))))))
 
 (deftest block-task!-test
@@ -211,7 +217,7 @@
     (let [task (core/create-task! {:task/type :implement})
           _ (core/start-task! (:task/id task) (random-uuid))]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Invalid state transition"
+                            (message-pattern :task/invalid-transition)
                             (core/block-task! (:task/id task) "reason"))))))
 
 (deftest unblock-task!-test
@@ -224,7 +230,7 @@
   (testing "throws for non-blocked task"
     (let [task (core/create-task! {:task/type :implement})]
       (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                            #"Invalid state transition"
+                            (message-pattern :task/invalid-transition)
                             (core/unblock-task! (:task/id task)))))))
 
 ;------------------------------------------------------------------------------ Layer 2
@@ -284,7 +290,7 @@
 
   (testing "throws for non-existent parent"
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
-                          #"Parent task not found"
+                          (message-pattern :task/parent-not-found)
                           (core/decompose-task! (random-uuid)
                                                 [{:task/type :test}])))))
 

--- a/components/task/test/ai/miniforge/task/core_test.clj
+++ b/components/task/test/ai/miniforge/task/core_test.clj
@@ -18,6 +18,7 @@
 
 (ns ai.miniforge.task.core-test
   (:require [clojure.test :as test :refer [deftest testing is use-fixtures]]
+            [ai.miniforge.fsm.interface :as fsm]
             [ai.miniforge.task.core :as core]))
 
 ;------------------------------------------------------------------------------ Fixtures
@@ -28,6 +29,18 @@
   (core/reset-store!))
 
 (use-fixtures :each reset-store-fixture)
+
+(defn reachable-states
+  [initial-state transitions]
+  (loop [visited #{}
+         pending [initial-state]]
+    (if-let [state (peek pending)]
+      (if (contains? visited state)
+        (recur visited (pop pending))
+        (let [next-states (seq (get transitions state #{}))]
+          (recur (conj visited state)
+                 (into (pop pending) next-states))))
+      visited)))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; State machine tests
@@ -61,6 +74,17 @@
     (is (thrown-with-msg? clojure.lang.ExceptionInfo
                           #"Invalid state transition"
                           (core/validate-transition :pending :completed)))))
+
+(deftest task-machine-reachability-test
+  (let [reachable (reachable-states core/initial-task-status
+                                    core/valid-transitions)
+        expected-states #{:pending :running :blocked :completed :failed}]
+    (testing "all task machine states are reachable from the initial state"
+      (is (= expected-states reachable)))
+    (testing "shared FSM marks terminal task states as final"
+      (is (true? (fsm/final? core/task-machine {:_state :completed})))
+      (is (true? (fsm/final? core/task-machine {:_state :failed})))
+      (is (false? (fsm/final? core/task-machine {:_state :running}))))))
 
 (deftest make-task-test
   (testing "creates task with required fields"

--- a/docs/pull-requests/2026-04-25-refactor-loop-task-fsm-slice.md
+++ b/docs/pull-requests/2026-04-25-refactor-loop-task-fsm-slice.md
@@ -1,0 +1,52 @@
+# refactor: move loop and task lifecycle slices toward shared FSMs
+
+## Overview
+
+Replace the hand-maintained loop/task lifecycle maps with shared `components/fsm`
+machine definitions, while keeping the public loop/task APIs stable for this
+slice.
+
+## Motivation
+
+The loop inner lifecycle and task lifecycle both duplicated transition authority
+as ad hoc maps and validation helpers. That made it easy for the transition
+tables, terminal-state checks, and tests to drift apart from the shared FSM
+direction already used elsewhere in the repo.
+
+This slice narrows that gap without expanding scope into orchestration or
+workflow runtime changes.
+
+## Changes In Detail
+
+- Define a shared-FSM-backed inner loop lifecycle machine in
+  `components/loop/src/ai/miniforge/loop/inner.clj`
+- Define a shared-FSM-backed task lifecycle machine in
+  `components/task/src/ai/miniforge/task/core.clj`
+- Derive transition maps and transition-event lookups from the machine
+  definitions instead of maintaining separate hand-written transition tables
+- Keep the existing public helpers such as `valid-transition?`,
+  `validate-transition`, `terminal-state?`, and `transition`
+- Extract small result/metric helpers to reduce duplicated lifecycle map
+  construction
+- Add reachability and final-state coverage in loop/task tests
+
+## Testing Plan
+
+- Run `clj-kondo` on the edited loop/task source and test files
+- Run `bb test components/loop components/task`
+
+## Deployment Plan
+
+No deployment changes. This is an internal refactor and test coverage update.
+
+## Related Issues/PRs
+
+- Follows the workflow FSM migration work already merged
+- Keeps the loop/task slice disjoint from concurrent workflow/supervision work
+
+## Checklist
+
+- [x] Shared FSM definitions added for loop/task lifecycle slices
+- [x] Hand-maintained transition authority removed from owned files
+- [x] Reachability and invalid-transition coverage added
+- [x] PR write set kept within owned files, related tests, and this doc


### PR DESCRIPTION
# refactor: move loop and task lifecycle slices toward shared FSMs

## Overview

Replace the hand-maintained loop/task lifecycle maps with shared `components/fsm`
machine definitions, while keeping the public loop/task APIs stable for this
slice.

## Motivation

The loop inner lifecycle and task lifecycle both duplicated transition authority
as ad hoc maps and validation helpers. That made it easy for the transition
tables, terminal-state checks, and tests to drift apart from the shared FSM
direction already used elsewhere in the repo.

This slice narrows that gap without expanding scope into orchestration or
workflow runtime changes.

## Changes In Detail

- Define a shared-FSM-backed inner loop lifecycle machine in
  `components/loop/src/ai/miniforge/loop/inner.clj`
- Define a shared-FSM-backed task lifecycle machine in
  `components/task/src/ai/miniforge/task/core.clj`
- Derive transition maps and transition-event lookups from the machine
  definitions instead of maintaining separate hand-written transition tables
- Keep the existing public helpers such as `valid-transition?`,
  `validate-transition`, `terminal-state?`, and `transition`
- Extract small result/metric helpers to reduce duplicated lifecycle map
  construction
- Add reachability and final-state coverage in loop/task tests

## Testing Plan

- Run `clj-kondo` on the edited loop/task source and test files
- Run `bb test components/loop components/task`

## Deployment Plan

No deployment changes. This is an internal refactor and test coverage update.

## Related Issues/PRs

- Follows the workflow FSM migration work already merged
- Keeps the loop/task slice disjoint from concurrent workflow/supervision work

## Checklist

- [x] Shared FSM definitions added for loop/task lifecycle slices
- [x] Hand-maintained transition authority removed from owned files
- [x] Reachability and invalid-transition coverage added
- [x] PR write set kept within owned files, related tests, and this doc
