### PR TITLE
spec: capsule runtime adapter (N11-delta) — Podman default

### DIFF
--- a/docs/design/runtime-adapter-plan.md
+++ b/docs/design/runtime-adapter-plan.md
@@ -1,0 +1,290 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# Implementation Plan — Capsule Runtime Adapter (N11-delta)
+
+**Date:** 2026-04-28
+**Status:** Draft
+**Spec:** [specs/normative/N11-delta-runtime-adapter.md](../../specs/normative/N11-delta-runtime-adapter.md)
+
+This is the implementation plan for N11-delta. It sequences the work into
+PR-sized phases, names the components touched, and calls out the points
+where verification is non-obvious.
+
+---
+
+## Premise
+
+The Docker integration is one component (`components/dag-executor`), one file
+(`docker.clj`), pure CLI shellouts, no daemon API. The protocol contract
+(`TaskExecutor`) is already capsule-shaped and runtime-agnostic. Phase 1 is a
+small, mechanical refactor; the larger surface is documentation, doctor, and
+verification on real hosts.
+
+Estimated total effort: **3–4 PRs**, roughly 1–2 weeks elapsed including
+real-host smoke testing on macOS and Linux.
+
+---
+
+## Phase 1 — Generalize the Docker executor (1 PR)
+
+**Goal:** rename the Docker executor to OCI-CLI executor, parameterize it by
+a runtime descriptor, ship with `:kind :docker` as the only supported value
+to keep the change a pure refactor.
+
+**Touch list:**
+
+- `components/dag-executor/src/ai/miniforge/dag_executor/docker.clj` — split
+  into:
+  - `runtime/descriptor.clj` — the runtime descriptor schema, probe helpers,
+    capability-set construction.
+  - `runtime/oci_cli.clj` — the generalized executor (the bulk of the
+    current `docker.clj`), accepting a runtime descriptor.
+  - `runtime/flags.clj` — the small flag-dialect lookup keyed by capability
+    and runtime kind. Initially Docker-only entries; Podman entries land in
+    Phase 2.
+- `components/dag-executor/src/ai/miniforge/dag_executor/protocols/executor.clj`
+  — unchanged. The protocol is correct as-is.
+- `components/dag-executor/src/ai/miniforge/dag_executor/factory.clj` (or
+  wherever `select-executor` lives) — `:docker` continues to resolve as
+  today; add a stub for `:podman` that returns "not yet supported."
+- `components/dag-executor/test/.../docker_test.clj` — rename to
+  `oci_cli_test.clj`. Existing assertions should pass unchanged because
+  `run-docker` mocks become `run-runtime` mocks with the binary parameter.
+
+**Verification:**
+
+- All existing `dag-executor` tests pass.
+- `projects/miniforge/e2e/.../sandbox_e2e_test.clj` still skips when Docker
+  is absent and runs to completion when Docker is present.
+- `bb test` is green.
+
+**Out of scope for this PR:**
+
+- No Podman code path yet.
+- No CLI surface changes.
+- No documentation changes.
+
+---
+
+## Phase 2 — Land Podman as a runtime (1 PR)
+
+**Goal:** Podman becomes a fully supported runtime kind with its own
+flag-dialect entries and capability advertisement. Selection still requires
+explicit `:kind :podman` configuration; auto-probe is in Phase 3.
+
+**Touch list:**
+
+- `components/dag-executor/src/.../runtime/flags.clj` — add Podman entries.
+  Differences vs Docker that must be handled:
+  - tmpfs `uid=` / `gid=` mount options — Podman supports these (capability
+    advertised).
+  - `--stop-timeout` — supported by Podman, no change.
+  - Default short-name resolution — avoided by §5 of the spec; defaults are
+    fully qualified.
+- `components/dag-executor/src/.../runtime/descriptor.clj` — Podman probe:
+  `podman info` returns success, parse `--version`, capability detection from
+  `podman info --format json`.
+- `components/workflow/resources/config/.../defaults.edn` — change default
+  image references to fully qualified
+  (`docker.io/miniforge/task-runner-clojure@sha256:...`) per spec §2.2 and §5.
+  This is a backwards-compatible change for Docker users (Docker resolves
+  fully qualified references identically).
+- New tests: `oci_cli_test` parameterized over `[:docker :podman]` for the
+  argument-construction paths. Real-runtime conformance suite is gated
+  behind a `--runtime` flag; default test run is mocked.
+
+**Verification:**
+
+- Mocked tests pass for both runtime kinds.
+- A user can set `:miniforge/runtime/kind :podman` and a Podman host runs
+  the existing e2e sandbox tests.
+- A user with Docker only continues to work as before.
+
+**Risk:**
+
+- The fully-qualified default images require the digests to actually exist
+  on `docker.io/miniforge/...`. If those images are not yet pushed with
+  pinned digests, this PR includes the publish step or pins to whatever
+  digest is currently `latest`.
+
+---
+
+## Phase 3 — Selection, doctor, CLI (1 PR)
+
+**Goal:** automated probe order, doctor reporting, `mf runtime info` and
+`mf runtime run`. This is where the user-facing default flips to Podman on
+hosts that have both runtimes.
+
+**Touch list:**
+
+- `components/dag-executor/src/.../factory.clj` — implement the spec §3
+  selection algorithm: explicit config > probe order (`podman`, `docker`,
+  `nerdctl`) > unavailable.
+- `bases/cli/.../doctor.clj` (or wherever `bb check:platform` lives, per
+  `docs/platform-support.md` §"Verifying Your Setup") — extend to print the
+  resolved runtime descriptor and the unselected runtimes.
+- `bases/cli/.../runtime.clj` (new) — `mf runtime info` and `mf runtime
+  run`.
+- `messages/en.edn` (or equivalent i18n keys) — strings for new doctor
+  output. Avoid hardcoded English per `feedback_pr_doc_localization`.
+- Tests for the selection algorithm: explicit-config-overrides-probe,
+  fail-loud-on-missing-explicit, probe-order-without-config.
+
+**Verification:**
+
+- `bb check:platform` on a host with Podman + Docker reports both, selects
+  Podman, and notes that explicit config can override.
+- `mf runtime run --rm hello-world` works on macOS (Podman) and Linux
+  (Podman or Docker, whichever is installed).
+- `mf runtime info` returns the descriptor as data.
+
+**Acceptance demo:**
+
+- On a Podman-only macOS host, run `examples/demo/run-demo.sh` (or its
+  cross-platform replacement) end-to-end.
+- On a Docker-only Linux host, run the same.
+
+---
+
+## Phase 4 — Docs, bootstrap, smoke matrix, runtime policies (1 PR)
+
+**Goal:** the user-facing narrative matches the contract, `bb bootstrap`
+installs a runtime on Mac as a courtesy (not a contract change), the
+conformance matrix has real entries, and the policy hooks from spec §6 are
+wired into the existing standards pack.
+
+**Touch list:**
+
+- `readme.md` — Podman-first; "OCI-compatible local runtime" framing.
+- `docs/quickstart.md` — Podman install per OS; Docker as alternative.
+- `docs/platform-support.md` — Runtime row in the status matrix; macOS
+  bind-mount caveats called out explicitly.
+- `docs/configuration.md` — `:miniforge/runtime` block.
+- `agents.md` — agents do not branch on runtime kind.
+- `components/bb-platform/src/.../core.clj` — owns all the actual logic.
+  Per `feedback_bb_edn_thin_wrapper`, `bb.edn` cannot host non-trivial
+  Clojure; it stays a thin dispatcher. Specifically:
+  - Add a `manual-install-hints` entry for `podman` (Linux distro packages,
+    Windows scoop) so users without brew get a useful pointer.
+  - Add a `podman-machine-status` / `init-podman-machine!` pair: probe
+    `podman machine list --format json`, init+start a default machine if
+    none exists. Mac-specific (Podman on Linux is daemonless and needs no
+    machine; Windows native is Beta and tracked separately).
+  - Add a `check-runtime` function returning `{:available? :selected
+    :reason}` for the OCI runtime layer. `check:platform` consumes this
+    with **warn-only** semantics — absence of any OCI runtime is a warning,
+    never a bootstrap failure, since Linux distro packages, Colima, OrbStack,
+    and Docker-only setups must continue to work.
+- `bb.edn` — three new one-line dispatchers, parallel to the existing
+  `install:clojure` / `install:poly` shape. No closures, no logic, no
+  `:init` additions. Concretely:
+  - `install:podman` → `(brew-install "podman")`, then `(run 'setup:podman-machine)`.
+  - `upgrade:podman` → `(brew-upgrade "podman")`.
+  - `setup:podman-machine` → calls `platform/init-podman-machine!`.
+  - Add `install:podman` to the `install:deps` `:depends` fan-out so
+    `bb bootstrap` includes it on Mac. Linux uses the platform package
+    manager per `docs/platform-support.md` precedent (`bb bootstrap` is
+    documented as Mac-only convenience).
+  - Extend the `check:platform` tool list (line 291) to include `"podman"`,
+    relying on the warn-only semantics added in `bb-platform`.
+- Standards pack (`bb standards:pack` per `project_standards_compilation_path`)
+  — add the four spec §6 policy rules: `:runtime/no-host-docker-socket`,
+  `:runtime/require-rootless`, `:runtime/restrict-host-mounts`,
+  `:runtime/require-image-digest-pin`.
+- `Dockerfile.task-runner*` — rename references in build instructions to be
+  runtime-neutral (`<exe> build -t ...`). The Dockerfile syntax itself is
+  OCI-standard; the build command is the only thing that changes.
+
+**Verification:**
+
+- macOS arm64 smoke run on Podman, Linux x86_64 smoke run on Podman, both
+  using bind-mounted worktrees.
+- `bb bootstrap` on a fresh Mac installs Podman, initializes
+  `podman machine`, and `mf doctor` reports a healthy runtime descriptor
+  without further user action.
+- `bb bootstrap` on a Mac that already has Docker installed but not Podman
+  succeeds, installs Podman, and `mf doctor` selects Podman by probe order
+  (per spec §3) while announcing the change so the Docker user is not
+  surprised.
+- Standards pack validates against an execution plan that mounts
+  `/var/run/docker.sock` and emits the expected hard-stop policy violation.
+
+**BYOR vs canonical-runtime tradeoff (decision recorded for posterity):**
+
+The contract from N11-delta §3 is BYOR (bring your own OCI-compatible
+runtime). `bb install:podman` is a Mac-only convenience consistent with how
+`install:clojure` / `install:poly` already work — bb bootstrap on Mac
+brew-installs the recommended development toolchain, but a user who already
+has Docker, who is on Linux with their distro's package manager, or who
+runs Colima/OrbStack is unaffected. The alternative — declaring Podman the
+**canonical** runtime and requiring its presence — was considered and
+rejected:
+
+- It would force users with working Docker setups to install a second
+  runtime they do not need.
+- It would couple OSS adoption to a specific runtime brand we just spent
+  this delta decoupling from.
+- It would not actually buy anything the capability surface in spec §4
+  does not already buy.
+
+If a future need emerges (e.g. governance policies that require rootless
+specifically and no other runtime in the matrix advertises `:rootless`),
+the decision can be revisited. Until then: bootstrap installs Podman as a
+courtesy, the contract stays BYOR.
+
+---
+
+## What this plan deliberately omits
+
+- **No new protocol.** `TaskExecutor` is the right seam. Adding a
+  `LocalContainerRuntime` protocol below it would be a pure tax: every
+  implementation would just shell out to a CLI, which is what the executor
+  already does.
+- **No daemon API integration.** Both Docker and Podman expose HTTP APIs;
+  using them would re-introduce the dependency we are removing. CLI
+  shellout is the contract.
+- **No Compose, no BuildKit-specific flags, no Docker Desktop integration.**
+  None of these exist in the codebase today. The plan does not add them.
+- **No local Kubernetes path.** Per `project_k8s_fleet_only`, K8s lives in
+  Fleet. This plan does not bring it into OSS as a substitute for Docker.
+- **No Phase 0 audit.** The audit was done while writing the spec; the
+  surface area is small enough that further inventory work would be
+  duplicative.
+
+---
+
+## Sequencing notes
+
+- Phase 1 and Phase 2 can land back-to-back without user-visible changes.
+- Phase 3 is the breaking-ish PR (the default flips on Podman-equipped
+  hosts). It MUST ship with the doctor messaging that surfaces the change
+  per spec §7.2.
+- Phase 4 is the polish PR. It can be split if the standards-pack policy
+  work needs more time than the docs.
+
+---
+
+## Risk Register
+
+| Risk                                                          | Mitigation                                                                 |
+|---------------------------------------------------------------|----------------------------------------------------------------------------|
+| Podman macOS bind-mount perf surprises a user mid-PR-cycle    | Smoke test in Phase 4 across worktree of representative size; document    |
+| Default image digests not yet published to docker.io          | Phase 2 includes the publish step or pins to known-good digest            |
+| Probe order surprises users who had Docker as expected default | Doctor surfaces the change on first run after upgrade per spec §7.2       |
+| nerdctl/containerd users want first-class support             | Capability set + flag-dialect lookup makes this additive; add when needed |
+| Windows native fails Podman conformance                       | Beta status preserved; not a Phase-4 blocker                              |
+| Existing tests assume `docker` literally on PATH              | Audited in Phase 1; tests parameterize over runtime kind                  |
+
+---
+
+## Cross-references
+
+- Spec: [N11-delta-runtime-adapter](../../specs/normative/N11-delta-runtime-adapter.md)
+- Parent: [N11-task-capsule-isolation](../../specs/normative/N11-task-capsule-isolation.md)
+- Platform: [docs/platform-support.md](../platform-support.md)
+- Memory: `project_capsule_agent_agnostic`, `project_k8s_fleet_only`,
+  `project_standards_compilation_path`

