### PR TITLE
feat: dependency attribution taxonomy

### DIFF
--- a/components/failure-classifier/resources/config/failure-classifier/rules.edn
+++ b/components/failure-classifier/resources/config/failure-classifier/rules.edn
@@ -21,6 +21,44 @@
    :failure.class/data-integrity    ; Hash mismatch, stale context, schema violation
    :failure.class/unknown}          ; Unclassified — treat as SLI incident
 
+ :failure-sources
+ #{:miniforge                       ; Product/runtime defect in Miniforge itself
+   :user-env                        ; Local setup, config, permission, account env
+   :external-provider               ; LLM or SaaS provider dependency
+   :external-platform}              ; Platform dependency like GitHub or Kubernetes
+
+ :dependency-vendors
+ #{:anthropic
+   :openai
+   :codex
+   :github
+   :gitlab
+   :kubernetes
+   :jira
+   :ollama
+   :google
+   :docker
+   :podman}
+
+ :dependency-classes
+ #{:outage
+   :degraded
+   :rate-limit
+   :auth
+   :account-limitation
+   :permission
+   :misconfiguration
+   :unsupported-feature
+   :timeout
+   :network
+   :quota
+   :unknown}
+
+ :dependency-retryabilities
+ #{:retryable
+   :non-retryable
+   :operator-action}
+
  :message-rules
  [;; Timeout
   {:patterns ["timeout" "timed?\\s*out" "deadline\\s*exceeded"

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/interface.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/interface.clj
@@ -26,18 +26,78 @@
   "Malli schema for a failure class keyword."
   taxonomy/FailureClass)
 
+(def FailureSource
+  "Malli schema for a failure source keyword."
+  taxonomy/FailureSource)
+
+(def DependencyVendor
+  "Malli schema for a dependency vendor keyword."
+  taxonomy/DependencyVendor)
+
+(def DependencyClass
+  "Malli schema for a dependency class keyword."
+  taxonomy/DependencyClass)
+
+(def DependencyRetryability
+  "Malli schema for a dependency retryability keyword."
+  taxonomy/DependencyRetryability)
+
+(def DependencyAttribution
+  "Malli schema for canonical dependency attribution."
+  taxonomy/DependencyAttribution)
+
 (def ClassifiedFailure
   "Malli schema: [:map [:failure/class FailureClass] [:failure/message :string] ...]"
   taxonomy/ClassifiedFailure)
+
+(def ClassifiedDependencyFailure
+  "Malli schema for a classified failure with dependency attribution."
+  taxonomy/ClassifiedDependencyFailure)
 
 (def valid-failure-class?
   "Returns true if the keyword is a valid canonical failure class."
   taxonomy/valid-failure-class?)
 
+(def valid-failure-source?
+  "Returns true if the keyword is a valid canonical failure source."
+  taxonomy/valid-failure-source?)
+
+(def valid-dependency-vendor?
+  "Returns true if the keyword is a known dependency vendor."
+  taxonomy/valid-dependency-vendor?)
+
+(def valid-dependency-class?
+  "Returns true if the keyword is a valid canonical dependency class."
+  taxonomy/valid-dependency-class?)
+
+(def valid-dependency-retryability?
+  "Returns true if the keyword is a valid dependency retryability state."
+  taxonomy/valid-dependency-retryability?)
+
 (def unknown-class?
   "Returns true if the failure class is :failure.class/unknown.
    Unknown failures MUST be treated as SLI incidents (N1 §5.3.3)."
   taxonomy/unknown-class?)
+
+(def dependency-failure?
+  "Returns true if the failure is dependency- or environment-driven."
+  taxonomy/dependency-failure?)
+
+(def retryable-dependency-failure?
+  "Returns true if the dependency failure is safe to retry automatically."
+  taxonomy/retryable-dependency-failure?)
+
+(def operator-action-required?
+  "Returns true if the dependency failure requires operator intervention."
+  taxonomy/operator-action-required?)
+
+(def make-dependency-attribution
+  "Construct canonical dependency attribution."
+  taxonomy/make-dependency-attribution)
+
+(def make-classified-dependency-failure
+  "Construct canonical classified dependency failure."
+  taxonomy/make-classified-dependency-failure)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Classification
@@ -87,5 +147,15 @@
 
   (classify {:error/message "Something mysterious happened"})
   ;; => :failure.class/unknown
+
+  (make-dependency-attribution
+   {:failure/source :external-provider
+    :failure/vendor :anthropic
+    :dependency/class :rate-limit
+    :dependency/retryability :retryable})
+  ;; => {:failure/source :external-provider
+  ;;     :failure/vendor :anthropic
+  ;;     :dependency/class :rate-limit
+  ;;     :dependency/retryability :retryable}
 
   :leave-this-here)

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
@@ -39,6 +39,11 @@
   "The complete set of canonical dependency retryability states."
   (:dependency-retryabilities config))
 
