### PR TITLE
tooling(strata): skip rich-comment blocks via :skip-comments

### DIFF
--- a/docs/standards/strata-violations-baseline.md
+++ b/docs/standards/strata-violations-baseline.md
@@ -1,7 +1,11 @@
 # Stratified-Design Violations — Baseline (2026-05-01, revised)
 
-Audit of `components/**/src` and `bases/**/src` for within-namespace stratified-design violations. Run via `bb
-tools/strata_audit.bb`.
+Audit of `components/**/src` and `bases/**/src` for within-namespace
+stratified-design violations. Run via:
+
+```bash
+bb tools/strata_audit.bb
+```
 
 ## Summary
 

--- a/docs/standards/strata-violations-baseline.md
+++ b/docs/standards/strata-violations-baseline.md
@@ -1,12 +1,12 @@
-# Stratified-Design Violations — Baseline (2026-05-01)
+# Stratified-Design Violations — Baseline (2026-05-01, revised)
 
 Audit of `components/**/src` and `bases/**/src` for within-namespace stratified-design violations. Run via `bb
 tools/strata_audit.bb`.
 
 ## Summary
 
-- **Files audited (with at least one violation):** 422
-- **Total violations:** 4196
+- **Files audited (with at least one violation):** 394
+- **Total violations:** 3861
 - **Components affected:** 83
 
 ## What counts as a violation?
@@ -18,86 +18,89 @@ rejected.
 Layer assignment is determined by the most recent `;-- Layer N` comment marker preceding the function definition. The
 audit uses `clj-kondo` analysis to build the call graph.
 
+Var-definitions and var-usages inside `(comment …)` rich-comment blocks are excluded via `clj-kondo --config
+{:skip-comments true}`. (Earlier baseline counted REPL experiments as production code.)
+
 ## By component (descending)
 
 | Component | Files | Violations |
 |---|---:|---:|
-| `tui-views` | 35 | 701 |
-| `workflow` | 31 | 348 |
+| `tui-views` | 34 | 688 |
+| `workflow` | 29 | 317 |
 | `web-dashboard` | 20 | 297 |
 | `cli` | 34 | 228 |
-| `pr-lifecycle` | 18 | 195 |
-| `policy-pack` | 16 | 187 |
-| `agent` | 17 | 169 |
-| `loop` | 7 | 123 |
-| `compliance-scanner` | 7 | 108 |
-| `supervisory-state` | 5 | 81 |
-| `lsp-mcp-bridge` | 9 | 79 |
+| `policy-pack` | 16 | 179 |
+| `pr-lifecycle` | 17 | 173 |
+| `agent` | 17 | 156 |
+| `compliance-scanner` | 7 | 101 |
+| `supervisory-state` | 4 | 80 |
+| `loop` | 5 | 78 |
+| `lsp-mcp-bridge` | 9 | 78 |
 | `phase-deployment` | 12 | 78 |
-| `dag-executor` | 7 | 77 |
 | `config` | 4 | 77 |
 | `pr-sync` | 2 | 72 |
 | `failure-classifier` | 2 | 69 |
-| `knowledge` | 8 | 64 |
 | `llm` | 4 | 62 |
-| `reliability` | 6 | 61 |
-| `repo-index` | 6 | 53 |
-| `evidence-bundle` | 9 | 53 |
-| `gate` | 9 | 45 |
+| `reliability` | 6 | 55 |
+| `knowledge` | 7 | 52 |
+| `repo-index` | 6 | 47 |
 | `phase-software-factory` | 5 | 45 |
-| `tui-engine` | 8 | 44 |
-| `event-stream` | 8 | 44 |
+| `gate` | 9 | 44 |
 | `phase` | 7 | 44 |
 | `mcp-context-server` | 3 | 43 |
-| `operator` | 5 | 42 |
-| `decision` | 3 | 42 |
-| `pr-train` | 7 | 38 |
+| `evidence-bundle` | 8 | 42 |
+| `operator` | 5 | 41 |
+| `tui-engine` | 7 | 39 |
 | `self-healing` | 3 | 37 |
+| `decision` | 2 | 36 |
 | `diagnosis` | 2 | 34 |
-| `schema` | 3 | 28 |
+| `event-stream` | 7 | 32 |
+| `dag-executor` | 7 | 30 |
+| `pr-train` | 4 | 26 |
 | `workflow-security-compliance` | 2 | 25 |
 | `pipeline-pack` | 2 | 24 |
