### PR TITLE
strata: clean up 5 small-component violations (batch 2)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/main/commands/init.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/init.clj
@@ -3,7 +3,13 @@
 ;; Licensed under the Apache License, Version 2.0
 
 (ns ai.miniforge.cli.main.commands.init
-  "Init command — analyze a repository and write .miniforge/config.edn."
+  "Init command — analyze a repository and write .miniforge/config.edn.
+
+   Stratification (intra-namespace):
+   Layer 0 — pure data + helpers with no in-ns deps.
+   Layer 1 — `config-path` composes the L0 path constants.
+   Layer 2 — `write-config!` composes Layer 1.
+   Layer 3 — `init-cmd` (public CLI entry)."
   (:require
    [babashka.fs :as fs]
    [clojure.pprint :as pprint]
@@ -12,11 +18,10 @@
    [ai.miniforge.cli.repo-analyzer :as analyzer]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Config file generation
+;; Pure data + helpers with no in-namespace dependencies.
 
 (def ^:private config-dir ".miniforge")
 (def ^:private config-file "config.edn")
-(def ^:private config-path (str config-dir "/" config-file))
 
 (defn- format-config
   "Format a repo config map as pretty-printed EDN with a header comment."
@@ -34,9 +39,6 @@
     (:git-host analysis)
     (assoc :repo/host (:git-host analysis))))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Init execution
-
 (defn- print-analysis
   "Print the analysis results to the user."
   [analysis]
@@ -48,6 +50,14 @@
   (display/print-info (messages/t :init/analysis-packs
                                   {:value (pr-str (:packs analysis))})))
 
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0 path constants.
+
+(def ^:private config-path (str config-dir "/" config-file))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Composes Layer 1.
+
 (defn- write-config!
   "Write the config file. Returns the path written."
   [repo-path config]
@@ -57,7 +67,7 @@
     (spit (str path) (format-config config))
     (str path)))
 
-;------------------------------------------------------------------------------ Layer 2
+;------------------------------------------------------------------------------ Layer 3
 ;; Command entry point
 
 (defn init-cmd

--- a/bases/cli/src/ai/miniforge/cli/main/commands/shared.clj
+++ b/bases/cli/src/ai/miniforge/cli/main/commands/shared.clj
@@ -27,7 +27,7 @@
    [ai.miniforge.cli.messages :as messages]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Constants
+;; Constants + helpers with no in-namespace dependencies.
 
 (def max-artifacts-display
   "Maximum number of artifact files to display in a listing."
@@ -61,9 +61,6 @@
   "Changed-files threshold above which a PR is considered medium risk."
   5)
 
-;------------------------------------------------------------------------------ Layer 1
-;; Shared functions
-
 (defn try-resolve
   "Attempt to require-resolve a fully-qualified function symbol.
    Returns the resolved var (a function), or nil when the namespace
@@ -73,6 +70,14 @@
     (requiring-resolve fn-sym)
     (catch Exception _ nil)))
 
+(defn exit!
+  "Wrapper around System/exit that can be redef'd in tests."
+  [code]
+  (System/exit code))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0.
+
 (defn try-resolve-fn
   "Require-resolve `fn-sym` and immediately apply it to `args`.
    Returns nil when the namespace or var cannot be loaded."
@@ -81,11 +86,6 @@
     (try
       (apply f args)
       (catch Exception _ nil))))
-
-(defn exit!
-  "Wrapper around System/exit that can be redef'd in tests."
-  [code]
-  (System/exit code))
 
 (defn usage-error!
   "Print a usage error with the given message key and command string, then exit 1."

--- a/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
+++ b/components/bb-proc/src/ai/miniforge/bb_proc/core.clj
@@ -21,14 +21,19 @@
    read the same way across the umbrella and so tests can inspect
    exit/capture output uniformly.
 
-   Layer 0: argument normalization and command-resolution planning (pure).
-   Layer 1: process invocations on top of Layer 0."
+   Stratification (intra-namespace):
+   Layer 0 — pure data + helpers with no in-ns deps.
+   Layer 1 — composes Layer 0 (`command-candidates`, `run!`,
+             `run-bg!`, `sh`).
+   Layer 2 — `resolve-command` composes `command-candidates` + the L0
+             `first-resolved-command`.
+   Layer 3 — `clojure-command` (public single-purpose entry over L2)."
   (:refer-clojure :exclude [run!])
   (:require [babashka.fs :as fs]
             [babashka.process :as p]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Argument normalization and command planning (pure)
+;; No in-namespace dependencies.
 
 (def ^:private windows-clojure-command
   "Fallback executable names for Clojure tooling on Windows runners."
@@ -42,14 +47,6 @@
     [(first args) (rest args)]
     [{} args]))
 
-(defn command-candidates
-  "Return candidate executable names for `cmd` on `os`."
-  [cmd os]
-  (let [candidates (if (and (= os :windows) (= cmd "clojure"))
-                     (into [cmd] windows-clojure-command)
-                     [cmd])]
-    (vec (distinct candidates))))
-
 (defn first-resolved-command
   "Return the first executable path found by `lookup-fn`, else the first
    candidate name unchanged."
@@ -59,21 +56,29 @@
             candidates)
       (first candidates)))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Process invocations
