### PR TITLE
feat: Codex tool parity — explicit sandbox/approval + required MCP server

### DIFF
--- a/components/agent/src/ai/miniforge/agent/artifact_session.clj
+++ b/components/agent/src/ai/miniforge/agent/artifact_session.clj
@@ -241,6 +241,11 @@
    If the file exists and already has an [mcp_servers.artifact] block,
    replaces it. Otherwise appends the block. Creates .codex/ dir if needed.
 
+   Sets `required = true` per Codex's config-reference so startup fails
+   loudly if our MCP server can't initialize, rather than silently
+   running with the artifact server absent. This mirrors Claude's
+   behavior when --mcp-config can't be loaded.
+
    Returns the path to the config file."
   [config-root server-cmd]
   (let [{:keys [command args]} server-cmd
@@ -250,7 +255,8 @@
         block-header "[mcp_servers.artifact]"
         block (str block-header "\n"
                    "command = " (json/generate-string command) "\n"
-                   "args = " (json/generate-string args) "\n")]
+                   "args = " (json/generate-string args) "\n"
+                   "required = true\n")]
     (.mkdirs dir)
     (if (.exists config-file)
       (let [content (slurp config-file)

--- a/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
+++ b/components/agent/test/ai/miniforge/agent/artifact_session_test.clj
@@ -291,6 +291,12 @@
         ;; Verify the codex path is tracked for cleanup
         (is (some? codex-file))
         (is (str/ends-with? codex-file "config.toml"))
+        ;; Verify the artifact block is marked required so Codex fails
+        ;; loudly if our MCP server can't initialize, instead of silently
+        ;; running without it.
+        (let [content (slurp codex-file)]
+          (is (str/includes? content "[mcp_servers.artifact]"))
+          (is (str/includes? content "required = true")))
         (finally
           (session/cleanup-session! s))))))
 

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -294,12 +294,34 @@
       true                         (conj prompt))))
 
 (defn- codex-args
-  "Build CLI arguments for the Codex backend."
+  "Build CLI arguments for the Codex backend.
+
+   Tool / approval surface (mirrors Claude's --allowedTools intent within
+   Codex's different tool model — see PR notes):
+
+   - --sandbox=workspace-write  — explicit sandbox; agent can edit files
+                                  in the workspace. Replaces the deprecated
+                                  --full-auto alias for clarity.
+   - -c approval_policy=never   — no human-in-the-loop pings. Codex's exec
+                                  mode honors this.
+   - -c mcp_servers.artifact.required=true
+                                — fail loudly if the artifact MCP server
+                                  doesn't initialize, instead of silently
+                                  proceeding without it. Matches Claude's
+                                  behavior when --mcp-config can't load.
+
+   What we cannot do (per Codex config-reference): allow-list individual
+   built-in tools. apply_patch / shell are governed by sandbox_mode
+   categorically. The implementer prompt + the artifact MCP server's own
+   `enabled_tools` list are the per-tool surface."
   [{:keys [prompt model system]}]
   (cond-> ["exec"
            "--json"
-           "--full-auto"
-           "--skip-git-repo-check"]
+           "--sandbox=workspace-write"
+           "--ask-for-approval=never"
+           "--skip-git-repo-check"
+           "-c" "approval_policy=\"never\""
+           "-c" "mcp_servers.artifact.required=true"]
     model  (into ["-m" model])
     system (into ["-c" (str "system_prompt=" (json/generate-string system))])
     true   (conj prompt)))

