### PR TITLE
fix: auto-attach supervisory snapshots for workflow runs

### DIFF
--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
@@ -134,10 +134,14 @@
 (defn ensure-attached!
   "Attach supervisory-state to `stream` exactly once.
 
+   The check-and-attach sequence is synchronized per stream so concurrent
+   callers cannot create multiple attachments for the same stream.
+
    Returns a component when a new attachment is created; otherwise nil."
   [stream]
-  (when-not (attached? stream)
-    (attach! stream)))
+  (locking stream
+    (when-not (attached? stream)
+      (attach! stream))))
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Query API

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj
@@ -126,6 +126,19 @@
   [stream]
   (start! (create stream)))
 
+(defn attached?
+  "True when supervisory-state is already subscribed to `stream`."
+  [stream]
+  (contains? (:subscribers @stream) subscriber-id))
+
+(defn ensure-attached!
+  "Attach supervisory-state to `stream` exactly once.
+
+   Returns a component when a new attachment is created; otherwise nil."
+  [stream]
+  (when-not (attached? stream)
+    (attach! stream)))
+
 ;------------------------------------------------------------------------------ Layer 4
 ;; Query API
 

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj
@@ -46,6 +46,8 @@
 (def start!  core/start!)
 (def stop!   core/stop!)
 (def attach! core/attach!)
+(def attached? core/attached?)
+(def ensure-attached! core/ensure-attached!)
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Query API (reads only; consumers should prefer subscribing to

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
@@ -76,6 +76,16 @@
         "attach! registers the stream subscription identically to create+start!")
     (iface/stop! comp)))
 
+(deftest ensure-attached!-is-idempotent
+  (let [stream (no-sink-stream)]
+    (is (false? (iface/attached? stream)))
+    (let [created (iface/ensure-attached! stream)]
+      (is (some? created))
+      (is (true? (iface/attached? stream)))
+      (is (= 1 (count (:subscribers @stream)))))
+    (is (nil? (iface/ensure-attached! stream)))
+    (is (= 1 (count (:subscribers @stream))))))
+
 ;------------------------------------------------------------------------------ Emission
 
 (deftest live-workflow-events-produce-supervisory-snapshots

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj
@@ -86,6 +86,18 @@
     (is (nil? (iface/ensure-attached! stream)))
     (is (= 1 (count (:subscribers @stream))))))
 
+(deftest ensure-attached!-is-atomic-per-stream
+  (let [stream (no-sink-stream)
+        attempts 8
+        results (->> (range attempts)
+                     (mapv (fn [_]
+                             (future (iface/ensure-attached! stream))))
+                     (mapv deref))
+        created-count (count (filter some? results))]
+    (is (= 1 created-count))
+    (is (true? (iface/attached? stream)))
+    (is (= 1 (count (:subscribers @stream))))))
+
 ;------------------------------------------------------------------------------ Emission
 
 (deftest live-workflow-events-produce-supervisory-snapshots

--- a/components/workflow/deps.edn
+++ b/components/workflow/deps.edn
@@ -13,6 +13,7 @@
         ai.miniforge/policy {:local/root "../policy"}      ; Gate evaluation
         ai.miniforge/heuristic {:local/root "../heuristic"} ; Workflow storage
         ai.miniforge/event-stream {:local/root "../event-stream"} ; N3 event emission
+        ai.miniforge/supervisory-state {:local/root "../supervisory-state"} ; Supervisory snapshot emission
         ai.miniforge/knowledge {:local/root "../knowledge"} ; KB for post-execution learning promotion
         ai.miniforge/self-healing {:local/root "../self-healing"} ; Optional backend failover
         ai.miniforge/phase {:local/root "../phase"}        ; Phase interceptors

--- a/components/workflow/src/ai/miniforge/workflow/runner.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner.clj
@@ -32,6 +32,7 @@
             [ai.miniforge.logging.interface :as log]
             [ai.miniforge.phase.interface :as phase]
             [ai.miniforge.response.interface :as response]
+            [ai.miniforge.supervisory-state.interface :as supervisory]
             [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
             [ai.miniforge.workflow.context :as ctx]
             [ai.miniforge.workflow.execution :as exec]
@@ -373,6 +374,9 @@
          initial-ctx         (build-initial-context workflow input opts)
          output-ctx-vol      (volatile! nil)
          exception-vol       (volatile! nil)]
+
+     (when event-stream
+       (supervisory/ensure-attached! event-stream))
 
      (checkpoint-store/persist-execution-state! initial-ctx)
 

--- a/components/workflow/test/ai/miniforge/workflow/runner_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_test.clj
@@ -23,6 +23,8 @@
   (:require
    [clojure.java.io :as io]
    [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.event-stream.interface :as es]
+   [ai.miniforge.supervisory-state.interface :as supervisory]
    [ai.miniforge.workflow.checkpoint-store :as checkpoint-store]
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]
@@ -126,6 +128,19 @@
           result (runner/run-pipeline workflow {:task "Test"} {})]
       (is (= :completed (:execution/status result)))
       (is (number? (:execution/ended-at result))))))
