### PR TITLE
refactor(runtime): pull container defaults to registry, name literals

### DIFF
--- a/components/dag-executor/resources/config/dag-executor/runtime/registry.edn
+++ b/components/dag-executor/resources/config/dag-executor/runtime/registry.edn
@@ -12,10 +12,16 @@
 ;;                 add capabilities incrementally without changing code.
 ;;   :capabilities Set of capability keywords advertised by this runtime
 ;;                 (see N11-delta §4 for the canonical list).
+;;   :defaults     Per-runtime container defaults. Single source of truth so
+;;                 Phase 2 can declare different values for Podman without
+;;                 code changes:
+;;                   :uid          Numeric UID for `--user` and tmpfs uid=
+;;                   :gid          Numeric GID for `--user` and tmpfs gid=
+;;                   :memory       Default RSS limit for `--memory`
+;;                   :cpu          Default fractional CPU count for `--cpus`
+;;                   :tmpfs-size   Tmpfs size for `--tmpfs <path>:size=`
 ;;   :flags        CLI flag dialect map keyed by capability:
 ;;                   :info-format-template  Go template for `<exe> info --format`
-;;                   :tmpfs-mount-options   Comma-separated options string
-;;                                          appended to `--tmpfs <path>:<opts>`
 {:docker  {:executable   "docker"
            :supported?   true
            :capabilities #{:oci-images
@@ -28,15 +34,21 @@
                            :graceful-stop
                            :no-new-privileges :read-only-root :cap-drop-all
                            :tmpfs-uid-gid-options}
-           :flags        {:info-format-template "{{.ServerVersion}}"
-                          :tmpfs-mount-options  "rw,nosuid,nodev,exec,size=512m,uid=1000,gid=1000"}}
+           :defaults     {:uid        1000
+                          :gid        1000
+                          :memory     "512m"
+                          :cpu        0.5
+                          :tmpfs-size "512m"}
+           :flags        {:info-format-template "{{.ServerVersion}}"}}
 
  :podman  {:executable   "podman"
            :supported?   false
            :capabilities #{}
+           :defaults     {}
            :flags        {}}
 
  :nerdctl {:executable   "nerdctl"
            :supported?   false
            :capabilities #{}
+           :defaults     {}
            :flags        {}}}

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
@@ -47,12 +47,22 @@
 
 (def default-image "alpine:latest")
 (def default-workdir "/workspace")
-(def default-stop-timeout 5)
 
-;; Default resource limits
-(def default-resources
-  {:memory "512m"
-   :cpu 0.5})
+(def default-stop-timeout
+  "Minimum graceful-stop timeout (seconds). Also the floor for the timeout
+   computed from an execution plan's :time-limit-ms — `--stop-timeout`
+   never goes below this."
+  5)
+
+(def container-name-prefix
+  "Prefix for generated container names: <prefix><task-id-slice>."
+  "miniforge-task-")
+
+(def container-name-uuid-slice
+  "Number of characters to take from the task UUID when constructing the
+   container name. Eight is enough collision space for a single-host
+   workflow."
+  8)
 
 ;; Resource paths for Dockerfiles (for documentation/building images).
 ;; The Dockerfile syntax is OCI-standard; "docker/" in the resource path is
@@ -60,6 +70,15 @@
 (def dockerfile-resources
   {:minimal "executor/docker/Dockerfile.task-runner"
    :clojure "executor/docker/Dockerfile.task-runner-clojure"})
+
+(defn- runtime-default-resources
+  "Per-runtime memory/cpu defaults sourced from the registry. Wrapping the
+   two lookups in a tiny constructor keeps the resource-arg builder a flat
+   key-value map."
+  [descriptor]
+  (let [k (descriptor/kind descriptor)]
+    {:memory (registry/default k :memory)
+     :cpu    (registry/default k :cpu)}))
 
 ;; ============================================================================
 ;; Helper Functions
