### PR TITLE
strata: clean up 4 small-component violations (batch 3)

### DIFF
--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj
@@ -69,7 +69,8 @@
       (git-remote-url ".")))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Sandbox preparation — composes Layer 1.
+;; Sandbox preparation — composes Layer 1 (`infer-repo-url`) plus
+;; Layer 0 (`infer-branch`).
 
 (defn prepare-sandbox [spec enriched-spec]
   (let [prep-result (dag/prepare-docker-executor! {:image-type :clojure})]

--- a/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj
+++ b/bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj
@@ -17,7 +17,14 @@
 ;; limitations under the License.
 
 (ns ai.miniforge.cli.workflow-runner.sandbox
-  "Docker sandbox setup for isolated workflow execution."
+  "Docker sandbox setup for isolated workflow execution.
+
+   Stratification (intra-namespace):
+   Layer 0 — `sandbox-release-fn`, `git-remote-url`, `infer-branch`
+             (no in-ns deps).
+   Layer 1 — `infer-repo-url` (composes `git-remote-url`).
+   Layer 2 — `prepare-sandbox` (composes Layer 1).
+   Layer 3 — `setup-sandbox-context` (composes Layer 2)."
   (:require
    [clojure.string :as str]
    [babashka.process :as p]
@@ -25,7 +32,7 @@
    [ai.miniforge.dag-executor.interface :as dag]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Sandbox helpers
+;; No in-namespace dependencies.
 
 (defn sandbox-release-fn [executor environment-id]
   (fn []
@@ -43,6 +50,14 @@
         (str/trim (:out result))))
     (catch Exception _ nil)))
 
+(defn infer-branch [spec enriched-spec]
+  (or (:spec/branch spec)
+      (get-in enriched-spec [:spec/context :git-branch])
+      "main"))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0.
+
 (defn infer-repo-url [spec enriched-spec]
   (or (:spec/repo-url spec)
       (get-in enriched-spec [:spec/context :repo-url])
@@ -53,13 +68,8 @@
       ;; Final fallback: cwd's repo
       (git-remote-url ".")))
 
-(defn infer-branch [spec enriched-spec]
-  (or (:spec/branch spec)
-      (get-in enriched-spec [:spec/context :git-branch])
-      "main"))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Sandbox preparation
+;------------------------------------------------------------------------------ Layer 2
+;; Sandbox preparation — composes Layer 1.
 
 (defn prepare-sandbox [spec enriched-spec]
   (let [prep-result (dag/prepare-docker-executor! {:image-type :clojure})]
@@ -80,8 +90,8 @@
                      :environment-id env-id
                      :sandbox-workdir "/workspace"})))))))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Sandbox context setup
+;------------------------------------------------------------------------------ Layer 3
+;; Composes Layer 2.
 
 (defn setup-sandbox-context [base-context sandbox? spec enriched-spec quiet]
   (if-not sandbox?

--- a/bases/etl/src/ai/miniforge/etl/main.clj
+++ b/bases/etl/src/ai/miniforge/etl/main.clj
@@ -19,7 +19,14 @@
 (ns ai.miniforge.etl.main
   "JVM entry point for `mf etl` subcommands. Shelled out to from the
    Babashka CLI because the concrete source connectors depend on hato
-   and Apache POI, which aren't BB-compatible."
+   and Apache POI, which aren't BB-compatible.
+
+   Stratification (intra-namespace):
+   Layer 0 — pure helpers with no in-ns deps.
+   Layer 1 — `emit-result!` (composes `stringify-instants`).
+   Layer 2 — subcommand handlers (compose Layer 1).
+   Layer 3 — `-main` (inlines the dispatch table to keep this file at
+             4 strata)."
   {:miniforge/runtime :jvm-only}
   (:require
    [ai.miniforge.etl.messages :as msg]
@@ -34,7 +41,7 @@
   (:gen-class))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Output formatting
+;; No in-namespace dependencies.
 
 (defn- stringify-instants
   "Walk `v` converting every `java.time.Instant` to its ISO-8601 string
@@ -58,6 +65,13 @@
           (when-let [error (:error result)]
             (println (msg/t :run/error {:value error})))))))
 
