### PR TITLE
fix: sync rich PR doc content into PR bodies

### DIFF
--- a/components/release-executor/src/ai/miniforge/release_executor/core.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/core.clj
@@ -208,7 +208,7 @@
     (let [{:keys [release-meta base-branch executor environment-id]} state
           result (sandbox/create-pr! executor environment-id
                                      {:title (:release/pr-title release-meta)
-                                      :body (:release/pr-description release-meta)
+                                      :body (:release/pr-body release-meta)
                                       :base-branch base-branch}
                                      (gh-exec-opts state))]
       (if (result/succeeded? result)
@@ -371,11 +371,16 @@
     (not (:pr-number state)) state
     :else
     (let [{:keys [release-meta pr-number pr-url branch
-                  executor environment-id logger]} state
-          doc-content (render-pr-doc release-meta
-                                    {:pr-number pr-number
-                                     :pr-url pr-url
-                                     :branch branch})]
+                  executor environment-id logger code-artifacts workflow-data
+                  pr-doc-content]} state
+          doc-content (or pr-doc-content
+                          (:release/pr-body release-meta)
+                          (render-pr-doc-full release-meta
+                                              {:pr-number pr-number
+                                               :pr-url pr-url
+                                               :branch branch}
+                                              code-artifacts
+                                              workflow-data))]
       (try
         (sandbox/edit-pr-body! executor environment-id
                                pr-number doc-content
@@ -431,7 +436,9 @@
         (sandbox/exec! executor environment-id
                        "git push --force-with-lease"
                        (gh-exec-opts state))
-        (assoc state :pr-doc-path rel-path)
+        (assoc state
+               :pr-doc-path rel-path
+               :pr-doc-content content)
         (catch Exception e
           (when logger
             (log/warn logger :release-executor :pr-doc-generation-failed

--- a/components/release-executor/src/ai/miniforge/release_executor/metadata.clj
+++ b/components/release-executor/src/ai/miniforge/release_executor/metadata.clj
@@ -230,6 +230,7 @@
   ([task-description code-artifacts workflow-data]
    (let [desc (or task-description (default-task-description))
          title (first-sentence desc 70)
+         summary (first-sentence desc 200)
          slug (slugify title)
          branch (str "mf/" slug "-" (subs (str (random-uuid)) 0 8))
          file-list (format-file-list code-artifacts)
@@ -239,14 +240,14 @@
                           (format-review-summary review-artifacts))
          gate-summary (when (seq review-artifacts)
                         (format-gate-results review-artifacts))
-         body (render-pr-body (first-sentence desc 200)
+         body (render-pr-body summary
                               file-list file-count
                               review-summary gate-summary)]
      {:release/branch-name branch
       :release/commit-message title
       :release/pr-title title
       :release/pr-body body
-      :release/pr-description body})))
+      :release/pr-description summary})))
 
 (defn generate-release-metadata
   "Generate release metadata using releaser agent, falling back to deterministic

--- a/components/release-executor/test/ai/miniforge/release_executor/core_pipeline_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/core_pipeline_test.clj
@@ -25,6 +25,7 @@
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
    [ai.miniforge.release-executor.core :as sut]
+   [ai.miniforge.release-executor.sandbox :as sandbox]
    [clojure.string :as str]
    [clojure.test :refer [deftest is testing]]))
 
@@ -402,6 +403,26 @@
     (let [state {:create-pr? false}
           result (sut/step-create-pr state)]
       (is (not (sut/failed? result))))))
+
+(deftest step-create-pr-uses-rich-pr-body-test
+  (testing "PR creation uses :release/pr-body instead of the short description"
+    (let [seen-payload (atom nil)]
+      (with-redefs [sandbox/create-pr!
+                    (fn [_exec _env-id payload _opts]
+                      (reset! seen-payload payload)
+                      {:success? true
+                       :pr-number 42
+                       :pr-url "https://github.com/org/repo/pull/42"})]
+        (sut/step-create-pr
+         {:create-pr? true
+          :base-branch "main"
+          :executor :mock
+          :environment-id "env-1"
+          :release-meta {:release/pr-title "feat: test"
+                         :release/pr-description "Short summary"
+                         :release/pr-body "# Rich Body\n\n## Summary\nDetailed"}})
+        (is (= "# Rich Body\n\n## Summary\nDetailed"
+               (:body @seen-payload)))))))
 
 ;; ============================================================================
 ;; step-build-artifact

