### PR TITLE
feat: project rolling dependency health

### DIFF
--- a/components/reliability/resources/config/reliability/defaults.edn
+++ b/components/reliability/resources/config/reliability/defaults.edn
@@ -2,4 +2,27 @@
 {:budget-critical-threshold 0.25
  :inverted-slis #{:SLI-6}
  :default-windows [:7d]
- :default-tiers [:standard :critical]}
+ :default-tiers [:standard :critical]
+ :dependency-health
+ {:window-size 5
+  :status-precedence [:operator-action-required
+                      :misconfigured
+                      :unavailable
+                      :degraded
+                      :healthy]
+  :status-thresholds {:operator-action-required 1
+                      :misconfigured 1
+                      :unavailable 3
+                      :degraded 1}
+  :class->status {:outage :unavailable
+                  :degraded :degraded
+                  :rate-limit :degraded
+                  :timeout :degraded
+                  :network :degraded
+                  :quota :degraded
+                  :auth :operator-action-required
+                  :account-limitation :operator-action-required
+                  :permission :misconfigured
+                  :misconfiguration :misconfigured
+                  :unsupported-feature :operator-action-required
+                  :unknown :degraded}}}

--- a/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
+++ b/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
@@ -138,23 +138,26 @@
   (let [source (or (:dependency/source entry) (:failure/source recovery))
         vendor (or (:dependency/vendor entry) (:failure/vendor recovery))
         resolved-id (or (recovery-id recovery) (:dependency/id entry))]
-    (cond-> {:dependency/id resolved-id
-             :dependency/source source
-             :dependency/kind (dependency-kind source)
-             :dependency/observations []
-             :dependency/last-recovered-at recovered-at}
-      vendor (assoc :dependency/vendor vendor)
-      (:dependency/last-observed-at entry)
-      (assoc :dependency/last-observed-at (:dependency/last-observed-at entry)))))
+    (when source
+      (cond-> {:dependency/id resolved-id
+               :dependency/source source
+               :dependency/kind (dependency-kind source)
+               :dependency/observations []
+               :dependency/last-recovered-at recovered-at}
+        vendor (assoc :dependency/vendor vendor)
+        (:dependency/last-observed-at entry)
+        (assoc :dependency/last-observed-at (:dependency/last-observed-at entry))))))
 
 (defn- register-recovery
   [state recovery default-instant]
   (let [entry-id (recovery-id recovery)
         recovered-at (recovery-observed-at recovery default-instant)]
     (if entry-id
-      (update state entry-id
-              (fn [entry]
-                (recovery-entry entry recovery recovered-at)))
+      (let [entry (get state entry-id)
+            updated-entry (recovery-entry entry recovery recovered-at)]
+        (if updated-entry
+          (assoc state entry-id updated-entry)
+          state))
       state)))
 
 (defn- project-entry
@@ -218,4 +221,3 @@
            (map (fn [[entry-id entry]]
                   [entry-id (project-entry entry effective-config)]))
            dependency-state))))
-

