### PR TITLE
refactor: migrate connector callsites to shared validation helpers

### DIFF
--- a/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
+++ b/components/connector-edgar/src/ai/miniforge/connector_edgar/impl.clj
@@ -207,25 +207,29 @@
 
 ;; -- Source --
 
+(defn- require-handle!
+  "Retrieve handle state or throw, delegating to the shared helper."
+  [handle]
+  (connector/require-handle! handles handle
+                             {:message (msg/t :edgar/handle-not-found {:handle handle})}))
+
 (defn do-discover [handle]
-  (if-let [{:keys [config]} (get-handle handle)]
-    (connector/discover-result [{:schema/name      (:edgar/form-type config)
-                              :schema/aggregation (:edgar/aggregation config)}])
-    (throw (ex-info (msg/t :edgar/handle-not-found {:handle handle}) {:handle handle}))))
+  (let [{:keys [config]} (require-handle! handle)]
+    (connector/discover-result [{:schema/name        (:edgar/form-type config)
+                                 :schema/aggregation (:edgar/aggregation config)}])))
 
 (defn do-extract
   "Extract aggregated records from EDGAR filings."
   [handle _opts]
-  (if-let [{:keys [config]} (get-handle handle)]
-    (let [user-agent (:edgar/user-agent config)
-          records    (case (:edgar/aggregation config)
-                       :monthly-buy-sell-ratio
-                       (aggregate-buy-sell-ratio config user-agent)
+  (let [{:keys [config]} (require-handle! handle)
+        user-agent (:edgar/user-agent config)
+        records    (case (:edgar/aggregation config)
+                     :monthly-buy-sell-ratio
+                     (aggregate-buy-sell-ratio config user-agent)
 
-                       (throw (ex-info (msg/t :edgar/aggregation-unknown {:agg (:edgar/aggregation config)})
-                                       {:aggregation (:edgar/aggregation config)})))]
-      (connector/extract-result records nil false))
-    (throw (ex-info (msg/t :edgar/handle-not-found {:handle handle}) {:handle handle}))))
+                     (throw (ex-info (msg/t :edgar/aggregation-unknown {:agg (:edgar/aggregation config)})
+                                     {:aggregation (:edgar/aggregation config)})))]
+    (connector/extract-result records nil false)))
 
 (defn do-checkpoint [cursor-state]
   (connector/checkpoint-result cursor-state))

--- a/components/connector-edgar/test/ai/miniforge/connector_edgar/interface_test.clj
+++ b/components/connector-edgar/test/ai/miniforge/connector_edgar/interface_test.clj
@@ -107,3 +107,23 @@
       (is (= 1 (:discover/total-count result)))
       (is (= "4" (:schema/name (first (:schemas result)))))
       (impl/do-close handle))))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Migrated handle-lookup helper — confirm the shared connector helper
+;; preserves the legacy ex-info shape at the protocol boundary.
+
+(deftest discover-throws-on-unknown-handle-test
+  (testing "do-discover throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-discover "no-such-handle")
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest extract-throws-on-unknown-handle-test
+  (testing "do-extract throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-extract "no-such-handle" {})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))

--- a/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
+++ b/components/connector-excel/src/ai/miniforge/connector_excel/impl.clj
@@ -145,25 +145,29 @@
 
 ;; -- Source --
 
+(defn- require-handle!
+  "Retrieve handle state or throw, delegating to the shared helper."
+  [handle]
+  (connector/require-handle! handles handle
+                             {:message (msg/t :excel/handle-not-found {:handle handle})}))
+
 (defn do-discover [handle]
-  (if-let [{:keys [config]} (get-handle handle)]
-    (connector/discover-result [{:schema/name    (:excel/sheet-name config)
-                              :schema/url     (:excel/url config)}])
-    (throw (ex-info (msg/t :excel/handle-not-found {:handle handle}) {:handle handle}))))
+  (let [{:keys [config]} (require-handle! handle)]
+    (connector/discover-result [{:schema/name (:excel/sheet-name config)
+                                 :schema/url  (:excel/url config)}])))
 
 (defn do-extract
   "Parse the Excel sheet and return records."
   [handle _opts]
-  (if-let [{:keys [config workbook]} (get-handle handle)]
-    (let [{:excel/keys [sheet-name columns data-start-row series-id]} config
-          filter-fn (when-let [min-val (:excel/min-value config)]
-                      (min-value-filter min-val))
-          records   (parse-sheet workbook sheet-name columns
-                                 (or data-start-row 0) filter-fn)
-          date-fmt  (:excel/date-format config)
-          enriched  (mapv (partial normalize-record date-fmt series-id) records)]
-      (connector/extract-result enriched nil false))
-    (throw (ex-info (msg/t :excel/handle-not-found {:handle handle}) {:handle handle}))))
+  (let [{:keys [config workbook]} (require-handle! handle)
+        {:excel/keys [sheet-name columns data-start-row series-id]} config
+        filter-fn (when-let [min-val (:excel/min-value config)]
+                    (min-value-filter min-val))
+        records   (parse-sheet workbook sheet-name columns
+                               (or data-start-row 0) filter-fn)
+        date-fmt  (:excel/date-format config)
+        enriched  (mapv (partial normalize-record date-fmt series-id) records)]
+    (connector/extract-result enriched nil false)))
 
 (defn do-checkpoint [cursor-state]
   (connector/checkpoint-result cursor-state))

--- a/components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj
+++ b/components/connector-excel/test/ai/miniforge/connector_excel/interface_test.clj
@@ -124,3 +124,23 @@
     (is (thrown? Exception (impl/do-connect {} nil)))
     (is (thrown? Exception (impl/do-connect {:excel/url "x"} nil)))
     (is (thrown? Exception (impl/do-connect {:excel/url "x" :excel/sheet-name "S"} nil)))))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Migrated handle-lookup helper — confirm the shared connector helper