-| `heuristic` | 4 | 21 |
 | `response` | 4 | 21 |
 | `release-executor` | 4 | 20 |
 | `semantic-analyzer` | 1 | 20 |
-| `repo-dag` | 3 | 20 |
+| `heuristic` | 3 | 20 |
 | `tool-registry` | 7 | 19 |
 | `spec-parser` | 2 | 19 |
-| `logging` | 3 | 18 |
+| `schema` | 2 | 18 |
 | `bb-platform` | 1 | 18 |
-| `control-plane` | 6 | 18 |
-| `reporting` | 2 | 16 |
 | `bb-test-runner` | 1 | 16 |
 | `content-hash` | 1 | 15 |
-| `orchestrator` | 2 | 15 |
-| `training-capture` | 3 | 15 |
-| `fsm` | 2 | 14 |
-| `context-pack` | 4 | 13 |
+| `repo-dag` | 2 | 15 |
+| `logging` | 3 | 14 |
 | `connector-jira` | 2 | 13 |
 | `metric-registry` | 1 | 13 |
+| `control-plane` | 5 | 13 |
+| `training-capture` | 2 | 13 |
 | `workflow-resume` | 1 | 12 |
+| `reporting` | 1 | 11 |
 | `gate-classification` | 3 | 10 |
-| `response-chain` | 2 | 10 |
 | `connector-pipeline-output` | 2 | 9 |
-| `improvement` | 3 | 9 |
-| `boundary` | 2 | 9 |
+| `improvement` | 2 | 8 |
 | `connector-http` | 2 | 8 |
-| `tool` | 2 | 8 |
-| `artifact` | 2 | 7 |
-| `adapter-claude-code` | 2 | 7 |
-| `task` | 2 | 7 |
+| `orchestrator` | 1 | 7 |
+| `response-chain` | 1 | 7 |
+| `context-pack` | 3 | 6 |
 | `connector-gitlab` | 1 | 6 |
 | `agent-runtime` | 2 | 6 |
+| `adapter-claude-code` | 2 | 6 |
 | `connector-github` | 1 | 6 |
+| `task` | 2 | 6 |
 | `pr-scoring` | 1 | 6 |
+| `artifact` | 1 | 5 |
 | `bb-data-plane-http` | 1 | 5 |
-| `policy` | 2 | 5 |
+| `boundary` | 2 | 5 |
+| `tool` | 2 | 5 |
 | `algorithms` | 1 | 5 |
+| `fsm` | 1 | 4 |
 | `connector-sarif` | 1 | 3 |
 | `connector` | 1 | 3 |
 | `bb-config` | 1 | 3 |
 | `connector-linter` | 1 | 2 |
+| `policy` | 1 | 2 |
 | `bb-proc` | 1 | 2 |
 | `etl` | 1 | 2 |
 | `bb-paths` | 1 | 1 |
@@ -114,46 +117,43 @@ audit uses `clj-kondo` analysis to build the call graph.
 | `components/tui-views/src/ai/miniforge/tui_views/view/project/trees.clj` | 92 |
 | `components/tui-views/src/ai/miniforge/tui_views/update.clj` | 85 |
 | `components/tui-views/src/ai/miniforge/tui_views/update/events.clj` | 79 |
-| `components/workflow/src/ai/miniforge/workflow/fsm.clj` | 78 |
-| `components/tui-views/src/ai/miniforge/tui_views/persistence.clj` | 75 |
+| `components/tui-views/src/ai/miniforge/tui_views/persistence.clj` | 73 |
+| `components/workflow/src/ai/miniforge/workflow/fsm.clj` | 73 |
 | `components/config/src/ai/miniforge/config/user.clj` | 68 |
 | `components/pr-sync/src/ai/miniforge/pr_sync/core.clj` | 64 |
 | `components/tui-views/src/ai/miniforge/tui_views/view/project/helpers.clj` | 59 |
 | `components/llm/src/ai/miniforge/llm/protocols/impl/llm_client.clj` | 51 |
 | `components/workflow/src/ai/miniforge/workflow/dag_orchestrator.clj` | 46 |
-| `components/loop/src/ai/miniforge/loop/inner.clj` | 43 |
-| `components/agent/src/ai/miniforge/agent/implementer.clj` | 40 |
 | `components/failure-classifier/src/ai/miniforge/failure_classifier/taxonomy.clj` | 40 |
