### PR TITLE
feat: local-mode fidelity — archive persist, tool-first delivery, harvest CLI

### DIFF
--- a/bases/cli/resources/config/cli/messages/en-US.edn
+++ b/bases/cli/resources/config/cli/messages/en-US.edn
@@ -154,6 +154,7 @@
   :workflow-runner/phase-started "→ Phase {phase} started"
   :workflow-runner/phase-completed "✓ Phase {phase} {outcome}"
   :workflow-runner/milestone "★ Milestone: {message}"
+  :workflow-runner/workspace-persisted "  ↳ Persisted ({phase}): {bundle-path}"
   :workflow-runner/agent-started "  • Agent {agent} started"
   :workflow-runner/agent-completed "  • Agent {agent} completed"
   :workflow-runner/agent-failed "  • Agent {agent} failed"

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/display.clj
@@ -87,6 +87,11 @@
                                        (str " (" (format-duration d) ")")))
       :workflow/milestone-reached (colorize :green (messages/t :workflow-runner/milestone
                                                                 {:message (:message event)}))
+      :workspace/persisted (colorize :cyan (messages/t :workflow-runner/workspace-persisted
+                                                       {:phase       (some-> (:workspace/phase event) name)
+                                                        :bundle-path (or (:workspace/bundle-path event)
+                                                                         (:workspace/commit-sha event)
+                                                                         "(no archive path)")}))
       :agent/started (colorize :cyan (messages/t :workflow-runner/agent-started
                                                  {:agent agent}))
       :agent/completed (colorize :green (messages/t :workflow-runner/agent-completed

--- a/bb.edn
+++ b/bb.edn
@@ -410,6 +410,11 @@
    :requires ([dogfood])
    :task (apply dogfood/run *command-line-args*)}
 
+  harvest
+  {:doc "Pull persisted task bundles back into this repo as branches.\n   Usage: bb harvest                  (list workflows)\n          bb harvest <workflow-id>    (fetch one workflow's bundles)\n          bb harvest --all            (fetch every checkpoint)"
+   :requires ([harvest])
+   :task (apply harvest/run *command-line-args*)}
+
   ;; ──────────────────────────────────────────────────────────────────────────
   ;; MCP Context Server
   ;; ──────────────────────────────────────────────────────────────────────────

--- a/bb.edn
+++ b/bb.edn
@@ -472,6 +472,8 @@
                  "components/config/src"
                  "components/config/resources"
                  "components/algorithms/src"
+                 "components/anomaly/src"
+                 "components/anomaly/resources"
                  "components/schema/src"
                  "components/schema/resources"
                  "components/logging/src"

--- a/components/agent/resources/prompts/implementer.edn
+++ b/components/agent/resources/prompts/implementer.edn
@@ -5,7 +5,7 @@
 ;; from task specifications.
 
 {:prompt/id :implementer
- :prompt/version "1.0.0"
+ :prompt/version "1.1.0"
  :prompt/agent :implementer
  :prompt/max-turns 40
 
@@ -33,28 +33,51 @@ You receive:
 3. The Repository Map is a compact table of contents for the codebase.
    Use it to understand what already exists before writing new code.
    If you need to reference or modify a file not in \"Existing Files in Scope\",
-   mention the path from the repo map in your code artifact.
+   mention the path from the repo map in your tool calls.
 
 4. **Search Results** may be provided when the orchestrator has searched the
    codebase for files relevant to your task. These show ranked file matches
    with preview snippets. Use them to understand existing patterns before
    generating code.
 
-## Output Format
+## Delivery — Tools Are the Mechanism
 
-You must output a structured code artifact as a Clojure map:
+Your work product is the **files you write to the working directory**.
+Code you only describe in this conversation but never commit to disk through
+a tool call is **not delivered** and will be discarded by the runtime.
+
+Required delivery sequence:
+
+1. **Use Write (or Edit) tools to create or modify each file.** One tool call
+   per file. Provide the complete file contents in each call — no placeholders,
+   no \"rest unchanged\" markers, no Clojure EDN maps in chat as a substitute.
+2. **After writing all files, call the `submit` MCP tool** with a brief
+   `:code/summary` describing what you changed and why. If `submit` is not
+   available in your environment, the runtime falls back to collecting
+   whatever files you wrote with Write/Edit — so Write/Edit alone is
+   sufficient delivery. `submit` is the structured confirmation path; never
+   the only path.
+
+Do NOT:
+- Emit a `{:code/files [...]}` map in this conversation in place of Write
+  calls. The fallback parser will read it but the files will only exist
+  as data, not on disk, and downstream phases will see an empty diff.
+- Print code blocks in chat \"for clarity\" before writing them. Write the
+  file first; the chat content is logged but never extracted into the
+  workspace.
+- Plan extensively in chat before any tool call. Start writing immediately
+  using the input you have.
+
+The structured confirmation that `submit` accepts is:
 
 ```clojure
-{:code/id <uuid>
- :code/files [{:path \"src/namespace/file.clj\"
-               :content \"(ns namespace.file...)\"
-               :action :create} ; or :modify, :delete
-              ...]
- :code/dependencies-added [\"library/name {:mvn/version \\\"1.0.0\\\"}\"]
+{:code/summary \"Brief description of changes made\"
  :code/tests-needed? true
- :code/language \"clojure\"
- :code/summary \"Brief description of changes made\"}
+ :code/dependencies-added [\"library/name {:mvn/version \\\"1.0.0\\\"}\"]}
 ```
+
+Note: `:code/files` is NOT part of the submit payload. The runtime derives
+the file list from your Write/Edit tool calls.
 
 ## Guidelines
 
@@ -104,7 +127,7 @@ You must output a structured code artifact as a Clojure map:
 ## Already-Implemented Response
 
 If the task is already fully implemented in the existing files provided to you,
-do NOT generate new code. Instead, output:
+do NOT generate new code. Instead, call `submit` with:
 
 ```clojure
 {:status :already-implemented
@@ -112,7 +135,7 @@ do NOT generate new code. Instead, output:
 ```
 
 Only use this when ALL acceptance criteria are already met by existing code.
-If even partial changes are needed, proceed with normal code generation.
+If even partial changes are needed, proceed with normal Write/Edit delivery.
 
 ## CRITICAL: Do NOT Re-Read Files Already In This Prompt
 
@@ -125,9 +148,12 @@ not reading files you already have.
 ## Turn Budget — HARD LIMIT
 
 You have at most 40 tool calls total.
-**Your FIRST action must be writing code (Write/Edit) — NOT reading files.**
-After at most 3 file reads, you MUST start generating code.
-A good-enough implementation written on time is better than a perfect plan that never arrives.
+**Your FIRST action must be a Write or Edit tool call — NOT reading files,
+NOT planning in chat, NOT printing the code first.**
+After at most 3 file reads, you MUST start writing.
+A good-enough implementation written to disk on time is better than a perfect
+plan that never lands as files.
 
 Remember: Your code will be validated, tested, and reviewed by other agents.
-Write code that is easy to understand, test, and maintain."}
+Write code that is easy to understand, test, and maintain. The files on disk
+are what they review — what you say in chat is just narration."}

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -147,6 +147,18 @@
 ;; Archive-based persistence (local-tier fidelity for :governed parity)
 ;; ============================================================================
 
+(def ^:private default-commit-message
+  "Commit message for the per-phase persist commit when the caller didn't
+   override `:message`. Internal infrastructure; not user-visible at
+   commit time."
+  "phase checkpoint")
+
+(def ^:private default-base-ref
+  "Final fallback base ref when neither :base-branch nor :base-ref was
+   passed by the caller. Used only by direct callers of `archive-bundle!`;
+   the runner threads the real base from environment metadata."
+  "main")
+
 (defn- ensure-archive-dir
   "Create the archive directory if it doesn't exist. Returns the absolute path."
   [archive-dir]
@@ -154,102 +166,174 @@
     (.mkdirs d)
     (.getAbsolutePath d)))
 
-(defn- has-dirty-changes?
-  "True when `git status --porcelain` in the worktree returns any lines."
+;; Each git helper below does exactly one operation, returns a result/ok
+;; on exit 0 with the parsed output, or a result/err carrying the git
+;; stderr. Persist treats all errors as diagnosable failures rather than
+;; silent zeros — Copilot review on PR #729 caught the original "treat
+;; non-zero exit as no-changes" pattern as a silent-failure vector.
+
+(defn- current-branch
+  [worktree-path]
+  (let [r (run-git "-C" worktree-path "rev-parse" "--abbrev-ref" "HEAD")]
+    (if (zero? (:exit r))
+      (result/ok (str/trim (or (:out r) "")))
+      (result/err :archive-no-branch (or (:err r) "could not resolve HEAD")))))
+
+(defn- dirty?
   [worktree-path]
   (let [r (run-git "-C" worktree-path "status" "--porcelain")]
-    (and (zero? (:exit r))
-         (-> (or (:out r) "") str/trim seq boolean))))
-
-(defn- count-commits-ahead
-  "Count commits on HEAD that are not reachable from base-ref. Returns 0 on error."
-  [worktree-path base-ref]
-  (let [r (run-git "-C" worktree-path
-                   "rev-list" "--count" (str base-ref "..HEAD"))]
     (if (zero? (:exit r))
-      (try (Integer/parseInt (str/trim (or (:out r) "0")))
-           (catch NumberFormatException _ 0))
-      0)))
+      (result/ok (-> (or (:out r) "") str/trim seq boolean))
+      (result/err :archive-status-failed
+                  (or (:err r) "git status --porcelain failed")))))
+
+(defn- commits-ahead
+  "Count commits on HEAD not reachable from base-ref."
+  [worktree-path base-ref]
+  (let [r (run-git "-C" worktree-path "rev-list" "--count"
+                   (str base-ref "..HEAD"))]
+    (if (zero? (:exit r))
+      (try
+        (result/ok (Integer/parseInt (str/trim (or (:out r) "0"))))
+        (catch NumberFormatException _
+          (result/err :archive-rev-list-parse-failed
+                      (str "could not parse rev-list output: " (:out r)))))
+      (result/err :archive-rev-list-failed
+                  (or (:err r) "git rev-list --count failed")))))
+
+(defn- stage-all!
+  [worktree-path]
+  (let [r (run-git "-C" worktree-path "add" "-A")]
+    (if (zero? (:exit r))
+      (result/ok :staged)
+      (result/err :archive-stage-failed (or (:err r) "git add -A failed")))))
+
+(defn- commit-staged!
+  "Commit staged changes with --no-verify. Persist runs inside a scratch
+   worktree where the host's pre-commit hook (bb pre-commit) fails because
+   deps aren't installed. Persist is infrastructure preservation, not a
+   validated commit — the gate layer upstream owns validation."
+  [worktree-path message]
+  (let [r (run-git "-C" worktree-path "commit"
+                   "--no-verify" "--allow-empty-message" "-m" message)]
+    (if (zero? (:exit r))
+      (result/ok :committed)
+      (result/err :archive-commit-failed
+                  (or (:err r) "git commit --no-verify failed")))))
+
+(defn- head-sha
+  [worktree-path]
+  (let [r (run-git "-C" worktree-path "rev-parse" "HEAD")]
+    (if (zero? (:exit r))
+      (result/ok (str/trim (or (:out r) "")))
+      (result/err :archive-rev-parse-failed
+                  (or (:err r) "git rev-parse HEAD failed")))))
+
+(defn- write-bundle!
+  "Run `git bundle create FILE BRANCH --not BASE`. The `BRANCH --not BASE`
+   form records `refs/heads/BRANCH` in the bundle, which is what
+   `git fetch <bundle> BRANCH:BRANCH` consumes when the harvest CLI pulls
+   the work back into the host repo."
+  [worktree-path bundle-path branch base-ref]
+  (let [r (run-git "-C" worktree-path "bundle" "create"
+                   bundle-path branch "--not" base-ref)]
+    (if (zero? (:exit r))
+      (result/ok bundle-path)
+      (result/err :archive-bundle-failed
+                  (or (:err r) "git bundle create failed")))))
+
+(defn- maybe-commit
+  "Commit only when the worktree has dirty changes. `git add -A` already
+   ran — if no paths were staged (e.g. all changes were gitignored),
+   commit-staged! would fail with `nothing to commit`, which is not an
+   archive error."
+  [worktree-path message]
+  (-> (dirty? worktree-path)
+      (result/and-then
+       (fn [is-dirty]
+         (if is-dirty
+           (commit-staged! worktree-path message)
+           (result/ok :clean))))))
+
+(defn- bundle-result
+  "Final step of the persist pipeline once we know the worktree is ahead
+   of base-ref. Reads HEAD, writes the bundle, and packages the persist
+   result map."
+  [worktree-path branch base-ref archive-dir task-id ahead]
+  (let [bundle-path (str (ensure-archive-dir archive-dir) "/" task-id ".bundle")]
+    (-> (head-sha worktree-path)
+        (result/and-then
+         (fn [sha]
+           (-> (write-bundle! worktree-path bundle-path branch base-ref)
+               (result/map-ok
+                (fn [_]
+                  {:persisted?    true
+                   :bundle-path   bundle-path
+                   :commit-sha    sha
+                   :branch        branch
+                   :commits-ahead ahead}))))))))
+
+(defn- commit-and-bundle!
+  "Pipeline: stage → commit-if-dirty → recompute ahead → bundle-or-noop."
+  [worktree-path branch base-ref archive-dir task-id message]
+  (-> (stage-all! worktree-path)
+      (result/and-then (fn [_] (maybe-commit worktree-path message)))
+      (result/and-then (fn [_] (commits-ahead worktree-path base-ref)))
+      (result/and-then
+       (fn [ahead]
+         (if (zero? ahead)
+           (result/ok {:persisted? false :no-changes? true :branch branch})
+           (bundle-result worktree-path branch base-ref archive-dir task-id ahead))))))
+
+(defn- already-clean?
+  "True when the worktree has no dirty paths AND no commits ahead of
+   base-ref — there's nothing to bundle. Returns a result so callers see
+   git failures rather than treating them as a clean state."
+  [worktree-path base-ref]
+  (-> (dirty? worktree-path)
+      (result/and-then
+       (fn [is-dirty]
+         (if is-dirty
+           (result/ok false)
+           (-> (commits-ahead worktree-path base-ref)
+               (result/map-ok zero?)))))))
 
 (defn archive-bundle!
   "Persist a worktree's task work as a git bundle.
 
-   Stages all dirty paths, commits them on the worktree's current branch,
-   then writes a bundle of `base-ref..HEAD` to <archive-dir>/<task-id>.bundle.
-   The bundle preserves the new commits' git objects in a single durable
-   file; a later `git fetch <bundle> <branch>:<branch>` from the host repo
-   restores the work without touching the live worktree.
+   Pipeline: resolve current branch → check for dirty changes or commits
+   ahead of base-ref → if clean, return no-changes; otherwise stage,
+   commit on the task branch with --no-verify, and write a bundle of
+   `base-ref..HEAD` to <archive-dir>/<task-id>.bundle. A later
+   `git fetch <bundle> <branch>:<branch>` round-trips the work into the
+   host repo without touching the live worktree.
 
    Arguments:
    - worktree-path: absolute path to the scratch worktree
    - opts: {:archive-dir string  — destination dir for bundles
            :task-id      string  — identifier used as the bundle filename
            :base-ref     string  — base branch the worktree was forked from
-           :message      string  — commit message for any pending changes}
+                                   (NEVER the task branch — that would make
+                                   commits-ahead always 0)
+           :message      string  — commit message for the persist commit}
 
    Returns result/ok with one of:
    - {:persisted? true  :bundle-path str :commit-sha str :branch str}
    - {:persisted? false :no-changes? true :branch str}