--- a/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
+++ b/components/reliability/src/ai/miniforge/reliability/dependency_health.clj
@@ -1,0 +1,221 @@
+;; Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+
+(ns ai.miniforge.reliability.dependency-health
+  "Pure dependency-health projection from classified dependency incidents.
+
+   Dependency health is modeled separately from workflow execution state. This
+   namespace owns rolling projection over canonical dependency incidents and
+   optional recovery signals."
+  (:require
+   [ai.miniforge.failure-classifier.interface :as failure-classifier]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Config and constants
+
+(def ^:private defaults
+  (-> (io/resource "config/reliability/defaults.edn") slurp edn/read-string))
+
+(def default-config
+  "Default dependency-health projection config."
+  (:dependency-health defaults))
+
+(def ^:private dependency-kind-by-source
+  {:external-provider :provider
+   :external-platform :platform
+   :user-env :environment})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Helpers
+
+(defn- dependency-id
+  [{vendor :failure/vendor source :failure/source}]
+  (or vendor source))
+
+(defn- dependency-kind
+  [source]
+  (get dependency-kind-by-source source :environment))
+
+(defn- incident-status
+  [incident config]
+  (let [retryability (:dependency/retryability incident)
+        dependency-class (:dependency/class incident)
+        class-status (get-in config [:class->status dependency-class] :degraded)]
+    (if (= retryability :operator-action)
+      :operator-action-required
+      class-status)))
+
+(defn- incident-observed-at
+  [incident default-instant]
+  (or (:dependency/observed-at incident)
+      (:event/timestamp incident)
+      default-instant))
+
+(defn- recovery-observed-at
+  [recovery default-instant]
+  (or (:dependency/recovered-at recovery)
+      (:event/timestamp recovery)
+      default-instant))
+
+(defn- status-counts
+  [observations]
+  (frequencies (map :dependency/status observations)))
+
+(defn- satisfied-threshold-status
+  [counts {:keys [status-precedence status-thresholds]}]
+  (some (fn [status]
+          (let [threshold (get status-thresholds status Long/MAX_VALUE)
+                count (get counts status 0)]
+            (when (>= count threshold)
+              status)))
+        status-precedence))
+
+(defn- projected-status
+  [observations config]
+  (or (some-> observations status-counts (satisfied-threshold-status config))
+      :healthy))
+
+(defn- trim-observations
+  [observations window-size]
+  (->> observations
+       (take-last window-size)
+       vec))
+
+(defn- base-entry
+  [incident]
+  (let [source (:failure/source incident)
+        vendor (:failure/vendor incident)]
+    (cond-> {:dependency/id (dependency-id incident)
+             :dependency/source source
+             :dependency/kind (dependency-kind source)}
+      vendor (assoc :dependency/vendor vendor))))
+
+(defn- observation
+  [incident observed-at config]
+  (let [status (incident-status incident config)]
+    {:dependency/status status
+     :dependency/class (:dependency/class incident)
+     :dependency/retryability (:dependency/retryability incident)
+     :failure/class (:failure/class incident)
+     :dependency/observed-at observed-at}))
+
+(defn- normalize-entry
+  [entry incident]
+  (merge (base-entry incident) entry))
+
+(defn dependency-incident?
+  "Returns true when the classified incident belongs in dependency-health
+   projection."
+  [incident]
+  (failure-classifier/dependency-failure? incident))
+
+(defn- register-incident
+  [state incident config default-instant]
+  (let [entry-id (dependency-id incident)
+        observed-at (incident-observed-at incident default-instant)
+        new-observation (observation incident observed-at config)
+        window-size (:window-size config)]
+    (update state entry-id
+            (fn [entry]
+              (let [existing-observations (:dependency/observations entry)
+                    observations (-> existing-observations
+                                     (conj new-observation)
+                                     (trim-observations window-size))]
+                (-> entry
+                    (normalize-entry incident)
+                    (assoc :dependency/observations observations
+                           :dependency/last-observed-at observed-at)))))))
+
+(defn- recovery-id
+  [recovery]
+  (or (:dependency/id recovery)
+      (:failure/vendor recovery)
+      (:failure/source recovery)))
+
+(defn- recovery-entry
+  [entry recovery recovered-at]
+  (let [source (or (:dependency/source entry) (:failure/source recovery))
+        vendor (or (:dependency/vendor entry) (:failure/vendor recovery))
+        resolved-id (or (recovery-id recovery) (:dependency/id entry))]
+    (cond-> {:dependency/id resolved-id
+             :dependency/source source
+             :dependency/kind (dependency-kind source)
+             :dependency/observations []
+             :dependency/last-recovered-at recovered-at}
+      vendor (assoc :dependency/vendor vendor)
+      (:dependency/last-observed-at entry)
+      (assoc :dependency/last-observed-at (:dependency/last-observed-at entry)))))
+
+(defn- register-recovery
+  [state recovery default-instant]
+  (let [entry-id (recovery-id recovery)
+        recovered-at (recovery-observed-at recovery default-instant)]
+    (if entry-id
+      (update state entry-id
+              (fn [entry]
+                (recovery-entry entry recovery recovered-at)))
+      state)))
+
+(defn- project-entry
+  [entry config]
+  (let [observations (:dependency/observations entry)
+        counts (status-counts observations)
+        status (projected-status observations config)
+        latest-observation (last observations)
+        failure-count (count observations)
+        last-observed-at (:dependency/last-observed-at entry)
+        last-recovered-at (:dependency/last-recovered-at entry)
+        dependency-class (:dependency/class latest-observation)
+        retryability (:dependency/retryability latest-observation)
+        failure-class (:failure/class latest-observation)
+        window-size (:window-size config)]
+    (cond-> {:dependency/id (:dependency/id entry)
+             :dependency/source (:dependency/source entry)
+             :dependency/kind (:dependency/kind entry)
+             :dependency/status status
+             :dependency/failure-count failure-count
+             :dependency/window-size window-size
+             :dependency/incident-counts counts}
+      (:dependency/vendor entry) (assoc :dependency/vendor (:dependency/vendor entry))
+      dependency-class (assoc :dependency/class dependency-class)
+      retryability (assoc :dependency/retryability retryability)
+      failure-class (assoc :failure/class failure-class)
+      last-observed-at (assoc :dependency/last-observed-at last-observed-at)
+      last-recovered-at (assoc :dependency/last-recovered-at last-recovered-at))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Public pipeline
+
+(defn apply-signals
+  "Apply dependency incidents and recovery signals to rolling state.
+
+   Arguments:
+     dependency-state - map keyed by dependency id
+     incidents        - vector of canonical classified dependency failures
+     recoveries       - vector of recovery signals
+     config           - optional dependency-health config
+     observed-at      - fallback timestamp when signals omit one"
+  ([dependency-state incidents recoveries]
+   (apply-signals dependency-state incidents recoveries default-config (java.util.Date.)))
+  ([dependency-state incidents recoveries config observed-at]
+   (let [effective-config (merge default-config config)
+         filtered-incidents (filter dependency-incident? incidents)
+         state-with-incidents (reduce #(register-incident %1 %2 effective-config observed-at)
+                                      (or dependency-state {})
+                                      filtered-incidents)]
+     (reduce #(register-recovery %1 %2 observed-at)
+             state-with-incidents
+             recoveries))))
+
+(defn project-health
+  "Project rolling dependency state into canonical dependency-health entities."
+  ([dependency-state]
+   (project-health dependency-state default-config))
+  ([dependency-state config]
+   (let [effective-config (merge default-config config)]
+     (into {}
+           (map (fn [[entry-id entry]]
+                  [entry-id (project-entry entry effective-config)]))
+           dependency-state))))
+

--- a/components/reliability/src/ai/miniforge/reliability/engine.clj
+++ b/components/reliability/src/ai/miniforge/reliability/engine.clj
@@ -6,11 +6,32 @@
    Layer 0: Engine record and creation
    Layer 1: Compute cycle (stateful, emits events)"
   (:require
+   [ai.miniforge.reliability.dependency-health :as dependency-health]
    [ai.miniforge.reliability.sli :as sli]
    [ai.miniforge.reliability.slo :as slo]
    [ai.miniforge.reliability.budget :as budget]
    [ai.miniforge.event-stream.interface.stream :as stream]
-   [ai.miniforge.event-stream.interface.events :as events]))
+   [ai.miniforge.event-stream.interface.events :as events]
+   [clojure.edn :as edn]
+   [clojure.java.io :as io]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Config loading
+
+(def ^:private defaults
+  (-> (io/resource "config/reliability/defaults.edn") slurp edn/read-string))
+
+(defn- merge-engine-config
+  [config]
+  (let [base-config {:windows (:default-windows defaults)
+                     :tiers (:default-tiers defaults)
+                     :dependency-health dependency-health/default-config
+                     :slo-targets slo/default-targets}
+        merged-config (merge base-config config)]
+    (assoc merged-config
+           :dependency-health
+           (merge (:dependency-health base-config)
+                  (:dependency-health config)))))
 
 ;------------------------------------------------------------------------------ Layer 0
 ;; Engine record
@@ -18,7 +39,7 @@
 (defrecord ReliabilityEngine
   [event-stream   ; event stream atom for emitting events
    state          ; atom: {:slis [...] :slo-checks [...] :budgets {...} :mode :nominal}
-   config])       ; {:windows [:7d] :tiers [:standard :critical]}
+   config])       ; {:windows [:7d] :tiers [:standard :critical] :dependency-health {...}}
 
 (defn create-engine
   "Create a ReliabilityEngine.
@@ -35,12 +56,11 @@
    (atom {:slis []
           :slo-checks []
           :budgets {}
+          :dependency-health {}
+          :dependency-health-state {}
           :mode :nominal
           :last-computed-at nil})
-   (merge {:windows [:7d]
-           :tiers [:standard :critical]
-           :slo-targets slo/default-targets}
-          config)))
+   (merge-engine-config config)))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Pipeline stages
@@ -92,7 +112,11 @@
       :recommendation :nominal | :degraded | :safe-mode}"
   [engine metrics]
   (let [{:keys [event-stream state config]} engine
-        {:keys [windows tiers slo-targets]} config
+        {:keys [windows tiers slo-targets dependency-health]} config
+        prior-dependency-state (:dependency-health-state @state)
+        dependency-incidents (:dependency/incidents metrics)
+        dependency-recoveries (:dependency/recoveries metrics)
+        computed-at (java.util.Date.)
 
         ;; 1. Compute SLIs for each window
         all-slis (vec (mapcat #(sli/compute-all-slis metrics %) windows))
@@ -103,6 +127,17 @@
 
         ;; 3. Compute error budgets for enforced SLOs
         budgets (compute-budgets all-slo-checks)
+
+        ;; 3b. Update rolling dependency-health projection
+        next-dependency-state (dependency-health/apply-signals
+                               prior-dependency-state
+                               dependency-incidents
+                               dependency-recoveries
+                               dependency-health
+                               computed-at)
+        dependency-health-projection (dependency-health/project-health
+                                      next-dependency-state
+                                      dependency-health)
 
         ;; 4. Determine degradation recommendation
         any-critical-exhausted? (budget/critical-budget-exhausted? budgets)
@@ -141,13 +176,16 @@
     (reset! state {:slis all-slis
                    :slo-checks all-slo-checks
                    :budgets budgets
+                   :dependency-health dependency-health-projection
+                   :dependency-health-state next-dependency-state
                    :mode recommendation
-                   :last-computed-at (java.util.Date.)})
+                   :last-computed-at computed-at})
 
     ;; 7. Return result
     {:slis all-slis
      :slo-checks all-slo-checks
      :budgets budgets
+     :dependency-health dependency-health-projection
      :breaches breaches
      :recommendation recommendation}))
 