+(def dependency-failure-sources
+  "Failure sources that represent dependency or environment issues rather than
+   Miniforge-internal failures."
+  (disj failure-sources :miniforge))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Schemas and predicates
 
@@ -123,7 +128,7 @@
   "Returns true if the classified failure is caused by an external dependency
    or user environment condition rather than a Miniforge-internal failure."
   [{source :failure/source}]
-  (contains? #{:user-env :external-provider :external-platform} source))
+  (contains? dependency-failure-sources source))
 
 (defn retryable-dependency-failure?
   "Returns true if the dependency failure is safe to retry automatically."
@@ -132,9 +137,14 @@
        (= retryability :retryable)))
 
 (defn operator-action-required?
-  "Returns true if the dependency failure requires human or operator action."
-  [{retryability :dependency/retryability}]
-  (= retryability :operator-action))
+  "Returns true if the dependency failure requires human or operator action.
+   When :failure/source is present, it must also be a dependency failure."
+  [{source :failure/source retryability :dependency/retryability :as failure}]
+  (let [operator-action? (= retryability :operator-action)
+        source-present? (contains? failure :failure/source)]
+    (if source-present?
+      (and (dependency-failure? {:failure/source source}) operator-action?)
+      operator-action?)))
 
 (defn- value-or-default
   "Return value when non-nil, otherwise return default-value."
@@ -142,6 +152,29 @@
   (if (nil? value)
     default-value
     value))
+
+(defn- invalid-constructor-input
+  "Create a canonical ex-info payload for invalid constructor inputs."
+  [message data]
+  (ex-info message (assoc data :anomaly/category :anomalies/incorrect)))
+
+(defn- require-field!
+  "Require a non-nil field and throw ex-info when missing."
+  [field-name value data]
+  (when (nil? value)
+    (throw (invalid-constructor-input
+            (str "Missing required field " field-name)
+            (assoc data :field field-name))))
+  value)
+
+(defn- validate-enum!
+  "Validate an enum field when present and throw ex-info when invalid."
+  [field-name value valid-fn data]
+  (when (and (some? value) (not (valid-fn value)))
+    (throw (invalid-constructor-input
+            (str "Invalid value for " field-name)
+            (assoc data :field field-name :value value))))
+  value)
 
 (defn make-dependency-attribution
   "Construct canonical dependency attribution.
@@ -153,6 +186,15 @@
     vendor :failure/vendor
     dependency-class :dependency/class
     retryability :dependency/retryability}]
