### PR TITLE
fix: restore Windows release clojure shim

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,25 @@ jobs:
           cli: latest
           bb: latest
 
+      # `bb build:cli` shells out to `clojure` through Java
+      # ProcessBuilder. On GitHub-hosted Windows runners setup-clojure
+      # exposes the Clojure CLI as a PowerShell module, not a real
+      # executable, so install deps.clj as clojure.exe / clj.exe.
+      - name: Install deps.clj shim (Windows)
+        shell: pwsh
+        run: |
+          $depsVersion = "1.12.4.1618"
+          $depsDir = "$env:USERPROFILE\.deps-clj"
+          New-Item -ItemType Directory -Force -Path $depsDir | Out-Null
+          Invoke-WebRequest `
+            -Uri "https://github.com/borkdude/deps.clj/releases/download/v${depsVersion}/deps.clj-${depsVersion}-windows-amd64.zip" `
+            -OutFile deps.zip
+          Expand-Archive deps.zip -DestinationPath $depsDir -Force
+          Copy-Item "$depsDir\deps.exe" "$depsDir\clojure.exe"
+          Copy-Item "$depsDir\deps.exe" "$depsDir\clj.exe"
+          "$depsDir" >> $env:GITHUB_PATH
+          Write-Host "clojure/clj installed at $depsDir (via deps.clj $depsVersion)"
+
       - name: Cache Clojure dependencies
         uses: actions/cache@v4
         with:

--- a/bb.edn
+++ b/bb.edn
@@ -9,6 +9,7 @@
  {:requires ([babashka.fs :as fs]
              [babashka.process :as p]
              [ai.miniforge.bb-dev-tools.interface :as bb-dev-tools]
+             [ai.miniforge.bb-proc.interface :as bb-proc]
              [ai.miniforge.bb-platform.interface :as platform])
 
   :init (do
@@ -20,6 +21,12 @@
           (defn run-stream! [& args]
             (let [{:keys [exit]} (deref (apply p/process {:out :inherit :err :inherit} args))]
               exit))
+
+          (defn run-clojure! [& args]
+            (apply run! (bb-proc/clojure-command) args))
+
+          (defn run-clojure-stream! [& args]
+            (apply run-stream! (bb-proc/clojure-command) args))
 
           ;; Cross-platform package install routing lives in the
           ;; ai.miniforge/bb-platform component. Aliased here so the
@@ -67,7 +74,7 @@
    :task (do
            (println "🧪 Running tests via poly test...")
            (println "Command: clojure -M:poly test")
-           (let [exit (run-stream! "clojure" "-M:poly" "test")]
+           (let [exit (run-clojure-stream! "-M:poly" "test")]
              (when-not (zero? exit)
                (println "❌ Tests failed with exit code:" exit)
                (System/exit exit))))}
@@ -141,7 +148,7 @@
   {:doc  "Clean all build artifacts"
    :task (do
            (println "🧹 Cleaning build artifacts...")
-           (run! "clojure" "-T:build" "clean"))}
+           (run-clojure! "-T:build" "clean"))}
 
   build:script
   {:doc  "Build BB dev script for a project (uses absolute paths)"
@@ -149,7 +156,7 @@
            (if project
              (do
                (println "🔨 Building BB script for project:" project)
-               (run! "clojure" "-T:build" "bb-script" (str ":project " project)))
+               (run-clojure! "-T:build" "bb-script" (str ":project " project)))
              (println "Usage: bb build:script <project>")))}
 
   build:cli