@@ -163,7 +201,7 @@
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment
-  (def stream (events/create-event-stream {:sinks []}))
+  (def stream (stream/create-event-stream {:sinks []}))
   (def eng (create-engine stream))
 
   (def now (java.util.Date.))

--- a/components/reliability/src/ai/miniforge/reliability/engine.clj
+++ b/components/reliability/src/ai/miniforge/reliability/engine.clj
@@ -108,6 +108,7 @@
      {:slis [...]
       :slo-checks [...]
       :budgets {...}
+      :dependency-health {...}
       :breaches [...]
       :recommendation :nominal | :degraded | :safe-mode}"
   [engine metrics]

--- a/components/reliability/src/ai/miniforge/reliability/interface.clj
+++ b/components/reliability/src/ai/miniforge/reliability/interface.clj
@@ -100,7 +100,13 @@
   "Execute one reliability computation cycle.
    Computes SLIs, checks SLOs, updates budgets, emits events.
 
-   Returns: {:slis :slo-checks :budgets :breaches :recommendation}"
+   Returns:
+   {:slis
+    :slo-checks
+    :budgets
+    :dependency-health
+    :breaches
+    :recommendation}"
   engine/compute-cycle!)
 
 (def current-state

--- a/components/reliability/src/ai/miniforge/reliability/interface.clj
+++ b/components/reliability/src/ai/miniforge/reliability/interface.clj
@@ -16,6 +16,7 @@
    [ai.miniforge.reliability.sli :as sli]
    [ai.miniforge.reliability.slo :as slo]
    [ai.miniforge.reliability.budget :as budget]
+   [ai.miniforge.reliability.dependency-health :as dependency-health]
    [ai.miniforge.reliability.engine :as engine]
    [ai.miniforge.reliability.degradation :as degradation]))
 
