### PR TITLE
fix(dag-executor): handle detached-HEAD scratch worktrees in persist

### DIFF
--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -92,6 +92,22 @@
    worktrees are acquired."
   (Object.))
 
+(defn- resolve-branch-sha
+  "Resolve a branch name to its commit sha so `git worktree add -b new path
+   <sha>` works even when <branch> is checked out in another worktree.
+
+   The straightforward `git worktree add -b new path <branch>` fails with
+   `fatal: '<branch>' is already checked out at <other-worktree>` when the
+   parent worktree is the one running miniforge — which is the common case
+   for `bb dogfood`. Passing the resolved sha sidesteps the refusal.
+
+   Returns the sha string on success, nil on failure (caller falls back to
+   the branch name and accepts any failure that follows)."
+  [repo-path branch]
+  (let [r (run-git "-C" repo-path "rev-parse" branch)]
+    (when (zero? (:exit r))
+      (str/trim (or (:out r) "")))))
+
 (defn create-worktree
   "Create a git worktree for the task.
 
@@ -100,16 +116,25 @@
    simultaneously.
 
    Attempts in order:
-   1. git worktree add -b <name> <path> <branch>  — new branch from branch tip
+   1. git worktree add -b <name> <path> <sha>      — new branch from branch's
+                                                     resolved sha (works even
+                                                     when <branch> is checked
+                                                     out in another worktree)
    2. Clean up stale branch/directory and retry step 1
-   3. git worktree add --detach <path>             — detached HEAD (last resort)"
+   3. git worktree add --detach <path>             — detached HEAD (last resort)
+
+   Detached HEAD is a real fallback path here, but downstream `archive-bundle!`
+   handles it defensively by creating a real branch at HEAD before bundling.
+   This one-two punch keeps `git worktree add` failures from cascading into
+   broken bundles whose only ref is a bare HEAD."
   [base-path repo-path worktree-name branch]
   (locking worktree-lock
-    (let [worktree-path (str base-path "/" worktree-name)]
+    (let [worktree-path (str base-path "/" worktree-name)
+          base-ref      (or (resolve-branch-sha repo-path branch) branch)]
       (ensure-directory base-path)
       (let [result (run-git "-C" repo-path
                             "worktree" "add" "-b" worktree-name
-                            worktree-path branch)]
+                            worktree-path base-ref)]
         (if (zero? (:exit result))
           (result/ok {:worktree-path worktree-path})
           ;; Failed — clean up stale branch/directory from a prior run and retry
@@ -119,7 +144,7 @@
             (run-git "-C" repo-path "branch" "-D" worktree-name)
             (let [result2 (run-git "-C" repo-path
                                    "worktree" "add" "-b" worktree-name
-                                   worktree-path branch)]
+                                   worktree-path base-ref)]
               (if (zero? (:exit result2))
                 (result/ok {:worktree-path worktree-path})
                 ;; Still failing — detached HEAD as last resort
@@ -172,12 +197,48 @@
 ;; silent zeros — Copilot review on PR #729 caught the original "treat
 ;; non-zero exit as no-changes" pattern as a silent-failure vector.
 
+(def ^:private detached-head-sentinel
+  "What `git rev-parse --abbrev-ref HEAD` prints in a detached worktree.
+   Treated as 'no branch' for archive purposes — `archive-bundle!` creates
+   a real branch before recording the bundle so the result always has a
+   `refs/heads/<name>` ref, never a bare HEAD."
+  "HEAD")
+
+(defn- detached?
+  [branch-name]
+  (= detached-head-sentinel branch-name))
+
 (defn- current-branch
+  "Returns the worktree's HEAD branch name, or the literal sentinel
+   `\"HEAD\"` when the worktree is detached. Callers that need a real
+   branch name should call `ensure-named-branch!` to materialize one."
   [worktree-path]
   (let [r (run-git "-C" worktree-path "rev-parse" "--abbrev-ref" "HEAD")]
     (if (zero? (:exit r))
       (result/ok (str/trim (or (:out r) "")))
       (result/err :archive-no-branch (or (:err r) "could not resolve HEAD")))))
