### PR TITLE
i18n(cli): localize tui/pr/etl subcommand strings

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -686,5 +686,21 @@
   :init/analysis-packs        "  Packs:        {value}"
   :init/git-host-unknown      "unknown"
   :init/existing-overwritten  "  Existing config at {path} will be overwritten."
-  :init/wrote                 "Wrote {path}"}}
+  :init/wrote                 "Wrote {path}"
 
+  ;; ---------- `mf pr respond` ----------
+  :pr/respond-bad-url         "Could not parse PR number from URL"
+  :pr/respond-checkout        "Checking out PR #{number}..."
+  :pr/respond-checkout-failed "Failed to checkout PR branch"
+  :pr/respond-on-branch       "On branch: {branch}"
+  :pr/respond-done            "\nDone: {comments} comment(s), {files} file(s) processed, {fixed} fixed{pushed}"
+  :pr/respond-pushed          ", pushed"
+
+  ;; ---------- `mf pr list` row format ----------
+  :pr/list-row                "  #{number} {state-badge} {title} ({author})"
+  :pr/list-state-badge        "[{state}]"
+  :pr/list-author-unknown     "unknown"
+
+  ;; ---------- `mf etl` (cli wrapper) ----------
+  :etl/run-requires-checkout
+  "mf etl run/list/validate currently requires running from inside a miniforge checkout (walks up looking for workspace.edn + bases/etl/deps.edn). The etl base is dev-alias-only until we publish an installable artifact."}}

--- a/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/etl.clj
@@ -165,7 +165,7 @@
                                                        :out  :inherit
                                                        :err  :inherit}))]
       exit)
-    (do (display/print-error "mf etl run/list/validate currently requires running from inside a miniforge checkout (walks up looking for workspace.edn + bases/etl/deps.edn). The etl base is dev-alias-only until we publish an installable artifact.")
+    (do (display/print-error (messages/t :etl/run-requires-checkout))
         1)))
 
 ;------------------------------------------------------------------------------ Layer 3

--- a/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/pr.clj
@@ -68,11 +68,16 @@
                                          "OPEN" :green
                                          "MERGED" :magenta
                                          "CLOSED" :red
-                                         :white)]
-                      (println (str "  #" number " "
-                                    (display/style (str "[" state "]") :foreground status-style)
-                                    " " title
-                                    " (" (:login author "unknown") ")"))))))
+                                         :white)
+                          state-badge (display/style
+                                       (messages/t :pr/list-state-badge {:state state})
+                                       :foreground status-style)]
+                      (println (messages/t :pr/list-row
+                                           {:number      number
+                                            :state-badge state-badge
+                                            :title       title
+                                            :author      (:login author
+                                                                 (messages/t :pr/list-author-unknown))}))))))
               (catch Exception _
                 (let [result2 (process/sh "gh" "pr" "list" "--repo" r "--limit" "10")]
                   (if (zero? (:exit result2))
@@ -99,24 +104,27 @@
             run-spec  (requiring-resolve 'ai.miniforge.cli.workflow-runner/run-workflow-from-spec!)
             {:keys [number]} (parse-url url)]
         (when-not number
-          (display/print-error "Could not parse PR number from URL")
+          (display/print-error (messages/t :pr/respond-bad-url))
           (System/exit 1))
-        (display/print-info (str "Checking out PR #" number "..."))
+        (display/print-info (messages/t :pr/respond-checkout {:number number}))
         (let [branch (checkout-pr! number)]
           (when-not branch
-            (display/print-error "Failed to checkout PR branch")
+            (display/print-error (messages/t :pr/respond-checkout-failed))
             (System/exit 1))
-          (display/print-info (str "On branch: " branch))
+          (display/print-info (messages/t :pr/respond-on-branch {:branch branch}))
           (let [cwd (System/getProperty "user.dir")
                 result (respond! url cwd
                                  (fn [spec run-opts] (run-spec spec (merge {:quiet true} run-opts)))
                                  push!
                                  opts)]
             (display/print-info
-             (str "\nDone: " (:comments-found result) " comment(s), "
-                  (:files-processed result) " file(s) processed, "
-                  (count (filter :succeeded? (:fixes result))) " fixed"
-                  (when (:pushed? result) ", pushed")))))))))
+             (messages/t :pr/respond-done
+                         {:comments (:comments-found result)
+                          :files    (:files-processed result)
+                          :fixed    (count (filter :succeeded? (:fixes result)))
+                          :pushed   (if (:pushed? result)
+                                      (messages/t :pr/respond-pushed)
+                                      "")}))))))))
 
 (defn pr-merge-cmd
   [opts]

--- a/bases/cli/src/ai/miniforge/cli/main/commands/tui.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/tui.clj
@@ -20,7 +20,8 @@
   "TUI command — launch standalone TUI monitor."
   (:require
    [ai.miniforge.cli.app-config :as app-config]
-   [ai.miniforge.cli.main.display :as display]))
+   [ai.miniforge.cli.main.display :as display]
+   [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; TUI command
@@ -29,7 +30,7 @@
   "Launch standalone TUI that monitors workflow event files.
    Tail-follows app event files for live workflow state."
   [opts]
-  (display/print-info "Starting TUI monitor...")
-  (display/print-info (str "Watching " (app-config/events-dir) " for workflow activity"))
+  (display/print-info (messages/t :tui/starting))
+  (display/print-info (messages/t :tui/watching {:events-dir (app-config/events-dir)}))
   (let [start-tui! (requiring-resolve 'ai.miniforge.tui-views.interface/start-standalone-tui!)]
     (start-tui! opts)))


### PR DESCRIPTION
## Summary
- Continues the localization sweep (after #718, #719, #720, #721, #722).
- Three small command-module mop-ups bundled into one PR:
  - `tui.clj` — wires `tui-cmd` to the existing `:tui/starting` / `:tui/watching` keys (the catalog already had them; the call site just hadn't been updated).
  - `pr.clj` — five strings across `pr-list-cmd` row format (`[STATE]` badge) and `pr-respond-cmd` (bad-url, checkout, on-branch, completion summary).
  - `etl.clj` — the long "mf etl run requires checkout" error.

## Test plan
- [x] `bb pre-commit` (lint + tests + GraalVM compat) green
- [ ] CI green