--- a/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
+++ b/components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj
@@ -299,19 +299,25 @@
    Tool / approval surface (mirrors Claude's --allowedTools intent within
    Codex's different tool model — see PR notes):
 
-   - --sandbox=workspace-write  — explicit sandbox; agent can edit files
-                                  in the workspace. Replaces the deprecated
-                                  --full-auto alias for clarity.
-   - -c approval_policy=never   — no human-in-the-loop pings. Codex's exec
-                                  mode honors this.
-   - -c mcp_servers.artifact.required=true
-                                — fail loudly if the artifact MCP server
-                                  doesn't initialize, instead of silently
-                                  proceeding without it. Matches Claude's
-                                  behavior when --mcp-config can't load.
+   - `--sandbox=workspace-write`     — explicit sandbox; agent can edit
+                                       files in the workspace. Replaces
+                                       the deprecated `--full-auto` alias
+                                       for clarity.
+   - `--ask-for-approval=never`      — CLI flag: no human-in-the-loop
+                                       pings during exec.
+   - `-c approval_policy=\"never\"`    — TOML override pinning the same
+                                       approval policy at the config
+                                       layer so any `~/.codex/config.toml`
+                                       default cannot relax it.
+   - `-c mcp_servers.artifact.required=true`
+                                     — TOML override: fail loudly if the
+                                       artifact MCP server doesn't
+                                       initialize. Matches Claude's
+                                       behavior when --mcp-config fails
+                                       to load.
 
    What we cannot do (per Codex config-reference): allow-list individual
-   built-in tools. apply_patch / shell are governed by sandbox_mode
+   built-in tools. `apply_patch` / `shell` are governed by `sandbox_mode`
    categorically. The implementer prompt + the artifact MCP server's own
    `enabled_tools` list are the per-tool surface."
   [{:keys [prompt model system]}]

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -173,8 +173,10 @@
       ;; mcp_servers.artifact.required=true makes Codex fail loudly if our
       ;; MCP server doesn't initialize, instead of running without it.
       (is (some #(= "mcp_servers.artifact.required=true" %) args))
-      ;; approval_policy=never is set both via the CLI flag and the -c
-      ;; override so it survives any config.toml defaults.
+      ;; --ask-for-approval=never sets the policy via the CLI flag, and
+      ;; approval_policy=never sets it via -c so any config.toml default
+      ;; cannot relax it. Two different knobs, both pinned to never.
+      (is (some #(= "--ask-for-approval=never" %) args))
       (is (some #(re-matches #"approval_policy=\"?never\"?" %) args)))))
 
 (deftest codex-args-model-test

--- a/components/llm/test/ai/miniforge/llm/args_fn_test.clj
+++ b/components/llm/test/ai/miniforge/llm/args_fn_test.clj
@@ -157,13 +157,25 @@
 ;; ============================================================================
 
 (deftest codex-args-minimal-test
-  (testing "minimal prompt produces exec with standard flags"
+  (testing "minimal prompt produces exec with explicit sandbox + approval flags"
     (let [args ((private-fn 'codex-args) {:prompt "fix bug"})]
       (is (= "exec" (first args)))
       (is (some #(= "--json" %) args))
-      (is (some #(= "--full-auto" %) args))
+      ;; Explicit sandbox + approval replaces the deprecated --full-auto alias.
+      (is (some #(= "--sandbox=workspace-write" %) args))
+      (is (some #(= "--ask-for-approval=never" %) args))
       (is (some #(= "--skip-git-repo-check" %) args))
       (is (= "fix bug" (last args))))))
+
+(deftest codex-args-mcp-required-test
+  (testing "config overrides force the artifact MCP server to be required"
+    (let [args ((private-fn 'codex-args) {:prompt "p"})]
+      ;; mcp_servers.artifact.required=true makes Codex fail loudly if our
+      ;; MCP server doesn't initialize, instead of running without it.
+      (is (some #(= "mcp_servers.artifact.required=true" %) args))
+      ;; approval_policy=never is set both via the CLI flag and the -c
+      ;; override so it survives any config.toml defaults.
+      (is (some #(re-matches #"approval_policy=\"?never\"?" %) args)))))
 
 (deftest codex-args-model-test
   (testing "model adds -m flag"

--- a/docs/pull-requests/2026-04-30-codex-tool-parity.md
+++ b/docs/pull-requests/2026-04-30-codex-tool-parity.md
@@ -10,9 +10,9 @@ instructions alone to keep the agent inside our intended capability surface.
 
 The PR #729 dogfood verified that the implementer prompt's tool-first delivery framing dramatically improved Codex's
 behavior, but Codex still ran with permissive defaults: `--full-auto` set the sandbox but nothing forced our artifact
-MCP server to be loaded, and any default in `~/.codex/config.toml` could override the approval policy. The earlier
-dogfood saw 1 of 5 runs trip a planner flake (15.7-min plan-phase no-op) where the agent presumably ran into approval
-friction with no clear failure mode.
+MCP server to be loaded, and any default in `<config-root>/.codex/config.toml` (or `~/.codex/config.toml` if Codex's
+search picked it up) could override the approval policy. The earlier dogfood saw 1 of 5 runs trip a planner flake
+(15.7-min plan-phase no-op) where the agent presumably ran into approval friction with no clear failure mode.
 
 Reading the Codex config-reference established the actual shape of the problem:
 
@@ -60,7 +60,12 @@ the implementer prompt picks up the slack.
 
 `components/agent/src/ai/miniforge/agent/artifact_session.clj`
 
-The artifact block written to `~/.codex/config.toml` now includes `required = true`:
+`write-codex-mcp-config!` writes to `<config-root>/.codex/config.toml`, where `config-root` defaults to the agent's
+working directory (the scratch worktree at runtime, not the user's home). Each session gets its own
+`.codex/config.toml` and the file is cleaned up at session teardown via `cleanup-codex-mcp-config!`. Codex's CLI
+search picks up the project-local config from the cwd at invocation time.
+
+The artifact block written there now includes `required = true`:
 
 ```toml
 [mcp_servers.artifact]

--- a/docs/pull-requests/2026-04-30-codex-tool-parity.md
+++ b/docs/pull-requests/2026-04-30-codex-tool-parity.md
@@ -1,0 +1,99 @@
+# feat: Codex tool parity — explicit sandbox/approval + required MCP server
+
+## Overview
+
+Follow-up to [PR #729](https://github.com/miniforge-ai/miniforge/pull/729). Closes the parity gap with Claude's
+`--allowedTools` / `--mcp-config` semantics that left Codex running with no tool-surface lock-down — relying on prompt
+instructions alone to keep the agent inside our intended capability surface.
+
+## Motivation
+
+The PR #729 dogfood verified that the implementer prompt's tool-first delivery framing dramatically improved Codex's
+behavior, but Codex still ran with permissive defaults: `--full-auto` set the sandbox but nothing forced our artifact
+MCP server to be loaded, and any default in `~/.codex/config.toml` could override the approval policy. The earlier
+dogfood saw 1 of 5 runs trip a planner flake (15.7-min plan-phase no-op) where the agent presumably ran into approval
+friction with no clear failure mode.
+
+Reading the Codex config-reference established the actual shape of the problem:
+
+- Codex has **no per-built-in-tool allow-list**. `apply_patch` and `shell` are governed by `sandbox_mode` categorically,
+  not toggleable individually. There is no equivalent to Claude's `--allowedTools`.
+- `approval_policy` is the human-in-the-loop control.
+- `mcp_servers.<id>.required = true` is the "fail loudly if my server can't load" lever — the closest Codex analog to
+  Claude's behavior when `--mcp-config` can't initialize.
+- `features.shell_tool = false` can disable Codex's default shell tool, but doing so is risky without a clear MCP
+  replacement; deferring.
+
+So the actionable parity work is small: move from the deprecated `--full-auto` alias to its explicit components, force
+our MCP server to be required, and pin the approval policy at both layers.
+
+## Changes In Detail
+
+### 1. `codex-args` — explicit flags
+
+`components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj`
+
+Replaces `--full-auto` (deprecated alias) with its constituents and adds two `-c` config overrides:
+
+```clojure
+;; Before:
+["exec" "--json" "--full-auto" "--skip-git-repo-check"]
+
+;; After:
+["exec" "--json"
+ "--sandbox=workspace-write"
+ "--ask-for-approval=never"
+ "--skip-git-repo-check"
+ "-c" "approval_policy=\"never\""
+ "-c" "mcp_servers.artifact.required=true"]
+```
+
+- `--sandbox=workspace-write` — explicit; agent can edit files in the workspace.
+- `--ask-for-approval=never` — no human prompts.
+- `-c approval_policy="never"` — same intent at the TOML layer so it survives any user-level config defaults.
+- `-c mcp_servers.artifact.required=true` — Codex startup fails if our MCP server can't initialize.
+
+The function's docstring documents the constraints: what Codex's tool model lets us control, what it doesn't, and where
+the implementer prompt picks up the slack.
+
+### 2. `write-codex-mcp-config!` — `required = true` in TOML
+
+`components/agent/src/ai/miniforge/agent/artifact_session.clj`
+
+The artifact block written to `~/.codex/config.toml` now includes `required = true`:
+
+```toml
+[mcp_servers.artifact]
+command = "..."
+args = [...]
+required = true
+```
+
+Defense in depth: if the CLI `-c` override is ever stripped by a future refactor, the persistent config remains
+authoritative.
+
+### 3. Tests
+
+- `codex-args-minimal-test` — asserts the new explicit flags replace `--full-auto`.
+- `codex-args-mcp-required-test` — asserts the two new `-c` overrides are present.
+- `write-codex-mcp-config-test` — asserts `required = true` lands in the TOML block.
+
+## What we cannot do (and don't try to in this PR)
+
+- **Allow-list individual built-in tools.** Codex doesn't expose that knob; `apply_patch` will always be available in
+  workspace-write mode. The implementer prompt remains the primary lever for steering toward intended tools.
+- **Force the artifact MCP server's tools to be exclusive.** The `mcp_servers.artifact.enabled_tools` allow-list IS
+  available in Codex config, but threading it through cleanly intersects with the `:context` vs `:artifact`
+  MCP-server-naming inconsistency in `components/agent` (the canonical name is `:context` in `mcp-tools` data; the Codex
+  TOML block names it `artifact`). That cleanup deserves its own PR.
+
+## Verification
+
+Pre-commit passes. The runtime change should be observable on the next dogfood: a misconfigured artifact MCP server now
+produces a Codex startup error rather than a silent run with the server absent.
+
+## Followups
+
+- `mcp_servers.artifact.enabled_tools` allow-list once the `:context` ↔ `:artifact` server-naming is unified.
+- `features.shell_tool = false` once an MCP-side shell replacement exists. Probably deferred until the per-task base
+  chaining work (PR #730 spec) lands and we have a fuller picture of which built-in tools are actually load-bearing.


### PR DESCRIPTION
## Summary

Follow-up to [#729](https://github.com/miniforge-ai/miniforge/pull/729). Closes the parity gap with Claude's `--allowedTools` / `--mcp-config` semantics.

Reading [Codex's config-reference](https://developers.openai.com/codex/config-reference) established that Codex's tool model is fundamentally different from Claude's — there is **no per-built-in-tool allow-list**. `apply_patch` and `shell` are governed by `sandbox_mode` categorically. The actionable parity is:

- **`codex-args`** — replace deprecated `--full-auto` alias with explicit `--sandbox=workspace-write --ask-for-approval=never`, plus `-c approval_policy="never"` and `-c mcp_servers.artifact.required=true`.
- **`write-codex-mcp-config!`** — set `required = true` in the artifact TOML block as defense-in-depth.

What we cannot do and don't try in this PR: allow-list individual built-in tools (Codex doesn't expose that knob); force the artifact MCP server's tools to be exclusive (intersects with the `:context` ↔ `:artifact` server-naming inconsistency in `components/agent`, deserves its own PR).

Full motivation, change set, and what-we-cannot-do rationale in [docs/pull-requests/2026-04-30-codex-tool-parity.md](docs/pull-requests/2026-04-30-codex-tool-parity.md).

## Test plan

- [x] `codex-args-minimal-test` asserts the new explicit flags
- [x] `codex-args-mcp-required-test` asserts the two new `-c` overrides
- [x] `write-codex-mcp-config-test` asserts `required = true` in TOML
- [x] `bb pre-commit` passes (475 assertions across 6 changed bricks)

## Followups (separate PRs)

- `mcp_servers.artifact.enabled_tools` allow-list once the `:context` ↔ `:artifact` server-naming is unified.
- `features.shell_tool = false` once an MCP-side shell replacement exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)