-
-(defn resolve-command
-  "Resolve `cmd` to an executable path when possible."
+(defn installed?
+  "True if `cmd` resolves on PATH. Uses `babashka.fs/which`, which is
+   portable: invokes `which` on Unix shells and `where` on Windows."
   [cmd]
-  (let [windows-os? (re-find #"(?i)windows" (System/getProperty "os.name" ""))
-        os          (if windows-os? :windows :unix)
-        candidates  (command-candidates cmd os)]
-    (first-resolved-command candidates fs/which)))
+  (some? (fs/which cmd)))
 
-(defn clojure-command
-  "Resolve the best Clojure executable for the current process."
-  []
-  (resolve-command "clojure"))
+(defn destroy!
+  "Destroy a background process and wait briefly for it to exit."
+  [proc]
+  (when proc
+    (p/destroy proc)
+    (try (deref proc 5000 nil) (catch Exception _ nil))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0.
+
+(defn command-candidates
+  "Return candidate executable names for `cmd` on `os`."
+  [cmd os]
+  (let [candidates (if (and (= os :windows) (= cmd "clojure"))
+                     (into [cmd] windows-clojure-command)
+                     [cmd])]
+    (vec (distinct candidates))))
 
 (defn run!
   "Run a command inheriting stdio. Throws ex-info on non-zero exit.
@@ -100,18 +105,24 @@
   (let [[opts cmd] (split-opts args)]
     (apply p/sh opts cmd)))
 
-(defn installed?
-  "True if `cmd` resolves on PATH. Uses `babashka.fs/which`, which is
-   portable: invokes `which` on Unix shells and `where` on Windows."
-  [cmd]
-  (some? (fs/which cmd)))
+;------------------------------------------------------------------------------ Layer 2
+;; Composes Layer 1.
 
-(defn destroy!
-  "Destroy a background process and wait briefly for it to exit."
-  [proc]
-  (when proc
-    (p/destroy proc)
-    (try (deref proc 5000 nil) (catch Exception _ nil))))
+(defn resolve-command
+  "Resolve `cmd` to an executable path when possible."
+  [cmd]
+  (let [windows-os? (re-find #"(?i)windows" (System/getProperty "os.name" ""))
+        os          (if windows-os? :windows :unix)
+        candidates  (command-candidates cmd os)]
+    (first-resolved-command candidates fs/which)))
+
+;------------------------------------------------------------------------------ Layer 3
+;; Composes Layer 2.
+
+(defn clojure-command
+  "Resolve the best Clojure executable for the current process."
+  []
+  (resolve-command "clojure"))
 
 ;------------------------------------------------------------------------------ Rich Comment
 (comment

--- a/components/config/src/ai/miniforge/config/digest.clj
+++ b/components/config/src/ai/miniforge/config/digest.clj
@@ -22,8 +22,11 @@
    Computes SHA-256 digests of governance EDN files and verifies them
    against a manifest to detect tampering.
 
-   Layer 0: SHA-256 computation
-   Layer 1: Manifest loading and verification"
+   Stratification (intra-namespace):
+   Layer 0 — `bytes->hex` and `load-digest-manifest` (no in-ns deps).
+   Layer 1 — `sha256-hex` (composes `bytes->hex`).
+   Layer 2 — `verify-governance-file` (composes the L0 manifest + L1
+             digest helper)."
   (:require
    [clojure.edn :as edn]
    [clojure.java.io :as io])
@@ -31,7 +34,7 @@
    [java.security MessageDigest]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; SHA-256 computation
+;; No in-namespace dependencies.
 
 (defn bytes->hex
   "Convert byte array to lowercase hex string. Babashka/GraalVM compatible."
@@ -40,17 +43,6 @@
     (dotimes [i (alength ba)]
       (.append sb (format "%02x" (aget ba i))))
     (.toString sb)))
-
-(defn sha256-hex
-  "Compute SHA-256 hex digest of a string.
-   Returns a prefixed string like \"sha256:a1b2c3d4...\"."
-  [^String content]
-  (let [digest (MessageDigest/getInstance "SHA-256")
-        hash-bytes (.digest digest (.getBytes content "UTF-8"))]
-    (str "sha256:" (bytes->hex hash-bytes))))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Manifest loading and verification
 
 (defn load-digest-manifest
   "Load governance/digests.edn from classpath.
@@ -61,6 +53,20 @@
       (edn/read-string (slurp resource))
       (catch Exception _e
         nil))))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0.
+
+(defn sha256-hex
+  "Compute SHA-256 hex digest of a string.
+   Returns a prefixed string like \"sha256:a1b2c3d4...\"."
+  [^String content]
+  (let [digest (MessageDigest/getInstance "SHA-256")
+        hash-bytes (.digest digest (.getBytes content "UTF-8"))]
+    (str "sha256:" (bytes->hex hash-bytes))))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Composes Layer 0 (`load-digest-manifest`) + Layer 1 (`sha256-hex`).
 
 (defn verify-governance-file
   "Verify content against the digest manifest.

--- a/components/connector/src/ai/miniforge/connector/validation.clj
+++ b/components/connector/src/ai/miniforge/connector/validation.clj
@@ -47,7 +47,7 @@
             [ai.miniforge.connector.handles :as handles]))
 
 ;;------------------------------------------------------------------------------ Layer 0
-;; Handle lookup
+;; No in-namespace dependencies — anomaly-returning primitives.
 
 (defn require-handle
   "Look up handle state in `store`. Return the state on success; return a
@@ -69,6 +69,14 @@
                       (cond-> {:handle handle}
                         connector (assoc :connector connector))))))
 
