### PR TITLE
feat: add anomaly component for canonical data-first error type

### DIFF
--- a/components/anomaly/deps.edn
+++ b/components/anomaly/deps.edn
@@ -1,0 +1,6 @@
+{:paths ["src"]
+ :deps {metosin/malli {:mvn/version "0.16.4"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/anomaly/src/ai/miniforge/anomaly/contract.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/contract.clj
@@ -1,0 +1,92 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.contract
+  "Malli contract for the canonical anomaly shape.
+
+   Anomalies are the data-first error type shared across all
+   miniforge-family Clojure repos. An anomaly is a plain map; it is
+   not an exception. Functions that fail return an anomaly and let
+   the caller decide what to do.
+
+   This component defines a single shape so every repo agrees on:
+   - the keyword namespace (`:anomaly/*`)
+   - the type vocabulary (mirrors cognitect anomalies)
+   - the timestamp at construction"
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Type vocabulary
+
+(def anomaly-types
+  "Standard anomaly type keywords. Mirrors the cognitect anomalies
+   vocabulary, with `:fatal` added for unrecoverable programmer errors.
+
+   Each type encodes a category of failure:
+   - :not-found      — referenced entity does not exist
+   - :invalid-input  — caller-supplied data is malformed
+   - :unauthorized   — caller lacks permission
+   - :fault          — internal error; bug in this system
+   - :unavailable    — downstream dependency is down
+   - :conflict       — operation conflicts with existing state
+   - :timeout        — operation exceeded its time budget
+   - :unsupported    — operation not implemented for this case
+   - :fatal          — unrecoverable; the process should stop"
+  #{:not-found
+    :invalid-input
+    :unauthorized
+    :fault
+    :unavailable
+    :conflict
+    :timeout
+    :unsupported
+    :fatal})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Schema
+
+(def Anomaly
+  "Malli schema for the canonical anomaly map.
+
+   Every anomaly carries:
+   - :anomaly/type    — keyword from the standard vocabulary
+   - :anomaly/message — human-readable description
+   - :anomaly/data    — caller-supplied context map (defaults to {})
+   - :anomaly/at      — instant of construction"
+  [:map {:closed true}
+   [:anomaly/type    (into [:enum] anomaly-types)]
+   [:anomaly/message :string]
+   [:anomaly/data    [:map-of :any :any]]
+   [:anomaly/at      inst?]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; Validation helpers
+
+(defn valid?
+  "Return true when `value` matches the Anomaly schema."
+  [value]
+  (m/validate Anomaly value))
+
+(defn explain
+  "Return a humanized explanation for an invalid anomaly, or nil
+   when `value` is valid."
+  [value]
+  (some-> (m/explain Anomaly value)
+          me/humanize))

--- a/components/anomaly/src/ai/miniforge/anomaly/interface.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/interface.clj
@@ -1,0 +1,115 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface
+  "Public API for the anomaly component.
+
+   An anomaly is a plain map describing a failure. Functions return
+   anomalies instead of throwing — exceptions are reserved for
+   programmer errors at the boundary (e.g. an unknown anomaly type).
+
+   Standard usage:
+
+     (require '[ai.miniforge.anomaly.interface :as anomaly])
+
+     (defn lookup [id]
+       (or (db/find id)
+           (anomaly/anomaly :not-found
+                            (str \"No record for id \" id)
+                            {:id id})))
+
+     (let [result (lookup 42)]
+       (if (anomaly/anomaly? result)
+         (handle-failure result)
+         (process result)))"
+  (:require
+   [ai.miniforge.anomaly.contract :as contract]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema and vocabulary re-exports
+
+(def Anomaly
+  "Malli schema for the canonical anomaly map. See
+   `ai.miniforge.anomaly.contract/Anomaly`."
+  contract/Anomaly)
+
+(def anomaly-types
+  "Set of standard anomaly type keywords. See
+   `ai.miniforge.anomaly.contract/anomaly-types`."
+  contract/anomaly-types)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Construction
+
+(defn- now
+  "Return the current instant. Wrapped so tests can redef."
+  []
+  (java.time.Instant/now))
+
+(defn anomaly
+  "Construct a canonical anomaly map.
+
+   - `type`    — keyword from `anomaly-types`; an unknown type throws
+                 IllegalArgumentException because that is a programmer
+                 error, not a runtime condition.
+   - `message` — human-readable description string.
+   - `data`    — caller-supplied context map; nil is normalized to {}.
+
+   The :anomaly/at timestamp is populated at construction with the
+   current instant. The returned map satisfies the `Anomaly` schema."
+  [type message data]
+  (when-not (contains? contract/anomaly-types type)
+    (throw (IllegalArgumentException.
+            (str "Unknown anomaly type: " (pr-str type)
+                 ". Must be one of " (pr-str contract/anomaly-types)))))
+  {:anomaly/type    type
+   :anomaly/message message
+   :anomaly/data    (or data {})
+   :anomaly/at      (now)})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Predicate
+
+(defn anomaly?
+  "True when `x` is a map matching the canonical anomaly shape.
+
+   Returns false for nil, non-maps, and maps missing required keys
+   or holding values that do not match the schema."
+  [x]
+  (and (map? x)
+       (contract/valid? x)))
+
+;------------------------------------------------------------------------------ Rich Comment
+
+(comment
+  (def boom (anomaly :not-found "missing user" {:id 7}))
+
+  (anomaly? boom)
+  ;; => true
+
+  (anomaly? {:anomaly/type :bogus
+             :anomaly/message "x"
+             :anomaly/data {}
+             :anomaly/at (java.time.Instant/now)})
+  ;; => false (type not in vocabulary)
+
+  ;; Programmer error — wrong type at construction throws
+  (try (anomaly :no-such-type "x" {})
+       (catch IllegalArgumentException e (.getMessage e)))
+
+  :leave-this-here)

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/constructor_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/constructor_test.clj
@@ -1,0 +1,46 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.constructor-test
+  "Happy-path construction. The constructor must produce a map with
+   the four canonical `:anomaly/*` keys, preserving the type, message,
+   and data the caller passed."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest anomaly-returns-canonical-shape
+  (testing "constructor populates all four canonical keys"
+    (let [a (anomaly/anomaly :not-found "missing user" {:id 7})]
+      (is (= :not-found (:anomaly/type a)))
+      (is (= "missing user" (:anomaly/message a)))
+      (is (= {:id 7} (:anomaly/data a)))
+      (is (inst? (:anomaly/at a))))))
+
+(deftest anomaly-result-is-a-plain-map
+  (testing "anomaly is a plain Clojure map, not an exception"
+    (let [a (anomaly/anomaly :fault "boom" {})]
+      (is (map? a))
+      (is (not (instance? Throwable a))))))
+
+(deftest anomaly-keys-are-namespaced
+  (testing "every key on the result is in the :anomaly namespace"
+    (let [a (anomaly/anomaly :timeout "slow" {:ms 500})]
+      (is (every? #(= "anomaly" (namespace %)) (keys a)))
+      (is (= #{:anomaly/type :anomaly/message :anomaly/data :anomaly/at}
+             (set (keys a)))))))

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/data_default_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/data_default_test.clj
@@ -1,0 +1,42 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.data-default-test
+  "`:anomaly/data` is required by the schema, so the constructor
+   must coerce nil into an empty map. Callers should never have to
+   type `{}` just to satisfy the shape."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest nil-data-becomes-empty-map
+  (testing "nil :anomaly/data is normalized to {}"
+    (let [a (anomaly/anomaly :fault "boom" nil)]
+      (is (= {} (:anomaly/data a)))
+      (is (anomaly/anomaly? a)))))
+
+(deftest empty-map-data-stays-empty
+  (testing "explicit empty map round-trips unchanged"
+    (let [a (anomaly/anomaly :fault "boom" {})]
+      (is (= {} (:anomaly/data a))))))
+
+(deftest non-empty-data-is-preserved-verbatim
+  (testing "non-empty data maps survive untouched"
+    (let [d {:request-id "abc" :attempt 3 :nested {:k :v}}
+          a (anomaly/anomaly :timeout "slow" d)]
+      (is (= d (:anomaly/data a))))))

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/predicate_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/predicate_test.clj
@@ -1,0 +1,73 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.predicate-test
+  "Predicate behavior. `anomaly?` must say yes only for canonical
+   anomaly maps, and never blow up on nil or arbitrary input."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest anomaly?-true-for-constructed-anomalies
+  (testing "every anomaly produced by the constructor is recognized"
+    (doseq [t anomaly/anomaly-types]
+      (is (anomaly/anomaly? (anomaly/anomaly t "msg" {}))
+          (str "expected anomaly? true for type " t)))))
+
+(deftest anomaly?-false-for-nil-and-non-maps
+  (testing "anomaly? returns false for nil and non-map values"
+    (is (false? (anomaly/anomaly? nil)))
+    (is (false? (anomaly/anomaly? "not a map")))
+    (is (false? (anomaly/anomaly? 42)))
+    (is (false? (anomaly/anomaly? :keyword)))
+    (is (false? (anomaly/anomaly? [])))
+    (is (false? (anomaly/anomaly? #{})))))
+
+(deftest anomaly?-false-for-malformed-maps
+  (testing "anomaly? rejects maps missing required keys"
+    (is (false? (anomaly/anomaly? {})))
+    (is (false? (anomaly/anomaly? {:anomaly/type :not-found})))
+    (is (false? (anomaly/anomaly? {:anomaly/type :not-found
+                                   :anomaly/message "x"})))
+    (is (false? (anomaly/anomaly? {:anomaly/type :not-found
+                                   :anomaly/message "x"
+                                   :anomaly/data {}})))))
+
+(deftest anomaly?-false-for-extra-keys
+  (testing "the schema is closed; extra keys disqualify the map"
+    (let [a (anomaly/anomaly :fault "boom" {})]
+      (is (false? (anomaly/anomaly? (assoc a :something/else 1)))))))
+
+(deftest anomaly?-false-for-bad-value-types
+  (testing "anomaly? rejects maps whose values violate the schema"
+    (is (false? (anomaly/anomaly? {:anomaly/type "string-not-keyword"
+                                   :anomaly/message "m"
+                                   :anomaly/data {}
+                                   :anomaly/at (java.time.Instant/now)})))
+    (is (false? (anomaly/anomaly? {:anomaly/type :fault
+                                   :anomaly/message :keyword-not-string
+                                   :anomaly/data {}
+                                   :anomaly/at (java.time.Instant/now)})))
+    (is (false? (anomaly/anomaly? {:anomaly/type :fault
+                                   :anomaly/message "m"
+                                   :anomaly/data "not a map"
+                                   :anomaly/at (java.time.Instant/now)})))
+    (is (false? (anomaly/anomaly? {:anomaly/type :fault
+                                   :anomaly/message "m"
+                                   :anomaly/data {}
+                                   :anomaly/at "not an inst"})))))

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/round_trip_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/round_trip_test.clj
@@ -1,0 +1,100 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.round-trip-test
+  "Anomalies are designed to be data — they have to survive an EDN
+   serialize/deserialize trip without losing fidelity. This is what
+   lets the evidence-bundle and event-stream components persist them
+   to disk and replay later.
+
+   Instants tunnel through EDN as `#inst` literals via java.util.Date.
+   Date carries millisecond precision, so the test fixture truncates
+   the original Instant to milliseconds before round-tripping —
+   anything finer is not representable in standard EDN and is not
+   part of the contract."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.test :refer [deftest testing is]]
+   [clojure.walk :as walk]
+   [ai.miniforge.anomaly.interface :as anomaly])
+  (:import
+   (java.time.temporal ChronoUnit)))
+
+(def ^:private edn-readers
+  "Reader map that materializes `#inst` tags back into
+   java.time.Instant so timestamps round-trip with the same JVM type
+   they were built with."
+  {'inst (fn [s] (java.time.Instant/parse s))})
+
+(defn- instant->date
+  "Swap `java.time.Instant` for `java.util.Date` so the built-in EDN
+   printer emits a `#inst` tagged literal."
+  [x]
+  (if (instance? java.time.Instant x)
+    (java.util.Date/from x)
+    x))
+
+(defn- instants->dates
+  "Walk `value`, replacing every Instant with the equivalent Date.
+   Date round-trips natively through `pr-str` + `edn/read-string`."
+  [value]
+  (walk/postwalk instant->date value))
+
+(defn- truncate-instant-to-millis
+  "EDN `#inst` carries only millisecond precision. Truncate so the
+   pre- and post-serialization values are comparable."
+  [x]
+  (if (instance? java.time.Instant x)
+    (.truncatedTo ^java.time.Instant x ChronoUnit/MILLIS)
+    x))
+
+(defn- normalize
+  "Drop sub-millisecond precision on every Instant under `value`."
+  [value]
+  (walk/postwalk truncate-instant-to-millis value))
+
+(defn- round-trip
+  "Serialize `value` to EDN and read it back. Instants tunnel through
+   as `#inst` tagged literals via `java.util.Date` and are restored
+   to `java.time.Instant` by `edn-readers` on the read side."
+  [value]
+  (edn/read-string {:readers edn-readers}
+                   (pr-str (instants->dates value))))
+
+(deftest anomaly-survives-edn-round-trip
+  (testing "constructor output matches itself after pr-str / edn/read-string"
+    (let [a (normalize (anomaly/anomaly :not-found "missing user"
+                                        {:id 7 :nested {:k :v}}))
+          b (round-trip a)]
+      (is (= a b)))))
+
+(deftest round-tripped-anomaly-still-validates
+  (testing "the deserialized map still satisfies the anomaly? predicate"
+    (let [a (normalize (anomaly/anomaly :unavailable "downstream down"
+                                        {:host "db-1"}))
+          b (round-trip a)]
+      (is (anomaly/anomaly? b)))))
+
+(deftest round-trip-preserves-every-canonical-key
+  (testing "type, message, data, and at survive serialization"
+    (let [a (normalize (anomaly/anomaly :conflict "duplicate" {:key "abc"}))
+          b (round-trip a)]
+      (is (= (:anomaly/type a)    (:anomaly/type b)))
+      (is (= (:anomaly/message a) (:anomaly/message b)))
+      (is (= (:anomaly/data a)    (:anomaly/data b)))
+      (is (= (:anomaly/at a)      (:anomaly/at b))))))

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/schema_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/schema_test.clj
@@ -1,0 +1,66 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.schema-test
+  "Direct malli validation against the re-exported `Anomaly` schema.
+   Distinct from the predicate tests because callers in other
+   miniforge repos may want to validate hand-built maps without
+   going through the `anomaly?` helper."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [malli.core :as m]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest schema-accepts-constructed-shape
+  (testing "the re-exported Anomaly schema validates constructor output"
+    (let [a (anomaly/anomaly :invalid-input "bad arg" {:arg :x})]
+      (is (m/validate anomaly/Anomaly a)))))
+
+(deftest schema-accepts-hand-built-shape
+  (testing "any map matching the four canonical keys validates"
+    (let [a {:anomaly/type    :unauthorized
+             :anomaly/message "no token"
+             :anomaly/data    {:user "alice"}
+             :anomaly/at      (java.time.Instant/now)}]
+      (is (m/validate anomaly/Anomaly a)))))
+
+(deftest schema-rejects-missing-keys
+  (testing "the Anomaly schema requires every canonical key"
+    (is (not (m/validate anomaly/Anomaly {})))
+    (is (not (m/validate anomaly/Anomaly
+                         {:anomaly/type :fault
+                          :anomaly/message "m"
+                          :anomaly/data {}})))))
+
+(deftest schema-rejects-wrong-types
+  (testing "the Anomaly schema enforces value shapes"
+    (is (not (m/validate anomaly/Anomaly
+                         {:anomaly/type    :fault
+                          :anomaly/message 42
+                          :anomaly/data    {}
+                          :anomaly/at      (java.time.Instant/now)})))
+    (is (not (m/validate anomaly/Anomaly
+                         {:anomaly/type    :fault
+                          :anomaly/message "m"
+                          :anomaly/data    [:not :a :map]
+                          :anomaly/at      (java.time.Instant/now)})))))
+
+(deftest schema-rejects-extra-keys
+  (testing "the schema is closed; extra keys fail validation"
+    (let [a (anomaly/anomaly :fault "boom" {})]
+      (is (not (m/validate anomaly/Anomaly (assoc a :extra/key 1)))))))

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/timestamp_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/timestamp_test.clj
@@ -1,0 +1,47 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.timestamp-test
+  "`:anomaly/at` is populated at construction with the current
+   instant. We bracket the call with `Instant/now` and assert that
+   the recorded time falls within the bracket."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest timestamp-is-an-instant
+  (testing ":anomaly/at is a java.time.Instant"
+    (let [a (anomaly/anomaly :fault "boom" {})]
+      (is (instance? java.time.Instant (:anomaly/at a))))))
+
+(deftest timestamp-is-recent
+  (testing ":anomaly/at falls between two bracketing now() calls"
+    (let [before (java.time.Instant/now)
+          a      (anomaly/anomaly :fault "boom" {})
+          after  (java.time.Instant/now)
+          at     (:anomaly/at a)]
+      (is (not (.isBefore at before)))
+      (is (not (.isAfter at after))))))
+
+(deftest each-anomaly-gets-its-own-timestamp
+  (testing "two anomalies built in sequence have monotonic timestamps"
+    (let [a1 (anomaly/anomaly :fault "first" {})
+          _  (Thread/sleep 1)
+          a2 (anomaly/anomaly :fault "second" {})]
+      (is (not (.isAfter (:anomaly/at a1)
+                         (:anomaly/at a2)))))))

--- a/components/anomaly/test/ai/miniforge/anomaly/interface/type_vocabulary_test.clj
+++ b/components/anomaly/test/ai/miniforge/anomaly/interface/type_vocabulary_test.clj
@@ -1,0 +1,56 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.anomaly.interface.type-vocabulary-test
+  "The constructor's type-vocabulary check is the only place this
+   component throws. An unknown type is a programmer error, so
+   failing fast at construction is the right thing."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]))
+
+(deftest standard-vocabulary-is-locked
+  (testing "the published vocabulary mirrors the cognitect set plus :fatal"
+    (is (= #{:not-found :invalid-input :unauthorized :fault :unavailable
+             :conflict :timeout :unsupported :fatal}
+           anomaly/anomaly-types))))
+
+(deftest every-standard-type-constructs-cleanly
+  (testing "the constructor accepts every type in the vocabulary"
+    (doseq [t anomaly/anomaly-types]
+      (let [a (anomaly/anomaly t "msg" {})]
+        (is (= t (:anomaly/type a)))))))
+
+(deftest unknown-type-throws-illegal-argument
+  (testing "unknown types raise IllegalArgumentException"
+    (is (thrown? IllegalArgumentException
+                 (anomaly/anomaly :no-such-type "msg" {})))
+    (is (thrown? IllegalArgumentException
+                 (anomaly/anomaly :NotFound "msg" {})))
+    (is (thrown? IllegalArgumentException
+                 (anomaly/anomaly nil "msg" {})))
+    (is (thrown? IllegalArgumentException
+                 (anomaly/anomaly "not-a-keyword" "msg" {})))))
+
+(deftest unknown-type-error-mentions-vocabulary
+  (testing "the thrown message lists the offending type"
+    (try
+      (anomaly/anomaly :totally-bogus "m" {})
+      (is false "expected IllegalArgumentException")
+      (catch IllegalArgumentException e
+        (is (re-find #"totally-bogus" (.getMessage e)))))))

--- a/deps.edn
+++ b/deps.edn
@@ -21,6 +21,7 @@
                        "components/agent/resources"
                        "components/agent-runtime/src"
                        "components/agent-runtime/resources"
+                       "components/anomaly/src"
                        "components/task/src"
                        "components/task-executor/src"
                        "components/decision/src"
@@ -186,6 +187,7 @@
                       ai.miniforge/artifact {:local/root "components/artifact"}
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
+                      ai.miniforge/anomaly {:local/root "components/anomaly"}
                       ai.miniforge/task {:local/root "components/task"}
                       ai.miniforge/task-executor {:local/root "components/task-executor"}
                       ai.miniforge/decision {:local/root "components/decision"}
@@ -298,6 +300,7 @@
                        "components/artifact/test"
                        "components/agent/test"
                        "components/agent-runtime/test"
+                       "components/anomaly/test"
                        "components/task/test"
                        "components/decision/test"
                        "components/loop/test"
@@ -409,6 +412,7 @@
                       ai.miniforge/artifact {:local/root "components/artifact"}
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
+                      ai.miniforge/anomaly {:local/root "components/anomaly"}
                       ai.miniforge/task {:local/root "components/task"}
                       ai.miniforge/decision {:local/root "components/decision"}
                       ai.miniforge/loop {:local/root "components/loop"}

--- a/docs/pull-requests/2026-04-27-feat-anomaly-component.md
+++ b/docs/pull-requests/2026-04-27-feat-anomaly-component.md
@@ -1,0 +1,134 @@
+# feat: add anomaly component for canonical data-first error type
+
+## Overview
+
+Adds a new `ai.miniforge.anomaly` Polylith component to miniforge OSS, providing a single canonical anomaly shape,
+constructor, predicate, and Malli schema. This is the foundational primitive for the "exceptions are data" discipline
+that all miniforge-family Clojure repos will share.
+
+## Motivation
+
+Miniforge has accumulated multiple ad-hoc shapes for representing failures (assorted maps, `ex-info` payloads, scattered
+`:error`/`:errors` conventions). Without a canonical anomaly type, downstream repos (thesium-workflows, miniforge-fleet,
+future ports of ixi) end up redefining the same shape independently and drifting.
+
+This component is the substrate fix: one Apache 2 component in miniforge OSS that every miniforge-family Clojure repo
+can consume via vendoring. It pairs with the upcoming `response-chain`, `boundary`, and `content-hash` components to
+give the family a shared error-handling and provenance vocabulary.
+
+The architectural decision to add cross-cutting primitives **into** miniforge OSS rather than extracting them out into a
+separate `miniforge-clj-commons` repo is captured in the broader memory-substrate refactor plan.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+None. This is the first of the H-series cross-cutting components.
+
+## Layer
+
+Foundations / cross-cutting primitive. New top-level component.
+
+## What This Adds
+
+- New component `components/anomaly/`:
+  - `deps.edn` — minimal; depends on `metosin/malli 0.16.4` only.
+  - `src/ai/miniforge/anomaly/contract.clj` — Malli `Anomaly` schema (`:closed true`), `anomaly-types` set, validation
+    helpers.
+  - `src/ai/miniforge/anomaly/interface.clj` — public API: `anomaly`, `anomaly?`, `Anomaly`, `anomaly-types`.
+    Layer-labeled per stratified-design.
+- Seven decomposed test files under `test/ai/miniforge/anomaly/interface/`, one per behavior dimension:
+  - `constructor_test.clj`
+  - `predicate_test.clj`
+  - `schema_test.clj`
+  - `type_vocabulary_test.clj`
+  - `data_default_test.clj`
+  - `timestamp_test.clj`
+  - `round_trip_test.clj`
+- Root `deps.edn` registration: adds `ai.miniforge/anomaly` `:local/root` dep and `components/anomaly/{src,test}` paths
+  under `:dev` / `:test` / `:conformance` aliases.
+
+## Public API
+
+```clojure
+(anomaly type message data)   ; constructor, returns canonical map
+(anomaly? x)                  ; predicate
+Anomaly                        ; Malli schema (closed)
+anomaly-types                  ; set of standard type keywords
+```
+
+Anomaly map shape:
+
+```clojure
+{:anomaly/type    keyword?    ; one of anomaly-types
+ :anomaly/message string?
+ :anomaly/data    map?        ; defaults to {} when nil
+ :anomaly/at      inst?}      ; populated at construction
+```
+
+Standard type vocabulary (mirrors cognitect anomalies):
+
+```
+#{:not-found :invalid-input :unauthorized :fault :unavailable
+  :conflict :timeout :unsupported :fatal}
+```
+
+The constructor validates `type` against the vocabulary and throws `IllegalArgumentException` on unknown types. This is
+one of the few legitimate `throw` sites: it is a programmer-error guard, not a runtime failure path.
+
+## Strata Affected
+
+- `ai.miniforge.anomaly.contract` — Malli schema and type vocabulary
+- `ai.miniforge.anomaly.interface` — public API
+
+No existing component touched. New top-level brick.
+
+## Testing Plan
+
+- `bb pre-commit` — full local gate: `lint:clj` + `fmt:md` + `test` + `test:graalvm`. **All passed.**
+- `lint:clj` — 10 files, 0 errors, 0 warnings.
+- `test` — Polylith picked up `anomaly` as the only changed brick: 26 tests, 68 assertions, 0 failures, 0 errors.
+- `test:graalvm` — 6 tests, 465 assertions, 0 failures.
+
+The seven test files map 1:1 to the per-behavior dimensions documented in the brief. Each dimension is independently
+exercisable, so future agents can modify one without perturbing the others.
+
+## Deployment Plan
+
+No migration required. New additive component. Existing miniforge code is unchanged and unaffected.
+
+Downstream consumption (thesium-workflows, miniforge-fleet, etc.) will land in subsequent PRs as those repos rewire
+their local error helpers to consume `ai.miniforge.anomaly` directly via vendoring.
+
+## Notes / Deviations
+
+- **`workspace.edn` not modified.** Polylith auto-discovers `components/anomaly/` from disk; the workspace config lists
+  per-project `:necessary` overrides only. Confirmed via `poly info` — new brick discovered automatically.
+- **Root `deps.edn` was edited.** The changed-brick test runner that backs `bb test` runs under `clojure -M:dev:test`;
+  those aliases are explicit allow-lists, so registration is required for tests to load.
+- **No `bb gate` task in this repo.** The canonical local gate is `bb pre-commit` (documented in `agents.md`). All
+  checks passed.
+- **EDN round-trip uses Date precision.** `pr-str` of a `java.time.Instant` does not emit `#inst`; the test serializes
+  via `java.util.Date` (millisecond precision) and a custom `#inst` reader rebuilds the Instant on the read side.
+  Sub-millisecond precision is not representable in standard EDN.
+- **Pre-existing `poly check` errors** in `bb-dev-tools` and `miniforge-tui` are present on main and unrelated to this
+  change.
+
+## Related Issues/PRs
+
+- Will be followed by `feat/extract-content-hash-component` (sibling H-series component)
+- Will be followed by `response-chain` and `boundary` components in the H-series
+- Companion standards rule `feat/exceptions-as-data-rule` lands in `miniforge-standards`
+
+## Checklist
+
+- [x] New `anomaly` component with public API (`anomaly`, `anomaly?`, `Anomaly`, `anomaly-types`)
+- [x] Malli schema in `contract.clj`
+- [x] Decomposed test files (one per behavior, seven total)
+- [x] Apache 2 license header on every file
+- [x] Layer-labeled comment headers
+- [x] No `requiring-resolve`
+- [x] Root `deps.edn` registration in `:dev`/`:test`/`:conformance`
+- [x] `bb pre-commit` green


### PR DESCRIPTION
# feat: add anomaly component for canonical data-first error type

## Overview

Adds a new `ai.miniforge.anomaly` Polylith component to miniforge OSS, providing a single canonical anomaly shape,
constructor, predicate, and Malli schema. This is the foundational primitive for the "exceptions are data" discipline
that all miniforge-family Clojure repos will share.

## Motivation

Miniforge has accumulated multiple ad-hoc shapes for representing failures (assorted maps, `ex-info` payloads, scattered
`:error`/`:errors` conventions). Without a canonical anomaly type, downstream repos (thesium-workflows, miniforge-fleet,
future ports of ixi) end up redefining the same shape independently and drifting.

This component is the substrate fix: one Apache 2 component in miniforge OSS that every miniforge-family Clojure repo
can consume via vendoring. It pairs with the upcoming `response-chain`, `boundary`, and `content-hash` components to
give the family a shared error-handling and provenance vocabulary.

The architectural decision to add cross-cutting primitives **into** miniforge OSS rather than extracting them out into a
separate `miniforge-clj-commons` repo is captured in the broader memory-substrate refactor plan.

## Base Branch

`main`

## Depends On

None. This is the first of the H-series cross-cutting components.

## Layer

Foundations / cross-cutting primitive. New top-level component.

## What This Adds

- New component `components/anomaly/`:
  - `deps.edn` — minimal; depends on `metosin/malli 0.16.4` only.
  - `src/ai/miniforge/anomaly/contract.clj` — Malli `Anomaly` schema (`:closed true`), `anomaly-types` set, validation
    helpers.
  - `src/ai/miniforge/anomaly/interface.clj` — public API: `anomaly`, `anomaly?`, `Anomaly`, `anomaly-types`.
    Layer-labeled per stratified-design.
- Seven decomposed test files under `test/ai/miniforge/anomaly/interface/`, one per behavior dimension:
  - `constructor_test.clj`
  - `predicate_test.clj`
  - `schema_test.clj`
  - `type_vocabulary_test.clj`
  - `data_default_test.clj`
  - `timestamp_test.clj`
  - `round_trip_test.clj`
- Root `deps.edn` registration: adds `ai.miniforge/anomaly` `:local/root` dep and `components/anomaly/{src,test}` paths
  under `:dev` / `:test` / `:conformance` aliases.

## Public API

```clojure
(anomaly type message data)   ; constructor, returns canonical map
(anomaly? x)                  ; predicate
Anomaly                        ; Malli schema (closed)
anomaly-types                  ; set of standard type keywords
```

Anomaly map shape:

```clojure
{:anomaly/type    keyword?    ; one of anomaly-types
 :anomaly/message string?
 :anomaly/data    map?        ; defaults to {} when nil
 :anomaly/at      inst?}      ; populated at construction
```

Standard type vocabulary (mirrors cognitect anomalies):

```
#{:not-found :invalid-input :unauthorized :fault :unavailable
  :conflict :timeout :unsupported :fatal}
```

The constructor validates `type` against the vocabulary and throws `IllegalArgumentException` on unknown types. This is
one of the few legitimate `throw` sites: it is a programmer-error guard, not a runtime failure path.

## Strata Affected

- `ai.miniforge.anomaly.contract` — Malli schema and type vocabulary
- `ai.miniforge.anomaly.interface` — public API

No existing component touched. New top-level brick.

## Testing Plan

- `bb pre-commit` — full local gate: `lint:clj` + `fmt:md` + `test` + `test:graalvm`. **All passed.**
- `lint:clj` — 10 files, 0 errors, 0 warnings.
- `test` — Polylith picked up `anomaly` as the only changed brick: 26 tests, 68 assertions, 0 failures, 0 errors.
- `test:graalvm` — 6 tests, 465 assertions, 0 failures.

The seven test files map 1:1 to the per-behavior dimensions documented in the brief. Each dimension is independently
exercisable, so future agents can modify one without perturbing the others.

## Deployment Plan

No migration required. New additive component. Existing miniforge code is unchanged and unaffected.

Downstream consumption (thesium-workflows, miniforge-fleet, etc.) will land in subsequent PRs as those repos rewire
their local error helpers to consume `ai.miniforge.anomaly` directly via vendoring.

## Notes / Deviations

- **`workspace.edn` not modified.** Polylith auto-discovers `components/anomaly/` from disk; the workspace config lists
  per-project `:necessary` overrides only. Confirmed via `poly info` — new brick discovered automatically.
- **Root `deps.edn` was edited.** The changed-brick test runner that backs `bb test` runs under `clojure -M:dev:test`;
  those aliases are explicit allow-lists, so registration is required for tests to load.
- **No `bb gate` task in this repo.** The canonical local gate is `bb pre-commit` (documented in `agents.md`). All
  checks passed.
- **EDN round-trip uses Date precision.** `pr-str` of a `java.time.Instant` does not emit `#inst`; the test serializes
  via `java.util.Date` (millisecond precision) and a custom `#inst` reader rebuilds the Instant on the read side.
  Sub-millisecond precision is not representable in standard EDN.
- **Pre-existing `poly check` errors** in `bb-dev-tools` and `miniforge-tui` are present on main and unrelated to this
  change.

## Related Issues/PRs

- Will be followed by `feat/extract-content-hash-component` (sibling H-series component)
- Will be followed by `response-chain` and `boundary` components in the H-series
- Companion standards rule `feat/exceptions-as-data-rule` lands in `miniforge-standards`

## Checklist

- [x] New `anomaly` component with public API (`anomaly`, `anomaly?`, `Anomaly`, `anomaly-types`)
- [x] Malli schema in `contract.clj`
- [x] Decomposed test files (one per behavior, seven total)
- [x] Apache 2 license header on every file
- [x] Layer-labeled comment headers
- [x] No `requiring-resolve`
- [x] Root `deps.edn` registration in `:dev`/`:test`/`:conformance`
- [x] `bb pre-commit` green
