### PR TITLE
feat: add boundary component for exception → anomaly conversion

### DIFF
--- a/components/boundary/deps.edn
+++ b/components/boundary/deps.edn
@@ -1,0 +1,8 @@
+{:paths ["src"]
+ :deps {ai.miniforge/anomaly        {:local/root "../anomaly"}
+        ai.miniforge/response-chain {:local/root "../response-chain"}
+        metosin/malli               {:mvn/version "0.16.4"}}
+ :aliases
+ {:test {:extra-paths ["test"]
+         :extra-deps {io.github.cognitect-labs/test-runner
+                      {:git/tag "v0.5.1" :git/sha "dfb30dd"}}}}}

--- a/components/boundary/src/ai/miniforge/boundary/contract.clj
+++ b/components/boundary/src/ai/miniforge/boundary/contract.clj
@@ -1,0 +1,121 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.contract
+  "Malli contracts for the boundary primitive.
+
+   The boundary component catches exceptions thrown by libraries (DBs,
+   HTTP clients, JVM I/O, parsers, ...) and converts them into anomaly
+   steps in a response-chain. It is the third H-series cross-cutting
+   primitive — anomaly is the shape, response-chain carries it through
+   a flow, boundary captures throws at the edges and turns them into
+   data.
+
+   The schemas here describe the exception-category vocabulary and the
+   shape of the captured exception payload that lands inside an
+   anomaly's `:anomaly/data`."
+  (:require
+   [malli.core :as m]
+   [malli.error :as me]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Exception-category vocabulary
+
+(def exception-categories
+  "Standard categories for classifying caught exceptions.
+
+   The category is supplied by the call site (the developer knows what
+   kind of library call they are wrapping) and drives the canonical
+   anomaly type the chain step ends up carrying:
+
+   - :network     — outbound network failure (connection refused,
+                    DNS, socket reset, TLS handshake)
+   - :db          — database driver/JDBC failure
+   - :io          — local filesystem or stream I/O failure
+   - :parse       — malformed input from a deserializer (JSON, EDN, ...)
+   - :timeout     — operation exceeded its time budget
+   - :unavailable — downstream dependency is down
+   - :unknown     — caller cannot classify; fall back to :fault"
+  #{:network
+    :db
+    :io
+    :parse
+    :timeout
+    :unavailable
+    :unknown})
+
+;------------------------------------------------------------------------------ Layer 1
+;; Captured-exception payload
+
+(def CapturedException
+  "Malli schema for the exception payload stored inside an anomaly's
+   `:anomaly/data` when boundary converts a throw into a chain step.
+
+   Every field is plain data so the payload can be serialized into the
+   evidence-bundle and replayed later:
+   - :exception/type    — fully-qualified class name (string)
+   - :exception/message — `(.getMessage e)` or nil
+   - :exception/cause   — root-cause message string, or nil when there
+                          is no cause
+   - :exception/data    — `(ex-data e)` for `ExceptionInfo`, else nil
+   - :boundary/category — the category the call site supplied"
+  [:map {:closed true}
+   [:exception/type     :string]
+   [:exception/message  [:maybe :string]]
+   [:exception/cause    [:maybe :string]]
+   [:exception/data     [:maybe [:map-of :any :any]]]
+   [:boundary/category  (into [:enum] exception-categories)]])
+
+;------------------------------------------------------------------------------ Layer 2
+;; check-fn shape (advisory)
+;;
+;; The boundary primitive is intentionally small: callers pass an
+;; ordinary 0+ arity function `f` plus its `args`. There is no
+;; mandatory pre-flight `check-fn` — but downstream callers commonly
+;; want to validate input before invoking `f`, and a `check-fn` is the
+;; conventional name for that. The schema below documents the shape
+;; consumers should use when they layer one on top of `execute`.
+
+(def CheckFn
+  "Malli schema for the optional pre-flight check function consumers
+   may layer on top of `execute`. A `check-fn` returns nil when its
+   inputs are acceptable, or an `Anomaly` when they are not. Boundary
+   itself does not consume a check-fn — this schema is exposed so
+   higher-level wrappers agree on the shape."
+  [:=> [:cat [:* :any]] [:maybe :map]])
+
+;------------------------------------------------------------------------------ Layer 3
+;; Validation helpers
+
+(defn valid-category?
+  "Return true when `value` is one of the standard
+   `exception-categories`."
+  [value]
+  (contains? exception-categories value))
+
+(defn valid-captured-exception?
+  "Return true when `value` matches the `CapturedException` schema."
+  [value]
+  (m/validate CapturedException value))
+
+(defn explain-captured-exception
+  "Return a humanized explanation for an invalid captured-exception
+   payload, or nil when `value` is valid."
+  [value]
+  (some-> (m/explain CapturedException value)
+          me/humanize))

--- a/components/boundary/src/ai/miniforge/boundary/contract.clj
+++ b/components/boundary/src/ai/miniforge/boundary/contract.clj
@@ -30,6 +30,7 @@
    shape of the captured exception payload that lands inside an
    anomaly's `:anomaly/data`."
   (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
    [malli.core :as m]
    [malli.error :as me]))
 
@@ -70,8 +71,13 @@
    evidence-bundle and replayed later:
    - :exception/type    — fully-qualified class name (string)
    - :exception/message — `(.getMessage e)` or nil
-   - :exception/cause   — root-cause message string, or nil when there
-                          is no cause
+   - :exception/cause   — immediate-cause message string from
+                          `(.getCause e)`, or nil when there is no
+                          cause. Note: this is the *immediate* cause
+                          only, not a walked root cause; nested causes
+                          remain accessible via the original throwable
+                          if a caller needs them, but boundary itself
+                          does not unwind the chain.
    - :exception/data    — `(ex-data e)` for `ExceptionInfo`, else nil
    - :boundary/category — the category the call site supplied"
   [:map {:closed true}
@@ -94,10 +100,11 @@
 (def CheckFn
   "Malli schema for the optional pre-flight check function consumers
    may layer on top of `execute`. A `check-fn` returns nil when its
-   inputs are acceptable, or an `Anomaly` when they are not. Boundary
-   itself does not consume a check-fn — this schema is exposed so
-   higher-level wrappers agree on the shape."
-  [:=> [:cat [:* :any]] [:maybe :map]])
+   inputs are acceptable, or a canonical `Anomaly` (per
+   `ai.miniforge.anomaly.interface/Anomaly`) when they are not.
+   Boundary itself does not consume a check-fn — this schema is
+   exposed so higher-level wrappers agree on the shape."
+  [:=> [:cat [:* :any]] [:maybe anomaly/Anomaly]])
 
 ;------------------------------------------------------------------------------ Layer 3
 ;; Validation helpers

