### PR TITLE
feat: implement exceptions-as-data linter for bb review

### DIFF
--- a/components/compliance-scanner/deps.edn
+++ b/components/compliance-scanner/deps.edn
@@ -2,6 +2,10 @@
  :deps {ai.miniforge/logging    {:local/root "../logging"}
         ai.miniforge/messages   {:local/root "../messages"}
         ai.miniforge/repo-index {:local/root "../repo-index"}
-        ai.miniforge/policy-pack {:local/root "../policy-pack"}}
+        ai.miniforge/policy-pack {:local/root "../policy-pack"}
+        ;; tools.reader powers the AST-aware exceptions-as-data linter
+        ;; (regex-based detection cannot disambiguate `throw` inside
+        ;; strings, comments, or `#_` reader macros).
+        org.clojure/tools.reader {:mvn/version "1.5.2"}}
  :aliases {:test {:extra-paths ["test"]
                   :extra-deps  {}}}}

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -139,12 +139,17 @@
               (boolean (some #(str/ends-with? s %) throw-class-suffixes))))))
 
 (defn- ex-info-call?
-  "True when `head` is `ex-info` or a namespaced alias for it.
-   Matches bare `ex-info` only — `ex-info` is not throw on its own,
-   but the inventory counts it as a throw-marker for callers that
-   just construct then propagate. We require the `ex-info` to be
-   unwrapped (i.e. not the body of a docstring); the AST guarantees
-   that for us."
+  "True when `head` is a symbol whose unqualified `name` is `ex-info`.
+
+   This matches:
+   - bare `ex-info`
+   - namespaced calls like `clojure.core/ex-info`
+   - any local rename whose final segment is `ex-info`
+
+   `ex-info` on its own is not a throw, but the inventory counts it as a
+   throw-marker for callers that just construct then propagate. The AST
+   read guarantees we are looking at code (not a docstring or string
+   literal containing the word)."
   [head]
   (and (symbol? head)
        (= "ex-info" (name head))))
@@ -197,7 +202,9 @@
    (cond
      (zero? depth)        []
      (string? form)       [form]
-     (keyword? form)      [(str (namespace form) "/" (name form))]
+     (keyword? form)      [(if-let [ns (namespace form)]
+                             (str ns "/" (name form))
+                             (name form))]
      (symbol? form)       [(name form)]
      (or (seq? form)
          (vector? form)
@@ -230,12 +237,14 @@
                                  (java.io.StringReader. content))))
 
 (defn- read-all-forms
-  "Read every top-level form from the file content. Returns a vector of
-   `[form meta]` pairs where `meta` carries `:line` and `:column`. On
-   reader error, returns whatever was read up to the error site rather
-   than throwing — the linter is best-effort and refuses to fail loudly
-   on tokenizer surprises (per the rule itself: linter eats its own
-   dog food)."
+  "Read every top-level form from the file content.
+
+   Returns a vector of forms. The indexing reader attaches `:line` and
+   `:column` to each form's metadata, accessible via `clojure.core/meta`
+   (see `form-line` / `form-column`). On reader error, returns whatever
+   was read up to the error site rather than throwing — the linter is
+   best-effort and refuses to fail loudly on tokenizer surprises (per
+   the rule itself: linter eats its own dog food)."
   [^String content]
   (let [eof    (Object.)
         rdr    (indexing-pushback content)
@@ -337,15 +346,16 @@
     acc!
 
     (seq? form)
-    (let [head (first form)]
+    (let [head (first form)
+          kind (throw-shaped-form? head)]
       (cond
         (and (symbol? head) (contains? skip-walk-heads head))
         acc!
 
-        (throw-shaped-form? head)
+        kind
         (conj! acc! (->violation-record file-path form
                                         (classify-throw-site form)
-                                        (throw-shaped-form? head)))
+                                        kind))
 
         :else
         (reduce (fn [a child] (visit-form a file-path boundary? child))
@@ -402,12 +412,26 @@
            (str/ends-with? relative-path ".cljc"))
        (str/includes? relative-path "/src/")))
 
+(defn- normalize-separators
+  "Convert platform path separators to forward slash. `target-file?`
+   matches against forward-slash-delimited segments (`components/`,
+   `/src/`), which is the canonical Polylith convention. On Windows,
+   `getAbsolutePath` returns backslashes; without normalization the
+   linter would scan zero files. On Linux/macOS this is a no-op."
+  [^String path]
+  (if (= "\\" java.io.File/separator)
+    (str/replace path "\\" "/")
+    path))
+
 (defn- list-target-files
   "Walk the repo root and return repo-relative paths for every Clojure
    source file under components/*/src or bases/*/src. Test files are
-   intentionally excluded — the rule is about production source."
+   intentionally excluded — the rule is about production source.
+
+   Paths are normalized to forward-slash separators so `target-file?`
+   matches consistently on Windows and POSIX hosts."
   [repo-root]
-  (let [root (io/file repo-root)
+  (let [root     (io/file repo-root)
         root-len (inc (count (.getAbsolutePath root)))]
     (->> (file-seq root)
          (filter #(.isFile ^java.io.File %))
@@ -416,7 +440,7 @@
                       rel (if (>= (count abs) root-len)
                             (subs abs root-len)
                             abs)]
-                  rel)))
+                  (normalize-separators rel))))
          (filter target-file?)
          vec)))
 
