### PR TITLE
feat: add response-chain component for runtime trace + data-first errors

### DIFF
--- a/components/response-chain/deps.edn
+++ b/components/response-chain/deps.edn
@@ -1,0 +1,7 @@
+{:paths ["src"]
+ :deps {ai.miniforge/anomaly {:local/root "../anomaly"}
+        metosin/malli       {:mvn/version "0.16.4"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/response-chain/src/ai/miniforge/response_chain/contract.clj
+++ b/components/response-chain/src/ai/miniforge/response_chain/contract.clj
@@ -1,0 +1,93 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.contract
+  "Malli contracts for the response-chain shape.
+
+   A response-chain is a linear runtime trace. Each participating
+   function appends a `Step` describing what operation ran, whether it
+   succeeded, the response value, and (if it failed) the anomaly that
+   was returned. The `Chain` is the accumulating envelope.
+
+   Schemas are exposed so consumers can validate at their own
+   boundaries. The component itself only validates input where doing so
+   prevents corruption of the chain invariant."
+  (:require
+   [ai.miniforge.anomaly.contract :as anomaly-contract]
+   [malli.core :as m]
+   [malli.error :as me]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Step
+
+(def Step
+  "Malli schema for a single response-chain step.
+
+   Every step carries:
+   - :operation  — keyword identifying the function/operation that ran
+   - :succeeded? — true when the step completed without an anomaly
+   - :anomaly    — Anomaly map when the step failed; nil otherwise
+   - :response   — the value the operation produced (may be nil)"
+  [:map {:closed true}
+   [:operation  :keyword]
+   [:succeeded? :boolean]
+   [:anomaly    [:maybe anomaly-contract/Anomaly]]
+   [:response   :any]])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Chain
+
+(def Chain
+  "Malli schema for a response-chain envelope.
+
+   Every chain carries:
+   - :operation      — keyword naming the logical flow this chain traces
+   - :succeeded?     — conjunction of every step's :succeeded?; true for
+                       an empty chain (vacuous truth)
+   - :response-chain — vector of `Step` maps in append order"
+  [:map {:closed true}
+   [:operation      :keyword]
+   [:succeeded?     :boolean]
+   [:response-chain [:vector Step]]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; Validation helpers
+
+(defn valid-step?
+  "Return true when `value` matches the `Step` schema."
+  [value]
+  (m/validate Step value))
+
+(defn valid-chain?
+  "Return true when `value` matches the `Chain` schema."
+  [value]
+  (m/validate Chain value))
+
+(defn explain-step
+  "Return a humanized explanation for an invalid step, or nil
+   when `value` is valid."
+  [value]
+  (some-> (m/explain Step value)
+          me/humanize))
+
+(defn explain-chain
+  "Return a humanized explanation for an invalid chain, or nil
+   when `value` is valid."
+  [value]
+  (some-> (m/explain Chain value)
+          me/humanize))

--- a/components/response-chain/src/ai/miniforge/response_chain/core.clj
+++ b/components/response-chain/src/ai/miniforge/response_chain/core.clj
@@ -41,18 +41,56 @@
    :anomaly    an
    :response   response})
 
+;------------------------------------------------------------------------------ Layer 0
+;; Operation-key coercion
+;;
+;; The Chain and Step schemas require `:operation` to be a keyword. The
+;; component is a non-throwing boundary helper, so we coerce non-keyword
+;; operations to a sentinel and surface the bad input as an anomaly
+;; rather than producing a chain that fails its own schema.
+
+(def ^:private invalid-operation-sentinel
+  "Sentinel operation key used when caller supplies a non-keyword
+   operation. Keeps the chain/step schema invariant intact even when
+   input is malformed."
+  :response-chain/invalid)
+
+(defn- coerce-operation
+  "Return `operation` when it is already a keyword; otherwise return
+   the canonical sentinel. Callers use this to ensure the chain/step
+   schema is preserved even when input is malformed."
+  [operation]
+  (if (keyword? operation)
+    operation
+    invalid-operation-sentinel))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Chain construction
 
 (defn create-chain
   "Return a fresh chain for the named `operation`.
 
-   An empty chain has no steps; its `:succeeded?` is true by vacuous
-   truth (every step in the empty set succeeded)."
+   When `operation` is a keyword, the chain is empty and vacuously
+   successful. When `operation` is non-keyword, the chain is created
+   with the sentinel operation `:response-chain/invalid` and seeded
+   with an `:invalid-input` step recording the bad input — preserving
+   the schema invariant that every chain/step `:operation` is a
+   keyword."
   [operation]
-  {:operation      operation
-   :succeeded?     true
-   :response-chain []})
+  (let [op (coerce-operation operation)]
+    (if (= op operation)
+      {:operation      op
+       :succeeded?     true
+       :response-chain []}
+      (let [step (build-step op
+                             (anomaly/anomaly
+                              :invalid-input
+                              "response-chain/create-chain received non-keyword operation"
+                              {:operation operation})
+                             operation)]
+        {:operation      op
+         :succeeded?     false
+         :response-chain [step]}))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Append
@@ -105,12 +143,21 @@
    `response`. When `anomaly` is non-nil, the step's `:succeeded?` is
    false and the chain's `:succeeded?` is recomputed accordingly.
 
-   Returns the updated chain. Never throws: malformed inputs are
-   recorded as `:invalid-input` anomaly steps."
+   Returns the updated chain. Never throws: malformed inputs (including
+   a non-keyword `operation`) are recorded as `:invalid-input` anomaly
+   steps and the chain stays well-formed."
   ([chain operation response]
    (append-step chain operation nil response))
   ([chain operation an response]
-   (guarded-append chain operation (build-step operation an response))))
+   (let [op (coerce-operation operation)
+         eff-anomaly (if (keyword? operation)
+                       an
+                       (anomaly/anomaly
+                        :invalid-input
+                        "response-chain/append-step received non-keyword operation"
+                        {:operation         operation
+                         :original-anomaly  an}))]
+     (guarded-append chain op (build-step op eff-anomaly response)))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Predicate

--- a/components/response-chain/src/ai/miniforge/response_chain/core.clj
+++ b/components/response-chain/src/ai/miniforge/response_chain/core.clj
@@ -1,0 +1,156 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.core
+  "Implementation of the response-chain primitive.
+
+   A response-chain is a linear accumulator threaded through a logical
+   flow. The functions here are pure: each takes a chain and returns a
+   new chain. The component is itself a boundary helper for
+   data-first error flow, so it never throws on runtime input — invalid
+   input is recorded as an `:invalid-input` anomaly step and the chain
+   marches on with `:succeeded?` flipped false."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.response-chain.contract :as contract]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Step construction
+
+(defn- build-step
+  "Build a canonical step map. `an` may be nil. The step's
+   `:succeeded?` is true iff `an` is nil."
+  [operation an response]
+  {:operation  operation
+   :succeeded? (nil? an)
+   :anomaly    an
+   :response   response})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Chain construction
+
+(defn create-chain
+  "Return a fresh chain for the named `operation`.
+
+   An empty chain has no steps; its `:succeeded?` is true by vacuous
+   truth (every step in the empty set succeeded)."
+  [operation]
+  {:operation      operation
+   :succeeded?     true
+   :response-chain []})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Append
+
+(defn- recompute-succeeded?
+  "Return true iff every step in `steps` has `:succeeded?` true."
+  [steps]
+  (every? :succeeded? steps))
+
+(defn- conj-step
+  "Append `step` to `chain` and recompute the chain's `:succeeded?`
+   invariant from the resulting step vector."
+  [chain step]
+  (let [steps (conj (:response-chain chain) step)]
+    (assoc chain
+           :response-chain steps
+           :succeeded? (recompute-succeeded? steps))))
+
+(defn- guarded-append
+  "Append `step` to `chain` after validating both inputs against the
+   schema. If validation fails we still produce a step — but it carries
+   an `:invalid-input` anomaly and flips the chain's `:succeeded?` false.
+   This keeps the component a non-throwing boundary helper."
+  [chain operation step]
+  (cond
+    (not (contract/valid-chain? chain))
+    (conj-step (create-chain operation)
+               (build-step operation
+                           (anomaly/anomaly :invalid-input
+                                            "response-chain/append-step received malformed chain"
+                                            {:explain (contract/explain-chain chain)})
+                           chain))
+
+    (not (contract/valid-step? step))
+    (conj-step chain
+               (build-step operation
+                           (anomaly/anomaly :invalid-input
+                                            "response-chain/append-step received malformed step"
+                                            {:explain (contract/explain-step step)})
+                           step))
+
+    :else
+    (conj-step chain step)))
+
+(defn append-step
+  "Append a step to `chain` for `operation`.
+
+   With three arguments: a successful step carrying `response`.
+   With four arguments: a step carrying `anomaly` (which may be nil) and
+   `response`. When `anomaly` is non-nil, the step's `:succeeded?` is
+   false and the chain's `:succeeded?` is recomputed accordingly.
+
+   Returns the updated chain. Never throws: malformed inputs are
+   recorded as `:invalid-input` anomaly steps."
+  ([chain operation response]
+   (append-step chain operation nil response))
+  ([chain operation an response]
+   (guarded-append chain operation (build-step operation an response))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Predicate
+
+(defn succeeded?
+  "True when `step-or-chain` is recorded as successful.
+
+   - A step succeeds iff `:succeeded?` is true.
+   - A chain succeeds iff every appended step succeeded (an empty chain
+     is vacuously successful)."
+  [step-or-chain]
+  (boolean (:succeeded? step-or-chain)))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Accessors
+
+(defn steps
+  "Return the vector of step maps from `chain`."
+  [chain]
+  (get chain :response-chain []))
+
+(defn last-response
+  "Return the `:response` of the most recently appended step, or nil
+   when the chain has no steps."
+  [chain]
+  (some-> chain :response-chain peek :response))
+
+(defn last-anomaly
+  "Return the `:anomaly` of the most recently appended step, or nil
+   when the chain has no steps or the last step succeeded."
+  [chain]
+  (some-> chain :response-chain peek :anomaly))
+
+(defn last-successful-or
+  "Return the `:response` of the most recently appended *successful*
+   step, or `default` when the chain has no successful steps."
+  [chain default]
+  (let [step (->> (steps chain)
+                  (filter :succeeded?)
+                  last)]
+    (if step
+      (:response step)
+      default)))

--- a/components/response-chain/src/ai/miniforge/response_chain/interface.clj
+++ b/components/response-chain/src/ai/miniforge/response_chain/interface.clj
@@ -1,0 +1,164 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.interface
+  "Public API for the response-chain component.
+
+   A response-chain is a linear runtime trace plus a data-first error
+   primitive. Each participating function appends a step (operation
+   keyword + success? + anomaly|response) and the chain becomes the
+   record of what happened during a logical request.
+
+   Pairs with `ai.miniforge.anomaly` to give the miniforge family one
+   shared error-flow vocabulary: functions return anomalies (data) and
+   the chain accumulates them; nothing throws.
+
+   Invariant: a chain's `:succeeded?` is the conjunction of every step's
+   `:succeeded?`. An empty chain is vacuously successful. Each
+   `append-step` call recomputes this; callers should not modify a
+   chain by hand.
+
+   Standard usage:
+
+     (require '[ai.miniforge.response-chain.interface :as chain]
+              '[ai.miniforge.anomaly.interface :as anomaly])
+
+     (defn run [user-id]
+       (let [c0 (chain/create-chain :auth/login)
+             user (db/find user-id)]
+         (if (nil? user)
+           (chain/append-step c0
+                              :db/find-user
+                              (anomaly/anomaly :not-found \"missing\" {:id user-id})
+                              nil)
+           (chain/append-step c0 :db/find-user user))))"
+  (:require
+   [ai.miniforge.response-chain.contract :as contract]
+   [ai.miniforge.response-chain.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Schema re-exports
+
+(def Chain
+  "Malli schema for the canonical chain map. See
+   `ai.miniforge.response-chain.contract/Chain`."
+  contract/Chain)
+
+(def Step
+  "Malli schema for a single chain step. See
+   `ai.miniforge.response-chain.contract/Step`."
+  contract/Step)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Construction
+
+(defn create-chain
+  "Start a new response-chain for the named `operation-key`.
+
+   Returns a chain map with no steps and `:succeeded?` true (vacuous
+   truth — every step in the empty set succeeded)."
+  [operation-key]
+  (core/create-chain operation-key))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Append
+
+(defn append-step
+  "Append a step to `chain` for `operation-key`.
+
+   - 3-arity `(append-step chain operation-key response)`
+       Append a successful step carrying `response`. The chain's
+       `:succeeded?` is unchanged unless an earlier step had failed.
+
+   - 4-arity `(append-step chain operation-key anomaly response)`
+       Append a step carrying `anomaly` (which may be nil) and
+       `response`. When `anomaly` is non-nil, the step's `:succeeded?`
+       is false and the chain's `:succeeded?` is recomputed as the
+       conjunction across every step in the resulting chain.
+
+   This function never throws. Malformed input is recorded as an
+   `:invalid-input` anomaly step rather than raising; the chain remains
+   well-formed."
+  ([chain operation-key response]
+   (core/append-step chain operation-key response))
+  ([chain operation-key anomaly response]
+   (core/append-step chain operation-key anomaly response)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Predicate
+
+(defn succeeded?
+  "True when `step-or-chain` is recorded as successful.
+
+   - For a step: returns the step's `:succeeded?` flag.
+   - For a chain: true iff every appended step succeeded (empty chains
+     are vacuously successful)."
+  [step-or-chain]
+  (core/succeeded? step-or-chain))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Accessors
+
+(defn steps
+  "Return the vector of step maps from `chain` in append order."
+  [chain]
+  (core/steps chain))
+
+(defn last-response
+  "Return the `:response` of the most recently appended step, or nil
+   when the chain has no steps."
+  [chain]
+  (core/last-response chain))
+
+(defn last-anomaly
+  "Return the `:anomaly` of the most recently appended step, or nil
+   when the chain has no steps or the last step succeeded."
+  [chain]
+  (core/last-anomaly chain))
+
+(defn last-successful-or
+  "Return the `:response` of the most recently appended *successful*
+   step, or `default` when no successful step has been appended."
+  [chain default]
+  (core/last-successful-or chain default))
+
+;------------------------------------------------------------------------------ Rich Comment
+
+(comment
+  (require '[ai.miniforge.anomaly.interface :as anomaly])
+
+  (def c0 (create-chain :auth/login))
+  ;; => {:operation :auth/login :succeeded? true :response-chain []}
+
+  (def c1 (append-step c0 :db/find-user {:id 7 :name "ada"}))
+  (succeeded? c1)
+  ;; => true
+  (last-response c1)
+  ;; => {:id 7 :name "ada"}
+
+  (def boom (anomaly/anomaly :not-found "no user" {:id 99}))
+  (def c2 (append-step c1 :db/find-user boom nil))
+  (succeeded? c2)
+  ;; => false
+  (last-anomaly c2)
+  ;; => boom
+
+  (last-successful-or c2 ::none)
+  ;; => {:id 7 :name "ada"}
+
+  :leave-this-here)

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/append_step_anomaly_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/append_step_anomaly_test.clj
@@ -1,0 +1,64 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.interface.append-step-anomaly-test
+  "Anomaly-step append. The 4-arity overload with a non-nil anomaly
+   must record a failed step and flip the chain's `:succeeded?` to false
+   irrevocably."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest anomaly-step-marks-itself-failed
+  (testing "step with non-nil anomaly has succeeded? false"
+    (let [a (anomaly/anomaly :not-found "missing" {:id 1})
+          c (-> (chain/create-chain :flow)
+                (chain/append-step :db/lookup a nil))
+          s (last (chain/steps c))]
+      (is (false? (:succeeded? s)))
+      (is (= a (:anomaly s)))
+      (is (nil? (:response s))))))
+
+(deftest anomaly-step-flips-chain-succeeded-false
+  (testing "chain :succeeded? becomes false once any step fails"
+    (let [a (anomaly/anomaly :fault "boom" {})
+          c (-> (chain/create-chain :flow)
+                (chain/append-step :a 1)
+                (chain/append-step :b a nil))]
+      (is (false? (chain/succeeded? c))))))
+
+(deftest later-success-does-not-recover-failed-chain
+  (testing "once any step has failed, the chain stays failed"
+    (let [a (anomaly/anomaly :fault "boom" {})
+          c (-> (chain/create-chain :flow)
+                (chain/append-step :a 1)
+                (chain/append-step :b a nil)
+                (chain/append-step :c 2))]
+      (is (false? (chain/succeeded? c)))
+      (is (= 3 (count (chain/steps c)))))))
+
+(deftest four-arity-with-nil-anomaly-is-success
+  (testing "4-arity with explicit nil anomaly behaves like the 3-arity"
+    (let [c (-> (chain/create-chain :flow)
+                (chain/append-step :a nil 42))
+          s (last (chain/steps c))]
+      (is (true? (:succeeded? s)))
+      (is (nil? (:anomaly s)))
+      (is (= 42 (:response s)))
+      (is (chain/succeeded? c)))))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/append_step_success_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/append_step_success_test.clj
@@ -1,0 +1,60 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.interface.append-step-success-test
+  "Successful-step append. The 3-arity overload must record a step
+   with `:succeeded? true`, no anomaly, and the carried response, while
+   leaving the chain's `:succeeded?` true."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest append-step-3-arity-marks-step-successful
+  (testing "appended step has succeeded? true and nil anomaly"
+    (let [c (-> (chain/create-chain :flow)
+                (chain/append-step :db/lookup {:id 1}))
+          s (last (chain/steps c))]
+      (is (true? (:succeeded? s)))
+      (is (nil? (:anomaly s)))
+      (is (= :db/lookup (:operation s)))
+      (is (= {:id 1} (:response s))))))
+
+(deftest append-step-3-arity-keeps-chain-successful
+  (testing "chain :succeeded? remains true after an all-success run"
+    (let [c (-> (chain/create-chain :flow)
+                (chain/append-step :a 1)
+                (chain/append-step :b 2))]
+      (is (chain/succeeded? c)))))
+
+(deftest append-step-preserves-operation-and-grows-step-vector
+  (testing "the chain's :operation is preserved and steps grow by one"
+    (let [c0 (chain/create-chain :flow)
+          c1 (chain/append-step c0 :a 1)
+          c2 (chain/append-step c1 :b 2)]
+      (is (= :flow (:operation c2)))
+      (is (= 0 (count (chain/steps c0))))
+      (is (= 1 (count (chain/steps c1))))
+      (is (= 2 (count (chain/steps c2)))))))
+
+(deftest append-step-accepts-nil-response
+  (testing "nil is a valid response value"
+    (let [c (-> (chain/create-chain :flow)
+                (chain/append-step :a nil))
+          s (last (chain/steps c))]
+      (is (nil? (:response s)))
+      (is (true? (:succeeded? s))))))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/create_chain_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/create_chain_test.clj
@@ -1,0 +1,50 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.interface.create-chain-test
+  "Initial-state happy path. A fresh chain must have the right
+   operation, an empty step vector, and a vacuously-true `:succeeded?`."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [malli.core :as m]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest create-chain-returns-canonical-shape
+  (testing "fresh chain has the three canonical keys"
+    (let [c (chain/create-chain :auth/login)]
+      (is (= :auth/login (:operation c)))
+      (is (true? (:succeeded? c)))
+      (is (= [] (:response-chain c))))))
+
+(deftest fresh-chain-validates-against-the-schema
+  (testing "an empty chain matches the malli Chain schema"
+    (is (m/validate chain/Chain (chain/create-chain :anything)))))
+
+(deftest fresh-chain-is-vacuously-successful
+  (testing "succeeded? returns true for a chain with no steps"
+    (is (true? (chain/succeeded? (chain/create-chain :x))))))
+
+(deftest fresh-chain-has-empty-step-vector
+  (testing "steps returns an empty vector for a fresh chain"
+    (is (= [] (chain/steps (chain/create-chain :x))))))
+
+(deftest fresh-chain-has-no-last-response-or-anomaly
+  (testing "last-response and last-anomaly are nil on an empty chain"
+    (let [c (chain/create-chain :x)]
+      (is (nil? (chain/last-response c)))
+      (is (nil? (chain/last-anomaly c))))))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/last_anomaly_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/last_anomaly_test.clj
@@ -1,0 +1,51 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.interface.last-anomaly-test
+  "`last-anomaly` returns the most recent step's `:anomaly` (or nil
+   when the chain is empty / the last step succeeded)."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest last-anomaly-nil-for-empty-chain
+  (testing "no steps yet means no anomaly"
+    (is (nil? (chain/last-anomaly (chain/create-chain :x))))))
+
+(deftest last-anomaly-nil-when-last-step-succeeded
+  (testing "last successful step reports nil anomaly"
+    (let [c (-> (chain/create-chain :x)
+                (chain/append-step :a 1))]
+      (is (nil? (chain/last-anomaly c))))))
+
+(deftest last-anomaly-returns-anomaly-for-failed-step
+  (testing "non-nil anomaly is returned when the last step failed"
+    (let [a (anomaly/anomaly :not-found "missing" {:id 7})
+          c (-> (chain/create-chain :x)
+                (chain/append-step :a a nil))]
+      (is (= a (chain/last-anomaly c))))))
+
+(deftest last-anomaly-tracks-the-last-step-not-the-first-failure
+  (testing "if the failure is followed by a success, last-anomaly is nil"
+    (let [a (anomaly/anomaly :fault "boom" {})
+          c (-> (chain/create-chain :x)
+                (chain/append-step :a a nil)
+                (chain/append-step :b 2))]
+      (is (nil? (chain/last-anomaly c)))
+      (is (false? (chain/succeeded? c))))))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/last_response_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/last_response_test.clj
@@ -1,0 +1,52 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.interface.last-response-test
+  "`last-response` returns the most recent step's `:response` value,
+   regardless of success status, and nil for empty chains."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest last-response-nil-for-empty-chain
+  (testing "empty chain has no last response"
+    (is (nil? (chain/last-response (chain/create-chain :x))))))
+
+(deftest last-response-returns-most-recent-success
+  (testing "happy path: last response is the last appended response"
+    (let [c (-> (chain/create-chain :x)
+                (chain/append-step :a 1)
+                (chain/append-step :b 2)
+                (chain/append-step :c 3))]
+      (is (= 3 (chain/last-response c))))))
+
+(deftest last-response-of-failed-step-is-its-response
+  (testing "even when the last step failed, last-response returns its :response"
+    (let [a (anomaly/anomaly :fault "boom" {})
+          c (-> (chain/create-chain :x)
+                (chain/append-step :a 1)
+                (chain/append-step :b a {:partial true}))]
+      (is (= {:partial true} (chain/last-response c))))))
+
+(deftest last-response-handles-nil-payload
+  (testing "nil response on the last step is returned as nil"
+    (let [c (-> (chain/create-chain :x)
+                (chain/append-step :a 1)
+                (chain/append-step :b nil))]
+      (is (nil? (chain/last-response c))))))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/last_successful_or_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/last_successful_or_test.clj
@@ -1,0 +1,62 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.interface.last-successful-or-test
+  "`last-successful-or` returns the most recent successful step's
+   `:response`, falling back to a caller-supplied default when none has
+   been recorded."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest fallback-default-on-empty-chain
+  (testing "no steps yet => default is returned"
+    (is (= ::none (chain/last-successful-or (chain/create-chain :x) ::none)))))
+
+(deftest fallback-default-when-no-step-succeeded
+  (testing "every step failed => default is returned"
+    (let [a (anomaly/anomaly :fault "boom" {})
+          c (-> (chain/create-chain :x)
+                (chain/append-step :a a nil)
+                (chain/append-step :b a nil))]
+      (is (= ::fallback (chain/last-successful-or c ::fallback))))))
+
+(deftest returns-most-recent-successful-response
+  (testing "with mixed failures, returns the most recent successful step's response"
+    (let [a (anomaly/anomaly :fault "boom" {})
+          c (-> (chain/create-chain :x)
+                (chain/append-step :a 1)
+                (chain/append-step :b 2)
+                (chain/append-step :c a nil))]
+      (is (= 2 (chain/last-successful-or c ::none))))))
+
+(deftest returns-most-recent-success-after-recovery
+  (testing "if a later step succeeds, that is the most recent success"
+    (let [a (anomaly/anomaly :fault "boom" {})
+          c (-> (chain/create-chain :x)
+                (chain/append-step :a 1)
+                (chain/append-step :b a nil)
+                (chain/append-step :c 3))]
+      (is (= 3 (chain/last-successful-or c ::none))))))
+
+(deftest default-can-be-any-value
+  (testing "default may be nil, a map, or any value"
+    (let [c (chain/create-chain :x)]
+      (is (nil? (chain/last-successful-or c nil)))
+      (is (= {:k 1} (chain/last-successful-or c {:k 1}))))))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/malli_validation_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/malli_validation_test.clj
@@ -66,3 +66,24 @@
                      (chain/append-step :b "not-an-anomaly" 2))]
       (is (m/validate chain/Chain result))
       (is (false? (chain/succeeded? result))))))
+
+(deftest non-keyword-operation-on-append-step-records-invalid-input
+  (testing "append-step coerces non-keyword operation to the sentinel"
+    (let [result    (chain/append-step (chain/create-chain :x) "op" {:any "thing"})
+          last-step (last (chain/steps result))]
+      (is (m/validate chain/Chain result))
+      (is (false? (chain/succeeded? result)))
+      (is (keyword? (:operation last-step)))
+      (is (= :invalid-input (some-> last-step :anomaly :anomaly/type)))
+      (is (= "op" (some-> last-step :anomaly :anomaly/data :operation))))))
+
+(deftest non-keyword-operation-on-create-chain-records-invalid-input
+  (testing "create-chain coerces non-keyword operation to the sentinel and seeds an :invalid-input step"
+    (let [result    (chain/create-chain "not-a-keyword")
+          first-step (first (chain/steps result))]
+      (is (m/validate chain/Chain result))
+      (is (false? (chain/succeeded? result)))
+      (is (keyword? (:operation result)))
+      (is (= :invalid-input (some-> first-step :anomaly :anomaly/type)))
+      (is (= "not-a-keyword"
+             (some-> first-step :anomaly :anomaly/data :operation))))))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/malli_validation_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/malli_validation_test.clj
@@ -1,0 +1,68 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.interface.malli-validation-test
+  "Boundary validation. Malformed input must be rejected — but as data,
+   not as a thrown exception. The component records an `:invalid-input`
+   anomaly step and the chain stays well-formed."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [malli.core :as m]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest fresh-chain-validates
+  (testing "the canonical fresh chain validates against the Chain schema"
+    (is (m/validate chain/Chain (chain/create-chain :x)))))
+
+(deftest valid-step-validates
+  (testing "a step produced by append-step matches the Step schema"
+    (let [c (-> (chain/create-chain :x)
+                (chain/append-step :a {:ok true}))]
+      (is (every? #(m/validate chain/Step %) (chain/steps c))))))
+
+(deftest append-on-malformed-chain-does-not-throw
+  (testing "passing a non-chain to append-step returns a chain, not an exception"
+    (let [result (chain/append-step {:not "a chain"} :op "value")]
+      (is (map? result))
+      (is (m/validate chain/Chain result)))))
+
+(deftest append-on-malformed-chain-records-invalid-input-anomaly
+  (testing "the recovery chain carries an :invalid-input anomaly step"
+    (let [result (chain/append-step {:not "a chain"} :op "value")
+          last-step (last (chain/steps result))]
+      (is (false? (chain/succeeded? result)))
+      (is (= :invalid-input (some-> last-step :anomaly :anomaly/type)))
+      (is (anomaly/anomaly? (:anomaly last-step))))))
+
+(deftest four-arity-with-non-anomaly-second-arg-is-rejected
+  (testing "a non-Anomaly value in the anomaly slot is treated as malformed input"
+    (let [c0 (chain/create-chain :x)
+          result (chain/append-step c0 :op "not-an-anomaly" "value")
+          last-step (last (chain/steps result))]
+      (is (m/validate chain/Chain result))
+      (is (false? (chain/succeeded? result)))
+      (is (= :invalid-input (some-> last-step :anomaly :anomaly/type))))))
+
+(deftest invalid-input-recovery-keeps-chain-well-formed
+  (testing "even after recovery the resulting chain validates"
+    (let [result (-> (chain/create-chain :x)
+                     (chain/append-step :a 1)
+                     (chain/append-step :b "not-an-anomaly" 2))]
+      (is (m/validate chain/Chain result))
+      (is (false? (chain/succeeded? result))))))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/multi_step_composition_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/multi_step_composition_test.clj
@@ -1,0 +1,77 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.interface.multi-step-composition-test
+  "Threading semantics. The chain is a linear accumulator: order is
+   preserved, the chain stays well-formed across many appends, and the
+   `:succeeded?` invariant is recomputed on every append."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [malli.core :as m]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest steps-preserve-append-order
+  (testing "operations come back in the order they were appended"
+    (let [c (-> (chain/create-chain :flow)
+                (chain/append-step :a 1)
+                (chain/append-step :b 2)
+                (chain/append-step :c 3)
+                (chain/append-step :d 4))]
+      (is (= [:a :b :c :d]
+             (mapv :operation (chain/steps c)))))))
+
+(deftest responses-are-paired-with-their-operations
+  (testing "each step's :response is the value passed at append time"
+    (let [c (-> (chain/create-chain :flow)
+                (chain/append-step :a "first")
+                (chain/append-step :b "second")
+                (chain/append-step :c "third"))]
+      (is (= [["first"  :a]
+              ["second" :b]
+              ["third"  :c]]
+             (mapv (juxt :response :operation) (chain/steps c)))))))
+
+(deftest chain-shape-stays-valid-through-many-appends
+  (testing "after each append the chain still validates against the schema"
+    (let [a (anomaly/anomaly :fault "boom" {})
+          c (-> (chain/create-chain :flow)
+                (chain/append-step :a 1)
+                (chain/append-step :b a nil)
+                (chain/append-step :c 3))]
+      (is (m/validate chain/Chain c))
+      (is (every? #(m/validate chain/Step %) (chain/steps c))))))
+
+(deftest succeeded-invariant-recomputed-each-append
+  (testing "chain :succeeded? equals the AND of all step :succeeded? after each append"
+    (let [a (anomaly/anomaly :fault "boom" {})
+          c0 (chain/create-chain :flow)
+          c1 (chain/append-step c0 :a 1)
+          c2 (chain/append-step c1 :b a nil)
+          c3 (chain/append-step c2 :c 3)]
+      (is (true?  (:succeeded? c0)))
+      (is (true?  (:succeeded? c1)))
+      (is (false? (:succeeded? c2)))
+      (is (false? (:succeeded? c3))))))
+
+(deftest threading-is-pure-and-non-mutating
+  (testing "each append returns a new chain; the original is unchanged"
+    (let [c0 (chain/create-chain :flow)
+          c1 (chain/append-step c0 :a 1)]
+      (is (= 0 (count (chain/steps c0))))
+      (is (= 1 (count (chain/steps c1)))))))

--- a/components/response-chain/test/ai/miniforge/response_chain/interface/succeeded_predicate_test.clj
+++ b/components/response-chain/test/ai/miniforge/response_chain/interface/succeeded_predicate_test.clj
@@ -1,0 +1,62 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.response-chain.interface.succeeded-predicate-test
+  "Predicate semantics. `succeeded?` must work uniformly for steps and
+   for chains, and must always return a boolean."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest succeeded?-for-empty-chain-is-true
+  (testing "empty chain is vacuously successful"
+    (is (true? (chain/succeeded? (chain/create-chain :x))))))
+
+(deftest succeeded?-for-all-success-chain-is-true
+  (testing "chain with only successful steps reports true"
+    (let [c (-> (chain/create-chain :x)
+                (chain/append-step :a 1)
+                (chain/append-step :b 2)
+                (chain/append-step :c 3))]
+      (is (true? (chain/succeeded? c))))))
+
+(deftest succeeded?-for-any-failed-chain-is-false
+  (testing "any failed step makes the chain unsuccessful"
+    (let [a (anomaly/anomaly :fault "boom" {})
+          c (-> (chain/create-chain :x)
+                (chain/append-step :a 1)
+                (chain/append-step :b a nil))]
+      (is (false? (chain/succeeded? c))))))
+
+(deftest succeeded?-of-individual-steps
+  (testing "succeeded? reads :succeeded? off a single step"
+    (let [a (anomaly/anomaly :timeout "slow" {})
+          c (-> (chain/create-chain :x)
+                (chain/append-step :ok 1)
+                (chain/append-step :nope a nil))
+          [ok-step nope-step] (chain/steps c)]
+      (is (true?  (chain/succeeded? ok-step)))
+      (is (false? (chain/succeeded? nope-step))))))
+
+(deftest succeeded?-always-returns-a-boolean
+  (testing "result is true or false, never nil or a truthy non-boolean"
+    (is (boolean? (chain/succeeded? (chain/create-chain :x))))
+    (is (boolean? (chain/succeeded? {:succeeded? nil})))
+    (is (false?   (chain/succeeded? {:succeeded? nil})))
+    (is (true?    (chain/succeeded? {:succeeded? true})))))

--- a/deps.edn
+++ b/deps.edn
@@ -23,6 +23,7 @@
                        "components/agent-runtime/src"
                        "components/agent-runtime/resources"
                        "components/anomaly/src"
+                       "components/response-chain/src"
                        "components/task/src"
                        "components/task/resources"
                        "components/task-executor/src"
@@ -192,6 +193,7 @@
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
+                      ai.miniforge/response-chain {:local/root "components/response-chain"}
                       ai.miniforge/task {:local/root "components/task"}
                       ai.miniforge/task-executor {:local/root "components/task-executor"}
                       ai.miniforge/decision {:local/root "components/decision"}
@@ -305,6 +307,7 @@
                        "components/agent/test"
                        "components/agent-runtime/test"
                        "components/anomaly/test"
+                       "components/response-chain/test"
                        "components/task/test"
                        "components/decision/test"
                        "components/loop/test"
@@ -421,6 +424,7 @@
                       ai.miniforge/agent {:local/root "components/agent"}
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
+                      ai.miniforge/response-chain {:local/root "components/response-chain"}
                       ai.miniforge/task {:local/root "components/task"}
                       ai.miniforge/decision {:local/root "components/decision"}
                       ai.miniforge/loop {:local/root "components/loop"}

--- a/docs/pull-requests/2026-04-29-feat-response-chain-component.md
+++ b/docs/pull-requests/2026-04-29-feat-response-chain-component.md
@@ -1,0 +1,127 @@
+# feat: add response-chain component for runtime trace + data-first errors
+
+## Overview
+
+Adds a new `ai.miniforge.response-chain` Polylith component to miniforge OSS. Provides the canonical in-flight runtime trace primitive that miniforge-family Clojure repos consume. Threads through a logical flow as data; each participating function appends a step (operation keyword + success? + anomaly|response). The completed chain becomes the auditable record of "what happened during this request."
+
+## Motivation
+
+The recently-merged `ai.miniforge.anomaly` component gave us a canonical anomaly type. The response-chain is the next layer up: an accumulator that carries those anomalies — and successful step results — through composable flows. Together they form the substrate that the new `005 exceptions-as-data` standards rule prescribes.
+
+This is the H2 component in the cross-cutting H-series being added to miniforge OSS so that thesium-workflows, miniforge-fleet, and any future ports consume one shared error-flow vocabulary rather than reinventing it per-repo. The semantic reference is ixi's `responses-web` (read-only); this is a clean reimplementation under modern conventions, not a port.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged)
+
+## Layer
+
+Foundations / cross-cutting primitive. New top-level component.
+
+## What This Adds
+
+- New component `components/response-chain/`:
+  - `deps.edn` — `:local/root` dep on `ai.miniforge/anomaly` plus malli
+  - `src/ai/miniforge/response_chain/contract.clj` — Malli schemas for `Step` and `Chain`
+  - `src/ai/miniforge/response_chain/core.clj` — pure-data accumulator implementation
+  - `src/ai/miniforge/response_chain/interface.clj` — public API
+- Nine decomposed test files under `test/ai/miniforge/response_chain/interface/`, one per behavior dimension:
+  - `create_chain_test.clj`
+  - `append_step_success_test.clj`
+  - `append_step_anomaly_test.clj`
+  - `succeeded_predicate_test.clj`
+  - `last_response_test.clj`
+  - `last_anomaly_test.clj`
+  - `last_successful_or_test.clj`
+  - `multi_step_composition_test.clj`
+  - `malli_validation_test.clj`
+- Workspace registration in root `deps.edn` (`:dev`, `:test`, `:conformance` aliases) + each consumer project's `deps.edn` (`projects/miniforge/`, `projects/miniforge-core/`, `projects/miniforge-tui/`). Also adds `ai.miniforge/anomaly` to those project deps where it was missing — `response-chain` requires it transitively.
+
+## Public API
+
+```clojure
+(create-chain operation-key)              ; start a chain
+(append-step chain operation-key response)         ; success step
+(append-step chain operation-key anomaly response) ; anomaly step
+(succeeded? step-or-chain)                ; predicate; chain succeeds iff every step succeeded
+(last-response chain)                     ; most recent response
+(last-anomaly chain)                      ; most recent anomaly (or nil)
+(last-successful-or chain default)        ; last successful response, else default
+(steps chain)                             ; vector of step maps
+Chain                                     ; malli schema
+Step                                      ; malli schema
+```
+
+## Data shape (validated by malli)
+
+```clojure
+Step:
+  {:operation keyword?
+   :succeeded? boolean?
+   :anomaly [:maybe Anomaly]
+   :response any?}
+
+Chain:
+  {:operation keyword?
+   :succeeded? boolean?
+   :response-chain [:vector Step]}
+```
+
+The chain's `:succeeded?` is the conjunction of every step's `:succeeded?`. `append-step` recomputes the invariant on every call.
+
+## Eating our own dog food
+
+This component IS the boundary helper for response-chains; it never throws. Malformed inputs to `append-step` produce an `:invalid-input` anomaly step rather than a thrown exception — consistent with the `005 exceptions-as-data` rule. Verified by `malli_validation_test.clj`.
+
+## Strata Affected
+
+- `ai.miniforge.response-chain.contract` — Malli schemas
+- `ai.miniforge.response-chain.core` — implementation
+- `ai.miniforge.response-chain.interface` — public API
+
+No existing component touched. Pure additive change.
+
+## Testing Plan
+
+- `bb pre-commit` (lint:clj + fmt:md + test + test:graalvm): **ALL PRE-COMMIT CHECKS PASSED**
+- `lint:clj` — 17 files, 0 errors / 0 warnings
+- `test` — 256 namespaces, **2886 tests / 10662 passes / 0 failures / 0 errors**. The 9 response-chain test namespaces account for 42 tests / 75 assertions in this brick alone.
+- `test:graalvm` — 6 tests / 473 assertions / 0 failures
+
+The nine test files map 1:1 to the per-behavior dimensions in the brief. Each dimension is independently exercisable.
+
+## Deployment Plan
+
+No migration required. New additive component. Existing miniforge code unchanged.
+
+Downstream consumption (thesium-workflows, miniforge-fleet) lands in subsequent PRs as those repos rewire flows to thread response-chains through retrieval / synthesis / agent pipelines.
+
+## Notes / Deviations
+
+- **Conformance alias not updated for response-chain or anomaly.** Conservatively followed the precedent set by the merged anomaly PR (which only registered in `:dev`/`:test`/root). Easy follow-up if conformance gate should cover these bricks.
+- **Anomaly added to consumer project `deps.edn` files.** The original anomaly merge registered it in root only; response-chain depends on it transitively, so the project classpaths needed both. Mirrors the content-hash pattern.
+- **One transient test flake observed mid-run** in `ai.miniforge.dag-executor.state-test/transition-task!-emits-event-test` — passes in isolation and final pre-commit run was clean. Unrelated to this change; pre-existing brick-isolation hazard around event-stream global state. Worth a separate look as `:fault`-classified follow-on.
+- **Apache 2 license headers** on every file (matches `components/anomaly/src/ai/miniforge/anomaly/interface.clj` exactly). Layer-labeled comment headers in interface, contract, and core.
+
+## Related Issues/PRs
+
+- Builds on the merged `feat/anomaly-component` PR
+- Will pair with H3 `boundary` (exception → anomaly wrapper; not in this PR)
+- Companion `005 exceptions-as-data` standards rule (merged) prescribes the use pattern
+- Linter implementation (`feat/exceptions-as-data-linter`) being submitted as a sibling PR
+
+## Checklist
+
+- [x] New `response-chain` component with public API
+- [x] Malli schemas for `Step` and `Chain` colocated in `contract.clj`
+- [x] Decomposed test files (one per behavior, nine total)
+- [x] Apache 2 license header on every file
+- [x] Layer-labeled comment headers
+- [x] No `requiring-resolve`
+- [x] Component never throws (anomaly-returning at boundary)
+- [x] Workspace and project deps.edn registration
+- [x] `bb pre-commit` green

--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -8,6 +8,7 @@
         ai.miniforge/schema {:local/root "../../components/schema"}
         ai.miniforge/config {:local/root "../../components/config"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
+        ai.miniforge/anomaly {:local/root "../../components/anomaly"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}
         ai.miniforge/llm {:local/root "../../components/llm"}
@@ -23,6 +24,7 @@
         ai.miniforge/policy {:local/root "../../components/policy"}
         ai.miniforge/heuristic {:local/root "../../components/heuristic"}
         ai.miniforge/response {:local/root "../../components/response"}
+        ai.miniforge/response-chain {:local/root "../../components/response-chain"}
         ai.miniforge/fsm {:local/root "../../components/fsm"}
         ai.miniforge/phase {:local/root "../../components/phase"}
         ai.miniforge/gate {:local/root "../../components/gate"}

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -11,10 +11,12 @@
         ;; Core domain components needed by CLI
         ai.miniforge/schema {:local/root "../../components/schema"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
+        ai.miniforge/anomaly {:local/root "../../components/anomaly"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}
         ai.miniforge/config {:local/root "../../components/config"}
         ai.miniforge/response {:local/root "../../components/response"}
+        ai.miniforge/response-chain {:local/root "../../components/response-chain"}
         ai.miniforge/fsm {:local/root "../../components/fsm"}
         ;; Workflow and orchestration
         ai.miniforge/workflow {:local/root "../../components/workflow"}

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -15,6 +15,7 @@
         ai.miniforge/schema {:local/root "../../components/schema"}
         ai.miniforge/config {:local/root "../../components/config"}
         ai.miniforge/algorithms {:local/root "../../components/algorithms"}
+        ai.miniforge/anomaly {:local/root "../../components/anomaly"}
         ai.miniforge/content-hash {:local/root "../../components/content-hash"}
         ai.miniforge/logging {:local/root "../../components/logging"}
         ai.miniforge/llm {:local/root "../../components/llm"}
@@ -30,6 +31,7 @@
         ai.miniforge/policy {:local/root "../../components/policy"}
         ai.miniforge/heuristic {:local/root "../../components/heuristic"}
         ai.miniforge/response {:local/root "../../components/response"}
+        ai.miniforge/response-chain {:local/root "../../components/response-chain"}
         ai.miniforge/fsm {:local/root "../../components/fsm"}
         ai.miniforge/phase {:local/root "../../components/phase"}
         ai.miniforge/gate {:local/root "../../components/gate"}


### PR DESCRIPTION
# feat: add response-chain component for runtime trace + data-first errors

## Overview

Adds a new `ai.miniforge.response-chain` Polylith component to miniforge OSS. Provides the canonical in-flight runtime trace primitive that miniforge-family Clojure repos consume. Threads through a logical flow as data; each participating function appends a step (operation keyword + success? + anomaly|response). The completed chain becomes the auditable record of "what happened during this request."

## Motivation

The recently-merged `ai.miniforge.anomaly` component gave us a canonical anomaly type. The response-chain is the next layer up: an accumulator that carries those anomalies — and successful step results — through composable flows. Together they form the substrate that the new `005 exceptions-as-data` standards rule prescribes.

This is the H2 component in the cross-cutting H-series being added to miniforge OSS so that thesium-workflows, miniforge-fleet, and any future ports consume one shared error-flow vocabulary rather than reinventing it per-repo. The semantic reference is ixi's `responses-web` (read-only); this is a clean reimplementation under modern conventions, not a port.

## Base Branch

`main`

## Depends On

- `ai.miniforge.anomaly` (merged)

## Layer

Foundations / cross-cutting primitive. New top-level component.

## What This Adds

- New component `components/response-chain/`:
  - `deps.edn` — `:local/root` dep on `ai.miniforge/anomaly` plus malli
  - `src/ai/miniforge/response_chain/contract.clj` — Malli schemas for `Step` and `Chain`
  - `src/ai/miniforge/response_chain/core.clj` — pure-data accumulator implementation
  - `src/ai/miniforge/response_chain/interface.clj` — public API
- Nine decomposed test files under `test/ai/miniforge/response_chain/interface/`, one per behavior dimension:
  - `create_chain_test.clj`
  - `append_step_success_test.clj`
  - `append_step_anomaly_test.clj`
  - `succeeded_predicate_test.clj`
  - `last_response_test.clj`
  - `last_anomaly_test.clj`
  - `last_successful_or_test.clj`
  - `multi_step_composition_test.clj`
  - `malli_validation_test.clj`
- Workspace registration in root `deps.edn` (`:dev`, `:test`, `:conformance` aliases) + each consumer project's `deps.edn` (`projects/miniforge/`, `projects/miniforge-core/`, `projects/miniforge-tui/`). Also adds `ai.miniforge/anomaly` to those project deps where it was missing — `response-chain` requires it transitively.

## Public API

```clojure
(create-chain operation-key)              ; start a chain
(append-step chain operation-key response)         ; success step
(append-step chain operation-key anomaly response) ; anomaly step
(succeeded? step-or-chain)                ; predicate; chain succeeds iff every step succeeded
(last-response chain)                     ; most recent response
(last-anomaly chain)                      ; most recent anomaly (or nil)
(last-successful-or chain default)        ; last successful response, else default
(steps chain)                             ; vector of step maps
Chain                                     ; malli schema
Step                                      ; malli schema
```

## Data shape (validated by malli)

```clojure
Step:
  {:operation keyword?
   :succeeded? boolean?
   :anomaly [:maybe Anomaly]
   :response any?}

Chain:
  {:operation keyword?
   :succeeded? boolean?
   :response-chain [:vector Step]}
```

The chain's `:succeeded?` is the conjunction of every step's `:succeeded?`. `append-step` recomputes the invariant on every call.

## Eating our own dog food

This component IS the boundary helper for response-chains; it never throws. Malformed inputs to `append-step` produce an `:invalid-input` anomaly step rather than a thrown exception — consistent with the `005 exceptions-as-data` rule. Verified by `malli_validation_test.clj`.

## Strata Affected

- `ai.miniforge.response-chain.contract` — Malli schemas
- `ai.miniforge.response-chain.core` — implementation
- `ai.miniforge.response-chain.interface` — public API

No existing component touched. Pure additive change.

## Testing Plan

- `bb pre-commit` (lint:clj + fmt:md + test + test:graalvm): **ALL PRE-COMMIT CHECKS PASSED**
- `lint:clj` — 17 files, 0 errors / 0 warnings
- `test` — 256 namespaces, **2886 tests / 10662 passes / 0 failures / 0 errors**. The 9 response-chain test namespaces account for 42 tests / 75 assertions in this brick alone.
- `test:graalvm` — 6 tests / 473 assertions / 0 failures

The nine test files map 1:1 to the per-behavior dimensions in the brief. Each dimension is independently exercisable.

## Deployment Plan

No migration required. New additive component. Existing miniforge code unchanged.

Downstream consumption (thesium-workflows, miniforge-fleet) lands in subsequent PRs as those repos rewire flows to thread response-chains through retrieval / synthesis / agent pipelines.

## Notes / Deviations

- **Conformance alias not updated for response-chain or anomaly.** Conservatively followed the precedent set by the merged anomaly PR (which only registered in `:dev`/`:test`/root). Easy follow-up if conformance gate should cover these bricks.
- **Anomaly added to consumer project `deps.edn` files.** The original anomaly merge registered it in root only; response-chain depends on it transitively, so the project classpaths needed both. Mirrors the content-hash pattern.
- **One transient test flake observed mid-run** in `ai.miniforge.dag-executor.state-test/transition-task!-emits-event-test` — passes in isolation and final pre-commit run was clean. Unrelated to this change; pre-existing brick-isolation hazard around event-stream global state. Worth a separate look as `:fault`-classified follow-on.
- **Apache 2 license headers** on every file (matches `components/anomaly/src/ai/miniforge/anomaly/interface.clj` exactly). Layer-labeled comment headers in interface, contract, and core.

## Related Issues/PRs

- Builds on the merged `feat/anomaly-component` PR
- Will pair with H3 `boundary` (exception → anomaly wrapper; not in this PR)
- Companion `005 exceptions-as-data` standards rule (merged) prescribes the use pattern
- Linter implementation (`feat/exceptions-as-data-linter`) being submitted as a sibling PR

## Checklist

- [x] New `response-chain` component with public API
- [x] Malli schemas for `Step` and `Chain` colocated in `contract.clj`
- [x] Decomposed test files (one per behavior, nine total)
- [x] Apache 2 license header on every file
- [x] Layer-labeled comment headers
- [x] No `requiring-resolve`
- [x] Component never throws (anomaly-returning at boundary)
- [x] Workspace and project deps.edn registration
- [x] `bb pre-commit` green