--- a/components/boundary/src/ai/miniforge/boundary/core.clj
+++ b/components/boundary/src/ai/miniforge/boundary/core.clj
@@ -1,0 +1,167 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.core
+  "Implementation of the boundary primitive.
+
+   `execute-with-exception-handling` runs an arbitrary 0+ arity
+   function and converts any thrown exception into an anomaly step
+   appended to the supplied response-chain. Success appends a
+   successful step.
+
+   The component is itself a boundary helper: it never throws on
+   runtime input. The single permitted throw is a programmer-error
+   guard for an unknown category (mirrors anomaly's vocabulary check
+   at construction)."
+  (:require
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.boundary.contract :as contract]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Category → anomaly-type mapping
+
+(def category->anomaly-type
+  "Data-driven mapping from boundary category to canonical anomaly
+   type. Public read-only table — exposed through the interface so
+   callers and reviewers can audit the wiring without reading code.
+
+   Every category in `contract/exception-categories` must appear here;
+   the assertion at namespace load guards the invariant."
+  {:network     :unavailable
+   :db          :fault
+   :io          :fault
+   :parse       :invalid-input
+   :timeout     :timeout
+   :unavailable :unavailable
+   :unknown     :fault})
+
+;; Compile-time invariant: every standard category resolves to an
+;; anomaly type. Catches drift if either set is edited in isolation.
+(assert (= contract/exception-categories
+           (set (keys category->anomaly-type)))
+        "boundary/category->anomaly-type must cover every exception-category")
+
+;------------------------------------------------------------------------------ Layer 1
+;; Programmer-error guard
+
+(defn- assert-known-category!
+  "Throw `IllegalArgumentException` when `category` is not in the
+   standard vocabulary. This is the one place boundary throws — the
+   exception means the call site is wrong, not that runtime data went
+   bad."
+  [category]
+  (when-not (contract/valid-category? category)
+    (throw (IllegalArgumentException.
+            (str "Unknown boundary category: " (pr-str category)
+                 ". Must be one of "
+                 (pr-str contract/exception-categories))))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Exception → captured payload
+
+(defn- cause-message
+  "Return the message of the immediate cause of `e`, or nil when there
+   is no cause. Boundary code may pass the cause as nil (no
+   `Throwable.getCause` link), so we explicitly nil-coalesce."
+  [^Throwable e]
+  (when-let [cause (.getCause e)]
+    (.getMessage ^Throwable cause)))
+
+(defn- exception-class-name
+  "Return the fully-qualified class name of `e`. Always a string —
+   every JVM Throwable has a class."
+  [^Throwable e]
+  (.getName (class e)))
+
+(defn- safe-ex-data
+  "Return `(ex-data e)` when `e` is an `ExceptionInfo`, else nil.
+   `ex-data` returns nil for non-`IExceptionInfo`, but callers may
+   subclass; this stays defensive."
+  [e]
+  (try
+    (ex-data e)
+    (catch Throwable _ nil)))
+
+(defn- capture-exception
+  "Build the `CapturedException` payload for the supplied exception
+   and category. Pure — never throws."
+  [^Throwable e category]
+  {:exception/type     (exception-class-name e)
+   :exception/message  (.getMessage e)
+   :exception/cause    (cause-message e)
+   :exception/data     (safe-ex-data e)
+   :boundary/category  category})
+
+;------------------------------------------------------------------------------ Layer 3
+;; Exception → anomaly
+
+(defn- category->type
+  "Resolve `category` to its anomaly type. Falls back to `:fault` for
+   unknown categories so the function stays non-throwing in the
+   recovery path; the public entry point's `assert-known-category!`
+   handles programmer-error rejection up front."
+  [category]
+  (get category->anomaly-type category :fault))
+
+(defn- exception->anomaly
+  "Convert exception `e` (under `category`) into a canonical anomaly.
+   The anomaly's `:anomaly/data` carries the captured payload."
+  [^Throwable e category]
+  (let [an-type (category->type category)
+        message (or (.getMessage e)
+                    (exception-class-name e))]
+    (anomaly/anomaly an-type message (capture-exception e category))))
+
+;------------------------------------------------------------------------------ Layer 4
+;; Safe invocation
+
+(defn- safe-apply
+  "Apply `f` to `args`, returning either {:ok value} on success or
+   {:throw e} on any thrown `Throwable`. Never propagates."
+  [f args]
+  (try
+    {:ok (apply f args)}
+    (catch Throwable e
+      {:throw e})))
+
+;------------------------------------------------------------------------------ Layer 5
+;; Public entry point
+
+(defn execute-with-exception-handling
+  "Canonical exception → anomaly wrapper.
+
+   Calls `(apply f args)`. On success appends a successful step under
+   `operation-key` to `chain` and returns the updated chain. On a
+   thrown exception, classifies the throw via `category`, converts it
+   into an anomaly carrying the `CapturedException` payload, appends
+   an anomaly step, and returns the (now-failed) chain.
+
+   Never throws on runtime input — the chain absorbs the exception as
+   data. Throws `IllegalArgumentException` only when `category` is not
+   in `contract/exception-categories`; that is a programmer error, not
+   a runtime condition."
+  [category chain operation-key f & args]
+  (assert-known-category! category)
+  (let [result (safe-apply f args)]
+    (if-let [e (:throw result)]
+      (chain/append-step chain
+                         operation-key
+                         (exception->anomaly e category)
+                         nil)
+      (chain/append-step chain operation-key (:ok result)))))

--- a/components/boundary/src/ai/miniforge/boundary/interface.clj
+++ b/components/boundary/src/ai/miniforge/boundary/interface.clj
@@ -59,6 +59,15 @@
    `ai.miniforge.boundary.contract/CapturedException`."
   contract/CapturedException)
 
+(def CheckFn
+  "Malli schema for an advisory pre-flight `check-fn` consumers may
+   layer on top of `execute`. Returns nil when its inputs are
+   acceptable, or a canonical `Anomaly` when they are not. Boundary
+   itself does not consume a check-fn; the schema is exposed so
+   higher-level wrappers agree on the shape. See
+   `ai.miniforge.boundary.contract/CheckFn`."
+  contract/CheckFn)
+
 (def category->anomaly-type
   "Read-only mapping from boundary category to canonical anomaly type.
    See `ai.miniforge.boundary.core/category->anomaly-type`.
@@ -69,8 +78,24 @@
        :parse       -> :invalid-input
        :timeout     -> :timeout
        :unavailable -> :unavailable
-       :unknown     -> :fault"
+       :unknown     -> :fault
+
+   The map is invokable as a function in Clojure for known keys
+   (`(category->anomaly-type :db) ;; => :fault`); use `classify-category`
+   when you want explicit lookup-with-`:fault`-default semantics for
+   unknown keys."
   core/category->anomaly-type)
+
+(defn classify-category
+  "Return the canonical anomaly type for `category`, falling back to
+   `:fault` when the category is not in `exception-categories`.
+
+   This is the function form of the lookup. The underlying
+   `category->anomaly-type` mapping is also re-exported as a map for
+   inspection (e.g. listing every (category, type) pair, or asserting
+   coverage in tests)."
+  [category]
+  (get category->anomaly-type category :fault))
 
 ;------------------------------------------------------------------------------ Layer 1
 ;; Canonical wrapper

--- a/components/boundary/src/ai/miniforge/boundary/interface.clj
+++ b/components/boundary/src/ai/miniforge/boundary/interface.clj
@@ -1,0 +1,130 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.interface
+  "Public API for the boundary component.
+
+   Boundary is the third H-series cross-cutting primitive. Together
+   with `ai.miniforge.anomaly` (the failure shape) and
+   `ai.miniforge.response-chain` (the runtime trace), it lets every
+   miniforge-family Clojure repo speak one error-flow vocabulary:
+   functions return anomalies, the chain accumulates them, and
+   `boundary/execute` is the canonical place to catch a thrown
+   exception from a library call and convert it into a chain step.
+
+   The component is itself a boundary helper: it never throws on
+   runtime input. The only acceptable throw is the programmer-error
+   guard for an unknown category.
+
+   Standard usage. Category comes first, chain second — so callers
+   thread with `as->` (or explicit `let` rebinding) rather than `->`:
+
+     (require '[ai.miniforge.boundary.interface :as boundary]
+              '[ai.miniforge.response-chain.interface :as chain])
+
+     (defn fetch-user [id]
+       (as-> (chain/create-chain :user/fetch) c
+         (boundary/execute :db      c :db/find-user      db-find id)
+         (boundary/execute :network c :api/sync-profile  sync!   id)))"
+  (:require
+   [ai.miniforge.boundary.contract :as contract]
+   [ai.miniforge.boundary.core :as core]))
+
+;------------------------------------------------------------------------------ Layer 0
+;; Vocabulary and schema re-exports
+
+(def exception-categories
+  "Set of standard exception-category keywords. See
+   `ai.miniforge.boundary.contract/exception-categories`."
+  contract/exception-categories)
+
+(def CapturedException
+  "Malli schema for the captured-exception payload that lives inside
+   an anomaly's `:anomaly/data`. See
+   `ai.miniforge.boundary.contract/CapturedException`."
+  contract/CapturedException)
+
+(def category->anomaly-type
+  "Read-only mapping from boundary category to canonical anomaly type.
+   See `ai.miniforge.boundary.core/category->anomaly-type`.
+
+       :network     -> :unavailable
+       :db          -> :fault
+       :io          -> :fault
+       :parse       -> :invalid-input
+       :timeout     -> :timeout
+       :unavailable -> :unavailable
+       :unknown     -> :fault"
+  core/category->anomaly-type)
+
+;------------------------------------------------------------------------------ Layer 1
+;; Canonical wrapper
+
+(defn execute-with-exception-handling
+  "Run `(apply f args)` and convert the outcome into a chain step.
+
+   - On success: appends a successful step under `operation-key` to
+     `chain` carrying the function's return value.
+   - On thrown exception: classifies the throw via `category`, builds
+     an anomaly whose type is determined by `category->anomaly-type`,
+     captures the exception payload (`:exception/type`,
+     `:exception/message`, `:exception/cause`, `:exception/data`,
+     `:boundary/category`), appends an anomaly step, and returns the
+     now-failed chain.
+
+   Never throws on runtime input. Throws `IllegalArgumentException`
+   only when `category` is not in `exception-categories` — that is a
+   programmer error at the call site, not a runtime condition."
+  [category chain operation-key f & args]
+  (apply core/execute-with-exception-handling
+         category chain operation-key f args))
+
+(defn execute
+  "Short alias for `execute-with-exception-handling`."
+  [category chain operation-key f & args]
+  (apply core/execute-with-exception-handling
+         category chain operation-key f args))
+
+;------------------------------------------------------------------------------ Rich Comment
+
+(comment
+  (require '[ai.miniforge.response-chain.interface :as chain])
+
+  (def c0 (chain/create-chain :demo))
+
+  (def c1 (execute :db c0 :db/lookup
+                   (fn [id] {:id id :name "ada"})
+                   42))
+  (chain/succeeded? c1)
+  ;; => true
+
+  (def c2 (execute :network c1 :api/call
+                   (fn [_] (throw (java.io.IOException. "connection refused")))
+                   :anything))
+  (chain/succeeded? c2)
+  ;; => false
+  (-> c2 chain/last-anomaly :anomaly/type)
+  ;; => :unavailable
+  (-> c2 chain/last-anomaly :anomaly/data :exception/type)
+  ;; => "java.io.IOException"
+
+  ;; Programmer error — unknown category throws
+  (try (execute :no-such-category c0 :op identity 1)
+       (catch IllegalArgumentException e (.getMessage e)))
+
+  :leave-this-here)

--- a/components/boundary/test/ai/miniforge/boundary/interface/category_classification_test.clj
+++ b/components/boundary/test/ai/miniforge/boundary/interface/category_classification_test.clj
@@ -68,3 +68,16 @@
                               :op
                               boom!)]
       (is (= :db (-> c chain/last-anomaly :anomaly/data :boundary/category))))))
