### PR TITLE
i18n(etl): localize CLI base output

### DIFF
--- a/bases/etl/deps.edn
+++ b/bases/etl/deps.edn
@@ -1,4 +1,5 @@
 {:paths ["src" "resources"]
- :deps {cheshire/cheshire {:mvn/version "5.13.0"}
-        org.babashka/cli  {:mvn/version "0.8.60"}}
+ :deps {cheshire/cheshire     {:mvn/version "5.13.0"}
+        org.babashka/cli      {:mvn/version "0.8.60"}
+        ai.miniforge/messages {:local/root "../../components/messages"}}
  :aliases {:test {:extra-paths ["test"]}}}

--- a/bases/etl/resources/config/etl/messages/en-US.edn
+++ b/bases/etl/resources/config/etl/messages/en-US.edn
@@ -1,0 +1,59 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+;; English (en-US) message catalog for the `mf etl` JVM base.
+;; Loaded by `ai.miniforge.etl.messages/t` via the shared
+;; `ai.miniforge.messages.interface/create-translator` helper.
+{:etl/messages
+ {;; -------- Pipeline-run summary (`run` subcommand) --------
+  :run/complete           "✓ pipeline run complete"
+  :run/run-id             "  run-id: {value}"
+  :run/status             "  status: {value}"
+  :run/stages             "  stages: {value}"
+  :run/failed             "✗ pipeline run failed"
+  :run/error              "  error: {value}"
+
+  ;; Result emission (--out)
+  :run/wrote              "  wrote: {path}"
+
+  ;; -------- Argument validation --------
+  :run/usage              "usage: etl run <pipeline.edn> --env <env.edn> [--out <result.edn|.json>]"
+  :run/missing-env        "etl run: missing --env <env.edn>"
+
+  ;; -------- `list` subcommand --------
+  :list/discovery-failed  "✗ discovery failed: {error}"
+  :list/header            "{count} pipeline(s) discovered under {path}:"
+  :list/entry             "  - {path}{name}{version}"
+  :list/entry-name        " [{value}]"
+  :list/entry-version     " v{value}"
+
+  ;; -------- `validate` subcommand --------
+  :validate/usage         "usage: etl validate <pipeline.edn> --env <env.edn>"
+  :validate/missing-env   "etl validate: missing --env <env.edn>"
+  :validate/ok            "✓ pack valid — pipeline & env resolve"
+  :validate/stages        "  stages: {value}"
+  :validate/failed        "✗ validation failed"
+  :validate/error         "  error: {value}"
+
+  ;; -------- `help` subcommand --------
+  :help/usage             "usage: etl {run|list|validate} ..."
+  :help/run               "  run      <pipeline.edn> --env <env.edn> [--out <path>]"
+  :help/list              "  list     [<search-path>]"
+  :help/validate          "  validate <pipeline.edn> --env <env.edn>"
+  :help/connector-types   "supported connector types:"
+  :help/connector-entry   "  - {value}"}}

--- a/bases/etl/src/ai/miniforge/etl/main.clj
+++ b/bases/etl/src/ai/miniforge/etl/main.clj
@@ -55,7 +55,8 @@
           (when-let [stages (:pipeline-run/stage-runs run)]
             (println (msg/t :run/stages {:value (count stages)}))))
       (do (println (msg/t :run/failed))
-          (some->> (:error result) (#(println (msg/t :run/error {:value %}))))))))
+          (when-let [error (:error result)]
+            (println (msg/t :run/error {:value error})))))))
 
 (defn- emit-result!
   "Write the pipeline-runner result to `out-path`. Writes JSON when the

--- a/bases/etl/src/ai/miniforge/etl/main.clj
+++ b/bases/etl/src/ai/miniforge/etl/main.clj
@@ -22,6 +22,7 @@
    and Apache POI, which aren't BB-compatible."
   {:miniforge/runtime :jvm-only}
   (:require
+   [ai.miniforge.etl.messages :as msg]
    [ai.miniforge.etl.registry :as registry]
    [ai.miniforge.etl.runner :as runner]
    [ai.miniforge.schema.interface :as schema]
@@ -48,13 +49,13 @@
   [result]
   (let [run (:pipeline-run result)]
     (if (schema/succeeded? result)
-      (do (println "✓ pipeline run complete")
-          (println "  run-id:" (:pipeline-run/id run))
-          (println "  status:" (:pipeline-run/status run))
+      (do (println (msg/t :run/complete))
+          (println (msg/t :run/run-id {:value (:pipeline-run/id run)}))
+          (println (msg/t :run/status  {:value (:pipeline-run/status run)}))
           (when-let [stages (:pipeline-run/stage-runs run)]
-            (println "  stages:" (count stages))))
-      (do (println "✗ pipeline run failed")
-          (some->> (:error result) (println "  error:"))))))
+            (println (msg/t :run/stages {:value (count stages)}))))
+      (do (println (msg/t :run/failed))
+          (some->> (:error result) (#(println (msg/t :run/error {:value %}))))))))
 
 (defn- emit-result!
   "Write the pipeline-runner result to `out-path`. Writes JSON when the
@@ -66,7 +67,7 @@
                      (cheshire/generate-string normalized {:pretty true})
                      (pr-str normalized))]
     (spit out-path body)
-    (println "  wrote:" out-path)))
+    (println (msg/t :run/wrote {:path out-path}))))
 
 (defn- exit! [code] (System/exit (or code 0)))
 