@@ -29,6 +30,9 @@
 (def SliResult schema/SliResult)
 (def SloCheck schema/SloCheck)
 (def ErrorBudget schema/ErrorBudget)
+(def DependencyKind schema/DependencyKind)
+(def DependencyHealthStatus schema/DependencyHealthStatus)
+(def DependencyHealth schema/DependencyHealth)
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; SLI computation (pure)
@@ -63,6 +67,23 @@
 (def compute-error-budget budget/compute-error-budget)
 (def budget-exhausted? budget/budget-exhausted?)
 (def budget-critical? budget/budget-critical?)
+
+;------------------------------------------------------------------------------ Layer 3b
+;; Dependency health projection (pure)
+
+(def dependency-incident?
+  "Returns true when the classified failure contributes to dependency-health
+   projection."
+  dependency-health/dependency-incident?)
+
+(def apply-dependency-signals
+  "Apply classified dependency incidents and recovery signals to rolling
+   dependency-health state."
+  dependency-health/apply-signals)
+
+(def project-dependency-health
+  "Project rolling dependency-health state into canonical dependency entities."
+  dependency-health/project-health)
 
 ;------------------------------------------------------------------------------ Layer 4
 ;; Engine (stateful)

--- a/components/reliability/src/ai/miniforge/reliability/schema.clj
+++ b/components/reliability/src/ai/miniforge/reliability/schema.clj
@@ -19,6 +19,12 @@
 (def DegradationMode
   [:enum :nominal :degraded :safe-mode])
 
+(def DependencyKind
+  [:enum :provider :platform :environment])
+
+(def DependencyHealthStatus
+  [:enum :healthy :degraded :unavailable :misconfigured :operator-action-required])
+
 ;------------------------------------------------------------------------------ Layer 0
 ;; Records
 
@@ -47,3 +53,19 @@
    [:error-budget/remaining :double]
    [:error-budget/burn-rate :double]
    [:error-budget/computed-at inst?]])
+
+(def DependencyHealth
+  [:map
+   [:dependency/id keyword?]
+   [:dependency/source keyword?]
+   [:dependency/kind DependencyKind]
+   [:dependency/status DependencyHealthStatus]
+   [:dependency/failure-count :int]
+   [:dependency/window-size :int]
+   [:dependency/incident-counts [:map-of DependencyHealthStatus :int]]
+   [:dependency/vendor {:optional true} keyword?]
+   [:dependency/class {:optional true} keyword?]
+   [:dependency/retryability {:optional true} keyword?]
+   [:failure/class {:optional true} keyword?]
+   [:dependency/last-observed-at {:optional true} inst?]
+   [:dependency/last-recovered-at {:optional true} inst?]])

--- a/components/reliability/test/ai/miniforge/reliability/dependency_health_test.clj
+++ b/components/reliability/test/ai/miniforge/reliability/dependency_health_test.clj
@@ -1,0 +1,82 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.reliability.dependency-health-test
+  (:require
+   [clojure.test :refer [deftest is]]
+   [ai.miniforge.reliability.interface :as rel]))
+
+(defn- dependency-failure
+  [overrides]
+  (merge {:failure/class :failure.class/external
+          :failure/source :external-provider
+          :failure/vendor :anthropic
+          :dependency/class :rate-limit
+          :dependency/retryability :retryable
+          :failure/message "rate limit"}
+         overrides))
+
+(deftest provider-rate-limits-project-degraded-health
+  (let [rolling-state (rel/apply-dependency-signals {}
+                                             [(dependency-failure {})]
+                                             [])
+        projection (rel/project-dependency-health rolling-state)
+        anthropic-health (get projection :anthropic)]
+    (is (= :degraded (:dependency/status anthropic-health)))
+    (is (= :provider (:dependency/kind anthropic-health)))
+    (is (= 1 (:dependency/failure-count anthropic-health)))))
+
+(deftest repeated-outages-cross-unavailable-threshold
+  (let [incidents (repeat 3 (dependency-failure {:dependency/class :outage
+                                                 :failure/message "provider outage"}))
+        rolling-state (rel/apply-dependency-signals {} incidents [])
+        projection (rel/project-dependency-health rolling-state)
+        anthropic-health (get projection :anthropic)]
+    (is (= :unavailable (:dependency/status anthropic-health)))
+    (is (= 3 (:dependency/failure-count anthropic-health)))))
+
+(deftest environment-misconfiguration-is-tracked-separately
+  (let [rolling-state (rel/apply-dependency-signals
+                       {}
+                       [(dependency-failure {:failure/source :user-env
+                                             :failure/vendor nil
+                                             :dependency/class :misconfiguration
+                                             :dependency/retryability :operator-action
+                                             :failure/message "missing api key"})]
+                       [])
+        projection (rel/project-dependency-health rolling-state)
+        env-health (get projection :user-env)]
+    (is (= :operator-action-required (:dependency/status env-health)))
+    (is (= :environment (:dependency/kind env-health)))))
+
+(deftest recovery-resets-health-to-healthy
+  (let [rolling-state (rel/apply-dependency-signals
+                       {}
+                       [(dependency-failure {:dependency/class :outage})]
+                       [])
+        recovered-state (rel/apply-dependency-signals
+                         rolling-state
+                         []
+                         [{:dependency/id :anthropic
+                           :failure/source :external-provider
+                           :failure/vendor :anthropic}])
+        projection (rel/project-dependency-health recovered-state)
+        anthropic-health (get projection :anthropic)]
+    (is (= :healthy (:dependency/status anthropic-health)))
+    (is (= 0 (:dependency/failure-count anthropic-health)))
+    (is (some? (:dependency/last-recovered-at anthropic-health)))))