-   Returns result/err on git failure or filesystem failure."
+   Returns result/err on any git failure (no silent fallbacks)."
   [worktree-path {:keys [archive-dir task-id base-ref message]
-                  :or   {message  "phase checkpoint"
-                         base-ref "main"}}]
-  (try
-    (let [branch-r (run-git "-C" worktree-path "rev-parse" "--abbrev-ref" "HEAD")
-          branch   (str/trim (or (:out branch-r) ""))]
-      (cond
-        (not (zero? (:exit branch-r)))
-        (result/err :archive-no-branch (or (:err branch-r) "could not resolve HEAD"))
-
-        ;; Nothing dirty AND nothing already-committed-but-unpushed → no-op
-        (and (not (has-dirty-changes? worktree-path))
-             (zero? (count-commits-ahead worktree-path base-ref)))
-        (result/ok {:persisted? false :no-changes? true :branch branch})
-
-        :else
-        (let [;; Stage and commit any pending dirty changes (idempotent if clean).
-              ;; --no-verify because the host repo may have a pre-commit hook
-              ;; (bb pre-commit, lint, tests) that fails inside a scratch
-              ;; worktree where deps aren't installed. Persist is internal
-              ;; infrastructure that preserves agent work as-is — validation
-              ;; is the gate's job upstream, not the archive step's.
-              _ (run-git "-C" worktree-path "add" "-A")
-              commit-r (when (has-dirty-changes? worktree-path)
-                         (run-git "-C" worktree-path "commit"
-                                  "--no-verify"
-                                  "--allow-empty-message" "-m" message))
-              _ (when (and commit-r (not (zero? (:exit commit-r))))
-                  (throw (ex-info "git commit failed during persist"
-                                  {:exit (:exit commit-r)
-                                   :err  (:err commit-r)
-                                   :out  (:out commit-r)})))
-              ahead (count-commits-ahead worktree-path base-ref)]
-          (if (zero? ahead)
-            ;; Commit produced nothing new vs base-ref — caller treats as no-op
-            (result/ok {:persisted? false :no-changes? true :branch branch})
-            (let [sha-r (run-git "-C" worktree-path "rev-parse" "HEAD")
-                  sha   (str/trim (or (:out sha-r) ""))
-                  abs-archive-dir (ensure-archive-dir archive-dir)
-                  bundle-path (str abs-archive-dir "/" task-id ".bundle")
-                  ;; `BRANCH --not BASE` creates a bundle with refs/heads/BRANCH
-                  ;; recorded as a head — `git fetch <bundle> BRANCH:BRANCH`
-                  ;; round-trips the work into the host repo. The shorter
-                  ;; `base-ref..HEAD` form bundles the same commits but only
-                  ;; records HEAD, leaving fetch unable to resolve the branch
-                  ;; by name.
-                  bundle-r (run-git "-C" worktree-path "bundle" "create"
-                                    bundle-path
-                                    branch "--not" base-ref)]
-              (if (zero? (:exit bundle-r))
-                (result/ok {:persisted?  true
-                            :bundle-path bundle-path
-                            :commit-sha  sha
-                            :branch      branch
-                            :commits-ahead ahead})
-                (result/err :archive-bundle-failed
-                            (or (:err bundle-r) "git bundle create failed"))))))))
-    (catch Exception e
-      (result/err :archive-persist-failed (.getMessage e)))))
+                  :or   {message  default-commit-message
+                         base-ref default-base-ref}}]
+  (-> (current-branch worktree-path)
+      (result/and-then
+       (fn [branch]
+         (-> (already-clean? worktree-path base-ref)
+             (result/and-then
+              (fn [clean?]
+                (if clean?
+                  (result/ok {:persisted? false :no-changes? true :branch branch})
+                  (commit-and-bundle! worktree-path branch base-ref
+                                      archive-dir task-id message)))))))))
 
 (defn restore-from-bundle!
   "Restore work from a previously-persisted bundle into the host repo.
@@ -438,21 +522,25 @@
     ;; release-environment!. Without this, the host worktree had no record of
     ;; per-task work — successful agent output was destroyed when the scratch
     ;; worktree was torn down.
+    ;;
+    ;; `:base-ref` only falls back across :base-branch → :base-ref →
+    ;; default-base-ref. The task branch (`:branch` opt) is intentionally
+    ;; NOT a fallback: using it would make `commits-ahead` compute
+    ;; `task..HEAD` (always 0) and silently skip bundling.
     (let [worktree-path (str base-path "/" environment-id)
-          archive-dir   (or (get opts :archive-dir)
-                            (get-in config [:archive-dir])
-                            (default-archive-dir))
+          configured-archive-dir (or (get opts :archive-dir)
+                                     (get-in config [:archive-dir])
+                                     (default-archive-dir))
           ;; Workflow id (when present) namespaces the archive path so
           ;; concurrent runs don't collide on the same task-id stem.
-          archive-dir   (if-let [wf (get opts :workflow-id)]
-                          (str archive-dir "/" wf)
-                          archive-dir)
-          base-ref      (or (get opts :base-branch)
-                            (get opts :base-ref)
-                            (get opts :branch)
-                            "main")
-          task-id       (or (get opts :task-id) environment-id)
-          message       (or (get opts :message) "phase checkpoint")]
+          archive-dir (if-let [wf (get opts :workflow-id)]
+                        (str configured-archive-dir "/" wf)
+                        configured-archive-dir)
+          base-ref    (or (get opts :base-branch)
+                          (get opts :base-ref)
+                          default-base-ref)
+          task-id     (or (get opts :task-id) environment-id)
+          message     (or (get opts :message) default-commit-message)]
       (archive-bundle! worktree-path
                        {:archive-dir archive-dir
                         :task-id     task-id

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -207,11 +207,22 @@
         (result/ok {:persisted? false :no-changes? true :branch branch})
 
         :else
-        (let [;; Stage and commit any pending dirty changes (idempotent if clean)
+        (let [;; Stage and commit any pending dirty changes (idempotent if clean).
+              ;; --no-verify because the host repo may have a pre-commit hook
+              ;; (bb pre-commit, lint, tests) that fails inside a scratch
+              ;; worktree where deps aren't installed. Persist is internal
+              ;; infrastructure that preserves agent work as-is — validation
+              ;; is the gate's job upstream, not the archive step's.
               _ (run-git "-C" worktree-path "add" "-A")
-              _ (when (has-dirty-changes? worktree-path)
-                  (run-git "-C" worktree-path "commit"
-                           "--allow-empty-message" "-m" message))
+              commit-r (when (has-dirty-changes? worktree-path)
+                         (run-git "-C" worktree-path "commit"
+                                  "--no-verify"
+                                  "--allow-empty-message" "-m" message))
+              _ (when (and commit-r (not (zero? (:exit commit-r))))
+                  (throw (ex-info "git commit failed during persist"
+                                  {:exit (:exit commit-r)
+                                   :err  (:err commit-r)
+                                   :out  (:out commit-r)})))
               ahead (count-commits-ahead worktree-path base-ref)]
           (if (zero? ahead)
             ;; Commit produced nothing new vs base-ref — caller treats as no-op

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -38,6 +38,13 @@
 (def default-base-path "/tmp/miniforge-worktrees")
 (def default-max-concurrent 4)
 
+(defn default-archive-dir
+  "Default location for persisted task work archives.
+   Lives under the user's home rather than /tmp so checkpoints survive reboots
+   and can be referenced from evidence bundles long after the run ends."
+  []
+  (str (System/getProperty "user.home") "/.miniforge/checkpoints"))
+
 ;; ============================================================================
 ;; Helper Functions
 ;; ============================================================================
@@ -135,6 +142,127 @@
       (do
         (run-shell "rm" "-rf" worktree-path)
         (result/ok {:released? true})))))
+
+;; ============================================================================
+;; Archive-based persistence (local-tier fidelity for :governed parity)
+;; ============================================================================
+
+(defn- ensure-archive-dir
+  "Create the archive directory if it doesn't exist. Returns the absolute path."
+  [archive-dir]
+  (let [d (File. ^String archive-dir)]
+    (.mkdirs d)
+    (.getAbsolutePath d)))
+
+(defn- has-dirty-changes?
+  "True when `git status --porcelain` in the worktree returns any lines."
+  [worktree-path]
+  (let [r (run-git "-C" worktree-path "status" "--porcelain")]
+    (and (zero? (:exit r))
+         (-> (or (:out r) "") str/trim seq boolean))))
+
+(defn- count-commits-ahead
+  "Count commits on HEAD that are not reachable from base-ref. Returns 0 on error."
+  [worktree-path base-ref]
+  (let [r (run-git "-C" worktree-path
+                   "rev-list" "--count" (str base-ref "..HEAD"))]
+    (if (zero? (:exit r))
+      (try (Integer/parseInt (str/trim (or (:out r) "0")))
+           (catch NumberFormatException _ 0))
+      0)))
+
+(defn archive-bundle!
+  "Persist a worktree's task work as a git bundle.
+
+   Stages all dirty paths, commits them on the worktree's current branch,
+   then writes a bundle of `base-ref..HEAD` to <archive-dir>/<task-id>.bundle.
+   The bundle preserves the new commits' git objects in a single durable
+   file; a later `git fetch <bundle> <branch>:<branch>` from the host repo
+   restores the work without touching the live worktree.
+
+   Arguments:
+   - worktree-path: absolute path to the scratch worktree
+   - opts: {:archive-dir string  — destination dir for bundles
+           :task-id      string  — identifier used as the bundle filename
+           :base-ref     string  — base branch the worktree was forked from
+           :message      string  — commit message for any pending changes}
+
+   Returns result/ok with one of:
+   - {:persisted? true  :bundle-path str :commit-sha str :branch str}
+   - {:persisted? false :no-changes? true :branch str}
+   Returns result/err on git failure or filesystem failure."
+  [worktree-path {:keys [archive-dir task-id base-ref message]
+                  :or   {message  "phase checkpoint"
+                         base-ref "main"}}]
+  (try
+    (let [branch-r (run-git "-C" worktree-path "rev-parse" "--abbrev-ref" "HEAD")
+          branch   (str/trim (or (:out branch-r) ""))]
+      (cond
+        (not (zero? (:exit branch-r)))
+        (result/err :archive-no-branch (or (:err branch-r) "could not resolve HEAD"))
+
+        ;; Nothing dirty AND nothing already-committed-but-unpushed → no-op
+        (and (not (has-dirty-changes? worktree-path))
+             (zero? (count-commits-ahead worktree-path base-ref)))
+        (result/ok {:persisted? false :no-changes? true :branch branch})
+
+        :else
+        (let [;; Stage and commit any pending dirty changes (idempotent if clean)
+              _ (run-git "-C" worktree-path "add" "-A")
+              _ (when (has-dirty-changes? worktree-path)
+                  (run-git "-C" worktree-path "commit"
+                           "--allow-empty-message" "-m" message))
+              ahead (count-commits-ahead worktree-path base-ref)]
+          (if (zero? ahead)
+            ;; Commit produced nothing new vs base-ref — caller treats as no-op
+            (result/ok {:persisted? false :no-changes? true :branch branch})
+            (let [sha-r (run-git "-C" worktree-path "rev-parse" "HEAD")
+                  sha   (str/trim (or (:out sha-r) ""))
+                  abs-archive-dir (ensure-archive-dir archive-dir)
+                  bundle-path (str abs-archive-dir "/" task-id ".bundle")
+                  ;; `BRANCH --not BASE` creates a bundle with refs/heads/BRANCH
+                  ;; recorded as a head — `git fetch <bundle> BRANCH:BRANCH`
+                  ;; round-trips the work into the host repo. The shorter
+                  ;; `base-ref..HEAD` form bundles the same commits but only
+                  ;; records HEAD, leaving fetch unable to resolve the branch
+                  ;; by name.
+                  bundle-r (run-git "-C" worktree-path "bundle" "create"
+                                    bundle-path
+                                    branch "--not" base-ref)]
+              (if (zero? (:exit bundle-r))
+                (result/ok {:persisted?  true
+                            :bundle-path bundle-path
+                            :commit-sha  sha
+                            :branch      branch
+                            :commits-ahead ahead})
+                (result/err :archive-bundle-failed
+                            (or (:err bundle-r) "git bundle create failed"))))))))
+    (catch Exception e
+      (result/err :archive-persist-failed (.getMessage e)))))
+
+(defn restore-from-bundle!
+  "Restore work from a previously-persisted bundle into the host repo.
+
+   `git fetch <bundle> <branch>:<branch>` pulls the branch and all reachable
+   commits into the host repo without touching the working tree. The host
+   user (or orchestrator) can then check the branch out wherever they want.
+
+   Arguments:
+   - host-repo-path: path to a worktree of the host repo (any worktree on
+                     the same repo works; fetch goes to the shared object DB)
+   - opts: {:bundle-path str :branch str}
+
+   Returns result/ok with {:restored? true :branch str} on success."
+  [host-repo-path {:keys [bundle-path branch]}]
+  (try
+    (let [r (run-git "-C" host-repo-path "fetch"
+                     bundle-path (str branch ":" branch))]
+      (if (zero? (:exit r))
+        (result/ok {:restored? true :branch branch :bundle-path bundle-path})
+        (result/err :archive-restore-failed
+                    (or (:err r) "git fetch from bundle failed"))))
+    (catch Exception e
+      (result/err :archive-restore-failed (.getMessage e)))))
 
 ;; ============================================================================
 ;; Command Execution
@@ -259,7 +387,11 @@
                       worktree-name :worktree task-id worktree-path
                       (assoc env-config
                              :metadata {:worktree-path worktree-path
-                                        :repo-path repo-path}))))
+                                        :repo-path repo-path
+                                        ;; Stored so persist-workspace! can bundle
+                                        ;; the right base..HEAD range without
+                                        ;; guessing the parent branch.
+                                        :base-branch branch}))))
         create-result)))
 
   (execute! [_this environment-id command opts]
@@ -289,13 +421,42 @@
         (result/ok {:status :running})
         (result/ok {:status :stopped}))))
 