+  (require-field! :failure/source source {:constructor :dependency-attribution})
+  (validate-enum! :failure/source source valid-failure-source?
+                  {:constructor :dependency-attribution})
+  (validate-enum! :failure/vendor vendor valid-dependency-vendor?
+                  {:constructor :dependency-attribution})
+  (validate-enum! :dependency/class dependency-class valid-dependency-class?
+                  {:constructor :dependency-attribution})
+  (validate-enum! :dependency/retryability retryability valid-dependency-retryability?
+                  {:constructor :dependency-attribution})
   (let [resolved-class (value-or-default dependency-class :unknown)
         resolved-retryability (value-or-default retryability :non-retryable)]
     (cond-> {:failure/source source
@@ -166,6 +208,12 @@
     message :failure/message
     context :failure/context
     :as dependency-attribution}]
+  (require-field! :failure/class failure-class
+                  {:constructor :classified-dependency-failure})
+  (require-field! :failure/message message
+                  {:constructor :classified-dependency-failure})
+  (validate-enum! :failure/class failure-class valid-failure-class?
+                  {:constructor :classified-dependency-failure})
   (let [attribution (make-dependency-attribution dependency-attribution)]
     (cond-> {:failure/class failure-class
              :failure/message message

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
@@ -23,12 +23,52 @@
    Loaded from config/failure-classifier/rules.edn — single source of truth."
   (:failure-classes config))
 
+(def failure-sources
+  "The complete set of canonical failure sources."
+  (:failure-sources config))
+
+(def dependency-vendors
+  "The supported set of known dependency vendors/platforms."
+  (:dependency-vendors config))
+
+(def dependency-classes
+  "The complete set of canonical dependency classes."
+  (:dependency-classes config))
+
+(def dependency-retryabilities
+  "The complete set of canonical dependency retryability states."
+  (:dependency-retryabilities config))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Schemas and predicates
 
 (def FailureClass
   "Malli schema for a failure class keyword."
   (into [:enum] (sort failure-classes)))
+
+(def FailureSource
+  "Malli schema for a failure source keyword."
+  (into [:enum] (sort failure-sources)))
+
+(def DependencyVendor
+  "Malli schema for a dependency vendor keyword."
+  (into [:enum] (sort dependency-vendors)))
+
+(def DependencyClass
+  "Malli schema for a dependency class keyword."
+  (into [:enum] (sort dependency-classes)))
+
+(def DependencyRetryability
+  "Malli schema for a dependency retryability keyword."
+  (into [:enum] (sort dependency-retryabilities)))
+
+(def DependencyAttribution
+  "Malli schema for canonical dependency attribution."
+  [:map
+   [:failure/source FailureSource]
+   [:dependency/class DependencyClass]
+   [:dependency/retryability DependencyRetryability]
+   [:failure/vendor {:optional true} DependencyVendor]])
 
 (def ClassifiedFailure
   "Malli schema for a classified failure record."
@@ -37,16 +77,103 @@
    [:failure/message :string]
    [:failure/context {:optional true} :map]])
 
+(def ClassifiedDependencyFailure
+  "Malli schema for a classified failure with dependency attribution."
+  [:map
+   [:failure/class FailureClass]
+   [:failure/message :string]
+   [:failure/source FailureSource]
+   [:dependency/class DependencyClass]
+   [:dependency/retryability DependencyRetryability]
+   [:failure/vendor {:optional true} DependencyVendor]
+   [:failure/context {:optional true} :map]])
+
 (defn valid-failure-class?
   "Returns true if the keyword is a valid canonical failure class."
   [kw]
   (contains? failure-classes kw))
+
+(defn valid-failure-source?
+  "Returns true if the keyword is a valid canonical failure source."
+  [kw]
+  (contains? failure-sources kw))
+
+(defn valid-dependency-vendor?
+  "Returns true if the keyword is a known dependency vendor."
+  [kw]
+  (contains? dependency-vendors kw))
+
+(defn valid-dependency-class?
+  "Returns true if the keyword is a valid canonical dependency class."
+  [kw]
+  (contains? dependency-classes kw))
+
+(defn valid-dependency-retryability?
+  "Returns true if the keyword is a valid dependency retryability state."
+  [kw]
+  (contains? dependency-retryabilities kw))
 
 (defn unknown-class?
   "Returns true if the failure class is :failure.class/unknown.
    Unknown failures MUST be treated as SLI incidents (N1 §5.3.3)."
   [kw]
   (= kw :failure.class/unknown))
+
+(defn dependency-failure?
+  "Returns true if the classified failure is caused by an external dependency
+   or user environment condition rather than a Miniforge-internal failure."
+  [{source :failure/source}]
+  (contains? #{:user-env :external-provider :external-platform} source))
+
+(defn retryable-dependency-failure?
+  "Returns true if the dependency failure is safe to retry automatically."
+  [{source :failure/source retryability :dependency/retryability}]
+  (and (dependency-failure? {:failure/source source})
+       (= retryability :retryable)))
+
+(defn operator-action-required?
+  "Returns true if the dependency failure requires human or operator action."
+  [{retryability :dependency/retryability}]
+  (= retryability :operator-action))
+
+(defn- value-or-default
+  "Return value when non-nil, otherwise return default-value."
+  [value default-value]
+  (if (nil? value)
+    default-value
+    value))
+
+(defn make-dependency-attribution
+  "Construct canonical dependency attribution.
+
+   Defaults:
+   - :dependency/class         => :unknown
+   - :dependency/retryability  => :non-retryable"
+  [{source :failure/source
+    vendor :failure/vendor
+    dependency-class :dependency/class
+    retryability :dependency/retryability}]
+  (let [resolved-class (value-or-default dependency-class :unknown)
+        resolved-retryability (value-or-default retryability :non-retryable)]
+    (cond-> {:failure/source source
+             :dependency/class resolved-class
+             :dependency/retryability resolved-retryability}
+      vendor (assoc :failure/vendor vendor))))
+
+(defn make-classified-dependency-failure
+  "Construct canonical classified dependency failure."
+  [{failure-class :failure/class
+    message :failure/message
+    context :failure/context
+    :as dependency-attribution}]
+  (let [attribution (make-dependency-attribution dependency-attribution)]
+    (cond-> {:failure/class failure-class
+             :failure/message message
+             :failure/source (:failure/source attribution)
+             :dependency/class (:dependency/class attribution)
+             :dependency/retryability (:dependency/retryability attribution)}
+      (:failure/vendor attribution) (assoc :failure/vendor (:failure/vendor attribution))
+      context (assoc :failure/context context))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
@@ -56,5 +183,10 @@
   (valid-failure-class? :failure.class/timeout)    ;; => true
   (valid-failure-class? :failure.class/bogus)      ;; => false
   (unknown-class? :failure.class/unknown)          ;; => true
+  (valid-failure-source? :external-provider)       ;; => true
+  (valid-dependency-class? :rate-limit)            ;; => true
+  (retryable-dependency-failure?
+   {:failure/source :external-provider
+    :dependency/retryability :retryable})          ;; => true
 
   :leave-this-here)

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
@@ -35,9 +35,86 @@
     (is (not (fc/valid-failure-class? :something-else)))
     (is (not (fc/valid-failure-class? nil)))))
 
+(deftest dependency-taxonomy-predicates-test
+  (testing "all canonical dependency enums are valid"
+    (doseq [source [:miniforge :user-env :external-provider :external-platform]]
+      (is (fc/valid-failure-source? source)))
+    (doseq [vendor [:anthropic :openai :github :kubernetes]]
+      (is (fc/valid-dependency-vendor? vendor)))
+    (doseq [dependency-class [:outage :rate-limit :permission :unsupported-feature]]
+      (is (fc/valid-dependency-class? dependency-class)))
+    (doseq [retryability [:retryable :non-retryable :operator-action]]
+      (is (fc/valid-dependency-retryability? retryability))))
+
+  (testing "bogus dependency enum values are invalid"
+    (is (not (fc/valid-failure-source? :bogus)))
+    (is (not (fc/valid-dependency-vendor? :bogus)))
+    (is (not (fc/valid-dependency-class? :bogus)))
+    (is (not (fc/valid-dependency-retryability? :bogus)))))
+
 (deftest unknown-class-test
   (is (fc/unknown-class? :failure.class/unknown))
   (is (not (fc/unknown-class? :failure.class/timeout))))
+
+(deftest dependency-failure-predicates-test
+  (testing "dependency-failure? distinguishes product failures from dependency failures"
+    (is (fc/dependency-failure? {:failure/source :user-env}))
+    (is (fc/dependency-failure? {:failure/source :external-provider}))
+    (is (fc/dependency-failure? {:failure/source :external-platform}))
+    (is (not (fc/dependency-failure? {:failure/source :miniforge}))))
+
+  (testing "retryable-dependency-failure? only accepts retryable dependency failures"
+    (is (fc/retryable-dependency-failure?
+         {:failure/source :external-provider
+          :dependency/retryability :retryable}))
+    (is (not (fc/retryable-dependency-failure?
+              {:failure/source :external-provider
+               :dependency/retryability :non-retryable})))
+    (is (not (fc/retryable-dependency-failure?
+              {:failure/source :miniforge
+               :dependency/retryability :retryable}))))
+
+  (testing "operator-action-required? reflects the retryability contract"
+    (is (fc/operator-action-required?
+         {:dependency/retryability :operator-action}))
+    (is (not (fc/operator-action-required?
+              {:dependency/retryability :retryable})))))
+
+(deftest dependency-constructors-test
+  (testing "dependency attribution constructor applies defaults"
+    (is (= {:failure/source :external-provider
+            :dependency/class :unknown
+            :dependency/retryability :non-retryable}
+           (fc/make-dependency-attribution
+            {:failure/source :external-provider}))))
+
+  (testing "dependency attribution constructor preserves explicit fields"
+    (is (= {:failure/source :external-provider
+            :failure/vendor :anthropic
+            :dependency/class :rate-limit
+            :dependency/retryability :retryable}
+           (fc/make-dependency-attribution
+            {:failure/source :external-provider
+             :failure/vendor :anthropic
+             :dependency/class :rate-limit
+             :dependency/retryability :retryable}))))
+
+  (testing "classified dependency failure constructor composes the canonical shape"
+    (is (= {:failure/class :failure.class/external
+            :failure/message "Provider rate limit"
+            :failure/source :external-provider
+            :failure/vendor :anthropic
+            :dependency/class :rate-limit
+            :dependency/retryability :retryable
+            :failure/context {:backend :anthropic}}
+           (fc/make-classified-dependency-failure
+            {:failure/class :failure.class/external
+             :failure/message "Provider rate limit"
+             :failure/source :external-provider
+             :failure/vendor :anthropic
+             :dependency/class :rate-limit
+             :dependency/retryability :retryable
+             :failure/context {:backend :anthropic}})))))
 
 ;; ---------------------------------------------------------------------------- Classification by anomaly category
 

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
@@ -77,6 +77,12 @@
   (testing "operator-action-required? reflects the retryability contract"
     (is (fc/operator-action-required?
          {:dependency/retryability :operator-action}))
+    (is (fc/operator-action-required?
+         {:failure/source :external-provider
+          :dependency/retryability :operator-action}))
+    (is (not (fc/operator-action-required?
+              {:failure/source :miniforge
+               :dependency/retryability :operator-action})))
     (is (not (fc/operator-action-required?
               {:dependency/retryability :retryable})))))
 
@@ -115,6 +121,42 @@
              :dependency/class :rate-limit
              :dependency/retryability :retryable
              :failure/context {:backend :anthropic}})))))
