### PR TITLE
refactor: remove legacy state runtime dependency

### DIFF
--- a/components/workflow/src/ai/miniforge/workflow/comparison.clj
+++ b/components/workflow/src/ai/miniforge/workflow/comparison.clj
@@ -17,12 +17,16 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.workflow.comparison
-  "Workflow execution comparison utilities."
-  (:require
-   [ai.miniforge.workflow.state :as state]))
+  "Workflow execution comparison utilities.")
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Summary creation
+
+(defn- execution-duration-ms
+  [{:execution/keys [started-at ended-at]
+    :or {started-at 0}}]
+  (let [end-time (or ended-at started-at)]
+    (- end-time started-at)))
 
 (defn execution-summary
   "Create a summary map from an execution state."
@@ -31,7 +35,7 @@
    :execution/workflow-id workflow-id
    :execution/status status
    :execution/metrics metrics
-   :execution/duration-ms (state/get-duration-ms exec-state)
+   :execution/duration-ms (execution-duration-ms exec-state)
    :artifact-count (count artifacts)
    :error-count (count errors)})
 

--- a/components/workflow/test/ai/miniforge/workflow/comparison_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/comparison_test.clj
@@ -1,0 +1,37 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.workflow.comparison-test
+  (:require
+   [ai.miniforge.workflow.comparison :as comparison]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest execution-summary-test
+  (testing "duration is derived from execution timestamps without workflow.state"
+    (let [exec-state {:execution/id 1
+                      :execution/workflow-id :wf
+                      :execution/status :completed
+                      :execution/metrics {:tokens 10 :cost-usd 1.0}
+                      :execution/artifacts [{:artifact/id 1}]
+                      :execution/errors []
+                      :execution/started-at 100
+                      :execution/ended-at 180}
+          summary (comparison/execution-summary exec-state)]
+      (is (= 80 (:execution/duration-ms summary)))
+      (is (= 1 (:artifact-count summary)))
+      (is (= 0 (:error-count summary))))))

--- a/docs/pull-requests/2026-04-25-refactor-fsm-cleanup-runtime-dependency.md
+++ b/docs/pull-requests/2026-04-25-refactor-fsm-cleanup-runtime-dependency.md
@@ -1,0 +1,24 @@
+# refactor/fsm-cleanup-final
+
+## Summary
+
+Removes the remaining live runtime dependency on `ai.miniforge.workflow.state`
+outside the legacy compatibility namespace itself.
+
+`workflow.comparison` now derives duration directly from execution timestamps,
+so the old state namespace is no longer on an active runtime path after the FSM
+refactor.
+
+## Key Changes
+
+- removed the `workflow.state` dependency from
+  [comparison.clj](/private/tmp/mf-fsm-cleanup-final/components/workflow/src/ai/miniforge/workflow/comparison.clj)
+- added direct coverage in
+  [comparison_test.clj](/private/tmp/mf-fsm-cleanup-final/components/workflow/test/ai/miniforge/workflow/comparison_test.clj)
+
+## Validation
+
+- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/comparison.clj
+  components/workflow/test/ai/miniforge/workflow/comparison_test.clj`
+- `clojure -M:dev:test -e "(require 'ai.miniforge.workflow.comparison-test)(let [result (clojure.test/run-tests
+  'ai.miniforge.workflow.comparison-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`


### PR DESCRIPTION
# refactor/fsm-cleanup-final

## Summary

Removes the remaining live runtime dependency on `ai.miniforge.workflow.state`
outside the legacy compatibility namespace itself.

`workflow.comparison` now derives duration directly from execution timestamps,
so the old state namespace is no longer on an active runtime path after the FSM
refactor.

## Key Changes

- removed the `workflow.state` dependency from
  [comparison.clj](/private/tmp/mf-fsm-cleanup-final/components/workflow/src/ai/miniforge/workflow/comparison.clj)
- added direct coverage in
  [comparison_test.clj](/private/tmp/mf-fsm-cleanup-final/components/workflow/test/ai/miniforge/workflow/comparison_test.clj)

## Validation

- `clj-kondo --lint components/workflow/src/ai/miniforge/workflow/comparison.clj
  components/workflow/test/ai/miniforge/workflow/comparison_test.clj`
- `clojure -M:dev:test -e "(require 'ai.miniforge.workflow.comparison-test)(let [result (clojure.test/run-tests
  'ai.miniforge.workflow.comparison-test)] (when (pos? (+ (:fail result) (:error result))) (System/exit 1)))"`