+| `components/agent/src/ai/miniforge/agent/implementer.clj` | 39 |
 | `components/supervisory-state/src/ai/miniforge/supervisory_state/accumulator.clj` | 37 |
+| `components/loop/src/ai/miniforge/loop/inner.clj` | 36 |
 | `bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/tasks.clj` | 35 |
-| `components/tui-views/src/ai/miniforge/tui_views/subscription.clj` | 35 |
 | `components/web-dashboard/src/ai/miniforge/web_dashboard/state/workflows.clj` | 34 |
-| `components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj` | 31 |
+| `components/tui-views/src/ai/miniforge/tui_views/subscription.clj` | 32 |
+| `components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj` | 30 |
 | `components/failure-classifier/src/ai/miniforge/failure_classifier/classifier.clj` | 29 |
 | `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/fsm.clj` | 29 |
-| `components/tui-views/src/ai/miniforge/tui_views/interface.clj` | 29 |
 | `components/web-dashboard/src/ai/miniforge/web_dashboard/views.clj` | 29 |
-| `components/loop/src/ai/miniforge/loop/outer.clj` | 28 |
 | `components/supervisory-state/src/ai/miniforge/supervisory_state/schema.clj` | 28 |
+| `components/tui-views/src/ai/miniforge/tui_views/interface.clj` | 27 |
 | `components/workflow/src/ai/miniforge/workflow/execution.clj` | 27 |
 | `components/policy-pack/src/ai/miniforge/policy_pack/mdc_compiler.clj` | 26 |
 | `components/tui-views/src/ai/miniforge/tui_views/update/command.clj` | 26 |
 | `components/operator/src/ai/miniforge/operator/intervention.clj` | 25 |
 | `components/tui-views/src/ai/miniforge/tui_views/update/navigation.clj` | 25 |
-| `components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj` | 24 |
 | `components/policy-pack/src/ai/miniforge/policy_pack/schema.clj` | 24 |
 | `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/classifier.clj` | 24 |
 | `components/workflow/src/ai/miniforge/workflow/checkpoint_store.clj` | 24 |
 | `components/compliance-scanner/src/ai/miniforge/compliance_scanner/execute.clj` | 23 |
-| `components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj` | 23 |
 | `components/web-dashboard/src/ai/miniforge/web_dashboard/views/workflows.clj` | 23 |
 | `bases/cli/src/ai/miniforge/cli/workflow_runner.clj` | 22 |
+| `components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj` | 22 |
+| `components/policy-pack/src/ai/miniforge/policy_pack/knowledge_safety.clj` | 22 |
 | `bases/cli/src/ai/miniforge/cli/tui.clj` | 21 |
 | `bases/mcp-context-server/src/ai/miniforge/mcp_context_server/context_cache.clj` | 21 |
-| `components/dag-executor/src/ai/miniforge/dag_executor/scheduler.clj` | 21 |
 | `components/diagnosis/src/ai/miniforge/diagnosis/correlator.clj` | 21 |
 | `components/phase-software-factory/src/ai/miniforge/phase_software_factory/implement.clj` | 21 |
-| `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_budget.clj` | 21 |
 | `components/pr-lifecycle/src/ai/miniforge/pr_lifecycle/monitor_loop.clj` | 21 |
 | `components/tui-views/src/ai/miniforge/tui_views/update/filter.clj` | 21 |
 | `components/tui-views/src/ai/miniforge/tui_views/update/mode.clj` | 21 |
@@ -161,5 +161,4 @@ audit uses `clj-kondo` analysis to build the call graph.
 | `bases/lsp-mcp-bridge/src/ai/miniforge/lsp_mcp_bridge/installer.clj` | 20 |
 | `components/decision/src/ai/miniforge/decision/spec.clj` | 20 |
 | `components/pipeline-pack/src/ai/miniforge/pipeline_pack/loader.clj` | 20 |
-| `components/policy-pack/src/ai/miniforge/policy_pack/loader.clj` | 20 |
 | `components/semantic-analyzer/src/ai/miniforge/semantic_analyzer/core.clj` | 20 |

--- a/tools/strata_audit.bb
+++ b/tools/strata_audit.bb
@@ -15,10 +15,19 @@
 ;; ---------------------------------------------------------------- Layer 0
 ;; pure helpers, no in-namespace dependencies
 