+
+(deftest classify-category-resolves-known-categories
+  (testing "classify-category mirrors the mapping table for every standard category"
+    (doseq [category boundary/exception-categories]
+      (is (= (get boundary/category->anomaly-type category)
+             (boundary/classify-category category))
+          (str "classify-category should agree with the table for " category)))))
+
+(deftest classify-category-falls-back-to-fault-for-unknown
+  (testing "classify-category returns :fault when the category is outside the standard vocabulary"
+    (is (= :fault (boundary/classify-category :no-such-category)))
+    (is (= :fault (boundary/classify-category nil)))
+    (is (= :fault (boundary/classify-category "string-not-keyword")))))

--- a/components/boundary/test/ai/miniforge/boundary/interface/category_classification_test.clj
+++ b/components/boundary/test/ai/miniforge/boundary/interface/category_classification_test.clj
@@ -1,0 +1,70 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.interface.category-classification-test
+  "Category → anomaly-type mapping. Each standard category resolves to
+   the expected canonical anomaly type, and the public mapping table
+   covers every category in the vocabulary."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.boundary.interface :as boundary]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(defn- boom! [] (throw (RuntimeException. "x")))
+
+(defn- category->anomaly-type-for-throw
+  "Run a throwing function under `category` and return the anomaly
+   type recorded on the chain."
+  [category]
+  (-> (boundary/execute category (chain/create-chain :flow) :op boom!)
+      chain/last-anomaly
+      :anomaly/type))
+
+(deftest mapping-table-covers-every-category
+  (testing "category->anomaly-type maps every standard category"
+    (is (= boundary/exception-categories
+           (set (keys boundary/category->anomaly-type))))))
+
+(deftest network-maps-to-unavailable
+  (is (= :unavailable (category->anomaly-type-for-throw :network))))
+
+(deftest db-maps-to-fault
+  (is (= :fault (category->anomaly-type-for-throw :db))))
+
+(deftest io-maps-to-fault
+  (is (= :fault (category->anomaly-type-for-throw :io))))
+
+(deftest parse-maps-to-invalid-input
+  (is (= :invalid-input (category->anomaly-type-for-throw :parse))))
+
+(deftest timeout-maps-to-timeout
+  (is (= :timeout (category->anomaly-type-for-throw :timeout))))
+
+(deftest unavailable-maps-to-unavailable
+  (is (= :unavailable (category->anomaly-type-for-throw :unavailable))))
+
+(deftest unknown-maps-to-fault
+  (is (= :fault (category->anomaly-type-for-throw :unknown))))
+
+(deftest captured-payload-records-the-supplied-category
+  (testing ":boundary/category in the captured payload echoes the call-site category"
+    (let [c (boundary/execute :db
+                              (chain/create-chain :flow)
+                              :op
+                              boom!)]
+      (is (= :db (-> c chain/last-anomaly :anomaly/data :boundary/category))))))

