### PR TITLE
refactor: use checkpoints as dag resume authority

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -556,7 +556,7 @@
   :workflow-runner/workflow-type-label ":workflow/type {type}"
   :workflow-runner/list-failed "Failed to list workflows: {error}"
   :workflow-runner/spec-execution-failed "\n❌ Workflow execution failed: {error}"
-  :workflow-runner/event-file-failed "Failed to load resume state: {error}"
+  :workflow-runner/resume-state-failed "Failed to load resume state: {error}"
   :workflow-runner/resuming "\n🔄 Resuming workflow {workflow-id}"
 
   :resume/resuming "Resuming workflow: {workflow-id}"

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner.clj
@@ -432,11 +432,10 @@
         (throw e)))))
 
 ;------------------------------------------------------------------------------ Layer 2b
-;; Resume workflow from event file
+;; Resume workflow from checkpointed DAG state
 
 (defn resume-workflow-from-spec!
-  "Resume a previously failed or paused workflow from checkpointed DAG state,
-   falling back to legacy event reconstruction when needed.
+  "Resume a previously failed or paused workflow from checkpointed DAG state.
 
    Arguments:
    - workflow-id: UUID string of the workflow to resume
@@ -445,12 +444,12 @@
   [workflow-id-str spec {:keys [quiet] :or {quiet false} :as opts}]
   (let [resume-ctx (try
                      (let [resume-fn (requiring-resolve
-                                      'ai.miniforge.workflow.dag-resilience/resume-context-from-event-file)]
+                                      'ai.miniforge.workflow.dag-resilience/resume-context)]
                        (resume-fn workflow-id-str))
                      (catch Exception e
                        (when-not quiet
                          (println (display/colorize :red
-                                   (messages/t :workflow-runner/event-file-failed {:error (ex-message e)}))))
+                                   (messages/t :workflow-runner/resume-state-failed {:error (ex-message e)}))))
                        nil))]
     (when-not quiet
       (println (display/colorize :cyan

--- a/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+++ b/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
@@ -24,15 +24,11 @@
    - Layer 0: Rate limit detection from error patterns
    - Layer 1: Backend failover + event emission
    - Layer 2: Batch analysis + rate limit handling
-   - Layer 3: Resume — reconstruct completed-ids from event file"
+   - Layer 3: Resume — restore DAG progress from machine snapshots"
   (:require
-   [ai.miniforge.config.interface :as config]
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.logging.interface :as log]
-   [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
-   [clojure.edn :as edn]
-   [clojure.java.io :as io]
-   [clojure.string :as str]))
+   [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]))
 
 ;--- Layer 0: Rate Limit Detection
 
@@ -416,92 +412,23 @@
        (or (try-backend-failover context logger)
            (pause-with-reason context))))))
 
-;--- Layer 3: Resume — Reconstruct from Event File
+;--- Layer 3: Resume — Restore from Authoritative Snapshot
 