+
+(defn- ensure-named-branch!
+  "If the worktree is in detached-HEAD state, create a real branch at HEAD
+   so the bundle records `refs/heads/<name>` (not just bare HEAD).
+
+   Returns result/ok with the branch name to use for bundling. Pass-through
+   when the worktree is already on a named branch.
+
+   The bundle's ref namespace is what the harvest CLI fetches by name —
+   without a real branch, harvest correctly diagnoses the bundle as the
+   legacy `base..HEAD` shape and refuses to fetch. This helper makes that
+   diagnostic moot for new bundles by always producing the new shape."
+  [worktree-path branch task-id]
+  (if-not (detached? branch)
+    (result/ok branch)
+    (let [name (str "task-" task-id)
+          r    (run-git "-C" worktree-path "checkout" "-b" name)]
+      (if (zero? (:exit r))
+        (result/ok name)
+        (result/err :archive-detach-recovery-failed
+                    (or (:err r)
+                        "could not create branch from detached HEAD"))))))
 
 (defn- dirty?
   [worktree-path]
@@ -326,14 +387,17 @@
                          base-ref default-base-ref}}]
   (-> (current-branch worktree-path)
       (result/and-then
-       (fn [branch]
-         (-> (already-clean? worktree-path base-ref)
+       (fn [raw-branch]
+         (-> (ensure-named-branch! worktree-path raw-branch task-id)
              (result/and-then
-              (fn [clean?]
-                (if clean?
-                  (result/ok {:persisted? false :no-changes? true :branch branch})
-                  (commit-and-bundle! worktree-path branch base-ref
-                                      archive-dir task-id message)))))))))
+              (fn [branch]
+                (-> (already-clean? worktree-path base-ref)
+                    (result/and-then
+                     (fn [clean?]
+                       (if clean?
+                         (result/ok {:persisted? false :no-changes? true :branch branch})
+                         (commit-and-bundle! worktree-path branch base-ref
+                                             archive-dir task-id message))))))))))))
 
 (defn restore-from-bundle!
   "Restore work from a previously-persisted bundle into the host repo.

--- a/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
+++ b/components/dag-executor/src/ai/miniforge/dag_executor/protocols/impl/worktree.clj
@@ -116,10 +116,16 @@
    simultaneously.
 
    Attempts in order:
-   1. git worktree add -b <name> <path> <sha>      — new branch from branch's
-                                                     resolved sha (works even
-                                                     when <branch> is checked
-                                                     out in another worktree)
+   1. git worktree add -b <name> <path> <sha-or-ref>
+                                                   — new branch from the
+                                                     branch's resolved sha
+                                                     (or the original ref
+                                                     name on lookup
+                                                     failure). The sha form
+                                                     works even when
+                                                     <branch> is checked
+                                                     out in another
+                                                     worktree.
    2. Clean up stale branch/directory and retry step 1
    3. git worktree add --detach <path>             — detached HEAD (last resort)
 
@@ -218,12 +224,33 @@
       (result/ok (str/trim (or (:out r) "")))
       (result/err :archive-no-branch (or (:err r) "could not resolve HEAD")))))
 