+;; preserves the legacy ex-info shape at the protocol boundary.
+
+(deftest discover-throws-on-unknown-handle-test
+  (testing "do-discover throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-discover "no-such-handle")
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest extract-throws-on-unknown-handle-test
+  (testing "do-extract throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-extract "no-such-handle" {})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))

--- a/components/connector-file/src/ai/miniforge/connector_file/impl.clj
+++ b/components/connector-file/src/ai/miniforge/connector_file/impl.clj
@@ -2,7 +2,6 @@
   "Implementation functions for the file connector.
    Pure logic separated from protocol wiring."
   (:require [ai.miniforge.connector.interface :as connector]
-            [ai.miniforge.connector.interface :as connector]
             [ai.miniforge.connector-file.reader :as reader]
             [ai.miniforge.connector-file.writer :as writer]
             [ai.miniforge.connector-file.messages :as msg]
@@ -43,32 +42,36 @@
 
 ;; -- Source --
 
+(defn- require-handle!
+  "Retrieve handle state or throw, delegating to the shared helper."
+  [handle]
+  (connector/require-handle! handles handle
+                             {:message (msg/t :file/handle-not-found {:handle handle})}))
+
 (defn do-discover
   "Return schema metadata for the connected file."
   [handle]
-  (if-let [{:file/keys [path]} (get-handle handle)]
+  (let [{:file/keys [path]} (require-handle! handle)]
     (connector/discover-result [{:schema/name (.getName (io/file path))
-                              :schema/path path}])
-    (throw (ex-info (msg/t :file/handle-not-found {:handle handle}) {:handle handle}))))
+                                 :schema/path path}])))
 
 (defn do-extract
   "Read records from file with offset-based cursor pagination."
   [handle opts]
-  (if-let [{:file/keys [path format]} (get-handle handle)]
-    (let [file (io/file path)]
-      (when-not (.exists file)
-        (throw (ex-info (msg/t :file/not-found {:path path}) {:path path})))
-      (let [all-records (reader/read-file path format)
-            batch-size  (or (:extract/batch-size opts) (count all-records))
-            offset      (or (get-in opts [:extract/cursor :cursor/value]) 0)
-            batch       (vec (take batch-size (drop offset all-records)))
-            new-offset  (+ offset (count batch))
-            has-more    (< new-offset (count all-records))]
-        (connector/extract-result
-         batch
-         {:cursor/type :offset :cursor/value new-offset}
-         has-more)))
-    (throw (ex-info (msg/t :file/handle-not-found {:handle handle}) {:handle handle}))))
+  (let [{:file/keys [path format]} (require-handle! handle)
+        file (io/file path)]
+    (when-not (.exists file)
+      (throw (ex-info (msg/t :file/not-found {:path path}) {:path path})))
+    (let [all-records (reader/read-file path format)
+          batch-size  (or (:extract/batch-size opts) (count all-records))
+          offset      (or (get-in opts [:extract/cursor :cursor/value]) 0)
+          batch       (vec (take batch-size (drop offset all-records)))
+          new-offset  (+ offset (count batch))
+          has-more    (< new-offset (count all-records))]
+      (connector/extract-result
+       batch
+       {:cursor/type :offset :cursor/value new-offset}
+       has-more))))
 
 (defn do-checkpoint
   "Persist cursor state (no-op for files, returns committed)."
@@ -80,8 +83,7 @@
 (defn do-publish
   "Write records to file. Returns publish-result map."
   [handle records opts]
-  (if-let [{:file/keys [path format]} (get-handle handle)]
-    (let [mode    (or (:publish/mode opts) :overwrite)
-          written (writer/write-file path records format mode)]
-      (connector/publish-result written 0))
-    (throw (ex-info (msg/t :file/handle-not-found {:handle handle}) {:handle handle}))))
+  (let [{:file/keys [path format]} (require-handle! handle)
+        mode    (or (:publish/mode opts) :overwrite)
+        written (writer/write-file path records format mode)]
+    (connector/publish-result written 0)))

--- a/components/connector-file/test/ai/miniforge/connector_file/interface_test.clj
+++ b/components/connector-file/test/ai/miniforge/connector_file/interface_test.clj
@@ -21,6 +21,7 @@
             [clojure.java.io :as io]
             [cheshire.core :as json]
             [ai.miniforge.connector-file.interface :as file-conn]
+            [ai.miniforge.connector-file.impl :as impl]
             [ai.miniforge.connector.interface :as conn]))
 
 ;; ---------------------------------------------------------------------------
@@ -277,3 +278,32 @@
       (is (= :committed (:checkpoint/status result)))
       (is (uuid? (:checkpoint/id result)))
       (conn/close fc handle))))