@@ -168,14 +175,14 @@
            (if project
              (do
                (println "🔨 Building uberjar for project:" project)
-               (run! "clojure" "-T:build" "uberjar" (str ":project " project)))
+               (run-clojure! "-T:build" "uberjar" (str ":project " project)))
              (println "Usage: bb build:jar <project>")))}
 
   build:all
   {:doc  "Build all changed projects"
    :task (do
            (println "🔨 Building all changed projects...")
-           (run! "clojure" "-T:build" "build-all"))}
+           (run-clojure! "-T:build" "build-all"))}
 
   build:tui
   {:doc  "Build miniforge-tui as JVM uberjar + jlink runtime"

--- a/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
+++ b/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
@@ -21,13 +21,18 @@
    read the same way across the umbrella and so tests can inspect
    exit/capture output uniformly.
 
-   Layer 0: argument normalization (pure).
+   Layer 0: argument normalization and command-resolution planning (pure).
    Layer 1: process invocations on top of Layer 0."
+  (:refer-clojure :exclude [run!])
   (:require [babashka.fs :as fs]
             [babashka.process :as p]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Argument normalization (pure)
+;; Argument normalization and command planning (pure)
+
+(def ^:private windows-clojure-command
+  "Fallback executable names for Clojure tooling on Windows runners."
+  ["clojure.exe" "clj.exe" "deps.exe"])
 
 (defn- split-opts
   "Split `args` into `[opts cmd]` where `opts` is the leading map (or an
@@ -37,8 +42,38 @@
     [(first args) (rest args)]
     [{} args]))
 
+(defn command-candidates
+  "Return candidate executable names for `cmd` on `os`."
+  [cmd os]
+  (let [candidates (if (and (= os :windows) (= cmd "clojure"))
+                     (into [cmd] windows-clojure-command)
+                     [cmd])]
+    (vec (distinct candidates))))
+
+(defn first-resolved-command
+  "Return the first executable path found by `lookup-fn`, else the first
+   candidate name unchanged."
+  [candidates lookup-fn]
+  (or (some (fn [candidate]
+              (some-> (lookup-fn candidate) str))
+            candidates)
+      (first candidates)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Process invocations
+
+(defn resolve-command
+  "Resolve `cmd` to an executable path when possible."
+  [cmd]
+  (let [windows-os? (re-find #"(?i)windows" (System/getProperty "os.name" ""))
+        os          (if windows-os? :windows :unix)
+        candidates  (command-candidates cmd os)]
+    (first-resolved-command candidates fs/which)))
+
+(defn clojure-command
+  "Resolve the best Clojure executable for the current process."
+  []
+  (resolve-command "clojure"))
 
 (defn run!
   "Run a command inheriting stdio. Throws ex-info on non-zero exit.

--- a/components/bb-proc/src/ai/miniforge/bb_proc/interface.clj
+++ b/components/bb-proc/src/ai/miniforge/bb_proc/interface.clj
@@ -18,6 +18,7 @@
 
 (ns ai.miniforge.bb-proc.interface
   "Subprocess helpers for Babashka tasks. Pass-through to `core`."
+  (:refer-clojure :exclude [run!])
   (:require [ai.miniforge.bb-proc.core :as core]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -45,6 +46,16 @@
   "True if `cmd` resolves on PATH."
   [cmd]
   (core/installed? cmd))
+
+(defn resolve-command
+  "Resolve `cmd` to an executable path when possible."
+  [cmd]
+  (core/resolve-command cmd))
+
+(defn clojure-command
+  "Resolve the best Clojure executable for the current process."
+  []
+  (core/clojure-command))
 
 (defn destroy!
   "Destroy a background process and wait briefly for it to exit."

--- a/components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj
+++ b/components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj
@@ -66,6 +66,33 @@
     (is (false? (sut/installed?
                  "definitely-not-a-real-binary-xyzzy-bb-proc")))))
 
+(deftest test-command-candidates-add-windows-clojure-fallbacks
+  (testing "given clojure on windows → includes executable fallbacks"
+    (is (= ["clojure" "clojure.exe" "clj.exe" "deps.exe"]
+           (sut/command-candidates "clojure" :windows)))))
+
+(deftest test-command-candidates-keep-other-cases-unchanged
+  (testing "given clojure on unix → keeps the canonical command only"
+    (is (= ["clojure"]
+           (sut/command-candidates "clojure" :unix))))
+  (testing "given a non-clojure command on windows → no extra fallbacks"
+    (is (= ["bb"]
+           (sut/command-candidates "bb" :windows)))))
+
+(deftest test-first-resolved-command-prefers-first-hit
+  (testing "given multiple candidates → returns the first resolved path"
+    (let [lookup {"clojure.exe" "C:/tools/clojure.exe"
+                  "deps.exe" "C:/tools/deps.exe"}]
+      (is (= "C:/tools/clojure.exe"
+             (sut/first-resolved-command
+              ["clojure" "clojure.exe" "deps.exe"]
+              lookup))))))
+
+(deftest test-first-resolved-command-falls-back-to-original-command
+  (testing "given no resolved candidates → returns the first candidate"
+    (is (= "clojure"
+           (sut/first-resolved-command ["clojure" "clojure.exe"] (constantly nil))))))
+
 (deftest test-run-bg!-starts-and-destroy!-tears-down
   (testing "given a long-running command → run-bg! returns handle, destroy! tears it down"
     (let [proc (sut/run-bg! {:out :string :err :string} "sleep" "30")]

--- a/docs/pull-requests/2026-04-26-fix-release-windows-clojure.md
+++ b/docs/pull-requests/2026-04-26-fix-release-windows-clojure.md
@@ -1,0 +1,43 @@
+# fix/release-windows-clojure
+
+## Summary
+
+Fixes the Windows release build by making Babashka task subprocesses resolve a
+real Clojure executable and by installing the same `deps.clj` shim in the
+release workflow that CI already uses on Windows.
+
+Without this, `bb build:cli` on GitHub-hosted Windows runners shells out via
+Java `ProcessBuilder`, which cannot resolve the PowerShell-module-only Clojure
+installation from `setup-clojure`.
+
+## Key Changes
+
+- added portable Clojure executable resolution helpers to
+  [core.clj](/tmp/mf-fix-release-windows/components/bb-proc/src/ai/miniforge/bb_proc/core.clj)
+  and
+  [interface.clj](/tmp/mf-fix-release-windows/components/bb-proc/src/ai/miniforge/bb_proc/interface.clj)
+- updated Babashka task entry points in
+  [build.clj](/tmp/mf-fix-release-windows/tasks/build.clj),
+  [test_runner.clj](/tmp/mf-fix-release-windows/tasks/test_runner.clj),
+  [standards.clj](/tmp/mf-fix-release-windows/tasks/standards.clj), and
+  [bb.edn](/tmp/mf-fix-release-windows/bb.edn)
+  to use the resolved Clojure command instead of the hard-coded `clojure`
+  token
+- added the Windows `deps.clj` shim install step to
+  [release.yml](/tmp/mf-fix-release-windows/.github/workflows/release.yml)
+- added unit coverage for the new resolver behavior in
+  [core_test.clj](/tmp/mf-fix-release-windows/components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj)
+
+## Validation
+
+- `clj-kondo --lint tasks/build.clj tasks/test_runner.clj
+  tasks/standards.clj
+  components/bb-proc/src/ai/miniforge/bb_proc/core.clj
+  components/bb-proc/src/ai/miniforge/bb_proc/interface.clj
+  components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj`
+- `clojure -M:dev:test -e "(require 'clojure.test
+  'ai.miniforge.bb-proc.core-test) (let [r
+  (clojure.test/run-tests 'ai.miniforge.bb-proc.core-test)] (System/exit (if
+  (zero? (+ (:fail r 0) (:error r 0))) 0 1)))"`
+- `bb build:cli`
+- `bb pre-commit`

--- a/tasks/build.clj
+++ b/tasks/build.clj
@@ -18,47 +18,57 @@
 
 (ns build
   (:require
+   [ai.miniforge.bb-proc.interface :as proc]
    [babashka.fs :as fs]
    [babashka.process :as p]
    [clojure.string :as str]))
 
+(defn- print-command-output!
+  [{:keys [out err]}]
+  (when-not (str/blank? out)
+    (println out))
+  (when-not (str/blank? err)
+    (binding [*out* *err*]
+      (println err))))
+
+(defn- build-command
+  [& args]
+  (into [(proc/clojure-command) "-T:build"] args))
+
+(defn- run-build-command!
+  [command failure-message]
+  (println "Command:" (str/join " " command))
+  (let [{:keys [exit] :as result} (apply p/sh {:out :string :err :string} command)]
+    (print-command-output! result)
+    (when-not (zero? exit)
+      (println failure-message exit)
+      (System/exit exit))))
+
 (defn cli []
   (println "🔨 Building miniforge CLI uberjar...")
-  (println "Command: clojure -T:build bb-uberjar :project miniforge")
-  (let [{:keys [exit out err]} (p/sh {:out :string :err :string}
-                                     "clojure" "-T:build" "bb-uberjar" ":project" "miniforge")]
-    (when-not (str/blank? out) (println out))
-    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-    (when-not (zero? exit)
-      (println "❌ Build failed with exit code:" exit)
-      (System/exit exit))))
+  (let [command (build-command "bb-uberjar" ":project" "miniforge")]
+    (run-build-command! command "❌ Build failed with exit code:")))
 
 (defn kernel []
   (println "🔨 Building miniforge-core CLI uberjar...")
-  (println "Command: clojure -T:build bb-uberjar :project miniforge-core")
-  (let [{:keys [exit out err]} (p/sh {:out :string :err :string}
-                                     "clojure" "-T:build" "bb-uberjar" ":project" "miniforge-core")]
-    (when-not (str/blank? out) (println out))
-    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-    (when-not (zero? exit)
-      (println "❌ Build failed with exit code:" exit)
-      (System/exit exit))))
+  (let [command (build-command "bb-uberjar" ":project" "miniforge-core")]
+    (run-build-command! command "❌ Build failed with exit code:")))
 
 (defn tui []
-  (let [jar-file   "dist/miniforge-tui.jar"
-        jlink-dir  "dist/miniforge-tui-runtime"
-        dist-dir   "dist/miniforge-tui"
-        java-home  (or (System/getenv "JAVA_HOME")
-                       "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home")]
+  (let [jar-file      "dist/miniforge-tui.jar"
+        jlink-dir     "dist/miniforge-tui-runtime"
+        dist-dir      "dist/miniforge-tui"
+        java-home     (get (System/getenv) "JAVA_HOME"
+                           "/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home")
+        uber-file-arg (str "\"" jar-file "\"")]
     (println "🔨 Building miniforge-tui JVM uberjar...")
     ;; Step 1: Build JVM uberjar
-    (let [{:keys [exit out err]}
-          (p/sh {:out :string :err :string}
-                "clojure" "-T:build" "uberjar"
-                ":project" "miniforge-tui"
-                ":uber-file" (str "\"" jar-file "\""))]
-      (when-not (str/blank? out) (println out))
-      (when-not (str/blank? err) (binding [*out* *err*] (println err)))
+    (let [command (build-command "uberjar"
+                                 ":project" "miniforge-tui"
+                                 ":uber-file" uber-file-arg)
+          {:keys [exit] :as result} (apply p/sh {:out :string :err :string} command)]
+      (println "Command:" (str/join " " command))
+      (print-command-output! result)
       (when-not (zero? exit)
         (println "❌ Uberjar build failed")
         (System/exit exit)))
@@ -120,11 +130,5 @@
 
 (defn compile-all []
   (println "⚙️  Compiling all code for syntax check...")
-  (println "Command: clojure -T:build compile-all")
-  (let [{:keys [exit out err]} (p/sh {:out :string :err :string}
-                                     "clojure" "-T:build" "compile-all")]
-    (when-not (str/blank? out) (println out))
-    (when-not (str/blank? err) (binding [*out* *err*] (println err)))
-    (when-not (zero? exit)
-      (println "❌ Compilation failed with exit code:" exit)
-      (System/exit exit))))
+  (let [command (build-command "compile-all")]
+    (run-build-command! command "❌ Compilation failed with exit code:")))

--- a/tasks/standards.clj
+++ b/tasks/standards.clj
@@ -18,6 +18,7 @@
 
 (ns standards
   (:require
+   [ai.miniforge.bb-proc.interface :as proc]
    [babashka.process :as p]
    [clojure.string :as str]))
 
@@ -45,9 +46,10 @@
    components/phase/resources/packs/miniforge-standards.pack.edn."
   []
   (println "Compiling standards pack from .standards/ ...")
-  (let [{:keys [exit out err]}
+  (let [clojure-cmd (proc/clojure-command)
+        {:keys [exit out err]}
         (p/sh {:out :string :err :string}
-              "clojure" "-M:dev" "-m" "compile-standards")]
+              clojure-cmd "-M:dev" "-m" "compile-standards")]
     (when-not (str/blank? out) (println out))
     (when-not (str/blank? err)
       (binding [*out* *err*] (println err)))

--- a/tasks/test_runner.clj
+++ b/tasks/test_runner.clj
@@ -18,6 +18,7 @@
 
 (ns test-runner
   (:require
+   [ai.miniforge.bb-proc.interface :as proc]
    [babashka.process :as p]
    [clojure.string :as str]))
 
@@ -32,13 +33,14 @@
 (defn- run-project-tests!
   [project test-nses]
   (let [deps (slurp (str "projects/" project "/deps.edn"))
+        clojure-cmd (proc/clojure-command)
         require-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
         run-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
         expr (str "(require 'clojure.test" require-expr ") "
                   "(let [r (clojure.test/run-tests" run-expr ")] "
                   "  (System/exit (if (zero? (+ (:fail r 0) (:error r 0))) 0 1)))")]
     (run-stream! {:dir (str "projects/" project)}
-                 "clojure" "-Sdeps" deps "-M" "-e" expr)))
+                 clojure-cmd "-Sdeps" deps "-M" "-e" expr)))
 
 (defn integration []
   (println "🧪 Running project integration tests...")
@@ -89,19 +91,21 @@
                    "conformance.agent_context_handoff_test"
                    "conformance.protocol_conformance_test"
                    "conformance.gate_enforcement_test"]
+        clojure-cmd (proc/clojure-command)
         require-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
         run-expr (apply str (map (fn [ns] (str " '" ns)) test-nses))
         expr (str "(require 'clojure.test" require-expr ") "
                   "(clojure.test/run-tests" run-expr ")")
-        exit (run-stream! "clojure" "-M:conformance" "-e" expr)]
+        exit (run-stream! clojure-cmd "-M:conformance" "-e" expr)]
     (when-not (zero? exit)
       (println "❌ Conformance tests failed with exit code:" exit)
       (System/exit exit))))
 
 (defn graalvm []
   (println "🧪 Testing GraalVM/Babashka compatibility...")
-  (let [;; Use :dev alias to get full component classpath
-        cp (-> (p/sh {:out :string} "clojure" "-A:dev" "-Spath")
+  (let [clojure-cmd (proc/clojure-command)
+        ;; Use :dev alias to get full component classpath
+        cp (-> (p/sh {:out :string} clojure-cmd "-A:dev" "-Spath")
                :out
                str/trim)
         ;; Add tests directory to classpath


### PR DESCRIPTION
# fix/release-windows-clojure

## Summary

Fixes the Windows release build by making Babashka task subprocesses resolve a
real Clojure executable and by installing the same `deps.clj` shim in the
release workflow that CI already uses on Windows.

Without this, `bb build:cli` on GitHub-hosted Windows runners shells out via
Java `ProcessBuilder`, which cannot resolve the PowerShell-module-only Clojure
installation from `setup-clojure`.

## Key Changes

- added portable Clojure executable resolution helpers to
  [core.clj](/tmp/mf-fix-release-windows/components/bb-proc/src/ai/miniforge/bb_proc/core.clj)
  and
  [interface.clj](/tmp/mf-fix-release-windows/components/bb-proc/src/ai/miniforge/bb_proc/interface.clj)
- updated Babashka task entry points in
  [build.clj](/tmp/mf-fix-release-windows/tasks/build.clj),
  [test_runner.clj](/tmp/mf-fix-release-windows/tasks/test_runner.clj),
  [standards.clj](/tmp/mf-fix-release-windows/tasks/standards.clj), and
  [bb.edn](/tmp/mf-fix-release-windows/bb.edn)
  to use the resolved Clojure command instead of the hard-coded `clojure`
  token
- added the Windows `deps.clj` shim install step to
  [release.yml](/tmp/mf-fix-release-windows/.github/workflows/release.yml)
- added unit coverage for the new resolver behavior in
  [core_test.clj](/tmp/mf-fix-release-windows/components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj)

## Validation

- `clj-kondo --lint tasks/build.clj tasks/test_runner.clj
  tasks/standards.clj
  components/bb-proc/src/ai/miniforge/bb_proc/core.clj
  components/bb-proc/src/ai/miniforge/bb_proc/interface.clj
  components/bb-proc/test/ai/miniforge/bb_proc/core_test.clj`
- `clojure -M:dev:test -e "(require 'clojure.test
  'ai.miniforge.bb-proc.core-test) (let [r
  (clojure.test/run-tests 'ai.miniforge.bb-proc.core-test)] (System/exit (if
  (zero? (+ (:fail r 0) (:error r 0))) 0 1)))"`
- `bb build:cli`
- `bb pre-commit`