+(def ^:private detached-branch-prefix
+  "Prefix prepended to a `task-id` to derive the recovery branch name in
+   `ensure-named-branch!`. Skipped when the task-id already starts with
+   the prefix (the common path: persist-workspace! defaults task-id to
+   the environment-id, which is itself shaped like `task-<id>`)."
+  "task-")
+
+(defn- recovery-branch-name
+  "Branch name to materialize when recovering from a detached scratch.
+   Avoids a `task-task-` double-prefix when task-id already carries it."
+  [task-id]
+  (let [s (str task-id)]
+    (if (str/starts-with? s detached-branch-prefix)
+      s
+      (str detached-branch-prefix s))))
+
 (defn- ensure-named-branch!
   "If the worktree is in detached-HEAD state, create a real branch at HEAD
    so the bundle records `refs/heads/<name>` (not just bare HEAD).
 
    Returns result/ok with the branch name to use for bundling. Pass-through
    when the worktree is already on a named branch.
+
+   Uses `git checkout -B` (force-reset to HEAD) so recovery is idempotent
+   across reruns with the same task-id and across leftover local refs from
+   prior runs. The branch is task-namespaced internal infrastructure, not
+   a user-curated ref; resetting it is the right semantics.
 
    The bundle's ref namespace is what the harvest CLI fetches by name —
    without a real branch, harvest correctly diagnoses the bundle as the
@@ -232,13 +259,13 @@
   [worktree-path branch task-id]
   (if-not (detached? branch)
     (result/ok branch)
-    (let [name (str "task-" task-id)
-          r    (run-git "-C" worktree-path "checkout" "-b" name)]
+    (let [name (recovery-branch-name task-id)
+          r    (run-git "-C" worktree-path "checkout" "-B" name)]
       (if (zero? (:exit r))
         (result/ok name)
         (result/err :archive-detach-recovery-failed
                     (or (:err r)
-                        "could not create branch from detached HEAD"))))))
+                        "could not create or reset branch from detached HEAD"))))))
 
 (defn- dirty?
   [worktree-path]

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -43,15 +43,20 @@
     (let [add-args (atom nil)]
       (with-redefs [worktree/run-git
                     (fn [& args]
-                      (cond
-                        (= ["rev-parse" "main"] (drop 2 args))
-                        {:exit 0 :out "abc1234deadbeef\n" :err ""}
+                      (let [tail (drop 2 args)]
+                        (cond
+                          (= ["rev-parse" "main"] tail)
+                          {:exit 0 :out "abc1234deadbeef\n" :err ""}
 
-                        (some #{"worktree" "add"} args)
-                        (do (reset! add-args (vec args))
-                            {:exit 0 :out "" :err ""})
+                          ;; Tight match on `worktree add` specifically —
+                          ;; `(some #{"worktree" "add"} args)` would also
+                          ;; trigger on `worktree prune` from the cleanup
+                          ;; path and read the wrong call's args.
+                          (= ["worktree" "add"] (take 2 tail))
+                          (do (reset! add-args (vec args))
+                              {:exit 0 :out "" :err ""})
 
-                        :else {:exit 0 :out "" :err ""}))
+                          :else {:exit 0 :out "" :err ""})))
                     worktree/run-shell        (fn [& _] {:exit 0 :out "" :err ""})
                     worktree/ensure-directory (fn [_] nil)]
         (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")
@@ -147,9 +152,12 @@
                           (= ["rev-parse" "--abbrev-ref" "HEAD"] tail)
                           {:exit 0 :out "HEAD\n" :err ""}
 
-                          ;; ensure-named-branch! runs `checkout -b task-<id>`
+                          ;; ensure-named-branch! runs `checkout -B <name>`
+                          ;; (-B, not -b — idempotent across reruns, doesn't
+                          ;; fail if the branch name already exists from a
+                          ;; previous run with the same task-id)
                           (and (= "checkout" (first tail))
-                               (= "-b" (second tail)))
+                               (= "-B" (second tail)))
                           (do (reset! checkout-args (vec tail))
                               {:exit 0 :out "" :err ""})
 
@@ -176,8 +184,10 @@
                                            :task-id     "abc"
                                            :base-ref    "main"})]
           (is (result/ok? r))
-          ;; Real branch name was created
-          (is (= ["checkout" "-b" "task-abc"] @checkout-args))
+          ;; Real branch name was created via `checkout -B` (force-reset)
+          ;; rather than `-b` (create-only) so reruns with the same task-id
+          ;; don't fail on a leftover ref from an earlier run.
+          (is (= ["checkout" "-B" "task-abc"] @checkout-args))
           ;; Bundle uses the new branch name, not "HEAD"
           (is (= ["bundle" "create" "/tmp/test-archive/abc.bundle"
                   "task-abc" "--not" "main"]
@@ -185,6 +195,34 @@
           (is (= "task-abc" (get-in r [:data :branch]))
               "result reports the materialized branch name so callers know
                which ref name to fetch"))))))
+
+(deftest archive-bundle-recovery-branch-no-double-prefix-test
+  (testing "recovery branch name is not double-prefixed when task-id already
+            starts with `task-`"
+    ;; persist-workspace! defaults :task-id to environment-id, which the
+    ;; executor names `task-<8-char-uuid>`. Naively prepending `task-` here
+    ;; would yield `task-task-<id>` — verbose and hard to grep for in logs.
+    (let [checkout-args (atom nil)]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (let [tail (drop 2 args)]
+                        (cond
+                          (= ["rev-parse" "--abbrev-ref" "HEAD"] tail)
+                          {:exit 0 :out "HEAD\n" :err ""}
+
+                          (and (= "checkout" (first tail))
+                               (= "-B" (second tail)))
+                          (do (reset! checkout-args (vec tail))
+                              {:exit 0 :out "" :err ""})
+
+                          :else {:exit 0 :out "" :err ""})))
+                    worktree/ensure-archive-dir (fn [d] d)]
+        (worktree/archive-bundle! "/tmp/scratch"
+                                  {:archive-dir "/tmp/test-archive"
+                                   :task-id     "task-already-prefixed"
+                                   :base-ref    "main"})
+        (is (= ["checkout" "-B" "task-already-prefixed"] @checkout-args)
+            "task-id already starts with `task-` so the prefix is not added again")))))
 
 (deftest persist-workspace-clean-worktree-no-changes-test
   (testing "persist-workspace! reports no-changes when the scratch worktree is clean"

--- a/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
+++ b/components/dag-executor/test/ai/miniforge/dag_executor/protocols/impl/worktree_test.clj
@@ -37,6 +37,31 @@
         (is (result/ok? r))
         (is (= "/tmp/base/task-abc" (:worktree-path (:data r))))))))
 
