### PR TITLE
test(dag-executor): add coverage for execution-plan, state-profile, workspace

### DIFF
--- a/components/dag-executor/test/ai/miniforge/dag_executor/execution_plan_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/execution_plan_test.clj
@@ -1,0 +1,155 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.execution-plan-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.dag-executor.execution-plan :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures and factories
+
+(defn- valid-mount
+  [& {:as overrides}]
+  (merge {:host-path      "/host/workspace"
+          :container-path "/work"
+          :read-only?     false}
+         overrides))
+
+(defn- valid-plan
+  "Build a minimal valid plan with optional overrides."
+  [& {:as overrides}]
+  (merge {:image-digest    "sha256:abc123"
+          :command         ["bb" "run" "test"]
+          :mounts          [(valid-mount)]
+          :env             {"HOME" "/root" "CI" "true"}
+          :secrets-refs    ["gh-token"]
+          :network-profile :standard
+          :time-limit-ms   60000
+          :memory-limit-mb 512
+          :trust-level     :trusted}
+         overrides))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Constant exposure — trust levels and network profiles
+
+(deftest trust-levels-test
+  (testing "trust-levels exposes the documented closed set"
+    (is (= #{:untrusted :trusted :privileged} sut/trust-levels))))
+
+(deftest network-profiles-test
+  (testing "network-profiles exposes the documented closed set"
+    (is (= #{:none :restricted :standard :full} sut/network-profiles))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; validate-plan — happy path
+
+(deftest validate-plan-accepts-fully-populated-plan-test
+  (testing "A plan with every key correctly typed validates"
+    (is (= {:valid? true} (sut/validate-plan (valid-plan))))))
+
+(deftest validate-plan-accepts-empty-collections-test
+  (testing "Empty mounts / empty env / empty secrets-refs still validate"
+    (is (= {:valid? true}
+           (sut/validate-plan (valid-plan :mounts       []
+                                          :env          {}
+                                          :secrets-refs []))))))
+
+(deftest validate-plan-each-trust-level-and-network-profile-test
+  (testing "Every trust-level and network-profile keyword validates"
+    (doseq [t sut/trust-levels]
+      (is (= {:valid? true}
+             (sut/validate-plan (valid-plan :trust-level t)))
+          (str ":trust-level " t " should be accepted")))
+    (doseq [n sut/network-profiles]
+      (is (= {:valid? true}
+             (sut/validate-plan (valid-plan :network-profile n)))
+          (str ":network-profile " n " should be accepted")))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; validate-plan — failure paths
+
+(deftest validate-plan-rejects-missing-required-keys-test
+  (testing "Removing :image-digest fails validation"
+    (let [{:keys [valid? errors]} (sut/validate-plan (dissoc (valid-plan) :image-digest))]
+      (is (false? valid?))
+      (is (some? errors)))))
+
+(deftest validate-plan-rejects-bad-trust-level-test
+  (testing "An unknown trust-level fails validation"
+    (let [{:keys [valid? errors]} (sut/validate-plan (valid-plan :trust-level :rogue))]
+      (is (false? valid?))
+      (is (some? errors)))))
+
+(deftest validate-plan-rejects-bad-network-profile-test
+  (testing "An unknown network-profile fails validation"
+    (let [{:keys [valid? errors]} (sut/validate-plan (valid-plan :network-profile :open))]
+      (is (false? valid?))
+      (is (some? errors)))))
+
+(deftest validate-plan-rejects-string-command-test
+  (testing ":command must be a vector of strings, not a single string"
+    (is (false? (:valid? (sut/validate-plan (valid-plan :command "bb run test")))))))
+
+(deftest validate-plan-rejects-non-string-env-values-test
+  (testing ":env must be string→string"
+    (is (false? (:valid? (sut/validate-plan (valid-plan :env {"PORT" 8080})))))))
+
+(deftest validate-plan-rejects-mount-with-missing-fields-test
+  (testing "A mount missing :read-only? fails validation"
+    (let [bad-mount (dissoc (valid-mount) :read-only?)
+          {:keys [valid?]} (sut/validate-plan (valid-plan :mounts [bad-mount]))]
+      (is (false? valid?)))))
+
+(deftest validate-plan-rejects-non-int-limits-test
+  (testing ":time-limit-ms and :memory-limit-mb must be ints"
+    (is (false? (:valid? (sut/validate-plan (valid-plan :time-limit-ms   "60000")))))
+    (is (false? (:valid? (sut/validate-plan (valid-plan :memory-limit-mb 1.5)))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; create-execution-plan — round-trip and throw paths
+
+(deftest create-execution-plan-returns-plan-unchanged-test
+  (testing "A valid plan is returned unchanged (identity, no normalization)"
+    (let [plan (valid-plan)]
+      (is (= plan (sut/create-execution-plan plan))))))
+
+(deftest create-execution-plan-throws-anomaly-on-invalid-input-test
+  (testing "create-execution-plan throws ExceptionInfo for invalid input,
+            with an :errors key in the ex-data and an :anomalies/incorrect category"
+    (let [thrown (try
+                   (sut/create-execution-plan {:trust-level :rogue})
+                   ::no-throw
+                   (catch clojure.lang.ExceptionInfo e e))]
+      (is (instance? clojure.lang.ExceptionInfo thrown))
+      (let [data (ex-data thrown)
+            anomaly (or (:anomaly data) data)]
+        (is (some? (:errors data)) "ex-data must carry :errors")
+        ;; throw-anomaly! pattern wraps the data under an anomaly category.
+        (is (or (= :anomalies/incorrect (:anomaly/category anomaly))
+                (= :anomalies/incorrect (:anomaly/category data))))))))
+
+(deftest create-execution-plan-error-includes-original-plan-test
+  (testing "ex-data carries the offending plan map under :plan"
+    (let [bad {:trust-level :rogue :command "wrong"}
+          thrown (try
+                   (sut/create-execution-plan bad)
+                   nil
+                   (catch clojure.lang.ExceptionInfo e e))]
+      (is (some? thrown))
+      (is (= bad (:plan (ex-data thrown)))))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/state_profile_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/state_profile_test.clj
@@ -1,0 +1,203 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.state-profile-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.dag-executor.state-profile :as sut]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures and factories
+
+(defn- raw-profile
+  "Build a raw (un-normalized) profile map suitable for build-profile."
+  [profile-id & {:as overrides}]
+  (merge {:profile/id                profile-id
+          :task-statuses             [:pending :ready :running :done]
+          :terminal-statuses         [:done :failed]
+          :success-terminal-statuses [:done]
+          :valid-transitions         {:pending [:ready]
+                                      :ready   [:running]
+                                      :running [:done :failed]
+                                      :done    []
+                                      :failed  []}
+          :event-mappings            {:start    {:type :transition :to :running}
+                                      :complete {:type :complete :to :done}}}
+         overrides))
+
+(defn- raw-provider
+  "Provider map with inline (map) profile definitions."
+  [& {:as overrides}]
+  (merge {:default-profile :testing
+          :profiles        {:testing (raw-profile :testing)
+                            :other   (raw-profile :other)}}
+         overrides))
+
+;------------------------------------------------------------------------------ Layer 1
+;; build-profile — set-coercion, transition-target sets, terminal-difference
+
+(deftest build-profile-coerces-collections-to-sets-test
+  (testing "task-statuses, terminal-statuses, success-terminal-statuses become sets"
+    (let [p (sut/build-profile (raw-profile :p
+                                            :task-statuses [:a :a :b]
+                                            :terminal-statuses [:b]
+                                            :success-terminal-statuses [:b]))]
+      (is (= #{:a :b} (:task-statuses p)))
+      (is (= #{:b}    (:terminal-statuses p)))
+      (is (= #{:b}    (:success-terminal-statuses p))))))
+
+(deftest build-profile-coerces-transition-targets-to-sets-test
+  (testing "Each value in valid-transitions becomes a set of target statuses"
+    (let [p (sut/build-profile (raw-profile :p
+                                            :valid-transitions {:a [:b :b :c]
+                                                                :b [:c]}))]
+      (is (= #{:b :c} (get-in p [:valid-transitions :a])))
+      (is (= #{:c}    (get-in p [:valid-transitions :b]))))))
+
+(deftest build-profile-derives-failure-terminal-statuses-test
+  (testing "failure-terminal-statuses = terminal-statuses minus success-terminal-statuses"
+    (let [p (sut/build-profile (raw-profile :p
+                                            :terminal-statuses [:done :failed :skipped]
+                                            :success-terminal-statuses [:done]))]
+      (is (= #{:failed :skipped} (:failure-terminal-statuses p))))))
+
+(deftest build-profile-preserves-profile-id-and-event-mappings-test
+  (testing "profile/id and event-mappings pass through unchanged"
+    (let [events {:s {:type :transition :to :running}}
+          p (sut/build-profile (raw-profile :pid :event-mappings events))]
+      (is (= :pid    (:profile/id p)))
+      (is (= events  (:event-mappings p))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; resolve-provider-profile — string vs map vs nil
+
+(deftest resolve-provider-profile-with-map-uses-supplied-id-test
+  (testing "When the definition is a map without :profile/id, the supplied id is used"
+    (let [[id profile] (sut/resolve-provider-profile :alpha
+                                                     (-> (raw-profile :ignored)
+                                                         (dissoc :profile/id)))]
+      (is (= :alpha id))
+      (is (= :alpha (:profile/id profile))))))
+
+(deftest resolve-provider-profile-map-preserves-explicit-id-test
+  (testing "When the map definition carries :profile/id, that id wins over the key"
+    (let [[id profile] (sut/resolve-provider-profile :alpha (raw-profile :explicit))]
+      (is (= :alpha id))
+      (is (= :explicit (:profile/id profile))))))
+
+(deftest resolve-provider-profile-string-resolves-classpath-resource-test
+  (testing "A string definition is read via read-edn-resource and built"
+    (let [[id profile] (sut/resolve-provider-profile
+                         :kernel
+                         "config/dag-executor/state-profiles/kernel.edn")]
+      (is (= :kernel id))
+      (is (= :kernel (:profile/id profile)))
+      (is (contains? (:task-statuses profile) :pending))
+      (is (set? (:terminal-statuses profile))))))
+
+(deftest resolve-provider-profile-nil-for-unknown-resource-test
+  (testing "Missing classpath resource → nil tuple"
+    (is (nil? (sut/resolve-provider-profile
+                :missing
+                "config/dag-executor/state-profiles/does-not-exist.edn")))))
+
+(deftest resolve-provider-profile-rejects-non-map-non-string-test
+  (testing "Numbers, vectors, etc. are not valid profile definitions → nil"
+    (is (nil? (sut/resolve-provider-profile :weird 42)))
+    (is (nil? (sut/resolve-provider-profile :weird [1 2 3])))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; build-provider — fallback id selection, profile normalization
+
+(deftest build-provider-normalizes-each-profile-test
+  (testing "Every profile in :profiles is run through build-profile"
+    (let [provider (sut/build-provider (raw-provider))
+          testing-p (get-in provider [:profiles :testing])]
+      (is (set? (:task-statuses testing-p)))
+      (is (set? (:terminal-statuses testing-p))))))
+
+(deftest build-provider-default-profile-honors-supplied-id-test
+  (testing "Supplied :default-profile is preserved"
+    (is (= :testing (:default-profile (sut/build-provider (raw-provider)))))))
+
+(deftest build-provider-default-falls-back-to-first-profile-test
+  (testing "When :default-profile is absent, the first profile id is used"
+    (let [provider (sut/build-provider {:profiles {:only (raw-profile :only)}})]
+      (is (= :only (:default-profile provider))))))
+
+(deftest build-provider-default-falls-back-to-kernel-when-no-profiles-test
+  (testing "When neither :default-profile nor :profiles are supplied,
+            the default-profile id falls back to :kernel"
+    (let [provider (sut/build-provider {})]
+      (is (= :kernel (:default-profile provider)))
+      (is (= {} (:profiles provider))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; default-provider, available-profile-ids, default-profile-id
+
+(deftest default-provider-returns-kernel-test
+  (testing "default-provider includes the kernel profile"
+    (let [provider (sut/default-provider)]
+      (is (= :kernel (:default-profile provider)))
+      (is (contains? (:profiles provider) :kernel)))))
+
+(deftest available-profile-ids-default-and-explicit-test
+  (testing "available-profile-ids reads from default-provider when no arg is given"
+    (is (some #{:kernel} (sut/available-profile-ids))))
+  (testing "available-profile-ids accepts a custom provider map"
+    (is (= #{:testing :other}
+           (set (sut/available-profile-ids (raw-provider)))))))
+
+(deftest default-profile-id-test
+  (testing "default-profile-id reads from default-provider when no arg is given"
+    (is (= :kernel (sut/default-profile-id))))
+  (testing "default-profile-id accepts a custom provider map"
+    (is (= :testing (sut/default-profile-id (raw-provider))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; resolve-profile — keyword / map / nil dispatch
+
+(deftest resolve-profile-nil-returns-default-test
+  (testing "Nil profile resolves to the provider's default profile"
+    (let [resolved (sut/resolve-profile (raw-provider) nil)]
+      (is (= :testing (:profile/id resolved))))))
+
+(deftest resolve-profile-known-keyword-returns-that-profile-test
+  (testing "A known keyword id returns the matching profile"
+    (let [resolved (sut/resolve-profile (raw-provider) :other)]
+      (is (= :other (:profile/id resolved))))))
+
+(deftest resolve-profile-unknown-keyword-falls-back-to-default-test
+  (testing "An unknown keyword id falls back to the provider's default"
+    (let [resolved (sut/resolve-profile (raw-provider) :nope)]
+      (is (= :testing (:profile/id resolved))))))
+
+(deftest resolve-profile-with-map-builds-inline-test
+  (testing "A map argument is run through build-profile and returned directly"
+    (let [resolved (sut/resolve-profile (raw-provider) (raw-profile :inline))]
+      (is (= :inline (:profile/id resolved)))
+      (is (set? (:task-statuses resolved))))))
+
+(deftest resolve-profile-default-overload-uses-default-provider-test
+  (testing "The single-arity overload uses the default provider"
+    (let [resolved (sut/resolve-profile :kernel)]
+      (is (= :kernel (:profile/id resolved))))))
+
+(deftest default-profile-resolves-via-default-provider-test
+  (testing "default-profile (no args) returns the default provider's default profile"
+    (is (= :kernel (:profile/id (sut/default-profile))))))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/workspace_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/workspace_test.clj
@@ -1,0 +1,154 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.workspace-test
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [clojure.string :as str]
+   [ai.miniforge.dag-executor.workspace :as sut]
+   [ai.miniforge.dag-executor.result :as result]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Test fixtures and factories
+
+(defn- shell-result
+  "Build the shape exec-fn callers expect: {:data {:stdout str}}."
+  [stdout]
+  {:data {:stdout stdout}})
+
+(defn- recording-exec-fn
+  "Return [exec-fn calls-atom replies-atom]. exec-fn records every command into
+   calls-atom and looks up its reply in replies-map by exact substring match.
+   default is the fallback when nothing matches."
+  ([replies-map] (recording-exec-fn replies-map (shell-result "")))
+  ([replies-map default]
+   (let [calls (atom [])]
+     [(fn [cmd]
+        (swap! calls conj cmd)
+        (or (some (fn [[needle reply]]
+                    (when (str/includes? cmd needle) reply))
+                  replies-map)
+            default))
+      calls])))
+
+(def ^:private head-sha "abc123def456")
+
+;------------------------------------------------------------------------------ Layer 1
+;; git-persist!
+
+(deftest git-persist!-no-changes-test
+  (testing "Empty `git status --porcelain` ⇒ no commit, no push, ok with :no-changes? true"
+    (let [[exec-fn calls] (recording-exec-fn
+                           {"git status" (shell-result "")
+                            "rev-parse"  (shell-result head-sha)})
+          r (sut/git-persist! exec-fn {:branch "task/foo" :message "checkpoint"})]
+      (is (result/ok? r))
+      (let [data (result/unwrap r)]
+        (is (false? (:persisted? data)))
+        (is (true?  (:no-changes? data)))
+        (is (nil?   (:commit-sha data))))
+      ;; git add was attempted, but commit/push were not.
+      (is (some #(str/includes? % "git add -A")        @calls))
+      (is (some #(str/includes? % "git status")        @calls))
+      (is (not (some #(str/includes? % "git commit") @calls)))
+      (is (not (some #(str/includes? % "git push")   @calls))))))
+
+(deftest git-persist!-with-changes-commits-and-pushes-test
+  (testing "Dirty `git status` ⇒ commit + push + read HEAD sha; ok carries the sha and branch"
+    (let [[exec-fn calls] (recording-exec-fn
+                           {"git status"   (shell-result " M src/foo.clj\n")
+                            "git rev-parse" (shell-result (str head-sha "\n"))})
+          r (sut/git-persist! exec-fn {:branch "feature/bar"
+                                       :message "phase: implement"})]
+      (is (result/ok? r))
+      (let [data (result/unwrap r)]
+        (is (true? (:persisted? data)))
+        (is (= head-sha (:commit-sha data)))
+        (is (= "feature/bar" (:branch data))))
+      ;; Verify expected commands ran in order.
+      (let [cmds @calls]
+        (is (some #(str/includes? % "git add -A") cmds))
+        (is (some #(str/includes? % "git commit -m 'phase: implement'") cmds))
+        (is (some #(str/includes? % "git push origin HEAD:feature/bar --force") cmds))))))
+
+(deftest git-persist!-defaults-branch-and-message-test
+  (testing "Missing :branch and :message use 'task/unknown' and 'phase checkpoint'"
+    (let [[exec-fn calls] (recording-exec-fn
+                           {"git status"   (shell-result " M file\n")
+                            "git rev-parse" (shell-result head-sha)})]
+      (sut/git-persist! exec-fn {})
+      (is (some #(str/includes? % "git commit -m 'phase checkpoint'") @calls))
+      (is (some #(str/includes? % "HEAD:task/unknown")                @calls)))))
+
+(deftest git-persist!-trims-stdout-test
+  (testing "stdout from git rev-parse is trimmed before being returned"
+    (let [[exec-fn _] (recording-exec-fn
+                       {"git status"   (shell-result " M file\n")
+                        "git rev-parse" (shell-result (str "  " head-sha "  \n"))})
+          r (sut/git-persist! exec-fn {:branch "task/x"})]
+      (is (= head-sha (:commit-sha (result/unwrap r)))))))
+
+(deftest git-persist!-catches-exec-exceptions-test
+  (testing "An exception from exec-fn is caught and turned into a :persist-failed result/err"
+    (let [boom-exec-fn (fn [cmd]
+                         (if (str/includes? cmd "status")
+                           (throw (Exception. "git unavailable"))
+                           (shell-result "")))
+          r (sut/git-persist! boom-exec-fn {:branch "task/x"})]
+      (is (result/err? r))
+      (is (= :persist-failed (-> r :error :code))))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; git-restore!
+
+(deftest git-restore!-fetches-checks-out-and-reads-head-test
+  (testing "git-restore! issues fetch + checkout + rev-parse and returns the sha"
+    (let [[exec-fn calls] (recording-exec-fn
+                           {"git rev-parse" (shell-result (str head-sha "\n"))})
+          r (sut/git-restore! exec-fn {:branch "feature/restore"})]
+      (is (result/ok? r))
+      (let [data (result/unwrap r)]
+        (is (true? (:restored? data)))
+        (is (= head-sha (:commit-sha data)))
+        (is (= "feature/restore" (:branch data))))
+      ;; Verify the expected git invocations occurred against the supplied branch.
+      (let [cmds @calls]
+        (is (some #(str/includes? % "git fetch origin feature/restore") cmds))
+        (is (some #(str/includes? % "git checkout feature/restore")     cmds))))))
+
+(deftest git-restore!-defaults-branch-test
+  (testing "Missing :branch defaults to 'task/unknown'"
+    (let [[exec-fn calls] (recording-exec-fn
+                           {"git rev-parse" (shell-result head-sha)})]
+      (sut/git-restore! exec-fn {})
+      (is (some #(str/includes? % "git fetch origin task/unknown") @calls))
+      (is (some #(str/includes? % "git checkout task/unknown")     @calls)))))
+
+(deftest git-restore!-trims-stdout-test
+  (testing "git rev-parse stdout is trimmed before return"
+    (let [[exec-fn _] (recording-exec-fn
+                       {"git rev-parse" (shell-result (str "\n" head-sha "\n"))})
+          r (sut/git-restore! exec-fn {:branch "task/x"})]
+      (is (= head-sha (:commit-sha (result/unwrap r)))))))
+
+(deftest git-restore!-catches-exec-exceptions-test
+  (testing "An exception from exec-fn is caught and turned into a :restore-failed result/err"
+    (let [boom-exec-fn (fn [_cmd] (throw (Exception. "fetch refused")))
+          r (sut/git-restore! boom-exec-fn {:branch "task/x"})]
+      (is (result/err? r))
+      (is (= :restore-failed (-> r :error :code))))))


### PR DESCRIPTION
## Summary

\`dag-executor\` was at **0.20** test/src ratio (4364 src LOC, 882 test LOC) — the largest under-tested component in the repo. This is **the first of an expected 2–3 PRs** lifting that ratio. Targets the three completely-untested but mechanically-tractable files:

| File | src LOC | new tests | new assertions |
|---|---|---|---|
| \`execution_plan.clj\` | 167 | 15 | 28 |
| \`state_profile.clj\`  | 136 | 22 | 38 |
| \`workspace.clj\`      |  71 |  9 | 31 |
| **Total** | **374** | **46** | **97** |

## Untouched by this PR (covered next)

- \`interface.clj\` (598 LOC, the public API surface)
- \`executor.clj\` (430), \`scheduler.clj\` (404), \`parallel.clj\` (356) — async / orchestration
- \`protocols/executor.clj\` (157) — protocol definitions
- \`protocols/impl/kubernetes.clj\` (392) — note that per the \`project_k8s_fleet_only\` memory, K8s has moved to Fleet; this may be deprecated in OSS before tests are warranted

## Test inventory

### \`execution_plan_test.clj\` (15 tests)
- **Constants**: \`trust-levels\` and \`network-profiles\` each expose the documented closed set.
- **\`validate-plan\` happy paths**: fully-populated plan; empty mounts / env / secrets-refs collections; every \`trust-level\` and every \`network-profile\` keyword.
- **\`validate-plan\` failure paths**: missing \`:image-digest\`, unknown trust-level, unknown network-profile, \`:command\` as string, non-string env values, mount missing \`:read-only?\`, non-int \`:time-limit-ms\` / \`:memory-limit-mb\`.
- **\`create-execution-plan\`**: identity round-trip on valid input; throws \`ExceptionInfo\` with \`:anomalies/incorrect\` category and \`:errors\` / \`:plan\` keys on invalid input.

### \`state_profile_test.clj\` (22 tests)
- **\`build-profile\`**: collection-to-set coercion for \`task-statuses\`, \`terminal-statuses\`, \`success-terminal-statuses\`; transition-target sets; failure-terminal-statuses derivation as \`terminal − success\`; \`profile/id\` and \`event-mappings\` preservation.
- **\`resolve-provider-profile\`**: map definition uses supplied id when \`:profile/id\` absent; preserves explicit \`:profile/id\` when present; string definition resolves a classpath EDN resource (uses the real shipped \`kernel.edn\`); nil for missing resource; nil for non-map non-string definitions.
- **\`build-provider\`**: each profile normalized; \`:default-profile\` honored when supplied; falls back to first profile id when absent; falls back to \`:kernel\` when \`:profiles\` also absent.
- **\`default-provider\` / \`default-profile\` / \`default-profile-id\` / \`available-profile-ids\`**: single-arity uses the kernel default, custom-arity accepts an inline provider map.
- **\`resolve-profile\` dispatch**: nil → default; known keyword → that profile; unknown keyword → fallback to default; map → built inline; single-arity goes through \`default-provider\`.

### \`workspace_test.clj\` (9 tests)
- **\`git-persist!\` with no changes** ⇒ ok with \`:no-changes? true\`; commit and push are NOT issued (verified by recording exec-fn).
- **\`git-persist!\` with changes** ⇒ \`commit\` + \`push --force\` to \`HEAD:branch\`; HEAD sha read and trimmed; \`:persisted? true\` and branch echoed.
- **\`git-persist!\` defaults**: missing \`:branch\` ⇒ \`task/unknown\`; missing \`:message\` ⇒ \`phase checkpoint\`.
- **\`git-persist!\`** catches exec-fn exceptions and returns \`result/err :persist-failed\`.
- **\`git-restore!\`**: fetch + checkout + rev-parse against the supplied branch; HEAD trimmed; defaults to \`task/unknown\`; exec-fn exceptions become \`:restore-failed\` errors.

## Context

PR 6 of the multi-PR test-coverage and standards-drift pass. Builds on #678, #679, #684, #685, #686.

## Test plan

- [x] \`bb pre-commit\` passes — lint + format clean, full unit + GraalVM suite green
- [x] All 46 new tests pass directly via the \`:test\` alias
- [x] Used the real shipped \`kernel.edn\` as the classpath resource fixture so the resource-resolution test is exercising a real file, not a mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)