+(defn- auth-success?
+  "True when `result` is a credential-ref validation success map."
+  [result]
+  (true? (:success? result)))
+
+;;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0.
+
 (defn require-handle!
   "Look up handle state in `store` or throw `ex-info` when absent.
 
@@ -85,14 +93,6 @@
        (throw (ex-info (or message (:anomaly/message result))
                        (:anomaly/data result)))
        result))))
-
-;;------------------------------------------------------------------------------ Layer 1
-;; Auth validation
-
-(defn- auth-success?
-  "True when `result` is a credential-ref validation success map."
-  [result]
-  (true? (:success? result)))
 
 (defn validate-auth
   "Validate a credential reference, if one is supplied. Return `nil` when
@@ -114,6 +114,9 @@
                             (or message "Credential validation failed")
                             (cond-> {:errors errors}
                               connector (assoc :connector connector)))))))))
+
+;;------------------------------------------------------------------------------ Layer 2
+;; Composes Layer 1.
 
 (defn validate-auth!
   "Validate a credential reference, throwing `ex-info` on failure.


### PR DESCRIPTION
## Summary

Second cleanup batch against the baseline in #733.

| File | Violations | Top fix |
|---|---:|---|
| `bases/cli/src/ai/miniforge/cli/main/commands/init.clj` | 2 | `config-path` lifted to L1; chain ends at L3 |
| `bases/cli/src/ai/miniforge/cli/main/commands/shared.clj` | 2 | `try-resolve` and `exit!` demoted to L0 |
| `components/bb-proc/src/ai/miniforge/bb_proc/core.clj` | 2 | Rebuilt as 4 strata; `clojure-command` ends at L3 |
| `components/config/src/ai/miniforge/config/digest.clj` | 2 | `bytes->hex`/`load-digest-manifest` to L0; chain to L2 |
| `components/connector/src/ai/miniforge/connector/validation.clj` | 3 | Anomaly-returning primitives to L0; throwing wrappers to L1; `validate-auth!` to L2 |

## Test plan

- [x] `bb tools/strata_audit.bb` reports zero violations across the touched paths.
- [x] `bb pre-commit` green.
- [ ] CI green.