+(deftest create-worktree-resolves-branch-to-sha-before-add-test
+  (testing "the parent branch is resolved to its sha before `worktree add -b` so the
+            command works even when that branch is already checked out elsewhere"
+    (let [add-args (atom nil)]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (cond
+                        (= ["rev-parse" "main"] (drop 2 args))
+                        {:exit 0 :out "abc1234deadbeef\n" :err ""}
+
+                        (some #{"worktree" "add"} args)
+                        (do (reset! add-args (vec args))
+                            {:exit 0 :out "" :err ""})
+
+                        :else {:exit 0 :out "" :err ""}))
+                    worktree/run-shell        (fn [& _] {:exit 0 :out "" :err ""})
+                    worktree/ensure-directory (fn [_] nil)]
+        (worktree/create-worktree "/tmp/base" "/tmp/repo" "task-abc" "main")
+        ;; Final positional arg of `worktree add` should be the resolved sha,
+        ;; not the literal branch name. Without this, `git worktree add -b
+        ;; new path main` fails when main is already checked out in another
+        ;; worktree (the common case for `bb dogfood` from a feature branch).
+        (is (= "abc1234deadbeef" (last @add-args))
+            "create-worktree must pass the resolved sha to `worktree add`, not the branch name")))))
+
 (deftest create-worktree-retries-after-cleanup-on-first-failure-test
   (testing "cleans up stale branch/dir and retries -b when first add fails"
     (let [add-b-calls (atom 0)]
@@ -101,6 +126,65 @@
 ;; ============================================================================
 ;; persist-workspace! / restore-workspace! (no-op for worktree)
 ;; ============================================================================
+
+(deftest archive-bundle-recovers-from-detached-head-test
+  (testing "detached-HEAD scratch gets a real branch before bundling so the
+            bundle records refs/heads/<name>, not bare HEAD"
+    ;; Regression: the dogfood of PR #732 caught this — when create-worktree
+    ;; falls back to `--detach`, archive-bundle! used to record the literal
+    ;; string \"HEAD\" as the branch name. The bundle then advertised only
+    ;; HEAD (legacy `base..HEAD` shape), which the harvest CLI correctly
+    ;; refused to fetch. ensure-named-branch! creates `task-<id>` at HEAD
+    ;; before any of the rest of the pipeline runs.
+    (let [checkout-args (atom nil)
+          bundle-args (atom nil)
+          status-calls (atom 0)]
+      (with-redefs [worktree/run-git
+                    (fn [& args]
+                      (let [tail (drop 2 args)]
+                        (cond
+                          ;; Scratch is detached — abbrev-ref returns the literal "HEAD"
+                          (= ["rev-parse" "--abbrev-ref" "HEAD"] tail)
+                          {:exit 0 :out "HEAD\n" :err ""}
+
+                          ;; ensure-named-branch! runs `checkout -b task-<id>`
+                          (and (= "checkout" (first tail))
+                               (= "-b" (second tail)))
+                          (do (reset! checkout-args (vec tail))
+                              {:exit 0 :out "" :err ""})
+
+                          (= ["status" "--porcelain"] tail)
+                          (do (swap! status-calls inc)
+                              (if (= 1 @status-calls)
+                                {:exit 0 :out " M file.clj\n" :err ""}
+                                {:exit 0 :out "" :err ""}))
+
+                          (= "rev-list" (first tail))
+                          {:exit 0 :out "1\n" :err ""}
+
+                          (= "rev-parse" (first tail))
+                          {:exit 0 :out "abc123\n" :err ""}
+
+                          (= "bundle" (first tail))
+                          (do (reset! bundle-args (vec tail))
+                              {:exit 0 :out "" :err ""})
+
+                          :else {:exit 0 :out "" :err ""})))
+                    worktree/ensure-archive-dir (fn [d] d)]
+        (let [r (worktree/archive-bundle! "/tmp/scratch"
+                                          {:archive-dir "/tmp/test-archive"
+                                           :task-id     "abc"
+                                           :base-ref    "main"})]
+          (is (result/ok? r))
+          ;; Real branch name was created
+          (is (= ["checkout" "-b" "task-abc"] @checkout-args))
+          ;; Bundle uses the new branch name, not "HEAD"
+          (is (= ["bundle" "create" "/tmp/test-archive/abc.bundle"
+                  "task-abc" "--not" "main"]
+                 @bundle-args))
+          (is (= "task-abc" (get-in r [:data :branch]))
+              "result reports the materialized branch name so callers know
+               which ref name to fetch"))))))
 
 (deftest persist-workspace-clean-worktree-no-changes-test
   (testing "persist-workspace! reports no-changes when the scratch worktree is clean"


### PR DESCRIPTION
## Summary

Two related fixes that together prevent the worst-case persist outcome (a bundle that advertises only bare HEAD instead of `refs/heads/<branch>`). Surfaced by the dogfood of [#732](https://github.com/miniforge-ai/miniforge/pull/732) (per-task-base-chaining spec) within minutes — the runtime hit both cases and the harvest CLI correctly diagnosed the result as a legacy-shape bundle.

### Why the dogfood hit this

`bb dogfood` runs from a feature branch (e.g. `chris/per-task-base-chaining-spec`). The runner passes that branch as the `:branch` opt to `create-worktree`. `git worktree add -b new-task-X path <branch>` then refuses with `fatal: '<branch>' is already checked out at <other-worktree>` because the running worktree IS that other worktree. Both retry attempts fail; the third path `--detach`es. Persist then sees `git rev-parse --abbrev-ref HEAD` return the literal string `"HEAD"` and uses that as the branch name — bundle records only HEAD.

## Changes

### 1. `create-worktree` resolves branch → sha before `worktree add -b`

`git worktree add -b new path <sha>` works regardless of which branches are checked out where; only `git worktree add -b new path <branch-name>` triggers the refusal. New private helper `resolve-branch-sha` does the rev-parse and returns the sha; nil falls through to the literal branch name (preserves existing behavior on lookup failure).

### 2. `archive-bundle!` materializes a branch when scratch is detached

New helpers `detached-head-sentinel`, `detached?`, and `ensure-named-branch!`. `ensure-named-branch!` sits between `current-branch` and the rest of the pipeline: when it sees the literal `"HEAD"`, it runs `git checkout -b task-<task-id>` to create a real branch at HEAD before bundling. The bundle then records `refs/heads/task-<task-id>` and harvest round-trips cleanly.

Defensive — works whether the detach came from `create-worktree`'s --detach fallback (now rare with fix #1) or any other source.

## Test plan

- [x] `create-worktree-resolves-branch-to-sha-before-add-test` — asserts the resolved sha (not the branch name) is the final positional arg of `worktree add -b`
- [x] `archive-bundle-recovers-from-detached-head-test` — full pipeline against a stubbed detached scratch; asserts `checkout -b task-abc` ran, the bundle command uses `task-abc` not `HEAD`, the result reports the materialized branch
- [x] All 14 worktree tests pass (was 12 before this PR)
- [x] `bb pre-commit` passes (479 assertions across 6 changed bricks)
- [x] Real-git smoke test (manual): detached scratch → bundle has `refs/heads/task-abc` ✓; create-worktree against an already-checked-out parent branch → new worktree on named `task-zzz`, not detached ✓

## Followups

The harvest CLI's "advertises no refs/heads/* — likely the legacy `base..HEAD` shape" diagnostic is now a should-never-fire case for newly-created bundles. Worth keeping the diagnostic for backward compat with bundles that pre-date this PR — they still exist on disk for many users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)