### PR TITLE
test: eliminate 37 of 68 Thread/sleep calls in tests

### DIFF
--- a/components/agent/test/ai/miniforge/agent/messaging_router_test.clj
+++ b/components/agent/test/ai/miniforge/agent/messaging_router_test.clj
@@ -112,8 +112,11 @@
                  :to-agent :implementer
                  :workflow-id test-workflow-id
                  :content "Msg 2"})]
-      (agent/route-message router msg1)
-      (Thread/sleep 10) ;; Ensure different timestamps
+      ;; Backdate msg1 so its timestamp is unambiguously earlier than msg2's,
+      ;; regardless of clock resolution.
+      (agent/route-message router
+                           (assoc msg1 :message/timestamp
+                                  (java.util.Date. (- (System/currentTimeMillis) 1000))))
       (agent/route-message router msg2)
 
       (let [all-msgs (agent/get-messages-by-workflow router test-workflow-id)]

--- a/components/connector/test/ai/miniforge/connector/interface_test.clj
+++ b/components/connector/test/ai/miniforge/connector/interface_test.clj
@@ -511,11 +511,14 @@
 
 (deftest cursor-advance-updates-timestamp-test
   (testing "Advancing cursor updates last-retrieved-at"
-    (let [cursor (conn/create-cursor :offset 0)
-          t1 (:cursor/last-retrieved-at cursor)
-          _ (Thread/sleep 5)
+    ;; Backdate the cursor's timestamp so advance-cursor's new timestamp
+    ;; is unambiguously later, regardless of clock resolution.
+    (let [cursor   (-> (conn/create-cursor :offset 0)
+                       (assoc :cursor/last-retrieved-at
+                              (.minusSeconds (java.time.Instant/now) 1)))
+          t1       (:cursor/last-retrieved-at cursor)
           advanced (conn/advance-cursor cursor 1)
-          t2 (:cursor/last-retrieved-at advanced)]
+          t2       (:cursor/last-retrieved-at advanced)]
       (is (.isAfter t2 t1)))))
 
 (deftest cursor-empty-map-test

--- a/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/interface_test.clj
@@ -217,12 +217,13 @@
                                      {:priority :high})
         d-blocked (cp/create-decision blocked-agent "Blocked agent, high"
                                       {:priority :high})]
-    ;; Submit normal first so it's older
     (cp/submit-decision! mgr d-normal)
-    (Thread/sleep 10)
     (cp/submit-decision! mgr d-blocked)
 
-    (testing "Blocked agent's decision appears first at same priority"
+    (testing "Filtering by agent set returns the blocked agent's decision"
+      ;; pending-decisions filters by the supplied agent set, so timestamp
+      ;; ordering between submissions is irrelevant — only blocked-agent's
+      ;; decision is returned.
       (let [pending (cp/pending-decisions mgr #{blocked-agent})]
         (is (= blocked-agent (:decision/agent-id (first pending))))))))
 
@@ -253,12 +254,15 @@
   (let [reg (cp/create-registry)
         agent (cp/register-agent! reg {:agent/vendor :test
                                         :agent/name "Stale"
-                                        :agent/heartbeat-interval-ms 1})]
-    ;; Transition to running first
-    (cp/transition-agent! reg (:agent/id agent) :running)
-    ;; Wait for heartbeat to be stale (3 * 1ms)
-    (Thread/sleep 50)
+                                        :agent/heartbeat-interval-ms 1000})
+        agent-id (:agent/id agent)]
+    ;; Transition to running first.
+    (cp/transition-agent! reg agent-id :running)
+    ;; Backdate the heartbeat far past the staleness threshold instead of waiting
+    ;; for wall-clock time to elapse. Threshold is heartbeat-interval-ms * 3.
+    (let [past (java.util.Date. (- (System/currentTimeMillis) 60000))]
+      (swap! reg assoc-in [:agents agent-id :agent/last-heartbeat] past))
     (testing "Stale agent detected and marked unreachable"
       (let [transitioned (cp/check-stale-agents reg)]
         (is (= 1 (count transitioned)))
-        (is (= :unreachable (:agent/status (cp/get-agent reg (:agent/id agent)))))))))
+        (is (= :unreachable (:agent/status (cp/get-agent reg agent-id))))))))

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_edge_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_edge_test.clj
@@ -14,6 +14,25 @@
    [ai.miniforge.control-plane-adapter.protocol :as adapter]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
