### PR TITLE
feat: emit richer supervisory decision and agent context

### DIFF
--- a/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
+++ b/components/adapter-miniforge/src/ai/miniforge/adapter_miniforge/interface.clj
@@ -49,15 +49,21 @@
 (defn- event->agent-info
   "Extract agent info from a miniforge event."
   [event]
-  (let [wf-id (:workflow/id event)]
+  (let [wf-id (:workflow/id event)
+        metadata (cond-> {:workflow-id wf-id
+                          :event-type (:event/type event)}
+                   (:workflow/spec event) (assoc :workflow-spec (:workflow/spec event))
+                   (:workflow/phase event) (assoc :workflow-phase (:workflow/phase event))
+                   (:agent/context event) (assoc :agent-context (:agent/context event))
+                   (:phase/context event) (assoc :phase-context (:phase/context event))
+                   (:message event) (assoc :message (:message event)))]
     {:agent/vendor :miniforge
      :agent/external-id (str wf-id)
      :agent/name (str (control-plane/t :adapter/miniforge-prefix) (or (:workflow/name event)
                                          (:message event)
                                          wf-id))
      :agent/capabilities #{:code-generation :test-writing :code-review}
-     :agent/metadata {:workflow-id wf-id
-                      :event-type (:event/type event)}}))
+     :agent/metadata metadata}))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Protocol implementation

--- a/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
+++ b/components/adapter-miniforge/test/ai/miniforge/adapter_miniforge/interface_test.clj
@@ -77,7 +77,8 @@
         (is (= #{:code-generation :test-writing :code-review}
                (:agent/capabilities info)))
         (is (= {:workflow-id "wf-123"
-                :event-type  :agent-started}
+                :event-type  :agent-started
+                :message "Starting agent"}
                (:agent/metadata info)))))
 
     (testing "falls back to :message when :workflow/name is nil"

--- a/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
+++ b/components/control-plane/src/ai/miniforge/control_plane/orchestrator.clj
@@ -106,7 +106,13 @@
                                    workflow-id
                                    (:agent/id registered)
                                    (:agent/vendor registered)
-                                   {:name (:agent/name registered)}))))))))
+                                   {:name (:agent/name registered)
+                                    :external-id (:agent/external-id registered)
+                                    :capabilities (:agent/capabilities registered)
+                                    :metadata (:agent/metadata registered)
+                                    :tags (:agent/tags registered)
+                                    :heartbeat-interval-ms (:agent/heartbeat-interval-ms
+                                                            registered)}))))))))
       (catch Exception _e nil))))
 
 (defn- run-poll-pass
@@ -134,6 +140,15 @@
                                                                (:agent/id agent-record)
                                                                heartbeat)
                       new-status (:agent/status updated-agent)]
