### PR TITLE
strata: clean up 5 single-violation small components

### DIFF
--- a/components/anomaly/src/ai/miniforge/anomaly/interface.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/interface.clj
@@ -41,7 +41,7 @@
    [ai.miniforge.anomaly.contract :as contract]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema and vocabulary re-exports
+;; Schema/vocabulary re-exports + in-namespace-pure helpers (no in-ns deps).
 
 (def Anomaly
   "Malli schema for the canonical anomaly map. See
@@ -53,13 +53,13 @@
    `ai.miniforge.anomaly.contract/anomaly-types`."
   contract/anomaly-types)
 
-;------------------------------------------------------------------------------ Layer 1
-;; Construction
-
 (defn- now
   "Return the current instant. Wrapped so tests can redef."
   []
   (java.time.Instant/now))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Construction — composes Layer 0 (`now`) and the contract namespace.
 
 (defn anomaly
   "Construct a canonical anomaly map.

--- a/components/anomaly/src/ai/miniforge/anomaly/interface.clj
+++ b/components/anomaly/src/ai/miniforge/anomaly/interface.clj
@@ -41,7 +41,7 @@
    [ai.miniforge.anomaly.contract :as contract]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Schema/vocabulary re-exports + in-namespace-pure helpers (no in-ns deps).
+;; Schema/vocabulary re-exports + helpers with no in-namespace deps.
 
 (def Anomaly
   "Malli schema for the canonical anomaly map. See
@@ -59,7 +59,9 @@
   (java.time.Instant/now))
 
 ;------------------------------------------------------------------------------ Layer 1
-;; Construction — composes Layer 0 (`now`) and the contract namespace.
+;; Construction — composes Layer 0 (`now`). Cross-namespace use of the
+;; `contract` namespace doesn't participate in the intra-namespace
+;; layering model.
 
 (defn anomaly
   "Construct a canonical anomaly map.

--- a/components/bb-paths/src/ai/miniforge/bb_paths/core.clj
+++ b/components/bb-paths/src/ai/miniforge/bb_paths/core.clj
@@ -22,13 +22,16 @@
    tasks and their tests see the same root regardless of where `bb` was
    invoked.
 
-   Layer 0: pure path walking.
-   Layer 1: repo-root resolution on top of Layer 0.
-   Layer 2: filesystem side-effects (create/delete)."
+   Stratification (intra-namespace dependencies only):
+   Layer 0 — no in-namespace deps. `find-up` and the side-effect
+             helpers (`ensure-dir!`, `tmp-dir!`, `delete-tree!`) only
+             call out to `babashka.fs`.
+   Layer 1 — composes Layer 0. `repo-root` drives `find-up`.
+   Layer 2 — composes Layer 1. `under-root` rests on `repo-root`."
   (:require [babashka.fs :as fs]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure path walking
+;; No in-namespace dependencies — only `babashka.fs` and built-ins.
 
 (defn- find-up
   "Walk up from `start` until a directory containing `marker` is found.
@@ -39,26 +42,6 @@
       (nil? dir)                        nil
       (fs/exists? (fs/path dir marker)) (str dir)
       :else                             (recur (fs/parent dir)))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Repo-root resolution
-
-(defn repo-root
-  "Absolute path to the repo root (nearest `bb.edn` above the cwd).
-   Throws ex-info if no `bb.edn` is found walking up from cwd."
-  []
-  (or (find-up (fs/cwd) "bb.edn")
-      (throw (ex-info "Could not locate bb.edn from cwd"
-                      {:cwd (str (fs/cwd))}))))
-
-(defn under-root
-  "Resolve `segments` beneath the repo root. Returns an absolute path
-   string."
-  [& segments]
-  (str (apply fs/path (repo-root) segments)))
-
-;------------------------------------------------------------------------------ Layer 2
-;; Filesystem side-effects
 
 (defn ensure-dir!
   "Create `path` (and parents) if it does not exist. Returns the path
@@ -78,6 +61,26 @@
   [path]
   (when (and path (fs/exists? path))
     (fs/delete-tree path)))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0.
+
+(defn repo-root
+  "Absolute path to the repo root (nearest `bb.edn` above the cwd).
+   Throws ex-info if no `bb.edn` is found walking up from cwd."
+  []
+  (or (find-up (fs/cwd) "bb.edn")
+      (throw (ex-info "Could not locate bb.edn from cwd"
+                      {:cwd (str (fs/cwd))}))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Composes Layer 1.
+
+(defn under-root
+  "Resolve `segments` beneath the repo root. Returns an absolute path
+   string."
+  [& segments]
+  (str (apply fs/path (repo-root) segments)))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/interface.clj
+++ b/components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/interface.clj
@@ -22,13 +22,14 @@
    Provides the ControlPlaneAdapter protocol that vendor-specific
    adapters must implement, plus shared utilities for building adapters.
 
-   Layer 0: Protocol re-exports
-   Layer 1: Adapter utilities"
+   Stratification (intra-namespace):
+   Layer 0: Protocol re-exports + pure data + helpers with no in-ns deps.
+   Layer 1: `heartbeat-interval-for-vendor` (consumes Layer 0 data)."
   (:require
    [ai.miniforge.control-plane-adapter.protocol :as proto]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Protocol re-exports
+;; Protocol re-exports + pure data + helpers with no in-namespace deps.
 
 (def ControlPlaneAdapter proto/ControlPlaneAdapter)
 (def ControlPlaneAdapterLogs proto/ControlPlaneAdapterLogs)
@@ -40,8 +41,12 @@
 (def send-command proto/send-command)
 (def agent-logs proto/agent-logs)
 
-;------------------------------------------------------------------------------ Layer 1
-;; Adapter utilities
+(def ^:private vendor-heartbeat-ms
+  "Recommended heartbeat intervals per vendor (ms)."
+  {:claude-code 15000    ;; local process, fast check
+   :miniforge   10000    ;; native, fastest
+   :openai      60000    ;; API rate limits
+   :cursor      30000})
 
 (defn normalize-status
   "Normalize a vendor-specific status string to a control plane status keyword.
@@ -69,12 +74,8 @@
   (when timestamp
     (- (System/currentTimeMillis) (.getTime timestamp))))
 
-(def ^:private vendor-heartbeat-ms
-  "Recommended heartbeat intervals per vendor (ms)."
-  {:claude-code 15000    ;; local process, fast check
-   :miniforge   10000    ;; native, fastest
-   :openai      60000    ;; API rate limits
-   :cursor      30000})
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0 (`vendor-heartbeat-ms`).
 
 (defn heartbeat-interval-for-vendor
   "Return the recommended heartbeat interval for a vendor.

--- a/components/cursor-store/src/ai/miniforge/cursor_store/store.clj
+++ b/components/cursor-store/src/ai/miniforge/cursor_store/store.clj
@@ -1,8 +1,12 @@
 (ns ai.miniforge.cursor-store.store
   "File-based cursor persistence.
 
-   Layer 0 — pure conversion helpers
-   Layer 1 — file I/O (save-cursors, load-cursors)"
+   Stratification (intra-namespace):
+   Layer 0 — no in-ns deps: cursor-file, normalize-for-storage,
+             stringify-instants, read-edn.
+   Layer 1 — write-edn (composes Layer 0's stringify-instants).
+   Layer 2 — public I/O (save-cursors, load-cursors). Both at L2 to
+             keep the persistence API at one stratum."
   (:require [clojure.edn :as edn]
             [clojure.java.io :as io]
             [clojure.pprint :as pp]
@@ -48,6 +52,13 @@
   [v]
   (walk/postwalk (fn [x] (if (instance? Instant x) (str x) x)) v))
 
+(defn- read-edn
+  "Parse an EDN string."
+  [s]
+  (edn/read-string s))
+
+;;------------------------------------------------------------------------------ Layer 1 — composes Layer 0
+
 (defn- write-edn
   "Render a value to a pretty-printed EDN string."
   [v]
@@ -55,12 +66,7 @@
     (pp/pprint (stringify-instants v) sw)
     (str sw)))
 
-(defn- read-edn
-  "Parse an EDN string."
-  [s]
-  (edn/read-string s))
-
-;;------------------------------------------------------------------------------ Layer 1 — I/O
+;;------------------------------------------------------------------------------ Layer 2 — public I/O
 
 (defn save-cursors
   "Persist connector cursors to <pipeline-dir>/.cursors/<pipeline-filename>.

--- a/components/evaluation/src/ai/miniforge/evaluation/golden_set.clj
+++ b/components/evaluation/src/ai/miniforge/evaluation/golden_set.clj
@@ -7,11 +7,14 @@
    They are stored as N6 evidence artifacts.
 
    Stratification (intra-namespace):
-   Layer 0 — pure CRUD + per-entry evaluation (no in-ns deps).
+   Layer 0 — CRUD + per-entry evaluation; no in-namespace deps.
+             (\"Pure\" in the stratification sense, not the
+             referential-transparency sense — `create-golden-set`
+             pulls `random-uuid`/`Date.` for ID and timestamp.)
    Layer 1 — `run-golden-set` (composes `evaluate-entry`).")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; No in-namespace dependencies — pure data construction and per-entry checks.
+;; No in-namespace dependencies — data construction and per-entry checks.
 
 (defn create-golden-set
   "Create a golden set from curated entries.

--- a/components/evaluation/src/ai/miniforge/evaluation/golden_set.clj
+++ b/components/evaluation/src/ai/miniforge/evaluation/golden_set.clj
@@ -6,11 +6,12 @@
    Golden sets are curated workflow inputs paired with known-good outcomes.
    They are stored as N6 evidence artifacts.
 
-   Layer 0: Golden set CRUD (pure data)
-   Layer 1: Golden set evaluation")
+   Stratification (intra-namespace):
+   Layer 0 — pure CRUD + per-entry evaluation (no in-ns deps).
+   Layer 1 — `run-golden-set` (composes `evaluate-entry`).")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Golden set management
+;; No in-namespace dependencies — pure data construction and per-entry checks.
 
 (defn create-golden-set
   "Create a golden set from curated entries.
@@ -35,9 +36,6 @@
 (defn entry-count [golden-set]
   (count (:golden-set/entries golden-set)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Evaluation
-
 (defn evaluate-entry
   "Evaluate a single golden set entry against actual output.
 
@@ -56,6 +54,9 @@
     {:entry/id (:entry/id entry)
      :passed? all-passed?
      :criteria-results results}))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0 (`evaluate-entry`).
 
 (defn run-golden-set
   "Run a golden set and compare actual vs expected outcomes.


### PR DESCRIPTION
## Summary

First cleanup batch against the baseline shipped in #733. Each of the five files below had exactly one within-namespace call where caller and callee sat at the same layer (or callee was higher) — pure relayering work, no behavioral changes.

| File | Violation |
|---|---|
| `components/bb-paths/src/ai/miniforge/bb_paths/core.clj` | `under-root(L1)` → `repo-root(L1)` |
| `components/anomaly/src/ai/miniforge/anomaly/interface.clj` | `anomaly(L1)` → `now(L1)` |
| `components/control-plane-adapter/src/ai/miniforge/control_plane_adapter/interface.clj` | `heartbeat-interval-for-vendor(L1)` → `vendor-heartbeat-ms(L1)` |
| `components/cursor-store/src/ai/miniforge/cursor_store/store.clj` | `write-edn(L0)` → `stringify-instants(L0)` |
| `components/evaluation/src/ai/miniforge/evaluation/golden_set.clj` | `run-golden-set(L1)` → `evaluate-entry(L1)` |

## Approach

Per the user's stratification rule (every intra-namespace call must go to a strictly lower layer):

1. Move pure data and helpers with no in-namespace deps to Layer 0.
2. Move callers of Layer 0 to Layer 1, callers of Layer 1 to Layer 2, etc.
3. Update the section-header comments and the `(ns …)` docstring summary.

For `cursor-store`, `save-cursors`/`load-cursors` were lifted to Layer 2 together to keep the persistence API at one stratum (rather than splitting them by their actual minimum-layer).

## Test plan

- [x] `bb tools/strata_audit.bb components/bb-paths components/anomaly components/control-plane-adapter components/cursor-store components/evaluation` reports zero violations.
- [x] `bb pre-commit` green.
- [ ] CI green.