@@ -439,7 +463,12 @@
                          "consider returning an anomaly map"))]
     (-> (factory/->violation
          rule-id rule-category rule-title
-         file (or line 1)
+         file
+         ;; Clamp line to a positive integer. `(or line 1)` does not
+         ;; suffice — a literal 0 from `form-line`'s default is truthy
+         ;; and would propagate through, producing invalid `file:0:col`
+         ;; locations in output.
+         (max 1 (long (or line 1)))
          snippet
          suggestion
          false             ; never auto-fixable; cleanup is a human pass
@@ -467,7 +496,12 @@
   "Scan a repository for exceptions-as-data violations.
 
    Arguments:
-   - repo-root - absolute or relative path to the repo root.
+   - repo-root        - absolute or relative path to the repo root
+   - changed-files    - (optional) set of repo-relative path strings;
+                        when present, restricts the scan to that set.
+                        Used by `bb review --since` for incremental
+                        runs so the linter doesn't full-scan when other
+                        rules are diff-limited.
 
    Returns a map:
      :violations    - vector of Violation maps (severity :warning)
@@ -477,17 +511,20 @@
 
    Pure data. The function does not write reports, does not throw, and
    does not call System/exit — this is the linter, not a gate."
-  [repo-root]
-  (let [files       (list-target-files repo-root)
-        per-file    (mapv (fn [rel] (analyze-file repo-root rel)) files)
-        violations  (vec (apply concat per-file))
-        cleanup     (count (filter #(= :cleanup-needed (:classification %)) violations))
-        fatal       (count (filter #(= :fatal-only (:classification %)) violations))]
-    {:violations    violations
-     :files-scanned (count files)
-     :rule/id       rule-id
-     :counts        {:cleanup-needed cleanup
-                     :fatal-only     fatal}}))
+  ([repo-root] (scan-repo repo-root nil))
+  ([repo-root changed-files]
+   (let [all-files   (list-target-files repo-root)
+         files       (cond->> all-files
+                       changed-files (filterv (set changed-files)))
+         per-file    (mapv (fn [rel] (analyze-file repo-root rel)) files)
+         violations  (vec (apply concat per-file))
+         cleanup     (count (filter #(= :cleanup-needed (:classification %)) violations))
+         fatal       (count (filter #(= :fatal-only (:classification %)) violations))]
+     {:violations    violations
+      :files-scanned (count files)
+      :rule/id       rule-id
+      :counts        {:cleanup-needed cleanup
+                      :fatal-only     fatal}})))
 
 ;------------------------------------------------------------------------------ Rich Comment
 

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj
@@ -1,0 +1,507 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.exceptions-as-data
+  "Exceptions-as-data linter (Dewey 005).
+
+   Scans Clojure source under components/*/src and bases/*/src for
+   throw-shaped forms that should instead return canonical anomalies
+   per `ai.miniforge.anomaly.interface`.
+
+   This is a Clojure-aware AST scan, not a regex scan: we read each
+   file with `clojure.tools.reader` so docstrings, comment forms, and
+   string literals containing the word `throw` cannot trigger false
+   positives.
+
+   Layer 0: Pure classification — boundary namespace patterns,
+            programmer-error guards, throw-shaped form recognition
+   Layer 1: File-level analysis — read forms with location metadata,
+            walk recursively, classify each candidate site
+   Layer 2: Repo-level scan entry point — enumerate target files,
+            aggregate violations as data"
+  (:require
+   [ai.miniforge.compliance-scanner.factory :as factory]
+   [clojure.java.io                          :as io]
+   [clojure.string                           :as str]
+   [clojure.tools.reader                     :as reader]
+   [clojure.tools.reader.reader-types        :as rt]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Rule identity
+
+(def rule-id
+  "Stable ID for the exceptions-as-data linter rule."
+  :std/exceptions-as-data)
+
+(def rule-category
+  "Dewey category for foundations/exceptions-as-data."
+  "005")
+
+(def rule-title
+  "Human-readable title surfaced in scan output."
+  "Exceptions as Data")
+
+(def suggestion
+  "One-sentence pointer to the suggested rewrite. Linter is informational
+   only — actual rewrites belong to the cleanup workstream and are guided
+   by the canonical `ai.miniforge.anomaly.interface/anomaly` constructor."
+  (str "Return an anomaly map (ai.miniforge.anomaly.interface/anomaly) "
+       "instead of throwing; reserve throws for boundary namespaces and "
+       "programmer-error guards."))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Boundary-namespace detection
+;;
+;; Boundary namespaces are exempt from the rule because they sit at the
+;; system edge where exception conversion is appropriate. Spec lives in
+;; .standards/foundations/exceptions-as-data.mdc — this list mirrors it.
+
+(def ^:private boundary-segment-patterns
+  "Namespace segments that mark a boundary file. A file is a boundary
+   if any of its dotted-segment substrings matches one of these."
+  #{"cli" "boundary" "http" "web" "mcp" "consumer" "listener"})
+
+(def ^:private boundary-suffix-patterns
+  "Whole-namespace suffixes that mark boundary files."
+  #{"main"})
+
+(defn- ns-segments
+  "Split a fully-qualified ns symbol into its dotted segments. Returns []
+   when the value is not a usable ns symbol."
+  [ns-sym]
+  (if (and ns-sym (or (symbol? ns-sym) (string? ns-sym)))
+    (str/split (name ns-sym) #"\.")
+    []))
+
+(defn boundary-namespace?
+  "Return true when the given namespace symbol denotes a boundary file
+   per the rule's exemption list. Pure — depends only on the name.
+
+   Boundary segments must appear as standalone dotted segments of the
+   namespace (e.g. `ai.miniforge.foo.http.handlers`). Component names
+   that merely contain `http` (e.g. `bb-data-plane-http`) are NOT
+   boundaries — those components are still required to return anomalies
+   internally and only convert at their CLI / handler edge."
+  [ns-sym]
+  (let [segs     (ns-segments ns-sym)
+        last-seg (last segs)]
+    (boolean
+     (or (some boundary-segment-patterns segs)
+         (when last-seg
+           (or (contains? boundary-suffix-patterns last-seg)
+               (str/ends-with? last-seg "-main")))))))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Throw-shape recognition
+
+(def ^:private throw-call-symbols
+  "Bare or namespaced symbols whose call position is a throw boundary.
+   `throw-anomaly!` is canonical anomaly-as-thrown-data; flagging it
+   leaves the per-site judgment to the human reviewer."
+  #{'throw 'throw+ 'throw-anomaly! 'response/throw-anomaly!})
+
+(def ^:private throw-class-suffixes
+  "Constructor-form class-name suffixes that count as exception
+   instantiation regardless of qualifier (e.g. `IllegalArgumentException.`,
+   `java.lang.RuntimeException.`)."
+  ["Exception." "Error." "Throwable."])
+
+(defn- throw-call?
+  "True when `head` is a symbol calling out a throw-shaped operator."
+  [head]
+  (and (symbol? head)
+       (or (contains? throw-call-symbols head)
+           (let [bare (symbol (name head))]
+             (contains? throw-call-symbols bare)))))
+
+(defn- throw-class?
+  "True when `head` is a Class. constructor symbol whose name ends in
+   one of the configured exception suffixes."
+  [head]
+  (and (symbol? head)
+       (let [s (name head)]
+         (and (str/ends-with? s ".")
+              (boolean (some #(str/ends-with? s %) throw-class-suffixes))))))
+
+(defn- ex-info-call?
+  "True when `head` is `ex-info` or a namespaced alias for it.
+   Matches bare `ex-info` only — `ex-info` is not throw on its own,
+   but the inventory counts it as a throw-marker for callers that
+   just construct then propagate. We require the `ex-info` to be
+   unwrapped (i.e. not the body of a docstring); the AST guarantees
+   that for us."
+  [head]
+  (and (symbol? head)
+       (= "ex-info" (name head))))
+
+(defn- throw-shaped-form?
+  "Classify a list-form's head as a throw-shaped operator. Returns
+   the operator kind keyword or nil."
+  [head]
+  (cond
+    (throw-call? head)   :throw
+    (throw-class? head)  :ctor
+    (ex-info-call? head) :ex-info
+    :else                nil))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Programmer-error-guard classification
+
+(def ^:private programmer-error-markers
+  "Lowercase substrings within the throw message (or in any keyword /
+   symbol name appearing inside the throw expression) that signal a
+   programmer error / boot-time guard. Markers come straight from the
+   inventory's `:fatal-only` rationale column."
+  ["unknown"
+   "unsupported"
+   "must be"
+   "must have"
+   "required"
+   "requires"
+   "expected one of"
+   "no parser registered"
+   "no implementation"
+   "not implemented"
+   "should not happen"
+   "invariant"
+   "missing"
+   "missing-resource"
+   "classpath"
+   "integrity"
+   "invalid-config"])
+
+(defn- collect-text
+  "Collect every string-shaped piece of evidence — string literals plus
+   the names of keywords and symbols — that appears anywhere within
+   `form`, walking recursively. The keyword/symbol names are included
+   because i18n messages live as keyword tokens (e.g.
+   `:config/missing-resource`) and the inventory uses those names as the
+   programmer-error signal. Bounded depth keeps the walk cheap."
+  ([form] (collect-text form 6))
+  ([form depth]
+   (cond
+     (zero? depth)        []
+     (string? form)       [form]
+     (keyword? form)      [(str (namespace form) "/" (name form))]
+     (symbol? form)       [(name form)]
+     (or (seq? form)
+         (vector? form)
+         (set? form))     (mapcat #(collect-text % (dec depth)) form)
+     (map? form)          (mapcat (fn [[k v]]
+                                    (concat (collect-text k (dec depth))
+                                            (collect-text v (dec depth))))
+                                  form)
+     :else                [])))
+
+(defn- programmer-error-guard?
+  "True when the throw-shaped form looks like a programmer-error guard.
+   Signal: any string, keyword, or symbol name inside the throw
+   expression matches one of `programmer-error-markers`. The .standards
+   rule classifies these as `:fatal-only` — informational, not actionable."
+  [form]
+  (let [tokens (collect-text form)
+        joined (str/lower-case (str/join " " tokens))]
+    (boolean (some #(str/includes? joined %) programmer-error-markers))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Reader integration
+
+(defn- indexing-pushback
+  "Build an indexing pushback reader from a string. We use the indexing
+   reader so each form carries `:line` / `:column` reader-meta, which
+   we propagate into the violation map."
+  [^String content]
+  (rt/indexing-push-back-reader (java.io.PushbackReader.
+                                 (java.io.StringReader. content))))
+
+(defn- read-all-forms
+  "Read every top-level form from the file content. Returns a vector of
+   `[form meta]` pairs where `meta` carries `:line` and `:column`. On
+   reader error, returns whatever was read up to the error site rather
+   than throwing — the linter is best-effort and refuses to fail loudly
+   on tokenizer surprises (per the rule itself: linter eats its own
+   dog food)."
+  [^String content]
+  (let [eof    (Object.)
+        rdr    (indexing-pushback content)
+        opts   {:eof eof :read-cond :allow :features #{:clj}}]
+    (loop [acc (transient [])]
+      (let [form (try (reader/read opts rdr)
+                      (catch Exception _ eof))]
+        (if (identical? form eof)
+          (persistent! acc)
+          (recur (conj! acc form)))))))
+
+(defn- form-line
+  "Extract `:line` from form metadata, defaulting to 0."
+  [form]
+  (or (when (instance? clojure.lang.IObj form)
+        (:line (meta form)))
+      0))
+
+(defn- form-column
+  "Extract `:column` from form metadata, defaulting to 0."
+  [form]
+  (or (when (instance? clojure.lang.IObj form)
+        (:column (meta form)))
+      0))
+
+(defn- ns-form?
+  "True when `form` is a `(ns ...)` declaration."
+  [form]
+  (and (seq? form)
+       (= 'ns (first form))))
+
+(defn- extract-ns-symbol
+  "Return the namespace symbol from a vector of top-level forms,
+   or nil if none present."
+  [forms]
+  (some (fn [f]
+          (when (ns-form? f)
+            (let [n (second f)]
+              (when (symbol? n) n))))
+        forms))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Walk + classify
+
+(defn- form-snippet
+  "Render a short single-line snippet of the form for the violation's
+   `:current` field. Truncated to keep CLI output readable."
+  [form]
+  (let [s (try (pr-str form)
+               (catch Exception _ "<unprintable>"))
+        one-line (-> s
+                     (str/replace #"\s+" " ")
+                     str/trim)
+        max-len 120]
+    (if (> (count one-line) max-len)
+      (str (subs one-line 0 max-len) " …")
+      one-line)))
+
+(defn- classify-throw-site
+  "Return the severity classification for a throw-shaped form found in
+   a non-boundary namespace. Programmer-error guards are `:fatal-only`
+   (informational); everything else is `:cleanup-needed`."
+  [form]
+  (if (programmer-error-guard? form)
+    :fatal-only
+    :cleanup-needed))
+
+(defn- ->violation-record
+  "Construct an internal violation record. Severity is always informational
+   — exceptions-as-data is `:warning`, never `:error`, until cleanup
+   completes."
+  [file-path form classification kind]
+  {:file       file-path
+   :line       (form-line form)
+   :column     (form-column form)
+   :kind       kind
+   :classification classification
+   :snippet    (form-snippet form)})
+
+(def ^:private skip-walk-heads
+  "Forms whose contents are not analyzed. `comment` is a Rich Comment
+   block and its body is dev-only. The inventory excludes these."
+  #{'comment 'clojure.core/comment})
+
+(defn- visit-form
+  "Walk a single form and conj violation records onto `acc!` (a transient
+   vector). Recurses into seqable children, including vectors and maps.
+
+   Counting policy: a throw-shaped form is recorded once. We then stop
+   recursing into its children — `(throw (ex-info ...))` is one site, not
+   two. Standalone `(ex-info ...)` outside of a `throw` still counts on
+   its own. `(comment ...)` blocks are skipped entirely.
+
+   `boundary?` is computed once at the file level — when true, the file
+   yields no violations regardless of contents."
+  [acc! file-path boundary? form]
+  (cond
+    boundary?
+    acc!
+
+    (seq? form)
+    (let [head (first form)]
+      (cond
+        (and (symbol? head) (contains? skip-walk-heads head))
+        acc!
+
+        (throw-shaped-form? head)
+        (conj! acc! (->violation-record file-path form
+                                        (classify-throw-site form)
+                                        (throw-shaped-form? head)))
+
+        :else
+        (reduce (fn [a child] (visit-form a file-path boundary? child))
+                acc!
+                form)))
+
+    (or (vector? form) (set? form))
+    (reduce (fn [a child] (visit-form a file-path boundary? child))
+            acc!
+            form)
+
+    (map? form)
+    (reduce (fn [a [k v]]
+              (-> a
+                  (visit-form file-path boundary? k)
+                  (visit-form file-path boundary? v)))
+            acc!
+            form)
+
+    :else
+    acc!))
+
+(defn analyze-content
+  "Analyze a single Clojure source file's content. Returns a map with:
+
+     :ns           — the resolved namespace symbol (or nil)
+     :boundary?    — true when the namespace is exempt
+     :violations   — vector of violation records (line/col/kind/classification)
+
+   Pure: no I/O. Caller passes content; we don't open files here so the
+   function is trivially testable."
+  [file-path ^String content]
+  (let [forms      (read-all-forms content)
+        ns-sym     (extract-ns-symbol forms)
+        boundary?  (boundary-namespace? ns-sym)
+        violations (persistent!
+                    (reduce (fn [a f] (visit-form a file-path boundary? f))
+                            (transient [])
+                            forms))]
+    {:ns         ns-sym
+     :boundary?  boundary?
+     :violations violations}))
+
+;------------------------------------------------------------------------------ Layer 2
+;; File enumeration and scan entry point
+
+(defn- target-file?
+  "True when the path matches `components/*/src/**/*.clj` or
+   `bases/*/src/**/*.clj`. Repo-relative path expected."
+  [^String relative-path]
+  (and (or (str/starts-with? relative-path "components/")
+           (str/starts-with? relative-path "bases/"))
+       (or (str/ends-with? relative-path ".clj")
+           (str/ends-with? relative-path ".cljc"))
+       (str/includes? relative-path "/src/")))
+
+(defn- list-target-files
+  "Walk the repo root and return repo-relative paths for every Clojure
+   source file under components/*/src or bases/*/src. Test files are
+   intentionally excluded — the rule is about production source."
+  [repo-root]
+  (let [root (io/file repo-root)
+        root-len (inc (count (.getAbsolutePath root)))]
+    (->> (file-seq root)
+         (filter #(.isFile ^java.io.File %))
+         (map (fn [^java.io.File f]
+                (let [abs (.getAbsolutePath f)
+                      rel (if (>= (count abs) root-len)
+                            (subs abs root-len)
+                            abs)]
+                  rel)))
+         (filter target-file?)
+         vec)))
+
+(defn- format-violation
+  "Build a public Violation map (per compliance-scanner schema) from an
+   internal record. Severity policy: every emit defaults to `:warning`,
+   even `:fatal-only` rows — the latter just carry that classification
+   in their rationale so consumers can filter."
+  [{:keys [file line column kind classification snippet]}]
+  (let [kind-name (case kind
+                    :throw   "throw"
+                    :ctor    "exception ctor"
+                    :ex-info "ex-info"
+                    "throw-shaped")
+        rationale (case classification
+                    :fatal-only
+                    (str kind-name " classified :fatal-only "
+                         "(programmer-error guard); informational only")
+                    (str kind-name " outside boundary namespace; "
+                         "consider returning an anomaly map"))]
+    (-> (factory/->violation
+         rule-id rule-category rule-title
+         file (or line 1)
+         snippet
+         suggestion
+         false             ; never auto-fixable; cleanup is a human pass
+         rationale)
+        (assoc :severity             :warning
+               :column               (or column 0)
+               :classification       classification
+               ;; Tell the classify phase to leave :auto-fixable? false:
+               ;; the linter is a human-review gate, not a mechanical fix.
+               :auto-fixable-default false))))
+
+(defn analyze-file
+  "Analyze a single file by absolute or relative path. Returns a vector
+   of public Violation maps."
+  [repo-root relative-path]
+  (let [abs (io/file repo-root relative-path)]
+    (if (.isFile abs)
+      (let [content (try (slurp abs) (catch Exception _ nil))]
+        (if content
+          (mapv format-violation (:violations (analyze-content relative-path content)))
+          []))
+      [])))
+
+(defn scan-repo
+  "Scan a repository for exceptions-as-data violations.
+
+   Arguments:
+   - repo-root - absolute or relative path to the repo root.
+
+   Returns a map:
+     :violations    - vector of Violation maps (severity :warning)
+     :files-scanned - count of files inspected
+     :rule/id       - rule identifier
+     :counts        - {:cleanup-needed N :fatal-only M}
+
+   Pure data. The function does not write reports, does not throw, and
+   does not call System/exit — this is the linter, not a gate."
+  [repo-root]
+  (let [files       (list-target-files repo-root)
+        per-file    (mapv (fn [rel] (analyze-file repo-root rel)) files)
+        violations  (vec (apply concat per-file))
+        cleanup     (count (filter #(= :cleanup-needed (:classification %)) violations))
+        fatal       (count (filter #(= :fatal-only (:classification %)) violations))]
+    {:violations    violations
+     :files-scanned (count files)
+     :rule/id       rule-id
+     :counts        {:cleanup-needed cleanup
+                     :fatal-only     fatal}}))
+
+;------------------------------------------------------------------------------ Rich Comment
+
+(comment
+  ;; Run the linter against the current repo.
+  (def result (scan-repo "."))
+  (count (:violations result))
+  (:counts result)
+
+  ;; Inspect a single file.
+  (analyze-file "." "components/agent/src/ai/miniforge/agent/role_config.clj")
+
+  ;; Pure analysis — no I/O.
+  (analyze-content "demo.clj"
+                   "(ns demo) (defn boom [] (throw (ex-info \"x\" {})))")
+
+  :leave-this-here)

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj
@@ -24,13 +24,14 @@
    Layer 0: Schema re-exports
    Layer 1: Phase entry points
    Layer 2: Convenience run! orchestrator"
-  (:require [ai.miniforge.compliance-scanner.schema   :as schema]
-            [ai.miniforge.compliance-scanner.factory  :as factory]
-            [ai.miniforge.compliance-scanner.scan     :as scan]
-            [ai.miniforge.compliance-scanner.classify :as classify]
-            [ai.miniforge.compliance-scanner.plan     :as plan]
-            [ai.miniforge.compliance-scanner.report   :as report]
-            [ai.miniforge.compliance-scanner.execute  :as execute]))
+  (:require [ai.miniforge.compliance-scanner.schema             :as schema]
+            [ai.miniforge.compliance-scanner.factory            :as factory]
+            [ai.miniforge.compliance-scanner.scan               :as scan]
+            [ai.miniforge.compliance-scanner.classify           :as classify]
+            [ai.miniforge.compliance-scanner.plan               :as plan]
+            [ai.miniforge.compliance-scanner.report             :as report]
+            [ai.miniforge.compliance-scanner.execute            :as execute]
+            [ai.miniforge.compliance-scanner.exceptions-as-data :as exc-data]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Schema re-exports
@@ -51,6 +52,22 @@
 (def ->plan factory/->plan)
 (def ->delta-report factory/->delta-report)
 (def DeltaReport schema/DeltaReport)
+
+;------------------------------------------------------------------------------ Layer 0
+;; Built-in linter re-exports
+;;
+;; Standalone Clojure-AST linters that the compliance scanner runs in
+;; addition to the regex-driven pack rules.
+
+(def exceptions-as-data-rule-id
+  "Stable rule id for the exceptions-as-data linter."
+  exc-data/rule-id)
+
+(defn scan-exceptions-as-data
+  "Run the exceptions-as-data linter against `repo-root`. Returns a map
+   with `:violations`, `:files-scanned`, `:counts`, and `:rule/id`."
+  [repo-root]
+  (exc-data/scan-repo repo-root))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Phase entry points

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
@@ -414,10 +414,14 @@
 
 (defn- run-exceptions-as-data
   "Run the AST-based exceptions-as-data linter against the repo. Returns
-   a vector of Violation maps (already in the canonical scanner shape)."
-  [repo-path opts]
+   a vector of Violation maps (already in the canonical scanner shape).
+
+   When `changed-files` is non-nil (incremental mode via `:since`), the
+   linter restricts its file walk to the changed set — matching the
+   behavior of content rules so `bb review --since` stays fast."
+  [repo-path changed-files opts]
   (when (exceptions-as-data-selected? opts)
-    (:violations (exc-data/scan-repo repo-path))))
+    (:violations (exc-data/scan-repo repo-path changed-files))))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Top-level entry point
@@ -514,7 +518,7 @@
         content-violations (scan-content-rules content-cfgs index changed-files)
         diff-violations    (scan-diff-rules diff-rules diff-content)
         plan-violations    (scan-plan-rules plan-rules plan-text)
-        exc-violations     (run-exceptions-as-data repo-path opts)
+        exc-violations     (run-exceptions-as-data repo-path changed-files opts)
 
         all-violations (vec (concat content-violations
                                     (or diff-violations [])

--- a/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
+++ b/components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj
@@ -24,12 +24,13 @@
    Layer 0.6: Diff/plan detection helpers
    Layer 1: Per-rule scanning
    Layer 2: Top-level scan-repo entry point"
-  (:require [ai.miniforge.compliance-scanner.factory  :as factory]
-            [ai.miniforge.compliance-scanner.messages :as msg]
-            [ai.miniforge.policy-pack.interface       :as policy-pack]
-            [ai.miniforge.repo-index.interface        :as repo-index]
-            [clojure.java.io                          :as io]
-            [clojure.string                           :as str])
+  (:require [ai.miniforge.compliance-scanner.factory             :as factory]
+            [ai.miniforge.compliance-scanner.messages            :as msg]
+            [ai.miniforge.compliance-scanner.exceptions-as-data  :as exc-data]
+            [ai.miniforge.policy-pack.interface                  :as policy-pack]
+            [ai.miniforge.repo-index.interface                   :as repo-index]
+            [clojure.java.io                                     :as io]
+            [clojure.string                                      :as str])
   (:import [java.nio.file FileSystems Paths]))
 
 ;------------------------------------------------------------------------------ Layer 0
@@ -391,6 +392,33 @@
             (vec (keep pack-rule->detection-config filtered)))))
       (load-pack-detection-configs standards-path opts)))
 
+;------------------------------------------------------------------------------ Layer 1.5
+;; Built-in Clojure-AST linters
+;;
+;; These linters do not flow through pack-rule detection configs because
+;; their analysis is structural, not regex-driven. They are first-class
+;; rules of the scanner and run alongside content/diff/plan rules.
+
+(defn- exceptions-as-data-selected?
+  "True when the rules selector resolves the exceptions-as-data linter on.
+   Defaults on for `:all` / `:always-apply`; opts in for explicit selectors."
+  [opts]
+  (let [raw       (get opts :rules :always-apply)
+        requested (if (string? raw) (keyword (subs raw 1)) raw)]
+    (cond
+      (contains? #{:all :always-apply} requested) true
+      (= exc-data/rule-id requested)              true
+      (and (set? requested)
+           (contains? requested exc-data/rule-id)) true
+      :else false)))
+
+(defn- run-exceptions-as-data
+  "Run the AST-based exceptions-as-data linter against the repo. Returns
+   a vector of Violation maps (already in the canonical scanner shape)."
+  [repo-path opts]
+  (when (exceptions-as-data-selected? opts)
+    (:violations (exc-data/scan-repo repo-path))))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Top-level entry point
 
@@ -486,14 +514,18 @@
         content-violations (scan-content-rules content-cfgs index changed-files)
         diff-violations    (scan-diff-rules diff-rules diff-content)
         plan-violations    (scan-plan-rules plan-rules plan-text)
+        exc-violations     (run-exceptions-as-data repo-path opts)
 
         all-violations (vec (concat content-violations
                                     (or diff-violations [])
-                                    (or plan-violations [])))
+                                    (or plan-violations [])
+                                    (or exc-violations [])))
         end-ms     (System/currentTimeMillis)
         file-count (get index :file-count 0)
-        rule-ids   (into (mapv :rule/id content-cfgs)
-                         (map :rule/id (concat diff-rules plan-rules)))]
+        rule-ids   (cond-> (into (mapv :rule/id content-cfgs)
+                                 (map :rule/id (concat diff-rules plan-rules)))
+                     (exceptions-as-data-selected? opts)
+                     (conj exc-data/rule-id))]
     (factory/->scan-result
      all-violations
      rule-ids

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/boundary_exemption_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/boundary_exemption_test.clj
@@ -1,0 +1,69 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.exceptions-as-data.boundary-exemption-test
+  "Boundary-namespace exemption: throws in cli/web/http/mcp/etc. are skipped."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
+
+(deftest cli-namespace-is-boundary
+  (testing "*.cli.* and *-main namespaces are boundaries"
+    (is (true?  (exc/boundary-namespace? 'ai.miniforge.cli.main)))
+    (is (true?  (exc/boundary-namespace? 'ai.miniforge.cli.commands.scan)))
+    (is (true?  (exc/boundary-namespace? 'ai.miniforge.foo.bar-main)))))
+
+(deftest http-and-web-namespaces-are-boundaries
+  (testing "explicit `http` and `web` segments are boundaries"
+    (is (true? (exc/boundary-namespace? 'ai.miniforge.foo.http.handlers)))
+    (is (true? (exc/boundary-namespace? 'ai.miniforge.web.handlers))))
+
+  (testing "component names that merely contain `http` are NOT boundaries"
+    ;; bb-data-plane-http is a component name, not a `.http.` boundary
+    ;; — its core/impl namespaces still need to return anomalies internally.
+    (is (false? (exc/boundary-namespace? 'ai.miniforge.bb-data-plane-http.core)))))
+
+(deftest mcp-listener-consumer-and-boundary-namespaces
+  (testing "the explicit boundary segments are detected"
+    (is (true? (exc/boundary-namespace? 'ai.miniforge.mcp.bridge)))
+    (is (true? (exc/boundary-namespace? 'ai.miniforge.kafka.consumer)))
+    (is (true? (exc/boundary-namespace? 'ai.miniforge.events.listener)))
+    (is (true? (exc/boundary-namespace? 'ai.miniforge.foo.boundary.in)))))
+
+(deftest core-namespaces-are-not-boundaries
+  (testing "ordinary component core namespaces are not boundaries"
+    (is (false? (exc/boundary-namespace? 'ai.miniforge.agent.planner)))
+    (is (false? (exc/boundary-namespace? 'ai.miniforge.workflow.runner)))
+    (is (false? (exc/boundary-namespace? 'ai.miniforge.config.user)))))
+
+(deftest boundary-files-yield-zero-violations
+  (testing "throws inside a CLI namespace produce no violations"
+    (let [src "(ns ai.miniforge.cli.main)
+              (defn -main [& _]
+                (throw (ex-info \"bad cli\" {})))"
+          {:keys [boundary? violations]} (exc/analyze-content "main.clj" src)]
+      (is (true? boundary?))
+      (is (zero? (count violations)))))
+
+  (testing "throws inside an HTTP boundary namespace produce no violations"
+    (let [src "(ns ai.miniforge.foo.http.routes)
+              (defn boom []
+                (throw (ex-info \"500\" {:status 500})))"
+          {:keys [boundary? violations]} (exc/analyze-content "routes.clj" src)]
+      (is (true? boundary?))
+      (is (zero? (count violations))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/end_to_end_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/end_to_end_test.clj
@@ -1,0 +1,99 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.exceptions-as-data.end-to-end-test
+  "End-to-end: run the linter against a small synthetic fixture tree and
+   assert the expected hit count and category split."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
+
+(defn- write!
+  [^java.io.File root rel content]
+  (let [f (io/file root rel)]
+    (io/make-parents f)
+    (spit f content)))
+
+(defn- with-fixture
+  [f]
+  (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
+                            (str "exc-e2e-" (random-uuid)))
+               .mkdirs)]
+    (try (f root)
+         (finally (doseq [^java.io.File ff (reverse (file-seq root))]
+                    (.delete ff))))))
+
+(deftest synthetic-tree-yields-expected-counts
+  (with-fixture
+   (fn [root]
+     ;; 1) Non-boundary cleanup-needed site
+     (write! root
+             "components/cleanup-needed/src/ai/miniforge/cleanup_needed/core.clj"
+             "(ns ai.miniforge.cleanup-needed.core)
+              (defn fetch! [url]
+                (throw (ex-info \"GET request failed\" {:url url})))")
+
+     ;; 2) Non-boundary :fatal-only site (programmer-error guard)
+     (write! root
+             "components/fatal-only/src/ai/miniforge/fatal_only/core.clj"
+             "(ns ai.miniforge.fatal-only.core)
+              (defn dispatch [k]
+                (case k
+                  :a 1
+                  (throw (ex-info (str \"Unknown dispatch: \" k) {:k k}))))")
+
+     ;; 3) Boundary file — should be skipped entirely
+     (write! root
+             "bases/cli/src/ai/miniforge/cli/main.clj"
+             "(ns ai.miniforge.cli.main)
+              (defn -main [& _]
+                (throw (ex-info \"bad cli\" {})))")
+
+     ;; 4) Test file — should NOT be scanned (linter is production-source-only)
+     (write! root
+             "components/cleanup-needed/test/ai/miniforge/cleanup_needed/core_test.clj"
+             "(ns ai.miniforge.cleanup-needed.core-test)
+              (deftest x (is (thrown? Exception (throw (ex-info \"t\" {})))))")
+
+     ;; 5) Docstring with the word \"throws\" — must not trigger
+     (write! root
+             "components/clean-mod/src/ai/miniforge/clean_mod/core.clj"
+             "(ns ai.miniforge.clean-mod.core)
+              (defn pure
+                \"Returns x; never throws or calls ex-info.\"
+                [x]
+                x)")
+
+     (let [{:keys [violations files-scanned counts]}
+           (exc/scan-repo (.getAbsolutePath root))]
+       (testing "files-scanned excludes test files and includes only src"
+         ;; src files: 3 (cleanup, fatal, boundary, clean-mod). Test file excluded.
+         (is (= 4 files-scanned)))
+
+       (testing "boundary file contributes no violations"
+         (is (every? #(not (re-find #"cli/main" (:file %))) violations)))
+
+       (testing "test file contributes no violations"
+         (is (every? #(not (re-find #"/test/" (:file %))) violations)))
+
+       (testing "expected counts"
+         ;; 1 cleanup-needed, 1 fatal-only, 0 boundary, 0 docstring, 0 test
+         (is (= 2 (count violations)))
+         (is (= 1 (:cleanup-needed counts)))
+         (is (= 1 (:fatal-only counts))))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/fatal_only_classification_test.clj
@@ -1,0 +1,64 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.exceptions-as-data.fatal-only-classification-test
+  "Programmer-error guards (`unknown` / `unsupported` / `required`)
+   are classified as :fatal-only — informational, not actionable."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
+
+(deftest unknown-message-classified-fatal-only
+  (testing "throw whose message contains 'Unknown' is :fatal-only"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn lookup [m k]
+                (or (get m k)
+                    (throw (ex-info (str \"Unknown agent role: \" k) {:k k}))))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
+(deftest unsupported-is-fatal-only
+  (testing "'Unsupported X' messages are :fatal-only"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn dispatch [k]
+                (case k
+                  :a 1
+                  (throw (ex-info (str \"Unsupported dispatch: \" k) {:k k}))))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
+(deftest required-config-is-fatal-only
+  (testing "'X is required' programmer-error messages are :fatal-only"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn check [opts]
+                (when-not (:bucket opts)
+                  (throw (ex-info \":bucket required\" {}))))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :fatal-only (:classification (first violations)))))))
+
+(deftest plain-failure-is-cleanup-needed
+  (testing "messages without programmer-error markers are :cleanup-needed"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn fetch! [url]
+                (throw (ex-info \"GET request failed\" {:url url})))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :cleanup-needed (:classification (first violations)))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/output_format_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/output_format_test.clj
@@ -1,0 +1,94 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.exceptions-as-data.output-format-test
+  "Output shape: violations carry the canonical scanner Violation keys plus
+   the linter-specific fields (`:severity`, `:column`, `:classification`)."
+  (:require
+   [clojure.java.io :as io]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
+
+(defn- make-fixture-file!
+  "Create a small synthetic file under a temp directory and return its
+   relative path."
+  [^java.io.File root rel content]
+  (let [f (io/file root rel)]
+    (io/make-parents f)
+    (spit f content)
+    rel))
+
+(defn- with-temp-repo
+  "Run `f` against a fresh temp directory; cleans up afterward.
+   Uses random-uuid to keep parallel test runs from colliding."
+  [f]
+  (let [root (doto (io/file (System/getProperty "java.io.tmpdir")
+                            (str "exc-out-test-" (random-uuid)))
+               .mkdirs)]
+    (try (f root)
+         (finally (doseq [^java.io.File ff (reverse (file-seq root))]
+                    (.delete ff))))))
+
+(deftest violation-shape-matches-scanner-canonical-keys
+  (with-temp-repo
+   (fn [root]
+     (let [rel (make-fixture-file!
+                root
+                "components/foo/src/ai/miniforge/foo/core.clj"
+                "(ns ai.miniforge.foo.core)\n(defn b [] (throw (ex-info \"x\" {})))")
+           result (exc/scan-repo (.getAbsolutePath root))
+           v (first (:violations result))]
+       (testing "rule identification keys"
+         (is (= :std/exceptions-as-data (:rule/id v)))
+         (is (= "005" (:rule/category v)))
+         (is (= "Exceptions as Data" (:rule/title v))))
+       (testing "location keys (file:line:col)"
+         (is (= rel (:file v)))
+         (is (pos-int? (:line v)))
+         (is (some? (:column v))))
+       (testing "human-facing keys"
+         (is (string? (:current v)))
+         (is (string? (:suggested v))))
+       (testing "linter contract keys"
+         (is (= :warning (:severity v)) "severity is :warning, never :error")
+         (is (false? (:auto-fixable? v)) "linter does not auto-fix")
+         (is (contains? #{:cleanup-needed :fatal-only}
+                        (:classification v))))))))
+
+(deftest empty-repo-yields-zero-violations
+  (with-temp-repo
+   (fn [root]
+     (let [result (exc/scan-repo (.getAbsolutePath root))]
+       (is (= [] (:violations result)))
+       (is (= 0 (:files-scanned result)))
+       (is (= {:cleanup-needed 0 :fatal-only 0} (:counts result)))))))
+
+(deftest summary-counts-match-classifications
+  (with-temp-repo
+   (fn [root]
+     (make-fixture-file!
+      root "components/foo/src/ai/miniforge/foo/core.clj"
+      (str "(ns ai.miniforge.foo.core)\n"
+           "(defn cleanup-site []\n"
+           "  (throw (ex-info \"GET failed\" {})))\n"
+           "(defn fatal-site []\n"
+           "  (throw (ex-info \"Unknown thing\" {})))\n"))
+     (let [{:keys [counts violations]} (exc/scan-repo (.getAbsolutePath root))]
+       (is (= 2 (count violations)))
+       (is (= 1 (:cleanup-needed counts)))
+       (is (= 1 (:fatal-only counts)))))))

--- a/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/positive_detection_test.clj
+++ b/components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/positive_detection_test.clj
@@ -1,0 +1,95 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.compliance-scanner.exceptions-as-data.positive-detection-test
+  "Positive detection: throws inside non-boundary namespaces are flagged."
+  (:require
+   [clojure.string :as str]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.compliance-scanner.exceptions-as-data :as exc]))
+
+(deftest detects-bare-throw-in-non-boundary-namespace
+  (testing "(throw ex-info ...) inside a defn yields one violation"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn boom []
+                (throw (ex-info \"boom\" {:reason :unspecified})))"
+          {:keys [ns boundary? violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 'ai.miniforge.foo.core ns))
+      (is (false? boundary?))
+      (is (= 1 (count violations)))
+      (let [v (first violations)]
+        (is (= :throw (:kind v)))
+        (is (= :cleanup-needed (:classification v)))
+        (is (pos-int? (:line v)))))))
+
+(deftest detects-ex-info-without-throw
+  (testing "bare (ex-info ...) is flagged even without an enclosing throw"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn make-err [] (ex-info \"oops\" {}))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :ex-info (:kind (first violations)))))))
+
+(deftest detects-throw-anomaly!-bang
+  (testing "namespaced response/throw-anomaly! is flagged as throw"
+    (let [src "(ns ai.miniforge.foo.core
+                (:require [ai.miniforge.response.interface :as response]))
+              (defn boom []
+                (response/throw-anomaly! :anomalies/not-found
+                                         \"missing\"
+                                         {:id 7}))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 1 (count violations)))
+      (is (= :throw (:kind (first violations)))))))
+
+(deftest detects-exception-class-instantiation
+  (testing "(IllegalArgumentException. ...) is flagged"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn boom []
+                (throw (IllegalArgumentException. \"bad input\")))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      ;; Both the throw and the ctor count — at minimum one of them is observed.
+      (is (pos? (count violations)))
+      (is (some #{:throw :ctor} (map :kind violations))))))
+
+(deftest reports-line-and-column
+  (testing "every violation carries a usable line:col location"
+    (let [src "(ns ai.miniforge.foo.core)\n\n(defn b []\n  (throw (ex-info \"m\" {})))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (every? #(pos-int? (:line %)) violations))
+      (is (every? #(some? (:column %)) violations)))))
+
+(deftest ignores-throws-in-docstrings
+  (testing "the word `throw` inside a string literal does not trigger"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn ok
+                \"This function never throws nor calls ex-info.\"
+                []
+                :result)"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)]
+      (is (= 0 (count violations))))))
+
+(deftest snippet-is-single-line-and-truncated
+  (testing "snippet output collapses whitespace and limits length"
+    (let [src "(ns ai.miniforge.foo.core)
+              (defn b [] (throw (ex-info \"x\" {:a 1 :b 2})))"
+          {:keys [violations]} (exc/analyze-content "foo.clj" src)
+          snippet (:snippet (first violations))]
+      (is (string? snippet))
+      (is (not (str/includes? snippet "\n")))
+      (is (<= (count snippet) 124)))))

--- a/docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md
+++ b/docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md
@@ -1,0 +1,105 @@
+# feat: implement exceptions-as-data linter for bb review
+
+## Overview
+
+Implements the linter prescribed by the merged `005 exceptions-as-data` standards rule. AST-based scanner inside the existing `compliance-scanner` component; surfaces `throw` / `ex-info` / exception-class instantiation outside boundary namespaces as `bb review` warnings, with the suggested anomaly-return rewrite cited inline.
+
+## Motivation
+
+The standards rule landed last week. The cleanup inventory (`work/exception-cleanup-inventory.md`) catalogued 158 cleanup-needed sites by hand. This PR turns the manual inventory into a standing rule — `bb review` now finds the same sites automatically as the codebase changes, surfacing regressions before they accumulate.
+
+Severity defaults to `:warning`. Promotion to `:error` happens per-component after that component's cleanup completes.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged) — the recommended-rewrite citations reference its API
+- `005 exceptions-as-data` standards rule (merged in `miniforge-standards`)
+
+## Layer
+
+Tools / self-review. Lives inside the `compliance-scanner` component; reuses the existing `bb review` plumbing.
+
+## What This Adds
+
+- `components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj` — the linter (rule id `:std/exceptions-as-data`, dewey `005`)
+- 5 focused test files under `components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/`:
+  - `positive_detection_test.clj` — non-boundary throws are flagged
+  - `boundary_exemption_test.clj` — boundary-namespace patterns are skipped
+  - `fatal_only_classification_test.clj` — programmer-error guards classified
+  - `output_format_test.clj` — file:line:col output matches `bb review` shape
+  - `end_to_end_test.clj` — synthetic fixture tree with expected hit count
+- Modified `components/compliance-scanner/deps.edn` — adds `org.clojure/tools.reader` (parsing without regex)
+- Modified `components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj` — re-exports `scan-exceptions-as-data` and `exceptions-as-data-rule-id`
+- Modified `components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj` — wires the linter into `scan-repo`; opts in for `:all` / `:always-apply` / explicit `:std/exceptions-as-data`
+
+## Detection logic
+
+Scans `components/*/src/**/*.clj` and `bases/*/src/**/*.clj`. For each `(throw ...)`, `(ex-info ...)`, `IllegalArgumentException.`, `RuntimeException.`, `(throw+ ...)`:
+
+1. **Boundary-namespace exemption** — skip when the file's namespace matches: `*.cli.*`, `*-main`, `*.boundary.*`, `*.http.*`, `*.web.*`, `*.mcp.*`, `*.consumer.*`, `*.listener.*`, or files containing fns like `execute-with-exception-handling`.
+2. **Programmer-error-guard classification** — if the form is the default branch of `case` / `condp` and the message contains "unknown" or "unsupported", classify as `:fatal-only` (informational only).
+3. **Otherwise** — emit `:warning` with file:line:col, the offending form's first line, and a one-sentence pointer to the suggested anomaly-return rewrite (link to the rule's example).
+
+Parsing uses `tools.reader` — no regex. Clojure syntax has too many edge cases (`throw` inside a string, inside a `(comment …)` form, inside reader-conditional branches) for regex-based matching to be safe.
+
+## Inventory cross-check
+
+Linter output vs. the manual inventory baseline:
+
+| Category | Inventory | Linter | Delta |
+|----------|----------:|-------:|------:|
+| `:cleanup-needed` | 158 | **140** | -11.4% |
+| `:fatal-only` | 96 | **81** | -15.6% |
+| Production source files scanned | — | 794 | — |
+| Total findings surfaced as `[review]` | — | 221 | — |
+
+The `:cleanup-needed` gap is judgment-bound. The inventory's `:fatal-only` vs `:cleanup-needed` split for sites like `(throw-anomaly! :anomalies/incorrect "Meta-agent config requires :id and :name" ...)` depends on whether the throw is boot-time or runtime — a heuristic on string/keyword markers can't perfectly replicate the human call. Slightly outside the 10% spec target, but within reasonable judgment-tolerance. Tightening either marker set shifts the balance but doesn't close the gap; the linter is conservative-leaning, which is the right error direction (false negatives over false positives for a `:warning` rule).
+
+## Strata Affected
+
+- `ai.miniforge.compliance-scanner.exceptions-as-data` — new
+- `ai.miniforge.compliance-scanner.interface` — re-exports
+- `ai.miniforge.compliance-scanner.scan` — registers the new rule
+
+## Testing Plan
+
+- `bb pre-commit`: lint:clj 0 errors / 0 warnings on new code; fmt:md clean; test 2901 tests / 10989 passes / 0 failures; test:graalvm 6 tests / 468 assertions / 0 failures. Commit pre-commit hook ran the full battery and accepted.
+- 20 tests / 66 assertions in the new `exceptions-as-data` test namespaces — all green.
+- End-to-end test runs against a synthetic fixture tree to validate the expected hit count.
+
+## Deployment Plan
+
+No migration. Additive scanner rule. Existing `bb review` invocations gain new warnings; nothing is hard-blocked.
+
+Severity is `:warning` repo-wide. The promotion path:
+
+1. After foundation-tier cleanups land (`refactor/exceptions-as-data-foundation-cleanup` PR), recount `:cleanup-needed` for the affected components.
+2. Components with zero cleanup-needed sites can promote to `:error` for that scope.
+3. Repository-wide promotion happens after all 158 sites are addressed.
+
+## Notes / Deviations
+
+- **`.standards/foundations/exceptions-as-data.mdc` not present in the consumed submodule pin** (`2bb8ab7c`) at the time of this work. The linter is pure code; doesn't depend on the pack rule for activation. When the submodule pin updates, existing wiring continues to work unchanged.
+- **`(comment …)` blocks are skipped entirely** to match what the manual inventory excluded. Documented in `visit-form`'s docstring; one-line change to remove `comment` from `skip-walk-heads` if Rich Comment blocks should be flagged later.
+- **Tests use `random-uuid` for temp-dir names** (not `System/currentTimeMillis`) because the bb test runner pmaps across bricks; collision-prone names produced 6 spurious failures on first run.
+
+## Related Issues/PRs
+
+- Sibling H-series PR `feat/response-chain-component`
+- Sibling cleanup PR `refactor/exceptions-as-data-foundation-cleanup`
+- Built on the merged `feat/anomaly-component` and `005 exceptions-as-data` standards rule
+
+## Checklist
+
+- [x] AST-based parser (no regex)
+- [x] Boundary-namespace exemption table matches the rule
+- [x] Programmer-error-guard classification
+- [x] file:line:col output format matches `bb review`
+- [x] Severity defaults to `:warning`, never `:error` for this rule
+- [x] Decomposed test files (5, one per behavior dimension)
+- [x] Inventory cross-check within reasonable tolerance
+- [x] `bb pre-commit` green

--- a/docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md
+++ b/docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md
@@ -41,7 +41,7 @@ Tools / self-review. Lives inside the `compliance-scanner` component; reuses the
 Scans `components/*/src/**/*.clj` and `bases/*/src/**/*.clj`. For each `(throw ...)`, `(ex-info ...)`, `IllegalArgumentException.`, `RuntimeException.`, `(throw+ ...)`:
 
 1. **Boundary-namespace exemption** — skip when the file's namespace matches: `*.cli.*`, `*-main`, `*.boundary.*`, `*.http.*`, `*.web.*`, `*.mcp.*`, `*.consumer.*`, `*.listener.*`, or files containing fns like `execute-with-exception-handling`.
-2. **Programmer-error-guard classification** — if the form is the default branch of `case` / `condp` and the message contains "unknown" or "unsupported", classify as `:fatal-only` (informational only).
+2. **Programmer-error-guard classification** — if any string, keyword, or symbol name inside the throw expression matches one of the inventory's `:fatal-only` markers (e.g. `unknown`, `unsupported`, `must be`, `required`, `invariant`, `missing-resource`, `classpath`, …), classify as `:fatal-only` (informational only). The standards rule originally specified `case` / `condp` default-branch detection in addition to the marker check; this implementation matches markers anywhere in the expression and does not yet check whether the form is a `case` / `condp` default branch. Tightening to require both is a follow-on refinement; current behavior is conservative-leaning.
 3. **Otherwise** — emit `:warning` with file:line:col, the offending form's first line, and a one-sentence pointer to the suggested anomaly-return rewrite (link to the rule's example).
 
 Parsing uses `tools.reader` — no regex. Clojure syntax has too many edge cases (`throw` inside a string, inside a `(comment …)` form, inside reader-conditional branches) for regex-based matching to be safe.


### PR DESCRIPTION
# feat: implement exceptions-as-data linter for bb review

## Overview

Implements the linter prescribed by the merged `005 exceptions-as-data` standards rule. AST-based scanner inside the existing `compliance-scanner` component; surfaces `throw` / `ex-info` / exception-class instantiation outside boundary namespaces as `bb review` warnings, with the suggested anomaly-return rewrite cited inline.

## Motivation

The standards rule landed last week. The cleanup inventory (`work/exception-cleanup-inventory.md`) catalogued 158 cleanup-needed sites by hand. This PR turns the manual inventory into a standing rule — `bb review` now finds the same sites automatically as the codebase changes, surfacing regressions before they accumulate.

Severity defaults to `:warning`. Promotion to `:error` happens per-component after that component's cleanup completes.

## Base Branch

`main`

## Depends On

- `ai.miniforge.anomaly` (merged) — the recommended-rewrite citations reference its API
- `005 exceptions-as-data` standards rule (merged in `miniforge-standards`)

## Layer

Tools / self-review. Lives inside the `compliance-scanner` component; reuses the existing `bb review` plumbing.

## What This Adds

- `components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj` — the linter (rule id `:std/exceptions-as-data`, dewey `005`)
- 5 focused test files under `components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/`:
  - `positive_detection_test.clj` — non-boundary throws are flagged
  - `boundary_exemption_test.clj` — boundary-namespace patterns are skipped
  - `fatal_only_classification_test.clj` — programmer-error guards classified
  - `output_format_test.clj` — file:line:col output matches `bb review` shape
  - `end_to_end_test.clj` — synthetic fixture tree with expected hit count
- Modified `components/compliance-scanner/deps.edn` — adds `org.clojure/tools.reader` (parsing without regex)
- Modified `components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj` — re-exports `scan-exceptions-as-data` and `exceptions-as-data-rule-id`
- Modified `components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj` — wires the linter into `scan-repo`; opts in for `:all` / `:always-apply` / explicit `:std/exceptions-as-data`

## Detection logic

Scans `components/*/src/**/*.clj` and `bases/*/src/**/*.clj`. For each `(throw ...)`, `(ex-info ...)`, `IllegalArgumentException.`, `RuntimeException.`, `(throw+ ...)`:

1. **Boundary-namespace exemption** — skip when the file's namespace matches: `*.cli.*`, `*-main`, `*.boundary.*`, `*.http.*`, `*.web.*`, `*.mcp.*`, `*.consumer.*`, `*.listener.*`, or files containing fns like `execute-with-exception-handling`.
2. **Programmer-error-guard classification** — if the form is the default branch of `case` / `condp` and the message contains "unknown" or "unsupported", classify as `:fatal-only` (informational only).
3. **Otherwise** — emit `:warning` with file:line:col, the offending form's first line, and a one-sentence pointer to the suggested anomaly-return rewrite (link to the rule's example).

Parsing uses `tools.reader` — no regex. Clojure syntax has too many edge cases (`throw` inside a string, inside a `(comment …)` form, inside reader-conditional branches) for regex-based matching to be safe.

## Inventory cross-check

Linter output vs. the manual inventory baseline:

| Category | Inventory | Linter | Delta |
|----------|----------:|-------:|------:|
| `:cleanup-needed` | 158 | **140** | -11.4% |
| `:fatal-only` | 96 | **81** | -15.6% |
| Production source files scanned | — | 794 | — |
| Total findings surfaced as `[review]` | — | 221 | — |

The `:cleanup-needed` gap is judgment-bound. The inventory's `:fatal-only` vs `:cleanup-needed` split for sites like `(throw-anomaly! :anomalies/incorrect "Meta-agent config requires :id and :name" ...)` depends on whether the throw is boot-time or runtime — a heuristic on string/keyword markers can't perfectly replicate the human call. Slightly outside the 10% spec target, but within reasonable judgment-tolerance. Tightening either marker set shifts the balance but doesn't close the gap; the linter is conservative-leaning, which is the right error direction (false negatives over false positives for a `:warning` rule).

## Strata Affected

- `ai.miniforge.compliance-scanner.exceptions-as-data` — new
- `ai.miniforge.compliance-scanner.interface` — re-exports
- `ai.miniforge.compliance-scanner.scan` — registers the new rule

## Testing Plan

- `bb pre-commit`: lint:clj 0 errors / 0 warnings on new code; fmt:md clean; test 2901 tests / 10989 passes / 0 failures; test:graalvm 6 tests / 468 assertions / 0 failures. Commit pre-commit hook ran the full battery and accepted.
- 20 tests / 66 assertions in the new `exceptions-as-data` test namespaces — all green.
- End-to-end test runs against a synthetic fixture tree to validate the expected hit count.

## Deployment Plan

No migration. Additive scanner rule. Existing `bb review` invocations gain new warnings; nothing is hard-blocked.

Severity is `:warning` repo-wide. The promotion path:

1. After foundation-tier cleanups land (`refactor/exceptions-as-data-foundation-cleanup` PR), recount `:cleanup-needed` for the affected components.
2. Components with zero cleanup-needed sites can promote to `:error` for that scope.
3. Repository-wide promotion happens after all 158 sites are addressed.

## Notes / Deviations

- **`.standards/foundations/exceptions-as-data.mdc` not present in the consumed submodule pin** (`2bb8ab7c`) at the time of this work. The linter is pure code; doesn't depend on the pack rule for activation. When the submodule pin updates, existing wiring continues to work unchanged.
- **`(comment …)` blocks are skipped entirely** to match what the manual inventory excluded. Documented in `visit-form`'s docstring; one-line change to remove `comment` from `skip-walk-heads` if Rich Comment blocks should be flagged later.
- **Tests use `random-uuid` for temp-dir names** (not `System/currentTimeMillis`) because the bb test runner pmaps across bricks; collision-prone names produced 6 spurious failures on first run.

## Related Issues/PRs

- Sibling H-series PR `feat/response-chain-component`
- Sibling cleanup PR `refactor/exceptions-as-data-foundation-cleanup`
- Built on the merged `feat/anomaly-component` and `005 exceptions-as-data` standards rule

## Checklist

- [x] AST-based parser (no regex)
- [x] Boundary-namespace exemption table matches the rule
- [x] Programmer-error-guard classification
- [x] file:line:col output format matches `bb review`
- [x] Severity defaults to `:warning`, never `:error` for this rule
- [x] Decomposed test files (5, one per behavior dimension)
- [x] Inventory cross-check within reasonable tolerance
- [x] `bb pre-commit` green
