### PR TITLE
fix: target release tag on workflow dispatch reruns

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
+      release_tag: ${{ steps.version.outputs.release_tag }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}
 
     steps:
@@ -186,11 +187,15 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
             VERSION="${{ github.event.inputs.version }}"
+            RELEASE_TAG="v${VERSION}"
           else
             VERSION="${GITHUB_REF#refs/tags/v}"
+            RELEASE_TAG="${GITHUB_REF_NAME}"
           fi
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
           echo "Version: $VERSION"
+          echo "Release tag: $RELEASE_TAG"
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -210,7 +215,7 @@ jobs:
         id: create_release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ github.ref_name != '' && github.ref_name || format('v{0}', steps.version.outputs.version) }}
+          tag_name: ${{ steps.version.outputs.release_tag }}
           name: Release ${{ steps.version.outputs.version }}
           draft: false
           prerelease: false

--- a/docs/pull-requests/2026-04-27-fix-release-dispatch-tag.md
+++ b/docs/pull-requests/2026-04-27-fix-release-dispatch-tag.md
@@ -1,0 +1,26 @@
+## Summary
+
+Fix the release workflow so manual reruns update the requested release tag
+instead of publishing to the dispatch ref name.
+
+## Problem
+
+Manual `Release` workflow dispatches were using `github.ref_name` for
+`tag_name`. When dispatched from `main`, the release job updated the `main`
+release instead of `v<version>`, so reruns did not attach rebuilt assets to
+the intended versioned release.
+
+## Changes
+
+- compute an explicit `release_tag` in [.github/workflows/release.yml](/.github/workflows/release.yml)
+- use `v<version>` for `workflow_dispatch`
+- use `GITHUB_REF_NAME` for tag-push releases
+- pass the computed `release_tag` to `softprops/action-gh-release`
+
+## Validation
+
+- inspected the failed rerun logs and confirmed the old workflow was publishing
+  to `https://github.com/miniforge-ai/miniforge/releases/tag/main`
+- reviewed the workflow diff to verify `workflow_dispatch` now targets
+  `v<version>` explicitly
+- `bb pre-commit`


### PR DESCRIPTION
## Summary

Fix the release workflow so manual reruns update the requested release tag
instead of publishing to the dispatch ref name.

## Problem

Manual `Release` workflow dispatches were using `github.ref_name` for
`tag_name`. When dispatched from `main`, the release job updated the `main`
release instead of `v<version>`, so reruns did not attach rebuilt assets to
the intended versioned release.

## Changes

- compute an explicit `release_tag` in [.github/workflows/release.yml](/.github/workflows/release.yml)
- use `v<version>` for `workflow_dispatch`
- use `GITHUB_REF_NAME` for tag-push releases
- pass the computed `release_tag` to `softprops/action-gh-release`

## Validation

- inspected the failed rerun logs and confirmed the old workflow was publishing
  to `https://github.com/miniforge-ai/miniforge/releases/tag/main`
- reviewed the workflow diff to verify `workflow_dispatch` now targets
  `v<version>` explicitly
- `bb pre-commit`