+                  (when (and workflow-id event-stream status)
+                    (publish-event! event-stream
+                                    (events/cp-agent-heartbeat
+                                     event-stream
+                                     workflow-id
+                                     (:agent/id agent-record)
+                                     status
+                                     {:task task
+                                      :metrics metrics})))
                   (when (and workflow-id
                              event-stream
                              new-status
@@ -231,7 +246,11 @@
                        agent-id
                        (:decision/id decision)
                        summary
-                       (:decision/priority decision))))
+                       {:priority (:decision/priority decision)
+                        :type (:decision/type decision)
+                        :context (:decision/context decision)
+                        :options (:decision/options decision)
+                        :deadline (:decision/deadline decision)})))
     decision))
 
 (defn resolve-and-deliver!
@@ -267,7 +286,8 @@
                            event-stream
                            workflow-id
                            decision-id
-                           resolution)))
+                           resolution
+                           comment)))
         {:resolved resolved
          :delivered? (get delivery :delivered? false)}))))
 

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
@@ -455,7 +455,7 @@
           "should have published at least one state-changed event"))))
 
 (deftest run-poll-pass-no-event-when-status-unchanged-test
-  (testing "poll pass does not emit event when status remains the same"
+  (testing "poll pass keeps heartbeats but skips state-changed when status remains the same"
     (let [reg (registry/create-registry)
           es (stream/create-event-stream)
           published (atom [])
@@ -475,9 +475,9 @@
                   :event-stream es}))]
       (#'sut/run-poll-pass orch)
       (Thread/sleep 100)
-      ;; Status didn't change, so no state-changed event expected
-      (is (zero? (count @published))
-          "should not publish event when status is unchanged"))))
+      (let [event-types (map :event/type @published)]
+        (is (= [:control-plane/agent-heartbeat] event-types)
+            "stable polls should publish heartbeat context but not a state change")))))
 
 (deftest run-poll-pass-multiple-vendors-test
   (testing "poll pass routes agents to correct adapters by vendor"

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -573,15 +573,24 @@
       (assoc :cp/agent-id agent-id
              :cp/vendor vendor)
       (cond->
-        (:name opts) (assoc :cp/agent-name (:name opts)))))
+        (:name opts) (assoc :cp/agent-name (:name opts))
+        (:external-id opts) (assoc :cp/external-id (:external-id opts))
+        (:capabilities opts) (assoc :cp/capabilities (vec (:capabilities opts)))
+        (:metadata opts) (assoc :cp/metadata (:metadata opts))
+        (:tags opts) (assoc :cp/tags (vec (:tags opts)))
+        (:heartbeat-interval-ms opts)
+        (assoc :cp/heartbeat-interval-ms (:heartbeat-interval-ms opts)))))
 
 (defn cp-agent-heartbeat
   "Emit when the control plane receives a heartbeat from an agent."
-  [stream workflow-id agent-id status]
+  [stream workflow-id agent-id status & [opts]]
   (-> (create-envelope stream :control-plane/agent-heartbeat workflow-id
                        (str "Heartbeat from " agent-id ": " (name status)))
       (assoc :cp/agent-id agent-id
-             :cp/status status)))
+             :cp/status status)
+      (cond->
+        (:task opts) (assoc :cp/task (:task opts))
+        (:metrics opts) (assoc :cp/metrics (:metrics opts)))))
 
 (defn cp-agent-state-changed
   "Emit when an agent's normalized state changes."
@@ -594,21 +603,30 @@
 
 (defn cp-decision-created
   "Emit when an agent submits a decision request."
-  [stream workflow-id agent-id decision-id summary & [priority]]
+  [stream workflow-id agent-id decision-id summary & [priority-or-opts]]
+  (let [opts (if (map? priority-or-opts)
+               priority-or-opts
+               {:priority priority-or-opts})]
   (-> (create-envelope stream :control-plane/decision-created workflow-id
                        (str "Decision needed from " agent-id ": " summary))
       (assoc :cp/agent-id agent-id
              :cp/decision-id decision-id
              :cp/summary summary)
-      (cond-> priority (assoc :cp/priority priority))))
+      (cond->
+        (:priority opts) (assoc :cp/priority (:priority opts))
+        (:type opts) (assoc :cp/type (:type opts))
+        (:context opts) (assoc :cp/context (:context opts))
+        (:options opts) (assoc :cp/options (vec (:options opts)))
+        (:deadline opts) (assoc :cp/deadline (:deadline opts))))))
 
 (defn cp-decision-resolved
   "Emit when a human resolves a decision."
-  [stream workflow-id decision-id resolution]
+  [stream workflow-id decision-id resolution & [comment]]
   (-> (create-envelope stream :control-plane/decision-resolved workflow-id
                        (str "Decision " decision-id " resolved: " resolution))
       (assoc :cp/decision-id decision-id
-             :cp/resolution resolution)))
+             :cp/resolution resolution)
+      (cond-> comment (assoc :cp/comment comment))))
 
 (defn intervention-requested
   "Emit when a bounded supervisory intervention is created."

--- a/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/core_test.clj
@@ -307,7 +307,21 @@
     (let [stream (no-op-stream)
           event (core/cp-agent-registered stream (random-uuid) "agent-1" :anthropic
                                           {:name "Implementer"})]
-      (is (= "Implementer" (:cp/agent-name event))))))
+      (is (= "Implementer" (:cp/agent-name event)))))
+
+  (testing "includes richer registration metadata when present"
+    (let [stream (no-op-stream)
+          event (core/cp-agent-registered stream (random-uuid) "agent-1" :anthropic
+                                          {:external-id "ext-1"
+                                           :capabilities #{:code-generation}
+                                           :metadata {:workflow-id "wf-1"}
+                                           :tags #{:native}
+                                           :heartbeat-interval-ms 15000})]
+      (is (= "ext-1" (:cp/external-id event)))
+      (is (= [:code-generation] (:cp/capabilities event)))
+      (is (= {:workflow-id "wf-1"} (:cp/metadata event)))
+      (is (= [:native] (:cp/tags event)))
+      (is (= 15000 (:cp/heartbeat-interval-ms event))))))
 
 (deftest cp-agent-heartbeat-test
   (testing "creates heartbeat event"
@@ -315,7 +329,15 @@
           event (core/cp-agent-heartbeat stream (random-uuid) "agent-1" :active)]
       (is (= :control-plane/agent-heartbeat (:event/type event)))
       (is (= "agent-1" (:cp/agent-id event)))
-      (is (= :active (:cp/status event))))))
+      (is (= :active (:cp/status event)))))
+
+  (testing "includes task and metrics when present"
+    (let [stream (no-op-stream)
+          event (core/cp-agent-heartbeat stream (random-uuid) "agent-1" :active
+                                         {:task "Reviewing PR"
+                                          :metrics {:tokens 42}})]
+      (is (= "Reviewing PR" (:cp/task event)))
+      (is (= {:tokens 42} (:cp/metrics event))))))
 
 (deftest cp-agent-state-changed-test
   (testing "creates state-change event with from/to"
@@ -334,7 +356,23 @@
       (is (= :control-plane/decision-created (:event/type event)))
       (is (= decision-id (:cp/decision-id event)))
       (is (= "Approve budget increase" (:cp/summary event)))
-      (is (= :high (:cp/priority event))))))
+      (is (= :high (:cp/priority event)))))
+
+  (testing "includes richer decision fields when present"
+    (let [stream (no-op-stream)
+          decision-id (random-uuid)
+          deadline (java.util.Date.)
+          event (core/cp-decision-created stream (random-uuid) "agent-1" decision-id
+                                          "Choose release target"
+                                          {:priority :medium
+                                           :type :choice
+                                           :context "Production cutover"
+                                           :options ["blue" "green"]
+                                           :deadline deadline})]
+      (is (= :choice (:cp/type event)))
+      (is (= "Production cutover" (:cp/context event)))
+      (is (= ["blue" "green"] (:cp/options event)))
+      (is (= deadline (:cp/deadline event))))))
 
 (deftest cp-decision-resolved-test
   (testing "creates resolved event"
@@ -343,7 +381,15 @@
           event (core/cp-decision-resolved stream (random-uuid) decision-id "approved")]
       (is (= :control-plane/decision-resolved (:event/type event)))
       (is (= decision-id (:cp/decision-id event)))
-      (is (= "approved" (:cp/resolution event))))))
+      (is (= "approved" (:cp/resolution event)))))
+
+  (testing "includes optional comment"
+    (let [stream (no-op-stream)
+          decision-id (random-uuid)
+          event (core/cp-decision-resolved stream (random-uuid) decision-id
+                                           "approved"
+                                           "Matches rollout plan")]
+      (is (= "Matches rollout plan" (:cp/comment event))))))
 
 (deftest intervention-requested-test
   (testing "creates supervisory intervention requested event"

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -276,13 +276,15 @@
                   :agent/last-heartbeat ts}))))
 
 (defn cp-agent-heartbeat
-  [table {:cp/keys [agent-id status] :as event}]
+  [table {:cp/keys [agent-id status task metrics] :as event}]
   (let [ts (event-instant event)]
     (cond-> table
       (get-in table [:agents agent-id])
       (update-in [:agents agent-id] merge
                  (cond-> {:agent/last-heartbeat ts}
-                   status (assoc :agent/status status))))))
+                   status (assoc :agent/status status)
+                   task (assoc :agent/task task)
+                   metrics (assoc :agent/metrics metrics))))))
 
 (defn agent-status
   "Coarse `:agent/status` event: maps status/type to AgentSession status.

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -429,6 +429,22 @@
     (is (some? (:decision/created-at card)))
     (is (nil? (:decision/resolved-at card)) "not resolved until a resolve event arrives")))
 
