### PR TITLE
feat(dag-executor): runtime adapter Phase 2 — Podman supported

### DIFF
--- a/components/dag-executor/resources/config/dag-executor/runtime/images.edn
+++ b/components/dag-executor/resources/config/dag-executor/runtime/images.edn
@@ -1,0 +1,31 @@
+;; Default OCI image references for the runtime adapter.
+;;
+;; Loaded by `ai.miniforge.dag-executor.protocols.impl.runtime.images`.
+;;
+;; Per N11-delta §5: image references MUST be fully qualified
+;; (`<registry>/<repo>:<tag>` or `<registry>/<repo>@sha256:<digest>`).
+;; Short-name references rely on per-host resolution which Podman prompts
+;; for interactively on first run; fully-qualified references behave the
+;; same on every supported runtime.
+;;
+;; Until pinned digests are published, tags are used; Phase 3 or a
+;; subsequent change can replace tags with @sha256: digests once images
+;; are pushed.
+;;
+;; Each entry:
+;;   :image       Fully qualified image reference.
+;;   :dockerfile  Classpath resource path to the Dockerfile that builds
+;;                this image (used by `build-image!` / `ensure-image!`).
+;;   :description Human-readable summary of what the image contains.
+;;
+;; The :default entry is used when an executor config omits :image.
+{:default {:image       "docker.io/library/alpine:latest"
+           :description "Bare Alpine Linux — used when no task-runner image is selected."}
+
+ :minimal {:image       "docker.io/miniforge/task-runner:latest"
+           :dockerfile  "executor/docker/Dockerfile.task-runner"
+           :description "Minimal Alpine image with git, bash, curl, jq."}
+
+ :clojure {:image       "docker.io/miniforge/task-runner-clojure:latest"
+           :dockerfile  "executor/docker/Dockerfile.task-runner-clojure"
+           :description "Full Clojure image with clj, bb, clj-kondo, node."}}

--- a/components/dag-executor/resources/config/dag-executor/runtime/messages/en-US.edn
+++ b/components/dag-executor/resources/config/dag-executor/runtime/messages/en-US.edn
@@ -3,4 +3,4 @@
   "Unknown runtime kind: {kind}. Known kinds: {known}."
 
   :descriptor/unsupported-kind
-  "Runtime kind {kind} is not yet supported. Phase 1 of N11-delta ships :docker only; :podman lands in Phase 2."}}
+  "Runtime kind {kind} is not yet supported. Supported runtimes: {supported}."}}

--- a/components/dag-executor/resources/config/dag-executor/runtime/registry.edn
+++ b/components/dag-executor/resources/config/dag-executor/runtime/registry.edn
@@ -42,10 +42,34 @@
            :flags        {:info-format-template "{{.ServerVersion}}"}}
 
  :podman  {:executable   "podman"
-           :supported?   false
-           :capabilities #{}
-           :defaults     {}
-           :flags        {}}
+           :supported?   true
+           ;; Same OCI surface as Docker plus :rootless. Podman's tmpfs
+           ;; mount accepts the same uid=/gid= options Docker does, so the
+           ;; capability set carries through unchanged.
+           :capabilities #{:oci-images
+                           :run :exec :build
+                           :bind-mounts :tmpfs-mounts
+                           :env-vars :working-dir :user-mapping
+                           :resource-limits
+                           :network-modes/none :network-modes/bridge
+                           :image-digest-pinning
+                           :graceful-stop
+                           :no-new-privileges :read-only-root :cap-drop-all
+                           :tmpfs-uid-gid-options
+                           :rootless}
+           ;; Container-process UID/GID stays 1000:1000 — under rootless
+           ;; Podman that maps to the host user via subuid/subgid, but the
+           ;; in-container value is the same. Memory / CPU / tmpfs sizes
+           ;; match Docker; Phase 3 (auto-probe) can revisit per host.
+           :defaults     {:uid        1000
+                          :gid        1000
+                          :memory     "512m"
+                          :cpu        0.5
+                          :tmpfs-size "512m"}
+           ;; Podman's `info` structure differs from Docker's: server
+           ;; version lives under .Version.Version rather than top-level
+           ;; .ServerVersion.
+           :flags        {:info-format-template "{{.Version.Version}}"}}
 
  :nerdctl {:executable   "nerdctl"
            :supported?   false

--- a/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/executor.clj
@@ -71,7 +71,7 @@
   "Create a Docker-backed OCI-CLI executor.
 
    Config:
-   - :image - Container image for tasks (default: alpine:latest)
+   - :image - Container image for tasks (default from images.edn :default entry)
    - :network - Docker network to attach to
    - :docker-path - Path to docker binary (legacy alias for :executable)"
   oci-cli/create-docker-executor)
@@ -80,9 +80,10 @@
   "Create an OCI-CLI executor for the runtime kind named on the config.
 
    Config:
-   - :runtime-kind - :docker (default; only kind supported in Phase 1)
+   - :runtime-kind - :docker (default) or :podman (Phase 2). :nerdctl is
+                     known but not yet supported.
    - :executable - explicit path to the runtime CLI binary
-   - :image - container image for tasks (default: alpine:latest)
+   - :image - container image for tasks (default from images.edn :default entry)
    - :network - network to attach to"
   oci-cli/create-oci-cli-executor)
 

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/descriptor.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/descriptor.clj
@@ -53,21 +53,37 @@
 ;------------------------------------------------------------------------------ Layer 1
 ;; Error factories
 
+(defn- format-kind-set
+  "Render a set of runtime-kind keywords as a stable, human-readable string
+   for embedding in error messages — `:docker, :podman` rather than the raw
+   `#{:docker :podman}` printed form."
+  [kinds]
+  (->> kinds
+       (map (fn [k] (str ":" (name k))))
+       sort
+       (str/join ", ")))
+
 (defn- unknown-kind-error
   "Return an ex-info anomaly for an unrecognized runtime kind."
   [kind]
-  (ex-info (messages/t :descriptor/unknown-kind
-                       {:kind  kind
-                        :known (registry/known-kinds)})
-           {:runtime/unknown-kind kind
-            :runtime/known-kinds  (registry/known-kinds)}))
+  (let [known     (registry/known-kinds)
+        known-str (format-kind-set known)]
+    (ex-info (messages/t :descriptor/unknown-kind
+                         {:kind  kind
+                          :known known-str})
+             {:runtime/unknown-kind kind
+              :runtime/known-kinds  known})))
 
 (defn- unsupported-kind-error
   "Return an ex-info anomaly for a known-but-not-yet-supported runtime kind."
   [kind]
-  (ex-info (messages/t :descriptor/unsupported-kind {:kind kind})
-           {:runtime/unsupported     kind
-            :runtime/supported-kinds (registry/supported-kinds)}))
+  (let [supported     (registry/supported-kinds)
+        supported-str (format-kind-set supported)]
+    (ex-info (messages/t :descriptor/unsupported-kind
+                         {:kind      kind
+                          :supported supported-str})
+             {:runtime/unsupported     kind
+              :runtime/supported-kinds supported})))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Resolvers

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/images.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/images.clj
@@ -1,0 +1,72 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.protocols.impl.runtime.images
+  "Loads the default OCI image references from
+   `config/dag-executor/runtime/images.edn` and exposes lookups.
+
+   Image references are configuration, not code — adding a new task-runner
+   image (or pinning one to a digest) is an EDN edit. Fully-qualified
+   references are required by N11-delta §5 so first-run on Podman never
+   prompts for short-name resolution."
+  (:require
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+(def images-resource-path
+  "Classpath resource path for the image registry EDN."
+  "config/dag-executor/runtime/images.edn")
+
+(defn- read-edn-resource
+  [resource-path]
+  (when-let [resource (io/resource resource-path)]
+    (-> resource slurp edn/read-string)))
+
+(def images
+  "Map of image-key -> {:image :dockerfile :description}, loaded once at
+   namespace init."
+  (delay (read-edn-resource images-resource-path)))
+
+(defn entry
+  "Return the image entry for `image-key`, or nil when not present."
+  [image-key]
+  (get @images image-key))
+
+(defn task-runner-images
+  "Return the map of buildable task-runner images (everything except
+   :default). Excluding :default keeps the build-related helpers focused
+   on images that ship with bundled Dockerfiles."
+  []
+  (dissoc @images :default))
+
+(defn default-image
+  "Fully-qualified default image reference used when an executor config
+   omits :image."
+  []
+  (some-> (entry :default) :image))
+
+(defn image
+  "Fully-qualified image reference for `image-key`, or nil when unknown."
+  [image-key]
+  (some-> (entry image-key) :image))
+
+(defn dockerfile
+  "Classpath resource path to the Dockerfile for `image-key`, or nil when
+   the image has no bundled Dockerfile."
+  [image-key]
+  (some-> (entry image-key) :dockerfile))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj
@@ -20,21 +20,24 @@
   "OCI-CLI executor — generalized container executor parameterized by a
    runtime descriptor.
 
-   Phase 1 of N11-delta: a pure refactor of the previous Docker-only
-   implementation. The CLI shellouts now take a descriptor instead of a
-   `docker-path`, and the defrecord is `OciCliExecutor` rather than
-   `DockerExecutor`. Behavior with `:runtime-kind :docker` is identical to
-   the prior implementation.
+   Per-kind data (executable, capability set, container defaults, CLI flag
+   dialect) lives in `runtime/registry.edn`. Default OCI image references
+   live in `runtime/images.edn` (fully qualified per N11-delta §5).
 