@@ -146,9 +165,10 @@
 
 (defn build-resource-args
   "Build resource limit arguments.
-   Merges provided resources with defaults."
-  [resources]
-  (let [merged (merge default-resources resources)]
+   Merges provided resources with the runtime's per-kind defaults from the
+   registry."
+  [descriptor resources]
+  (let [merged (merge (runtime-default-resources descriptor) resources)]
     (cond-> []
       (:memory merged)
       (into ["--memory" (:memory merged)])
@@ -162,7 +182,7 @@
    Applies a fixed set of hardening flags to every container plus
    network restrictions and memory limits derived from the plan:
 
-   - :memory-limit-mb  RSS ceiling in mebibytes  (overrides default-resources)
+   - :memory-limit-mb  RSS ceiling in mebibytes  (overrides registry default)
    - :time-limit-ms    Not enforced at runtime level (handled by executor logic)
    - :network-profile  :none/:restricted -> --network=none
                        :standard/:full   -> no extra network arg
@@ -172,13 +192,14 @@
    - --security-opt=no-new-privileges
    - --cap-drop=ALL
    - --read-only
-   - --user 1000:1000"
-  [execution-plan]
+   - --user <uid>:<gid> from the runtime registry's :uid / :gid defaults"
+  [descriptor execution-plan]
   (let [{:keys [memory-limit-mb network-profile]} execution-plan
+        user-spec (registry/user-spec (descriptor/kind descriptor))
         base ["--security-opt=no-new-privileges"
               "--cap-drop=ALL"
               "--read-only"
-              "--user" "1000:1000"]]
+              "--user" user-spec]]
     (cond-> base
       (some? memory-limit-mb)
       (into ["--memory" (str memory-limit-mb "m")])
@@ -207,7 +228,7 @@
                              (not (contains? mounted-paths workdir))
                              (not= workdir "/tmp"))
                         (conj workdir))
-        opts          (registry/flag (descriptor/kind descriptor) :tmpfs-mount-options)]
+        opts          (registry/tmpfs-mount-options (descriptor/kind descriptor))]
     (mapcat (fn [path]
               ["--tmpfs" (str path ":" opts)])
             scratch-paths)))
