### PR TITLE
fix: [810] Enforce Miniforge.ai header and copyright on published content compliance pass

### DIFF
--- a/PR-552.md
+++ b/PR-552.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 ## Summary
 
 Prototypes the mixed mechanical/semantic compliance pipeline from #552. Three new Polylith components:

--- a/PR-552.md
+++ b/PR-552.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 ## Summary
 
 Prototypes the mixed mechanical/semantic compliance pipeline from #552. Three new Polylith components:

--- a/docs/archive/pr-logs/2026-04-10-fix-210-nil-safe-map-access.md
+++ b/docs/archive/pr-logs/2026-04-10-fix-210-nil-safe-map-access.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix: [210] Nil-safe map access compliance pass
 
 **Branch:** `fix/compliance-210-nil-safe-map-access`

--- a/docs/archive/pr-logs/2026-04-10-fix-210-nil-safe-map-access.md
+++ b/docs/archive/pr-logs/2026-04-10-fix-210-nil-safe-map-access.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: [210] Nil-safe map access compliance pass
 
 **Branch:** `fix/compliance-210-nil-safe-map-access`

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Miniforge Demo: Spec to PR in 5 Minutes
 
 Watch miniforge plan, implement, test, review, and open a pull request —

--- a/docs/demo.md
+++ b/docs/demo.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Miniforge Demo: Spec to PR in 5 Minutes
 
 Watch miniforge plan, implement, test, review, and open a pull request —

--- a/docs/demo/compliance-demo.md
+++ b/docs/demo/compliance-demo.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Compliance Scanner Demo — YC Week
 
 ## Setup (before demo)

--- a/docs/demo/compliance-demo.md
+++ b/docs/demo/compliance-demo.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Compliance Scanner Demo — YC Week
 
 ## Setup (before demo)
@@ -46,6 +50,7 @@ bb miniforge init examples/demo-polyglot-repo
 > Clojure, Python, TypeScript, and Kubernetes manifests."
 
 **Key points:**
+
 - Technologies detected automatically
 - Policy packs selected based on what's in the repo
 - Config written to `.miniforge/config.edn`
@@ -76,6 +81,7 @@ bb miniforge scan examples/demo-polyglot-repo
 > or linter can catch."
 
 **Key output to highlight:**
+
 - Policy violations: secrets in setup.sh, unsafe Rust, Swift force-unwraps
 - Linter violations: Clippy findings, clj-kondo namespace mismatch
 - Combined count with breakdown
@@ -92,6 +98,7 @@ bb miniforge scan examples/demo-polyglot-repo --execute --report false
 > review. One command, every language."
 
 **Show the git diff after:**
+
 ```bash
 cd examples/demo-polyglot-repo && git diff --stat
 ```
@@ -123,11 +130,13 @@ cd examples/demo-polyglot-repo && git diff --stat
 ## Fallback Plan
 
 If semantic analysis is slow during live demo:
+
 - Skip `--semantic` and mention it verbally
 - Show pre-recorded output from a previous run
 - Or run with `--semantic --report false` which completes faster
 
 If a linter isn't installed:
+
 - The scanner gracefully reports "not installed (skipped)"
 - This is actually a feature to demo — shows graceful degradation
 

--- a/docs/design/workflow-methodologies.md
+++ b/docs/design/workflow-methodologies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Workflow Methodologies
 
 ## Context

--- a/docs/design/workflow-methodologies.md
+++ b/docs/design/workflow-methodologies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Workflow Methodologies
 
 ## Context

--- a/docs/pull-requests/2026-04-22-feat-formalize-workflow-supervision-specs.md
+++ b/docs/pull-requests/2026-04-22-feat-formalize-workflow-supervision-specs.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: formalize workflow, supervision, and operator-loop specs
 
 ## Overview

--- a/docs/pull-requests/2026-04-22-feat-formalize-workflow-supervision-specs.md
+++ b/docs/pull-requests/2026-04-22-feat-formalize-workflow-supervision-specs.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: formalize workflow, supervision, and operator-loop specs
 
 ## Overview

--- a/docs/pull-requests/2026-04-22-feat-phase-outcome-events.md
+++ b/docs/pull-requests/2026-04-22-feat-phase-outcome-events.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: normalize phase transition requests into explicit outcomes
 
 ## Overview

--- a/docs/pull-requests/2026-04-22-feat-phase-outcome-events.md
+++ b/docs/pull-requests/2026-04-22-feat-phase-outcome-events.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: normalize phase transition requests into explicit outcomes
 
 ## Overview

--- a/docs/pull-requests/2026-04-22-feat-unified-workflow-machine.md
+++ b/docs/pull-requests/2026-04-22-feat-unified-workflow-machine.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: make the workflow execution machine authoritative
 
 ## Overview

--- a/docs/pull-requests/2026-04-22-feat-unified-workflow-machine.md
+++ b/docs/pull-requests/2026-04-22-feat-unified-workflow-machine.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: make the workflow execution machine authoritative
 
 ## Overview

--- a/docs/pull-requests/2026-04-22-fix-phase-outcome-standards-followup.md
+++ b/docs/pull-requests/2026-04-22-fix-phase-outcome-standards-followup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix: tighten phase outcome standards follow-up
 
 ## Overview

--- a/docs/pull-requests/2026-04-22-fix-phase-outcome-standards-followup.md
+++ b/docs/pull-requests/2026-04-22-fix-phase-outcome-standards-followup.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: tighten phase outcome standards follow-up
 
 ## Overview

--- a/docs/pull-requests/2026-04-22-fix-precommit-kondo-warnings.md
+++ b/docs/pull-requests/2026-04-22-fix-precommit-kondo-warnings.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix: clear persistent clj-kondo warnings from workflow execution
 
 ## Overview

--- a/docs/pull-requests/2026-04-22-fix-precommit-kondo-warnings.md
+++ b/docs/pull-requests/2026-04-22-fix-precommit-kondo-warnings.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: clear persistent clj-kondo warnings from workflow execution
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md
+++ b/docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: formalize PR lifecycle controller FSM
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md
+++ b/docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: formalize PR lifecycle controller FSM
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-feat-workflow-machine-snapshot-resume.md
+++ b/docs/pull-requests/2026-04-23-feat-workflow-machine-snapshot-resume.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: restore workflows from durable machine snapshots
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-feat-workflow-machine-snapshot-resume.md
+++ b/docs/pull-requests/2026-04-23-feat-workflow-machine-snapshot-resume.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: restore workflows from durable machine snapshots
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md
+++ b/docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: formalize workflow supervision and intervention lifecycle
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md
+++ b/docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: formalize workflow supervision and intervention lifecycle
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-fix-workflow-supervision-dry-factories.md
+++ b/docs/pull-requests/2026-04-23-fix-workflow-supervision-dry-factories.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: remove ad hoc supervision payload duplication
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-fix-workflow-supervision-dry-factories.md
+++ b/docs/pull-requests/2026-04-23-fix-workflow-supervision-dry-factories.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix: remove ad hoc supervision payload duplication
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-fleet-spec-deltas.md
+++ b/docs/pull-requests/2026-04-23-fleet-spec-deltas.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # docs: pack interchange, control surface, and per-workflow streaming amendments
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-fleet-spec-deltas.md
+++ b/docs/pull-requests/2026-04-23-fleet-spec-deltas.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # docs: pack interchange, control surface, and per-workflow streaming amendments
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-refactor-learning-loop-authority.md
+++ b/docs/pull-requests/2026-04-23-refactor-learning-loop-authority.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: make `agent.meta.loop` the learning-loop authority
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-refactor-learning-loop-authority.md
+++ b/docs/pull-requests/2026-04-23-refactor-learning-loop-authority.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: make `agent.meta.loop` the learning-loop authority
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-refactor-workflow-supervision-boundary.md
+++ b/docs/pull-requests/2026-04-23-refactor-workflow-supervision-boundary.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: extract workflow supervision boundary
 
 ## Overview

--- a/docs/pull-requests/2026-04-23-refactor-workflow-supervision-boundary.md
+++ b/docs/pull-requests/2026-04-23-refactor-workflow-supervision-boundary.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: extract workflow supervision boundary
 
 ## Overview

--- a/docs/pull-requests/2026-04-24-chore-gitignore-work-failed.md
+++ b/docs/pull-requests/2026-04-24-chore-gitignore-work-failed.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # chore: gitignore `work/failed/` — only `:not-started` and `:finished` belong in git
 
 ## Overview

--- a/docs/pull-requests/2026-04-24-chore-gitignore-work-failed.md
+++ b/docs/pull-requests/2026-04-24-chore-gitignore-work-failed.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # chore: gitignore `work/failed/` — only `:not-started` and `:finished` belong in git
 
 ## Overview

--- a/docs/pull-requests/2026-04-24-feat-fsm-reachability-guards.md
+++ b/docs/pull-requests/2026-04-24-feat-fsm-reachability-guards.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: add FSM reachability guards for compiled workflows
 
 ## Overview

--- a/docs/pull-requests/2026-04-24-feat-fsm-reachability-guards.md
+++ b/docs/pull-requests/2026-04-24-feat-fsm-reachability-guards.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: add FSM reachability guards for compiled workflows
 
 ## Overview

--- a/docs/pull-requests/2026-04-24-feat-run-pr-and-artifact-projections.md
+++ b/docs/pull-requests/2026-04-24-feat-run-pr-and-artifact-projections.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: emit workflow-owned PRs and run artifact inventory
 
 ## Overview

--- a/docs/pull-requests/2026-04-24-feat-run-pr-and-artifact-projections.md
+++ b/docs/pull-requests/2026-04-24-feat-run-pr-and-artifact-projections.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: emit workflow-owned PRs and run artifact inventory
 
 ## Overview

--- a/docs/pull-requests/2026-04-24-refactor-standard-workflow-machine-phase-authority.md
+++ b/docs/pull-requests/2026-04-24-refactor-standard-workflow-machine-phase-authority.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: make standard workflow phase selection machine-driven
 
 ## Overview

--- a/docs/pull-requests/2026-04-24-refactor-standard-workflow-machine-phase-authority.md
+++ b/docs/pull-requests/2026-04-24-refactor-standard-workflow-machine-phase-authority.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: make standard workflow phase selection machine-driven
 
 ## Overview

--- a/docs/pull-requests/2026-04-25-feat-configurable-machine-fsm.md
+++ b/docs/pull-requests/2026-04-25-feat-configurable-machine-fsm.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat/configurable-machine-final
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-feat-configurable-machine-fsm.md
+++ b/docs/pull-requests/2026-04-25-feat-configurable-machine-fsm.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat/configurable-machine-final
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-refactor-configurable-workflow-compiled-machine.md
+++ b/docs/pull-requests/2026-04-25-refactor-configurable-workflow-compiled-machine.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Refactor Configurable Workflow To Compiled Machine
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-refactor-configurable-workflow-compiled-machine.md
+++ b/docs/pull-requests/2026-04-25-refactor-configurable-workflow-compiled-machine.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Refactor Configurable Workflow To Compiled Machine
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-refactor-dag-checkpoint-resume-authority.md
+++ b/docs/pull-requests/2026-04-25-refactor-dag-checkpoint-resume-authority.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor/dag-snapshot-final
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-refactor-dag-checkpoint-resume-authority.md
+++ b/docs/pull-requests/2026-04-25-refactor-dag-checkpoint-resume-authority.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor/dag-snapshot-final
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-refactor-dag-resume-machine-snapshot-convergence.md
+++ b/docs/pull-requests/2026-04-25-refactor-dag-resume-machine-snapshot-convergence.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Refactor DAG Resume To Machine Snapshot Convergence
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-refactor-dag-resume-machine-snapshot-convergence.md
+++ b/docs/pull-requests/2026-04-25-refactor-dag-resume-machine-snapshot-convergence.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Refactor DAG Resume To Machine Snapshot Convergence
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-refactor-fsm-cleanup-runtime-dependency.md
+++ b/docs/pull-requests/2026-04-25-refactor-fsm-cleanup-runtime-dependency.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor/fsm-cleanup-final
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-refactor-fsm-cleanup-runtime-dependency.md
+++ b/docs/pull-requests/2026-04-25-refactor-fsm-cleanup-runtime-dependency.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor/fsm-cleanup-final
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-refactor-implicit-fsm-cleanup-slice.md
+++ b/docs/pull-requests/2026-04-25-refactor-implicit-fsm-cleanup-slice.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: clean up remaining lightweight implicit state machines
 
 ## Overview

