### PR TITLE
fix: web dashboard approval handler race

### DIFF
--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -18,6 +18,8 @@
    [clojure.string :as str]
    [clojure.java.io :as io]
    [cheshire.core :as json]
+   [ai.miniforge.event-stream.interface :as event-stream]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.web-dashboard.server.responses :as responses]
    [ai.miniforge.web-dashboard.server.filters :as filters]
    [ai.miniforge.web-dashboard.views :as views]
@@ -26,30 +28,28 @@
    [ai.miniforge.web-dashboard.server.websocket :as ws]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Anomaly/response helpers (via requiring-resolve, no hard dep on response component)
+;; Anomaly/response helpers
 
 (defn make-anomaly
-  "Create an anomaly map via response/make-anomaly."
+  "Create an anomaly map."
   [category message & [context]]
-  ((requiring-resolve 'ai.miniforge.response.interface/make-anomaly)
-   category message (or context {})))
+  (response/make-anomaly category message (or context {})))
 
 (defn from-exception
-  "Convert an exception to an anomaly map via response/from-exception."
+  "Convert an exception to an anomaly map."
   [^Throwable e]
-  ((requiring-resolve 'ai.miniforge.response.interface/from-exception) e))
+  (response/from-exception e))
 
 (defn response-success?
-  "Check if a response builder result represents success.
-   Wraps response/success? via requiring-resolve to keep the soft dep."
+  "Check if a response builder result represents success."
   [response]
-  ((requiring-resolve 'ai.miniforge.response.interface/success?) response))
+  (response/success? response))
 
 (defn anomaly-http-response
   "Translate an anomaly map to a Ring HTTP response.
    Body is JSON-encoded for wire transport."
   [anomaly-map]
-  (let [raw ((requiring-resolve 'ai.miniforge.response.interface/anomaly->http-response) anomaly-map)]
+  (let [raw (response/anomaly->http-response anomaly-map)]
     (update raw :body json/generate-string)))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -598,17 +598,15 @@
           action-id (parse-uuid (str (:action-id data)))
           signers (vec (:required-signers data))
           quorum (get data :quorum (count signers))
-          create-fn (requiring-resolve 'ai.miniforge.event-stream.interface/create-approval-request)
-          store-fn (requiring-resolve 'ai.miniforge.event-stream.interface/store-approval!)
-          mgr-fn (requiring-resolve 'ai.miniforge.event-stream.interface/create-approval-manager)
           ;; Get or create approval manager from state
           mgr (or (:approval-manager @state)
-                  (let [m (mgr-fn)]
+                  (let [m (event-stream/create-approval-manager)]
                     (swap! state assoc :approval-manager m)
                     m))
-          approval (create-fn action-id signers quorum
-                              {:expires-in-hours (get data :expires-in-hours 24)})]
-      (store-fn mgr approval)
+          approval (event-stream/create-approval-request
+                    action-id signers quorum
+                    {:expires-in-hours (get data :expires-in-hours 24)})]
+      (event-stream/store-approval! mgr approval)
       (responses/json-response
        {:status "created"
         :approval-id (str (:approval/id approval))
@@ -622,13 +620,11 @@
   [state approval-id-str]
   (try
     (let [approval-id (parse-uuid approval-id-str)
-          get-fn (requiring-resolve 'ai.miniforge.event-stream.interface/get-approval)
-          status-fn (requiring-resolve 'ai.miniforge.event-stream.interface/check-approval-status)
           mgr (:approval-manager @state)]
-      (if-let [approval (and mgr (get-fn mgr approval-id))]
+      (if-let [approval (and mgr (event-stream/get-approval mgr approval-id))]
         (responses/json-response
          {:approval-id (str (:approval/id approval))
-          :status (name (status-fn approval))
+          :status (name (event-stream/check-approval-status approval))
           :quorum (:approval/quorum approval)
           :signatures (count (:approval/signatures approval))
           :required-signers (:approval/required-signers approval)
@@ -647,23 +643,21 @@
   (try
     (let [data (json/parse-string body true)
           approval-id (parse-uuid approval-id-str)
-          get-fn (requiring-resolve 'ai.miniforge.event-stream.interface/get-approval)
-          submit-fn (requiring-resolve 'ai.miniforge.event-stream.interface/submit-approval)
-          update-fn (requiring-resolve 'ai.miniforge.event-stream.interface/update-approval!)
           mgr (:approval-manager @state)
-          approval (and mgr (get-fn mgr approval-id))]
+          approval (and mgr (event-stream/get-approval mgr approval-id))]
       (if-not approval
         (anomaly-http-response
          (make-anomaly :anomalies/not-found
                        "Approval not found"
                        {:approval-id approval-id-str}))
-        (let [result (submit-fn approval
-                                (:signer data)
-                                (keyword (:decision data))
-                                {:reason (:reason data)})]
+        (let [result (event-stream/submit-approval
+                      approval
+                      (:signer data)
+                      (keyword (:decision data))
+                      {:reason (:reason data)})]
           (if (response-success? result)
             (do
-              (update-fn mgr (:output result))
+              (event-stream/update-approval! mgr (:output result))
               (responses/json-response
                {:status "signed"
                 :approval-status (name (:approval/status (:output result)))}))

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/server/handlers_approval_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/server/handlers_approval_test.clj
@@ -207,3 +207,11 @@
           after-two (parse-body (sut/handle-api-approval-get state approval-id))]
       (is (= "approved" (:status after-two)))
       (is (= 2 (:signatures after-two))))))
+
+(deftest create-approval-exception-returns-anomaly-test
+  (testing "POST /api/approvals returns an anomaly response for invalid request bodies"
+    (let [state (fresh-state)
+          response (sut/handle-api-approval-create state "{not-json")
+          data (parse-body response)]
+      (is (= 500 (:status response)))
+      (is (= "fault" (get-in data [:error :code]))))))

--- a/docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md
+++ b/docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md
@@ -1,0 +1,44 @@
+# fix/approval-handler-soft-dep-race
+
+## Summary
+
+Fixes a repo-green race in the web dashboard approval handlers that only showed
+up under the full parallel `bb pre-commit` run.
+
+The root problem was late `requiring-resolve` on the approval-handler response
+and approval-manager path. Under the parallel test runner, those soft
+dependency lookups could intermittently return `nil`, which then caused the
+exception handler itself to throw a `NullPointerException` instead of returning
+an anomaly response.
+
+This PR removes that race from the approval-handler path by using normal
+compiled dependencies for the response helpers and approval event-stream API.
+
+## Key Changes
+
+- adds direct `response` and `event-stream` requires in
+  [handlers.clj](../../components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj)
+- replaces ad hoc `requiring-resolve` calls in the approval create/get/sign
+  handlers with direct function calls in
+  [handlers.clj](../../components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj)
+- keeps the small local anomaly helper functions, but makes them delegate to
+  the directly required response interface in
+  [handlers.clj](../../components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj)
+
+## Tests
+
+- adds exception-path coverage for approval creation in
+  [handlers_approval_test.clj](../../components/web-dashboard/test/ai/miniforge/web_dashboard/server/handlers_approval_test.clj)
+- validates the full approval handler namespace under the JVM test runner
+- validates the full repo hook path with `bb pre-commit`
+
+## Validation
+
+- `clj-kondo --lint` on touched files
+- isolated JVM run of `ai.miniforge.web-dashboard.server.handlers-approval-test`
+- `bb pre-commit`
+
+## Outcome
+
+The intermittent approval-handler NPE no longer reproduces under the full
+parallel pre-commit run, and repo-green is restored for the next stacked PR.


### PR DESCRIPTION
# fix/approval-handler-soft-dep-race

## Summary

Fixes a repo-green race in the web dashboard approval handlers that only showed
up under the full parallel `bb pre-commit` run.

The root problem was late `requiring-resolve` on the approval-handler response
and approval-manager path. Under the parallel test runner, those soft
dependency lookups could intermittently return `nil`, which then caused the
exception handler itself to throw a `NullPointerException` instead of returning
an anomaly response.

This PR removes that race from the approval-handler path by using normal
compiled dependencies for the response helpers and approval event-stream API.

## Key Changes

- adds direct `response` and `event-stream` requires in
  [handlers.clj](../../components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj)
- replaces ad hoc `requiring-resolve` calls in the approval create/get/sign
  handlers with direct function calls in
  [handlers.clj](../../components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj)
- keeps the small local anomaly helper functions, but makes them delegate to
  the directly required response interface in
  [handlers.clj](../../components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj)

## Tests

- adds exception-path coverage for approval creation in
  [handlers_approval_test.clj](../../components/web-dashboard/test/ai/miniforge/web_dashboard/server/handlers_approval_test.clj)
- validates the full approval handler namespace under the JVM test runner
- validates the full repo hook path with `bb pre-commit`

## Validation

- `clj-kondo --lint` on touched files
- isolated JVM run of `ai.miniforge.web-dashboard.server.handlers-approval-test`
- `bb pre-commit`

## Outcome

The intermittent approval-handler NPE no longer reproduces under the full
parallel pre-commit run, and repo-green is restored for the next stacked PR.
