### PR TITLE
fix: correct Windows bb uberjar classpath

### DIFF
--- a/build.clj
+++ b/build.clj
@@ -46,6 +46,16 @@
 (def script-dir "dist")
 (def class-dir "target/classes")
 
+(defn join-classpath-roots
+  "Join classpath roots with the provided platform separator."
+  [separator cp-roots]
+  (str/join separator cp-roots))
+
+(defn classpath-string
+  "Build a platform-correct classpath string for subprocess invocation."
+  [cp-roots]
+  (join-classpath-roots (System/getProperty "path.separator") cp-roots))
+
 (defn today-commit-count
   "Count commits made today (for DateVer patch number)."
   []
@@ -181,14 +191,19 @@
     (binding [b/*project-root* root]
       (:classpath-roots (b/create-basis {:aliases [:poly]})))))
 
+(defn captured-command-result
+  "Run a command and capture stdout/stderr without throwing on non-zero exit."
+  [& args]
+  (apply bp/sh {:out :string :err :string} args))
+
 (defn bb-compatible?
   "Return true if main-ns loads successfully in Babashka.
    Prints stack trace on failure for debugging."
   [main-ns cp-roots]
-  (let [cp            (str/join ":" cp-roots)
+  (let [cp            (classpath-string cp-roots)
         sexpr         (build-prompt-sexpr main-ns)
-        {:keys [exit out err]} (bp/shell {:out :string :err :string}
-                                         "bb" "--classpath" cp "-e" sexpr)]
+        {:keys [exit out err]} (captured-command-result
+                                "bb" "--classpath" cp "-e" sexpr)]
     (when-not (zero? exit)
       (println "BB compatibility check failed:")
       (when (seq out) (println "stdout:" out))
@@ -300,10 +315,10 @@
 
     ;; Use bb uberscript to bundle everything
     (let [{:keys [exit err out]}
-          (bp/shell {:out :string :err :string}
-                    "bb" "uberscript" output
-                    "-cp" (str/join ":" cp-roots)
-                    "-m" (str main-ns))]
+          (captured-command-result
+           "bb" "uberscript" output
+           "-cp" (classpath-string cp-roots)
+           "-m" (str main-ns))]
       (when-not (zero? exit)
         (throw (ex-info "bb uberscript failed" {:exit exit :err err :out out}))))
 
@@ -340,10 +355,10 @@
     ;; Use bb uberjar to bundle everything
     ;; This will fail on its own if the code isn't Babashka-compatible
     (let [{:keys [exit err out]}
-          (bp/shell {:out :string :err :string}
-                    "bb" "uberjar" output
-                    "-cp" (str/join ":" cp-roots)
-                    "-m" (str main-ns))]
+          (captured-command-result
+           "bb" "uberjar" output
+           "-cp" (classpath-string cp-roots)
+           "-m" (str main-ns))]
       (when-not (zero? exit)
         (println "stdout:" out)
         (println "stderr:" err)

--- a/development/test/build_test.clj
+++ b/development/test/build_test.clj
@@ -1,0 +1,35 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns build-test
+  (:require [clojure.test :refer [deftest is testing]]))
+
+(load-file "build.clj")
+
+(def join-classpath-roots (resolve 'build/join-classpath-roots))
+
+(deftest join-classpath-roots-test
+  (testing "unix-like path separators use colon"
+    (is (= "/a:/b:/c"
+           (join-classpath-roots ":" ["/a" "/b" "/c"]))))
+  (testing "windows path separators use semicolon"
+    (is (= "C:\\a;D:\\b;E:\\c"
+           (join-classpath-roots ";" ["C:\\a" "D:\\b" "E:\\c"]))))
+  (testing "empty classpath roots stay empty"
+    (is (= ""
+           (join-classpath-roots ";" [])))))

--- a/docs/pull-requests/2026-04-27-fix-windows-build-classpath-separator.md
+++ b/docs/pull-requests/2026-04-27-fix-windows-build-classpath-separator.md
@@ -1,0 +1,36 @@
+# fix/windows-build-failure
+
+## Summary
+
+Fixes the remaining Windows release-build failure after the `clojure.exe`
+shim landed.
+
+The root problem was that the root `build.clj` script was assembling Babashka
+classpath arguments with a hard-coded `:` separator. That works on Unix, but it
+breaks on Windows where the classpath separator is `;` and drive letters already
+contain `:`.
+
+This PR also switches the build-script Babashka subprocess calls from
+throwing `bp/shell` to captured `bp/sh`, so non-zero exits produce stable
+stdout/stderr diagnostics instead of the broken `clojure.pprint` multimethod
+error that was obscuring the real failure.
+
+## Key Changes
+
+- added platform-aware classpath helpers in
+  [build.clj](/tmp/mf-fix-windows-build-failure/build.clj)
+- updated `bb-compatible?`, `bb-uberscript`, and `bb-uberjar` to use the
+  platform-correct classpath string
+- switched those subprocess paths to captured command execution so non-zero
+  exits are reported cleanly
+- added focused coverage for the classpath-join helper in
+  [build_test.clj](/tmp/mf-fix-windows-build-failure/development/test/build_test.clj)
+
+## Validation
+
+- `clj-kondo --lint build.clj development/test/build_test.clj`
+- `clojure -M:build:dev:test -e "(require 'clojure.test 'build-test)
+  (let [r (clojure.test/run-tests 'build-test)]
+  (System/exit (if (zero? (+ (:fail r 0) (:error r 0))) 0 1)))"`
+- `bb build:cli`
+- `bb pre-commit`


### PR DESCRIPTION
# fix/windows-build-failure

## Summary

Fixes the remaining Windows release-build failure after the `clojure.exe`
shim landed.

The root problem was that the root `build.clj` script was assembling Babashka
classpath arguments with a hard-coded `:` separator. That works on Unix, but it
breaks on Windows where the classpath separator is `;` and drive letters already
contain `:`.

This PR also switches the build-script Babashka subprocess calls from
throwing `bp/shell` to captured `bp/sh`, so non-zero exits produce stable
stdout/stderr diagnostics instead of the broken `clojure.pprint` multimethod
error that was obscuring the real failure.

## Key Changes

- added platform-aware classpath helpers in
  [build.clj](/tmp/mf-fix-windows-build-failure/build.clj)
- updated `bb-compatible?`, `bb-uberscript`, and `bb-uberjar` to use the
  platform-correct classpath string
- switched those subprocess paths to captured command execution so non-zero
  exits are reported cleanly
- added focused coverage for the classpath-join helper in
  [build_test.clj](/tmp/mf-fix-windows-build-failure/development/test/build_test.clj)

## Validation

- `clj-kondo --lint build.clj development/test/build_test.clj`
- `clojure -M:build:dev:test -e "(require 'clojure.test 'build-test)
  (let [r (clojure.test/run-tests 'build-test)]
  (System/exit (if (zero? (+ (:fail r 0) (:error r 0))) 0 1)))"`
- `bb build:cli`
- `bb pre-commit`