+(deftest cp-decision-created-copies-rich-fields
+  (let [did   (random-uuid)
+        aid   (random-uuid)
+        due   (java.util.Date.)
+        table (acc/apply-event schema/empty-table
+                               (decision-created-event did aid "Choose target"
+                                                       {:cp/type :choice
+                                                        :cp/context "Production migration"
+                                                        :cp/options ["blue" "green"]
+                                                        :cp/deadline due}))
+        card  (get-in table [:decisions did])]
+    (is (= :choice (:decision/type card)))
+    (is (= "Production migration" (:decision/context card)))
+    (is (= ["blue" "green"] (:decision/options card)))
+    (is (= due (:decision/deadline card)))))
+
 (deftest cp-decision-created-attaches-workflow-run-id-when-present
   (let [did   (random-uuid)
         wf    (random-uuid)
@@ -456,6 +472,21 @@
     ;; Creation fields must survive the resolve update.
     (is (= aid (:decision/agent-id card)))
     (is (= "Choose target" (:decision/summary card)))))
+
+(deftest cp-agent-heartbeat-updates-task-and-metrics
+  (let [aid (random-uuid)
+        table (-> schema/empty-table
+                  (acc/apply-event (ev :control-plane/agent-registered
+                                       {:cp/agent-id aid
+                                        :cp/vendor :claude-code}))
+                  (acc/apply-event (ev :control-plane/agent-heartbeat
+                                       {:cp/agent-id aid
+                                        :cp/status :running
+                                        :cp/task "Reviewing PR #42"
+                                        :cp/metrics {:tokens 12}})))
+        agent (get-in table [:agents aid])]
+    (is (= "Reviewing PR #42" (:agent/task agent)))
+    (is (= {:tokens 12} (:agent/metrics agent)))))
 
 (deftest cp-decision-resolved-before-created-stubs-minimal-card
   (let [did   (random-uuid)

--- a/docs/pull-requests/2026-04-27-feat-rich-decision-agent-context.md
+++ b/docs/pull-requests/2026-04-27-feat-rich-decision-agent-context.md
@@ -1,0 +1,162 @@
+# feat: emit richer supervisory decision and agent context
+
+## Overview
+
+Enrich the control-plane producer events and supervisory projections so
+downstream clients receive actionable decision context and richer agent state
+without inventing UI-only fields.
+
+This PR stays within the producer, event-stream, adapter, and supervisory-state
+layers. It does not change the workflow FSM, phase transition authority, or
+decision model semantics.
+
+## Motivation
+
+The current supervisory clients can already render:
+
+- `DecisionCard.decision_type`
+- `DecisionCard.context`
+- `DecisionCard.options`
+- `DecisionCard.deadline`
+- `DecisionCard.comment`
+- `AgentSession.metadata`
+- `AgentSession.task`
+
+But `miniforge` was not actually emitting most of that data on the wire.
+
+In practice that meant:
+
+- decision queues collapsed into UUIDs plus a vague summary
+- bulk approvals had no real grouping context beyond the summary line
+- agent detail had almost no useful run/task metadata
+- clients had to guess whether missing context was a rendering problem or a
+  producer problem
+
+This PR fixes the producer side of that gap.
+
+## Changes In Detail
+
+### 1. Preserve richer decision context on `:control-plane/decision-*`
+
+`event-stream.core/cp-decision-created` now accepts and emits the richer fields
+already present on control-plane decisions:
+
+- `:cp/priority`
+- `:cp/type`
+- `:cp/context`
+- `:cp/options`
+- `:cp/deadline`
+
+`event-stream.core/cp-decision-resolved` now also preserves:
+
+- `:cp/comment`
+
+`control-plane.orchestrator/submit-decision-from-agent!` now projects those
+fields from the created decision record into the emitted event, and
+`resolve-and-deliver!` now carries the optional resolution comment.
+
+### 2. Stop dropping agent registration metadata
+
+`control-plane.orchestrator/run-discovery-pass` previously emitted only the
+registered agent id, vendor, and name. It now preserves the rest of the
+already-known registration state:
+
+- `:cp/external-id`
+- `:cp/capabilities`
+- `:cp/metadata`
+- `:cp/tags`
+- `:cp/heartbeat-interval-ms`
+
+That means supervisory-state can retain richer `AgentSession` records instead of
+reconstructing a thinner shadow of the registry.
+
+### 3. Mirror heartbeat task context into supervisory state
+
+Stable status is still meaningful when the task changes. This PR makes that
+observable by:
+
+- enriching `:control-plane/agent-heartbeat` with optional `:cp/task` and
+  `:cp/metrics`
+- emitting heartbeat events during poll passes even when normalized status does
+  not change
+- updating supervisory-state accumulation so `AgentSession.task` and
+  `AgentSession.metrics` track the latest heartbeat payload
+
+### 4. Preserve richer native miniforge agent metadata
+
+`adapter-miniforge` now carries more source event context into
+`AgentSession.metadata` when it is present on native miniforge events:
+
+- `:workflow-spec`
+- `:workflow-phase`
+- `:agent-context`
+- `:phase-context`
+- `:message`
+
+This keeps the producer aligned with the existing “metadata is open” contract
+instead of forcing downstream clients to infer context from a single message
+string.
+
+## Scope And Non-Goals
+
+This PR intentionally does not:
+
+- add new workflow-machine states
+- change the finite state machine refactor or phase execution semantics
+- invent new client-shaped decision fields outside the existing decision model
+- solve every detail-view UX gap by itself
+
+The goal here is to make authoritative producer data richer and more faithful to
+the canonical decision and registry state that already exists.
+
+## Why This Shape
+
+The cleanest source of truth was already in-process:
+
+- the control-plane decision record already had type, context, options, and
+  deadline
+- the control-plane registry already had agent metadata, capabilities, and task
+  context
+
+The bug was that the event projection was dropping those fields before
+supervisory-state and downstream clients ever saw them.
+
+So the right fix is to preserve existing canonical data across the event
+boundary, not to invent special-case TUI payloads.
+
+## Enabled Follow-On Work
+
+This producer slice is intended to make all supervisory clients denser and more
+actionable immediately, especially `miniforge-control`.
+
+Concrete downstream effects:
+
+1. decision queues can render the actual decision type, context, options, and
+   resolution comments already supported by the current Rust contract
+2. agent detail can rely on richer metadata/task state instead of UUID-only
+   placeholders
+3. bulk decision resolution can group around meaningful context instead of just
+   summary text
+
+## Testing Plan
+
+Executed in repository root:
+
+```sh
+bb test components/event-stream components/control-plane components/adapter-miniforge components/supervisory-state
+```
+
+Result:
+
+- targeted producer/control-plane bricks passed
+- no failures in the enriched event-stream, control-plane, adapter-miniforge,
+  or supervisory-state coverage
+
+## Checklist
+
+- [x] Decision-created events preserve existing decision context fields
+- [x] Decision-resolved events preserve optional operator comment
+- [x] Agent registration events preserve already-known registry metadata
+- [x] Heartbeat events preserve task/metrics and update supervisory sessions
+- [x] Native miniforge adapter metadata is richer without changing protocol
+- [x] Tests cover the richer event and projection behavior


### PR DESCRIPTION
# feat: emit richer supervisory decision and agent context

## Overview

Enrich the control-plane producer events and supervisory projections so
downstream clients receive actionable decision context and richer agent state
without inventing UI-only fields.

This PR stays within the producer, event-stream, adapter, and supervisory-state
layers. It does not change the workflow FSM, phase transition authority, or
decision model semantics.

## Motivation

The current supervisory clients can already render:

- `DecisionCard.decision_type`
- `DecisionCard.context`
- `DecisionCard.options`
- `DecisionCard.deadline`
- `DecisionCard.comment`
- `AgentSession.metadata`
- `AgentSession.task`

But `miniforge` was not actually emitting most of that data on the wire.

In practice that meant:

- decision queues collapsed into UUIDs plus a vague summary
- bulk approvals had no real grouping context beyond the summary line
- agent detail had almost no useful run/task metadata
- clients had to guess whether missing context was a rendering problem or a
  producer problem

This PR fixes the producer side of that gap.

## Changes In Detail

### 1. Preserve richer decision context on `:control-plane/decision-*`

`event-stream.core/cp-decision-created` now accepts and emits the richer fields
already present on control-plane decisions:

- `:cp/priority`
- `:cp/type`
- `:cp/context`
- `:cp/options`
- `:cp/deadline`

`event-stream.core/cp-decision-resolved` now also preserves:

- `:cp/comment`

`control-plane.orchestrator/submit-decision-from-agent!` now projects those
fields from the created decision record into the emitted event, and
`resolve-and-deliver!` now carries the optional resolution comment.

### 2. Stop dropping agent registration metadata

`control-plane.orchestrator/run-discovery-pass` previously emitted only the
registered agent id, vendor, and name. It now preserves the rest of the
already-known registration state:

- `:cp/external-id`
- `:cp/capabilities`
- `:cp/metadata`
- `:cp/tags`
- `:cp/heartbeat-interval-ms`

That means supervisory-state can retain richer `AgentSession` records instead of
reconstructing a thinner shadow of the registry.

### 3. Mirror heartbeat task context into supervisory state

Stable status is still meaningful when the task changes. This PR makes that
observable by:

- enriching `:control-plane/agent-heartbeat` with optional `:cp/task` and
  `:cp/metrics`
- emitting heartbeat events during poll passes even when normalized status does
  not change
- updating supervisory-state accumulation so `AgentSession.task` and
  `AgentSession.metrics` track the latest heartbeat payload

### 4. Preserve richer native miniforge agent metadata

`adapter-miniforge` now carries more source event context into
`AgentSession.metadata` when it is present on native miniforge events:

- `:workflow-spec`
- `:workflow-phase`
- `:agent-context`
- `:phase-context`
- `:message`

This keeps the producer aligned with the existing “metadata is open” contract
instead of forcing downstream clients to infer context from a single message
string.

## Scope And Non-Goals

This PR intentionally does not:

- add new workflow-machine states
- change the finite state machine refactor or phase execution semantics
- invent new client-shaped decision fields outside the existing decision model
- solve every detail-view UX gap by itself

The goal here is to make authoritative producer data richer and more faithful to
the canonical decision and registry state that already exists.

## Why This Shape

The cleanest source of truth was already in-process:

- the control-plane decision record already had type, context, options, and
  deadline
- the control-plane registry already had agent metadata, capabilities, and task
  context

The bug was that the event projection was dropping those fields before
supervisory-state and downstream clients ever saw them.

So the right fix is to preserve existing canonical data across the event
boundary, not to invent special-case TUI payloads.

## Enabled Follow-On Work

This producer slice is intended to make all supervisory clients denser and more
actionable immediately, especially `miniforge-control`.

Concrete downstream effects:

1. decision queues can render the actual decision type, context, options, and
   resolution comments already supported by the current Rust contract
2. agent detail can rely on richer metadata/task state instead of UUID-only
   placeholders
3. bulk decision resolution can group around meaningful context instead of just
   summary text

## Testing Plan

Executed in repository root:

```sh
bb test components/event-stream components/control-plane components/adapter-miniforge components/supervisory-state
```

Result:

- targeted producer/control-plane bricks passed
- no failures in the enriched event-stream, control-plane, adapter-miniforge,
  or supervisory-state coverage

## Checklist

- [x] Decision-created events preserve existing decision context fields
- [x] Decision-resolved events preserve optional operator comment
- [x] Agent registration events preserve already-known registry metadata
- [x] Heartbeat events preserve task/metrics and update supervisory sessions
- [x] Native miniforge adapter metadata is richer without changing protocol
- [x] Tests cover the richer event and projection behavior