--- a/docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md
+++ b/docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md
@@ -1,0 +1,130 @@
+# spec: capsule runtime adapter (N11-delta) — Podman default, Docker compatible
+
+## Overview
+
+This is a docs-only PR that lands a normative spec delta and a corresponding
+implementation plan. It does not change any code paths.
+
+The delta amends N11 (Task Capsule Isolation) so that miniforge depends on
+an OCI-compatible local container runtime via a small *runtime descriptor*
+rather than on Docker specifically. Podman becomes the default OSS runtime;
+Docker remains a first-class supported configuration; nerdctl is reserved as
+future-additive. The `TaskExecutor` protocol is unchanged — the surgery is
+below the protocol.
+
+## Motivation
+
+The current OSS execution path requires Docker. That couples adoption to
+Docker Desktop's licensing, daemon model, and product surface area. The
+capsule contract from N11 already describes Podman as a satisfying substrate
+in §2.3, but the implementation defaults to Docker and has no abstraction
+for swapping it.
+
+The good news from the audit: the existing Docker integration is much
+smaller than its product footprint suggests. One component, one file, pure
+CLI shellouts. No daemon API, no Compose, no Desktop integration, no
+BuildKit-specific flags. The `TaskExecutor` protocol is already capsule-
+shaped, and it already has Docker, Kubernetes, and worktree implementations
+side-by-side.
+
+The right shape, then, is to parameterize the existing executor with a
+runtime descriptor (data) rather than introduce a new protocol layer. This
+spec delta defines that descriptor and the surrounding contract; the plan
+sequences the implementation across roughly four PRs.
+
+## Changes In Detail
+
+### 1. `specs/normative/N11-delta-runtime-adapter.md` (new)
+
+Normative delta that amends N11 §2.3, §5, §10 and N1 §11. Defines:
+
+- The **runtime descriptor** schema (`:runtime/kind`, `:runtime/executable`,
+  `:runtime/version`, `:runtime/rootless?`, `:runtime/capabilities`).
+- The **selection algorithm**: explicit configuration first, then probe
+  order (`podman` → `docker` → `nerdctl`), then unavailable. Explicit
+  configuration MUST NOT silently fall back.
+- The **capability set** required for capsule conformance, separated into
+  MUST and SHOULD tiers, expressed as data so policies can read it without
+  branching on runtime kind.
+- **Image reference rules**: defaults are fully qualified
+  (`docker.io/...@sha256:...`) so Podman's interactive short-name resolution
+  does not surprise first-run users.
+- **Policy hooks** enabled by the descriptor — `:runtime/no-host-docker-socket`,
+  `:runtime/require-rootless`, `:runtime/restrict-host-mounts`,
+  `:runtime/require-image-digest-pin` — referenced for forward-compatibility
+  with N4. Definitions land alongside the implementation in plan Phase 4.
+- **Conformance and migration**: how the existing Docker-only path maps onto
+  the new descriptor, what the doctor command must surface, and the initial
+  conformance matrix (Podman + Docker stable on macOS arm64 / x86_64 and
+  Linux x86_64 / arm64; Beta on Windows; nerdctl Future).
+- **Non-goals** are explicit: no `LocalContainerRuntime` protocol
+  duplicating `TaskExecutor`, no Docker daemon HTTP API, no Compose, no
+  Docker Desktop integration, no local Kubernetes path, no removal of
+  Docker support.
+- A `bb bootstrap` note makes clear that any brew installation of Podman is
+  a Mac-only **convenience**, not a contract change. The contract from §3
+  is BYOR (bring your own OCI-compatible runtime). `check:platform` SHALL
+  warn on missing runtime, never fail bootstrap.
+
+### 2. `docs/design/runtime-adapter-plan.md` (new)
+
+Implementation plan sequenced into four PRs:
+
+- **Phase 1** — generalize the Docker executor into an OCI-CLI executor
+  parameterized by a runtime descriptor. Pure refactor; ships with
+  `:kind :docker` only. `components/dag-executor` reorganizes
+  `docker.clj` into `runtime/descriptor.clj`, `runtime/oci_cli.clj`, and
+  `runtime/flags.clj`. The `TaskExecutor` protocol is unchanged.
+- **Phase 2** — land Podman behind explicit `:miniforge/runtime/kind
+  :podman`. Adds Podman flag-dialect entries to `runtime/flags.clj`,
+  Podman probe + capability detection to `runtime/descriptor.clj`, and
+  fully qualified default image references to
+  `runner-defaults.edn`.
+- **Phase 3** — flip the default on probe order, add the doctor surface
+  (`bb check:platform`), and introduce `mf runtime info` and
+  `mf runtime run`. Includes the messaging that surfaces the default flip
+  to existing Docker users so the change is not silent.
+- **Phase 4** — docs (`readme.md`, `quickstart.md`, `platform-support.md`,
+  `configuration.md`, `agents.md`), bb bootstrap (`install:podman`,
+  `upgrade:podman`, `setup:podman-machine` as one-line dispatchers in
+  `bb.edn`, with all logic in `components/bb-platform/src/.../core.clj`
+  per `feedback_bb_edn_thin_wrapper`), the smoke matrix on macOS arm64
+  and Linux x86_64 with bind-mounted worktrees, and the standards-pack
+  policy rules from spec §6.
+
+The plan calls out a Risk Register including macOS bind-mount perf under
+`podman machine`, default-image digest publication, the surprise factor of
+flipping the default on probe order, and tests that assume `docker`
+literally on PATH.
+
+It also records a **BYOR vs canonical-runtime tradeoff** decision: bootstrap
+installs Podman as Mac convenience, contract stays BYOR, canonical-runtime
+alternative considered and rejected because it would force a second-runtime
+install on Docker users and re-couple OSS adoption to one brand we just
+spent this delta decoupling from. Decision is revisitable when a future
+policy demands a runtime-specific capability.
+
+## What this PR does NOT change
+
+- No code in `components/dag-executor`. Phase 1 is the first code PR and is
+  out of scope here.
+- No `bb.edn` or `components/bb-platform` changes. Phase 4 implements them.
+- No README, quickstart, platform-support, or configuration doc edits.
+  Phase 4 implements them.
+- No new policy rules in the standards pack. Phase 4 lands them alongside
+  the policy hooks defined in spec §6.
+
+## Files
+
+- `specs/normative/N11-delta-runtime-adapter.md` — new spec delta.
+- `docs/design/runtime-adapter-plan.md` — new implementation plan.
+
+## Cross-references
+
+- Parent spec: [N11-task-capsule-isolation](../../specs/normative/N11-task-capsule-isolation.md)
+- Spec index: [SPEC_INDEX.md](../../specs/SPEC_INDEX.md) (entry for
+  N11-delta to be added when the index is next refreshed)
+- Platform: [docs/platform-support.md](../platform-support.md)
+- Memory references: `project_capsule_agent_agnostic`,
+  `project_k8s_fleet_only`, `project_standards_compilation_path`,
+  `feedback_bb_edn_thin_wrapper`