+(def ^:private default-wait-timeout-ms 2000)
+
+(defn- wait-until-count
+  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
+   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
+  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
+  ([items-atom n timeout-ms]
+   (let [done (promise)
+         k    (gensym "wait-count-")]
+     (when (>= (count @items-atom) n)
+       (deliver done :immediate))
+     (add-watch items-atom k
+                (fn [_ _ _ new-val]
+                  (when (>= (count new-val) n)
+                    (deliver done :reached))))
+     (let [result (deref done timeout-ms ::timeout)]
+       (remove-watch items-atom k)
+       (not= result ::timeout)))))
+
 ;; ---------------------------------------------------------------------------
 ;; Test helpers
 ;; ---------------------------------------------------------------------------
@@ -131,13 +150,12 @@
                             :event-stream es}))
           decision (sut/submit-decision-from-agent!
                     orch (:agent/id agent-rec) "Resolve event test")
-          ;; Clear events from submit
-          _ (Thread/sleep 50)
+          ;; Wait for submit-emitted events, then clear before resolve.
+          _ (wait-until-count published 1)
           _ (reset! published [])
           _ (sut/resolve-and-deliver!
              orch (:decision/id decision) "approved")]
-      (Thread/sleep 100)
-      (is (pos? (count @published))
+      (is (wait-until-count published 1)
           "should have published decision-resolved event"))))
 
 ;; ---------------------------------------------------------------------------
@@ -304,10 +322,9 @@
                             :adapters [adapter]
                             :event-stream es}))]
       (#'sut/run-poll-pass orch)
-      (Thread/sleep 100)
       ;; Agent was :initializing, poll returned :status :running
       ;; This should trigger a state-changed event
-      (is (pos? (count @published))
+      (is (wait-until-count published 1)
           "should emit state-changed when :status key differs from current"))))
 
 ;; ---------------------------------------------------------------------------

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_supplemental_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_supplemental_test.clj
@@ -14,6 +14,25 @@
    [ai.miniforge.control-plane-adapter.protocol :as adapter]
    [ai.miniforge.event-stream.interface.stream :as stream]))
 
+(def ^:private default-wait-timeout-ms 2000)
+
+(defn- wait-until-count
+  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
+   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
+  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
+  ([items-atom n timeout-ms]
+   (let [done (promise)
+         k    (gensym "wait-count-")]
+     (when (>= (count @items-atom) n)
+       (deliver done :immediate))
+     (add-watch items-atom k
+                (fn [_ _ _ new-val]
+                  (when (>= (count new-val) n)
+                    (deliver done :reached))))
+     (let [result (deref done timeout-ms ::timeout)]
+       (remove-watch items-atom k)
+       (not= result ::timeout)))))
+
 ;; ---------------------------------------------------------------------------
 ;; Test helpers
 ;; ---------------------------------------------------------------------------
@@ -142,9 +161,8 @@
                             :adapters [adapter]
                             :event-stream es}))]
       (#'sut/run-poll-pass orch)
-      (Thread/sleep 100)
       ;; Verify at least one event was published with state change
-      (is (pos? (count @published))
+      (is (wait-until-count published 1)
           "should emit event for status change"))))
 
 ;; ---------------------------------------------------------------------------
@@ -246,8 +264,7 @@
                             :event-stream es}))
           decision (sut/submit-decision-from-agent!
                     orch (:agent/id agent-rec) "Event field test")]
-      (Thread/sleep 100)
-      (is (pos? (count @published))
+      (is (wait-until-count published 1)
           "should have published decision-created event")
       ;; Verify the returned decision is well-formed
       (is (= (:agent/id agent-rec) (:decision/agent-id decision))))))
@@ -292,10 +309,9 @@
                 (base-opts {:adapters [adapter]
                             :discovery-interval-ms 10
                             :poll-interval-ms 10}))]