-  (persist-workspace! [_this _environment-id _opts]
-    ;; Worktree files are already on host — no persistence needed
-    (result/ok {:persisted? false :no-changes? true}))
+  (persist-workspace! [_this environment-id opts]
+    ;; Local-tier persistence parity with :governed (per N11 §7.4 fidelity goal):
+    ;; bundle the task branch into a durable archive so work survives
+    ;; release-environment!. Without this, the host worktree had no record of
+    ;; per-task work — successful agent output was destroyed when the scratch
+    ;; worktree was torn down.
+    (let [worktree-path (str base-path "/" environment-id)
+          archive-dir   (or (get opts :archive-dir)
+                            (get-in config [:archive-dir])
+                            (default-archive-dir))
+          ;; Workflow id (when present) namespaces the archive path so
+          ;; concurrent runs don't collide on the same task-id stem.
+          archive-dir   (if-let [wf (get opts :workflow-id)]
+                          (str archive-dir "/" wf)
+                          archive-dir)
+          base-ref      (or (get opts :base-branch)
+                            (get opts :base-ref)
+                            (get opts :branch)
+                            "main")
+          task-id       (or (get opts :task-id) environment-id)
+          message       (or (get opts :message) "phase checkpoint")]
+      (archive-bundle! worktree-path
+                       {:archive-dir archive-dir
+                        :task-id     task-id
+                        :base-ref    base-ref
+                        :message     message})))
 
-  (restore-workspace! [_this _environment-id _opts]
-    ;; Worktree files are already on host — no restore needed
-    (result/ok {:restored? false})))
+  (restore-workspace! [_this _environment-id opts]
+    ;; Pull a previously-persisted bundle back into the host repo's object DB.
+    ;; Caller supplies :host-repo-path (any worktree of the host repo works)
+    ;; and :bundle-path. The branch shows up as a ref in the host repo and
+    ;; can be checked out wherever the orchestrator wants.
+    (let [host-repo (or (get opts :host-repo-path)
+                        (get opts :workdir)
+                        ".")]
+      (restore-from-bundle! host-repo opts))))
 
 ;; ============================================================================
 ;; Factory

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -194,6 +194,94 @@
                   "/tmp/checkpoints/env-1.bundle" "task-1:task-1"]
                  @fetch-args)))))))
 
+(deftest persist-workspace-base-ref-never-falls-back-to-task-branch-test
+  (testing "persist-workspace! does NOT use the task branch as base-ref fallback"
+    ;; Regression: the original fallback chain was
+    ;;   (or :base-branch :base-ref :branch \"main\")
+    ;; which made commits-ahead compute task-branch..HEAD = 0, silently
+    ;; skipping bundle creation when callers passed :branch but not
+    ;; :base-branch. The current chain stops at default-base-ref ('main').
+    (let [executor (worktree/create-worktree-executor {})
+          rev-list-args (atom nil)]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (let [tail (drop 2 args)]
+                        (cond
+                          (= ["rev-parse" "--abbrev-ref" "HEAD"] tail)
+                          {:exit 0 :out "task-1\n" :err ""}
+
+                          (= ["status" "--porcelain"] tail)
+                          {:exit 0 :out " M src/foo.clj\n" :err ""}
+
+                          (= "rev-list" (first tail))
+                          (do (reset! rev-list-args (vec tail))
+                              {:exit 0 :out "1\n" :err ""})
+
+                          (= "rev-parse" (first tail))
+                          {:exit 0 :out "abc123\n" :err ""}
+
+                          (= "bundle" (first tail))
+                          {:exit 0 :out "" :err ""}
+
+                          :else {:exit 0 :out "" :err ""})))
+                    worktree/ensure-archive-dir (fn [d] d)]
+        (proto/persist-workspace! executor "env-1"
+                                  ;; Caller passes :branch but no :base-branch
+                                  ;; — the executor must NOT use task-1 as base.
+                                  {:branch "task-1"
+                                   :archive-dir "/tmp/test-archive"
+                                   :task-id "env-1"})
+        (is (some? @rev-list-args))
+        (is (some #(re-matches #"main\.\.HEAD" %) @rev-list-args)
+            "rev-list must compare against the default base ('main'),
+             not against the task branch")))))
+
+(deftest archive-bundle-surfaces-status-failure-test
+  (testing "git status failure returns result/err — not a silent no-changes"
+    (with-redefs [worktree/run-git
+                  (fn [& args]
+                    (let [tail (drop 2 args)]
+                      (cond
+                        (= ["rev-parse" "--abbrev-ref" "HEAD"] tail)
+                        {:exit 0 :out "task-1\n" :err ""}
+
+                        (= ["status" "--porcelain"] tail)
+                        {:exit 128 :out "" :err "fatal: not a git repository"}
+
+                        :else {:exit 0 :out "" :err ""})))]
+      (let [r (worktree/archive-bundle! "/tmp/scratch"
+                                        {:archive-dir "/tmp/test-archive"
+                                         :task-id     "env-1"
+                                         :base-ref    "main"})]
+        (is (result/err? r))
+        (is (= :archive-status-failed (get-in r [:error :code]))
+            "git status failure must bubble up; the previous code silently
+             treated non-zero exit as 'no changes' and dropped the persist")))))
+
+(deftest archive-bundle-surfaces-rev-list-failure-test
+  (testing "git rev-list failure returns result/err — not a silent zero"
+    (with-redefs [worktree/run-git
+                  (fn [& args]
+                    (let [tail (drop 2 args)]
+                      (cond
+                        (= ["rev-parse" "--abbrev-ref" "HEAD"] tail)
+                        {:exit 0 :out "task-1\n" :err ""}
+
+                        (= ["status" "--porcelain"] tail)
+                        {:exit 0 :out "" :err ""}
+
+                        (= "rev-list" (first tail))
+                        {:exit 128 :out "" :err "fatal: bad revision"}
+
+                        :else {:exit 0 :out "" :err ""})))]
+      (let [r (worktree/archive-bundle! "/tmp/scratch"
+                                        {:archive-dir "/tmp/test-archive"
+                                         :task-id     "env-1"
+                                         :base-ref    "main"})]
+        (is (result/err? r))
+        (is (= :archive-rev-list-failed (get-in r [:error :code]))
+            "rev-list failure must bubble up rather than be coerced to 0")))))
+
 (deftest archive-bundle-fails-cleanly-on-bundle-error-test
   (testing "archive-bundle! returns an err result when git bundle fails"
     (with-redefs [worktree/run-git

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -102,20 +102,121 @@
 ;; persist-workspace! / restore-workspace! (no-op for worktree)
 ;; ============================================================================
 
-(deftest persist-workspace-noop-test
-  (testing "worktree persist-workspace! is a no-op — files are already on host"
-    (let [executor (worktree/create-worktree-executor {})]
-      (with-redefs [worktree/run-git   (fn [& _] {:exit 0 :out "" :err ""})
-                    worktree/run-shell (fn [& _] {:exit 0 :out "" :err ""})]
-        (let [r (proto/persist-workspace! executor "env-1" {:branch "task/x"})]
+(deftest persist-workspace-clean-worktree-no-changes-test
+  (testing "persist-workspace! reports no-changes when the scratch worktree is clean"
+    (let [executor (worktree/create-worktree-executor {})
+          calls (atom [])]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (swap! calls conj (vec args))
+                      (cond
+                        ;; rev-parse --abbrev-ref HEAD → some branch name
+                        (= ["rev-parse" "--abbrev-ref" "HEAD"] (drop 2 args))
+                        {:exit 0 :out "task-1\n" :err ""}
+                        ;; status --porcelain → empty (clean)
+                        (= ["status" "--porcelain"] (drop 2 args))
+                        {:exit 0 :out "" :err ""}
+                        ;; rev-list --count → 0 (no commits ahead of base)
+                        (= "rev-list" (nth args 2))
+                        {:exit 0 :out "0\n" :err ""}
+                        :else {:exit 0 :out "" :err ""}))]
+        (let [r (proto/persist-workspace! executor "env-1"
+                                          {:branch "task-1" :base-branch "main"})]
           (is (result/ok? r))
-          (is (false? (get-in r [:data :persisted?]))))))))
+          (is (false? (get-in r [:data :persisted?])))
+          (is (true? (get-in r [:data :no-changes?]))))))))
 
-(deftest restore-workspace-noop-test
-  (testing "worktree restore-workspace! is a no-op"
-    (let [executor (worktree/create-worktree-executor {})]
-      (with-redefs [worktree/run-git   (fn [& _] {:exit 0 :out "" :err ""})
-                    worktree/run-shell (fn [& _] {:exit 0 :out "" :err ""})]
-        (let [r (proto/restore-workspace! executor "env-1" {:branch "task/x"})]
+(deftest persist-workspace-dirty-bundles-test
+  (testing "persist-workspace! commits dirty changes and writes a bundle"
+    (let [executor (worktree/create-worktree-executor {})
+          status-calls (atom 0)
+          bundle-args (atom nil)]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (let [tail (drop 2 args)]
+                        (cond
+                          (= ["rev-parse" "--abbrev-ref" "HEAD"] tail)
+                          {:exit 0 :out "task-1\n" :err ""}
+
+                          (= ["status" "--porcelain"] tail)
+                          (do (swap! status-calls inc)
+                              ;; Dirty before commit, clean after
+                              (if (= 1 @status-calls)
+                                {:exit 0 :out " M src/foo.clj\n" :err ""}
+                                {:exit 0 :out "" :err ""}))
+
+                          (= "rev-list" (first tail))
+                          {:exit 0 :out "1\n" :err ""}
+
+                          (= "rev-parse" (first tail))
+                          {:exit 0 :out "abc123\n" :err ""}
+
+                          (= "bundle" (first tail))
+                          (do (reset! bundle-args (vec tail))
+                              {:exit 0 :out "" :err ""})
+
+                          :else {:exit 0 :out "" :err ""})))
+                    worktree/ensure-archive-dir
+                    (fn [d] d)]
+        (let [r (proto/persist-workspace!
+                 executor "env-1"
+                 {:branch "task-1"
+                  :base-branch "main"
+                  :archive-dir "/tmp/test-archive"
+                  :task-id "env-1"})]
           (is (result/ok? r))
-          (is (false? (get-in r [:data :restored?]))))))))
+          (is (true? (get-in r [:data :persisted?])))
+          (is (= "abc123" (get-in r [:data :commit-sha])))
+          (is (= "/tmp/test-archive/env-1.bundle"
+                 (get-in r [:data :bundle-path])))
+          (is (= ["bundle" "create" "/tmp/test-archive/env-1.bundle"
+                  "task-1" "--not" "main"]
+                 @bundle-args)))))))
+
+(deftest restore-workspace-fetches-from-bundle-test
+  (testing "restore-workspace! fetches the branch back into the host repo"
+    (let [executor (worktree/create-worktree-executor {})
+          fetch-args (atom nil)]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (when (= "fetch" (nth args 2 nil))
+                        (reset! fetch-args (vec args)))
+                      {:exit 0 :out "" :err ""})]
+        (let [r (proto/restore-workspace!
+                 executor "env-1"
+                 {:host-repo-path "/host/repo"
+                  :bundle-path    "/tmp/checkpoints/env-1.bundle"
+                  :branch         "task-1"})]
+          (is (result/ok? r))
+          (is (true? (get-in r [:data :restored?])))
+          (is (= "task-1" (get-in r [:data :branch])))
+          (is (= ["-C" "/host/repo" "fetch"
+                  "/tmp/checkpoints/env-1.bundle" "task-1:task-1"]
+                 @fetch-args)))))))
+
+(deftest archive-bundle-fails-cleanly-on-bundle-error-test
+  (testing "archive-bundle! returns an err result when git bundle fails"
+    (with-redefs [worktree/run-git
+                  (fn [& args]
+                    (let [tail (drop 2 args)]
+                      (cond
+                        (= ["rev-parse" "--abbrev-ref" "HEAD"] tail)
+                        {:exit 0 :out "task-1\n" :err ""}
+
+                        (= ["status" "--porcelain"] tail)
+                        {:exit 0 :out " M src/foo.clj\n" :err ""}
+
+                        (= "rev-list" (first tail))
+                        {:exit 0 :out "1\n" :err ""}
+
+                        (= "bundle" (first tail))
+                        {:exit 128 :out "" :err "fatal: refusing to create empty bundle"}
+
+                        :else {:exit 0 :out "" :err ""})))
+                  worktree/ensure-archive-dir (fn [d] d)]
+      (let [r (worktree/archive-bundle! "/tmp/scratch"
+                                        {:archive-dir "/tmp/test-archive"
+                                         :task-id     "env-1"
+                                         :base-ref    "main"})]
+        (is (result/err? r))
+        (is (= :archive-bundle-failed (get-in r [:error :code])))))))

--- a/components/event-stream/src/ai/miniforge/event_stream/core.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/core.clj
@@ -211,6 +211,32 @@
           (:tokens result) (assoc :phase/tokens (:tokens result))
           (:cost-usd result) (assoc :phase/cost-usd (:cost-usd result))))))
 