-   Phase 2 will land Podman support by adding entries to
-   the runtime registry (`runtime/registry.edn`) and flipping
-   `:supported?` for that kind."
+   Currently supported runtime kinds: `:docker` (Phase 1) and `:podman`
+   (Phase 2). `:nerdctl` is known but not supported; constructing a
+   descriptor for it raises `:runtime/unsupported`.
+
+   Adding a runtime is an EDN edit — flip the kind's `:supported?` to true,
+   declare its `:capabilities`, `:defaults`, and any `:flags` overrides,
+   and the executor picks it up without code changes."
   (:require
    [ai.miniforge.config.interface :as config]
    [ai.miniforge.dag-executor.result :as result]
    [ai.miniforge.dag-executor.workspace :as workspace]
    [ai.miniforge.dag-executor.protocols.executor :as proto]
    [ai.miniforge.dag-executor.protocols.impl.runtime.descriptor :as descriptor]
+   [ai.miniforge.dag-executor.protocols.impl.runtime.images :as images]
    [ai.miniforge.dag-executor.protocols.impl.runtime.registry :as registry]
    [ai.miniforge.response.interface :as response]
    [clojure.java.io]
@@ -45,7 +48,6 @@
 ;; Configuration
 ;; ============================================================================
 
-(def default-image "alpine:latest")
 (def default-workdir "/workspace")
 
 (def default-stop-timeout
@@ -376,13 +378,11 @@
 ;; ============================================================================
 
 (def task-runner-images
-  "Pre-defined task runner images that can be built from bundled Dockerfiles."
-  {:minimal {:image "miniforge/task-runner:latest"
-             :dockerfile "executor/docker/Dockerfile.task-runner"
-             :description "Minimal Alpine image with git, bash, curl, jq"}
-   :clojure {:image "miniforge/task-runner-clojure:latest"
-             :dockerfile "executor/docker/Dockerfile.task-runner-clojure"
-             :description "Full Clojure image with clj, bb, clj-kondo, node"}})
+  "Pre-defined task runner images that can be built from bundled Dockerfiles.
+   Sourced from `runtime/images.edn` so image references stay
+   configuration-not-code. Resolved at namespace load and exposed as a map
+   for callers that expect map semantics."
+  (images/task-runner-images))
 
 (defn image-exists?
   "Check if a container image exists locally."
@@ -691,7 +691,7 @@
    Config:
    - :runtime-kind — :docker (default in Phase 1). :podman lands in Phase 2.
    - :executable   — explicit path to the runtime CLI binary
-   - :image        — container image for tasks (default: alpine:latest)
+   - :image        — container image for tasks (default from images.edn :default entry)
    - :network      — network name to attach to (legacy; execution-plan
                      network-profile takes precedence when present)"
   [config]
@@ -699,7 +699,7 @@
     (map->OciCliExecutor
      {:config     config
       :descriptor descriptor
-      :image      (get config :image default-image)
+      :image      (get config :image (images/default-image))
       :network    (:network config)})))
 
 (defn create-docker-executor
@@ -710,7 +710,7 @@
    `{:runtime-kind :docker}`.
 
    Config:
-   - :image       — container image for tasks (default: alpine:latest)
+   - :image       — container image for tasks (default from images.edn :default entry)
    - :network     — network to attach to
    - :docker-path — path to the docker binary (legacy alias for :executable)"
   [config]

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/images_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/images_test.clj
@@ -1,0 +1,72 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.protocols.impl.runtime.images-test
+  "Tests for the runtime image registry — EDN load, default lookup, and the
+   N11-delta §5 fully-qualified-reference invariant."
+  (:require
+   [clojure.string]
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.dag-executor.protocols.impl.runtime.images :as images]))
+
+(def ^:private fully-qualified-image-pattern
+  "Acceptable shape for default image references per N11-delta §5:
+   `<registry>/<repo>:<tag>` or `<registry>/<repo>@sha256:<digest>`.
+   The leading registry segment must contain a dot (e.g. `docker.io`)."
+  #"^[a-z0-9.-]+\.[a-z0-9.-]+/[^/]+(/[^/]+)*(:[^@:/]+|@sha256:[a-f0-9]{64})$")
+
+(deftest images-default-image-fully-qualified-test
+  (testing "default image reference is fully qualified per N11-delta §5"
+    (let [ref (images/default-image)]
+      (is (string? ref))
+      (is (re-matches fully-qualified-image-pattern ref)
+          (str "Default image is not fully qualified: " ref)))))
+
+(deftest images-task-runner-images-fully-qualified-test
+  (testing "every task-runner image reference is fully qualified"
+    (doseq [[k entry] (images/task-runner-images)]
+      (testing (str "image " k)
+        (is (re-matches fully-qualified-image-pattern (:image entry))
+            (str "Image " k " is not fully qualified: " (:image entry)))))))
+
+(deftest images-task-runner-images-excludes-default-test
+  (testing "task-runner-images returns only buildable runners (no :default)"
+    (let [keys (set (keys (images/task-runner-images)))]
+      (is (not (contains? keys :default)))
+      (is (contains? keys :minimal))
+      (is (contains? keys :clojure)))))
+
+(deftest images-image-lookup-test
+  (testing "image lookup returns the registered reference"
+    (is (clojure.string/includes? (images/image :minimal) "task-runner"))
+    (is (clojure.string/includes? (images/image :clojure) "task-runner-clojure"))
+    (is (nil? (images/image :unknown-image)))))
+
+(deftest images-dockerfile-lookup-test
+  (testing "dockerfile lookup returns the bundled resource path"
+    (is (clojure.string/ends-with? (images/dockerfile :minimal)
+                                   "Dockerfile.task-runner"))
+    (is (clojure.string/ends-with? (images/dockerfile :clojure)
+                                   "Dockerfile.task-runner-clojure"))
+    (is (nil? (images/dockerfile :default))
+        "Default entry has no Dockerfile — it is a base image, not a builder")))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.dag-executor.protocols.impl.runtime.images-test)
+  :leave-this-here)

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_test.clj
@@ -31,11 +31,19 @@
   (var-get (ns-resolve 'ai.miniforge.dag-executor.protocols.impl.runtime.oci-cli sym)))
 
 ;; Default descriptor used by tests that exercise CLI argument shaping
-;; rather than runtime selection. `make-descriptor` defaults to :docker
-;; which matches Phase 1 supported-kinds.
+;; rather than runtime selection. `make-descriptor` defaults to :docker.
 (defn- docker-descriptor
   ([] (descriptor/make-descriptor {}))
   ([opts] (descriptor/make-descriptor opts)))
+
+;; Phase 2: argument-construction tests run against every supported kind so
+;; a Podman regression in flag shaping shows up at unit-test time.
+(def ^:private supported-kinds-under-test
+  [:docker :podman])
+
+(defn- descriptor-for-kind
+  [kind]
+  (descriptor/make-descriptor {:runtime-kind kind}))
 
 ;; ============================================================================
 ;; descriptor — basic construction
@@ -57,13 +65,23 @@
     (let [d (descriptor/make-descriptor {:docker-path "/usr/bin/docker"})]
       (is (= "/usr/bin/docker" (descriptor/executable d))))))
 