+
+(deftest dependency-constructor-validation-test
+  (testing "dependency attribution constructor rejects missing required fields"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Missing required field :failure/source"
+         (fc/make-dependency-attribution {}))))
+
+  (testing "dependency attribution constructor rejects invalid enum values"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid value for :dependency/class"
+         (fc/make-dependency-attribution
+          {:failure/source :external-provider
+           :dependency/class :bogus})))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid value for :failure/vendor"
+         (fc/make-dependency-attribution
+          {:failure/source :external-provider
+           :failure/vendor :bogus}))))
+
+  (testing "classified dependency failure constructor rejects invalid required fields"
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Missing required field :failure/class"
+         (fc/make-classified-dependency-failure
+          {:failure/message "oops"
+           :failure/source :external-provider})))
+    (is (thrown-with-msg?
+         clojure.lang.ExceptionInfo
+         #"Invalid value for :failure/class"
+         (fc/make-classified-dependency-failure
+          {:failure/class :bogus
+           :failure/message "oops"
+           :failure/source :external-provider})))))
 
 ;; ---------------------------------------------------------------------------- Classification by anomaly category
 

--- a/docs/pull-requests/2026-04-29-feat-dependency-attribution-taxonomy.md
+++ b/docs/pull-requests/2026-04-29-feat-dependency-attribution-taxonomy.md
@@ -1,0 +1,60 @@
+# feat/dependency-attribution-taxonomy
+
+## Summary
+
+Adds the first implementation slice for the external dependency health and
+failure attribution stack introduced in `#696`.
+
+This PR keeps the scope narrow:
+
+- adds canonical dependency-attribution enums to failure-classifier config
+- exposes config-backed schemas and predicates for dependency attribution
+- adds small factory functions for canonical dependency attribution records
+- adds test coverage for the new taxonomy surface
+
+It does **not** yet change runtime classification behavior. The next PR will
+wire the classifier engine to return and consume this richer attribution data.
+
+## Why This Slice First
+
+Before Miniforge can distinguish provider/platform/setup failures from product
+failures in reliability, supervision, CLI output, or behavioral evidence, it
+needs one authoritative data model for:
+
+- where a failure came from
+- what kind of dependency issue it was
+- whether it is retryable or requires operator action
+
+This PR establishes that vocabulary in `failure-classifier`, where the rest of
+the stack can depend on it cleanly.
+
+## Key Changes
+
+- extended [rules.edn](../../components/failure-classifier/resources/config/failure-classifier/rules.edn)
+  with config-backed canonical sets for:
+  - `:failure-sources`
+  - `:dependency-vendors`
+  - `:dependency-classes`
+  - `:dependency-retryabilities`
+- added new schemas and predicates in
+  [taxonomy.clj](../../components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj)
+  for dependency attribution and classified dependency failures
+- exported the new public API from
+  [interface.clj](../../components/failure-classifier/src/ai/miniforge/failure_classifier/interface.clj)
+- added constructor/predicate coverage in
+  [classifier_test.clj](../../components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj)
+
+## What This PR Does Not Do
+
+- no classifier-engine behavior change yet
+- no reliability or supervisory-state integration yet
+- no event-stream changes yet
+- no CLI or dashboard attribution yet
+
+Those are intentionally kept for the next PRs in the stack.
+
+## Validation
+
+- `clj-kondo --lint` on touched failure-classifier files
+- `bb test components/failure-classifier`
+- full `bb pre-commit`