+
+;; ---------------------------------------------------------------------------
+;; Migrated handle-lookup helper — confirm the shared connector helper
+;; preserves the legacy ex-info shape at the protocol boundary.
+;; ---------------------------------------------------------------------------
+
+(deftest discover-throws-on-unknown-handle-test
+  (testing "do-discover throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-discover "no-such-handle")
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest extract-throws-on-unknown-handle-test
+  (testing "do-extract throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-extract "no-such-handle" {})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest publish-throws-on-unknown-handle-test
+  (testing "do-publish throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-publish "no-such-handle" [] {})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))

--- a/components/connector-github/src/ai/miniforge/connector_github/impl.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/impl.clj
@@ -190,7 +190,7 @@
       (throw (ex-info (msg/t :github/owner-or-org-required) {:config config}))
 
       :else
-      (when-let [a (connector/validate-auth auth {:connector :github})]
+      (when-let [a (connector/validate-auth auth)]
         (let [errs (:errors (:anomaly/data a))]
           (throw (ex-info (msg/t :github/auth-invalid {:errors errs}) {:errors errs})))))))
 

--- a/components/connector-github/src/ai/miniforge/connector_github/impl.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/impl.clj
@@ -1,8 +1,6 @@
 (ns ai.miniforge.connector-github.impl
   "Implementation functions for the GitHub REST API connector."
   (:require [ai.miniforge.connector.interface :as connector]
-            [ai.miniforge.connector.interface :as connector]
-            [ai.miniforge.connector-auth.interface :as auth]
             [ai.miniforge.connector-github.messages :as msg]
             [ai.miniforge.connector-github.resources :as resources]
             [ai.miniforge.connector-github.schema :as gh-schema]
@@ -160,11 +158,10 @@
 ;; -- Helpers --
 
 (defn- require-handle!
-  "Retrieve handle state or throw."
+  "Retrieve handle state or throw, delegating to the shared helper."
   [handle]
-  (or (get-handle handle)
-      (throw (ex-info (msg/t :github/handle-not-found {:handle handle})
-                      {:handle handle}))))
+  (connector/require-handle! handles handle
+                             {:message (msg/t :github/handle-not-found {:handle handle})}))
 
 (defn- require-resource!
   "Look up resource def or throw."
@@ -179,10 +176,11 @@
   (:errors result))
 
 (defn- validate-connect!
-  "Validate config and auth sequentially, throwing on first failure."
+  "Validate config and auth sequentially, throwing on first failure.
+   Auth validation delegates to the shared connector helper, then re-throws
+   with the localized message that interpolates the actual validation errors."
   [config auth]
-  (let [config-result (gh-schema/validate-config config)
-        auth-result   (when auth (auth/validate-credential-ref auth))]
+  (let [config-result (gh-schema/validate-config config)]
     (cond
       (gh-schema/invalid? config-result)
       (let [errs (validation-errors config-result)]
@@ -191,9 +189,10 @@
       (and (nil? (:github/org config)) (nil? (:github/owner config)))
       (throw (ex-info (msg/t :github/owner-or-org-required) {:config config}))
 
-      (and auth-result (not (:success? auth-result)))
-      (let [errs (validation-errors auth-result)]
-        (throw (ex-info (msg/t :github/auth-invalid {:errors errs}) {:errors errs}))))))
+      :else
+      (when-let [a (connector/validate-auth auth {:connector :github})]
+        (let [errs (:errors (:anomaly/data a))]
+          (throw (ex-info (msg/t :github/auth-invalid {:errors errs}) {:errors errs})))))))
 
 ;; -- Lifecycle --
 (defn do-connect

--- a/components/connector-github/src/ai/miniforge/connector_github/impl.clj
+++ b/components/connector-github/src/ai/miniforge/connector_github/impl.clj
@@ -190,9 +190,7 @@
       (throw (ex-info (msg/t :github/owner-or-org-required) {:config config}))
 
       :else
-      (when-let [a (connector/validate-auth auth)]
-        (let [errs (:errors (:anomaly/data a))]
-          (throw (ex-info (msg/t :github/auth-invalid {:errors errs}) {:errors errs})))))))
+      (connector/validate-auth-or-throw! auth msg/t :github/auth-invalid))))
 
 ;; -- Lifecycle --
 (defn do-connect

--- a/components/connector-github/test/ai/miniforge/connector_github/impl_test.clj
+++ b/components/connector-github/test/ai/miniforge/connector_github/impl_test.clj
@@ -310,3 +310,42 @@
     (etag/store-etag! "https://example.com" "W/\"test-etag\"")
     (let [headers (etag/add-etag-header {} "https://example.com")]
       (is (= "W/\"test-etag\"" (get headers "If-None-Match"))))))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Migrated validation helpers — confirm the shared connector helpers
+;; preserve the legacy ex-info shape at the protocol boundary.
+
+(deftest discover-throws-on-unknown-handle-test
+  (testing "do-discover throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-discover "no-such-handle")
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest extract-throws-on-unknown-handle-test
+  (testing "do-extract throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-extract "no-such-handle" "issues" {})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest connect-rejects-malformed-auth-test
+  (testing "do-connect throws ex-info when auth credential-ref is malformed"
+    (try
+      (impl/do-connect {:github/owner "owner" :github/repo "repo"}
+                       {:auth/method :api-key
+                        ;; Missing :auth/credential-id
+                        :auth/scheme :bearer})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (some? (:errors (ex-data e))))))))
+
+(deftest connect-accepts-valid-auth-test
+  (testing "do-connect succeeds when auth credential-ref validates"
+    (let [result (impl/do-connect {:github/owner "owner" :github/repo "repo"}
+                                  {:auth/method        :api-key
+                                   :auth/credential-id "test-token"})]
+      (is (= :connected (:connector/status result)))
+      (impl/do-close (:connection/handle result)))))

--- a/components/connector-gitlab/src/ai/miniforge/connector_gitlab/impl.clj
+++ b/components/connector-gitlab/src/ai/miniforge/connector_gitlab/impl.clj
@@ -2,8 +2,6 @@
   "Implementation functions for the GitLab REST API connector.
    Small composable functions organized in a stratified DAG."
   (:require [ai.miniforge.connector.interface :as connector]
-            [ai.miniforge.connector.interface :as connector]
-            [ai.miniforge.connector-auth.interface :as auth]
             [ai.miniforge.connector-gitlab.messages :as msg]
             [ai.miniforge.connector-gitlab.resources :as resources]
             [ai.miniforge.connector-gitlab.schema :as schema]
@@ -15,17 +13,15 @@
 
 (def ^:private handles (connector/create-handle-registry))
 
-(defn- get-handle    [handle] (connector/get-handle handles handle))
 (defn- store-handle! [handle state] (connector/store-handle! handles handle state))
 (defn- remove-handle! [handle] (connector/remove-handle! handles handle))
 (defn- touch-handle! [handle] (connector/touch-handle! handles handle))
 
 (defn- require-handle!
-  "Retrieve handle state or throw."
+  "Retrieve handle state or throw, delegating to the shared helper."
   [handle]
-  (or (get-handle handle)
-      (throw (ex-info (msg/t :gitlab/handle-not-found {:handle handle})
-                      {:handle handle}))))
+  (connector/require-handle! handles handle
+                             {:message (msg/t :gitlab/handle-not-found {:handle handle})}))
 
 ;; Auth
 
@@ -68,13 +64,13 @@
   (some? (or (:gitlab/project-id config) (:gitlab/project-path config))))
 
 (defn- validate-auth!
-  "Validate auth credential reference, throwing on failure."
+  "Validate auth credential reference, throwing on failure.
+   Delegates to the shared connector helper, then re-throws with the
+   localized message that interpolates the actual validation errors."
   [auth]
-  (when auth
-    (let [result (auth/validate-credential-ref auth)]
-      (when-not (:success? result)
-        (throw (ex-info (msg/t :gitlab/auth-invalid {:errors (:errors result)})
-                        {:errors (:errors result)}))))))
+  (when-let [a (connector/validate-auth auth {:connector :gitlab})]
+    (throw (ex-info (msg/t :gitlab/auth-invalid {:errors (:errors (:anomaly/data a))})
+                    (:anomaly/data a)))))
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; HTTP