+(defn workspace-persisted
+  "Build a :workspace/persisted event recording that a phase's worktree was
+   archived to a checkpoint. Surfaces the bundle path so dashboards and
+   evidence bundles can offer 'inspect/resume from this checkpoint'
+   affordances without grepping logs.
+
+   Arguments:
+   - stream:      event stream
+   - workflow-id: id of the (sub-)workflow whose work was persisted
+   - data:        {:phase keyword     phase at which persistence ran
+                   :env-id str        executor environment id (task-X)
+                   :branch str        branch the work landed on
+                   :commit-sha str    sha of the persisted commit
+                   :bundle-path str   absolute path to the .bundle file
+                   :persist-tier kw   :worktree (local) or :remote (governed)}"
+  [stream workflow-id data]
+  (-> (create-envelope stream :workspace/persisted workflow-id
+                       (str "Workspace persisted: "
+                            (or (:bundle-path data) (:commit-sha data))))
+      (assoc :workspace/phase       (:phase data)
+             :workspace/env-id      (:env-id data)
+             :workspace/branch      (:branch data)
+             :workspace/commit-sha  (:commit-sha data)
+             :workspace/bundle-path (:bundle-path data)
+             :workspace/tier        (or (:persist-tier data) :worktree))))
+
 (defn agent-chunk [stream workflow-id agent-id delta & [done?]]
   (-> (create-envelope stream :agent/chunk workflow-id
                        (if done? "Agent stream completed" "Agent streaming"))

--- a/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/event_type_registry.clj
@@ -144,6 +144,11 @@
     :json-string "tool/completed"
     :browser?    false}
 
+   {:constructor "workspace-persisted"
+    :event-type  :workspace/persisted
+    :json-string "workspace/persisted"
+    :browser?    false}
+
    {:constructor "milestone-reached"
     :event-type  :workflow/milestone-reached
     :json-string "workflow/milestone-reached"

--- a/components/event-stream/src/ai/miniforge/event_stream/interface.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface.clj
@@ -54,6 +54,7 @@
 (def workflow-started events/workflow-started)
 (def phase-started events/phase-started)
 (def phase-completed events/phase-completed)
+(def workspace-persisted events/workspace-persisted)
 (def agent-chunk events/agent-chunk)
 (def agent-status events/agent-status)
 (def agent-tool-call events/agent-tool-call)

--- a/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/interface/events.clj
@@ -27,6 +27,7 @@
 (def workflow-started core/workflow-started)
 (def phase-started core/phase-started)
 (def phase-completed core/phase-completed)
+(def workspace-persisted core/workspace-persisted)
 (def agent-chunk core/agent-chunk)
 (def agent-status core/agent-status)
 (def agent-tool-call core/agent-tool-call)

--- a/components/event-stream/src/ai/miniforge/event_stream/schema.clj
+++ b/components/event-stream/src/ai/miniforge/event_stream/schema.clj
@@ -98,6 +98,27 @@
    [:phase/cost-usd {:optional true} number?]
    [:message string?]])
 
+(def WorkspacePersisted
+  "Schema for workspace/persisted event.
+
+   Emitted at phase boundaries when persist-workspace! has captured a
+   checkpoint. Carries enough provenance for the dashboard / evidence
+   bundle to surface 'inspect or resume from this archive'."
+  [:map
+   [:event/type [:= :workspace/persisted]]
+   [:event/id uuid?]
+   [:event/timestamp inst?]
+   [:event/version string?]
+   [:event/sequence-number int?]
+   [:workflow/id uuid?]
+   [:workspace/phase {:optional true} keyword?]
+   [:workspace/env-id {:optional true} string?]
+   [:workspace/branch {:optional true} string?]
+   [:workspace/commit-sha {:optional true} string?]
+   [:workspace/bundle-path {:optional true} string?]
+   [:workspace/tier {:optional true} [:enum :worktree :remote]]
+   [:message string?]])
+
 (def WorkflowCompleted
   "Schema for workflow/completed event."
   [:map
@@ -308,6 +329,7 @@
    :workflow/phase-started   :public
    :workflow/phase-completed :public
    :workflow/milestone-reached :public
+   :workspace/persisted :public
    :agent/started    :internal
    :agent/completed  :internal
    :agent/failed     :internal

--- a/components/gate/src/ai/miniforge/gate/format.clj
+++ b/components/gate/src/ai/miniforge/gate/format.clj
@@ -13,7 +13,6 @@
    Layer 2: Gate check/repair + registration"
   (:require
    [ai.miniforge.gate.registry :as registry]
-   [ai.miniforge.response.interface :as response]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]))
@@ -96,8 +95,9 @@
   "Check which files can be formatted. Always passes — formatting is repair."
   [artifact _ctx]
   (let [formattable (filterv formattable-file? (get artifact :code/files []))]
-    (response/success {:formattable-files (mapv :path formattable)
-                       :message (str (count formattable) " file(s) support LSP formatting")})))
+    {:passed? true
+     :formattable-files (mapv :path formattable)
+     :message (str (count formattable) " file(s) support LSP formatting")}))
 
 (defn repair-format
   "Format files via LSP."
@@ -107,7 +107,9 @@
         formattable (filterv formattable-file? (get artifact :code/files []))
         results     (mapv #(format-single-file manager (:path %) worktree) formattable)
         formatted   (mapv :path (filter :formatted? results))]
-    (response/success {:artifact artifact :formatted formatted})))
+    {:success? true
+     :artifact artifact
+     :formatted formatted}))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Gate registration

--- a/components/gate/src/ai/miniforge/gate/format.clj
+++ b/components/gate/src/ai/miniforge/gate/format.clj
@@ -13,6 +13,7 @@
    Layer 2: Gate check/repair + registration"
   (:require
    [ai.miniforge.gate.registry :as registry]
+   [ai.miniforge.response.interface :as response]
    [clojure.edn :as edn]
    [clojure.java.io :as io]
    [clojure.string :as str]))
@@ -92,24 +93,25 @@
 ;; Gate check/repair
 
 (defn check-format
-  "Check which files can be formatted. Always passes — formatting is repair."
+  "Check which files can be formatted. Always passes — formatting is repair.
+
+   Returns the canonical `response/success` shape; the gate machinery's
+   `passed?` predicate recognizes it via `response/success?`."
   [artifact _ctx]
   (let [formattable (filterv formattable-file? (get artifact :code/files []))]
-    {:passed? true
-     :formattable-files (mapv :path formattable)
-     :message (str (count formattable) " file(s) support LSP formatting")}))
+    (response/success {:formattable-files (mapv :path formattable)
+                       :message (str (count formattable)
+                                     " file(s) support LSP formatting")})))
 
 (defn repair-format
-  "Format files via LSP."
+  "Format files via LSP. Returns the canonical `response/success` shape."
   [artifact _errors ctx]
   (let [worktree    (or (get ctx :execution/worktree-path) ".")
         manager     (get-or-create-lsp-manager ctx)
         formattable (filterv formattable-file? (get artifact :code/files []))
         results     (mapv #(format-single-file manager (:path %) worktree) formattable)
         formatted   (mapv :path (filter :formatted? results))]
-    {:success? true
-     :artifact artifact
-     :formatted formatted}))
+    (response/success {:artifact artifact :formatted formatted})))
 
 ;------------------------------------------------------------------------------ Layer 2
 ;; Gate registration

