### PR TITLE
feat: classify dependency attribution failures

### DIFF
--- a/components/agent-runtime/resources/error-patterns/backend-setup.edn
+++ b/components/agent-runtime/resources/error-patterns/backend-setup.edn
@@ -1,11 +1,14 @@
 {:description "Backend setup and configuration errors"
  :type :external
- :vendor "External Service"
  :patterns
  [{:id :codex-permission-error
    :regex "Codex cannot access session files.*permission denied"
    :vendor "Codex"
    :description "Codex session directory owned by root"
+   :failure/source :user-env
+   :failure/vendor :codex
+   :dependency/class :permission
+   :dependency/retryability :operator-action
    :workaround {:type :shell-command
                 :command "sudo chown -R $(whoami) ~/.codex"
                 :description "Fix ownership of Codex session directory"
@@ -17,6 +20,10 @@
    :regex "connection refused.*localhost:11434"
    :vendor "Ollama"
    :description "Ollama server not running"
+   :failure/source :user-env
+   :failure/vendor :ollama
+   :dependency/class :misconfiguration
+   :dependency/retryability :operator-action
    :workaround {:type :shell-command
                 :command "ollama serve"
                 :description "Start Ollama server in background"
@@ -28,6 +35,10 @@
    :regex "ANTHROPIC_API_KEY.*not set|Invalid API key"
    :vendor "Anthropic"
    :description "Missing or invalid Anthropic API key"
+   :failure/source :user-env
+   :failure/vendor :anthropic
+   :dependency/class :misconfiguration
+   :dependency/retryability :operator-action
    :workaround {:type :env-var
                 :env-var "ANTHROPIC_API_KEY"
                 :description "Set ANTHROPIC_API_KEY environment variable"
@@ -39,6 +50,10 @@
    :regex "OPENAI_API_KEY.*not set|Invalid API key"
    :vendor "OpenAI"
    :description "Missing or invalid OpenAI API key"
+   :failure/source :user-env
+   :failure/vendor :openai
+   :dependency/class :misconfiguration
+   :dependency/retryability :operator-action
    :workaround {:type :env-var
                 :env-var "OPENAI_API_KEY"
                 :description "Set OPENAI_API_KEY environment variable"

--- a/components/agent-runtime/resources/error-patterns/external.edn
+++ b/components/agent-runtime/resources/error-patterns/external.edn
@@ -1,42 +1,114 @@
-{:description "Patterns that indicate external service errors"
+{:description "Patterns that indicate external provider and platform failures"
  :type :external
- :vendor "External Service"
  :patterns
- [{:regex "ECONNREFUSED"
-   :description "Connection refused"}
-  {:regex "Network error"
-   :description "Network connectivity issue"}
-  {:regex "API rate limit exceeded"
-   :description "API rate limit hit"
-   :rate-limit? true}
-  {:regex "API service unavailable"
-   :description "API temporarily unavailable"}
-  {:regex "Request timeout"
-   :description "Request timed out"}
-  {:regex "502 Bad Gateway"
-   :description "Bad gateway error"}
-  {:regex "503 Service Unavailable"
-   :description "Service unavailable"}
-  {:regex "Connection refused"
-   :description "Connection refused"}
-  {:regex "DNS lookup failed"
-   :description "DNS resolution failure"}
-  {:regex "permission denied|Permission denied|EACCES"
-   :description "File permission error"}
-  {:regex "Codex cannot access session files"
-   :description "Codex session directory permission issue"}
-  {:regex "(?i)you've hit your limit"
-   :description "Claude CLI rate limit reached"
-   :rate-limit? true}
-  {:regex "(?i)rate.?limit"
-   :description "Generic rate limit"
-   :rate-limit? true}
-  {:regex "(?i)quota.?exceeded"
-   :description "API quota exceeded"
-   :rate-limit? true}
-  {:regex "429|Too Many Requests"
-   :description "HTTP 429 Too Many Requests"
-   :rate-limit? true}
-  {:regex "resets \\d+[ap]m|resets in \\d+"
-   :description "Rate limit with reset time indicator"
-   :rate-limit? true}]}
+ [{:id :anthropic-rate-limit
+   :regex "(anthropic|claude).*(rate limit|429|too many requests)"
+   :vendor "Anthropic"
+   :description "Anthropic provider rate limit"
+   :failure/source :external-provider
+   :failure/vendor :anthropic
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :openai-rate-limit
+   :regex "(openai|codex).*(rate limit|429|too many requests)"
+   :vendor "OpenAI"
+   :description "OpenAI or Codex provider rate limit"
+   :failure/source :external-provider
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :github-rate-limit
+   :regex "GitHub API rate limit exceeded|GitHub.*(rate limit|429|too many requests)"
+   :vendor "GitHub"
+   :description "GitHub platform rate limit"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :provider-rate-limit
+   :regex "API rate limit exceeded|rate limit exceeded|Rate limit reached|rate-limit error|429|Too Many Requests|too many requests|Quota exceeded|You've hit your limit|resets \\d|resets in \\d+"
+   :vendor "External Service"
+   :description "Provider or platform rate limit"
+   :failure/source :external-provider
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :github-auth-failed
+   :regex "GitHub.*(401|403|authentication failed|bad credentials|forbidden)"
+   :vendor "GitHub"
+   :description "GitHub authentication failed"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :auth
+   :dependency/retryability :operator-action}
+
+  {:id :github-platform-unavailable
+   :regex "GitHub.*(502|503|service unavailable|temporarily unavailable)"
+   :vendor "GitHub"
+   :description "GitHub platform unavailable"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :outage
+   :dependency/retryability :retryable}
+
+  {:id :github-network-failure
+   :regex "GitHub.*(connection refused|connection reset|dns lookup failed|dns resolution failed|network error)"
+   :vendor "GitHub"
+   :description "GitHub platform network failure"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :network
+   :dependency/retryability :retryable}
+
+  {:id :kubernetes-auth-failed
+   :regex "Kubernetes.*(401|403|forbidden|unauthorized|authentication failed)"
+   :vendor "Kubernetes"
+   :description "Kubernetes authentication failed"
+   :failure/source :external-platform
+   :failure/vendor :kubernetes
+   :dependency/class :auth
+   :dependency/retryability :operator-action}
+
+  {:id :kubernetes-platform-unavailable
+   :regex "Kubernetes.*(connection refused|service unavailable|i/o timeout|dial tcp)"
+   :vendor "Kubernetes"
+   :description "Kubernetes platform unavailable"
+   :failure/source :external-platform
+   :failure/vendor :kubernetes
+   :dependency/class :outage
+   :dependency/retryability :retryable}
+
+  {:id :codex-account-limitation
+   :regex "Codex account cannot use model|model .* unsupported|unsupported model|does not have access to model|model .* not available for your account"
+   :vendor "Codex"
+   :description "Codex or provider account limitation"
+   :failure/source :external-provider
+   :failure/vendor :codex
+   :dependency/class :account-limitation
+   :dependency/retryability :operator-action}
+
+  {:id :provider-service-unavailable
+   :regex "API service unavailable|503 Service Unavailable|502 Bad Gateway|overloaded_error"
+   :vendor "External Service"
+   :description "Provider service unavailable"
+   :failure/source :external-provider
+   :dependency/class :outage
+   :dependency/retryability :retryable}
+
+  {:id :provider-request-timeout
+   :regex "Request timeout|timed out waiting for response|deadline exceeded"
+   :vendor "External Service"
+   :description "Provider request timeout"
+   :failure/source :external-provider
+   :dependency/class :timeout
+   :dependency/retryability :retryable}
+
+  {:id :provider-network-failure
+   :regex "ECONNREFUSED|Connection refused|connection reset|DNS lookup failed|DNS resolution failed|Network error"
+   :vendor "External Service"
+   :description "Provider network failure"
+   :failure/source :external-provider
+   :dependency/class :network
+   :dependency/retryability :retryable}]}

--- a/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/patterns.clj
+++ b/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/patterns.clj
@@ -54,11 +54,18 @@
      type - Error type keyword
      vendor - Vendor name string
 
-   Returns: Pattern map with compiled :regex"
+  Returns: Pattern map with compiled :regex"
   [pattern type vendor]
-  (-> pattern
-      (assoc :type type :vendor vendor)
-      (update :regex re-pattern)))
+  (let [pattern-vendor (or (:vendor pattern)
+                           (:failure/vendor pattern)
+                           vendor)
+        rate-limit? (or (:rate-limit? pattern)
+                        (= (:dependency/class pattern) :rate-limit))]
+    (-> pattern
+        (assoc :type type
+               :vendor pattern-vendor
+               :rate-limit? rate-limit?)
+        (update :regex re-pattern))))
 
 (defn load-patterns
   "Load and compile patterns from a config file.

--- a/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/patterns.clj
+++ b/components/agent-runtime/src/ai/miniforge/agent_runtime/error_classifier/patterns.clj
@@ -47,7 +47,7 @@
         nil))))
 
 (defn compile-pattern
-  "Compile a pattern map with regex string to regex object.
+  "Compile a pattern map with regex string to a case-insensitive regex.
 
    Arguments:
      pattern - Map with :regex string
@@ -65,7 +65,7 @@
         (assoc :type type
                :vendor pattern-vendor
                :rate-limit? rate-limit?)
-        (update :regex re-pattern))))
+        (update :regex #(re-pattern (str "(?i)" %))))))
 
 (defn load-patterns
   "Load and compile patterns from a config file.

--- a/components/failure-classifier/resources/error-patterns/backend-setup.edn
+++ b/components/failure-classifier/resources/error-patterns/backend-setup.edn
@@ -1,0 +1,62 @@
+{:description "Backend setup and configuration errors"
+ :type :external
+ :patterns
+ [{:id :codex-permission-error
+   :regex "Codex cannot access session files.*permission denied"
+   :vendor "Codex"
+   :description "Codex session directory owned by root"
+   :failure/source :user-env
+   :failure/vendor :codex
+   :dependency/class :permission
+   :dependency/retryability :operator-action
+   :workaround {:type :shell-command
+                :command "sudo chown -R $(whoami) ~/.codex"
+                :description "Fix ownership of Codex session directory"
+                :requires-sudo true
+                :auto-apply false}
+   :docs-url "https://codex.dev/docs/troubleshooting#permissions"}
+
+  {:id :ollama-not-running
+   :regex "connection refused.*localhost:11434"
+   :vendor "Ollama"
+   :description "Ollama server not running"
+   :failure/source :user-env
+   :failure/vendor :ollama
+   :dependency/class :misconfiguration
+   :dependency/retryability :operator-action
+   :workaround {:type :shell-command
+                :command "ollama serve"
+                :description "Start Ollama server in background"
+                :requires-sudo false
+                :auto-apply false}
+   :docs-url "https://ollama.ai/docs"}
+
+  {:id :anthropic-key-missing
+   :regex "ANTHROPIC_API_KEY.*not set|Invalid API key"
+   :vendor "Anthropic"
+   :description "Missing or invalid Anthropic API key"
+   :failure/source :user-env
+   :failure/vendor :anthropic
+   :dependency/class :misconfiguration
+   :dependency/retryability :operator-action
+   :workaround {:type :env-var
+                :env-var "ANTHROPIC_API_KEY"
+                :description "Set ANTHROPIC_API_KEY environment variable"
+                :requires-sudo false
+                :auto-apply false}
+   :docs-url "https://console.anthropic.com/settings/keys"}
+
+  {:id :openai-key-missing
+   :regex "OPENAI_API_KEY.*not set|Invalid API key"
+   :vendor "OpenAI"
+   :description "Missing or invalid OpenAI API key"
+   :failure/source :user-env
+   :failure/vendor :openai
+   :dependency/class :misconfiguration
+   :dependency/retryability :operator-action
+   :workaround {:type :env-var
+                :env-var "OPENAI_API_KEY"
+                :description "Set OPENAI_API_KEY environment variable"
+                :requires-sudo false
+                :auto-apply false}
+   :docs-url "https://platform.openai.com/api-keys"}]}

--- a/components/failure-classifier/resources/error-patterns/external.edn
+++ b/components/failure-classifier/resources/error-patterns/external.edn
@@ -1,0 +1,114 @@
+{:description "Patterns that indicate external provider and platform failures"
+ :type :external
+ :patterns
+ [{:id :anthropic-rate-limit
+   :regex "(anthropic|claude).*(rate limit|429|too many requests)"
+   :vendor "Anthropic"
+   :description "Anthropic provider rate limit"
+   :failure/source :external-provider
+   :failure/vendor :anthropic
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :openai-rate-limit
+   :regex "(openai|codex).*(rate limit|429|too many requests)"
+   :vendor "OpenAI"
+   :description "OpenAI or Codex provider rate limit"
+   :failure/source :external-provider
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :github-rate-limit
+   :regex "GitHub API rate limit exceeded|GitHub.*(rate limit|429|too many requests)"
+   :vendor "GitHub"
+   :description "GitHub platform rate limit"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :provider-rate-limit
+   :regex "API rate limit exceeded|rate limit exceeded|Rate limit reached|rate-limit error|429|Too Many Requests|too many requests|Quota exceeded|You've hit your limit|resets \\d|resets in \\d+"
+   :vendor "External Service"
+   :description "Provider or platform rate limit"
+   :failure/source :external-provider
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :github-auth-failed
+   :regex "GitHub.*(401|403|authentication failed|bad credentials|forbidden)"
+   :vendor "GitHub"
+   :description "GitHub authentication failed"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :auth
+   :dependency/retryability :operator-action}
+
+  {:id :github-platform-unavailable
+   :regex "GitHub.*(502|503|service unavailable|temporarily unavailable)"
+   :vendor "GitHub"
+   :description "GitHub platform unavailable"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :outage
+   :dependency/retryability :retryable}
+
+  {:id :github-network-failure
+   :regex "GitHub.*(connection refused|connection reset|dns lookup failed|dns resolution failed|network error)"
+   :vendor "GitHub"
+   :description "GitHub platform network failure"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :network
+   :dependency/retryability :retryable}
+
+  {:id :kubernetes-auth-failed
+   :regex "Kubernetes.*(401|403|forbidden|unauthorized|authentication failed)"
+   :vendor "Kubernetes"
+   :description "Kubernetes authentication failed"
+   :failure/source :external-platform
+   :failure/vendor :kubernetes
+   :dependency/class :auth
+   :dependency/retryability :operator-action}
+
+  {:id :kubernetes-platform-unavailable
+   :regex "Kubernetes.*(connection refused|service unavailable|i/o timeout|dial tcp)"
+   :vendor "Kubernetes"
+   :description "Kubernetes platform unavailable"
+   :failure/source :external-platform
+   :failure/vendor :kubernetes
+   :dependency/class :outage
+   :dependency/retryability :retryable}
+
+  {:id :codex-account-limitation
+   :regex "Codex account cannot use model|model .* unsupported|unsupported model|does not have access to model|model .* not available for your account"
+   :vendor "Codex"
+   :description "Codex or provider account limitation"
+   :failure/source :external-provider
+   :failure/vendor :codex
+   :dependency/class :account-limitation
+   :dependency/retryability :operator-action}
+
+  {:id :provider-service-unavailable
+   :regex "API service unavailable|503 Service Unavailable|502 Bad Gateway|overloaded_error"
+   :vendor "External Service"
+   :description "Provider service unavailable"
+   :failure/source :external-provider
+   :dependency/class :outage
+   :dependency/retryability :retryable}
+
+  {:id :provider-request-timeout
+   :regex "Request timeout|timed out waiting for response|deadline exceeded"
+   :vendor "External Service"
+   :description "Provider request timeout"
+   :failure/source :external-provider
+   :dependency/class :timeout
+   :dependency/retryability :retryable}
+
+  {:id :provider-network-failure
+   :regex "ECONNREFUSED|Connection refused|connection reset|DNS lookup failed|DNS resolution failed|Network error"
+   :vendor "External Service"
+   :description "Provider network failure"
+   :failure/source :external-provider
+   :dependency/class :network
+   :dependency/retryability :retryable}]}

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
@@ -14,6 +14,7 @@
    Layer 1: Classification strategies (pure)
    Layer 2: Orchestration (pure)"
   (:require
+   [ai.miniforge.failure-classifier.taxonomy :as taxonomy]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]))
@@ -21,9 +22,19 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Config loading and compilation
 