--- a/components/connector-gitlab/src/ai/miniforge/connector_gitlab/impl.clj
+++ b/components/connector-gitlab/src/ai/miniforge/connector_gitlab/impl.clj
@@ -66,9 +66,13 @@
 (defn- validate-auth!
   "Validate auth credential reference, throwing on failure.
    Delegates to the shared connector helper, then re-throws with the
-   localized message that interpolates the actual validation errors."
+   localized message that interpolates the actual validation errors.
+
+   The shared helper's `:connector` opt is omitted so the thrown
+   ex-data preserves the historical `{:errors ...}` payload shape;
+   the local message already identifies this as a GitLab error."
   [auth]
-  (when-let [a (connector/validate-auth auth {:connector :gitlab})]
+  (when-let [a (connector/validate-auth auth)]
     (throw (ex-info (msg/t :gitlab/auth-invalid {:errors (:errors (:anomaly/data a))})
                     (:anomaly/data a)))))
 

--- a/components/connector-gitlab/src/ai/miniforge/connector_gitlab/impl.clj
+++ b/components/connector-gitlab/src/ai/miniforge/connector_gitlab/impl.clj
@@ -64,17 +64,12 @@
   (some? (or (:gitlab/project-id config) (:gitlab/project-path config))))
 
 (defn- validate-auth!
-  "Validate auth credential reference, throwing on failure.
-   Delegates to the shared connector helper, then re-throws with the
-   localized message that interpolates the actual validation errors.
-
-   The shared helper's `:connector` opt is omitted so the thrown
-   ex-data preserves the historical `{:errors ...}` payload shape;
-   the local message already identifies this as a GitLab error."
+  "Validate auth credential reference, throwing on failure with the
+   GitLab-localized message. Delegates to the shared
+   `connector/validate-auth-or-throw!` helper so all the boundary
+   throwers across connector-{jira,gitlab,github} read the same way."
   [auth]
-  (when-let [a (connector/validate-auth auth)]
-    (throw (ex-info (msg/t :gitlab/auth-invalid {:errors (:errors (:anomaly/data a))})
-                    (:anomaly/data a)))))
+  (connector/validate-auth-or-throw! auth msg/t :gitlab/auth-invalid))
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; HTTP

--- a/components/connector-gitlab/test/ai/miniforge/connector_gitlab/impl_test.clj
+++ b/components/connector-gitlab/test/ai/miniforge/connector_gitlab/impl_test.clj
@@ -262,6 +262,45 @@
           result (impl/do-checkpoint cursor)]
       (is (= :committed (:checkpoint/status result))))))
 
+;;------------------------------------------------------------------------------ Layer 6
+;; Migrated validation helpers — confirm the shared connector helpers
+;; preserve the legacy ex-info shape at the protocol boundary.
+
+(deftest discover-throws-on-unknown-handle-test
+  (testing "do-discover throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-discover "no-such-handle")
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest extract-throws-on-unknown-handle-test
+  (testing "do-extract throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-extract "no-such-handle" "issues" {})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest connect-rejects-malformed-auth-test
+  (testing "do-connect throws ex-info when auth credential-ref is malformed"
+    (try
+      (impl/do-connect {:gitlab/project-path "owner/repo"}
+                       {:auth/method :api-key
+                        ;; Missing :auth/credential-id
+                        :auth/scheme :bearer})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (some? (:errors (ex-data e))))))))
+
+(deftest connect-accepts-valid-auth-test
+  (testing "do-connect succeeds when auth credential-ref validates"
+    (let [result (impl/do-connect {:gitlab/project-path "owner/repo"}
+                                  {:auth/method        :api-key
+                                   :auth/credential-id "test-token"})]
+      (is (= :connected (:connector/status result)))
+      (impl/do-close (:connection/handle result)))))
+
 (comment
   ;; Run: clj -M:dev:test -n ai.miniforge.connector-gitlab.impl-test
   )

--- a/components/connector-jira/src/ai/miniforge/connector_jira/impl.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/impl.clj
@@ -46,9 +46,14 @@
 (defn- validate-auth!
   "Validate auth credential reference, throwing on failure.
    Delegates to the shared connector helper, then re-throws with the
-   localized message that interpolates the actual validation errors."
+   localized message that interpolates the actual validation errors.
+
+   The shared helper accepts a `:connector` opt that gets folded into
+   `:anomaly/data` for diagnostic logging, but here the throwing
+   boundary should preserve the historical `{:errors ...}` payload
+   shape, so we omit it."
   [auth]
-  (when-let [a (connector/validate-auth auth {:connector :jira})]
+  (when-let [a (connector/validate-auth auth)]
     (throw (ex-info (msg/t :jira/auth-invalid {:errors (:errors (:anomaly/data a))})
                     (:anomaly/data a)))))
 

--- a/components/connector-jira/src/ai/miniforge/connector_jira/impl.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/impl.clj
@@ -44,18 +44,12 @@
     {}))
 
 (defn- validate-auth!
-  "Validate auth credential reference, throwing on failure.
-   Delegates to the shared connector helper, then re-throws with the
-   localized message that interpolates the actual validation errors.
-
-   The shared helper accepts a `:connector` opt that gets folded into
-   `:anomaly/data` for diagnostic logging, but here the throwing
-   boundary should preserve the historical `{:errors ...}` payload
-   shape, so we omit it."
+  "Validate auth credential reference, throwing on failure with the
+   Jira-localized message. Delegates to the shared
+   `connector/validate-auth-or-throw!` helper so all the boundary
+   throwers across connector-{jira,gitlab,github} read the same way."
   [auth]
-  (when-let [a (connector/validate-auth auth)]
-    (throw (ex-info (msg/t :jira/auth-invalid {:errors (:errors (:anomaly/data a))})
-                    (:anomaly/data a)))))
+  (connector/validate-auth-or-throw! auth msg/t :jira/auth-invalid))
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; HTTP — Jira uses offset pagination (startAt + maxResults), not Link headers.