--- a/components/reliability/test/ai/miniforge/reliability/sli_test.clj
+++ b/components/reliability/test/ai/miniforge/reliability/sli_test.clj
@@ -170,12 +170,20 @@
     (let [stream (stream/create-event-stream {:sinks []})
           eng (rel/create-engine stream {:windows [:7d] :tiers [:standard]})
           metrics {:workflow-metrics [{:status :completed :timestamp now}
-                                     {:status :completed :timestamp now}
-                                     {:status :failed :timestamp now}]}
+                                      {:status :completed :timestamp now}
+                                      {:status :failed :timestamp now}]
+                   :dependency/incidents [{:failure/class :failure.class/external
+                                           :failure/source :external-provider
+                                           :failure/vendor :anthropic
+                                           :dependency/class :rate-limit
+                                           :dependency/retryability :retryable
+                                           :failure/message "rate limit"}]}
           result (rel/compute-cycle! eng metrics)]
       (is (vector? (:slis result)))
       (is (vector? (:slo-checks result)))
       (is (map? (:budgets result)))
+      (is (map? (:dependency-health result)))
+      (is (= :degraded (get-in result [:dependency-health :anthropic :dependency/status])))
       (is (contains? #{:nominal :degraded :safe-mode} (:recommendation result)))
       ;; Events should have been emitted
       (is (pos? (count (:events @stream)))))))

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -723,13 +723,17 @@
   [table event]
   (let [dependency-id (:dependency/id event)
         existing (get-in table [:dependencies dependency-id])
+        source (or (:dependency/source event)
+                   (:dependency/source existing))
+        kind (or (:dependency/kind event)
+                 (:dependency/kind existing))
         recovered-at (or (:dependency/last-recovered-at event)
                          (:dependency/recovered-at event)
                          (event-instant event))
         updated (cond-> (merge existing
                                {:dependency/id dependency-id
-                                :dependency/source (:dependency/source event)
-                                :dependency/kind (:dependency/kind event)
+                                :dependency/source source
+                                :dependency/kind kind
                                 :dependency/status :healthy
                                 :dependency/failure-count 0
                                 :dependency/window-size (or (:dependency/window-size event)

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -693,6 +693,56 @@
     (cond-> table
       entity (assoc-in [:interventions (:intervention/id entity)] entity))))
 
+(defn- dependency-entity
+  [event]
+  (or (:supervisory/entity event)
+      (:dependency/entity event)
+      (select-keys event
+                   [:dependency/id
+                    :dependency/source
+                    :dependency/kind
+                    :dependency/status
+                    :dependency/failure-count
+                    :dependency/window-size
+                    :dependency/incident-counts
+                    :dependency/vendor
+                    :dependency/class
+                    :dependency/retryability
+                    :failure/class
+                    :dependency/last-observed-at
+                    :dependency/last-recovered-at])))
+
+(defn dependency-health-updated
+  [table event]
+  (let [entity (dependency-entity event)
+        dependency-id (:dependency/id entity)]
+    (cond-> table
+      dependency-id (assoc-in [:dependencies dependency-id] entity))))
+
+(defn dependency-recovered
+  [table event]
+  (let [dependency-id (:dependency/id event)
+        existing (get-in table [:dependencies dependency-id])
+        recovered-at (or (:dependency/last-recovered-at event)
+                         (:dependency/recovered-at event)
+                         (event-instant event))
+        updated (cond-> (merge existing
+                               {:dependency/id dependency-id
+                                :dependency/source (:dependency/source event)
+                                :dependency/kind (:dependency/kind event)
+                                :dependency/status :healthy
+                                :dependency/failure-count 0
+                                :dependency/window-size (or (:dependency/window-size event)
+                                                            (:dependency/window-size existing)
+                                                            0)
+                                :dependency/incident-counts {}})
+                  recovered-at (assoc :dependency/last-recovered-at recovered-at)
+                  (:dependency/source event) (assoc :dependency/source (:dependency/source event))
+                  (:dependency/kind event) (assoc :dependency/kind (:dependency/kind event))
+                  (:dependency/vendor event) (assoc :dependency/vendor (:dependency/vendor event)))]
+    (cond-> table
+      dependency-id (assoc-in [:dependencies dependency-id] updated))))
+
 ;------------------------------------------------------------------------------ Layer 3
 ;; Dispatch table — events not listed are no-ops at the entity-state level
 
@@ -727,6 +777,9 @@
    :supervisory/task-node-upserted         supervisory-task-node-upserted
    :supervisory/decision-upserted          supervisory-decision-upserted
    :supervisory/intervention-upserted      supervisory-intervention-upserted
+   :supervisory/dependency-upserted        dependency-health-updated
+   :dependency/health-updated              dependency-health-updated
+   :dependency/recovered                   dependency-recovered
    :supervisory/policy-evaluated           supervisory-policy-evaluated
    :supervisory/attention-derived          supervisory-attention-derived})
 

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj
@@ -712,6 +712,45 @@
                     :dependency/last-observed-at
                     :dependency/last-recovered-at])))
 