+(defn- load-edn-resource
+  "Load an EDN resource by path."
+  [resource-path]
+  (-> (io/resource resource-path) slurp edn/read-string))
+
 (def ^:private rules-config
   "Classification rules loaded from EDN config."
-  (-> (io/resource "config/failure-classifier/rules.edn") slurp edn/read-string))
+  (load-edn-resource "config/failure-classifier/rules.edn"))
+
+(def ^:private dependency-pattern-configs
+  "Ordered dependency pattern sources. Earlier files take priority."
+  [(load-edn-resource "error-patterns/backend-setup.edn")
+   (load-edn-resource "error-patterns/external.edn")])
 
 (defn- compile-pattern
   "Compile a string pattern into a case-insensitive regex."
@@ -35,6 +46,11 @@
   [{:keys [patterns class]}]
   {:patterns (mapv compile-pattern patterns)
    :class class})
+
+(defn- compile-dependency-pattern
+  "Compile a dependency pattern rule into a canonical matcher map."
+  [{:keys [regex] :as pattern}]
+  (assoc pattern :pattern (compile-pattern regex)))
 
 (def ^:private classification-rules
   "Compiled ordered list of [{:patterns [regex...] :class keyword}].
@@ -49,6 +65,12 @@
   "Maps anomaly category keywords to failure classes."
   (:anomaly-map rules-config))
 