--- a/specs/normative/N11-delta-runtime-adapter.md
+++ b/specs/normative/N11-delta-runtime-adapter.md
@@ -1,0 +1,354 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
+
+# N11-delta — Capsule Runtime Adapter
+
+**Version:** 0.1.0-draft
+**Date:** 2026-04-28
+**Status:** Draft
+**Conformance:** MUST
+**Amends:** N11 §2.3, §5, §10; N1 §11
+
+---
+
+## 0. Architectural Decision Record
+
+> **Miniforge SHALL depend on an OCI-compatible local container runtime, not on
+> Docker specifically. Podman SHALL be the default OSS runtime. Docker remains
+> a supported configuration. Selection is data-driven via a runtime descriptor;
+> the `TaskExecutor` protocol contract is unchanged.**
+
+This decision removes Docker as an installation requirement and replaces it
+with a capability surface. It does not introduce a new protocol layer above
+`TaskExecutor`; the existing protocol is already CLI-agnostic and capsule-
+shaped. What changes is *below* the protocol: the Docker executor becomes a
+generalized **OCI-CLI executor** parameterized by a runtime descriptor.
+
+---
+
+## 1. Purpose and Scope
+
+This delta defines:
+
+- The **runtime descriptor** schema that parameterizes the OCI-CLI executor (§2)
+- The **default selection algorithm** with explicit-config-first ordering (§3)
+- The **capability set** a runtime MUST expose for capsule conformance (§4)
+- **Image reference rules** that survive runtime swapping (§5)
+- **Policy hooks** on runtime properties that this delta enables (§6)
+- **Conformance and migration** from the current Docker-only path (§7)
+
+This delta is **non-substantive** with respect to capsule semantics: §2 and §4
+of N11 are unchanged. A capsule produced by Podman MUST be indistinguishable
+from a capsule produced by Docker at the boundaries N11 already enforces
+(filesystem, network, credentials, time, resources).
+
+### 1.1 Non-Goals
+
+- This delta does NOT introduce a `LocalContainerRuntime` protocol distinct
+  from `TaskExecutor`. The capability surface is data, not a protocol.
+- This delta does NOT make local Kubernetes (kind, k3d, minikube, Rancher
+  Desktop) part of the OSS execution path. K8s remains a Fleet concern per
+  N1 §5 and the `project_k8s_fleet_only` decision.
+- This delta does NOT remove Docker support. Docker remains a first-class
+  configured runtime.
+- This delta does NOT add Docker Compose, Docker Desktop, BuildKit, or
+  Docker Engine HTTP API surface area. The implementation continues to shell
+  out to a single CLI.
+
+---
+
+## 2. Runtime Descriptor
+
+A **runtime descriptor** is a value that fully specifies the local container
+runtime used by an OCI-CLI executor. It MUST contain:
+
+```clojure
+{:runtime/kind         keyword     ; :podman | :docker | :nerdctl
+ :runtime/executable   string      ; resolved CLI path, e.g. "/opt/homebrew/bin/podman"
+ :runtime/version      string      ; reported by `<exe> --version`
+ :runtime/rootless?    boolean     ; rootless execution available
+ :runtime/capabilities #{keyword}} ; see §4
+```
+
+The descriptor MAY contain runtime-specific tuning under
+`:runtime/<kind>-options`, e.g. `:runtime/podman-options
+{:network "slirp4netns" :pull-policy :missing}`. Code SHALL NOT branch on
+`:runtime/kind` outside the runtime adapter; all branching SHALL go through
+capability lookup or runtime-options indirection.
+
+### 2.1 Configuration Surface
+
+A user SHALL be able to declare the runtime in `miniforge.edn` (or an
+equivalent profile) under `:miniforge/runtime`:
+
+```clojure
+{:miniforge/runtime
+ {:kind :podman}}
+```
+
+Or, with overrides:
+
+```clojure
+{:miniforge/runtime
+ {:kind        :docker
+  :executable  "/usr/local/bin/docker"}}
+```
+
+Environment override `MINIFORGE_RUNTIME=podman|docker|nerdctl` SHALL take
+precedence over file configuration, per the existing repo-config / Aero
+override model (`project_repo_config_profile`).
+
+### 2.2 Image References
+
+The execution-plan schema (`MountSchema`, `ExecutionPlanSchema` in
+`components/dag-executor/src/.../execution_plan.clj`) is unchanged. However,
+all default image references SHALL be **fully qualified** (e.g.
+`docker.io/miniforge/task-runner-clojure@sha256:...`). Short-name references
+(e.g. `miniforge/task-runner-clojure:latest`) MUST NOT appear in defaults
+because Podman's short-name resolution is interactive on first run and varies
+by host configuration.
+
+---
+
+## 3. Selection Algorithm
+
+The OCI-CLI executor SHALL resolve its runtime descriptor in this order:
+
+1. **Explicit configuration.** If `:miniforge/runtime/kind` is set in the
+   resolved configuration, use it. If the named runtime is unavailable, the
+   executor MUST fail with a structured error; it MUST NOT silently fall back.
+2. **Probe order on `PATH`.** With no explicit configuration: probe `podman`,
+   then `docker`, then `nerdctl`. The first runtime whose `<exe> info`
+   command returns success is selected.
+3. **No runtime available.** If no runtime is found, the OCI-CLI executor's
+   `available?` returns `{:available? false :reason ...}`. Executor selection
+   (per N11 §10) then falls through to `:worktree`.
+
+The doctor command (`bb doctor` / `mf doctor`) SHALL report the resolved
+runtime, its version, its capability set, and any runtimes detected but not
+selected. When more than one runtime is available and none is configured, the
+doctor command SHALL surface the choice to the user; it SHALL NOT silently
+prefer one over another beyond the documented probe order.
+
+---
+
+## 4. Capability Set
+
+A capsule-conformant runtime MUST advertise the following capabilities:
+
+| Capability                    | Meaning                                                  |
+|-------------------------------|----------------------------------------------------------|
+| `:oci-images`                 | Pulls and runs OCI-format images                         |
+| `:run`                        | `<exe> run` semantics equivalent to `docker run`         |
+| `:exec`                       | `<exe> exec` into a running container                    |
+| `:build`                      | Builds OCI images from a Dockerfile context              |
+| `:bind-mounts`                | Bind-mounts host paths into the container                |
+| `:tmpfs-mounts`               | tmpfs mounts with `nosuid,nodev` semantics               |
+| `:env-vars`                   | Sets process environment from CLI flags                  |
+| `:working-dir`                | Sets working directory inside the container              |
+| `:user-mapping`               | Runs as a non-root UID/GID                               |
+| `:resource-limits`            | CPU and memory limits enforced by the runtime            |
+| `:network-modes/none`         | `--network none` disables container networking           |
+| `:network-modes/bridge`       | Default bridged network with NAT                         |
+| `:image-digest-pinning`       | Resolves and inspects image digests post-pull            |
+| `:graceful-stop`              | Graceful stop with configurable timeout                  |
+
+A capsule-conformant runtime SHOULD additionally advertise:
+
+| Capability                    | Meaning                                                  |
+|-------------------------------|----------------------------------------------------------|
+| `:rootless`                   | Container processes run under user namespaces            |
+| `:tmpfs-uid-gid-options`      | `tmpfs` mounts accept `uid=` / `gid=` mount options      |
+| `:no-new-privileges`          | `no-new-privileges` security option enforced             |
+| `:read-only-root`             | Read-only root filesystem with explicit RW mounts        |
+| `:cap-drop-all`               | Drop all Linux capabilities, opt back in by name         |
+
+The OCI-CLI executor MUST verify required capabilities before
+`acquire-environment!` and SHALL raise a structured error naming the missing
+capability if any are absent. Workflows MAY declare additional required
+capabilities under `:workflow/runtime-requires`; the executor MUST honor
+these requirements.
+
+---
+
+## 5. Image References (Normative)
+
+- Default images in `runner-defaults.edn` and any image referenced by an
+  execution plan MUST use a fully qualified reference of the form
+  `<registry>/<repo>:<tag>` or `<registry>/<repo>@sha256:<digest>`.
+- Image digest pinning per N6 (Evidence & Provenance) is unchanged. The
+  evidence record continues to capture the resolved digest after pull.
+- The OCI-CLI executor MUST NOT rely on the runtime's short-name resolution.
+  Behavior diverges across runtimes; explicit references make execution
+  reproducible.
+
+---
+
+## 6. Policy Hooks Enabled by This Delta
+
+This delta makes the following policies expressible. They are referenced for
+forward-compatibility; their normative definitions live under N4 (Policy
+Compilation Contract) when authored.
+
+- `:runtime/no-host-docker-socket` — reject mounts that bind
+  `/var/run/docker.sock` (or equivalent runtime sockets) into the capsule.
+  Such a mount collapses isolation and grants host container-control.
+- `:runtime/require-rootless` — warn or hard-stop when the resolved runtime
+  does not advertise `:rootless`. Default level: `:warn` for OSS, `:hard-stop`
+  for governed Fleet workflows.
+- `:runtime/restrict-host-mounts` — review or block bind mounts of host paths
+  outside an allowlist (workspace, secret material, model cache).
+- `:runtime/require-image-digest-pin` — reject execution plans whose
+  `:image-digest` is unresolved or is a tag rather than a digest.
+- `:runtime/disallow-privileged` — reject any `:privileged true` in the
+  execution plan. The current schema does not surface this flag; this policy
+  exists to defend the invariant.
+
+These policies are runtime-agnostic; they read the descriptor's capability
+set and the execution plan, not the runtime kind.
+
+---
+
+## 7. Conformance and Migration
+
+### 7.1 Implementation Mapping
+
+The current implementation in
+`components/dag-executor/src/ai/miniforge/dag_executor/docker.clj` (lines
+60–652) satisfies this delta when reorganized as follows:
+
+- The shellout helpers (`docker-cmd`, `run-docker`, `run-docker-process`)
+  generalize to take a runtime descriptor; the binary name comes from
+  `:runtime/executable`. Existing callers that pass `:docker-path` map to
+  `:runtime/executable` with `:kind :docker`.
+- The Docker executor record becomes an **OCI-CLI executor** record holding
+  the runtime descriptor. `executor-type` returns `:docker` or `:podman`
+  according to `:runtime/kind`, preserving existing observability.
+- Flag dialect differences (currently only `--stop-timeout`, tmpfs `uid/gid`
+  options) move to a small `runtime-flags` lookup keyed by capability and
+  runtime kind. Code paths SHALL prefer capability checks; `:runtime/kind`
+  branches MUST be commented with the dialect difference being papered over.
+- The `kubernetes` executor and the `worktree` executor are unaffected.
+
+### 7.2 Migration
+
+A repository whose configuration omits `:miniforge/runtime` retains its
+current behavior on a host that has only Docker installed (probe order finds
+Docker, executor reports `:docker` as in N1). On a host with Podman
+installed and Docker absent, the OCI-CLI executor will select Podman; this
+is the intended OSS default.
+
+A repository that pins `:miniforge/runtime/kind :docker` continues to use
+Docker on hosts that have it.
+
+The doctor command MUST surface the runtime change at first execution after
+upgrade so users on Podman-equipped hosts are not silently switched.
+
+### 7.3 Testing Conformance
+
+A runtime SHALL be considered conformant for capsule execution if it passes:
+
+- **Capability advertisement** — the descriptor's capability set matches
+  what the runtime exposes when probed.
+- **Smoke suite** — `acquire-environment!`, `execute!`, `copy-to!`,
+  `copy-from!`, `release-environment!`, `persist-workspace!`,
+  `restore-workspace!` against a Clojure task-runner image.
+- **Boundary suite** (corresponds to N11 §2.2) — filesystem isolation,
+  outbound network restriction under `:network-modes/none`, credential
+  ephemerality, timeout enforcement, resource-limit enforcement.
+
+Conformance is asserted per `(runtime, OS, OS-arch)` triple. Initial OSS
+support targets:
+
+| Runtime | macOS arm64 | macOS x86_64 | Linux x86_64 | Linux arm64 | Windows |
+|---------|-------------|---------------|--------------|-------------|---------|
+| Podman  | Stable      | Stable        | Stable       | Stable      | Beta    |
+| Docker  | Stable      | Stable        | Stable       | Stable      | Beta    |
+| nerdctl | Future      | Future        | Future       | Future      | N/A     |
+
+Windows native conformance follows the existing platform-support beta status
+(`docs/platform-support.md`). The bash demo script and `bb` tasks that
+currently invoke `docker` directly SHALL switch to `mf runtime run` (see §8).
+
+---
+
+## 8. CLI Surface
+
+The user-facing CLI gains the following commands. Their detailed contracts
+live in N5 (CLI/TUI/API). This delta defines what they MUST do.
+
+- `mf doctor` — extends the existing platform check to report the resolved
+  runtime descriptor, its capability set, and runtimes detected but not
+  selected.
+- `mf runtime info` — print the resolved runtime descriptor as data.
+- `mf runtime run -- <args>` — pass-through invocation of the resolved
+  runtime CLI for ad-hoc use, equivalent to `<exe> run <args>`. Provided so
+  documentation does not need to say "install Docker" or "install Podman" —
+  the user can just `mf runtime run --rm hello-world`.
+
+The `mf runtime run` pass-through SHALL NOT be used by the workflow engine
+itself. The engine continues to compose its own argument lists per
+execution-plan; it does not shell through `mf runtime run`.
+
+---
+
+## 9. Documentation Updates
+
+The following documents SHALL be updated as part of this delta's
+implementation. None of these updates are normative on their own; they are
+called out to ensure the user-facing story matches the contract.
+
+- `readme.md` — replace any "install Docker" guidance with "install an
+  OCI-compatible runtime; Podman is recommended."
+- `docs/quickstart.md` — Podman-first install instructions per OS, with
+  Docker noted as a supported alternative.
+- `docs/platform-support.md` — add a Runtime row to the Status Matrix.
+- `docs/configuration.md` — document the `:miniforge/runtime` configuration
+  block.
+- `agents.md` — note that the agent capsule runs under whatever runtime is
+  resolved; agents have no business inspecting the runtime kind.
+- `bb.edn` and `components/bb-platform` — `bb bootstrap` on macOS SHOULD
+  brew-install Podman as a development convenience, parallel to the
+  existing `install:clojure` / `install:poly` tasks. This is NOT a contract
+  change. The contract from §3 is BYOR (bring your own OCI-compatible
+  runtime); bootstrap is opt-in convenience for users who run it.
+  `check:platform` SHALL treat the absence of any OCI runtime as a warning,
+  not a failure, so users on Linux distro packages, Colima, OrbStack, or
+  Docker-only setups are unaffected.
+
+---
+
+## 10. Open Questions
+
+- **macOS performance.** Podman on macOS runs inside `podman machine`
+  (a Linux VM). Bind mounts cross the VM boundary via virtiofs/9p; large
+  worktrees and file-watcher events behave differently from Docker
+  Desktop's virtio. Conformance MUST include a worktree-mount smoke test on
+  macOS arm64 before Podman becomes the documented default.
+- **Windows native.** Both Docker Desktop and Podman on Windows depend on
+  WSL2 in practice. The conformance matrix labels both Beta. Whether either
+  graduates to Stable depends on the existing Windows native effort
+  (`docs/platform-support.md`); not a goal of this delta.
+- **nerdctl/containerd.** Listed as Future. Adding nerdctl is a runtime
+  descriptor plus a flag-dialect entry; the work is small but is gated on
+  there being an actual user need, not on architectural readiness.
+- **OrbStack.** Not a runtime; OrbStack ships its own `docker` CLI and is
+  consumed via `:kind :docker` with no further work. Documented as a
+  supported development convenience, not an OSS default.
+
+---
+
+## 11. Cross-References
+
+- N11 §2.3 — capsule mechanisms (this delta narrows "Container (Docker,
+  Podman)" to a normative descriptor).
+- N11 §10 — TaskExecutor protocol (unchanged).
+- N1 §11 — context tool contract (unaffected; runtime is below this layer).
+- N4 — Policy Compilation Contract (the runtime policies in §6 will be
+  authored against N4's policy schema).
+- N6 — Evidence & Provenance (image-digest pinning is N6's responsibility;
+  this delta only requires that defaults are pin-friendly).
+- `docs/platform-support.md` — host platforms that miniforge supports.


### PR DESCRIPTION
## Summary

- Adds N11-delta normative spec: miniforge depends on an OCI-compatible local container runtime via a runtime descriptor, not on Docker specifically. Podman becomes the default; Docker remains a first-class supported configuration.
- Adds the implementation plan (four phases, risk register, BYOR vs canonical-runtime decision recorded).
- Adds the PR doc under `docs/pull-requests/`.

Docs-only PR. No code paths touched. Phase 1 of the linked plan is the first code PR.

The full PR doc with motivation, non-goals, and cross-references lives at [`docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md`](docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md).

## Test plan

- [ ] Reviewer reads N11-delta spec and confirms the runtime descriptor schema, capability set, and selection algorithm match expectations.
- [ ] Reviewer reads the plan and confirms the four-PR sequencing is the right granularity.
- [ ] Reviewer confirms the BYOR vs canonical-runtime decision (recorded in the plan) reflects the project's current preference.
- [ ] No code or build verification needed — docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)