--- a/docs/pull-requests/2026-04-25-refactor-implicit-fsm-cleanup-slice.md
+++ b/docs/pull-requests/2026-04-25-refactor-implicit-fsm-cleanup-slice.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: clean up remaining lightweight implicit state machines
 
 ## Overview

--- a/docs/pull-requests/2026-04-25-refactor-loop-task-fsm-slice.md
+++ b/docs/pull-requests/2026-04-25-refactor-loop-task-fsm-slice.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: move loop and task lifecycle slices toward shared FSMs
 
 ## Overview

--- a/docs/pull-requests/2026-04-25-refactor-loop-task-fsm-slice.md
+++ b/docs/pull-requests/2026-04-25-refactor-loop-task-fsm-slice.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: move loop and task lifecycle slices toward shared FSMs
 
 ## Overview

--- a/docs/pull-requests/2026-04-25-refactor-workflow-validator-compiler-unification.md
+++ b/docs/pull-requests/2026-04-25-refactor-workflow-validator-compiler-unification.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Refactor Workflow Validator And Compiler Unification
 
 ## Summary

--- a/docs/pull-requests/2026-04-25-refactor-workflow-validator-compiler-unification.md
+++ b/docs/pull-requests/2026-04-25-refactor-workflow-validator-compiler-unification.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Refactor Workflow Validator And Compiler Unification
 
 ## Summary

--- a/docs/pull-requests/2026-04-26-fix-release-windows-clojure.md
+++ b/docs/pull-requests/2026-04-26-fix-release-windows-clojure.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix/release-windows-clojure
 
 ## Summary

--- a/docs/pull-requests/2026-04-26-fix-release-windows-clojure.md
+++ b/docs/pull-requests/2026-04-26-fix-release-windows-clojure.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix/release-windows-clojure
 
 ## Summary

--- a/docs/pull-requests/2026-04-27-docs-exception-cleanup-inventory.md
+++ b/docs/pull-requests/2026-04-27-docs-exception-cleanup-inventory.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # docs: inventory exception/throw sites for cleanup
 
 ## Overview

--- a/docs/pull-requests/2026-04-27-docs-exception-cleanup-inventory.md
+++ b/docs/pull-requests/2026-04-27-docs-exception-cleanup-inventory.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # docs: inventory exception/throw sites for cleanup
 
 ## Overview

--- a/docs/pull-requests/2026-04-27-feat-anomaly-component.md
+++ b/docs/pull-requests/2026-04-27-feat-anomaly-component.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: add anomaly component for canonical data-first error type
 
 ## Overview
@@ -71,7 +75,7 @@ Anomaly map shape:
 
 Standard type vocabulary (mirrors cognitect anomalies):
 
-```
+```clojure
 #{:not-found :invalid-input :unauthorized :fault :unavailable
   :conflict :timeout :unsupported :fatal}
 ```

--- a/docs/pull-requests/2026-04-27-feat-anomaly-component.md
+++ b/docs/pull-requests/2026-04-27-feat-anomaly-component.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: add anomaly component for canonical data-first error type
 
 ## Overview

--- a/docs/pull-requests/2026-04-27-feat-rich-decision-agent-context.md
+++ b/docs/pull-requests/2026-04-27-feat-rich-decision-agent-context.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: emit richer supervisory decision and agent context
 
 ## Overview

--- a/docs/pull-requests/2026-04-27-feat-rich-decision-agent-context.md
+++ b/docs/pull-requests/2026-04-27-feat-rich-decision-agent-context.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: emit richer supervisory decision and agent context
 
 ## Overview

--- a/docs/pull-requests/2026-04-27-fix-release-dispatch-tag.md
+++ b/docs/pull-requests/2026-04-27-fix-release-dispatch-tag.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 ## Summary
 
 Fix the release workflow so manual reruns update the requested release tag

--- a/docs/pull-requests/2026-04-27-fix-release-dispatch-tag.md
+++ b/docs/pull-requests/2026-04-27-fix-release-dispatch-tag.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 ## Summary
 
 Fix the release workflow so manual reruns update the requested release tag

--- a/docs/pull-requests/2026-04-27-fix-windows-build-classpath-separator.md
+++ b/docs/pull-requests/2026-04-27-fix-windows-build-classpath-separator.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix/windows-build-failure
 
 ## Summary

--- a/docs/pull-requests/2026-04-27-fix-windows-build-classpath-separator.md
+++ b/docs/pull-requests/2026-04-27-fix-windows-build-classpath-separator.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix/windows-build-failure
 
 ## Summary

--- a/docs/pull-requests/2026-04-27-refactor-extract-content-hash-component.md
+++ b/docs/pull-requests/2026-04-27-refactor-extract-content-hash-component.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: extract content-hash into standalone component
 
 ## Overview

--- a/docs/pull-requests/2026-04-27-refactor-extract-content-hash-component.md
+++ b/docs/pull-requests/2026-04-27-refactor-extract-content-hash-component.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: extract content-hash into standalone component
 
 ## Overview

--- a/docs/pull-requests/2026-04-28-fix-dogfood-worktree-phase-failure.md
+++ b/docs/pull-requests/2026-04-28-fix-dogfood-worktree-phase-failure.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix/dogfood-isolation-and-events
 
 ## Summary

--- a/docs/pull-requests/2026-04-28-fix-dogfood-worktree-phase-failure.md
+++ b/docs/pull-requests/2026-04-28-fix-dogfood-worktree-phase-failure.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix/dogfood-isolation-and-events
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-feat-dependency-attribution-taxonomy.md
+++ b/docs/pull-requests/2026-04-29-feat-dependency-attribution-taxonomy.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat/dependency-attribution-taxonomy
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-feat-dependency-attribution-taxonomy.md
+++ b/docs/pull-requests/2026-04-29-feat-dependency-attribution-taxonomy.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat/dependency-attribution-taxonomy
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md
+++ b/docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: implement exceptions-as-data linter for bb review
 
 ## Overview

--- a/docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md
+++ b/docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md
@@ -1,13 +1,21 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: implement exceptions-as-data linter for bb review
 
 ## Overview
 
-Implements the linter prescribed by the merged `005 exceptions-as-data` standards rule. AST-based scanner inside the existing `compliance-scanner` component; surfaces `throw` / `ex-info` / exception-class instantiation outside boundary namespaces as `bb review` warnings, with the suggested anomaly-return rewrite cited inline.
+Implements the linter prescribed by the merged `005 exceptions-as-data` standards rule. AST-based scanner inside the
+existing `compliance-scanner` component; surfaces `throw` / `ex-info` / exception-class instantiation outside boundary
+namespaces as `bb review` warnings, with the suggested anomaly-return rewrite cited inline.
 
 ## Motivation
 
-The standards rule landed last week. The cleanup inventory (`work/exception-cleanup-inventory.md`) catalogued 158 cleanup-needed sites by hand. This PR turns the manual inventory into a standing rule — `bb review` now finds the same sites automatically as the codebase changes, surfacing regressions before they accumulate.
+The standards rule landed last week. The cleanup inventory (`work/exception-cleanup-inventory.md`) catalogued 158
+cleanup-needed sites by hand. This PR turns the manual inventory into a standing rule — `bb review` now finds the same
+sites automatically as the codebase changes, surfacing regressions before they accumulate.
 
 Severity defaults to `:warning`. Promotion to `:error` happens per-component after that component's cleanup completes.
 
@@ -26,7 +34,8 @@ Tools / self-review. Lives inside the `compliance-scanner` component; reuses the
 
 ## What This Adds
 
-- `components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj` — the linter (rule id `:std/exceptions-as-data`, dewey `005`)
+- `components/compliance-scanner/src/ai/miniforge/compliance_scanner/exceptions_as_data.clj` — the linter (rule id
+  `:std/exceptions-as-data`, dewey `005`)
 - 5 focused test files under `components/compliance-scanner/test/ai/miniforge/compliance_scanner/exceptions_as_data/`:
   - `positive_detection_test.clj` — non-boundary throws are flagged
   - `boundary_exemption_test.clj` — boundary-namespace patterns are skipped
@@ -34,18 +43,30 @@ Tools / self-review. Lives inside the `compliance-scanner` component; reuses the
   - `output_format_test.clj` — file:line:col output matches `bb review` shape
   - `end_to_end_test.clj` — synthetic fixture tree with expected hit count
 - Modified `components/compliance-scanner/deps.edn` — adds `org.clojure/tools.reader` (parsing without regex)
-- Modified `components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj` — re-exports `scan-exceptions-as-data` and `exceptions-as-data-rule-id`
-- Modified `components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj` — wires the linter into `scan-repo`; opts in for `:all` / `:always-apply` / explicit `:std/exceptions-as-data`
+- Modified `components/compliance-scanner/src/ai/miniforge/compliance_scanner/interface.clj` — re-exports
+  `scan-exceptions-as-data` and `exceptions-as-data-rule-id`
+- Modified `components/compliance-scanner/src/ai/miniforge/compliance_scanner/scan.clj` — wires the linter into
+  `scan-repo`; opts in for `:all` / `:always-apply` / explicit `:std/exceptions-as-data`
 
 ## Detection logic
 
-Scans `components/*/src/**/*.clj` and `bases/*/src/**/*.clj`. For each `(throw ...)`, `(ex-info ...)`, `IllegalArgumentException.`, `RuntimeException.`, `(throw+ ...)`:
+Scans `components/*/src/**/*.clj` and `bases/*/src/**/*.clj`. For each `(throw ...)`, `(ex-info ...)`,
+`IllegalArgumentException.`, `RuntimeException.`, `(throw+ ...)`:
 
-1. **Boundary-namespace exemption** — skip when the file's namespace matches: `*.cli.*`, `*-main`, `*.boundary.*`, `*.http.*`, `*.web.*`, `*.mcp.*`, `*.consumer.*`, `*.listener.*`, or files containing fns like `execute-with-exception-handling`.
-2. **Programmer-error-guard classification** — if any string, keyword, or symbol name inside the throw expression matches one of the inventory's `:fatal-only` markers (e.g. `unknown`, `unsupported`, `must be`, `required`, `invariant`, `missing-resource`, `classpath`, …), classify as `:fatal-only` (informational only). The standards rule originally specified `case` / `condp` default-branch detection in addition to the marker check; this implementation matches markers anywhere in the expression and does not yet check whether the form is a `case` / `condp` default branch. Tightening to require both is a follow-on refinement; current behavior is conservative-leaning.
-3. **Otherwise** — emit `:warning` with file:line:col, the offending form's first line, and a one-sentence pointer to the suggested anomaly-return rewrite (link to the rule's example).
+1. **Boundary-namespace exemption** — skip when the file's namespace matches: `*.cli.*`, `*-main`, `*.boundary.*`,
+  `*.http.*`, `*.web.*`, `*.mcp.*`, `*.consumer.*`, `*.listener.*`, or files containing fns like
+  `execute-with-exception-handling`.
+2. **Programmer-error-guard classification** — if any string, keyword, or symbol name inside the throw expression
+  matches one of the inventory's `:fatal-only` markers (e.g. `unknown`, `unsupported`, `must be`, `required`,
+  `invariant`, `missing-resource`, `classpath`, …), classify as `:fatal-only` (informational only). The standards rule
+  originally specified `case` / `condp` default-branch detection in addition to the marker check; this implementation
+  matches markers anywhere in the expression and does not yet check whether the form is a `case` / `condp` default
+  branch. Tightening to require both is a follow-on refinement; current behavior is conservative-leaning.
+3. **Otherwise** — emit `:warning` with file:line:col, the offending form's first line, and a one-sentence pointer to
+  the suggested anomaly-return rewrite (link to the rule's example).
 
-Parsing uses `tools.reader` — no regex. Clojure syntax has too many edge cases (`throw` inside a string, inside a `(comment …)` form, inside reader-conditional branches) for regex-based matching to be safe.
+Parsing uses `tools.reader` — no regex. Clojure syntax has too many edge cases (`throw` inside a string, inside a
+`(comment …)` form, inside reader-conditional branches) for regex-based matching to be safe.
 
 ## Inventory cross-check
 
@@ -58,7 +79,12 @@ Linter output vs. the manual inventory baseline:
 | Production source files scanned | — | 794 | — |
 | Total findings surfaced as `[review]` | — | 221 | — |
 
-The `:cleanup-needed` gap is judgment-bound. The inventory's `:fatal-only` vs `:cleanup-needed` split for sites like `(throw-anomaly! :anomalies/incorrect "Meta-agent config requires :id and :name" ...)` depends on whether the throw is boot-time or runtime — a heuristic on string/keyword markers can't perfectly replicate the human call. Slightly outside the 10% spec target, but within reasonable judgment-tolerance. Tightening either marker set shifts the balance but doesn't close the gap; the linter is conservative-leaning, which is the right error direction (false negatives over false positives for a `:warning` rule).
+The `:cleanup-needed` gap is judgment-bound. The inventory's `:fatal-only` vs `:cleanup-needed` split for sites like
+`(throw-anomaly! :anomalies/incorrect "Meta-agent config requires :id and :name" ...)` depends on whether the throw is
+boot-time or runtime — a heuristic on string/keyword markers can't perfectly replicate the human call. Slightly outside
+the 10% spec target, but within reasonable judgment-tolerance. Tightening either marker set shifts the balance but
+doesn't close the gap; the linter is conservative-leaning, which is the right error direction (false negatives over
+false positives for a `:warning` rule).
 
 ## Strata Affected
 
@@ -68,7 +94,9 @@ The `:cleanup-needed` gap is judgment-bound. The inventory's `:fatal-only` vs `:
 
 ## Testing Plan
 