+(defn- exit! [code] (System/exit (or code 0)))
+
+(defn- get-opts [m] (if (contains? m :opts) (:opts m) m))
+
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0.
+
 (defn- emit-result!
   "Write the pipeline-runner result to `out-path`. Writes JSON when the
    path ends in `.json`; EDN otherwise. Instants are stringified first
@@ -70,12 +84,8 @@
     (spit out-path body)
     (println (msg/t :run/wrote {:path out-path}))))
 
-(defn- exit! [code] (System/exit (or code 0)))
-
-(defn- get-opts [m] (if (contains? m :opts) (:opts m) m))
-
-;------------------------------------------------------------------------------ Layer 1
-;; Subcommand handlers
+;------------------------------------------------------------------------------ Layer 2
+;; Subcommand handlers — compose Layer 1.
 
 (defn- run-cmd
   [m]
@@ -134,15 +144,14 @@
     (println (msg/t :help/connector-entry {:value t})))
   (exit! 2))
 
-;------------------------------------------------------------------------------ Layer 2
-;; Entry point
-
-(def dispatch-table
-  [{:cmds ["run"]      :fn run-cmd      :args->opts [:pipeline]}
-   {:cmds ["list"]     :fn list-cmd     :args->opts [:path]}
-   {:cmds ["validate"] :fn validate-cmd :args->opts [:pipeline]}
-   {:cmds []           :fn help-cmd}])
+;------------------------------------------------------------------------------ Layer 3
+;; Entry point — composes Layer 2.
 
 (defn -main
   [& args]
-  (cli/dispatch dispatch-table args))
+  (cli/dispatch
+   [{:cmds ["run"]      :fn run-cmd      :args->opts [:pipeline]}
+    {:cmds ["list"]     :fn list-cmd     :args->opts [:path]}
+    {:cmds ["validate"] :fn validate-cmd :args->opts [:pipeline]}
+    {:cmds []           :fn help-cmd}]
+   args))

--- a/bases/etl/src/ai/miniforge/etl/main.clj
+++ b/bases/etl/src/ai/miniforge/etl/main.clj
@@ -22,7 +22,9 @@
    and Apache POI, which aren't BB-compatible.
 
    Stratification (intra-namespace):