+(def ^:private dependency-patterns
+  "Ordered dependency-specific matchers compiled from external/setup resources."
+  (->> dependency-pattern-configs
+       (mapcat :patterns)
+       (mapv compile-dependency-pattern)))
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Classification strategies
 
@@ -57,6 +79,12 @@
   [text patterns]
   (when (and text (seq patterns))
     (some #(re-find % text) patterns)))
+
+(defn- matches-pattern?
+  "Returns true if text matches the compiled dependency pattern."
+  [text pattern]
+  (when text
+    (re-find pattern text)))
 
 (defn- classify-by-message
   "Classify failure by matching error message against ordered pattern rules."
@@ -94,6 +122,71 @@
   [anomaly-category]
   (get anomaly-category-map anomaly-category))
 
+(defn- remove-nil-entries
+  "Return map entries whose values are non-nil."
+  [m]
+  (into {}
+        (remove (fn [[_ value]] (nil? value)))
+        m))
+
+(defn- failure-message
+  "Resolve the canonical failure message from failure context."
+  [{message :error/message}]
+  (or message ""))
+
+(defn- failure-record-context
+  "Project context fields into the canonical record context."
+  [failure-context]
+  (-> failure-context
+      (dissoc :error/message)
+      remove-nil-entries
+      not-empty))
+
+(defn- match-dependency-pattern
+  "Return the first matching dependency pattern for a failure message."
+  [message]
+  (some (fn [{compiled-pattern :pattern :as dependency-pattern}]
+          (when (matches-pattern? message compiled-pattern)
+            dependency-pattern))
+        dependency-patterns))
+
+(defn- dependency-attribution
+  "Build canonical dependency attribution from a matched dependency pattern."
+  [{source :failure/source
+    vendor :failure/vendor
+    dependency-class :dependency/class
+    retryability :dependency/retryability}]
+  (taxonomy/make-dependency-attribution
+   {:failure/source source
+    :failure/vendor vendor
+    :dependency/class dependency-class
+    :dependency/retryability retryability}))
+
+(defn- classify-dependency-record
+  "Construct canonical classified dependency failure from a matched pattern."
+  [failure-context failure-class dependency-pattern]
+  (let [message (failure-message failure-context)
+        context (failure-record-context failure-context)
+        attribution (dependency-attribution dependency-pattern)]
+    (taxonomy/make-classified-dependency-failure
+     {:failure/class failure-class
+      :failure/message message
+      :failure/source (:failure/source attribution)
+      :failure/vendor (:failure/vendor attribution)
+      :dependency/class (:dependency/class attribution)
+      :dependency/retryability (:dependency/retryability attribution)
+      :failure/context context})))
+
+(defn- classify-standard-record
+  "Construct canonical classified failure without dependency attribution."
+  [failure-context failure-class]
+  (let [message (failure-message failure-context)
+        context (failure-record-context failure-context)]
+    (taxonomy/make-classified-failure
+     {:failure/class failure-class
+      :failure/message message
+      :failure/context context})))
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Orchestration
 
@@ -123,6 +216,26 @@
   "Convenience: classify a Throwable directly."
   [^Throwable ex]
   (classify-failure
+   {:anomaly/category  nil
+    :exception/class   (str (type ex))
+    :error/message     (.getMessage ex)}))
+
+(defn classify-failure-record
+  "Classify a failure into a canonical record with optional dependency
+   attribution."
+  [failure-context]
+  (let [resolved-context (or failure-context {})
+        message (failure-message resolved-context)
+        failure-class (classify-failure resolved-context)
+        dependency-pattern (match-dependency-pattern message)]
+    (if dependency-pattern
+      (classify-dependency-record resolved-context failure-class dependency-pattern)
+      (classify-standard-record resolved-context failure-class))))
+
+(defn classify-exception-record
+  "Convenience: classify a Throwable into a canonical record."
+  [^Throwable ex]
+  (classify-failure-record
    {:anomaly/category  nil
     :exception/class   (str (type ex))
     :error/message     (.getMessage ex)}))

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj
@@ -22,19 +22,35 @@
 ;------------------------------------------------------------------------------ Layer 0
 ;; Config loading and compilation
 
-(defn- load-edn-resource
-  "Load an EDN resource by path."
+(defn- missing-resource
+  "Create a canonical missing-resource exception."
   [resource-path]
-  (-> (io/resource resource-path) slurp edn/read-string))
+  (ex-info (str "Missing EDN resource: " resource-path)
+           {:resource/path resource-path
+            :anomaly/category :anomalies/not-found}))
+
+(defn- load-edn-resource
+  "Load a required EDN resource by path."
+  [resource-path]
+  (when-let [resource (io/resource resource-path)]
+    (-> resource slurp edn/read-string)))
+
+(defn- require-edn-resource
+  "Load a required EDN resource or throw ex-info when missing."
+  [resource-path]
+  (or (load-edn-resource resource-path)
+      (throw (missing-resource resource-path))))
 
 (def ^:private rules-config
   "Classification rules loaded from EDN config."
-  (load-edn-resource "config/failure-classifier/rules.edn"))
+  (require-edn-resource "config/failure-classifier/rules.edn"))
 
 (def ^:private dependency-pattern-configs
   "Ordered dependency pattern sources. Earlier files take priority."
-  [(load-edn-resource "error-patterns/backend-setup.edn")
-   (load-edn-resource "error-patterns/external.edn")])
+  (->> [(load-edn-resource "error-patterns/backend-setup.edn")
+        (load-edn-resource "error-patterns/external.edn")]
+       (keep identity)
+       vec))
 
 (defn- compile-pattern
   "Compile a string pattern into a case-insensitive regex."
@@ -84,7 +100,7 @@
   "Returns true if text matches the compiled dependency pattern."
   [text pattern]
   (when text
-    (re-find pattern text)))
+    (boolean (re-find pattern text))))
 
 (defn- classify-by-message
   "Classify failure by matching error message against ordered pattern rules."

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/interface.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/interface.clj
@@ -99,6 +99,10 @@
   "Construct canonical classified dependency failure."
   taxonomy/make-classified-dependency-failure)
 
