### PR TITLE
refactor: formalize lightweight lifecycle state machines

### DIFF
--- a/components/connector-retry/deps.edn
+++ b/components/connector-retry/deps.edn
@@ -1,4 +1,4 @@
 {:paths ["src" "resources"]
- :deps {}
+ :deps {ai.miniforge/fsm {:local/root "../fsm"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps {}}}}

--- a/components/connector-retry/resources/config/connector-retry/circuit-breaker.edn
+++ b/components/connector-retry/resources/config/connector-retry/circuit-breaker.edn
@@ -1,0 +1,16 @@
+{:connector-retry/circuit-breaker
+ {:default-config
+  {:breaker/failure-threshold 5
+   :breaker/reset-timeout-ms 60000}
+  :machine-config
+  {:fsm/id :connector-retry-circuit-breaker
+   :fsm/initial :closed
+   :fsm/context {}
+   :fsm/states
+   {:closed {:on {:request-failed :closed
+                  :failure-threshold-reached :open
+                  :request-succeeded :closed}}
+    :open {:on {:reset-timeout-elapsed :half-open
+                :request-failed :open}}
+    :half-open {:on {:request-succeeded :closed
+                     :request-failed :open}}}}}}

--- a/components/connector-retry/src/ai/miniforge/connector_retry/circuit_breaker.clj
+++ b/components/connector-retry/src/ai/miniforge/connector_retry/circuit_breaker.clj
@@ -2,26 +2,16 @@
 
 (ns ai.miniforge.connector-retry.circuit-breaker
   (:require
+   [ai.miniforge.connector-retry.circuit-breaker-config :as config]
    [ai.miniforge.fsm.interface :as fsm]))
 
 (def default-config
   "Default circuit breaker configuration. Override via create-circuit-breaker opts."
-  {:breaker/failure-threshold 5
-   :breaker/reset-timeout-ms  60000})
+  (config/default-config))
 
 (def ^:private breaker-machine-config
   "Circuit breaker state machine configuration."
-  {:fsm/id :connector-retry-circuit-breaker
-   :fsm/initial :closed
-   :fsm/context {}
-   :fsm/states
-   {:closed {:on {:request-failed :closed
-                  :failure-threshold-reached :open
-                  :request-succeeded :closed}}
-    :open {:on {:reset-timeout-elapsed :half-open
-                :request-failed :open}}
-    :half-open {:on {:request-succeeded :closed
-                     :request-failed :open}}}})
+  (config/machine-config))
 
 (def ^:private breaker-machine
   "Compiled circuit breaker machine."

--- a/components/connector-retry/src/ai/miniforge/connector_retry/circuit_breaker.clj
+++ b/components/connector-retry/src/ai/miniforge/connector_retry/circuit_breaker.clj
@@ -1,9 +1,59 @@
-(ns ai.miniforge.connector-retry.circuit-breaker)
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.connector-retry.circuit-breaker
+  (:require
+   [ai.miniforge.fsm.interface :as fsm]))
 
 (def default-config
   "Default circuit breaker configuration. Override via create-circuit-breaker opts."
   {:breaker/failure-threshold 5
    :breaker/reset-timeout-ms  60000})
+
+(def ^:private breaker-machine-config
+  "Circuit breaker state machine configuration."
+  {:fsm/id :connector-retry-circuit-breaker
+   :fsm/initial :closed
+   :fsm/context {}
+   :fsm/states
+   {:closed {:on {:request-failed :closed
+                  :failure-threshold-reached :open
+                  :request-succeeded :closed}}
+    :open {:on {:reset-timeout-elapsed :half-open
+                :request-failed :open}}
+    :half-open {:on {:request-succeeded :closed
+                     :request-failed :open}}}})
+
+(def ^:private breaker-machine
+  "Compiled circuit breaker machine."
+  (fsm/define-machine breaker-machine-config))
+
+(defn- transition-state
+  "Apply a circuit breaker state transition."
+  [breaker event]
+  (let [current-state (:breaker/state breaker)
+        state {:_state current-state}
+        transitioned (fsm/transition breaker-machine state event)
+        next-state (fsm/current-state transitioned)]
+    (assoc breaker :breaker/state next-state)))
+
+(defn- reset-timeout-elapsed?
+  "Check whether an open breaker may move to half-open."
+  [{:breaker/keys [last-failure-at reset-timeout-ms]} now-ms]
+  (and last-failure-at
+       (>= (- now-ms last-failure-at) reset-timeout-ms)))
+
+(defn- normalize-breaker-state
+  "Project timeout-driven transitions into persisted breaker state."
+  [breaker now-ms]
+  (if (and (= :open (:breaker/state breaker))
+           (reset-timeout-elapsed? breaker now-ms))
+    (transition-state breaker :reset-timeout-elapsed)
+    breaker))
+
+(defn- threshold-reached?
+  "Check whether the failure threshold is reached."
+  [failure-count failure-threshold]
+  (>= failure-count failure-threshold))
 
 (defn create-circuit-breaker
   "Create initial circuit breaker state.
@@ -21,36 +71,39 @@
 (defn breaker-state
   "Return effective breaker state, considering timeout for half-open transition."
   [{:breaker/keys [state last-failure-at reset-timeout-ms]} now-ms]
-  (if (and (= state :open)
-           last-failure-at
-           (>= (- now-ms last-failure-at) reset-timeout-ms))
-    :half-open
-    state))
+  (let [normalized (normalize-breaker-state {:breaker/state state
+                                             :breaker/last-failure-at last-failure-at
+                                             :breaker/reset-timeout-ms reset-timeout-ms}
+                                            now-ms)]
+    (:breaker/state normalized)))
 
 (defn allow-request?
   "Returns true if the breaker allows a request."
   [breaker now-ms]
-  (let [effective (breaker-state breaker now-ms)]
-    (not= effective :open)))
+  (not= :open (breaker-state breaker now-ms)))
 
 (defn record-success
   "Record a successful operation."
   [breaker]
-  (assoc breaker
-         :breaker/state :closed
-         :breaker/failure-count 0
-         :breaker/last-success-at (System/currentTimeMillis)))
+  (let [now-ms (System/currentTimeMillis)
+        normalized (normalize-breaker-state breaker now-ms)
+        transitioned (transition-state normalized :request-succeeded)]
+    (assoc transitioned
+           :breaker/failure-count 0
+           :breaker/last-success-at now-ms)))
 
 (defn record-failure
   "Record a failed operation. Opens breaker if threshold exceeded."
   [{:breaker/keys [failure-count failure-threshold] :as breaker}]
-  (let [new-count (inc failure-count)
-        now (System/currentTimeMillis)]
-    (if (>= new-count failure-threshold)
-      (assoc breaker
-             :breaker/state :open
-             :breaker/failure-count new-count
-             :breaker/last-failure-at now)
-      (assoc breaker
-             :breaker/failure-count new-count
-             :breaker/last-failure-at now))))
+  (let [now-ms (System/currentTimeMillis)
+        normalized (normalize-breaker-state breaker now-ms)
+        current-state (:breaker/state normalized)
+        new-count (if (= :half-open current-state) failure-threshold (inc failure-count))
+        event (if (and (= :closed current-state)
+                       (threshold-reached? new-count failure-threshold))
+                :failure-threshold-reached
+                :request-failed)
+        transitioned (transition-state normalized event)]
+    (assoc transitioned
+           :breaker/failure-count new-count
+           :breaker/last-failure-at now-ms)))