-(defn safe-read-edn
-  "Read an EDN string, returning nil on parse failure.
-   Handles #object, #uuid, and #inst tagged literals gracefully."
-  [s]
-  (try
-    (let [readers (merge {'object (fn [& args] (str "#object" args))
-                          'uuid   (fn [s] (java.util.UUID/fromString s))
-                          'inst   (fn [s] (java.time.Instant/parse s))}
-                         clojure.core/*data-readers*)]
-      (edn/read-string {:readers readers :default tagged-literal} s))
-    (catch Exception _ nil)))
-
-(defn read-event-file
-  "Read all events from a workflow event file.
-   Returns a vector of parsed event maps, skipping unparseable lines."
-  [file-path]
-  (let [f (io/file file-path)]
-    (when (.exists f)
-      (with-open [rdr (io/reader f)]
-        (->> (line-seq rdr)
-             (keep (fn [line]
-                     (when-not (str/blank? line)
-                       (safe-read-edn line))))
-             vec)))))
-
-(defn extract-completed-task-ids
-  "Extract the set of completed DAG task IDs from a sequence of events.
-   Looks for :dag/task-completed events and returns their task IDs."
-  [events]
-  (->> events
-       (filter #(= :dag/task-completed (:event/type %)))
-       (map :dag/task-id)
-       set))
-
-(defn extract-completed-artifacts
-  "Extract artifacts from completed task events for merging into results."
-  [events]
-  (->> events
-       (filter #(= :dag/task-completed (:event/type %)))
-       (mapcat #(get-in % [:dag/result :data :artifacts] []))
-       vec))
-
-(def default-events-dir
-  "Default directory for workflow event files."
-  (delay (str (config/miniforge-home) "/events")))
-
-(defn checkpoint-resume-context
-  "Build resume context from authoritative checkpoint data when available."
-  [workflow-id opts]
-  (when-let [checkpoint-data (checkpoint-store/load-checkpoint-data workflow-id opts)]
-    (let [dag-result (get-in checkpoint-data [:machine-snapshot :execution/dag-result])
-          completed-task-ids (set (:completed-task-ids dag-result))
-          artifacts (vec (get dag-result :artifacts []))]
-      (when (or (seq completed-task-ids) (seq artifacts))
-        {:pre-completed-ids completed-task-ids
-         :pre-completed-artifacts artifacts
-         :resumed? true
-         :resume-source :checkpoint}))))
-
-(defn resume-context-from-event-file
-  "Build resume context from durable checkpoint data, falling back to
-   legacy event-file reconstruction when checkpoint DAG state is absent.
-
-   Arguments:
-   - workflow-id: UUID of the workflow to resume
-   - opts: Optional map with :events-dir to override default path
-
-   Returns a map suitable for merging into the DAG execution context:
-   {:pre-completed-ids #{task-id-1 task-id-2 ...}
-    :pre-completed-artifacts [artifact-1 ...]
-    :resumed? true}"
-  ([workflow-id] (resume-context-from-event-file workflow-id {}))
+(defn resume-context
+  "Build DAG resume context from the authoritative machine snapshot."
+  ([workflow-id]
+   (resume-context workflow-id {}))
   ([workflow-id opts]
-   (or (checkpoint-resume-context workflow-id opts)
-       (let [events-dir (or (:events-dir opts) @default-events-dir)
-             file-path (str events-dir "/" workflow-id ".edn")
-             events (read-event-file file-path)]
-         (if (seq events)
-           (let [completed-ids (extract-completed-task-ids events)
-                 artifacts (extract-completed-artifacts events)]
-             {:pre-completed-ids completed-ids
-              :pre-completed-artifacts artifacts
-              :resumed? true
-              :resume-source file-path})
-           {:pre-completed-ids #{}
-            :pre-completed-artifacts []
-            :resumed? false})))))
+   (or
+    (when-let [checkpoint-data (checkpoint-store/load-checkpoint-data workflow-id opts)]
+      (let [dag-result (get-in checkpoint-data [:machine-snapshot :execution/dag-result])
+            completed-task-ids (set (:completed-task-ids dag-result))
+            artifacts (vec (get dag-result :artifacts []))]
+        (when (or (seq completed-task-ids) (seq artifacts))
+          {:pre-completed-ids completed-task-ids
+           :pre-completed-artifacts artifacts
+           :resumed? true
+           :resume-source :checkpoint})))
+    {:pre-completed-ids #{}
+     :pre-completed-artifacts []
+     :resumed? false})))

--- a/components/workflow/test/ai/miniforge/workflow/dag_resilience_resume_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/dag_resilience_resume_test.clj
@@ -17,176 +17,40 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.workflow.dag-resilience-resume-test
-  "Tests for resume helpers: safe-read-edn, read-event-file, extract functions, and resume context."
+  "Tests for DAG resume context restoration from authoritative checkpoints."
   (:require
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
-   [clojure.test :refer [deftest testing is]]
-   [clojure.java.io :as io]
-   [ai.miniforge.workflow.dag-resilience :as resilience]))
+   [ai.miniforge.workflow.dag-resilience :as resilience]
+   [clojure.test :refer [deftest is testing]]))
 
-;------------------------------------------------------------------------------ Resume helpers
-
-(defn temp-dir []
-  (doto (io/file (System/getProperty "java.io.tmpdir")
-                 (str "miniforge-resilience-test-" (System/nanoTime)))
-    .mkdirs))
-
-(defn cleanup! [dir]
-  (doseq [f (.listFiles dir)]
-    (when (.isDirectory f) (cleanup! f))
-    (.delete f))
-  (.delete dir))
-
-(defn write-events! [dir filename events]
-  (let [f (io/file dir filename)]
-    (with-open [w (io/writer f)]
-      (doseq [event events]
-        (.write w (pr-str event))
-        (.write w "\n")))
-    f))
-
-;------------------------------------------------------------------------------ Layer 3: safe-read-edn
-
-(deftest test-safe-read-edn-normal-values
-  (testing "reads map"
-    (is (= {:a 1 :b "hello"} (resilience/safe-read-edn "{:a 1 :b \"hello\"}"))))
-  (testing "reads vector"
-    (is (= [1 2 3] (resilience/safe-read-edn "[1 2 3]"))))
-  (testing "reads keyword"
-    (is (= :foo (resilience/safe-read-edn ":foo")))))
-
-(deftest test-safe-read-edn-tagged-literals
-  (testing "reads #uuid"
-    (let [result (resilience/safe-read-edn
-                  "{:id #uuid \"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee\"}")]
-      (is (uuid? (:id result)))))
-  (testing "reads #inst"
-    (let [result (resilience/safe-read-edn
-                  "{:ts #inst \"2026-03-08T18:14:28Z\"}")]
-      (is (some? (:ts result)))))
-  (testing "tolerates #object tags"
-    (let [result (resilience/safe-read-edn
-                  (str "{:err #object[java.time.Instant 0x25d0 "
-                       "\"2026-03-08T18:14:28Z\"]}"))]
-      (is (some? result)))))
-
-(deftest test-safe-read-edn-error-cases
-  (testing "returns nil for malformed EDN"
-    (is (nil? (resilience/safe-read-edn "{:broken {{{ invalid"))))
-  (testing "returns nil for empty string"
-    (is (nil? (resilience/safe-read-edn ""))))
-  (testing "returns nil for nil input"
-    (is (nil? (resilience/safe-read-edn nil)))))
-
-;------------------------------------------------------------------------------ Layer 3: read-event-file
-
-(deftest test-read-event-file-happy-path
-  (testing "reads all events from file"
-    (let [dir (temp-dir)]
-      (try
-        (let [events [{:event/type :workflow/started :workflow/id "test"}
-                      {:event/type :dag/task-completed :dag/task-id :task-a}
-                      {:event/type :workflow/failed}]
-              f (write-events! dir "test.edn" events)
-              result (resilience/read-event-file (.getAbsolutePath f))]
-          (is (= 3 (count result)))
-          (is (= :workflow/started (:event/type (first result))))
-          (is (= :workflow/failed (:event/type (last result)))))
-        (finally (cleanup! dir))))))
-
-(deftest test-read-event-file-skips-blank-lines
-  (testing "blank lines between events are ignored"
-    (let [dir (temp-dir)]
-      (try
-        (let [f (io/file dir "gaps.edn")]
-          (spit f (str (pr-str {:event/type :a}) "\n"
-                       "\n"
-                       "   \n"
-                       (pr-str {:event/type :b}) "\n"))
-          (let [result (resilience/read-event-file (.getAbsolutePath f))]
-            (is (= 2 (count result)))))
-        (finally (cleanup! dir))))))
-
-(deftest test-read-event-file-missing-file
-  (testing "returns nil for non-existent file"
-    (is (nil? (resilience/read-event-file "/nonexistent/path.edn")))))
-
-;------------------------------------------------------------------------------ Layer 3: Extract functions
-
-(deftest test-extract-completed-task-ids
-  (testing "extracts only :dag/task-completed event task IDs"
-    (let [events [{:event/type :workflow/started}
-                  {:event/type :dag/task-completed :dag/task-id :task-a}
-                  {:event/type :dag/task-failed :dag/task-id :task-b}
-                  {:event/type :dag/task-completed :dag/task-id :task-c}
-                  {:event/type :workflow/failed}]]
-      (is (= #{:task-a :task-c} (resilience/extract-completed-task-ids events)))))
-  (testing "returns empty set when no completions"
-    (is (= #{} (resilience/extract-completed-task-ids
-                [{:event/type :workflow/started}]))))
-  (testing "deduplicates"
-    (let [events [{:event/type :dag/task-completed :dag/task-id :task-a}
-                  {:event/type :dag/task-completed :dag/task-id :task-a}]]
-      (is (= #{:task-a} (resilience/extract-completed-task-ids events))))))
-
-(deftest test-extract-completed-artifacts
-  (testing "collects artifacts from completed tasks"
-    (let [events [{:event/type :dag/task-completed
-                   :dag/task-id :task-a
-                   :dag/result {:data {:artifacts [{:code/id "art-1"}]}}}
-                  {:event/type :dag/task-completed
-                   :dag/task-id :task-b
-                   :dag/result {:data {:artifacts [{:code/id "art-2"} {:code/id "art-3"}]}}}]]
-      (is (= 3 (count (resilience/extract-completed-artifacts events))))))
-  (testing "handles tasks with no artifacts"
-    (let [events [{:event/type :dag/task-completed
-                   :dag/result {:data {}}}]]
-      (is (= [] (resilience/extract-completed-artifacts events)))))
-  (testing "ignores non-completed events"
-    (let [events [{:event/type :dag/task-failed
-                   :dag/result {:data {:artifacts [{:code/id "ignored"}]}}}]]
-      (is (= [] (resilience/extract-completed-artifacts events))))))
-
-;------------------------------------------------------------------------------ Layer 3: Resume context end-to-end
-
-(deftest test-resume-context-end-to-end
-  (testing "checkpoint data is authoritative when persisted DAG resume state exists"
+(deftest resume-context-test
+  (testing "checkpoint DAG state is restored as resume context"
     (let [workflow-id (str (random-uuid))
-          checkpoint-data {:machine-snapshot {:execution/dag-result
-                                             {:completed-task-ids [:task-a :task-c]
-                                              :artifacts [{:code/id "art-1"}]
-                                              :pause-reason :rate-limit}}}]
+          checkpoint-data {:machine-snapshot
+                           {:execution/dag-result
+                            {:completed-task-ids [:task-a :task-c]
+                             :artifacts [{:code/id "art-1"}]
+                             :pause-reason :rate-limit}}}]
       (with-redefs [checkpoint-store/load-checkpoint-data
                     (fn [_workflow-run-id _opts] checkpoint-data)]
-        (let [ctx (resilience/resume-context-from-event-file workflow-id)]
+        (let [ctx (resilience/resume-context workflow-id)]
           (is (= #{:task-a :task-c} (:pre-completed-ids ctx)))
           (is (= [{:code/id "art-1"}] (:pre-completed-artifacts ctx)))
           (is (true? (:resumed? ctx)))
           (is (= :checkpoint (:resume-source ctx)))))))
-  (testing "builds full resume context from event file"
-    (let [dir (temp-dir)]
-      (try
-        (let [events [{:event/type :workflow/started :workflow/id "wf-123"}
-                      {:event/type :dag/task-completed
-                       :dag/task-id :task-a
-                       :dag/result {:data {:artifacts [{:code/id "art-1"}]}}}
-                      {:event/type :dag/task-failed
-                       :dag/task-id :task-b
-                       :dag/error {:message "quota"}}
-                      {:event/type :dag/task-completed
-                       :dag/task-id :task-c
-                       :dag/result {:data {:artifacts [{:code/id "art-2"}]}}}]
-              f (write-events! dir "wf-123.edn" events)
-              parsed (resilience/read-event-file (.getAbsolutePath f))
-              completed (resilience/extract-completed-task-ids parsed)
-              artifacts (resilience/extract-completed-artifacts parsed)]
-          (is (= #{:task-a :task-c} completed))
-          (is (not (contains? completed :task-b)))
-          (is (= 2 (count artifacts))))
-        (finally (cleanup! dir)))))
-  (testing "resume-context-from-event-file returns non-resumed for missing file"
+
+  (testing "checkpoint without DAG progress returns a non-resumed context"
+    (with-redefs [checkpoint-store/load-checkpoint-data
+                  (fn [_workflow-run-id _opts]
+                    {:machine-snapshot {:execution/status :paused}})]
+      (let [ctx (resilience/resume-context (str (random-uuid)))]
+        (is (= #{} (:pre-completed-ids ctx)))
+        (is (= [] (:pre-completed-artifacts ctx)))
+        (is (false? (:resumed? ctx))))))
+
+  (testing "missing checkpoint data returns a non-resumed context"
     (with-redefs [checkpoint-store/load-checkpoint-data (fn [_workflow-run-id _opts] nil)]
-      (let [ctx (resilience/resume-context-from-event-file "nonexistent-workflow-id")]
+      (let [ctx (resilience/resume-context (str (random-uuid)))]
         (is (= #{} (:pre-completed-ids ctx)))
         (is (= [] (:pre-completed-artifacts ctx)))
         (is (false? (:resumed? ctx)))))))

--- a/docs/pull-requests/2026-04-25-refactor-dag-checkpoint-resume-authority.md
+++ b/docs/pull-requests/2026-04-25-refactor-dag-checkpoint-resume-authority.md
@@ -1,0 +1,32 @@
+# refactor/dag-snapshot-final
+
+## Summary
+
+Removes the last runtime DAG resume path that reconstructed progress from
+workflow event files.
+
+The CLI workflow runner now restores pre-completed DAG task state from the
+authoritative workflow checkpoint snapshot only, and the workflow DAG resume
+helper no longer falls back to event-file parsing.
+
+## Key Changes
+
+- removed legacy event-file DAG resume logic from
+  [dag_resilience.clj](/private/tmp/mf-dag-snapshot-final/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj)
+  and replaced it with checkpoint-only `resume-context`
+- updated
+  [workflow_runner.clj](/private/tmp/mf-dag-snapshot-final/bases/cli/src/ai/miniforge/cli/workflow_runner.clj)
+  to resolve the checkpoint-based helper
+- renamed the emitted CLI error message key in
+  [en-US.edn](/private/tmp/mf-dag-snapshot-final/bases/cli/resources/config/cli/messages/en-US.edn)
+- replaced the old event-file-focused tests with checkpoint-authority tests in
+  [dag_resilience_resume_test.clj](/private/tmp/mf-dag-snapshot-final/components/workflow/test/ai/miniforge/workflow/dag_resilience_resume_test.clj)
+
+## Validation
+
+- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
+  bases/cli/src/ai/miniforge/cli/workflow_runner.clj
+  components/workflow/test/ai/miniforge/workflow/dag_resilience_resume_test.clj`
+- `clojure -M:dev:test -e "(require 'ai.miniforge.workflow.dag-resilience-resume-test)(let [result
+  (clojure.test/run-tests 'ai.miniforge.workflow.dag-resilience-resume-test)] (when (pos? (+ (:fail result) (:error
+  result))) (System/exit 1)))"`


### PR DESCRIPTION
# refactor/dag-snapshot-final

## Summary

Removes the last runtime DAG resume path that reconstructed progress from
workflow event files.

The CLI workflow runner now restores pre-completed DAG task state from the
authoritative workflow checkpoint snapshot only, and the workflow DAG resume
helper no longer falls back to event-file parsing.

## Key Changes

- removed legacy event-file DAG resume logic from
  [dag_resilience.clj](/private/tmp/mf-dag-snapshot-final/components/workflow/src/ai/miniforge/workflow/dag_resilience.clj)
  and replaced it with checkpoint-only `resume-context`
- updated
  [workflow_runner.clj](/private/tmp/mf-dag-snapshot-final/bases/cli/src/ai/miniforge/cli/workflow_runner.clj)
  to resolve the checkpoint-based helper
- renamed the emitted CLI error message key in
  [en-US.edn](/private/tmp/mf-dag-snapshot-final/bases/cli/resources/config/cli/messages/en-US.edn)
- replaced the old event-file-focused tests with checkpoint-authority tests in
  [dag_resilience_resume_test.clj](/private/tmp/mf-dag-snapshot-final/components/workflow/test/ai/miniforge/workflow/dag_resilience_resume_test.clj)

## Validation

- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/dag_resilience.clj
  bases/cli/src/ai/miniforge/cli/workflow_runner.clj
  components/workflow/test/ai/miniforge/workflow/dag_resilience_resume_test.clj`
- `clojure -M:dev:test -e "(require 'ai.miniforge.workflow.dag-resilience-resume-test)(let [result
  (clojure.test/run-tests 'ai.miniforge.workflow.dag-resilience-resume-test)] (when (pos? (+ (:fail result) (:error
  result))) (System/exit 1)))"`