@@ -230,8 +251,8 @@
   [descriptor container-name image workdir env-map resources network
    & {:keys [execution-plan]}]
   (let [env-args      (build-env-args env-map)
-        resource-args (build-resource-args resources)
-        security-args (build-security-args execution-plan)
+        resource-args (build-resource-args descriptor resources)
+        security-args (build-security-args descriptor execution-plan)
         runtime-fs-args (build-runtime-fs-args descriptor workdir execution-plan)
         mount-args    (when (some? execution-plan)
                         (build-mount-args execution-plan))
@@ -594,7 +615,8 @@
       (when-let [image-key (->> task-runner-images
                                 (some (fn [[k v]] (when (= image (:image v)) k))))]
         (ensure-image! descriptor image-key)))
-    (let [container-name (str "miniforge-task-" (subs (str task-id) 0 8))
+    (let [container-name (str container-name-prefix
+                               (subs (str task-id) 0 container-name-uuid-slice))
           workdir (get env-config :workdir default-workdir)
           create-result (create-container descriptor
                                           container-name

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
@@ -215,10 +215,11 @@
    workdir scratch mount when the workdir is not already covered by caller
    mounts.
 
-   The tmpfs option string comes from the runtime registry so a future
-   runtime that diverges (e.g. does not accept `uid=`/`gid=` on tmpfs) can
-   be papered over by adding an entry to the dialect map rather than
-   branching on `:runtime/kind` here."
+   The tmpfs option string is built by `registry/tmpfs-mount-options` from
+   the runtime's `:defaults` (`:uid`, `:gid`, `:tmpfs-size`) so a future
+   runtime that diverges (e.g. does not accept `uid=`/`gid=` on tmpfs) is
+   papered over by adjusting that helper or its registry inputs rather
+   than branching on `:runtime/kind` here."
   [descriptor workdir execution-plan]
   (let [mounted-paths (into #{}
                             (map :container-path)

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/registry.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/registry.clj
@@ -87,3 +87,29 @@
   [k flag-key]
   (or (get-in (entry k) [:flags flag-key])
       (get-in (entry :docker) [:flags flag-key])))
+
+(defn default
+  "Look up per-runtime container default `default-key` for kind `k`.
+   Falls back to the Docker default when `k` has no override; this lets
+   future kinds inherit Docker's defaults until they declare their own."
+  [k default-key]
+  (or (get-in (entry k) [:defaults default-key])
+      (get-in (entry :docker) [:defaults default-key])))
+
+(defn user-spec
+  "Return the `<uid>:<gid>` string for runtime kind `k`, derived from the
+   numeric :uid and :gid defaults so the user spec and tmpfs uid=/gid=
+   options stay in lockstep."
+  [k]
+  (str (default k :uid) ":" (default k :gid)))
+
+(defn tmpfs-mount-options
+  "Build the comma-separated options string appended to `--tmpfs <path>:`
+   from the runtime's defaults. Uses the runtime's :uid / :gid / :tmpfs-size
+   so changing one of those defaults flows through the user spec and the
+   tmpfs options together."
+  [k]
+  (let [uid  (default k :uid)
+        gid  (default k :gid)
+        size (default k :tmpfs-size)]
+    (str "rw,nosuid,nodev,exec,size=" size ",uid=" uid ",gid=" gid)))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/registry_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/registry_test.clj
@@ -19,6 +19,7 @@
 (ns ai.miniforge.dag-executor.protocols.impl.runtime.registry-test
   "Tests for the runtime registry — EDN load, kind lookups, flag fallback."
   (:require
+   [clojure.string]
    [clojure.test :refer [deftest is testing]]
    [ai.miniforge.dag-executor.protocols.impl.runtime.registry :as registry]))
 
@@ -71,6 +72,30 @@
       ;; so existing call sites keep working until Phase 2 declares overrides.
       (is (= docker-template (registry/flag :podman :info-format-template)))
       (is (= docker-template (registry/flag :nerdctl :info-format-template))))))
+
+(deftest registry-default-test
+  (testing "default lookup returns per-kind container defaults"
+    (is (= 1000 (registry/default :docker :uid)))
+    (is (= 1000 (registry/default :docker :gid)))
+    (is (= "512m" (registry/default :docker :memory)))
+    (is (= 0.5 (registry/default :docker :cpu)))
+    (is (= "512m" (registry/default :docker :tmpfs-size))))
+
+  (testing "default lookup falls back to Docker for kinds with no override"
+    (is (= 1000 (registry/default :podman :uid)))
+    (is (= "512m" (registry/default :nerdctl :memory)))))
+
+(deftest registry-user-spec-test
+  (testing "user-spec stitches uid:gid from the registry defaults"
+    (is (= "1000:1000" (registry/user-spec :docker)))))
+
+(deftest registry-tmpfs-mount-options-test
+  (testing "tmpfs-mount-options builds the comma-separated string from defaults"
+    (let [opts (registry/tmpfs-mount-options :docker)]
+      (is (clojure.string/includes? opts "size=512m"))
+      (is (clojure.string/includes? opts "uid=1000"))
+      (is (clojure.string/includes? opts "gid=1000"))
+      (is (clojure.string/includes? opts "rw,nosuid,nodev,exec")))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment


### PR DESCRIPTION
## Summary

Follow-up to [#694](https://github.com/miniforge-ai/miniforge/pull/694) (now merged). Per the review feedback "It's in scope if it's our code, so if we're working in that, then change those so they're not magic numbers anymore", this PR applies the same data-driven move the rest of Phase 1 used to the remaining magic literals in `oci_cli.clj`.

## Changes

**Registry gets a per-kind `:defaults` map** ([registry.edn](components/dag-executor/resources/config/dag-executor/runtime/registry.edn)) containing `:uid`, `:gid`, `:memory`, `:cpu`, `:tmpfs-size`. New helpers in [registry.clj](components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/registry.clj):

- `registry/default` — single-value lookup with Docker fallback.
- `registry/user-spec` — stitches `<uid>:<gid>` from numeric `:uid` / `:gid` so the user spec and tmpfs `uid=` / `gid=` options stay in lockstep.
- `registry/tmpfs-mount-options` — builds the comma-separated string from `:uid` / `:gid` / `:tmpfs-size`.

**`oci_cli.clj` changes**:

- `build-resource-args` now takes a descriptor; reads `:memory` / `:cpu` from the registry instead of a top-level `default-resources` literal.
- `build-security-args` now takes a descriptor; reads `--user` from `registry/user-spec` instead of hardcoded `"1000:1000"`.
- `build-runtime-fs-args` now reads its tmpfs option string from `registry/tmpfs-mount-options` rather than `registry/flag` — derived from the same defaults so there's a single source of truth.
- Container-name construction now uses two named constants instead of inline literals: `container-name-prefix` (`"miniforge-task-"`) and `container-name-uuid-slice` (`8`). These are container-construction code (not runtime config), so they live in `oci_cli.clj` rather than the registry.
- `default-stop-timeout` gains a docstring clarifying it doubles as the floor for the execution-plan-derived stop timeout.

## Test plan

- [x] `registry_test.clj` adds 4 deftest forms covering `default`, `user-spec`, `tmpfs-mount-options`, and the Docker-fallback path for `default` lookups.
- [x] Component test suite: 30 tests, 68 assertions, 0 failures.
- [x] `bb test:integration`: clean.
- [x] Full `bb test`: 0 failures, 0 errors (the `state_test/transition-task!-emits-event-test` flake from the prior PR is untouched here — it's the pre-existing `requiring-resolve` race in `state.clj`, tracked under `feedback_avoid_requiring_resolve`).

## Out of scope

- The `state.clj` `requiring-resolve` flake. That's its own PR — Phase 1 didn't touch `state.clj` and the fix involves adding a hard `event-stream` dep and removing the soft-dep dance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)