--- a/components/boundary/test/ai/miniforge/boundary/interface/ex_data_preservation_test.clj
+++ b/components/boundary/test/ai/miniforge/boundary/interface/ex_data_preservation_test.clj
@@ -1,0 +1,78 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.interface.ex-data-preservation-test
+  "ex-data preservation. Libraries that throw `ExceptionInfo` carry
+   structured data through `(ex-data e)`. Boundary must surface that
+   payload intact so downstream handlers can branch on it without
+   re-parsing exception messages."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.boundary.interface :as boundary]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(defn- ex-data-from [chain]
+  (-> chain chain/last-anomaly :anomaly/data :exception/data))
+
+(deftest plain-keyword-keys-survive
+  (testing "ex-data with simple keyword keys is preserved verbatim"
+    (let [payload {:user/id 42 :retry? true}
+          c (boundary/execute :db
+                              (chain/create-chain :flow)
+                              :db/lookup
+                              (fn [] (throw (ex-info "lookup failed" payload))))]
+      (is (= payload (ex-data-from c))))))
+
+(deftest namespaced-keys-survive
+  (testing "namespaced ex-data keys are preserved without rewriting"
+    (let [payload {:db.error/code :sql.unique-violation
+                   :db.error/table "users"}
+          c (boundary/execute :db
+                              (chain/create-chain :flow)
+                              :db/insert
+                              (fn [] (throw (ex-info "constraint" payload))))]
+      (is (= payload (ex-data-from c))))))
+
+(deftest nested-data-structures-survive
+  (testing "nested maps and vectors inside ex-data are preserved"
+    (let [payload {:request {:url "https://x" :headers {"x-trace" "1"}}
+                   :attempts [1 2 3]}
+          c (boundary/execute :network
+                              (chain/create-chain :flow)
+                              :http/get
+                              (fn [] (throw (ex-info "5xx" payload))))]
+      (is (= payload (ex-data-from c))))))
+
+(deftest empty-ex-data-is-an-empty-map
+  (testing "ex-info with an empty data map preserves the empty map (not nil)"
+    (let [c (boundary/execute :db
+                              (chain/create-chain :flow)
+                              :db/op
+                              (fn [] (throw (ex-info "x" {}))))]
+      (is (= {} (ex-data-from c))))))
+
+(deftest ex-data-preservation-survives-cause-chain
+  (testing "ex-data on the outer ExceptionInfo is preserved even when there is a cause"
+    (let [root (RuntimeException. "root")
+          wrap (ex-info "wrapped" {:layer :outer} root)
+          c    (boundary/execute :network
+                                 (chain/create-chain :flow)
+                                 :op
+                                 (fn [] (throw wrap)))]
+      (is (= {:layer :outer} (ex-data-from c)))
+      (is (= "root" (-> c chain/last-anomaly :anomaly/data :exception/cause))))))

--- a/components/boundary/test/ai/miniforge/boundary/interface/exception_data_capture_test.clj
+++ b/components/boundary/test/ai/miniforge/boundary/interface/exception_data_capture_test.clj
@@ -1,0 +1,91 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.interface.exception-data-capture-test
+  "Exception payload capture. The anomaly's `:anomaly/data` carries
+   the canonical `CapturedException` shape — type, message, cause,
+   ex-data, and the boundary category."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [malli.core :as m]
+   [ai.miniforge.boundary.interface :as boundary]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(defn- captured [chain]
+  (-> chain chain/last-anomaly :anomaly/data))
+
+(deftest type-is-fully-qualified-class-name
+  (testing ":exception/type is the FQCN of the thrown exception"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :op
+                              (fn [] (throw (java.io.IOException. "boom"))))]
+      (is (= "java.io.IOException"
+             (:exception/type (captured c)))))))
+
+(deftest message-is-the-exception-message
+  (testing ":exception/message is (.getMessage e)"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :op
+                              (fn [] (throw (RuntimeException. "down for maintenance"))))]
+      (is (= "down for maintenance"
+             (:exception/message (captured c)))))))
+
+(deftest cause-is-captured-when-present
+  (testing ":exception/cause is the message of the immediate cause"
+    (let [root  (IllegalStateException. "root")
+          wrap  (RuntimeException. "wrap" root)
+          c     (boundary/execute :unknown
+                                  (chain/create-chain :flow)
+                                  :op
+                                  (fn [] (throw wrap)))]
+      (is (= "root" (:exception/cause (captured c)))))))
+
+(deftest cause-is-nil-when-absent
+  (testing ":exception/cause is nil when the exception has no cause"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :op
+                              (fn [] (throw (RuntimeException. "lonely"))))]
+      (is (nil? (:exception/cause (captured c)))))))
+
+(deftest data-is-ex-data-for-exceptioninfo
+  (testing ":exception/data carries the (ex-data e) map for ExceptionInfo"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :op
+                              (fn [] (throw (ex-info "boom" {:user/id 7 :retry? true}))))]
+      (is (= {:user/id 7 :retry? true}
+             (:exception/data (captured c)))))))
+
+(deftest data-is-nil-for-plain-exceptions
+  (testing ":exception/data is nil when the throw is a plain Throwable"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :op
+                              (fn [] (throw (RuntimeException. "no data"))))]
+      (is (nil? (:exception/data (captured c)))))))
+
+(deftest captured-payload-validates-against-schema
+  (testing "the captured payload satisfies the CapturedException schema"
+    (let [c (boundary/execute :db
+                              (chain/create-chain :flow)
+                              :op
+                              (fn [] (throw (ex-info "x" {:k :v}))))]
+      (is (m/validate boundary/CapturedException (captured c))))))

--- a/components/boundary/test/ai/miniforge/boundary/interface/exception_to_anomaly_test.clj
+++ b/components/boundary/test/ai/miniforge/boundary/interface/exception_to_anomaly_test.clj
@@ -1,0 +1,70 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.interface.exception-to-anomaly-test
+  "Exception → anomaly conversion. A throw inside the wrapped function
+   must produce an anomaly step on the chain — the throw never escapes
+   `execute`."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.anomaly.interface :as anomaly]
+   [ai.miniforge.boundary.interface :as boundary]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(defn- boom! [_]
+  (throw (RuntimeException. "kaboom")))
+
+(deftest thrown-exception-becomes-anomaly-step
+  (testing "the appended step carries an anomaly and succeeded? false"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :op/risky
+                              boom!
+                              :ignored)
+          step (last (chain/steps c))]
+      (is (false? (:succeeded? step)))
+      (is (anomaly/anomaly? (:anomaly step)))
+      (is (nil? (:response step))))))
+
+(deftest thrown-exception-flips-chain-failed
+  (testing "chain/succeeded? is false once a wrapped throw is recorded"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :op/risky
+                              boom!
+                              :ignored)]
+      (is (false? (chain/succeeded? c))))))
+
+(deftest later-success-does-not-recover-failed-chain
+  (testing "subsequent successful execute calls cannot un-fail the chain"
+    (let [c (as-> (chain/create-chain :flow) c
+              (boundary/execute :unknown c :a (constantly 1))
+              (boundary/execute :unknown c :b boom! :ignored)
+              (boundary/execute :unknown c :c (constantly 3)))]
+      (is (false? (chain/succeeded? c)))
+      (is (= 3 (count (chain/steps c)))))))
+
+(deftest anomaly-message-defaults-to-exception-class-when-message-nil
+  (testing "boundary still produces a non-nil :anomaly/message even when (.getMessage e) is nil"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :op/silent
+                              (fn [] (throw (RuntimeException.))))
+          msg (:anomaly/message (chain/last-anomaly c))]
+      (is (string? msg))
+      (is (not (clojure.string/blank? msg))))))