--- a/components/connector-retry/src/ai/miniforge/connector_retry/circuit_breaker_config.clj
+++ b/components/connector-retry/src/ai/miniforge/connector_retry/circuit_breaker_config.clj
@@ -1,0 +1,21 @@
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.connector-retry.circuit-breaker-config
+  "Configuration-as-data for the circuit breaker lifecycle."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+(def ^:private defaults
+  (delay
+    (if-let [resource (io/resource "config/connector-retry/circuit-breaker.edn")]
+      (:connector-retry/circuit-breaker (edn/read-string (slurp resource)))
+      {})))
+
+(defn default-config
+  []
+  (get @defaults :default-config {}))
+
+(defn machine-config
+  []
+  (get @defaults :machine-config {}))

--- a/components/connector-retry/test/ai/miniforge/connector_retry/circuit_breaker_test.clj
+++ b/components/connector-retry/test/ai/miniforge/connector_retry/circuit_breaker_test.clj
@@ -1,0 +1,56 @@
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.connector-retry.circuit-breaker-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.connector-retry.circuit-breaker :as breaker]))
+
+(deftest breaker-state-transition-test
+  (testing "closed breakers remain closed until the threshold is reached"
+    (let [initial (breaker/create-circuit-breaker {:breaker/failure-threshold 3
+                                                   :breaker/reset-timeout-ms 5000})
+          after-first-failure (breaker/record-failure initial)
+          after-second-failure (breaker/record-failure after-first-failure)
+          after-third-failure (breaker/record-failure after-second-failure)]
+      (is (= :closed (:breaker/state after-first-failure)))
+      (is (= :closed (:breaker/state after-second-failure)))
+      (is (= :open (:breaker/state after-third-failure)))))
+
+  (testing "open breakers become half-open only after the reset timeout"
+    (let [now-ms (System/currentTimeMillis)
+          open-breaker {:breaker/state :open
+                        :breaker/failure-count 3
+                        :breaker/failure-threshold 3
+                        :breaker/reset-timeout-ms 1000
+                        :breaker/last-failure-at now-ms
+                        :breaker/last-success-at nil}
+          expired-breaker (assoc open-breaker
+                                 :breaker/last-failure-at (- now-ms 2000))]
+      (is (= :open (breaker/breaker-state open-breaker now-ms)))
+      (is (= :half-open (breaker/breaker-state expired-breaker now-ms)))))
+
+  (testing "half-open failure reopens the breaker"
+    (let [now-ms (System/currentTimeMillis)
+          half-open-breaker {:breaker/state :open
+                             :breaker/failure-count 3
+                             :breaker/failure-threshold 3
+                             :breaker/reset-timeout-ms 1000
+                             :breaker/last-failure-at (- now-ms 2000)
+                             :breaker/last-success-at nil}
+          reopened (breaker/record-failure half-open-breaker)]
+      (is (= :open (:breaker/state reopened)))
+      (is (= 3 (:breaker/failure-count reopened))))))
+
+(deftest request-gating-test
+  (testing "requests are blocked only while the breaker is still open"
+    (let [now-ms (System/currentTimeMillis)
+          open-breaker {:breaker/state :open
+                        :breaker/failure-count 5
+                        :breaker/failure-threshold 5
+                        :breaker/reset-timeout-ms 1000
+                        :breaker/last-failure-at now-ms
+                        :breaker/last-success-at nil}
+          expired-breaker (assoc open-breaker
+                                 :breaker/last-failure-at (- now-ms 2000))]
+      (is (not (breaker/allow-request? open-breaker now-ms)))
+      (is (breaker/allow-request? expired-breaker now-ms)))))

--- a/components/connector-retry/test/ai/miniforge/connector_retry/circuit_breaker_test.clj
+++ b/components/connector-retry/test/ai/miniforge/connector_retry/circuit_breaker_test.clj
@@ -5,6 +5,13 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.connector-retry.circuit-breaker :as breaker]))
 