-      ;; Rapid cycle 3 times
+      ;; Rapid cycle 3 times — the test is the hygiene of start/stop, not loop firing.
       (dotimes [_ 3]
         (let [started (sut/start! orch)]
-          (Thread/sleep 30)
           (sut/stop! started)))
       (is (false? @(:running orch))
           "should be stopped after cycling")

--- a/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
+++ b/components/control-plane/test/ai/miniforge/control_plane/orchestrator_test.clj
@@ -47,6 +47,38 @@
     {:stream (stream/create-event-stream)
      :published events-atom}))
 
+(def ^:private default-wait-timeout-ms 2000)
+
+(defn- wait-until-count
+  "Block until `(count @items-atom) >= n` or `timeout-ms` elapses.
+   Uses add-watch + promise — no fixed sleep. Returns true if reached, false on timeout."
+  ([items-atom n] (wait-until-count items-atom n default-wait-timeout-ms))
+  ([items-atom n timeout-ms]
+   (let [done (promise)
+         k    (gensym "wait-count-")]
+     (when (>= (count @items-atom) n)
+       (deliver done :immediate))
+     (add-watch items-atom k
+                (fn [_ _ _ new-val]
+                  (when (>= (count new-val) n)
+                    (deliver done :reached))))
+     (let [result (deref done timeout-ms ::timeout)]
+       (remove-watch items-atom k)
+       (not= result ::timeout)))))
+
+(defn- wait-until
+  "Block until `(pred)` returns truthy or `timeout-ms` elapses.
+   Returns true if pred satisfied, false on timeout."
+  ([pred] (wait-until pred default-wait-timeout-ms))
+  ([pred timeout-ms]
+   (let [deadline (+ (System/currentTimeMillis) timeout-ms)]
+     (loop []
+       (cond
+         (pred) true
+         (> (System/currentTimeMillis) deadline) false
+         :else (do (java.util.concurrent.locks.LockSupport/parkNanos 1000000)
+                   (recur)))))))
+
 (def test-workflow-id (java.util.UUID/fromString "00000000-0000-0000-0000-000000000001"))
 
 (defn base-orchestrator-opts
@@ -258,9 +290,7 @@
                   :adapters [adapter]
                   :event-stream es}))]
       (#'sut/run-discovery-pass orch)
-      ;; Give async publish a moment
-      (Thread/sleep 50)
-      (is (>= (count @published) 1)
+      (is (wait-until-count published 1)
           "should have published at least one event"))))
 
 (deftest run-discovery-pass-empty-results-test
@@ -449,9 +479,8 @@
                   :adapters [adapter]
                   :event-stream es}))]
       (#'sut/run-poll-pass orch)
-      (Thread/sleep 100)
       ;; Should have emitted a state-changed event since status went from :initializing to :running
-      (is (>= (count @published) 1)
+      (is (wait-until-count published 1)
           "should have published at least one state-changed event"))))
 
 (deftest run-poll-pass-no-event-when-status-unchanged-test
@@ -474,7 +503,7 @@
                   :adapters [adapter]
                   :event-stream es}))]
       (#'sut/run-poll-pass orch)
-      (Thread/sleep 100)
+      (wait-until-count published 1)
       (let [event-types (map :event/type @published)]
         (is (= [:control-plane/agent-heartbeat] event-types)
             "stable polls should publish heartbeat context but not a state change")))))
@@ -560,8 +589,8 @@
                   :discovery-interval-ms 50
                   :poll-interval-ms 50}))]
       (sut/start! orch)
-      ;; Wait for at least one discovery cycle
-      (Thread/sleep 200)
+      ;; Wait for at least one discovery cycle to register an agent.
+      (wait-until #(pos? (registry/count-agents reg)))
       (sut/stop! orch)
       (is (pos? (registry/count-agents reg))
           "discovery loop should have registered agents")
@@ -695,8 +724,7 @@
                   :event-stream es}))]
       (sut/submit-decision-from-agent!
        orch (:agent/id agent-rec) "Event decision?")