+(def make-classified-failure
+  "Construct canonical classified failure."
+  taxonomy/make-classified-failure)
+
 ;------------------------------------------------------------------------------ Layer 1
 ;; Classification
 
@@ -136,6 +140,22 @@
      (classify-exception (java.net.SocketTimeoutException. \"timeout\"))
      ;; => :failure.class/timeout"
   classifier/classify-exception)
+
+(def classify-record
+  "Classify a failure into a canonical failure record.
+
+   Returns either:
+   - ClassifiedFailure
+   - ClassifiedDependencyFailure
+
+   Dependency attribution is added when the failure matches provider,
+   platform, or user-environment patterns."
+  classifier/classify-failure-record)
+
+(def classify-exception-record
+  "Classify a Throwable into a canonical failure record with optional
+   dependency attribution."
+  classifier/classify-exception-record)
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
+++ b/components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj
@@ -223,6 +223,21 @@
       (:failure/vendor attribution) (assoc :failure/vendor (:failure/vendor attribution))
       context (assoc :failure/context context))))
 
+(defn make-classified-failure
+  "Construct canonical classified failure."
+  [{failure-class :failure/class
+    message :failure/message
+    context :failure/context}]
+  (require-field! :failure/class failure-class
+                  {:constructor :classified-failure})
+  (require-field! :failure/message message
+                  {:constructor :classified-failure})
+  (validate-enum! :failure/class failure-class valid-failure-class?
+                  {:constructor :classified-failure})
+  (cond-> {:failure/class failure-class
+           :failure/message message}
+    context (assoc :failure/context context)))
+
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
   failure-classes