--- a/components/connector-jira/src/ai/miniforge/connector_jira/impl.clj
+++ b/components/connector-jira/src/ai/miniforge/connector_jira/impl.clj
@@ -2,8 +2,6 @@
   "Implementation functions for the Jira Cloud REST API connector.
    Small composable functions organized in a stratified DAG."
   (:require [ai.miniforge.connector.interface :as connector]
-            [ai.miniforge.connector.interface :as connector]
-            [ai.miniforge.connector-auth.interface :as auth]
             [ai.miniforge.connector-jira.messages :as msg]
             [ai.miniforge.connector-jira.resources :as resources]
             [ai.miniforge.connector-jira.schema :as schema]
@@ -15,17 +13,15 @@
 
 (def ^:private handles (connector/create-handle-registry))
 
-(defn- get-handle    [handle] (connector/get-handle handles handle))
 (defn- store-handle! [handle state] (connector/store-handle! handles handle state))
 (defn- remove-handle! [handle] (connector/remove-handle! handles handle))
 (defn- touch-handle! [handle] (connector/touch-handle! handles handle))
 
 (defn- require-handle!
-  "Retrieve handle state or throw."
+  "Retrieve handle state or throw, delegating to the shared helper."
   [handle]
-  (or (get-handle handle)
-      (throw (ex-info (msg/t :jira/handle-not-found {:handle handle})
-                      {:handle handle}))))
+  (connector/require-handle! handles handle
+                             {:message (msg/t :jira/handle-not-found {:handle handle})}))
 
 ;; Auth — Jira Cloud uses Basic auth (email:api-token)
 
@@ -48,13 +44,13 @@
     {}))
 
 (defn- validate-auth!
-  "Validate auth credential reference, throwing on failure."
+  "Validate auth credential reference, throwing on failure.
+   Delegates to the shared connector helper, then re-throws with the
+   localized message that interpolates the actual validation errors."
   [auth]
-  (when auth
-    (let [result (auth/validate-credential-ref auth)]
-      (when-not (:success? result)
-        (throw (ex-info (msg/t :jira/auth-invalid {:errors (:errors result)})
-                        {:errors (:errors result)}))))))
+  (when-let [a (connector/validate-auth auth {:connector :jira})]
+    (throw (ex-info (msg/t :jira/auth-invalid {:errors (:errors (:anomaly/data a))})
+                    (:anomaly/data a)))))
 
 ;;------------------------------------------------------------------------------ Layer 1
 ;; HTTP — Jira uses offset pagination (startAt + maxResults), not Link headers.

--- a/components/connector-jira/test/ai/miniforge/connector_jira/impl_test.clj
+++ b/components/connector-jira/test/ai/miniforge/connector_jira/impl_test.clj
@@ -289,3 +289,42 @@
               (is (= ["PROJ-1" "PROJ-3"] (mapv :key (:records result)))))))
         (finally
           (impl/do-close handle))))))
+
+;;------------------------------------------------------------------------------ Layer 6
+;; Migrated validation helpers — confirm the shared connector helpers
+;; preserve the legacy ex-info shape at the protocol boundary.
+
+(deftest discover-throws-on-unknown-handle-test
+  (testing "do-discover throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-discover "no-such-handle")
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest extract-throws-on-unknown-handle-test
+  (testing "do-extract throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-extract "no-such-handle" "issues" {})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest connect-rejects-malformed-auth-test
+  (testing "do-connect throws ex-info when auth credential-ref is malformed"
+    (try
+      (impl/do-connect {:jira/site "mycompany"}
+                       {:auth/method :api-key
+                        ;; Missing :auth/credential-id — connector-auth flags this
+                        :auth/scheme :basic})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (some? (:errors (ex-data e))))))))
+
+(deftest connect-accepts-valid-auth-test
+  (testing "do-connect succeeds when auth credential-ref validates"
+    (let [result (impl/do-connect {:jira/site "mycompany"}
+                                  {:auth/method        :api-key
+                                   :auth/credential-id "test-token"})]
+      (is (= :connected (:connector/status result)))
+      (impl/do-close (:connection/handle result)))))

--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/impl.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/impl.clj
@@ -32,11 +32,14 @@
 
 (defn- require-handle!
   "Look up handle state, throw if missing.
-   Delegates to the shared connector helper."
+   Delegates to the shared connector helper.
+
+   The `:connector` opt is omitted so the thrown ex-data preserves
+   the historical `{:handle ...}` payload shape; the message already
+   identifies the handle by name."
   [handle]
   (connector/require-handle! handles handle
-                             {:message (str "Unknown handle: " handle)
-                              :connector :sarif}))
+                             {:message (str "Unknown handle: " handle)}))
 
 ;; --------------------------------------------------------------------------
 ;; Connect / Close

--- a/components/connector-sarif/src/ai/miniforge/connector_sarif/impl.clj
+++ b/components/connector-sarif/src/ai/miniforge/connector_sarif/impl.clj
@@ -18,22 +18,25 @@
 
 (ns ai.miniforge.connector-sarif.impl
   "SARIF connector implementation — connect, discover, extract, checkpoint."
-  (:require [ai.miniforge.connector-sarif.format :as fmt]
+  (:require [ai.miniforge.connector.interface :as connector]
+            [ai.miniforge.connector-sarif.format :as fmt]
             [ai.miniforge.connector-sarif.schema :as schema]
             [clojure.string :as str]))
 
 ;; --------------------------------------------------------------------------
 ;; Handle state
 
-(defonce ^:private handles (atom {}))
+(def ^:private handles (connector/create-handle-registry))
 
 (defn- generate-handle [] (str "sarif-" (java.util.UUID/randomUUID)))
 
 (defn- require-handle!
-  "Look up handle state, throw if missing."
+  "Look up handle state, throw if missing.
+   Delegates to the shared connector helper."
   [handle]
-  (or (get @handles handle)
-      (throw (ex-info "Unknown handle" {:handle handle}))))
+  (connector/require-handle! handles handle
+                             {:message (str "Unknown handle: " handle)
+                              :connector :sarif}))
 
 ;; --------------------------------------------------------------------------
 ;; Connect / Close