-      (Thread/sleep 100)
-      (is (>= (count @published) 1)
+      (is (wait-until-count published 1)
           "should have published a decision-created event"))))
 
 (deftest submit-multiple-decisions-same-agent-test
@@ -816,9 +844,8 @@
                     orch (:agent/id agent-rec) "Event test?")
           _ (sut/resolve-and-deliver!
              orch (:decision/id decision) "approved")]
-      (Thread/sleep 100)
       ;; Should have events for: decision-created, decision-resolved
-      (is (>= (count @published) 2)
+      (is (wait-until-count published 2)
           "should have published decision-created and decision-resolved events"))))
 
 (deftest resolve-and-deliver-without-comment-test
@@ -912,10 +939,9 @@
                   :discovery-interval-ms 50
                   :poll-interval-ms 50}))]
 
-      ;; Start orchestrator
+      ;; Start orchestrator and wait for discovery to register the agent.
       (sut/start! orch)
-      ;; Wait for discovery
-      (Thread/sleep 200)
+      (wait-until #(pos? (registry/count-agents reg)))
 
       (let [agents (registry/list-agents reg)]
         (is (= 1 (count agents)) "should have discovered one agent")
@@ -959,7 +985,7 @@
                   :discovery-interval-ms 50
                   :poll-interval-ms 50}))]
       (sut/start! orch)
-      (Thread/sleep 200)
+      (wait-until #(pos? (registry/count-agents reg)))
 
       (let [agents (registry/list-agents reg)
             agent-id (:agent/id (first agents))
@@ -969,9 +995,8 @@
                       orch agent-id "Full lifecycle event test")
             _ (sut/resolve-and-deliver!
                orch (:decision/id decision) "yes")]
-        (Thread/sleep 100)
         ;; Should have: agent-registered, possibly state-changed, decision-created, decision-resolved
-        (is (>= (count @published) 3)
+        (is (wait-until-count published 3)
             "should have published multiple events throughout lifecycle"))
 
       (sut/stop! orch))))

--- a/components/event-stream/test/ai/miniforge/event_stream/approval_test.clj
+++ b/components/event-stream/test/ai/miniforge/event_stream/approval_test.clj
@@ -71,10 +71,12 @@
 
 (deftest expiry-test
   (testing "check-approval-status detects expiry"
-    (let [req (es/create-approval-request (random-uuid) ["alice"] 1
-                                          {:expires-in-hours 0})]
-      ;; With 0 hours, it should be expired immediately (or very soon)
-      (Thread/sleep 10) ; ensure time passes
+    ;; Backdate :approval/expires-at into the past so it is unambiguously
+    ;; expired without waiting for wall-clock time to advance.
+    (let [req (-> (es/create-approval-request (random-uuid) ["alice"] 1
+                                              {:expires-in-hours 1})
+                  (assoc :approval/expires-at
+                         (java.util.Date. (- (System/currentTimeMillis) 1000))))]
       (is (= :expired (es/check-approval-status req)))))
 
   (testing "non-expired request shows correct status"

--- a/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
+++ b/components/pr-lifecycle/test/ai/miniforge/pr_lifecycle/controller_test.clj
@@ -234,14 +234,16 @@
   (testing "update-status! updates the :updated-at timestamp"
     (let [ctrl (controller/create-controller
                  "dag" "run" "task" test-task
-                 :worktree-path "/tmp")
-          before-ts (:updated-at @ctrl)]
-      ;; Small sleep to ensure timestamp differs
-      (Thread/sleep 5)
-      (controller/update-status! ctrl :monitoring-ci)
-      (let [after-ts (:updated-at @ctrl)]
-        (is (not= before-ts after-ts))
-        (is (.after ^java.util.Date after-ts ^java.util.Date before-ts))))))
+                 :worktree-path "/tmp")]
+      ;; Backdate the initial :updated-at so the post-update timestamp is
+      ;; unambiguously later, regardless of clock resolution.
+      (swap! ctrl assoc :updated-at
+             (java.util.Date. (- (System/currentTimeMillis) 1000)))
+      (let [before-ts (:updated-at @ctrl)]
+        (controller/update-status! ctrl :monitoring-ci)
+        (let [after-ts (:updated-at @ctrl)]
+          (is (not= before-ts after-ts))
+          (is (.after ^java.util.Date after-ts ^java.util.Date before-ts)))))))
 
 (deftest state-machine-full-happy-path-test
   (testing "State transitions through the full happy path: pending -> creating-pr -> monitoring-ci -> monitoring-review -> ready-to-merge -> merging -> merged"

--- a/components/task-executor/test/ai/miniforge/task_executor/orchestrator_test.clj
+++ b/components/task-executor/test/ai/miniforge/task_executor/orchestrator_test.clj
@@ -154,12 +154,9 @@
           run-atom (create-mock-run-atom task-defs)
           context (create-mock-context run-atom {} execution-tracker)]
 
-      ;; Execute task
+      ;; Execute task (synchronous — work and tracker updates complete before return)
       (update-task-status! run-atom "a" :implementing)
       ((:execute-task-fn context) "a" context)
-
-      ;; Wait for completion
-      (Thread/sleep 200)
 
       (is (= ["a"] (:started @execution-tracker))
           "Task should be started")
@@ -175,22 +172,17 @@
                                        {:task-delay-ms 50}
                                        execution-tracker)]
 