-   Layer 0 — pure helpers with no in-ns deps.
+   Layer 0 — helpers with no in-namespace deps. Mix of pure and
+             side-effecting (`stringify-instants` is pure;
+             `print-run-summary!` and `exit!` write to stdout / exit).
    Layer 1 — `emit-result!` (composes `stringify-instants`).
    Layer 2 — subcommand handlers (compose Layer 1).
    Layer 3 — `-main` (inlines the dispatch table to keep this file at

--- a/components/bb-config/src/ai/miniforge/bb_config/core.clj
+++ b/components/bb-config/src/ai/miniforge/bb_config/core.clj
@@ -19,8 +19,10 @@
 (ns ai.miniforge.bb-config.core
   "Config loader implementation.
 
-   Layer 0: pure EDN reader — no filesystem root assumed.
-   Layer 1: repo-rooted default path + map slicing."
+   Stratification (intra-namespace):
+   Layer 0 — `read-edn` and `default-path` (no in-ns deps).
+   Layer 1 — `load` (composes Layer 0).
+   Layer 2 — `get` (composes Layer 0 + Layer 1)."
   (:refer-clojure :exclude [load get])
   (:require [ai.miniforge.bb-paths.interface :as paths]
             [babashka.fs :as fs]
@@ -29,7 +31,7 @@
 (def ^:const default-filename "bb-tasks.edn")
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Pure EDN reader
+;; No in-namespace dependencies.
 
 (defn read-edn
   "Parse `path` as EDN. Returns `{}` if the file is absent."
@@ -38,18 +40,21 @@
     (edn/read-string (slurp path))
     {}))
 
-;------------------------------------------------------------------------------ Layer 1
-;; Repo-rooted loader + slice
-
 (defn default-path
   "Absolute path to `bb-tasks.edn` under the current repo root."
   []
   (str (paths/repo-root) "/" default-filename))
 
+;------------------------------------------------------------------------------ Layer 1
+;; Composes Layer 0.
+
 (defn load
   "Load the whole config map."
   ([] (read-edn (default-path)))
   ([path] (read-edn path)))
+
+;------------------------------------------------------------------------------ Layer 2
+;; Composes Layer 0 (`default-path`) + Layer 1 (`load`).
 
 (defn get
   "Return the config slice for `task-key`."

--- a/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
+++ b/components/connector-linter/src/ai/miniforge/connector_linter/runner.clj
@@ -5,15 +5,18 @@
 (ns ai.miniforge.connector-linter.runner
   "Run linter subprocesses and parse output via ETL mappings.
 
-   Layer 0: Subprocess execution
-   Layer 1: Run a single linter
-   Layer 2: Run all linters for detected technologies"
+   Stratification (intra-namespace):
+   Layer 0 — `linter-available?`, `run-subprocess`, `lintable-tech`
+             (no in-ns deps).
+   Layer 1 — `run-linter` (composes Layer 0).
+   Layer 2 — `run-all`, `run-fixes` (public orchestration; compose
+             Layer 1)."
   (:require
    [ai.miniforge.connector-linter.etl :as etl]
    [babashka.process :as process]))
 
 ;------------------------------------------------------------------------------ Layer 0
-;; Subprocess
+;; No in-namespace dependencies.
 
 (defn linter-available?
   "Check if a linter CLI is available on PATH."
@@ -35,8 +38,14 @@
     (catch Exception e
       {:exit -1 :out "" :err (.getMessage e)})))
 
+(defn- lintable-tech
+  "True when a fingerprint has a linter and is in the detected set."
+  [detected-techs fingerprint]
+  (and (:tech/linter fingerprint)
+       (contains? detected-techs (:tech/id fingerprint))))
+
 ;------------------------------------------------------------------------------ Layer 1
-;; Single linter execution
+;; Composes Layer 0.
 
 (defn run-linter
   "Run a single linter and parse output via ETL mapping.
@@ -60,13 +69,8 @@
          :duration-ms (- end-ms start-ms)}))))
 
 ;------------------------------------------------------------------------------ Layer 2
-;; Multi-linter orchestration
-
-(defn- lintable-tech
-  "True when a fingerprint has a linter and is in the detected set."
-  [detected-techs fingerprint]
-  (and (:tech/linter fingerprint)
-       (contains? detected-techs (:tech/id fingerprint))))
+;; Public orchestration — composes Layer 1 (`run-linter`) + Layer 0
+;; helpers (`lintable-tech`, `linter-available?`, `run-subprocess`).
 
 (defn run-all
   "Run linters for all detected technologies.


### PR DESCRIPTION
## Summary

Third cleanup batch against the baseline in #733.

| File | Violations | Top fix |
|---|---:|---|
| `bases/cli/src/ai/miniforge/cli/workflow_runner/sandbox.clj` | 2 | `infer-repo-url` lifted to L1; chain ends at L3 |
| `bases/etl/src/ai/miniforge/etl/main.clj` | 2 | `emit-result!` lifted to L1; `dispatch-table` inlined into `-main` to keep the file at 4 strata |
| `components/bb-config/src/ai/miniforge/bb_config/core.clj` | 3 | `default-path` to L0; `load` to L1; `get` to L2 |
| `components/connector-linter/src/ai/miniforge/connector_linter/runner.clj` | 2 | `lintable-tech` to L0; `run-all`/`run-fixes` at L2 |

## Test plan

- [x] `bb tools/strata_audit.bb` reports zero violations across the touched paths.
- [x] `bb pre-commit` green.
- [ ] CI green.

## Notes

`lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/lsp/process.clj` had two within-namespace violations and a clean fix, but pre-commit triggered the MCP-bridge subprocess integration tests which fail on this host (`ProcessBuilder.java:447`) regardless of my change. I dropped it from this batch and will ship it in a separate PR after the integration-test stability is investigated.