--- a/components/gate/src/ai/miniforge/gate/interface.clj
+++ b/components/gate/src/ai/miniforge/gate/interface.clj
@@ -72,22 +72,28 @@
 (defn passed?
   "Check if a gate result passed.
 
-   Arguments:
-     result - Gate result map from check-gate
+   Accepts either of two canonical result shapes:
+   1. Hand-shaped gate result with explicit `:passed?` key
+      (legacy gate convention — syntax, lint, etc.).
+   2. Canonical response shape from `response/success` /
+      `response/error` (what format and any new gate should return).
+      `response/success?` recognizes the `:status :success` form.
+
+   Bridging both lets gates return the project-wide success/anomaly
+   factories without each one re-establishing its own ad-hoc shape.
 
    Returns: boolean"
   [result]
-  (boolean (:passed? result)))
+  (cond
+    (contains? result :passed?) (boolean (:passed? result))
+    (response/success? result)  true
+    (response/error? result)    false
+    :else                       false))
 
 (defn failed?
-  "Check if a gate result failed.
-
-   Arguments:
-     result - Gate result map from check-gate
-
-   Returns: boolean"
+  "Check if a gate result failed. See `passed?` for accepted shapes."
   [result]
-  (not (:passed? result)))
+  (not (passed? result)))
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; Gate operations
@@ -135,6 +141,15 @@
           (emit-gate-event! ctx gate-kw :failed (:errors result))
           result)))))
 
+(defn- repair-succeeded?
+  "True when a repair result indicates success in either accepted shape:
+   the legacy `:success? bool` or the canonical `response/success`."
+  [result]
+  (cond
+    (contains? result :success?) (boolean (:success? result))
+    (response/success? result)   true
+    :else                        false))
+
 (defn repair-gate
   "Attempt to repair gate failures.
 
@@ -144,15 +159,15 @@
      errors   - Errors from check
      ctx      - Execution context
 
-   Returns:
-     {:success? bool :artifact ... :gate gate-kw}"
+   Returns the gate's repair result (either `{:success? bool :artifact ...}`
+   or a `response/success` map) with `:gate gate-kw` assoc'd on top."
   [gate-kw artifact errors ctx]
   (let [{:keys [repair]} (get-gate gate-kw)]
     (if repair
       (try
-        (let [result (repair artifact errors ctx)
-              result (assoc result :gate gate-kw)]
-          (if (:success? result)
+        (let [result (-> (repair artifact errors ctx)
+                         (assoc :gate gate-kw))]
+          (if (repair-succeeded? result)
             (emit-gate-event! ctx gate-kw :passed)
             (emit-gate-event! ctx gate-kw :failed (:errors result)))
           result)

--- a/components/gate/test/ai/miniforge/gate/format_test.clj
+++ b/components/gate/test/ai/miniforge/gate/format_test.clj
@@ -19,33 +19,37 @@
 (ns ai.miniforge.gate.format-test
   "Tests for the LSP format gate.
 
-   Regression coverage: check-format must return the gate-protocol shape
-   {:passed? true ...} so the gate-interface passed? predicate accepts it.
-   Earlier returns of (response/success {...}) silently produced {:status
-   :success ...} with no :passed? key, so every implement phase tripped a
-   spurious :format gate failure even when nothing was wrong."
+   Regression coverage: `check-format` must return the canonical
+   `response/success` shape AND `gate/passed?` must accept it.
+   Earlier the gate machinery only checked `(:passed? result)` and
+   `response/success` produces `{:status :success}` with no `:passed?`
+   key, so every implement phase tripped a spurious :format failure
+   even when nothing was wrong. Both halves of that contract are
+   exercised here."
   (:require
    [ai.miniforge.gate.format :as format-gate]
    [ai.miniforge.gate.interface :as gate]
+   [ai.miniforge.response.interface :as response]
    [clojure.test :refer [deftest is testing]]))
 
-(deftest check-format-returns-passed-true
-  (testing "check-format returns the gate-protocol shape with :passed? true"
+(deftest check-format-returns-canonical-success
+  (testing "check-format returns response/success and gate/passed? accepts it"
     (let [artifact {:code/files [{:path "src/foo.clj"}]}
           result (format-gate/check-format artifact {})]
-      (is (true? (:passed? result))
-          "check-format must set :passed? true so gate/passed? accepts it")
+      (is (response/success? result)
+          "check-format must return the canonical response/success shape")
       (is (gate/passed? (assoc result :gate :format))
-          "gate/passed? must accept the shape returned by check-format")))
+          "gate/passed? must accept the canonical shape returned by check-format")))
 
   (testing "check-format passes even when no files are formattable"
     (let [result (format-gate/check-format {:code/files []} {})]
-      (is (true? (:passed? result)))
-      (is (= [] (:formattable-files result))))))
+      (is (response/success? result))
+      (is (gate/passed? (assoc result :gate :format)))
+      (is (= [] (get-in result [:output :formattable-files]))))))
 
 (deftest check-format-reports-formattable-files
-  (testing "Formattable files are listed in the result"
+  (testing "Formattable files are listed in the result output"
     (let [artifact {:code/files [{:path "a.clj"} {:path "b.md"}]}
           result (format-gate/check-format artifact {})]
-      (is (true? (:passed? result)))
-      (is (vector? (:formattable-files result))))))
+      (is (response/success? result))
+      (is (vector? (get-in result [:output :formattable-files]))))))

--- a/components/gate/test/ai/miniforge/gate/format_test.clj
+++ b/components/gate/test/ai/miniforge/gate/format_test.clj
@@ -1,0 +1,51 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns ai.miniforge.gate.format-test
+  "Tests for the LSP format gate.
+
+   Regression coverage: check-format must return the gate-protocol shape
+   {:passed? true ...} so the gate-interface passed? predicate accepts it.
+   Earlier returns of (response/success {...}) silently produced {:status
+   :success ...} with no :passed? key, so every implement phase tripped a
+   spurious :format gate failure even when nothing was wrong."
+  (:require
+   [ai.miniforge.gate.format :as format-gate]
+   [ai.miniforge.gate.interface :as gate]
+   [clojure.test :refer [deftest is testing]]))
+
+(deftest check-format-returns-passed-true
+  (testing "check-format returns the gate-protocol shape with :passed? true"
+    (let [artifact {:code/files [{:path "src/foo.clj"}]}
+          result (format-gate/check-format artifact {})]
+      (is (true? (:passed? result))
+          "check-format must set :passed? true so gate/passed? accepts it")
+      (is (gate/passed? (assoc result :gate :format))
+          "gate/passed? must accept the shape returned by check-format")))
+
+  (testing "check-format passes even when no files are formattable"
+    (let [result (format-gate/check-format {:code/files []} {})]
+      (is (true? (:passed? result)))
+      (is (= [] (:formattable-files result))))))
+
+(deftest check-format-reports-formattable-files
+  (testing "Formattable files are listed in the result"
+    (let [artifact {:code/files [{:path "a.clj"} {:path "b.md"}]}
+          result (format-gate/check-format artifact {})]
+      (is (true? (:passed? result)))
+      (is (vector? (:formattable-files result))))))

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -23,6 +23,7 @@
    workspace persistence at phase boundaries. Extracted from runner.clj."
   (:require
    [ai.miniforge.dag-executor.interface :as dag]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.response.interface :as response]
    [ai.miniforge.workflow.context :as context]
@@ -183,11 +184,8 @@
                           (:base-branch metadata) (assoc :base-branch
                                                          (:base-branch metadata))))
                 data   (when (dag/ok? result) (dag/unwrap result))]
-            ;; Surface the persisted archive's location so it's grep-able in
-            ;; run logs and reachable from evidence bundles. A future change
-            ;; should promote this to a first-class :workspace/persisted event
-            ;; in event_type_registry so the dashboard can link it.
             (when (:persisted? data)
+              ;; Log line — grep-able from run logs.
               (log/info env-logger :workflow :workflow/workspace-persisted
                         {:message  (str "Workspace persisted: "
                                         (or (:bundle-path data)
@@ -196,7 +194,23 @@
                                     :env-id      env-id
                                     :branch      (:branch data)
                                     :commit-sha  (:commit-sha data)
-                                    :bundle-path (:bundle-path data)}}))
+                                    :bundle-path (:bundle-path data)}})
+              ;; First-class event — picked up by evidence-bundle and the
+              ;; dashboard so 'inspect/resume from this checkpoint' has a
+              ;; structured surface, not just a log line.
+              (when-let [stream (get context :event-stream)]
+                (try
+                  (es/publish! stream
+                               (es/workspace-persisted
+                                stream
+                                (get context :execution/id)
+                                {:phase        phase
+                                 :env-id       env-id
+                                 :branch       (:branch data)
+                                 :commit-sha   (:commit-sha data)
+                                 :bundle-path  (:bundle-path data)
+                                 :persist-tier :worktree}))
+                  (catch Exception _e nil))))
             result)
           (catch Exception e
             (log/warn env-logger :workflow :workflow/persist-failed

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -152,65 +152,108 @@
       last-phase
       :unknown)))
 