-(def layer-marker-pattern #"(?i);+\s*(?:-+\s*)?Layer\s+(\d+)")
+;; The miniforge convention writes layer headers as
+;;   `;------------------------------------------------------------------------------ Layer N`
+;; or  `;; --- Layer N ---`. Both have at least one dash separating the
+;; comment marker from the word `Layer`. The regex requires that — a
+;; bare `;; Layer 1` mention in prose or a docstring will not be treated
+;; as a section marker.
+(def layer-marker-pattern #"(?i);+\s*-+\s*Layer\s+(\d+)\b")
 
 (defn parse-layer-markers
-  "Return [[line layer] …] for every `;-- Layer N` comment in `lines`."
+  "Return [[line layer] …] for every `;------ Layer N` section header
+   in `lines`. Match requires at least one dash between the comment
+   marker and the word `Layer` so prose and docstring mentions are not
+   picked up."
   [lines]
   (->> lines
        (map-indexed vector)
@@ -35,8 +44,17 @@
        last
        second))
 
+(defn- normalize-path
+  "Return `path` with platform path separators flipped to forward
+   slashes. Lets path-segment substring tests work uniformly on Unix
+   and Windows."
+  [^String path]
+  (str/replace path "\\" "/"))
+
 (defn read-clj-files
-  "Walk `roots` and return every .clj/.cljc file path under */src trees."
+  "Walk `roots` and return every .clj/.cljc file path under */src trees.
+   Path comparisons use forward slashes so the filter is portable to
+   Windows (where `File/getPath` returns backslash-separated paths)."
   [roots]
   (->> roots
        (mapcat (fn [r] (file-seq (io/file r))))
@@ -48,30 +66,94 @@
                         (not (str/ends-with? n "_test.clj"))
                         (not (str/ends-with? n "_test.cljc"))))))
        (filter (fn [f]
-                 (let [p (.getPath ^java.io.File f)]
-                   (str/includes? p "/src/"))))
+                 (str/includes? (normalize-path (.getPath ^java.io.File f))
+                                "/src/")))
        (map #(.getPath ^java.io.File %))))
 
 ;; ---------------------------------------------------------------- Layer 1
 ;; clj-kondo wrapper — depends only on Layer 0 helpers and built-ins
 
-(defn analyse-file
-  "Run clj-kondo on `path` and return the parsed `:analysis` map (or nil
-   if kondo blew up).
+(defn- warn-analysis-failure!
+  "Emit an explicit warning when clj-kondo analysis could not be
+   produced. Goes to stderr so it doesn't pollute the EDN report on
+   stdout."
+  [paths message]
+  (binding [*out* *err*]
+    (println (str "WARNING: strata-audit could not analyse "
+                  (count paths) " file(s): " message))
+    (doseq [p (take 5 paths)]
+      (println (str "  - " p)))
+    (when (> (count paths) 5)
+      (println (str "  … and " (- (count paths) 5) " more")))))
+
+(defn analyse-paths
+  "Run clj-kondo once over every path in `paths` and return the parsed
+   analysis map (`:namespace-definitions`/`:var-definitions`/
+   `:var-usages`).
+
+   Bundles every file into a single kondo invocation rather than one
+   process per file — typical 100×+ speed-up on a repo of this size.
 
    Uses `:skip-comments true` so var-definitions and var-usages inside
-   `(comment …)` rich-comment blocks are excluded from the call graph.
+   `(comment …)` rich-comment blocks are excluded from the call graph;
    REPL-only experiments under `;;-- Rich Comment` are otherwise
-   reported as production violations."
-  [path]
+   reported as production violations.
+
+   On failure, emits a warning to stderr (so the EDN report stays
+   parseable) and returns nil."
+  [paths]
   (try
-    (let [{:keys [out exit]}
-          (p/sh ["clj-kondo" "--lint" path
-                 "--config" "{:output {:analysis true :format :edn} :skip-comments true}"]
-                {:out :string})]
-      (when (and (zero? exit) (not (str/blank? out)))
-        (-> out edn/read-string :analysis)))
-    (catch Exception _ nil)))
+    (let [{:keys [out exit err]}
+          (p/sh (into ["clj-kondo"
+                       "--config"
+                       "{:output {:analysis true :format :edn} :skip-comments true}"
+                       "--lint"]
+                      paths)
+                {:out :string :err :string})]
+      (cond
+        (str/blank? out)
+        (do (warn-analysis-failure!
+             paths
+             (str "kondo produced no analysis output (exit " exit
+                  (when-not (str/blank? err)
+                    (str " — " (str/trim err)))
+                  ")"))
+            nil)
+
+        ;; kondo exits 2 when it found lint warnings/errors; exit 3 when
+        ;; the analysis itself crashed. We trust the analysis output as
+        ;; long as there is some.
+        (#{0 2 3} exit)
+        (-> out edn/read-string :analysis)
+
+        :else
+        (do (warn-analysis-failure!
+             paths
+             (str "kondo exited with status " exit
+                  (when-not (str/blank? err)
+                    (str " — " (str/trim err)))))
+            nil)))
+    (catch Exception e
+      (warn-analysis-failure! paths (.getMessage e))
+      nil)))
+
+(defn- index-by-filename
+  "Group items in `analysis-vec` by their `:filename` (relative path
+   string from kondo)."
+  [analysis-vec]
+  (group-by :filename analysis-vec))
+
+(defn file-analysis
+  "Carve a per-file slice out of the bulk analysis map. Returns a map
+   shaped like the single-file `(p/sh \"clj-kondo …\")` output for the
+   downstream `file-violations` consumer."
+  [bulk path]
+  {:namespace-definitions (get (index-by-filename (:namespace-definitions bulk))
+                               path [])
+   :var-definitions       (get (index-by-filename (:var-definitions bulk))
+                               path [])
+   :var-usages            (get (index-by-filename (:var-usages bulk))
+                               path [])})
 
 (defn file-violations
   "Compute the violations for a single file, given its analysis map and
@@ -110,16 +192,18 @@
 
 (defn audit-tree
   [roots]
-  (->> (read-clj-files roots)
-       (sort)
-       (keep (fn [path]
-               (when-let [analysis (analyse-file path)]
-                 (let [lines (str/split-lines (slurp path))
-                       violations (file-violations path analysis lines)]
-                   (when (seq violations)
-                     {:file path
-                      :violations violations
-                      :count (count violations)})))))))
+  (let [paths (vec (sort (read-clj-files roots)))
+        bulk  (analyse-paths paths)]
+    (->> paths
+         (keep (fn [path]
+                 (let [analysis (file-analysis bulk path)]
+                   (when (seq (:namespace-definitions analysis))
+                     (let [lines (str/split-lines (slurp path))
+                           violations (file-violations path analysis lines)]
+                       (when (seq violations)
+                         {:file path
+                          :violations violations
+                          :count (count violations)})))))))))
 
 (defn rank-by-violations
   [reports]

--- a/tools/strata_audit.bb
+++ b/tools/strata_audit.bb
@@ -57,12 +57,17 @@
 
 (defn analyse-file
   "Run clj-kondo on `path` and return the parsed `:analysis` map (or nil
-   if kondo blew up)."
+   if kondo blew up).
+
+   Uses `:skip-comments true` so var-definitions and var-usages inside
+   `(comment …)` rich-comment blocks are excluded from the call graph.
+   REPL-only experiments under `;;-- Rich Comment` are otherwise
+   reported as production violations."
   [path]
   (try
     (let [{:keys [out exit]}
           (p/sh ["clj-kondo" "--lint" path
-                 "--config" "{:output {:analysis true :format :edn}}"]
+                 "--config" "{:output {:analysis true :format :edn} :skip-comments true}"]
                 {:out :string})]
       (when (and (zero? exit) (not (str/blank? out)))
         (-> out edn/read-string :analysis)))


### PR DESCRIPTION
## Summary

Stacked on top of #733 — fixes a false-positive class in the audit script.

The earlier baseline counted var-definitions and var-usages from `(comment …)` rich-comment blocks as production code. That produced spurious violations like `store(L2) → create-datalevin-store(L2)` in `components/artifact/src/ai/miniforge/artifact/datalevin_store.clj` — but both `def store` references actually live in the `(comment …)` REPL playground at the bottom of the file; the surrounding production code is clean.

This PR adds `:skip-comments true` to the kondo analysis config so those blocks are excluded.

## Baseline change

| | Files | Violations |
|---|---:|---:|
| Old (#733) | 422 | 4196 |
| New (this PR) | 394 | 3861 |
| Δ | -28 | -335 |

## Test plan

- [x] `bb tools/strata_audit.bb components/artifact` no longer reports `datalevin_store.clj` (it was previously flagged with 2 false-positive violations, now 0).
- [x] `bb pre-commit` green.
- [ ] CI green.

## Note

Stacked on `chris/strata-audit` (#733) so the diff stays narrow. Will rebase once #733 merges.