### PR TITLE
feat: runtime adapter Phase 3 — auto-probe, doctor, mf runtime CLI

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -97,6 +97,21 @@
    ["claude" "Claude CLI" "Required for LLM backend"]]
   :doctor/config-exists "Config file exists at {config-path}"
   :doctor/no-config "No config file. Run '{command}'"
+
+  ;; Runtime adapter (N11-delta Phase 3)
+  :runtime/doctor-section-title "Container runtime"
+  :runtime/doctor-line "Runtime: {kind} {runtime-version} (selected by {selection})"
+  :runtime/doctor-error-line "No usable container runtime: {code} — {message}"
+  :runtime/doctor-probed-line "Probed: {probed}"
+  :runtime/doctor-override-hint "Override with :runtime-kind in config or {env-var}=docker|podman"
+  :runtime/probed-available "{kind} ({runtime-version})"
+  :runtime/probed-unavailable "{kind} — {reason}"
+  :runtime/info-kind "Runtime:        {kind}"
+  :runtime/info-executable "Executable:     {executable}"
+  :runtime/info-runtime-version "Version:        {runtime-version}"
+  :runtime/info-selection "Selected by:    {selection}"
+  :runtime/info-probed "Probed:         {probed}"
+  :runtime/error-no-runtime "No usable container runtime: {code} — {message}"
   :status/workflow "Status for workflow: {workflow-id}"
   :status/workflow-todo "TODO: Query workflow component"
   :status/all-workflows "All workflows:"

--- a/bases/cli/src/ai/miniforge/cli/main.clj
+++ b/bases/cli/src/ai/miniforge/cli/main.clj
@@ -58,6 +58,7 @@
    [ai.miniforge.cli.main.commands.scan :as cmd-scan]
    [ai.miniforge.cli.main.commands.init :as cmd-init]
    [ai.miniforge.cli.main.commands.worktree :as cmd-worktree]
+   [ai.miniforge.cli.main.commands.runtime :as cmd-runtime]
    ;; N5 command modules
    [ai.miniforge.cli.main.commands.workflow-commands :as cmd-workflow]
    [ai.miniforge.cli.main.commands.policy :as cmd-policy]
@@ -174,6 +175,12 @@
 
     (println)
 