-      ;; Execute A
+      ;; Execute A → B → C synchronously; each call returns once the work is done.
       (update-task-status! run-atom "a" :implementing)
       ((:execute-task-fn context) "a" context)
-      (Thread/sleep 100)
       (update-task-status! run-atom "a" :merged)
 
-      ;; Execute B (depends on A)
       (update-task-status! run-atom "b" :implementing)
       ((:execute-task-fn context) "b" context)
-      (Thread/sleep 100)
       (update-task-status! run-atom "b" :merged)
 
-      ;; Execute C (depends on B)
       (update-task-status! run-atom "c" :implementing)
       ((:execute-task-fn context) "c" context)
-      (Thread/sleep 100)
 
       (is (= ["a" "b" "c"] (:started @execution-tracker))
           "Tasks should execute in order: A → B → C"))))
@@ -202,22 +194,17 @@
           run-atom (create-mock-run-atom mock-parallel-dag)
           context (create-mock-context run-atom
                                        {:task-delay-ms 100}
-                                       execution-tracker)]
-
-      ;; Launch all tasks in parallel
-      (doseq [task-id ["a" "b" "c"]]
-        (update-task-status! run-atom task-id :implementing)
-        (future ((:execute-task-fn context) task-id context)))
-
-      ;; Wait for all to start
-      (Thread/sleep 50)
-
+                                       execution-tracker)
+          ;; Launch all tasks in parallel and capture the futures.
+          futs (doall
+                 (for [task-id ["a" "b" "c"]]
+                   (do
+                     (update-task-status! run-atom task-id :implementing)
+                     (future ((:execute-task-fn context) task-id context)))))]
+      ;; Deterministically wait for each task to finish.
+      (doseq [f futs] @f)
       (is (= 3 (count (:started @execution-tracker)))
           "All 3 tasks should start")
-
-      ;; Wait for completion
-      (Thread/sleep 150)
-
       (is (= 3 (count (:completed @execution-tracker)))
           "All 3 tasks should complete"))))
 
@@ -233,22 +220,20 @@
       ;; Execute A
       (update-task-status! run-atom "a" :implementing)
       ((:execute-task-fn context) "a" context)
-      (Thread/sleep 100)
       (update-task-status! run-atom "a" :merged)
 
-      ;; Execute B and C in parallel (both depend on A)
+      ;; Execute B and C in parallel (both depend on A); deref to wait.
       (update-task-status! run-atom "b" :implementing)
       (update-task-status! run-atom "c" :implementing)
-      (future ((:execute-task-fn context) "b" context))
-      (future ((:execute-task-fn context) "c" context))
-      (Thread/sleep 150)
+      (let [bc-futs [(future ((:execute-task-fn context) "b" context))
+                     (future ((:execute-task-fn context) "c" context))]]
+        (doseq [f bc-futs] @f))
       (update-task-status! run-atom "b" :merged)
       (update-task-status! run-atom "c" :merged)
 
       ;; Execute D (depends on B and C)
       (update-task-status! run-atom "d" :implementing)
       ((:execute-task-fn context) "d" context)
