### PR TITLE
fix(tui-engine): localize raw log strings to en-US.edn

### DIFF
--- a/components/tui-engine/deps.edn
+++ b/components/tui-engine/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src" "resources"]
  :deps {ai.miniforge/config {:local/root "../config"}
+        ai.miniforge/messages {:local/root "../messages"}
         babashka/clojure-lanterna {:mvn/version "0.9.8"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/components/tui-engine/resources/config/tui-engine/messages/en-US.edn
+++ b/components/tui-engine/resources/config/tui-engine/messages/en-US.edn
@@ -1,0 +1,14 @@
+{:tui-engine/messages
+ {;; Runtime — input thread + resize/tick lifecycle
+  :runtime/input-dispatch-error
+  "input dispatch error"
+
+  :runtime/resize-tick-render-error
+  "resize/tick render error"
+
+  :runtime/tui-starting
+  "TUI starting"
+
+  ;; Render watcher — fires when the model ref changes and a re-render fails.
+  :render/render-failed
+  "render failed view={view}"}}

--- a/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/core.clj
@@ -29,6 +29,7 @@
    - Rendering is serialized via a lock to prevent concurrent screen writes"
   (:require
    [ai.miniforge.tui-engine.log :as log]
+   [ai.miniforge.tui-engine.messages :as msg]
    [ai.miniforge.tui-engine.screen :as screen]
    [ai.miniforge.tui-engine.layout :as layout]))
 
@@ -177,7 +178,8 @@
                  (try
                    (do-render! app-state new-model)
                    (catch Exception e
-                     (log/error (str "render failed view=" (:view new-model)) e)
+                     (log/error (msg/t :render/render-failed
+                                       {:view (:view new-model)}) e)
                      (paint-error-banner! scr e)))))
     (atom app-state)))
 

--- a/components/tui-engine/src/ai/miniforge/tui_engine/messages.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/messages.clj
@@ -1,0 +1,27 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.tui-engine.messages
+  "Component-level message catalog for tui-engine.
+   Delegates to the shared messages component."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  "Look up a tui-engine message by key, with optional param substitution."
+  (messages/create-translator "config/tui-engine/messages/en-US.edn"
+                              :tui-engine/messages))

--- a/components/tui-engine/src/ai/miniforge/tui_engine/runtime.clj
+++ b/components/tui-engine/src/ai/miniforge/tui_engine/runtime.clj
@@ -26,6 +26,7 @@
   (:require
    [ai.miniforge.tui-engine.core :as core]
    [ai.miniforge.tui-engine.log :as log]
+   [ai.miniforge.tui-engine.messages :as msg]
    [ai.miniforge.tui-engine.screen :as screen]
    [ai.miniforge.tui-engine.input :as input]))
 
@@ -114,7 +115,7 @@
                             (Thread/sleep 16))) ; ~60Hz polling
                         (catch InterruptedException e (throw e))
                         (catch Exception e
-                          (log/warn "input dispatch error" e))))
+                          (log/warn (msg/t :runtime/input-dispatch-error) e))))
                     (catch InterruptedException _))))]
     (.setDaemon thread true)
     (.setName thread "tui-input-poll")
@@ -139,7 +140,7 @@
       (when (or resized? tick?)
         (core/do-render! @app model)))
     (catch Exception e
-      (log/warn "resize/tick render error" e))))
+      (log/warn (msg/t :runtime/resize-tick-render-error) e))))
 
 (defn start-resize-thread!
   "Start a scheduled executor that checks for terminal size changes and forces
@@ -176,7 +177,7 @@
    Returns the app atom."
   [app]
   (let [screen (:screen @app)]
-    (log/info "TUI starting")
+    (log/info (msg/t :runtime/tui-starting))
     (screen/start-screen! screen)
     (swap! app assoc :running? true)
     ;; Initial render


### PR DESCRIPTION
## Summary

Per the no-raw-strings rule, \`tui-engine\` had four raw strings inside \`log/*\` calls that flow into \`~/.miniforge/logs/tui.log\`. Following the same pattern PR #708 introduced for \`gate\`, this PR adds tui-engine's messages catalog and migrates the four call sites.

## Changes

**Added:**
- \`components/tui-engine/src/ai/miniforge/tui_engine/messages.clj\` — translator binding
- \`components/tui-engine/resources/config/tui-engine/messages/en-US.edn\` — catalog (4 keys)

**Changed:**
- \`components/tui-engine/deps.edn\` — add \`ai.miniforge/messages\` dep
- \`tui_engine/runtime.clj\`:
  - \`log/warn "input dispatch error"\` → \`:runtime/input-dispatch-error\`
  - \`log/warn "resize/tick render error"\` → \`:runtime/resize-tick-render-error\`
  - \`log/info "TUI starting"\` → \`:runtime/tui-starting\`
- \`tui_engine/core.clj\`:
  - \`log/error (str "render failed view=" v)\` → \`:render/render-failed {:view v}\` (uses \`{view}\` interpolation)

## Context

PR 1 of a multi-PR localization sweep cleanup. \`gate\` was first (PR #708). Components still missing a messages catalog include: many under \`bb-*\`, \`agent\` and other large components, \`policy-pack\`, \`evidence-bundle\`, \`tool-registry\`, \`tui-views\`, \`lsp-mcp-bridge\`, etc. Each will be its own focused PR rather than a single mega-refactor.

## Test plan

- [x] \`bb pre-commit\` passes — lint + format clean, full unit + GraalVM suite green
- [x] All 39 existing tui-engine tests still pass
- [x] Catalog round-trip verified at the REPL: \`(messages/t :runtime/tui-starting)\` returns \`"TUI starting"\` and \`(messages/t :render/render-failed {:view :workflow})\` returns \`"render failed view=:workflow"\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)