-(deftest descriptor-rejects-podman-in-phase-1-test
-  (testing "make-descriptor throws :runtime/unsupported for :podman in Phase 1"
+(deftest descriptor-accepts-podman-test
+  (testing "make-descriptor builds a :podman descriptor in Phase 2"
+    (let [d (descriptor/make-descriptor {:runtime-kind :podman})]
+      (is (= :podman (descriptor/kind d)))
+      (is (= "podman" (descriptor/executable d)))
+      (is (descriptor/capable? d :rootless))
+      (is (descriptor/capable? d :oci-images)))))
+
+(deftest descriptor-rejects-nerdctl-as-unsupported-test
+  (testing "make-descriptor throws :runtime/unsupported for :nerdctl (Future)"
     (try
-      (descriptor/make-descriptor {:runtime-kind :podman})
+      (descriptor/make-descriptor {:runtime-kind :nerdctl})
       (is false "expected ex-info")
       (catch clojure.lang.ExceptionInfo e
-        (is (= :podman (-> e ex-data :runtime/unsupported)))))))
+        (is (= :nerdctl (-> e ex-data :runtime/unsupported)))
+        (is (contains? (-> e ex-data :runtime/supported-kinds) :docker))
+        (is (contains? (-> e ex-data :runtime/supported-kinds) :podman))))))
 
 (deftest descriptor-rejects-unknown-kind-test
   (testing "make-descriptor throws :runtime/unknown-kind for unknown kinds"
@@ -226,38 +244,39 @@
 ;; create-container --stop-timeout (N11 §2.2)
 ;; ============================================================================
 
+(defn- capture-create-container-args
+  "Run create-container with `oci-cli/run-runtime` stubbed and return the
+   captured argv. Keeps the parameterized stop-timeout tests focused on
+   the assertions rather than mock plumbing."
+  [descriptor & {:as create-opts}]
+  (let [captured-args (atom nil)
+        stub          (fn [_descriptor & args]
+                        (reset! captured-args (vec args))
+                        {:exit 0 :out "container-id-123\n" :err ""})]
+    (with-redefs [oci-cli/run-runtime stub]
+      (apply oci-cli/create-container
+             descriptor "test-ctr" "alpine" "/workspace" nil nil nil
+             (mapcat identity create-opts))
+      @captured-args)))
+
 (deftest create-container-stop-timeout-test
-  (testing "includes --stop-timeout when execution-plan has :time-limit-ms"
-    (let [captured-args (atom nil)]
-      (with-redefs [oci-cli/run-runtime (fn [_descriptor & args]
-                                          (reset! captured-args (vec args))
-                                          {:exit 0 :out "container-id-123\n" :err ""})]
-        (oci-cli/create-container (docker-descriptor) "test-ctr" "alpine"
-                                  "/workspace" nil nil nil
-                                  :execution-plan {:time-limit-ms 120000})
-        (let [args @captured-args]
+  (doseq [kind supported-kinds-under-test]
+    (testing (str "runtime " kind)
+      (testing "  includes --stop-timeout when execution-plan has :time-limit-ms"
+        (let [args (capture-create-container-args
+                    (descriptor-for-kind kind)
+                    :execution-plan {:time-limit-ms 120000})]
           (is (some #(= "--stop-timeout" %) args))
-          (is (some #(= "120" %) args))))))
+          (is (some #(= "120" %) args))))
 
-  (testing "omits --stop-timeout when no execution-plan"
-    (let [captured-args (atom nil)]
-      (with-redefs [oci-cli/run-runtime (fn [_descriptor & args]
-                                          (reset! captured-args (vec args))
-                                          {:exit 0 :out "container-id-123\n" :err ""})]
-        (oci-cli/create-container (docker-descriptor) "test-ctr" "alpine"
-                                  "/workspace" nil nil nil)
-        (let [args @captured-args]
-          (is (not (some #(= "--stop-timeout" %) args)))))))
+      (testing "  omits --stop-timeout when no execution-plan"
+        (let [args (capture-create-container-args (descriptor-for-kind kind))]
+          (is (not (some #(= "--stop-timeout" %) args)))))
 
-  (testing "enforces minimum 5s stop-timeout"
-    (let [captured-args (atom nil)]
-      (with-redefs [oci-cli/run-runtime (fn [_descriptor & args]
-                                          (reset! captured-args (vec args))
-                                          {:exit 0 :out "container-id-123\n" :err ""})]
-        (oci-cli/create-container (docker-descriptor) "test-ctr" "alpine"
-                                  "/workspace" nil nil nil
-                                  :execution-plan {:time-limit-ms 2000})
-        (let [args @captured-args]
+      (testing "  enforces minimum 5s stop-timeout"
+        (let [args (capture-create-container-args
+                    (descriptor-for-kind kind)
+                    :execution-plan {:time-limit-ms 2000})]
           (is (some #(= "5" %) args)))))))
 
 ;; ============================================================================
@@ -266,8 +285,11 @@
 
 (deftest executor-type-from-descriptor-test
   (testing "OciCliExecutor reports its descriptor's runtime kind"
-    (let [exec (oci-cli/create-docker-executor {:image "alpine:latest"})]
-      (is (= :docker (proto/executor-type exec))))))
+    (doseq [kind supported-kinds-under-test]
+      (testing (str "kind " kind)
+        (let [exec (oci-cli/create-oci-cli-executor
+                    {:runtime-kind kind :image "test:latest"})]
+          (is (= kind (proto/executor-type exec))))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/registry_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/registry_test.clj
@@ -30,11 +30,11 @@
       (is (contains? known :podman))
       (is (contains? known :nerdctl)))))
 
-(deftest registry-supported-kinds-phase-1-test
-  (testing "Phase 1 supports :docker only"
+(deftest registry-supported-kinds-phase-2-test
+  (testing "Phase 2 supports :docker and :podman; :nerdctl is future"
     (let [supported (registry/supported-kinds)]
       (is (contains? supported :docker))
-      (is (not (contains? supported :podman)))
+      (is (contains? supported :podman))
       (is (not (contains? supported :nerdctl))))))
 
 (deftest registry-known?-test
@@ -45,9 +45,9 @@
     (is (not (registry/known? :unknown-runtime)))))
 
 (deftest registry-supported?-test
-  (testing "supported? gates Phase 1 :docker only"
+  (testing "Phase 2: :docker and :podman supported; :nerdctl and unknowns not"
     (is (registry/supported? :docker))
-    (is (not (registry/supported? :podman)))
+    (is (registry/supported? :podman))
     (is (not (registry/supported? :nerdctl)))
     (is (not (registry/supported? :unknown-runtime)))))
 
@@ -62,15 +62,25 @@
   (testing "Docker advertises the OCI capability set; unknown kinds get empty"
     (is (contains? (registry/capabilities :docker) :oci-images))
     (is (contains? (registry/capabilities :docker) :graceful-stop))
-    (is (= #{} (registry/capabilities :unknown-runtime)))))
+    (is (= #{} (registry/capabilities :unknown-runtime))))
+
+  (testing "Podman matches Docker's OCI surface and adds :rootless"
+    (is (contains? (registry/capabilities :podman) :oci-images))
+    (is (contains? (registry/capabilities :podman) :tmpfs-uid-gid-options))
+    (is (contains? (registry/capabilities :podman) :rootless))
+    (is (not (contains? (registry/capabilities :docker) :rootless)))))
+
+(deftest registry-flag-podman-info-template-test
+  (testing "Podman declares its own :info-format-template (Podman info shape)"
+    (is (= "{{.Version.Version}}" (registry/flag :podman :info-format-template)))
+    (is (= "{{.ServerVersion}}" (registry/flag :docker :info-format-template)))))
 
 (deftest registry-flag-fallback-test
-  (testing "flag lookup falls back to the Docker dialect when the kind has no entry"
+  (testing "flag lookup falls back to the Docker dialect when the kind has no override"
     (let [docker-template (registry/flag :docker :info-format-template)]
       (is (some? docker-template))
-      ;; Phase 1 has empty flags for podman/nerdctl; lookups fall back to Docker
-      ;; so existing call sites keep working until Phase 2 declares overrides.
-      (is (= docker-template (registry/flag :podman :info-format-template)))
+      ;; :nerdctl has empty :flags so it inherits from Docker. :podman now
+      ;; declares its own override, so it does NOT fall back.
       (is (= docker-template (registry/flag :nerdctl :info-format-template))))))
 
 (deftest registry-default-test
@@ -81,21 +91,30 @@
     (is (= 0.5 (registry/default :docker :cpu)))
     (is (= "512m" (registry/default :docker :tmpfs-size))))
 
-  (testing "default lookup falls back to Docker for kinds with no override"
+  (testing "Podman declares its own defaults (matching Docker's values today)"
     (is (= 1000 (registry/default :podman :uid)))
+    (is (= 1000 (registry/default :podman :gid)))
+    (is (= "512m" (registry/default :podman :memory)))
+    (is (= 0.5 (registry/default :podman :cpu)))
+    (is (= "512m" (registry/default :podman :tmpfs-size))))
+
+  (testing "default lookup falls back to Docker for kinds with no override"
     (is (= "512m" (registry/default :nerdctl :memory)))))
 
 (deftest registry-user-spec-test
   (testing "user-spec stitches uid:gid from the registry defaults"
-    (is (= "1000:1000" (registry/user-spec :docker)))))
+    (is (= "1000:1000" (registry/user-spec :docker)))
+    (is (= "1000:1000" (registry/user-spec :podman)))))
 
 (deftest registry-tmpfs-mount-options-test
   (testing "tmpfs-mount-options builds the comma-separated string from defaults"
-    (let [opts (registry/tmpfs-mount-options :docker)]
-      (is (clojure.string/includes? opts "size=512m"))
-      (is (clojure.string/includes? opts "uid=1000"))
-      (is (clojure.string/includes? opts "gid=1000"))
-      (is (clojure.string/includes? opts "rw,nosuid,nodev,exec")))))
+    (doseq [kind [:docker :podman]]
+      (testing (str "kind " kind)
+        (let [opts (registry/tmpfs-mount-options kind)]
+          (is (clojure.string/includes? opts "size=512m"))
+          (is (clojure.string/includes? opts "uid=1000"))
+          (is (clojure.string/includes? opts "gid=1000"))
+          (is (clojure.string/includes? opts "rw,nosuid,nodev,exec")))))))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md
+++ b/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md
@@ -1,0 +1,190 @@
+# feat(dag-executor): runtime adapter Phase 2 — Podman as a supported runtime
+
+## Overview
+
+Phase 2 of the four-phase runtime-adapter implementation plan from
+[N11-delta](../../specs/normative/N11-delta-runtime-adapter.md) and the
+[runtime-adapter-plan](../design/runtime-adapter-plan.md). Podman becomes
+a fully supported runtime kind. Selection still requires explicit
+`:miniforge/runtime/kind :podman` configuration; the auto-probe / default
+flip is Phase 3.
+
+This PR is a registry change plus the surrounding tests and docs. No new
+code paths in `oci_cli.clj` — the parameterization landed in Phase 1, so
+Podman support is data-driven.
+
+## Motivation
+
+Phase 1 left Podman behind a `:runtime/unsupported` error gate. The plan's
+Phase 2 step is to flip `:supported?` for Podman in the registry, declare
+its capability set + container defaults + flag dialect, and parameterize
+the existing argument-construction tests over both kinds so a Podman flag
+regression shows up at unit-test time.
+
+Per N11-delta §5, default OCI image references must be **fully qualified**
+to avoid Podman's interactive short-name resolution prompt on first run.
+This PR also pulls image references out of `oci_cli.clj` into a new
+`runtime/images.edn` config and fully-qualifies them.
+
+## Changes In Detail
+
+### 1. `runtime/registry.edn` — Podman flipped to supported
+
+The `:podman` entry now has:
+
+- `:supported? true` — `make-descriptor` accepts `:runtime-kind :podman`.
+- `:capabilities` — same OCI surface as Docker, plus `:rootless`.
+- `:defaults` — `:uid` / `:gid` `1000`, `:memory "512m"`, `:cpu 0.5`,
+  `:tmpfs-size "512m"`. Identical to Docker today; Phase 3 (auto-probe)
+  can revisit per host.
+- `:flags` — `:info-format-template "{{.Version.Version}}"`. Podman's
+  `info` structure differs from Docker's: server version lives under
+  `.Version.Version` rather than top-level `.ServerVersion`. The dialect
+  fallback in `registry/flag` would have given Podman the Docker template,
+  which would silently produce `{{.ServerVersion}}` parse errors against
+  the Podman info shape — declaring the override prevents that.
+
+`:nerdctl` stays `:supported? false` (Future per the conformance matrix).
+
+### 2. `runtime/images.edn` (new) + `runtime/images.clj` (new)
+
+Default OCI image references are now data, not code. Three entries:
+
+- `:default` — `docker.io/library/alpine:latest`, used when an executor
+  config omits `:image`.
+- `:minimal` — `docker.io/miniforge/task-runner:latest`.
+- `:clojure` — `docker.io/miniforge/task-runner-clojure:latest`.
+
+All references are fully qualified (registry + repo + tag). Pinned
+`@sha256:` digests are a follow-up — the EDN structure is ready for them
+the moment the images get pushed with stable digests.
+
+`runtime/images.clj` loads the EDN once at namespace init and exposes
+`default-image`, `task-runner-images` (excludes `:default`), `image`,
+`dockerfile`, and `entry` accessors. Pattern mirrors `runtime/registry.clj`.
+
+### 3. `runtime/oci_cli.clj` — consume images namespace
+
+- Removed the top-level `default-image` constant; `create-oci-cli-executor`
+  now reads from `images/default-image`.
+- `task-runner-images` is now a `def` bound to `(images/task-runner-images)`
+  at namespace load. Map semantics preserved for callers.
+- Namespace docstring updated to describe Phase 2 state and the
+  data-driven extension model.
+
+### 4. `runtime/descriptor.clj` — error-message factories
+
+- `format-kind-set` helper renders a set of kind keywords as a stable
+  human-readable string (`:docker, :podman` rather than the raw set's
+  printed form). Used by both error factories.
+- `unsupported-kind-error` interpolates the live `supported-kinds` set
+  into the message — no more "Phase 1 ships :docker only" copy that goes
+  stale with each phase.
+- `unknown-kind-error` likewise interpolates `known-kinds` via
+  `format-kind-set`.
+
+### 5. Localized message update
+
+`config/dag-executor/runtime/messages/en-US.edn`:
+
+```edn
+:descriptor/unsupported-kind
+"Runtime kind {kind} is not yet supported. Supported runtimes: {supported}."
+```
+
+The `{supported}` placeholder is filled by the live `supported-kinds`
+set from the registry.
+
+### 6. Tests
+
+- **`oci_cli_test.clj`**:
+  - `descriptor-rejects-podman-in-phase-1-test` removed.
+  - `descriptor-accepts-podman-test` added — verifies the Podman
+    descriptor is constructible, reports `:podman`, names `"podman"` as
+    its executable, and advertises `:rootless` + `:oci-images`.
+  - `descriptor-rejects-nerdctl-as-unsupported-test` added — :nerdctl
+    is now the future-kind that exercises the unsupported error path.
+    Also asserts that the error data carries the live `supported-kinds`
+    set (containing both `:docker` and `:podman`).
+  - `create-container-stop-timeout-test` parameterized over `[:docker
+    :podman]` via a `doseq`; uses a new `capture-create-container-args`
+    helper to keep the assertions focused on flag shape.
+  - `executor-type-from-descriptor-test` parameterized similarly.
+
+- **`registry_test.clj`**:
+  - `registry-supported-kinds-phase-1-test` → `…-phase-2-test` (now
+    expects `:docker` and `:podman` in the supported set).
+  - `registry-supported?-test` updated for Phase 2 expectations.
+  - `registry-capabilities-test` extended — Podman matches Docker's OCI
+    surface and adds `:rootless`. The negative assertion confirms Docker
+    does not advertise `:rootless`, which is correct.
+  - New `registry-flag-podman-info-template-test` — pins the
+    Podman-specific template (`{{.Version.Version}}`) and the Docker
+    template (`{{.ServerVersion}}`). Catches regressions where one
+    accidentally falls back to the other.
+  - `registry-flag-fallback-test` updated — `:podman` no longer falls
+    back to Docker for `:info-format-template` (it has its own override);
+    `:nerdctl` still does.
+  - `registry-default-test` extended with explicit Podman assertions.
+  - `registry-tmpfs-mount-options-test` parameterized over both kinds.
+
+- **`images_test.clj`** (new):
+  - Default image and every task-runner image pass a regex that requires
+    fully-qualified `<registry>/<repo>:<tag>` or `@sha256:` form per
+    N11-delta §5. This test is the unit-level enforcement of the spec
+    invariant.
+  - `task-runner-images` excludes `:default` (it is a base image, not a
+    builder).
+  - `image` and `dockerfile` lookups behave per the EDN.
+
+## What this PR does NOT change
+
+- Auto-probe / selection algorithm / default flip — that is Phase 3.
+- `mf doctor` and `mf runtime` CLI surface — Phase 3.
+- `bb install:podman` and bb-platform integration — Phase 4.
+- Standards-pack runtime policies (no-host-docker-socket, require-rootless,
+  etc.) — Phase 4.
+- `kubernetes.clj`, `worktree.clj`, `protocols/executor.clj` — untouched.
+
+## Files
+
+- `components/dag-executor/resources/config/dag-executor/runtime/registry.edn` — Podman entry filled in
+- `components/dag-executor/resources/config/dag-executor/runtime/messages/en-US.edn` — unsupported-kind message
+  generalized
+- `components/dag-executor/resources/config/dag-executor/runtime/images.edn` — new (default image references, fully
+  qualified)
+- `components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/images.clj` — new
+- `components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/descriptor.clj` — `format-kind-set`
+  helper, error factories interpolate live registry sets
+- `components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli.clj` — consume images namespace,
+  namespace docstring updated
+- `components/dag-executor/src/ai/miniforge/dag_executor/executor.clj` — docstring updates for the public re-exports
+- `components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/oci_cli_test.clj` — Phase 2 descriptor
+  tests, parameterized argument tests
+- `components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/registry_test.clj` — Phase 2
+  supported-set + Podman capability/flag/default tests
+- `components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/images_test.clj` — new
+  (fully-qualified-reference invariant)
+
+## Verification
+
+- New runtime suite (oci_cli + registry + images): 37 tests, 106
+  assertions, 0 failures, 0 errors.
+- Full `bb test`: 2935 tests, 10919 passes, 0 failures, 0 errors.
+- `bb test:integration`: 0 failures, 0 errors.
+
+## Open follow-ups
+
+- **Pin default images to digests.** `docker.io/miniforge/task-runner-clojure@sha256:...`
+  is the spec-preferred form. The EDN entries are tag-based today; once
+  images are published with stable digests, swapping `:latest` → `@sha256:...`
+  is a one-line per-entry edit. The `images_test.clj` regex already accepts
+  both forms.
+- **Phase 3** — auto-probe + `mf doctor` + `mf runtime` CLI.
+
+## Cross-references
+
+- Spec: [N11-delta-runtime-adapter](../../specs/normative/N11-delta-runtime-adapter.md)
+- Plan: [runtime-adapter-plan](../design/runtime-adapter-plan.md)
+- Phase 1: [#694](https://github.com/miniforge-ai/miniforge/pull/694),
+  [#701](https://github.com/miniforge-ai/miniforge/pull/701)


### PR DESCRIPTION
## Summary

- N11-delta Phase 2: flip `:supported?` for Podman in the runtime registry, declare its capability set + container defaults + flag dialect. Selection still requires explicit `:runtime-kind :podman`; auto-probe + default flip are Phase 3.
- Image references pulled to a new `runtime/images.edn` (configuration as data) and fully-qualified per N11-delta §5 to avoid Podman's interactive short-name resolution prompt.
- Error messages now interpolate live registry sets via a `format-kind-set` helper — no more "Phase 1 ships :docker only" copy that goes stale every phase.
- Argument-construction tests parameterized over `[:docker :podman]` so a Podman regression in flag shaping shows up at unit-test time.
- New `images_test.clj` enforces the fully-qualified-reference invariant via regex against every default and task-runner image.

Full breakdown: [`docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md`](docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md).

## Phase 2 surface — kept tight

No new code paths in `oci_cli.clj` — the parameterization landed in Phase 1, so Podman support is data-driven. The diff is mostly EDN edits, two new namespaces (`images.clj` + its test), and the test parameterization.

## Test plan

- [x] Runtime suite (oci_cli + registry + images): 37 tests, 106 assertions, 0 failures, 0 errors.
- [x] Full `bb test`: 2935 tests, 10919 passes, 0 failures, 0 errors.
- [x] `bb test:integration`: clean.
- [ ] Reviewer confirms `{{.Version.Version}}` is the right Podman info-template (vs Docker's `{{.ServerVersion}}`).
- [ ] Reviewer confirms `:rootless` is the right capability tier for Podman in the absence of an actual rootless-mode probe — this is a static declaration today; Phase 3's doctor will verify it dynamically.

## Open follow-ups

- **Pin default images to digests.** Tags today; `@sha256:` is the spec-preferred form. The `images_test.clj` regex already accepts both, so swapping is a per-entry edit when stable digests are published.
- **Phase 3** — auto-probe + `mf doctor` + `mf runtime` CLI; default flip on Podman-equipped hosts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)