-      (Thread/sleep 100)
 
       (is (= ["a" "b" "c" "d"] (sort (:completed @execution-tracker)))
           "All tasks should complete")
@@ -303,13 +288,11 @@
       ;; Execute A (succeeds)
       (update-task-status! run-atom "a" :implementing)
       ((:execute-task-fn context) "a" context)
-      (Thread/sleep 100)
       (update-task-status! run-atom "a" :merged)
 
       ;; Execute B (fails)
       (update-task-status! run-atom "b" :implementing)
       (let [result ((:execute-task-fn context) "b" context)]
-        (Thread/sleep 100)
         (is (false? (:success? result))
             "Task B should fail")
         (update-task-status! run-atom "b" :failed))
@@ -358,13 +341,11 @@
       ;; Execute first task (1000 tokens)
       (update-task-status! run-atom "a" :implementing)
       ((:execute-task-fn context) "a" context)
-      (Thread/sleep 100)
       (swap! run-atom update-in [:metrics :tokens] + 1000)
 
       ;; Execute second task (1000 tokens)
       (update-task-status! run-atom "b" :implementing)
       ((:execute-task-fn context) "b" context)
-      (Thread/sleep 100)
       (swap! run-atom update-in [:metrics :tokens] + 1000)
 
       ;; Check if budget would be exceeded
@@ -384,17 +365,15 @@
                                        execution-tracker)]
 
       ;; Execute all tasks sequentially
-      (doseq [_task-id ["a" "b" "c"]]
-        (let [tid _task-id]
-          (update-task-status! run-atom tid :implementing)
-          ((:execute-task-fn context) tid context)
-          (Thread/sleep 100)
+      (doseq [tid ["a" "b" "c"]]
+        (update-task-status! run-atom tid :implementing)
+        ((:execute-task-fn context) tid context)
 
-          ;; Accumulate metrics
-          (swap! run-atom update-in [:metrics :tokens] + 1000)
-          (swap! run-atom update-in [:metrics :cost-usd] + 0.05)
+        ;; Accumulate metrics
+        (swap! run-atom update-in [:metrics :tokens] + 1000)
+        (swap! run-atom update-in [:metrics :cost-usd] + 0.05)
 
-          (update-task-status! run-atom tid :merged)))
+        (update-task-status! run-atom tid :merged))
 
       (is (= 3000 (get-in @run-atom [:metrics :tokens]))
           "Should accumulate 3000 tokens total")
@@ -475,7 +454,6 @@
       ;; Execute task
       (update-task-status! run-atom "a" :implementing)
       ((:execute-task-fn context) "a" context)
-      (Thread/sleep 100)
 
       (is (= :running (:status @run-atom))
           "Run should remain :running during execution")