+(defn- resolved-dependency-source
+  [event existing]
+  (or (:dependency/source event)
+      (:dependency/source existing)))
+
+(defn- resolved-dependency-kind
+  [event existing]
+  (or (:dependency/kind event)
+      (:dependency/kind existing)))
+
+(defn- recovered-dependency-entity
+  [event existing recovered-at]
+  (let [dependency-id (:dependency/id event)
+        source (resolved-dependency-source event existing)
+        kind (resolved-dependency-kind event existing)
+        vendor (or (:dependency/vendor event)
+                   (:dependency/vendor existing))
+        window-size (or (:dependency/window-size event)
+                        (:dependency/window-size existing)
+                        0)
+        last-observed-at (:dependency/last-observed-at existing)
+        dependency-class (:dependency/class existing)
+        retryability (:dependency/retryability existing)
+        failure-class (:failure/class existing)]
+    (when dependency-id
+      (cond-> {:dependency/id dependency-id
+               :dependency/source source
+               :dependency/kind kind
+               :dependency/status :healthy
+               :dependency/failure-count 0
+               :dependency/window-size window-size
+               :dependency/incident-counts {}}
+        vendor (assoc :dependency/vendor vendor)
+        dependency-class (assoc :dependency/class dependency-class)
+        retryability (assoc :dependency/retryability retryability)
+        failure-class (assoc :failure/class failure-class)
+        last-observed-at (assoc :dependency/last-observed-at last-observed-at)
+        recovered-at (assoc :dependency/last-recovered-at recovered-at)))))
+
 (defn dependency-health-updated
   [table event]
   (let [entity (dependency-entity event)
@@ -723,29 +762,12 @@
   [table event]
   (let [dependency-id (:dependency/id event)
         existing (get-in table [:dependencies dependency-id])
-        source (or (:dependency/source event)
-                   (:dependency/source existing))
-        kind (or (:dependency/kind event)
-                 (:dependency/kind existing))
         recovered-at (or (:dependency/last-recovered-at event)
                          (:dependency/recovered-at event)
                          (event-instant event))
-        updated (cond-> (merge existing
-                               {:dependency/id dependency-id
-                                :dependency/source source
-                                :dependency/kind kind
-                                :dependency/status :healthy
-                                :dependency/failure-count 0
-                                :dependency/window-size (or (:dependency/window-size event)
-                                                            (:dependency/window-size existing)
-                                                            0)
-                                :dependency/incident-counts {}})
-                  recovered-at (assoc :dependency/last-recovered-at recovered-at)
-                  (:dependency/source event) (assoc :dependency/source (:dependency/source event))
-                  (:dependency/kind event) (assoc :dependency/kind (:dependency/kind event))
-                  (:dependency/vendor event) (assoc :dependency/vendor (:dependency/vendor event)))]
+        updated (recovered-dependency-entity event existing recovered-at)]
     (cond-> table
-      dependency-id (assoc-in [:dependencies dependency-id] updated))))
+      updated (assoc-in [:dependencies dependency-id] updated))))
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Dispatch table — events not listed are no-ops at the entity-state level

--- a/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
+++ b/components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj
@@ -104,6 +104,12 @@
    N5-delta-supervisory-control-plane §3.3."
   [:proposed :pending-human :approved :rejected :dispatched :applied :verified :failed])
 
+(def dependency-kinds
+  [:provider :platform :environment])
+
+(def dependency-statuses
+  [:healthy :degraded :unavailable :misconfigured :operator-action-required])
+
 ;------------------------------------------------------------------------------ Layer 0a
 ;; Registry extensions for supervisory v1
 
@@ -168,7 +174,12 @@
 
    ;; InterventionRequest (N5 supervisory delta §3.1 / §3.3)
    :intervention/id              :id/uuid
-   :intervention/state           (into [:enum] intervention-states)})
+   :intervention/state           (into [:enum] intervention-states)
+
+   ;; DependencyHealth
+   :dependency/id                keyword?
+   :dependency/kind              (into [:enum] dependency-kinds)
+   :dependency/status            (into [:enum] dependency-statuses)})
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Entity schemas — open maps, mirror N5-delta-1 §3.1
@@ -423,6 +434,23 @@
    [:intervention/reason {:optional true} [:maybe string?]]
    [:intervention/outcome {:optional true} any?]])
 
+(def DependencyHealth
+  "Projected health for an external provider, platform, or user environment."
+  [:map {:registry registry}
+   [:dependency/id :dependency/id]
+   [:dependency/source keyword?]
+   [:dependency/kind :dependency/kind]
+   [:dependency/status :dependency/status]
+   [:dependency/failure-count :common/non-neg-int]
+   [:dependency/window-size :common/non-neg-int]
+   [:dependency/incident-counts [:map-of :dependency/status :common/non-neg-int]]
+   [:dependency/vendor {:optional true} [:maybe keyword?]]
+   [:dependency/class {:optional true} [:maybe keyword?]]
+   [:dependency/retryability {:optional true} [:maybe keyword?]]
+   [:failure/class {:optional true} [:maybe keyword?]]
+   [:dependency/last-observed-at {:optional true} [:maybe :common/timestamp]]
+   [:dependency/last-recovered-at {:optional true} [:maybe :common/timestamp]]])
+
 ;------------------------------------------------------------------------------ Layer 2
 ;; Component-internal entity table
 
@@ -436,7 +464,8 @@
    [:attention     [:map-of :id/uuid AttentionItem]]
    [:tasks         [:map-of :id/uuid TaskNode]]
    [:decisions     [:map-of :id/uuid DecisionCard]]
-   [:interventions [:map-of :id/uuid InterventionRequest]]])
+   [:interventions [:map-of :id/uuid InterventionRequest]]
+   [:dependencies  [:map-of :dependency/id DependencyHealth]]])
 
 (def empty-table
   "Initial empty entity table."
@@ -447,4 +476,5 @@
    :attention {}
    :tasks {}
    :decisions {}
-   :interventions {}})
+   :interventions {}
+   :dependencies {}})

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -124,6 +124,40 @@
                   (acc/apply-event (ev :workflow/cancelled {:workflow/id wf-id})))]
     (is (= :cancelled (get-in table [:workflows wf-id :workflow-run/status])))))
 