--- a/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
+++ b/components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj
@@ -120,7 +120,16 @@
              :failure/vendor :anthropic
              :dependency/class :rate-limit
              :dependency/retryability :retryable
-             :failure/context {:backend :anthropic}})))))
+             :failure/context {:backend :anthropic}}))))
+
+  (testing "classified failure constructor composes the canonical shape"
+    (is (= {:failure/class :failure.class/timeout
+            :failure/message "deadline exceeded"
+            :failure/context {:phase :plan}}
+           (fc/make-classified-failure
+            {:failure/class :failure.class/timeout
+             :failure/message "deadline exceeded"
+             :failure/context {:phase :plan}})))))
 
 (deftest dependency-constructor-validation-test
   (testing "dependency attribution constructor rejects missing required fields"
@@ -290,6 +299,79 @@
            (fc/classify-exception (java.net.ConnectException. "Connection refused"))))
     (is (= :failure.class/external
            (fc/classify-exception (java.net.UnknownHostException. "host.invalid"))))))
+
+;; ---------------------------------------------------------------------------- Rich dependency attribution records
+
+(deftest classify-record-standard-failure-test
+  (let [record (fc/classify-record {:anomaly/category :anomalies/timeout
+                                    :phase :plan
+                                    :tool/id :planner})]
+    (is (= :failure.class/timeout (:failure/class record)))
+    (is (= "" (:failure/message record)))
+    (is (= {:anomaly/category :anomalies/timeout
+            :phase :plan
+            :tool/id :planner}
+           (:failure/context record)))
+    (is (not (fc/dependency-failure? record)))))
+
+(deftest classify-record-dependency-failure-test
+  (let [test-cases [{:name "Anthropic provider outage"
+                     :input {:error/message "Anthropic API service unavailable"}
+                     :expected {:failure/class :failure.class/external
+                                :failure/source :external-provider
+                                :dependency/class :outage
+                                :dependency/retryability :retryable}}
+                    {:name "Codex unsupported model"
+                     :input {:error/message "Codex account cannot use model gpt-5.2-codex"}
+                     :expected {:failure/class :failure.class/unknown
+                                :failure/source :external-provider
+                                :failure/vendor :codex
+                                :dependency/class :account-limitation
+                                :dependency/retryability :operator-action}}
+                    {:name "Codex session permission"
+                     :input {:error/message "Codex cannot access session files: permission denied"}
+                     :expected {:failure/class :failure.class/unknown
+                                :failure/source :user-env
+                                :failure/vendor :codex
+                                :dependency/class :permission
+                                :dependency/retryability :operator-action}}
+                    {:name "Missing Anthropic key"
+                     :input {:error/message "ANTHROPIC_API_KEY is not set"}
+                     :expected {:failure/class :failure.class/unknown
+                                :failure/source :user-env
+                                :failure/vendor :anthropic
+                                :dependency/class :misconfiguration
+                                :dependency/retryability :operator-action}}
+                    {:name "GitHub platform unavailable"
+                     :input {:error/message "GitHub 503 Service Unavailable"}
+                     :expected {:failure/class :failure.class/external
+                                :failure/source :external-platform
+                                :failure/vendor :github
+                                :dependency/class :outage
+                                :dependency/retryability :retryable}}
+                    {:name "Kubernetes authentication failed"
+                     :input {:error/message "Kubernetes 401 unauthorized"}
+                     :expected {:failure/class :failure.class/policy
+                                :failure/source :external-platform
+                                :failure/vendor :kubernetes
+                                :dependency/class :auth
+                                :dependency/retryability :operator-action}}]]
+    (doseq [{:keys [name input expected]} test-cases]
+      (testing name
+        (let [record (fc/classify-record input)]
+          (is (= expected
+                 (select-keys record (keys expected))))
+          (is (= (:error/message input) (:failure/message record)))
+          (is (fc/dependency-failure? record)))))))
+
+(deftest classify-exception-record-test
+  (let [record (fc/classify-exception-record
+                (java.net.ConnectException. "GitHub 503 Service Unavailable"))]
+    (is (= :failure.class/external (:failure/class record)))
+    (is (= :external-platform (:failure/source record)))
+    (is (= :github (:failure/vendor record)))
+    (is (= :outage (:dependency/class record)))
+    (is (= :retryable (:dependency/retryability record)))))
 
 ;; ---------------------------------------------------------------------------- Fallback to unknown
 