### PR DESCRIPTION
# feat/dependency-attribution-taxonomy

## Summary

Adds the first implementation slice for the external dependency health and
failure attribution stack introduced in `#696`.

This PR keeps the scope narrow:

- adds canonical dependency-attribution enums to failure-classifier config
- exposes config-backed schemas and predicates for dependency attribution
- adds small factory functions for canonical dependency attribution records
- adds test coverage for the new taxonomy surface

It does **not** yet change runtime classification behavior. The next PR will
wire the classifier engine to return and consume this richer attribution data.

## Why This Slice First

Before Miniforge can distinguish provider/platform/setup failures from product
failures in reliability, supervision, CLI output, or behavioral evidence, it
needs one authoritative data model for:

- where a failure came from
- what kind of dependency issue it was
- whether it is retryable or requires operator action

This PR establishes that vocabulary in `failure-classifier`, where the rest of
the stack can depend on it cleanly.

## Key Changes

- extended [rules.edn](../../components/failure-classifier/resources/config/failure-classifier/rules.edn)
  with config-backed canonical sets for:
  - `:failure-sources`
  - `:dependency-vendors`
  - `:dependency-classes`
  - `:dependency-retryabilities`
- added new schemas and predicates in
  [taxonomy.clj](../../components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj)
  for dependency attribution and classified dependency failures
- exported the new public API from
  [interface.clj](../../components/failure-classifier/src/ai/miniforge/failure_classifier/interface.clj)
- added constructor/predicate coverage in
  [classifier_test.clj](../../components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj)

## What This PR Does Not Do

- no classifier-engine behavior change yet
- no reliability or supervisory-state integration yet
- no event-stream changes yet
- no CLI or dashboard attribution yet

Those are intentionally kept for the next PRs in the stack.

## Validation

- `clj-kondo --lint` on touched failure-classifier files
- `bb test components/failure-classifier`
- full `bb pre-commit`