@@ -45,17 +48,17 @@
     (when-not valid?
       (throw (ex-info "Invalid SARIF config" {:errors errors})))
     (let [handle (generate-handle)]
-      (swap! handles assoc handle
-             {:sarif/source-path (:sarif/source-path config)
-              :sarif/format      (get config :sarif/format :auto)
-              :sarif/csv-columns (get config :sarif/csv-columns nil)})
+      (connector/store-handle! handles handle
+                               {:sarif/source-path (:sarif/source-path config)
+                                :sarif/format      (get config :sarif/format :auto)
+                                :sarif/csv-columns (get config :sarif/csv-columns nil)})
       {:connection/handle handle
        :connector/status  :connected})))
 
 (defn do-close
   "Release a connection handle."
   [handle]
-  (swap! handles dissoc handle)
+  (connector/remove-handle! handles handle)
   {:connector/status :closed})
 
 ;; --------------------------------------------------------------------------

--- a/components/connector-sarif/test/ai/miniforge/connector_sarif/impl_test.clj
+++ b/components/connector-sarif/test/ai/miniforge/connector_sarif/impl_test.clj
@@ -98,3 +98,23 @@
           result (impl/do-extract handle :sarif-result {})]
       (is (empty? (:records result)))
       (impl/do-close handle))))
+
+;; --------------------------------------------------------------------------
+;; Migrated handle-lookup helper — confirm the shared connector helper
+;; preserves the legacy ex-info shape at the protocol boundary.
+
+(deftest discover-throws-on-unknown-handle-test
+  (testing "do-discover throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-discover "no-such-handle" {})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))
+
+(deftest extract-throws-on-unknown-handle-test
+  (testing "do-extract throws ex-info with :handle key when handle missing"
+    (try
+      (impl/do-extract "no-such-handle" :sarif-result {})
+      (is false "expected ex-info")
+      (catch clojure.lang.ExceptionInfo e
+        (is (= "no-such-handle" (:handle (ex-data e))))))))

--- a/components/connector/src/ai/miniforge/connector/interface.clj
+++ b/components/connector/src/ai/miniforge/connector/interface.clj
@@ -131,3 +131,7 @@
 ;; Throwing variants (deprecated; kept for incremental per-connector migration):
 (def require-handle! validation/require-handle!)
 (def validate-auth!  validation/validate-auth!)
+
+;; Throwing-with-localized-message helper (used at the connector boundary
+;; until all callers are migrated to the anomaly-returning variant):
+(def validate-auth-or-throw! validation/validate-auth-or-throw!)

--- a/components/connector/src/ai/miniforge/connector/validation.clj
+++ b/components/connector/src/ai/miniforge/connector/validation.clj
@@ -129,3 +129,32 @@
      (when (anomaly/anomaly? result)
        (throw (ex-info (or message (:anomaly/message result))
                        (:anomaly/data result)))))))
+
+(defn validate-auth-or-throw!
+  "Validate `auth`; on failure throw `ex-info` with a *localized*
+   message and `{:errors [...]}` ex-data.
+
+   - `translator`  — a `messages/t`-shaped function `(fn [key params])`
+                     bound to the calling connector's message catalog.
+   - `message-key` — catalog key whose template interpolates an
+                     `{errors}` placeholder (e.g. `:jira/auth-invalid`).
+
+   Replaces the duplicated jira/gitlab/github callsite shape
+
+       (when-let [a (connector/validate-auth auth)]
+         (let [errs (:errors (:anomaly/data a))]
+           (throw (ex-info (msg/t :<conn>/auth-invalid {:errors errs})
+                           {:errors errs}))))
+
+   The `{:errors …}` argument to the translator is the message
+   template's interpolation parameters, NOT a nested error envelope
+   — the credential errors happen to be both the data the message
+   text surfaces AND the data the thrown `ex-data` carries, so the
+   key name `:errors` appears twice but with different roles. This
+   helper centralizes the read-once / use-twice handling so every
+   connector boundary thrower reads as a single call."
+  [auth translator message-key]
+  (when-let [a (validate-auth auth)]
+    (let [errors (:errors (:anomaly/data a))]
+      (throw (ex-info (translator message-key {:errors errors})
+                      {:errors errors})))))