--- a/components/boundary/test/ai/miniforge/boundary/interface/happy_path_test.clj
+++ b/components/boundary/test/ai/miniforge/boundary/interface/happy_path_test.clj
@@ -1,0 +1,79 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.interface.happy-path-test
+  "Happy path. When the wrapped function returns normally, boundary
+   appends a successful step under the supplied operation key, the
+   chain stays successful, and the response is the function's return
+   value."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.boundary.interface :as boundary]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest successful-call-appends-successful-step
+  (testing "execute on a returning function appends a step with succeeded? true"
+    (let [c0 (chain/create-chain :flow)
+          c1 (boundary/execute :db c0 :db/find-user
+                               (fn [id] {:id id})
+                               7)
+          step (last (chain/steps c1))]
+      (is (true? (:succeeded? step)))
+      (is (nil?  (:anomaly step)))
+      (is (= :db/find-user (:operation step))))))
+
+(deftest successful-call-keeps-chain-succeeded
+  (testing "chain remains successful after a successful execute"
+    (let [c0 (chain/create-chain :flow)
+          c  (boundary/execute :db c0 :db/find-user (constantly :ok))]
+      (is (chain/succeeded? c)))))
+
+(deftest response-is-the-functions-return-value
+  (testing "step :response equals the value the wrapped function returned"
+    (let [c (boundary/execute :io
+                              (chain/create-chain :flow)
+                              :io/read-file
+                              (fn [path] {:path path :bytes 12})
+                              "/tmp/x")]
+      (is (= {:path "/tmp/x" :bytes 12} (chain/last-response c))))))
+
+(deftest variadic-args-are-applied-in-order
+  (testing "extra args after f are forwarded to (apply f args) in order"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :math/add
+                              +
+                              1 2 3 4)]
+      (is (= 10 (chain/last-response c))))))
+
+(deftest zero-arg-function-is-supported
+  (testing "execute supports zero-arg wrapped functions"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :pure/now
+                              (constantly 42))]
+      (is (chain/succeeded? c))
+      (is (= 42 (chain/last-response c))))))
+
+(deftest execute-and-long-form-are-equivalent-on-success
+  (testing "execute is a true alias for execute-with-exception-handling"
+    (let [c0 (chain/create-chain :flow)
+          a  (boundary/execute :db c0 :op (constantly :ok))
+          b  (boundary/execute-with-exception-handling :db c0 :op (constantly :ok))]
+      (is (= (chain/last-response a) (chain/last-response b)))
+      (is (= (chain/succeeded? a)    (chain/succeeded? b))))))