+;------------------------------------------------------------------------------ DependencyHealth
+
+(deftest dependency-health-updated-inserts-projection
+  (let [table (acc/apply-event schema/empty-table
+                               (ev :dependency/health-updated
+                                   {:dependency/id :anthropic
+                                    :dependency/source :external-provider
+                                    :dependency/kind :provider
+                                    :dependency/status :degraded
+                                    :dependency/failure-count 1
+                                    :dependency/window-size 5
+                                    :dependency/incident-counts {:degraded 1}}))
+        dependency (get-in table [:dependencies :anthropic])]
+    (is (= :degraded (:dependency/status dependency)))
+    (is (= :provider (:dependency/kind dependency)))))
+
+(deftest dependency-recovered-resets-entity-to-healthy
+  (let [table (-> schema/empty-table
+                  (acc/apply-event (ev :dependency/health-updated
+                                       {:dependency/id :anthropic
+                                        :dependency/source :external-provider
+                                        :dependency/kind :provider
+                                        :dependency/status :unavailable
+                                        :dependency/failure-count 3
+                                        :dependency/window-size 5
+                                        :dependency/incident-counts {:unavailable 3}}))
+                  (acc/apply-event (ev :dependency/recovered
+                                       {:dependency/id :anthropic
+                                        :dependency/source :external-provider
+                                        :dependency/kind :provider
+                                        :dependency/vendor :anthropic})))]
+    (is (= :healthy (get-in table [:dependencies :anthropic :dependency/status])))
+    (is (= 0 (get-in table [:dependencies :anthropic :dependency/failure-count])))))
+
 ;------------------------------------------------------------------------------ AgentSession
 
 (deftest cp-agent-registered-inserts-session

--- a/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
+++ b/components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj
@@ -126,16 +126,22 @@
 
 ;------------------------------------------------------------------------------ DependencyHealth
 
+(defn- dependency-health-attrs
+  [attrs]
+  (merge {:dependency/id :anthropic
+          :dependency/source :external-provider
+          :dependency/kind :provider
+          :dependency/vendor :anthropic
+          :dependency/window-size 5}
+         attrs))
+
 (deftest dependency-health-updated-inserts-projection
   (let [table (acc/apply-event schema/empty-table
                                (ev :dependency/health-updated
-                                   {:dependency/id :anthropic
-                                    :dependency/source :external-provider
-                                    :dependency/kind :provider
-                                    :dependency/status :degraded
-                                    :dependency/failure-count 1
-                                    :dependency/window-size 5
-                                    :dependency/incident-counts {:degraded 1}}))
+                                   (dependency-health-attrs
+                                    {:dependency/status :degraded
+                                     :dependency/failure-count 1
+                                     :dependency/incident-counts {:degraded 1}})))
         dependency (get-in table [:dependencies :anthropic])]
     (is (= :degraded (:dependency/status dependency)))
     (is (= :provider (:dependency/kind dependency)))))
@@ -143,18 +149,12 @@
 (deftest dependency-recovered-resets-entity-to-healthy
   (let [table (-> schema/empty-table
                   (acc/apply-event (ev :dependency/health-updated
-                                       {:dependency/id :anthropic
-                                        :dependency/source :external-provider
-                                        :dependency/kind :provider
-                                        :dependency/status :unavailable
-                                        :dependency/failure-count 3
-                                        :dependency/window-size 5
-                                        :dependency/incident-counts {:unavailable 3}}))
+                                       (dependency-health-attrs
+                                        {:dependency/status :unavailable
+                                         :dependency/failure-count 3
+                                         :dependency/incident-counts {:unavailable 3}})))
                   (acc/apply-event (ev :dependency/recovered
-                                       {:dependency/id :anthropic
-                                        :dependency/source :external-provider
-                                        :dependency/kind :provider
-                                        :dependency/vendor :anthropic})))]
+                                       (dependency-health-attrs {}))))]
     (is (= :healthy (get-in table [:dependencies :anthropic :dependency/status])))
     (is (= 0 (get-in table [:dependencies :anthropic :dependency/failure-count])))))
 

