### PR TITLE
fix: dag executor event soft-dep race

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/state.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/state.clj
@@ -420,6 +420,22 @@
   [run-state]
   (atom run-state))
 
+(def resolved-publish-event!
+  "Cached reference to event-stream publish! fn."
+  (delay
+    (try
+      (require 'ai.miniforge.event-stream.interface)
+      (ns-resolve (find-ns 'ai.miniforge.event-stream.interface) 'publish!)
+      (catch Exception _ nil))))
+
+(def resolved-task-state-changed
+  "Cached reference to event-stream task-state-changed constructor."
+  (delay
+    (try
+      (require 'ai.miniforge.event-stream.interface)
+      (ns-resolve (find-ns 'ai.miniforge.event-stream.interface) 'task-state-changed)
+      (catch Exception _ nil))))
+
 (defn update-task!
   "Atomically update a task within a run atom."
   [run-atom task-id update-fn logger]
@@ -434,12 +450,12 @@
     result))
 
 (defn emit-task-state-event!
-  "Emit task/state-changed event via requiring-resolve (no hard dep on event-stream)."
+  "Emit task/state-changed event via cached soft-dep resolution."
   [run-state task-id from-status to-status]
   (try
     (when-let [stream (get-in run-state [:run/config :event-stream])]
-      (when-let [publish-fn (requiring-resolve 'ai.miniforge.event-stream.interface/publish!)]
-        (when-let [constructor (requiring-resolve 'ai.miniforge.event-stream.interface/task-state-changed)]
+      (when-let [publish-fn @resolved-publish-event!]
+        (when-let [constructor @resolved-task-state-changed]
           (let [workflow-id (get-in run-state [:run/config :workflow-id])
                 dag-id (:dag/id run-state)]
             (publish-fn stream (constructor stream workflow-id dag-id task-id from-status to-status))))))

--- a/docs/pull-requests/2026-04-29-fix-dag-executor-event-soft-dep-race.md
+++ b/docs/pull-requests/2026-04-29-fix-dag-executor-event-soft-dep-race.md
@@ -1,0 +1,37 @@
+# fix/dag-executor-event-soft-dep-race
+
+## Summary
+
+Fixes a flaky `dag-executor` event-emission path that was failing under the
+repo's parallel pre-commit test run.
+
+The issue was in
+[state.clj](../../components/dag-executor/src/ai/miniforge/dag_executor/state.clj):
+`emit-task-state-event!` was resolving `event-stream` vars with raw
+`requiring-resolve` on every call and swallowing failures. Under the full
+parallel suite, that could race during namespace loading and silently skip
+publishing `:task/state-changed`.
+
+This PR switches that path to cached delayed soft-dependency resolution, which
+matches the pattern already used in other parts of the repo.
+
+## Key Change
+
+- added cached delayed soft-dep resolution for:
+  - `ai.miniforge.event-stream.interface/publish!`
+  - `ai.miniforge.event-stream.interface/task-state-changed`
+- updated `emit-task-state-event!` to use the cached vars instead of raw
+  `requiring-resolve`
+
+## Why This Matters
+
+This is the kind of repo-health issue that blocks unrelated PRs in pre-commit.
+The taxonomy branch for dependency attribution surfaced it, but the bug is in
+`dag-executor` and should be fixed independently.
+
+## Validation
+
+- `clj-kondo --lint components/dag-executor/src/ai/miniforge/dag_executor/state.clj`
+- `clojure -M:dev:test -e \"(require 'clojure.test 'ai.miniforge.dag-executor.state-test) ...\"`
+- `bb test components/dag-executor`
+- full `bb pre-commit`


### PR DESCRIPTION
# fix/dag-executor-event-soft-dep-race

## Summary

Fixes a flaky `dag-executor` event-emission path that was failing under the
repo's parallel pre-commit test run.

The issue was in
[state.clj](../../components/dag-executor/src/ai/miniforge/dag_executor/state.clj):
`emit-task-state-event!` was resolving `event-stream` vars with raw
`requiring-resolve` on every call and swallowing failures. Under the full
parallel suite, that could race during namespace loading and silently skip
publishing `:task/state-changed`.

This PR switches that path to cached delayed soft-dependency resolution, which
matches the pattern already used in other parts of the repo.

## Key Change

- added cached delayed soft-dep resolution for:
  - `ai.miniforge.event-stream.interface/publish!`
  - `ai.miniforge.event-stream.interface/task-state-changed`
- updated `emit-task-state-event!` to use the cached vars instead of raw
  `requiring-resolve`

## Why This Matters

This is the kind of repo-health issue that blocks unrelated PRs in pre-commit.
The taxonomy branch for dependency attribution surfaced it, but the bug is in
`dag-executor` and should be fixed independently.

## Validation

- `clj-kondo --lint components/dag-executor/src/ai/miniforge/dag_executor/state.clj`
- `clojure -M:dev:test -e \"(require 'clojure.test 'ai.miniforge.dag-executor.state-test) ...\"`
- `bb test components/dag-executor`
- full `bb pre-commit`