+    ;; Container runtime (N11-delta Phase 3)
+    (println (display/style (messages/t :runtime/doctor-section-title)
+                            :foreground :cyan :bold true))
+    (cmd-runtime/print-doctor-runtime-section)
+    (println)
+
     ;; Check config
     (if (fs/exists? config/default-user-config-path)
       (println (display/style "✓" :foreground :green)
@@ -288,6 +295,8 @@
 (defn scan-cmd [m] (cmd-scan/scan-cmd (get-opts m)))
 (defn init-cmd [m] (cmd-init/init-cmd (get-opts m)))
 (defn worktree-cmd [m] (cmd-worktree/worktree-cmd m))
+(defn runtime-info-cmd [m] (cmd-runtime/runtime-info-cmd m))
+(defn runtime-run-cmd [m] (cmd-runtime/runtime-run-cmd m))
 (defn web-cmd [m] (cmd-monitoring/web-cmd (get-opts m)))
 (defn tui-cmd [m] (cmd-monitoring/tui-cmd (get-opts m)))
 (defn fleet-start-cmd [m] (cmd-fleet/fleet-start-cmd (get-opts m)))
@@ -427,6 +436,11 @@
    {:cmds ["worktree"]
     :fn worktree-cmd
     :spec {:path {:alias :p}}}
+
+   ;; Runtime adapter (N11-delta Phase 3) — info / pass-through run
+   {:cmds ["runtime"]      :fn help-cmd}
+   {:cmds ["runtime" "info"] :fn runtime-info-cmd}
+   {:cmds ["runtime" "run"]  :fn runtime-run-cmd}
 
    ;; Scan command — compliance scanner
    {:cmds ["scan"]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/runtime.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/runtime.clj
@@ -1,0 +1,166 @@
+;; Title: Miniforge.ai
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;; Licensed under the Apache License, Version 2.0
+
+(ns ai.miniforge.cli.main.commands.runtime
+  "`mf runtime` subcommands — info / run.
+
+   Phase 3 of N11-delta. Exposes the runtime adapter to end users:
+   - `mf runtime info` — print the resolved runtime descriptor as data.
+   - `mf runtime run -- <args>` — pass-through to the resolved runtime CLI.
+
+   The selection algorithm (explicit config first, then probe order
+   `[:podman :docker :nerdctl]`, then unavailable) lives in
+   `dag-executor.protocols.impl.runtime.selector`. This namespace owns the
+   user-facing rendering."
+  (:require
+   [babashka.process :as process]
+   [clojure.pprint :as pprint]
+   [clojure.string :as str]
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]
+   [ai.miniforge.dag-executor.interface :as dag]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Config sourcing
+
+(def ^:private runtime-env-var
+  "MINIFORGE_RUNTIME environment variable — overrides file config per
+   N11-delta §2.1."
+  "MINIFORGE_RUNTIME")
+
+(defn- env-runtime-kind
+  "Read MINIFORGE_RUNTIME from the environment and coerce to a keyword.
+   Returns nil when unset or blank."
+  []
+  (some-> (System/getenv runtime-env-var) str/trim not-empty keyword))
+
+(defn- selection-config
+  "Build the config map passed to the selector. Today the only source is
+   the env var; file config integration is a separate concern that layers
+   on without changing the selector contract."
+  []
+  (cond-> {}
+    (env-runtime-kind) (assoc :runtime-kind (env-runtime-kind))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Render helpers
+
+(defn- format-probed-kind
+  "Render one entry from the auto-probe :probed list — '<kind> (<version>)'
+   for available kinds, '<kind> — <reason>' for unavailable."
+  [{:keys [kind available? runtime-version reason]}]
+  (if available?
+    (messages/t :runtime/probed-available
+                {:kind            (name kind)
+                 :runtime-version (or runtime-version "?")})
+    (messages/t :runtime/probed-unavailable
+                {:kind   (name kind)
+                 :reason (or reason "")})))
+
+(defn- format-probed-list
+  [probed]
+  (when (seq probed)
+    (str/join ", " (map format-probed-kind probed))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; `mf runtime info`
+
+(defn- print-info-success
+  "Render a successful selection as human-readable lines plus the raw
+   descriptor as EDN at the end (so `mf runtime info` is grep-able and
+   programmable)."
+  [{:keys [descriptor kind selection runtime-version probed]}]
+  (println (messages/t :runtime/info-kind             {:kind (name kind)}))
+  (println (messages/t :runtime/info-executable       {:executable (dag/runtime-executable descriptor)}))
+  (println (messages/t :runtime/info-runtime-version  {:runtime-version (or runtime-version "?")}))
+  (println (messages/t :runtime/info-selection        {:selection (name selection)}))
+  (when (seq probed)
+    (println (messages/t :runtime/info-probed         {:probed (format-probed-list probed)})))
+  (println)
+  (pprint/pprint descriptor))
+
+(defn- print-info-error
+  [error]
+  (display/print-error
+   (messages/t :runtime/error-no-runtime
+               {:code    (some-> (:code error) name)
+                :message (:message error)})))
+
+(defn runtime-info-cmd
+  "Resolve the runtime per N11-delta §3 and print the result. Used both
+   from `mf runtime info` and from the doctor."
+  [_m]
+  (let [result (dag/select-runtime (selection-config))]
+    (if (dag/ok? result)
+      (print-info-success (:data result))
+      (print-info-error (:error result)))))
+
+;------------------------------------------------------------------------------ Layer 3
+;; `mf runtime run -- <args>`
+
+(defn- forward-args
+  "Pull the args list off the babashka.cli dispatch map and strip a
+   leading `--` separator if present. Matches the convention used by
+   `mf worktree run -- <cmd>`."
+  [m]
+  (->> (get m :args [])
+       (remove #{"--"})
+       vec))
+
+(defn runtime-run-cmd
+  "Resolve the runtime, then exec `<resolved-exe> <args>`. Args after
+   `--` are forwarded verbatim. Exit code propagates.
+
+   This pass-through is for ad-hoc use (`mf runtime run --rm hello-world`).
+   The workflow engine builds its own argv via the OCI-CLI executor; it
+   does NOT shell through this command."
+  [m]
+  (let [result (dag/select-runtime (selection-config))]
+    (if (dag/err? result)
+      (do (print-info-error (:error result))
+          (System/exit 1))
+      (let [{:keys [descriptor]} (:data result)
+            exe                  (dag/runtime-executable descriptor)
+            args                 (forward-args m)
+            proc                 (process/process (into [exe] args)
+                                                  {:inherit true})
+            exit                 (-> proc deref :exit)]
+        (when (and (number? exit) (not (zero? exit)))
+          (System/exit exit))))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Doctor integration
+
+(defn- format-runtime-line
+  "One-line summary for the doctor. Uses display/style for color."
+  [{:keys [kind selection runtime-version]}]
+  (str (display/style "✓" :foreground :green) " "
+       (messages/t :runtime/doctor-line
+                   {:kind            (name kind)
+                    :runtime-version (or runtime-version "?")
+                    :selection       (name selection)})))
+
+(defn- print-runtime-error-line
+  [error]
+  (println (display/style "✗" :foreground :red) " "
+           (messages/t :runtime/doctor-error-line
+                       {:code    (some-> (:code error) name)
+                        :message (:message error)})))
+
+(defn print-doctor-runtime-section
+  "Emit the runtime block of `mf doctor`. Picked up by main.clj's
+   doctor-cmd."
+  []
+  (let [result (dag/select-runtime (selection-config))]
+    (if (dag/ok? result)
+      (let [data (:data result)]
+        (println (format-runtime-line data))
+        (when-let [probed-str (format-probed-list (:probed data))]
+          (println "  " (messages/t :runtime/doctor-probed-line
+                                    {:probed probed-str})))
+        (println "  " (messages/t :runtime/doctor-override-hint
+                                  {:env-var runtime-env-var})))
+      (do (print-runtime-error-line (:error result))
+          (println "  " (messages/t :runtime/doctor-override-hint
+                                    {:env-var runtime-env-var}))))))

--- a/components/dag-executor/src/ai/miniforge/dag_executor/interface.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/interface.clj
@@ -34,7 +34,10 @@
    [ai.miniforge.dag-executor.state :as state]
    [ai.miniforge.dag-executor.parallel :as parallel]
    [ai.miniforge.dag-executor.scheduler :as scheduler]
-   [ai.miniforge.dag-executor.executor :as executor]))
+   [ai.miniforge.dag-executor.executor :as executor]
+   [ai.miniforge.dag-executor.protocols.impl.runtime.descriptor :as descriptor]
+   [ai.miniforge.dag-executor.protocols.impl.runtime.registry :as registry]
+   [ai.miniforge.dag-executor.protocols.impl.runtime.selector :as selector]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Result helpers (re-exports)
@@ -481,6 +484,55 @@
 (def task-runner-images
   "Pre-defined task runner images (:minimal :clojure)."
   executor/task-runner-images)
+
+;------------------------------------------------------------------------------ Layer 6.5
+;; Runtime adapter (N11-delta) — descriptor / registry / selection
+
+(def select-runtime
+  "Resolve a runtime descriptor from config + host state per N11-delta §3.
+
+   Returns a result map. On success, :data carries:
+     {:descriptor       <runtime descriptor>
+      :kind             <:docker | :podman | ...>
+      :selection        :explicit | :auto-probe
+      :runtime-version  <string>
+      :probed           [<per-kind summary>] (auto-probe only)}
+
+   On failure, :error :code is one of:
+     :runtime/explicit-unsupported   (the named kind is not :supported?)
+     :runtime/explicit-unavailable   (named kind probe failed)
+     :runtime/none-available         (auto-probe found nothing)"
+  selector/select-runtime)
+
+(def runtime-probe-order
+  "Auto-probe order applied when :runtime-kind is not configured."
+  selector/probe-order)
+
+(defn runtime-known-kinds
+  "Set of all runtime kinds the registry knows about."
+  []
+  (registry/known-kinds))
+
+(defn runtime-supported-kinds
+  "Set of runtime kinds the executor can construct a working descriptor for."
+  []
+  (registry/supported-kinds))
+
+(defn runtime-info
+  "Probe a descriptor for availability and version. Returns
+   {:available? bool :runtime-version str | :reason str}."
+  [descriptor]
+  (descriptor/runtime-info descriptor))
+
+(defn runtime-executable
+  "Return the resolved CLI binary for a descriptor."
+  [descriptor]
+  (descriptor/executable descriptor))
+
+(defn runtime-kind
+  "Return the runtime kind keyword for a descriptor."
+  [descriptor]
+  (descriptor/kind descriptor))
 
 ;------------------------------------------------------------------------------ Layer 7
 ;; Convenience functions

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/selector.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/selector.clj
@@ -1,0 +1,148 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.protocols.impl.runtime.selector
+  "Resolve a runtime descriptor from config + host state.
+
+   Implements N11-delta §3 selection algorithm:
+     1. Explicit `:runtime-kind` in config wins. Probe the runtime; if the
+        probe fails, return an error. NEVER silently fall back when the
+        user named a specific runtime — surfacing that the named runtime
+        is missing is the whole point of allowing explicit configuration.
+     2. No explicit kind: probe `probe-order` in sequence. First whose
+        runtime-info probe returns `:available? true` is selected. The
+        full probed list is returned alongside so the doctor can show the
+        user every runtime it tried.
+     3. Nothing available: return an error with the probed list. Callers
+        can fall through to a non-OCI executor (e.g. worktree) if their
+        contract allows."
+  (:require
+   [ai.miniforge.dag-executor.protocols.impl.runtime.descriptor :as descriptor]
+   [ai.miniforge.dag-executor.protocols.impl.runtime.registry :as registry]
+   [ai.miniforge.dag-executor.result :as result]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Constants
+
+(def probe-order
+  "Auto-probe order. Podman first as the OSS-preferred default per
+   N11-delta; Docker second for compatibility; nerdctl is :supported?
+   false today and is filtered out at probe time."
+  [:podman :docker :nerdctl])
+
+;------------------------------------------------------------------------------ Layer 1
+;; Probe — single-kind helper used by both explicit and auto paths
+
+(defn- probe-kind!
+  "Build a descriptor for `kind` and run the runtime-info probe. Returns
+   {:kind :descriptor :probe-result} so callers can surface every part
+   (the descriptor for the chosen runtime, the probe-result for the
+   doctor's per-kind report)."
+  [kind]
+  (let [d            (descriptor/make-descriptor {:runtime-kind kind})
+        probe-result (descriptor/runtime-info d)]
+    {:kind         kind
+     :descriptor   d
+     :probe-result probe-result}))
+
+(defn- probe-summary
+  "Compact map describing a single probe outcome — the shape the doctor
+   command renders. Strips the descriptor itself so logs/output stay
+   small; callers that need the descriptor get it from the chosen entry."
+  [{:keys [kind probe-result]}]
+  {:kind            kind
+   :available?      (boolean (:available? probe-result))
+   :runtime-version (:runtime-version probe-result)
+   :reason          (:reason probe-result)})
+
+;------------------------------------------------------------------------------ Layer 2
+;; Selection
+
+(defn- select-explicit
+  "Resolve an explicit :runtime-kind. Fails loudly when the named runtime
+   is unsupported or when its probe fails — never falls back."
+  [kind]
+  (if-not (registry/supported? kind)
+    (result/err :runtime/explicit-unsupported
+                (str "Runtime kind " kind " is not supported.")
+                {:kind      kind
+                 :supported (registry/supported-kinds)})
+    (let [{:keys [descriptor probe-result]} (probe-kind! kind)]
+      (if (:available? probe-result)
+        (result/ok {:descriptor      descriptor
+                    :kind            kind
+                    :selection       :explicit
+                    :runtime-version (:runtime-version probe-result)})
+        (result/err :runtime/explicit-unavailable
+                    (str "Runtime " kind " is configured but unavailable.")
+                    {:kind   kind
+                     :reason (:reason probe-result)})))))
+
+(defn- supported-probe-order
+  "probe-order filtered to runtimes the registry currently supports.
+   Phase 3 ships [:podman :docker]; nerdctl is filtered out until Phase 4+."
+  []
+  (filterv registry/supported? probe-order))
+
+(defn- run-auto-probe
+  "Walk the supported probe-order, building a per-kind summary list.
+   Returns {:probed [...] :winner {...|nil}} where :winner is the first
+   summary with :available? true plus the descriptor."
+  []
+  (let [probes  (mapv probe-kind! (supported-probe-order))
+        probed  (mapv probe-summary probes)
+        winner  (some (fn [{:keys [probe-result] :as p}]
+                        (when (:available? probe-result) p))
+                      probes)]
+    {:probed probed :winner winner}))
+
+(defn- select-auto
+  "Auto-probe selection per N11-delta §3 step 2."
+  []
+  (let [{:keys [probed winner]} (run-auto-probe)]
+    (if winner
+      (result/ok {:descriptor      (:descriptor winner)
+                  :kind            (:kind winner)
+                  :selection       :auto-probe
+                  :runtime-version (:runtime-version (:probe-result winner))
+                  :probed          probed})
+      (result/err :runtime/none-available
+                  "No OCI-compatible container runtime is available."
+                  {:probed probed}))))
+
+(defn select-runtime
+  "Resolve a runtime descriptor from `config`.
+
+   Returns a result map. On success, `:data` carries:
+     {:descriptor       <runtime descriptor>
+      :kind             <runtime kind keyword>
+      :selection        :explicit | :auto-probe
+      :runtime-version  <string>
+      :probed           [<per-kind summary>]   ; auto-probe only}
+
+   Errors:
+     :runtime/explicit-unsupported   — explicit kind is not :supported?
+     :runtime/explicit-unavailable   — explicit kind probe failed
+     :runtime/none-available         — auto-probe found nothing usable
+
+   Callers SHOULD render the error data via i18n; this function returns
+   data, not strings, so the doctor and the CLI can localize."
+  [config]
+  (if-let [kind (:runtime-kind config)]
+    (select-explicit kind)
+    (select-auto)))

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/selector_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/selector_test.clj
@@ -1,0 +1,133 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.dag-executor.protocols.impl.runtime.selector-test
+  "Tests for the runtime selector — N11-delta §3 selection algorithm."
+  (:require
+   [clojure.test :refer [deftest is testing]]
+   [ai.miniforge.dag-executor.protocols.impl.runtime.descriptor :as descriptor]
+   [ai.miniforge.dag-executor.protocols.impl.runtime.selector :as selector]
+   [ai.miniforge.dag-executor.result :as result]))
+
+;; Per-kind probe stub. Tests pass a map of kind -> probe-result and stub
+;; descriptor/runtime-info to look up by descriptor kind.
+(defn- stub-runtime-info
+  [kind->result]
+  (fn [d]
+    (get kind->result (descriptor/kind d)
+         {:available? false :reason "not stubbed"})))
+
+(def ^:private all-available
+  {:docker {:available? true :runtime-version "28.0.4"}
+   :podman {:available? true :runtime-version "5.4.0"}})
+
+(def ^:private only-docker
+  {:docker {:available? true :runtime-version "28.0.4"}
+   :podman {:available? false :reason "podman not installed"}})
+
+(def ^:private only-podman
+  {:docker {:available? false :reason "Cannot connect to docker daemon"}
+   :podman {:available? true :runtime-version "5.4.0"}})
+
+(def ^:private nothing-available
+  {:docker {:available? false :reason "Cannot connect to docker daemon"}
+   :podman {:available? false :reason "podman not installed"}})
+
+;; ============================================================================
+;; Auto-probe — N11-delta §3 step 2
+;; ============================================================================
+
+(deftest auto-probe-prefers-podman-when-both-available-test
+  (testing "auto-probe selects Podman when both Podman and Docker are available"
+    (with-redefs [descriptor/runtime-info (stub-runtime-info all-available)]
+      (let [result (selector/select-runtime {})]
+        (is (result/ok? result))
+        (is (= :podman (-> result :data :kind)))
+        (is (= :auto-probe (-> result :data :selection)))
+        (is (= "5.4.0" (-> result :data :runtime-version)))))))
+
+(deftest auto-probe-falls-through-to-docker-test
+  (testing "auto-probe selects Docker when Podman is not available"
+    (with-redefs [descriptor/runtime-info (stub-runtime-info only-docker)]
+      (let [result (selector/select-runtime {})]
+        (is (result/ok? result))
+        (is (= :docker (-> result :data :kind)))
+        (is (= "28.0.4" (-> result :data :runtime-version)))))))
+
+(deftest auto-probe-selects-podman-when-only-podman-test
+  (testing "auto-probe selects Podman when only Podman is available"
+    (with-redefs [descriptor/runtime-info (stub-runtime-info only-podman)]
+      (let [result (selector/select-runtime {})]
+        (is (result/ok? result))
+        (is (= :podman (-> result :data :kind)))))))
+
+(deftest auto-probe-reports-every-kind-it-tried-test
+  (testing "auto-probe :probed list contains a summary for every supported kind"
+    (with-redefs [descriptor/runtime-info (stub-runtime-info all-available)]
+      (let [probed (-> (selector/select-runtime {}) :data :probed)
+            kinds  (set (map :kind probed))]
+        (is (contains? kinds :docker))
+        (is (contains? kinds :podman))
+        ;; Each summary names its availability so the doctor can render
+        ;; "available: x, y" / "unavailable: z" without re-probing.
+        (is (every? #(contains? % :available?) probed))))))
+
+(deftest auto-probe-fails-loud-when-nothing-available-test
+  (testing "auto-probe returns :runtime/none-available when no runtime probes"
+    (with-redefs [descriptor/runtime-info (stub-runtime-info nothing-available)]
+      (let [result (selector/select-runtime {})]
+        (is (result/err? result))
+        (is (= :runtime/none-available (-> result :error :code)))
+        (is (seq (-> result :error :data :probed)))))))
+
+;; ============================================================================
+;; Explicit configuration — N11-delta §3 step 1
+;; ============================================================================
+
+(deftest explicit-kind-overrides-probe-order-test
+  (testing "explicit :runtime-kind :docker selects Docker even when Podman is available"
+    (with-redefs [descriptor/runtime-info (stub-runtime-info all-available)]
+      (let [result (selector/select-runtime {:runtime-kind :docker})]
+        (is (result/ok? result))
+        (is (= :docker (-> result :data :kind)))
+        (is (= :explicit (-> result :data :selection)))))))
+
+(deftest explicit-kind-fails-loud-when-unavailable-test
+  (testing "explicit :runtime-kind :docker fails loud when Docker is unavailable"
+    (with-redefs [descriptor/runtime-info (stub-runtime-info only-podman)]
+      (let [result (selector/select-runtime {:runtime-kind :docker})]
+        (is (result/err? result))
+        (is (= :runtime/explicit-unavailable (-> result :error :code)))
+        (is (= :docker (-> result :error :data :kind)))
+        ;; The whole point of explicit config is honoring the user's
+        ;; choice; falling through to Podman would defeat that.
+        (is (not (contains? (:error result) :descriptor)))))))
+
+(deftest explicit-kind-rejects-unsupported-kind-test
+  (testing "explicit :runtime-kind :nerdctl returns :runtime/explicit-unsupported"
+    ;; Nothing to stub — the registry rejects :nerdctl before any probe runs.
+    (let [result (selector/select-runtime {:runtime-kind :nerdctl})]
+      (is (result/err? result))
+      (is (= :runtime/explicit-unsupported (-> result :error :code)))
+      (is (contains? (-> result :error :data :supported) :docker))
+      (is (contains? (-> result :error :data :supported) :podman)))))
+
+;------------------------------------------------------------------------------ Rich Comment
+(comment
+  (clojure.test/run-tests 'ai.miniforge.dag-executor.protocols.impl.runtime.selector-test)
+  :leave-this-here)

--- a/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md
+++ b/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md
@@ -1,0 +1,198 @@
+# feat: runtime adapter Phase 3 — auto-probe, doctor, `mf runtime` CLI
+
+## Overview
+
+Phase 3 of the four-phase runtime-adapter implementation plan from
+[N11-delta](../../specs/normative/N11-delta-runtime-adapter.md) and the
+[runtime-adapter-plan](../design/runtime-adapter-plan.md). This is the
+**user-facing flip**: hosts with both runtimes installed will now pick
+Podman by default, the doctor surfaces every probe outcome, and `mf
+runtime` exposes the descriptor + a runtime-CLI pass-through.
+
+## Motivation
+
+Phase 1 generalized the executor; Phase 2 marked Podman supported. Both
+were transparent to end users — selection still required explicit
+`:runtime-kind`. Phase 3 closes the loop:
+
+1. **Auto-probe.** Without explicit config, the selector tries
+   `:podman → :docker → :nerdctl`. First whose `runtime-info` probe
+   succeeds wins. Per N11-delta §3.
+2. **Fail-loud on explicit config.** If a user pins `:runtime-kind`,
+   selection MUST honor it. If that runtime is unavailable, surface
+   the failure rather than silently falling back — the user named a
+   specific runtime; defying that defeats the purpose.
+3. **Doctor visibility.** `mf doctor` now lists every probed kind with
+   per-kind status, names the selected runtime + version, and shows
+   how to override.
+4. **CLI surface.** `mf runtime info` prints the descriptor as data;
+   `mf runtime run -- <args>` is a pass-through to the resolved CLI
+   for ad-hoc use (`mf runtime run --rm hello-world`).
+
+## Changes In Detail
+
+### 1. New `runtime/selector.clj`
+
+Implements the §3 selection algorithm. Pure-data interface — the CLI
+and doctor render the result, this namespace stays string-free except
+for internal-use error messages on the result map.
+
+- `select-runtime` — single entry point. Branches on
+  `(:runtime-kind config)`:
+  - present → `select-explicit`. Validates the kind is `:supported?`,
+    runs the probe, returns ok with the descriptor or err with
+    `:runtime/explicit-unsupported` / `:runtime/explicit-unavailable`.
+    Never falls back.
+  - absent → `select-auto`. Walks `probe-order` (Podman, Docker,
+    nerdctl) filtered by `:supported?`, returns the first kind whose
+    probe succeeds, or err with `:runtime/none-available` and the
+    full per-kind summary list.
+- `probe-order` is a top-level def — `[:podman :docker :nerdctl]` —
+  exposed for documentation and the CLI doctor.
+
+### 2. `dag-executor.interface` — new public re-exports
+
+The CLI consumes the runtime adapter through the public interface:
+
+- `select-runtime`
+- `runtime-probe-order`
+- `runtime-known-kinds`, `runtime-supported-kinds`
+- `runtime-info`, `runtime-executable`, `runtime-kind`
+
+Existing exports (`create-docker-executor`, `task-runner-images`, etc.)
+unchanged.
+
+### 3. New CLI module `cli/main/commands/runtime.clj`
+
+Owns user-facing rendering. No business logic — calls
+`dag/select-runtime` and renders the result through the shared CLI
+message catalog.
+
+- `runtime-info-cmd` — `mf runtime info`. Prints kind / executable /
+  version / selection method / per-kind probe summary, then the raw
+  descriptor as EDN (so the output is grep-able and programmable).
+- `runtime-run-cmd` — `mf runtime run -- <args>`. Resolves the runtime
+  descriptor, then `process/process` with `:inherit true` for stdio
+  pass-through. Exit code propagates. Per the spec: this command is for
+  ad-hoc use; the workflow engine builds its own argv via the OCI-CLI
+  executor.
+- `print-doctor-runtime-section` — used by `doctor-cmd` in main.clj.
+  Renders one line for the selected runtime plus the per-kind probe
+  list and the override hint.
+
+Config sourcing: `MINIFORGE_RUNTIME` env var is read here. File-config
+integration (the broader `:miniforge/runtime/kind` key per N11-delta
+§2.1) layers on without changing the selector contract.
+
+### 4. `main.clj` wiring
+
+- Import `cmd-runtime`.
+- Three command-fn shims: `runtime-info-cmd`, `runtime-run-cmd`.
+- Doctor extended with the runtime section between the system checks
+  and the config-file check.
+- Dispatch table entries:
+  - `mf runtime`        → help
+  - `mf runtime info`   → `runtime-info-cmd`
+  - `mf runtime run`    → `runtime-run-cmd` (args after `--` forwarded)
+
+### 5. i18n
+
+New keys in `bases/cli/resources/config/cli/messages/en-US.edn`:
+
+- `:runtime/doctor-section-title`
+- `:runtime/doctor-line` — `Runtime: {kind} {runtime-version} (selected by {selection})`
+- `:runtime/doctor-error-line`
+- `:runtime/doctor-probed-line`
+- `:runtime/doctor-override-hint`
+- `:runtime/probed-available` / `:runtime/probed-unavailable`
+- `:runtime/info-{kind,executable,runtime-version,selection,probed}`
+- `:runtime/error-no-runtime`
+
+No raw English strings in the runtime command code paths.
+
+### 6. Tests — `selector_test.clj`
+
+Eight tests covering the §3 algorithm:
+
+- `auto-probe-prefers-podman-when-both-available-test`
+- `auto-probe-falls-through-to-docker-test`
+- `auto-probe-selects-podman-when-only-podman-test`
+- `auto-probe-reports-every-kind-it-tried-test`
+- `auto-probe-fails-loud-when-nothing-available-test`
+- `explicit-kind-overrides-probe-order-test`
+- `explicit-kind-fails-loud-when-unavailable-test`
+- `explicit-kind-rejects-unsupported-kind-test`
+
+Probe is stubbed via `with-redefs` on `descriptor/runtime-info` so the
+tests don't depend on host state.
+
+### 7. Manual smoke (this host: Docker 29.4.0, no Podman)
+
+Auto-probe (no env var):
+
+```text
+✓ Runtime: docker 29.4.0 (selected by auto-probe)
+   Probed: podman — Cannot run program "podman": ... , docker (29.4.0)
+   Override with :runtime-kind in config or MINIFORGE_RUNTIME=docker|podman
+```
+
+`MINIFORGE_RUNTIME=podman mf runtime info` (Podman absent):
+
+```text
+Error: No usable container runtime: explicit-unavailable — Runtime :podman is configured but unavailable.
+```
+
+`MINIFORGE_RUNTIME=nerdctl mf runtime info` (unsupported):
+
+```text
+Error: No usable container runtime: explicit-unsupported — Runtime kind :nerdctl is not supported.
+```
+
+## What this PR does NOT change
+
+- The `OciCliExecutor` defrecord and its CLI shellout helpers — Phase
+  1/2 territory.
+- The runtime registry data — Phase 2 already declared Podman supported.
+- `bb install:podman` and standards-pack runtime policies — Phase 4.
+- File-config integration for `:miniforge/runtime/kind` — Phase 4 docs
+  pass; the selector contract already accepts the kind via its config map,
+  so wiring file config into the CLI is a layered change.
+- `kubernetes.clj`, `worktree.clj`, `protocols/executor.clj` — untouched.
+
+## Files
+
+- `components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/runtime/selector.clj` — new
+- `components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/runtime/selector_test.clj` — new
+- `components/dag-executor/src/ai/miniforge/dag_executor/interface.clj` — added `select-runtime` and
+  `runtime-{probe-order,known-kinds,supported-kinds,info,executable,kind}` re-exports
+- `bases/cli/src/ai/miniforge/cli/main/commands/runtime.clj` — new
+- `bases/cli/src/ai/miniforge/cli/main.clj` — runtime dispatch entries, doctor extension,
+  command-fn shims
+- `bases/cli/resources/config/cli/messages/en-US.edn` — new `:runtime/*` keys
+
+## Verification
+
+- New selector tests: 8 deftest forms, 26 assertions, 0 failures.
+- Full `bb test`: 2943 tests, 10945 passes, 0 failures, 0 errors.
+- Manual: `mf runtime info`, `mf doctor`, `MINIFORGE_RUNTIME=podman mf
+  runtime info`, `MINIFORGE_RUNTIME=nerdctl mf runtime info` all
+  render correctly.
+
+## Open follow-ups (Phase 4)
+
+- `bb install:podman` + `bb upgrade:podman` brew tasks; `bb-platform`
+  `manual-install-hints` entry; `check:platform` warn-only entry.
+- README + `quickstart.md` + `platform-support.md` + `configuration.md`
+  - `agents.md` updates.
+- Standards-pack runtime policies:
+  `:runtime/no-host-docker-socket`, `:runtime/require-rootless`,
+  `:runtime/restrict-host-mounts`, `:runtime/require-image-digest-pin`.
+- Pin default images to `@sha256:` digests when published.
+
+## Cross-references
+
+- Spec: [N11-delta-runtime-adapter](../../specs/normative/N11-delta-runtime-adapter.md)
+- Plan: [runtime-adapter-plan](../design/runtime-adapter-plan.md)
+- Phase 1: [#694](https://github.com/miniforge-ai/miniforge/pull/694),
+  [#701](https://github.com/miniforge-ai/miniforge/pull/701)
+- Phase 2: [#706](https://github.com/miniforge-ai/miniforge/pull/706)


### PR DESCRIPTION
## Summary

- N11-delta §3 selection algorithm: auto-probe (Podman → Docker → nerdctl) when no explicit kind set; explicit `:runtime-kind` config honored and fails loud if unavailable (no silent fallback).
- `mf doctor` surfaces every probe outcome plus override hint.
- New `mf runtime info` prints the resolved descriptor as data; `mf runtime run -- <args>` is a pass-through to the resolved CLI for ad-hoc use.
- Default flips to Podman on hosts that have it installed alongside Docker.

Full breakdown: [`docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md`](docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md).

## Architecture — pure-data selector

`runtime/selector.clj` returns a result map. The CLI / doctor render the result through the shared message catalog. No raw English in the new code paths.

Error codes: `:runtime/explicit-unsupported`, `:runtime/explicit-unavailable`, `:runtime/none-available`. Each carries enough data for the caller to render a helpful message without re-deriving anything.

## Manual smoke (host: Docker 29.4.0, no Podman)

- Auto-probe: selects Docker, lists podman as probed-unavailable in the doctor block.
- `MINIFORGE_RUNTIME=podman mf runtime info`: returns `explicit-unavailable` error (no silent fallback to Docker — the user named Podman).
- `MINIFORGE_RUNTIME=nerdctl mf runtime info`: returns `explicit-unsupported` error.

## Test plan

- [x] New `selector_test.clj`: 8 deftest forms covering auto-probe ordering, fail-loud paths, both error codes, and the per-kind `:probed` summary list.
- [x] Full `bb test`: 2943 tests, 10945 passes, 0 failures, 0 errors.
- [x] Manual smoke against the dispatch table verifying `mf doctor`, `mf runtime info`, and the explicit-kind error paths.
- [ ] Reviewer with both Podman and Docker installed verifies that auto-probe selects Podman and that `mf doctor` reports both as available.

## Phases ahead

- **Phase 4** — `bb install:podman` brew tasks, `bb-platform` warn-only check, README/quickstart/platform-support/configuration/agents docs, standards-pack runtime policies. Pinning images to `@sha256:` digests when published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)