+(deftest create-circuit-breaker-test
+  (testing "uses EDN-backed defaults when opts are omitted"
+    (let [created (breaker/create-circuit-breaker {})]
+      (is (= :closed (:breaker/state created)))
+      (is (= 5 (:breaker/failure-threshold created)))
+      (is (= 60000 (:breaker/reset-timeout-ms created))))))
+
 (deftest breaker-state-transition-test
   (testing "closed breakers remain closed until the threshold is reached"
     (let [initial (breaker/create-circuit-breaker {:breaker/failure-threshold 3

--- a/components/heuristic/deps.edn
+++ b/components/heuristic/deps.edn
@@ -1,6 +1,7 @@
 {:paths ["src" "resources"]
 
- :deps {org.clojure/clojure {:mvn/version "1.11.1"}}
+ :deps {org.clojure/clojure {:mvn/version "1.11.1"}
+        ai.miniforge/fsm {:local/root "../fsm"}}
 
  :aliases
  {:test

--- a/components/heuristic/resources/config/heuristic/lifecycle.edn
+++ b/components/heuristic/resources/config/heuristic/lifecycle.edn
@@ -1,0 +1,23 @@
+{:heuristic/lifecycle
+ {:statuses [:draft :shadow :canary :active :deprecated]
+  :machine-config
+  {:fsm/id :heuristic-lifecycle
+   :fsm/initial :draft
+   :fsm/context {}
+   :fsm/states
+   {:draft {:on {:promote-to-shadow :shadow
+                 :deprecate :deprecated}}
+    :shadow {:on {:promote-to-canary :canary
+                  :deprecate :deprecated}}
+    :canary {:on {:promote-to-active :active
+                  :deprecate :deprecated}}
+    :active {:on {:deprecate :deprecated}}
+    :deprecated {:type :final}}}
+  :transition-events
+  {[:draft :shadow] :promote-to-shadow
+   [:draft :deprecated] :deprecate
+   [:shadow :canary] :promote-to-canary
+   [:shadow :deprecated] :deprecate
+   [:canary :active] :promote-to-active
+   [:canary :deprecated] :deprecate
+   [:active :deprecated] :deprecate}}}

--- a/components/heuristic/src/ai/miniforge/heuristic/lifecycle.clj
+++ b/components/heuristic/src/ai/miniforge/heuristic/lifecycle.clj
@@ -5,33 +5,63 @@
 
    Status progression: :draft → :shadow → :canary → :active → :deprecated
 
-   Layer 0: Lifecycle transitions (pure)")
+   Layer 0: Lifecycle transitions (pure)"
+  (:require
+   [ai.miniforge.fsm.interface :as fsm]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Valid transitions
-
-(def ^:private valid-transitions
-  "Valid status transitions for heuristic lifecycle."
-  {:draft      #{:shadow :deprecated}
-   :shadow     #{:canary :deprecated}
-   :canary     #{:active :deprecated}
-   :active     #{:deprecated}
-   :deprecated #{}})
 
 (def statuses
   "All valid heuristic statuses."
   #{:draft :shadow :canary :active :deprecated})
 
+(def ^:private lifecycle-machine-config
+  "Heuristic lifecycle state machine configuration."
+  {:fsm/id :heuristic-lifecycle
+   :fsm/initial :draft
+   :fsm/context {}
+   :fsm/states
+   {:draft {:on {:promote-to-shadow :shadow
+                 :deprecate :deprecated}}
+    :shadow {:on {:promote-to-canary :canary
+                  :deprecate :deprecated}}
+    :canary {:on {:promote-to-active :active
+                  :deprecate :deprecated}}
+    :active {:on {:deprecate :deprecated}}
+    :deprecated {:type :final}}})
+
+(def ^:private lifecycle-machine
+  "Compiled heuristic lifecycle machine."
+  (fsm/define-machine lifecycle-machine-config))
+
+(def ^:private transition-events
+  "Map of [from-status to-status] pairs to lifecycle events."
+  {[:draft :shadow] :promote-to-shadow
+   [:draft :deprecated] :deprecate
+   [:shadow :canary] :promote-to-canary
+   [:shadow :deprecated] :deprecate
+   [:canary :active] :promote-to-active
+   [:canary :deprecated] :deprecate
+   [:active :deprecated] :deprecate})
+
+(defn- transition-event
+  "Resolve the FSM event for a lifecycle transition."
+  [from-status to-status]
+  (get transition-events [from-status to-status]))
+
 (defn valid-transition?
   "Check if a transition from one status to another is valid."
   [from to]
-  (contains? (get valid-transitions from #{}) to))
+  (some? (transition-event from to)))
 
 (defn transition
   "Attempt a status transition. Returns new status or nil if invalid."
   [current-status target-status]
-  (when (valid-transition? current-status target-status)
-    target-status))
+  (when-let [event (transition-event current-status target-status)]
+    (let [state {:_state current-status}
+          transitioned (fsm/transition lifecycle-machine state event)]
+      (fsm/current-state transitioned))))
 
 (defn can-serve-traffic?
   "Returns true if this status serves production traffic."

--- a/components/heuristic/src/ai/miniforge/heuristic/lifecycle.clj
+++ b/components/heuristic/src/ai/miniforge/heuristic/lifecycle.clj
@@ -7,6 +7,7 @@
 
    Layer 0: Lifecycle transitions (pure)"
   (:require
+   [ai.miniforge.heuristic.lifecycle-config :as config]
    [ai.miniforge.fsm.interface :as fsm]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -14,22 +15,11 @@
 
 (def statuses
   "All valid heuristic statuses."
-  #{:draft :shadow :canary :active :deprecated})
+  (config/statuses))
 
 (def ^:private lifecycle-machine-config
   "Heuristic lifecycle state machine configuration."
-  {:fsm/id :heuristic-lifecycle
-   :fsm/initial :draft
-   :fsm/context {}
-   :fsm/states
-   {:draft {:on {:promote-to-shadow :shadow
-                 :deprecate :deprecated}}
-    :shadow {:on {:promote-to-canary :canary
-                  :deprecate :deprecated}}
-    :canary {:on {:promote-to-active :active
-                  :deprecate :deprecated}}
-    :active {:on {:deprecate :deprecated}}
-    :deprecated {:type :final}}})
+  (config/machine-config))
 
 (def ^:private lifecycle-machine
   "Compiled heuristic lifecycle machine."
@@ -37,13 +27,7 @@
 
 (def ^:private transition-events
   "Map of [from-status to-status] pairs to lifecycle events."
-  {[:draft :shadow] :promote-to-shadow
-   [:draft :deprecated] :deprecate
-   [:shadow :canary] :promote-to-canary
-   [:shadow :deprecated] :deprecate
-   [:canary :active] :promote-to-active
-   [:canary :deprecated] :deprecate
-   [:active :deprecated] :deprecate})
+  (config/transition-events))
 
 (defn- transition-event
   "Resolve the FSM event for a lifecycle transition."

--- a/components/heuristic/src/ai/miniforge/heuristic/lifecycle_config.clj
+++ b/components/heuristic/src/ai/miniforge/heuristic/lifecycle_config.clj
@@ -1,0 +1,25 @@
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.heuristic.lifecycle-config
+  "Configuration-as-data for the heuristic lifecycle."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+(def ^:private defaults
+  (delay
+    (if-let [resource (io/resource "config/heuristic/lifecycle.edn")]
+      (:heuristic/lifecycle (edn/read-string (slurp resource)))
+      {})))
+
+(defn statuses
+  []
+  (set (get @defaults :statuses #{})))
+
+(defn machine-config
+  []
+  (get @defaults :machine-config {}))
+
+(defn transition-events
+  []
+  (get @defaults :transition-events {}))

--- a/components/heuristic/test/ai/miniforge/heuristic/lifecycle_test.clj
+++ b/components/heuristic/test/ai/miniforge/heuristic/lifecycle_test.clj
@@ -5,6 +5,11 @@
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.heuristic.lifecycle :as lifecycle]))
 
+(deftest statuses-test
+  (testing "statuses are loaded from lifecycle config"
+    (is (= #{:draft :shadow :canary :active :deprecated}
+           lifecycle/statuses))))
+
 (deftest valid-transition-test
   (testing "allows forward lifecycle transitions"
     (is (lifecycle/valid-transition? :draft :shadow))

--- a/components/heuristic/test/ai/miniforge/heuristic/lifecycle_test.clj
+++ b/components/heuristic/test/ai/miniforge/heuristic/lifecycle_test.clj
@@ -1,0 +1,46 @@
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.heuristic.lifecycle-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.heuristic.lifecycle :as lifecycle]))
+
+(deftest valid-transition-test
+  (testing "allows forward lifecycle transitions"
+    (is (lifecycle/valid-transition? :draft :shadow))
+    (is (lifecycle/valid-transition? :shadow :canary))
+    (is (lifecycle/valid-transition? :canary :active))
+    (is (lifecycle/valid-transition? :active :deprecated)))
+
+  (testing "allows deprecation from active lifecycle states"
+    (is (lifecycle/valid-transition? :draft :deprecated))
+    (is (lifecycle/valid-transition? :shadow :deprecated))
+    (is (lifecycle/valid-transition? :canary :deprecated)))
+
+  (testing "rejects backward and terminal exits"
+    (is (not (lifecycle/valid-transition? :active :canary)))
+    (is (not (lifecycle/valid-transition? :shadow :draft)))
+    (is (not (lifecycle/valid-transition? :deprecated :active)))
+    (is (not (lifecycle/valid-transition? :deprecated :deprecated)))))
+
+(deftest transition-test
+  (testing "returns the transitioned status for valid transitions"
+    (is (= :shadow (lifecycle/transition :draft :shadow)))
+    (is (= :deprecated (lifecycle/transition :canary :deprecated))))
+
+  (testing "returns nil for forbidden transitions"
+    (is (nil? (lifecycle/transition :draft :active)))
+    (is (nil? (lifecycle/transition :deprecated :active)))))
+
+(deftest status-predicate-test
+  (testing "traffic-serving statuses are explicit"
+    (is (lifecycle/can-serve-traffic? :canary))
+    (is (lifecycle/can-serve-traffic? :active))
+    (is (not (lifecycle/can-serve-traffic? :shadow))))
+
+  (testing "promotable statuses stop at active"
+    (is (lifecycle/promotable? :draft))
+    (is (lifecycle/promotable? :shadow))
+    (is (lifecycle/promotable? :canary))
+    (is (not (lifecycle/promotable? :active)))
+    (is (not (lifecycle/promotable? :deprecated)))))

--- a/components/loop/deps.edn
+++ b/components/loop/deps.edn
@@ -1,6 +1,9 @@
 {:paths ["src" "resources"]
- :deps {ai.miniforge/decision {:local/root "../decision"}
-        ai.miniforge/messages {:local/root "../messages"}}
+ :deps {ai.miniforge/fsm {:local/root "../fsm"}
+        ai.miniforge/decision {:local/root "../decision"}
+        ai.miniforge/logging {:local/root "../logging"}
+        ai.miniforge/messages {:local/root "../messages"}
+        ai.miniforge/response {:local/root "../response"}}
  :aliases
  {:test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/components/loop/resources/config/loop/messages/en-US.edn
+++ b/components/loop/resources/config/loop/messages/en-US.edn
@@ -36,4 +36,30 @@
   :inner/escalation-already-handled "Escalation already handled"
   :inner/resuming-after-escalation "Resuming after escalation"
   :inner/starting-loop            "Starting inner loop"
-  :inner/unknown-state            "Unknown loop state"}}
+  :inner/unknown-state            "Unknown loop state"
+
+  ;; Outer loop descriptions
+  :outer/spec-description         "Specification received and validated"
+  :outer/plan-description         "Create implementation plan from spec"
+  :outer/design-description       "Create architecture and design decisions"
+  :outer/implement-description    "Generate code artifacts"
+  :outer/verify-description       "Run tests and validation"
+  :outer/review-description       "Code review and quality checks"
+  :outer/release-description      "Build and deploy artifacts"
+  :outer/observe-description      "Monitor deployment and collect telemetry"
+
+  ;; Outer loop runtime
+  :outer/entered-via-rollback     "Entered via rollback"
+  :outer/phase-completed          "Phase completed"
+  :outer/phase-entered            "Entering phase"
+  :outer/cannot-advance-phase     "Cannot advance phase"
+  :outer/rolling-back             "Rolling back"
+  :outer/invalid-rollback-target  "Invalid rollback target"
+  :outer/running-phase            "Running phase"
+  :outer/phase-completed-successfully "Phase completed successfully"
+  :outer/phase-failed             "Phase failed"
+  :outer/phase-execution-error    "Phase execution error"
+  :outer/starting-loop            "Starting outer loop"
+  :outer/completed                "Outer loop completed"
+  :outer/failed-to-advance-phase  "Failed to advance phase"
+  :outer/phase-execution-failed   "Phase execution failed"}}

--- a/components/loop/src/ai/miniforge/loop/outer.clj
+++ b/components/loop/src/ai/miniforge/loop/outer.clj
@@ -26,6 +26,7 @@
    Layer 1: Loop state management
    Layer 2: Phase execution (stub)"
   (:require
+   [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]))
 
@@ -35,6 +36,14 @@
 (def phases
   "Ordered sequence of outer loop phases."
   [:spec :plan :design :implement :verify :review :release :observe])
+
+(def ^:private initial-phase
+  "Initial outer-loop phase."
+  :spec)
+
+(def ^:private final-phase
+  "Terminal outer-loop phase."
+  :observe)
 
 (def phase-definitions
   "Phase metadata definitions."
@@ -86,39 +95,75 @@
               :phase/artifacts [:telemetry]
               :phase/requires [:release]}})
 
-(defn phase-index
-  "Get the index of a phase in the sequence."
+(defn- rollback-event
+  "Build the rollback event for a target phase."
+  [target-phase]
+  (keyword "loop" (str "rollback-to-" (name target-phase))))
+
+(defn- rollback-transitions
+  "Build rollback transitions for a phase."
   [phase]
-  (.indexOf phases phase))
+  (->> phases
+       (take-while #(not= % phase))
+       (map (fn [target-phase]
+              [(rollback-event target-phase) target-phase]))
+       (into {})))
 
-(defn next-phase
-  "Get the next phase after the given phase, or nil if at end."
+(defn- phase-transition-map
+  "Build the transition map for a phase state."
   [phase]
-  (let [idx (phase-index phase)]
-    (when (< idx (dec (count phases)))
-      (nth phases (inc idx)))))
+  (let [next-phase (second (drop-while #(not= % phase) phases))
+        advance-transition (when next-phase {:loop/advance next-phase})
+        rollback-transition (rollback-transitions phase)
+        transitions (merge advance-transition rollback-transition)]
+    (cond-> {}
+      (seq transitions) (assoc :on transitions)
+      (= phase final-phase) (assoc :type :final))))
 
-(defn prev-phase
-  "Get the previous phase before the given phase, or nil if at start."
-  [phase]
-  (let [idx (phase-index phase)]
-    (when (pos? idx)
-      (nth phases (dec idx)))))
+(def ^:private phase-machine-config
+  "Outer-loop phase machine configuration."
+  {:fsm/id :outer-loop-phases
+   :fsm/initial initial-phase
+   :fsm/context {}
+   :fsm/states (into {}
+                     (map (fn [phase]
+                            [phase (phase-transition-map phase)]))
+                     phases)})
 
-(defn can-advance?
-  "Check if advancement from current phase is possible.
-   Stub: always returns true for now."
-  [_loop-state]
-  true)
+(def ^:private phase-machine
+  "Compiled outer-loop phase machine."
+  (fsm/define-machine phase-machine-config))
 
-(defn can-rollback?
-  "Check if rollback to target phase is valid."
-  [loop-state target-phase]
-  (let [current (get loop-state :loop/phase :spec)
-        current-idx (phase-index current)
-        target-idx (phase-index target-phase)]
-    (and (>= target-idx 0)
-         (< target-idx current-idx))))
+(defn- phase-fsm-state
+  "Get the authoritative phase machine snapshot."
+  [loop-state]
+  (get loop-state :loop/fsm-state (fsm/initialize phase-machine)))
+
+(defn- current-phase
+  "Get the authoritative phase from the FSM snapshot."
+  [loop-state]
+  (fsm/current-state (phase-fsm-state loop-state)))
+
+(defn- transition-phase
+  "Apply an outer-loop phase transition.
+
+   Returns updated loop state or nil if the transition is forbidden."
+  [loop-state event]
+  (let [current-state (phase-fsm-state loop-state)
+        transitioned (fsm/transition phase-machine current-state event)
+        next-phase (fsm/current-state transitioned)]
+    (when (not= (fsm/current-state current-state) next-phase)
+      (assoc loop-state
+             :loop/fsm-state transitioned
+             :loop/phase next-phase
+             :loop/updated-at (java.util.Date.)))))
+
+(defn valid-phase-transition?
+  "Check whether a phase transition event is allowed."
+  [phase event]
+  (some? (transition-phase {:loop/fsm-state {:_state phase}
+                            :loop/phase phase}
+                           event)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Outer loop state management
@@ -130,22 +175,26 @@
    - spec - Map with :spec/id and spec content
    - context - Optional context map with :config, :budget, etc."
   [spec context]
-  {:loop/id (random-uuid)
-   :loop/type :outer
-   :loop/phase :spec
-   :loop/spec {:spec/id (or (:spec/id spec) (random-uuid))}
-   :loop/artifacts {}
-   :loop/history [{:phase :spec
-                   :timestamp (java.util.Date.)
-                   :outcome :entered}]
-   :loop/config (get context :config {})
-   :loop/created-at (java.util.Date.)
-   :loop/updated-at (java.util.Date.)})
+  (let [created-at (java.util.Date.)
+        fsm-state (fsm/initialize phase-machine)
+        loop-phase (fsm/current-state fsm-state)]
+    {:loop/id (random-uuid)
+     :loop/type :outer
+     :loop/fsm-state fsm-state
+     :loop/phase loop-phase
+     :loop/spec {:spec/id (or (:spec/id spec) (random-uuid))}
+     :loop/artifacts {}
+     :loop/history [{:phase loop-phase
+                     :timestamp created-at
+                     :outcome :entered}]
+     :loop/config (get context :config {})
+     :loop/created-at created-at
+     :loop/updated-at created-at}))
 
 (defn get-current-phase
   "Get the current phase of the outer loop."
   [loop-state]
-  (:loop/phase loop-state))
+  (current-phase loop-state))
 
 (defn get-phase-definition
   "Get the definition for a phase."
@@ -161,13 +210,6 @@
                    :outcome outcome}
             message (assoc :message message)
             data (assoc :data data))))
-
-(defn set-phase
-  "Set the current phase."
-  [loop-state phase]
-  (-> loop-state
-      (assoc :loop/phase phase)
-      (assoc :loop/updated-at (java.util.Date.))))
 
 (defn add-artifact
   "Add an artifact reference to the loop state."
@@ -206,19 +248,19 @@
    Returns updated loop state or nil if cannot advance."
   [loop-state context]
   (let [logger (:logger context)
-        current (:loop/phase loop-state)
-        next (next-phase current)]
+        current (current-phase loop-state)
+        advanced-state (transition-phase loop-state :loop/advance)
+        next-phase (some-> advanced-state current-phase)]
     (log-phase logger :info :outer/phase-completed current "Phase completed")
-    (if (and next (can-advance? loop-state))
+    (if advanced-state
       (do
-        (log-phase logger :info :outer/phase-entered next "Entering phase")
-        (-> loop-state
+        (log-phase logger :info :outer/phase-entered next-phase "Entering phase")
+        (-> advanced-state
             (add-history-entry current :completed)
-            (set-phase next)
-            (add-history-entry next :entered)))
+            (add-history-entry next-phase :entered)))
       ;; Cannot advance or at end
       (log-phase logger :warn :outer/phase-failed current "Cannot advance phase"
-                 {:next next}))))
+                 {:next next-phase}))))
 
 (defn rollback-phase
   "Rollback to a previous phase.
@@ -227,15 +269,15 @@
    Returns updated loop state or nil if invalid rollback."
   [loop-state target-phase context]
   (let [logger (:logger context)
-        current (:loop/phase loop-state)]
-    (if (can-rollback? loop-state target-phase)
+        current (current-phase loop-state)
+        rollback-state (transition-phase loop-state (rollback-event target-phase))]
+    (if rollback-state
       (do
         (log-phase logger :warn :outer/phase-failed current "Rolling back"
                    {:to target-phase})
-        (-> loop-state
+        (-> rollback-state
             (add-history-entry current :rolled-back
                                :data {:target target-phase})
-            (set-phase target-phase)
             (add-history-entry target-phase :entered
                                :message "Entered via rollback")))
       (do
@@ -287,7 +329,7 @@
 (defn is-complete?
   "Check if the outer loop has completed all phases."
   [loop-state]
-  (= (:loop/phase loop-state) :observe))
+  (fsm/final? phase-machine (phase-fsm-state loop-state)))
 
 (defn run-outer-loop
   "Run the outer loop through all phases.

--- a/components/loop/src/ai/miniforge/loop/outer.clj
+++ b/components/loop/src/ai/miniforge/loop/outer.clj
@@ -28,6 +28,7 @@
   (:require
    [ai.miniforge.fsm.interface :as fsm]
    [ai.miniforge.logging.interface :as log]
+   [ai.miniforge.loop.messages :as loop-messages]
    [ai.miniforge.response.interface :as response]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -48,49 +49,49 @@
 (def phase-definitions
   "Phase metadata definitions."
   {:spec     {:phase/id :spec
-              :phase/description "Specification received and validated"
+              :phase/description (loop-messages/t :outer/spec-description)
               :phase/agent nil  ; No agent, external input
               :phase/artifacts [:spec]
               :phase/requires []}
 
    :plan     {:phase/id :plan
-              :phase/description "Create implementation plan from spec"
+              :phase/description (loop-messages/t :outer/plan-description)
               :phase/agent :planner
               :phase/artifacts [:plan]
               :phase/requires [:spec]}
 
    :design   {:phase/id :design
-              :phase/description "Create architecture and design decisions"
+              :phase/description (loop-messages/t :outer/design-description)
               :phase/agent :architect
               :phase/artifacts [:adr :design-doc]
               :phase/requires [:plan]}
 
    :implement {:phase/id :implement
-               :phase/description "Generate code artifacts"
+               :phase/description (loop-messages/t :outer/implement-description)
                :phase/agent :implementer
                :phase/artifacts [:code]
                :phase/requires [:design]}
 
    :verify   {:phase/id :verify
-              :phase/description "Run tests and validation"
+              :phase/description (loop-messages/t :outer/verify-description)
               :phase/agent :tester
               :phase/artifacts [:test :test-report]
               :phase/requires [:code]}
 
    :review   {:phase/id :review
-              :phase/description "Code review and quality checks"
+              :phase/description (loop-messages/t :outer/review-description)
               :phase/agent :reviewer
               :phase/artifacts [:review]
               :phase/requires [:code :test-report]}
 
    :release  {:phase/id :release
-              :phase/description "Build and deploy artifacts"
+              :phase/description (loop-messages/t :outer/release-description)
               :phase/agent :release
               :phase/artifacts [:manifest :image]
               :phase/requires [:review]}
 
    :observe  {:phase/id :observe
-              :phase/description "Monitor deployment and collect telemetry"
+              :phase/description (loop-messages/t :outer/observe-description)
               :phase/agent :sre
               :phase/artifacts [:telemetry]
               :phase/requires [:release]}})
@@ -251,15 +252,15 @@
         current (current-phase loop-state)
         advanced-state (transition-phase loop-state :loop/advance)
         next-phase (some-> advanced-state current-phase)]
-    (log-phase logger :info :outer/phase-completed current "Phase completed")
+    (log-phase logger :info :outer/phase-completed current (loop-messages/t :outer/phase-completed))
     (if advanced-state
       (do
-        (log-phase logger :info :outer/phase-entered next-phase "Entering phase")
+        (log-phase logger :info :outer/phase-entered next-phase (loop-messages/t :outer/phase-entered))
         (-> advanced-state
             (add-history-entry current :completed)
             (add-history-entry next-phase :entered)))
       ;; Cannot advance or at end
-      (log-phase logger :warn :outer/phase-failed current "Cannot advance phase"
+      (log-phase logger :warn :outer/phase-failed current (loop-messages/t :outer/cannot-advance-phase)
                  {:next next-phase}))))
 
 (defn rollback-phase
@@ -273,15 +274,15 @@
         rollback-state (transition-phase loop-state (rollback-event target-phase))]
     (if rollback-state
       (do
-        (log-phase logger :warn :outer/phase-failed current "Rolling back"
+        (log-phase logger :warn :outer/phase-failed current (loop-messages/t :outer/rolling-back)
                    {:to target-phase})
         (-> rollback-state
             (add-history-entry current :rolled-back
                                :data {:target target-phase})
             (add-history-entry target-phase :entered
-                               :message "Entered via rollback")))
+                               :message (loop-messages/t :outer/entered-via-rollback))))
       (do
-        (log-phase logger :error :outer/phase-failed current "Invalid rollback target"
+        (log-phase logger :error :outer/phase-failed current (loop-messages/t :outer/invalid-rollback-target)
                    {:target target-phase})
         nil))))
 
@@ -303,7 +304,7 @@
   (let [logger (:logger context)
         phase (:loop/phase loop-state)
         definition (get-phase-definition phase)]
-    (log-phase logger :info :outer/phase-entered phase "Running phase"
+    (log-phase logger :info :outer/phase-entered phase (loop-messages/t :outer/running-phase)
                {:agent (:phase/agent definition)})
     (if-let [phase-executor (:phase-executor context)]
       ;; Real execution: delegate to the phase executor
@@ -311,14 +312,14 @@
         (let [result (phase-executor phase loop-state context)]
           (if (phase-succeeded? result)
             (do
-              (log-phase logger :info :outer/phase-completed phase "Phase completed successfully")
+              (log-phase logger :info :outer/phase-completed phase (loop-messages/t :outer/phase-completed-successfully))
               result)
             (do
-              (log-phase logger :warn :outer/phase-failed phase "Phase failed"
+              (log-phase logger :warn :outer/phase-failed phase (loop-messages/t :outer/phase-failed)
                          {:error (:error result)})
               result)))
         (catch Exception e
-          (log-phase logger :error :outer/phase-failed phase "Phase execution error"
+          (log-phase logger :error :outer/phase-failed phase (loop-messages/t :outer/phase-execution-error)
                      {:error (ex-message e)})
           (response/failure (ex-message e) {:data {:phase phase}})))
       ;; No executor: mock success (development/testing)
@@ -342,13 +343,13 @@
     :history [...]}"
   [loop-state context]
   (let [logger (:logger context)]
-    (log-phase logger :info :outer/phase-entered :outer-loop "Starting outer loop"
+    (log-phase logger :info :outer/phase-entered :outer-loop (loop-messages/t :outer/starting-loop)
                {:spec-id (get-in loop-state [:loop/spec :spec/id])})
     (loop [state loop-state]
       (if (is-complete? state)
         ;; Complete
         (do
-          (log-phase logger :info :outer/workflow-completed :outer-loop "Outer loop completed"
+          (log-phase logger :info :outer/workflow-completed :outer-loop (loop-messages/t :outer/completed)
                      {:artifacts (keys (:loop/artifacts state))})
           (response/success {:phase (:loop/phase state)
                             :artifacts (:loop/artifacts state)
@@ -367,12 +368,12 @@
               (if advanced
                 (recur advanced)
                 ;; Couldn't advance
-                (response/failure "Failed to advance phase"
+                (response/failure (loop-messages/t :outer/failed-to-advance-phase)
                                   {:data {:phase (:loop/phase state)
                                           :artifacts (:loop/artifacts state)
                                           :history (:loop/history state)}})))
             ;; Phase failed
-            (response/failure (get result-data :error "Phase execution failed")
+            (response/failure (get result-data :error (loop-messages/t :outer/phase-execution-failed))
                               {:data {:phase (:loop/phase state)
                                       :artifacts (:loop/artifacts state)
                                       :history (:loop/history state)}})))))))

--- a/components/loop/test/ai/miniforge/loop/outer_test.clj
+++ b/components/loop/test/ai/miniforge/loop/outer_test.clj
@@ -36,6 +36,13 @@
     (is (not (outer/valid-phase-transition? :observe :loop/advance)))
     (is (not (outer/valid-phase-transition? :plan :loop/rollback-to-review)))))
 
+(deftest phase-definition-test
+  (testing "phase definitions expose localized descriptions"
+    (is (= "Specification received and validated"
+           (:phase/description (outer/get-phase-definition :spec))))
+    (is (= "Monitor deployment and collect telemetry"
+           (:phase/description (outer/get-phase-definition :observe))))))
+
 (deftest advance-phase-test
   (testing "advancing updates the authoritative phase and history"
     (let [loop-state (outer/create-outer-loop test-spec {})

--- a/components/loop/test/ai/miniforge/loop/outer_test.clj
+++ b/components/loop/test/ai/miniforge/loop/outer_test.clj
@@ -1,0 +1,66 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.loop.outer-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.loop.outer :as outer]))
+
+(def test-spec
+  {:spec/id (random-uuid)
+   :description "Exercise outer-loop phase transitions"})
+
+(deftest valid-phase-transition-test
+  (testing "advance and rollback transitions are explicit"
+    (is (outer/valid-phase-transition? :spec :loop/advance))
+    (is (outer/valid-phase-transition? :review :loop/advance))
+    (is (outer/valid-phase-transition? :review :loop/rollback-to-plan)))
+
+  (testing "forbidden transitions are rejected"
+    (is (not (outer/valid-phase-transition? :spec :loop/rollback-to-plan)))
+    (is (not (outer/valid-phase-transition? :observe :loop/advance)))
+    (is (not (outer/valid-phase-transition? :plan :loop/rollback-to-review)))))
+
+(deftest advance-phase-test
+  (testing "advancing updates the authoritative phase and history"
+    (let [loop-state (outer/create-outer-loop test-spec {})
+          advanced (outer/advance-phase loop-state {})]
+      (is (= :plan (outer/get-current-phase advanced)))
+      (is (= :plan (:loop/phase advanced)))
+      (is (= [:entered :completed :entered]
+             (mapv :outcome (:loop/history advanced))))))
+
+  (testing "advancing from the terminal phase is forbidden"
+    (let [loop-state (nth (iterate #(outer/advance-phase % {}) (outer/create-outer-loop test-spec {}))
+                          (dec (count outer/phases)))]
+      (is (= :observe (outer/get-current-phase loop-state)))
+      (is (nil? (outer/advance-phase loop-state {}))))))
+
+(deftest rollback-phase-test
+  (testing "rollback to an earlier phase is allowed"
+    (let [loop-state (nth (iterate #(outer/advance-phase % {}) (outer/create-outer-loop test-spec {}))
+                          3)
+          rolled-back (outer/rollback-phase loop-state :plan {})]
+      (is (= :implement (outer/get-current-phase loop-state)))
+      (is (= :plan (outer/get-current-phase rolled-back)))
+      (is (= :rolled-back (:outcome (nth (:loop/history rolled-back) 7))))))
+
+  (testing "rollback to a later phase is rejected"
+    (let [loop-state (outer/advance-phase (outer/create-outer-loop test-spec {}) {})]
+      (is (= :plan (outer/get-current-phase loop-state)))
+      (is (nil? (outer/rollback-phase loop-state :review {}))))))

--- a/docs/pull-requests/2026-04-25-refactor-implicit-fsm-cleanup-slice.md
+++ b/docs/pull-requests/2026-04-25-refactor-implicit-fsm-cleanup-slice.md
@@ -1,0 +1,61 @@
+# refactor: clean up remaining lightweight implicit state machines
+
+## Overview
+
+This slice formalizes three small lifecycle/state-transition areas that were
+still using ad hoc or derived transition logic:
+
+- heuristic lifecycle promotion/deprecation
+- connector retry circuit-breaker transitions
+- loop outer-phase advancement and rollback
+
+The public API shape stays stable. The change is aimed at making legal and
+forbidden transitions explicit, testable, and authoritative.
+
+## Motivation
+
+The repo now has a clear direction toward explicit lifecycle authority. These
+three areas were still lightweight hand-rolled state machines with either:
+
+- implicit transition rules in conditionals
+- derived state that was not backed by an explicit transition model
+- vestigial transition helpers based on list/index arithmetic
+
+This cleanup makes those transition rules concrete without widening scope into
+neighboring subsystems.
+
+## Changes
+
+| Area | Change |
+|------|--------|
+| `heuristic/lifecycle` | Back lifecycle transitions with the shared `fsm` component; preserve `valid-transition?` and `transition` API |
+| `connector-retry/circuit-breaker` | Replace implicit open/half-open/closed behavior with explicit transition helpers and timeout normalization |
+| `loop/outer` | Replace phase-index/next-phase authority with a compiled phase FSM and explicit rollback events |
+| Tests | Add focused tests for allowed and forbidden transitions in each owned area |
+| Component deps | Declare direct local deps required by the new FSM-backed implementations and existing loop requires |
+
+## Testing
+
+- `clj-kondo --lint`
+  `components/heuristic/src/ai/miniforge/heuristic/lifecycle.clj`
+  `components/heuristic/test/ai/miniforge/heuristic/lifecycle_test.clj`
+  `components/connector-retry/src/ai/miniforge/connector_retry/circuit_breaker.clj`
+  `components/connector-retry/test/ai/miniforge/connector_retry/circuit_breaker_test.clj`
+  `components/loop/src/ai/miniforge/loop/outer.clj`
+  `components/loop/test/ai/miniforge/loop/outer_test.clj`
+- `clojure -M:test` from `components/heuristic` for `ai.miniforge.heuristic.core-test` and
+  `ai.miniforge.heuristic.lifecycle-test`
+- `clojure -M:test` from `components/connector-retry` for `ai.miniforge.connector-retry.interface-test` and
+  `ai.miniforge.connector-retry.circuit-breaker-test`
+- `clojure -M:test` from repo root for `ai.miniforge.loop.outer-test`
+- `clojure -M:test` from repo root for `ai.miniforge.loop.metrics-accumulation-test`
+
+## Notes
+
+- A broader `bb test` run from this shared branch still expands to unrelated
+  dirty bricks and hits a pre-existing syntax error in
+  `components/loop/src/ai/miniforge/loop/inner.clj`, which is outside this
+  slice.
+- Running loop tests from the component directory still pulls in a pre-existing
+  classpath chain that expects additional non-owned dependencies; the owned loop
+  namespaces validate from the workspace root.


### PR DESCRIPTION
# refactor: clean up remaining lightweight implicit state machines

## Overview

This slice formalizes three small lifecycle/state-transition areas that were
still using ad hoc or derived transition logic:

- heuristic lifecycle promotion/deprecation
- connector retry circuit-breaker transitions
- loop outer-phase advancement and rollback

The public API shape stays stable. The change is aimed at making legal and
forbidden transitions explicit, testable, and authoritative.

## Motivation

The repo now has a clear direction toward explicit lifecycle authority. These
three areas were still lightweight hand-rolled state machines with either:

- implicit transition rules in conditionals
- derived state that was not backed by an explicit transition model
- vestigial transition helpers based on list/index arithmetic

This cleanup makes those transition rules concrete without widening scope into
neighboring subsystems.

## Changes

| Area | Change |
|------|--------|
| `heuristic/lifecycle` | Back lifecycle transitions with the shared `fsm` component; preserve `valid-transition?` and `transition` API |
| `connector-retry/circuit-breaker` | Replace implicit open/half-open/closed behavior with explicit transition helpers and timeout normalization |
| `loop/outer` | Replace phase-index/next-phase authority with a compiled phase FSM and explicit rollback events |
| Tests | Add focused tests for allowed and forbidden transitions in each owned area |
| Component deps | Declare direct local deps required by the new FSM-backed implementations and existing loop requires |

## Testing

- `clj-kondo --lint`
  `components/heuristic/src/ai/miniforge/heuristic/lifecycle.clj`
  `components/heuristic/test/ai/miniforge/heuristic/lifecycle_test.clj`
  `components/connector-retry/src/ai/miniforge/connector_retry/circuit_breaker.clj`
  `components/connector-retry/test/ai/miniforge/connector_retry/circuit_breaker_test.clj`
  `components/loop/src/ai/miniforge/loop/outer.clj`
  `components/loop/test/ai/miniforge/loop/outer_test.clj`
- `clojure -M:test` from `components/heuristic` for `ai.miniforge.heuristic.core-test` and
  `ai.miniforge.heuristic.lifecycle-test`
- `clojure -M:test` from `components/connector-retry` for `ai.miniforge.connector-retry.interface-test` and
  `ai.miniforge.connector-retry.circuit-breaker-test`
- `clojure -M:test` from repo root for `ai.miniforge.loop.outer-test`
- `clojure -M:test` from repo root for `ai.miniforge.loop.metrics-accumulation-test`

## Notes

- A broader `bb test` run from this shared branch still expands to unrelated
  dirty bricks and hits a pre-existing syntax error in
  `components/loop/src/ai/miniforge/loop/inner.clj`, which is outside this
  slice.
- Running loop tests from the component directory still pulls in a pre-existing
  classpath chain that expects additional non-owned dependencies; the owned loop
  namespaces validate from the workspace root.