+
+(deftest run-pipeline-ensures-supervisory-attachment-test
+  (testing "run-pipeline auto-attaches supervisory-state for event-stream callers"
+    (let [workflow {:workflow/id :test
+                    :workflow/version "1.0.0"
+                    :workflow/pipeline [{:phase :done}]}
+          stream (es/create-event-stream {:sinks []})]
+      (is (false? (supervisory/attached? stream)))
+      (let [result (runner/run-pipeline workflow {:task "Test"} {:event-stream stream})
+            event-types (map :event/type (es/get-events stream))]
+        (is (= :completed (:execution/status result)))
+        (is (true? (supervisory/attached? stream)))
+        (is (some #{:supervisory/workflow-upserted} event-types))))))
 
 (deftest run-pipeline-persists-machine-snapshot-test
   (with-temp-checkpoint-root

--- a/docs/pull-requests/2026-04-29-fix-supervisory-run-snapshot-attachment.md
+++ b/docs/pull-requests/2026-04-29-fix-supervisory-run-snapshot-attachment.md
@@ -1,0 +1,59 @@
+# fix/supervisory-run-snapshots
+
+## Summary
+
+Ensure workflow execution attaches supervisory-state to the active event stream
+before lifecycle events are published, so running workflows emit fresh
+`:supervisory/*` snapshot events for downstream clients.
+
+The immediate user-visible symptom was that real workflows were running and
+writing raw workflow events, but the TUI only showed old runs because no fresh
+`:supervisory/workflow-upserted` events were being emitted on that execution
+path.
+
+## Why
+
+`miniforge-control` reads supervisory snapshot entities, not raw workflow
+events. We confirmed that:
+
+- fresh raw `:workflow/*` and `:phase/*` events were present
+- fresh `:supervisory/workflow-upserted` events were not
+- the supervisory projector itself still worked when explicitly attached
+
+That meant the failure mode was not in projection logic. It was that some
+workflow execution paths were relying on callers to have already attached
+supervisory-state to the stream.
+
+This PR makes supervisory snapshot emission a workflow-runner guarantee instead
+of a fragile caller obligation.
+
+## Changes
+
+- add idempotent supervisory attachment helpers in
+  [core.clj](../../components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj)
+  - `attached?`
+  - `ensure-attached!`
+- re-export those helpers from
+  [interface.clj](../../components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj)
+- add `supervisory-state` as a workflow component dependency in
+  [deps.edn](../../components/workflow/deps.edn)
+- ensure `run-pipeline` auto-attaches supervisory-state whenever an
+  `:event-stream` is supplied in
+  [runner.clj](../../components/workflow/src/ai/miniforge/workflow/runner.clj)
+- add regression coverage for:
+  - idempotent supervisory attachment in
+    [core_test.clj](../../components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj)
+  - workflow-runner auto-attachment and emitted
+    `:supervisory/workflow-upserted` events in
+    [runner_test.clj](../../components/workflow/test/ai/miniforge/workflow/runner_test.clj)
+
+## Validation
+
+- `clj-kondo --lint` on touched files
+- `bb test components/supervisory-state components/workflow`
+
+## Outcome
+
+Workflow execution now emits fresh supervisory snapshots even when the caller
+only provides an event stream. That restores the data path the TUI depends on
+for live runs, agents, decisions, and correlated run context.


### PR DESCRIPTION
# fix/supervisory-run-snapshots

## Summary

Ensure workflow execution attaches supervisory-state to the active event stream
before lifecycle events are published, so running workflows emit fresh
`:supervisory/*` snapshot events for downstream clients.

The immediate user-visible symptom was that real workflows were running and
writing raw workflow events, but the TUI only showed old runs because no fresh
`:supervisory/workflow-upserted` events were being emitted on that execution
path.

## Why

`miniforge-control` reads supervisory snapshot entities, not raw workflow
events. We confirmed that:

- fresh raw `:workflow/*` and `:phase/*` events were present
- fresh `:supervisory/workflow-upserted` events were not
- the supervisory projector itself still worked when explicitly attached

That meant the failure mode was not in projection logic. It was that some
workflow execution paths were relying on callers to have already attached
supervisory-state to the stream.

This PR makes supervisory snapshot emission a workflow-runner guarantee instead
of a fragile caller obligation.

## Changes

- add idempotent supervisory attachment helpers in
  [core.clj](../../components/supervisory-state/src/ai/miniforge/supervisory_state/core.clj)
  - `attached?`
  - `ensure-attached!`
- re-export those helpers from
  [interface.clj](../../components/supervisory-state/src/ai/miniforge/supervisory_state/interface.clj)
- add `supervisory-state` as a workflow component dependency in
  [deps.edn](../../components/workflow/deps.edn)
- ensure `run-pipeline` auto-attaches supervisory-state whenever an
  `:event-stream` is supplied in
  [runner.clj](../../components/workflow/src/ai/miniforge/workflow/runner.clj)
- add regression coverage for:
  - idempotent supervisory attachment in
    [core_test.clj](../../components/supervisory-state/test/ai/miniforge/supervisory_state/core_test.clj)
  - workflow-runner auto-attachment and emitted
    `:supervisory/workflow-upserted` events in
    [runner_test.clj](../../components/workflow/test/ai/miniforge/workflow/runner_test.clj)

## Validation

- `clj-kondo --lint` on touched files
- `bb test components/supervisory-state components/workflow`

## Outcome

Workflow execution now emits fresh supervisory snapshots even when the caller
only provides an event stream. That restores the data path the TUI depends on
for live runs, agents, decisions, and correlated run context.