-- `bb pre-commit`: lint:clj 0 errors / 0 warnings on new code; fmt:md clean; test 2901 tests / 10989 passes / 0 failures; test:graalvm 6 tests / 468 assertions / 0 failures. Commit pre-commit hook ran the full battery and accepted.
+- `bb pre-commit`: lint:clj 0 errors / 0 warnings on new code; fmt:md clean; test 2901 tests / 10989 passes / 0
+  failures; test:graalvm 6 tests / 468 assertions / 0 failures. Commit pre-commit hook ran the full battery and
+  accepted.
 - 20 tests / 66 assertions in the new `exceptions-as-data` test namespaces — all green.
 - End-to-end test runs against a synthetic fixture tree to validate the expected hit count.
 
@@ -78,15 +106,21 @@ No migration. Additive scanner rule. Existing `bb review` invocations gain new w
 
 Severity is `:warning` repo-wide. The promotion path:
 
-1. After foundation-tier cleanups land (`refactor/exceptions-as-data-foundation-cleanup` PR), recount `:cleanup-needed` for the affected components.
+1. After foundation-tier cleanups land (`refactor/exceptions-as-data-foundation-cleanup` PR), recount `:cleanup-needed`
+  for the affected components.
 2. Components with zero cleanup-needed sites can promote to `:error` for that scope.
 3. Repository-wide promotion happens after all 158 sites are addressed.
 
 ## Notes / Deviations
 
-- **`.standards/foundations/exceptions-as-data.mdc` not present in the consumed submodule pin** (`2bb8ab7c`) at the time of this work. The linter is pure code; doesn't depend on the pack rule for activation. When the submodule pin updates, existing wiring continues to work unchanged.
-- **`(comment …)` blocks are skipped entirely** to match what the manual inventory excluded. Documented in `visit-form`'s docstring; one-line change to remove `comment` from `skip-walk-heads` if Rich Comment blocks should be flagged later.
-- **Tests use `random-uuid` for temp-dir names** (not `System/currentTimeMillis`) because the bb test runner pmaps across bricks; collision-prone names produced 6 spurious failures on first run.
+- **`.standards/foundations/exceptions-as-data.mdc` not present in the consumed submodule pin** (`2bb8ab7c`) at the time
+  of this work. The linter is pure code; doesn't depend on the pack rule for activation. When the submodule pin updates,
+  existing wiring continues to work unchanged.
+- **`(comment …)` blocks are skipped entirely** to match what the manual inventory excluded. Documented in
+  `visit-form`'s docstring; one-line change to remove `comment` from `skip-walk-heads` if Rich Comment blocks should be
+  flagged later.
+- **Tests use `random-uuid` for temp-dir names** (not `System/currentTimeMillis`) because the bb test runner pmaps
+  across bricks; collision-prone names produced 6 spurious failures on first run.
 
 ## Related Issues/PRs
 

--- a/docs/pull-requests/2026-04-29-feat-response-chain-component.md
+++ b/docs/pull-requests/2026-04-29-feat-response-chain-component.md
@@ -1,15 +1,27 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: add response-chain component for runtime trace + data-first errors
 
 ## Overview
 
-Adds a new `ai.miniforge.response-chain` Polylith component to miniforge OSS. Provides the canonical in-flight runtime trace primitive that miniforge-family Clojure repos consume. Threads through a logical flow as data; each participating function appends a step (operation keyword + success? + anomaly|response). The completed chain becomes the auditable record of "what happened during this request."
+Adds a new `ai.miniforge.response-chain` Polylith component to miniforge OSS. Provides the canonical in-flight runtime
+trace primitive that miniforge-family Clojure repos consume. Threads through a logical flow as data; each participating
+function appends a step (operation keyword + success? + anomaly|response). The completed chain becomes the auditable
+record of "what happened during this request."
 
 ## Motivation
 
-The recently-merged `ai.miniforge.anomaly` component gave us a canonical anomaly type. The response-chain is the next layer up: an accumulator that carries those anomalies — and successful step results — through composable flows. Together they form the substrate that the new `005 exceptions-as-data` standards rule prescribes.
+The recently-merged `ai.miniforge.anomaly` component gave us a canonical anomaly type. The response-chain is the next
+layer up: an accumulator that carries those anomalies — and successful step results — through composable flows. Together
+they form the substrate that the new `005 exceptions-as-data` standards rule prescribes.
 
-This is the H2 component in the cross-cutting H-series being added to miniforge OSS so that thesium-workflows, miniforge-fleet, and any future ports consume one shared error-flow vocabulary rather than reinventing it per-repo. The semantic reference is ixi's `responses-web` (read-only); this is a clean reimplementation under modern conventions, not a port.
+This is the H2 component in the cross-cutting H-series being added to miniforge OSS so that thesium-workflows,
+miniforge-fleet, and any future ports consume one shared error-flow vocabulary rather than reinventing it per-repo. The
+semantic reference is ixi's `responses-web` (read-only); this is a clean reimplementation under modern conventions, not
+a port.
 
 ## Base Branch
 
@@ -40,7 +52,9 @@ Foundations / cross-cutting primitive. New top-level component.
   - `last_successful_or_test.clj`
   - `multi_step_composition_test.clj`
   - `malli_validation_test.clj`
-- Workspace registration in root `deps.edn` (`:dev`, `:test`, `:conformance` aliases) + each consumer project's `deps.edn` (`projects/miniforge/`, `projects/miniforge-core/`, `projects/miniforge-tui/`). Also adds `ai.miniforge/anomaly` to those project deps where it was missing — `response-chain` requires it transitively.
+- Workspace registration in root `deps.edn` (`:dev`, `:test`, `:conformance` aliases) + each consumer project's
+  `deps.edn` (`projects/miniforge/`, `projects/miniforge-core/`, `projects/miniforge-tui/`). Also adds
+  `ai.miniforge/anomaly` to those project deps where it was missing — `response-chain` requires it transitively.
 
 ## Public API
 