--- a/docs/pull-requests/2026-04-30-feat-dependency-health-projection.md
+++ b/docs/pull-requests/2026-04-30-feat-dependency-health-projection.md
@@ -1,0 +1,96 @@
+# feat/dependency-health-projection
+
+## Summary
+
+Adds the next implementation slice for external dependency health and failure
+attribution by modeling rolling dependency health separately from workflow
+execution state.
+
+This PR keeps the scope narrow:
+
+- adds config-driven dependency-health thresholds and status mapping
+- introduces a pure dependency-health projector in `reliability`
+- extends the reliability engine state to carry dependency-health projections
+- adds dependency-health entities to `supervisory-state`
+- wires supervisory-state to store projected dependency health from canonical
+  dependency events
+- adds focused tests for projection, engine integration, and accumulator
+  behavior
+
+It does **not** yet add typed dependency-health event constructors or connect
+dependency health to degradation policy transitions. Those are the next slice.
+
+## Why This Slice
+
+The dependency-attribution taxonomy and classifier work can now say whether a
+failure came from:
+
+- Miniforge
+- user environment/setup
+- an external provider
+- an external platform
+
+What the system still lacked was a canonical, rolling health model that can
+answer:
+
+- is Anthropic degraded or unavailable right now?
+- is GitHub unavailable or just rate-limited?
+- is the local user environment misconfigured?
+- does this require retries, operator action, or neither?
+
+That health state belongs in the reliability/supervisory layer, not inside
+workflow phases.
+
+## Key Changes
+
+- extended
+  [defaults.edn](../../components/reliability/resources/config/reliability/defaults.edn)
+  with dependency-health config:
+  - window size
+  - status precedence
+  - status thresholds
+  - dependency-class to health-status mapping
+- added the pure projector in
+  [dependency_health.clj](../../components/reliability/src/ai/miniforge/reliability/dependency_health.clj)
+- extended
+  [engine.clj](../../components/reliability/src/ai/miniforge/reliability/engine.clj)
+  so `compute-cycle!` accepts:
+  - `:dependency/incidents`
+  - `:dependency/recoveries`
+  and returns/stores `:dependency-health`
+- exported the new projection API and schemas from
+  [interface.clj](../../components/reliability/src/ai/miniforge/reliability/interface.clj)
+  and
+  [schema.clj](../../components/reliability/src/ai/miniforge/reliability/schema.clj)
+- added a new supervisory dependency entity in
+  [schema.clj](../../components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj)
+- updated
+  [accumulator.clj](../../components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj)
+  to accept:
+  - `:dependency/health-updated`
+  - `:dependency/recovered`
+  - `:supervisory/dependency-upserted`
+- added focused coverage in:
+  - [dependency_health_test.clj](../../components/reliability/test/ai/miniforge/reliability/dependency_health_test.clj)
+  - [sli_test.clj](../../components/reliability/test/ai/miniforge/reliability/sli_test.clj)
+  - [accumulator_test.clj](../../components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj)
+
+## What This PR Does Not Do
+
+- no event-stream schema or constructor additions yet
+- no degradation-policy changes yet
+- no attention derivation changes yet
+- no CLI or dashboard attribution yet
+- no workflow/evidence integration yet
+
+Those are intentionally left for the next PRs in the stack.
+
+## Validation
+
+- `clj-kondo --lint` on touched reliability and supervisory-state files
+- targeted JVM tests for:
+  - `ai.miniforge.reliability.dependency-health-test`
+  - `ai.miniforge.reliability.sli-test`
+  - `ai.miniforge.reliability.degradation-test`
+  - `ai.miniforge.supervisory-state.accumulator-test`
+- full `bb pre-commit`


### PR DESCRIPTION
# feat/dependency-health-projection

## Summary

Adds the next implementation slice for external dependency health and failure
attribution by modeling rolling dependency health separately from workflow
execution state.

This PR keeps the scope narrow:

- adds config-driven dependency-health thresholds and status mapping
- introduces a pure dependency-health projector in `reliability`
- extends the reliability engine state to carry dependency-health projections
- adds dependency-health entities to `supervisory-state`
- wires supervisory-state to store projected dependency health from canonical
  dependency events
- adds focused tests for projection, engine integration, and accumulator
  behavior

It does **not** yet add typed dependency-health event constructors or connect
dependency health to degradation policy transitions. Those are the next slice.

## Why This Slice

The dependency-attribution taxonomy and classifier work can now say whether a
failure came from:

- Miniforge
- user environment/setup
- an external provider
- an external platform

What the system still lacked was a canonical, rolling health model that can
answer:

- is Anthropic degraded or unavailable right now?
- is GitHub unavailable or just rate-limited?
- is the local user environment misconfigured?
- does this require retries, operator action, or neither?

That health state belongs in the reliability/supervisory layer, not inside
workflow phases.

## Key Changes

- extended
  [defaults.edn](../../components/reliability/resources/config/reliability/defaults.edn)
  with dependency-health config:
  - window size
  - status precedence
  - status thresholds
  - dependency-class to health-status mapping
- added the pure projector in
  [dependency_health.clj](../../components/reliability/src/ai/miniforge/reliability/dependency_health.clj)
- extended
  [engine.clj](../../components/reliability/src/ai/miniforge/reliability/engine.clj)
  so `compute-cycle!` accepts:
  - `:dependency/incidents`
  - `:dependency/recoveries`
  and returns/stores `:dependency-health`
- exported the new projection API and schemas from
  [interface.clj](../../components/reliability/src/ai/miniforge/reliability/interface.clj)
  and
  [schema.clj](../../components/reliability/src/ai/miniforge/reliability/schema.clj)
- added a new supervisory dependency entity in
  [schema.clj](../../components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj)
- updated
  [accumulator.clj](../../components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj)
  to accept:
  - `:dependency/health-updated`
  - `:dependency/recovered`
  - `:supervisory/dependency-upserted`
- added focused coverage in:
  - [dependency_health_test.clj](../../components/reliability/test/ai/miniforge/reliability/dependency_health_test.clj)
  - [sli_test.clj](../../components/reliability/test/ai/miniforge/reliability/sli_test.clj)
  - [accumulator_test.clj](../../components/supervisory-state/test/ai/miniforge/supervisory_state/accumulator_test.clj)

## What This PR Does Not Do

- no event-stream schema or constructor additions yet
- no degradation-policy changes yet
- no attention derivation changes yet
- no CLI or dashboard attribution yet
- no workflow/evidence integration yet

Those are intentionally left for the next PRs in the stack.

## Validation

- `clj-kondo --lint` on touched reliability and supervisory-state files
- targeted JVM tests for:
  - `ai.miniforge.reliability.dependency-health-test`
  - `ai.miniforge.reliability.sli-test`
  - `ai.miniforge.reliability.degradation-test`
  - `ai.miniforge.supervisory-state.accumulator-test`
- full `bb pre-commit`