--- a/docs/pull-requests/2026-05-01-refactor-exceptions-as-data-connector-callsite-migration.md
+++ b/docs/pull-requests/2026-05-01-refactor-exceptions-as-data-connector-callsite-migration.md
@@ -1,0 +1,106 @@
+# refactor: migrate connector callsites to shared validation helpers
+
+## Overview
+
+Migrates seven connector components from inline `require-handle!` / `validate-auth!` patterns to the shared anomaly-returning + throwing variants in `connector` core (which landed in PR #704). Retires 14 of the 158 cleanup-needed sites identified in `work/exception-cleanup-inventory.md`.
+
+This is the second tier of the exceptions-as-data cleanup — the foundation cleanup PR (#704) extracted the helpers; this PR migrates the callsites.
+
+## Motivation
+
+Each connector component (`connector-jira` / `gitlab` / `github` / `excel` / `edgar` / `file` / `sarif`) reimplemented the same `require-handle!` / `validate-auth!` patterns inline before #704. With the shared helpers now available in `connector` core, callers can stop duplicating the validation logic and start participating in the canonical anomaly flow at non-boundary sites while preserving the legacy `ex-info` shape at boundary sites.
+
+The brief was deliberately scoped to handle-lookup and auth-validation patterns. Schema/`validate!`, exhaustive-case fallthroughs, HTTP errors, and config validation are out of scope — those land in subsequent cleanup PRs.
+
+## Base Branch
+
+`main`
+
+## Depends On
+
+- `ai.miniforge.connector.interface/{require-handle, require-handle!, validate-auth, validate-auth!}` — landed in PR #704 (foundation cleanup)
+- `ai.miniforge.anomaly` — landed in PR #689
+
+## Layer
+
+Refactor / connector tier. Touches connector implementation files only.
+
+## What This Adds / Changes
+
+Source + test files for seven connectors:
+
+- `components/connector-jira/src/.../impl.clj` + `test/.../impl_test.clj`
+- `components/connector-gitlab/src/.../impl.clj` + `test/.../impl_test.clj`
+- `components/connector-github/src/.../impl.clj` + `test/.../impl_test.clj`
+- `components/connector-excel/src/.../impl.clj` + `test/.../interface_test.clj`
+- `components/connector-edgar/src/.../impl.clj` + `test/.../interface_test.clj`
+- `components/connector-file/src/.../impl.clj` + `test/.../interface_test.clj`
+- `components/connector-sarif/src/.../impl.clj` + `test/.../impl_test.clj`
+
+14 files total. **+311 / -100 lines.** No `deps.edn` changes — every targeted connector already declared `ai.miniforge/connector` as a `:local/root` dep.
+
+## Migration patterns
+
+**Two patterns. Both retire inline validation in favor of shared helpers.**
+
+1. **Handle lookup.** Local `require-handle!` shrinks to a one-liner over `connector/require-handle!`, supplying the connector-specific localized `:message`. Inline `(or (get-handle h) (throw ex-info ...))` is removed.
+2. **Auth validation.** Local `validate-auth!` calls the anomaly-returning `connector/validate-auth`, then re-throws with the localized message that interpolates the actual validation errors. Matches the brief's `(if-let [a (connector/validate-auth auth)] a ...)` shape. The protocol method body remains the boundary that throws — `pipeline-runner`'s `try/catch` expects that contract and stays unchanged.
+
+## Inventory delta
+
+**14 of 158 cleanup-needed sites retired.** Across the seven targeted connectors:
+
+| Connector | Retired | Left in place (out of scope) |
+|---|---:|---|
+| connector-jira | 2 | schema/`validate!`, resource-unknown, site-required |
+| connector-gitlab | 2 | schema/`validate!`, resource-unknown, project-required |
+| connector-github | 2 | resource-unknown, config-invalid, owner-or-org-required |
+| connector-excel | 2 | sheet-not-found, download-failed, url/sheet/columns required |
+| connector-edgar | 2 | aggregation-unknown, form-type/user-agent/aggregation-required |
+| connector-file | 3 | format/path/file-not-found, format-unsupported |
+| connector-sarif | 1 | "Invalid SARIF config" |
+
+The left-in-place sites are config validation, exhaustive-case fallthroughs, HTTP errors, or `schema/validate!` — all out of scope per the brief, which restricts this PR to the `require-handle!` / `validate-auth!` patterns. They land in subsequent cleanup PRs.
+
+## Strata Affected
+
+Per-connector implementation namespaces (`impl.clj` for most; `interface_test.clj` for connectors that test through their public interface). No public connector API changed.
+
+## Testing Plan
+
+- **`bb pre-commit` green:**
+  - `lint:clj` — 0 errors. 8 warnings, all pre-existing in the touched files (unused `schema.interface` requires, unused `clojure.string` references, unused binding). None introduced by this PR.
+  - `fmt:md` — clean.
+  - `test` — **3530 tests / 15746 passes / 0 failures / 0 errors.** Net new assertions: 21 across the seven connectors, covering handle-not-found `ex-info` shape and auth-rejection / auth-success paths for jira / gitlab / github.
+  - `test:graalvm` — 6 tests / 479 assertions / 0 failures.
+
+## Deployment Plan
+
+No migration required. Backward-compatible.
+
+- `pipeline-runner` already destructures protocol-method results and wraps in `try/catch Exception` for stage failures. The shared `require-handle!` / `validate-auth!` preserve the legacy `ex-info` shape, so existing CLI/MCP error handling is unchanged.
+- New non-boundary call sites (where they exist post-migration) consume the anomaly-returning variants directly.
+
+## Notes / Surprises
+
+1. **`connector-sarif` used a private `(atom {})`** instead of `connector/create-handle-registry`. Migrated it to the shared registry as part of this PR — modest scope creep, but necessary to call the shared helper. Tests don't peek at the atom internals; behavior preserved.
+2. **`pipeline-runner` is the architectural boundary, not the connector protocol body.** A strict reading of "boundary call sites use throwing variants" could imply CLI/MCP only. But `pipeline-runner` destructures result maps directly inside a `try/catch Exception` outer wrapper. Returning anomalies there would silently produce empty `:records` instead of `:failed` stage results. So protocol method bodies kept the throw at exit; internal helpers use the anomaly form. Aligns with the "preserve legacy ex-info shape" intent in the brief. Pipeline-runner adapter changes belong to a separate workstream.
+3. **Duplicate `connector.interface` requires** — `connector-jira`, `connector-gitlab`, `connector-file`, and `connector-github` had the namespace listed twice in their `ns` form. Removed during the touch.
+
+## Related Issues/PRs
+
+- Built on PR #704 (`refactor: foundation-tier exceptions-as-data cleanup`)
+- Built on PR #689 (`feat: add anomaly component`)
+- Tracked in PR #691 (`docs: inventory exception/throw sites for cleanup`)
+- Companion to PR #708 (`fix: brick-isolation hygiene`)
+
+## Checklist
+
+- [x] All seven connectors migrated to shared helpers
+- [x] Inline `require-handle!` / `validate-auth!` patterns removed
+- [x] `pipeline-runner` boundary contract preserved (`ex-info` shape unchanged)
+- [x] Tests added for handle-not-found / auth-rejection / auth-success paths
+- [x] No `deps.edn` changes (all connectors already had the required `:local/root` dep)
+- [x] No public API change
+- [x] Apache 2 license headers preserved
+- [x] `bb pre-commit` green


### PR DESCRIPTION
# refactor: migrate connector callsites to shared validation helpers

## Overview

Migrates seven connector components from inline `require-handle!` / `validate-auth!` patterns to the shared anomaly-returning + throwing variants in `connector` core (which landed in PR #704). Retires 14 of the 158 cleanup-needed sites identified in `work/exception-cleanup-inventory.md`.

This is the second tier of the exceptions-as-data cleanup — the foundation cleanup PR (#704) extracted the helpers; this PR migrates the callsites.

## Motivation

Each connector component (`connector-jira` / `gitlab` / `github` / `excel` / `edgar` / `file` / `sarif`) reimplemented the same `require-handle!` / `validate-auth!` patterns inline before #704. With the shared helpers now available in `connector` core, callers can stop duplicating the validation logic and start participating in the canonical anomaly flow at non-boundary sites while preserving the legacy `ex-info` shape at boundary sites.

The brief was deliberately scoped to handle-lookup and auth-validation patterns. Schema/`validate!`, exhaustive-case fallthroughs, HTTP errors, and config validation are out of scope — those land in subsequent cleanup PRs.

## Base Branch

`main`

## Depends On

- `ai.miniforge.connector.interface/{require-handle, require-handle!, validate-auth, validate-auth!}` — landed in PR #704 (foundation cleanup)
- `ai.miniforge.anomaly` — landed in PR #689

## Layer

Refactor / connector tier. Touches connector implementation files only.

## What This Adds / Changes

Source + test files for seven connectors:

- `components/connector-jira/src/.../impl.clj` + `test/.../impl_test.clj`
- `components/connector-gitlab/src/.../impl.clj` + `test/.../impl_test.clj`
- `components/connector-github/src/.../impl.clj` + `test/.../impl_test.clj`
- `components/connector-excel/src/.../impl.clj` + `test/.../interface_test.clj`
- `components/connector-edgar/src/.../impl.clj` + `test/.../interface_test.clj`
- `components/connector-file/src/.../impl.clj` + `test/.../interface_test.clj`
- `components/connector-sarif/src/.../impl.clj` + `test/.../impl_test.clj`

14 files total. **+311 / -100 lines.** No `deps.edn` changes — every targeted connector already declared `ai.miniforge/connector` as a `:local/root` dep.

## Migration patterns

**Two patterns. Both retire inline validation in favor of shared helpers.**

1. **Handle lookup.** Local `require-handle!` shrinks to a one-liner over `connector/require-handle!`, supplying the connector-specific localized `:message`. Inline `(or (get-handle h) (throw ex-info ...))` is removed.
2. **Auth validation.** Local `validate-auth!` calls the anomaly-returning `connector/validate-auth`, then re-throws with the localized message that interpolates the actual validation errors. Matches the brief's `(if-let [a (connector/validate-auth auth)] a ...)` shape. The protocol method body remains the boundary that throws — `pipeline-runner`'s `try/catch` expects that contract and stays unchanged.

## Inventory delta

**14 of 158 cleanup-needed sites retired.** Across the seven targeted connectors:

| Connector | Retired | Left in place (out of scope) |
|---|---:|---|
| connector-jira | 2 | schema/`validate!`, resource-unknown, site-required |
| connector-gitlab | 2 | schema/`validate!`, resource-unknown, project-required |
| connector-github | 2 | resource-unknown, config-invalid, owner-or-org-required |
| connector-excel | 2 | sheet-not-found, download-failed, url/sheet/columns required |
| connector-edgar | 2 | aggregation-unknown, form-type/user-agent/aggregation-required |
| connector-file | 3 | format/path/file-not-found, format-unsupported |
| connector-sarif | 1 | "Invalid SARIF config" |

The left-in-place sites are config validation, exhaustive-case fallthroughs, HTTP errors, or `schema/validate!` — all out of scope per the brief, which restricts this PR to the `require-handle!` / `validate-auth!` patterns. They land in subsequent cleanup PRs.

## Strata Affected

Per-connector implementation namespaces (`impl.clj` for most; `interface_test.clj` for connectors that test through their public interface). No public connector API changed.

## Testing Plan

- **`bb pre-commit` green:**
  - `lint:clj` — 0 errors. 8 warnings, all pre-existing in the touched files (unused `schema.interface` requires, unused `clojure.string` references, unused binding). None introduced by this PR.
  - `fmt:md` — clean.
  - `test` — **3530 tests / 15746 passes / 0 failures / 0 errors.** Net new assertions: 21 across the seven connectors, covering handle-not-found `ex-info` shape and auth-rejection / auth-success paths for jira / gitlab / github.
  - `test:graalvm` — 6 tests / 479 assertions / 0 failures.

## Deployment Plan

No migration required. Backward-compatible.

- `pipeline-runner` already destructures protocol-method results and wraps in `try/catch Exception` for stage failures. The shared `require-handle!` / `validate-auth!` preserve the legacy `ex-info` shape, so existing CLI/MCP error handling is unchanged.
- New non-boundary call sites (where they exist post-migration) consume the anomaly-returning variants directly.

## Notes / Surprises

1. **`connector-sarif` used a private `(atom {})`** instead of `connector/create-handle-registry`. Migrated it to the shared registry as part of this PR — modest scope creep, but necessary to call the shared helper. Tests don't peek at the atom internals; behavior preserved.
2. **`pipeline-runner` is the architectural boundary, not the connector protocol body.** A strict reading of "boundary call sites use throwing variants" could imply CLI/MCP only. But `pipeline-runner` destructures result maps directly inside a `try/catch Exception` outer wrapper. Returning anomalies there would silently produce empty `:records` instead of `:failed` stage results. So protocol method bodies kept the throw at exit; internal helpers use the anomaly form. Aligns with the "preserve legacy ex-info shape" intent in the brief. Pipeline-runner adapter changes belong to a separate workstream.
3. **Duplicate `connector.interface` requires** — `connector-jira`, `connector-gitlab`, `connector-file`, and `connector-github` had the namespace listed twice in their `ns` form. Removed during the touch.

## Related Issues/PRs

- Built on PR #704 (`refactor: foundation-tier exceptions-as-data cleanup`)
- Built on PR #689 (`feat: add anomaly component`)
- Tracked in PR #691 (`docs: inventory exception/throw sites for cleanup`)
- Companion to PR #708 (`fix: brick-isolation hygiene`)

## Checklist

- [x] All seven connectors migrated to shared helpers
- [x] Inline `require-handle!` / `validate-auth!` patterns removed
- [x] `pipeline-runner` boundary contract preserved (`ex-info` shape unchanged)
- [x] Tests added for handle-not-found / auth-rejection / auth-success paths
- [x] No `deps.edn` changes (all connectors already had the required `:local/root` dep)
- [x] No public API change
- [x] Apache 2 license headers preserved
- [x] `bb pre-commit` green