--- a/components/boundary/test/ai/miniforge/boundary/interface/multi_step_composition_test.clj
+++ b/components/boundary/test/ai/miniforge/boundary/interface/multi_step_composition_test.clj
@@ -1,0 +1,73 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.interface.multi-step-composition-test
+  "Threading semantics. `execute` returns the updated chain so each
+   call composes with the next. The chain is the *second* positional
+   argument (category comes first), so callers thread with `as->` or
+   explicit `let` rebinding rather than `->`. Steps accumulate in
+   append order; later successes do not mask earlier failures."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [malli.core :as m]
+   [ai.miniforge.boundary.interface :as boundary]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(defn- boom! [] (throw (RuntimeException. "boom")))
+
+(deftest steps-accumulate-in-append-order
+  (testing "operations are recorded in the order they were executed"
+    (let [c (as-> (chain/create-chain :flow) c
+              (boundary/execute :db      c :a (constantly 1))
+              (boundary/execute :io      c :b (constantly 2))
+              (boundary/execute :network c :c (constantly 3)))]
+      (is (= [:a :b :c] (mapv :operation (chain/steps c)))))))
+
+(deftest mixed-success-and-failure-records-all-steps
+  (testing "a throw mid-flow does not stop subsequent steps from being appended"
+    (let [c (as-> (chain/create-chain :flow) c
+              (boundary/execute :db      c :a (constantly 1))
+              (boundary/execute :network c :b boom!)
+              (boundary/execute :io      c :c (constantly 3)))]
+      (is (= 3 (count (chain/steps c))))
+      (is (false? (chain/succeeded? c)))
+      (is (= [true false true]
+             (mapv :succeeded? (chain/steps c)))))))
+
+(deftest chain-stays-schema-valid-through-composition
+  (testing "after each execute the chain still validates against the schema"
+    (let [c (as-> (chain/create-chain :flow) c
+              (boundary/execute :db      c :a (constantly 1))
+              (boundary/execute :timeout c :b boom!)
+              (boundary/execute :parse   c :c (constantly 3)))]
+      (is (m/validate chain/Chain c))
+      (is (every? #(m/validate chain/Step %) (chain/steps c))))))
+
+(deftest last-successful-or-finds-the-pre-failure-success
+  (testing "after a failure, last-successful-or returns the most recent successful response"
+    (let [c (as-> (chain/create-chain :flow) c
+              (boundary/execute :db      c :a (constantly {:user 1}))
+              (boundary/execute :network c :b boom!))]
+      (is (= {:user 1} (chain/last-successful-or c ::none))))))
+
+(deftest threading-is-pure
+  (testing "each execute returns a new chain; the original is unchanged"
+    (let [c0 (chain/create-chain :flow)
+          c1 (boundary/execute :db c0 :a (constantly 1))]
+      (is (= 0 (count (chain/steps c0))))
+      (is (= 1 (count (chain/steps c1)))))))

--- a/components/boundary/test/ai/miniforge/boundary/interface/never_throws_test.clj
+++ b/components/boundary/test/ai/miniforge/boundary/interface/never_throws_test.clj
@@ -1,0 +1,66 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.interface.never-throws-test
+  "Boundary helper invariant. With a known category, no runtime input
+   may cause `execute` to escape with a thrown exception. Every
+   pathological case turns into a chain step instead."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [malli.core :as m]
+   [ai.miniforge.boundary.interface :as boundary]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest error-thrown-by-wrapped-fn-is-absorbed
+  (testing "even a JVM Error subclass becomes an anomaly step"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :op
+                              (fn [] (throw (AssertionError. "assert"))))]
+      (is (false? (chain/succeeded? c)))
+      (is (m/validate chain/Chain c)))))
+
+(deftest deeply-nested-throw-is-absorbed
+  (testing "a throw triggered by a chain of helpers still becomes a step"
+    (let [boom (fn [] (throw (RuntimeException. "deep")))
+          mid  (fn [] (boom))
+          top  (fn [] (mid))
+          c    (boundary/execute :unknown
+                                 (chain/create-chain :flow)
+                                 :op
+                                 top)]
+      (is (false? (chain/succeeded? c))))))
+
+(deftest non-ifn-in-f-slot-becomes-anomaly-step
+  (testing "passing a non-IFn (string) as f doesn't escape — apply throws, boundary captures it"
+    (let [c (boundary/execute :unknown
+                              (chain/create-chain :flow)
+                              :op
+                              "not-a-fn"
+                              :ignored)]
+      (is (m/validate chain/Chain c))
+      (is (false? (chain/succeeded? c))))))
+
+(deftest already-failed-chain-stays-failed
+  (testing "execute on a chain that already has a failed step keeps the chain failed and well-formed"
+    (let [c0 (chain/create-chain :flow)
+          c1 (boundary/execute :unknown c0 :a (fn [] (throw (RuntimeException. "x"))))
+          c2 (boundary/execute :unknown c1 :b (constantly :ok))]
+      (is (m/validate chain/Chain c2))
+      (is (false? (chain/succeeded? c2)))
+      (is (= 2 (count (chain/steps c2)))))))

--- a/components/boundary/test/ai/miniforge/boundary/interface/programmer_error_guard_test.clj
+++ b/components/boundary/test/ai/miniforge/boundary/interface/programmer_error_guard_test.clj
@@ -1,0 +1,73 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.boundary.interface.programmer-error-guard-test
+  "Programmer-error guard. An unknown category is a wiring mistake at
+   the call site, not a runtime condition — boundary throws
+   `IllegalArgumentException` (mirrors `anomaly/anomaly`'s vocabulary
+   check)."
+  (:require
+   [clojure.test :refer [deftest testing is]]
+   [ai.miniforge.boundary.interface :as boundary]
+   [ai.miniforge.response-chain.interface :as chain]))
+
+(deftest unknown-category-throws-illegal-argument
+  (testing "execute with a non-vocabulary category throws IllegalArgumentException"
+    (is (thrown? IllegalArgumentException
+                 (boundary/execute :no-such-category
+                                   (chain/create-chain :flow)
+                                   :op
+                                   (constantly :ok))))))
+
+(deftest unknown-category-on-long-form-also-throws
+  (testing "execute-with-exception-handling enforces the same guard"
+    (is (thrown? IllegalArgumentException
+                 (boundary/execute-with-exception-handling
+                  :bogus
+                  (chain/create-chain :flow)
+                  :op
+                  (constantly :ok))))))
+
+(deftest non-keyword-category-throws-illegal-argument
+  (testing "a string in the category slot is a programmer error and throws"
+    (is (thrown? IllegalArgumentException
+                 (boundary/execute "db"
+                                   (chain/create-chain :flow)
+                                   :op
+                                   (constantly :ok))))))
+
+(deftest nil-category-throws-illegal-argument
+  (testing "nil in the category slot is a programmer error and throws"
+    (is (thrown? IllegalArgumentException
+                 (boundary/execute nil
+                                   (chain/create-chain :flow)
+                                   :op
+                                   (constantly :ok))))))
+
+(deftest illegal-argument-message-lists-known-categories
+  (testing "the thrown message lists the standard category vocabulary so the call site can self-correct"
+    (try
+      (boundary/execute :no-such-category
+                        (chain/create-chain :flow)
+                        :op
+                        (constantly :ok))
+      (is false "expected IllegalArgumentException")
+      (catch IllegalArgumentException e
+        (let [msg (.getMessage e)]
+          (is (re-find #":no-such-category" msg))
+          (is (re-find #":db" msg)))))))

--- a/deps.edn
+++ b/deps.edn
@@ -24,6 +24,7 @@
                        "components/agent-runtime/resources"
                        "components/anomaly/src"
                        "components/response-chain/src"
+                       "components/boundary/src"
                        "components/task/src"
                        "components/task/resources"
                        "components/task-executor/src"
@@ -194,6 +195,7 @@
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
+                      ai.miniforge/boundary {:local/root "components/boundary"}
                       ai.miniforge/task {:local/root "components/task"}
                       ai.miniforge/task-executor {:local/root "components/task-executor"}
                       ai.miniforge/decision {:local/root "components/decision"}
@@ -308,6 +310,7 @@
                        "components/agent-runtime/test"
                        "components/anomaly/test"
                        "components/response-chain/test"
+                       "components/boundary/test"
                        "components/task/test"
                        "components/decision/test"
                        "components/loop/test"
@@ -425,6 +428,7 @@
                       ai.miniforge/agent-runtime {:local/root "components/agent-runtime"}
                       ai.miniforge/anomaly {:local/root "components/anomaly"}
                       ai.miniforge/response-chain {:local/root "components/response-chain"}
+                      ai.miniforge/boundary {:local/root "components/boundary"}
                       ai.miniforge/task {:local/root "components/task"}
                       ai.miniforge/decision {:local/root "components/decision"}
                       ai.miniforge/loop {:local/root "components/loop"}

--- a/docs/pull-requests/2026-04-30-feat-boundary-component.md
+++ b/docs/pull-requests/2026-04-30-feat-boundary-component.md
@@ -60,17 +60,31 @@ Foundations / cross-cutting primitive. New top-level component.
 exception-categories
 ;; #{:network :db :io :parse :timeout :unavailable :unknown}
 
-(category->anomaly-type category)
-;; :network    → :unavailable
-;; :db         → :fault
-;; :io         → :fault
-;; :parse      → :invalid-input
-;; :timeout    → :timeout
-;; :unavailable → :unavailable
-;; :unknown    → :fault
+category->anomaly-type
+;; Read-only mapping (a Clojure map, also invokable as a function for
+;; known keys: (category->anomaly-type :db) ;; => :fault):
+;;   :network    → :unavailable
+;;   :db         → :fault
+;;   :io         → :fault
+;;   :parse      → :invalid-input
+;;   :timeout    → :timeout
+;;   :unavailable → :unavailable
+;;   :unknown    → :fault
+
+(classify-category category)
+;; Function form of the lookup. Returns :fault when category is not
+;; in exception-categories. Use this when you want explicit
+;; lookup-with-default semantics; use the map directly for inspection.
+
+CapturedException
+;; Malli schema for the payload that lives inside an anomaly's
+;; :anomaly/data when boundary converts a throw.
 
 CheckFn
-;; Advisory malli schema for higher-level wrappers.
+;; Advisory malli schema for higher-level wrappers. Returns nil or a
+;; canonical Anomaly (per ai.miniforge.anomaly.interface/Anomaly).
+;; Re-exported from contract for consumers that reach for the schema
+;; via the interface namespace.
 ```
 
 ## Anomaly data shape

--- a/docs/pull-requests/2026-04-30-feat-boundary-component.md
+++ b/docs/pull-requests/2026-04-30-feat-boundary-component.md
@@ -1,0 +1,138 @@
+# feat: add boundary component for exception → anomaly conversion
+
+## Overview
+
+Adds the third H-series cross-cutting primitive to miniforge OSS: `ai.miniforge.boundary`. Provides `execute-with-exception-handling` (and a short `execute` alias) — the canonical wrapper that catches thrown exceptions from libraries (DBs, HTTP clients, JVM I/O, parser failures, timeouts) and converts them into anomaly steps inside an existing `response-chain`, without bespoke try/catch noise at every call site.
+
+Together with the merged `anomaly` (H1) and `response-chain` (H2) components, this completes the "exceptions are data" trio: anomaly is the shape, response-chain carries it through a flow, boundary catches throws at the edges.
+
+## Motivation
+
+The standards rule `005 exceptions-as-data` (merged) prescribes that non-boundary code returns anomalies as data. The companion linter (`feat/exceptions-as-data-linter`, merged) flags violations. The cleanup workstream (`refactor/exceptions-as-data-foundation-cleanup`, merged) started replacing throw sites with anomaly returns.
+
+What was still missing: the canonical wrapper for the *boundary* itself — the place where exceptions from external libraries (which you cannot rewrite) get converted into the anomaly-shaped flow. Without this primitive, every boundary site reinvents try/catch, the conversion logic drifts, and the exception-data capture is inconsistent.
+
+This PR is the wrapper. It is the third (and final) H-series primitive.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.anomaly` (merged) — anomaly shape and constructor
+- `ai.miniforge.response-chain` (merged) — chain accumulator
+
+## Layer
+
+Foundations / cross-cutting primitive. New top-level component.
+
+## What This Adds
+
+- New component `components/boundary/`:
+  - `deps.edn` — `:local/root` deps on `ai.miniforge/anomaly` + `ai.miniforge/response-chain` + malli
+  - `src/ai/miniforge/boundary/contract.clj` — Malli schemas for the exception-category vocabulary plus the advisory `CheckFn` shape
+  - `src/ai/miniforge/boundary/core.clj` — implementation, including the data-driven `category->anomaly-type` mapping table
+  - `src/ai/miniforge/boundary/interface.clj` — public API
+- Eight decomposed test files under `test/ai/miniforge/boundary/interface/`, one per behavior dimension:
+  - `happy_path_test.clj`
+  - `exception_to_anomaly_test.clj`
+  - `category_classification_test.clj`
+  - `exception_data_capture_test.clj`
+  - `never_throws_test.clj`
+  - `programmer_error_guard_test.clj`
+  - `multi_step_composition_test.clj`
+  - `ex_data_preservation_test.clj`
+- Workspace registration: root `deps.edn` (`:dev`, `:test`) + each consumer project (`projects/miniforge/`, `projects/miniforge-core/`, `projects/miniforge-tui/`)
+
+## Public API
+
+```clojure
+(execute-with-exception-handling category chain operation-key f & args)
+;; Calls (apply f args). On success, append a successful step to chain.
+;; On thrown exception, classify via category, build the appropriate
+;; anomaly type, append an anomaly step, and return the chain.
+;; Never throws — the chain absorbs the exception as data.
+
+(execute category chain operation-key f & args)
+;; Short alias.
+
+exception-categories
+;; #{:network :db :io :parse :timeout :unavailable :unknown}
+
+(category->anomaly-type category)
+;; :network    → :unavailable
+;; :db         → :fault
+;; :io         → :fault
+;; :parse      → :invalid-input
+;; :timeout    → :timeout
+;; :unavailable → :unavailable
+;; :unknown    → :fault
+
+CheckFn
+;; Advisory malli schema for higher-level wrappers.
+```
+
+## Anomaly data shape
+
+The anomaly's `:anomaly/data` carries everything a triage tool needs:
+
+```clojure
+{:exception/type     "java.lang.RuntimeException"   ; class name
+ :exception/message  "..."                           ; (.getMessage e)
+ :exception/cause    "..."                           ; (-> e ex-cause ex-message), nil if absent
+ :exception/data     {...}                           ; (ex-data e), nil if absent
+ :boundary/category  :db}                            ; the supplied category
+```
+
+`(ex-data e)` from libraries propagates verbatim into `:exception/data`, so structured information from `ex-info`-throwing libraries (e.g. clj-http, datalevin) survives the conversion.
+
+## Strata Affected
+
+- `ai.miniforge.boundary.contract` — Malli schemas and the category vocabulary
+- `ai.miniforge.boundary.core` — implementation + data-driven category mapping
+- `ai.miniforge.boundary.interface` — public API
+
+No existing component touched. Pure additive change.
+
+## Testing Plan
+
+- **`bb pre-commit` green:**
+  - `lint:clj` clean
+  - `fmt:md` clean
+  - `test` — 3419 tests / 15052 passes / 0 failures / 0 errors. New component contributes 45 tests / 63 assertions.
+  - `test:graalvm` — 6 tests / 478 assertions / 0 failures
+- Eight decomposed test files map 1:1 to the per-behavior dimensions; each is independently exercisable.
+
+## Deployment Plan
+
+No migration required. New additive component. Existing miniforge code unchanged.
+
+The boundary wrapper is opt-in — components that need it migrate one site at a time. The linter rule (`005 exceptions-as-data`) does not require usage of `boundary`; it only requires that non-boundary code returns anomalies. Boundary is the *sanctioned* way to convert thrown exceptions in the namespaces that ARE allowed to throw.
+
+## Notes / Deviations
+
+- **`:conformance` alias not updated.** The conformance gate carries a curated subset of components; `response-chain` is not in it either. Followed that precedent.
+- **Argument order is `category chain operation-key f & args`** — category first, chain second. This makes naive `->` threading land the chain in the category slot. Tests use `as->` or explicit `let` rebinding when threading. Rich-comment example in `interface.clj` reflects this. No public API change.
+- **`CheckFn` schema is advisory.** Boundary itself doesn't consume one; the schema is exposed for higher-level wrappers (HTTP-flavored, DB-flavored variants) that may layer on top later. This matches the spec's framing that boundary is the generic primitive.
+- **Apache 2 license headers** on every new file. Layer-labeled comment headers in interface, contract, and core. Malli throughout. No `requiring-resolve`.
+- **The component is itself a non-throwing boundary helper.** The one acceptable throw is a programmer-error guard for unknown category (similar to anomaly's vocabulary check). Verified by `programmer_error_guard_test.clj`.
+
+## Related Issues/PRs
+
+- Builds on the merged `feat/anomaly-component` and `feat/response-chain-component`
+- Companion to the merged `005 exceptions-as-data` standards rule
+- Companion to the merged `feat/exceptions-as-data-linter`
+- Unblocks Wave 3+ wiring work (e.g. response-chain integration in thesium-workflows retrieval paths)
+
+## Checklist
+
+- [x] New `boundary` component with public API (`execute-with-exception-handling`, `execute`, `exception-categories`, `category->anomaly-type`, `CheckFn`)
+- [x] Data-driven category mapping table (no nested ifs)
+- [x] Anomaly data captures `:exception/{type,message,cause,data}` plus `:boundary/category`
+- [x] Decomposed test files (eight, one per behavior)
+- [x] Apache 2 license headers
+- [x] Layer-labeled comment headers
+- [x] Component never throws on runtime input (programmer-error guard for unknown category is the only acceptable throw)
+- [x] Workspace and project deps.edn registration
+- [x] `bb pre-commit` green

--- a/projects/miniforge-core/deps.edn
+++ b/projects/miniforge-core/deps.edn
@@ -25,6 +25,7 @@
         ai.miniforge/heuristic {:local/root "../../components/heuristic"}
         ai.miniforge/response {:local/root "../../components/response"}
         ai.miniforge/response-chain {:local/root "../../components/response-chain"}
+        ai.miniforge/boundary {:local/root "../../components/boundary"}
         ai.miniforge/fsm {:local/root "../../components/fsm"}
         ai.miniforge/phase {:local/root "../../components/phase"}
         ai.miniforge/gate {:local/root "../../components/gate"}

--- a/projects/miniforge-tui/deps.edn
+++ b/projects/miniforge-tui/deps.edn
@@ -17,6 +17,7 @@
         ai.miniforge/config {:local/root "../../components/config"}
         ai.miniforge/response {:local/root "../../components/response"}
         ai.miniforge/response-chain {:local/root "../../components/response-chain"}
+        ai.miniforge/boundary {:local/root "../../components/boundary"}
         ai.miniforge/fsm {:local/root "../../components/fsm"}
         ;; Workflow and orchestration
         ai.miniforge/workflow {:local/root "../../components/workflow"}

--- a/projects/miniforge/deps.edn
+++ b/projects/miniforge/deps.edn
@@ -32,6 +32,7 @@
         ai.miniforge/heuristic {:local/root "../../components/heuristic"}
         ai.miniforge/response {:local/root "../../components/response"}
         ai.miniforge/response-chain {:local/root "../../components/response-chain"}
+        ai.miniforge/boundary {:local/root "../../components/boundary"}
         ai.miniforge/fsm {:local/root "../../components/fsm"}
         ai.miniforge/phase {:local/root "../../components/phase"}
         ai.miniforge/gate {:local/root "../../components/gate"}


### PR DESCRIPTION
# feat: add boundary component for exception → anomaly conversion

## Overview

Adds the third H-series cross-cutting primitive to miniforge OSS: `ai.miniforge.boundary`. Provides `execute-with-exception-handling` (and a short `execute` alias) — the canonical wrapper that catches thrown exceptions from libraries (DBs, HTTP clients, JVM I/O, parser failures, timeouts) and converts them into anomaly steps inside an existing `response-chain`, without bespoke try/catch noise at every call site.

Together with the merged `anomaly` (H1) and `response-chain` (H2) components, this completes the "exceptions are data" trio: anomaly is the shape, response-chain carries it through a flow, boundary catches throws at the edges.

## Motivation

The standards rule `005 exceptions-as-data` (merged) prescribes that non-boundary code returns anomalies as data. The companion linter (`feat/exceptions-as-data-linter`, merged) flags violations. The cleanup workstream (`refactor/exceptions-as-data-foundation-cleanup`, merged) started replacing throw sites with anomaly returns.

What was still missing: the canonical wrapper for the *boundary* itself — the place where exceptions from external libraries (which you cannot rewrite) get converted into the anomaly-shaped flow. Without this primitive, every boundary site reinvents try/catch, the conversion logic drifts, and the exception-data capture is inconsistent.

This PR is the wrapper. It is the third (and final) H-series primitive.

## Base Branch

`main`

## Depends On

- `ai.miniforge.anomaly` (merged) — anomaly shape and constructor
- `ai.miniforge.response-chain` (merged) — chain accumulator

## Layer

Foundations / cross-cutting primitive. New top-level component.

## What This Adds

- New component `components/boundary/`:
  - `deps.edn` — `:local/root` deps on `ai.miniforge/anomaly` + `ai.miniforge/response-chain` + malli
  - `src/ai/miniforge/boundary/contract.clj` — Malli schemas for the exception-category vocabulary plus the advisory `CheckFn` shape
  - `src/ai/miniforge/boundary/core.clj` — implementation, including the data-driven `category->anomaly-type` mapping table
  - `src/ai/miniforge/boundary/interface.clj` — public API
- Eight decomposed test files under `test/ai/miniforge/boundary/interface/`, one per behavior dimension:
  - `happy_path_test.clj`
  - `exception_to_anomaly_test.clj`
  - `category_classification_test.clj`
  - `exception_data_capture_test.clj`
  - `never_throws_test.clj`
  - `programmer_error_guard_test.clj`
  - `multi_step_composition_test.clj`
  - `ex_data_preservation_test.clj`
- Workspace registration: root `deps.edn` (`:dev`, `:test`) + each consumer project (`projects/miniforge/`, `projects/miniforge-core/`, `projects/miniforge-tui/`)

## Public API

```clojure
(execute-with-exception-handling category chain operation-key f & args)
;; Calls (apply f args). On success, append a successful step to chain.
;; On thrown exception, classify via category, build the appropriate
;; anomaly type, append an anomaly step, and return the chain.
;; Never throws — the chain absorbs the exception as data.

(execute category chain operation-key f & args)
;; Short alias.

exception-categories
;; #{:network :db :io :parse :timeout :unavailable :unknown}

(category->anomaly-type category)
;; :network    → :unavailable
;; :db         → :fault
;; :io         → :fault
;; :parse      → :invalid-input
;; :timeout    → :timeout
;; :unavailable → :unavailable
;; :unknown    → :fault

CheckFn
;; Advisory malli schema for higher-level wrappers.
```

## Anomaly data shape

The anomaly's `:anomaly/data` carries everything a triage tool needs:

```clojure
{:exception/type     "java.lang.RuntimeException"   ; class name
 :exception/message  "..."                           ; (.getMessage e)
 :exception/cause    "..."                           ; (-> e ex-cause ex-message), nil if absent
 :exception/data     {...}                           ; (ex-data e), nil if absent
 :boundary/category  :db}                            ; the supplied category
```

`(ex-data e)` from libraries propagates verbatim into `:exception/data`, so structured information from `ex-info`-throwing libraries (e.g. clj-http, datalevin) survives the conversion.

## Strata Affected

- `ai.miniforge.boundary.contract` — Malli schemas and the category vocabulary
- `ai.miniforge.boundary.core` — implementation + data-driven category mapping
- `ai.miniforge.boundary.interface` — public API

No existing component touched. Pure additive change.

## Testing Plan

- **`bb pre-commit` green:**
  - `lint:clj` clean
  - `fmt:md` clean
  - `test` — 3419 tests / 15052 passes / 0 failures / 0 errors. New component contributes 45 tests / 63 assertions.
  - `test:graalvm` — 6 tests / 478 assertions / 0 failures
- Eight decomposed test files map 1:1 to the per-behavior dimensions; each is independently exercisable.

## Deployment Plan

No migration required. New additive component. Existing miniforge code unchanged.

The boundary wrapper is opt-in — components that need it migrate one site at a time. The linter rule (`005 exceptions-as-data`) does not require usage of `boundary`; it only requires that non-boundary code returns anomalies. Boundary is the *sanctioned* way to convert thrown exceptions in the namespaces that ARE allowed to throw.

## Notes / Deviations

- **`:conformance` alias not updated.** The conformance gate carries a curated subset of components; `response-chain` is not in it either. Followed that precedent.
- **Argument order is `category chain operation-key f & args`** — category first, chain second. This makes naive `->` threading land the chain in the category slot. Tests use `as->` or explicit `let` rebinding when threading. Rich-comment example in `interface.clj` reflects this. No public API change.
- **`CheckFn` schema is advisory.** Boundary itself doesn't consume one; the schema is exposed for higher-level wrappers (HTTP-flavored, DB-flavored variants) that may layer on top later. This matches the spec's framing that boundary is the generic primitive.
- **Apache 2 license headers** on every new file. Layer-labeled comment headers in interface, contract, and core. Malli throughout. No `requiring-resolve`.
- **The component is itself a non-throwing boundary helper.** The one acceptable throw is a programmer-error guard for unknown category (similar to anomaly's vocabulary check). Verified by `programmer_error_guard_test.clj`.

## Related Issues/PRs

- Builds on the merged `feat/anomaly-component` and `feat/response-chain-component`
- Companion to the merged `005 exceptions-as-data` standards rule
- Companion to the merged `feat/exceptions-as-data-linter`
- Unblocks Wave 3+ wiring work (e.g. response-chain integration in thesium-workflows retrieval paths)

## Checklist

- [x] New `boundary` component with public API (`execute-with-exception-handling`, `execute`, `exception-categories`, `category->anomaly-type`, `CheckFn`)
- [x] Data-driven category mapping table (no nested ifs)
- [x] Anomaly data captures `:exception/{type,message,cause,data}` plus `:boundary/category`
- [x] Decomposed test files (eight, one per behavior)
- [x] Apache 2 license headers
- [x] Layer-labeled comment headers
- [x] Component never throws on runtime input (programmer-error guard for unknown category is the only acceptable throw)
- [x] Workspace and project deps.edn registration
- [x] `bb pre-commit` green