+(def ^:private persist-tier-by-mode
+  "Maps `:execution/mode` to the persist tier the executor is using.
+   :governed routes through the docker/k8s tier's `git-persist!` (push to
+   remote). :local routes through the worktree tier's `archive-bundle!`
+   (git bundle on local disk). The event consumers (dashboard, evidence
+   bundle) display the tier so users can tell push-to-remote checkpoints
+   from local-archive checkpoints at a glance."
+  {:governed :remote
+   :local    :worktree})
+
+(def ^:private default-persist-tier
+  "Tier label used when `:execution/mode` is missing or unrecognized.
+   Conservative default — local archive is always present in OSS."
+  :worktree)
+
+(defn- persist-tier-for
+  [context]
+  (get persist-tier-by-mode (get context :execution/mode) default-persist-tier))
+
+(defn- persist-opts
+  "Build the opts map passed to `dag/persist-workspace!`. Keeps map
+   construction key-value with all derivations lifted into the let so
+   readers see the shape of the call without a cond-> obscuring it."
+  [context phase env-id]
+  (let [metadata    (get context :execution/environment-metadata)
+        branch      (get context :execution/task-branch)
+        base-branch (:base-branch metadata)
+        message     (messages/t :env/persist-message {:phase (name phase)})]
+    (cond-> {:message     message
+             :workdir     (get context :execution/worktree-path)
+             :workflow-id (get context :execution/id)
+             :task-id     env-id}
+      branch      (assoc :branch branch)
+      base-branch (assoc :base-branch base-branch))))
+
+(defn- persist-event-data
+  "Shared event/log payload for a persisted checkpoint. Both the log line
+   and the `:workspace/persisted` event read from this — single source of
+   truth for the persistence record."
+  [context phase env-id data]
+  {:phase        phase
+   :env-id       env-id
+   :branch       (:branch data)
+   :commit-sha   (:commit-sha data)
+   :bundle-path  (:bundle-path data)
+   :persist-tier (persist-tier-for context)})
+
+(defn- log-workspace-persisted!
+  [event-data]
+  (let [bundle-or-sha (or (:bundle-path event-data) (:commit-sha event-data))
+        message       (str "Workspace persisted: " bundle-or-sha)]
+    (log/info env-logger :workflow :workflow/workspace-persisted
+              {:message message
+               :data    event-data})))
+
+(defn- publish-workspace-persisted!
+  "Publish the `:workspace/persisted` event when the run has an event
+   stream. Swallows publish exceptions — persistence already succeeded;
+   a downstream subscriber's failure should not surface as a workflow
+   error."
+  [context event-data]
+  (when-let [stream (get context :event-stream)]
+    (try
+      (es/publish! stream
+                   (es/workspace-persisted stream
+                                           (get context :execution/id)
+                                           event-data))
+      (catch Exception _e nil))))
+
+(defn- announce-persisted!
+  "Announce a successful persist on every visibility surface: log line,
+   first-class event, and (transitively) the evidence-bundle collector
+   that harvests events."
+  [context phase env-id data]
+  (let [event-data (persist-event-data context phase env-id data)]
+    (log-workspace-persisted! event-data)
+    (publish-workspace-persisted! context event-data)))
+
 (defn persist-workspace-at-phase-boundary!
   "Persist workspace at phase completion.
 
    Both modes (:governed and :local) participate. :governed pushes to a
-   remote via the docker/k8s tier's git-persist!. :local writes a git bundle
-   via the worktree tier's archive-bundle! so work survives
-   release-environment!.
+   remote via the docker/k8s tier's `git-persist!`; :local writes a git
+   bundle via the worktree tier's `archive-bundle!` so work survives
+   `release-environment!`.
 
    Earlier this was guarded on :governed only, which combined with the
-   worktree tier's no-op `persist-workspace!` meant local-mode tasks lost
-   their work the moment the scratch worktree was torn down. Per the
-   fidelity goal in N11 §7.4, local should match governed in not destroying
-   work on failure."
+   worktree tier's no-op `persist-workspace!` meant local-mode tasks
+   lost their work the moment the scratch worktree was torn down. Per
+   the fidelity goal in N11 §7.4, local should match governed in not
+   destroying work on failure."
   [context phase-ctx]
   (when-let [executor (get context :execution/executor)]
-    (let [env-id   (get context :execution/environment-id)
-          metadata (get context :execution/environment-metadata)
-          branch   (get context :execution/task-branch)
-          phase    (boundary-phase phase-ctx)]
+    (let [env-id (get context :execution/environment-id)
+          phase  (boundary-phase phase-ctx)]
       (when env-id
         (try
-          (let [result (dag/persist-workspace!
-                        executor env-id
-                        (cond-> {:message     (messages/t :env/persist-message
-                                                          {:phase (name phase)})
-                                 :workdir     (get context :execution/worktree-path)
-                                 :workflow-id (get context :execution/id)
-                                 :task-id     env-id}
-                          branch                  (assoc :branch branch)
-                          (:base-branch metadata) (assoc :base-branch
-                                                         (:base-branch metadata))))
+          (let [result (dag/persist-workspace! executor env-id
+                                               (persist-opts context phase env-id))
                 data   (when (dag/ok? result) (dag/unwrap result))]
             (when (:persisted? data)
-              ;; Log line — grep-able from run logs.
-              (log/info env-logger :workflow :workflow/workspace-persisted
-                        {:message  (str "Workspace persisted: "
-                                        (or (:bundle-path data)
-                                            (:commit-sha data)))
-                         :data     {:phase       phase
-                                    :env-id      env-id
-                                    :branch      (:branch data)
-                                    :commit-sha  (:commit-sha data)
-                                    :bundle-path (:bundle-path data)}})
-              ;; First-class event — picked up by evidence-bundle and the
-              ;; dashboard so 'inspect/resume from this checkpoint' has a
-              ;; structured surface, not just a log line.
-              (when-let [stream (get context :event-stream)]
-                (try
-                  (es/publish! stream
-                               (es/workspace-persisted
-                                stream
-                                (get context :execution/id)
-                                {:phase        phase
-                                 :env-id       env-id
-                                 :branch       (:branch data)
-                                 :commit-sha   (:commit-sha data)
-                                 :bundle-path  (:bundle-path data)
-                                 :persist-tier :worktree}))
-                  (catch Exception _e nil))))
+              (announce-persisted! context phase env-id data))
             result)
           (catch Exception e
             (log/warn env-logger :workflow :workflow/persist-failed

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -172,15 +172,32 @@
           phase    (boundary-phase phase-ctx)]
       (when env-id
         (try
-          (dag/persist-workspace!
-           executor env-id
-           (cond-> {:message     (messages/t :env/persist-message
-                                             {:phase (name phase)})
-                    :workdir     (get context :execution/worktree-path)
-                    :workflow-id (get context :execution/id)
-                    :task-id     env-id}
-             branch                  (assoc :branch branch)
-             (:base-branch metadata) (assoc :base-branch (:base-branch metadata))))
+          (let [result (dag/persist-workspace!
+                        executor env-id
+                        (cond-> {:message     (messages/t :env/persist-message
+                                                          {:phase (name phase)})
+                                 :workdir     (get context :execution/worktree-path)
+                                 :workflow-id (get context :execution/id)
+                                 :task-id     env-id}
+                          branch                  (assoc :branch branch)
+                          (:base-branch metadata) (assoc :base-branch
+                                                         (:base-branch metadata))))
+                data   (when (dag/ok? result) (dag/unwrap result))]
+            ;; Surface the persisted archive's location so it's grep-able in
+            ;; run logs and reachable from evidence bundles. A future change
+            ;; should promote this to a first-class :workspace/persisted event
+            ;; in event_type_registry so the dashboard can link it.
+            (when (:persisted? data)
+              (log/info env-logger :workflow :workflow/workspace-persisted
+                        {:message  (str "Workspace persisted: "
+                                        (or (:bundle-path data)
+                                            (:commit-sha data)))
+                         :data     {:phase       phase
+                                    :env-id      env-id
+                                    :branch      (:branch data)
+                                    :commit-sha  (:commit-sha data)
+                                    :bundle-path (:bundle-path data)}}))
+            result)
           (catch Exception e
             (log/warn env-logger :workflow :workflow/persist-failed
                       {:message (messages/t :env/persist-failed

--- a/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
+++ b/components/workflow/src/ai/miniforge/workflow/runner_environment.clj
@@ -152,19 +152,37 @@
       :unknown)))
 
 (defn persist-workspace-at-phase-boundary!
-  "Persist workspace to task branch after phase completes (governed mode only)."
+  "Persist workspace at phase completion.
+
+   Both modes (:governed and :local) participate. :governed pushes to a
+   remote via the docker/k8s tier's git-persist!. :local writes a git bundle
+   via the worktree tier's archive-bundle! so work survives
+   release-environment!.
+
+   Earlier this was guarded on :governed only, which combined with the
+   worktree tier's no-op `persist-workspace!` meant local-mode tasks lost
+   their work the moment the scratch worktree was torn down. Per the
+   fidelity goal in N11 §7.4, local should match governed in not destroying
+   work on failure."
   [context phase-ctx]
   (when-let [executor (get context :execution/executor)]
-    (when (= :governed (get context :execution/mode))
-      (let [env-id (get context :execution/environment-id)
-            branch (get context :execution/task-branch)
-            phase  (boundary-phase phase-ctx)]
+    (let [env-id   (get context :execution/environment-id)
+          metadata (get context :execution/environment-metadata)
+          branch   (get context :execution/task-branch)
+          phase    (boundary-phase phase-ctx)]
+      (when env-id
         (try
-          (dag/persist-workspace! executor env-id
-                                       {:branch  branch
-                                        :message (messages/t :env/persist-message {:phase (name phase)})
-                                        :workdir (get context :execution/worktree-path)})
+          (dag/persist-workspace!
+           executor env-id
+           (cond-> {:message     (messages/t :env/persist-message
+                                             {:phase (name phase)})
+                    :workdir     (get context :execution/worktree-path)
+                    :workflow-id (get context :execution/id)
+                    :task-id     env-id}
+             branch                  (assoc :branch branch)
+             (:base-branch metadata) (assoc :base-branch (:base-branch metadata))))
           (catch Exception e
             (log/warn env-logger :workflow :workflow/persist-failed
-                      {:message (messages/t :env/persist-failed {:error (ex-message e)})})
+                      {:message (messages/t :env/persist-failed
+                                            {:error (ex-message e)})})
             nil))))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -24,6 +24,7 @@
    [ai.miniforge.workflow.runner :as runner]
    [ai.miniforge.workflow.context :as ctx]
    [ai.miniforge.dag-executor.interface :as dag-exec]
+   [ai.miniforge.event-stream.interface :as es]
    [ai.miniforge.logging.interface :as log]
    [ai.miniforge.workflow.messages :as messages]
    [ai.miniforge.workflow.execution :as exec]
@@ -382,3 +383,52 @@
                     (fn [& _] nil)]
         ;; Should not throw
         (is (nil? (persist-fn context phase-ctx)))))))
+
+(defn- capture-persist-event-data
+  "Capture the data passed to es/workspace-persisted by running the
+   persist boundary against a stub executor that always reports a
+   successful persist."
+  [context phase-ctx]
+  (let [event-data (atom nil)
+        ok-result  (dag-exec/ok {:persisted? true
+                                 :branch "task-1"
+                                 :commit-sha "abc123"
+                                 :bundle-path "/tmp/x.bundle"})]
+    (with-redefs [dag-exec/persist-workspace!
+                  (fn [_exec _env-id _opts] ok-result)
+                  log/info
+                  (fn [& _] nil)
+                  es/workspace-persisted
+                  (fn [_stream _wf-id data]
+                    (reset! event-data data)
+                    {:event/type :workspace/persisted})
+                  es/publish!
+                  (fn [& _] nil)]
+      (persist-fn context phase-ctx)
+      @event-data)))
+
+(deftest persist-tier-is-worktree-in-local-mode-test
+  (testing ":workspace/persisted event labels :local mode as :worktree tier"
+    (let [data (capture-persist-event-data
+                {:execution/executor :stub
+                 :execution/mode :local
+                 :execution/environment-id "env-1"
+                 :execution/environment-metadata {:base-branch "feat/foo"}
+                 :event-stream :stub-stream
+                 :execution/id #uuid "00000000-0000-0000-0000-000000000001"}
+                {:execution/current-phase :implement})]
+      (is (= :worktree (:persist-tier data))
+          "local mode persists to a local archive — worktree tier"))))
+
+(deftest persist-tier-is-remote-in-governed-mode-test
+  (testing ":workspace/persisted event labels :governed mode as :remote tier"
+    (let [data (capture-persist-event-data
+                {:execution/executor :stub
+                 :execution/mode :governed
+                 :execution/environment-id "env-1"
+                 :execution/task-branch "task/abc"
+                 :event-stream :stub-stream
+                 :execution/id #uuid "00000000-0000-0000-0000-000000000002"}
+                {:execution/current-phase :implement})]
+      (is (= :remote (:persist-tier data))
+          "governed mode pushes to remote — remote tier label, not worktree"))))

--- a/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
+++ b/components/workflow/test/ai/miniforge/workflow/runner_extended_test.clj
@@ -311,18 +311,25 @@
           phase-ctx {:execution/current-phase :implement}]
       (is (nil? (persist-fn context phase-ctx))))))
 
-(deftest persist-workspace-noop-when-not-governed-test
-  (testing "returns nil when execution mode is :local (not :governed)"
-    (let [called (atom false)
+(deftest persist-workspace-fires-in-local-mode-test
+  (testing "persist fires in :local mode (parity with :governed) so worktree-tier work survives release"
+    (let [call-args (atom nil)
           context {:execution/executor :stub
                    :execution/mode :local
                    :execution/environment-id "env-1"
-                   :execution/task-branch "task/branch"}
+                   :execution/environment-metadata {:base-branch "feat/foo"}
+                   :execution/worktree-path "/tmp/scratch"}
           phase-ctx {:execution/current-phase :implement}]
       (with-redefs [dag-exec/persist-workspace!
-                    (fn [& _] (reset! called true))]
+                    (fn [executor env-id opts]
+                      (reset! call-args {:executor executor :env-id env-id :opts opts}))]
         (persist-fn context phase-ctx)
-        (is (false? @called))))))
+        (is (some? @call-args))
+        (is (= "env-1" (:env-id @call-args)))
+        ;; base-branch comes from environment-metadata so the worktree tier
+        ;; can bundle the right base..HEAD range
+        (is (= "feat/foo" (get-in @call-args [:opts :base-branch])))
+        (is (= "env-1" (get-in @call-args [:opts :task-id])))))))
 
 (deftest persist-workspace-calls-executor-in-governed-mode-test
   (testing "calls dag-exec/persist-workspace! with correct args in governed mode"

--- a/docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md
+++ b/docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md
@@ -1,0 +1,201 @@
+# feat: local-mode fidelity — archive persist, tool-first delivery, harvest CLI
+
+## Overview
+
+Closes the gap where dogfooding miniforge in `:local` mode silently destroyed task work at scratch-worktree teardown,
+and surfaced multiple smaller bugs along the way. After this PR:
+
+- **Workflow runs end-to-end on the local tier.** Plan + DAG tasks complete through to release without losing the
+  agent's output.
+- **Per-task work is preserved as a real git bundle** under `~/.miniforge/checkpoints/<workflow-id>/<task-id>.bundle`,
+  so every successful task leaves an inspectable, fetchable archive even if the workflow later fails.
+- **Recovery is one CLI call:** `bb harvest <workflow-id>` pulls the archives back into the host repo as named branches.
+- **`:workspace/persisted` is a first-class event,** flowing through the event stream into the evidence bundle and
+  rendered in the CLI display.
+- **The implementer prompt no longer contradicts itself,** mandating tool-based file delivery rather than allowing a
+  model to "deliver" by emitting an EDN map in chat.
+- **Two pre-existing fail-closed bugs were unblocked** along the way: `bb miniforge` couldn't load namespaces because
+  the classpath was missing `components/anomaly`, and the `:format` gate's `check-format` returned a `response/success`
+  shape instead of `{:passed? true}`, so every implement phase tripped a spurious gate failure.
+
+## Motivation
+
+Dogfooding the new generalized-classification-runtime spec on the local tier exposed a fidelity gap between `:governed`
+and `:local` modes that violated the project's "don't destroy user work on failure" principle (N11 §7.4):
+
+1. The worktree executor's `persist-workspace!` was a no-op, with the comment *"Worktree files are already on host — no
+  persistence needed."*
+2. `persist-workspace-at-phase-boundary!` was guarded on `:execution/mode :governed`, so even if the worktree
+  implementation worked, local mode never invoked it.
+3. `release-environment!` then ran `git worktree remove --force` on the scratch worktree.
+
+Combined: every task's work was destroyed at the end of execution. A workflow that ran 6 implementations and produced
+~3000 lines of code ended with zero files on the host worktree.
+
+This PR makes `:local` mode match `:governed` in not destroying work. The persistence model differs (local uses `git
+bundle` to a file under `~/.miniforge/checkpoints/`, governed uses `git push` to a remote), but both tiers now leave a
+recoverable artifact behind.
+
+## Changes In Detail
+
+### 1. Worktree-tier archive persist (`components/dag-executor`)
+
+- `archive-bundle!` — stages dirty paths, commits on the task branch with `--no-verify` (commit is internal
+  infrastructure; validation is the gate's job upstream), and writes `git bundle create <bundle-path> <branch> --not
+  <base-ref>`. The `--not <base-ref>` form is essential: the alternative `<base>..HEAD` form bundles the same commits
+  but only records HEAD as a head, leaving `git fetch <bundle> <branch>:<branch>` unable to resolve the branch by name.
+- `restore-from-bundle!` — `git -C <host-repo> fetch <bundle> <branch>:<branch>` brings the branch and its objects into
+  the host repo's object DB. The orchestrator can then check the branch out wherever it wants without touching the live
+  worktree.
+- Default archive root is `~/.miniforge/checkpoints/`, namespaced by `workflow-id` so concurrent runs don't collide on
+  the same `task-id` stem. Override via `:archive-dir` opt or the `:archive-dir` config field.
+- `acquire-environment!` now stores `:base-branch` in the env-record's `:metadata` so persist can bundle the right
+  `<base-ref>..HEAD` range without guessing.
+- `persist-workspace!` is now the real implementation; `restore-workspace!` calls `restore-from-bundle!`.
+
+Tests added:
+
+- `persist-workspace-clean-worktree-no-changes-test`
+- `persist-workspace-dirty-bundles-test`
+- `restore-workspace-fetches-from-bundle-test`
+- `archive-bundle-fails-cleanly-on-bundle-error-test`
+
+The two pre-existing `persist-workspace-noop-test` / `restore-workspace-noop-test` were rewritten to assert the new
+contract; they previously asserted the buggy no-op behavior.
+
+### 2. Wire `:local` mode to persist (`components/workflow`)
+
+`persist-workspace-at-phase-boundary!` no longer gates on `:execution/mode :governed`. Both modes participate. The
+dispatched implementation differs by tier — docker/k8s pushes to a remote via `git-persist!`; worktree writes a bundle
+via `archive-bundle!`.
+
+The call site threads `:base-branch` from `:execution/environment-metadata` into the persist opts so the worktree tier
+can bundle the right range.
+
+`persist-workspace-noop-when-not-governed-test` was renamed to `persist-workspace-fires-in-local-mode-test` and its
+assertions inverted.
+
+### 3. `:workspace/persisted` first-class event (`components/event-stream`, `bases/cli`)
+
+Promotes the previous `log/info` line to a real event so the dashboard and evidence bundle have a structured handle on
+persistence.
+
+- `events/workspace-persisted` constructor in `event-stream/core.clj`. Carries `:workspace/phase`, `:workspace/env-id`,
+  `:workspace/branch`, `:workspace/commit-sha`, `:workspace/bundle-path`, `:workspace/tier`.
+- Registered in `event_type_registry` and `default-event-privacy` (`:public` — bundle paths are user-facing and contain
+  no secrets).
+- `WorkspacePersisted` Malli schema added.
+- Re-exported through `interface.clj` and `interface/events.clj`.
+- `runner_environment.clj` publishes the event in addition to logging it. Falls back silently if no `:event-stream` is
+  on context (keeps the persist path robust in test contexts).
+- CLI display renders `↳ Persisted (<phase>): <bundle-path>` so the user sees checkpoint creation in real time.
+
+### 4. Implementer prompt: tools are delivery (`components/agent`)
+
+The previous prompt had a contradiction:
+
+- *"Your FIRST action must be writing code (Write/Edit) — NOT reading files."*
+- *"You must output a structured code artifact as a Clojure map: `{:code/files [...]}`"*
+
+A model could satisfy the second by emitting the EDN map in chat without calling Write or Edit. Claude was corralled
+into tool use by `--allowedTools` at the CLI layer; Codex (which the codex-args function ships with no tool restriction)
+had no such corral and inconsistently chose the chat path. When that happened, the parse-code-response fallback
+extracted files from chat into an in-memory artifact, gates passed on the data, but the curator's environment check
+found nothing on disk and correctly failed with `:curator/no-files-written`.
+
+The new prompt:
+
+- "Delivery — Tools Are the Mechanism" replaces "Output Format". The first sentence: the work product is files on disk.
+- Explicit `Do NOT` list: emitting `:code/files` in chat, printing code blocks "for clarity", planning extensively in
+  chat.
+- The structured payload `submit` accepts no longer includes `:code/files` — the runtime derives that from Write/Edit
+  calls. This removes the path that lets a model confuse "describe the work" with "deliver the work".
+- Already-implemented response now goes through `submit` rather than a bare chat output.
+- `:prompt/version` bumped to `1.1.0`.
+
+The existing `parse-code-response` fallback tests still pass — they cover the "if the model emits chat anyway, parser
+handles it" safety net, which remains valuable.
+
+### 5. `:format` gate fail-closed (`components/gate`)
+
+`check-format` and `repair-format` returned `(response/success {...})`, which produces `{:status :success ...}` with no
+`:passed?` key. The gate machinery checks `(boolean (:passed? result))` — so every format-gate run was treated as
+failing.
+
+Other gates (syntax, lint, test, behavioral, no-secrets) correctly return `{:passed? bool}`. There were no tests on the
+format gate; that's how this drifted in unnoticed.
+
+Fix: return `{:passed? true ...}` from `check-format` and `{:success? true ...}` from `repair-format`. Drop the
+now-unused `response.interface` require. Add `format_test.clj` covering both the value AND its acceptance by
+`gate/passed?` so future regressions trip the test in either direction.
+
+### 6. `bb miniforge` classpath: anomaly component
+
+The `bb miniforge` task's `:extra-paths` was missing `components/anomaly/{src,resources}`. The schema component requires
+`ai.miniforge.anomaly.interface`, so every `bb miniforge` invocation died at namespace load with `FileNotFoundException`
+before reaching CLI dispatch.
+
+Adding the two paths unblocks the task. The broader `bb.edn` classpath drift (~76 components on disk are absent from
+this `:extra-paths` list) is a separate issue and should be addressed by deriving the classpath from `workspace.edn`
+rather than maintaining the path list by hand. Tracked separately.
+
+### 7. `bb harvest` CLI command
+
+Pulls persisted task bundles back into the host repo as named branches. Closes the visibility gap between
+`persist-workspace!` (which writes archives) and the user's host worktree (which had no automatic way to materialize
+them).
+
+```text
+bb harvest                  # list all checkpoint workflows
+bb harvest <workflow-id>    # fetch one workflow's bundles
+bb harvest --all            # fetch every checkpoint on disk
+```
+
+Each bundle becomes a `harvest/<workflow-id>/<task-id>` ref in the host repo. Standard git tools take it from there:
+
+```text
+git log    harvest/<wf>/<task>      # see what the agent produced
+git checkout harvest/<wf>/<task>    # try the alternative
+git cherry-pick harvest/<wf>/<task> # integrate a chosen version
+```
+
+Override the checkpoint root via `MINIFORGE_CHECKPOINT_DIR` if needed.
+
+## Why CLI harvest, not automatic merge
+
+The orchestrator currently runs every DAG task in a scratch worktree off the same parent base, so tasks that should
+depend on each other (per their declared `:dependencies`) actually run from a clean slate. In the dogfood verification
+run that drove this PR, four of six tasks independently rewrote `components/classification/engine.clj` because each
+agent was looking at the same un-extended base.
+
+Auto-merging those task branches into the spec branch would be a conflict storm. A user-driven `bb harvest` is the safe
+shape until **per-task base chaining** lands — the followup that has each task acquire a scratch worktree from its
+dependency-task's branch rather than the spec branch. That work belongs in its own PR and architectural conversation.
+
+## Verification
+
+End-to-end dogfood on `work/generalized-classification-runtime.spec.edn`:
+
+```text
+✓ Phase :plan success (2.3m)
+:completed 6, :failed 0, :iterations 5
+✓ Workflow completed (4.5m planner + ~42m total)
+```
+
+Six bundles in `~/.miniforge/checkpoints/<workflow-id>/`, each with a fresh task commit carrying real
+`components/classification/...` files (~430–760 lines per task). `bb harvest <wf>` round-trips them back as
+`harvest/<wf>/task-<id>` refs. `git ls-tree refs/heads/harvest/<wf>/task-<id>` shows the agent's writes intact.
+
+Pre-commit (lint + format + changed-brick tests) passes on every commit.
+
+## Followups (not in this PR)
+
+1. **Per-task base chaining.** Orchestrator should pass dependency-task's branch as the env-config `:branch` for
+  downstream task acquisition, so tasks see each other's intermediate output. Without this, harvest is the user's
+  recovery path; with it, the spec branch can naturally absorb chained work.
+2. **Codex tool parity.** `codex-args` ships zero tool config (`--full-auto` only sandboxes commands, doesn't restrict
+  tools). Claude's `--allowedTools` / `--mcp-config` lock the surface; Codex needs equivalent `-c` overrides into
+  `~/.codex/config.toml` keys (`tools.<name>.enabled`, `[approval]`). Pending review of the Codex config schema.
+3. **Podman as the default isolation tier.** Worktree should become the documented fallback; isolated containers should
+  be the primary execution surface.
+4. **`bb miniforge` classpath drift.** Derive `:extra-paths` from `workspace.edn` instead of the hand-curated list.

--- a/tasks/harvest.clj
+++ b/tasks/harvest.clj
@@ -1,0 +1,188 @@
+;; Title: Miniforge.ai
+;; Subtitle: An agentic SDLC / fleet-control platform
+;; Author: Christopher Lester
+;; Line: Founder, Miniforge.ai (project)
+;; Copyright 2025-2026 Christopher Lester (christopher@miniforge.ai)
+;;
+;; Licensed under the Apache License, Version 2.0 (the "License");
+;; you may not use this file except in compliance with the License.
+;; You may obtain a copy of the License at
+;;
+;;     http://www.apache.org/licenses/LICENSE-2.0
+;;
+;; Unless required by applicable law or agreed to in writing, software
+;; distributed under the License is distributed on an "AS IS" BASIS,
+;; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+;; See the License for the specific language governing permissions and
+;; limitations under the License.
+
+(ns harvest
+  "Pull persisted task bundles back into the host repo as named branches.
+
+   Each `bb dogfood` (or any miniforge run) writes a `.bundle` file per
+   task under `~/.miniforge/checkpoints/<workflow-id>/<task-id>.bundle`.
+   The bundles preserve the agent's work as a real git commit on the
+   task branch, but nothing automatically merges them into the host
+   working tree because tasks running off the same base often produce
+   conflicting alternative cuts of the same files.
+
+   Harvest is the explicit, user-driven recovery step:
+     bb harvest                  # list all checkpoint workflows
+     bb harvest <workflow-id>    # fetch all bundles for one workflow
+     bb harvest --all            # fetch every bundle on disk
+
+   Each bundle becomes a `harvest/<workflow-id>/<task-id>` ref in the
+   host repo. Use `git log` / `git checkout` / `git cherry-pick` to
+   inspect or integrate."
+  (:require
+   [babashka.fs :as fs]
+   [babashka.process :as p]
+   [clojure.string :as str]))
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Layer 0 — paths
+
+(def ^:private default-checkpoint-dir
+  (str (System/getProperty "user.home") "/.miniforge/checkpoints"))
+
+(defn- checkpoint-dir
+  "Resolve checkpoint root: env override → default."
+  []
+  (or (System/getenv "MINIFORGE_CHECKPOINT_DIR")
+      default-checkpoint-dir))
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Layer 1 — discovery
+
+(defn- workflow-dirs
+  "Return [workflow-id absolute-path] pairs under checkpoint root."
+  [root]
+  (when (fs/exists? root)
+    (->> (fs/list-dir root)
+         (filter fs/directory?)
+         (mapv (fn [d] [(fs/file-name d) (str d)])))))
+
+(defn- bundles-in
+  "Return [task-id absolute-path] pairs for .bundle files in a workflow dir."
+  [workflow-path]
+  (->> (fs/list-dir workflow-path)
+       (filter #(str/ends-with? (fs/file-name %) ".bundle"))
+       (mapv (fn [b]
+               [(str/replace (fs/file-name b) #"\.bundle$" "")
+                (str b)]))
+       (sort-by first)))
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Layer 2 — git operations
+
+(defn- run-git
+  "Run a git command, return {:exit :out :err}."
+  [& args]
+  (let [{:keys [exit out err]}
+        (apply p/sh {:continue true :out :string :err :string} "git" args)]
+    {:exit exit :out (or out "") :err (or err "")}))
+
+(defn- in-git-repo? []
+  (zero? (:exit (run-git "rev-parse" "--git-dir"))))
+
+(defn- fetch-bundle!
+  "git fetch <bundle> HEAD:<ref>. Returns {:ok? :ref :err}."
+  [bundle-path ref]
+  (let [r (run-git "fetch" bundle-path (str "HEAD:" ref))]
+    (if (zero? (:exit r))
+      {:ok? true :ref ref}
+      {:ok? false :ref ref :err (str/trim (:err r))})))
+
+;; ──────────────────────────────────────────────────────────────────────
+;; Layer 3 — commands
+
+(defn- list-checkpoints
+  "Print every workflow checkpoint dir, with bundle counts."
+  []
+  (let [root (checkpoint-dir)
+        wfs  (workflow-dirs root)]
+    (cond
+      (not (fs/exists? root))
+      (do (println "No checkpoint root yet:" root)
+          (println "Run `bb dogfood` (or any miniforge workflow) to create one."))
+
+      (empty? wfs)
+      (println "Checkpoint root is empty:" root)
+
+      :else
+      (do
+        (println "Checkpoint root:" root)
+        (doseq [[wf-id path] wfs
+                :let [bundles (bundles-in path)]]
+          (println (format "  %s  (%d bundle%s)"
+                           wf-id
+                           (count bundles)
+                           (if (= 1 (count bundles)) "" "s"))))
+        (println)
+        (println "Pull a workflow's work back into this repo:")
+        (println "  bb harvest <workflow-id>")
+        (println "Or pull everything:")
+        (println "  bb harvest --all")))))
+
+(defn- harvest-workflow!
+  "Fetch every bundle for one workflow-id into refs/harvest/<workflow-id>/<task-id>."
+  [workflow-id]
+  (let [root         (checkpoint-dir)
+        wf-path      (str root "/" workflow-id)]
+    (cond
+      (not (fs/exists? wf-path))
+      (do
+        (println "No such workflow checkpoint dir:" wf-path)
+        (System/exit 1))
+
+      (not (in-git-repo?))
+      (do
+        (println "Not inside a git repository — harvest needs a host repo to fetch into.")
+        (System/exit 1))
+
+      :else
+      (let [bundles (bundles-in wf-path)]
+        (when (empty? bundles)
+          (println "No bundles found in" wf-path)
+          (System/exit 1))
+        (println (format "Harvesting %d bundle(s) from workflow %s → refs/heads/harvest/%s/<task-id>"
+                         (count bundles) workflow-id workflow-id))
+        (doseq [[task-id bundle-path] bundles
+                :let [ref (str "harvest/" workflow-id "/" task-id)
+                      r   (fetch-bundle! bundle-path ref)]]
+          (if (:ok? r)
+            (println (format "  ✓ %s  ← %s" ref bundle-path))
+            (println (format "  ✗ %s  (%s)" ref (:err r)))))
+        (println)
+        (println "Inspect a task's work:")
+        (println (format "  git log harvest/%s/<task-id>" workflow-id))
+        (println (format "  git checkout harvest/%s/<task-id>" workflow-id))))))
+
+(defn- harvest-all!
+  "Harvest every workflow checkpoint."
+  []
+  (let [root (checkpoint-dir)
+        wfs  (workflow-dirs root)]
+    (when (empty? wfs)
+      (println "Nothing to harvest — checkpoint root is empty:" root)
+      (System/exit 0))
+    (doseq [[wf-id _] wfs]
+      (println "─── workflow:" wf-id)
+      (harvest-workflow! wf-id)
+      (println))))
+
+(defn run
+  "Entry point. Usage:
+     bb harvest                  # list workflows
+     bb harvest <workflow-id>    # fetch all bundles for one workflow
+     bb harvest --all            # fetch every bundle on disk"
+  [& args]
+  (let [arg (first args)]
+    (cond
+      (or (nil? arg) (= arg "--list") (= arg "list"))  (list-checkpoints)
+      (= arg "--all")                                  (harvest-all!)
+      (str/starts-with? (str arg) "-")
+      (do (println "Unknown option:" arg)
+          (println "Usage: bb harvest [--all | <workflow-id>]")
+          (System/exit 1))
+      :else (harvest-workflow! arg))))

--- a/tasks/harvest.clj
+++ b/tasks/harvest.clj
@@ -85,13 +85,47 @@
 (defn- in-git-repo? []
   (zero? (:exit (run-git "rev-parse" "--git-dir"))))
 
-(defn- fetch-bundle!
-  "git fetch <bundle> HEAD:<ref>. Returns {:ok? :ref :err}."
-  [bundle-path ref]
-  (let [r (run-git "fetch" bundle-path (str "HEAD:" ref))]
+(defn- parse-list-heads-line
+  "Parse one line of `git bundle list-heads` output.
+
+   Lines look like:
+     <40-hex-sha> refs/heads/<branch>
+     <40-hex-sha> HEAD
+     <40-hex-sha> refs/tags/<tag>
+
+   We only want branch refs — fetching the HEAD pseudo-ref or tag refs
+   into a host repo branch isn't what `bb harvest` is for. Returns the
+   bare branch name when the line names a refs/heads/* ref, otherwise nil."
+  [line]
+  (let [parts (str/split (str/trim line) #"\s+")
+        ref   (second parts)]
+    (when (and ref (str/starts-with? ref "refs/heads/"))
+      (subs ref (count "refs/heads/")))))
+
+(defn- bundle-branches
+  "List the branch names recorded as heads in a bundle.
+
+   Bundles created via `git bundle create FILE BRANCH --not BASE` advertise
+   `refs/heads/BRANCH`. Bundles created via the older `BASE..HEAD` form
+   advertise only `HEAD` and we filter those out — fetching `HEAD:<ref>`
+   blindly was the original PR #729 bug Copilot caught: it works on
+   recent bundles but fails on any bundle whose only head is the
+   pseudo-HEAD ref. Surface that as an empty list so the caller can
+   report 'no branches in bundle' instead of an opaque fetch failure."
+  [bundle-path]
+  (let [r (run-git "bundle" "list-heads" bundle-path)]
+    (when (zero? (:exit r))
+      (->> (str/split-lines (:out r))
+           (keep parse-list-heads-line)
+           vec))))
+
+(defn- fetch-branch!
+  "git fetch <bundle> <branch>:<ref>. Returns {:ok? :ref :branch :err}."
+  [bundle-path branch ref]
+  (let [r (run-git "fetch" bundle-path (str branch ":" ref))]
     (if (zero? (:exit r))
-      {:ok? true :ref ref}
-      {:ok? false :ref ref :err (str/trim (:err r))})))
+      {:ok? true :ref ref :branch branch}
+      {:ok? false :ref ref :branch branch :err (str/trim (:err r))})))
 
 ;; ──────────────────────────────────────────────────────────────────────
 ;; Layer 3 — commands
@@ -124,11 +158,38 @@
         (println "Or pull everything:")
         (println "  bb harvest --all")))))
 
+(defn- ref-for
+  "Compose the harvest ref name for one task's branch."
+  [workflow-id task-id]
+  (str "harvest/" workflow-id "/" task-id))
+
+(defn- harvest-bundle!
+  "Fetch every branch advertised by one bundle. Reports per-branch
+   ok/err lines so users see which fetches succeeded. Returns nil —
+   stdout-driven CLI helper."
+  [workflow-id task-id bundle-path]
+  (let [branches (bundle-branches bundle-path)]
+    (cond
+      (nil? branches)
+      (println (format "  ✗ %s  (could not list bundle heads)" bundle-path))
+
+      (empty? branches)
+      (println (format "  ✗ %s  (bundle advertises no refs/heads/* — likely the legacy `base..HEAD` shape that only recorded HEAD; re-create with the post-PR#729 archive-bundle!)"
+                       bundle-path))
+
+      :else
+      (doseq [branch branches
+              :let [ref (ref-for workflow-id task-id)
+                    r   (fetch-branch! bundle-path branch ref)]]
+        (if (:ok? r)
+          (println (format "  ✓ %s  ← %s (branch %s)" ref bundle-path branch))
+          (println (format "  ✗ %s  (%s)" ref (:err r))))))))
+
 (defn- harvest-workflow!
-  "Fetch every bundle for one workflow-id into refs/harvest/<workflow-id>/<task-id>."
+  "Fetch every bundle for one workflow-id into harvest/<workflow-id>/<task-id>."
   [workflow-id]
-  (let [root         (checkpoint-dir)
-        wf-path      (str root "/" workflow-id)]
+  (let [root    (checkpoint-dir)
+        wf-path (str root "/" workflow-id)]
     (cond
       (not (fs/exists? wf-path))
       (do
@@ -147,12 +208,8 @@
           (System/exit 1))
         (println (format "Harvesting %d bundle(s) from workflow %s → refs/heads/harvest/%s/<task-id>"
                          (count bundles) workflow-id workflow-id))
-        (doseq [[task-id bundle-path] bundles
-                :let [ref (str "harvest/" workflow-id "/" task-id)
-                      r   (fetch-bundle! bundle-path ref)]]
-          (if (:ok? r)
-            (println (format "  ✓ %s  ← %s" ref bundle-path))
-            (println (format "  ✗ %s  (%s)" ref (:err r)))))
+        (doseq [[task-id bundle-path] bundles]
+          (harvest-bundle! workflow-id task-id bundle-path))
         (println)
         (println "Inspect a task's work:")
         (println (format "  git log harvest/%s/<task-id>" workflow-id))


### PR DESCRIPTION
## Summary

- **Workflow runs end-to-end on `:local` mode now.** Per-task work persists to `~/.miniforge/checkpoints/<workflow-id>/<task-id>.bundle` via `git bundle`, surviving `release-environment!`. Closes the gap that violated the project's "don't destroy user work on failure" principle (N11 §7.4).
- **`bb harvest` CLI pulls archives back into the host repo as `harvest/<wf>/<task>` branches.** Explicit, user-driven recovery (auto-merge isn't safe yet — tasks running off the same base produce conflicting alternative cuts; tracked as a follow-up).
- **`:workspace/persisted` is a first-class event,** rendered in CLI, harvested by evidence bundle.
- **Implementer prompt mandates tool-based delivery,** removing the contradiction that let Codex emit code in chat instead of writing files.
- **Two pre-existing fail-closed bugs unblocked:** `bb miniforge` classpath was missing `components/anomaly`; the `:format` gate returned a `response/success` shape with no `:passed?` key so every implement phase tripped a spurious gate failure.

Full per-component breakdown, motivation, and verification log in [docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md](docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md).

## Test plan

- [x] `bb pre-commit` passes on every commit (lint + format + 474 brick assertions across 6 changed bricks)
- [x] New `dag-executor.protocols.impl.worktree-test`: 9 tests, 25 assertions
- [x] New `gate.format-test`: 2 tests, 6 assertions
- [x] Real-git smoke test of `archive-bundle!` → `restore-from-bundle!` round-trip
- [x] End-to-end dogfood on `work/generalized-classification-runtime.spec.edn`: 6 of 6 tasks completed, 0 failed, 5 iterations, 4.5min planner + ~42min total
- [x] `bb harvest <workflow-id>` round-trip verified against checkpoints from the dogfood run

## Followups (separate PRs)

1. **Per-task base chaining.** Orchestrator passes dependency-task's branch as the env-config `:branch` for downstream task acquisition, so tasks see each other's intermediate output. Without this, the dogfood saw 4 of 6 tasks independently rewriting `components/classification/engine.clj`.
2. **Codex tool parity.** Mirror Claude's `--allowedTools` semantics by passing `-c` overrides into `codex-args`. Pending review of the Codex `config.toml` schema (`tools.<name>.enabled`, `[approval]`).
3. **Podman as the default isolation tier.** Worktree becomes the documented fallback.
4. **`bb miniforge` classpath drift.** Derive `:extra-paths` from `workspace.edn` instead of the hand-curated list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)