@@ -72,11 +86,14 @@ Chain:
    :response-chain [:vector Step]}
 ```
 
-The chain's `:succeeded?` is the conjunction of every step's `:succeeded?`. `append-step` recomputes the invariant on every call.
+The chain's `:succeeded?` is the conjunction of every step's `:succeeded?`. `append-step` recomputes the invariant on
+every call.
 
 ## Eating our own dog food
 
-This component IS the boundary helper for response-chains; it never throws. Malformed inputs to `append-step` produce an `:invalid-input` anomaly step rather than a thrown exception — consistent with the `005 exceptions-as-data` rule. Verified by `malli_validation_test.clj`.
+This component IS the boundary helper for response-chains; it never throws. Malformed inputs to `append-step` produce an
+`:invalid-input` anomaly step rather than a thrown exception — consistent with the `005 exceptions-as-data` rule.
+Verified by `malli_validation_test.clj`.
 
 ## Strata Affected
 
@@ -90,7 +107,8 @@ No existing component touched. Pure additive change.
 
 - `bb pre-commit` (lint:clj + fmt:md + test + test:graalvm): **ALL PRE-COMMIT CHECKS PASSED**
 - `lint:clj` — 17 files, 0 errors / 0 warnings
-- `test` — 256 namespaces, **2886 tests / 10662 passes / 0 failures / 0 errors**. The 9 response-chain test namespaces account for 42 tests / 75 assertions in this brick alone.
+- `test` — 256 namespaces, **2886 tests / 10662 passes / 0 failures / 0 errors**. The 9 response-chain test namespaces
+  account for 42 tests / 75 assertions in this brick alone.
 - `test:graalvm` — 6 tests / 473 assertions / 0 failures
 
 The nine test files map 1:1 to the per-behavior dimensions in the brief. Each dimension is independently exercisable.
@@ -99,14 +117,22 @@ The nine test files map 1:1 to the per-behavior dimensions in the brief. Each di
 
 No migration required. New additive component. Existing miniforge code unchanged.
 
-Downstream consumption (thesium-workflows, miniforge-fleet) lands in subsequent PRs as those repos rewire flows to thread response-chains through retrieval / synthesis / agent pipelines.
+Downstream consumption (thesium-workflows, miniforge-fleet) lands in subsequent PRs as those repos rewire flows to
+thread response-chains through retrieval / synthesis / agent pipelines.
 
 ## Notes / Deviations
 
-- **Conformance alias not updated for response-chain or anomaly.** Conservatively followed the precedent set by the merged anomaly PR (which only registered in `:dev`/`:test`/root). Easy follow-up if conformance gate should cover these bricks.
-- **Anomaly added to consumer project `deps.edn` files.** The original anomaly merge registered it in root only; response-chain depends on it transitively, so the project classpaths needed both. Mirrors the content-hash pattern.
-- **One transient test flake observed mid-run** in `ai.miniforge.dag-executor.state-test/transition-task!-emits-event-test` — passes in isolation and final pre-commit run was clean. Unrelated to this change; pre-existing brick-isolation hazard around event-stream global state. Worth a separate look as `:fault`-classified follow-on.
-- **Apache 2 license headers** on every file (matches `components/anomaly/src/ai/miniforge/anomaly/interface.clj` exactly). Layer-labeled comment headers in interface, contract, and core.
+- **Conformance alias not updated for response-chain or anomaly.** Conservatively followed the precedent set by the
+  merged anomaly PR (which only registered in `:dev`/`:test`/root). Easy follow-up if conformance gate should cover
+  these bricks.
+- **Anomaly added to consumer project `deps.edn` files.** The original anomaly merge registered it in root only;
+  response-chain depends on it transitively, so the project classpaths needed both. Mirrors the content-hash pattern.
+- **One transient test flake observed mid-run** in
+  `ai.miniforge.dag-executor.state-test/transition-task!-emits-event-test` — passes in isolation and final pre-commit
+  run was clean. Unrelated to this change; pre-existing brick-isolation hazard around event-stream global state. Worth a
+  separate look as `:fault`-classified follow-on.
+- **Apache 2 license headers** on every file (matches `components/anomaly/src/ai/miniforge/anomaly/interface.clj`
+  exactly). Layer-labeled comment headers in interface, contract, and core.
 
 ## Related Issues/PRs
 

--- a/docs/pull-requests/2026-04-29-feat-response-chain-component.md
+++ b/docs/pull-requests/2026-04-29-feat-response-chain-component.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: add response-chain component for runtime trace + data-first errors
 
 ## Overview

--- a/docs/pull-requests/2026-04-29-feat-runtime-adapter-phase-1-oci-cli-executor.md
+++ b/docs/pull-requests/2026-04-29-feat-runtime-adapter-phase-1-oci-cli-executor.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat(dag-executor): generalize Docker executor into OCI-CLI executor (N11-delta Phase 1)
 
 ## Overview

--- a/docs/pull-requests/2026-04-29-feat-runtime-adapter-phase-1-oci-cli-executor.md
+++ b/docs/pull-requests/2026-04-29-feat-runtime-adapter-phase-1-oci-cli-executor.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat(dag-executor): generalize Docker executor into OCI-CLI executor (N11-delta Phase 1)
 
 ## Overview

--- a/docs/pull-requests/2026-04-29-fix-dag-executor-event-soft-dep-race.md
+++ b/docs/pull-requests/2026-04-29-fix-dag-executor-event-soft-dep-race.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix/dag-executor-event-soft-dep-race
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-fix-dag-executor-event-soft-dep-race.md
+++ b/docs/pull-requests/2026-04-29-fix-dag-executor-event-soft-dep-race.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix/dag-executor-event-soft-dep-race
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-fix-dag-executor-gate-test-isolation.md
+++ b/docs/pull-requests/2026-04-29-fix-dag-executor-gate-test-isolation.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix: remove with-redefs of clojure.core/requiring-resolve from gate.behavioral-test
 
 ## Overview

--- a/docs/pull-requests/2026-04-29-fix-dag-executor-gate-test-isolation.md
+++ b/docs/pull-requests/2026-04-29-fix-dag-executor-gate-test-isolation.md
@@ -1,18 +1,32 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: remove with-redefs of clojure.core/requiring-resolve from gate.behavioral-test
 
 ## Overview
 
-Eliminates a brick-isolation hazard reported by two sibling Wave 2 PRs (#702 response-chain, #704 foundation cleanup): under bb's brick-pmap test runner, `gate.behavioral-test` and `dag-executor.state-test` raced through a globally redefined `clojure.core/requiring-resolve`, producing intermittent failures.
+Eliminates a brick-isolation hazard reported by two sibling Wave 2 PRs (#702 response-chain, #704 foundation cleanup):
+under bb's brick-pmap test runner, `gate.behavioral-test` and `dag-executor.state-test` raced through a globally
+redefined `clojure.core/requiring-resolve`, producing intermittent failures.
 
-The fix is dependency injection on `gate.behavioral/check-behavioral`. Six tests no longer redefine a core fn globally; they pass a stub via `ctx` instead.
+The fix is dependency injection on `gate.behavioral/check-behavioral`. Six tests no longer redefine a core fn globally;
+they pass a stub via `ctx` instead.
 
 ## Motivation
 
 Two-headed root cause:
 
-1. **The dag-executor side was already fixed upstream** in merge commit `38f8f486` ("keep direct event-stream require over soft-dep resolution"). `state.clj` no longer uses `requiring-resolve` for event-stream lookup. Originally-flaky path is dormant on `main`.
-2. **The actual remaining hazard was in `gate.behavioral-test`.** Six tests wrapped their bodies in `with-redefs [clojure.core/requiring-resolve …]` to stub out `policy-pack.core/check-artifact`. `with-redefs` mutates a global var root — brick isolation is irrelevant. While the scope was active, any parallel test on any brick that called `requiring-resolve` (directly or transitively, through middleware, defmulti dispatch, future code paths) received the stub and got `nil` for any sym that wasn't `policy-pack.core/check-artifact`. The dag-executor pre-fix path hit it; the same hazard remained for every other brick, even after dag-executor was cleaned up.
+1. **The dag-executor side was already fixed upstream** in merge commit `38f8f486` ("keep direct event-stream require
+  over soft-dep resolution"). `state.clj` no longer uses `requiring-resolve` for event-stream lookup. Originally-flaky
+  path is dormant on `main`.
+2. **The actual remaining hazard was in `gate.behavioral-test`.** Six tests wrapped their bodies in `with-redefs
+  [clojure.core/requiring-resolve …]` to stub out `policy-pack.core/check-artifact`. `with-redefs` mutates a global var
+  root — brick isolation is irrelevant. While the scope was active, any parallel test on any brick that called
+  `requiring-resolve` (directly or transitively, through middleware, defmulti dispatch, future code paths) received the
+  stub and got `nil` for any sym that wasn't `policy-pack.core/check-artifact`. The dag-executor pre-fix path hit it;
+  the same hazard remained for every other brick, even after dag-executor was cleaned up.
 
 This PR removes the hazard entirely by replacing the global redef with a non-global mechanism.
 
@@ -33,22 +47,33 @@ Bug fix / test hygiene. `gate` component.
 `components/gate/src/ai/miniforge/gate/behavioral.clj`:
 
 - `check-behavioral` now reads an optional `:check-fn` from its `ctx` argument.
-- Default is a new private `default-check-fn` that performs the same lazy `requiring-resolve` of `policy-pack.core/check-artifact` as before — preserving the intentional soft-dependency semantics (policy-pack is *not* on `gate/deps.edn`'s classpath in isolation; the lazy resolution is intrinsic to production behavior).
-- `default-check-fn` throws a single `ex-info` at the soft-dep resolution boundary when policy-pack is genuinely absent. The existing try/catch in `check-behavioral` converts it to the same `:behavioral-check-error` warning shape as before — public contract unchanged.
+- Default is a new private `default-check-fn` that performs the same lazy `requiring-resolve` of
+  `policy-pack.core/check-artifact` as before — preserving the intentional soft-dependency semantics (policy-pack is
+  *not* on `gate/deps.edn`'s classpath in isolation; the lazy resolution is intrinsic to production behavior).
+- `default-check-fn` throws a single `ex-info` at the soft-dep resolution boundary when policy-pack is genuinely absent.
+  The existing try/catch in `check-behavioral` converts it to the same `:behavioral-check-error` warning shape as before
+  — public contract unchanged.
 
 `components/gate/test/ai/miniforge/gate/behavioral_test.clj`:
 
-- Six tests that previously used `with-redefs` now construct a `ctx` with a `:check-fn` stub. No global var-root mutation. Two private test helpers (`stub-check-fn`, `throwing-check-fn`) keep the per-test bodies focused on the behavior under test.
+- Six tests that previously used `with-redefs` now construct a `ctx` with a `:check-fn` stub. No global var-root
+  mutation. Two private test helpers (`stub-check-fn`, `throwing-check-fn`) keep the per-test bodies focused on the
+  behavior under test.
 
 ## Why option B (DI) instead of option A (direct require)
 
-Option A — replacing `requiring-resolve` with a top-level `:require` of `ai.miniforge.policy-pack.interface` — was infeasible. `policy-pack` is a *deliberate soft dependency* of `gate`; it is not on `gate/deps.edn`'s classpath in isolation. The lazy resolution in production is intrinsic.
+Option A — replacing `requiring-resolve` with a top-level `:require` of `ai.miniforge.policy-pack.interface` — was
+infeasible. `policy-pack` is a *deliberate soft dependency* of `gate`; it is not on `gate/deps.edn`'s classpath in
+isolation. The lazy resolution in production is intrinsic.
 
-Option B — dependency injection — keeps the soft-dep semantics intact while removing the global mutation. Tests now inject stubs through the call surface without touching a core fn.
+Option B — dependency injection — keeps the soft-dep semantics intact while removing the global mutation. Tests now
+inject stubs through the call surface without touching a core fn.
 
 ## Out of scope
 
-`policy.clj` and `lint.clj` use the same `requiring-resolve` pattern, but their tests do not currently `with-redefs` around them — no race exists today. Per the task scope, this PR fixes the one site that was actually causing flakes. Refactoring those siblings as a hygiene exercise is a follow-on.
+`policy.clj` and `lint.clj` use the same `requiring-resolve` pattern, but their tests do not currently `with-redefs`
+around them — no race exists today. Per the task scope, this PR fixes the one site that was actually causing flakes.
+Refactoring those siblings as a hygiene exercise is a follow-on.
 
 ## Strata Affected
 
@@ -64,12 +89,16 @@ The race no longer reproduces under brick-pmap concurrency.
 
 ## Deployment Plan
 
-No migration required. Public contract of `gate.behavioral/check-behavioral` is preserved — production callers do not pass `:check-fn`, so behavior is identical. The `default-check-fn` performs the same soft-dep resolution and emits the same `:behavioral-check-error` warning shape as before.
+No migration required. Public contract of `gate.behavioral/check-behavioral` is preserved — production callers do not
+pass `:check-fn`, so behavior is identical. The `default-check-fn` performs the same soft-dep resolution and emits the
+same `:behavioral-check-error` warning shape as before.
 
 ## Notes
 
 - **Apache 2 license headers** preserved on both files.
-- **Anomalies-as-data discipline:** the one `throw ex-info` in `default-check-fn` sits at the soft-dep resolution boundary and is caught by the existing try/catch wrapper in `check-behavioral`, which converts it to the warning shape. Boundary-flavored throw + immediate catch + return-as-data — consistent with the `005 exceptions-as-data` rule.
+- **Anomalies-as-data discipline:** the one `throw ex-info` in `default-check-fn` sits at the soft-dep resolution
+  boundary and is caught by the existing try/catch wrapper in `check-behavioral`, which converts it to the warning
+  shape. Boundary-flavored throw + immediate catch + return-as-data — consistent with the `005 exceptions-as-data` rule.
 - **Per-behavior test decomposition** preserved (one deftest per scenario).
 
 ## Related Issues/PRs

--- a/docs/pull-requests/2026-04-29-fix-release-pr-doc-body-sync.md
+++ b/docs/pull-requests/2026-04-29-fix-release-pr-doc-body-sync.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix/release-pr-doc-body-sync
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-fix-release-pr-doc-body-sync.md
+++ b/docs/pull-requests/2026-04-29-fix-release-pr-doc-body-sync.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix/release-pr-doc-body-sync
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-fix-supervisory-run-snapshot-attachment.md
+++ b/docs/pull-requests/2026-04-29-fix-supervisory-run-snapshot-attachment.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix/supervisory-run-snapshots
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-fix-supervisory-run-snapshot-attachment.md
+++ b/docs/pull-requests/2026-04-29-fix-supervisory-run-snapshot-attachment.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix/supervisory-run-snapshots
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md
+++ b/docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix/approval-handler-soft-dep-race
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md
+++ b/docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # fix/approval-handler-soft-dep-race
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-refactor-exceptions-as-data-foundation-cleanup.md
+++ b/docs/pull-requests/2026-04-29-refactor-exceptions-as-data-foundation-cleanup.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # refactor: foundation-tier exceptions-as-data cleanup
 
 ## Overview

--- a/docs/pull-requests/2026-04-29-refactor-exceptions-as-data-foundation-cleanup.md
+++ b/docs/pull-requests/2026-04-29-refactor-exceptions-as-data-foundation-cleanup.md
@@ -1,17 +1,29 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # refactor: foundation-tier exceptions-as-data cleanup
 
 ## Overview
 
-First cleanup PR for the `005 exceptions-as-data` discipline. Per the recommended ordering in `work/exception-cleanup-inventory.md`, this PR addresses the foundation tier — high-leverage helpers that every downstream component eventually calls. Three scopes covered: `schema/validate`, `dag-primitives/unwrap`, and connector-core validation helpers.
+First cleanup PR for the `005 exceptions-as-data` discipline. Per the recommended ordering in
+`work/exception-cleanup-inventory.md`, this PR addresses the foundation tier — high-leverage helpers that every
+downstream component eventually calls. Three scopes covered: `schema/validate`, `dag-primitives/unwrap`, and
+connector-core validation helpers.
 
-Each scope adds an anomaly-returning variant alongside the existing throwing function. The throwers are preserved (and now delegate to the anomaly variant) so existing callers see no behavior change.
+Each scope adds an anomaly-returning variant alongside the existing throwing function. The throwers are preserved (and
+now delegate to the anomaly variant) so existing callers see no behavior change.
 
 ## Motivation
 
-Foundation helpers throw on bad input today. Every caller wraps in try/catch, or worse, lets the exception unwind past structured information that should have stayed with the failure. Per the new standards rule, these foundation helpers should expose anomaly-returning variants so downstream code can compose with response-chains and evidence records cleanly.
+Foundation helpers throw on bad input today. Every caller wraps in try/catch, or worse, lets the exception unwind past
+structured information that should have stayed with the failure. Per the new standards rule, these foundation helpers
+should expose anomaly-returning variants so downstream code can compose with response-chains and evidence records
+cleanly.
 
-This is the "high leverage" tier per the inventory — converting these unblocks ~38 follow-on cleanup sites in connector components alone.
+This is the "high leverage" tier per the inventory — converting these unblocks ~38 follow-on cleanup sites in connector
+components alone.
 
 ## Base Branch
 
@@ -33,7 +45,8 @@ Refactor / foundation tier. Three independent commits, one per scope, can be rev
 - Modified `components/schema/deps.edn` — `:local/root` dep on `ai.miniforge/anomaly`
 - Modified `components/schema/src/ai/miniforge/schema/interface.clj`:
   - New `validate-anomaly` — returns the validated value or an `:invalid-input` anomaly
-  - Existing `validate` is now deprecated; delegates to `validate-anomaly` and translates anomalies back into `ex-info` for backward compat
+  - Existing `validate` is now deprecated; delegates to `validate-anomaly` and translates anomalies back into `ex-info`
+    for backward compat
 - New decomposed tests:
   - `interface/validate_anomaly_happy_path_test.clj`
   - `interface/validate_anomaly_failure_test.clj`
@@ -43,7 +56,8 @@ Refactor / foundation tier. Three independent commits, one per scope, can be rev
 
 - Modified `components/dag-primitives/deps.edn` — `:local/root` dep on `ai.miniforge/anomaly`
 - Modified `components/dag-primitives/src/ai/miniforge/dag_primitives/result.clj`:
-  - New `unwrap-anomaly` — returns the unwrapped value or a `:fault` anomaly. Original `:code` (e.g. `:cycle-detected`) is preserved in `:anomaly/data :code` for callers that pattern-match on it.
+  - New `unwrap-anomaly` — returns the unwrapped value or a `:fault` anomaly. Original `:code` (e.g. `:cycle-detected`)
+    is preserved in `:anomaly/data :code` for callers that pattern-match on it.
   - Existing `unwrap` is now deprecated; delegates and re-throws via the original `ex-info` shape.
 - Modified `components/dag-primitives/src/ai/miniforge/dag_primitives/interface.clj` — exports `unwrap-anomaly`
 - New decomposed tests:
@@ -53,7 +67,9 @@ Refactor / foundation tier. Three independent commits, one per scope, can be rev
 
 ### Scope 3 — connector-core extraction (commit `81a5ac00`)
 
-The recurring `require-handle!` / `validate-auth!` patterns that each connector component (`connector-jira`, `connector-gitlab`, `connector-github`, `connector-excel`, …) reimplemented are extracted into a shared helper in `connector` core. Both throwing and anomaly-returning variants are provided.
+The recurring `require-handle!` / `validate-auth!` patterns that each connector component (`connector-jira`,
+`connector-gitlab`, `connector-github`, `connector-excel`, …) reimplemented are extracted into a shared helper in
+`connector` core. Both throwing and anomaly-returning variants are provided.
 
 - Modified `components/connector/deps.edn` — `:local/root` dep on `ai.miniforge/anomaly`
 - New `components/connector/src/ai/miniforge/connector/validation.clj`:
@@ -62,11 +78,13 @@ The recurring `require-handle!` / `validate-auth!` patterns that each connector 
 - Modified `components/connector/src/ai/miniforge/connector/interface.clj` — exports all four
 - 6 decomposed test files under `components/connector/test/ai/miniforge/connector/validation/`
 
-**Per-connector callsite migration is NOT in this PR.** Each connector currently inlines its own validation logic; migrating their callsites to the new shared helpers is a follow-on workstream. ~38 inventory `:cleanup-needed` sites across the connector family will be addressed by those follow-ons.
+**Per-connector callsite migration is NOT in this PR.** Each connector currently inlines its own validation logic;
+  migrating their callsites to the new shared helpers is a follow-on workstream. ~38 inventory `:cleanup-needed` sites
+  across the connector family will be addressed by those follow-ons.
 
 ## New API surface
 
-```
+```text
 ai.miniforge.schema.interface/validate-anomaly        → value | :invalid-input anomaly
 ai.miniforge.dag-primitives.interface/unwrap-anomaly  → data  | :fault anomaly
 ai.miniforge.connector.interface/require-handle       → state | :not-found anomaly
@@ -79,8 +97,11 @@ ai.miniforge.connector.interface/validate-auth!       → nil   | throws (deprec
 
 Inventory totals: 158 cleanup-needed sites repo-wide.
 
-- **Directly retired by this PR: 2 sites** — `schema/interface.clj:84` and `dag-primitives/result.clj:48`. Both tagged "high-leverage" foundations in the inventory's recommended week-1 ordering.
-- **Set up to be retired by follow-ons: ~38 sites** — `:handle-not-found` and `:auth-invalid` entries across `connector-jira` (~5), `connector-gitlab` (~5), `connector-github` (~6), `connector-excel` (~5), `connector-edgar` (~3), `connector-file` (~3), `connector-sarif` (~2), `connector-pipeline-output` (~1).
+- **Directly retired by this PR: 2 sites** — `schema/interface.clj:84` and `dag-primitives/result.clj:48`. Both tagged
+  "high-leverage" foundations in the inventory's recommended week-1 ordering.
+- **Set up to be retired by follow-ons: ~38 sites** — `:handle-not-found` and `:auth-invalid` entries across
+  `connector-jira` (~5), `connector-gitlab` (~5), `connector-github` (~6), `connector-excel` (~5), `connector-edgar`
+  (~3), `connector-file` (~3), `connector-sarif` (~2), `connector-pipeline-output` (~1).
 
 ## Strata Affected
 
@@ -90,24 +111,39 @@ Inventory totals: 158 cleanup-needed sites repo-wide.
 
 ## Testing Plan
 
-- `bb pre-commit` green: lint:clj + fmt:md + test (**2906 tests / 10675 passes / 0 failures**) + test:graalvm (6 tests / 468 assertions / 0 failures).
-- All 12 new test files exercised. Each anomaly-returning fn has happy-path, failure-path, and throwing-variant compatibility tests.
-- clj-kondo emits intentional deprecation warnings on the deprecated throwers; only fires inside the compat tests that exercise those paths.
+- `bb pre-commit` green: lint:clj + fmt:md + test (**2906 tests / 10675 passes / 0 failures**) + test:graalvm (6 tests /
+  468 assertions / 0 failures).
+- All 12 new test files exercised. Each anomaly-returning fn has happy-path, failure-path, and throwing-variant
+  compatibility tests.
+- clj-kondo emits intentional deprecation warnings on the deprecated throwers; only fires inside the compat tests that
+  exercise those paths.
 
 ## Deployment Plan
 
 No migration. Backward-compatible.
 
 - Callers of the existing throwing functions see no change. Same signatures, same `ex-info` shape on failure.
-- New code should reach for the anomaly-returning variants. Existing call sites can migrate at their leisure (or be migrated by follow-on PRs).
-- Promotion of the linter rule to `:error` for these specific files happens after the per-connector callsite migrations land.
+- New code should reach for the anomaly-returning variants. Existing call sites can migrate at their leisure (or be
+  migrated by follow-on PRs).
+- Promotion of the linter rule to `:error` for these specific files happens after the per-connector callsite migrations
+  land.
 
 ## Notes / Design calls
 
-1. **Naming inversion.** The brief described the convention as "`validate!` (throws) vs `validate` (anomaly)." But the existing throwers in this codebase are unsuffixed (`validate`, `unwrap`). Renaming would break every downstream caller. Kept the unsuffixed name as the deprecated thrower; introduced `validate-anomaly` / `unwrap-anomaly` for the new shape. Connector helpers are brand-new — followed the spec naming exactly there (`require-handle` anomaly, `require-handle!` thrower).
-2. **dag-primitives anomaly type chosen as `:fault`.** The original err result is a programmer/system fault by convention (caller should have checked `ok?`). `:fault` is more accurate than `:invalid-input`. Original `:code` keyword preserved in `:anomaly/data :code`.
-3. **`validate-auth` returns `nil` on success.** Mirrors the `validate-auth!` shape where success was just "no throw." Callers can use `(when-let [a (validate-auth auth)] …)` to short-circuit on anomaly.
-4. **Test runner flake observed during work** — `dag-executor.state-test/transition-task!-emits-event-test` raced with `gate.behavioral-test` (which `with-redefs [clojure.core/requiring-resolve …]`). Not introduced by this PR; pre-existing brick-isolation hazard around event-stream global state. Final pre-commit run is green; flagging as a separate hygiene issue worth a follow-on fix.
+1. **Naming inversion.** The brief described the convention as "`validate!` (throws) vs `validate` (anomaly)." But the
+  existing throwers in this codebase are unsuffixed (`validate`, `unwrap`). Renaming would break every downstream
+  caller. Kept the unsuffixed name as the deprecated thrower; introduced `validate-anomaly` / `unwrap-anomaly` for the
+  new shape. Connector helpers are brand-new — followed the spec naming exactly there (`require-handle` anomaly,
+  `require-handle!` thrower).
+2. **dag-primitives anomaly type chosen as `:fault`.** The original err result is a programmer/system fault by
+  convention (caller should have checked `ok?`). `:fault` is more accurate than `:invalid-input`. Original `:code`
+  keyword preserved in `:anomaly/data :code`.
+3. **`validate-auth` returns `nil` on success.** Mirrors the `validate-auth!` shape where success was just "no throw."
+  Callers can use `(when-let [a (validate-auth auth)] …)` to short-circuit on anomaly.
+4. **Test runner flake observed during work** — `dag-executor.state-test/transition-task!-emits-event-test` raced with
+  `gate.behavioral-test` (which `with-redefs [clojure.core/requiring-resolve …]`). Not introduced by this PR;
+  pre-existing brick-isolation hazard around event-stream global state. Final pre-commit run is green; flagging as a
+  separate hygiene issue worth a follow-on fix.
 
 ## Related Issues/PRs
 

--- a/docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md
+++ b/docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # spec: capsule runtime adapter (N11-delta) — Podman default, Docker compatible
 
 ## Overview

--- a/docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md
+++ b/docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # spec: capsule runtime adapter (N11-delta) — Podman default, Docker compatible
 
 ## Overview

--- a/docs/pull-requests/2026-04-29-spec-external-dependency-health-and-failure-attribution.md
+++ b/docs/pull-requests/2026-04-29-spec-external-dependency-health-and-failure-attribution.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # spec/external-dependency-health-and-failure-attribution
 
 ## Summary

--- a/docs/pull-requests/2026-04-29-spec-external-dependency-health-and-failure-attribution.md
+++ b/docs/pull-requests/2026-04-29-spec-external-dependency-health-and-failure-attribution.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # spec/external-dependency-health-and-failure-attribution
 
 ## Summary

--- a/docs/pull-requests/2026-04-30-chore-bump-standards-submodule-post-merge.md
+++ b/docs/pull-requests/2026-04-30-chore-bump-standards-submodule-post-merge.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # chore(standards): bump `.standards` to merged-main commit
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-chore-bump-standards-submodule-post-merge.md
+++ b/docs/pull-requests/2026-04-30-chore-bump-standards-submodule-post-merge.md
@@ -1,11 +1,18 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # chore(standards): bump `.standards` to merged-main commit
 
 ## Overview
 
 Small follow-up to [miniforge#713](https://github.com/miniforge-ai/miniforge/pull/713). The Phase 4b PR shipped with the
 `.standards` submodule pointing at the head of
-[`miniforge-standards/claude/runtime-policies`](https://github.com/miniforge-ai/miniforge-standards/tree/claude/runtime-policies) (`6f536a0`) — the branch HEAD before the standards repo's PR landed. miniforge-standards#14 merged in the
+[`miniforge-standards/claude/runtime-policies`][rtp-branch] (`6f536a0`) — the branch HEAD before the standards repo's
+PR landed. miniforge-standards#14 merged in the
+
+[rtp-branch]: https://github.com/miniforge-ai/miniforge-standards/tree/claude/runtime-policies
 meantime; this PR rebases the submodule pointer onto the merge commit on main
 ([`164d143`](https://github.com/miniforge-ai/miniforge-standards/commit/164d143)) so the consumer is tracking main
 rather than a now-orphan branch.

--- a/docs/pull-requests/2026-04-30-codex-tool-parity.md
+++ b/docs/pull-requests/2026-04-30-codex-tool-parity.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: Codex tool parity — explicit sandbox/approval + required MCP server
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-codex-tool-parity.md
+++ b/docs/pull-requests/2026-04-30-codex-tool-parity.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: Codex tool parity — explicit sandbox/approval + required MCP server
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-feat-boundary-component.md
+++ b/docs/pull-requests/2026-04-30-feat-boundary-component.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: add boundary component for exception → anomaly conversion
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-feat-boundary-component.md
+++ b/docs/pull-requests/2026-04-30-feat-boundary-component.md
@@ -1,17 +1,29 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: add boundary component for exception → anomaly conversion
 
 ## Overview
 
-Adds the third H-series cross-cutting primitive to miniforge OSS: `ai.miniforge.boundary`. Provides `execute-with-exception-handling` (and a short `execute` alias) — the canonical wrapper that catches thrown exceptions from libraries (DBs, HTTP clients, JVM I/O, parser failures, timeouts) and converts them into anomaly steps inside an existing `response-chain`, without bespoke try/catch noise at every call site.
+Adds the third H-series cross-cutting primitive to miniforge OSS: `ai.miniforge.boundary`. Provides
+`execute-with-exception-handling` (and a short `execute` alias) — the canonical wrapper that catches thrown exceptions
+from libraries (DBs, HTTP clients, JVM I/O, parser failures, timeouts) and converts them into anomaly steps inside an
+existing `response-chain`, without bespoke try/catch noise at every call site.
 
-Together with the merged `anomaly` (H1) and `response-chain` (H2) components, this completes the "exceptions are data" trio: anomaly is the shape, response-chain carries it through a flow, boundary catches throws at the edges.
+Together with the merged `anomaly` (H1) and `response-chain` (H2) components, this completes the "exceptions are data"
+trio: anomaly is the shape, response-chain carries it through a flow, boundary catches throws at the edges.
 
 ## Motivation
 
-The standards rule `005 exceptions-as-data` (merged) prescribes that non-boundary code returns anomalies as data. The companion linter (`feat/exceptions-as-data-linter`, merged) flags violations. The cleanup workstream (`refactor/exceptions-as-data-foundation-cleanup`, merged) started replacing throw sites with anomaly returns.
+The standards rule `005 exceptions-as-data` (merged) prescribes that non-boundary code returns anomalies as data. The
+companion linter (`feat/exceptions-as-data-linter`, merged) flags violations. The cleanup workstream
+(`refactor/exceptions-as-data-foundation-cleanup`, merged) started replacing throw sites with anomaly returns.
 
-What was still missing: the canonical wrapper for the *boundary* itself — the place where exceptions from external libraries (which you cannot rewrite) get converted into the anomaly-shaped flow. Without this primitive, every boundary site reinvents try/catch, the conversion logic drifts, and the exception-data capture is inconsistent.
+What was still missing: the canonical wrapper for the *boundary* itself — the place where exceptions from external
+libraries (which you cannot rewrite) get converted into the anomaly-shaped flow. Without this primitive, every boundary
+site reinvents try/catch, the conversion logic drifts, and the exception-data capture is inconsistent.
 
 This PR is the wrapper. It is the third (and final) H-series primitive.
 
@@ -32,8 +44,10 @@ Foundations / cross-cutting primitive. New top-level component.
 
 - New component `components/boundary/`:
   - `deps.edn` — `:local/root` deps on `ai.miniforge/anomaly` + `ai.miniforge/response-chain` + malli
-  - `src/ai/miniforge/boundary/contract.clj` — Malli schemas for the exception-category vocabulary plus the advisory `CheckFn` shape
-  - `src/ai/miniforge/boundary/core.clj` — implementation, including the data-driven `category->anomaly-type` mapping table
+  - `src/ai/miniforge/boundary/contract.clj` — Malli schemas for the exception-category vocabulary plus the advisory
+    `CheckFn` shape
+  - `src/ai/miniforge/boundary/core.clj` — implementation, including the data-driven `category->anomaly-type` mapping
+    table
   - `src/ai/miniforge/boundary/interface.clj` — public API
 - Eight decomposed test files under `test/ai/miniforge/boundary/interface/`, one per behavior dimension:
   - `happy_path_test.clj`
@@ -44,7 +58,8 @@ Foundations / cross-cutting primitive. New top-level component.
   - `programmer_error_guard_test.clj`
   - `multi_step_composition_test.clj`
   - `ex_data_preservation_test.clj`
-- Workspace registration: root `deps.edn` (`:dev`, `:test`) + each consumer project (`projects/miniforge/`, `projects/miniforge-core/`, `projects/miniforge-tui/`)
+- Workspace registration: root `deps.edn` (`:dev`, `:test`) + each consumer project (`projects/miniforge/`,
+  `projects/miniforge-core/`, `projects/miniforge-tui/`)
 
 ## Public API
 
@@ -100,7 +115,8 @@ The anomaly's `:anomaly/data` carries everything a triage tool needs:
  :boundary/category  :db}                            ; the supplied category
 ```
 