--- a/docs/pull-requests/2026-04-30-feat-dependency-attribution-classifier.md
+++ b/docs/pull-requests/2026-04-30-feat-dependency-attribution-classifier.md
@@ -1,0 +1,58 @@
+# Dependency Attribution Classifier
+
+## Summary
+
+This PR wires the canonical dependency-attribution model into
+`failure-classifier` without breaking the existing `classify` API.
+
+The classifier can now return rich classified failure records that distinguish:
+
+- Miniforge product failures
+- user environment and setup failures
+- external provider failures
+- external platform failures
+
+## Changes
+
+- adds canonical classified failure record construction in
+  [taxonomy.clj](components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj)
+- adds rich classifier APIs in
+  [interface.clj](components/failure-classifier/src/ai/miniforge/failure_classifier/interface.clj):
+  - `classify-record`
+  - `classify-exception-record`
+- extends
+  [classifier.clj](components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj)
+  to compile and apply dependency attribution patterns from the existing
+  `external.edn` and `backend-setup.edn` resources
+- upgrades the dependency pattern resources to canonical machine-oriented data in:
+  - [resources/error-patterns/external.edn](resources/error-patterns/external.edn)
+  - [resources/error-patterns/backend-setup.edn](resources/error-patterns/backend-setup.edn)
+- keeps the duplicated `agent-runtime` resource copies in sync so classpath
+  resolution cannot silently pick stale pattern data
+- adds representative coverage in
+  [classifier_test.clj](components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj)
+  for:
+  - provider outage
+  - provider rate limit
+  - account limitation
+  - local permission failure
+  - missing API key
+  - GitHub and Kubernetes platform failures
+
+## Why
+
+Dogfood runs exposed an important operational gap: Miniforge could tell that a
+workflow failed, but not whether the failure was caused by Miniforge itself,
+the user environment, an LLM provider, or an external platform.
+
+This PR closes the first functional part of that gap by making failure
+classification return canonical attribution data instead of only a single
+failure-class keyword.
+
+## Validation
+
+- `clj-kondo --lint components/failure-classifier/src/ai/miniforge/failure_classifier
+  components/failure-classifier/test/ai/miniforge/failure_classifier resources/error-patterns
+  components/agent-runtime/resources/error-patterns`
+- targeted `ai.miniforge.failure-classifier.classifier-test`
+- full `bb pre-commit`