--- a/components/release-executor/test/ai/miniforge/release_executor/metadata_comprehensive_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/metadata_comprehensive_test.clj
@@ -561,5 +561,7 @@
       (is (contains? result :release/pr-title))
       (is (contains? result :release/pr-body))
       (is (contains? result :release/pr-description))
-      ;; pr-body and pr-description should be identical
-      (is (= (:release/pr-body result) (:release/pr-description result))))))
+      (is (string? (:release/pr-description result)))
+      (is (not= (:release/pr-body result) (:release/pr-description result)))
+      (is (not (str/includes? (:release/pr-description result) "## Changes")))
+      (is (str/includes? (:release/pr-body result) "## Changes")))))

--- a/components/release-executor/test/ai/miniforge/release_executor/pr_body_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/pr_body_test.clj
@@ -123,6 +123,7 @@
             :environment-id "env-1"
             :release-meta {:release/pr-title "feat: test"
                            :release/pr-description "## Summary\nChange"
+                           :release/pr-body "## Summary\nChange"
                            :release/commit-message "feat: test"}}
            overrides)))
 
@@ -145,9 +146,10 @@
   (testing "step-update-pr-body calls sandbox/edit-pr-body! and returns state"
     (let [called (atom false)]
       (with-redefs [sandbox/edit-pr-body!
-                    (fn [_exec _env-id pr-number _body _opts]
+                    (fn [_exec _env-id pr-number body _opts]
                       (reset! called true)
                       (is (= 42 pr-number))
+                      (is (= "## Summary\nChange" body))
                       {:success? true})]
         (let [state (make-state {})
               result (core/step-update-pr-body state)]
@@ -155,6 +157,17 @@
           ;; step-update-pr-body returns state (not the edit result)
           (is (= (:pr-number state) (:pr-number result)))
           (is (not (contains? result :failure))))))))
+
+(deftest step-update-pr-body-prefers-generated-doc-content-test
+  (testing "generated PR doc content overrides the initial fallback body"
+    (let [seen-body (atom nil)]
+      (with-redefs [sandbox/edit-pr-body!
+                    (fn [_exec _env-id _pr-number body _opts]
+                      (reset! seen-body body)
+                      {:success? true})]
+        (core/step-update-pr-body
+         (make-state {:pr-doc-content "# Rich Doc\n\n## Summary\nGenerated"}))
+        (is (= "# Rich Doc\n\n## Summary\nGenerated" @seen-body))))))
 
 (deftest step-update-pr-body-survives-exception-test
   (testing "step-update-pr-body catches exceptions and returns state (non-fatal)"

--- a/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
+++ b/components/release-executor/test/ai/miniforge/release_executor/sandbox_test.clj
@@ -322,6 +322,7 @@
     (let [[exec _cmds] (create-mock-executor
                         :default-response {:exit-code 1 :stdout "" :stderr "signing failed"})
           result (sandbox/push-branch! exec "env-1" "feat/test")]
-      (is (dag/ok? result))
-      (is (= 1 (get-in result [:data :exit-code]))))))
-
+      (is (= {:success? false
+              :error "signing failed"
+              :output ""}
+             result)))))

--- a/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
+++ b/components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj
@@ -18,6 +18,8 @@
    [clojure.string :as str]
    [clojure.java.io :as io]
    [cheshire.core :as json]
+   [ai.miniforge.event-stream.interface :as event-stream]
+   [ai.miniforge.response.interface :as response]
    [ai.miniforge.web-dashboard.server.responses :as responses]
    [ai.miniforge.web-dashboard.server.filters :as filters]
    [ai.miniforge.web-dashboard.views :as views]