-`(ex-data e)` from libraries propagates verbatim into `:exception/data`, so structured information from `ex-info`-throwing libraries (e.g. clj-http, datalevin) survives the conversion.
+`(ex-data e)` from libraries propagates verbatim into `:exception/data`, so structured information from
+`ex-info`-throwing libraries (e.g. clj-http, datalevin) survives the conversion.
 
 ## Strata Affected
 
@@ -123,15 +139,24 @@ No existing component touched. Pure additive change.
 
 No migration required. New additive component. Existing miniforge code unchanged.
 
-The boundary wrapper is opt-in — components that need it migrate one site at a time. The linter rule (`005 exceptions-as-data`) does not require usage of `boundary`; it only requires that non-boundary code returns anomalies. Boundary is the *sanctioned* way to convert thrown exceptions in the namespaces that ARE allowed to throw.
+The boundary wrapper is opt-in — components that need it migrate one site at a time. The linter rule (`005
+exceptions-as-data`) does not require usage of `boundary`; it only requires that non-boundary code returns anomalies.
+Boundary is the *sanctioned* way to convert thrown exceptions in the namespaces that ARE allowed to throw.
 
 ## Notes / Deviations
 
-- **`:conformance` alias not updated.** The conformance gate carries a curated subset of components; `response-chain` is not in it either. Followed that precedent.
-- **Argument order is `category chain operation-key f & args`** — category first, chain second. This makes naive `->` threading land the chain in the category slot. Tests use `as->` or explicit `let` rebinding when threading. Rich-comment example in `interface.clj` reflects this. No public API change.
-- **`CheckFn` schema is advisory.** Boundary itself doesn't consume one; the schema is exposed for higher-level wrappers (HTTP-flavored, DB-flavored variants) that may layer on top later. This matches the spec's framing that boundary is the generic primitive.
-- **Apache 2 license headers** on every new file. Layer-labeled comment headers in interface, contract, and core. Malli throughout. No `requiring-resolve`.
-- **The component is itself a non-throwing boundary helper.** The one acceptable throw is a programmer-error guard for unknown category (similar to anomaly's vocabulary check). Verified by `programmer_error_guard_test.clj`.
+- **`:conformance` alias not updated.** The conformance gate carries a curated subset of components; `response-chain` is
+  not in it either. Followed that precedent.
+- **Argument order is `category chain operation-key f & args`** — category first, chain second. This makes naive `->`
+  threading land the chain in the category slot. Tests use `as->` or explicit `let` rebinding when threading.
+  Rich-comment example in `interface.clj` reflects this. No public API change.
+- **`CheckFn` schema is advisory.** Boundary itself doesn't consume one; the schema is exposed for higher-level wrappers
+  (HTTP-flavored, DB-flavored variants) that may layer on top later. This matches the spec's framing that boundary is
+  the generic primitive.
+- **Apache 2 license headers** on every new file. Layer-labeled comment headers in interface, contract, and core. Malli
+  throughout. No `requiring-resolve`.
+- **The component is itself a non-throwing boundary helper.** The one acceptable throw is a programmer-error guard for
+  unknown category (similar to anomaly's vocabulary check). Verified by `programmer_error_guard_test.clj`.
 
 ## Related Issues/PRs
 
@@ -142,7 +167,8 @@ The boundary wrapper is opt-in — components that need it migrate one site at a
 
 ## Checklist
 
-- [x] New `boundary` component with public API (`execute-with-exception-handling`, `execute`, `exception-categories`, `category->anomaly-type`, `CheckFn`)
+- [x] New `boundary` component with public API (`execute-with-exception-handling`, `execute`, `exception-categories`,
+  `category->anomaly-type`, `CheckFn`)
 - [x] Data-driven category mapping table (no nested ifs)
 - [x] Anomaly data captures `:exception/{type,message,cause,data}` plus `:boundary/category`
 - [x] Decomposed test files (eight, one per behavior)

--- a/docs/pull-requests/2026-04-30-feat-dependency-attribution-classifier.md
+++ b/docs/pull-requests/2026-04-30-feat-dependency-attribution-classifier.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Dependency Attribution Classifier
 
 ## Summary

--- a/docs/pull-requests/2026-04-30-feat-dependency-attribution-classifier.md
+++ b/docs/pull-requests/2026-04-30-feat-dependency-attribution-classifier.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Dependency Attribution Classifier
 
 ## Summary

--- a/docs/pull-requests/2026-04-30-feat-dependency-health-projection.md
+++ b/docs/pull-requests/2026-04-30-feat-dependency-health-projection.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat/dependency-health-projection
 
 ## Summary

--- a/docs/pull-requests/2026-04-30-feat-dependency-health-projection.md
+++ b/docs/pull-requests/2026-04-30-feat-dependency-health-projection.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat/dependency-health-projection
 
 ## Summary

--- a/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md
+++ b/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat(dag-executor): runtime adapter Phase 2 — Podman as a supported runtime
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md
+++ b/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat(dag-executor): runtime adapter Phase 2 — Podman as a supported runtime
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md
+++ b/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: runtime adapter Phase 3 — auto-probe, doctor, `mf runtime` CLI
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md
+++ b/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: runtime adapter Phase 3 — auto-probe, doctor, `mf runtime` CLI
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4a-bootstrap-docs.md
+++ b/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4a-bootstrap-docs.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: runtime adapter Phase 4a — bb install:podman + docs pass
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4a-bootstrap-docs.md
+++ b/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4a-bootstrap-docs.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: runtime adapter Phase 4a — bb install:podman + docs pass
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4b-runtime-policies.md
+++ b/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4b-runtime-policies.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: runtime adapter Phase 4b — runtime policies via .standards submodule
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4b-runtime-policies.md
+++ b/docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4b-runtime-policies.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: runtime adapter Phase 4b — runtime policies via .standards submodule
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md
+++ b/docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # feat: local-mode fidelity — archive persist, tool-first delivery, harvest CLI
 
 ## Overview

--- a/docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md
+++ b/docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # feat: local-mode fidelity — archive persist, tool-first delivery, harvest CLI
 
 ## Overview

--- a/docs/pull-requests/2026-05-01-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content.md
+++ b/docs/pull-requests/2026-05-01-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content.md
@@ -1,0 +1,101 @@
+# fix: [810] Enforce Miniforge.ai header and copyright on published content compliance pass
+
+**Branch:** `fix/compliance-810-enforce-miniforge-ai-header-and-copyright-on-published-content`
+**Date:** 2026-05-01
+
+---
+```yaml
+generated-by: miniforge-compliance-scanner
+rule-id: 810
+rule-title: "Enforce Miniforge.ai header and copyright on published content"
+fix-type: mechanical
+violations-fixed: 67
+files-changed: 67
+date: 2026-05-01
+```
+---
+
+## Summary
+
+Automated compliance pass applying mechanical fixes for **Enforce Miniforge.ai header and copyright on published content** (Dewey 810).
+67 violations fixed across 67 files.
+
+## Files Changed
+
+| File | Line | Current | Suggested |
+|------|------|---------|-----------|
+| `docs/pull-requests/2026-04-26-fix-release-windows-clojure.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-24-feat-run-pr-and-artifact-projections.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-22-feat-phase-outcome-events.md` | 1 | `(missing copyright header)` |
+| `PR-552.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-30-feat-dependency-attribution-classifier.md` | 1 | `(missing copyright header)` |
+| `specs/informative/I-CANDIDATE-REVIEW-WORKFLOW.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-22-feat-formalize-workflow-supervision-specs.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-27-refactor-extract-content-hash-component.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-27-fix-windows-build-classpath-separator.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-25-refactor-configurable-workflow-compiled-machine.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-25-refactor-loop-task-fsm-slice.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-27-docs-exception-cleanup-inventory.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-25-feat-configurable-machine-fsm.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-23-feat-workflow-machine-snapshot-resume.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-22-fix-precommit-kondo-warnings.md` | 1 | `(missing copyright header)` |
+| `specs/informative/I-PACK-ATTACHMENT-PRECEDENCE.md` | 1 | `(missing copyright header)` |
+| `docs/user-guide/architecture.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4b-runtime-policies.md` | 1 | `(missing copyright header)` |
+| `specs/normative/N4-delta-policy-compilation-contract.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-25-refactor-fsm-cleanup-runtime-dependency.md` | 1 | `(missing copyright header)` |
+| `docs/user-guide/configuration.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-30-feat-boundary-component.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-30-codex-tool-parity.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-feat-runtime-adapter-phase-1-oci-cli-executor.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-fix-dag-executor-event-soft-dep-race.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-27-feat-anomaly-component.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-spec-external-dependency-health-and-failure-attribution.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-22-fix-phase-outcome-standards-followup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-23-fix-workflow-supervision-dry-factories.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-30-feat-dependency-health-projection.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-23-fleet-spec-deltas.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-feat-response-chain-component.md` | 1 | `(missing copyright header)` |
+| `docs/archive/pr-logs/2026-04-10-fix-210-nil-safe-map-access.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-30-chore-bump-standards-submodule-post-merge.md` | 1 | `(missing copyright header)` |
+| `docs/user-guide/phases.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-24-refactor-standard-workflow-machine-phase-authority.md` | 1 | `(missing copyright header)` |
+| `docs/demo.md` | 1 | `(missing copyright header)` |
+| `docs/user-guide/writing-specs.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-24-feat-fsm-reachability-guards.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-27-fix-release-dispatch-tag.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md` | 1 | `(missing copyright header)` |
+| `docs/design/workflow-methodologies.md` | 1 | `(missing copyright header)` |
+| `docs/demo/compliance-demo.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-28-fix-dogfood-worktree-phase-failure.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-25-refactor-dag-checkpoint-resume-authority.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-23-refactor-learning-loop-authority.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-24-chore-gitignore-work-failed.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-27-feat-rich-decision-agent-context.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-feat-dependency-attribution-taxonomy.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4a-bootstrap-docs.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-23-refactor-workflow-supervision-boundary.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-22-feat-unified-workflow-machine.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-25-refactor-dag-resume-machine-snapshot-convergence.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-fix-dag-executor-gate-test-isolation.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-fix-release-pr-doc-body-sync.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-refactor-exceptions-as-data-foundation-cleanup.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-25-refactor-implicit-fsm-cleanup-slice.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-25-refactor-workflow-validator-compiler-unification.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md` | 1 | `(missing copyright header)` |
+| `docs/quickstart.md` | 1 | `(missing copyright header)` |
+| `docs/pull-requests/2026-04-29-fix-supervisory-run-snapshot-attachment.md` | 1 | `(missing copyright header)` |
+
+## Verification
+
+- Re-run `bb miniforge run docs/compliance/miniforge-scan.md` to confirm zero violations for this rule
+- All fixes are mechanical — no semantic changes
+
+---
+*Auto-generated by the Miniforge compliance scanner.*

--- a/docs/pull-requests/2026-05-01-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content.md
+++ b/docs/pull-requests/2026-05-01-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content.md
@@ -1,9 +1,15 @@
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # fix: [810] Enforce Miniforge.ai header and copyright on published content compliance pass
 
 **Branch:** `fix/compliance-810-enforce-miniforge-ai-header-and-copyright-on-published-content`
 **Date:** 2026-05-01
 
 ---
+
 ```yaml
 generated-by: miniforge-compliance-scanner
 rule-id: 810
@@ -13,84 +19,89 @@ violations-fixed: 67
 files-changed: 67
 date: 2026-05-01
 ```
+
 ---
 
 ## Summary
 
-Automated compliance pass applying mechanical fixes for **Enforce Miniforge.ai header and copyright on published content** (Dewey 810).
+Automated compliance pass applying mechanical fixes for **Enforce Miniforge.ai header and copyright on published
+content** (Dewey 810).
 67 violations fixed across 67 files.
 
 ## Files Changed
 
-| File | Line | Current | Suggested |
-|------|------|---------|-----------|
-| `docs/pull-requests/2026-04-26-fix-release-windows-clojure.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-24-feat-run-pr-and-artifact-projections.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-22-feat-phase-outcome-events.md` | 1 | `(missing copyright header)` |
-| `PR-552.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-30-feat-dependency-attribution-classifier.md` | 1 | `(missing copyright header)` |
-| `specs/informative/I-CANDIDATE-REVIEW-WORKFLOW.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-22-feat-formalize-workflow-supervision-specs.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-27-refactor-extract-content-hash-component.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-27-fix-windows-build-classpath-separator.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-25-refactor-configurable-workflow-compiled-machine.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-25-refactor-loop-task-fsm-slice.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-27-docs-exception-cleanup-inventory.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-25-feat-configurable-machine-fsm.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-23-feat-workflow-machine-snapshot-resume.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-22-fix-precommit-kondo-warnings.md` | 1 | `(missing copyright header)` |
-| `specs/informative/I-PACK-ATTACHMENT-PRECEDENCE.md` | 1 | `(missing copyright header)` |
-| `docs/user-guide/architecture.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4b-runtime-policies.md` | 1 | `(missing copyright header)` |
-| `specs/normative/N4-delta-policy-compilation-contract.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-25-refactor-fsm-cleanup-runtime-dependency.md` | 1 | `(missing copyright header)` |
-| `docs/user-guide/configuration.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-30-feat-boundary-component.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-30-codex-tool-parity.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-feat-runtime-adapter-phase-1-oci-cli-executor.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-fix-dag-executor-event-soft-dep-race.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-27-feat-anomaly-component.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-spec-external-dependency-health-and-failure-attribution.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-22-fix-phase-outcome-standards-followup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-23-fix-workflow-supervision-dry-factories.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-30-feat-dependency-health-projection.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-23-fleet-spec-deltas.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-feat-response-chain-component.md` | 1 | `(missing copyright header)` |
-| `docs/archive/pr-logs/2026-04-10-fix-210-nil-safe-map-access.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-30-chore-bump-standards-submodule-post-merge.md` | 1 | `(missing copyright header)` |
-| `docs/user-guide/phases.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-24-refactor-standard-workflow-machine-phase-authority.md` | 1 | `(missing copyright header)` |
-| `docs/demo.md` | 1 | `(missing copyright header)` |
-| `docs/user-guide/writing-specs.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-24-feat-fsm-reachability-guards.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-27-fix-release-dispatch-tag.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md` | 1 | `(missing copyright header)` |
-| `docs/design/workflow-methodologies.md` | 1 | `(missing copyright header)` |
-| `docs/demo/compliance-demo.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-28-fix-dogfood-worktree-phase-failure.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-25-refactor-dag-checkpoint-resume-authority.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-23-refactor-learning-loop-authority.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-24-chore-gitignore-work-failed.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-27-feat-rich-decision-agent-context.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-feat-dependency-attribution-taxonomy.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4a-bootstrap-docs.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-23-refactor-workflow-supervision-boundary.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-22-feat-unified-workflow-machine.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-25-refactor-dag-resume-machine-snapshot-convergence.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-fix-dag-executor-gate-test-isolation.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-fix-release-pr-doc-body-sync.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-refactor-exceptions-as-data-foundation-cleanup.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-25-refactor-implicit-fsm-cleanup-slice.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-25-refactor-workflow-validator-compiler-unification.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md` | 1 | `(missing copyright header)` |
-| `docs/quickstart.md` | 1 | `(missing copyright header)` |
-| `docs/pull-requests/2026-04-29-fix-supervisory-run-snapshot-attachment.md` | 1 | `(missing copyright header)` |
+Each row below received the canonical multi-line `<!-- … -->` header at line 1. The applied header is the same in every
+case (Title / Author / Copyright / Apache 2.0), so the table is condensed to file paths.
+
+| File |
+|------|
+| `docs/pull-requests/2026-04-26-fix-release-windows-clojure.md` |
+| `docs/pull-requests/2026-04-23-feat-pr-lifecycle-fsm.md` |
+| `docs/pull-requests/2026-04-29-feat-exceptions-as-data-linter.md` |
+| `docs/pull-requests/2026-04-23-feat-workflow-supervision-fsm.md` |
+| `docs/pull-requests/2026-04-24-feat-run-pr-and-artifact-projections.md` |
+| `docs/pull-requests/2026-04-22-feat-phase-outcome-events.md` |
+| `PR-552.md` |
+| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-2-podman-supported.md` |
+| `docs/pull-requests/2026-04-30-local-mode-fidelity-archive-persist-prompt-fix.md` |
+| `docs/pull-requests/2026-04-30-feat-dependency-attribution-classifier.md` |
+| `specs/informative/I-CANDIDATE-REVIEW-WORKFLOW.md` |
+| `docs/pull-requests/2026-04-22-feat-formalize-workflow-supervision-specs.md` |
+| `docs/pull-requests/2026-04-27-refactor-extract-content-hash-component.md` |
+| `docs/pull-requests/2026-04-27-fix-windows-build-classpath-separator.md` |
+| `docs/pull-requests/2026-04-25-refactor-configurable-workflow-compiled-machine.md` |
+| `docs/pull-requests/2026-04-25-refactor-loop-task-fsm-slice.md` |
+| `docs/pull-requests/2026-04-27-docs-exception-cleanup-inventory.md` |
+| `docs/pull-requests/2026-04-25-feat-configurable-machine-fsm.md` |
+| `docs/pull-requests/2026-04-23-feat-workflow-machine-snapshot-resume.md` |
+| `docs/pull-requests/2026-04-22-fix-precommit-kondo-warnings.md` |
+| `specs/informative/I-PACK-ATTACHMENT-PRECEDENCE.md` |
+| `docs/user-guide/architecture.md` |
+| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4b-runtime-policies.md` |
+| `specs/normative/N4-delta-policy-compilation-contract.md` |
+| `docs/pull-requests/2026-04-25-refactor-fsm-cleanup-runtime-dependency.md` |
+| `docs/user-guide/configuration.md` |
+| `docs/pull-requests/2026-04-30-feat-boundary-component.md` |
+| `docs/pull-requests/2026-04-30-codex-tool-parity.md` |
+| `docs/pull-requests/2026-04-29-feat-runtime-adapter-phase-1-oci-cli-executor.md` |
+| `docs/pull-requests/2026-04-29-fix-dag-executor-event-soft-dep-race.md` |
+| `docs/pull-requests/2026-04-27-feat-anomaly-component.md` |
+| `docs/pull-requests/2026-04-29-spec-external-dependency-health-and-failure-attribution.md` |
+| `docs/pull-requests/2026-04-22-fix-phase-outcome-standards-followup.md` |
+| `docs/pull-requests/2026-04-29-fix-web-dashboard-approval-handler-soft-dep-race.md` |
+| `docs/pull-requests/2026-04-23-fix-workflow-supervision-dry-factories.md` |
+| `docs/pull-requests/2026-04-30-feat-dependency-health-projection.md` |
+| `docs/pull-requests/2026-04-23-fleet-spec-deltas.md` |
+| `docs/pull-requests/2026-04-29-feat-response-chain-component.md` |
+| `docs/archive/pr-logs/2026-04-10-fix-210-nil-safe-map-access.md` |
+| `docs/pull-requests/2026-04-30-chore-bump-standards-submodule-post-merge.md` |
+| `docs/user-guide/phases.md` |
+| `docs/pull-requests/2026-04-24-refactor-standard-workflow-machine-phase-authority.md` |
+| `docs/demo.md` |
+| `docs/user-guide/writing-specs.md` |
+| `docs/pull-requests/2026-04-24-feat-fsm-reachability-guards.md` |
+| `docs/pull-requests/2026-04-27-fix-release-dispatch-tag.md` |
+| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-3-selection-doctor-cli.md` |
+| `docs/design/workflow-methodologies.md` |
+| `docs/demo/compliance-demo.md` |
+| `docs/pull-requests/2026-04-28-fix-dogfood-worktree-phase-failure.md` |
+| `docs/pull-requests/2026-04-25-refactor-dag-checkpoint-resume-authority.md` |
+| `docs/pull-requests/2026-04-23-refactor-learning-loop-authority.md` |
+| `docs/pull-requests/2026-04-24-chore-gitignore-work-failed.md` |
+| `docs/pull-requests/2026-04-27-feat-rich-decision-agent-context.md` |
+| `docs/pull-requests/2026-04-29-feat-dependency-attribution-taxonomy.md` |
+| `docs/pull-requests/2026-04-30-feat-runtime-adapter-phase-4a-bootstrap-docs.md` |
+| `docs/pull-requests/2026-04-23-refactor-workflow-supervision-boundary.md` |
+| `docs/pull-requests/2026-04-22-feat-unified-workflow-machine.md` |
+| `docs/pull-requests/2026-04-25-refactor-dag-resume-machine-snapshot-convergence.md` |
+| `docs/pull-requests/2026-04-29-fix-dag-executor-gate-test-isolation.md` |
+| `docs/pull-requests/2026-04-29-fix-release-pr-doc-body-sync.md` |
+| `docs/pull-requests/2026-04-29-refactor-exceptions-as-data-foundation-cleanup.md` |
+| `docs/pull-requests/2026-04-25-refactor-implicit-fsm-cleanup-slice.md` |
+| `docs/pull-requests/2026-04-25-refactor-workflow-validator-compiler-unification.md` |
+| `docs/pull-requests/2026-04-29-spec-capsule-runtime-adapter.md` |
+| `docs/quickstart.md` |
+| `docs/pull-requests/2026-04-29-fix-supervisory-run-snapshot-attachment.md` |
 
 ## Verification
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Quickstart: Run Your First Workflow
 
 Get from zero to a miniforge-generated pull request in under 5 minutes.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Quickstart: Run Your First Workflow
 
 Get from zero to a miniforge-generated pull request in under 5 minutes.

--- a/docs/user-guide/architecture.md
+++ b/docs/user-guide/architecture.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Architecture Overview
 
 Miniforge is built as a governed workflow engine with pluggable phases,

--- a/docs/user-guide/architecture.md
+++ b/docs/user-guide/architecture.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Architecture Overview
 
 Miniforge is built as a governed workflow engine with pluggable phases,

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Configuration
 
 ## LLM Backend

--- a/docs/user-guide/configuration.md
+++ b/docs/user-guide/configuration.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Configuration
 
 ## LLM Backend

--- a/docs/user-guide/phases.md
+++ b/docs/user-guide/phases.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Pipeline Phases
 
 Miniforge executes a sequential pipeline of phases. Each phase is driven by

--- a/docs/user-guide/phases.md
+++ b/docs/user-guide/phases.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Pipeline Phases
 
 Miniforge executes a sequential pipeline of phases. Each phase is driven by

--- a/docs/user-guide/writing-specs.md
+++ b/docs/user-guide/writing-specs.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Writing Specs
 
 A spec tells miniforge what you want built. You describe the intent, constraints,

--- a/docs/user-guide/writing-specs.md
+++ b/docs/user-guide/writing-specs.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Writing Specs
 
 A spec tells miniforge what you want built. You describe the intent, constraints,

--- a/specs/informative/I-CANDIDATE-REVIEW-WORKFLOW.md
+++ b/specs/informative/I-CANDIDATE-REVIEW-WORKFLOW.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Supporting Note: Candidate Review Workflow
 
 ## Purpose

--- a/specs/informative/I-CANDIDATE-REVIEW-WORKFLOW.md
+++ b/specs/informative/I-CANDIDATE-REVIEW-WORKFLOW.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Supporting Note: Candidate Review Workflow
 
 ## Purpose

--- a/specs/informative/I-PACK-ATTACHMENT-PRECEDENCE.md
+++ b/specs/informative/I-PACK-ATTACHMENT-PRECEDENCE.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Companion Note: Pack Attachment and Precedence
 
 ## Purpose

--- a/specs/informative/I-PACK-ATTACHMENT-PRECEDENCE.md
+++ b/specs/informative/I-PACK-ATTACHMENT-PRECEDENCE.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Companion Note: Pack Attachment and Precedence
 
 ## Purpose

--- a/specs/normative/N4-delta-policy-compilation-contract.md
+++ b/specs/normative/N4-delta-policy-compilation-contract.md
@@ -1,4 +1,8 @@
-<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
+<!--
+  Title: Miniforge.ai
+  Author: Christopher Lester (christopher@miniforge.ai)
+  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.
+-->
 # Normative Spec Extension: Policy Candidate Model and Pack Compilation Contract
 
 ## Purpose

--- a/specs/normative/N4-delta-policy-compilation-contract.md
+++ b/specs/normative/N4-delta-policy-compilation-contract.md
@@ -1,3 +1,4 @@
+<!--\n  Title: Miniforge.ai\n  Author: Christopher Lester (christopher@miniforge.ai)\n  Copyright 2025-2026 Christopher Lester. Licensed under Apache 2.0.\n-->
 # Normative Spec Extension: Policy Candidate Model and Pack Compilation Contract
 
 ## Purpose


### PR DESCRIPTION
```yaml
generated-by: miniforge-compliance-scanner
rule-id: 810
rule-title: "Enforce Miniforge.ai header and copyright on published content"
fix-type: mechanical
violations-fixed: 67
files-changed: 67
date: 2026-05-01
```

Applies mechanical fixes for all auto-fixable violations of this rule.
Violations requiring semantic review are excluded — see the work spec
at `docs/compliance/` for the full list.

PR documentation: [`docs/pull-requests/2026-05-01-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content.md`](docs/pull-requests/2026-05-01-fix-810-enforce-miniforge-ai-header-and-copyright-on-published-content.md)

🤖 Generated with [Miniforge](https://miniforge.ai)