--- a/resources/error-patterns/backend-setup.edn
+++ b/resources/error-patterns/backend-setup.edn
@@ -5,6 +5,10 @@
    :regex "Codex cannot access session files.*permission denied"
    :vendor "Codex"
    :description "Codex session directory owned by root"
+   :failure/source :user-env
+   :failure/vendor :codex
+   :dependency/class :permission
+   :dependency/retryability :operator-action
    :workaround {:type :shell-command
                 :command "sudo chown -R $(whoami) ~/.codex"
                 :description "Fix ownership of Codex session directory"
@@ -16,6 +20,10 @@
    :regex "connection refused.*localhost:11434"
    :vendor "Ollama"
    :description "Ollama server not running"
+   :failure/source :user-env
+   :failure/vendor :ollama
+   :dependency/class :misconfiguration
+   :dependency/retryability :operator-action
    :workaround {:type :shell-command
                 :command "ollama serve"
                 :description "Start Ollama server in background"
@@ -27,6 +35,10 @@
    :regex "ANTHROPIC_API_KEY.*not set|Invalid API key"
    :vendor "Anthropic"
    :description "Missing or invalid Anthropic API key"
+   :failure/source :user-env
+   :failure/vendor :anthropic
+   :dependency/class :misconfiguration
+   :dependency/retryability :operator-action
    :workaround {:type :env-var
                 :env-var "ANTHROPIC_API_KEY"
                 :description "Set ANTHROPIC_API_KEY environment variable"
@@ -38,6 +50,10 @@
    :regex "OPENAI_API_KEY.*not set|Invalid API key"
    :vendor "OpenAI"
    :description "Missing or invalid OpenAI API key"
+   :failure/source :user-env
+   :failure/vendor :openai
+   :dependency/class :misconfiguration
+   :dependency/retryability :operator-action
    :workaround {:type :env-var
                 :env-var "OPENAI_API_KEY"
                 :description "Set OPENAI_API_KEY environment variable"

--- a/resources/error-patterns/external.edn
+++ b/resources/error-patterns/external.edn
@@ -1,36 +1,114 @@
-{:description "Patterns that indicate external service errors"
+{:description "Patterns that indicate external provider and platform failures"
  :type :external
  :patterns
- [{:regex "ECONNREFUSED"
+ [{:id :anthropic-rate-limit
+   :regex "(anthropic|claude).*(rate limit|429|too many requests)"
+   :vendor "Anthropic"
+   :description "Anthropic provider rate limit"
+   :failure/source :external-provider
+   :failure/vendor :anthropic
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :openai-rate-limit
+   :regex "(openai|codex).*(rate limit|429|too many requests)"
+   :vendor "OpenAI"
+   :description "OpenAI or Codex provider rate limit"
+   :failure/source :external-provider
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :github-rate-limit
+   :regex "GitHub API rate limit exceeded|GitHub.*(rate limit|429|too many requests)"
+   :vendor "GitHub"
+   :description "GitHub platform rate limit"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :provider-rate-limit
+   :regex "API rate limit exceeded|rate limit exceeded|Rate limit reached|rate-limit error|429|Too Many Requests|too many requests|Quota exceeded|You've hit your limit|resets \\d|resets in \\d+"
    :vendor "External Service"
-   :description "Connection refused"}
-  {:regex "Network error"
-   :vendor "External Service"
-   :description "Network connectivity issue"}
-  {:regex "API rate limit exceeded"
-   :vendor "External Service"
-   :description "API rate limit hit"}
-  {:regex "API service unavailable"
-   :vendor "External Service"
-   :description "API temporarily unavailable"}
-  {:regex "Request timeout"
-   :vendor "External Service"
-   :description "Request timed out"}
-  {:regex "502 Bad Gateway"
-   :vendor "External Service"
-   :description "Bad gateway error"}
-  {:regex "503 Service Unavailable"
-   :vendor "External Service"
-   :description "Service unavailable"}
-  {:regex "Connection refused"
-   :vendor "External Service"
-   :description "Connection refused"}
-  {:regex "DNS lookup failed"
-   :vendor "External Service"
-   :description "DNS resolution failure"}
-  {:regex "permission denied|Permission denied|EACCES"
-   :vendor "External Service"
-   :description "File permission error"}
-  {:regex "Codex cannot access session files"
+   :description "Provider or platform rate limit"
+   :failure/source :external-provider
+   :dependency/class :rate-limit
+   :dependency/retryability :retryable}
+
+  {:id :github-auth-failed
+   :regex "GitHub.*(401|403|authentication failed|bad credentials|forbidden)"
+   :vendor "GitHub"
+   :description "GitHub authentication failed"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :auth
+   :dependency/retryability :operator-action}
+
+  {:id :github-platform-unavailable
+   :regex "GitHub.*(502|503|service unavailable|temporarily unavailable)"
+   :vendor "GitHub"
+   :description "GitHub platform unavailable"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :outage
+   :dependency/retryability :retryable}
+
+  {:id :github-network-failure
+   :regex "GitHub.*(connection refused|connection reset|dns lookup failed|dns resolution failed|network error)"
+   :vendor "GitHub"
+   :description "GitHub platform network failure"
+   :failure/source :external-platform
+   :failure/vendor :github
+   :dependency/class :network
+   :dependency/retryability :retryable}
+
+  {:id :kubernetes-auth-failed
+   :regex "Kubernetes.*(401|403|forbidden|unauthorized|authentication failed)"
+   :vendor "Kubernetes"
+   :description "Kubernetes authentication failed"
+   :failure/source :external-platform
+   :failure/vendor :kubernetes
+   :dependency/class :auth
+   :dependency/retryability :operator-action}
+
+  {:id :kubernetes-platform-unavailable
+   :regex "Kubernetes.*(connection refused|service unavailable|i/o timeout|dial tcp)"
+   :vendor "Kubernetes"
+   :description "Kubernetes platform unavailable"
+   :failure/source :external-platform
+   :failure/vendor :kubernetes
+   :dependency/class :outage
+   :dependency/retryability :retryable}
+
+  {:id :codex-account-limitation
+   :regex "Codex account cannot use model|model .* unsupported|unsupported model|does not have access to model|model .* not available for your account"
    :vendor "Codex"
-   :description "Codex session directory permission issue"}]}
+   :description "Codex or provider account limitation"
+   :failure/source :external-provider
+   :failure/vendor :codex
+   :dependency/class :account-limitation
+   :dependency/retryability :operator-action}
+
+  {:id :provider-service-unavailable
+   :regex "API service unavailable|503 Service Unavailable|502 Bad Gateway|overloaded_error"
+   :vendor "External Service"
+   :description "Provider service unavailable"
+   :failure/source :external-provider
+   :dependency/class :outage
+   :dependency/retryability :retryable}
+
+  {:id :provider-request-timeout
+   :regex "Request timeout|timed out waiting for response|deadline exceeded"
+   :vendor "External Service"
+   :description "Provider request timeout"
+   :failure/source :external-provider
+   :dependency/class :timeout
+   :dependency/retryability :retryable}
+
+  {:id :provider-network-failure
+   :regex "ECONNREFUSED|Connection refused|connection reset|DNS lookup failed|DNS resolution failed|Network error"
+   :vendor "External Service"
+   :description "Provider network failure"
+   :failure/source :external-provider
+   :dependency/class :network
+   :dependency/retryability :retryable}]}


### PR DESCRIPTION
# Dependency Attribution Classifier

## Summary

This PR wires the canonical dependency-attribution model into
`failure-classifier` without breaking the existing `classify` API.

The classifier can now return rich classified failure records that distinguish:

- Miniforge product failures
- user environment and setup failures
- external provider failures
- external platform failures

## Changes

- adds canonical classified failure record construction in
  [taxonomy.clj](components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj)
- adds rich classifier APIs in
  [interface.clj](components/failure-classifier/src/ai/miniforge/failure_classifier/interface.clj):
  - `classify-record`
  - `classify-exception-record`
- extends
  [classifier.clj](components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj)
  to compile and apply dependency attribution patterns from the existing
  `external.edn` and `backend-setup.edn` resources
- upgrades the dependency pattern resources to canonical machine-oriented data in:
  - [resources/error-patterns/external.edn](resources/error-patterns/external.edn)
  - [resources/error-patterns/backend-setup.edn](resources/error-patterns/backend-setup.edn)
- keeps the duplicated `agent-runtime` resource copies in sync so classpath
  resolution cannot silently pick stale pattern data
- adds representative coverage in
  [classifier_test.clj](components/failure-classifier/test/ai/miniforge/failure_classifier/classifier_test.clj)
  for:
  - provider outage
  - provider rate limit
  - account limitation
  - local permission failure
  - missing API key
  - GitHub and Kubernetes platform failures

## Why

Dogfood runs exposed an important operational gap: Miniforge could tell that a
workflow failed, but not whether the failure was caused by Miniforge itself,
the user environment, an LLM provider, or an external platform.

This PR closes the first functional part of that gap by making failure
classification return canonical attribution data instead of only a single
failure-class keyword.

## Validation

- `clj-kondo --lint components/failure-classifier/src/ai/miniforge/failure_classifier
  components/failure-classifier/test/ai/miniforge/failure_classifier resources/error-patterns
  components/agent-runtime/resources/error-patterns`
- targeted `ai.miniforge.failure-classifier.classifier-test`
- full `bb pre-commit`