@@ -79,8 +80,8 @@
   [m]
   (let [{:keys [pipeline env out]} (get-opts m)]
     (cond
-      (nil? pipeline) (do (println "usage: etl run <pipeline.edn> --env <env.edn> [--out <result.edn|.json>]") (exit! 1))
-      (nil? env)      (do (println "etl run: missing --env <env.edn>") (exit! 1))
+      (nil? pipeline) (do (println (msg/t :run/usage)) (exit! 1))
+      (nil? env)      (do (println (msg/t :run/missing-env)) (exit! 1))
       :else
       (let [result (runner/run-pack pipeline env {})]
         (print-run-summary! result)
@@ -92,42 +93,44 @@
   (let [path   (:path (get-opts m) ".")
         result (runner/list-pipelines [path])]
     (if (schema/failed? result)
-      (do (println "✗ discovery failed:" (:error result)) (exit! 1))
+      (do (println (msg/t :list/discovery-failed {:error (:error result)})) (exit! 1))
       (let [pipelines (filter :name (:pipelines result))]
-        (println (str (count pipelines) " pipeline(s) discovered under " path ":"))
+        (println (msg/t :list/header {:count (count pipelines) :path path}))
         (doseq [p pipelines]
-          (println "  -" (:path p)
-                   (some->> (:name p) (str "  [") (#(str % "]")))
-                   (some->> (:version p) (str " v"))))
+          (println (msg/t :list/entry
+                          {:path    (:path p)
+                           :name    (or (some->> (:name p)    (#(msg/t :list/entry-name    {:value %}))) "")
+                           :version (or (some->> (:version p) (#(msg/t :list/entry-version {:value %}))) "")})))
         (exit! 0)))))
 
 (defn- validate-cmd
   [m]
   (let [{:keys [pipeline env]} (get-opts m)]
     (cond
-      (nil? pipeline) (do (println "usage: etl validate <pipeline.edn> --env <env.edn>") (exit! 1))
-      (nil? env)      (do (println "etl validate: missing --env <env.edn>") (exit! 1))
+      (nil? pipeline) (do (println (msg/t :validate/usage)) (exit! 1))
+      (nil? env)      (do (println (msg/t :validate/missing-env)) (exit! 1))
       :else
       (let [result (runner/validate-pack pipeline env)]
         (if (schema/succeeded? result)
-          (do (println "✓ pack valid — pipeline & env resolve")
-              (println "  stages:" (count (:pipeline/stages (:pipeline result))))
+          (do (println (msg/t :validate/ok))
+              (println (msg/t :validate/stages
+                              {:value (count (:pipeline/stages (:pipeline result)))}))
               (exit! 0))
-          (do (println "✗ validation failed")
-              (when-let [e (:error result)] (println "  error:" e))
+          (do (println (msg/t :validate/failed))
+              (when-let [e (:error result)] (println (msg/t :validate/error {:value e})))
               (exit! 1)))))))
 
 (defn- help-cmd
   [_m]
-  (println "usage: etl {run|list|validate} ...")
+  (println (msg/t :help/usage))
   (println)
-  (println "  run      <pipeline.edn> --env <env.edn> [--out <path>]")
-  (println "  list     [<search-path>]")
-  (println "  validate <pipeline.edn> --env <env.edn>")
+  (println (msg/t :help/run))
+  (println (msg/t :help/list))
+  (println (msg/t :help/validate))
   (println)
-  (println "supported connector types:")
+  (println (msg/t :help/connector-types))
   (doseq [t (registry/supported-types)]
-    (println "  -" t))
+    (println (msg/t :help/connector-entry {:value t})))
   (exit! 2))
 
 ;------------------------------------------------------------------------------ Layer 2

--- a/bases/etl/src/ai/miniforge/etl/messages.clj
+++ b/bases/etl/src/ai/miniforge/etl/messages.clj
@@ -1,0 +1,29 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.etl.messages
+  "Message catalog accessor for the `mf etl` JVM base.
+
+   Wraps `ai.miniforge.messages.interface/create-translator` so the
+   `run`, `list`, and `validate` handlers in `ai.miniforge.etl.main`
+   can resolve user-visible copy from a locale-specific EDN resource
+   instead of holding raw English strings inline."
+  (:require [ai.miniforge.messages.interface :as messages]))
+
+(def t
+  (messages/create-translator "config/etl/messages/en-US.edn" :etl/messages))

--- a/bases/etl/src/ai/miniforge/etl/messages.clj
+++ b/bases/etl/src/ai/miniforge/etl/messages.clj
@@ -26,4 +26,6 @@
   (:require [ai.miniforge.messages.interface :as messages]))
 
 (def t
+  "Translate an ETL message key. `(t k)` returns the localized string;
+   `(t k params)` interpolates `{placeholder}` markers from `params`."
   (messages/create-translator "config/etl/messages/en-US.edn" :etl/messages))

--- a/bases/etl/test/ai/miniforge/etl/messages_test.clj
+++ b/bases/etl/test/ai/miniforge/etl/messages_test.clj
@@ -1,0 +1,40 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.etl.messages-test
+  "Smoke tests for the etl base's message catalog. Guards against the
+   resource path or section key drifting and against keys silently
+   disappearing from the EDN catalog."
+  (:require [clojure.test :refer [deftest testing is]]
+            [ai.miniforge.etl.messages :as sut]))
+
+(deftest catalog-resolves-keyless-message-test
+  (testing "static catalog keys resolve to non-blank strings"
+    (is (string? (sut/t :run/complete)))
+    (is (string? (sut/t :run/failed)))
+    (is (string? (sut/t :validate/ok)))
+    (is (string? (sut/t :help/usage)))))
+
+(deftest catalog-interpolates-params-test
+  (testing "{placeholder} markers are substituted from the param map"
+    (is (= "  run-id: abc-123"
+           (sut/t :run/run-id {:value "abc-123"})))
+    (is (= "2 pipeline(s) discovered under .:"
+           (sut/t :list/header {:count 2 :path "."})))
+    (is (= "  wrote: /tmp/out.edn"
+           (sut/t :run/wrote {:path "/tmp/out.edn"})))))


### PR DESCRIPTION
## Summary
- Continues the localization sweep (after #718 tui-engine, #719 cli/main).
- Migrates the 26 raw `println` strings in `bases/etl/src/ai/miniforge/etl/main.clj` (`run`/`list`/`validate`/`help` subcommand handlers) to a new `config/etl/messages/en-US.edn` catalog.
- Adds a thin `ai.miniforge.etl.messages/t` translator wrapping the shared `ai.miniforge.messages.interface/create-translator` helper.
- Adds the `ai.miniforge/messages` dep to `bases/etl/deps.edn`.

Output of `mf etl list` is slightly tidier — the original `println`-with-many-args produced double spaces around the optional `[name]` and `v<version>` segments; the catalog template emits single spaces. All other handlers preserve byte-identical output.

## Test plan
- [x] `bb pre-commit` (lint + 3378 tests + GraalVM compat) green
- [x] Smoke: `(ai.miniforge.etl.messages/t :run/complete)` resolves catalog
- [ ] CI green