--- a/components/workflow/test/ai/miniforge/workflow/state_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/state_test.clj
@@ -229,16 +229,18 @@
           "Should return accumulated metrics")))
 
   (testing "get-duration-ms"
-    ;; Must first transition to running before completing
-    (let [exec-state (state/create-execution-state sample-workflow {})
-          exec-state-running (state/transition-status exec-state :start)]
-      (Thread/sleep 10)  ; Wait a bit
-      (let [exec-state2 (state/mark-completed exec-state-running)
-            duration (state/get-duration-ms exec-state2)]
-        (is (pos? duration)
-            "Duration should be positive")
-        (is (>= duration 10)
-            "Duration should be at least 10ms")))))
+    ;; Backdate :execution/created-at instead of waiting for wall-clock
+    ;; time to advance, so the test is deterministic.
+    (let [exec-state (-> (state/create-execution-state sample-workflow {})
+                         (assoc :execution/created-at
+                                (- (System/currentTimeMillis) 50)))
+          exec-state-running (state/transition-status exec-state :start)
+          exec-state2 (state/mark-completed exec-state-running)
+          duration (state/get-duration-ms exec-state2)]
+      (is (pos? duration)
+          "Duration should be positive")
+      (is (>= duration 10)
+          "Duration should be at least 10ms"))))
 
 (deftest state-transitions-flow-test
   (testing "Complete workflow execution flow"


### PR DESCRIPTION
## Summary

Per \`.standards/testing/standards.mdc\`: **\"No sleep — use deterministic time injection or fast-forward mechanisms.\"**

Pass 1 of N attacks the mechanically-tractable cases. **37 of 68 \`Thread/sleep\` calls eliminated**, 31 remaining (covered below).

## Three patterns of fix

### 1. Delete dead waits after synchronous calls

\`task-executor/orchestrator_test.clj\` had 13 \`(Thread/sleep N)\` calls *after* synchronous \`((:execute-task-fn context) ...)\`. The mock was already blocking on its own internal delay-ms — by the time the call returned, the work was done. The test sleeps were dead code waiting for nothing.

### 2. Future deref instead of sleep+poll

For parallel/diamond DAG tests that genuinely launched async work, capture the futures and \`(doseq [f] @f)\` to wait deterministically.

### 3. \`wait-until-count\` helper (promise + add-watch)

For async-publish waits in control-plane orchestrator tests, introduced a per-file helper:

\`\`\`clojure
(defn- wait-until-count
  \"Block until (count @items-atom) >= n or timeout-ms elapses.
   Uses add-watch + promise — no fixed sleep.\"
  ...)
\`\`\`

Replaces \`(Thread/sleep 100)\` + \`(is (>= (count @published) 1))\` with \`(is (wait-until-count published 1))\`. Faster (fires the moment the count is reached), deterministic (timeout if never), and self-documenting.

### 4. Backdate timestamps instead of waiting for them

For \"clock progression\" sleeps where the test waits for wall-clock time to advance so two timestamps differ, backdate the *first* timestamp into the past via \`assoc\`/\`swap!\`. Applied to:
- \`event_stream/approval_test\` — \`:approval/expires-at\`
- \`workflow/state_test\` — \`:execution/created-at\`
- \`connector/interface_test\` — \`:cursor/last-retrieved-at\`
- \`agent/messaging_router_test\` — \`:message/timestamp\`
- \`pr-lifecycle/controller_test\` — \`:updated-at\`
- \`control-plane/interface_test\` (stale-agent test) — \`:agent/last-heartbeat\`

## Files changed

| File | Sleeps removed |
|---|---|
| \`task-executor/orchestrator_test.clj\` | 13 |
| \`control-plane/orchestrator_test.clj\` | 9 |
| \`control-plane/orchestrator_edge_test.clj\` | 3 |
| \`control-plane/orchestrator_supplemental_test.clj\` | 3 |
| \`control-plane/interface_test.clj\` | 2 |
| \`event-stream/approval_test.clj\` | 1 |
| \`workflow/state_test.clj\` | 1 |
| \`connector/interface_test.clj\` | 1 |
| \`agent/messaging_router_test.clj\` | 1 |
| \`pr-lifecycle/controller_test.clj\` | 1 |
| **Total** | **37** |

## What's still on the board (out of scope for this PR)

31 sleeps remain across 15 files. They fall into three categories:

1. **Production-side time injection needed** (~10 sleeps in \`llm/progress_monitor_test\`, \`gate/pipeline_test\`, etc.). These test interval/throttling logic that calls \`(System/currentTimeMillis)\` directly. Eliminating the sleeps requires introducing a \`*now-fn*\` dynamic var or similar in the production code — separate refactor.
2. **Real-system integration** (\`tool_registry/integration_test\` LSP warmup, \`dag_executor\` Docker exec, \`tui-views/file_subscription\` fsnotify). These are honest waits for external systems to do real work. Hard to eliminate without restructuring the tests.
3. **Load-bearing sleeps inside test fixtures or as the work being timed** (\`logging/interface_test\` passes \`#(Thread/sleep 10)\` as the body of a \`log/timed\` call — the sleep IS the work being measured).

Categories 1 and 3 should be tracked as a follow-up. Category 2 is genuinely necessary.

## Test plan

- [x] \`bb pre-commit\` passes — lint clean, 2094 tests / 8620 passes / 0 failures, GraalVM clean
- [x] \`bb test:integration\` passes — 296 tests / 0 failures (no regression from PR #678 baseline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)