@@ -26,30 +28,28 @@
    [ai.miniforge.web-dashboard.server.websocket :as ws]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Anomaly/response helpers (via requiring-resolve, no hard dep on response component)
+;; Anomaly/response helpers
 
 (defn make-anomaly
-  "Create an anomaly map via response/make-anomaly."
+  "Create an anomaly map."
   [category message & [context]]
-  ((requiring-resolve 'ai.miniforge.response.interface/make-anomaly)
-   category message (or context {})))
+  (response/make-anomaly category message (or context {})))
 
 (defn from-exception
-  "Convert an exception to an anomaly map via response/from-exception."
+  "Convert an exception to an anomaly map."
   [^Throwable e]
-  ((requiring-resolve 'ai.miniforge.response.interface/from-exception) e))
+  (response/from-exception e))
 
 (defn response-success?
-  "Check if a response builder result represents success.
-   Wraps response/success? via requiring-resolve to keep the soft dep."
+  "Check if a response builder result represents success."
   [response]
-  ((requiring-resolve 'ai.miniforge.response.interface/success?) response))
+  (response/success? response))
 
 (defn anomaly-http-response
   "Translate an anomaly map to a Ring HTTP response.
    Body is JSON-encoded for wire transport."
   [anomaly-map]
-  (let [raw ((requiring-resolve 'ai.miniforge.response.interface/anomaly->http-response) anomaly-map)]
+  (let [raw (response/anomaly->http-response anomaly-map)]
     (update raw :body json/generate-string)))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -598,17 +598,15 @@
           action-id (parse-uuid (str (:action-id data)))
           signers (vec (:required-signers data))
           quorum (get data :quorum (count signers))
-          create-fn (requiring-resolve 'ai.miniforge.event-stream.interface/create-approval-request)
-          store-fn (requiring-resolve 'ai.miniforge.event-stream.interface/store-approval!)
-          mgr-fn (requiring-resolve 'ai.miniforge.event-stream.interface/create-approval-manager)
           ;; Get or create approval manager from state
           mgr (or (:approval-manager @state)
-                  (let [m (mgr-fn)]
+                  (let [m (event-stream/create-approval-manager)]
                     (swap! state assoc :approval-manager m)
                     m))
-          approval (create-fn action-id signers quorum
-                              {:expires-in-hours (get data :expires-in-hours 24)})]
-      (store-fn mgr approval)
+          approval (event-stream/create-approval-request
+                    action-id signers quorum
+                    {:expires-in-hours (get data :expires-in-hours 24)})]
+      (event-stream/store-approval! mgr approval)
       (responses/json-response
        {:status "created"
         :approval-id (str (:approval/id approval))
@@ -622,13 +620,11 @@
   [state approval-id-str]
   (try
     (let [approval-id (parse-uuid approval-id-str)
-          get-fn (requiring-resolve 'ai.miniforge.event-stream.interface/get-approval)
-          status-fn (requiring-resolve 'ai.miniforge.event-stream.interface/check-approval-status)
           mgr (:approval-manager @state)]
-      (if-let [approval (and mgr (get-fn mgr approval-id))]
+      (if-let [approval (and mgr (event-stream/get-approval mgr approval-id))]
         (responses/json-response
          {:approval-id (str (:approval/id approval))
-          :status (name (status-fn approval))
+          :status (name (event-stream/check-approval-status approval))
           :quorum (:approval/quorum approval)
           :signatures (count (:approval/signatures approval))
           :required-signers (:approval/required-signers approval)
@@ -647,23 +643,21 @@
   (try
     (let [data (json/parse-string body true)
           approval-id (parse-uuid approval-id-str)
-          get-fn (requiring-resolve 'ai.miniforge.event-stream.interface/get-approval)
-          submit-fn (requiring-resolve 'ai.miniforge.event-stream.interface/submit-approval)
-          update-fn (requiring-resolve 'ai.miniforge.event-stream.interface/update-approval!)
           mgr (:approval-manager @state)
-          approval (and mgr (get-fn mgr approval-id))]
+          approval (and mgr (event-stream/get-approval mgr approval-id))]
       (if-not approval
         (anomaly-http-response
          (make-anomaly :anomalies/not-found
                        "Approval not found"
                        {:approval-id approval-id-str}))
-        (let [result (submit-fn approval
-                                (:signer data)
-                                (keyword (:decision data))
-                                {:reason (:reason data)})]
+        (let [result (event-stream/submit-approval
+                      approval
+                      (:signer data)
+                      (keyword (:decision data))
+                      {:reason (:reason data)})]
           (if (response-success? result)
             (do
-              (update-fn mgr (:output result))
+              (event-stream/update-approval! mgr (:output result))
               (responses/json-response
                {:status "signed"
                 :approval-status (name (:approval/status (:output result)))}))

--- a/components/web-dashboard/test/ai/miniforge/web_dashboard/server/handlers_approval_test.clj
+++ b/components/web-dashboard/test/ai/miniforge/web_dashboard/server/handlers_approval_test.clj
@@ -207,3 +207,11 @@
           after-two (parse-body (sut/handle-api-approval-get state approval-id))]
       (is (= "approved" (:status after-two)))
       (is (= 2 (:signatures after-two))))))
+
+(deftest create-approval-exception-returns-anomaly-test
+  (testing "POST /api/approvals returns an anomaly response for invalid request bodies"
+    (let [state (fresh-state)
+          response (sut/handle-api-approval-create state "{not-json")
+          data (parse-body response)]
+      (is (= 500 (:status response)))
+      (is (= "fault" (get-in data [:error :code]))))))

--- a/docs/pull-requests/2026-04-29-fix-release-pr-doc-body-sync.md
+++ b/docs/pull-requests/2026-04-29-fix-release-pr-doc-body-sync.md
@@ -1,0 +1,55 @@
+# fix/release-pr-doc-body-sync
+
+## Summary
+
+Fixes the release-executor seam that was causing Miniforge-generated PRs to
+open with thin generic bodies even when a richer PR doc had already been
+generated.
+
+The root cause was split metadata authority:
+
+- `:release/pr-description` was storing a fully rendered fallback body instead
+  of a plain summary string
+- PR creation used `:release/pr-description` instead of the richer
+  `:release/pr-body`
+- PR body updates rebuilt a minimal template instead of reusing the generated
+  PR doc content
+
+This PR restores the intended contract so Miniforge-generated PRs carry the
+full rich description and the short summary remains a summary.
+
+## Key Changes
+
+- makes PR creation use `:release/pr-body` in
+  [core.clj](../../components/release-executor/src/ai/miniforge/release_executor/core.clj)
+- makes PR body updates prefer generated doc content, then the rich body, then
+  a full renderer fallback in
+  [core.clj](../../components/release-executor/src/ai/miniforge/release_executor/core.clj)
+- persists generated PR doc content into pipeline state so later steps reuse
+  the exact rich markdown in
+  [core.clj](../../components/release-executor/src/ai/miniforge/release_executor/core.clj)
+- restores `:release/pr-description` to a short summary string while keeping
+  `:release/pr-body` as the rich markdown body in
+  [metadata.clj](../../components/release-executor/src/ai/miniforge/release_executor/metadata.clj)
+
+## Tests
+
+- adds PR creation coverage proving the rich body is used in
+  [core_pipeline_test.clj](../../components/release-executor/test/ai/miniforge/release_executor/core_pipeline_test.clj)
+- updates metadata coverage to assert summary/body separation in
+  [metadata_comprehensive_test.clj](../../components/release-executor/test/ai/miniforge/release_executor/metadata_comprehensive_test.clj)
+- adds PR body update coverage proving generated doc content wins over the
+  fallback body in
+  [pr_body_test.clj](../../components/release-executor/test/ai/miniforge/release_executor/pr_body_test.clj)
+
+## Validation
+
+- `clj-kondo --lint` on touched release-executor files
+- `bb test components/release-executor`
+- `bb pre-commit`
+
+## Outcome
+
+After this change, Miniforge PRs should open and update with the same rich
+content that is written to `docs/pull-requests/...`, instead of falling back to
+the thin generic template.

--- a/docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md
+++ b/docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md
@@ -1,0 +1,44 @@
+# fix/approval-handler-soft-dep-race
+
+## Summary
+
+Fixes a repo-green race in the web dashboard approval handlers that only showed
+up under the full parallel `bb pre-commit` run.
+
+The root problem was late `requiring-resolve` on the approval-handler response
+and approval-manager path. Under the parallel test runner, those soft
+dependency lookups could intermittently return `nil`, which then caused the
+exception handler itself to throw a `NullPointerException` instead of returning
+an anomaly response.
+
+This PR removes that race from the approval-handler path by using normal
+compiled dependencies for the response helpers and approval event-stream API.
+
+## Key Changes
+
+- adds direct `response` and `event-stream` requires in
+  [handlers.clj](../../components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj)
+- replaces ad hoc `requiring-resolve` calls in the approval create/get/sign
+  handlers with direct function calls in
+  [handlers.clj](../../components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj)
+- keeps the small local anomaly helper functions, but makes them delegate to
+  the directly required response interface in
+  [handlers.clj](../../components/web-dashboard/src/ai/miniforge/web_dashboard/server/handlers.clj)
+
+## Tests
+
+- adds exception-path coverage for approval creation in
+  [handlers_approval_test.clj](../../components/web-dashboard/test/ai/miniforge/web_dashboard/server/handlers_approval_test.clj)
+- validates the full approval handler namespace under the JVM test runner
+- validates the full repo hook path with `bb pre-commit`
+
+## Validation
+
+- `clj-kondo --lint` on touched files
+- isolated JVM run of `ai.miniforge.web-dashboard.server.handlers-approval-test`
+- `bb pre-commit`
+
+## Outcome
+
+The intermittent approval-handler NPE no longer reproduces under the full
+parallel pre-commit run, and repo-green is restored for the next stacked PR.


### PR DESCRIPTION
# fix/release-pr-doc-body-sync

## Summary

Fixes the release-executor seam that was causing Miniforge-generated PRs to
open with thin generic bodies even when a richer PR doc had already been
generated.

The root cause was split metadata authority:

- `:release/pr-description` was storing a fully rendered fallback body instead
  of a plain summary string
- PR creation used `:release/pr-description` instead of the richer
  `:release/pr-body`
- PR body updates rebuilt a minimal template instead of reusing the generated
  PR doc content

This PR restores the intended contract so Miniforge-generated PRs carry the
full rich description and the short summary remains a summary.

## Key Changes

- makes PR creation use `:release/pr-body` in
  [core.clj](../../components/release-executor/src/ai/miniforge/release_executor/core.clj)
- makes PR body updates prefer generated doc content, then the rich body, then
  a full renderer fallback in
  [core.clj](../../components/release-executor/src/ai/miniforge/release_executor/core.clj)
- persists generated PR doc content into pipeline state so later steps reuse
  the exact rich markdown in
  [core.clj](../../components/release-executor/src/ai/miniforge/release_executor/core.clj)
- restores `:release/pr-description` to a short summary string while keeping
  `:release/pr-body` as the rich markdown body in
  [metadata.clj](../../components/release-executor/src/ai/miniforge/release_executor/metadata.clj)

## Tests

- adds PR creation coverage proving the rich body is used in
  [core_pipeline_test.clj](../../components/release-executor/test/ai/miniforge/release_executor/core_pipeline_test.clj)
- updates metadata coverage to assert summary/body separation in
  [metadata_comprehensive_test.clj](../../components/release-executor/test/ai/miniforge/release_executor/metadata_comprehensive_test.clj)
- adds PR body update coverage proving generated doc content wins over the
  fallback body in
  [pr_body_test.clj](../../components/release-executor/test/ai/miniforge/release_executor/pr_body_test.clj)

## Validation

- `clj-kondo --lint` on touched release-executor files
- `bb test components/release-executor`
- `bb pre-commit`

## Outcome

After this change, Miniforge PRs should open and update with the same rich
content that is written to `docs/pull-requests/...`, instead of falling back to
the thin generic template.
